### PR TITLE
feat(kbar): embed snippet/signature/task create forms in palette

### DIFF
--- a/apps/web/src/components/kbar/actions/create.ts
+++ b/apps/web/src/components/kbar/actions/create.ts
@@ -5,8 +5,6 @@ import { useMemo } from 'react'
 import { useCreateEntityStore } from '~/components/global-create/create-entity-store'
 import { SYSTEM_CREATE_HOTKEYS } from '~/components/global-create/system-hotkeys'
 import { useResources } from '~/components/resources/hooks/use-resources'
-import { useSignatureDialogStore } from '~/components/signatures/stores/signature-dialog-store'
-import { useSnippetDialogStore } from '~/components/snippets/snippet-dialog-store'
 import { useCommandPaletteStore } from '../store'
 import type { PaletteAction } from '../types'
 
@@ -36,10 +34,10 @@ export function useCreateActions(): PaletteAction[] {
 }
 
 /**
- * Create actions that aren't entity instances — signatures and snippets — each
- * driven by its own global dialog store ({@link useSignatureDialogStore} /
- * {@link useSnippetDialogStore}). Kept out of the resource loop above since they
- * have no entity definition.
+ * Create actions that aren't entity instances — signatures and snippets. Inside
+ * the palette these drill into their embedded `create-signature` / `create-snippet`
+ * pages (the form renders as a step); the standalone dialog stores stay mounted for
+ * use outside the palette (settings pages).
  */
 export function useNonEntityCreateActions(): PaletteAction[] {
   return useMemo<PaletteAction[]>(
@@ -50,10 +48,7 @@ export function useNonEntityCreateActions(): PaletteAction[] {
         subtitle: 'New email signature',
         icon: 'pen-tool',
         keywords: 'create new signature email',
-        perform: () => {
-          useSignatureDialogStore.getState().openCreate()
-          useCommandPaletteStore.getState().close()
-        },
+        perform: () => useCommandPaletteStore.getState().openCreateSignature(),
       },
       {
         id: 'create.snippet',
@@ -61,10 +56,7 @@ export function useNonEntityCreateActions(): PaletteAction[] {
         subtitle: 'New reusable snippet',
         icon: 'braces',
         keywords: 'create new snippet canned response',
-        perform: () => {
-          useSnippetDialogStore.getState().openCreate()
-          useCommandPaletteStore.getState().close()
-        },
+        perform: () => useCommandPaletteStore.getState().openCreateSnippet(),
       },
     ],
     []

--- a/apps/web/src/components/kbar/actions/general.ts
+++ b/apps/web/src/components/kbar/actions/general.ts
@@ -3,7 +3,6 @@
 
 import { useMemo } from 'react'
 import { useComposeStore } from '~/components/mail/store/compose-store'
-import { useCreateTaskStore } from '~/components/tasks/stores/create-task-store'
 import { useCommandPaletteStore } from '../store'
 import type { PaletteAction } from '../types'
 
@@ -32,10 +31,7 @@ export function useGeneralActions(): PaletteAction[] {
         subtitle: 'Create a new task',
         icon: 'list-checks',
         keywords: 'task create new to-do',
-        perform: () => {
-          useCreateTaskStore.getState().openDialog()
-          useCommandPaletteStore.getState().close()
-        },
+        perform: () => useCommandPaletteStore.getState().openCreateTask(),
       },
     ],
     []

--- a/apps/web/src/components/kbar/command-palette.tsx
+++ b/apps/web/src/components/kbar/command-palette.tsx
@@ -5,8 +5,12 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@auxx/ui/compo
 import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
 import { useEffect, useState } from 'react'
 import { useResources } from '~/components/resources/hooks/use-resources'
+import { preventTaskPickerEscape } from '~/components/tasks/ui/task-form'
 import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
 import { CreatePage } from './pages/create'
+import { CreateSignaturePage } from './pages/create-signature'
+import { CreateSnippetPage } from './pages/create-snippet'
+import { CreateTaskPage } from './pages/create-task'
 import { RecordActionsPage } from './pages/record-actions'
 import { RootPage } from './pages/root'
 import { SearchPage } from './pages/search'
@@ -70,6 +74,8 @@ export function CommandPalette() {
           // The palette pages supply their own titles (DialogNav / sr-only) but
           // no description; opt out explicitly so Radix doesn't warn.
           aria-describedby={undefined}
+          // Keep the @mention picker's Esc from closing the palette on the task page.
+          onEscapeKeyDown={page === 'create-task' ? preventTaskPickerEscape : undefined}
           {...(isCreate ? guardProps : {})}>
           {page === 'root' ? (
             // Root has its own cmdk search input, so it skips the breadcrumb bar —
@@ -94,6 +100,20 @@ export function CommandPalette() {
               crumbs={[{ label: `Create ${createLabel ?? 'record'}` }]}
               onBack={guardedClose}
             />
+          ) : page === 'create-snippet' ? (
+            <DialogNav
+              title='Create Snippet'
+              crumbs={[{ label: 'Create Snippet' }]}
+              onBack={back}
+            />
+          ) : page === 'create-signature' ? (
+            <DialogNav
+              title='Create Signature'
+              crumbs={[{ label: 'Create Signature' }]}
+              onBack={back}
+            />
+          ) : page === 'create-task' ? (
+            <DialogNav title='Create Task' crumbs={[{ label: 'Create Task' }]} onBack={back} />
           ) : null}
 
           <DialogNavPages value={page}>
@@ -108,6 +128,15 @@ export function CommandPalette() {
             </DialogNavPage>
             <DialogNavPage value='create' size='lg'>
               <CreatePage onDirtyChange={setCreateDirty} onRequestClose={guardedClose} />
+            </DialogNavPage>
+            <DialogNavPage value='create-snippet' size='xxl'>
+              <CreateSnippetPage />
+            </DialogNavPage>
+            <DialogNavPage value='create-signature' size='xxl'>
+              <CreateSignaturePage />
+            </DialogNavPage>
+            <DialogNavPage value='create-task' size='xl'>
+              <CreateTaskPage />
             </DialogNavPage>
           </DialogNavPages>
         </DialogContent>

--- a/apps/web/src/components/kbar/pages/create-signature.tsx
+++ b/apps/web/src/components/kbar/pages/create-signature.tsx
@@ -1,0 +1,27 @@
+// apps/web/src/components/kbar/pages/create-signature.tsx
+'use client'
+
+import { SignatureForm } from '~/components/signatures/ui/signature-form'
+import { useCommandPaletteStore } from '../store'
+
+/**
+ * Hosts the shell-free {@link SignatureForm} as a palette page (create mode only).
+ * The breadcrumb supplies the title (no header slot). On success / cancel the
+ * palette closes; back returns to root.
+ */
+export function CreateSignaturePage() {
+  const page = useCommandPaletteStore((s) => s.page)
+  const close = useCommandPaletteStore((s) => s.close)
+  const goTo = useCommandPaletteStore((s) => s.goTo)
+
+  return (
+    <div className='p-4'>
+      <SignatureForm
+        open={page === 'create-signature'}
+        onSuccess={close}
+        onClose={close}
+        onCancel={() => goTo('root')}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/pages/create-snippet.tsx
+++ b/apps/web/src/components/kbar/pages/create-snippet.tsx
@@ -1,0 +1,27 @@
+// apps/web/src/components/kbar/pages/create-snippet.tsx
+'use client'
+
+import { SnippetForm } from '~/app/(protected)/app/settings/snippets/_components/snippet-form'
+import { useCommandPaletteStore } from '../store'
+
+/**
+ * Hosts {@link SnippetForm} as a palette page. `SnippetForm` is already shell-free
+ * (no `Dialog`, no header — it owns its own mutations + cache invalidation), so the
+ * page just renders it; the breadcrumb supplies the title. On success the palette
+ * closes; cancel / back returns to root.
+ */
+export function CreateSnippetPage() {
+  const folderId = useCommandPaletteStore((s) => s.createSnippetFolderId)
+  const close = useCommandPaletteStore((s) => s.close)
+  const goTo = useCommandPaletteStore((s) => s.goTo)
+
+  return (
+    <div className='p-4'>
+      <SnippetForm
+        initialValues={{ folderId: folderId ?? undefined }}
+        onSuccess={close}
+        onCancel={() => goTo('root')}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/pages/create-task.tsx
+++ b/apps/web/src/components/kbar/pages/create-task.tsx
@@ -1,0 +1,29 @@
+// apps/web/src/components/kbar/pages/create-task.tsx
+'use client'
+
+import { TaskForm } from '~/components/tasks/ui/task-form'
+import { useCommandPaletteStore } from '../store'
+
+/**
+ * Hosts the shell-free {@link TaskForm} as a palette page (create mode). The
+ * breadcrumb supplies the title; the Esc carve-out for the @mention picker lives
+ * in the palette shell (see `command-palette.tsx`). On save the palette closes
+ * (or, with "Create more", the form resets and stays); cancel / back returns to
+ * root.
+ */
+export function CreateTaskPage() {
+  const page = useCommandPaletteStore((s) => s.page)
+  const ref = useCommandPaletteStore((s) => s.createTaskRef)
+  const close = useCommandPaletteStore((s) => s.close)
+  const goTo = useCommandPaletteStore((s) => s.goTo)
+
+  return (
+    <TaskForm
+      open={page === 'create-task'}
+      mode='create'
+      defaultReferencedEntity={ref ?? undefined}
+      onClose={close}
+      onCancel={() => goTo('root')}
+    />
+  )
+}

--- a/apps/web/src/components/kbar/pages/record-actions.tsx
+++ b/apps/web/src/components/kbar/pages/record-actions.tsx
@@ -6,7 +6,6 @@ import { Command, CommandGroup, CommandItem, CommandList } from '@auxx/ui/compon
 import { Copy, ExternalLink, Link2, ListChecks, SquareArrowOutUpRight } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useResourceStore } from '~/components/resources/store/resource-store'
-import { useCreateTaskStore } from '~/components/tasks/stores/create-task-store'
 import { recordHref } from '../record-href'
 import { selectOnEnter } from '../select-on-enter'
 import { useCommandPaletteStore } from '../store'
@@ -48,8 +47,8 @@ export function RecordActionsPage() {
   }
 
   const createTask = () => {
-    useCreateTaskStore.getState().openDialog({ referencedEntity: selected.recordId as RecordId })
-    close()
+    // Drill into the embedded task page with the record pre-linked (stays in-palette).
+    useCommandPaletteStore.getState().openCreateTask(selected.recordId as RecordId)
   }
 
   return (

--- a/apps/web/src/components/kbar/store.ts
+++ b/apps/web/src/components/kbar/store.ts
@@ -1,6 +1,7 @@
 // apps/web/src/components/kbar/store.ts
 'use client'
 
+import type { RecordId } from '@auxx/lib/field-values/client'
 import { create } from 'zustand'
 import type { PalettePage } from './types'
 
@@ -23,6 +24,10 @@ interface CommandPaletteState {
   searchActive: PaletteSelectedRecord | null
   /** Entity definition id for the embedded `create` page. */
   createEntityId: string | null
+  /** Optional folder pre-selection for the embedded `create-snippet` page. */
+  createSnippetFolderId: string | null
+  /** Optional record to pre-link on the embedded `create-task` page. */
+  createTaskRef: RecordId | null
 
   openPalette: () => void
   close: () => void
@@ -32,6 +37,9 @@ interface CommandPaletteState {
   openRecordActions: (record: PaletteSelectedRecord) => void
   setSearchActive: (record: PaletteSelectedRecord | null) => void
   openCreate: (entityDefinitionId: string) => void
+  openCreateSnippet: (folderId?: string) => void
+  openCreateSignature: () => void
+  openCreateTask: (ref?: RecordId) => void
   /** `Meta+K`: open when closed; on the search page open the active record's
    *  actions; otherwise toggle closed. */
   metaK: () => void
@@ -43,6 +51,9 @@ const BACK_TARGET: Record<PalettePage, PalettePage> = {
   search: 'root',
   'record-actions': 'search',
   create: 'root',
+  'create-snippet': 'root',
+  'create-signature': 'root',
+  'create-task': 'root',
 }
 
 /**
@@ -56,9 +67,11 @@ export const useCommandPaletteStore = create<CommandPaletteState>((set, get) => 
   selectedRecord: null,
   searchActive: null,
   createEntityId: null,
+  createSnippetFolderId: null,
+  createTaskRef: null,
 
   openPalette: () => set({ open: true, page: 'root' }),
-  close: () => set({ open: false }),
+  close: () => set({ open: false, createSnippetFolderId: null, createTaskRef: null }),
   toggle: () => (get().open ? set({ open: false }) : set({ open: true, page: 'root' })),
   goTo: (page) => set({ page }),
   back: () => set({ page: BACK_TARGET[get().page] }),
@@ -66,6 +79,10 @@ export const useCommandPaletteStore = create<CommandPaletteState>((set, get) => 
   setSearchActive: (record) => set({ searchActive: record }),
   openCreate: (entityDefinitionId) =>
     set({ open: true, createEntityId: entityDefinitionId, page: 'create' }),
+  openCreateSnippet: (folderId) =>
+    set({ open: true, createSnippetFolderId: folderId ?? null, page: 'create-snippet' }),
+  openCreateSignature: () => set({ open: true, page: 'create-signature' }),
+  openCreateTask: (ref) => set({ open: true, createTaskRef: ref ?? null, page: 'create-task' }),
   metaK: () => {
     const s = get()
     if (!s.open) return set({ open: true, page: 'root' })

--- a/apps/web/src/components/kbar/types.ts
+++ b/apps/web/src/components/kbar/types.ts
@@ -1,7 +1,14 @@
 // apps/web/src/components/kbar/types.ts
 
 /** Pages the command palette can show. */
-export type PalettePage = 'root' | 'search' | 'record-actions' | 'create'
+export type PalettePage =
+  | 'root'
+  | 'search'
+  | 'record-actions'
+  | 'create'
+  | 'create-snippet'
+  | 'create-signature'
+  | 'create-task'
 
 /**
  * A single command-palette entry. The whole palette is built from plain arrays

--- a/apps/web/src/components/signatures/ui/signature-dialog.tsx
+++ b/apps/web/src/components/signatures/ui/signature-dialog.tsx
@@ -1,47 +1,8 @@
 // apps/web/src/components/signatures/ui/signature-dialog.tsx
 'use client'
 
-import { parseRecordId } from '@auxx/types/resource'
-import { Button } from '@auxx/ui/components/button'
-import { Card, CardContent } from '@auxx/ui/components/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
-import { Form, FormLabel } from '@auxx/ui/components/form'
-import { InputGroup, InputGroupAddon, InputGroupInput } from '@auxx/ui/components/input-group'
-import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
-import { toastError } from '@auxx/ui/components/toast'
-import { TooltipError } from '@auxx/ui/components/tooltip'
-import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { GlobeIcon, LockIcon, StarIcon } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { z } from 'zod'
-import { EditorToolbar } from '~/components/editor/editor-button'
-import { EditorProvider } from '~/components/editor/editor-context'
-import { type SignatureVisibility, useSignature, useSignatureMutations } from '../hooks'
-import { SignatureBodyEditor } from './signature-body-editor'
-
-/** Form validation schema for signatures */
-const formSchema = z.object({
-  name: z.string().min(1, 'Signature name is required'),
-  body: z.string().min(1, 'Signature content is required'),
-  isDefault: z.boolean().optional(),
-  visibility: z.enum(['private', 'org_members'] as const),
-})
-
-type FormData = z.infer<typeof formSchema>
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@auxx/ui/components/dialog'
+import { SignatureForm } from './signature-form'
 
 /** Props for SignatureDialog */
 interface SignatureDialogProps {
@@ -54,9 +15,9 @@ interface SignatureDialogProps {
 }
 
 /**
- * Unified dialog for creating and editing email signatures.
- * - Create mode: signatureId is null/undefined
- * - Edit mode: signatureId resolves an existing signature via useSignature
+ * Thin modal wrapper around {@link SignatureForm}. Supplies the `Dialog` shell and
+ * the header; all form logic lives in the core, which the command palette hosts
+ * directly as a page. Public API is unchanged.
  */
 export function SignatureDialog({
   open,
@@ -64,176 +25,20 @@ export function SignatureDialog({
   signatureId,
   onSuccess,
 }: SignatureDialogProps) {
-  const isEditing = !!signatureId
-  const { signature } = useSignature(signatureId)
-  const { create, update, isCreating, isUpdating } = useSignatureMutations()
-
-  const [html, setHtml] = useState(signature?.body || '')
-
-  const form = useForm<FormData>({
-    resolver: standardSchemaResolver(formSchema, undefined, { mode: 'sync' }),
-    mode: 'onSubmit',
-    reValidateMode: 'onChange',
-    defaultValues: {
-      name: signature?.name || '',
-      body: signature?.body || '',
-      isDefault: signature?.isDefault || false,
-      visibility: signature?.visibility || 'private',
-    },
-  })
-
-  // Guard: editing an id that resolves to nothing (e.g. deleted) -> close.
-  useEffect(() => {
-    if (open && isEditing && !signature) {
-      toastError({
-        title: 'Signature not found',
-        description: 'The signature may have been deleted.',
-      })
-      onOpenChange(false)
-    }
-  }, [open, isEditing, signature, onOpenChange])
-
-  // Hydrate the form once the signature resolves (edit mode).
-  useEffect(() => {
-    if (open && signature) {
-      form.reset({
-        name: signature.name,
-        body: signature.body,
-        isDefault: signature.isDefault,
-        visibility: signature.visibility,
-      })
-      setHtml(signature.body)
-    }
-  }, [open, signature, form])
-
-  const onSubmit = async (data: FormData) => {
-    data.body = html
-
-    let savedId = signatureId ?? ''
-
-    if (signature?.recordId) {
-      await update(signature.recordId, {
-        name: data.name,
-        body: data.body,
-        isDefault: data.isDefault,
-        visibility: data.visibility,
-      })
-    } else {
-      const result = await create({
-        name: data.name,
-        body: data.body,
-        isDefault: data.isDefault,
-        visibility: data.visibility,
-      })
-      savedId = parseRecordId(result.recordId).entityInstanceId
-    }
-
-    onSuccess?.(savedId)
-    onOpenChange(false)
-  }
-
-  const handleEditorChange = (newHtml: string) => {
-    setHtml(newHtml)
-    form.setValue('body', newHtml, { shouldDirty: true, shouldTouch: true })
-  }
-
-  const visibility = form.watch('visibility')
-  const isDefault = form.watch('isDefault')
-  const isPending = isCreating || isUpdating
-
-  const VisibilityIcon = visibility === 'org_members' ? GlobeIcon : LockIcon
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent position='tc' size='xxl' innerClassName='max-h-[90vh] overflow-auto'>
-        <DialogHeader className='mb-4'>
-          <DialogTitle>{isEditing ? 'Edit Signature' : 'Create Signature'}</DialogTitle>
-        </DialogHeader>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-6'>
-            <div className='flex flex-col space-y-2'>
-              <FormLabel htmlFor='signature-name'>Signature Name</FormLabel>
-              <InputGroup>
-                <InputGroupInput
-                  id='signature-name'
-                  placeholder='e.g., Professional, Casual, Support Team'
-                  aria-invalid={!!form.formState.errors.name}
-                  {...form.register('name')}
-                />
-                <InputGroupAddon align='inline-end'>
-                  <button
-                    type='button'
-                    title={isDefault ? 'Default signature' : 'Set as default'}
-                    onClick={() => form.setValue('isDefault', !isDefault, { shouldDirty: true })}
-                    className='flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-muted'>
-                    <StarIcon
-                      className={isDefault ? 'size-4 fill-yellow-500 text-yellow-500' : 'size-4'}
-                    />
-                  </button>
-                  <Select
-                    value={visibility}
-                    onValueChange={(v) =>
-                      form.setValue('visibility', v as SignatureVisibility, { shouldDirty: true })
-                    }>
-                    <SelectTrigger
-                      variant='ghost'
-                      size='xs'
-                      className='mr-0.5 gap-1 text-muted-foreground'>
-                      <VisibilityIcon className='size-3.5' />
-                      <SelectValue placeholder='Visibility' />
-                    </SelectTrigger>
-                    <SelectContent align='end'>
-                      <SelectItem value='private'>Private</SelectItem>
-                      <SelectItem value='org_members'>All Members</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  {form.formState.errors.name && (
-                    <TooltipError text={form.formState.errors.name.message ?? ''} />
-                  )}
-                </InputGroupAddon>
-              </InputGroup>
-            </div>
-
-            <div className='space-y-2'>
-              <EditorProvider>
-                <FormLabel>Signature Content</FormLabel>
-                <Card className='overflow-hidden'>
-                  <CardContent className='p-0'>
-                    <div className='border-b px-3 py-2'>
-                      <EditorToolbar showSend={false} />
-                    </div>
-                    <SignatureBodyEditor
-                      content={html}
-                      onChange={handleEditorChange}
-                      placeholder='Design your signature here...'
-                      className='h-full'
-                    />
-                  </CardContent>
-                </Card>
-                {form.formState.errors.body && (
-                  <p className='text-sm font-medium text-destructive'>
-                    {form.formState.errors.body.message}
-                  </p>
-                )}
-              </EditorProvider>
-            </div>
-
-            <DialogFooter>
-              <Button type='button' size='sm' variant='ghost' onClick={() => onOpenChange(false)}>
-                Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-              </Button>
-              <Button
-                type='submit'
-                size='sm'
-                variant='outline'
-                loading={isPending}
-                loadingText={isEditing ? 'Saving...' : 'Creating...'}>
-                {isEditing ? 'Save Changes' : 'Create Signature'}{' '}
-                <KbdSubmit variant='outline' size='sm' />
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
+        <SignatureForm
+          open={open}
+          signatureId={signatureId}
+          onSuccess={onSuccess}
+          onClose={() => onOpenChange(false)}
+          header={({ title }) => (
+            <DialogHeader className='mb-4'>
+              <DialogTitle>{title}</DialogTitle>
+            </DialogHeader>
+          )}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/components/signatures/ui/signature-form.tsx
+++ b/apps/web/src/components/signatures/ui/signature-form.tsx
@@ -1,0 +1,246 @@
+// apps/web/src/components/signatures/ui/signature-form.tsx
+'use client'
+
+import { parseRecordId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import { Card, CardContent } from '@auxx/ui/components/card'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { Form, FormLabel } from '@auxx/ui/components/form'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@auxx/ui/components/input-group'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { toastError } from '@auxx/ui/components/toast'
+import { TooltipError } from '@auxx/ui/components/tooltip'
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
+import { GlobeIcon, LockIcon, StarIcon } from 'lucide-react'
+import { type ReactNode, useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { EditorToolbar } from '~/components/editor/editor-button'
+import { EditorProvider } from '~/components/editor/editor-context'
+import { type SignatureVisibility, useSignature, useSignatureMutations } from '../hooks'
+import { SignatureBodyEditor } from './signature-body-editor'
+
+/** Form validation schema for signatures */
+const formSchema = z.object({
+  name: z.string().min(1, 'Signature name is required'),
+  body: z.string().min(1, 'Signature content is required'),
+  isDefault: z.boolean().optional(),
+  visibility: z.enum(['private', 'org_members'] as const),
+})
+
+type FormData = z.infer<typeof formSchema>
+
+/** Props for the shell-free signature form core. */
+export interface SignatureFormProps {
+  /** Whether the form is "open" — drives the init/reset cycle. In a dialog this is
+   *  the dialog's open state; in the palette it's `page === 'create-signature'`. */
+  open: boolean
+  /** Signature id (instance id) for edit mode; null/undefined = create */
+  signatureId?: string | null
+  /** Called after a successful save with the saved signature id (for auto-select) */
+  onSuccess?: (signatureId: string) => void
+  /** Dismiss after a successful save / unrecoverable state (dialog closes; palette
+   *  closes). */
+  onClose: () => void
+  /** Cancel/back dismiss. Defaults to {@link onClose}; the palette routes it back
+   *  to the root action list instead of closing outright. */
+  onCancel?: () => void
+  /** Host-specific header. Dialogs render a `DialogHeader`; the palette omits it
+   *  (the breadcrumb supplies the title). */
+  header?: (ctx: { title: string }) => ReactNode
+}
+
+/**
+ * Shell-free signature create/edit form: all hooks/state, the field body, and the
+ * footer (Cancel / Create). The only host seams are the `header` slot and `onClose`.
+ * `signature-dialog.tsx` wraps this in a `Dialog`; the command palette hosts it as a
+ * page. Behavior is unchanged from the original dialog (no "create more", no dirty
+ * guard).
+ */
+export function SignatureForm({
+  open,
+  signatureId,
+  onSuccess,
+  onClose,
+  onCancel,
+  header,
+}: SignatureFormProps) {
+  const cancel = onCancel ?? onClose
+  const isEditing = !!signatureId
+  const { signature } = useSignature(signatureId)
+  const { create, update, isCreating, isUpdating } = useSignatureMutations()
+
+  const [html, setHtml] = useState(signature?.body || '')
+
+  const form = useForm<FormData>({
+    resolver: standardSchemaResolver(formSchema, undefined, { mode: 'sync' }),
+    mode: 'onSubmit',
+    reValidateMode: 'onChange',
+    defaultValues: {
+      name: signature?.name || '',
+      body: signature?.body || '',
+      isDefault: signature?.isDefault || false,
+      visibility: signature?.visibility || 'private',
+    },
+  })
+
+  // Guard: editing an id that resolves to nothing (e.g. deleted) -> close.
+  useEffect(() => {
+    if (open && isEditing && !signature) {
+      toastError({
+        title: 'Signature not found',
+        description: 'The signature may have been deleted.',
+      })
+      onClose()
+    }
+  }, [open, isEditing, signature, onClose])
+
+  // Hydrate the form once the signature resolves (edit mode).
+  useEffect(() => {
+    if (open && signature) {
+      form.reset({
+        name: signature.name,
+        body: signature.body,
+        isDefault: signature.isDefault,
+        visibility: signature.visibility,
+      })
+      setHtml(signature.body)
+    }
+  }, [open, signature, form])
+
+  const onSubmit = async (data: FormData) => {
+    data.body = html
+
+    let savedId = signatureId ?? ''
+
+    if (signature?.recordId) {
+      await update(signature.recordId, {
+        name: data.name,
+        body: data.body,
+        isDefault: data.isDefault,
+        visibility: data.visibility,
+      })
+    } else {
+      const result = await create({
+        name: data.name,
+        body: data.body,
+        isDefault: data.isDefault,
+        visibility: data.visibility,
+      })
+      savedId = parseRecordId(result.recordId).entityInstanceId
+    }
+
+    onSuccess?.(savedId)
+    onClose()
+  }
+
+  const handleEditorChange = (newHtml: string) => {
+    setHtml(newHtml)
+    form.setValue('body', newHtml, { shouldDirty: true, shouldTouch: true })
+  }
+
+  const visibility = form.watch('visibility')
+  const isDefault = form.watch('isDefault')
+  const isPending = isCreating || isUpdating
+  const title = isEditing ? 'Edit Signature' : 'Create Signature'
+
+  const VisibilityIcon = visibility === 'org_members' ? GlobeIcon : LockIcon
+
+  return (
+    <>
+      {header?.({ title })}
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-6'>
+          <div className='flex flex-col space-y-2'>
+            <FormLabel htmlFor='signature-name'>Signature Name</FormLabel>
+            <InputGroup>
+              <InputGroupInput
+                id='signature-name'
+                placeholder='e.g., Professional, Casual, Support Team'
+                aria-invalid={!!form.formState.errors.name}
+                {...form.register('name')}
+              />
+              <InputGroupAddon align='inline-end'>
+                <button
+                  type='button'
+                  title={isDefault ? 'Default signature' : 'Set as default'}
+                  onClick={() => form.setValue('isDefault', !isDefault, { shouldDirty: true })}
+                  className='flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-muted'>
+                  <StarIcon
+                    className={isDefault ? 'size-4 fill-yellow-500 text-yellow-500' : 'size-4'}
+                  />
+                </button>
+                <Select
+                  value={visibility}
+                  onValueChange={(v) =>
+                    form.setValue('visibility', v as SignatureVisibility, { shouldDirty: true })
+                  }>
+                  <SelectTrigger
+                    variant='ghost'
+                    size='xs'
+                    className='mr-0.5 gap-1 text-muted-foreground'>
+                    <VisibilityIcon className='size-3.5' />
+                    <SelectValue placeholder='Visibility' />
+                  </SelectTrigger>
+                  <SelectContent align='end'>
+                    <SelectItem value='private'>Private</SelectItem>
+                    <SelectItem value='org_members'>All Members</SelectItem>
+                  </SelectContent>
+                </Select>
+                {form.formState.errors.name && (
+                  <TooltipError text={form.formState.errors.name.message ?? ''} />
+                )}
+              </InputGroupAddon>
+            </InputGroup>
+          </div>
+
+          <div className='space-y-2'>
+            <EditorProvider>
+              <FormLabel>Signature Content</FormLabel>
+              <Card className='overflow-hidden'>
+                <CardContent className='p-0'>
+                  <div className='border-b px-3 py-2'>
+                    <EditorToolbar showSend={false} />
+                  </div>
+                  <SignatureBodyEditor
+                    content={html}
+                    onChange={handleEditorChange}
+                    placeholder='Design your signature here...'
+                    className='h-full'
+                  />
+                </CardContent>
+              </Card>
+              {form.formState.errors.body && (
+                <p className='text-sm font-medium text-destructive'>
+                  {form.formState.errors.body.message}
+                </p>
+              )}
+            </EditorProvider>
+          </div>
+
+          <DialogFooter>
+            <Button type='button' size='sm' variant='ghost' onClick={cancel}>
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+            </Button>
+            <Button
+              type='submit'
+              size='sm'
+              variant='outline'
+              loading={isPending}
+              loadingText={isEditing ? 'Saving...' : 'Creating...'}>
+              {isEditing ? 'Save Changes' : 'Create Signature'}{' '}
+              <KbdSubmit variant='outline' size='sm' />
+            </Button>
+          </DialogFooter>
+        </form>
+      </Form>
+    </>
+  )
+}

--- a/apps/web/src/components/tasks/ui/task-dialog.tsx
+++ b/apps/web/src/components/tasks/ui/task-dialog.tsx
@@ -3,33 +3,15 @@
 'use client'
 
 import type { RecordId } from '@auxx/lib/field-values/client'
-import type { CreateTaskInput, TaskWithRelations, UpdateTaskInput } from '@auxx/lib/tasks'
-import { DateLanguageModule, TextDateParser } from '@auxx/lib/tasks/client'
-import type { ActorId } from '@auxx/types/actor'
-import { Button, buttonVariants } from '@auxx/ui/components/button'
+import type { TaskWithRelations } from '@auxx/lib/tasks'
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@auxx/ui/components/dialog'
-import { Kbd } from '@auxx/ui/components/kbd'
-import { Switch } from '@auxx/ui/components/switch'
-import { toastSuccess } from '@auxx/ui/components/toast'
-import { cn } from '@auxx/ui/lib/utils'
-import { EditorContent } from '@tiptap/react'
-import { Calendar, Link2, User, X } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { InlinePickerPopover, useMentionEditor } from '~/components/editor/inline-picker'
-import { SubmitOnEnter } from '~/components/global/comments/comment-composer'
-import { ActorPicker } from '~/components/pickers/actor-picker/actor-picker'
-import { ActorPickerContent } from '~/components/pickers/actor-picker/actor-picker-content'
-import { DateTimePicker } from '~/components/pickers/date-time-picker'
-import { RecordPicker } from '~/components/pickers/record-picker'
-import { useTaskMutations } from '../hooks/use-task-mutations'
-import { formatTaskDeadlineDisplay } from '../utils/group-tasks-by-period'
+import { preventTaskPickerEscape, TaskForm } from './task-form'
 
 /**
  * Props for TaskDialog component
@@ -48,21 +30,10 @@ interface TaskDialogProps {
 }
 
 /**
- * Check if editor content is empty (just empty paragraph tags)
- */
-function isEmptyContent(html: string): boolean {
-  if (!html) return true
-  const stripped = html
-    .replace(/<p[^>]*>/g, '')
-    .replace(/<\/p>/g, '')
-    .trim()
-  return stripped === ''
-}
-
-/**
- * TaskDialog renders a dialog for creating or editing tasks.
- * Uses tiptap editor for rich text input with @mentions.
- * Auto-parses date expressions from text and sets deadline automatically.
+ * Thin modal wrapper around {@link TaskForm}. Supplies the `Dialog` shell, the
+ * header, and the Esc carve-out that keeps the @mention picker's Esc from closing
+ * the dialog. All form logic lives in the core, which the command palette hosts
+ * directly as a page. Public API is unchanged.
  */
 export function TaskDialog({
   open,
@@ -71,364 +42,26 @@ export function TaskDialog({
   task,
   defaultReferencedEntity,
 }: TaskDialogProps) {
-  // Form state
-  const [deadline, setDeadline] = useState<Date | undefined>(undefined)
-  const [deadlineManuallySet, setDeadlineManuallySet] = useState(false)
-  const [assigneeActorIds, setAssigneeActorIds] = useState<ActorId[]>([])
-  const [linkedRecords, setLinkedRecords] = useState<RecordId[]>([])
-  const [createMore, setCreateMore] = useState(false)
-
-  // Mutations
-  const { createTask, updateTask, isCreating, isUpdating } = useTaskMutations()
-  const isSaving = isCreating || isUpdating
-
-  // Container ref for popover positioning
-  const containerRef = useRef<HTMLDivElement>(null)
-
-  // Create parser and date module (memoized)
-  const textDateParser = useMemo(() => new TextDateParser(), [])
-  const dateModule = useMemo(() => {
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-    return new DateLanguageModule(timezone)
-  }, [])
-
-  // Ref to track handleSave for SubmitOnEnter extension (updated after handleSave is defined)
-  const handleSaveRef = useRef<() => void>(() => {})
-
-  // Build initial content from task
-  const initialContent = useMemo(() => {
-    if (!task) return ''
-    return `<p>${task.title}</p>`
-  }, [task])
-
-  // Initialize mention editor using the inline-picker system
-  const mentionEditor = useMentionEditor({
-    initialContent,
-    placeholder: 'What needs to be done? Use @ to assign members...',
-    editable: true,
-    className: cn(
-      'prose prose-sm prose-p:my-0 focus:outline-hidden max-w-none',
-      'dark:prose-invert'
-    ),
-    extensions: [
-      SubmitOnEnter.configure({
-        isExpanded: () => false,
-        onSubmit: () => {
-          handleSaveRef.current()
-        },
-      }),
-    ],
-  })
-  const { editor, suggestionState, insertMention, closePicker } = mentionEditor
-
-  /**
-   * Handle editor text change - auto-set deadline if not manually set
-   */
-  const handleEditorUpdate = useCallback(() => {
-    if (!editor || deadlineManuallySet) {
-      return
-    }
-
-    const text = editor.getText().trim()
-    const result = textDateParser.parse(text)
-
-    if (result.found && result.duration && result.confidence >= 0.7) {
-      const calculatedDate = dateModule.calculateTargetDate(result.duration)
-      setDeadline(calculatedDate)
-    } else {
-      setDeadline(undefined)
-    }
-  }, [editor, textDateParser, dateModule, deadlineManuallySet])
-
-  // Add editor update listener
-  useEffect(() => {
-    if (!editor) return
-
-    editor.on('update', handleEditorUpdate)
-    return () => {
-      editor.off('update', handleEditorUpdate)
-    }
-  }, [editor, handleEditorUpdate])
-
-  // Reset form when task changes or dialog opens
-  // biome-ignore lint/correctness/useExhaustiveDependencies: mentionEditor.setContent is stable
-  useEffect(() => {
-    if (open) {
-      if (task) {
-        // Edit mode: populate from existing task
-        setDeadline(task.deadline ? new Date(task.deadline) : undefined)
-        setDeadlineManuallySet(!!task.deadline)
-        setAssigneeActorIds(task.assignments ?? [])
-        setLinkedRecords(task.references ?? [])
-      } else {
-        // Create mode: start fresh
-        setDeadline(undefined)
-        setDeadlineManuallySet(false)
-        setAssigneeActorIds([])
-        setLinkedRecords(defaultReferencedEntity ? [defaultReferencedEntity] : [])
-      }
-      // Defer editor operations using double requestAnimationFrame to ensure
-      // we're outside React's render cycle and avoid flushSync errors
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (task) {
-            mentionEditor.setContent(`<p>${task.title}</p>`)
-          } else {
-            editor?.commands.clearContent()
-          }
-          editor?.commands.focus()
-        })
-      })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [task, open, editor, defaultReferencedEntity])
-
-  /**
-   * Handle manual deadline change from date picker
-   * This marks the deadline as "manually set" and stops auto-parsing
-   */
-  const handleDeadlineChange = useCallback((date: Date | undefined) => {
-    setDeadline(date)
-    if (date !== undefined) {
-      setDeadlineManuallySet(true)
-    }
-  }, [])
-
-  /**
-   * Handle clearing the deadline - re-enables auto-parsing
-   */
-  const handleDeadlineClear = useCallback(() => {
-    setDeadline(undefined)
-    setDeadlineManuallySet(false)
-  }, [])
-
-  /**
-   * Reset form state for creating another task
-   */
-  const resetForm = useCallback(() => {
-    editor?.commands.clearContent()
-    setDeadline(undefined)
-    setDeadlineManuallySet(false)
-    setAssigneeActorIds([])
-    setLinkedRecords(defaultReferencedEntity ? [defaultReferencedEntity] : [])
-    // Use double requestAnimationFrame to avoid flushSync errors
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        editor?.commands.focus()
-      })
-    })
-  }, [editor, defaultReferencedEntity])
-
-  /**
-   * Handle save button click
-   */
-  const handleSave = useCallback(async () => {
-    if (!editor) return
-
-    const html = editor.getHTML()
-    if (isEmptyContent(html)) return
-
-    const text = editor.getText().trim()
-    const lines = text.split('\n')
-    const title = lines[0]?.trim() || ''
-    const description = html
-
-    if (!title) return
-
-    if (mode === 'create') {
-      const input: CreateTaskInput = {
-        title,
-        description,
-        deadline: deadline ? { type: 'static', value: deadline.toISOString() } : undefined,
-        assigneeActorIds,
-        referencedEntities: linkedRecords.length > 0 ? linkedRecords : undefined,
-      }
-      createTask.mutate(input)
-      toastSuccess({ title: 'Task created' })
-    } else if (task) {
-      const input: UpdateTaskInput = {
-        id: task.id,
-        title,
-        description,
-        deadline: deadline ? { type: 'static', value: deadline.toISOString() } : null,
-        assigneeActorIds,
-        referencedEntities: linkedRecords,
-      }
-      updateTask.mutate(input)
-    }
-
-    // If createMore is enabled and we're in create mode, reset form instead of closing
-    if (createMore && mode === 'create') {
-      resetForm()
-    } else {
-      onOpenChange(false)
-    }
-  }, [
-    editor,
-    mode,
-    task,
-    deadline,
-    assigneeActorIds,
-    linkedRecords,
-    createTask,
-    updateTask,
-    onOpenChange,
-    createMore,
-    resetForm,
-  ])
-
-  /**
-   * Handle cancel button click
-   */
-  const handleCancel = useCallback(() => {
-    onOpenChange(false)
-  }, [onOpenChange])
-
-  // Update handleSaveRef with current handleSave function
-  handleSaveRef.current = handleSave
-
-  /**
-   * Handle Escape key - prevent dialog close when inside command picker
-   */
-  const handleEscapeKeyDown = useCallback((event: KeyboardEvent) => {
-    // If ESC is pressed from within a command picker, prevent dialog close
-    if (event.target instanceof HTMLElement && event.target.closest('[cmdk-root]')) {
-      event.preventDefault()
-    }
-  }, [])
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         position='tc'
         size='xl'
         innerClassName='p-0'
-        onEscapeKeyDown={handleEscapeKeyDown}>
-        <DialogHeader className='border-b px-3 py-2 mb-0 h-10 '>
-          <DialogTitle className='text-base font-medium'>
-            {mode === 'create' ? 'Create task' : 'Edit task'}
-          </DialogTitle>
-          <DialogDescription className='sr-only'>Template selector</DialogDescription>
-        </DialogHeader>
-
-        {/* Editor Area */}
-        <div ref={containerRef} className='p-4 relative'>
-          <EditorContent editor={editor} className='w-full bg-transparent text-sm outline-hidden' />
-
-          {/* Mention Picker Popover */}
-          <InlinePickerPopover
-            state={suggestionState}
-            containerRef={containerRef}
-            width={280}
-            onClose={closePicker}>
-            <ActorPickerContent
-              value={[]}
-              onChange={() => {}}
-              target='user'
-              multi={false}
-              onSelectSingle={(actorId) => {
-                insertMention(actorId)
-                // Add to assignees if not already present
-                setAssigneeActorIds((prev) => (prev.includes(actorId) ? prev : [...prev, actorId]))
-              }}
-              placeholder='Search team members...'
-            />
-          </InlinePickerPopover>
-        </div>
-
-        {/* Footer with pickers and actions (merged inline) */}
-        <DialogFooter className='border-t py-1 px-4'>
-          <div className='flex items-center justify-between w-full flex-col sm:flex-row gap-2 sm:gap-0'>
-            {/* Left side: Pickers */}
-            <div className='flex items-center gap-1'>
-              {/* Date Picker with clear button */}
-              <DateTimePicker
-                value={deadline}
-                onChange={handleDeadlineChange}
-                mode='date'
-                noConfirm
-                placeholder='Due date'>
-                <Button variant='ghost' size='sm'>
-                  <Calendar />
-                  {deadline ? formatTaskDeadlineDisplay(deadline) : 'Due date'}
-                </Button>
-              </DateTimePicker>
-
-              {/* Clear deadline button (shown when deadline is set) */}
-              {deadline && (
-                <Button
-                  variant='ghost'
-                  size='icon'
-                  className='h-6 w-6'
-                  onClick={handleDeadlineClear}
-                  title='Clear deadline'>
-                  <X className='h-3 w-3' />
-                </Button>
-              )}
-
-              {/* Assignee Picker */}
-              <ActorPicker
-                value={assigneeActorIds}
-                onChange={setAssigneeActorIds}
-                multi
-                target='user'
-                emptyLabel='Assignee'>
-                <Button variant='ghost' size='sm'>
-                  <User />
-                  {assigneeActorIds.length > 0 ? `${assigneeActorIds.length} assigned` : 'Assignee'}
-                </Button>
-              </ActorPicker>
-
-              {/* Record Linking */}
-              <RecordPicker
-                value={linkedRecords}
-                onChange={setLinkedRecords}
-                multi
-                emptyLabel='Link record'>
-                <Button variant='ghost' size='sm'>
-                  <Link2 />
-                  {linkedRecords.length > 0
-                    ? `${linkedRecords.length} linked record${linkedRecords.length > 1 ? 's' : ''}`
-                    : 'Link record'}
-                </Button>
-              </RecordPicker>
-            </div>
-
-            {/* Right side: Actions */}
-            <div className='flex items-center gap-2'>
-              {/* Create more toggle - only shown in create mode */}
-              {mode === 'create' && (
-                <label
-                  className={cn(
-                    buttonVariants({ variant: 'ghost', size: 'sm' }),
-                    'gap-2 cursor-pointer'
-                  )}>
-                  <span className='text-muted-foreground text-xs'>Create more</span>
-                  <Switch
-                    size='sm'
-                    checked={createMore}
-                    onCheckedChange={setCreateMore}
-                    disabled={isSaving}
-                  />
-                </label>
-              )}
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={handleCancel}
-                disabled={isSaving && !createMore}>
-                Cancel <Kbd shortcut='esc' size='sm' variant='outline' />
-              </Button>
-              <Button
-                size='sm'
-                onClick={handleSave}
-                loading={isSaving && !createMore}
-                loadingText='Saving...'>
-                Save <Kbd shortcut='enter' size='sm' variant='default' />
-              </Button>
-            </div>
-          </div>
-        </DialogFooter>
+        onEscapeKeyDown={preventTaskPickerEscape}>
+        <TaskForm
+          open={open}
+          mode={mode}
+          task={task}
+          defaultReferencedEntity={defaultReferencedEntity}
+          onClose={() => onOpenChange(false)}
+          header={({ title }) => (
+            <DialogHeader className='border-b px-3 py-2 mb-0 h-10 '>
+              <DialogTitle className='text-base font-medium'>{title}</DialogTitle>
+              <DialogDescription className='sr-only'>Template selector</DialogDescription>
+            </DialogHeader>
+          )}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/components/tasks/ui/task-form.tsx
+++ b/apps/web/src/components/tasks/ui/task-form.tsx
@@ -1,0 +1,417 @@
+// apps/web/src/components/tasks/ui/task-form.tsx
+
+'use client'
+
+import type { RecordId } from '@auxx/lib/field-values/client'
+import type { CreateTaskInput, TaskWithRelations, UpdateTaskInput } from '@auxx/lib/tasks'
+import { DateLanguageModule, TextDateParser } from '@auxx/lib/tasks/client'
+import type { ActorId } from '@auxx/types/actor'
+import { Button, buttonVariants } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { Kbd } from '@auxx/ui/components/kbd'
+import { Switch } from '@auxx/ui/components/switch'
+import { toastSuccess } from '@auxx/ui/components/toast'
+import { cn } from '@auxx/ui/lib/utils'
+import { EditorContent } from '@tiptap/react'
+import { Calendar, Link2, User, X } from 'lucide-react'
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { InlinePickerPopover, useMentionEditor } from '~/components/editor/inline-picker'
+import { SubmitOnEnter } from '~/components/global/comments/comment-composer'
+import { ActorPicker } from '~/components/pickers/actor-picker/actor-picker'
+import { ActorPickerContent } from '~/components/pickers/actor-picker/actor-picker-content'
+import { DateTimePicker } from '~/components/pickers/date-time-picker'
+import { RecordPicker } from '~/components/pickers/record-picker'
+import { useTaskMutations } from '../hooks/use-task-mutations'
+import { formatTaskDeadlineDisplay } from '../utils/group-tasks-by-period'
+
+/**
+ * Swallow Esc when it originates inside a cmdk picker (the @mention popover) so
+ * Esc closes the picker, not the host (dialog or palette). Shared by
+ * `TaskDialog` (`DialogContent onEscapeKeyDown`) and the command palette shell.
+ */
+export function preventTaskPickerEscape(event: KeyboardEvent): void {
+  if (event.target instanceof HTMLElement && event.target.closest('[cmdk-root]')) {
+    event.preventDefault()
+  }
+}
+
+/** Check if editor content is empty (just empty paragraph tags) */
+function isEmptyContent(html: string): boolean {
+  if (!html) return true
+  const stripped = html
+    .replace(/<p[^>]*>/g, '')
+    .replace(/<\/p>/g, '')
+    .trim()
+  return stripped === ''
+}
+
+/** Props for the shell-free task form core. */
+export interface TaskFormProps {
+  /** Whether the form is "open" — drives the reset/focus cycle. In a dialog this is
+   *  the dialog's open state; in the palette it's `page === 'create-task'`. */
+  open: boolean
+  /** Create or edit mode */
+  mode: 'create' | 'edit'
+  /** Task to edit (required for edit mode) */
+  task?: TaskWithRelations
+  /** Default entity reference when creating from an entity drawer / record action */
+  defaultReferencedEntity?: RecordId
+  /** Dismiss after a successful save (dialog closes; palette closes). */
+  onClose: () => void
+  /** Cancel/back dismiss. Defaults to {@link onClose}; the palette routes it back
+   *  to the root action list instead of closing outright. */
+  onCancel?: () => void
+  /** Host-specific header. Dialogs render a `DialogHeader`; the palette omits it. */
+  header?: (ctx: { title: string }) => ReactNode
+}
+
+/**
+ * Shell-free task create/edit form: the mention editor, footer pickers
+ * (date/actor/record), the "Create more" toggle, and Save/Cancel. The only host
+ * seams are the `header` slot and `onClose`/`onCancel`. `task-dialog.tsx` wraps
+ * this in a `Dialog`; the command palette hosts it as a page. Behavior (including
+ * "Create more") is unchanged from the original dialog.
+ */
+export function TaskForm({
+  open,
+  mode,
+  task,
+  defaultReferencedEntity,
+  onClose,
+  onCancel,
+  header,
+}: TaskFormProps) {
+  const cancel = onCancel ?? onClose
+
+  // Form state
+  const [deadline, setDeadline] = useState<Date | undefined>(undefined)
+  const [deadlineManuallySet, setDeadlineManuallySet] = useState(false)
+  const [assigneeActorIds, setAssigneeActorIds] = useState<ActorId[]>([])
+  const [linkedRecords, setLinkedRecords] = useState<RecordId[]>([])
+  const [createMore, setCreateMore] = useState(false)
+
+  // Mutations
+  const { createTask, updateTask, isCreating, isUpdating } = useTaskMutations()
+  const isSaving = isCreating || isUpdating
+
+  // Container ref for popover positioning
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Create parser and date module (memoized)
+  const textDateParser = useMemo(() => new TextDateParser(), [])
+  const dateModule = useMemo(() => {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    return new DateLanguageModule(timezone)
+  }, [])
+
+  // Ref to track handleSave for SubmitOnEnter extension (updated after handleSave is defined)
+  const handleSaveRef = useRef<() => void>(() => {})
+
+  // Build initial content from task
+  const initialContent = useMemo(() => {
+    if (!task) return ''
+    return `<p>${task.title}</p>`
+  }, [task])
+
+  // Initialize mention editor using the inline-picker system
+  const mentionEditor = useMentionEditor({
+    initialContent,
+    placeholder: 'What needs to be done? Use @ to assign members...',
+    editable: true,
+    className: cn(
+      'prose prose-sm prose-p:my-0 focus:outline-hidden max-w-none',
+      'dark:prose-invert'
+    ),
+    extensions: [
+      SubmitOnEnter.configure({
+        isExpanded: () => false,
+        onSubmit: () => {
+          handleSaveRef.current()
+        },
+      }),
+    ],
+  })
+  const { editor, suggestionState, insertMention, closePicker } = mentionEditor
+
+  /**
+   * Handle editor text change - auto-set deadline if not manually set
+   */
+  const handleEditorUpdate = useCallback(() => {
+    if (!editor || deadlineManuallySet) {
+      return
+    }
+
+    const text = editor.getText().trim()
+    const result = textDateParser.parse(text)
+
+    if (result.found && result.duration && result.confidence >= 0.7) {
+      const calculatedDate = dateModule.calculateTargetDate(result.duration)
+      setDeadline(calculatedDate)
+    } else {
+      setDeadline(undefined)
+    }
+  }, [editor, textDateParser, dateModule, deadlineManuallySet])
+
+  // Add editor update listener
+  useEffect(() => {
+    if (!editor) return
+
+    editor.on('update', handleEditorUpdate)
+    return () => {
+      editor.off('update', handleEditorUpdate)
+    }
+  }, [editor, handleEditorUpdate])
+
+  // Reset form when task changes or dialog opens
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mentionEditor.setContent is stable
+  useEffect(() => {
+    if (open) {
+      if (task) {
+        // Edit mode: populate from existing task
+        setDeadline(task.deadline ? new Date(task.deadline) : undefined)
+        setDeadlineManuallySet(!!task.deadline)
+        setAssigneeActorIds(task.assignments ?? [])
+        setLinkedRecords(task.references ?? [])
+      } else {
+        // Create mode: start fresh
+        setDeadline(undefined)
+        setDeadlineManuallySet(false)
+        setAssigneeActorIds([])
+        setLinkedRecords(defaultReferencedEntity ? [defaultReferencedEntity] : [])
+      }
+      // Defer editor operations using double requestAnimationFrame to ensure
+      // we're outside React's render cycle and avoid flushSync errors
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (task) {
+            mentionEditor.setContent(`<p>${task.title}</p>`)
+          } else {
+            editor?.commands.clearContent()
+          }
+          editor?.commands.focus()
+        })
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [task, open, editor, defaultReferencedEntity])
+
+  /**
+   * Handle manual deadline change from date picker
+   * This marks the deadline as "manually set" and stops auto-parsing
+   */
+  const handleDeadlineChange = useCallback((date: Date | undefined) => {
+    setDeadline(date)
+    if (date !== undefined) {
+      setDeadlineManuallySet(true)
+    }
+  }, [])
+
+  /**
+   * Handle clearing the deadline - re-enables auto-parsing
+   */
+  const handleDeadlineClear = useCallback(() => {
+    setDeadline(undefined)
+    setDeadlineManuallySet(false)
+  }, [])
+
+  /**
+   * Reset form state for creating another task
+   */
+  const resetForm = useCallback(() => {
+    editor?.commands.clearContent()
+    setDeadline(undefined)
+    setDeadlineManuallySet(false)
+    setAssigneeActorIds([])
+    setLinkedRecords(defaultReferencedEntity ? [defaultReferencedEntity] : [])
+    // Use double requestAnimationFrame to avoid flushSync errors
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        editor?.commands.focus()
+      })
+    })
+  }, [editor, defaultReferencedEntity])
+
+  /**
+   * Handle save button click
+   */
+  const handleSave = useCallback(async () => {
+    if (!editor) return
+
+    const html = editor.getHTML()
+    if (isEmptyContent(html)) return
+
+    const text = editor.getText().trim()
+    const lines = text.split('\n')
+    const title = lines[0]?.trim() || ''
+    const description = html
+
+    if (!title) return
+
+    if (mode === 'create') {
+      const input: CreateTaskInput = {
+        title,
+        description,
+        deadline: deadline ? { type: 'static', value: deadline.toISOString() } : undefined,
+        assigneeActorIds,
+        referencedEntities: linkedRecords.length > 0 ? linkedRecords : undefined,
+      }
+      createTask.mutate(input)
+      toastSuccess({ title: 'Task created' })
+    } else if (task) {
+      const input: UpdateTaskInput = {
+        id: task.id,
+        title,
+        description,
+        deadline: deadline ? { type: 'static', value: deadline.toISOString() } : null,
+        assigneeActorIds,
+        referencedEntities: linkedRecords,
+      }
+      updateTask.mutate(input)
+    }
+
+    // If createMore is enabled and we're in create mode, reset form instead of closing
+    if (createMore && mode === 'create') {
+      resetForm()
+    } else {
+      onClose()
+    }
+  }, [
+    editor,
+    mode,
+    task,
+    deadline,
+    assigneeActorIds,
+    linkedRecords,
+    createTask,
+    updateTask,
+    onClose,
+    createMore,
+    resetForm,
+  ])
+
+  // Update handleSaveRef with current handleSave function
+  handleSaveRef.current = handleSave
+
+  const title = mode === 'create' ? 'Create task' : 'Edit task'
+
+  return (
+    <>
+      {header?.({ title })}
+
+      {/* Editor Area */}
+      <div ref={containerRef} className='p-4 relative'>
+        <EditorContent editor={editor} className='w-full bg-transparent text-sm outline-hidden' />
+
+        {/* Mention Picker Popover */}
+        <InlinePickerPopover
+          state={suggestionState}
+          containerRef={containerRef}
+          width={280}
+          onClose={closePicker}>
+          <ActorPickerContent
+            value={[]}
+            onChange={() => {}}
+            target='user'
+            multi={false}
+            onSelectSingle={(actorId) => {
+              insertMention(actorId)
+              // Add to assignees if not already present
+              setAssigneeActorIds((prev) => (prev.includes(actorId) ? prev : [...prev, actorId]))
+            }}
+            placeholder='Search team members...'
+          />
+        </InlinePickerPopover>
+      </div>
+
+      {/* Footer with pickers and actions (merged inline) */}
+      <DialogFooter className='border-t py-1 px-4'>
+        <div className='flex items-center justify-between w-full flex-col sm:flex-row gap-2 sm:gap-0'>
+          {/* Left side: Pickers */}
+          <div className='flex items-center gap-1'>
+            {/* Date Picker with clear button */}
+            <DateTimePicker
+              value={deadline}
+              onChange={handleDeadlineChange}
+              mode='date'
+              noConfirm
+              placeholder='Due date'>
+              <Button variant='ghost' size='sm'>
+                <Calendar />
+                {deadline ? formatTaskDeadlineDisplay(deadline) : 'Due date'}
+              </Button>
+            </DateTimePicker>
+
+            {/* Clear deadline button (shown when deadline is set) */}
+            {deadline && (
+              <Button
+                variant='ghost'
+                size='icon'
+                className='h-6 w-6'
+                onClick={handleDeadlineClear}
+                title='Clear deadline'>
+                <X className='h-3 w-3' />
+              </Button>
+            )}
+
+            {/* Assignee Picker */}
+            <ActorPicker
+              value={assigneeActorIds}
+              onChange={setAssigneeActorIds}
+              multi
+              target='user'
+              emptyLabel='Assignee'>
+              <Button variant='ghost' size='sm'>
+                <User />
+                {assigneeActorIds.length > 0 ? `${assigneeActorIds.length} assigned` : 'Assignee'}
+              </Button>
+            </ActorPicker>
+
+            {/* Record Linking */}
+            <RecordPicker
+              value={linkedRecords}
+              onChange={setLinkedRecords}
+              multi
+              emptyLabel='Link record'>
+              <Button variant='ghost' size='sm'>
+                <Link2 />
+                {linkedRecords.length > 0
+                  ? `${linkedRecords.length} linked record${linkedRecords.length > 1 ? 's' : ''}`
+                  : 'Link record'}
+              </Button>
+            </RecordPicker>
+          </div>
+
+          {/* Right side: Actions */}
+          <div className='flex items-center gap-2'>
+            {/* Create more toggle - only shown in create mode */}
+            {mode === 'create' && (
+              <label
+                className={cn(
+                  buttonVariants({ variant: 'ghost', size: 'sm' }),
+                  'gap-2 cursor-pointer'
+                )}>
+                <span className='text-muted-foreground text-xs'>Create more</span>
+                <Switch
+                  size='sm'
+                  checked={createMore}
+                  onCheckedChange={setCreateMore}
+                  disabled={isSaving}
+                />
+              </label>
+            )}
+            <Button variant='outline' size='sm' onClick={cancel} disabled={isSaving && !createMore}>
+              Cancel <Kbd shortcut='esc' size='sm' variant='outline' />
+            </Button>
+            <Button
+              size='sm'
+              onClick={handleSave}
+              loading={isSaving && !createMore}
+              loadingText='Saving...'>
+              Save <Kbd shortcut='enter' size='sm' variant='default' />
+            </Button>
+          </div>
+        </div>
+      </DialogFooter>
+    </>
+  )
+}


### PR DESCRIPTION
## What

Renders **Create Snippet**, **Create Signature**, and **Create Task** as in-chrome command-palette pages — the same inline-create treatment the entity-instance form already has — instead of closing the palette and popping a separate modal.

Follow-on to the kbar v2 build plan (Phase 3 embedded only entity-instance; Phase 4 shipped these three as separate-modal launchers).

## How

- **Signature / Task**: extracted shell-free `SignatureForm` / `TaskForm` cores (body + footer + header slot). `signature-dialog.tsx` and `task-dialog.tsx` are now thin `Dialog` wrappers with **unchanged public API**.
  - `TaskForm` keeps its **Create more** toggle and exports `preventTaskPickerEscape`; the palette shell applies that Esc carve-out on the task page so Esc closes the @mention picker, not the palette.
  - Verified the shared `DialogContent` Enter-interception only blocks plain Enter on single-line `<input>`s, so the task editor's `SubmitOnEnter` and Cmd+Enter both still work hosted in the palette.
- **Snippet**: `SnippetForm` was already shell-free, so it's hosted directly.
- New palette pages `create-snippet` / `create-signature` / `create-task`, store openers + carried params (`createSnippetFolderId`, `createTaskRef`), breadcrumb routing, and `DialogNavPage` sizes (snippet/signature `xxl`, task `xl`).
- Record-actions **Create task** now drills into the embedded task page with the record pre-linked, instead of opening the standalone modal.

## Behavior parity

Per request, behavior is kept as-is per form: task keeps **Create more**; snippet/signature gain no "Create more" and no new dirty guard. Only the entity-instance create page keeps its unsaved-changes guard.

## Standalone unaffected

Settings pages, `t,n` / `c,*` hotkeys, sidebar actions, and the record drawer keep working through the existing dialog wrappers + global stores/roots (still mounted in `app-layout-wrapper`).

## Lazy rendering

`DialogNavPages` mounts only the active page, so each form's editor + queries spin up only on navigation — opening cmd+k doesn't instantiate three TipTap editors.

## Test plan

- [ ] cmd+k → Create Snippet / Signature / Task each render inline (breadcrumb `Create X`); create works + invalidates the relevant list
- [ ] Task: editor focuses, `@` picker opens, **Esc closes the picker not the palette**, Enter + Cmd+Enter save, date/actor/record pickers work, **Create more** keeps the page open
- [ ] Cancel / back returns to the root action list; successful save closes the palette
- [ ] Standalone create still works: settings pages, `t,n`, sidebar, record drawer
- [ ] Record-actions "Create task" pre-links the record