### PR TITLE
feat: app record actions + async option picker

### DIFF
--- a/apps/api/public/app-runtime/index.html
+++ b/apps/api/public/app-runtime/index.html
@@ -73,7 +73,7 @@
 
     <!-- Platform Runtime Bundle (same for ALL extensions) -->
     <!-- Hash is replaced during build: platform.{HASH}.js -->
-    <script src="/api/v1/app-runtime/platform.3ec297e6.js"></script>
+    <script src="/api/v1/app-runtime/platform.fd8fcd2e.js"></script>
 
     <!-- Extension bundle will be loaded dynamically by platform runtime -->
   </body>

--- a/apps/web/src/components/contacts/drawer/contact-drawer.tsx
+++ b/apps/web/src/components/contacts/drawer/contact-drawer.tsx
@@ -10,7 +10,6 @@ import { Expand, Mail, MessagesSquare, Trash, User } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import * as React from 'react'
 import { BaseEntityDrawer } from '~/components/drawers/base-entity-drawer'
-import { DockToggleButton } from '~/components/global/dock-toggle-button'
 import { Tooltip } from '~/components/global/tooltip'
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions'
@@ -174,7 +173,6 @@ export function ContactDrawer({
                 <Trash className='text-bad-500' />
               </Button>
             </Tooltip>
-            <DockToggleButton />
           </>
         }
         cardContent={

--- a/apps/web/src/components/detail-view/components/app-record-actions.tsx
+++ b/apps/web/src/components/detail-view/components/app-record-actions.tsx
@@ -1,0 +1,84 @@
+// apps/web/src/components/detail-view/components/app-record-actions.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { Blocks, MoreHorizontal } from 'lucide-react'
+import type { RecordId } from '~/components/resources'
+import { useSurfaces } from '~/lib/extensions/use-surfaces'
+import { useInternalAppsContext } from '~/providers/extensions/internal-apps-context'
+
+interface AppRecordActionsProps {
+  /** Full record id (`<entityDefinitionId>:<entityInstanceId>`). */
+  recordId: RecordId
+  /** Entity slug of the record (e.g. `contact`, `ticket`). */
+  recordType: string
+  /** Icon-only trigger for tight headers like the record drawer. */
+  compact?: boolean
+}
+
+/**
+ * Renders record-action surfaces declared by installed apps in an overflow menu
+ * on the detail-view header. Triggering an action posts to the app iframe via
+ * `store.triggerSurface`; any `showDialog` the app opens is rendered globally by
+ * `ExtensionDialog`.
+ *
+ * v1 shows every installed app's record action on every record type — apps gate
+ * applicability inside their own dialog. The overflow menu keeps N installed
+ * apps from crowding the header.
+ */
+export function AppRecordActions({ recordId, recordType, compact }: AppRecordActionsProps) {
+  const { store } = useInternalAppsContext()
+  const { data: actions } = useSurfaces({
+    surfaceType: 'record-action',
+    context: { recordId, recordType },
+  })
+
+  if (actions.length === 0) return null
+
+  const handleTrigger = (appId: string, appInstallationId: string, surfaceId: string) => {
+    void store.triggerSurface({
+      appId,
+      appInstallationId,
+      surfaceType: 'record-action',
+      surfaceId,
+      payload: { recordId, recordType },
+    })
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {compact ? (
+          <Button variant='ghost' size='icon-xs' className='rounded-full' title='App actions'>
+            <Blocks />
+          </Button>
+        ) : (
+          <Button variant='outline' size='sm'>
+            <MoreHorizontal /> More
+          </Button>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='end' className='w-56'>
+        <DropdownMenuLabel>App actions</DropdownMenuLabel>
+        {actions.map(({ surface, appId, appInstallationId }) => (
+          <DropdownMenuItem
+            key={`${appId}:${appInstallationId}:${surface.id}`}
+            onSelect={() => handleTrigger(appId, appInstallationId, surface.id)}
+            className='flex items-center gap-2'>
+            {typeof surface.icon === 'string' && surface.icon.length <= 2 && (
+              <span>{surface.icon}</span>
+            )}
+            <span className='truncate'>{surface.label ?? surface.id}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/src/components/detail-view/components/detail-view-actions.tsx
+++ b/apps/web/src/components/detail-view/components/detail-view-actions.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react'
 import { MergeDialog } from '~/components/merge'
 import { useConfirm } from '~/hooks/use-confirm'
 import type { DetailViewActionsProps } from '../types'
+import { AppRecordActions } from './app-record-actions'
 
 /**
  * DetailViewActions - action buttons for the detail view header
@@ -116,6 +117,8 @@ export function DetailViewActions({
             <Trash2 /> Delete
           </Button>
         )}
+
+        <AppRecordActions recordId={recordId} recordType={entityType} />
       </div>
 
       <ConfirmDialog />

--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -24,8 +24,10 @@ import {
 } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import * as React from 'react'
+import { AppRecordActions } from '~/components/detail-view/components/app-record-actions'
 import EntityFields from '~/components/fields/entity-fields'
 import DrawerComments from '~/components/global/comments/drawer-comments'
+import { DockToggleButton } from '~/components/global/dock-toggle-button'
 import { useRecord, useResource } from '~/components/resources'
 import { TasksSection } from '~/components/tasks/ui/tasks-section'
 import { TimelineTab } from '~/components/timeline'
@@ -245,7 +247,13 @@ export function BaseEntityDrawer({
         icon={headerIcon ?? resource?.icon}
         title={headerTitle ?? resource?.label ?? 'Record'}
         onClose={handleClose}
-        actions={headerActions}
+        actions={
+          <>
+            {headerActions}
+            <AppRecordActions recordId={recordId} recordType={entityType} compact />
+            <DockToggleButton />
+          </>
+        }
       />
 
       <div className='flex-1 overflow-y-auto'>

--- a/apps/web/src/components/extensions/data-handlers/record-data-handler.tsx
+++ b/apps/web/src/components/extensions/data-handlers/record-data-handler.tsx
@@ -1,0 +1,123 @@
+// apps/web/src/components/extensions/data-handlers/record-data-handler.tsx
+'use client'
+
+import type { FieldType } from '@auxx/database/types'
+import { extractValues } from '@auxx/lib/field-values/client'
+import { getFieldOutputKey, parseRecordId, type RecordId } from '@auxx/lib/resources/client'
+import { type FieldReference, fieldRefToKey } from '@auxx/types/field'
+import type { TypedFieldValue } from '@auxx/types/field-value'
+import { useEffect } from 'react'
+import {
+  buildFieldValueKey,
+  useFieldValueStore,
+} from '~/components/resources/store/field-value-store'
+import { getRecordStoreState } from '~/components/resources/store/record-store'
+import { useResourceStore } from '~/components/resources/store/resource-store'
+import { getNormalizedRecordId } from '~/components/resources/utils/normalize-record-id'
+import { useExtensionDataHandlerContext } from '~/providers/extensions/extension-data-handler-context'
+import { api } from '~/trpc/react'
+
+/**
+ * Serializable record returned to an app's `useRecord(recordId)` hook.
+ * `data` is keyed by each field's stable attribute key (its `systemAttribute`,
+ * e.g. `primary_email`, `phone`) and carries plain unwrapped values (scalar for
+ * single-value fields, array for multi-value fields).
+ */
+interface AppRecord {
+  id: string
+  type: string
+  displayName?: string
+  data: Record<string, unknown>
+  createdAt?: string | Date
+  updatedAt?: string | Date
+}
+
+/** Unwrap a typed field value to a plain JS value for the app. */
+function unwrapValue(
+  value: TypedFieldValue | TypedFieldValue[] | null,
+  fieldType: FieldType
+): unknown {
+  const raws = extractValues(value, fieldType)
+  return raws.length <= 1 ? (raws[0] ?? null) : raws
+}
+
+/**
+ * Serves an app's `get-record` requests (the `useRecord` SDK hook). Reads
+ * through the two client stores the detail view already hydrates — record
+ * metadata + the field-value store — and falls back to the authoritative
+ * `fieldValue.batchGet` for any field not yet in the store, so `useRecord`
+ * is correct from any surface, not just a warm detail view.
+ *
+ * Returns every field on the record, attribute-keyed, so an app reads whatever
+ * it declares interest in (e.g. the Stripe link dialog reads `data.primary_email`).
+ */
+export function RecordDataHandler() {
+  const { messageClient } = useExtensionDataHandlerContext()
+  const getResourceById = useResourceStore((s) => s.getResourceById)
+  const batchGetAsync = api.fieldValue.batchGet.useMutation().mutateAsync
+
+  useEffect(() => {
+    const unsubscribe = messageClient.listenForRequest(
+      'get-record',
+      async ({ recordId }: { recordId: string }): Promise<AppRecord> => {
+        const normalized = getNormalizedRecordId(recordId as RecordId)
+        const { entityDefinitionId, entityInstanceId } = parseRecordId(normalized)
+
+        const resource = getResourceById(entityDefinitionId)
+        if (!resource) throw new Error(`Unknown resource for record ${recordId}`)
+
+        const meta = getRecordStoreState().records[entityDefinitionId]?.get(entityInstanceId)
+        const stored = useFieldValueStore.getState().values
+
+        const data: Record<string, unknown> = {}
+        const missing: FieldReference[] = []
+        const refToField = new Map<string, (typeof resource.fields)[number]>()
+
+        // Fast path: read whatever the field-value store already holds.
+        for (const field of resource.fields) {
+          if (!field.fieldType) continue
+          const ref = (field.resourceFieldId ?? field.id) as FieldReference
+          const key = buildFieldValueKey(normalized, ref)
+          if (key in stored) {
+            data[getFieldOutputKey(field)] = unwrapValue(
+              stored[key] as TypedFieldValue | TypedFieldValue[] | null,
+              field.fieldType as FieldType
+            )
+          } else {
+            missing.push(ref)
+            refToField.set(fieldRefToKey(ref), field)
+          }
+        }
+
+        // Slow path: authoritative read for fields the store hasn't cached.
+        if (missing.length > 0) {
+          try {
+            const result = await batchGetAsync({
+              recordIds: [normalized],
+              fieldReferences: missing,
+            })
+            for (const row of result.values) {
+              const field = refToField.get(fieldRefToKey(row.fieldRef))
+              if (field) data[getFieldOutputKey(field)] = unwrapValue(row.value, row.fieldType)
+            }
+          } catch {
+            // Best-effort: uncached fields are simply absent from `data`.
+          }
+        }
+
+        return {
+          id: entityInstanceId,
+          type: resource.entityType ?? entityDefinitionId,
+          displayName: meta?.displayName,
+          data,
+          createdAt: meta?.createdAt,
+          updatedAt: meta?.updatedAt,
+        }
+      }
+    )
+
+    return unsubscribe
+  }, [messageClient, getResourceById, batchGetAsync])
+
+  return null
+}

--- a/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
+++ b/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
@@ -23,6 +23,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { ChevronDown, ChevronRight, X, Zap } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useMemo, useRef, useState } from 'react'
+import { AsyncOptionPicker } from '~/components/pickers/async-option-picker'
 import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
 import { useQuickActions } from '~/hooks/use-quick-actions'
 import type { SerializedQuickAction } from '~/lib/workflow/workflow-block-loader'
@@ -585,14 +586,10 @@ function QuickActionDynamicSelectField({
   )
 
   const resolved = optionsQuery.data?.options ?? []
-  const comboOptions = resolved.map((o) => ({
+  const comboOptions: SelectOption[] = resolved.map((o) => ({
     value: o.value,
     label: o.sublabel ? `${o.label} — ${o.sublabel}` : o.label,
   }))
-  // Keep a previously-picked value visible even before/without a fresh load.
-  if (value && !comboOptions.some((o) => o.value === value)) {
-    comboOptions.unshift({ value, label: value })
-  }
 
   const noOptions = enabled && !optionsQuery.isLoading && resolved.length === 0
   const hintText =
@@ -606,17 +603,22 @@ function QuickActionDynamicSelectField({
   return (
     <div className='flex items-center gap-2'>
       <label className='min-w-16 shrink-0 text-xs text-muted-foreground'>{label}</label>
-      <Combobox
-        options={comboOptions}
-        placeholder={isDisabled ? hintText : placeholder || 'Select...'}
-        emptyText={optionsQuery.isLoading ? 'Loading…' : hintText}
+      <AsyncOptionPicker
+        staticOptions={comboOptions}
+        isLoading={optionsQuery.isLoading}
         value={value}
-        onChangeValue={(v) => onChange(v || undefined)}
-        loading={optionsQuery.isLoading}
+        onChange={(selected) => onChange(selected[0] || undefined)}
+        multi={false}
         disabled={isDisabled}
-        variant='outline'
-        size='sm'
-        className='h-6 text-xs'
+        placeholder={isDisabled ? hintText : placeholder || 'Select...'}
+        searchPlaceholder='Search…'
+        triggerProps={{
+          variant: 'outline',
+          size: 'sm',
+          className: 'h-6 text-xs',
+          showClear: false,
+        }}
+        className='flex-1'
         popoverClassName={popoverClassName}
         onOpenChange={(o) => {
           if (o) setOpened(true)

--- a/apps/web/src/components/pickers/async-option-picker.tsx
+++ b/apps/web/src/components/pickers/async-option-picker.tsx
@@ -1,0 +1,221 @@
+// apps/web/src/components/pickers/async-option-picker.tsx
+'use client'
+
+import type { SelectOption } from '@auxx/types/custom-field'
+import { Badge } from '@auxx/ui/components/badge'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { cn } from '@auxx/ui/lib/utils'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
+import { ItemsListView } from '~/components/ui/items-list-view'
+import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
+import { useDebouncedValue } from '~/hooks/use-debounced-value'
+
+export interface AsyncOptionPickerProps {
+  /**
+   * Async resolver. Called on open and on each debounced keystroke with the live
+   * search string (`''` on open). Mutually exclusive with `staticOptions` —
+   * `staticOptions` short-circuits and disables internal fetching.
+   */
+  loadOptions?: (query: string) => Promise<SelectOption[]>
+
+  /**
+   * Pre-resolved options. When provided, the picker renders these and filters
+   * them client-side (via `MultiSelectPicker`); `loadOptions` is ignored. Pair
+   * with `isLoading` when the options are themselves loaded externally.
+   */
+  staticOptions?: SelectOption[]
+
+  /** External loading flag, for `staticOptions` mode (e.g. a tRPC query in flight). */
+  isLoading?: boolean
+
+  /** Selected value(s). */
+  value: string | string[]
+
+  /** Called with the next selection (always an array; single-select yields one). */
+  onChange: (selected: string[]) => void
+
+  /** Single (`false`, radio) or multi (`true`, checkbox). Default `false`. */
+  multi?: boolean
+
+  /** Debounce for `loadOptions` in ms. Default 250. */
+  debounceMs?: number
+
+  /** Trigger placeholder when nothing is selected. */
+  placeholder?: string
+
+  /** Search-input placeholder inside the popover. */
+  searchPlaceholder?: string
+
+  disabled?: boolean
+  className?: string
+  /** Extra className for the popover content (e.g. to scope it inside a panel). */
+  popoverClassName?: string
+  triggerProps?: PickerTriggerOptions
+
+  /** Controlled open state. */
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+/**
+ * AsyncOptionPicker
+ *
+ * One searchable, server-backed picker rendered host-side as the platform's
+ * `MultiSelectPicker` (inside a `Popover`/`PickerTrigger`). The single contract
+ * is `loadOptions(query) => Promise<SelectOption[]>` for server-driven search,
+ * or `staticOptions` for the client-filtered/parity path.
+ *
+ * It owns debounce, loading/empty, stale-response dropping, and selected-value
+ * label persistence so the chosen option keeps its label even after the option
+ * list reloads to a page that no longer contains it (search-driven lists are
+ * transient). See `plans/actions/11-async-option-picker.md`.
+ */
+export function AsyncOptionPicker({
+  loadOptions,
+  staticOptions,
+  isLoading: externalLoading = false,
+  value,
+  onChange,
+  multi = false,
+  debounceMs = 250,
+  placeholder = 'Select…',
+  searchPlaceholder = 'Search…',
+  disabled = false,
+  className,
+  popoverClassName,
+  triggerProps,
+  open: controlledOpen,
+  onOpenChange,
+}: AsyncOptionPickerProps) {
+  const normalizedValue = useMemo(
+    () => (Array.isArray(value) ? value : value ? [value] : []),
+    [value]
+  )
+  const isStatic = staticOptions !== undefined
+
+  const [internalOpen, setInternalOpen] = useState(false)
+  const open = controlledOpen ?? internalOpen
+
+  const [searchQuery, setSearchQuery] = useState('')
+  const [debouncedSearch] = useDebouncedValue(searchQuery, debounceMs)
+
+  const [loaded, setLoaded] = useState<SelectOption[]>(staticOptions ?? [])
+  const [asyncLoading, setAsyncLoading] = useState(false)
+  // Persisted value → label so a selection survives the option list reloading.
+  const [labelCache, setLabelCache] = useState<Record<string, string>>({})
+
+  // Monotonic request id — only the latest in-flight resolution may apply.
+  const latestReqRef = useRef(0)
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!next) setSearchQuery('')
+      if (controlledOpen === undefined) setInternalOpen(next)
+      onOpenChange?.(next)
+    },
+    [controlledOpen, onOpenChange]
+  )
+
+  // Static mode: mirror the externally-provided options.
+  useEffect(() => {
+    if (isStatic) setLoaded(staticOptions ?? [])
+  }, [isStatic, staticOptions])
+
+  // Async mode: resolve on open and on each debounced keystroke, dropping stale
+  // responses so out-of-order results can't clobber a newer query.
+  useEffect(() => {
+    if (isStatic || !loadOptions || !open) return
+    const reqId = ++latestReqRef.current
+    setAsyncLoading(true)
+    loadOptions(debouncedSearch)
+      .then((opts) => {
+        if (reqId === latestReqRef.current) setLoaded(opts)
+      })
+      .catch(() => {
+        if (reqId === latestReqRef.current) setLoaded([])
+      })
+      .finally(() => {
+        if (reqId === latestReqRef.current) setAsyncLoading(false)
+      })
+  }, [isStatic, loadOptions, open, debouncedSearch])
+
+  // Cache labels of every option we see, for selected-value persistence.
+  useEffect(() => {
+    if (loaded.length === 0) return
+    setLabelCache((prev) => {
+      const next = { ...prev }
+      for (const o of loaded) next[o.value] = o.label
+      return next
+    })
+  }, [loaded])
+
+  // Show selected values that aren't in the current list as extra rows (so they
+  // stay checked + labeled), ahead of the resolved options.
+  const options = useMemo<SelectOption[]>(() => {
+    const present = new Set(loaded.map((o) => o.value))
+    const extras = normalizedValue
+      .filter((v) => !present.has(v))
+      .map<SelectOption>((v) => ({ value: v, label: labelCache[v] ?? v }))
+    return [...extras, ...loaded]
+  }, [loaded, normalizedValue, labelCache])
+
+  const handleChange = useCallback((selected: string[]) => onChange(selected), [onChange])
+
+  const handleSelectSingle = useCallback(() => setOpen(false), [setOpen])
+
+  const hasValue = normalizedValue.length > 0
+  const isLoading = isStatic ? externalLoading : asyncLoading
+
+  return (
+    <Popover open={open} onOpenChange={disabled ? undefined : setOpen}>
+      <PopoverTrigger asChild>
+        <PickerTrigger
+          open={open}
+          disabled={disabled}
+          variant={triggerProps?.variant ?? 'outline'}
+          size={triggerProps?.size}
+          hasValue={hasValue}
+          placeholder={placeholder}
+          showClear={triggerProps?.showClear ?? multi}
+          hideIcon={triggerProps?.hideIcon}
+          onClear={(e) => {
+            e.stopPropagation()
+            onChange([])
+          }}
+          asCombobox
+          className={cn('h-auto min-h-8', className, triggerProps?.className)}>
+          <ItemsListView
+            items={normalizedValue}
+            maxDisplay={3}
+            renderItem={(v) => (
+              <Badge variant='outline' className='text-xs truncate max-w-[180px]'>
+                {labelCache[v] ?? v}
+              </Badge>
+            )}
+          />
+        </PickerTrigger>
+      </PopoverTrigger>
+      <PopoverContent
+        className={cn(
+          'p-0 min-w-[max(var(--radix-popover-trigger-width),18rem)]',
+          popoverClassName
+        )}
+        align='start'>
+        <MultiSelectPicker
+          options={options}
+          value={normalizedValue}
+          onChange={handleChange}
+          isLoading={isLoading}
+          onSearchChange={setSearchQuery}
+          canManage={false}
+          canAdd={false}
+          multi={multi}
+          placeholder={searchPlaceholder}
+          onSelectSingle={handleSelectSingle}
+          disabled={disabled}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -31,7 +31,6 @@ import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-insta
 import { BaseEntityDrawer } from '~/components/drawers/base-entity-drawer'
 import { getHeaderActions } from '~/components/drawers/drawer-action-registry'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
-import { DockToggleButton } from '~/components/global/dock-toggle-button'
 import { Tooltip } from '~/components/global/tooltip'
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions'
@@ -391,8 +390,6 @@ export const RecordDrawer = React.memo(function RecordDrawer({
                 <Expand />
               </Button>
             </Tooltip>
-
-            <DockToggleButton />
           </>
         }
         cardContent={

--- a/apps/web/src/lib/extensions/forms/deserialize-schema.ts
+++ b/apps/web/src/lib/extensions/forms/deserialize-schema.ts
@@ -39,9 +39,37 @@ function deserializeField(name: string, field: SerializedFormValue): z.ZodTypeAn
     case 'select':
       return deserializeSelectField(field)
 
+    case 'picker':
+      return deserializePickerField(field)
+
     default:
       handleUnknownFieldType((field as any).type, name)
   }
+}
+
+/**
+ * Deserialize picker field. Values are free-form strings (server-resolved or
+ * static option values), so we validate shape — a string, or string[] when
+ * multi — not membership.
+ */
+function deserializePickerField(
+  field: Extract<SerializedFormValue, { type: 'picker' }>
+): z.ZodTypeAny {
+  const { metadata } = field
+  const errors = metadata.errorMessages || {}
+
+  if (metadata.multi) {
+    let schema: any = z.array(z.string())
+    if (!metadata.optional) {
+      schema = schema.min(1, errors.required || 'Please select at least one option')
+    }
+    return metadata.optional ? schema.optional() : schema
+  }
+
+  const schema = z.string({ message: errors.required || 'Please select an option' })
+  return metadata.optional
+    ? z.preprocess((val) => (val === '' ? undefined : val), schema.optional())
+    : schema.min(1, errors.required || 'Please select an option')
 }
 
 /**

--- a/apps/web/src/lib/extensions/forms/field-renderer.tsx
+++ b/apps/web/src/lib/extensions/forms/field-renderer.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import type { SelectOption } from '@auxx/types/custom-field'
 import { Checkbox } from '@auxx/ui/components/checkbox'
 import { Input } from '@auxx/ui/components/input'
 import { Label } from '@auxx/ui/components/label'
@@ -15,6 +16,7 @@ import {
 import { Textarea } from '@auxx/ui/components/textarea'
 import React from 'react'
 import { useFormContext } from 'react-hook-form'
+import { AsyncOptionPicker } from '~/components/pickers/async-option-picker'
 import type { SerializedFormValue } from './types'
 
 interface FieldRendererProps {
@@ -24,6 +26,9 @@ interface FieldRendererProps {
   description?: string
   disabled?: boolean
   fieldSchema: SerializedFormValue
+  /** Form instance id + bridge callback — picker fields resolve options through these. */
+  formInstanceId?: number
+  onCallHandler?: (instanceId: number, eventName: string, ...args: any[]) => Promise<any>
 }
 
 /**
@@ -37,6 +42,8 @@ export const FieldRenderer = React.memo(function FieldRenderer({
   description,
   disabled = false,
   fieldSchema,
+  formInstanceId,
+  onCallHandler,
 }: FieldRendererProps) {
   const {
     register,
@@ -48,6 +55,23 @@ export const FieldRenderer = React.memo(function FieldRenderer({
   const error = errors[name]?.message as string | undefined
   const isOptional =
     'optional' in fieldSchema.metadata ? (fieldSchema.metadata.optional ?? false) : false
+
+  // Picker bridge adapter: resolve options through the form instance's
+  // `loadOptions:<field>` handler (registered by the SDK FormTag), reusing the
+  // proven `call-instance-method` request/response path. Computed unconditionally
+  // to respect rules-of-hooks; only used by the `picker` case.
+  const pickerLoadOptions = React.useMemo(() => {
+    const meta = fieldSchema.metadata as { hasLoadOptions?: boolean }
+    if (!meta.hasLoadOptions || !onCallHandler || formInstanceId == null) return undefined
+    return async (query: string): Promise<SelectOption[]> => {
+      const res = await onCallHandler(formInstanceId, `loadOptions:${name}`, query)
+      if (res && typeof res === 'object' && 'error' in res && res.error) {
+        throw new Error(res.error.message || 'Failed to load options')
+      }
+      const opts = res && typeof res === 'object' && 'result' in res ? res.result : res
+      return Array.isArray(opts) ? opts : []
+    }
+  }, [fieldSchema.metadata, onCallHandler, formInstanceId, name])
 
   // Use placeholder from props or fallback to schema
   const effectivePlaceholder =
@@ -209,6 +233,49 @@ export const FieldRenderer = React.memo(function FieldRenderer({
               ))}
             </SelectContent>
           </Select>
+
+          {description && (
+            <p id={descriptionId} className='text-sm text-muted-foreground'>
+              {description}
+            </p>
+          )}
+
+          {error && (
+            <p id={errorId} role='alert' className='text-sm text-destructive'>
+              {error}
+            </p>
+          )}
+        </div>
+      )
+    }
+
+    case 'picker': {
+      const { metadata } = fieldSchema
+      const multi = metadata.multi ?? false
+      const value = watch(name) ?? (multi ? [] : '')
+
+      return (
+        <div className='space-y-2'>
+          <Label htmlFor={fieldId}>
+            {label}
+            {!isOptional && <span className='text-destructive ml-1'>*</span>}
+          </Label>
+
+          <AsyncOptionPicker
+            loadOptions={pickerLoadOptions}
+            staticOptions={metadata.hasLoadOptions ? undefined : (metadata.options ?? [])}
+            value={value}
+            onChange={(selected) =>
+              setValue(name, multi ? selected : (selected[0] ?? ''), {
+                shouldValidate: true,
+                shouldDirty: true,
+              })
+            }
+            multi={multi}
+            disabled={disabled}
+            placeholder={effectivePlaceholder || 'Select…'}
+            className='w-full'
+          />
 
           {description && (
             <p id={descriptionId} className='text-sm text-muted-foreground'>

--- a/apps/web/src/lib/extensions/forms/form-reconstructor.tsx
+++ b/apps/web/src/lib/extensions/forms/form-reconstructor.tsx
@@ -20,8 +20,8 @@ interface FormProps {
   /** Form instance ID */
   __instanceId: number
 
-  /** Callback to call extension's event handlers */
-  __onCallHandler: (instanceId: number, eventName: string, args?: any[]) => Promise<any>
+  /** Callback to call extension's event handlers (request/response over the bridge) */
+  __onCallHandler: (instanceId: number, eventName: string, ...args: any[]) => Promise<any>
 
   /** Whether form has event handlers */
   __hasOnSubmit: boolean
@@ -200,6 +200,8 @@ export const Form = React.memo(function Form({
                 description={child.attributes.description}
                 disabled={child.attributes.disabled}
                 fieldSchema={fieldSchema}
+                formInstanceId={__instanceId}
+                onCallHandler={__onCallHandler}
               />
             )
           }

--- a/apps/web/src/lib/extensions/forms/types.ts
+++ b/apps/web/src/lib/extensions/forms/types.ts
@@ -88,6 +88,21 @@ export interface FormSelectMetadata<T extends string = string> {
 }
 
 /**
+ * Picker field metadata (mirrors SDK `FormPickerMetadata`). `loadOptions` is
+ * never serialized — the picker resolves over the bridge when `hasLoadOptions`.
+ */
+export interface FormPickerMetadata {
+  hasLoadOptions?: boolean
+  options?: SelectOption[]
+  multi?: boolean
+  optional?: boolean
+  placeholder?: string
+  errorMessages?: {
+    required?: string
+  }
+}
+
+/**
  * Discriminated union for serialized field types.
  * Ensures type safety when reconstructing schemas on web app side.
  */
@@ -96,6 +111,7 @@ export type SerializedFormValue =
   | { type: 'number'; metadata: FormNumberMetadata }
   | { type: 'boolean'; metadata: FormBooleanMetadata }
   | { type: 'select'; metadata: FormSelectMetadata }
+  | { type: 'picker'; metadata: FormPickerMetadata }
 
 /**
  * Serialized schema format.

--- a/apps/web/src/providers/extensions/extensions-provider.tsx
+++ b/apps/web/src/providers/extensions/extensions-provider.tsx
@@ -16,6 +16,7 @@ import {
 import { ConnectionExpiredDialog } from '~/components/apps/ui/connection-expired-dialog'
 import { AssetsDataHandler } from '~/components/extensions/data-handlers/assets-data-handler'
 import { DialogDataHandler } from '~/components/extensions/data-handlers/dialog-data-handler'
+import { RecordDataHandler } from '~/components/extensions/data-handlers/record-data-handler'
 import { RenderDataHandler } from '~/components/extensions/data-handlers/render-data-handler'
 import { SurfacesDataHandler } from '~/components/extensions/data-handlers/surfaces-data-handler'
 import { TriggerDataHandler } from '~/components/extensions/data-handlers/trigger-data-handler'
@@ -198,6 +199,9 @@ export function ExtensionsProvider({ children }: ExtensionsProviderProps) {
 
                         {/* Listen for dialog render/unrender */}
                         <DialogDataHandler />
+
+                        {/* Serve record reads for the app `useRecord` hook */}
+                        <RecordDataHandler />
                       </ExtensionDataHandlerContextProvider>
                     </Suspense>
                   </ErrorBoundary>

--- a/packages/sdk/src/client/forms/index.ts
+++ b/packages/sdk/src/client/forms/index.ts
@@ -2,6 +2,7 @@
 
 import { FormBoolean } from './types/boolean.js'
 import { FormNumber } from './types/number.js'
+import { FormPicker, type PickerConfig } from './types/picker.js'
 import { FormSelect } from './types/select.js'
 import { FormString } from './types/string.js'
 import type { SelectOption } from './types.js'
@@ -9,6 +10,7 @@ import type { SelectOption } from './types.js'
 export * from './base.js'
 export { FormBoolean } from './types/boolean.js'
 export { FormNumber } from './types/number.js'
+export { FormPicker, type PickerConfig } from './types/picker.js'
 export { FormSelect } from './types/select.js'
 export { FormString } from './types/string.js'
 export * from './types.js'
@@ -34,6 +36,7 @@ export const Forms = {
   number: () => FormNumber.create(),
   boolean: () => FormBoolean.create(),
   select: <T extends string>(options: SelectOption<T>[]) => FormSelect.create(options),
+  picker: ((config?: PickerConfig) => FormPicker.create(config as any)) as typeof FormPicker.create,
 }
 
 /**

--- a/packages/sdk/src/client/forms/types.ts
+++ b/packages/sdk/src/client/forms/types.ts
@@ -9,6 +9,7 @@ export type SerializedFormValue =
   | { type: 'number'; metadata: FormNumberMetadata }
   | { type: 'boolean'; metadata: FormBooleanMetadata }
   | { type: 'select'; metadata: FormSelectMetadata }
+  | { type: 'picker'; metadata: FormPickerMetadata }
 
 /**
  * String field metadata.
@@ -76,6 +77,36 @@ export interface FormSelectMetadata<T extends string = string> {
   optional?: boolean
   placeholder?: string
   defaultValue?: T
+  errorMessages?: {
+    required?: string
+  }
+}
+
+/**
+ * Async option resolver for {@link FormPickerMetadata}. Called with the live
+ * search string (`''` on open); runs in the app sandbox (may call `.server`
+ * functions) and returns the matching options.
+ */
+export type PickerLoadOptions = (query: string) => Promise<SelectOption[]>
+
+/**
+ * Picker field metadata.
+ *
+ * `loadOptions` is a runtime-only function (kept in `_metadata` so the form tag
+ * can invoke it across the bridge); it is NOT serialized — `toJSON()` emits
+ * `hasLoadOptions` instead. `options` is the static / client-filtered path.
+ */
+export interface FormPickerMetadata {
+  /** Runtime-only resolver; stripped from the serialized form (see `hasLoadOptions`). */
+  loadOptions?: PickerLoadOptions
+  /** Serialized flag: the field resolves options via `loadOptions` over the bridge. */
+  hasLoadOptions?: boolean
+  /** Static options (client-filtered). Mutually exclusive with `loadOptions`. */
+  options?: SelectOption[]
+  /** Multi-select (string[]) vs single (string). Default false. */
+  multi?: boolean
+  optional?: boolean
+  placeholder?: string
   errorMessages?: {
     required?: string
   }

--- a/packages/sdk/src/client/forms/types/picker.ts
+++ b/packages/sdk/src/client/forms/types/picker.ts
@@ -1,0 +1,79 @@
+// packages/sdk/src/client/forms/types/picker.ts
+
+import { FormValue } from '../base.js'
+import type {
+  FormPickerMetadata,
+  PickerLoadOptions,
+  SelectOption,
+  SerializedFormValue,
+} from '../types.js'
+
+/**
+ * Config for {@link FormPicker}. Provide `loadOptions` for server-backed,
+ * search-driven options, or `options` for a static / client-filtered list.
+ */
+export interface PickerConfig {
+  loadOptions?: PickerLoadOptions
+  options?: SelectOption[]
+  multi?: boolean
+}
+
+/**
+ * Picker field builder — a searchable, optionally server-backed select.
+ *
+ * Renders host-side as the platform's rich picker (`AsyncOptionPicker`). Unlike
+ * {@link FormSelect} (a static `<Select>`), the picker can resolve options at
+ * search time via `loadOptions`, which runs in the app sandbox and may call
+ * `.server` functions.
+ *
+ * @example
+ * Forms.picker({ loadOptions: searchStripeCandidates, multi: false })
+ * Forms.picker({ options: [{ value, label }] })
+ */
+export class FormPicker<V extends string | string[] = string> extends FormValue<V> {
+  public readonly _metadata: FormPickerMetadata
+
+  private constructor(metadata: FormPickerMetadata) {
+    super(metadata)
+    this._metadata = metadata
+  }
+
+  static create(config: PickerConfig & { multi: true }): FormPicker<string[]>
+  static create(config?: PickerConfig): FormPicker<string>
+  static create(config: PickerConfig = {}): FormPicker<string | string[]> {
+    if (!config.loadOptions && !config.options) {
+      throw new Error('Forms.picker requires either `loadOptions` or `options`')
+    }
+    return new FormPicker({
+      loadOptions: config.loadOptions,
+      options: config.options,
+      multi: config.multi ?? false,
+    })
+  }
+
+  static is(value: unknown): value is FormPicker {
+    return value instanceof FormPicker
+  }
+
+  get type(): 'picker' {
+    return 'picker' as const
+  }
+
+  optional(): FormPicker<V> {
+    return new FormPicker<V>({ ...this._metadata, optional: true })
+  }
+
+  placeholder(text: string): FormPicker<V> {
+    return new FormPicker<V>({ ...this._metadata, placeholder: text })
+  }
+
+  toJSON(): SerializedFormValue {
+    // Strip the runtime-only resolver; expose a flag instead. The form tag keeps
+    // the live `loadOptions` and invokes it over the bridge.
+    const { loadOptions, ...rest } = this._metadata
+    return {
+      type: this.type,
+      metadata: { ...rest, hasLoadOptions: typeof loadOptions === 'function' },
+    }
+  }
+}

--- a/packages/sdk/src/client/hooks/index.ts
+++ b/packages/sdk/src/client/hooks/index.ts
@@ -4,18 +4,26 @@
  * React hooks for accessing Auxx platform data and functionality
  */
 
+import { Host } from '../../runtime/host.js'
+import { useAsyncCache } from './use-async-cache.js'
+
 // Export async cache hook
 export { type AsyncCacheConfig, type AsyncFunction, useAsyncCache } from './use-async-cache.js'
 
 /**
- * Record data structure
+ * Record data structure returned by {@link useRecord}.
+ *
+ * `data` is keyed by each field's stable attribute key (e.g. `primary_email`,
+ * `phone`) and carries plain values — a scalar for single-value fields, an
+ * array for multi-value fields.
  */
 export interface AuxxRecord {
   id: string
   type: string
+  displayName?: string
   data: Record<string, any>
-  createdAt: Date
-  updatedAt: Date
+  createdAt?: string | Date
+  updatedAt?: string | Date
 }
 
 /**
@@ -45,24 +53,37 @@ export interface AppSettings {
   [key: string]: any
 }
 
+/** Fetch a record from the host platform (resolved by the record data-handler). */
+function fetchRecordFromHost(recordId: string): Promise<AuxxRecord> {
+  return Host.sendRequest<AuxxRecord>('get-record', { recordId })
+}
+
 /**
- * Hook to access a single record by ID
+ * Hook to access a single record by ID, with its field values.
  *
- * @param _recordId - The ID of the record to fetch
- * @returns The record data
+ * Backed by {@link useAsyncCache}, so it **suspends** until the record loads —
+ * render it under a `<Suspense>` boundary. Results are cached per `recordId`.
+ *
+ * @param recordId - The full record id (`<entityDefinitionId>:<entityInstanceId>`)
+ * @returns The record, with field values keyed under `data` by each field's
+ *   stable attribute key (e.g. the contact email is `data.primary_email`, not
+ *   `data.email`).
  *
  * @example
  * ```typescript
  * import { useRecord } from '@auxx/sdk/client'
  *
- * function MyComponent() {
- *   const record = useRecord('rec_123')
- *   return <div>{record.data.title}</div>
+ * function ContactEmail({ recordId }: { recordId: string }) {
+ *   const record = useRecord(recordId)
+ *   return <TextBlock>{record.data.primary_email}</TextBlock>
  * }
  * ```
  */
-export function useRecord(_recordId: string): AuxxRecord {
-  throw new Error('[auxx/client] useRecord hook not available - must be provided by runtime')
+export function useRecord(recordId: string): AuxxRecord {
+  const {
+    values: { record },
+  } = useAsyncCache({ record: [fetchRecordFromHost, recordId] })
+  return record
 }
 
 /**

--- a/packages/sdk/src/runtime/reconciler/tags/form-tag.ts
+++ b/packages/sdk/src/runtime/reconciler/tags/form-tag.ts
@@ -1,10 +1,15 @@
 // packages/sdk/src/runtime/reconciler/tags/form-tag.ts
 
-import type { FormSchema } from '../../../client/forms/types.js'
+import type { FormSchema, PickerLoadOptions } from '../../../client/forms/types.js'
 import { serializeSchema } from '../../../client/forms/utils/serialize.js'
 import { validateFormFields } from '../../../client/forms/utils/validation.js'
+import { eventBus } from '../../event-bus.js'
 import { registerEventHandler } from '../../register-event-handler.js'
+import { wrapEventHandler } from '../../wrap-event-handler.js'
 import { BaseTag } from './base-tag.js'
+
+/** Event-name prefix for a picker field's async option resolver (see host `AsyncOptionPicker`). */
+const LOAD_OPTIONS_PREFIX = 'loadOptions:'
 
 /**
  * Tag for Form component.
@@ -22,8 +27,51 @@ export class FormTag extends BaseTag {
     registerEventHandler(this, 'onError')
     registerEventHandler(this, 'onValidationError')
 
+    // Register each picker field's `loadOptions` as an invokable instance method
+    // (`loadOptions:<field>`) so the host's `AsyncOptionPicker` can resolve
+    // options over the existing `call-instance-method` bridge. The resolver is a
+    // runtime-only closure (stripped from the serialized schema), so it lives
+    // here, keyed by the form's instance id.
+    this.registerPickerLoadOptions(props.schema)
+
     // Store internal ref for form control
     this.internalRef = props.__internalRef
+  }
+
+  /** Collect `{ fieldName, loadOptions }` for every picker field with a resolver. */
+  private pickerResolvers(
+    schema: unknown
+  ): Array<{ name: string; loadOptions: PickerLoadOptions }> {
+    if (!schema || typeof schema !== 'object') return []
+    const out: Array<{ name: string; loadOptions: PickerLoadOptions }> = []
+    for (const [name, field] of Object.entries(schema as Record<string, any>)) {
+      if (field?.type === 'picker' && typeof field._metadata?.loadOptions === 'function') {
+        out.push({ name, loadOptions: field._metadata.loadOptions })
+      }
+    }
+    return out
+  }
+
+  private registerPickerLoadOptions(schema: unknown): void {
+    const resolvers = this.pickerResolvers(schema)
+    if (resolvers.length === 0) return
+
+    this.mounted.addListener(({ instance }) => {
+      for (const { name, loadOptions } of resolvers) {
+        const eventName = `${LOAD_OPTIONS_PREFIX}${name}`
+        eventBus.setTagEventListener(
+          eventName,
+          instance.instance_id,
+          wrapEventHandler((query: string) => loadOptions(query ?? ''), { eventName })
+        )
+      }
+    })
+
+    this.destroyed.addListener(({ instance }) => {
+      for (const { name } of resolvers) {
+        eventBus.clearTagEventListener(`${LOAD_OPTIONS_PREFIX}${name}`, instance.instance_id)
+      }
+    })
   }
 
   getTagName(): string {


### PR DESCRIPTION
## Summary

Implements two paired plans:

- **plan 10 — link contact → Stripe customer:** renders app `record.actions` in the contact detail view (`DetailViewActions`) and every drawer (via `BaseEntityDrawer`), and adds the reusable **`useRecord`** platform primitive (host `record-data-handler` reading the field-value store with a `fieldValue.batchGet` fallback, attribute-keyed values).
- **plan 11 — async option picker:** one searchable, server-backed picker (`AsyncOptionPicker`, wrapping `MultiSelectPicker`) reused by both action surfaces.

## Details

**`AsyncOptionPicker`** — debounced async `loadOptions(query)` or static client-filtered `options`; selected-value label persistence; stale-response dropping; single/multi.

**Adapter A (quick-actions):** `dynamic-select` now renders `AsyncOptionPicker`, retiring the `Combobox`.

**Adapter B (iframe app forms):** new SDK `Forms.picker` field; `FormTag` registers each picker's `loadOptions` as a `loadOptions:<field>` instance method, invoked host→iframe over the existing `call-instance-method` request/response bridge (no new channel). Host `field-renderer` gains a `picker` case wired through `form-reconstructor`; rebuilt the platform-runtime bundle.

## Verification
- TS diagnostics clean on all changed files.
- Builds green: `@auxx/sdk`, platform-runtime bundle (hash `fd8fcd2e`), and the Stripe app (`auxx build`).

## Outstanding (follow-up)
- `@auxx/sdk` release (needed for the prod Stripe-app publish — CI type-checks against the registry SDK, which lacks `Forms.picker`).
- Republish the Stripe app (separate repo PR) and runtime-verify the `loadOptions` bridge.
- Stripe `/customers/search` substring query (`email~ OR name~`) not yet exercised live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)