### PR TITLE
refactor(pickers): consolidate file pickers onto shared FileBrowseLevel

### DIFF
--- a/apps/web/src/components/editor/placeholders/placeholder-picker-content.tsx
+++ b/apps/web/src/components/editor/placeholders/placeholder-picker-content.tsx
@@ -179,7 +179,7 @@ function RootListContent({
           exit()
           return
         }
-        if (e.key === 'Backspace' && !search && exit) {
+        if ((e.key === 'Backspace' || e.key === 'ArrowLeft') && !search && exit) {
           e.preventDefault()
           exit()
           return

--- a/apps/web/src/components/mail/email-editor/hooks/index.ts
+++ b/apps/web/src/components/mail/email-editor/hooks/index.ts
@@ -6,3 +6,10 @@ export type { UseDraftOptions, UseDraftReturn } from './use-draft'
 export { useDraft } from './use-draft'
 export type { UseDraftMutationsOptions, UseDraftMutationsReturn } from './use-draft-mutations'
 export { useDraftMutations } from './use-draft-mutations'
+export type {
+  SnippetEntity,
+  SnippetFolderEntity,
+  UseSnippetSearchOptions,
+  UseSnippetSearchResult,
+} from './use-snippet-search'
+export { useSnippetSearch } from './use-snippet-search'

--- a/apps/web/src/components/mail/email-editor/hooks/use-snippet-search.ts
+++ b/apps/web/src/components/mail/email-editor/hooks/use-snippet-search.ts
@@ -1,0 +1,125 @@
+// apps/web/src/components/mail/email-editor/hooks/use-snippet-search.ts
+
+import { useMemo } from 'react'
+import type { RouterOutputs } from '~/trpc/react'
+import { api } from '~/trpc/react'
+
+export type SnippetEntity = RouterOutputs['snippet']['all']['snippets'][number]
+export type SnippetFolderEntity = RouterOutputs['snippet']['getFolders']['folders'][number]
+
+export interface UseSnippetSearchOptions {
+  /** Lowercased search query typed into the open `/` chip. Empty = browse mode. */
+  query: string
+  /** The folder the picker is drilled into, or null at the Snippets scope root. */
+  currentFolderId: string | null
+  /** Whether the slash menu is at its absolute root (drives cross-folder search). */
+  isAtRoot: boolean
+}
+
+export interface UseSnippetSearchResult {
+  /** Every snippet in the org (for id lookups on insert). */
+  allSnippets: SnippetEntity[]
+  /** True while the snippet list is still being fetched. */
+  loading: boolean
+  /** Browse view: snippets directly in the current level. */
+  currentSnippets: SnippetEntity[]
+  /** Browse view: folders directly in the current level. */
+  currentFolders: SnippetFolderEntity[]
+  /**
+   * Search results scoped to the current folder + all its subfolders
+   * (excludes the parent folder and siblings). At the Snippets scope root this
+   * is the whole library. Empty when not searching.
+   */
+  subtreeSnippetResults: SnippetEntity[]
+  /** Cross-folder search across the whole library, only at the menu root. */
+  rootSnippetResults: SnippetEntity[]
+}
+
+/**
+ * Owns the snippet + folder queries for the mail slash menu and derives the
+ * browse and search views. Search recurses the current folder's subtree rather
+ * than the single drilled level, so snippets nested in subfolders are found.
+ */
+export function useSnippetSearch({
+  query,
+  currentFolderId,
+  isAtRoot,
+}: UseSnippetSearchOptions): UseSnippetSearchResult {
+  const { data: snippetsData, isLoading: loading } = api.snippet.all.useQuery(
+    {},
+    { staleTime: 5 * 60 * 1000 }
+  )
+  const allSnippets = snippetsData?.snippets ?? []
+
+  const { data: foldersData } = api.snippet.getFolders.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  })
+  const allFolders = foldersData?.folders ?? []
+
+  const q = query.toLowerCase()
+
+  // Browse view: the direct children of the current level.
+  const currentSnippets = useMemo(
+    () =>
+      allSnippets.filter((s) => (currentFolderId ? s.folderId === currentFolderId : !s.folderId)),
+    [allSnippets, currentFolderId]
+  )
+
+  const currentFolders = useMemo(
+    () =>
+      allFolders.filter((f) => (currentFolderId ? f.parentId === currentFolderId : !f.parentId)),
+    [allFolders, currentFolderId]
+  )
+
+  // Current folder + all descendant folders (excludes parent + siblings). null
+  // at the Snippets scope root = no folder restriction (the whole library).
+  const subtreeFolderIds = useMemo(() => {
+    if (!currentFolderId) return null
+    const childrenByParent = new Map<string, string[]>()
+    for (const f of allFolders) {
+      if (!f.parentId) continue
+      const siblings = childrenByParent.get(f.parentId) ?? []
+      siblings.push(f.id)
+      childrenByParent.set(f.parentId, siblings)
+    }
+    const ids = new Set<string>([currentFolderId])
+    const queue = [currentFolderId]
+    while (queue.length > 0) {
+      const id = queue.pop()
+      if (!id) continue
+      for (const child of childrenByParent.get(id) ?? []) {
+        if (!ids.has(child)) {
+          ids.add(child)
+          queue.push(child)
+        }
+      }
+    }
+    return ids
+  }, [allFolders, currentFolderId])
+
+  // Searching inside the Snippets scope recurses the subtree (current folder +
+  // all subfolders), flattening matches — not just the current level.
+  const subtreeSnippetResults = useMemo(() => {
+    if (!q) return []
+    return allSnippets.filter((s) => {
+      if (!s.title.toLowerCase().includes(q)) return false
+      if (!subtreeFolderIds) return true
+      return s.folderId ? subtreeFolderIds.has(s.folderId) : false
+    })
+  }, [q, allSnippets, subtreeFolderIds])
+
+  // Cross-folder snippet search when typing at the menu root.
+  const rootSnippetResults = useMemo(() => {
+    if (!isAtRoot || !q) return []
+    return allSnippets.filter((s) => s.title.toLowerCase().includes(q))
+  }, [isAtRoot, allSnippets, q])
+
+  return {
+    allSnippets,
+    loading,
+    currentSnippets,
+    currentFolders,
+    subtreeSnippetResults,
+    rootSnippetResults,
+  }
+}

--- a/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
@@ -20,6 +20,7 @@ import { useCmdkRemote } from '~/components/pickers/use-cmdk-remote'
 import { api } from '~/trpc/react'
 import { AI_LANG_TYPE, AI_OPERATION, AI_TONE_TYPE, type AIOperation } from '~/types/ai-tools'
 import { isBodyEmptyIgnoringChips } from '../composer-shared/content-empty'
+import { useSnippetSearch } from './hooks'
 
 type Range = { from: number; to: number }
 
@@ -318,44 +319,16 @@ function MailSlashContentInner({
     onError: (error) => console.error('Failed to update snippet usage count', error),
   })
 
-  const { data: snippetsData, isLoading: snippetsLoading } = api.snippet.all.useQuery(
-    {},
-    { staleTime: 5 * 60 * 1000 }
-  )
-  const allSnippets = snippetsData?.snippets ?? []
-
-  const { data: foldersData } = api.snippet.getFolders.useQuery(undefined, {
-    staleTime: 5 * 60 * 1000,
-  })
-  const allFolders = foldersData?.folders ?? []
-
   const q = query.toLowerCase()
 
-  const currentSnippets = useMemo(
-    () =>
-      allSnippets.filter((s) => {
-        const matchesFolder = currentFolderId ? s.folderId === currentFolderId : !s.folderId
-        if (q) return matchesFolder && s.title.toLowerCase().includes(q)
-        return matchesFolder
-      }),
-    [allSnippets, currentFolderId, q]
-  )
-
-  const currentFolders = useMemo(
-    () =>
-      allFolders.filter((f) => {
-        const matchesParent = currentFolderId ? f.parentId === currentFolderId : !f.parentId
-        if (q) return matchesParent && f.name.toLowerCase().includes(q)
-        return matchesParent
-      }),
-    [allFolders, currentFolderId, q]
-  )
-
-  // Cross-folder snippet search when typing at root.
-  const rootSnippetResults = useMemo(() => {
-    if (!isAtRoot || !q) return []
-    return allSnippets.filter((s) => s.title.toLowerCase().includes(q))
-  }, [isAtRoot, allSnippets, q])
+  const {
+    allSnippets,
+    loading: snippetsLoading,
+    currentSnippets,
+    currentFolders,
+    subtreeSnippetResults,
+    rootSnippetResults,
+  } = useSnippetSearch({ query, currentFolderId, isAtRoot })
 
   const enterSnippetsDrillDown = useCallback(() => {
     push({ id: 'snippets', label: 'Snippets', type: 'snippets' })
@@ -500,20 +473,29 @@ function MailSlashContentInner({
     }
 
     if (isInSnippets) {
-      const snippetItems: SnippetItem[] = [
-        ...currentFolders.map<SnippetItem>((f) => ({
-          id: `folder-${f.id}`,
-          title: f.name,
-          drillDown: true,
-          kind: 'folder',
-          folderCount: f._count.snippets,
-        })),
-        ...currentSnippets.map<SnippetItem>((s) => ({
-          id: `snippet-${s.id}`,
-          title: s.title,
-          kind: 'snippet',
-        })),
-      ]
+      // While searching, show flattened subtree matches (snippets only) so
+      // snippets nested in subfolders surface. While browsing, show this
+      // level's folders + direct snippets.
+      const snippetItems: SnippetItem[] = q
+        ? subtreeSnippetResults.map<SnippetItem>((s) => ({
+            id: `snippet-${s.id}`,
+            title: s.title,
+            kind: 'snippet',
+          }))
+        : [
+            ...currentFolders.map<SnippetItem>((f) => ({
+              id: `folder-${f.id}`,
+              title: f.name,
+              drillDown: true,
+              kind: 'folder',
+              folderCount: f._count.snippets,
+            })),
+            ...currentSnippets.map<SnippetItem>((s) => ({
+              id: `snippet-${s.id}`,
+              title: s.title,
+              kind: 'snippet',
+            })),
+          ]
       const snippetsSection: SlashCommandSection<SnippetItem> = {
         id: 'snippets',
         heading: current?.type === 'folder' ? current.label : 'Snippets',
@@ -591,9 +573,11 @@ function MailSlashContentInner({
 
     return out
   }, [
+    q,
     isInSnippets,
     currentFolders,
     currentSnippets,
+    subtreeSnippetResults,
     current,
     handleSuggestionSelect,
     rootSnippetResults,
@@ -615,7 +599,9 @@ function MailSlashContentInner({
         emptyMessage={
           isInSnippets ? 'No snippets found.' : isInAi ? 'No options.' : 'No results found.'
         }
-        loading={snippetsLoading}
+        // Only the snippet drill-down needs the snippet fetch; the static root
+        // suggestions (Ask AI, formatting commands, placeholder) render instantly.
+        loading={isInSnippets && snippetsLoading}
       />
     </div>
   )

--- a/apps/web/src/components/pickers/file-browse-level.tsx
+++ b/apps/web/src/components/pickers/file-browse-level.tsx
@@ -1,0 +1,580 @@
+// apps/web/src/components/pickers/file-browse-level.tsx
+'use client'
+
+import { Checkbox } from '@auxx/ui/components/checkbox'
+import {
+  Command,
+  CommandBreadcrumb,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandList,
+  CommandLoading,
+  CommandNavigableItem,
+  CommandNavigation,
+  CommandSeparator,
+  type NavigationItem,
+  useCommandNavigation,
+  useCommandNavigationOptional,
+} from '@auxx/ui/components/command'
+import { Kbd } from '@auxx/ui/components/kbd'
+import { radioGroupVariants } from '@auxx/ui/components/radio-group'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { cn } from '@auxx/ui/lib/utils'
+import { Circle, File, Folder } from 'lucide-react'
+import type React from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ParentBackHeader } from '~/components/editor/placeholders/placeholder-picker-content'
+import type { FileItem } from '~/components/files/files-store'
+import { useFilesystemContext } from '~/components/files/provider/filesystem-provider'
+
+/**
+ * Navigation item type for files/folders.
+ */
+export type FileNavigationItem = NavigationItem & {
+  id: string
+  name: string
+}
+
+/**
+ * Props for {@link FileBrowseLevel}.
+ *
+ * The level is host-agnostic: it reads the filesystem from the app-global
+ * `FilesystemProvider`, manages folder drill-in on the surrounding
+ * `CommandNavigation` (or wraps its own when none is present), and reports row
+ * choices through {@link onSelectItem}. The host owns selection semantics — what
+ * happens to the chosen item (toggle a set, push to a tray) and whether to
+ * close — so this component never mutates selection state itself.
+ */
+export interface FileBrowseLevelProps {
+  /** Currently selected file ids — drives the row indicators. */
+  selectedFiles?: string[]
+  /** Currently selected folder ids — drives the row indicators. */
+  selectedFolders?: string[]
+  /** Fired when a file row, or the "this folder" row, is chosen. */
+  onSelectItem: (item: FileItem) => void
+
+  // Selection behavior
+  allowMultiple?: boolean
+  allowFiles?: boolean
+  allowFolders?: boolean
+  onlyLeafSelection?: boolean
+
+  // Filtering
+  fileExtensions?: string[]
+  maxFileSize?: number
+
+  // Search
+  enableGlobalSearch?: boolean
+  searchPlaceholder?: string
+  showPath?: boolean
+
+  // Keyboard
+  enableKeyboardNavigation?: boolean
+  /** Escape / request to dismiss the surface. */
+  onRequestClose?: () => void
+
+  /**
+   * When provided, the browse root shows a back affordance (and ←/Backspace on
+   * an empty search returns) to the parent menu — for embedded drill-in hosts.
+   */
+  onBack?: () => void
+  /** Label for the back affordance. Defaults to 'Back'. */
+  backLabel?: string
+}
+
+/**
+ * Right-aligned selection indicator. A checkbox in multi-select mode, a radio
+ * dot in single-select mode. Purely visual — the surrounding row owns the click.
+ */
+function SelectionIndicator({
+  allowMultiple,
+  selected,
+}: {
+  allowMultiple: boolean
+  selected: boolean
+}) {
+  if (allowMultiple) {
+    return <Checkbox checked={selected} className='pointer-events-none' />
+  }
+  return (
+    <span
+      className={cn(
+        radioGroupVariants({ variant: 'outline', size: 'default' }),
+        'pointer-events-none flex items-center justify-center'
+      )}>
+      {selected && <Circle className='size-2!' />}
+    </span>
+  )
+}
+
+/**
+ * A single file/folder row. Folders are navigate-only (chevron via
+ * `hasChildren`); files (and the current-folder row) carry the selection
+ * indicator. Single line — an optional muted path suffix shows in search.
+ */
+function FileRow({
+  id,
+  name,
+  isFolder,
+  isSelected,
+  isSelectable,
+  isNavigable,
+  isKeyboardSelected,
+  allowMultiple,
+  pathText,
+  hint,
+  onSelect,
+}: {
+  id: string
+  name: string
+  isFolder: boolean
+  isSelected: boolean
+  isSelectable: boolean
+  isNavigable: boolean
+  isKeyboardSelected?: boolean
+  allowMultiple: boolean
+  pathText?: string
+  hint?: string
+  onSelect: () => void
+}) {
+  return (
+    <CommandNavigableItem
+      item={{ id, name, label: name }}
+      hasChildren={isNavigable}
+      onSelect={onSelect}
+      className={cn('px-2', isKeyboardSelected && 'bg-accent text-accent-foreground')}>
+      <span className='shrink-0 text-muted-foreground'>{isFolder ? <Folder /> : <File />}</span>
+      <span className='min-w-0 truncate'>{name}</span>
+      {hint && <span className='shrink-0 text-[10px] text-muted-foreground'>{hint}</span>}
+      {(pathText || isSelectable) && (
+        <div className='ml-auto flex shrink-0 items-center gap-2 pl-2'>
+          {pathText && (
+            <span className='max-w-[160px] truncate text-xs text-muted-foreground'>{pathText}</span>
+          )}
+          {isSelectable && (
+            <SelectionIndicator allowMultiple={allowMultiple} selected={isSelected} />
+          )}
+        </div>
+      )}
+    </CommandNavigableItem>
+  )
+}
+
+/**
+ * Internal file list. Folders navigate (drill in); files toggle selection.
+ */
+function FilesList({
+  items,
+  selectedFiles,
+  selectedFolders,
+  allowMultiple,
+  showPathSuffix,
+  isGlobalSearch,
+  search,
+  selectedIndex,
+  enableKeyboardNavigation,
+  onToggleFile,
+  onNavigateFolder,
+}: {
+  items: FileItem[]
+  selectedFiles: string[]
+  selectedFolders: string[]
+  allowMultiple: boolean
+  showPathSuffix: boolean
+  isGlobalSearch: boolean
+  search: string
+  selectedIndex: number
+  enableKeyboardNavigation: boolean
+  onToggleFile: (item: FileItem) => void
+  onNavigateFolder: (item: FileItem) => void
+}) {
+  const selectedIds = useMemo(
+    () => new Set([...selectedFiles, ...selectedFolders]),
+    [selectedFiles, selectedFolders]
+  )
+
+  if (items.length === 0) {
+    return (
+      <CommandEmpty>{search ? 'No files or folders found.' : 'This folder is empty.'}</CommandEmpty>
+    )
+  }
+
+  return (
+    <ScrollArea className='max-h-[300px]'>
+      <CommandGroup>
+        {items.map((item, index) => {
+          const isFolder = item.type === 'folder'
+          const isKeyboardSelected = enableKeyboardNavigation && selectedIndex === index
+          const pathText = showPathSuffix
+            ? item.type === 'file'
+              ? (item as FileItem & { hierarchy?: { fullPath: string } }).hierarchy?.fullPath ||
+                item.path
+              : isGlobalSearch
+                ? item.path
+                : undefined
+            : undefined
+
+          return (
+            <FileRow
+              key={item.id}
+              id={item.id}
+              name={item.name}
+              isFolder={isFolder}
+              isSelected={selectedIds.has(item.id)}
+              isSelectable={!isFolder}
+              isNavigable={isFolder}
+              isKeyboardSelected={isKeyboardSelected}
+              allowMultiple={allowMultiple}
+              pathText={pathText || undefined}
+              onSelect={() => (isFolder ? onNavigateFolder(item) : onToggleFile(item))}
+            />
+          )
+        })}
+      </CommandGroup>
+    </ScrollArea>
+  )
+}
+
+/**
+ * The browse content: search input, breadcrumb, current-folder row, list,
+ * keyboard. Assumes a surrounding `CommandNavigation` (provided by
+ * {@link FileBrowseLevel}).
+ */
+function FileBrowseInner({
+  selectedFiles,
+  selectedFolders,
+  onSelectItem,
+  allowMultiple,
+  allowFiles,
+  allowFolders,
+  onlyLeafSelection,
+  fileExtensions,
+  maxFileSize,
+  enableGlobalSearch,
+  searchPlaceholder,
+  showPath,
+  enableKeyboardNavigation,
+  onRequestClose,
+  onBack,
+  backLabel,
+  search,
+  setSearch,
+  isGlobalSearchActive,
+}: Required<
+  Pick<
+    FileBrowseLevelProps,
+    | 'allowMultiple'
+    | 'allowFiles'
+    | 'allowFolders'
+    | 'onlyLeafSelection'
+    | 'enableGlobalSearch'
+    | 'searchPlaceholder'
+    | 'showPath'
+    | 'enableKeyboardNavigation'
+  >
+> &
+  Pick<
+    FileBrowseLevelProps,
+    | 'selectedFiles'
+    | 'selectedFolders'
+    | 'onSelectItem'
+    | 'fileExtensions'
+    | 'maxFileSize'
+    | 'onRequestClose'
+    | 'onBack'
+    | 'backLabel'
+  > & {
+    search: string
+    setSearch: (search: string) => void
+    isGlobalSearchActive: boolean
+  }) {
+  const {
+    handleKeyDown: handleNavKeyDown,
+    current,
+    isAtRoot,
+    push,
+  } = useCommandNavigation<FileNavigationItem>()
+  const { items, isLoading, navigateToFolder, totalFiles, hasMoreFiles, loadMoreFiles } =
+    useFilesystemContext()
+  const [selectedIndex, setSelectedIndex] = useState(-1)
+  const isLoadingMoreRef = useRef(false)
+
+  const files = selectedFiles ?? []
+  const folders = selectedFolders ?? []
+
+  /** Filtering with optional global search. */
+  const filteredItems = useMemo(() => {
+    let baseItems = items
+
+    if (enableGlobalSearch && search.trim()) {
+      const query = search.toLowerCase()
+      baseItems = baseItems.filter((item) => {
+        if (item.name.toLowerCase().includes(query)) return true
+        if (item.ext?.toLowerCase().includes(query)) return true
+        if (item.path?.toLowerCase().includes(query)) return true
+        if (item.type === 'file' && item.mimeType && item.mimeType.toLowerCase().includes(query))
+          return true
+        return false
+      })
+    }
+
+    return baseItems.filter((item) => {
+      if (item.type === 'file' && !allowFiles) return false
+
+      if (item.type === 'file' && fileExtensions && fileExtensions.length > 0) {
+        const ext = item.ext?.toLowerCase()
+        if (!ext || !fileExtensions.map((e) => e.toLowerCase()).includes(ext)) return false
+      }
+
+      if (item.type === 'file' && maxFileSize && item.displaySize > maxFileSize) return false
+
+      return true
+    })
+  }, [items, search, enableGlobalSearch, allowFiles, fileExtensions, maxFileSize])
+
+  // Keep the filesystem store in sync with the nav stack's current folder.
+  useEffect(() => {
+    navigateToFolder(current?.id ?? null)
+  }, [current, navigateToFolder])
+
+  // Reset the filesystem to root when the level unmounts (popover close).
+  useEffect(() => {
+    return () => navigateToFolder(null)
+  }, [navigateToFolder])
+
+  // Auto-load more files when approaching the end of a global-search list.
+  useEffect(() => {
+    if (!enableGlobalSearch || !hasMoreFiles || !filteredItems.length) return
+    const threshold = Math.max(100, Math.floor(totalFiles * 0.7))
+    if (filteredItems.length >= threshold && !isLoadingMoreRef.current) {
+      isLoadingMoreRef.current = true
+      Promise.resolve(loadMoreFiles()).finally(() => {
+        isLoadingMoreRef.current = false
+      })
+    }
+  }, [enableGlobalSearch, hasMoreFiles, filteredItems.length, totalFiles, loadMoreFiles])
+
+  // Reset highlight when the visible list changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: filteredItems triggers index reset when list changes
+  useEffect(() => {
+    setSelectedIndex(-1)
+  }, [filteredItems])
+
+  const handleToggleFile = useCallback(
+    (item: FileItem) => {
+      onSelectItem(item)
+    },
+    [onSelectItem]
+  )
+
+  const handleNavigateFolder = useCallback(
+    (item: FileItem) => {
+      if (item.type !== 'folder') return
+      push({ id: item.id, name: item.name, label: item.name })
+      setSelectedIndex(-1)
+    },
+    [push]
+  )
+
+  const selectedItem = useMemo(() => {
+    if (selectedIndex < 0 || selectedIndex >= filteredItems.length) return null
+    const item = filteredItems[selectedIndex]
+    return item ? { id: item.id, label: item.name, name: item.name } : null
+  }, [selectedIndex, filteredItems])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!enableKeyboardNavigation) return
+
+      // ←, →, Enter. ArrowRight pushes the folder via the nav.
+      handleNavKeyDown(e, {
+        selectedItem,
+        onNavigateRight: (item) => {
+          const fileItem = filteredItems.find((f) => f.id === item.id)
+          if (fileItem?.type === 'folder') {
+            setSelectedIndex(-1)
+            return true
+          }
+          return false
+        },
+        onSelect: (item) => {
+          const fileItem = filteredItems.find((f) => f.id === item.id)
+          if (!fileItem) return
+          if (fileItem.type === 'folder') handleNavigateFolder(fileItem)
+          else handleToggleFile(fileItem)
+        },
+      })
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setSelectedIndex((prev) => (prev < filteredItems.length - 1 ? prev + 1 : 0))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : filteredItems.length - 1))
+      } else if (
+        (e.key === 'ArrowLeft' || e.key === 'Backspace') &&
+        isAtRoot &&
+        onBack &&
+        !search
+      ) {
+        // At the browse root, ← / Backspace returns to the parent menu.
+        e.preventDefault()
+        onBack()
+      } else if (e.key === 'Escape') {
+        onRequestClose?.()
+      }
+    },
+    [
+      enableKeyboardNavigation,
+      handleNavKeyDown,
+      selectedItem,
+      filteredItems,
+      handleNavigateFolder,
+      handleToggleFile,
+      onRequestClose,
+      isAtRoot,
+      onBack,
+      search,
+    ]
+  )
+
+  // To select a folder you drill into it; the current folder is then offered as
+  // a "this folder" row in its own group above the list.
+  const showCurrentFolderRow =
+    allowFolders && !onlyLeafSelection && !!current && !isGlobalSearchActive
+
+  return (
+    <Command shouldFilter={false} onKeyDown={handleKeyDown}>
+      {onBack && isAtRoot && <ParentBackHeader label={backLabel ?? 'Back'} onBack={onBack} />}
+      <CommandList>
+        <CommandInput
+          placeholder={enableGlobalSearch ? `Search ${totalFiles} files...` : searchPlaceholder}
+          value={search}
+          onValueChange={setSearch}
+          loading={isLoading}
+          className='h-9'
+          autoFocus
+        />
+
+        {isGlobalSearchActive && (
+          <div className='px-3 py-1 text-xs text-muted-foreground bg-muted/50 border-b'>
+            Searching across all files... ({filteredItems.length} results)
+          </div>
+        )}
+
+        <CommandBreadcrumb rootLabel='Files' />
+
+        {showCurrentFolderRow && current && (
+          <>
+            <CommandGroup>
+              <FileRow
+                id={current.id}
+                name={current.name}
+                isFolder
+                isSelected={folders.includes(current.id)}
+                isSelectable
+                isNavigable={false}
+                allowMultiple={allowMultiple}
+                hint='(this folder)'
+                onSelect={() =>
+                  onSelectItem({ id: current.id, name: current.name, type: 'folder' } as FileItem)
+                }
+              />
+            </CommandGroup>
+            <CommandSeparator />
+          </>
+        )}
+
+        {isLoading ? (
+          <CommandLoading>Loading files…</CommandLoading>
+        ) : (
+          <FilesList
+            items={filteredItems}
+            selectedFiles={files}
+            selectedFolders={folders}
+            allowMultiple={allowMultiple}
+            showPathSuffix={isGlobalSearchActive || showPath}
+            isGlobalSearch={isGlobalSearchActive}
+            search={search}
+            selectedIndex={selectedIndex}
+            enableKeyboardNavigation={enableKeyboardNavigation}
+            onToggleFile={handleToggleFile}
+            onNavigateFolder={handleNavigateFolder}
+          />
+        )}
+      </CommandList>
+
+      {enableKeyboardNavigation && (
+        <div className='border-t px-3 py-2 text-xs text-muted-foreground bg-neutral-50/50 rounded-b-xl dark:bg-primary-50'>
+          <div className='flex items-center gap-3'>
+            <span className='flex items-center gap-1'>
+              <span>Select</span>
+              <Kbd variant='outline'>↵</Kbd>
+            </span>
+            {!isGlobalSearchActive && (
+              <>
+                <span className='flex items-center gap-1'>
+                  <span>Open</span>
+                  <Kbd variant='outline'>→</Kbd>
+                </span>
+                <span className='flex items-center gap-1'>
+                  <span>Back</span>
+                  <Kbd variant='outline'>←</Kbd>
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </Command>
+  )
+}
+
+/**
+ * Host-agnostic filesystem browse level. Renders a searchable, drill-in
+ * file/folder list as a cmdk command surface. Reuses a surrounding
+ * `CommandNavigation` when present (embedded in a larger drill flow), otherwise
+ * wraps its own. The host decides what selecting an item does via
+ * {@link FileBrowseLevelProps.onSelectItem}.
+ */
+export function FileBrowseLevel({
+  allowMultiple = true,
+  allowFiles = true,
+  allowFolders = true,
+  onlyLeafSelection = false,
+  enableGlobalSearch = false,
+  searchPlaceholder = 'Search files and folders...',
+  showPath = false,
+  enableKeyboardNavigation = true,
+  ...props
+}: FileBrowseLevelProps) {
+  const parentNav = useCommandNavigationOptional<FileNavigationItem>()
+  const [search, setSearch] = useState('')
+  const isGlobalSearchActive = enableGlobalSearch && !!search.trim()
+
+  const inner = (
+    <FileBrowseInner
+      {...props}
+      allowMultiple={allowMultiple}
+      allowFiles={allowFiles}
+      allowFolders={allowFolders}
+      onlyLeafSelection={onlyLeafSelection}
+      enableGlobalSearch={enableGlobalSearch}
+      searchPlaceholder={searchPlaceholder}
+      showPath={showPath}
+      enableKeyboardNavigation={enableKeyboardNavigation}
+      search={search}
+      setSearch={setSearch}
+      isGlobalSearchActive={isGlobalSearchActive}
+    />
+  )
+
+  if (parentNav) return inner
+
+  return (
+    <CommandNavigation<FileNavigationItem> isGlobalSearch={isGlobalSearchActive}>
+      {inner}
+    </CommandNavigation>
+  )
+}

--- a/apps/web/src/components/pickers/file-select-picker.tsx
+++ b/apps/web/src/components/pickers/file-select-picker.tsx
@@ -16,13 +16,13 @@ import {
 } from '@auxx/ui/components/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
-import { Download, File, FolderOpen, RotateCw, Trash2, Upload } from 'lucide-react'
+import { Download, File, FolderOpen, Loader2, RotateCw, Trash2, Upload } from 'lucide-react'
 import type React from 'react'
-import { useMemo, useState } from 'react'
-import { FileSelectDialog } from '~/components/file-select/file-select-dialog'
+import { useCallback, useMemo, useState } from 'react'
 import { useFileSelect } from '~/components/file-select/hooks/use-file-select'
 import type { UseFileSelectReturn } from '~/components/file-select/types'
 import type { FileItem as FileItemType } from '~/components/files/files-store'
+import { FileBrowseLevel } from '~/components/pickers/file-browse-level'
 
 /**
  * Props for FileSelectPicker component
@@ -146,8 +146,8 @@ function downloadUrlFor(item: FileItemType): string | undefined {
  *
  * Mirrors the dynamic-view `FilePicker` look — a searchable Command list with
  * hover-reveal row actions and Upload / Browse rows — but driven by the
- * composer's `useFileSelect` data model. "Browse files" opens the shared
- * `FileSelectDialog`.
+ * composer's `useFileSelect` data model. "Browse files" drills inline into the
+ * shared {@link FileBrowseLevel} (same popover) rather than opening a modal.
  */
 function FileSelectPickerContent({
   fileSelect,
@@ -165,7 +165,20 @@ function FileSelectPickerContent({
   children,
 }: FileSelectPickerContentProps) {
   const [search, setSearch] = useState('')
-  const [browseOpen, setBrowseOpen] = useState(false)
+  // 'menu' = tray + actions; 'browse' = the inline filesystem drill-in.
+  const [mode, setMode] = useState<'menu' | 'browse'>('menu')
+  const [internalOpen, setInternalOpen] = useState(false)
+
+  // Support both controlled and uncontrolled open state so content actions
+  // (single-select close, Escape) can dismiss the popover either way.
+  const resolvedOpen = open !== undefined ? open : internalOpen
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) setMode('menu')
+      ;(onOpenChange ?? setInternalOpen)(next)
+    },
+    [onOpenChange]
+  )
 
   const { selectedItems } = fileSelect
 
@@ -180,6 +193,20 @@ function FileSelectPickerContent({
     [selectedItems]
   )
 
+  // Library files already in the tray — echoed as checked in the browse list.
+  const selectedLibraryFileIds = useMemo(
+    () => selectedItems.filter((it) => it.source === 'filesystem').map((it) => it.id),
+    [selectedItems]
+  )
+
+  const handleBrowseSelect = useCallback(
+    (item: FileItemType) => {
+      fileSelect.addExistingFiles([item])
+      if (!allowMultiple) handleOpenChange(false)
+    },
+    [fileSelect, allowMultiple, handleOpenChange]
+  )
+
   const filteredReady = useMemo(() => {
     if (!search) return readyFiles
     const q = search.toLowerCase()
@@ -189,7 +216,6 @@ function FileSelectPickerContent({
   const hasAnyFiles = selectedItems.length > 0
   const hasVisibleFiles = filteredReady.length > 0 || inProgressFiles.length > 0
   const canAddMore = maxFiles ? selectedItems.length < maxFiles : true
-  const remainingSlots = maxFiles ? Math.max(0, maxFiles - selectedItems.length) : undefined
 
   const openNativeFilePicker = () => {
     const input = document.createElement('input')
@@ -204,16 +230,41 @@ function FileSelectPickerContent({
   }
 
   return (
-    <>
-      <Popover open={open} onOpenChange={onOpenChange}>
-        <PopoverTrigger asChild>{children}</PopoverTrigger>
+    <Popover open={resolvedOpen} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
 
-        <PopoverContent
-          className={cn('w-96 p-0', className)}
-          align={align}
-          side={side}
-          sideOffset={sideOffset}
-          disabled={disabled}>
+      <PopoverContent
+        className={cn('w-96 p-0', className)}
+        align={align}
+        side={side}
+        sideOffset={sideOffset}
+        disabled={disabled}>
+        {mode === 'browse' ? (
+          <>
+            {inProgressFiles.length > 0 && (
+              <button
+                type='button'
+                onClick={() => setMode('menu')}
+                className='flex w-full items-center gap-2 border-b px-3 py-2 text-xs text-muted-foreground hover:bg-accent/50'>
+                <Loader2 className='size-3.5 animate-spin' />
+                {inProgressFiles.length} uploading…
+              </button>
+            )}
+            <FileBrowseLevel
+              selectedFiles={selectedLibraryFileIds}
+              onSelectItem={handleBrowseSelect}
+              allowMultiple={allowMultiple}
+              allowFiles
+              allowFolders={false}
+              fileExtensions={fileTypes}
+              enableGlobalSearch
+              showPath
+              onBack={() => setMode('menu')}
+              backLabel='Attach'
+              onRequestClose={() => handleOpenChange(false)}
+            />
+          </>
+        ) : (
           <Command shouldFilter={false}>
             {hasAnyFiles && (
               <CommandInput
@@ -265,7 +316,7 @@ function FileSelectPickerContent({
                       Upload file
                     </CommandItem>
                     {!hideBrowseExisting && (
-                      <CommandItem onSelect={() => setBrowseOpen(true)}>
+                      <CommandItem onSelect={() => setMode('browse')}>
                         <FolderOpen className='size-4' />
                         Browse files
                       </CommandItem>
@@ -277,24 +328,9 @@ function FileSelectPickerContent({
               </CommandGroup>
             </CommandList>
           </Command>
-        </PopoverContent>
-      </Popover>
-
-      {browseOpen && (
-        <FileSelectDialog
-          open={browseOpen}
-          onOpenChange={setBrowseOpen}
-          onFilesSelected={(files) => {
-            fileSelect.addExistingFiles(files)
-            setBrowseOpen(false)
-          }}
-          allowMultiple={allowMultiple}
-          maxSelection={remainingSlots}
-          title='Select files'
-          confirmText='Attach'
-        />
-      )}
-    </>
+        )}
+      </PopoverContent>
+    </Popover>
   )
 }
 

--- a/apps/web/src/components/pickers/files-picker.tsx
+++ b/apps/web/src/components/pickers/files-picker.tsx
@@ -1,30 +1,12 @@
 // apps/web/src/components/pickers/files-picker.tsx
 'use client'
 
-import { Button } from '@auxx/ui/components/button'
-import { Checkbox } from '@auxx/ui/components/checkbox'
-import {
-  Command,
-  CommandBreadcrumb,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandNavigation,
-  type NavigationItem,
-  useCommandNavigation,
-} from '@auxx/ui/components/command'
-import { Kbd } from '@auxx/ui/components/kbd'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
-import { formatBytes } from '@auxx/utils/file'
-import { ChevronRight, File, Folder } from 'lucide-react'
 import type React from 'react'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useState } from 'react'
 import type { FileItem } from '~/components/files/files-store'
-import { useFilesystemContext } from '~/components/files/provider/filesystem-provider'
+import { FileBrowseLevel } from '~/components/pickers/file-browse-level'
 
 /**
  * Selection state interface
@@ -32,14 +14,6 @@ import { useFilesystemContext } from '~/components/files/provider/filesystem-pro
 export interface FileSelection {
   files: string[]
   folders: string[]
-}
-
-/**
- * Navigation item type for files/folders
- */
-type FileNavigationItem = NavigationItem & {
-  id: string
-  name: string
 }
 
 /**
@@ -88,494 +62,9 @@ interface FilesPickerProps {
 }
 
 /**
- * Internal file list component that uses the navigation context
- */
-function FilesList({
-  items,
-  selectedFiles,
-  selectedFolders,
-  onChange,
-  onOpenChange,
-  allowMultiple,
-  allowFiles,
-  allowFolders,
-  onlyLeafSelection,
-  enableGlobalSearch,
-  showPath,
-  search,
-  enableKeyboardNavigation,
-  selectedIndex,
-  onSelect,
-  navigateToFolder,
-}: {
-  items: FileItem[]
-  selectedFiles: string[]
-  selectedFolders: string[]
-  onChange?: (selection: FileSelection) => void
-  onOpenChange: (open: boolean) => void
-  allowMultiple: boolean
-  allowFiles: boolean
-  allowFolders: boolean
-  onlyLeafSelection: boolean
-  enableGlobalSearch: boolean
-  showPath: boolean
-  search: string
-  enableKeyboardNavigation: boolean
-  selectedIndex: number
-  onSelect?: (item: FileItem) => void
-  navigateToFolder: (folderId: string | null) => void
-}) {
-  const { push } = useCommandNavigation<FileNavigationItem>()
-
-  const allSelectedIds = useMemo(() => {
-    return new Set([...selectedFiles, ...selectedFolders])
-  }, [selectedFiles, selectedFolders])
-
-  /**
-   * Handle item selection
-   */
-  const toggleItem = useCallback(
-    (item: FileItem) => {
-      // If it's a folder and folders are not allowed for selection, or in leaf-only mode, navigate instead
-      if (item.type === 'folder' && (!allowFolders || onlyLeafSelection)) {
-        push({ id: item.id, name: item.name, label: item.name })
-        navigateToFolder(item.id)
-        return
-      }
-
-      const isSelected = allSelectedIds.has(item.id)
-
-      if (isSelected) {
-        // Remove from selection
-        if (item.type === 'file') {
-          onChange?.({
-            files: selectedFiles.filter((id: string) => id !== item.id),
-            folders: selectedFolders,
-          })
-        } else {
-          onChange?.({
-            files: selectedFiles,
-            folders: selectedFolders.filter((id: string) => id !== item.id),
-          })
-        }
-      } else {
-        // Add to selection
-        if (!allowMultiple) {
-          // Single select mode
-          if (item.type === 'file') {
-            onChange?.({ files: [item.id], folders: [] })
-          } else {
-            onChange?.({ files: [], folders: [item.id] })
-          }
-          onOpenChange(false)
-        } else {
-          // Multi select mode
-          if (item.type === 'file') {
-            onChange?.({
-              files: [...selectedFiles, item.id],
-              folders: selectedFolders,
-            })
-          } else {
-            onChange?.({
-              files: selectedFiles,
-              folders: [...selectedFolders, item.id],
-            })
-          }
-        }
-      }
-    },
-    [
-      allSelectedIds,
-      selectedFiles,
-      selectedFolders,
-      onChange,
-      allowMultiple,
-      allowFolders,
-      onlyLeafSelection,
-      push,
-      navigateToFolder,
-      onOpenChange,
-    ]
-  )
-
-  /**
-   * Navigate to folder
-   */
-  const handleNavigateToFolder = useCallback(
-    (item: FileItem) => {
-      if (item.type !== 'folder') return
-      push({ id: item.id, name: item.name, label: item.name })
-      navigateToFolder(item.id)
-    },
-    [push, navigateToFolder]
-  )
-
-  /**
-   * Get appropriate icon for item
-   */
-  const getItemIcon = useCallback((item: FileItem) => {
-    if (item.type === 'folder') {
-      return <Folder className='h-4 w-4' />
-    }
-    return <File className='h-4 w-4' />
-  }, [])
-
-  /**
-   * Check if item is selectable
-   */
-  const isItemSelectable = useCallback(
-    (item: FileItem) => {
-      if (item.type === 'folder' && !allowFolders) {
-        return false
-      }
-      if (onlyLeafSelection && item.type === 'folder') {
-        return false
-      }
-      return true
-    },
-    [allowFolders, onlyLeafSelection]
-  )
-
-  if (items.length === 0) {
-    return (
-      <CommandEmpty>{search ? 'No files or folders found.' : 'This folder is empty.'}</CommandEmpty>
-    )
-  }
-
-  return (
-    <ScrollArea className='max-h-[300px]'>
-      <CommandGroup>
-        {items.map((item, index) => {
-          const isSelected = allSelectedIds.has(item.id)
-          const isSelectable = isItemSelectable(item)
-          const canNavigate = item.type === 'folder'
-          const isKeyboardSelected = enableKeyboardNavigation && selectedIndex === index
-
-          return (
-            <CommandItem
-              key={item.id}
-              value={item.id}
-              onSelect={() => {
-                if (onSelect) onSelect(item)
-                toggleItem(item)
-              }}
-              className={cn(
-                'flex cursor-pointer items-center justify-between px-2',
-                isKeyboardSelected && 'bg-accent text-accent-foreground'
-              )}>
-              <div className='flex items-center space-x-2 flex-1 min-w-0'>
-                {isSelectable && (
-                  <Checkbox
-                    checked={isSelected}
-                    onCheckedChange={() => toggleItem(item)}
-                    aria-label={`Select ${item.name}`}
-                    onClick={(e) => e.stopPropagation()}
-                  />
-                )}
-
-                {getItemIcon(item)}
-                <div className='flex-1 min-w-0'>
-                  <div className='font-medium truncate'>{item.name}</div>
-
-                  {item.type === 'file' && (
-                    <div className='text-xs text-muted-foreground'>
-                      {formatBytes(item.displaySize)}
-                      {item.ext && ` • ${item.ext.toUpperCase()}`}
-
-                      {(showPath || (enableGlobalSearch && search.trim())) && (
-                        <>
-                          {' • '}
-                          <span className='truncate'>
-                            {(item as FileItem & { hierarchy?: { fullPath: string } }).hierarchy
-                              ?.fullPath || item.path}
-                          </span>
-                        </>
-                      )}
-                    </div>
-                  )}
-
-                  {item.type === 'folder' && enableGlobalSearch && search.trim() && item.path && (
-                    <div className='text-xs text-muted-foreground truncate'>{item.path}</div>
-                  )}
-                </div>
-              </div>
-
-              <div className='flex items-center space-x-1'>
-                {canNavigate && (
-                  <Button
-                    variant='ghost'
-                    size='icon'
-                    className='h-6 w-6'
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      handleNavigateToFolder(item)
-                    }}>
-                    <ChevronRight className='h-4 w-4' />
-                    <span className='sr-only'>Open folder</span>
-                  </Button>
-                )}
-              </div>
-            </CommandItem>
-          )
-        })}
-      </CommandGroup>
-    </ScrollArea>
-  )
-}
-
-/**
- * Inner content component that has access to CommandNavigation context
- */
-function FilesPickerContent({
-  items,
-  filteredItems,
-  selectedFiles,
-  selectedFolders,
-  onChange,
-  onOpenChange,
-  allowMultiple,
-  allowFiles,
-  allowFolders,
-  onlyLeafSelection,
-  enableGlobalSearch,
-  showPath,
-  search,
-  setSearch,
-  searchPlaceholder,
-  totalFiles,
-  hasMoreFiles,
-  enableKeyboardNavigation,
-  onSelect,
-  navigateToFolder,
-  isLoading,
-  isGlobalSearchActive,
-  searchInputRef,
-}: {
-  items: FileItem[]
-  filteredItems: FileItem[]
-  selectedFiles: string[]
-  selectedFolders: string[]
-  onChange?: (selection: FileSelection) => void
-  onOpenChange: (open: boolean) => void
-  allowMultiple: boolean
-  allowFiles: boolean
-  allowFolders: boolean
-  onlyLeafSelection: boolean
-  enableGlobalSearch: boolean
-  showPath: boolean
-  search: string
-  setSearch: (search: string) => void
-  searchPlaceholder: string
-  totalFiles: number
-  hasMoreFiles: boolean
-  enableKeyboardNavigation: boolean
-  onSelect?: (item: FileItem) => void
-  navigateToFolder: (folderId: string | null) => void
-  isLoading: boolean
-  isGlobalSearchActive: boolean
-  searchInputRef: React.RefObject<HTMLInputElement | null>
-}) {
-  const { handleKeyDown: handleNavKeyDown } = useCommandNavigation<FileNavigationItem>()
-  const [selectedIndex, setSelectedIndex] = useState(-1)
-
-  // Reset selected index when filtered items change
-  // biome-ignore lint/correctness/useExhaustiveDependencies: filteredItems triggers index reset when list changes
-  useEffect(() => {
-    setSelectedIndex(-1)
-  }, [filteredItems])
-
-  // Get selected item for keyboard navigation
-  const selectedItem = useMemo(() => {
-    if (selectedIndex < 0 || selectedIndex >= filteredItems.length) return null
-    const item = filteredItems[selectedIndex]
-    return item ? { id: item.id, label: item.name, name: item.name } : null
-  }, [selectedIndex, filteredItems])
-
-  /**
-   * Toggle item selection
-   */
-  const toggleItem = useCallback(
-    (item: FileItem) => {
-      const allSelectedIds = new Set([...selectedFiles, ...selectedFolders])
-      const isSelected = allSelectedIds.has(item.id)
-
-      if (isSelected) {
-        if (item.type === 'file') {
-          onChange?.({
-            files: selectedFiles.filter((id) => id !== item.id),
-            folders: selectedFolders,
-          })
-        } else {
-          onChange?.({
-            files: selectedFiles,
-            folders: selectedFolders.filter((id) => id !== item.id),
-          })
-        }
-      } else {
-        if (!allowMultiple) {
-          if (item.type === 'file') {
-            onChange?.({ files: [item.id], folders: [] })
-          } else {
-            onChange?.({ files: [], folders: [item.id] })
-          }
-          onOpenChange(false)
-        } else {
-          if (item.type === 'file') {
-            onChange?.({ files: [...selectedFiles, item.id], folders: selectedFolders })
-          } else {
-            onChange?.({ files: selectedFiles, folders: [...selectedFolders, item.id] })
-          }
-        }
-      }
-    },
-    [selectedFiles, selectedFolders, onChange, allowMultiple, onOpenChange]
-  )
-
-  /**
-   * Keyboard handler combining navigation and selection
-   */
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (!enableKeyboardNavigation) return
-
-      // Handle navigation keys (←, →, Enter)
-      handleNavKeyDown(e, {
-        selectedItem,
-        onNavigateRight: (item) => {
-          const fileItem = filteredItems.find((f) => f.id === item.id)
-          if (fileItem?.type === 'folder') {
-            navigateToFolder(fileItem.id)
-            setSelectedIndex(-1)
-            return true
-          }
-          return false
-        },
-        onSelect: (item) => {
-          const fileItem = filteredItems.find((f) => f.id === item.id)
-          if (fileItem) {
-            if (onSelect) onSelect(fileItem)
-            // For folders in leaf-only mode, navigate instead of select
-            if (fileItem.type === 'folder' && (!allowFolders || onlyLeafSelection)) {
-              navigateToFolder(fileItem.id)
-              setSelectedIndex(-1)
-            } else {
-              toggleItem(fileItem)
-            }
-          }
-        },
-      })
-
-      // Handle selection keys (↑, ↓)
-      if (e.key === 'ArrowDown') {
-        e.preventDefault()
-        setSelectedIndex((prev) => (prev < filteredItems.length - 1 ? prev + 1 : 0))
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault()
-        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : filteredItems.length - 1))
-      } else if (e.key === 'Escape') {
-        onOpenChange(false)
-      }
-    },
-    [
-      enableKeyboardNavigation,
-      handleNavKeyDown,
-      selectedItem,
-      filteredItems,
-      navigateToFolder,
-      onSelect,
-      allowFolders,
-      onlyLeafSelection,
-      toggleItem,
-      onOpenChange,
-    ]
-  )
-
-  return (
-    <Command shouldFilter={false} onKeyDown={handleKeyDown}>
-      <CommandList>
-        <CommandInput
-          ref={searchInputRef}
-          placeholder={
-            enableGlobalSearch
-              ? `Search ${totalFiles} files...`
-              : searchPlaceholder || 'Search files and folders...'
-          }
-          value={search}
-          onValueChange={setSearch}
-          className='h-9'
-          autoFocus
-        />
-
-        {/* Global search indicator */}
-        {isGlobalSearchActive && (
-          <div className='px-3 py-1 text-xs text-muted-foreground bg-muted/50 border-b'>
-            Searching across all files... ({filteredItems.length} results)
-          </div>
-        )}
-
-        <CommandBreadcrumb rootLabel='Files' />
-
-        {isLoading ? (
-          <div className='py-6 text-center text-sm text-muted-foreground'>Loading files...</div>
-        ) : (
-          <FilesList
-            items={filteredItems}
-            selectedFiles={selectedFiles}
-            selectedFolders={selectedFolders}
-            onChange={onChange}
-            onOpenChange={onOpenChange}
-            allowMultiple={allowMultiple}
-            allowFiles={allowFiles}
-            allowFolders={allowFolders}
-            onlyLeafSelection={onlyLeafSelection}
-            enableGlobalSearch={enableGlobalSearch}
-            showPath={showPath}
-            search={search}
-            enableKeyboardNavigation={enableKeyboardNavigation}
-            selectedIndex={selectedIndex}
-            onSelect={onSelect}
-            navigateToFolder={navigateToFolder}
-          />
-        )}
-      </CommandList>
-
-      {/* Keyboard shortcuts footer */}
-      {enableKeyboardNavigation && (
-        <div className='border-t px-3 py-2 text-xs text-muted-foreground bg-neutral-50/50 rounded-b-xl dark:bg-primary-50'>
-          <div className='flex items-center justify-between gap-4'>
-            <div className='flex items-center gap-3'>
-              <span className='flex items-center gap-1'>
-                <span>Select</span>
-                <Kbd variant='outline'>↵</Kbd>
-              </span>
-              {!isGlobalSearchActive && (
-                <>
-                  <span className='flex items-center gap-1'>
-                    <span>Open</span>
-                    <Kbd variant='outline'>→</Kbd>
-                  </span>
-                  <span className='flex items-center gap-1'>
-                    <span>Back</span>
-                    <Kbd variant='outline'>←</Kbd>
-                  </span>
-                </>
-              )}
-            </div>
-            {enableGlobalSearch && (
-              <div className='text-xs'>
-                {search.trim() ? `${totalFiles} files total` : `${filteredItems.length} items`}
-                {hasMoreFiles && search.trim() && ' (loading more...)'}
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-    </Command>
-  )
-}
-
-/**
- * Files picker component with Popover wrapper
+ * Files picker — a Popover wrapper around {@link FileBrowseLevel}. Owns the
+ * popover open state and the selection semantics (toggle the controlled
+ * file/folder id sets; single-select replaces and closes).
  */
 function filesPicker({
   selectedFiles = [],
@@ -604,108 +93,39 @@ function filesPicker({
 }: FilesPickerProps): React.ReactElement {
   // Internal open state for uncontrolled mode
   const [internalOpen, setInternalOpen] = useState(false)
-
-  // Use controlled or uncontrolled open state
   const open = controlledOpen !== undefined ? controlledOpen : internalOpen
   const onOpenChange = controlledOnOpenChange || setInternalOpen
 
-  // Filesystem context
-  const { items, isLoading, navigateToFolder, totalFiles, hasMoreFiles, loadMoreFiles } =
-    useFilesystemContext()
+  const handleSelectItem = useCallback(
+    (item: FileItem) => {
+      onSelect?.(item)
+      const isFile = item.type === 'file'
+      const alreadySelected = isFile
+        ? selectedFiles.includes(item.id)
+        : selectedFolders.includes(item.id)
 
-  // Local state
-  const [search, setSearch] = useState('')
-  const contentRef = useRef<HTMLDivElement>(null)
-  const searchInputRef = useRef<HTMLInputElement>(null)
-  const isLoadingMoreRef = useRef(false)
-
-  /**
-   * Enhanced filtering with global search capability
-   */
-  const filteredItems = useMemo(() => {
-    let baseItems = items
-
-    // Apply search filter first
-    if (enableGlobalSearch && search.trim()) {
-      const query = search.toLowerCase()
-      baseItems = baseItems.filter((item) => {
-        if (item.name.toLowerCase().includes(query)) return true
-        if (item.ext?.toLowerCase().includes(query)) return true
-        if (item.path?.toLowerCase().includes(query)) return true
-        if (item.type === 'file' && item.mimeType && item.mimeType.toLowerCase().includes(query))
-          return true
-        return false
-      })
-    }
-
-    // Apply additional filters
-    const filtered = baseItems.filter((item) => {
-      if (item.type === 'file' && !allowFiles) return false
-
-      if (item.type === 'file' && fileExtensions && fileExtensions.length > 0) {
-        const ext = item.ext?.toLowerCase()
-        if (!ext || !fileExtensions.map((e: string) => e.toLowerCase()).includes(ext)) {
-          return false
-        }
+      if (alreadySelected) {
+        onChange?.(
+          isFile
+            ? { files: selectedFiles.filter((id) => id !== item.id), folders: selectedFolders }
+            : { files: selectedFiles, folders: selectedFolders.filter((id) => id !== item.id) }
+        )
+        return
       }
 
-      if (item.type === 'file' && maxFileSize && item.displaySize > maxFileSize) {
-        return false
+      if (!allowMultiple) {
+        onChange?.(isFile ? { files: [item.id], folders: [] } : { files: [], folders: [item.id] })
+        onOpenChange(false)
+        return
       }
 
-      return true
-    })
-
-    return filtered
-  }, [items, search, enableGlobalSearch, allowFiles, fileExtensions, maxFileSize])
-
-  // Auto-load more files when approaching end of list
-  useEffect(() => {
-    if (!enableGlobalSearch || !hasMoreFiles || !filteredItems.length) return
-
-    const threshold = Math.max(100, Math.floor(totalFiles * 0.7))
-    const shouldLoad = filteredItems.length >= threshold && !isLoadingMoreRef.current
-
-    if (shouldLoad) {
-      isLoadingMoreRef.current = true
-      Promise.resolve(loadMoreFiles()).finally(() => {
-        isLoadingMoreRef.current = false
-      })
-    }
-  }, [enableGlobalSearch, hasMoreFiles, filteredItems.length, totalFiles, loadMoreFiles])
-
-  /**
-   * Reset state when popover closes
-   */
-  useEffect(() => {
-    if (!open) {
-      setSearch('')
-      navigateToFolder(null)
-    }
-  }, [open, navigateToFolder])
-
-  // Auto-focus search input when picker opens
-  useEffect(() => {
-    if (open && searchInputRef.current) {
-      searchInputRef.current.focus()
-    }
-  }, [open])
-
-  // Determine if global search is active (for hiding breadcrumb)
-  const isGlobalSearchActive = enableGlobalSearch && !!search.trim()
-
-  /**
-   * Handle navigation change from CommandNavigation
-   */
-  const handleNavigationChange = useCallback(
-    (stack: FileNavigationItem[], current: FileNavigationItem | null) => {
-      navigateToFolder(current?.id || null)
-      // Scroll to top when navigating
-      if (contentRef.current) {
-        contentRef.current.scrollTop = 0
-      }
+      onChange?.(
+        isFile
+          ? { files: [...selectedFiles, item.id], folders: selectedFolders }
+          : { files: selectedFiles, folders: [...selectedFolders, item.id] }
+      )
     },
-    [navigateToFolder]
+    [selectedFiles, selectedFolders, onChange, allowMultiple, onOpenChange, onSelect]
   )
 
   return (
@@ -715,42 +135,26 @@ function filesPicker({
       </PopoverTrigger>
       <PopoverContent
         className={cn('p-0', className)}
-        ref={contentRef}
         align={align}
         side={side}
         sideOffset={sideOffset}
-        style={{
-          width: typeof width === 'number' ? `${width}px` : width,
-        }}>
-        <CommandNavigation<FileNavigationItem>
-          isGlobalSearch={isGlobalSearchActive}
-          onNavigationChange={handleNavigationChange}>
-          <FilesPickerContent
-            items={items}
-            filteredItems={filteredItems}
-            selectedFiles={selectedFiles}
-            selectedFolders={selectedFolders}
-            onChange={onChange}
-            onOpenChange={onOpenChange}
-            allowMultiple={allowMultiple}
-            allowFiles={allowFiles}
-            allowFolders={allowFolders}
-            onlyLeafSelection={onlyLeafSelection}
-            enableGlobalSearch={enableGlobalSearch}
-            showPath={showPath}
-            search={search}
-            setSearch={setSearch}
-            searchPlaceholder={searchPlaceholder}
-            totalFiles={totalFiles}
-            hasMoreFiles={hasMoreFiles}
-            enableKeyboardNavigation={enableKeyboardNavigation}
-            onSelect={onSelect}
-            navigateToFolder={navigateToFolder}
-            isLoading={isLoading}
-            isGlobalSearchActive={isGlobalSearchActive}
-            searchInputRef={searchInputRef}
-          />
-        </CommandNavigation>
+        style={{ width: typeof width === 'number' ? `${width}px` : width }}>
+        <FileBrowseLevel
+          selectedFiles={selectedFiles}
+          selectedFolders={selectedFolders}
+          onSelectItem={handleSelectItem}
+          allowMultiple={allowMultiple}
+          allowFiles={allowFiles}
+          allowFolders={allowFolders}
+          onlyLeafSelection={onlyLeafSelection}
+          fileExtensions={fileExtensions}
+          maxFileSize={maxFileSize}
+          enableGlobalSearch={enableGlobalSearch}
+          searchPlaceholder={searchPlaceholder}
+          showPath={showPath}
+          enableKeyboardNavigation={enableKeyboardNavigation}
+          onRequestClose={() => onOpenChange(false)}
+        />
       </PopoverContent>
     </Popover>
   )

--- a/apps/web/src/components/pickers/index.ts
+++ b/apps/web/src/components/pickers/index.ts
@@ -23,6 +23,8 @@ export {
   FieldPickerContent,
   FieldPickerInnerContent,
 } from './field-picker'
+export type { FileBrowseLevelProps, FileNavigationItem } from './file-browse-level'
+export { FileBrowseLevel } from './file-browse-level'
 export type { FileSelection } from './files-picker'
 export { FilesPicker } from './files-picker'
 export type { MultiSelectPickerProps } from './multi-select-picker'

--- a/apps/web/src/components/tags/ui/tag-picker/tag-picker-content.tsx
+++ b/apps/web/src/components/tags/ui/tag-picker/tag-picker-content.tsx
@@ -16,6 +16,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandLoading,
   useCommandNavigation,
 } from '@auxx/ui/components/command'
 import { toastError } from '@auxx/ui/components/toast'
@@ -474,7 +475,7 @@ export function TagPickerContent({
           )}
 
           {isLoading ? (
-            <div className='py-6 text-center text-sm text-muted-foreground'>Loading tags...</div>
+            <CommandLoading>Loading tags…</CommandLoading>
           ) : !Array.isArray(tagsToDisplay) ? (
             <CommandEmpty>Error loading tags or invalid data.</CommandEmpty>
           ) : tagsToDisplay.length === 0 ? (

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/file-input.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/file-input.tsx
@@ -152,13 +152,13 @@ export const FileInput = createNodeInput<FileInputProps>(
       selectedFolders: [] as string[],
       onChange: handleSelectionChange,
       allowFiles: true,
-      showPath: true,
+      showPath: false,
       allowFolders: false,
       allowMultiple,
       fileExtensions,
       maxFileSize,
       enableGlobalSearch: true,
-      width: 450,
+      // width: 450,
       maxHeight: 400,
     }
 

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -455,6 +455,22 @@ function CommandPlaceholder({ className, ...props }: React.HTMLAttributes<HTMLDi
   )
 }
 
+/** Centered spinner + message for use inside a CommandList while data is fetching.
+ *  Render it conditionally yourself (it does not auto-show/hide). */
+function CommandLoading({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground',
+        className
+      )}
+      {...props}>
+      <Loader2 className='size-4 animate-spin' />
+      {children}
+    </div>
+  )
+}
+
 function CommandGroup({
   className,
   ...props
@@ -935,6 +951,7 @@ export {
   CommandList,
   CommandEmpty,
   CommandPlaceholder,
+  CommandLoading,
   CommandGroup,
   CommandGroupLabel,
   CommandItem,


### PR DESCRIPTION
## Summary

Consolidates the two file pickers onto a single shared browse component and tidies up a few adjacent picker/command surfaces.

- **New `FileBrowseLevel`** (`apps/web/src/components/pickers/file-browse-level.tsx`) — host-agnostic filesystem browse list owning drill-in, global search, keyboard nav, and selection indicators (checkbox in multi-select, radio dot in single-select). Reads from the app-global `FilesystemProvider`; the host owns selection semantics.
- **`FilesPicker`** is now a thin Popover wrapper around `FileBrowseLevel` (~630 lines of duplicated list/keyboard logic removed).
- **`FileSelectPicker`** "Browse files" drills **inline in the same popover** via `FileBrowseLevel` instead of opening the `FileSelectDialog` modal. Supports controlled + uncontrolled open state so single-select / Escape can dismiss.
- **`useSnippetSearch`** hook extracted from `mail-slash-content`; snippet search now **recurses the current folder's subtree** so snippets nested in subfolders surface (previously only the current level was searched). Snippet fetch loading no longer blocks the static root slash suggestions.
- **`CommandLoading`** primitive added to `@auxx/ui` (centered spinner + message); tag picker switched to it.
- **Placeholder picker**: `ArrowLeft` now exits like `Backspace` on an empty search.
- **Workflow `FileInput`**: drop the fixed 450px width / `showPath` so it uses the shared default.

## Test plan
- [ ] Mail composer `/` menu: browse snippet folders, search surfaces nested snippets, insert works
- [ ] Composer attach → Browse files drills inline; single-select closes, multi-select stays open with checkboxes
- [ ] Workflow file input picker browse + global search + keyboard nav
- [ ] Tag picker loading state renders the spinner