### PR TITLE
fix(field-values): resolve created/updated for EntityInstance entities

### DIFF
--- a/packages/lib/src/field-values/field-value-queries.ts
+++ b/packages/lib/src/field-values/field-value-queries.ts
@@ -32,6 +32,7 @@ import {
 import {
   batchFetchSystemRelationships,
   isVirtualField,
+  resolveEntityInstanceFields,
   resolveSystemTableFields,
   resolveVirtualFields,
   type SystemFieldDescriptor,
@@ -303,6 +304,17 @@ async function batchGetAllDirectFieldValues(
     results.push(...systemResults)
   }
 
+  // EntityInstance column fields (created_at/updated_at/id on EntityDefinition entities)
+  if (categorized.entityInstanceDbFields.length > 0) {
+    const entityInstanceResults = await resolveEntityInstanceFields(
+      ctx,
+      entityDefinitionId,
+      entityInstanceIds,
+      categorized.entityInstanceDbFields
+    )
+    results.push(...entityInstanceResults)
+  }
+
   // Virtual fields (Layer 2)
   if (categorized.virtualFields.length > 0) {
     const virtualResults = await fetchVirtualFieldResults(
@@ -343,6 +355,13 @@ async function batchGetAllDirectFieldValues(
 
 interface CategorizedFields {
   systemDbFields: SystemFieldDescriptor[]
+  /**
+   * System fields backed by columns on the shared `EntityInstance` table
+   * (`id` / `createdAt` / `updatedAt`). EntityDefinition-backed resources
+   * (contact, ticket, custom entities) are not `isSystemResourceId`, so these
+   * can't go through `systemDbFields` — they resolve from EntityInstance.
+   */
+  entityInstanceDbFields: SystemFieldDescriptor[]
   virtualFields: Array<{
     fieldKey: string
     fieldId: string
@@ -352,6 +371,15 @@ interface CategorizedFields {
   }>
   fieldValueFieldIds: string[]
   fieldIdToKeyMap: Map<string, string>
+}
+
+/**
+ * Whether a dbColumn exists as a real column on the shared EntityInstance table.
+ * Used to route EntityDefinition-backed system fields (created_at/updated_at/id)
+ * to the EntityInstance resolver instead of the (empty) FieldValue query.
+ */
+function isEntityInstanceColumn(dbColumn: string): boolean {
+  return Boolean((schema.EntityInstance as Record<string, unknown>)[dbColumn])
 }
 
 /**
@@ -374,6 +402,7 @@ async function categorizeFields(
   const cachedResource = await findCachedResource(ctx.organizationId, entityDefinitionId)
 
   const systemDbFields: SystemFieldDescriptor[] = []
+  const entityInstanceDbFields: SystemFieldDescriptor[] = []
   const virtualFields: CategorizedFields['virtualFields'] = []
   const fieldValueFieldIds: string[] = []
   const fieldIdToKeyMap = new Map<string, string>()
@@ -411,13 +440,32 @@ async function categorizeFields(
         fieldOptions: fieldOptionsMap.get(fieldId),
       })
       fieldIdToKeyMap.set(cachedField.key, fieldId)
+    } else if (!isSystem && cachedField?.dbColumn && isEntityInstanceColumn(cachedField.dbColumn)) {
+      // EntityDefinition-backed resource (contact/ticket/custom): column-backed
+      // system fields (created_at/updated_at/id) live on the shared EntityInstance
+      // table, not FieldValue. Resolve them directly from EntityInstance.
+      entityInstanceDbFields.push({
+        fieldKey: cachedField.key,
+        fieldId,
+        fieldRef: ref,
+        fieldType,
+        fieldOptions: fieldOptionsMap.get(fieldId),
+        dbColumn: cachedField.dbColumn,
+        relationship: cachedField.relationship,
+      })
     } else {
       // System field stored in FieldValue (e.g. tags), or a custom/non-system field.
       fieldValueFieldIds.push(fieldId)
     }
   }
 
-  return { systemDbFields, virtualFields, fieldValueFieldIds, fieldIdToKeyMap }
+  return {
+    systemDbFields,
+    entityInstanceDbFields,
+    virtualFields,
+    fieldValueFieldIds,
+    fieldIdToKeyMap,
+  }
 }
 
 // =============================================================================

--- a/packages/lib/src/field-values/resolvers/index.ts
+++ b/packages/lib/src/field-values/resolvers/index.ts
@@ -1,6 +1,10 @@
 // packages/lib/src/field-values/resolvers/index.ts
 
 export { batchFetchSystemRelationships } from './system-relationship-resolver'
-export { resolveSystemTableFields, type SystemFieldDescriptor } from './system-table-resolver'
+export {
+  resolveEntityInstanceFields,
+  resolveSystemTableFields,
+  type SystemFieldDescriptor,
+} from './system-table-resolver'
 export { resolveThreadVirtualFields } from './thread-virtual-fields'
 export { isVirtualField, resolveVirtualFields } from './virtual-field-registry'

--- a/packages/lib/src/field-values/resolvers/system-table-resolver.ts
+++ b/packages/lib/src/field-values/resolvers/system-table-resolver.ts
@@ -129,12 +129,50 @@ async function queryWithJoinScoping(
 }
 
 /**
+ * Resolve system fields backed by real columns on the shared `EntityInstance`
+ * table (`id` / `createdAt` / `updatedAt`).
+ *
+ * EntityDefinition-backed resources (contact, ticket, custom entities) are NOT
+ * in `RESOURCE_TABLE_MAP`, so their column-backed system fields can't go through
+ * {@link resolveSystemTableFields} — every such record is a row in
+ * `EntityInstance` instead. One query per batch, org + id scoped.
+ */
+export async function resolveEntityInstanceFields(
+  ctx: FieldValueContext,
+  entityDefId: string,
+  entityIds: string[],
+  fields: SystemFieldDescriptor[]
+): Promise<TypedFieldValueResult[]> {
+  if (entityIds.length === 0 || fields.length === 0) return []
+
+  const table = schema.EntityInstance
+
+  // Build column selection: { fieldKey: drizzleColumn }
+  const selectedColumns: Record<string, any> = {}
+  for (const field of fields) {
+    const col = (table as any)[field.dbColumn]
+    if (col) {
+      selectedColumns[field.fieldKey] = col
+    }
+  }
+
+  if (Object.keys(selectedColumns).length === 0) return []
+
+  const rows = await ctx.db
+    .select({ id: table.id, ...selectedColumns })
+    .from(table)
+    .where(and(inArray(table.id, entityIds), eq(table.organizationId, ctx.organizationId)))
+
+  return mapRowsToResults(rows, fields, entityDefId)
+}
+
+/**
  * Map raw DB rows to TypedFieldValueResult[].
  */
 function mapRowsToResults(
   rows: Record<string, any>[],
   fields: SystemFieldDescriptor[],
-  entityDefId: TableId
+  entityDefId: string
 ): TypedFieldValueResult[] {
   const results: TypedFieldValueResult[] = []
 


### PR DESCRIPTION
## Problem

The property panel (`entity-fields`) leaves **Created** and **Updated** blank, while the dynamic-view table renders them correctly for the same records.

`created_at`/`updated_at`/`id` are **columns on the shared `EntityInstance` table**, not `FieldValue` rows. EntityDefinition-backed resources (contact, ticket, company, custom entities) are **not** `isSystemResourceId`, so `categorizeFields` routed these column-backed system fields to the (empty) `FieldValue` query → they come back blank for any `batchGet`-only consumer.

The table only worked *by accident*: record-list data is hydrated into the field-value store (`hydrateMultipleRecords`), and `flush()` preserves the hydrated value. The panel has no hydration — it reads purely via `useFieldValue(..., { autoFetch: true })` → `batchGet` → blank. (Custom fields work in the panel because they're real `FieldValue` rows.)

## Fix

Make `batchGet` authoritative by adding an `EntityInstance` column resolver.

- **`resolveEntityInstanceFields`** (`system-table-resolver.ts`) — one org + id scoped query against `EntityInstance`, selecting all requested `dbColumn`s for all instances in the batch (no per-field, no per-instance queries):
  ```sql
  SELECT id, "createdAt", "updatedAt" FROM "EntityInstance"
  WHERE id IN ($1, …) AND "organizationId" = $n
  ```
- **`categorizeFields`** (`field-value-queries.ts`) — routes `!isSystem` fields whose `dbColumn` exists on `EntityInstance` to the new resolver via a new `entityInstanceDbFields` bucket; everything else falls through unchanged.
- Exported the resolver from `resolvers/index.ts`.

No client change is needed: the panel already requests `<entityDef>:createdAt` via `PropertyProvider`'s auto-fetch, and `batchGet` echoes the client's original ref, so the resolved value lands on the exact store key the panel reads.

## Safety

- The column name comes from the **server field registry** (`cachedField.dbColumn`), never client input; it's validated up front by `validateFieldReferences` and double-gated by `isEntityInstanceColumn` + the resolver's `table[dbColumn]` existence check → no arbitrary column reads.
- Hard org scoping (`organizationId` from the auth context) → no cross-tenant reads.
- Matches the existing `FieldValue` / `resolveSystemTableFields` security posture; introduces no new access path.

## Scope

- Only `id` / `createdAt` / `updatedAt` qualify (the only `dbColumn`-backed fields on EntityInstance entities). Custom fields (no `dbColumn`) and FieldValue-backed system fields like tags are untouched; true system tables (thread/user) keep using `resolveSystemTableFields`.

## Verification

- Biome clean, no IDE/type diagnostics.
- Manual check recommended: open a contact/ticket/custom-entity drawer → panel Created/Updated populate; table + custom fields still render.