### PR TITLE
feat(actions): dynamic-select quick-action inputs

### DIFF
--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -4,6 +4,7 @@ import type { IdentifierType } from '@auxx/database/types'
 import { PLATFORM_CAPABILITIES, type PlatformCapabilities } from '@auxx/lib/channels/client'
 import type { DraftActionPayload } from '@auxx/lib/quick-actions/client'
 import { type ParticipantRole, toParticipantId } from '@auxx/types'
+import { toRecordId } from '@auxx/types/resource'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Separator } from '@auxx/ui/components/separator'
@@ -29,6 +30,7 @@ import {
   toAttachmentMeta,
 } from '~/components/threads/hooks/append-optimistic-message'
 import type { MessageMeta } from '~/components/threads/store/message-store'
+import { useParticipantStore } from '~/components/threads/store/participant-store'
 import { getThreadStoreState } from '~/components/threads/store/thread-store'
 import { useAnalytics } from '~/hooks/use-analytics'
 import { useConfirm } from '~/hooks/use-confirm'
@@ -930,6 +932,25 @@ function ReplyComposeEditorComponent({
     return null
   }, [sourceMessage, state.sourceMessageId, thread])
 
+  // Resolve the thread's primary contact record for dynamic-select quick-action
+  // inputs — the sender (`from:`) of the message being replied to, mapped to its
+  // linked contact entity instance. Null when unlinked → pickers render disabled.
+  const contactParticipantId = useMemo(() => {
+    const from = messageForPrevComponent?.participants?.find(
+      (p) => p.role?.toUpperCase() === 'FROM'
+    )
+    return from?.participant?.id ?? null
+  }, [messageForPrevComponent])
+  const contactEntityInstanceId = useParticipantStore((s) =>
+    contactParticipantId
+      ? (s.participants.get(contactParticipantId)?.entityInstanceId ?? null)
+      : null
+  )
+  const contactRecordId = useMemo(
+    () => (contactEntityInstanceId ? toRecordId('contact', contactEntityInstanceId) : null),
+    [contactEntityInstanceId]
+  )
+
   return (
     <>
       <ConfirmDialog />
@@ -1217,6 +1238,7 @@ function ReplyComposeEditorComponent({
                   )
                 }
                 threadId={thread?.id || state.threadId || undefined}
+                contactRecordId={contactRecordId}
                 disabled={isSending}
                 popoverClassName={popoverZIndex}
                 onPopoverOpenChange={(open) =>

--- a/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
+++ b/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
@@ -26,6 +26,7 @@ import { useCallback, useMemo, useRef, useState } from 'react'
 import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
 import { useQuickActions } from '~/hooks/use-quick-actions'
 import type { SerializedQuickAction } from '~/lib/workflow/workflow-block-loader'
+import { api } from '~/trpc/react'
 
 interface QuickActionPanelProps {
   actions: DraftActionPayload[]
@@ -34,6 +35,9 @@ interface QuickActionPanelProps {
   onUpdate: (actionId: string, inputs: Record<string, unknown>) => void
   threadId?: string
   ticketId?: string
+  /** The thread's primary contact record id (`contact:<instanceId>`), if known.
+   * Dynamic-select inputs bind their options against it. */
+  contactRecordId?: string | null
   disabled?: boolean
   popoverClassName?: string
   onPopoverOpenChange?: (open: boolean) => void
@@ -46,6 +50,7 @@ export function QuickActionPanel({
   disabled,
   threadId,
   ticketId,
+  contactRecordId,
   popoverClassName,
   onPopoverOpenChange,
 }: QuickActionPanelProps) {
@@ -82,6 +87,7 @@ export function QuickActionPanel({
               key={`${action.appId}:${action.actionId}`}
               action={action}
               schema={schemaByKey.get(`${action.appId}:${action.actionId}`)}
+              contactRecordId={contactRecordId}
               onRemove={() => onRemove(action.actionId)}
               onUpdate={onUpdate}
               disabled={disabled}
@@ -98,6 +104,7 @@ export function QuickActionPanel({
 function QuickActionChip({
   action,
   schema,
+  contactRecordId,
   onRemove,
   onUpdate,
   disabled,
@@ -106,6 +113,7 @@ function QuickActionChip({
 }: {
   action: DraftActionPayload
   schema?: { inputs: Record<string, any> }
+  contactRecordId?: string | null
   onRemove: () => void
   onUpdate: (actionId: string, inputs: Record<string, unknown>) => void
   disabled?: boolean
@@ -172,6 +180,10 @@ function QuickActionChip({
                 fields={schema.inputs}
                 values={action.inputs}
                 onChange={(inputs) => onUpdate(action.actionId, inputs)}
+                appId={action.appId}
+                installationId={action.installationId}
+                actionId={action.actionId}
+                contactRecordId={contactRecordId}
                 disabled={disabled}
                 popoverClassName={popoverClassName}
                 onPopoverOpenChange={onPopoverOpenChange}
@@ -336,6 +348,10 @@ function QuickActionForm({
   fields,
   values,
   onChange,
+  appId,
+  installationId,
+  actionId,
+  contactRecordId,
   disabled,
   popoverClassName,
   onPopoverOpenChange,
@@ -343,6 +359,10 @@ function QuickActionForm({
   fields: Record<string, any>
   values: Record<string, unknown>
   onChange: (values: Record<string, unknown>) => void
+  appId: string
+  installationId: string
+  actionId: string
+  contactRecordId?: string | null
   disabled?: boolean
   popoverClassName?: string
   onPopoverOpenChange?: (open: boolean) => void
@@ -359,6 +379,10 @@ function QuickActionForm({
           field={field}
           value={values[key]}
           onChange={(v) => onChange({ ...values, [key]: v })}
+          appId={appId}
+          installationId={installationId}
+          actionId={actionId}
+          contactRecordId={contactRecordId}
           disabled={disabled}
           popoverClassName={popoverClassName}
           onPopoverOpenChange={onPopoverOpenChange}
@@ -373,6 +397,10 @@ function QuickActionField({
   field,
   value,
   onChange,
+  appId,
+  installationId,
+  actionId,
+  contactRecordId,
   disabled,
   popoverClassName,
   onPopoverOpenChange,
@@ -381,6 +409,10 @@ function QuickActionField({
   field: any
   value: unknown
   onChange: (value: unknown) => void
+  appId: string
+  installationId: string
+  actionId: string
+  contactRecordId?: string | null
   disabled?: boolean
   popoverClassName?: string
   onPopoverOpenChange?: (open: boolean) => void
@@ -388,6 +420,25 @@ function QuickActionField({
   const label = field.label || fieldKey
 
   switch (field.type) {
+    case 'dynamic-select':
+      return (
+        <QuickActionDynamicSelectField
+          label={label}
+          value={(value as string) ?? ''}
+          onChange={onChange}
+          appId={appId}
+          installationId={installationId}
+          actionId={actionId}
+          fieldKey={fieldKey}
+          contactRecordId={contactRecordId}
+          emptyHint={field.dynamicSelect?.emptyHint}
+          placeholder={field.placeholder}
+          disabled={disabled}
+          popoverClassName={popoverClassName}
+          onPopoverOpenChange={onPopoverOpenChange}
+        />
+      )
+
     case 'string':
       return (
         <div className='flex items-center gap-2'>
@@ -480,6 +531,100 @@ function QuickActionField({
       }
       return null
   }
+}
+
+/**
+ * A select whose options are loaded at open time from `quickAction.resolveOptions`
+ * — the app's resolver tool run against the thread's contact. When no contact is
+ * linked or zero options resolve, the control renders disabled with the hint
+ * (decision 6 — show, don't hide). See plans/actions/09-dynamic-action-inputs.md.
+ */
+function QuickActionDynamicSelectField({
+  label,
+  value,
+  onChange,
+  appId,
+  installationId,
+  actionId,
+  fieldKey,
+  contactRecordId,
+  emptyHint,
+  placeholder,
+  disabled,
+  popoverClassName,
+  onPopoverOpenChange,
+}: {
+  label: string
+  value: string
+  onChange: (value: unknown) => void
+  appId: string
+  installationId: string
+  actionId: string
+  fieldKey: string
+  contactRecordId?: string | null
+  emptyHint?: string
+  placeholder?: string
+  disabled?: boolean
+  popoverClassName?: string
+  onPopoverOpenChange?: (open: boolean) => void
+}) {
+  const [opened, setOpened] = useState(false)
+  // Fetch when the picker is opened, or up-front when a value is already stored
+  // (so we can render its label). Cached for the compose session — charges don't
+  // change mid-compose, so re-opening doesn't re-invoke the lambda.
+  const enabled = !!contactRecordId && (opened || !!value)
+  const optionsQuery = api.quickAction.resolveOptions.useQuery(
+    {
+      appId,
+      installationId,
+      actionId,
+      fieldKey,
+      recordId: contactRecordId ?? '',
+    },
+    { enabled, staleTime: 60_000, refetchOnWindowFocus: false }
+  )
+
+  const resolved = optionsQuery.data?.options ?? []
+  const comboOptions = resolved.map((o) => ({
+    value: o.value,
+    label: o.sublabel ? `${o.label} — ${o.sublabel}` : o.label,
+  }))
+  // Keep a previously-picked value visible even before/without a fresh load.
+  if (value && !comboOptions.some((o) => o.value === value)) {
+    comboOptions.unshift({ value, label: value })
+  }
+
+  const noOptions = enabled && !optionsQuery.isLoading && resolved.length === 0
+  const hintText =
+    (!contactRecordId ? emptyHint : optionsQuery.data?.disabledHint) ??
+    emptyHint ??
+    'No options available'
+  // Disabled when there's nothing to pick (no contact, or resolved empty) and no
+  // value already chosen.
+  const isDisabled = disabled || ((!contactRecordId || noOptions) && !value)
+
+  return (
+    <div className='flex items-center gap-2'>
+      <label className='min-w-16 shrink-0 text-xs text-muted-foreground'>{label}</label>
+      <Combobox
+        options={comboOptions}
+        placeholder={isDisabled ? hintText : placeholder || 'Select...'}
+        emptyText={optionsQuery.isLoading ? 'Loading…' : hintText}
+        value={value}
+        onChangeValue={(v) => onChange(v || undefined)}
+        loading={optionsQuery.isLoading}
+        disabled={isDisabled}
+        variant='outline'
+        size='sm'
+        className='h-6 text-xs'
+        popoverClassName={popoverClassName}
+        onOpenChange={(o) => {
+          if (o) setOpened(true)
+          onPopoverOpenChange?.(o)
+        }}
+      />
+    </div>
+  )
 }
 
 function QuickActionCurrencyField({

--- a/apps/web/src/hooks/use-quick-actions.ts
+++ b/apps/web/src/hooks/use-quick-actions.ts
@@ -41,7 +41,8 @@ function installationToActions(installation: AppInstallation): SerializedQuickAc
     color: action.color,
     // The catalog ships tool inputs as a JSON Schema; the quick-action form
     // reads the SDK field-descriptor map. Bridge here (see comment on the fn).
-    inputs: jsonSchemaToActionFields(action.inputsJsonSchema),
+    // `inputHints` layers dynamic-select pickers over named inputs.
+    inputs: jsonSchemaToActionFields(action.inputsJsonSchema, action.inputHints),
     outputs: {},
     defaults: {},
     appId: installation.app.id,
@@ -62,7 +63,8 @@ function installationToActions(installation: AppInstallation): SerializedQuickAc
  * derived from the field key.
  */
 export function jsonSchemaToActionFields(
-  schema: Record<string, any> | undefined
+  schema: Record<string, any> | undefined,
+  inputHints?: Record<string, any> | null
 ): Record<string, any> {
   const properties = schema?.properties as Record<string, any> | undefined
   if (!properties) return {}
@@ -70,7 +72,15 @@ export function jsonSchemaToActionFields(
 
   const fields: Record<string, any> = {}
   for (const [key, prop] of Object.entries(properties)) {
-    fields[key] = jsonSchemaPropToField(key, prop, required.includes(key))
+    const base = jsonSchemaPropToField(key, prop, required.includes(key))
+    // A dynamic-select hint wins over the JSON-Schema-derived type: the field
+    // renders a live, contact-scoped picker instead of a text/number input.
+    const hint = inputHints?.[key]
+    if (hint?.kind === 'dynamic-select') {
+      fields[key] = { ...base, type: 'dynamic-select', dynamicSelect: hint.dynamicSelect }
+    } else {
+      fields[key] = base
+    }
   }
   return fields
 }

--- a/apps/web/src/server/api/routers/quick-actions.ts
+++ b/apps/web/src/server/api/routers/quick-actions.ts
@@ -1,6 +1,6 @@
 // apps/web/src/server/api/routers/quick-actions.ts
 
-import { QuickActionExecutor } from '@auxx/lib/quick-actions'
+import { QuickActionExecutor, resolveQuickActionOptions } from '@auxx/lib/quick-actions'
 import { TicketEventType, TimelineActorType, TimelineEntityType } from '@auxx/lib/timeline'
 import { createScopedLogger } from '@auxx/logger'
 import { createTimelineEvent } from '@auxx/services/timeline'
@@ -104,5 +104,63 @@ export const quickActionRouter = createTRPCRouter({
       }
 
       return results
+    }),
+
+  /**
+   * Resolve the live options for a quick-action `dynamic-select` input (e.g. the
+   * Stripe charges for the thread's contact). Read-only — runs the app's resolver
+   * tool, scoped to `recordId`. See plans/actions/09-dynamic-action-inputs.md.
+   */
+  resolveOptions: protectedProcedure
+    .input(
+      z.object({
+        appId: z.string(),
+        installationId: z.string(),
+        actionId: z.string(),
+        fieldKey: z.string(),
+        recordId: z.string(),
+        query: z.string().optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+
+      // Validate the subject record belongs to the caller's org before binding.
+      const [entityDefinitionId, entityInstanceId] = input.recordId.split(':')
+      if (!entityDefinitionId || !entityInstanceId) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid recordId' })
+      }
+      const instance = await ctx.db.query.EntityInstance.findFirst({
+        where: (rows, { eq, and }) =>
+          and(eq(rows.id, entityInstanceId), eq(rows.organizationId, organizationId)),
+        columns: { id: true },
+      })
+      if (!instance) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Record not found' })
+      }
+
+      const organization = await ctx.db.query.Organization.findFirst({
+        where: (orgs, { eq }) => eq(orgs.id, organizationId),
+      })
+      if (!organization?.handle) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Organization not found' })
+      }
+      const user = await ctx.db.query.User.findFirst({
+        where: (users, { eq }) => eq(users.id, userId),
+      })
+
+      return resolveQuickActionOptions({
+        appId: input.appId,
+        installationId: input.installationId,
+        actionId: input.actionId,
+        fieldKey: input.fieldKey,
+        recordId: input.recordId,
+        query: input.query,
+        organizationId,
+        organizationHandle: organization.handle,
+        userId,
+        userEmail: user?.email ?? '',
+        userName: user?.name ?? '',
+      })
     }),
 })

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -78,6 +78,25 @@ export interface CatalogAgentTool extends CatalogTool {
   }>
 }
 
+/**
+ * Per-input presentation override for the quick-action form. Lock-step copy of
+ * the SDK `ActionInputHint` (`packages/sdk/src/root/tools/types.ts`) — the
+ * database package can't depend on the published SDK. See
+ * plans/actions/09-dynamic-action-inputs.md.
+ */
+export type ActionInputHint = { kind: 'dynamic-select'; dynamicSelect: DynamicSelectHint }
+
+export interface DynamicSelectHint {
+  optionsFrom: string
+  bindArgsFrom?: Record<string, string>
+  args?: Record<string, unknown>
+  valuePath: string
+  itemsPath?: string
+  labelTemplate: string
+  sublabelTemplate?: string
+  emptyHint?: string
+}
+
 export interface CatalogAction {
   toolId: string
   label: string
@@ -87,6 +106,8 @@ export interface CatalogAction {
   surface: 'ticket-header' | 'email-editor'
   requiresConfirmation?: boolean
   confirmationMessage?: string
+  /** Per-input presentation overrides, carried verbatim from `tool.action.inputs`. */
+  inputHints?: Record<string, ActionInputHint>
 }
 
 export interface CatalogToolset {

--- a/packages/lib/src/agents/bindings/index.ts
+++ b/packages/lib/src/agents/bindings/index.ts
@@ -3,5 +3,5 @@
 export { buildApplyBindings } from './apply'
 export { computeEffectiveBindings } from './effective'
 export { projectBindingSchemas } from './project-schema'
-export { buildResolveVarSource } from './resolve'
+export { buildResolveVarSource, resolveAppFieldValue } from './resolve'
 export type { ToolBindingMap, VarRef, VarSource } from './types'

--- a/packages/lib/src/agents/bindings/resolve.ts
+++ b/packages/lib/src/agents/bindings/resolve.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/agents/bindings/resolve.ts
 
+import { type Database, database } from '@auxx/database'
 import { extractValue, type TypedFieldValue } from '@auxx/types'
 import type {
   FieldPath,
@@ -15,7 +16,7 @@ import {
   parseResourceFieldId,
   toResourceFieldId,
 } from '@auxx/types/field'
-import { parseRecordId } from '@auxx/types/resource'
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
 import type { Subject, ToolContext } from '../../ai/agent-framework/tool-context'
 import {
   getCachedEntityDefId,
@@ -132,6 +133,21 @@ function parseAppSegment(fieldPart: string): { slug: string; key: string } | nul
  * pass through unchanged.
  */
 async function resolveAppSegments(ref: VarRef, ctx: ToolContext): Promise<VarRef | null> {
+  return resolveAppSegmentsWith(ref, ctx.organizationId, (slug) => ctx.appAccounts?.[slug]?.credId)
+}
+
+/**
+ * Connection-explicit core of {@link resolveAppSegments}. `credIdForSlug` returns
+ * the bound connection id for an app slug — the agent reads it from
+ * `ctx.appAccounts`, the quick-action picker passes the workspace connection
+ * id (one app, one connection). Returns `null` when any `@app:` segment can't
+ * resolve (no connection, no provisioned field).
+ */
+async function resolveAppSegmentsWith(
+  ref: VarRef,
+  orgId: string,
+  credIdForSlug: (slug: string) => string | undefined
+): Promise<VarRef | null> {
   const segments: ResourceFieldId[] = isFieldPath(ref) ? ref : [ref]
   const rewritten: ResourceFieldId[] = []
 
@@ -142,16 +158,46 @@ async function resolveAppSegments(ref: VarRef, ctx: ToolContext): Promise<VarRef
       rewritten.push(segment)
       continue
     }
-    const credId = ctx.appAccounts?.[app.slug]?.credId
+    const credId = credIdForSlug(app.slug)
     if (!credId) return null // no bound store → "connect a store"
-    const entityDefId = await getCachedEntityDefId(ctx.organizationId, slug)
+    const entityDefId = await getCachedEntityDefId(orgId, slug)
     if (!entityDefId) return null
-    const cfId = await resolveAppFieldId(ctx.organizationId, entityDefId, app.slug, app.key, credId)
+    const cfId = await resolveAppFieldId(orgId, entityDefId, app.slug, app.key, credId)
     if (!cfId) return null
     rewritten.push(toResourceFieldId(entityDefId, cfId))
   }
 
   return isFieldPath(ref) ? (rewritten as FieldPath) : rewritten[0]!
+}
+
+/**
+ * Read a single field value off a known record, resolving `@app:<slug>:<key>`
+ * segments against an explicit connection. The decoupled core shared by the
+ * agent binding resolver and the quick-action `resolveOptions` endpoint — it
+ * needs only `(orgId, recordId, connectionId)`, never a `ToolContext`/`Subject`.
+ *
+ * Returns `undefined` when the ref can't resolve (no provisioned field, empty
+ * value) — the caller treats that as the disabled/empty state. See
+ * plans/actions/09-dynamic-action-inputs.md.
+ */
+export async function resolveAppFieldValue(params: {
+  orgId: string
+  recordId: RecordId
+  ref: string
+  connectionId: string
+  db?: Database
+}): Promise<unknown> {
+  const { orgId, recordId, ref, connectionId, db = database } = params
+  const resolved = await resolveAppSegmentsWith(ref as VarRef, orgId, () => connectionId)
+  if (!resolved) return undefined
+  if (fieldPartOf(resolved) === 'self') return parseRecordId(recordId).entityInstanceId
+
+  const service = new FieldValueService(orgId, undefined, db)
+  const result = await service.batchGetValues({
+    recordIds: [recordId],
+    fieldReferences: [resolved],
+  })
+  return firstScalar(result.values)
 }
 
 /**

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -508,7 +508,8 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   overages: { prefix: 'org:overages', ttlSeconds: 900 },
   orgSettings: { prefix: 'org:settings', ttlSeconds: ONE_DAY },
   // v2: connectionDefinition (singular) → connectionDefinitions (pair). Bump on shape changes.
-  installedApps: { prefix: 'org:installed-apps:v3', ttlSeconds: 900 },
+  // v4: CachedAction.inputHints (dynamic-select pickers). See plans/actions/09-dynamic-action-inputs.md.
+  installedApps: { prefix: 'org:installed-apps:v4', ttlSeconds: 900 },
   mcpServers: { prefix: 'org:mcpServers', ttlSeconds: ONE_DAY },
   workflowApps: { prefix: 'org:workflow-apps', ttlSeconds: ONE_DAY },
 

--- a/packages/lib/src/quick-actions/__tests__/resolve-options.test.ts
+++ b/packages/lib/src/quick-actions/__tests__/resolve-options.test.ts
@@ -1,0 +1,90 @@
+// packages/lib/src/quick-actions/__tests__/resolve-options.test.ts
+
+import type { DynamicSelectHint } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { mapResolverOutputToOptions } from '../resolve-options'
+
+const STRIPE_HINT: DynamicSelectHint = {
+  optionsFrom: 'list_stripe_charges_for_customer',
+  itemsPath: 'charges',
+  valuePath: 'chargeId',
+  labelTemplate: '{amount} {currency} · {status}',
+  sublabelTemplate: '{description}',
+  emptyHint: 'No Stripe customer linked to this contact',
+}
+
+const SAMPLE = {
+  charges: [
+    {
+      chargeId: 'ch_1',
+      amount: 2400,
+      currency: 'usd',
+      status: 'succeeded',
+      description: 'Order #1042',
+    },
+    {
+      chargeId: 'ch_2',
+      amount: 999,
+      currency: 'usd',
+      status: 'refunded',
+      description: 'Order #1043',
+    },
+  ],
+  truncated: false,
+}
+
+describe('mapResolverOutputToOptions', () => {
+  it('maps items at itemsPath through value/label/sublabel templates', () => {
+    const { options, disabledHint } = mapResolverOutputToOptions(SAMPLE, STRIPE_HINT)
+    expect(disabledHint).toBeNull()
+    expect(options).toEqual([
+      { value: 'ch_1', label: '2400 usd · succeeded', sublabel: 'Order #1042' },
+      { value: 'ch_2', label: '999 usd · refunded', sublabel: 'Order #1043' },
+    ])
+  })
+
+  it('returns the emptyHint when nothing resolves', () => {
+    expect(mapResolverOutputToOptions({ charges: [] }, STRIPE_HINT)).toEqual({
+      options: [],
+      disabledHint: 'No Stripe customer linked to this contact',
+    })
+  })
+
+  it('locally filters by query across value, label, and sublabel', () => {
+    const byStatus = mapResolverOutputToOptions(SAMPLE, STRIPE_HINT, 'refunded')
+    expect(byStatus.options.map((o) => o.value)).toEqual(['ch_2'])
+
+    const byValue = mapResolverOutputToOptions(SAMPLE, STRIPE_HINT, 'ch_1')
+    expect(byValue.options.map((o) => o.value)).toEqual(['ch_1'])
+
+    const byDescription = mapResolverOutputToOptions(SAMPLE, STRIPE_HINT, '1042')
+    expect(byDescription.options.map((o) => o.value)).toEqual(['ch_1'])
+  })
+
+  it('drops rows missing the value path', () => {
+    const data = {
+      charges: [
+        { amount: 100 },
+        { chargeId: 'ch_ok', amount: 200, currency: 'usd', status: 'paid' },
+      ],
+    }
+    const { options } = mapResolverOutputToOptions(data, STRIPE_HINT)
+    expect(options.map((o) => o.value)).toEqual(['ch_ok'])
+  })
+
+  it('treats the output as the array when no itemsPath is set', () => {
+    const hint: DynamicSelectHint = { ...STRIPE_HINT, itemsPath: undefined }
+    const { options } = mapResolverOutputToOptions(SAMPLE.charges, hint)
+    expect(options.map((o) => o.value)).toEqual(['ch_1', 'ch_2'])
+  })
+
+  it('falls back to the value when the label template renders empty', () => {
+    const hint: DynamicSelectHint = {
+      optionsFrom: 'x',
+      valuePath: 'id',
+      labelTemplate: '{missing}',
+    }
+    const { options } = mapResolverOutputToOptions([{ id: 'abc' }], hint)
+    expect(options).toEqual([{ value: 'abc', label: 'abc', sublabel: undefined }])
+  })
+})

--- a/packages/lib/src/quick-actions/index.ts
+++ b/packages/lib/src/quick-actions/index.ts
@@ -1,6 +1,12 @@
 // packages/lib/src/quick-actions/index.ts
 
 export { QuickActionExecutor } from './quick-action-executor'
+export {
+  type QuickActionOption,
+  type ResolveQuickActionOptionsInput,
+  type ResolveQuickActionOptionsResult,
+  resolveQuickActionOptions,
+} from './resolve-options'
 export type {
   DraftActionPayload,
   ExecuteQuickActionsInput,

--- a/packages/lib/src/quick-actions/resolve-options.ts
+++ b/packages/lib/src/quick-actions/resolve-options.ts
@@ -1,0 +1,230 @@
+// packages/lib/src/quick-actions/resolve-options.ts
+
+import type { DynamicSelectHint } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { RecordId } from '@auxx/types/resource'
+import { resolveAppFieldValue } from '../agents/bindings'
+import { getCachedInstalledApps } from '../cache/org-cache-helpers'
+
+const logger = createScopedLogger('quick-action-resolve-options')
+
+/** Input for {@link resolveQuickActionOptions}. */
+export interface ResolveQuickActionOptionsInput {
+  appId: string
+  installationId: string
+  /** The action tool id — used to look up its `inputHints`. */
+  actionId: string
+  /** Which dynamic-select input on the action. */
+  fieldKey: string
+  /** The subject record to bind against (`<entityDefId>:<entityInstanceId>`). */
+  recordId: string
+  /** Search term — filters the resolved list locally (never sent to the resolver). */
+  query?: string
+  organizationId: string
+  organizationHandle: string
+  userId: string
+  userEmail: string
+  userName: string
+}
+
+export interface QuickActionOption {
+  value: string
+  label: string
+  sublabel?: string
+}
+
+export interface ResolveQuickActionOptionsResult {
+  options: QuickActionOption[]
+  /** Hint shown disabled when no options resolve; null when there are options. */
+  disabledHint: string | null
+}
+
+/**
+ * Resolve the live options for a quick-action `dynamic-select` input. Runs the
+ * app's resolver tool (`dynamicSelect.optionsFrom`) in the lambda, scoped to the
+ * thread's contact, and shapes its output into selectable options.
+ *
+ * Read-only: the resolver tool should be `idempotent`. Mirrors
+ * {@link QuickActionExecutor.execute}'s lambda plumbing but invokes the resolver
+ * and maps its output. See plans/actions/09-dynamic-action-inputs.md §6.
+ */
+export async function resolveQuickActionOptions(
+  input: ResolveQuickActionOptionsInput
+): Promise<ResolveQuickActionOptionsResult> {
+  // 1. Look up the dynamic-select hint from the org cache.
+  const installedApps = await getCachedInstalledApps(input.organizationId)
+  const installation = installedApps.find((a) => a.installationId === input.installationId)
+  const action = installation?.actions?.find((a) => a.toolId === input.actionId)
+  const hint = action?.inputHints?.[input.fieldKey]
+  if (!hint || hint.kind !== 'dynamic-select') {
+    throw new Error(
+      `No dynamic-select hint for action "${input.actionId}" input "${input.fieldKey}"`
+    )
+  }
+  const ds: DynamicSelectHint = hint.dynamicSelect
+  const disabled = (): ResolveQuickActionOptionsResult => ({
+    options: [],
+    disabledHint: ds.emptyHint ?? null,
+  })
+
+  // 2. Resolve the workspace (org) connection credId — reuse the executor path.
+  //    The same credId drives both the field read (step 3) and the lambda call
+  //    (step 4), so they can't drift to different accounts.
+  const { resolveAppConnectionForRuntime } = await import(
+    '../apps/connections/resolve-app-connection-for-runtime'
+  )
+  const connectionsResult = await resolveAppConnectionForRuntime({
+    appId: input.appId,
+    organizationId: input.organizationId,
+    userId: input.userId,
+  })
+  if (connectionsResult.isErr()) return disabled()
+  const { userConnection, organizationConnection } = connectionsResult.value
+  const connId = organizationConnection?.id ?? userConnection?.id
+  if (!connId) return disabled()
+
+  // 3. Resolve each bound arg off the record via the shared helper. An empty
+  //    bound value (e.g. no Stripe customer linked) → disabled/empty state.
+  const boundArgs: Record<string, unknown> = {}
+  for (const [argName, ref] of Object.entries(ds.bindArgsFrom ?? {})) {
+    const value = await resolveAppFieldValue({
+      orgId: input.organizationId,
+      recordId: input.recordId as RecordId,
+      ref,
+      connectionId: connId,
+    })
+    if (value === undefined || value === null || value === '') return disabled()
+    boundArgs[argName] = value
+  }
+
+  // 4. Invoke the resolver tool in the lambda — mirror QuickActionExecutor.
+  const { getInstallationDeployment } = await import(
+    '../apps/installations/get-installation-deployment'
+  )
+  const { prepareLambdaContext, invokeLambdaExecutor } = await import('../apps/lambda')
+
+  const installationResult = await getInstallationDeployment({
+    installationId: input.installationId,
+    organizationHandle: input.organizationHandle,
+    appId: input.appId,
+  })
+  if (installationResult.isErr()) {
+    logger.warn('Failed to get installation deployment', {
+      installationId: input.installationId,
+      error: installationResult.error.message,
+    })
+    return disabled()
+  }
+  const { serverBundleSha, installation: inst } = installationResult.value
+  if (!serverBundleSha) return disabled()
+
+  const baseContext = prepareLambdaContext({
+    appId: input.appId,
+    installationId: inst.id,
+    organizationId: input.organizationId,
+    organizationHandle: input.organizationHandle,
+    userId: input.userId,
+    userEmail: input.userEmail,
+    userName: input.userName,
+    userConnection,
+    organizationConnection,
+  })
+
+  const lambdaResult = await invokeLambdaExecutor({
+    caller: 'quick-action',
+    payload: {
+      type: 'tool',
+      serverBundleSha,
+      toolId: ds.optionsFrom,
+      inputs: { ...ds.args, ...boundArgs },
+      context: baseContext,
+      invocationContext: { kind: 'action', recordId: input.recordId },
+      timeout: 30000,
+    },
+  })
+  if (lambdaResult.isErr()) {
+    logger.warn('Resolver lambda invocation failed', {
+      optionsFrom: ds.optionsFrom,
+      error: lambdaResult.error.message,
+    })
+    return disabled()
+  }
+  const result = lambdaResult.value
+  if (result.metadata?.runtime_error || result.metadata?.validation_error) {
+    return disabled()
+  }
+  const data = result.execution_result?.data ?? result.execution_result ?? {}
+
+  // 5. Map output → options, then local-filter by query.
+  return mapResolverOutputToOptions(data, ds, input.query)
+}
+
+/**
+ * Pure mapping from a resolver tool's raw output to the option list — the
+ * testable core of step 5. Selects items at `itemsPath`, projects each via
+ * `valuePath`/`labelTemplate`/`sublabelTemplate`, drops valueless rows, and
+ * locally filters by `query`.
+ */
+export function mapResolverOutputToOptions(
+  data: unknown,
+  ds: DynamicSelectHint,
+  query?: string
+): ResolveQuickActionOptionsResult {
+  const items = selectItems(data, ds.itemsPath)
+  const options: QuickActionOption[] = []
+  for (const item of items) {
+    const value = getPath(item, ds.valuePath)
+    if (value === undefined || value === null || value === '') continue
+    options.push({
+      value: String(value),
+      label: renderTemplate(ds.labelTemplate, item) || String(value),
+      sublabel: ds.sublabelTemplate ? renderTemplate(ds.sublabelTemplate, item) : undefined,
+    })
+  }
+
+  const filtered = filterOptions(options, query)
+  return { options: filtered, disabledHint: filtered.length ? null : (ds.emptyHint ?? null) }
+}
+
+/** Pull the option array out of the resolver output via `itemsPath`, else the first array found. */
+function selectItems(data: unknown, itemsPath?: string): Array<Record<string, unknown>> {
+  if (Array.isArray(data)) return data as Array<Record<string, unknown>>
+  if (itemsPath) {
+    const at = getPath(data, itemsPath)
+    return Array.isArray(at) ? (at as Array<Record<string, unknown>>) : []
+  }
+  // No itemsPath and not an array — take the first array-valued top-level field.
+  if (data && typeof data === 'object') {
+    for (const value of Object.values(data as Record<string, unknown>)) {
+      if (Array.isArray(value)) return value as Array<Record<string, unknown>>
+    }
+  }
+  return []
+}
+
+/** Read a dotted path (`a.b.c`) off an object. */
+function getPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === 'object') return (acc as Record<string, unknown>)[key]
+    return undefined
+  }, obj)
+}
+
+/** Substitute `{field}` / `{a.b}` placeholders in a template from an item. */
+function renderTemplate(template: string, item: Record<string, unknown>): string {
+  return template
+    .replace(/\{([^}]+)\}/g, (_, key: string) => {
+      const value = getPath(item, key.trim())
+      return value === undefined || value === null ? '' : String(value)
+    })
+    .trim()
+}
+
+/** Case-insensitive substring filter over value + label + sublabel. */
+function filterOptions(options: QuickActionOption[], query?: string): QuickActionOption[] {
+  const q = query?.trim().toLowerCase()
+  if (!q) return options
+  return options.filter((o) =>
+    `${o.value} ${o.label} ${o.sublabel ?? ''}`.toLowerCase().includes(q)
+  )
+}

--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -173,6 +173,52 @@ export interface ToolActionSurface {
   readonly confirmationMessage?: string
   readonly shouldShow?: (ctx: ToolActionContext) => boolean
   readonly getDefaults?: (ctx: ToolActionContext) => Record<string, unknown>
+  /**
+   * Per-input presentation overrides for the quick-action form, keyed by
+   * top-level input name. Does NOT replace the Zod input schema — that stays the
+   * source of truth for validation. The annotation only layers presentation +
+   * option-resolution metadata onto named inputs. Absent inputs render from the
+   * JSON Schema as usual. See plans/actions/09-dynamic-action-inputs.md.
+   */
+  readonly inputs?: Record<string, ActionInputHint>
+}
+
+/**
+ * A presentation override for a single quick-action input. Discriminated by
+ * `kind` so new control flavors (`currency`, `entity-picker`, …) can be added
+ * without breaking existing readers.
+ */
+export type ActionInputHint = { kind: 'dynamic-select'; dynamicSelect: DynamicSelectHint }
+
+/**
+ * Loads a select field's options at form-open time by running an app resolver
+ * tool, scoped to the thread's contact. The human-form analog of
+ * `ToolAgentSurface.inputBindings`. See plans/actions/09-dynamic-action-inputs.md.
+ */
+export interface DynamicSelectHint {
+  /** Local tool id (same app) whose execute() returns the candidate list. */
+  readonly optionsFrom: string
+  /**
+   * Maps the resolver tool's inputs to var refs resolved against the thread's
+   * contact — same ref grammar as `ToolAgentSurface.inputBindings`
+   * (e.g. `{ stripeCustomerId: 'contact:@app:stripe:customerId' }`).
+   */
+  readonly bindArgsFrom?: Record<string, string>
+  /** Constant args merged into the resolver call (e.g. `{ limit: 20 }`). */
+  readonly args?: Record<string, unknown>
+  /**
+   * Path into each output item that becomes the field's stored value. The
+   * resolver output is treated as an array; if it's an object, `itemsPath`
+   * selects the array first.
+   */
+  readonly valuePath: string
+  readonly itemsPath?: string
+  /** `{field}` template over each item for the option label. */
+  readonly labelTemplate: string
+  /** Optional `{field}` template for a dimmer secondary line. */
+  readonly sublabelTemplate?: string
+  /** Text shown disabled when no options resolve. */
+  readonly emptyHint?: string
 }
 
 /**

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -7,6 +7,7 @@ import { fileURLToPath, pathToFileURL } from 'url'
 import { HIDDEN_AUXX_DIRECTORY } from '../constants/hidden-auxx-directory.js'
 import { complete, errored, type Result } from '../errors.js'
 import type {
+  ActionInputHint,
   AgentSurface,
   ToolActionSurface,
   ToolAgentSurface,
@@ -92,6 +93,12 @@ export interface CatalogAction {
   surface: 'ticket-header' | 'email-editor'
   requiresConfirmation?: boolean
   confirmationMessage?: string
+  /**
+   * Per-input presentation overrides, carried verbatim from `tool.action.inputs`.
+   * Drives dynamic-select pickers in the quick-action form. See
+   * plans/actions/09-dynamic-action-inputs.md.
+   */
+  inputHints?: Record<string, ActionInputHint>
 }
 
 export interface CatalogToolset {
@@ -430,7 +437,31 @@ export async function compileAndExtractCatalog(): Promise<
         surface: tool.action.surface,
         requiresConfirmation: tool.action.requiresConfirmation,
         confirmationMessage: tool.action.confirmationMessage,
+        ...(tool.action.inputs ? { inputHints: tool.action.inputs } : {}),
       })
+    }
+  }
+
+  // Validate dynamic-select hints now that every tool id is known. Each
+  // `optionsFrom` must reference a tool in this same app, and `valuePath` /
+  // `labelTemplate` must be present so the form can render an option.
+  const toolIds = new Set(cataloguedTools.map((t) => t.id))
+  for (const action of cataloguedActions) {
+    for (const [fieldKey, hint] of Object.entries(action.inputHints ?? {})) {
+      if (hint.kind !== 'dynamic-select') continue
+      const ds = hint.dynamicSelect
+      if (!toolIds.has(ds.optionsFrom)) {
+        return errored({
+          code: 'CATALOG_VALIDATION_FAILED',
+          message: `Action "${action.toolId}" input "${fieldKey}": optionsFrom "${ds.optionsFrom}" is not a tool in this app`,
+        })
+      }
+      if (!ds.valuePath || !ds.labelTemplate) {
+        return errored({
+          code: 'CATALOG_VALIDATION_FAILED',
+          message: `Action "${action.toolId}" input "${fieldKey}": dynamic-select requires valuePath and labelTemplate`,
+        })
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a general **dynamic-select action-input** primitive: a quick-action form field whose options are loaded at form-open time by running an app resolver tool, scoped to the thread's contact. It's the human-form analog of the agent's `inputBindings`.

The Stripe **Refund Charge** action is the first consumer — its `chargeId` input becomes a live, contact-scoped picker of recent charges instead of a blind `ch_…` text box. Any app can now declare a `dynamic-select` input and reuse one of its existing tools as the option resolver.

## How it flows

```
tool.action.inputs.chargeId = { kind: 'dynamic-select', dynamicSelect: {...} }   (SDK)
  → CatalogAction.inputHints (extraction + validation)
  → CachedAction.inputHints (cache v4)
  → jsonSchemaToActionFields merges hint → field.type = 'dynamic-select'
  → QuickActionDynamicSelectField → quickAction.resolveOptions (lambda) → options
```

## Changes

- **SDK** — `ActionInputHint` / `DynamicSelectHint` + `ToolActionSurface.inputs`; catalog extraction projects + validates `inputHints` (`optionsFrom` must be a same-app tool; `valuePath`/`labelTemplate` required).
- **Schema/cache** — `CatalogAction.inputHints` (lock-step copy in `@auxx/database`); `installedApps` cache bumped **v3 → v4**.
- **Binding (decoupled core)** — extracted `resolveAppFieldValue` (`resolveAppFieldId` + `batchGetValues`) shared by the agent resolver and the picker, so the picker needs only `(orgId, recordId, connectionId)` — no `ToolContext`/`Subject` construction.
- **`quickAction.resolveOptions`** tRPC + `resolveQuickActionOptions`: resolves the **workspace (org) connection** credId (same id drives the field read and the lambda call), binds args off the record, invokes the resolver, maps output, local-filters by `query`.
- **Client** — `jsonSchemaToActionFields` merges the hint; `QuickActionDynamicSelectField` renders a `Combobox` fed by `resolveOptions`; the composer resolves the contact `recordId` from the reply's `FROM` participant. No contact / zero options → disabled field with hint.

## Tests

- `mapResolverOutputToOptions` unit tests (mapping, empty path, query filter, missing-value rows, no-itemsPath, label fallback) — 6 passing.
- SDK catalog-extraction test still green.

## Notes / follow-ups

- Pairs with the Stripe app change (separate `auxxai-apps` PR) declaring the `customerId` field + annotating the refund action.
- Until contact→Stripe `customerId` population lands, the picker correctly shows the disabled "No Stripe customer linked" state — the intended degraded path.
- Built on the existing `Combobox` (fetch-once + local filter). Charge labels show the raw amount for now (resolver output has no formatted helpers).
- Requires `@auxx/lib` rebuild + Stripe app republish for the new catalog shape to take effect.