### PR TITLE
fix(mail): restore quick-action inline form

### DIFF
--- a/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
@@ -29,7 +29,7 @@ import { AI_LANG_TYPE, AI_OPERATION, AI_TONE_TYPE, type AIOperation } from '~/ty
 import { isBodyEmptyIgnoringChips } from '../composer-shared/content-empty'
 import { FileSlashContent } from './file-slash-content'
 import { useSnippetSearch } from './hooks'
-import { cacheActionSchema, toDraftActionPayload } from './quick-action-panel'
+import { toDraftActionPayload } from './quick-action-panel'
 
 type Range = { from: number; to: number }
 
@@ -482,7 +482,6 @@ function MailSlashContentInner({
       if (isSelected) {
         references.onRemoveAction(action.id)
       } else {
-        cacheActionSchema(action) // populate the shared cache so the belowEditor form renders
         references.onAddAction(toDraftActionPayload(action))
       }
     },

--- a/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
+++ b/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
@@ -27,11 +27,6 @@ import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
 import { useQuickActions } from '~/hooks/use-quick-actions'
 import type { SerializedQuickAction } from '~/lib/workflow/workflow-block-loader'
 
-// Schema cache for form rendering (populated when actions are loaded).
-// Exported so the mail `@` menu (mail-slash-content.tsx) can populate the SAME
-// cache when it adds an action — the belowEditor chip's inline form keys off it.
-export const quickActionSchemaCache = new Map<string, { inputs: Record<string, any> }>()
-
 interface QuickActionPanelProps {
   actions: DraftActionPayload[]
   onAdd: (action: DraftActionPayload) => void
@@ -49,9 +44,28 @@ export function QuickActionPanel({
   onRemove,
   onUpdate,
   disabled,
+  threadId,
+  ticketId,
   popoverClassName,
   onPopoverOpenChange,
 }: QuickActionPanelProps) {
+  // Resolve each chip's input schema from the LIVE installed-app catalog rather
+  // than a module cache populated at add-time. This survives reloads / restored
+  // drafts: a chip rehydrated from a saved draft still finds its schema here,
+  // keyed by `appId:actionId`, with no dependency on the add flow having run
+  // this session. An uninstalled app's action resolves to `undefined` (no
+  // schema to edit) — correct; the chip just isn't expandable.
+  const { actions: availableActions } = useQuickActions(threadId, ticketId)
+  const schemaByKey = useMemo(() => {
+    const map = new Map<string, { inputs: Record<string, any> }>()
+    for (const a of availableActions) {
+      if (a.inputs && Object.keys(a.inputs).length > 0) {
+        map.set(`${a.appId}:${a.id}`, { inputs: a.inputs })
+      }
+    }
+    return map
+  }, [availableActions])
+
   if (actions.length === 0) return null
 
   return (
@@ -67,6 +81,7 @@ export function QuickActionPanel({
             <QuickActionChip
               key={`${action.appId}:${action.actionId}`}
               action={action}
+              schema={schemaByKey.get(`${action.appId}:${action.actionId}`)}
               onRemove={() => onRemove(action.actionId)}
               onUpdate={onUpdate}
               disabled={disabled}
@@ -82,6 +97,7 @@ export function QuickActionPanel({
 
 function QuickActionChip({
   action,
+  schema,
   onRemove,
   onUpdate,
   disabled,
@@ -89,6 +105,7 @@ function QuickActionChip({
   onPopoverOpenChange,
 }: {
   action: DraftActionPayload
+  schema?: { inputs: Record<string, any> }
   onRemove: () => void
   onUpdate: (actionId: string, inputs: Record<string, unknown>) => void
   disabled?: boolean
@@ -96,7 +113,6 @@ function QuickActionChip({
   onPopoverOpenChange?: (open: boolean) => void
 }) {
   const [expanded, setExpanded] = useState(false)
-  const schema = quickActionSchemaCache.get(`${action.appId}:${action.actionId}`)
 
   return (
     <Collapsible open={expanded} onOpenChange={setExpanded}>
@@ -105,41 +121,49 @@ function QuickActionChip({
           'group inline-flex flex-col rounded-md border bg-muted/50 text-xs',
           disabled && 'opacity-50'
         )}>
-        <CollapsibleTrigger
-          disabled={!schema || disabled}
-          className={cn(
-            'inline-flex items-center gap-1 px-2 py-1',
-            schema && !disabled && 'cursor-pointer'
-          )}>
-          {schema && (
-            <span className='size-3 shrink-0 text-muted-foreground'>
-              {expanded ? <ChevronDown className='size-3' /> : <ChevronRight className='size-3' />}
+        {/* Header row: the trigger and the remove control are siblings. The
+            remove <button> must NOT nest inside the trigger's <button> —
+            that's invalid HTML and triggers a hydration error that kills all
+            chip interactivity (expand + remove both stop working). */}
+        <div className='inline-flex items-center'>
+          <CollapsibleTrigger
+            disabled={!schema || disabled}
+            className={cn(
+              'inline-flex items-center gap-1 py-1 pl-2',
+              disabled ? 'pr-2' : 'pr-1',
+              schema && !disabled && 'cursor-pointer'
+            )}>
+            {schema && (
+              <span className='size-3 shrink-0 text-muted-foreground'>
+                {expanded ? (
+                  <ChevronDown className='size-3' />
+                ) : (
+                  <ChevronRight className='size-3' />
+                )}
+              </span>
+            )}
+
+            {action.display.color && (
+              <span
+                className='size-2 shrink-0 rounded-full'
+                style={{ backgroundColor: action.display.color }}
+              />
+            )}
+
+            <span className='max-w-48 truncate font-medium'>
+              {action.display.summary || action.display.label}
             </span>
-          )}
-
-          {action.display.color && (
-            <span
-              className='size-2 shrink-0 rounded-full'
-              style={{ backgroundColor: action.display.color }}
-            />
-          )}
-
-          <span className='max-w-48 truncate font-medium'>
-            {action.display.summary || action.display.label}
-          </span>
+          </CollapsibleTrigger>
 
           {!disabled && (
             <button
               type='button'
-              className='ml-0.5 opacity-0 transition-opacity group-hover:opacity-100'
-              onClick={(e) => {
-                e.stopPropagation()
-                onRemove()
-              }}>
+              className='mr-2 ml-0.5 opacity-0 transition-opacity group-hover:opacity-100'
+              onClick={() => onRemove()}>
               <X className='size-3' />
             </button>
           )}
-        </CollapsibleTrigger>
+        </div>
 
         {schema && (
           <CollapsibleContent className='overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down'>
@@ -248,7 +272,6 @@ function QuickActionPicker({
         if (!prevSet.has(id)) {
           const action = actionMap.get(id)
           if (!action) continue
-          cacheActionSchema(action)
           onAdd(toDraftActionPayload(action))
         }
       }
@@ -286,18 +309,11 @@ function QuickActionPicker({
   )
 }
 
-/** Cache action schema for inline form rendering */
-export function cacheActionSchema(action: SerializedQuickAction) {
-  const key = `${action.appId}:${action.id}`
-  if (action.inputs && Object.keys(action.inputs).length > 0) {
-    quickActionSchemaCache.set(key, { inputs: action.inputs })
-  }
-}
-
 /**
  * Build the draft-level payload for a selected quick action. Shared by the
- * belowEditor picker and the mail `@` menu so both mint byte-identical payloads
- * into the same `quickActionSchemaCache`.
+ * belowEditor picker and the mail `@` menu so both mint byte-identical payloads.
+ * Input schemas are resolved at render time from the live catalog (see
+ * `QuickActionPanel`), so adding an action carries no schema-caching step.
  */
 export function toDraftActionPayload(action: SerializedQuickAction): DraftActionPayload {
   return {

--- a/apps/web/src/hooks/use-quick-actions.ts
+++ b/apps/web/src/hooks/use-quick-actions.ts
@@ -33,24 +33,87 @@ function installationToActions(installation: AppInstallation): SerializedQuickAc
   const actions = installation.actions ?? []
   if (actions.length === 0) return []
 
-  // Build a tool-id → agent tool lookup for input schemas. Action-only tools
-  // aren't in `agentTools`, so their inputs render as an empty form until the
-  // envelope is extended with a tools-by-id projection.
-  const toolsById = new Map((installation.agentTools ?? []).map((t) => [t.id, t]))
+  return actions.map((action) => ({
+    id: action.toolId,
+    label: action.label,
+    description: action.description,
+    icon: action.iconKey ?? undefined,
+    color: action.color,
+    // The catalog ships tool inputs as a JSON Schema; the quick-action form
+    // reads the SDK field-descriptor map. Bridge here (see comment on the fn).
+    inputs: jsonSchemaToActionFields(action.inputsJsonSchema),
+    outputs: {},
+    defaults: {},
+    appId: installation.app.id,
+    installationId: installation.installationId,
+  }))
+}
 
-  return actions.map((action) => {
-    const tool = toolsById.get(action.toolId)
+/**
+ * Convert a tool's input JSON Schema — `zodToProviderToolSchema` output, shaped
+ * `{ type: 'object', properties: {…}, required: [...] }` — into the flat
+ * field-descriptor map the quick-action form renders
+ * (`{ fieldKey: { type, label, options, … } }`, keyed by field name).
+ *
+ * Tool inputs ship as JSON Schema since the catalog refactor; the form predates
+ * it and was built against the old iframe SDK descriptor shape, so this bridges
+ * the two. Lossy by design: JSON Schema carries no `currency`-type or label
+ * metadata, so currency inputs fall back to plain number fields and labels are
+ * derived from the field key.
+ */
+export function jsonSchemaToActionFields(
+  schema: Record<string, any> | undefined
+): Record<string, any> {
+  const properties = schema?.properties as Record<string, any> | undefined
+  if (!properties) return {}
+  const required: string[] = Array.isArray(schema?.required) ? schema.required : []
+
+  const fields: Record<string, any> = {}
+  for (const [key, prop] of Object.entries(properties)) {
+    fields[key] = jsonSchemaPropToField(key, prop, required.includes(key))
+  }
+  return fields
+}
+
+function jsonSchemaPropToField(key: string, prop: any, required: boolean): Record<string, any> {
+  const base = { label: titleCaseKey(key), required, description: prop?.description }
+
+  // A fixed value set → single-select, regardless of the underlying scalar type.
+  if (Array.isArray(prop?.enum)) {
     return {
-      id: action.toolId,
-      label: action.label,
-      description: action.description,
-      icon: action.iconKey ?? undefined,
-      color: action.color,
-      inputs: (tool?.inputsJsonSchema as Record<string, any>) ?? {},
-      outputs: (tool?.outputsJsonSchema as Record<string, any>) ?? {},
-      defaults: {},
-      appId: installation.app.id,
-      installationId: installation.installationId,
+      ...base,
+      type: 'select',
+      options: prop.enum.map((value: unknown) => ({ value, label: String(value) })),
     }
-  })
+  }
+
+  switch (prop?.type) {
+    case 'integer':
+    case 'number':
+      return {
+        ...base,
+        type: 'number',
+        integer: prop.type === 'integer',
+        // JSON Schema's exclusiveMinimum (e.g. `> 0`) maps to the input's
+        // inclusive `min` — close enough for the UI; the server re-validates.
+        min:
+          prop.minimum ??
+          (typeof prop.exclusiveMinimum === 'number' ? prop.exclusiveMinimum : undefined),
+        max: prop.maximum,
+      }
+    case 'boolean':
+      return { ...base, type: 'boolean' }
+    default:
+      return { ...base, type: 'string' }
+  }
+}
+
+/** `maxRedemptions` / `duration_in_months` → `Max Redemptions` / `Duration In Months`. */
+function titleCaseKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^\w/, (c) => c.toUpperCase())
 }

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -297,6 +297,18 @@ export interface CachedAgentTool extends CatalogAgentTool {
  * `subGroup` and leave the rest `undefined` (the builder falls back
  * to sensible defaults). The synthetic auxx row populates everything.
  */
+/**
+ * Cache-side projection of a quick action. Extends the SDK-defined
+ * `CatalogAction` with the referenced tool's `inputsJsonSchema`, joined from the
+ * full `catalog.tools` registry at projection time. The quick-action form reads
+ * this to render an inline input form. Joining here (rather than client-side
+ * against `agent.tools`) means **action-only** tools — which carry no agent
+ * surface and so are absent from `agent.tools` — still get their inputs.
+ */
+export interface CachedAction extends CatalogAction {
+  inputsJsonSchema: Record<string, unknown>
+}
+
 export interface CachedAgentToolset extends CatalogToolset {
   /** Short header text used inside the app/sub-group render. Falls back to `name`. */
   shortLabel?: string
@@ -382,7 +394,7 @@ export interface CachedInstalledApp {
   agentTriggers?: CatalogTriggerProjection[]
   workflowBlocks?: CatalogBlock[]
   workflowTriggers?: CatalogTriggerProjection[]
-  actions?: CatalogAction[]
+  actions?: CachedAction[]
 
   /**
    * Org-scope connection presence + expiry (decision G2 split path).
@@ -496,7 +508,7 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   overages: { prefix: 'org:overages', ttlSeconds: 900 },
   orgSettings: { prefix: 'org:settings', ttlSeconds: ONE_DAY },
   // v2: connectionDefinition (singular) → connectionDefinitions (pair). Bump on shape changes.
-  installedApps: { prefix: 'org:installed-apps:v2', ttlSeconds: 900 },
+  installedApps: { prefix: 'org:installed-apps:v3', ttlSeconds: 900 },
   mcpServers: { prefix: 'org:mcpServers', ttlSeconds: ONE_DAY },
   workflowApps: { prefix: 'org:workflow-apps', ttlSeconds: ONE_DAY },
 

--- a/packages/lib/src/cache/providers/installed-apps-provider.ts
+++ b/packages/lib/src/cache/providers/installed-apps-provider.ts
@@ -4,7 +4,7 @@ import { schema } from '@auxx/database'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { getBuiltinAuxxInstalledRow } from '../../agents/builtin-installed-row'
 import { getRegisteredToolName } from '../../ai/kopilot/capabilities/apps/tool-naming'
-import type { CachedAgentTool, CachedInstalledApp } from '../org-cache-keys'
+import type { CachedAction, CachedAgentTool, CachedInstalledApp } from '../org-cache-keys'
 import type { CacheProvider } from '../org-cache-provider'
 
 /**
@@ -112,6 +112,16 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
           iconId: toolsetIconBySlug.get(t.toolsetSlug) ?? appIconId,
         })) ?? undefined
 
+      // Join action → tool inputs from the FULL tool registry (`catalog.tools`),
+      // not `agent.tools`: action-only tools have no agent surface and so aren't
+      // in `agent.tools`. The quick-action form keys off `inputsJsonSchema`.
+      const toolInputsById = new Map(
+        (inst.currentDeployment?.catalog?.tools ?? []).map((t) => [t.id, t.inputsJsonSchema])
+      )
+      const actions: CachedAction[] | undefined = inst.currentDeployment?.catalog?.actions.map(
+        (a) => ({ ...a, inputsJsonSchema: toolInputsById.get(a.toolId) ?? {} })
+      )
+
       return {
         installationId: inst.id,
         installationType: inst.installationType as 'development' | 'production',
@@ -158,7 +168,7 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
         agentTriggers: inst.currentDeployment?.catalog?.agent.triggers ?? undefined,
         workflowBlocks: inst.currentDeployment?.catalog?.workflow.blocks ?? undefined,
         workflowTriggers: inst.currentDeployment?.catalog?.workflow.triggers ?? undefined,
-        actions: inst.currentDeployment?.catalog?.actions ?? undefined,
+        actions,
         orgConnectionPresent: orgConnByAppId.get(inst.app.id)?.present ?? false,
         orgConnectionExpiresAt: orgConnByAppId.get(inst.app.id)?.expiresAt?.toISOString() ?? null,
       }


### PR DESCRIPTION
## Problem

The email composer's quick-action chips (e.g. **Create Coupon**) couldn't be expanded or edited — opening one showed an empty form, and after the chip nesting bug, expand/remove stopped working entirely. Broken since the catalog/tools refactor (#629).

## Root causes

1. **Shape mismatch.** Tool inputs ship as a JSON Schema (`{ type:'object', properties, required }`, via `zodToProviderToolSchema`), but `QuickActionForm` was built against the SDK field-descriptor map (`{ field: { type, label, options, … } }`). Iterating the JSON Schema's top-level keys (`type`/`properties`/`required`) made every field fall through to the `default` branch → empty form.
2. **Action-only tools have no inputs.** `useQuickActions` looked up schemas in `catalog.agent.tools`; a tool with an `action` surface but no `agent` surface isn't there, so its inputs were `{}`.
3. **Add-time-only schema cache.** Expand was gated on a module-level `quickActionSchemaCache` populated only when an action was *added* — chips restored from a saved/reloaded draft never had an entry, so they silently stopped expanding.
4. **Invalid DOM.** The chip's remove `<button>` was nested inside the `CollapsibleTrigger`'s `<button>` → hydration error that killed both expand and remove.

## Changes

- **`installedAppsProvider`**: join each action → its tool's `inputsJsonSchema` from the full `catalog.tools` registry (new `CachedAction` type), so action-only tools also get inputs. Bumped `installedApps` cache version `v2 → v3` for the new envelope shape.
- **`use-quick-actions`**: `jsonSchemaToActionFields()` converts the JSON Schema → the form's field-descriptor map (enum→select, integer/number→number with min/max, boolean, string; labels title-cased from the key).
- **`quick-action-panel`**: resolve each chip's schema at **render time** from the live `useQuickActions` catalog (keyed `appId:actionId`) instead of the module cache. Removed `quickActionSchemaCache` / `cacheActionSchema`. Chips survive reloads/restored drafts; uninstalled-app actions resolve to no-schema (not expandable) — correct.
- **`quick-action-panel`**: un-nested the remove button from the trigger (sibling flex children) — fixes the hydration error.
- **`mail-slash-content`**: dropped the now-unused `cacheActionSchema` call in the `@`-menu add path.

## Notes / not in scope

- **Surface leak:** `create_stripe_coupon`'s action `surface` is `ticket-header`, yet it shows in the email composer because the mail picker doesn't filter by surface. Left as-is pending product intent.
- **`@auxx/lib` rebuild required** for the projection + cache-version changes to take effect at runtime (web resolves `@auxx/lib` to built `dist`).