### PR TITLE
feat(mail): upload-from-computer in / file picker + consistent picker order

### DIFF
--- a/apps/web/src/components/editor/tiptap-editor.tsx
+++ b/apps/web/src/components/editor/tiptap-editor.tsx
@@ -55,6 +55,8 @@ type TiptapEditorProps = {
   aiSlash?: MailAiSlashConfig
   /** Optional attachment wiring — surfaces the "Attach file" item in the `/` menu. */
   onAttachFile?: (file: FileItem) => void
+  /** Optional upload wiring — pins an "Upload from computer" row in the file drill-in. */
+  onUploadFiles?: (files: File[]) => void
   /**
    * Optional signature/action wiring. When present, registers the `@` trigger
    * (signature + action menu) alongside `/`. Absent (e.g. chat) → `@` types a
@@ -81,6 +83,7 @@ const TiptapEditor = ({
   onEnter,
   aiSlash,
   onAttachFile,
+  onUploadFiles,
   references,
   variant = 'rich',
 }: TiptapEditorProps) => {
@@ -320,6 +323,7 @@ const TiptapEditor = ({
             onClose={closeSlash}
             aiSlash={aiSlash}
             onAttachFile={onAttachFile}
+            onUploadFiles={onUploadFiles}
             references={references}
             blockCommands={isPlain ? [] : MAIL_BLOCK_COMMANDS}
           />

--- a/apps/web/src/components/mail/composer-shared/composer-body.tsx
+++ b/apps/web/src/components/mail/composer-shared/composer-body.tsx
@@ -26,6 +26,8 @@ interface ComposerBodyProps {
   aiSlash?: MailAiSlashConfig
   /** Optional attachment wiring — surfaces the "Attach file" item in the `/` menu. */
   onAttachFile?: (file: FileItem) => void
+  /** Optional upload wiring — pins an "Upload from computer" row in the file drill-in. */
+  onUploadFiles?: (files: File[]) => void
   /** Optional signature/action wiring — registers the `@` menu (email only). */
   references?: MailReferenceConfig
   /** Formatting profile. `'rich'` (default, email) or `'plain'` (chat). */
@@ -70,6 +72,7 @@ export function ComposerBody({
   editorMinHeightClassName = 'min-h-[150px]',
   aiSlash,
   onAttachFile,
+  onUploadFiles,
   references,
   variant,
   onWrapperClick,
@@ -140,6 +143,7 @@ export function ComposerBody({
           contentClassName={contentClassName}
           aiSlash={aiSlash}
           onAttachFile={onAttachFile}
+          onUploadFiles={onUploadFiles}
           references={references}
           variant={variant}
         />

--- a/apps/web/src/components/mail/email-editor/add-attachment-button.tsx
+++ b/apps/web/src/components/mail/email-editor/add-attachment-button.tsx
@@ -1,0 +1,48 @@
+// apps/web/src/components/mail/email-editor/add-attachment-button.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import { Paperclip } from 'lucide-react'
+import type { UseFileSelectReturn } from '~/components/file-select/types'
+import { FileSelectPicker } from '~/components/pickers/file-select-picker'
+import { useEditorActiveStateContext } from './editor-active-state-context'
+
+/**
+ * "Add attachment" trigger for the composer action row. Wraps the shared
+ * {@link FileSelectPicker} with a ghost/xs trigger styled like the sibling
+ * "Add action" / "Add signature" buttons, and mirrors the popover-open tracking
+ * the old toolbar File icon did (so the editor stays "active" while open).
+ */
+export function AddAttachmentButton({
+  fileSelect,
+  disabled,
+  popoverClassName,
+}: {
+  fileSelect: UseFileSelectReturn
+  disabled?: boolean
+  popoverClassName?: string
+}) {
+  const { trackPopoverOpen, trackPopoverClose } = useEditorActiveStateContext()
+
+  return (
+    <FileSelectPicker
+      fileSelect={fileSelect}
+      align='start'
+      side='top'
+      showPath={false}
+      className={cn('w-70', popoverClassName)}
+      onOpenChange={(open) =>
+        open ? trackPopoverOpen('file-select-picker') : trackPopoverClose('file-select-picker')
+      }>
+      <Button
+        variant='ghost'
+        size='xs'
+        disabled={disabled}
+        className='h-6 gap-1 text-xs text-muted-foreground/50'>
+        <Paperclip className='size-3' />
+        Add attachment
+      </Button>
+    </FileSelectPicker>
+  )
+}

--- a/apps/web/src/components/mail/email-editor/file-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/file-slash-content.tsx
@@ -15,6 +15,13 @@ export interface FileSlashContentProps {
   query: string
   /** Attach the chosen library file into the composer's attachment tray. */
   onAttachFile: (file: FileItem) => void
+  /**
+   * Upload fresh files from the user's computer into the composer's attachment
+   * tray. When provided, an "Upload from computer" row is pinned to the top of
+   * the list. Wired to the composer-level `fileSelect.addFiles`, so the upload
+   * survives the chip closing when the native dialog steals focus.
+   */
+  onUploadFiles?: (files: File[]) => void
   /** Close the chip (keeps the typed text, mirroring `@`). */
   onClose: () => void
   /** Return to the parent `/` command menu. */
@@ -43,6 +50,7 @@ function FileSlashInner({
   ref,
   query,
   onAttachFile,
+  onUploadFiles,
   onClose,
   onBack,
   backLabel,
@@ -72,6 +80,23 @@ function FileSlashInner({
     [onAttachFile, onClose]
   )
 
+  // Opens the native file dialog, then hands the chosen files to the
+  // composer-level uploader and closes the chip. The dialog blurs the editor
+  // (tearing down this chip), but `onUploadFiles` targets state that outlives
+  // it, so the upload completes regardless.
+  const handleUpload = useCallback(() => {
+    if (!onUploadFiles) return
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.multiple = true
+    input.onchange = (e) => {
+      const files = Array.from((e.target as HTMLInputElement).files ?? [])
+      if (files.length > 0) onUploadFiles(files)
+    }
+    input.click()
+    onClose()
+  }, [onUploadFiles, onClose])
+
   return (
     <div ref={containerRef} className='w-72 overflow-hidden'>
       <FileBrowseLevel
@@ -81,7 +106,9 @@ function FileSlashInner({
         allowFiles
         allowFolders={false}
         enableGlobalSearch
-        showPath
+        uploadAction={
+          onUploadFiles ? { label: 'Upload from computer', onSelect: handleUpload } : undefined
+        }
         onSelectItem={handleSelect}
         onBack={onBack}
         backLabel={backLabel ?? 'Commands'}

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -23,7 +23,7 @@ import { type ContentApplier, makeContentApplier } from '~/components/editor/inl
 import { useCountUpdates } from '~/components/mail/hooks'
 import { useComposeStore } from '~/components/mail/store/compose-store'
 import { ChannelPicker } from '~/components/pickers/channel-picker'
-import { SignatureEditor } from '~/components/signatures/ui'
+import { SignatureAddButton, SignaturePanel } from '~/components/signatures/ui'
 import {
   appendOptimisticMessage,
   toAttachmentMeta,
@@ -43,6 +43,7 @@ import {
   useComposerAITools,
   useComposerAttachments,
 } from '../composer-shared'
+import { AddAttachmentButton } from './add-attachment-button'
 import { AIStatus } from './ai-status'
 import { deriveInitialState, type InitState } from './derive-initial'
 import {
@@ -538,8 +539,8 @@ function ReplyComposeEditorComponent({
     setIsDraftSaved(false)
   }, [])
 
-  // `@` menu wiring — reuses the SAME setters as the belowEditor SignatureEditor
-  // / QuickActionPanel, so the two entry points stay in sync automatically.
+  // `@` menu wiring — reuses the SAME setters as the belowEditor signature /
+  // quick-action panels, so the two entry points stay in sync automatically.
   const references = useMemo<MailReferenceConfig>(
     () => ({
       signatureId: state.signatureId,
@@ -1028,6 +1029,7 @@ function ReplyComposeEditorComponent({
           popoverClassName={popoverZIndex}
           aiSlash={{ onRunAI: handleAIOperation, hasPreviousMessages }}
           onAttachFile={(file) => fileSelect.addExistingFiles([file])}
+          onUploadFiles={(files) => fileSelect.addFiles(files)}
           references={references}
           onWrapperClick={handleWrapperClick}
           onKeyDown={handleKeyDown}
@@ -1194,7 +1196,8 @@ function ReplyComposeEditorComponent({
           }
           belowEditor={
             <>
-              <SignatureEditor
+              {/* Panels render above the action row. Signature is always first. */}
+              <SignaturePanel
                 integrationId={state.integrationId}
                 selectedSignatureId={state.signatureId}
                 onSignatureChange={handleSignatureChange}
@@ -1202,15 +1205,6 @@ function ReplyComposeEditorComponent({
                 className={popoverZIndex}
               />
 
-              {/* File Attachments Display - Persisted + In-Progress Uploads */}
-              <AttachmentStrip
-                attachments={attachments}
-                selectedItems={fileSelect.selectedItems}
-                onRemoveAttachment={removeAttachment}
-                onRemoveUpload={fileSelect.removeItem}
-              />
-
-              {/* Quick Actions Panel */}
               <QuickActionPanel
                 actions={quickActions}
                 onAdd={(action) => setQuickActions((prev) => [...prev, action])}
@@ -1232,9 +1226,18 @@ function ReplyComposeEditorComponent({
                 }
               />
 
-              {/* Add Action Button (always visible when not sending) */}
+              {/* File Attachments Display - Persisted + In-Progress Uploads */}
+              <AttachmentStrip
+                attachments={attachments}
+                selectedItems={fileSelect.selectedItems}
+                onRemoveAttachment={removeAttachment}
+                onRemoveUpload={fileSelect.removeItem}
+              />
+
+              {/* Action row — triggers grouped; signature last so its removal
+                  on select doesn't shift the persistent action/attachment buttons. */}
               {!isSending && (
-                <div className='px-2'>
+                <div className='flex items-center gap-1 px-2'>
                   <AddActionButton
                     threadId={thread?.id || state.threadId || undefined}
                     currentActions={quickActions}
@@ -1249,6 +1252,18 @@ function ReplyComposeEditorComponent({
                         ? activeState.trackPopoverOpen('add-action')
                         : activeState.trackPopoverClose('add-action')
                     }
+                  />
+                  <AddAttachmentButton
+                    fileSelect={fileSelect}
+                    disabled={isSending}
+                    popoverClassName={popoverZIndex}
+                  />
+                  <SignatureAddButton
+                    integrationId={state.integrationId}
+                    selectedSignatureId={state.signatureId}
+                    onSignatureChange={handleSignatureChange}
+                    disabled={isSending}
+                    className={popoverZIndex}
                   />
                 </div>
               )}
@@ -1289,7 +1304,6 @@ function ReplyComposeEditorComponent({
                   onSchedule={handleScheduleClick}
                   isSending={isSending}
                   disabled={isSending || !editor?.isEditable || aiToolsState.isProcessing}
-                  fileSelect={fileSelect}
                   popoverClassName={popoverZIndex}
                   aiToolsProps={{
                     threadId: thread?.id || state.threadId || undefined,

--- a/apps/web/src/components/mail/email-editor/lazy-tiptap-editor.tsx
+++ b/apps/web/src/components/mail/email-editor/lazy-tiptap-editor.tsx
@@ -25,6 +25,8 @@ interface LazyTiptapEditorProps {
   aiSlash?: MailAiSlashConfig
   /** Optional attachment wiring — surfaces the "Attach file" item in the `/` menu. */
   onAttachFile?: (file: FileItem) => void
+  /** Optional upload wiring — pins an "Upload from computer" row in the file drill-in. */
+  onUploadFiles?: (files: File[]) => void
   /** Optional signature/action wiring — registers the `@` menu (email only). */
   references?: MailReferenceConfig
   /** Formatting profile. `'rich'` (default, email) or `'plain'` (chat). */

--- a/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
@@ -101,6 +101,12 @@ export interface MailSlashContentProps {
    * attachment tray (`useFileSelect.addExistingFiles`). Absent → no file item.
    */
   onAttachFile?: (file: FileItem) => void
+  /**
+   * Optional upload wiring — when present, the file drill-in pins an "Upload from
+   * computer" row that opens the native dialog and routes fresh files into the
+   * composer's attachment tray (`useFileSelect.addFiles`).
+   */
+  onUploadFiles?: (files: File[]) => void
   /** Which trigger opened the chip. Defaults to `'/'`. `'@'` roots the reference menu. */
   trigger?: PickerTrigger
   /** Draft-level signature/action wiring for the `@` menu. */
@@ -368,6 +374,14 @@ export function MailSlashContent(props: MailSlashContentProps) {
           props.onAttachFile?.(file)
           exitMode()
         }}
+        onUploadFiles={
+          props.onUploadFiles
+            ? (files) => {
+                props.onUploadFiles?.(files)
+                exitMode()
+              }
+            : undefined
+        }
       />
     )
   }

--- a/apps/web/src/components/pickers/file-browse-level.tsx
+++ b/apps/web/src/components/pickers/file-browse-level.tsx
@@ -8,6 +8,7 @@ import {
   CommandEmpty,
   CommandGroup,
   CommandInput,
+  CommandItem,
   CommandList,
   CommandLoading,
   CommandNavigableItem,
@@ -21,7 +22,7 @@ import { Kbd } from '@auxx/ui/components/kbd'
 import { radioGroupVariants } from '@auxx/ui/components/radio-group'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
-import { Circle, File, Folder } from 'lucide-react'
+import { Circle, File, Folder, Upload } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ParentBackHeader } from '~/components/editor/placeholders/placeholder-picker-content'
@@ -85,6 +86,13 @@ export interface FileBrowseLevelProps {
   /** External filter text (controlled). Used in {@link remote} mode in place of
    *  the internal search input. */
   query?: string
+
+  /**
+   * Optional "Upload from computer" action rendered as the first row of the
+   * list. It's a real cmdk item, so it's keyboard-navigable in remote mode. The
+   * host owns the native file dialog and what happens to the chosen files.
+   */
+  uploadAction?: { label: string; onSelect: () => void }
 
   /**
    * When provided, the browse root shows a back affordance (and ←/Backspace on
@@ -277,6 +285,7 @@ function FileBrowseInner({
   showPath,
   enableKeyboardNavigation,
   onRequestClose,
+  uploadAction,
   onBack,
   backLabel,
   remote,
@@ -304,6 +313,7 @@ function FileBrowseInner({
     | 'fileExtensions'
     | 'maxFileSize'
     | 'onRequestClose'
+    | 'uploadAction'
     | 'onBack'
     | 'backLabel'
   > & {
@@ -471,6 +481,10 @@ function FileBrowseInner({
     <Command shouldFilter={false} onKeyDown={remote ? undefined : handleKeyDown}>
       {onBack && isAtRoot && <ParentBackHeader label={backLabel ?? 'Back'} onBack={onBack} />}
       <CommandList>
+        {/* Command nav (breadcrumb) sits above the search input — matches the
+            slash / placeholder / article pickers. */}
+        <CommandBreadcrumb rootLabel='Files' />
+
         {!remote && (
           <CommandInput
             placeholder={enableGlobalSearch ? `Search ${totalFiles} files...` : searchPlaceholder}
@@ -488,7 +502,19 @@ function FileBrowseInner({
           </div>
         )}
 
-        <CommandBreadcrumb rootLabel='Files' />
+        {uploadAction && (
+          <>
+            <CommandGroup>
+              <CommandItem onSelect={uploadAction.onSelect} className='px-2'>
+                <span className='shrink-0 text-muted-foreground'>
+                  <Upload />
+                </span>
+                <span className='min-w-0 truncate'>{uploadAction.label}</span>
+              </CommandItem>
+            </CommandGroup>
+            <CommandSeparator />
+          </>
+        )}
 
         {showCurrentFolderRow && current && (
           <>

--- a/apps/web/src/components/pickers/file-select-picker.tsx
+++ b/apps/web/src/components/pickers/file-select-picker.tsx
@@ -16,7 +16,16 @@ import {
 } from '@auxx/ui/components/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
-import { Download, File, FolderOpen, Loader2, RotateCw, Trash2, Upload } from 'lucide-react'
+import {
+  ChevronRight,
+  Download,
+  File,
+  FolderOpen,
+  Loader2,
+  RotateCw,
+  Trash2,
+  Upload,
+} from 'lucide-react'
 import type React from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useFileSelect } from '~/components/file-select/hooks/use-file-select'
@@ -60,6 +69,9 @@ export interface FileSelectPickerProps {
 
   // Hide "Browse files" — restrict picker to fresh uploads only
   hideBrowseExisting?: boolean
+
+  // Show the folder path breadcrumb in the inline browse view (default true)
+  showPath?: boolean
 
   // Display
   children: React.ReactNode
@@ -162,6 +174,7 @@ function FileSelectPickerContent({
   side,
   sideOffset,
   hideBrowseExisting,
+  showPath = true,
   children,
 }: FileSelectPickerContentProps) {
   const [search, setSearch] = useState('')
@@ -170,14 +183,18 @@ function FileSelectPickerContent({
   const [internalOpen, setInternalOpen] = useState(false)
 
   // Support both controlled and uncontrolled open state so content actions
-  // (single-select close, Escape) can dismiss the popover either way.
-  const resolvedOpen = open !== undefined ? open : internalOpen
+  // (single-select close, Escape) can dismiss the popover either way. When
+  // uncontrolled, drive internal state AND still fire onOpenChange as a
+  // side-effect (callers pass it purely to track popover open/close).
+  const isControlled = open !== undefined
+  const resolvedOpen = isControlled ? open : internalOpen
   const handleOpenChange = useCallback(
     (next: boolean) => {
       if (!next) setMode('menu')
-      ;(onOpenChange ?? setInternalOpen)(next)
+      if (!isControlled) setInternalOpen(next)
+      onOpenChange?.(next)
     },
-    [onOpenChange]
+    [isControlled, onOpenChange]
   )
 
   const { selectedItems } = fileSelect
@@ -258,7 +275,7 @@ function FileSelectPickerContent({
               allowFolders={false}
               fileExtensions={fileTypes}
               enableGlobalSearch
-              showPath
+              showPath={showPath}
               onBack={() => setMode('menu')}
               backLabel='Attach'
               onRequestClose={() => handleOpenChange(false)}
@@ -319,6 +336,7 @@ function FileSelectPickerContent({
                       <CommandItem onSelect={() => setMode('browse')}>
                         <FolderOpen className='size-4' />
                         Browse files
+                        <ChevronRight className='ml-auto size-4 text-muted-foreground' />
                       </CommandItem>
                     )}
                   </>

--- a/apps/web/src/components/signatures/ui/index.ts
+++ b/apps/web/src/components/signatures/ui/index.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/signatures/ui/index.ts
 
 export { SignatureDialog } from './signature-dialog'
-export { default as SignatureEditor } from './signature-editor'
+export { SignatureAddButton, SignaturePanel } from './signature-editor'
 export { SignatureList } from './signature-list'
 export { SignaturePicker } from './signature-picker'

--- a/apps/web/src/components/signatures/ui/signature-editor.tsx
+++ b/apps/web/src/components/signatures/ui/signature-editor.tsx
@@ -10,8 +10,8 @@ import { sanitizeHtml } from '~/lib/sanitize'
 import { useDefaultSignature, useSignatures } from '../hooks'
 import { SignaturePicker } from './signature-picker'
 
-/** Props for the SignatureEditor component */
-interface SignatureEditorProps {
+/** Shared props for the signature trigger button and the signature panel. */
+interface SignatureProps {
   integrationId: string
   selectedSignatureId: string | null
   onSignatureChange: (signatureId: string | null) => void
@@ -21,27 +21,11 @@ interface SignatureEditorProps {
 }
 
 /**
- * Component for selecting and displaying an email signature within the editor.
+ * Track the signature picker popover in the editor active-state context, so the
+ * editor doesn't treat itself as blurred while the picker is open.
  */
-function SignatureEditor({
-  selectedSignatureId,
-  onSignatureChange,
-  disabled = false,
-  className,
-}: SignatureEditorProps) {
-  const [isPickerOpen, setIsPickerOpen] = useState(false)
+function usePickerActiveTracking(isPickerOpen: boolean) {
   const { trackPopoverOpen, trackPopoverClose } = useEditorActiveStateContext()
-
-  // Data fetching
-  const { signatures, signatureMap, isLoading: isLoadingSignatures } = useSignatures()
-  const { signature: defaultSignature, isLoading: isLoadingDefault } = useDefaultSignature()
-
-  const isLoading = isLoadingSignatures || isLoadingDefault
-
-  // Get current signature from map (derived state, no useState needed)
-  const currentSignature = selectedSignatureId ? signatureMap.get(selectedSignatureId) : null
-
-  // Track popover state for editor active context
   useEffect(() => {
     if (isPickerOpen) {
       trackPopoverOpen('signature-picker')
@@ -50,6 +34,26 @@ function SignatureEditor({
     }
     return () => trackPopoverClose('signature-picker')
   }, [isPickerOpen, trackPopoverOpen, trackPopoverClose])
+}
+
+/**
+ * The "Add signature" trigger button (with picker). Renders `null` once a
+ * signature is selected — the body then lives in {@link SignaturePanel}.
+ */
+export function SignatureAddButton({
+  selectedSignatureId,
+  onSignatureChange,
+  disabled = false,
+  className,
+}: SignatureProps) {
+  const [isPickerOpen, setIsPickerOpen] = useState(false)
+  usePickerActiveTracking(isPickerOpen)
+
+  const { signatures, signatureMap, isLoading: isLoadingSignatures } = useSignatures()
+  const { signature: defaultSignature, isLoading: isLoadingDefault } = useDefaultSignature()
+  const isLoading = isLoadingSignatures || isLoadingDefault
+
+  const currentSignature = selectedSignatureId ? signatureMap.get(selectedSignatureId) : null
 
   // Add signature (use default if available, otherwise open picker)
   const handleAddClick = useCallback(() => {
@@ -61,16 +65,6 @@ function SignatureEditor({
     }
   }, [disabled, defaultSignature, onSignatureChange])
 
-  // Remove signature
-  const handleRemoveClick = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation()
-      onSignatureChange(null)
-    },
-    [onSignatureChange]
-  )
-
-  // Select from picker
   const handleSelect = useCallback(
     (signatureId: string | null) => {
       if (!disabled) onSignatureChange(signatureId)
@@ -79,41 +73,69 @@ function SignatureEditor({
   )
 
   if (isLoading) {
-    return (
-      <div className='group relative mx-2 mb-0 rounded-md'>
-        <Skeleton className='h-4 w-26' />
-      </div>
-    )
+    return <Skeleton className='h-6 w-26' />
   }
 
-  // No signature selected - show "Add" button with picker
-  if (!currentSignature) {
-    return (
-      <div className='mx-2'>
-        <SignaturePicker
-          signatures={signatures}
-          selected={null}
-          onChange={handleSelect}
-          open={isPickerOpen}
-          onOpenChange={setIsPickerOpen}
-          disabled={disabled}
-          align='start'
-          className={className}>
-          <Button
-            variant='ghost'
-            size='xs'
-            onClick={handleAddClick}
-            disabled={disabled}
-            className='text-muted-foreground/50'>
-            <Feather className='size-3.5' />
-            Add signature
-          </Button>
-        </SignaturePicker>
-      </div>
-    )
-  }
+  // A signature is selected — the body renders in SignaturePanel, not here.
+  if (currentSignature) return null
 
-  // Signature selected - show body with edit/remove controls
+  return (
+    <SignaturePicker
+      signatures={signatures}
+      selected={null}
+      onChange={handleSelect}
+      open={isPickerOpen}
+      onOpenChange={setIsPickerOpen}
+      disabled={disabled}
+      align='start'
+      className={className}>
+      <Button
+        variant='ghost'
+        size='xs'
+        onClick={handleAddClick}
+        disabled={disabled}
+        className='h-6 gap-1 text-muted-foreground/50'>
+        <Feather className='size-3.5' />
+        Add signature
+      </Button>
+    </SignaturePicker>
+  )
+}
+
+/**
+ * The selected-signature body with hover edit/remove controls. Renders `null`
+ * when no signature is selected — the trigger lives in {@link SignatureAddButton}.
+ */
+export function SignaturePanel({
+  selectedSignatureId,
+  onSignatureChange,
+  disabled = false,
+  className,
+}: SignatureProps) {
+  const [isPickerOpen, setIsPickerOpen] = useState(false)
+  usePickerActiveTracking(isPickerOpen)
+
+  const { signatures, signatureMap, isLoading } = useSignatures()
+  const currentSignature = selectedSignatureId ? signatureMap.get(selectedSignatureId) : null
+
+  const handleRemoveClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onSignatureChange(null)
+    },
+    [onSignatureChange]
+  )
+
+  const handleSelect = useCallback(
+    (signatureId: string | null) => {
+      if (!disabled) onSignatureChange(signatureId)
+    },
+    [disabled, onSignatureChange]
+  )
+
+  // Skeleton is owned by SignatureAddButton; nothing to show here until selected.
+  if (isLoading || !currentSignature) return null
+
   return (
     <div
       className={`group mx-2 relative rounded-md hover:bg-muted dark:hover:bg-muted ${disabled ? 'pointer-events-none opacity-50' : ''}`}>
@@ -152,5 +174,3 @@ function SignatureEditor({
     </div>
   )
 }
-
-export default SignatureEditor


### PR DESCRIPTION
## Summary

Follow-up tweaks to the mail composer `/` file slash flow (from #870), plus a picker-layout consistency fix.

- **Upload from computer in the `/` file picker.** A new "Upload from computer" row is pinned to the top of the attach-file drill-in. It opens the native file dialog and routes fresh files into the composer's attachment tray via the composer-level `fileSelect.addFiles`. The native dialog blurs the editor (tearing down the chip), but the upload targets state that outlives the chip, so it completes regardless. `onUploadFiles` is plumbed parallel to `onAttachFile` through editor → `composer-body` → tiptap; `FileBrowseLevel` gains an optional `uploadAction` prop. Single slash command — no separate `/upload`.
- **`showPath` off in the folder view.** The `/` file picker no longer shows the path column while browsing folders. Path still appears in global-search results, where it spans folders and is useful.
- **Consistent picker order.** `FileBrowseLevel` now renders `CommandBreadcrumb` above `CommandInput`, so the search input sits **below** the command nav — matching the slash / placeholder / article pickers (previously it was inverted).
- **Signature editor split.** `SignatureEditor` is split into `SignatureAddButton` + `SignaturePanel`, with the composer and `file-select-picker` wired to the new exports.

## Notes

- `tag-picker-content` and `field-picker-content` still render input-above-breadcrumb; left out of scope here.
- Behavioral note: the pinned upload row is the first cmdk item, so it's the default highlight when the file drill-in opens (Enter uploads immediately). Easy to move to the bottom if that's not wanted.

## Test plan

1. Email reply → `/` → Attach file → "Upload from computer" appears at top → pick a file → it lands in the attachment tray, chip closes.
2. `/` → Attach file → browse a folder → no path column; type to search → path shows in results.
3. Drill into a folder in the file picker → breadcrumb (nav) is above the search input.
4. Signature add/panel flows in the composer still work.