### PR TITLE
fix(mail): always center ThreadDisplay

### DIFF
--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -706,10 +706,7 @@ function MailboxInner({
                   </div>
                 )}
                 <div className='flex-1 overflow-hidden'>
-                  <ThreadDisplay
-                    centered={layoutMode === 'list'}
-                    expectedThreadId={selectedThreadId}
-                  />
+                  <ThreadDisplay centered expectedThreadId={selectedThreadId} />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Always center `ThreadDisplay` instead of only centering when `layoutMode === 'list'`. The thread view is now centered in both list and split layouts.

## Changes
- `apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx`: pass `centered` unconditionally to `ThreadDisplay`.

## Test plan
- [ ] Verify thread view is centered in list layout
- [ ] Verify thread view is centered in split layout