### PR TITLE
feat(mail): "@" signature + action picker via the chip pipeline

### DIFF
--- a/apps/web/src/components/editor/slash-commands/slash-list.tsx
+++ b/apps/web/src/components/editor/slash-commands/slash-list.tsx
@@ -104,7 +104,8 @@ export function SlashList({
                           {item.iconId && (
                             <EntityIcon
                               iconId={item.iconId}
-                              size='xs'
+                              size='sm'
+                              variant='full'
                               className='text-muted-foreground'
                             />
                           )}

--- a/apps/web/src/components/editor/tiptap-editor.tsx
+++ b/apps/web/src/components/editor/tiptap-editor.tsx
@@ -19,6 +19,7 @@ import type { FileItem } from '~/components/files/files-store'
 import {
   MAIL_BLOCK_COMMANDS,
   type MailAiSlashConfig,
+  type MailReferenceConfig,
   MailSlashContent,
 } from '~/components/mail/email-editor/mail-slash-content'
 import { useEditorContext } from './editor-context'
@@ -55,6 +56,12 @@ type TiptapEditorProps = {
   /** Optional attachment wiring — surfaces the "Attach file" item in the `/` menu. */
   onAttachFile?: (file: FileItem) => void
   /**
+   * Optional signature/action wiring. When present, registers the `@` trigger
+   * (signature + action menu) alongside `/`. Absent (e.g. chat) → `@` types a
+   * literal character.
+   */
+  references?: MailReferenceConfig
+  /**
    * Formatting profile. `'rich'` (default) = full StarterKit + block commands
    * in the `/` menu (email). `'plain'` = a compact composer with headings /
    * lists / blockquote / code blocks removed from the schema (so markdown
@@ -74,9 +81,14 @@ const TiptapEditor = ({
   onEnter,
   aiSlash,
   onAttachFile,
+  references,
   variant = 'rich',
 }: TiptapEditorProps) => {
   const isPlain = variant === 'plain'
+  // Only the *presence* of references gates `@` registration — the live config
+  // (mutators/selection) is read by the popover, not the extension. Depend on a
+  // boolean so a new references object each render doesn't churn the extensions.
+  const hasReferences = !!references
   const { setEditor } = useEditorContext()
   const externalSyncRef = useRef<{ markLocalEdit: (key: string) => void }>({
     markLocalEdit: () => {},
@@ -126,12 +138,17 @@ const TiptapEditor = ({
       TextAlign.configure({ types: ['heading', 'paragraph'] }),
       Link.configure({ openOnClick: false, autolink: true }),
       Placeholder.configure({ placeholder }),
-      // `/`-only chip picker: no `@` mention (mail has no references) — typing
-      // `@` inserts a literal character. The popover is mounted below via
-      // `useActivePicker`; keyboard is forwarded through the `onSlash*` hooks.
+      // Chip picker. `/` is always a command trigger. When `references` is
+      // supplied (email), `@` becomes a SECOND command trigger rooting the
+      // signature/action menu — both share the slash keyboard path. Without
+      // `references` (chat), `@` is unregistered and types a literal character.
       ReferencePickerNode.configure({
-        mention: false,
-        slash: true,
+        triggers: hasReferences
+          ? [
+              { char: '@', kind: 'command' },
+              { char: '/', kind: 'command' },
+            ]
+          : [{ char: '/', kind: 'command' }],
         onSlashEnter,
         onSlashArrowVertical,
         onSlashBackspacePop,
@@ -143,6 +160,7 @@ const TiptapEditor = ({
       isPlain,
       placeholder,
       placeholderNodeExtension,
+      hasReferences,
       onSlashEnter,
       onSlashArrowVertical,
       onSlashBackspacePop,
@@ -235,7 +253,9 @@ const TiptapEditor = ({
 
   // Reactive view of the open chip — drives the slash popover mount + anchor.
   const activePicker = useActivePicker(editorInstance)
-  const slashOpen = !!activePicker && activePicker.trigger === '/'
+  const activeTrigger = activePicker?.trigger ?? null
+  // Both command triggers ('/' formatting, '@' references) open this popover.
+  const pickerOpen = !!activePicker && (activeTrigger === '/' || activeTrigger === '@')
 
   // Run a slash executor with the open chip's range — the executor's chain
   // deletes the chip and applies the command in one transaction.
@@ -278,7 +298,7 @@ const TiptapEditor = ({
       {editorInstance && (
         <InlinePickerPopover
           state={{
-            isOpen: slashOpen,
+            isOpen: pickerOpen,
             query: activePicker?.query ?? '',
             range: null,
             clientRect: activePicker?.clientRect ?? null,
@@ -292,6 +312,7 @@ const TiptapEditor = ({
           onClose={closeSlash}>
           <MailSlashContent
             ref={slashRef}
+            trigger={activeTrigger ?? '/'}
             query={activePicker?.query ?? ''}
             editor={editorInstance}
             onExecute={runWithChipRange}
@@ -299,6 +320,7 @@ const TiptapEditor = ({
             onClose={closeSlash}
             aiSlash={aiSlash}
             onAttachFile={onAttachFile}
+            references={references}
             blockCommands={isPlain ? [] : MAIL_BLOCK_COMMANDS}
           />
         </InlinePickerPopover>

--- a/apps/web/src/components/mail/composer-shared/composer-body.tsx
+++ b/apps/web/src/components/mail/composer-shared/composer-body.tsx
@@ -10,7 +10,7 @@ import type { useDropzone } from 'react-dropzone'
 import type { FileItem } from '~/components/files/files-store'
 import { useEditorActiveStateContext } from '../email-editor/editor-active-state-context'
 import { LazyTiptapEditor } from '../email-editor/lazy-tiptap-editor'
-import type { MailAiSlashConfig } from '../email-editor/mail-slash-content'
+import type { MailAiSlashConfig, MailReferenceConfig } from '../email-editor/mail-slash-content'
 
 interface ComposerBodyProps {
   // editor wiring
@@ -26,6 +26,8 @@ interface ComposerBodyProps {
   aiSlash?: MailAiSlashConfig
   /** Optional attachment wiring — surfaces the "Attach file" item in the `/` menu. */
   onAttachFile?: (file: FileItem) => void
+  /** Optional signature/action wiring — registers the `@` menu (email only). */
+  references?: MailReferenceConfig
   /** Formatting profile. `'rich'` (default, email) or `'plain'` (chat). */
   variant?: 'rich' | 'plain'
 
@@ -68,6 +70,7 @@ export function ComposerBody({
   editorMinHeightClassName = 'min-h-[150px]',
   aiSlash,
   onAttachFile,
+  references,
   variant,
   onWrapperClick,
   onKeyDown,
@@ -137,6 +140,7 @@ export function ComposerBody({
           contentClassName={contentClassName}
           aiSlash={aiSlash}
           onAttachFile={onAttachFile}
+          references={references}
           variant={variant}
         />
         {belowEditor}

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -50,6 +50,7 @@ import {
   useEditorActiveStateContext,
 } from './editor-active-state-context'
 import { useDraftMutations } from './hooks'
+import type { MailReferenceConfig } from './mail-slash-content'
 import PrevMessage from './prev-message'
 import { AddActionButton, QuickActionPanel } from './quick-action-panel'
 import { type RecipientField, RecipientInput, type RecipientInputHandle } from './recipient-input'
@@ -536,6 +537,21 @@ function ReplyComposeEditorComponent({
     setState((prev) => ({ ...prev, signatureId }))
     setIsDraftSaved(false)
   }, [])
+
+  // `@` menu wiring — reuses the SAME setters as the belowEditor SignatureEditor
+  // / QuickActionPanel, so the two entry points stay in sync automatically.
+  const references = useMemo<MailReferenceConfig>(
+    () => ({
+      signatureId: state.signatureId,
+      onSignatureChange: handleSignatureChange,
+      actionIds: quickActions.map((a) => a.actionId),
+      onAddAction: (action) => setQuickActions((prev) => [...prev, action]),
+      onRemoveAction: (actionId) =>
+        setQuickActions((prev) => prev.filter((a) => a.actionId !== actionId)),
+      threadId: thread?.id || state.threadId || undefined,
+    }),
+    [state.signatureId, state.threadId, handleSignatureChange, quickActions, thread?.id]
+  )
   const handleIntegrationChange = useCallback((integrationId: string) => {
     setState((prev) => ({ ...prev, integrationId }))
     setIsDraftSaved(false)
@@ -1007,11 +1023,12 @@ function ReplyComposeEditorComponent({
         <ComposerBody
           content={content}
           onContentChange={handleContentChange}
-          placeholder='Write a reply…  press / for commands'
+          placeholder='Type / for commands or @ for signatures & actions'
           editable={!aiToolsState.isProcessing}
           popoverClassName={popoverZIndex}
           aiSlash={{ onRunAI: handleAIOperation, hasPreviousMessages }}
           onAttachFile={(file) => fileSelect.addExistingFiles([file])}
+          references={references}
           onWrapperClick={handleWrapperClick}
           onKeyDown={handleKeyDown}
           dropzone={dropzone}

--- a/apps/web/src/components/mail/email-editor/lazy-tiptap-editor.tsx
+++ b/apps/web/src/components/mail/email-editor/lazy-tiptap-editor.tsx
@@ -6,7 +6,7 @@ import type { JSONContent } from '@tiptap/core'
 import { Loader2 } from 'lucide-react'
 import React, { Suspense } from 'react'
 import type { FileItem } from '~/components/files/files-store'
-import type { MailAiSlashConfig } from './mail-slash-content'
+import type { MailAiSlashConfig, MailReferenceConfig } from './mail-slash-content'
 
 const TiptapEditor = React.lazy(() => import('~/components/editor/tiptap-editor'))
 
@@ -25,6 +25,8 @@ interface LazyTiptapEditorProps {
   aiSlash?: MailAiSlashConfig
   /** Optional attachment wiring — surfaces the "Attach file" item in the `/` menu. */
   onAttachFile?: (file: FileItem) => void
+  /** Optional signature/action wiring — registers the `@` menu (email only). */
+  references?: MailReferenceConfig
   /** Formatting profile. `'rich'` (default, email) or `'plain'` (chat). */
   variant?: 'rich' | 'plain'
 }

--- a/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mail/email-editor/mail-slash-content.tsx
 'use client'
 
+import type { DraftActionPayload } from '@auxx/lib/quick-actions/client'
 import {
   CommandBreadcrumb,
   CommandNavigation,
@@ -8,7 +9,9 @@ import {
 } from '@auxx/ui/components/command'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import type { Editor } from '@tiptap/react'
+import { Check } from 'lucide-react'
 import { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import type { PickerTrigger } from '~/components/editor/inline-picker'
 import { PlaceholderSlashContent } from '~/components/editor/slash-commands/placeholder-slash-content'
 import type {
   SlashCommandItem,
@@ -18,11 +21,15 @@ import { type SlashContentHandle, SlashList } from '~/components/editor/slash-co
 import type { FileItem } from '~/components/files/files-store'
 import { SparkleIcon } from '~/components/kopilot/ui/sparkle-icon'
 import { useCmdkRemote } from '~/components/pickers/use-cmdk-remote'
+import { useSignatures } from '~/components/signatures/hooks'
+import { useQuickActions } from '~/hooks/use-quick-actions'
+import type { SerializedQuickAction } from '~/lib/workflow/workflow-block-loader'
 import { api } from '~/trpc/react'
 import { AI_LANG_TYPE, AI_OPERATION, AI_TONE_TYPE, type AIOperation } from '~/types/ai-tools'
 import { isBodyEmptyIgnoringChips } from '../composer-shared/content-empty'
 import { FileSlashContent } from './file-slash-content'
 import { useSnippetSearch } from './hooks'
+import { cacheActionSchema, toDraftActionPayload } from './quick-action-panel'
 
 type Range = { from: number; to: number }
 
@@ -39,6 +46,27 @@ export interface MailAiSlashConfig {
   onRunAI: (operation: AIOperation, options?: { tone?: string; language?: string }) => void
   /** Compose requires a thread to reply to. Gates the empty-body "Ask AI" item. */
   hasPreviousMessages: boolean
+}
+
+/**
+ * Draft-level wiring for the `@` menu. When absent, the `@` root renders no
+ * signature/action items (and the trigger isn't registered — see tiptap-editor).
+ * Data (signatures, available actions) is fetched inside the component; only the
+ * current selection + mutators are passed, since they own the draft state.
+ */
+export interface MailReferenceConfig {
+  /** Currently-selected signature id (instance id), or null when none. */
+  signatureId: string | null
+  /** Set / clear the draft signature. Same setter as the belowEditor editor. */
+  onSignatureChange: (id: string | null) => void
+  /** Currently-selected quick-action ids — drives the checked state. */
+  actionIds: string[]
+  /** Push a quick action onto the draft. */
+  onAddAction: (payload: DraftActionPayload) => void
+  /** Remove a quick action from the draft by action id. */
+  onRemoveAction: (actionId: string) => void
+  /** Scopes `useQuickActions` to the active thread. */
+  threadId?: string
 }
 
 /**
@@ -73,6 +101,10 @@ export interface MailSlashContentProps {
    * attachment tray (`useFileSelect.addExistingFiles`). Absent → no file item.
    */
   onAttachFile?: (file: FileItem) => void
+  /** Which trigger opened the chip. Defaults to `'/'`. `'@'` roots the reference menu. */
+  trigger?: PickerTrigger
+  /** Draft-level signature/action wiring for the `@` menu. */
+  references?: MailReferenceConfig
   /**
    * Block commands offered at the root (Heading / lists / blockquote).
    * Defaults to {@link MAIL_BLOCK_COMMANDS}. Chat passes `[]` — it's a plain,
@@ -91,6 +123,14 @@ export interface MailBlockCommand extends SlashCommandItem {
 }
 
 export const MAIL_BLOCK_COMMANDS: MailBlockCommand[] = [
+  {
+    id: 'text',
+    title: 'Text',
+    description: 'Plain text block',
+    keywords: ['p', 'paragraph', 'body', 'normal'],
+    iconId: 'text',
+    run: (editor, range) => editor.chain().focus().deleteRange(range).setParagraph().run(),
+  },
   {
     id: 'h1',
     title: 'Heading 1',
@@ -244,8 +284,34 @@ const AI_TRANSFORM_ITEMS: SlashCommandItem[] = [
 type NavItem = {
   id: string
   label: string
-  type: 'snippets' | 'folder' | 'ai' | 'ai-tone' | 'ai-translate'
+  type: 'snippets' | 'folder' | 'ai' | 'ai-tone' | 'ai-translate' | 'signatures' | 'actions'
 }
+
+// --- `@` reference root (signature + action drill-ins) --------------------
+// Only rendered when `references` is supplied (email composer). Both items
+// drill into a list; selection is draft-level state, not a body insertion.
+
+const REFERENCE_ROOT_ITEMS: SlashCommandItem[] = [
+  {
+    id: 'use-signature',
+    title: 'Use signature',
+    description: 'Apply a saved signature to this reply',
+    keywords: ['signature', 'sign', 'footer', 'sign-off'],
+    iconId: 'feather',
+    drillDown: true,
+  },
+  {
+    id: 'add-action',
+    title: 'Add action',
+    description: 'Run an app action when you send',
+    keywords: ['action', 'app', 'automation', 'workflow'],
+    iconId: 'zap',
+    drillDown: true,
+  },
+]
+
+// Sentinel row id for clearing the selected signature from the drill list.
+const REMOVE_SIGNATURE_ID = '__remove_signature__'
 
 // Snippet-mode rows reuse `SlashCommandItem` plus a `kind` tag so the section's
 // `onSelect` can dispatch without re-scanning data.
@@ -333,6 +399,8 @@ function MailSlashContentInner({
   onEnterFileMode,
   onAttachFile,
   aiSlash,
+  trigger = '/',
+  references,
   blockCommands = MAIL_BLOCK_COMMANDS,
 }: MailSlashContentProps & {
   onEnterPlaceholderMode: () => void
@@ -372,6 +440,56 @@ function MailSlashContentInner({
     subtreeSnippetResults,
     rootSnippetResults,
   } = useSnippetSearch({ query, currentFolderId, isAtRoot })
+
+  // `@` reference data — fetched inside the component (like snippets). Hooks
+  // run unconditionally; the lists only render under the `@` trigger.
+  const { signatures } = useSignatures()
+  const { actions: availableActions, isLoading: actionsLoading } = useQuickActions(
+    references?.threadId
+  )
+
+  // Signature/action selections are draft-level state, not body insertions, so
+  // (like the AI ops) the executor only strips the chip; the actual mutation
+  // goes through `references`. Both also close the menu by removing the chip.
+  const selectSignature = useCallback(
+    (id: string | null) => {
+      if (!references) return
+      onExecute((editor, range) => editor.chain().focus().deleteRange(range).run())
+      references.onSignatureChange(id)
+    },
+    [references, onExecute]
+  )
+
+  const toggleAction = useCallback(
+    (action: SerializedQuickAction) => {
+      if (!references) return
+      const isSelected = references.actionIds.includes(action.id)
+      onExecute((editor, range) => editor.chain().focus().deleteRange(range).run())
+      if (isSelected) {
+        references.onRemoveAction(action.id)
+      } else {
+        cacheActionSchema(action) // populate the shared cache so the belowEditor form renders
+        references.onAddAction(toDraftActionPayload(action))
+      }
+    },
+    [references, onExecute]
+  )
+
+  const enterReferenceScope = useCallback(
+    (type: 'signatures' | 'actions', label: string) => {
+      push({ id: type, label, type })
+      onScopeChange(label)
+    },
+    [push, onScopeChange]
+  )
+
+  const handleReferenceRootSelect = useCallback(
+    (item: SlashCommandItem) => {
+      if (item.id === 'use-signature') enterReferenceScope('signatures', 'Signature')
+      else if (item.id === 'add-action') enterReferenceScope('actions', 'Add action')
+    },
+    [enterReferenceScope]
+  )
 
   const enterSnippetsDrillDown = useCallback(() => {
     push({ id: 'snippets', label: 'Snippets', type: 'snippets' })
@@ -495,6 +613,77 @@ function MailSlashContentInner({
   )
 
   const sections: SlashCommandSection<SlashCommandItem>[] = useMemo(() => {
+    // `@` reference menu — a focused signature/action surface. Distinct from
+    // the `/` formatting menu; never mixes block commands or Ask AI.
+    if (trigger === '@') {
+      if (!references) return []
+
+      if (current?.type === 'signatures') {
+        const sigItems: SlashCommandItem[] = signatures.map((s) => ({ id: s.id, title: s.name }))
+        if (references.signatureId) {
+          sigItems.push({ id: REMOVE_SIGNATURE_ID, title: 'Remove signature', iconId: 'x' })
+        }
+        const signaturesSection: SlashCommandSection<SlashCommandItem> = {
+          id: 'signatures',
+          heading: 'Signatures',
+          items: sigItems,
+          itemValue: (item) => item.id,
+          onSelect: (item) => selectSignature(item.id === REMOVE_SIGNATURE_ID ? null : item.id),
+          renderItem: (item) => (
+            <div className='flex w-full items-center gap-2'>
+              <EntityIcon
+                iconId={item.iconId ?? 'feather'}
+                size='sm'
+                className='text-muted-foreground'
+              />
+              <span className='flex-1 truncate'>{item.title}</span>
+              {references.signatureId === item.id && (
+                <Check className='size-3.5 shrink-0 text-primary-600' />
+              )}
+            </div>
+          ),
+        }
+        return [signaturesSection]
+      }
+
+      if (current?.type === 'actions') {
+        const actionItems: SlashCommandItem[] = availableActions.map((a) => ({
+          id: a.id,
+          title: a.label,
+          description: a.description,
+        }))
+        const actionsSection: SlashCommandSection<SlashCommandItem> = {
+          id: 'actions',
+          heading: 'Actions',
+          items: actionItems,
+          itemValue: (item) => item.id,
+          onSelect: (item) => {
+            const action = availableActions.find((a) => a.id === item.id)
+            if (action) toggleAction(action)
+          },
+          renderItem: (item) => (
+            <div className='flex w-full items-center gap-2'>
+              <EntityIcon iconId='zap' size='sm' className='text-muted-foreground' />
+              <span className='flex-1 truncate'>{item.title}</span>
+              {references.actionIds.includes(item.id) && (
+                <Check className='size-3.5 shrink-0 text-primary-600' />
+              )}
+            </div>
+          ),
+        }
+        return [actionsSection]
+      }
+
+      return [
+        {
+          id: 'reference-root',
+          heading: 'Insert',
+          items: REFERENCE_ROOT_ITEMS,
+          onSelect: handleReferenceRootSelect,
+        },
+      ]
+    }
+
     if (current?.type === 'ai') {
       return [
         {
@@ -566,7 +755,7 @@ function MailSlashContentInner({
           <div className='flex items-center gap-2'>
             <EntityIcon
               iconId={item.kind === 'folder' ? 'folder' : 'file-text'}
-              size='xs'
+              size='sm'
               className='text-muted-foreground'
             />
             <span>{item.title}</span>
@@ -600,7 +789,7 @@ function MailSlashContentInner({
         ) : (
           <div className='flex items-center gap-2'>
             {item.iconId && (
-              <EntityIcon iconId={item.iconId} size='xs' className='text-muted-foreground' />
+              <EntityIcon iconId={item.iconId} size='sm' className='text-muted-foreground' />
             )}
             <span>{item.title}</span>
           </div>
@@ -622,7 +811,7 @@ function MailSlashContentInner({
         itemValue: (item) => item.id,
         renderItem: (item) => (
           <div className='flex items-center gap-2'>
-            <EntityIcon iconId='file-text' size='xs' className='text-muted-foreground' />
+            <EntityIcon iconId='file-text' size='sm' className='text-muted-foreground' />
             <span>{item.title}</span>
           </div>
         ),
@@ -648,20 +837,35 @@ function MailSlashContentInner({
     handleAiOpSelect,
     runAI,
     onAttachFile,
+    trigger,
+    references,
+    signatures,
+    availableActions,
+    selectSignature,
+    toggleAction,
+    handleReferenceRootSelect,
   ])
+
+  const isInActions = current?.type === 'actions'
 
   return (
     <div ref={containerRef} className='w-72 overflow-hidden'>
       <SlashList
         query={query}
         sections={sections}
-        header={<CommandBreadcrumb rootLabel='Commands' />}
+        header={<CommandBreadcrumb rootLabel={trigger === '@' ? 'Insert' : 'Commands'} />}
         emptyMessage={
-          isInSnippets ? 'No snippets found.' : isInAi ? 'No options.' : 'No results found.'
+          isInSnippets
+            ? 'No snippets found.'
+            : isInAi
+              ? 'No options.'
+              : isInActions
+                ? 'No actions available.'
+                : 'No results found.'
         }
-        // Only the snippet drill-down needs the snippet fetch; the static root
-        // suggestions (Ask AI, formatting commands, placeholder) render instantly.
-        loading={isInSnippets && snippetsLoading}
+        // Only drill-downs that fetch need a loading state — the static root
+        // suggestions render instantly. Snippets and `@`-actions are the two.
+        loading={(isInSnippets && snippetsLoading) || (isInActions && actionsLoading)}
       />
     </div>
   )

--- a/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
+++ b/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
@@ -27,8 +27,10 @@ import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
 import { useQuickActions } from '~/hooks/use-quick-actions'
 import type { SerializedQuickAction } from '~/lib/workflow/workflow-block-loader'
 
-// Schema cache for form rendering (populated when actions are loaded)
-const quickActionSchemaCache = new Map<string, { inputs: Record<string, any> }>()
+// Schema cache for form rendering (populated when actions are loaded).
+// Exported so the mail `@` menu (mail-slash-content.tsx) can populate the SAME
+// cache when it adds an action — the belowEditor chip's inline form keys off it.
+export const quickActionSchemaCache = new Map<string, { inputs: Record<string, any> }>()
 
 interface QuickActionPanelProps {
   actions: DraftActionPayload[]
@@ -247,18 +249,7 @@ function QuickActionPicker({
           const action = actionMap.get(id)
           if (!action) continue
           cacheActionSchema(action)
-          onAdd({
-            appId: action.appId!,
-            installationId: action.installationId!,
-            actionId: action.id,
-            inputs: action.defaults ?? {},
-            display: {
-              label: action.label,
-              icon: action.icon,
-              color: action.color,
-              summary: action.label,
-            },
-          })
+          onAdd(toDraftActionPayload(action))
         }
       }
 
@@ -296,10 +287,30 @@ function QuickActionPicker({
 }
 
 /** Cache action schema for inline form rendering */
-function cacheActionSchema(action: SerializedQuickAction) {
+export function cacheActionSchema(action: SerializedQuickAction) {
   const key = `${action.appId}:${action.id}`
   if (action.inputs && Object.keys(action.inputs).length > 0) {
     quickActionSchemaCache.set(key, { inputs: action.inputs })
+  }
+}
+
+/**
+ * Build the draft-level payload for a selected quick action. Shared by the
+ * belowEditor picker and the mail `@` menu so both mint byte-identical payloads
+ * into the same `quickActionSchemaCache`.
+ */
+export function toDraftActionPayload(action: SerializedQuickAction): DraftActionPayload {
+  return {
+    appId: action.appId!,
+    installationId: action.installationId!,
+    actionId: action.id,
+    inputs: action.defaults ?? {},
+    display: {
+      label: action.label,
+      icon: action.icon,
+      color: action.color,
+      summary: action.label,
+    },
   }
 }
 

--- a/packages/ui/src/components/icon-data.ts
+++ b/packages/ui/src/components/icon-data.ts
@@ -70,6 +70,7 @@ import {
   ExternalLink,
   Eye,
   EyeOff,
+  Feather,
   File,
   FileAudio,
   FileCode,
@@ -267,6 +268,7 @@ export const ICON_DATA: IconItem[] = [
   { id: 'user-x', label: 'User X', icon: UserX },
   { id: 'circle-user', label: 'Circle User', icon: CircleUser },
   // Files/Documents
+  { id: 'feather', label: 'Feather', icon: Feather },
   { id: 'file', label: 'File', icon: File },
   { id: 'file-text', label: 'File Text', icon: FileText },
   { id: 'file-image', label: 'File Image', icon: FileImage },


### PR DESCRIPTION
## What

Brings the **signature** and **quick-action** pickers into the email composer's in-editor chip picker, triggered by `@`. Reuses the existing `ReferencePickerNode` + `MailSlashContent` + chip pipeline — **no new popover, no new keyboard plugin, no server change**. Implements `plans/tiptap/mail-at-signature-action-picker.md`.

## How

- **`@` is a second `kind: command` trigger**, registered only when `references` is wired through (email composer). It gets the slash keyboard path (drill + list-nav + Backspace-pop), **not** the reference/mention tabs. Chat passes no `references`, so `@` stays a literal character there.
- **Signature + action are draft-level state, not body insertions.** Selecting strips the chip (like the AI ops) and routes through the **same setters** already wired to the belowEditor `SignatureEditor` / `QuickActionPanel`, so the `@` menu and the below-editor chips stay in sync automatically.
- Exported `quickActionSchemaCache` / `cacheActionSchema` / `toDraftActionPayload` from `quick-action-panel.tsx` so the `@` menu mints byte-identical payloads into the shared schema cache (the belowEditor inline form keys off it).

## Also in this PR

- Added a **"Text"** (paragraph) block command above Heading 1 in the `/` menu.
- Registered the **`feather`** icon in the shared `EntityIcon` registry (it was missing, so "Use signature" rendered without an icon).
- Bumped slash-menu icons **`xs` → `sm`** (mail menu + `slash-list` default).
- Updated the composer placeholder to surface both shortcuts: `Type / for commands or @ for signatures & actions`.

## Known trade-off

`@` at start-of-block or after whitespace now opens the chip; mid-word `@` (e.g. `john@example.com`) still types a literal — same `(^|\s)@$` gating as `/`. Escape collapses an open `@` chip back to literal `@<query>` text.

## Test plan

- [ ] Email reply, empty body, type `@` at start → chip opens with **Use signature** / **Add action**; `/` still opens the formatting menu
- [ ] `@` → Use signature → pick one → chip vanishes, `SignatureEditor` below reflects it; re-open `@` → row marked selected + "Remove signature" works
- [ ] `@` → Add action → pick one → chip vanishes, action appears as a `QuickActionPanel` chip and expands to its inline form (proves shared cache populated); re-open `@` → shows checked, re-selecting removes
- [ ] `john@example.com` mid-word → `@` stays literal
- [ ] Escape collapses open `@` chip; Backspace on empty chip closes; arrow/Enter drill nav matches `/`
- [ ] Chat composer: `@` types a literal character; `/` unaffected
- [ ] Selections made in the belowEditor controls reflect as checked in the `@` menu and vice-versa