### PR TITLE
feat(mail): "Ask AI" slash drill-in + stale-pending-message sweeper

### DIFF
--- a/apps/web/src/components/editor/editor-button.tsx
+++ b/apps/web/src/components/editor/editor-button.tsx
@@ -13,7 +13,7 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
-import type { Editor } from '@tiptap/react'
+import { type Editor, useEditorState } from '@tiptap/react'
 import {
   Bold,
   File,
@@ -98,13 +98,18 @@ interface EditorButtonsProps {
 
 // Font Selector Button
 export const FontSelectorButton = ({ editor, disabled, popoverClassName }: EditorButtonsProps) => {
+  const fontFamily = useEditorState({
+    editor,
+    selector: ({ editor }) => editor?.getAttributes('textStyle').fontFamily || '',
+  })
+
   if (!editor) return null
 
   return (
     <EditorSelector
       id='font-selector'
       options={fontOptions}
-      value={editor.getAttributes('textStyle').fontFamily || ''}
+      value={fontFamily}
       onChange={(value) => editor.chain().focus().setFontFamily(value).run()}
       placeholder='Font'
       disabled={disabled}
@@ -116,13 +121,18 @@ export const FontSelectorButton = ({ editor, disabled, popoverClassName }: Edito
 
 // Font Size Selector Button
 export const FontSizeButton = ({ editor, disabled, popoverClassName }: EditorButtonsProps) => {
+  const fontSize = useEditorState({
+    editor,
+    selector: ({ editor }) => editor?.getAttributes('textStyle').fontSize || '',
+  })
+
   if (!editor) return null
 
   return (
     <EditorSelector
       id='font-size-selector'
       options={fontSizeOptions}
-      value={editor.getAttributes('textStyle').fontSize || ''}
+      value={fontSize}
       onChange={(value) => editor.chain().focus().setFontSize(value).run()}
       placeholder='Size'
       disabled={disabled}
@@ -134,6 +144,11 @@ export const FontSizeButton = ({ editor, disabled, popoverClassName }: EditorBut
 
 // Color Picker Button
 export const ColorPickerButton = ({ editor, disabled, popoverClassName }: EditorButtonsProps) => {
+  const color = useEditorState({
+    editor,
+    selector: ({ editor }) => editor?.getAttributes('textStyle').color || '',
+  })
+
   if (!editor) return null
 
   // Try to get active state context if available
@@ -167,7 +182,7 @@ export const ColorPickerButton = ({ editor, disabled, popoverClassName }: Editor
               <div className='flex size-4 items-center justify-center rounded-full border border-gray-300'>
                 <div
                   className='size-3 rounded-full'
-                  style={{ backgroundColor: editor.getAttributes('textStyle').color || '#000000' }}
+                  style={{ backgroundColor: color || '#000000' }}
                 />
               </div>
             </Button>
@@ -176,15 +191,15 @@ export const ColorPickerButton = ({ editor, disabled, popoverClassName }: Editor
       </PopoverTrigger>
       <PopoverContent className={cn('w-64 p-2', popoverClassName)}>
         <div className='grid grid-cols-5 gap-1'>
-          {colorOptions.map((color) => (
+          {colorOptions.map((c) => (
             <button
-              key={color.value}
+              key={c.value}
               type='button'
               className='size-6 rounded-md border p-0.5'
-              style={{ backgroundColor: color.value }}
-              onClick={() => editor.chain().focus().setColor(color.value).run()}
-              title={color.label}>
-              {editor.getAttributes('textStyle').color === color.value && (
+              style={{ backgroundColor: c.value }}
+              onClick={() => editor.chain().focus().setColor(c.value).run()}
+              title={c.label}>
+              {color === c.value && (
                 <div className='flex h-full w-full items-center justify-center rounded-sm bg-black/10'>
                   <div className='size-3 rounded-full bg-white' />
                 </div>
@@ -199,6 +214,14 @@ export const ColorPickerButton = ({ editor, disabled, popoverClassName }: Editor
 
 // Bold Button
 export const BoldButton = ({ editor, disabled }: EditorButtonsProps) => {
+  // Subscribe to mark state so the button reflects/toggles active formatting —
+  // the editor runs with shouldRerenderOnTransaction: false, so selection
+  // changes won't re-render this button otherwise.
+  const isActive = useEditorState({
+    editor,
+    selector: ({ editor }) => editor?.isActive('bold') ?? false,
+  })
+
   if (!editor) return null
 
   return (
@@ -207,7 +230,7 @@ export const BoldButton = ({ editor, disabled }: EditorButtonsProps) => {
         variant='ghost'
         type='button'
         size='icon-sm'
-        className={`rounded-full ${editor.isActive('bold') ? 'bg-muted' : ''}`}
+        className={`rounded-full ${isActive ? 'bg-muted' : ''}`}
         onClick={() => editor.chain().focus().toggleBold().run()}
         disabled={disabled}>
         <Bold />
@@ -218,6 +241,11 @@ export const BoldButton = ({ editor, disabled }: EditorButtonsProps) => {
 
 // Italic Button
 export const ItalicButton = ({ editor, disabled }: EditorButtonsProps) => {
+  const isActive = useEditorState({
+    editor,
+    selector: ({ editor }) => editor?.isActive('italic') ?? false,
+  })
+
   if (!editor) return null
 
   return (
@@ -226,7 +254,7 @@ export const ItalicButton = ({ editor, disabled }: EditorButtonsProps) => {
         variant='ghost'
         type='button'
         size='icon-sm'
-        className={`rounded-full ${editor.isActive('italic') ? 'bg-muted' : ''}`}
+        className={`rounded-full ${isActive ? 'bg-muted' : ''}`}
         onClick={() => editor.chain().focus().toggleItalic().run()}
         disabled={disabled}>
         <Italic />
@@ -237,6 +265,11 @@ export const ItalicButton = ({ editor, disabled }: EditorButtonsProps) => {
 
 // Underline Button
 export const UnderlineButton = ({ editor, disabled }: EditorButtonsProps) => {
+  const isActive = useEditorState({
+    editor,
+    selector: ({ editor }) => editor?.isActive('underline') ?? false,
+  })
+
   if (!editor) return null
 
   return (
@@ -245,7 +278,7 @@ export const UnderlineButton = ({ editor, disabled }: EditorButtonsProps) => {
         variant='ghost'
         type='button'
         size='icon-sm'
-        className={`rounded-full ${editor.isActive('underline') ? 'bg-muted' : ''}`}
+        className={`rounded-full ${isActive ? 'bg-muted' : ''}`}
         onClick={() => editor.chain().focus().toggleUnderline().run()}
         disabled={disabled}>
         <Underline />
@@ -256,6 +289,11 @@ export const UnderlineButton = ({ editor, disabled }: EditorButtonsProps) => {
 
 // Strikethrough Button
 export const StrikethroughButton = ({ editor, disabled }: EditorButtonsProps) => {
+  const isActive = useEditorState({
+    editor,
+    selector: ({ editor }) => editor?.isActive('strike') ?? false,
+  })
+
   if (!editor) return null
 
   return (
@@ -264,7 +302,7 @@ export const StrikethroughButton = ({ editor, disabled }: EditorButtonsProps) =>
         variant='ghost'
         type='button'
         size='icon-sm'
-        className={`rounded-full ${editor.isActive('strike') ? 'bg-muted' : ''}`}
+        className={`rounded-full ${isActive ? 'bg-muted' : ''}`}
         onClick={() => editor.chain().focus().toggleStrike().run()}
         disabled={disabled}>
         <Strikethrough />
@@ -275,6 +313,17 @@ export const StrikethroughButton = ({ editor, disabled }: EditorButtonsProps) =>
 
 // List Button
 export const ListButton = ({ editor, disabled, popoverClassName }: EditorButtonsProps) => {
+  const listState = useEditorState({
+    editor,
+    selector: ({ editor }) => ({
+      bullet: editor?.isActive('bulletList') ?? false,
+      ordered: editor?.isActive('orderedList') ?? false,
+    }),
+  })
+
+  // Track auto-formatting state
+  const [autoFormatting, setAutoFormatting] = useState(false)
+
   if (!editor) return null
 
   // Try to get active state context if available
@@ -284,9 +333,6 @@ export const ListButton = ({ editor, disabled, popoverClassName }: EditorButtons
   } catch {
     // Context not available, component used outside email editor
   }
-
-  // Track auto-formatting state
-  const [autoFormatting, setAutoFormatting] = useState(false)
 
   return (
     <DropdownMenu
@@ -304,21 +350,19 @@ export const ListButton = ({ editor, disabled, popoverClassName }: EditorButtons
           variant='ghost'
           size='icon-sm'
           type='button'
-          className={`rounded-full ${
-            editor.isActive('bulletList') || editor.isActive('orderedList') ? 'bg-muted' : ''
-          }`}
+          className={`rounded-full ${listState.bullet || listState.ordered ? 'bg-muted' : ''}`}
           disabled={disabled}>
           <List />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className={cn('w-56', popoverClassName)} align='start' side='bottom'>
         <DropdownMenuItem
-          className={editor.isActive('bulletList') ? 'bg-muted' : ''}
+          className={listState.bullet ? 'bg-muted' : ''}
           onClick={() => editor.chain().focus().toggleBulletList().run()}>
           Bulleted List
         </DropdownMenuItem>
         <DropdownMenuItem
-          className={editor.isActive('orderedList') ? 'bg-muted' : ''}
+          className={listState.ordered ? 'bg-muted' : ''}
           onClick={() => editor.chain().focus().toggleOrderedList().run()}>
           Numbered List
         </DropdownMenuItem>
@@ -339,6 +383,11 @@ export const ListButton = ({ editor, disabled, popoverClassName }: EditorButtons
 
 // Link Button
 export const LinkButton = ({ editor, disabled }: EditorButtonsProps) => {
+  const isActive = useEditorState({
+    editor,
+    selector: ({ editor }) => editor?.isActive('link') ?? false,
+  })
+
   if (!editor || disabled) return null
 
   const setLink = () => {
@@ -362,7 +411,7 @@ export const LinkButton = ({ editor, disabled }: EditorButtonsProps) => {
         variant='ghost'
         type='button'
         size='icon-sm'
-        className={`rounded-full ${editor.isActive('link') ? 'bg-muted' : ''}`}
+        className={`rounded-full ${isActive ? 'bg-muted' : ''}`}
         onClick={setLink}>
         <LinkIcon />
       </Button>
@@ -372,6 +421,11 @@ export const LinkButton = ({ editor, disabled }: EditorButtonsProps) => {
 
 // Quote Button
 export const QuoteButton = ({ editor, disabled }: EditorButtonsProps) => {
+  const isActive = useEditorState({
+    editor,
+    selector: ({ editor }) => editor?.isActive('blockquote') ?? false,
+  })
+
   if (!editor) return null
 
   return (
@@ -380,7 +434,7 @@ export const QuoteButton = ({ editor, disabled }: EditorButtonsProps) => {
         variant='ghost'
         type='button'
         size='icon-sm'
-        className={`rounded-full ${editor.isActive('blockquote') ? 'bg-muted' : ''}`}
+        className={`rounded-full ${isActive ? 'bg-muted' : ''}`}
         onClick={() => editor.chain().focus().toggleBlockquote().run()}
         disabled={disabled}>
         <Quote />

--- a/apps/web/src/components/editor/tiptap-editor.tsx
+++ b/apps/web/src/components/editor/tiptap-editor.tsx
@@ -15,7 +15,10 @@ import { type Editor, EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import '~/styles/prosemirror.css'
-import { MailSlashContent } from '~/components/mail/email-editor/mail-slash-content'
+import {
+  type MailAiSlashConfig,
+  MailSlashContent,
+} from '~/components/mail/email-editor/mail-slash-content'
 import { useEditorContext } from './editor-context'
 import { FontSize } from './extensions'
 import { Indent } from './extensions/indent'
@@ -45,6 +48,8 @@ type TiptapEditorProps = {
   popoverClassName?: string
   /** When provided, plain Enter (no shift) calls this handler instead of inserting a paragraph break. */
   onEnter?: () => void
+  /** Optional AI-tools wiring — surfaces the "Ask AI" item in the `/` menu. */
+  aiSlash?: MailAiSlashConfig
 }
 
 const TiptapEditor = ({
@@ -56,6 +61,7 @@ const TiptapEditor = ({
   editable = true,
   popoverClassName,
   onEnter,
+  aiSlash,
 }: TiptapEditorProps) => {
   const { setEditor } = useEditorContext()
   const externalSyncRef = useRef<{ markLocalEdit: (key: string) => void }>({
@@ -264,6 +270,7 @@ const TiptapEditor = ({
             onExecute={runWithChipRange}
             onScopeChange={changeSlashScope}
             onClose={closeSlash}
+            aiSlash={aiSlash}
           />
         </InlinePickerPopover>
       )}

--- a/apps/web/src/components/kopilot/options/types.ts
+++ b/apps/web/src/components/kopilot/options/types.ts
@@ -10,7 +10,8 @@ import type { ReactNode } from 'react'
  */
 export interface KopilotChatOptions {
   /**
-   * Composer placeholder. Defaults to 'Ask Kopilot…'. Computed lazily so callers
+   * Composer placeholder. Defaults to 'Ask anything.  / for prompts, @ to reference'.
+   * Computed lazily so callers
    * can inject `{{agent.name}}` etc.
    */
   placeholder?: string

--- a/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
@@ -273,7 +273,7 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
   senderHotkeyOpenRef.current = () => setIsSenderPickerOpen(true)
 
   const { editor, confirmReference, closePicker } = useReferencePickerEditor({
-    placeholder: placeholder ?? 'Ask Kopilot...',
+    placeholder: placeholder ?? 'Ask anything.  / for prompts, @ to reference',
     editable: true,
     enableReferencePicker: allowReferencePicker,
     className: cn('prose prose-sm prose-p:my-0 focus:outline-hidden max-w-none dark:prose-invert'),

--- a/apps/web/src/components/mail/chat-composer/index.tsx
+++ b/apps/web/src/components/mail/chat-composer/index.tsx
@@ -150,6 +150,10 @@ function ChatComposerInner({
         popoverClassName={popoverZIndex}
         contentClassName='sm:min-h-[60px] py-2 text-sm'
         editorMinHeightClassName='min-h-[60px]'
+        aiSlash={{
+          onRunAI: handleAIOperation,
+          hasPreviousMessages: (thread.messageCount ?? thread.messages?.length ?? 0) > 0,
+        }}
         onWrapperClick={handleWrapperClick}
         onKeyDown={handleKeyDown}
         dropzone={dropzone}

--- a/apps/web/src/components/mail/chat-composer/use-chat-send.ts
+++ b/apps/web/src/components/mail/chat-composer/use-chat-send.ts
@@ -1,6 +1,7 @@
 // apps/web/src/components/mail/chat-composer/use-chat-send.ts
 'use client'
 
+import { type ParticipantRole, toParticipantId } from '@auxx/types'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { useCallback, useState } from 'react'
 import {
@@ -62,7 +63,11 @@ export function useChatSend({ threadId, integrationId, onSendSuccess }: UseChatS
           sentAt,
           receivedAt: null,
           createdAt: sentAt,
-          participants: [],
+          // Tag ids as `<role>:<id>` so the participant store + grouping render
+          // sender/recipient immediately rather than waiting on the realtime echo.
+          participants: (sentMessage.participants ?? []).map((p) =>
+            toParticipantId(p.role.toLowerCase() as ParticipantRole, p.id)
+          ),
           createdById: null,
           sendStatus: 'SENT',
           providerError: null,

--- a/apps/web/src/components/mail/chat-timeline.ts
+++ b/apps/web/src/components/mail/chat-timeline.ts
@@ -81,7 +81,11 @@ export function buildChatTimeline(
 }
 
 function messageTimestamp(m: MessageMeta): number {
+  // Unsent / in-flight rows (PENDING send, or a stranded send) have no `sentAt`.
+  // Falling back to `createdAt` keeps them in chronological position instead of
+  // sorting them to the epoch and pinning them to the top of the thread.
   if (m.sentAt) return new Date(m.sentAt).getTime()
+  if (m.createdAt) return new Date(m.createdAt).getTime()
   return 0
 }
 
@@ -89,8 +93,8 @@ function canGroupChat(a: MessageMeta, b: MessageMeta): boolean {
   if (b.messageType !== 'CHAT') return false
   if (a.isInbound !== b.isInbound) return false
   if (fromParticipant(a) !== fromParticipant(b)) return false
-  const aT = a.sentAt ? new Date(a.sentAt).getTime() : null
-  const bT = b.sentAt ? new Date(b.sentAt).getTime() : null
+  const aT = messageTimestamp(a) || null
+  const bT = messageTimestamp(b) || null
   if (aT === null || bT === null) return true
   return Math.abs(bT - aT) <= CHAT_GROUP_WINDOW_MS
 }

--- a/apps/web/src/components/mail/composer-shared/composer-body.tsx
+++ b/apps/web/src/components/mail/composer-shared/composer-body.tsx
@@ -9,6 +9,7 @@ import type React from 'react'
 import type { useDropzone } from 'react-dropzone'
 import { useEditorActiveStateContext } from '../email-editor/editor-active-state-context'
 import { LazyTiptapEditor } from '../email-editor/lazy-tiptap-editor'
+import type { MailAiSlashConfig } from '../email-editor/mail-slash-content'
 
 interface ComposerBodyProps {
   // editor wiring
@@ -20,6 +21,8 @@ interface ComposerBodyProps {
   contentClassName?: string
   /** Min-height for the editor region. Email 'min-h-[150px]', chat 'min-h-[60px]'. */
   editorMinHeightClassName?: string
+  /** Optional AI-tools wiring — surfaces the "Ask AI" item in the `/` menu. */
+  aiSlash?: MailAiSlashConfig
 
   // interaction
   onWrapperClick: React.MouseEventHandler<HTMLDivElement>
@@ -58,6 +61,7 @@ export function ComposerBody({
   popoverClassName,
   contentClassName,
   editorMinHeightClassName = 'min-h-[150px]',
+  aiSlash,
   onWrapperClick,
   onKeyDown,
   dropzone,
@@ -124,6 +128,7 @@ export function ComposerBody({
           editable={editable}
           popoverClassName={popoverClassName}
           contentClassName={contentClassName}
+          aiSlash={aiSlash}
         />
         {belowEditor}
       </div>

--- a/apps/web/src/components/mail/composer-shared/content-empty.ts
+++ b/apps/web/src/components/mail/composer-shared/content-empty.ts
@@ -1,7 +1,12 @@
 // apps/web/src/components/mail/composer-shared/content-empty.ts
 'use client'
 
+import type { JSONContent } from '@tiptap/core'
 import type { Editor } from '@tiptap/react'
+import { REFERENCE_PICKER_NODE } from '~/components/editor/inline-picker'
+
+/** Seed ZWSP an open picker chip holds so ProseMirror can keep its cursor. */
+const ZWSP = /​/g
 
 /**
  * Selectors for elements that should not steal focus into the editor when the
@@ -25,4 +30,24 @@ export const INTERACTIVE_ELEMENT_SELECTORS = `
 export function isContentEmpty(editor: Editor | null): boolean {
   if (!editor) return true
   return (editor.getText()?.trim() ?? '') === ''
+}
+
+/** Concatenate text content, skipping open picker chips. A chip's text is the
+ *  transient `/` or `@` query (plus a seed ZWSP) — not body content. */
+function textIgnoringChips(node: JSONContent): string {
+  if (node.type === REFERENCE_PICKER_NODE) return ''
+  if (node.type === 'text') return node.text ?? ''
+  return (node.content ?? []).map(textIgnoringChips).join('')
+}
+
+/**
+ * Like {@link isContentEmpty} but ignores any open `/`/`@` picker chip. Use
+ * where the chip is expected to be open while measuring emptiness — e.g. the
+ * `/` menu deciding whether to offer Compose (empty body) or transform ops.
+ * Without this, the chip's seed ZWSP (which `.trim()` doesn't strip) and its
+ * in-progress query both read as "content".
+ */
+export function isBodyEmptyIgnoringChips(editor: Editor | null): boolean {
+  if (!editor) return true
+  return textIgnoringChips(editor.getJSON()).replace(ZWSP, '').trim() === ''
 }

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -3,6 +3,7 @@
 import type { IdentifierType } from '@auxx/database/types'
 import { PLATFORM_CAPABILITIES, type PlatformCapabilities } from '@auxx/lib/channels/client'
 import type { DraftActionPayload } from '@auxx/lib/quick-actions/client'
+import { type ParticipantRole, toParticipantId } from '@auxx/types'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Separator } from '@auxx/ui/components/separator'
@@ -349,7 +350,12 @@ function ReplyComposeEditorComponent({
           sentAt,
           receivedAt: null,
           createdAt: sentAt,
-          participants: [],
+          // Tag ids as `<role>:<id>` so the participant store + grouping render
+          // from/to/cc immediately. Without this the optimistic row shows no
+          // participants until the realtime echo / refetch lands.
+          participants: (sentMessage.participants ?? []).map((p) =>
+            toParticipantId(p.role.toLowerCase() as ParticipantRole, p.id)
+          ),
           createdById: null,
           sendStatus: 'SENT',
           providerError: null,
@@ -1004,6 +1010,7 @@ function ReplyComposeEditorComponent({
           placeholder='Type / to insert a snippet.'
           editable={!aiToolsState.isProcessing}
           popoverClassName={popoverZIndex}
+          aiSlash={{ onRunAI: handleAIOperation, hasPreviousMessages }}
           onWrapperClick={handleWrapperClick}
           onKeyDown={handleKeyDown}
           dropzone={dropzone}

--- a/apps/web/src/components/mail/email-editor/lazy-tiptap-editor.tsx
+++ b/apps/web/src/components/mail/email-editor/lazy-tiptap-editor.tsx
@@ -5,6 +5,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import type { JSONContent } from '@tiptap/core'
 import { Loader2 } from 'lucide-react'
 import React, { Suspense } from 'react'
+import type { MailAiSlashConfig } from './mail-slash-content'
 
 const TiptapEditor = React.lazy(() => import('~/components/editor/tiptap-editor'))
 
@@ -19,6 +20,8 @@ interface LazyTiptapEditorProps {
   popoverClassName?: string
   /** When provided, plain Enter (no shift/cmd/ctrl) calls this instead of inserting a paragraph break. */
   onEnter?: () => void
+  /** Optional AI-tools wiring — surfaces the "Ask AI" item in the `/` menu. */
+  aiSlash?: MailAiSlashConfig
 }
 
 /**

--- a/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
@@ -17,8 +17,25 @@ import type {
 import { type SlashContentHandle, SlashList } from '~/components/editor/slash-commands/slash-list'
 import { useCmdkRemote } from '~/components/pickers/use-cmdk-remote'
 import { api } from '~/trpc/react'
+import { AI_LANG_TYPE, AI_OPERATION, AI_TONE_TYPE, type AIOperation } from '~/types/ai-tools'
+import { isBodyEmptyIgnoringChips } from '../composer-shared/content-empty'
 
 type Range = { from: number; to: number }
+
+/**
+ * Optional AI-tools wiring for the `/` menu's "Ask AI" drill-in. When absent,
+ * the "Ask AI" item simply doesn't render — keeps `MailSlashContent` usable by
+ * any chip-pipeline consumer without forcing AI wiring. Email and chat pass
+ * `handleAIOperation` from `useComposerAITools`. Note: `hasContent` is computed
+ * inside the component (chip-aware) rather than passed in — the open `/` chip
+ * would otherwise pollute a consumer-side content check (see `bodyHasContent`).
+ */
+export interface MailAiSlashConfig {
+  /** Runs the shared AI entrypoint. Mirrors the toolbar `onOperation` contract. */
+  onRunAI: (operation: AIOperation, options?: { tone?: string; language?: string }) => void
+  /** Compose requires a thread to reply to. Gates the empty-body "Ask AI" item. */
+  hasPreviousMessages: boolean
+}
 
 /**
  * Props for the mail composer's `/` content. Mirrors the chip-driven
@@ -44,6 +61,8 @@ export interface MailSlashContentProps {
   onScopeChange: (scope: string | null) => void
   /** Close the chip (keeps the typed text, mirroring `@`). */
   onClose: () => void
+  /** Optional AI-tools wiring — when present, adds the "Ask AI" drill-in item. */
+  aiSlash?: MailAiSlashConfig
 }
 
 // --- Curated mail block commands (StarterKit executors) -------------------
@@ -130,10 +149,75 @@ const TOOL_COMMANDS: SlashCommandItem[] = [
   },
 ]
 
-interface SnippetNavItem {
+// --- AI "Ask AI" drill items -----------------------------------------------
+// AI ops don't insert at the chip range — they rewrite the whole body async.
+// The leaf `onSelect` strips the chip then calls `onRunAI` (see `runAI` below).
+
+const AI_ROOT_COMMAND: SlashCommandItem = {
+  id: 'ask-ai',
+  title: 'Ask AI',
+  description: 'Compose or rewrite with AI',
+  keywords: ['ai', 'compose', 'rewrite', 'grammar', 'tone', 'translate', 'expand', 'shorten'],
+  iconId: 'sparkles',
+  drillDown: true,
+}
+
+// Shown when the body is empty (compose a fresh reply).
+const AI_COMPOSE_ITEMS: SlashCommandItem[] = [
+  {
+    id: 'ai-compose',
+    title: 'Compose',
+    description: 'Draft a reply from the conversation',
+    keywords: ['write', 'draft', 'generate'],
+    iconId: 'sparkles',
+  },
+]
+
+// Shown when the body has content (transform the existing draft).
+const AI_TRANSFORM_ITEMS: SlashCommandItem[] = [
+  {
+    id: 'ai-fix-grammar',
+    title: 'Fix grammar',
+    description: 'Correct spelling and grammar',
+    keywords: ['spelling', 'grammar', 'proofread'],
+    iconId: 'check-circle',
+  },
+  {
+    id: 'ai-expand',
+    title: 'Expand',
+    description: 'Make it longer',
+    keywords: ['longer', 'elaborate', 'lengthen'],
+    iconId: 'arrows-up-down',
+  },
+  {
+    id: 'ai-shorten',
+    title: 'Shorten',
+    description: 'Make it more concise',
+    keywords: ['shorter', 'concise', 'trim'],
+    iconId: 'chevrons-up-down',
+  },
+  {
+    id: 'ai-tone',
+    title: 'Tone',
+    description: 'Rewrite in a different tone',
+    keywords: ['voice', 'style', 'professional', 'friendly'],
+    iconId: 'pen-tool',
+    drillDown: true,
+  },
+  {
+    id: 'ai-translate',
+    title: 'Translate',
+    description: 'Translate to another language',
+    keywords: ['language', 'localize'],
+    iconId: 'globe',
+    drillDown: true,
+  },
+]
+
+type NavItem = {
   id: string
   label: string
-  type: 'snippets' | 'folder'
+  type: 'snippets' | 'folder' | 'ai' | 'ai-tone' | 'ai-translate'
 }
 
 // Snippet-mode rows reuse `SlashCommandItem` plus a `kind` tag so the section's
@@ -180,7 +264,7 @@ export function MailSlashContent(props: MailSlashContentProps) {
   }
 
   return (
-    <CommandNavigation<SnippetNavItem>>
+    <CommandNavigation<NavItem>>
       <MailSlashContentInner
         {...props}
         onEnterPlaceholderMode={() => {
@@ -195,14 +279,18 @@ export function MailSlashContent(props: MailSlashContentProps) {
 function MailSlashContentInner({
   ref,
   query,
+  editor,
   onExecute,
   onScopeChange,
   onEnterPlaceholderMode,
+  aiSlash,
 }: MailSlashContentProps & { onEnterPlaceholderMode: () => void }) {
-  const { push, pop, isAtRoot, current, stack } = useCommandNavigation<SnippetNavItem>()
+  const { push, pop, isAtRoot, current, stack } = useCommandNavigation<NavItem>()
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const isInSnippets = stack.length > 0
+  const isInSnippets = current?.type === 'snippets' || current?.type === 'folder'
+  const isInAi =
+    current?.type === 'ai' || current?.type === 'ai-tone' || current?.type === 'ai-translate'
   const currentFolderId = current?.type === 'folder' ? current.id : null
 
   const remote = useCmdkRemote(containerRef, `${stack.map((s) => s.id).join('/')}:${query}`)
@@ -273,6 +361,37 @@ function MailSlashContentInner({
     [push, onScopeChange]
   )
 
+  // AI ops rewrite the whole body async — they don't insert at the chip range.
+  // Step 1: strip the typed "/ai…" chip (deleting the range closes the picker).
+  // Step 2: run AI on the now-clean doc (the existing processing UI takes over).
+  const runAI = useCallback(
+    (operation: AIOperation, options?: { tone?: string; language?: string }) => {
+      if (!aiSlash) return
+      onExecute((editor, range) => editor.chain().focus().deleteRange(range).run())
+      aiSlash.onRunAI(operation, options)
+    },
+    [aiSlash, onExecute]
+  )
+
+  const enterAiScope = useCallback(
+    (type: 'ai' | 'ai-tone' | 'ai-translate', label: string) => {
+      push({ id: type, label, type })
+      onScopeChange(label)
+    },
+    [push, onScopeChange]
+  )
+
+  // Whether the body has real content — measured *ignoring the open `/` chip*.
+  // The chip seeds a ZWSP + holds the in-progress query, both of which would
+  // otherwise read as content and wrongly flip us to the transform ops on an
+  // empty body. Recomputed as the query changes (the chip text mutates).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: query drives chip text changes
+  const bodyHasContent = useMemo(() => !isBodyEmptyIgnoringChips(editor ?? null), [editor, query])
+
+  // Empty body + no thread to reply to → the AI submenu would be empty, so hide
+  // the root item entirely rather than drill into a dead list (plan §7).
+  const showAskAI = !!aiSlash && (bodyHasContent || aiSlash.hasPreviousMessages)
+
   const insertSnippet = useCallback(
     (snippetId: string) => {
       const snippet = allSnippets.find((s) => s.id === snippetId)
@@ -294,6 +413,10 @@ function MailSlashContentInner({
 
   const handleSuggestionSelect = useCallback(
     (item: SlashCommandItem) => {
+      if (item.id === 'ask-ai') {
+        enterAiScope('ai', 'Ask AI')
+        return
+      }
       if (item.id === 'snippet') {
         enterSnippetsDrillDown()
         return
@@ -305,10 +428,68 @@ function MailSlashContentInner({
       const cmd = MAIL_BLOCK_COMMANDS.find((c) => c.id === item.id)
       if (cmd) onExecute(cmd.run)
     },
-    [enterSnippetsDrillDown, onEnterPlaceholderMode, onExecute]
+    [enterAiScope, enterSnippetsDrillDown, onEnterPlaceholderMode, onExecute]
+  )
+
+  // Dispatch for the AI ops list (root of the "Ask AI" drill).
+  const handleAiOpSelect = useCallback(
+    (item: SlashCommandItem) => {
+      switch (item.id) {
+        case 'ai-compose':
+          runAI(AI_OPERATION.COMPOSE)
+          break
+        case 'ai-fix-grammar':
+          runAI(AI_OPERATION.FIX_GRAMMAR)
+          break
+        case 'ai-expand':
+          runAI(AI_OPERATION.EXPAND)
+          break
+        case 'ai-shorten':
+          runAI(AI_OPERATION.SHORTEN)
+          break
+        case 'ai-tone':
+          enterAiScope('ai-tone', 'Tone')
+          break
+        case 'ai-translate':
+          enterAiScope('ai-translate', 'Translate')
+          break
+      }
+    },
+    [runAI, enterAiScope]
   )
 
   const sections: SlashCommandSection<SlashCommandItem>[] = useMemo(() => {
+    if (current?.type === 'ai') {
+      return [
+        {
+          id: 'ai-ops',
+          heading: 'Ask AI',
+          items: bodyHasContent ? AI_TRANSFORM_ITEMS : AI_COMPOSE_ITEMS,
+          onSelect: handleAiOpSelect,
+        },
+      ]
+    }
+    if (current?.type === 'ai-tone') {
+      return [
+        {
+          id: 'ai-tone',
+          heading: 'Tone',
+          items: Object.values(AI_TONE_TYPE).map((tone) => ({ id: tone, title: tone })),
+          onSelect: (item) => runAI(AI_OPERATION.TONE, { tone: item.id }),
+        },
+      ]
+    }
+    if (current?.type === 'ai-translate') {
+      return [
+        {
+          id: 'ai-translate',
+          heading: 'Translate',
+          items: Object.values(AI_LANG_TYPE).map((language) => ({ id: language, title: language })),
+          onSelect: (item) => runAI(AI_OPERATION.TRANSLATE, { language: item.id }),
+        },
+      ]
+    }
+
     if (isInSnippets) {
       const snippetItems: SnippetItem[] = [
         ...currentFolders.map<SnippetItem>((f) => ({
@@ -356,7 +537,7 @@ function MailSlashContentInner({
     const suggestionsSection: SlashCommandSection<SlashCommandItem> = {
       id: 'suggestions',
       heading: 'Suggestions',
-      items: [...TOOL_COMMANDS, ...MAIL_BLOCK_COMMANDS],
+      items: [...(showAskAI ? [AI_ROOT_COMMAND] : []), ...TOOL_COMMANDS, ...MAIL_BLOCK_COMMANDS],
       onSelect: handleSuggestionSelect,
     }
 
@@ -393,6 +574,10 @@ function MailSlashContentInner({
     rootSnippetResults,
     enterFolder,
     insertSnippet,
+    bodyHasContent,
+    showAskAI,
+    handleAiOpSelect,
+    runAI,
   ])
 
   return (
@@ -401,7 +586,9 @@ function MailSlashContentInner({
         query={query}
         sections={sections}
         header={<CommandBreadcrumb rootLabel='Commands' />}
-        emptyMessage={isInSnippets ? 'No snippets found.' : 'No results found.'}
+        emptyMessage={
+          isInSnippets ? 'No snippets found.' : isInAi ? 'No options.' : 'No results found.'
+        }
         loading={snippetsLoading}
       />
     </div>

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -197,6 +197,26 @@ export async function setupSchedules() {
     }
   )
 
+  // Stale PENDING message sweeper — every 5 minutes. The synchronous send path
+  // creates a PENDING row then sends/reconciles in-request; a process death
+  // between the two strands the row in PENDING forever (retry rejects it, UI
+  // shows a permanent "being sent" spinner). This flips rows older than the
+  // threshold to FAILED so they're retryable.
+  await maintenanceQueue.upsertJobScheduler(
+    'stalePendingMessageSweeperJob',
+    { pattern: '*/5 * * * *' },
+    {
+      data: { dryRun: false },
+      opts: {
+        attempts: 2,
+        backoff: { type: 'exponential', delay: 60000 },
+        priority: 7,
+        removeOnComplete: { count: 60 },
+        removeOnFail: { count: 100 },
+      },
+    }
+  )
+
   // Eval-run watchdog — every 5 minutes. Times out runs whose heartbeat went
   // stale (worker died mid-run) or that were never claimed off the queue.
   await maintenanceQueue.upsertJobScheduler(

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -30,6 +30,7 @@ import {
   sendTrialConversionEmailsJob,
   shopifyBillingSyncJob,
   shopifySeatUsageJob,
+  stalePendingMessageSweeperJob,
   storageCleanupJob,
   stripeSubscriptionSyncJob,
   taskDeadlineScannerJob,
@@ -158,6 +159,10 @@ const jobMappings = {
 
   // Agent draft cleanup (daily; archives stale builder drafts with no chat)
   agentDraftCleanupJob,
+
+  // Stale PENDING message sweeper (every 5 min; flips outbound rows stranded in
+  // PENDING by a mid-send process death to FAILED so they're retryable)
+  stalePendingMessageSweeperJob,
 
   // App KV storage TTL sweep (hourly; lazy expiry on read makes cadence non-critical)
   appStorageSweepJob,

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -141,6 +141,10 @@ export {
 } from './maintenance/org-seed-job'
 export { type QuotaResetStats, quotaResetJob } from './maintenance/quota-reset-job'
 export {
+  type StalePendingMessageSweeperStats,
+  stalePendingMessageSweeperJob,
+} from './maintenance/stale-pending-message-sweeper-job'
+export {
   enqueueStorageCleanupJob,
   type StorageCleanupJobData,
   storageCleanupJob,

--- a/packages/lib/src/jobs/maintenance/index.ts
+++ b/packages/lib/src/jobs/maintenance/index.ts
@@ -23,6 +23,10 @@ export { type MidTrialStats, sendMidTrialEmailsJob } from './mid-trial-job'
 export { oauth2TokenRefreshScannerJob } from './oauth2-token-refresh-scanner-job'
 export { type QuotaResetStats, quotaResetJob } from './quota-reset-job'
 export {
+  type StalePendingMessageSweeperStats,
+  stalePendingMessageSweeperJob,
+} from './stale-pending-message-sweeper-job'
+export {
   enqueueStorageCleanupJob,
   type StorageCleanupJobData,
   storageCleanupJob,

--- a/packages/lib/src/jobs/maintenance/stale-pending-message-sweeper-job.ts
+++ b/packages/lib/src/jobs/maintenance/stale-pending-message-sweeper-job.ts
@@ -1,0 +1,91 @@
+// packages/lib/src/jobs/maintenance/stale-pending-message-sweeper-job.ts
+
+import { database, schema } from '@auxx/database'
+import { SendStatus } from '@auxx/database/enums'
+import { createScopedLogger } from '@auxx/logger'
+import type { Job } from 'bullmq'
+import { and, eq, lt, sql } from 'drizzle-orm'
+
+const logger = createScopedLogger('stale-pending-message-sweeper')
+
+interface StalePendingMessageSweeperJobData {
+  /**
+   * Messages still PENDING this many minutes after creation are considered
+   * stranded and flipped to FAILED. The send path is synchronous and completes
+   * in seconds, so anything older than a few minutes never finished its send.
+   * Defaults to 5.
+   */
+  staleMinutes?: number
+  batchSize?: number
+  dryRun?: boolean
+}
+
+export interface StalePendingMessageSweeperStats {
+  swept: number
+}
+
+/**
+ * Recovers outbound messages stranded in PENDING.
+ *
+ * The immediate send path creates the Message row as PENDING, then sends and
+ * reconciles synchronously within the request. A clean provider failure already
+ * lands as FAILED, but if the process dies mid-request (e.g. a deploy/restart
+ * between row creation and reconciliation) the row is never revisited: it stays
+ * PENDING forever, retry rejects non-FAILED rows, and the viewer shows a
+ * permanent "being sent" spinner.
+ *
+ * This sweep flips those abandoned rows to FAILED so they become retryable and
+ * render correctly. The in-request catch handles the common case; this covers
+ * the hard process-death case where no catch can run.
+ */
+export async function stalePendingMessageSweeperJob(
+  job: Job<StalePendingMessageSweeperJobData>
+): Promise<StalePendingMessageSweeperStats> {
+  const { staleMinutes = 5, batchSize = 500, dryRun = false } = job.data
+  const cutoff = new Date(Date.now() - staleMinutes * 60 * 1000)
+
+  logger.info('Starting stale PENDING message sweep', { staleMinutes, batchSize, dryRun, cutoff })
+
+  const candidates = await database
+    .select({ id: schema.Message.id, organizationId: schema.Message.organizationId })
+    .from(schema.Message)
+    .where(
+      and(eq(schema.Message.sendStatus, SendStatus.PENDING), lt(schema.Message.createdAt, cutoff))
+    )
+    .limit(batchSize)
+
+  if (candidates.length === 0) {
+    logger.info('Stale PENDING message sweep finished', { swept: 0 })
+    return { swept: 0 }
+  }
+
+  if (dryRun) {
+    logger.info('Stale PENDING message sweep (dry run)', {
+      swept: candidates.length,
+      ids: candidates.map((c) => c.id),
+    })
+    return { swept: candidates.length }
+  }
+
+  // Re-assert the PENDING + cutoff predicate in the UPDATE so an in-flight send
+  // that reconciles between the select and the write isn't clobbered.
+  const now = new Date()
+  await database
+    .update(schema.Message)
+    .set({
+      sendStatus: SendStatus.FAILED,
+      providerError: 'Send did not complete (stranded in PENDING and swept).',
+      lastAttemptAt: now,
+      attempts: sql`${schema.Message.attempts} + 1`,
+      updatedAt: now,
+    })
+    .where(
+      and(eq(schema.Message.sendStatus, SendStatus.PENDING), lt(schema.Message.createdAt, cutoff))
+    )
+
+  logger.info('Stale PENDING message sweep finished', {
+    swept: candidates.length,
+    ids: candidates.map((c) => c.id),
+  })
+  return { swept: candidates.length }
+}

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/messages/message-sender.service.ts
 import { type Database, database as db, schema } from '@auxx/database'
-import { ParticipantRole } from '@auxx/database/enums'
+import { ParticipantRole, SendStatus } from '@auxx/database/enums'
 import type { ParticipantRole as ParticipantRoleType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
@@ -102,6 +102,8 @@ export class MessageSenderService {
       }
     }
     let threadContext: ThreadContext | undefined
+    // Hoisted so the catch can mark a freshly-composed-but-unsent row FAILED.
+    let composed: ComposedMessage | undefined
     try {
       // Step 1: Prepare thread
       threadContext = await this.threadManager.getOrCreateThreadForSending({
@@ -118,7 +120,7 @@ export class MessageSenderService {
       // Step 2: Process participants
       const participants = await this.processParticipants(input)
       // Step 3: Compose message
-      const composed = await this.composer.composeMessage({
+      composed = await this.composer.composeMessage({
         threadId: threadContext.id,
         userId: input.userId,
         organizationId: input.organizationId,
@@ -222,8 +224,11 @@ export class MessageSenderService {
       if (input.attachmentIds && input.attachmentIds.length > 0 && sendResult.success) {
         await this.convertAttachmentsToPermanent(input.attachmentIds)
       }
-      // Step 11: Return result
-      return this.getUpdatedMessage(composed.id)
+      // Step 11: Return result, carrying the resolved participants so the
+      // client can render the optimistic row with correct from/to immediately.
+      const sent = await this.getUpdatedMessage(composed.id)
+      sent.participants = participants.all.map((p) => ({ id: p.id, role: p.role }))
+      return sent
     } catch (error) {
       logger.error('Failed to send message', {
         error,
@@ -233,6 +238,32 @@ export class MessageSenderService {
           threadId: input.threadId,
         },
       })
+
+      // Mark the composed-but-unsent row FAILED so it doesn't strand as PENDING
+      // forever. The send runs synchronously in the request, so a throw between
+      // row creation (Step 3) and reconciliation (Step 7) leaves a PENDING row
+      // that retry rejects and the UI shows as a permanent "being sent" spinner.
+      // Marking FAILED makes it retryable. (A hard process death can't run this
+      // — the stale-PENDING sweeper covers that case.)
+      if (composed?.id) {
+        try {
+          await (this.db ?? db)
+            .update(schema.Message)
+            .set({
+              sendStatus: SendStatus.FAILED,
+              providerError: error instanceof Error ? error.message : String(error),
+              lastAttemptAt: new Date(),
+              attempts: sql`${schema.Message.attempts} + 1`,
+              updatedAt: new Date(),
+            })
+            .where(eq(schema.Message.id, composed.id))
+        } catch (markError) {
+          logger.warn('Failed to mark message FAILED after send error', {
+            messageId: composed.id,
+            error: markError instanceof Error ? markError.message : String(markError),
+          })
+        }
+      }
 
       // Clean up orphaned thread if we created a new one during this send attempt
       if (threadContext?.isPending) {
@@ -314,12 +345,17 @@ export class MessageSenderService {
    * Processes participants and ensures they exist in the database
    */
   private async processParticipants(input: SendMessageInput): Promise<ProcessedParticipants> {
-    // Get sender
-    const fromParticipant = await this.participantService.findOrCreateParticipantForUser(
-      input.userId
-    )
+    // FROM is the sending mailbox (e.g. markus@auxx.ai), not the operator's
+    // login email — those can differ, and keying FROM off the user collapses it
+    // onto a recipient when the operator's email matches a recipient. Providers
+    // without a mailbox address (e.g. chat) fall back to the user identity.
+    const fromParticipant =
+      (await this.participantService.findOrCreateParticipantForIntegration(input.integrationId)) ??
+      (await this.participantService.findOrCreateParticipantForUser(input.userId))
     if (!fromParticipant) {
-      throw new Error(`Could not find or create participant for user ${input.userId}`)
+      throw new Error(
+        `Could not resolve FROM participant for integration ${input.integrationId} / user ${input.userId}`
+      )
     }
     // Process recipients
     const processParticipant = async (p: (typeof input.to)[0], role: ParticipantRoleType) => {

--- a/packages/lib/src/messages/types/message-sending.types.ts
+++ b/packages/lib/src/messages/types/message-sending.types.ts
@@ -118,6 +118,12 @@ export interface SentMessage {
   sendStatus: SendStatus
   sentAt: Date | null
   error?: string | null
+  /**
+   * Resolved participants (id + role) for the sent message, so the client can
+   * render the optimistic row with correct from/to/cc immediately instead of a
+   * participant-less row that waits on the realtime echo / refetch.
+   */
+  participants?: { id: string; role: ParticipantRole }[]
 }
 /**
  * Reconciliation input

--- a/packages/lib/src/participants/participant-service.ts
+++ b/packages/lib/src/participants/participant-service.ts
@@ -244,6 +244,53 @@ export class ParticipantService {
   }
 
   /**
+   * Finds or creates the Participant that represents an Integration's sending
+   * mailbox (e.g. `markus@auxx.ai`). This is the correct FROM identity for an
+   * outbound message — not the operator's login email, which may differ from
+   * the mailbox and would otherwise collapse onto a recipient participant.
+   *
+   * Returns `null` for integrations without a mailbox address (e.g. `chat`),
+   * letting the caller fall back to the user-based participant.
+   *
+   * @param integrationId - The integration the message is being sent from.
+   * @returns The mailbox Participant, or null if the integration has no email.
+   */
+  async findOrCreateParticipantForIntegration(
+    integrationId: string
+  ): Promise<ParticipantEntity | null> {
+    const [integration] = await this.db
+      .select({
+        email: schema.Integration.email,
+        name: schema.Integration.name,
+        organizationId: schema.Integration.organizationId,
+      })
+      .from(schema.Integration)
+      .where(
+        and(
+          eq(schema.Integration.id, integrationId),
+          eq(schema.Integration.organizationId, this.organizationId)
+        )
+      )
+      .limit(1)
+
+    if (!integration) {
+      logger.warn('Integration not found when resolving FROM participant', {
+        integrationId,
+        organizationId: this.organizationId,
+      })
+      return null
+    }
+    // Providers without a mailbox address (e.g. chat) — caller falls back.
+    if (!integration.email) return null
+
+    return this.findOrCreateParticipant({
+      identifier: integration.email,
+      identifierType: 'EMAIL' as IdentifierType,
+      name: integration.name,
+    })
+  }
+
+  /**
    * Batch fetch participants by ID.
    * Returns participants in same order as input IDs (missing IDs are excluded).
    */


### PR DESCRIPTION
## Summary

Bundles two workstreams that share working-tree files.

### 1. Mail composer — "Ask AI" slash drill-in (plans/tiptap PR 4)

Surfaces the AI compose tools as an **"Ask AI" ▸** item inside the `/` menu, alongside the existing toolbar row (both surfaces kept). Reuses `handleAIOperation` + the `CommandNavigation` drill machinery. **No server/DB change.**

Menu shape:
- Empty body → **Compose** (only)
- Empty body + no previous messages → "Ask AI" hidden
- Body has content → **Fix grammar / Expand / Shorten / Tone ▸ / Translate ▸**

Wiring: optional `aiSlash` prop threads `tiptap-editor → lazy-tiptap-editor → composer-body → MailSlashContent`; email + chat composers pass `{ onRunAI, hasPreviousMessages }`.

**Empty-body bugfix:** the open `/` chip seeds a zero-width space (so ProseMirror can hold the cursor) and stores the in-progress query as real text. Both leaked into `editor.getText()`, so `isContentEmpty` returned `false` the instant the menu opened — wrongly showing the transform ops (Tone/Translate/…) on an empty body. Added `isBodyEmptyIgnoringChips()` (drops the open chip node + strips ZWSP) and compute a chip-aware `bodyHasContent` inside `MailSlashContent` instead of trusting a consumer-side flag.

### 2. Kopilot composer placeholder

`"Ask Kopilot..."` → **`"Ask anything.  / for prompts, @ to reference"`** — names both triggers (`/` = prompt templates, `@` = reference records).

### 3. Stale-pending-message sweeper (outbound reliability)

New maintenance job that recovers outbound messages stranded in `PENDING` (the synchronous send path never finished) by flipping them to `FAILED` after a staleness window. Wired into the maintenance worker, plus related `message-sender` / `participant-service` adjustments.

## Test plan
- [ ] Empty body, has previous msgs: `/` → Ask AI → only **Compose**; selecting it strips the `/` chip and runs compose.
- [ ] Body has content: `/` → Ask AI shows transforms; Fix grammar / Expand / Shorten rewrite; Tone/Translate drill in.
- [ ] Empty body + no previous msgs: "Ask AI" hidden.
- [ ] Toolbar AI row still works unchanged.
- [ ] Kopilot placeholder renders the new copy.
- [ ] Sweeper flips a stranded PENDING message to FAILED; healthy sends unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
