### PR TITLE
feat(mail): "/" slash attach-file drill-in

### DIFF
--- a/apps/web/src/components/editor/tiptap-editor.tsx
+++ b/apps/web/src/components/editor/tiptap-editor.tsx
@@ -15,6 +15,7 @@ import { type Editor, EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import '~/styles/prosemirror.css'
+import type { FileItem } from '~/components/files/files-store'
 import {
   MAIL_BLOCK_COMMANDS,
   type MailAiSlashConfig,
@@ -51,6 +52,8 @@ type TiptapEditorProps = {
   onEnter?: () => void
   /** Optional AI-tools wiring — surfaces the "Ask AI" item in the `/` menu. */
   aiSlash?: MailAiSlashConfig
+  /** Optional attachment wiring — surfaces the "Attach file" item in the `/` menu. */
+  onAttachFile?: (file: FileItem) => void
   /**
    * Formatting profile. `'rich'` (default) = full StarterKit + block commands
    * in the `/` menu (email). `'plain'` = a compact composer with headings /
@@ -70,6 +73,7 @@ const TiptapEditor = ({
   popoverClassName,
   onEnter,
   aiSlash,
+  onAttachFile,
   variant = 'rich',
 }: TiptapEditorProps) => {
   const isPlain = variant === 'plain'
@@ -294,6 +298,7 @@ const TiptapEditor = ({
             onScopeChange={changeSlashScope}
             onClose={closeSlash}
             aiSlash={aiSlash}
+            onAttachFile={onAttachFile}
             blockCommands={isPlain ? [] : MAIL_BLOCK_COMMANDS}
           />
         </InlinePickerPopover>

--- a/apps/web/src/components/mail/chat-composer/index.tsx
+++ b/apps/web/src/components/mail/chat-composer/index.tsx
@@ -154,6 +154,7 @@ function ChatComposerInner({
           onRunAI: handleAIOperation,
           hasPreviousMessages: (thread.messageCount ?? thread.messages?.length ?? 0) > 0,
         }}
+        onAttachFile={(file) => fileSelect.addExistingFiles([file])}
         // Plain compact composer — no block formatting in the schema or `/` menu.
         variant='plain'
         onWrapperClick={handleWrapperClick}

--- a/apps/web/src/components/mail/composer-shared/composer-body.tsx
+++ b/apps/web/src/components/mail/composer-shared/composer-body.tsx
@@ -7,6 +7,7 @@ import type { JSONContent } from '@tiptap/core'
 import { Upload } from 'lucide-react'
 import type React from 'react'
 import type { useDropzone } from 'react-dropzone'
+import type { FileItem } from '~/components/files/files-store'
 import { useEditorActiveStateContext } from '../email-editor/editor-active-state-context'
 import { LazyTiptapEditor } from '../email-editor/lazy-tiptap-editor'
 import type { MailAiSlashConfig } from '../email-editor/mail-slash-content'
@@ -23,6 +24,8 @@ interface ComposerBodyProps {
   editorMinHeightClassName?: string
   /** Optional AI-tools wiring — surfaces the "Ask AI" item in the `/` menu. */
   aiSlash?: MailAiSlashConfig
+  /** Optional attachment wiring — surfaces the "Attach file" item in the `/` menu. */
+  onAttachFile?: (file: FileItem) => void
   /** Formatting profile. `'rich'` (default, email) or `'plain'` (chat). */
   variant?: 'rich' | 'plain'
 
@@ -64,6 +67,7 @@ export function ComposerBody({
   contentClassName,
   editorMinHeightClassName = 'min-h-[150px]',
   aiSlash,
+  onAttachFile,
   variant,
   onWrapperClick,
   onKeyDown,
@@ -132,6 +136,7 @@ export function ComposerBody({
           popoverClassName={popoverClassName}
           contentClassName={contentClassName}
           aiSlash={aiSlash}
+          onAttachFile={onAttachFile}
           variant={variant}
         />
         {belowEditor}

--- a/apps/web/src/components/mail/email-editor/file-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/file-slash-content.tsx
@@ -1,0 +1,92 @@
+// apps/web/src/components/mail/email-editor/file-slash-content.tsx
+'use client'
+
+import { CommandNavigation, useCommandNavigation } from '@auxx/ui/components/command'
+import { useCallback, useImperativeHandle, useRef } from 'react'
+import type { SlashContentHandle } from '~/components/editor/slash-commands/slash-list'
+import type { FileItem } from '~/components/files/files-store'
+import { FileBrowseLevel, type FileNavigationItem } from '~/components/pickers/file-browse-level'
+import { useCmdkRemote } from '~/components/pickers/use-cmdk-remote'
+
+export interface FileSlashContentProps {
+  /** Keyboard handle — the `/` chip forwards Enter / arrows / Backspace-empty here. */
+  ref?: React.Ref<SlashContentHandle>
+  /** Live filter — the `/` chip's text content (drives the focusless browse). */
+  query: string
+  /** Attach the chosen library file into the composer's attachment tray. */
+  onAttachFile: (file: FileItem) => void
+  /** Close the chip (keeps the typed text, mirroring `@`). */
+  onClose: () => void
+  /** Return to the parent `/` command menu. */
+  onBack: () => void
+  /** Label for the browse-root back affordance. Defaults to 'Commands'. */
+  backLabel?: string
+}
+
+/**
+ * Chip-driven file attachment picker — the shared {@link FileBrowseLevel} run in
+ * focusless `remote` mode, wrapped as `SlashContentProps`. The `/` chip keeps
+ * editor focus and owns the query; `useCmdkRemote` drives highlight / confirm /
+ * drill via pointer events (no `CommandInput`). Selecting a file hands it to the
+ * composer's `onAttachFile` and closes the chip — the transient slash popover
+ * owns no tray of its own (the composer's `useFileSelect` does).
+ */
+export function FileSlashContent(props: FileSlashContentProps) {
+  return (
+    <CommandNavigation<FileNavigationItem>>
+      <FileSlashInner {...props} />
+    </CommandNavigation>
+  )
+}
+
+function FileSlashInner({
+  ref,
+  query,
+  onAttachFile,
+  onClose,
+  onBack,
+  backLabel,
+}: FileSlashContentProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const { isAtRoot, pop, stack } = useCommandNavigation<FileNavigationItem>()
+  const remote = useCmdkRemote(containerRef, `${stack.map((s) => s.id).join('/')}:${query}`)
+
+  // Backspace on an empty chip pops a folder level; at the browse root it
+  // returns to the parent command menu.
+  const popLevel = useCallback(() => {
+    if (!isAtRoot) {
+      pop()
+      return true
+    }
+    onBack()
+    return true
+  }, [isAtRoot, pop, onBack])
+
+  useImperativeHandle(ref, () => ({ ...remote, popLevel }), [remote, popLevel])
+
+  const handleSelect = useCallback(
+    (item: FileItem) => {
+      onAttachFile(item)
+      onClose()
+    },
+    [onAttachFile, onClose]
+  )
+
+  return (
+    <div ref={containerRef} className='w-72 overflow-hidden'>
+      <FileBrowseLevel
+        remote
+        query={query}
+        allowMultiple={false}
+        allowFiles
+        allowFolders={false}
+        enableGlobalSearch
+        showPath
+        onSelectItem={handleSelect}
+        onBack={onBack}
+        backLabel={backLabel ?? 'Commands'}
+        onRequestClose={onClose}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -1011,6 +1011,7 @@ function ReplyComposeEditorComponent({
           editable={!aiToolsState.isProcessing}
           popoverClassName={popoverZIndex}
           aiSlash={{ onRunAI: handleAIOperation, hasPreviousMessages }}
+          onAttachFile={(file) => fileSelect.addExistingFiles([file])}
           onWrapperClick={handleWrapperClick}
           onKeyDown={handleKeyDown}
           dropzone={dropzone}

--- a/apps/web/src/components/mail/email-editor/lazy-tiptap-editor.tsx
+++ b/apps/web/src/components/mail/email-editor/lazy-tiptap-editor.tsx
@@ -5,6 +5,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import type { JSONContent } from '@tiptap/core'
 import { Loader2 } from 'lucide-react'
 import React, { Suspense } from 'react'
+import type { FileItem } from '~/components/files/files-store'
 import type { MailAiSlashConfig } from './mail-slash-content'
 
 const TiptapEditor = React.lazy(() => import('~/components/editor/tiptap-editor'))
@@ -22,6 +23,8 @@ interface LazyTiptapEditorProps {
   onEnter?: () => void
   /** Optional AI-tools wiring — surfaces the "Ask AI" item in the `/` menu. */
   aiSlash?: MailAiSlashConfig
+  /** Optional attachment wiring — surfaces the "Attach file" item in the `/` menu. */
+  onAttachFile?: (file: FileItem) => void
   /** Formatting profile. `'rich'` (default, email) or `'plain'` (chat). */
   variant?: 'rich' | 'plain'
 }

--- a/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
@@ -15,11 +15,13 @@ import type {
   SlashCommandSection,
 } from '~/components/editor/slash-commands/slash-command-picker'
 import { type SlashContentHandle, SlashList } from '~/components/editor/slash-commands/slash-list'
+import type { FileItem } from '~/components/files/files-store'
 import { SparkleIcon } from '~/components/kopilot/ui/sparkle-icon'
 import { useCmdkRemote } from '~/components/pickers/use-cmdk-remote'
 import { api } from '~/trpc/react'
 import { AI_LANG_TYPE, AI_OPERATION, AI_TONE_TYPE, type AIOperation } from '~/types/ai-tools'
 import { isBodyEmptyIgnoringChips } from '../composer-shared/content-empty'
+import { FileSlashContent } from './file-slash-content'
 import { useSnippetSearch } from './hooks'
 
 type Range = { from: number; to: number }
@@ -65,6 +67,12 @@ export interface MailSlashContentProps {
   onClose: () => void
   /** Optional AI-tools wiring — when present, adds the "Ask AI" drill-in item. */
   aiSlash?: MailAiSlashConfig
+  /**
+   * Optional attachment wiring — when present, adds the "Attach file" drill-in
+   * item. Receives the chosen library file; the composer routes it into its own
+   * attachment tray (`useFileSelect.addExistingFiles`). Absent → no file item.
+   */
+  onAttachFile?: (file: FileItem) => void
   /**
    * Block commands offered at the root (Heading / lists / blockquote).
    * Defaults to {@link MAIL_BLOCK_COMMANDS}. Chat passes `[]` — it's a plain,
@@ -157,6 +165,16 @@ const TOOL_COMMANDS: SlashCommandItem[] = [
   },
 ]
 
+// Added to the suggestions only when the composer supplies `onAttachFile`.
+const ATTACH_FILE_COMMAND: SlashCommandItem = {
+  id: 'attach-file',
+  title: 'Attach file',
+  description: 'Attach a file from your library',
+  keywords: ['file', 'attachment', 'upload', 'document', 'image'],
+  iconId: 'paperclip',
+  drillDown: true,
+}
+
 // --- AI "Ask AI" drill items -----------------------------------------------
 // AI ops don't insert at the chip range — they rewrite the whole body async.
 // The leaf `onSelect` strips the chip then calls `onRunAI` (see `runAI` below).
@@ -243,7 +261,7 @@ interface SnippetItem extends SlashCommandItem {
  * block schema and article-link mode.
  */
 export function MailSlashContent(props: MailSlashContentProps) {
-  const [mode, setMode] = useState<'default' | 'placeholder'>('default')
+  const [mode, setMode] = useState<'default' | 'placeholder' | 'file'>('default')
 
   const exitMode = useCallback(() => {
     setMode('default')
@@ -272,6 +290,22 @@ export function MailSlashContent(props: MailSlashContentProps) {
     )
   }
 
+  if (mode === 'file' && props.onAttachFile) {
+    return (
+      <FileSlashContent
+        ref={props.ref}
+        query={props.query}
+        onBack={exitMode}
+        backLabel='Commands'
+        onClose={props.onClose}
+        onAttachFile={(file) => {
+          props.onAttachFile?.(file)
+          exitMode()
+        }}
+      />
+    )
+  }
+
   return (
     <CommandNavigation<NavItem>>
       <MailSlashContentInner
@@ -279,6 +313,10 @@ export function MailSlashContent(props: MailSlashContentProps) {
         onEnterPlaceholderMode={() => {
           setMode('placeholder')
           props.onScopeChange('Placeholder')
+        }}
+        onEnterFileMode={() => {
+          setMode('file')
+          props.onScopeChange('Files')
         }}
       />
     </CommandNavigation>
@@ -292,9 +330,14 @@ function MailSlashContentInner({
   onExecute,
   onScopeChange,
   onEnterPlaceholderMode,
+  onEnterFileMode,
+  onAttachFile,
   aiSlash,
   blockCommands = MAIL_BLOCK_COMMANDS,
-}: MailSlashContentProps & { onEnterPlaceholderMode: () => void }) {
+}: MailSlashContentProps & {
+  onEnterPlaceholderMode: () => void
+  onEnterFileMode: () => void
+}) {
   const { push, pop, isAtRoot, current, stack } = useCommandNavigation<NavItem>()
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -407,10 +450,21 @@ function MailSlashContentInner({
         onEnterPlaceholderMode()
         return
       }
+      if (item.id === 'attach-file') {
+        onEnterFileMode()
+        return
+      }
       const cmd = blockCommands.find((c) => c.id === item.id)
       if (cmd) onExecute(cmd.run)
     },
-    [blockCommands, enterAiScope, enterSnippetsDrillDown, onEnterPlaceholderMode, onExecute]
+    [
+      blockCommands,
+      enterAiScope,
+      enterSnippetsDrillDown,
+      onEnterPlaceholderMode,
+      onEnterFileMode,
+      onExecute,
+    ]
   )
 
   // Dispatch for the AI ops list (root of the "Ask AI" drill).
@@ -528,7 +582,12 @@ function MailSlashContentInner({
     const suggestionsSection: SlashCommandSection<SlashCommandItem> = {
       id: 'suggestions',
       heading: 'Suggestions',
-      items: [...(showAskAI ? [AI_ROOT_COMMAND] : []), ...TOOL_COMMANDS, ...blockCommands],
+      items: [
+        ...(showAskAI ? [AI_ROOT_COMMAND] : []),
+        ...TOOL_COMMANDS,
+        ...(onAttachFile ? [ATTACH_FILE_COMMAND] : []),
+        ...blockCommands,
+      ],
       onSelect: handleSuggestionSelect,
       // "Ask AI" gets the branded gradient sparkle + purple label; all other
       // suggestion rows keep the default EntityIcon + title layout.
@@ -588,6 +647,7 @@ function MailSlashContentInner({
     blockCommands,
     handleAiOpSelect,
     runAI,
+    onAttachFile,
   ])
 
   return (

--- a/apps/web/src/components/pickers/file-browse-level.tsx
+++ b/apps/web/src/components/pickers/file-browse-level.tsx
@@ -75,6 +75,18 @@ export interface FileBrowseLevelProps {
   onRequestClose?: () => void
 
   /**
+   * Focusless mode for chip-driven `/` slash hosts. The host's `/` chip owns
+   * focus and the query, driving the list through `useCmdkRemote` — so this
+   * level renders NO `CommandInput`, no keyboard footer, and no internal key
+   * handling, and reads its filter from {@link query} instead. Folder rows are
+   * stamped `data-drilldown` for ArrowRight drill-in.
+   */
+  remote?: boolean
+  /** External filter text (controlled). Used in {@link remote} mode in place of
+   *  the internal search input. */
+  query?: string
+
+  /**
    * When provided, the browse root shows a back affordance (and ←/Backspace on
    * an empty search returns) to the parent menu — for embedded drill-in hosts.
    */
@@ -97,13 +109,16 @@ function SelectionIndicator({
   if (allowMultiple) {
     return <Checkbox checked={selected} className='pointer-events-none' />
   }
+  // Single-select: only render the radio dot when selected; otherwise a bare
+  // size-4 spacer keeps row layout stable without showing an empty circle.
+  if (!selected) return <span className='size-4' />
   return (
     <span
       className={cn(
         radioGroupVariants({ variant: 'outline', size: 'default' }),
         'pointer-events-none flex items-center justify-center'
       )}>
-      {selected && <Circle className='size-2!' />}
+      <Circle className='size-2!' />
     </span>
   )
 }
@@ -124,6 +139,7 @@ function FileRow({
   allowMultiple,
   pathText,
   hint,
+  drillDown,
   onSelect,
 }: {
   id: string
@@ -136,12 +152,14 @@ function FileRow({
   allowMultiple: boolean
   pathText?: string
   hint?: string
+  drillDown?: boolean
   onSelect: () => void
 }) {
   return (
     <CommandNavigableItem
       item={{ id, name, label: name }}
       hasChildren={isNavigable}
+      drillDown={drillDown}
       onSelect={onSelect}
       className={cn('px-2', isKeyboardSelected && 'bg-accent text-accent-foreground')}>
       <span className='shrink-0 text-muted-foreground'>{isFolder ? <Folder /> : <File />}</span>
@@ -174,6 +192,7 @@ function FilesList({
   search,
   selectedIndex,
   enableKeyboardNavigation,
+  remote,
   onToggleFile,
   onNavigateFolder,
 }: {
@@ -186,6 +205,7 @@ function FilesList({
   search: string
   selectedIndex: number
   enableKeyboardNavigation: boolean
+  remote: boolean
   onToggleFile: (item: FileItem) => void
   onNavigateFolder: (item: FileItem) => void
 }) {
@@ -227,6 +247,7 @@ function FilesList({
               isKeyboardSelected={isKeyboardSelected}
               allowMultiple={allowMultiple}
               pathText={pathText || undefined}
+              drillDown={remote && isFolder}
               onSelect={() => (isFolder ? onNavigateFolder(item) : onToggleFile(item))}
             />
           )
@@ -258,6 +279,7 @@ function FileBrowseInner({
   onRequestClose,
   onBack,
   backLabel,
+  remote,
   search,
   setSearch,
   isGlobalSearchActive,
@@ -285,6 +307,7 @@ function FileBrowseInner({
     | 'onBack'
     | 'backLabel'
   > & {
+    remote: boolean
     search: string
     setSearch: (search: string) => void
     isGlobalSearchActive: boolean
@@ -445,17 +468,19 @@ function FileBrowseInner({
     allowFolders && !onlyLeafSelection && !!current && !isGlobalSearchActive
 
   return (
-    <Command shouldFilter={false} onKeyDown={handleKeyDown}>
+    <Command shouldFilter={false} onKeyDown={remote ? undefined : handleKeyDown}>
       {onBack && isAtRoot && <ParentBackHeader label={backLabel ?? 'Back'} onBack={onBack} />}
       <CommandList>
-        <CommandInput
-          placeholder={enableGlobalSearch ? `Search ${totalFiles} files...` : searchPlaceholder}
-          value={search}
-          onValueChange={setSearch}
-          loading={isLoading}
-          className='h-9'
-          autoFocus
-        />
+        {!remote && (
+          <CommandInput
+            placeholder={enableGlobalSearch ? `Search ${totalFiles} files...` : searchPlaceholder}
+            value={search}
+            onValueChange={setSearch}
+            loading={isLoading}
+            className='h-9'
+            autoFocus
+          />
+        )}
 
         {isGlobalSearchActive && (
           <div className='px-3 py-1 text-xs text-muted-foreground bg-muted/50 border-b'>
@@ -499,13 +524,14 @@ function FileBrowseInner({
             search={search}
             selectedIndex={selectedIndex}
             enableKeyboardNavigation={enableKeyboardNavigation}
+            remote={remote}
             onToggleFile={handleToggleFile}
             onNavigateFolder={handleNavigateFolder}
           />
         )}
       </CommandList>
 
-      {enableKeyboardNavigation && (
+      {!remote && enableKeyboardNavigation && (
         <div className='border-t px-3 py-2 text-xs text-muted-foreground bg-neutral-50/50 rounded-b-xl dark:bg-primary-50'>
           <div className='flex items-center gap-3'>
             <span className='flex items-center gap-1'>
@@ -547,10 +573,16 @@ export function FileBrowseLevel({
   searchPlaceholder = 'Search files and folders...',
   showPath = false,
   enableKeyboardNavigation = true,
+  remote = false,
+  query,
   ...props
 }: FileBrowseLevelProps) {
   const parentNav = useCommandNavigationOptional<FileNavigationItem>()
-  const [search, setSearch] = useState('')
+  const [internalSearch, setInternalSearch] = useState('')
+  // In remote mode the host's `/` chip owns the query; otherwise the internal
+  // CommandInput does.
+  const search = remote ? (query ?? '') : internalSearch
+  const setSearch = remote ? () => {} : setInternalSearch
   const isGlobalSearchActive = enableGlobalSearch && !!search.trim()
 
   const inner = (
@@ -564,6 +596,7 @@ export function FileBrowseLevel({
       searchPlaceholder={searchPlaceholder}
       showPath={showPath}
       enableKeyboardNavigation={enableKeyboardNavigation}
+      remote={remote}
       search={search}
       setSearch={setSearch}
       isGlobalSearchActive={isGlobalSearchActive}

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -584,6 +584,12 @@ interface CommandNavigableItemProps<T extends NavigationItem> {
   className?: string
   /** Value for the command item */
   value?: string
+  /**
+   * Stamp `data-drilldown` so a focusless host (chip-driven `/` menus) can
+   * ArrowRight-drill this row via `useCmdkRemote.drillHighlighted`. Independent
+   * of `hasChildren`, which only controls the visible chevron.
+   */
+  drillDown?: boolean
 }
 
 /**
@@ -598,13 +604,18 @@ function CommandNavigableItem<T extends NavigationItem>({
   onSelect,
   className,
   value,
+  drillDown,
 }: CommandNavigableItemProps<T>) {
   const handleSelect = React.useCallback(() => {
     onSelect?.(item)
   }, [onSelect, item])
 
   return (
-    <CommandItem value={value || item.id} onSelect={handleSelect} className={cn('', className)}>
+    <CommandItem
+      value={value || item.id}
+      onSelect={handleSelect}
+      className={cn('', className)}
+      data-drilldown={drillDown ? '' : undefined}>
       <div className='flex items-center flex-row gap-1 flex-1'>{children}</div>
       {hasChildren && <ChevronRight className='size-4 text-muted-foreground' />}
     </CommandItem>


### PR DESCRIPTION
## What

Adds an **"Attach file"** drill to the mail composer's `/` slash menu — pick a library file inline (chip-driven, focusless) and it lands in the composer's attachment tray. Completes **step 4** of the unified file-select drill-in plan (steps 1–3 shipped in #869).

## How

- **`FileBrowseLevel` — new focusless `remote` mode.** Controlled `query` prop, no `CommandInput`/footer/key handling; folder rows stamped `data-drilldown` for ArrowRight drill-in. The focused popover hosts (`FilesPicker`, `FileSelectPicker`) are unchanged — `remote` defaults `false`.
- **`CommandNavigableItem` — new `drillDown` prop** that stamps `data-drilldown`, so `useCmdkRemote.drillHighlighted` can drill folder rows in a focusless host.
- **`file-slash-content.tsx` (new)** — mirrors `PlaceholderSlashContent`: own `CommandNavigation`, `useCmdkRemote` handle + `popLevel`, renders `FileBrowseLevel` in remote mode with `enableGlobalSearch` (chip query searches all files) and `allowFolders={false}`. Picking a file calls `onAttachFile` then closes the chip.
- **`mail-slash-content.tsx`** — new `file` mode mirroring the `placeholder` mode; an "Attach file" suggestion appears only when the composer supplies `onAttachFile`.
- **Composer seam** — `onAttachFile` threads composer → `ComposerBody` → `LazyTiptapEditor` → `TiptapEditor` → `MailSlashContent` (same path as `aiSlash`). Both email and chat composers pass `(file) => fileSelect.addExistingFiles([file])`, routing the pick into their own `useComposerAttachments` tray.
- Minor: single-select `SelectionIndicator` renders a `size-4` spacer instead of an empty radio circle when unselected.

### Design note

The slash file scope uses its **own** `CommandNavigation` (inside `FileSlashContent`), not the host `MailSlashContent` nav stack — a shared stack would mismap the entry item's id to a filesystem folder id in `navigateToFolder` (same reasoning as step 3's view-swap). `popLevel` pops folders on the file nav, then returns to the command menu at the file root.

## Test

`/` → **Attach file** → type to search the library → ArrowRight to drill a folder → Enter to attach. The file appears in the composer's attachment strip; Backspace on an empty chip pops a folder, then returns to the command menu. Covers both the email reply composer and the chat composer.

Biome clean. `tsc` not run (repo convention — OOM).