### PR TITLE
fix(workflow): exclude hidden app-block fields from single-node inputs

### DIFF
--- a/apps/web/src/lib/workflow/components/app-workflow-panel.tsx
+++ b/apps/web/src/lib/workflow/components/app-workflow-panel.tsx
@@ -14,6 +14,7 @@ import { reconstructReactTree } from '~/lib/extensions/reconstruct-react-tree'
 import { useOptionalMessageClient } from '~/lib/extensions/use-optional-message-client'
 import { useExtensionsContext } from '~/providers/extensions/extensions-context'
 import type { WorkflowBlock } from '../types'
+import { collectHiddenFields } from '../utils/collect-hidden-fields'
 import { computeOutputSignature, resolveAppBlockOutputFields } from '../utils/resolve-app-outputs'
 import { convertOutputFieldsToVariables } from '../utils/type-mapping'
 import { AppPollingSection } from './app-polling-section'
@@ -328,6 +329,21 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
 
       return unsubscribe
     }, [nodeId, messageClient])
+
+    // Track which input fields are currently hidden by a ConditionalRender so
+    // the single-node Input tab and variable extraction can ignore stale values
+    // from fields that don't apply to the active operation. Derived from the
+    // rendered panel tree (the iframe already evaluated each condition) and
+    // stashed under `_hiddenFields` — a `_`-prefixed key, so it's ephemeral and
+    // stripped on save. Absent for nodes whose panel was never opened.
+    useEffect(() => {
+      if (!panelComponent) return
+      const hidden = collectHiddenFields(panelComponent)
+      const prev = (nodeDataRef.current._hiddenFields as string[] | undefined) ?? []
+      // Stable compare (collectHiddenFields returns sorted) to avoid update loops
+      if (hidden.length === prev.length && hidden.every((f, i) => f === prev[i])) return
+      setInputs({ ...nodeDataRef.current, _hiddenFields: hidden })
+    }, [panelComponent, setInputs])
 
     // Send data updates to iframe when React Flow data changes
     // biome-ignore lint/correctness/useExhaustiveDependencies: panelComponent is intentionally excluded - only send when nodeData changes

--- a/apps/web/src/lib/workflow/utils/collect-hidden-fields.test.ts
+++ b/apps/web/src/lib/workflow/utils/collect-hidden-fields.test.ts
@@ -1,0 +1,79 @@
+// apps/web/src/lib/workflow/utils/collect-hidden-fields.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { collectHiddenFields } from './collect-hidden-fields'
+
+/** Build a ConditionalRender node with a serialized `shouldRender` result. */
+const cond = (shouldRender: boolean, children: any[]) => ({
+  instance_type: 'instance',
+  component: 'ConditionalRenderInternal',
+  attributes: { shouldRender },
+  children,
+})
+
+/** Build an input field node carrying its `name`. */
+const field = (name: string) => ({
+  instance_type: 'instance',
+  component: 'StringInputInternal',
+  attributes: { name },
+  children: [],
+})
+
+/** Wrap children in a layout node (no name, no condition) — should be transparent. */
+const layout = (children: any[]) => ({
+  instance_type: 'instance',
+  component: 'SectionInternal',
+  attributes: {},
+  children,
+})
+
+describe('collectHiddenFields', () => {
+  it('returns [] for a null/empty tree', () => {
+    expect(collectHiddenFields(null)).toEqual([])
+    expect(collectHiddenFields(undefined)).toEqual([])
+    expect(collectHiddenFields({ children: [] })).toEqual([])
+  })
+
+  it('does not hide fields outside any ConditionalRender', () => {
+    const tree = { children: [field('operation'), field('connectionId')] }
+    expect(collectHiddenFields(tree)).toEqual([])
+  })
+
+  it('hides fields under a shouldRender=false ConditionalRender', () => {
+    const tree = {
+      children: [
+        cond(true, [field('getOrderId')]),
+        cond(false, [field('getManyLimit'), field('getManyStatus')]),
+      ],
+    }
+    expect(collectHiddenFields(tree)).toEqual(['getManyLimit', 'getManyStatus'])
+  })
+
+  it('finds fields nested deep inside layout wrappers', () => {
+    const tree = {
+      children: [cond(false, [layout([layout([field('getOrderId')])])])],
+    }
+    expect(collectHiddenFields(tree)).toEqual(['getOrderId'])
+  })
+
+  it('treats a hidden ancestor as dominant over a visible nested condition', () => {
+    const tree = {
+      children: [cond(false, [cond(true, [field('createEmail')])])],
+    }
+    expect(collectHiddenFields(tree)).toEqual(['createEmail'])
+  })
+
+  it('hides a field under a nested shouldRender=false even when the outer is visible', () => {
+    const tree = {
+      children: [cond(true, [field('createEmail'), cond(false, [field('createTestFlag')])])],
+    }
+    expect(collectHiddenFields(tree)).toEqual(['createTestFlag'])
+  })
+
+  it('de-duplicates and sorts', () => {
+    const tree = {
+      children: [cond(false, [field('b'), field('a'), field('b')])],
+    }
+    expect(collectHiddenFields(tree)).toEqual(['a', 'b'])
+  })
+})

--- a/apps/web/src/lib/workflow/utils/collect-hidden-fields.ts
+++ b/apps/web/src/lib/workflow/utils/collect-hidden-fields.ts
@@ -1,0 +1,52 @@
+// apps/web/src/lib/workflow/utils/collect-hidden-fields.ts
+
+/**
+ * A node in the serialized app-panel tree (see `reconstruct-react-tree.tsx`).
+ * Only the fields relevant to visibility are typed here.
+ */
+interface PanelTreeNode {
+  component?: string
+  attributes?: Record<string, any>
+  children?: PanelTreeNode[]
+}
+
+/**
+ * Walk a serialized app workflow panel tree and return the names of input
+ * fields that are currently hidden by a `ConditionalRender`.
+ *
+ * App blocks declare per-operation field visibility in their panel via
+ * `<ConditionalRender when={(d) => d.operation === 'get'}>`. The reconciler
+ * evaluates that predicate inside the iframe and serializes only the resulting
+ * `shouldRender` boolean (`ConditionalRenderInternal`), with the input fields —
+ * each carrying its `name` — nested beneath it. The host can't re-evaluate the
+ * predicate, but it already receives this tree, so a field is hidden iff it sits
+ * under a `ConditionalRender` whose `shouldRender` is `false`.
+ *
+ * Visibility composes: once an ancestor is hidden, everything beneath it is
+ * hidden too, so nested `ConditionalRender`s are handled for free.
+ *
+ * @returns sorted, de-duplicated list of hidden field names
+ */
+export function collectHiddenFields(
+  root: { children?: PanelTreeNode[] } | null | undefined
+): string[] {
+  const hidden = new Set<string>()
+
+  const walk = (node: PanelTreeNode | null | undefined, inheritedHidden: boolean): void => {
+    if (!node) return
+
+    const isHidden =
+      inheritedHidden ||
+      (node.component === 'ConditionalRenderInternal' && node.attributes?.shouldRender === false)
+
+    if (isHidden && typeof node.attributes?.name === 'string') {
+      hidden.add(node.attributes.name)
+    }
+
+    node.children?.forEach((child) => walk(child, isHidden))
+  }
+
+  root?.children?.forEach((child) => walk(child, false))
+
+  return Array.from(hidden).sort()
+}

--- a/apps/web/src/lib/workflow/workflow-block-registry.tsx
+++ b/apps/web/src/lib/workflow/workflow-block-registry.tsx
@@ -355,10 +355,18 @@ export class WorkflowBlockRegistry {
    */
   private extractAppBlockVariables(block: WorkflowBlock, data: any): string[] {
     const fieldModes: Record<string, boolean> = data?.fieldModes || {}
+    // Fields hidden by a ConditionalRender for the current operation. Their
+    // stale values must not leak into the Input tab's required variables — e.g.
+    // switching `order` from `get` to `getMany` leaves a `{{var}}` in the now-
+    // hidden `getOrderId`. Populated by AppWorkflowPanel from the rendered panel
+    // tree; absent (→ no filtering) for nodes whose panel was never opened.
+    const hiddenFields = new Set<string>((data?._hiddenFields as string[]) || [])
     const variables = new Set<string>()
     const varPattern = /\{\{([^}]+)\}\}/g
 
     for (const fieldName of Object.keys(block.schema.inputs || {})) {
+      // Skip fields not visible for the current operation/resource
+      if (hiddenFields.has(fieldName)) continue
       // Only extract from fields in variable mode (constant mode = true/undefined)
       if (fieldModes[fieldName] !== false) continue
 


### PR DESCRIPTION
## Problem

App blocks gate fields per operation via `<ConditionalRender when={(d) => d.operation === 'get'}>`, evaluated **inside the iframe**. Switching operation (e.g. Shopify `order` `get` → `getMany`) hid the old operation's fields visually, **but left their values in node data**. The single-node **Input tab** then kept demanding a variable for a now-hidden field (e.g. `getOrderId` still holding `{{extractor.order_number}}`), and since `canRun` requires every listed variable to be filled, the node couldn't be run.

Root cause: `extractAppBlockVariables` (`workflow-block-registry.tsx`) scanned every variable-mode field in the schema with no awareness of current visibility — and the serialized field schema carries no visibility metadata, since the `when` predicate only ever exists in the iframe.

## Fix

The host **already receives the serialized panel tree**, which carries each `ConditionalRender`'s `shouldRender` boolean plus the field `name`s nested under it. So no SDK/schema/authoring changes are needed:

- **`utils/collect-hidden-fields.ts`** — walks that tree and returns field names sitting under any `ConditionalRender` with `shouldRender === false`. Nested conditions compose for free (a hidden ancestor dominates).
- **`AppWorkflowPanel`** — when the panel tree updates (i.e. the operation changes), records the hidden set on the node as `_hiddenFields`. The `_` prefix means it's stripped on save (`use-workflow-save.ts`), so it's ephemeral and never persisted.
- **`extractAppBlockVariables`** — skips any field in `_hiddenFields` before extracting its `{{variable}}` refs. Single choke point for both the Input tab and `runWithDefaults`.

## Scope / notes

- **Host-only.** The backend extractor still over-asks, but that's benign here (the stale `{{var}}` still resolves and `getMany` ignores it); only a reference to a since-deleted variable would fail. Left as-is.
- **Fallback.** A node whose panel was never opened has no `_hiddenFields` → prior behavior, no regression.
- No SDK, schema, or app-authoring changes.

## Tests

`collect-hidden-fields.test.ts` — 7 vitest cases (all pass): no-condition fields stay visible, `shouldRender:false` hides, deep layout nesting, hidden-ancestor dominance, nested `false` under a visible outer, dedup/sort, null tree.