### PR TITLE
fix(files): breadcrumbs on refresh, upload-to-current-folder, stuck "moving" state

### DIFF
--- a/apps/web/src/components/file-upload/hooks/use-file-upload.ts
+++ b/apps/web/src/components/file-upload/hooks/use-file-upload.ts
@@ -196,15 +196,25 @@ export function useFileUpload(options: UseFileUploadOptions): UseFileUploadRetur
 
   // LAZY SESSION CREATION - Only create when actually needed
   const ensureSession = React.useCallback(async (): Promise<string> => {
-    // Return existing session if available
-    if (sessionRef.current && sessions[sessionRef.current]) {
-      return sessionRef.current
-    }
+    // Find a reusable session for this uploader, if one is still alive.
+    const reusableId =
+      (sessionRef.current && sessions[sessionRef.current] && sessionRef.current) ||
+      (uploaderSession && sessions[uploaderSession] && uploaderSession) ||
+      null
 
-    // Check if uploader already has a session
-    if (uploaderSession && sessions[uploaderSession]) {
-      sessionRef.current = uploaderSession
-      return uploaderSession
+    if (reusableId) {
+      // Only reuse it if it still targets the same entity. When entityId changes
+      // (e.g. navigating between folders in the file manager) the session is stale:
+      // its entityId — sent to the server at presign time — would route uploads to
+      // the folder the session was born with, not the current one. Discard it so a
+      // fresh session is created for the current entity. For consumers with a fixed
+      // entityId (avatars, ticket attachments, ...) this branch never fires.
+      if (sessions[reusableId].entityId === entityId) {
+        sessionRef.current = reusableId
+        return reusableId
+      }
+      closeSession(reusableId)
+      sessionRef.current = null
     }
 
     // Create session on-demand with proper entity type
@@ -248,6 +258,7 @@ export function useFileUpload(options: UseFileUploadOptions): UseFileUploadRetur
     uploaderSession,
     sessions,
     createSessionWithGuard,
+    closeSession,
     entityType,
     entityId,
     maxFiles,

--- a/apps/web/src/components/files/files-store.ts
+++ b/apps/web/src/components/files/files-store.ts
@@ -135,7 +135,6 @@ export interface FileSystemStore {
 
   // Navigation state
   currentFolderId: string | null
-  breadcrumbs: BreadcrumbItem[]
 
   // Selection (optimized with Set)
   selectedItemIds: Set<string> // Selected item IDs only
@@ -202,7 +201,6 @@ export interface FileSystemStore {
 
   // Loading state
   setIsLoading: (isLoading: boolean) => void
-  setBreadcrumbs: (breadcrumbs: BreadcrumbItem[]) => void
 
   // Tree operations (O(1) or O(log n))
   getItemPath: (itemId: string) => FileItem[] // Get full path to item
@@ -229,7 +227,6 @@ export const useFileSystemStore = create<FileSystemStore>()(
 
     // State
     currentFolderId: null,
-    breadcrumbs: [{ id: null, name: 'Files', path: '/' }],
     selectedItemIds: new Set(),
     viewMode: 'list',
     sortBy: 'name',
@@ -613,7 +610,6 @@ export const useFileSystemStore = create<FileSystemStore>()(
     setSorting: (sortBy, sortOrder) => set({ sortBy, sortOrder }),
     setFilterSettings: (settings) => set({ filterSettings: settings }),
     setIsLoading: (isLoading) => set({ isLoading }),
-    setBreadcrumbs: (breadcrumbs) => set({ breadcrumbs }),
 
     // Tree operations - O(1) or O(log n) with Maps
     getItemPath: (itemId) => {
@@ -685,7 +681,6 @@ export const useFileSystemStore = create<FileSystemStore>()(
         filesNextCursor: null,
         hasMoreFiles: false,
         lastSync: null,
-        breadcrumbs: [{ id: null, name: 'Files', path: '/' }],
       }),
   }))
 )

--- a/apps/web/src/components/files/hooks/use-filesystem.tsx
+++ b/apps/web/src/components/files/hooks/use-filesystem.tsx
@@ -70,7 +70,6 @@ export function useFilesystem() {
 
   // Use specific selectors to avoid unnecessary re-renders
   const setFileSystemData = useFileSystemStore((state) => state.setFileSystemData)
-  const setBreadcrumbs = useFileSystemStore((state) => state.setBreadcrumbs)
   const getItemPath = useFileSystemStore((state) => state.getItemPath)
   const setCurrentFolder = useFileSystemStore((state) => state.setCurrentFolder)
   const getItemChildren = useFileSystemStore((state) => state.getItemChildren)
@@ -118,12 +117,19 @@ export function useFilesystem() {
     }
   )
 
-  // Update store when filesystem data changes - idempotent write to avoid render loops
+  // Update store when filesystem data changes - idempotent write to avoid render loops.
+  // The key includes `isOptimisticMove` so the store re-syncs when an optimistic move
+  // settles: onMutate pre-applies the final parentId, so the post-settle refetch has the
+  // same id:parentId — without the flag in the key, the update would be skipped and the
+  // row would stay stuck on the "moving" style after landing in the target folder.
   const flatIds = useMemo(() => {
     if (!fileSystemData?.pages?.length) return ''
     return fileSystemData.pages
       .flatMap((p) => p.items || [])
-      .map((i) => `${i.id}:${i.parentId ?? ''}`)
+      .map(
+        (i) =>
+          `${i.id}:${i.parentId ?? ''}:${(i as { isOptimisticMove?: boolean }).isOptimisticMove ? 1 : 0}`
+      )
       .join('|')
   }, [fileSystemData?.pages])
 
@@ -141,26 +147,7 @@ export function useFilesystem() {
     setFileSystemData(allItems)
   }, [fileSystemData?.pages, flatIds, setFileSystemData])
 
-  // Update breadcrumbs when current folder changes - O(log n) with Maps
   const currentFolderId = useFileSystemStore((state) => state.currentFolderId)
-  useEffect(() => {
-    if (!currentFolderId) {
-      setBreadcrumbs([{ id: null, name: 'Files', path: '/' }])
-      return
-    }
-
-    // O(log n) path traversal instead of O(n) search
-    const path = getItemPath(currentFolderId)
-    const breadcrumbs = [
-      { id: null, name: 'Files', path: '/' },
-      ...path.map((item) => ({
-        id: item.id,
-        name: item.name,
-        path: item.path,
-      })),
-    ]
-    setBreadcrumbs(breadcrumbs)
-  }, [currentFolderId, getItemPath, setBreadcrumbs])
 
   // Get store state that affects item computation
   const itemsById = useFileSystemStore((state) => state.itemsById)
@@ -168,7 +155,6 @@ export function useFilesystem() {
   const foldersByParent = useFileSystemStore((state) => state.foldersByParent)
   const showUploading = useFileSystemStore((state) => state.showUploading)
   const selectedItemIds = useFileSystemStore((state) => state.selectedItemIds)
-  const breadcrumbs = useFileSystemStore((state) => state.breadcrumbs)
   const folderTreeById = useFileSystemStore((state) => state.folderTreeById)
   // Don't use store's hierarchicalItems directly - need to integrate uploads
   // const hierarchicalItems = useFileSystemStore((state) => state.hierarchicalItems)
@@ -201,10 +187,36 @@ export function useFilesystem() {
     return Array.from(folderTreeById.values())
   }, [folderTreeById])
 
+  // Breadcrumbs derived from the current folder + loaded items. Keyed on `itemsById`
+  // so it self-heals once the filesystem data arrives — important on a hard refresh
+  // into ?folder=<id>, where currentFolderId is set before the data has loaded.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: getItemPath reads itemsById via the store internally, so itemsById must stay in the deps to recompute when data loads
+  const breadcrumbs = useMemo(() => {
+    const root = { id: null as string | null, name: 'Files', path: '/' }
+    if (!currentFolderId) return [root]
+    return [
+      root,
+      ...getItemPath(currentFolderId).map((item) => ({
+        id: item.id,
+        name: item.name,
+        path: item.path,
+      })),
+    ]
+  }, [currentFolderId, getItemPath, itemsById])
+
+  // Target folder for uploads, forwarded to the server in the session metadata.
+  // The FILE upload processor reads `session.metadata.folderId` (NOT entityId) to decide
+  // where the file lands — without this every upload silently goes to the root folder.
+  const uploadSessionMetadata = useMemo(
+    () => ({ folderId: currentFolderId ?? null }),
+    [currentFolderId]
+  )
+
   // File upload integration for FILE entity type
   const upload = useFileUpload({
     entityType: 'FILE',
     entityId: currentFolderId || undefined, // Current folder or undefined for root
+    sessionMetadata: uploadSessionMetadata,
     autoStart: false, // Manual control
     onComplete: async (results) => {
       // Refresh file system to show new server files


### PR DESCRIPTION
Three long-standing bugs in the Files manager, each traced to a concrete root cause.

## 1. Breadcrumbs empty after refreshing inside a folder
Refreshing on `?folder=<id>` showed correct folder contents but only `Files` in the breadcrumb trail.

The trail was built by a `useEffect` whose deps (`currentFolderId` + stable Zustand action refs) never changed once the filesystem data loaded. On a hard refresh the URL sets `currentFolderId` **before** the data arrives, so the effect ran once against an empty `itemsById` and never recomputed.

**Fix:** derive breadcrumbs from a `useMemo` keyed on `itemsById`, so it self-heals when the data loads. Removed the now-dead `breadcrumbs` state/action from the store.

## 2. Uploads always landed in the root folder
Uploading from inside a folder (dialog or drag-drop) put the file in root.

Two compounding faults:
- The FILE upload processor places files by `session.metadata.folderId`, but the client only sent the folder in `entityId` and never populated `metadata.folderId` — so the server always saw `undefined` → root.
- `useFileUpload` reused one lazily-created session for the uploader's whole lifetime, so its scope was frozen to whatever folder was active on the first upload.

**Fix:** forward the current folder as session metadata (`{ folderId }`) so it reaches the field the server reads, and make `ensureSession` reuse a session only when its `entityId` matches the current folder — otherwise close and recreate it. Fixed-`entityId` consumers (avatars, ticket attachments) are unaffected.

## 3. Moved file stuck on the "moving" style in the target folder
After dragging a file into a folder and opening it, the row stayed amber forever.

The query→store sync used an `id:parentId` idempotency key. The optimistic move pre-applied the final `parentId` **and** `isOptimisticMove`, so the post-settle refetch produced an identical key — the sync was skipped and the flag was orphaned in the store.

**Fix:** include `isOptimisticMove` in the idempotency key so the store re-syncs and clears it when the move settles.

## Testing
Manually verified in the running app: breadcrumbs render on hard-refresh into a nested folder; uploads (dialog + drag-drop) land in the current folder across root→A→B navigation; dragged files resolve out of the "moving" state. Lint clean.