### PR TITLE
feat(mail): plain chat composer variant + redesigned file picker

### DIFF
--- a/apps/web/src/components/editor/tiptap-editor.tsx
+++ b/apps/web/src/components/editor/tiptap-editor.tsx
@@ -16,6 +16,7 @@ import StarterKit from '@tiptap/starter-kit'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import '~/styles/prosemirror.css'
 import {
+  MAIL_BLOCK_COMMANDS,
   type MailAiSlashConfig,
   MailSlashContent,
 } from '~/components/mail/email-editor/mail-slash-content'
@@ -50,6 +51,13 @@ type TiptapEditorProps = {
   onEnter?: () => void
   /** Optional AI-tools wiring — surfaces the "Ask AI" item in the `/` menu. */
   aiSlash?: MailAiSlashConfig
+  /**
+   * Formatting profile. `'rich'` (default) = full StarterKit + block commands
+   * in the `/` menu (email). `'plain'` = a compact composer with headings /
+   * lists / blockquote / code blocks removed from the schema (so markdown
+   * shortcuts can't create them) and no block commands in the menu (chat).
+   */
+  variant?: 'rich' | 'plain'
 }
 
 const TiptapEditor = ({
@@ -62,7 +70,9 @@ const TiptapEditor = ({
   popoverClassName,
   onEnter,
   aiSlash,
+  variant = 'rich',
 }: TiptapEditorProps) => {
+  const isPlain = variant === 'plain'
   const { setEditor } = useEditorContext()
   const externalSyncRef = useRef<{ markLocalEdit: (key: string) => void }>({
     markLocalEdit: () => {},
@@ -88,9 +98,21 @@ const TiptapEditor = ({
 
   const extensions = useMemo(
     () => [
-      StarterKit.configure({
-        heading: { levels: [1, 2, 3] },
-      }),
+      StarterKit.configure(
+        isPlain
+          ? {
+              // Plain composer (chat): strip block-level nodes so neither the
+              // toolbar, the `/` menu, nor markdown input shortcuts can create
+              // them. Inline marks (bold/italic/…) stay.
+              heading: false,
+              bulletList: false,
+              orderedList: false,
+              listItem: false,
+              blockquote: false,
+              codeBlock: false,
+            }
+          : { heading: { levels: [1, 2, 3] } }
+      ),
       Indent,
       TextStyle,
       FontFamily,
@@ -114,6 +136,7 @@ const TiptapEditor = ({
       placeholderNodeExtension,
     ],
     [
+      isPlain,
       placeholder,
       placeholderNodeExtension,
       onSlashEnter,
@@ -271,6 +294,7 @@ const TiptapEditor = ({
             onScopeChange={changeSlashScope}
             onClose={closeSlash}
             aiSlash={aiSlash}
+            blockCommands={isPlain ? [] : MAIL_BLOCK_COMMANDS}
           />
         </InlinePickerPopover>
       )}

--- a/apps/web/src/components/mail/chat-composer/index.tsx
+++ b/apps/web/src/components/mail/chat-composer/index.tsx
@@ -154,6 +154,8 @@ function ChatComposerInner({
           onRunAI: handleAIOperation,
           hasPreviousMessages: (thread.messageCount ?? thread.messages?.length ?? 0) > 0,
         }}
+        // Plain compact composer — no block formatting in the schema or `/` menu.
+        variant='plain'
         onWrapperClick={handleWrapperClick}
         onKeyDown={handleKeyDown}
         dropzone={dropzone}

--- a/apps/web/src/components/mail/composer-shared/composer-body.tsx
+++ b/apps/web/src/components/mail/composer-shared/composer-body.tsx
@@ -23,6 +23,8 @@ interface ComposerBodyProps {
   editorMinHeightClassName?: string
   /** Optional AI-tools wiring — surfaces the "Ask AI" item in the `/` menu. */
   aiSlash?: MailAiSlashConfig
+  /** Formatting profile. `'rich'` (default, email) or `'plain'` (chat). */
+  variant?: 'rich' | 'plain'
 
   // interaction
   onWrapperClick: React.MouseEventHandler<HTMLDivElement>
@@ -62,6 +64,7 @@ export function ComposerBody({
   contentClassName,
   editorMinHeightClassName = 'min-h-[150px]',
   aiSlash,
+  variant,
   onWrapperClick,
   onKeyDown,
   dropzone,
@@ -129,6 +132,7 @@ export function ComposerBody({
           popoverClassName={popoverClassName}
           contentClassName={contentClassName}
           aiSlash={aiSlash}
+          variant={variant}
         />
         {belowEditor}
       </div>

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -1007,7 +1007,7 @@ function ReplyComposeEditorComponent({
         <ComposerBody
           content={content}
           onContentChange={handleContentChange}
-          placeholder='Type / to insert a snippet.'
+          placeholder='Write a reply…  press / for commands'
           editable={!aiToolsState.isProcessing}
           popoverClassName={popoverZIndex}
           aiSlash={{ onRunAI: handleAIOperation, hasPreviousMessages }}

--- a/apps/web/src/components/mail/email-editor/lazy-tiptap-editor.tsx
+++ b/apps/web/src/components/mail/email-editor/lazy-tiptap-editor.tsx
@@ -22,6 +22,8 @@ interface LazyTiptapEditorProps {
   onEnter?: () => void
   /** Optional AI-tools wiring — surfaces the "Ask AI" item in the `/` menu. */
   aiSlash?: MailAiSlashConfig
+  /** Formatting profile. `'rich'` (default, email) or `'plain'` (chat). */
+  variant?: 'rich' | 'plain'
 }
 
 /**

--- a/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
@@ -15,6 +15,7 @@ import type {
   SlashCommandSection,
 } from '~/components/editor/slash-commands/slash-command-picker'
 import { type SlashContentHandle, SlashList } from '~/components/editor/slash-commands/slash-list'
+import { SparkleIcon } from '~/components/kopilot/ui/sparkle-icon'
 import { useCmdkRemote } from '~/components/pickers/use-cmdk-remote'
 import { api } from '~/trpc/react'
 import { AI_LANG_TYPE, AI_OPERATION, AI_TONE_TYPE, type AIOperation } from '~/types/ai-tools'
@@ -63,6 +64,12 @@ export interface MailSlashContentProps {
   onClose: () => void
   /** Optional AI-tools wiring — when present, adds the "Ask AI" drill-in item. */
   aiSlash?: MailAiSlashConfig
+  /**
+   * Block commands offered at the root (Heading / lists / blockquote).
+   * Defaults to {@link MAIL_BLOCK_COMMANDS}. Chat passes `[]` — it's a plain,
+   * compact composer with formatting disabled, so block commands don't belong.
+   */
+  blockCommands?: MailBlockCommand[]
 }
 
 // --- Curated mail block commands (StarterKit executors) -------------------
@@ -70,11 +77,11 @@ export interface MailSlashContentProps {
 // target the mail editor's StarterKit schema (heading / lists / blockquote),
 // distinct from the block-schema `BASIC_BLOCK_COMMANDS`.
 
-interface MailBlockCommand extends SlashCommandItem {
+export interface MailBlockCommand extends SlashCommandItem {
   run: (editor: Editor, range: Range) => void
 }
 
-const MAIL_BLOCK_COMMANDS: MailBlockCommand[] = [
+export const MAIL_BLOCK_COMMANDS: MailBlockCommand[] = [
   {
     id: 'h1',
     title: 'Heading 1',
@@ -153,12 +160,13 @@ const TOOL_COMMANDS: SlashCommandItem[] = [
 // AI ops don't insert at the chip range — they rewrite the whole body async.
 // The leaf `onSelect` strips the chip then calls `onRunAI` (see `runAI` below).
 
+// Icon is supplied by the section's `renderItem` (branded SparkleIcon), so no
+// `iconId` here.
 const AI_ROOT_COMMAND: SlashCommandItem = {
   id: 'ask-ai',
   title: 'Ask AI',
   description: 'Compose or rewrite with AI',
   keywords: ['ai', 'compose', 'rewrite', 'grammar', 'tone', 'translate', 'expand', 'shorten'],
-  iconId: 'sparkles',
   drillDown: true,
 }
 
@@ -284,6 +292,7 @@ function MailSlashContentInner({
   onScopeChange,
   onEnterPlaceholderMode,
   aiSlash,
+  blockCommands = MAIL_BLOCK_COMMANDS,
 }: MailSlashContentProps & { onEnterPlaceholderMode: () => void }) {
   const { push, pop, isAtRoot, current, stack } = useCommandNavigation<NavItem>()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -425,10 +434,10 @@ function MailSlashContentInner({
         onEnterPlaceholderMode()
         return
       }
-      const cmd = MAIL_BLOCK_COMMANDS.find((c) => c.id === item.id)
+      const cmd = blockCommands.find((c) => c.id === item.id)
       if (cmd) onExecute(cmd.run)
     },
-    [enterAiScope, enterSnippetsDrillDown, onEnterPlaceholderMode, onExecute]
+    [blockCommands, enterAiScope, enterSnippetsDrillDown, onEnterPlaceholderMode, onExecute]
   )
 
   // Dispatch for the AI ops list (root of the "Ask AI" drill).
@@ -537,8 +546,24 @@ function MailSlashContentInner({
     const suggestionsSection: SlashCommandSection<SlashCommandItem> = {
       id: 'suggestions',
       heading: 'Suggestions',
-      items: [...(showAskAI ? [AI_ROOT_COMMAND] : []), ...TOOL_COMMANDS, ...MAIL_BLOCK_COMMANDS],
+      items: [...(showAskAI ? [AI_ROOT_COMMAND] : []), ...TOOL_COMMANDS, ...blockCommands],
       onSelect: handleSuggestionSelect,
+      // "Ask AI" gets the branded gradient sparkle + purple label; all other
+      // suggestion rows keep the default EntityIcon + title layout.
+      renderItem: (item) =>
+        item.id === 'ask-ai' ? (
+          <div className='flex items-center gap-2'>
+            <SparkleIcon className='shrink-0' />
+            <span className='font-medium text-purple-500 dark:text-purple-400'>{item.title}</span>
+          </div>
+        ) : (
+          <div className='flex items-center gap-2'>
+            {item.iconId && (
+              <EntityIcon iconId={item.iconId} size='xs' className='text-muted-foreground' />
+            )}
+            <span>{item.title}</span>
+          </div>
+        ),
     }
 
     const out: SlashCommandSection<SlashCommandItem>[] = [suggestionsSection]
@@ -576,6 +601,7 @@ function MailSlashContentInner({
     insertSnippet,
     bodyHasContent,
     showAskAI,
+    blockCommands,
     handleAiOpSelect,
     runAI,
   ])

--- a/apps/web/src/components/pickers/file-select-picker.tsx
+++ b/apps/web/src/components/pickers/file-select-picker.tsx
@@ -3,22 +3,25 @@
 'use client'
 
 import type { EntityType } from '@auxx/lib/files/types'
+import { type FileRef, getFileRefDownloadUrl, toFileRef } from '@auxx/types/file-ref'
 import { Button } from '@auxx/ui/components/button'
 import {
   Command,
-  CommandEmpty,
   CommandGroup,
+  CommandInput,
   CommandItem,
   CommandList,
+  CommandPlaceholder,
+  CommandSeparator,
 } from '@auxx/ui/components/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
-import { Files, Upload } from 'lucide-react'
+import { Download, File, FolderOpen, RotateCw, Trash2, Upload } from 'lucide-react'
 import type React from 'react'
-import { FileSelectPickerButton } from '~/components/file-select/file-select-picker-button'
+import { useMemo, useState } from 'react'
+import { FileSelectDialog } from '~/components/file-select/file-select-dialog'
 import { useFileSelect } from '~/components/file-select/hooks/use-file-select'
 import type { UseFileSelectReturn } from '~/components/file-select/types'
-import { FileItem } from '~/components/file-upload/ui/file-item'
 import type { FileItem as FileItemType } from '~/components/files/files-store'
 
 /**
@@ -55,7 +58,7 @@ export interface FileSelectPickerProps {
   side?: 'top' | 'right' | 'bottom' | 'left'
   sideOffset?: number
 
-  // Hide "Browse Existing" — restrict picker to fresh uploads only
+  // Hide "Browse files" — restrict picker to fresh uploads only
   hideBrowseExisting?: boolean
 
   // Display
@@ -122,21 +125,35 @@ function FileSelectPickerWithInternalHook({
     <FileSelectPickerContent
       fileSelect={fileSelect}
       allowMultiple={allowMultiple}
+      maxFiles={maxFiles}
       fileTypes={fileTypes}
       {...props}
     />
   )
 }
 
+/** Build a download URL for a ready file (filesystem item or completed upload). */
+function downloadUrlFor(item: FileItemType): string | undefined {
+  if (item.source === 'filesystem') return getFileRefDownloadUrl(toFileRef('file', item.id))
+  if (item.status === 'completed') {
+    return getFileRefDownloadUrl(toFileRef('asset', item.serverFileId ?? item.id))
+  }
+  return undefined
+}
+
 /**
- * The actual picker UI content
- * Always receives a fileSelect instance (either external or internal)
+ * The actual picker UI content.
+ *
+ * Mirrors the dynamic-view `FilePicker` look — a searchable Command list with
+ * hover-reveal row actions and Upload / Browse rows — but driven by the
+ * composer's `useFileSelect` data model. "Browse files" opens the shared
+ * `FileSelectDialog`.
  */
 function FileSelectPickerContent({
   fileSelect,
   allowMultiple = true,
+  maxFiles,
   fileTypes,
-  onSelect,
   open,
   onOpenChange,
   className,
@@ -147,78 +164,218 @@ function FileSelectPickerContent({
   hideBrowseExisting,
   children,
 }: FileSelectPickerContentProps) {
+  const [search, setSearch] = useState('')
+  const [browseOpen, setBrowseOpen] = useState(false)
+
+  const { selectedItems } = fileSelect
+
+  // Ready files are downloadable (filesystem items or completed uploads); the
+  // rest are still in flight (pending / uploading / failed).
+  const readyFiles = useMemo(
+    () => selectedItems.filter((it) => it.source === 'filesystem' || it.status === 'completed'),
+    [selectedItems]
+  )
+  const inProgressFiles = useMemo(
+    () => selectedItems.filter((it) => it.source !== 'filesystem' && it.status !== 'completed'),
+    [selectedItems]
+  )
+
+  const filteredReady = useMemo(() => {
+    if (!search) return readyFiles
+    const q = search.toLowerCase()
+    return readyFiles.filter((f) => f.name.toLowerCase().includes(q))
+  }, [readyFiles, search])
+
+  const hasAnyFiles = selectedItems.length > 0
+  const hasVisibleFiles = filteredReady.length > 0 || inProgressFiles.length > 0
+  const canAddMore = maxFiles ? selectedItems.length < maxFiles : true
+  const remainingSlots = maxFiles ? Math.max(0, maxFiles - selectedItems.length) : undefined
+
+  const openNativeFilePicker = () => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.multiple = allowMultiple
+    input.accept = fileTypes ? fileTypes.join(',') : '*/*'
+    input.onchange = (e) => {
+      const files = Array.from((e.target as HTMLInputElement).files || [])
+      if (files.length > 0) fileSelect.addFiles(files)
+    }
+    input.click()
+  }
+
   return (
-    <Popover open={open} onOpenChange={onOpenChange}>
-      <PopoverTrigger asChild>{children}</PopoverTrigger>
+    <>
+      <Popover open={open} onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>{children}</PopoverTrigger>
 
-      <PopoverContent
-        className={cn('w-96 p-0', className)}
-        align={align}
-        side={side}
-        sideOffset={sideOffset}
-        disabled={disabled}>
-        {/* Action buttons at top */}
-        <div className='flex gap-2 p-3 border-b'>
-          <Button
-            variant='outline'
-            size='sm'
-            className='flex-1'
-            onClick={() => {
-              const input = document.createElement('input')
-              input.type = 'file'
-              input.multiple = allowMultiple
-              input.accept = fileTypes ? fileTypes.join(',') : '*/*'
-              input.onchange = (e) => {
-                const files = Array.from((e.target as HTMLInputElement).files || [])
-                if (files.length > 0) {
-                  fileSelect.addFiles(files)
-                }
-              }
-              input.click()
-            }}>
-            <Upload />
-            Choose Files
-          </Button>
-
-          {!hideBrowseExisting && (
-            <FileSelectPickerButton
-              open={fileSelect.pickerOpen}
-              onOpenChange={(open) => (open ? fileSelect.openPicker() : fileSelect.closePicker())}
-              onFilesSelected={(files) => fileSelect.addExistingFiles(files)}
-              allowMultiple={allowMultiple}
-              variant='outline'
-              size='sm'
-              className='flex-1'>
-              <Files />
-              Browse Existing
-            </FileSelectPickerButton>
-          )}
-        </div>
-
-        <Command>
-          <CommandList>
-            <CommandEmpty>No files selected.</CommandEmpty>
-            {fileSelect.selectedItems.length > 0 && (
-              <CommandGroup heading='Files'>
-                {fileSelect.selectedItems.map((item) => (
-                  <CommandItem
-                    key={item.id}
-                    className='py-1 px-2 data-[selected=true]:bg-transparent'>
-                    <FileItem
-                      file={item}
-                      onRemove={() => fileSelect.removeItem(item.id)}
-                      onRetry={() => fileSelect.retryUpload(item.id)}
-                      onCancel={() => fileSelect.cancelUpload()}
-                      showControls={true}
-                      className='w-full'
-                    />
-                  </CommandItem>
-                ))}
-              </CommandGroup>
+        <PopoverContent
+          className={cn('w-96 p-0', className)}
+          align={align}
+          side={side}
+          sideOffset={sideOffset}
+          disabled={disabled}>
+          <Command shouldFilter={false}>
+            {hasAnyFiles && (
+              <CommandInput
+                placeholder='Search files...'
+                value={search}
+                onValueChange={setSearch}
+              />
             )}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+            <CommandList>
+              {hasVisibleFiles && (
+                <CommandGroup>
+                  {filteredReady.map((file) => (
+                    <FileSelectRow
+                      key={file.id}
+                      value={file.id}
+                      name={file.name}
+                      downloadUrl={downloadUrlFor(file)}
+                      onRemove={() => fileSelect.removeItem(file.id)}
+                    />
+                  ))}
+
+                  {inProgressFiles.map((file) => (
+                    <FileSelectRow
+                      key={file.id}
+                      value={file.id}
+                      name={file.name}
+                      progress={file.progress}
+                      status={file.status}
+                      onRetry={
+                        file.status === 'failed' ? () => fileSelect.retryUpload(file.id) : undefined
+                      }
+                      onRemove={() => fileSelect.removeItem(file.id)}
+                    />
+                  ))}
+                </CommandGroup>
+              )}
+
+              {hasAnyFiles && !hasVisibleFiles && (
+                <CommandPlaceholder>No matching files</CommandPlaceholder>
+              )}
+              {!hasAnyFiles && <CommandPlaceholder>No files attached</CommandPlaceholder>}
+
+              <CommandSeparator />
+              <CommandGroup>
+                {canAddMore ? (
+                  <>
+                    <CommandItem onSelect={openNativeFilePicker}>
+                      <Upload className='size-4' />
+                      Upload file
+                    </CommandItem>
+                    {!hideBrowseExisting && (
+                      <CommandItem onSelect={() => setBrowseOpen(true)}>
+                        <FolderOpen className='size-4' />
+                        Browse files
+                      </CommandItem>
+                    )}
+                  </>
+                ) : (
+                  <CommandPlaceholder>Maximum files reached</CommandPlaceholder>
+                )}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {browseOpen && (
+        <FileSelectDialog
+          open={browseOpen}
+          onOpenChange={setBrowseOpen}
+          onFilesSelected={(files) => {
+            fileSelect.addExistingFiles(files)
+            setBrowseOpen(false)
+          }}
+          allowMultiple={allowMultiple}
+          maxSelection={remainingSlots}
+          title='Select files'
+          confirmText='Attach'
+        />
+      )}
+    </>
+  )
+}
+
+interface FileSelectRowProps {
+  name: string
+  progress?: number
+  status?: string
+  downloadUrl?: string
+  onRemove?: () => void
+  onRetry?: () => void
+  value: string
+}
+
+/**
+ * A single file row with a hover-reveal action rail (download / retry / remove).
+ * In-progress rows are disabled and show their upload percentage instead.
+ */
+function FileSelectRow({
+  name,
+  progress,
+  status,
+  downloadUrl,
+  onRemove,
+  onRetry,
+  ...commandItemProps
+}: FileSelectRowProps) {
+  const isUploading = status === 'uploading' || status === 'processing' || status === 'pending'
+
+  return (
+    <CommandItem
+      {...commandItemProps}
+      disabled={isUploading}
+      className='group/file relative overflow-hidden'>
+      <div className='flex min-w-0 flex-1 items-center gap-2'>
+        <File className='size-4 shrink-0 text-muted-foreground' />
+        <span className='truncate text-sm'>{name}</span>
+        {isUploading && progress != null && (
+          <span className='ml-auto tabular-nums text-xs text-muted-foreground'>
+            {Math.round(progress)}%
+          </span>
+        )}
+        {status === 'failed' && <span className='ml-auto text-xs text-destructive'>Failed</span>}
+      </div>
+      {!isUploading && (downloadUrl || onRetry || onRemove) && (
+        <div
+          style={{ '--btn-width': '50px' } as React.CSSProperties}
+          className='absolute inset-y-0 right-0 flex items-center translate-x-[calc(var(--btn-width)+8px)] group-hover/file:translate-x-0 transition-transform duration-200 ease-out'>
+          <div className='w-4 h-full bg-gradient-to-r from-transparent to-accent/50 dark:to-[#404754]/50 transition-opacity duration-200' />
+          <div className='flex items-center gap-0.5 bg-accent/50 dark:bg-[#404754]/50 pr-0.5'>
+            {downloadUrl && (
+              <Button variant='ghost' size='icon-xs' asChild>
+                <a href={downloadUrl} download onClick={(e) => e.stopPropagation()}>
+                  <Download />
+                </a>
+              </Button>
+            )}
+            {onRetry && (
+              <Button
+                variant='ghost'
+                size='icon-xs'
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onRetry()
+                }}>
+                <RotateCw />
+              </Button>
+            )}
+            {onRemove && (
+              <Button
+                variant='destructive-hover'
+                size='icon-xs'
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onRemove()
+                }}>
+                <Trash2 />
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </CommandItem>
   )
 }


### PR DESCRIPTION
## Summary
- Add a `variant` prop (`'rich'` | `'plain'`) to the tiptap editor. The **plain** profile strips block-level nodes (headings / lists / blockquote / code blocks) from the StarterKit schema so the toolbar, the `/` menu, and markdown input shortcuts can't create them, and passes `[]` block commands to the slash menu. Chat composer opts into `'plain'`; email stays `'rich'`.
- Brand the **"Ask AI"** slash row with the gradient `SparkleIcon` + purple label via the section's `renderItem`, and refresh the reply placeholder copy.
- Rework `file-select-picker` to mirror the dynamic-view `FilePicker`: a searchable `Command` list with hover-reveal row actions (download / retry / remove), Upload / Browse rows, `maxFiles` handling, and the shared `FileSelectDialog` for browsing existing files.

## Files
- `editor/tiptap-editor.tsx` — `variant` prop, conditional StarterKit config, block-command wiring
- `mail/chat-composer/index.tsx` — opt into `variant='plain'`
- `mail/composer-shared/composer-body.tsx`, `mail/email-editor/lazy-tiptap-editor.tsx` — thread `variant` through
- `mail/email-editor/index.tsx` — updated placeholder copy
- `mail/email-editor/mail-slash-content.tsx` — export `MAIL_BLOCK_COMMANDS`, `blockCommands` prop, branded Ask AI row
- `pickers/file-select-picker.tsx` — redesigned picker UI

## Test plan
- [ ] Chat composer: `/` menu shows no block commands; markdown shortcuts (`#`, `-`, `>`) don't create blocks
- [ ] Email composer: full block commands still available
- [ ] "Ask AI" row renders branded sparkle + purple label
- [ ] File picker: upload, browse existing, search, download/retry/remove row actions, maxFiles limit