### PR TITLE
feat(mail): free-text "Ask AI" instruction in the / menu

### DIFF
--- a/apps/web/src/components/mail/chat-composer/index.tsx
+++ b/apps/web/src/components/mail/chat-composer/index.tsx
@@ -150,10 +150,7 @@ function ChatComposerInner({
         popoverClassName={popoverZIndex}
         contentClassName='sm:min-h-[60px] py-2 text-sm'
         editorMinHeightClassName='min-h-[60px]'
-        aiSlash={{
-          onRunAI: handleAIOperation,
-          hasPreviousMessages: (thread.messageCount ?? thread.messages?.length ?? 0) > 0,
-        }}
+        aiSlash={{ onRunAI: handleAIOperation }}
         onAttachFile={(file) => fileSelect.addExistingFiles([file])}
         // Plain compact composer — no block formatting in the schema or `/` menu.
         variant='plain'

--- a/apps/web/src/components/mail/composer-shared/use-composer-ai-tools.ts
+++ b/apps/web/src/components/mail/composer-shared/use-composer-ai-tools.ts
@@ -86,11 +86,19 @@ export function useComposerAITools({
   })
 
   const handleAIOperation = useCallback(
-    async (operation: AIOperation, options?: { tone?: string; language?: string }) => {
+    async (
+      operation: AIOperation,
+      options?: { tone?: string; language?: string; instruction?: string }
+    ) => {
       if (!editor || state.isProcessing) return
       const currentContent = editor.getHTML()
-      // Don't process if content is empty (except for compose).
-      if (operation !== AI_OPERATION.COMPOSE && !currentContent.replace(/<[^>]*>/g, '').trim()) {
+      // Don't process if content is empty — except for compose / custom, which
+      // both can generate from scratch (custom uses the typed instruction).
+      if (
+        operation !== AI_OPERATION.COMPOSE &&
+        operation !== AI_OPERATION.CUSTOM &&
+        !currentContent.replace(/<[^>]*>/g, '').trim()
+      ) {
         toastError({
           title: 'No content',
           description: 'Please add some content before using AI tools',

--- a/apps/web/src/components/mail/email-editor/ai-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/ai-slash-content.tsx
@@ -1,0 +1,233 @@
+// apps/web/src/components/mail/email-editor/ai-slash-content.tsx
+'use client'
+
+import {
+  Command,
+  CommandBreadcrumb,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandInputWithSubmit,
+  CommandItem,
+  CommandList,
+  useCommandNavigation,
+} from '@auxx/ui/components/command'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import type { Editor } from '@tiptap/react'
+import { ChevronRight } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { SparkleIcon } from '~/components/kopilot/ui/sparkle-icon'
+import { AI_LANG_TYPE, AI_OPERATION, AI_TONE_TYPE, type AIOperation } from '~/types/ai-tools'
+import { isBodyEmptyIgnoringChips } from '../composer-shared/content-empty'
+
+export interface AiSlashContentProps {
+  /** Live editor — detects whether the body has content (chip-aware). */
+  editor?: Editor | null
+  /** Strips the chip + runs the shared AI entrypoint. */
+  onRunAI: (
+    operation: AIOperation,
+    options?: { tone?: string; language?: string; instruction?: string }
+  ) => void
+  /** Sync the chip scope label + restore editor focus on nav transitions. */
+  onScopeChange: (scope: string | null) => void
+  /** Close the chip entirely. */
+  onClose: () => void
+}
+
+/** Compatible shape for the shared nav stack (mail uses a richer `type`). */
+type AiNavItem = { id: string; label: string; type: string }
+
+// Single-shot ops at the root. `needsContent` ops are disabled on an empty body.
+const ROOT_PRESETS = [
+  {
+    id: 'compose',
+    title: 'Compose',
+    iconId: 'sparkles',
+    op: AI_OPERATION.COMPOSE,
+    needsContent: false,
+  },
+  {
+    id: 'fix-grammar',
+    title: 'Fix grammar',
+    iconId: 'check-circle',
+    op: AI_OPERATION.FIX_GRAMMAR,
+    needsContent: true,
+  },
+  {
+    id: 'expand',
+    title: 'Expand',
+    iconId: 'arrows-up-down',
+    op: AI_OPERATION.EXPAND,
+    needsContent: true,
+  },
+  {
+    id: 'shorten',
+    title: 'Shorten',
+    iconId: 'chevrons-up-down',
+    op: AI_OPERATION.SHORTEN,
+    needsContent: true,
+  },
+] as const
+
+// Drill rows — both transform the existing draft, so both need content.
+const DRILL_PRESETS = [
+  { id: 'tone', title: 'Tone', iconId: 'pen-tool', level: 'tone' as const },
+  { id: 'translate', title: 'Translate', iconId: 'globe', level: 'translate' as const },
+]
+
+/**
+ * Focus-owning "Ask AI" panel for the mail `/` menu. The instruction is typed
+ * into a real {@link CommandInputWithSubmit} (placeholder + inline send button);
+ * the preset ops sit below as static shortcuts (`shouldFilter={false}` at root).
+ * Tone / Translate drill into a filterable sub-list.
+ *
+ * Lives inside the mail `CommandNavigation`, so it pushes/pops the shared stack
+ * and renders the real {@link CommandBreadcrumb} ("Commands › Ask AI › Tone").
+ * Every transition routes through `onScopeChange`, which re-runs the editor's
+ * `setPickerScope` command and restores focus to the chip on the way out.
+ */
+export function AiSlashContent({ editor, onRunAI, onScopeChange, onClose }: AiSlashContentProps) {
+  const { current, push, pop } = useCommandNavigation<AiNavItem>()
+  const [instruction, setInstruction] = useState('')
+  const [search, setSearch] = useState('')
+
+  const level =
+    current?.type === 'ai-tone' ? 'tone' : current?.type === 'ai-translate' ? 'translate' : 'root'
+
+  // Chip-aware: the open `/` chip is ignored so an empty body reads as empty.
+  const hasContent = !isBodyEmptyIgnoringChips(editor ?? null)
+
+  const back = useCallback(() => {
+    pop()
+    // Tone/Translate → back to "Ask AI"; "Ask AI" → back to the slash root.
+    onScopeChange(level === 'root' ? null : 'Ask AI')
+    setSearch('')
+  }, [pop, onScopeChange, level])
+
+  const drill = useCallback(
+    (target: 'tone' | 'translate') => {
+      push({
+        id: `ai-${target}`,
+        label: target === 'tone' ? 'Tone' : 'Translate',
+        type: `ai-${target}`,
+      })
+      onScopeChange(target === 'tone' ? 'Tone' : 'Translate')
+    },
+    [push, onScopeChange]
+  )
+
+  const run = useCallback(
+    (
+      operation: AIOperation,
+      options?: { tone?: string; language?: string; instruction?: string }
+    ) => {
+      onRunAI(operation, options)
+      onClose()
+    },
+    [onRunAI, onClose]
+  )
+
+  if (level === 'tone' || level === 'translate') {
+    const isTone = level === 'tone'
+    const options = isTone ? Object.values(AI_TONE_TYPE) : Object.values(AI_LANG_TYPE)
+    return (
+      <div className='w-72 overflow-hidden'>
+        <Command
+          className='w-full overflow-hidden'
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.stopPropagation()
+              back()
+            } else if ((e.key === 'Backspace' || e.key === 'ArrowLeft') && !search) {
+              e.preventDefault()
+              back()
+            }
+          }}>
+          <CommandBreadcrumb rootLabel='Commands' />
+          <CommandInput
+            value={search}
+            onValueChange={setSearch}
+            placeholder={isTone ? 'Search tones…' : 'Search languages…'}
+            autoFocus
+          />
+          <CommandList>
+            <CommandEmpty>No options.</CommandEmpty>
+            <CommandGroup heading={isTone ? 'Tone' : 'Translate'}>
+              {options.map((opt) => (
+                <CommandItem
+                  key={opt}
+                  value={opt}
+                  onSelect={() =>
+                    run(
+                      isTone ? AI_OPERATION.TONE : AI_OPERATION.TRANSLATE,
+                      isTone ? { tone: opt } : { language: opt }
+                    )
+                  }>
+                  {opt}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </div>
+    )
+  }
+
+  return (
+    <div className='w-72 overflow-hidden'>
+      <Command
+        className='w-full overflow-hidden'
+        shouldFilter={false}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.stopPropagation()
+            back()
+          } else if ((e.key === 'Backspace' || e.key === 'ArrowLeft') && !instruction) {
+            e.preventDefault()
+            back()
+          }
+        }}>
+        <CommandBreadcrumb rootLabel='Commands' />
+        <CommandInputWithSubmit
+          autoFocus
+          value={instruction}
+          onValueChange={setInstruction}
+          onSubmit={(value) => run(AI_OPERATION.CUSTOM, { instruction: value })}
+          placeholder='Ask Kopilot to edit or write'
+          leftIcon={<SparkleIcon className='shrink-0' />}
+        />
+        <CommandList>
+          <CommandGroup heading='Ask AI'>
+            {ROOT_PRESETS.map((preset) => {
+              const disabled = preset.needsContent && !hasContent
+              return (
+                <CommandItem
+                  key={preset.id}
+                  value={preset.id}
+                  disabled={disabled}
+                  onSelect={() => !disabled && run(preset.op)}
+                  className='aria-disabled:opacity-50'>
+                  <EntityIcon iconId={preset.iconId} size='sm' className='text-muted-foreground' />
+                  <span>{preset.title}</span>
+                </CommandItem>
+              )
+            })}
+            {DRILL_PRESETS.map((preset) => (
+              <CommandItem
+                key={preset.id}
+                value={preset.id}
+                disabled={!hasContent}
+                data-drilldown={hasContent ? '' : undefined}
+                onSelect={() => hasContent && drill(preset.level)}
+                className='aria-disabled:opacity-50'>
+                <EntityIcon iconId={preset.iconId} size='sm' className='text-muted-foreground' />
+                <span className='flex-1'>{preset.title}</span>
+                <ChevronRight className='size-4 opacity-50' />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    </div>
+  )
+}

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -1027,7 +1027,7 @@ function ReplyComposeEditorComponent({
           placeholder='Type / for commands or @ for signatures & actions'
           editable={!aiToolsState.isProcessing}
           popoverClassName={popoverZIndex}
-          aiSlash={{ onRunAI: handleAIOperation, hasPreviousMessages }}
+          aiSlash={{ onRunAI: handleAIOperation }}
           onAttachFile={(file) => fileSelect.addExistingFiles([file])}
           onUploadFiles={(files) => fileSelect.addFiles(files)}
           references={references}

--- a/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
+++ b/apps/web/src/components/mail/email-editor/mail-slash-content.tsx
@@ -25,8 +25,8 @@ import { useSignatures } from '~/components/signatures/hooks'
 import { useQuickActions } from '~/hooks/use-quick-actions'
 import type { SerializedQuickAction } from '~/lib/workflow/workflow-block-loader'
 import { api } from '~/trpc/react'
-import { AI_LANG_TYPE, AI_OPERATION, AI_TONE_TYPE, type AIOperation } from '~/types/ai-tools'
-import { isBodyEmptyIgnoringChips } from '../composer-shared/content-empty'
+import type { AIOperation } from '~/types/ai-tools'
+import { AiSlashContent } from './ai-slash-content'
 import { FileSlashContent } from './file-slash-content'
 import { useSnippetSearch } from './hooks'
 import { toDraftActionPayload } from './quick-action-panel'
@@ -34,18 +34,18 @@ import { toDraftActionPayload } from './quick-action-panel'
 type Range = { from: number; to: number }
 
 /**
- * Optional AI-tools wiring for the `/` menu's "Ask AI" drill-in. When absent,
- * the "Ask AI" item simply doesn't render — keeps `MailSlashContent` usable by
- * any chip-pipeline consumer without forcing AI wiring. Email and chat pass
- * `handleAIOperation` from `useComposerAITools`. Note: `hasContent` is computed
- * inside the component (chip-aware) rather than passed in — the open `/` chip
- * would otherwise pollute a consumer-side content check (see `bodyHasContent`).
+ * Optional AI-tools wiring for the `/` menu's "Ask AI" item. When absent, the
+ * "Ask AI" item simply doesn't render — keeps `MailSlashContent` usable by any
+ * chip-pipeline consumer without forcing AI wiring. Email and chat pass
+ * `handleAIOperation` from `useComposerAITools`. Selecting "Ask AI" opens the
+ * focus-owning {@link AiSlashContent} panel (its own instruction input).
  */
 export interface MailAiSlashConfig {
   /** Runs the shared AI entrypoint. Mirrors the toolbar `onOperation` contract. */
-  onRunAI: (operation: AIOperation, options?: { tone?: string; language?: string }) => void
-  /** Compose requires a thread to reply to. Gates the empty-body "Ask AI" item. */
-  hasPreviousMessages: boolean
+  onRunAI: (
+    operation: AIOperation,
+    options?: { tone?: string; language?: string; instruction?: string }
+  ) => void
 }
 
 /**
@@ -221,12 +221,10 @@ const ATTACH_FILE_COMMAND: SlashCommandItem = {
   drillDown: true,
 }
 
-// --- AI "Ask AI" drill items -----------------------------------------------
-// AI ops don't insert at the chip range — they rewrite the whole body async.
-// The leaf `onSelect` strips the chip then calls `onRunAI` (see `runAI` below).
-
-// Icon is supplied by the section's `renderItem` (branded SparkleIcon), so no
-// `iconId` here.
+// --- AI "Ask AI" root item -------------------------------------------------
+// Selecting it opens the focus-owning `AiSlashContent` panel (instruction input
+// + preset ops). Icon is supplied by the section's `renderItem` (branded
+// SparkleIcon), so no `iconId` here.
 const AI_ROOT_COMMAND: SlashCommandItem = {
   id: 'ask-ai',
   title: 'Ask AI',
@@ -234,58 +232,6 @@ const AI_ROOT_COMMAND: SlashCommandItem = {
   keywords: ['ai', 'compose', 'rewrite', 'grammar', 'tone', 'translate', 'expand', 'shorten'],
   drillDown: true,
 }
-
-// Shown when the body is empty (compose a fresh reply).
-const AI_COMPOSE_ITEMS: SlashCommandItem[] = [
-  {
-    id: 'ai-compose',
-    title: 'Compose',
-    description: 'Draft a reply from the conversation',
-    keywords: ['write', 'draft', 'generate'],
-    iconId: 'sparkles',
-  },
-]
-
-// Shown when the body has content (transform the existing draft).
-const AI_TRANSFORM_ITEMS: SlashCommandItem[] = [
-  {
-    id: 'ai-fix-grammar',
-    title: 'Fix grammar',
-    description: 'Correct spelling and grammar',
-    keywords: ['spelling', 'grammar', 'proofread'],
-    iconId: 'check-circle',
-  },
-  {
-    id: 'ai-expand',
-    title: 'Expand',
-    description: 'Make it longer',
-    keywords: ['longer', 'elaborate', 'lengthen'],
-    iconId: 'arrows-up-down',
-  },
-  {
-    id: 'ai-shorten',
-    title: 'Shorten',
-    description: 'Make it more concise',
-    keywords: ['shorter', 'concise', 'trim'],
-    iconId: 'chevrons-up-down',
-  },
-  {
-    id: 'ai-tone',
-    title: 'Tone',
-    description: 'Rewrite in a different tone',
-    keywords: ['voice', 'style', 'professional', 'friendly'],
-    iconId: 'pen-tool',
-    drillDown: true,
-  },
-  {
-    id: 'ai-translate',
-    title: 'Translate',
-    description: 'Translate to another language',
-    keywords: ['language', 'localize'],
-    iconId: 'globe',
-    drillDown: true,
-  },
-]
 
 type NavItem = {
   id: string
@@ -409,6 +355,7 @@ function MailSlashContentInner({
   editor,
   onExecute,
   onScopeChange,
+  onClose,
   onEnterPlaceholderMode,
   onEnterFileMode,
   onAttachFile,
@@ -437,8 +384,6 @@ function MailSlashContentInner({
     onScopeChange(parent ? parent.label : null)
     return true
   }, [isAtRoot, pop, stack, onScopeChange])
-
-  useImperativeHandle(ref, () => ({ ...remote, popLevel: popDrill }), [remote, popDrill])
 
   const incrementUsage = api.snippet.incrementUsage.useMutation({
     onError: (error) => console.error('Failed to update snippet usage count', error),
@@ -509,6 +454,14 @@ function MailSlashContentInner({
     onScopeChange('Snippets')
   }, [push, onScopeChange])
 
+  // "Ask AI" pushes onto the real nav stack (so `CommandBreadcrumb` renders
+  // "Commands › Ask AI"); the AI scope renders `AiSlashContent` instead of the
+  // focusless `SlashList`.
+  const enterAiScope = useCallback(() => {
+    push({ id: 'ai', label: 'Ask AI', type: 'ai' })
+    onScopeChange('Ask AI')
+  }, [push, onScopeChange])
+
   const enterFolder = useCallback(
     (id: string, label: string) => {
       push({ id, label, type: 'folder' })
@@ -517,36 +470,7 @@ function MailSlashContentInner({
     [push, onScopeChange]
   )
 
-  // AI ops rewrite the whole body async — they don't insert at the chip range.
-  // Step 1: strip the typed "/ai…" chip (deleting the range closes the picker).
-  // Step 2: run AI on the now-clean doc (the existing processing UI takes over).
-  const runAI = useCallback(
-    (operation: AIOperation, options?: { tone?: string; language?: string }) => {
-      if (!aiSlash) return
-      onExecute((editor, range) => editor.chain().focus().deleteRange(range).run())
-      aiSlash.onRunAI(operation, options)
-    },
-    [aiSlash, onExecute]
-  )
-
-  const enterAiScope = useCallback(
-    (type: 'ai' | 'ai-tone' | 'ai-translate', label: string) => {
-      push({ id: type, label, type })
-      onScopeChange(label)
-    },
-    [push, onScopeChange]
-  )
-
-  // Whether the body has real content — measured *ignoring the open `/` chip*.
-  // The chip seeds a ZWSP + holds the in-progress query, both of which would
-  // otherwise read as content and wrongly flip us to the transform ops on an
-  // empty body. Recomputed as the query changes (the chip text mutates).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: query drives chip text changes
-  const bodyHasContent = useMemo(() => !isBodyEmptyIgnoringChips(editor ?? null), [editor, query])
-
-  // Empty body + no thread to reply to → the AI submenu would be empty, so hide
-  // the root item entirely rather than drill into a dead list (plan §7).
-  const showAskAI = !!aiSlash && (bodyHasContent || aiSlash.hasPreviousMessages)
+  useImperativeHandle(ref, () => ({ ...remote, popLevel: popDrill }), [remote, popDrill])
 
   const insertSnippet = useCallback(
     (snippetId: string) => {
@@ -570,7 +494,7 @@ function MailSlashContentInner({
   const handleSuggestionSelect = useCallback(
     (item: SlashCommandItem) => {
       if (item.id === 'ask-ai') {
-        enterAiScope('ai', 'Ask AI')
+        enterAiScope()
         return
       }
       if (item.id === 'snippet') {
@@ -596,33 +520,6 @@ function MailSlashContentInner({
       onEnterFileMode,
       onExecute,
     ]
-  )
-
-  // Dispatch for the AI ops list (root of the "Ask AI" drill).
-  const handleAiOpSelect = useCallback(
-    (item: SlashCommandItem) => {
-      switch (item.id) {
-        case 'ai-compose':
-          runAI(AI_OPERATION.COMPOSE)
-          break
-        case 'ai-fix-grammar':
-          runAI(AI_OPERATION.FIX_GRAMMAR)
-          break
-        case 'ai-expand':
-          runAI(AI_OPERATION.EXPAND)
-          break
-        case 'ai-shorten':
-          runAI(AI_OPERATION.SHORTEN)
-          break
-        case 'ai-tone':
-          enterAiScope('ai-tone', 'Tone')
-          break
-        case 'ai-translate':
-          enterAiScope('ai-translate', 'Translate')
-          break
-      }
-    },
-    [runAI, enterAiScope]
   )
 
   const sections: SlashCommandSection<SlashCommandItem>[] = useMemo(() => {
@@ -697,37 +594,6 @@ function MailSlashContentInner({
       ]
     }
 
-    if (current?.type === 'ai') {
-      return [
-        {
-          id: 'ai-ops',
-          heading: 'Ask AI',
-          items: bodyHasContent ? AI_TRANSFORM_ITEMS : AI_COMPOSE_ITEMS,
-          onSelect: handleAiOpSelect,
-        },
-      ]
-    }
-    if (current?.type === 'ai-tone') {
-      return [
-        {
-          id: 'ai-tone',
-          heading: 'Tone',
-          items: Object.values(AI_TONE_TYPE).map((tone) => ({ id: tone, title: tone })),
-          onSelect: (item) => runAI(AI_OPERATION.TONE, { tone: item.id }),
-        },
-      ]
-    }
-    if (current?.type === 'ai-translate') {
-      return [
-        {
-          id: 'ai-translate',
-          heading: 'Translate',
-          items: Object.values(AI_LANG_TYPE).map((language) => ({ id: language, title: language })),
-          onSelect: (item) => runAI(AI_OPERATION.TRANSLATE, { language: item.id }),
-        },
-      ]
-    }
-
     if (isInSnippets) {
       // While searching, show flattened subtree matches (snippets only) so
       // snippets nested in subfolders surface. While browsing, show this
@@ -785,7 +651,7 @@ function MailSlashContentInner({
       id: 'suggestions',
       heading: 'Suggestions',
       items: [
-        ...(showAskAI ? [AI_ROOT_COMMAND] : []),
+        ...(aiSlash ? [AI_ROOT_COMMAND] : []),
         ...TOOL_COMMANDS,
         ...(onAttachFile ? [ATTACH_FILE_COMMAND] : []),
         ...blockCommands,
@@ -844,11 +710,8 @@ function MailSlashContentInner({
     rootSnippetResults,
     enterFolder,
     insertSnippet,
-    bodyHasContent,
-    showAskAI,
+    aiSlash,
     blockCommands,
-    handleAiOpSelect,
-    runAI,
     onAttachFile,
     trigger,
     references,
@@ -861,6 +724,25 @@ function MailSlashContentInner({
 
   const isInActions = current?.type === 'actions'
 
+  // The "Ask AI" scope renders its own focus-owning panel (instruction input +
+  // presets) instead of the focusless `SlashList`. It lives inside this same
+  // `CommandNavigation`, so its `CommandBreadcrumb` shows the real path.
+  if (isInAi && aiSlash) {
+    return (
+      <AiSlashContent
+        editor={editor}
+        onScopeChange={onScopeChange}
+        onClose={onClose}
+        // Strip the chip (mirrors snippet/placeholder executors) then run AI on
+        // the now-clean doc — the existing processing UI takes over.
+        onRunAI={(operation, options) => {
+          onExecute((e, range) => e.chain().focus().deleteRange(range).run())
+          aiSlash.onRunAI(operation, options)
+        }}
+      />
+    )
+  }
+
   return (
     <div ref={containerRef} className='w-72 overflow-hidden'>
       <SlashList
@@ -870,11 +752,9 @@ function MailSlashContentInner({
         emptyMessage={
           isInSnippets
             ? 'No snippets found.'
-            : isInAi
-              ? 'No options.'
-              : isInActions
-                ? 'No actions available.'
-                : 'No results found.'
+            : isInActions
+              ? 'No actions available.'
+              : 'No results found.'
         }
         // Only drill-downs that fetch need a loading state — the static root
         // suggestions render instantly. Snippets and `@`-actions are the two.

--- a/apps/web/src/components/tags/ui/tag-picker/tag-list-row.tsx
+++ b/apps/web/src/components/tags/ui/tag-picker/tag-list-row.tsx
@@ -4,7 +4,6 @@
 import { getOptionColor, type SelectOptionColor } from '@auxx/lib/custom-fields/client'
 import { Checkbox } from '@auxx/ui/components/checkbox'
 import { CommandGroup, CommandNavigableItem } from '@auxx/ui/components/command'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
 import { ManageActions } from './manage-actions'
 import type { Tag } from './types'
@@ -118,34 +117,32 @@ export function TagList({
   onDelete,
 }: TagListProps) {
   return (
-    <ScrollArea className='max-h-[300px]'>
-      <CommandGroup>
-        {tags.map((tag, index) => {
-          if (!tag) return null
-          const isSelected = selectedTags.includes(tag.id)
-          const isIndeterminate = !isSelected && indeterminateTags.includes(tag.id)
-          const hasChildren = (tag.children?.length || 0) > 0
-          const isSelectable = !onlyLeafSelection || !hasChildren
-          const isKeyboardSelected = enableKeyboardNavigation && selectedIndex === index
+    <CommandGroup>
+      {tags.map((tag, index) => {
+        if (!tag) return null
+        const isSelected = selectedTags.includes(tag.id)
+        const isIndeterminate = !isSelected && indeterminateTags.includes(tag.id)
+        const hasChildren = (tag.children?.length || 0) > 0
+        const isSelectable = !onlyLeafSelection || !hasChildren
+        const isKeyboardSelected = enableKeyboardNavigation && selectedIndex === index
 
-          return (
-            <TagListRow
-              key={tag.id}
-              tag={tag}
-              isSelected={isSelected}
-              isIndeterminate={isIndeterminate}
-              hasChildren={hasChildren}
-              isSelectable={isSelectable}
-              isKeyboardSelected={isKeyboardSelected}
-              isManageMode={isManageMode}
-              navigateToTag={navigateToTag}
-              toggleTag={toggleTag}
-              onEdit={onEdit}
-              onDelete={onDelete}
-            />
-          )
-        })}
-      </CommandGroup>
-    </ScrollArea>
+        return (
+          <TagListRow
+            key={tag.id}
+            tag={tag}
+            isSelected={isSelected}
+            isIndeterminate={isIndeterminate}
+            hasChildren={hasChildren}
+            isSelectable={isSelectable}
+            isKeyboardSelected={isKeyboardSelected}
+            isManageMode={isManageMode}
+            navigateToTag={navigateToTag}
+            toggleTag={toggleTag}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        )
+      })}
+    </CommandGroup>
   )
 }

--- a/apps/web/src/components/tags/ui/tag-picker/tag-picker-content.tsx
+++ b/apps/web/src/components/tags/ui/tag-picker/tag-picker-content.tsx
@@ -378,16 +378,16 @@ export function TagPickerContent({
   return (
     <>
       <Command shouldFilter={false} onKeyDown={handleKeyDown}>
+        <CommandInput
+          placeholder='Search or create tags...'
+          value={search}
+          onValueChange={setSearch}
+          autoFocus
+        />
+
+        <CommandBreadcrumb rootLabel='All Tags' />
+
         <CommandList>
-          <CommandInput
-            placeholder='Search or create tags...'
-            value={search}
-            onValueChange={setSearch}
-            autoFocus
-          />
-
-          <CommandBreadcrumb rootLabel='All Tags' />
-
           {current && isManageMode && tagEntityDefinitionId && (
             <>
               <CommandGroup>
@@ -497,30 +497,29 @@ export function TagPickerContent({
               onDelete={handleDelete}
             />
           )}
-
-          {canShowManageToggle && (
-            <>
-              <div className='-mx-1 h-px bg-border/50' />
-              <CommandGroup>
-                <CommandItem
-                  onSelect={() => setIsManageMode((v) => !v)}
-                  className='cursor-pointer h-7.5'>
-                  {isManageMode ? (
-                    <>
-                      <Check className='text-good-500' />
-                      <span>Done</span>
-                    </>
-                  ) : (
-                    <>
-                      <Settings className='text-muted-foreground' />
-                      <span>Manage tags</span>
-                    </>
-                  )}
-                </CommandItem>
-              </CommandGroup>
-            </>
-          )}
         </CommandList>
+
+        {canShowManageToggle && (
+          <div className='border-t border-border/50'>
+            <CommandGroup>
+              <CommandItem
+                onSelect={() => setIsManageMode((v) => !v)}
+                className='cursor-pointer h-7.5'>
+                {isManageMode ? (
+                  <>
+                    <Check className='text-good-500' />
+                    <span>Done</span>
+                  </>
+                ) : (
+                  <>
+                    <Settings className='text-muted-foreground' />
+                    <span>Manage tags</span>
+                  </>
+                )}
+              </CommandItem>
+            </CommandGroup>
+          </div>
+        )}
       </Command>
 
       {editTagId && (

--- a/apps/web/src/server/api/routers/aiFeature.ts
+++ b/apps/web/src/server/api/routers/aiFeature.ts
@@ -26,6 +26,7 @@ const AIComposeInputSchema = z.object({
   senderId: z.string().optional(), // Will be filled from session
   tone: z.enum(AI_TONE_TYPE).optional(),
   language: z.string().optional(), // Allow any string for flexibility
+  instruction: z.string().optional(), // Free-text steering for the CUSTOM op
   output: z.enum(OUTPUT_FORMAT),
 })
 
@@ -198,6 +199,17 @@ function validateOperationInput(input: z.infer<typeof AIComposeInputSchema>) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'Either message content or entity ID is required for compose',
+        })
+      }
+      break
+
+    case AI_OPERATION.CUSTOM:
+      // No messageHtml requirement — an empty body is valid (composes a fresh
+      // draft from the instruction). Only the instruction itself is required.
+      if (!input.instruction?.trim()) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'An instruction is required for a custom AI request',
         })
       }
       break

--- a/packages/lib/src/ai-features/compose/ai-compose.service.ts
+++ b/packages/lib/src/ai-features/compose/ai-compose.service.ts
@@ -75,9 +75,13 @@ export class AIComposeService {
         hasEntityId: !!request.entityId,
       })
 
-      // Get thread context if needed for compose operation
+      // Get thread context when the operation can compose from the conversation
+      // (COMPOSE always; CUSTOM uses it as reference for a fresh draft).
       let threadContext: ThreadContext | undefined
-      if (request.operation === AI_OPERATION.COMPOSE && request.entityId) {
+      if (
+        (request.operation === AI_OPERATION.COMPOSE || request.operation === AI_OPERATION.CUSTOM) &&
+        request.entityId
+      ) {
         threadContext = await this.getThreadContext(request.entityId, organizationId, userId)
       }
 
@@ -219,6 +223,7 @@ export class AIComposeService {
     const prompts = getPrompt(request.operation, content, {
       tone: request.tone,
       language: request.language,
+      instruction: request.instruction,
       context,
     })
 
@@ -253,6 +258,8 @@ export class AIComposeService {
         return 'Unable to fix grammar'
       case AI_OPERATION.COMPOSE:
         return 'Unable to compose'
+      case AI_OPERATION.CUSTOM:
+        return 'Unable to complete the request'
       default:
         return 'AI operation failed'
     }
@@ -271,6 +278,11 @@ export class AIComposeService {
       [AI_OPERATION.COMPOSE]: {
         ...baseParams,
         temperature: 0.7,
+        max_tokens: 1500,
+      },
+      [AI_OPERATION.CUSTOM]: {
+        ...baseParams,
+        temperature: 0.6,
         max_tokens: 1500,
       },
       [AI_OPERATION.TONE]: {

--- a/packages/lib/src/ai-features/compose/prompts.ts
+++ b/packages/lib/src/ai-features/compose/prompts.ts
@@ -46,6 +46,19 @@ IMPORTANT INSTRUCTIONS:
 - Format the response as clean HTML ready for the email body
 ${HTML_FORMATTING_INSTRUCTIONS}`,
 
+  [AI_OPERATION.CUSTOM]: `You are an AI assistant helping with a professional email, following the user's instruction.
+The user will give you an instruction and, when present, the current draft and/or the conversation context.
+
+IMPORTANT INSTRUCTIONS:
+- Follow the user's instruction precisely
+- If a current draft is provided, edit it per the instruction (rewrite/extend/adjust) and preserve its meaning unless the instruction says otherwise
+- If no draft is provided, compose a fresh email body that fulfils the instruction, using the conversation context when available
+- Return ONLY the email body content
+- Do NOT include a subject line
+- Do NOT include any email signature or sign-offs (no "Best regards", "Sincerely", the sender's name, etc.)
+- The response should end with the last sentence of the main content
+${HTML_FORMATTING_INSTRUCTIONS}`,
+
   [AI_OPERATION.TONE]: `You are an AI assistant specialized in adjusting the tone of email messages.
 Rewrite the provided email content to match the requested tone while preserving the original meaning.
 
@@ -122,6 +135,7 @@ export function getUserPrompt(
   options?: {
     tone?: AIToneType
     language?: string
+    instruction?: string
     context?: {
       previousMessages?: string
       subject?: string
@@ -137,7 +151,7 @@ export function getUserPrompt(
     case AI_OPERATION.COMPOSE:
       if (options?.context?.previousMessages) {
         return `Based on the following conversation, compose an appropriate response:
-        
+
 Previous Messages:
 ${options.context.previousMessages}
 
@@ -146,6 +160,34 @@ Original Subject: ${options.context.subject || 'Email Response'}
 Generate a professional response. Remember to return ONLY the email body content without any subject line or signature. Use proper HTML formatting with <p> tags for paragraphs and <ul>/<ol> with <li> tags for any lists.${htmlReminder}`
       }
       return `Compose a professional email body about: ${options?.context?.subject || 'the topic'}. Return ONLY the body content without subject or signature. Use proper HTML formatting.${htmlReminder}`
+
+    case AI_OPERATION.CUSTOM: {
+      const instruction = options?.instruction?.trim() || 'Write an appropriate email body.'
+      // Branch on whether there's a draft to edit. With content → edit it; without
+      // → compose fresh, using thread context when available.
+      if (content) {
+        return `Apply this instruction to the email draft below.
+
+Instruction: ${instruction}
+
+Return ONLY the resulting email body content without any subject line or signature. The following content is in HTML format - preserve its HTML structure including lists:
+
+${content}${htmlReminder}`
+      }
+      const contextBlock = options?.context?.previousMessages
+        ? `\n\nFor reference, here is the conversation so far:
+
+Previous Messages:
+${options.context.previousMessages}
+
+Original Subject: ${options.context.subject || 'Email Response'}`
+        : ''
+      return `Write an email body that fulfils this instruction.
+
+Instruction: ${instruction}${contextBlock}
+
+Return ONLY the email body content without any subject line or signature. Use proper HTML formatting with <p> tags for paragraphs and <ul>/<ol> with <li> tags for any lists.${htmlReminder}`
+    }
 
     case AI_OPERATION.TONE:
       return `Rewrite this email to be ${options?.tone?.toLowerCase()}. Return ONLY the body content without adding any signature. The following content is in HTML format - preserve and maintain all HTML structure including lists:
@@ -211,6 +253,7 @@ export function getPrompt(
   options?: {
     tone?: AIToneType
     language?: string
+    instruction?: string
     context?: {
       previousMessages?: string
       subject?: string

--- a/packages/lib/src/ai-features/compose/types.ts
+++ b/packages/lib/src/ai-features/compose/types.ts
@@ -5,6 +5,7 @@
  */
 export const AI_OPERATION = {
   COMPOSE: 'compose',
+  CUSTOM: 'custom',
   TONE: 'tone',
   TRANSLATE: 'translate',
   FIX_GRAMMAR: 'fix_grammar',
@@ -82,6 +83,8 @@ export interface AIComposeRequest {
   senderId: string
   tone?: AIToneType
   language?: AILangType | string
+  /** Free-text instruction for the CUSTOM operation. */
+  instruction?: string
   output: OutputFormat
 }
 

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -41,6 +41,7 @@ import {
   GripVertical,
   Loader2,
   Search,
+  Send,
   X,
 } from 'lucide-react'
 import type { DialogProps } from 'radix-ui'
@@ -394,6 +395,78 @@ function CommandInput({
           <X className='size-3' />
         </a>
       )}
+    </div>
+  )
+}
+
+interface CommandInputWithSubmitProps
+  extends Omit<
+    React.ComponentProps<typeof CommandPrimitive.Input>,
+    'value' | 'onValueChange' | 'onSubmit'
+  > {
+  value: string
+  onValueChange: (value: string) => void
+  /** Fires on Enter (when non-empty) and on the send button. */
+  onSubmit: (value: string) => void
+  /** Fires on Escape — e.g. to step back a level. */
+  onEscape?: () => void
+  /** Leading icon slot. Defaults to nothing. */
+  leftIcon?: React.ReactNode
+  /** Swap the send icon for a spinner and block submit. */
+  loading?: boolean
+}
+
+/**
+ * A {@link CommandInput} variant with an inline submit button — for prompt-style
+ * inputs where the typed text is an instruction to run, not a filter. Pair with
+ * `<Command shouldFilter={false}>` so the list below stays static. Enter (when
+ * non-empty) and the send button both call `onSubmit`; an empty Enter falls
+ * through to cmdk so the highlighted item is selected instead.
+ */
+function CommandInputWithSubmit({
+  className,
+  value,
+  onValueChange,
+  onSubmit,
+  onEscape,
+  leftIcon,
+  loading = false,
+  ...props
+}: CommandInputWithSubmitProps) {
+  const canSubmit = !!value.trim() && !loading
+  return (
+    <div
+      className='flex items-center gap-2 border-b border-border/50 dark:border-[#323842]/80 ps-3 pe-2'
+      cmdk-input-wrapper=''>
+      {leftIcon}
+      <CommandPrimitive.Input
+        className={cn(
+          'flex h-9 w-full rounded-md bg-transparent py-1 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        onValueChange={onValueChange}
+        value={value}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && canSubmit) {
+            // Stop cmdk from also selecting the highlighted item.
+            e.preventDefault()
+            e.stopPropagation()
+            onSubmit(value.trim())
+          } else if (e.key === 'Escape' && onEscape) {
+            e.preventDefault()
+            onEscape()
+          }
+        }}
+        {...props}
+      />
+      <button
+        type='button'
+        aria-label='Run'
+        disabled={!canSubmit}
+        onClick={() => canSubmit && onSubmit(value.trim())}
+        className='grid size-6 shrink-0 place-items-center rounded-full bg-primary-500 text-white transition-colors hover:bg-primary-600 disabled:bg-muted disabled:text-muted-foreground'>
+        {loading ? <Loader2 className='size-3 animate-spin' /> : <Send className='size-3' />}
+      </button>
     </div>
   )
 }
@@ -959,6 +1032,7 @@ export {
   Command,
   CommandDialog,
   CommandInput,
+  CommandInputWithSubmit,
   CommandList,
   CommandEmpty,
   CommandPlaceholder,


### PR DESCRIPTION
## Summary

Reworks the mail composer's `/` → **Ask AI** flow from a fixed drill-in list into a focus-owning panel with a real instruction input. Typing a prompt and hitting Enter (or the inline send button) runs a new `CUSTOM` compose operation that either edits the current draft or composes a fresh body from the thread context when the body is empty.

## Changes

- **New `AI_OPERATION.CUSTOM`** wired end-to-end: `types.ts`, `prompts.ts`, `ai-compose.service.ts`, and the `aiFeature` tRPC router (validates a non-empty `instruction`; thread context is pulled for both `COMPOSE` and `CUSTOM`).
- **New `AiSlashContent` panel** (`ai-slash-content.tsx`) — instruction input + preset ops (Compose / Fix grammar / Expand / Shorten) and Tone/Translate drill-ins. Content-requiring ops disable on an empty body (chip-aware).
- **`CommandInputWithSubmit`** primitive added to `@auxx/ui/components/command` — a prompt-style command input with an inline send button.
- Drops the `hasPreviousMessages` gating from `MailAiSlashConfig`; the "Ask AI" item now always renders when AI wiring is present.
- **Tag picker cleanup**: sticky search input + breadcrumb, footer "Manage tags" toggle, removed redundant `ScrollArea`.

## Test plan

- [ ] In a reply composer, type `/` → Ask AI, enter an instruction on an empty body → composes a fresh draft from the thread.
- [ ] With existing draft content, enter an instruction → edits the draft in place.
- [ ] Preset ops (Fix grammar / Expand / Shorten) are disabled on an empty body; Compose is always enabled.
- [ ] Tone / Translate drill-ins still run their respective ops.
- [ ] Tag picker search, breadcrumb nav, and manage toggle behave as before.