### PR TITLE
feat(kbar): embed create forms in command palette

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/apiKeys/_components/api-key-form.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apiKeys/_components/api-key-form.tsx
@@ -1,0 +1,148 @@
+// apps/web/src/app/(protected)/app/settings/apiKeys/_components/api-key-form.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { DialogDescription, DialogFooter } from '@auxx/ui/components/dialog'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@auxx/ui/components/form'
+import { Input } from '@auxx/ui/components/input'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { toastError, toastSuccess } from '@auxx/ui/components/toast'
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
+import { type ReactNode, useCallback, useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { CopyInput } from '~/components/global/copy-input'
+import { useAnalytics } from '~/hooks/use-analytics'
+import { api } from '~/trpc/react'
+
+export const createApiKeyBody = z.object({
+  id: z.string().nullish().optional(),
+  name: z.string().optional(),
+  hashedKey: z.string().nullish().optional(),
+})
+export type CreateApiKeyBody = z.infer<typeof createApiKeyBody>
+
+/** Props for the shell-free API key create form core. */
+export interface ApiKeyFormProps {
+  /** Whether the form is "open" — drives the init/reset cycle. In a dialog this is
+   *  the dialog's open state; in the palette it's `page === 'create-api-key'`. */
+  open: boolean
+  /** Called after a successful create. */
+  onSuccess?: () => void
+  /** Dismiss after the secret is revealed/done (dialog closes; palette closes). */
+  onClose: () => void
+  /** Cancel/back dismiss. Defaults to {@link onClose}; the palette routes it back
+   *  to the root action list instead of closing outright. */
+  onCancel?: () => void
+  /** Host-specific header. Dialogs render a `DialogHeader`; the palette omits it
+   *  (the breadcrumb supplies the title). */
+  header?: (ctx: { title: string }) => ReactNode
+}
+
+/**
+ * Shell-free API key create form: all hooks/state, the create mutation, the
+ * post-create secret-reveal state, and the footer (Cancel / Create). The only host
+ * seams are the `header` slot and `onClose`. `create-api-key-button.tsx` wraps this
+ * in a `Dialog`; the command palette hosts it as a page. Create-only (no edit mode).
+ */
+export function ApiKeyForm({ open, onSuccess, onClose, onCancel, header }: ApiKeyFormProps) {
+  const cancel = onCancel ?? onClose
+  const utils = api.useUtils()
+  const posthog = useAnalytics()
+  const [secret, setSecret] = useState('')
+
+  const form = useForm<CreateApiKeyBody>({
+    resolver: standardSchemaResolver(createApiKeyBody),
+    defaultValues: { name: '', hashedKey: '' },
+  })
+
+  // Reset form + clear the secret on a fresh open (open transitions to true).
+  useEffect(() => {
+    if (open) {
+      form.reset()
+      setSecret('')
+    }
+  }, [open, form])
+
+  const createApiKey = api.apiKey.create.useMutation({
+    onSuccess: async (data) => {
+      setSecret(data.secretKey)
+      toastSuccess({ description: 'API key created' })
+      posthog?.capture('api_key_created')
+      utils.apiKey.getAll.invalidate()
+      onSuccess?.()
+    },
+    onError: (error) => {
+      toastError({ description: error.message })
+    },
+  })
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: createApiKey.mutateAsync is stable
+  const onSubmit = useCallback(async (values: CreateApiKeyBody) => {
+    await createApiKey.mutateAsync(values)
+  }, [])
+
+  const title = 'Create new secret key'
+
+  return (
+    <>
+      {header?.({ title })}
+      {secret ? (
+        <>
+          <DialogDescription className='mb-2'>
+            This will only be shown once. Please copy it. Your secret key is:
+          </DialogDescription>
+          <CopyInput value={secret} toastMessage='Secret key copied to clipboard' />
+          <div className='mt-4 flex items-center justify-end'>
+            <Button type='button' size='sm' variant='outline' onClick={onClose}>
+              Done
+            </Button>
+          </div>
+        </>
+      ) : (
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <FormField
+              control={form.control}
+              name='name'
+              render={({ field }) => (
+                <FormItem className='flex flex-col gap-1'>
+                  <FormLabel>Name (Optional)</FormLabel>
+                  <FormControl>
+                    <Input placeholder='My secret key' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button
+                type='button'
+                size='sm'
+                variant='ghost'
+                onClick={cancel}
+                disabled={form.formState.isSubmitting}>
+                Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+              </Button>
+              <Button
+                type='submit'
+                size='sm'
+                variant='outline'
+                loading={form.formState.isSubmitting}
+                loadingText='Creating...'>
+                Create <KbdSubmit variant='outline' size='sm' />
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/app/(protected)/app/settings/apiKeys/_components/create-api-key-button.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apiKeys/_components/create-api-key-button.tsx
@@ -9,143 +9,85 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@auxx/ui/components/dialog'
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@auxx/ui/components/form'
-import { Input } from '@auxx/ui/components/input'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
-import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-// import { PointerDownOutsideEvent } from 'radix-ui'
 import { PlusIcon } from 'lucide-react'
-import { useCallback, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { z } from 'zod'
-import { CopyInput } from '~/components/global/copy-input'
-import { useAnalytics } from '~/hooks/use-analytics'
+import { useState } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
+import { ApiKeyForm } from './api-key-form'
 
 type PointerDownOutsideEvent = CustomEvent<{
   originalEvent: PointerEvent
 }>
-export const createApiKeyBody = z.object({
-  id: z.string().nullish().optional(),
-  name: z.string().optional(),
-  hashedKey: z.string().nullish().optional(),
-})
-export type CreateApiKeyBody = z.infer<typeof createApiKeyBody>
+
 type CreateAPIKeyButtonProps = {
   open?: boolean
   onOpenChange?: (open: boolean) => void
   trigger?: React.ReactNode
 }
+
+/**
+ * Thin modal wrapper around {@link ApiKeyForm}. Supplies the `Dialog` shell, the
+ * header, and the controlled/uncontrolled + trigger-hiding behavior; all form logic
+ * lives in the core, which the command palette hosts directly as a page. Public API
+ * is unchanged.
+ */
 export function CreateAPIKeyButton({
   open: externalOpen,
   onOpenChange: externalOnOpenChange,
   trigger,
 }: CreateAPIKeyButtonProps) {
-  const utils = api.useUtils()
-  const posthog = useAnalytics()
-  const form = useForm<CreateApiKeyBody>({
-    resolver: standardSchemaResolver(createApiKeyBody),
-    defaultValues: { name: '', hashedKey: '' },
-  })
   const [internalOpen, setInternalOpen] = useState(false)
-  // const [isConnecting, setIsConnecting] = useState(false)
-  const [secret, setSecret] = useState('')
+  const [isSecretShown, setIsSecretShown] = useState(false)
   const isControlled = externalOpen !== undefined
   const open = isControlled ? externalOpen : internalOpen
-  // Handle open state changes
+
   const handleOpenChange = (newOpen: boolean) => {
     if (!newOpen) {
-      form.reset()
-      setSecret('')
+      setIsSecretShown(false)
     }
     if (!isControlled) {
       setInternalOpen(newOpen)
     }
     externalOnOpenChange?.(newOpen)
   }
-  const createApiKey = api.apiKey.create.useMutation({
-    onSuccess: async (data) => {
-      setSecret(data.secretKey)
-      toastSuccess({ description: 'API key created' })
-      posthog?.capture('api_key_created')
-      utils.apiKey.getAll.invalidate()
-    },
-    onError: (error) => {
-      toastError({ description: error.message })
-    },
-  })
-  // biome-ignore lint/correctness/useExhaustiveDependencies: createApiKey.mutateAsync is stable
-  const onSubmit = useCallback(async (values: CreateApiKeyBody) => {
-    await createApiKey.mutateAsync(values)
-  }, [])
+
+  // Block escape/outside-click dismissal while the secret is shown so it isn't lost.
   const onEscapeOrOutsideClick = (e: KeyboardEvent | PointerDownOutsideEvent) => {
-    if (secret || form.formState.isSubmitting) {
+    if (isSecretShown) {
       e.preventDefault()
     }
   }
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button variant='outline' size='sm'>
-          <PlusIcon className='h-4 w-4' />
-          Create API Key
-        </Button>
+        {trigger ?? (
+          <Button variant='outline' size='sm'>
+            <PlusIcon />
+            Create API Key
+          </Button>
+        )}
       </DialogTrigger>
 
       <DialogContent
         onEscapeKeyDown={onEscapeOrOutsideClick}
-        onPointerDownOutside={onEscapeOrOutsideClick}>
-        <DialogHeader className='mb-4'>
-          <DialogTitle>Create new secret key</DialogTitle>
-          <DialogDescription>
-            This will create a new secret key for your account. You will need to use this secret key
-            to authenticate your requests to the API.
-          </DialogDescription>
-        </DialogHeader>
-        {secret ? (
-          <>
-            <DialogDescription className='mb-2'>
-              This will only be shown once. Please copy it. Your secret key is:
-            </DialogDescription>
-            <CopyInput value={secret} />
-          </>
-        ) : (
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
-              <FormField
-                control={form.control}
-                name='name'
-                render={({ field }) => (
-                  <FormItem className='flex flex-col gap-1'>
-                    <FormLabel>Name (Optional)</FormLabel>
-                    <FormControl>
-                      <Input placeholder='My secret key' {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <div className='flex items-center justify-end'>
-                <Button
-                  type='submit'
-                  size='sm'
-                  disabled={form.formState.isSubmitting}
-                  variant='outline'
-                  loading={form.formState.isSubmitting}
-                  loadingText='Creating...'>
-                  Create
-                </Button>
-              </div>
-            </form>
-          </Form>
-        )}
+        onPointerDownOutside={onEscapeOrOutsideClick}
+        position='tc'>
+        <ApiKeyForm
+          open={open}
+          onSuccess={() => setIsSecretShown(true)}
+          onClose={() => handleOpenChange(false)}
+          header={({ title }) => (
+            <DialogHeader className='mb-4'>
+              <DialogTitle>{title}</DialogTitle>
+              <DialogDescription>
+                This will create a new secret key for your account. You will need to use this secret
+                key to authenticate your requests to the API.
+              </DialogDescription>
+            </DialogHeader>
+          )}
+        />
       </DialogContent>
     </Dialog>
   )
@@ -158,6 +100,7 @@ export function RevokeAPIKeyButton({
   buttonProps?: ButtonProps
 }) {
   const utils = api.useUtils()
+  const [confirm, ConfirmDialog] = useConfirm()
   const revokeApiKey = api.apiKey.delete.useMutation({
     onSuccess: async () => {
       await utils.apiKey.getAll.invalidate()
@@ -167,12 +110,26 @@ export function RevokeAPIKeyButton({
       toastError({ description: error.message })
     },
   })
+
+  const handleRevoke = async () => {
+    const confirmed = await confirm({
+      title: 'Revoke API key?',
+      description: 'This action cannot be undone. Any application using this key will lose access.',
+      confirmText: 'Revoke',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) {
+      await revokeApiKey.mutateAsync({ id })
+    }
+  }
+
   return (
-    <Button
-      onClick={() => revokeApiKey.mutateAsync({ id })}
-      {...buttonProps}
-      disabled={revokeApiKey.isPending}>
-      Revoke
-    </Button>
+    <>
+      <Button onClick={handleRevoke} {...buttonProps} disabled={revokeApiKey.isPending}>
+        Revoke
+      </Button>
+      <ConfirmDialog />
+    </>
   )
 }

--- a/apps/web/src/app/(protected)/app/settings/webhooks/_components/dialog-webhook.tsx
+++ b/apps/web/src/app/(protected)/app/settings/webhooks/_components/dialog-webhook.tsx
@@ -1,191 +1,36 @@
 // apps/web/src/app/(protected)/app/settings/webhooks/_components/dialog-webhook.tsx
 'use client'
 import type { WebhookEntity as Webhook } from '@auxx/database/types'
-import { Button } from '@auxx/ui/components/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@auxx/ui/components/form'
-import { Input } from '@auxx/ui/components/input'
-import { InputGroup, InputGroupAddon, InputGroupInput } from '@auxx/ui/components/input-group'
-import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
-import { Label } from '@auxx/ui/components/label'
-import { Switch } from '@auxx/ui/components/switch'
-import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { z } from 'zod'
-import { EventTypePicker } from './event-type-picker'
-import { useWebhook } from './use-webhook'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@auxx/ui/components/dialog'
+import { WebhookForm } from './webhook-form'
 
-// Import event types from library
 interface DialogWebhookProps {
   open: boolean
   onClose: () => void
   webhook?: Webhook
   onSuccess?: () => void
 }
-const webhookSchema = z.object({
-  id: z.string().optional(),
-  name: z.string().min(1, 'Name is required'),
-  url: z.string().url('Must be a valid URL'),
-  eventTypes: z.array(z.string()).optional(),
-  isActive: z.boolean().default(true),
-})
-type WebhookSchema = z.infer<typeof webhookSchema>
+
+/**
+ * Thin modal wrapper around {@link WebhookForm}. Supplies the `Dialog` shell and
+ * the header; all form logic lives in the core, which the command palette hosts
+ * directly as a page. Public API is unchanged.
+ */
 export function DialogWebhook({ open, onClose, webhook, onSuccess }: DialogWebhookProps) {
-  const { create, update, testWebhook } = useWebhook()
-  const [selectedEventTypes, setSelectedEventTypes] = useState<string[]>(webhook?.eventTypes || [])
-
-  const form = useForm<WebhookSchema>({
-    resolver: standardSchemaResolver(webhookSchema),
-    defaultValues: {
-      name: webhook?.name || '',
-      url: webhook?.url || '',
-      isActive: webhook?.isActive ?? true,
-    },
-  })
-  const currentUrl = form.watch('url')
-  const onSubmit = async (data: { name: string; url: string; isActive: boolean }) => {
-    if (webhook) {
-      await update.mutateAsync({
-        id: webhook.id,
-        name: data.name,
-        url: data.url,
-        eventTypes: selectedEventTypes,
-        isActive: data.isActive,
-      })
-    } else {
-      await create.mutateAsync({
-        name: data.name,
-        url: data.url,
-        eventTypes: selectedEventTypes,
-        isActive: data.isActive,
-      })
-    }
-    if (onSuccess) onSuccess()
-    onClose()
-  }
-  const handleTestWebhook = async () => {
-    await testWebhook.mutateAsync({ url: currentUrl })
-  }
-
   return (
-    <Dialog open={open} onOpenChange={(open) => !open && onClose()}>
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent size='sm' position='tc'>
-        <DialogHeader>
-          <DialogTitle>{webhook ? 'Edit Webhook' : 'Create Webhook'}</DialogTitle>
-        </DialogHeader>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className=''>
-            <div className='space-y-4'>
-              <div className='space-y-2 mt-3'>
-                <FormField
-                  control={form.control}
-                  name='name'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Input id='name' placeholder='My Webhook' {...field} />
-                      </FormControl>
-
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              <FormField
-                control={form.control}
-                name='url'
-                render={({ field }) => (
-                  <FormItem>
-                    <Label htmlFor='url'>URL</Label>
-                    <FormControl>
-                      <InputGroup>
-                        <InputGroupInput
-                          id='url'
-                          placeholder='https://example.com/webhook'
-                          {...field}
-                        />
-                        <InputGroupAddon align='inline-end' className=''>
-                          <Button
-                            type='button'
-                            variant='outline'
-                            className='mr-0.5'
-                            size='xs'
-                            onClick={handleTestWebhook}
-                            disabled={testWebhook.isPending || !currentUrl}
-                            loading={testWebhook.isPending}
-                            loadingText='Testing...'>
-                            Test
-                          </Button>
-                        </InputGroupAddon>
-                      </InputGroup>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <div className='space-y-2'>
-                {/* Replace the old eventTypes selector with the new EventTypePicker */}
-                <EventTypePicker
-                  selectedEventTypes={selectedEventTypes}
-                  onChange={setSelectedEventTypes}
-                  placeholder='Select event types...'
-                />
-              </div>
-
-              <div className='flex items-center space-x-2'>
-                <FormField
-                  control={form.control}
-                  name='isActive'
-                  render={({ field }) => (
-                    <FormItem className='flex flex-row items-center justify-between rounded-lg shadow-none  gap-2 space-y-0'>
-                      <FormControl>
-                        <Switch checked={field.value} onCheckedChange={field.onChange} />
-                      </FormControl>
-                      <div className=''>
-                        <FormLabel className='mt-0 pt-0'>Active</FormLabel>
-                      </div>
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </div>
-
-            <DialogFooter>
-              <Button
-                variant='ghost'
-                size='sm'
-                onClick={onClose}
-                type='button'
-                disabled={create.isPending || update.isPending}>
-                Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-              </Button>
-              <Button
-                type='submit'
-                size='sm'
-                variant='outline'
-                loading={create.isPending || update.isPending}
-                loadingText='Saving...'>
-                {webhook ? 'Update' : 'Create'} <KbdSubmit variant='outline' size='sm' />
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
+        <WebhookForm
+          open={open}
+          webhook={webhook}
+          onSuccess={onSuccess}
+          onClose={onClose}
+          header={({ title }) => (
+            <DialogHeader>
+              <DialogTitle>{title}</DialogTitle>
+            </DialogHeader>
+          )}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/app/(protected)/app/settings/webhooks/_components/webhook-form.tsx
+++ b/apps/web/src/app/(protected)/app/settings/webhooks/_components/webhook-form.tsx
@@ -1,0 +1,222 @@
+// apps/web/src/app/(protected)/app/settings/webhooks/_components/webhook-form.tsx
+'use client'
+
+import type { WebhookEntity as Webhook } from '@auxx/database/types'
+import { Button } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@auxx/ui/components/form'
+import { Input } from '@auxx/ui/components/input'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@auxx/ui/components/input-group'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { Label } from '@auxx/ui/components/label'
+import { Switch } from '@auxx/ui/components/switch'
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
+import { type ReactNode, useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { EventTypePicker } from './event-type-picker'
+import { useWebhook } from './use-webhook'
+
+const webhookSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1, 'Name is required'),
+  url: z.string().url('Must be a valid URL'),
+  eventTypes: z.array(z.string()).optional(),
+  isActive: z.boolean().default(true),
+})
+type WebhookSchema = z.infer<typeof webhookSchema>
+
+/** Props for the shell-free webhook create/edit form core. */
+export interface WebhookFormProps {
+  /** Whether the form is "open" — drives the init/reset cycle. In a dialog this is
+   *  the dialog's open state; in the palette it's `page === 'create-webhook'`. */
+  open: boolean
+  /** Webhook to edit; omitted = create */
+  webhook?: Webhook
+  /** Called after a successful save */
+  onSuccess?: () => void
+  /** Dismiss after a successful save (dialog closes; palette closes). */
+  onClose: () => void
+  /** Cancel/back dismiss. Defaults to {@link onClose}; the palette routes it back
+   *  to the root action list instead of closing outright. */
+  onCancel?: () => void
+  /** Host-specific header. Dialogs render a `DialogHeader`; the palette omits it
+   *  (the breadcrumb supplies the title). */
+  header?: (ctx: { title: string }) => ReactNode
+}
+
+/**
+ * Shell-free webhook create/edit form: all hooks/state, the field body, and the
+ * footer (Cancel / Create|Update). The only host seams are the `header` slot and
+ * `onClose`. `dialog-webhook.tsx` wraps this in a `Dialog`; the command palette
+ * hosts it as a page.
+ */
+export function WebhookForm({
+  open,
+  webhook,
+  onSuccess,
+  onClose,
+  onCancel,
+  header,
+}: WebhookFormProps) {
+  const cancel = onCancel ?? onClose
+  const { create, update, testWebhook } = useWebhook()
+  const [selectedEventTypes, setSelectedEventTypes] = useState<string[]>(webhook?.eventTypes || [])
+
+  const form = useForm<WebhookSchema>({
+    resolver: standardSchemaResolver(webhookSchema),
+    defaultValues: {
+      name: webhook?.name || '',
+      url: webhook?.url || '',
+      isActive: webhook?.isActive ?? true,
+    },
+  })
+
+  // Reset/re-init the form whenever the form becomes "open".
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        name: webhook?.name || '',
+        url: webhook?.url || '',
+        isActive: webhook?.isActive ?? true,
+      })
+      setSelectedEventTypes(webhook?.eventTypes || [])
+    }
+  }, [open, webhook, form])
+
+  const currentUrl = form.watch('url')
+
+  const onSubmit = async (data: { name: string; url: string; isActive: boolean }) => {
+    if (webhook) {
+      await update.mutateAsync({
+        id: webhook.id,
+        name: data.name,
+        url: data.url,
+        eventTypes: selectedEventTypes,
+        isActive: data.isActive,
+      })
+    } else {
+      await create.mutateAsync({
+        name: data.name,
+        url: data.url,
+        eventTypes: selectedEventTypes,
+        isActive: data.isActive,
+      })
+    }
+    onSuccess?.()
+    onClose()
+  }
+
+  const handleTestWebhook = async () => {
+    await testWebhook.mutateAsync({ url: currentUrl })
+  }
+
+  const title = webhook ? 'Edit Webhook' : 'Create Webhook'
+  const isPending = create.isPending || update.isPending
+
+  return (
+    <>
+      {header?.({ title })}
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className=''>
+          <div className='space-y-4'>
+            <div className='space-y-2 mt-3'>
+              <FormField
+                control={form.control}
+                name='name'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <Input id='name' placeholder='My Webhook' {...field} />
+                    </FormControl>
+
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name='url'
+              render={({ field }) => (
+                <FormItem>
+                  <Label htmlFor='url'>URL</Label>
+                  <FormControl>
+                    <InputGroup>
+                      <InputGroupInput
+                        id='url'
+                        placeholder='https://example.com/webhook'
+                        {...field}
+                      />
+                      <InputGroupAddon align='inline-end' className=''>
+                        <Button
+                          type='button'
+                          variant='outline'
+                          className='mr-0.5'
+                          size='xs'
+                          onClick={handleTestWebhook}
+                          disabled={testWebhook.isPending || !currentUrl}
+                          loading={testWebhook.isPending}
+                          loadingText='Testing...'>
+                          Test
+                        </Button>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className='space-y-2'>
+              <EventTypePicker
+                selectedEventTypes={selectedEventTypes}
+                onChange={setSelectedEventTypes}
+                placeholder='Select event types...'
+              />
+            </div>
+
+            <div className='flex items-center space-x-2'>
+              <FormField
+                control={form.control}
+                name='isActive'
+                render={({ field }) => (
+                  <FormItem className='flex flex-row items-center justify-between rounded-lg shadow-none  gap-2 space-y-0'>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                    <div className=''>
+                      <FormLabel className='mt-0 pt-0'>Active</FormLabel>
+                    </div>
+                  </FormItem>
+                )}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant='ghost' size='sm' onClick={cancel} type='button' disabled={isPending}>
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+            </Button>
+            <Button
+              type='submit'
+              size='sm'
+              variant='outline'
+              loading={isPending}
+              loadingText='Saving...'>
+              {webhook ? 'Update' : 'Create'} <KbdSubmit variant='outline' size='sm' />
+            </Button>
+          </DialogFooter>
+        </form>
+      </Form>
+    </>
+  )
+}

--- a/apps/web/src/components/calls/ui/create-meeting-dialog.tsx
+++ b/apps/web/src/components/calls/ui/create-meeting-dialog.tsx
@@ -1,285 +1,41 @@
 // apps/web/src/components/calls/ui/create-meeting-dialog.tsx
 'use client'
 
-import type { RecordId } from '@auxx/types/resource'
-import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@auxx/ui/components/dialog'
-import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
-import { toastError, toastSuccess } from '@auxx/ui/components/toast'
-import { useCallback, useEffect, useState } from 'react'
-import { BaseType } from '~/components/workflow/types'
-import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
-import { api } from '~/trpc/react'
-
-const PLATFORM_OPTIONS = [
-  { label: 'Google Meet', value: 'google_meet' },
-  { label: 'Zoom', value: 'zoom' },
-  { label: 'Teams', value: 'teams' },
-  { label: 'Other', value: 'other' },
-]
-
-const DURATION_OPTIONS = [
-  { label: '15 min', value: '15' },
-  { label: '30 min', value: '30' },
-  { label: '45 min', value: '45' },
-  { label: '60 min', value: '60' },
-  { label: '90 min', value: '90' },
-  { label: '120 min', value: '120' },
-]
-
-/**
- * Get the next half-hour as default start time.
- */
-function getDefaultStartTime(): string {
-  const now = new Date()
-  const minutes = now.getMinutes()
-  const roundedMinutes = minutes < 30 ? 30 : 60
-  now.setMinutes(roundedMinutes, 0, 0)
-  if (roundedMinutes === 60) {
-    now.setHours(now.getHours())
-  }
-  return now.toISOString()
-}
+import { MeetingForm } from './meeting-form'
 
 interface CreateMeetingDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
+/**
+ * Thin modal wrapper around {@link MeetingForm}. Supplies the `Dialog` shell and the
+ * header; all form logic lives in the core, which the command palette hosts directly
+ * as a page. Public API is unchanged.
+ */
 export function CreateMeetingDialog({ open, onOpenChange }: CreateMeetingDialogProps) {
-  const [values, setValues] = useState({
-    title: '',
-    platform: 'google_meet',
-    startTime: '',
-    duration: '30',
-    meetingUrl: '',
-    participants: [] as RecordId[],
-    description: '',
-  })
-  const [errors, setErrors] = useState<Record<string, string>>({})
-
-  // Reset when dialog opens
-  useEffect(() => {
-    if (open) {
-      setValues({
-        title: '',
-        platform: 'google_meet',
-        startTime: getDefaultStartTime(),
-        duration: '30',
-        meetingUrl: '',
-        participants: [],
-        description: '',
-      })
-      setErrors({})
-    }
-  }, [open])
-
-  const handleChange = useCallback((field: string, value: any) => {
-    setValues((prev) => ({ ...prev, [field]: value }))
-    setErrors((prev) => {
-      if (prev[field]) {
-        const next = { ...prev }
-        delete next[field]
-        return next
-      }
-      return prev
-    })
-  }, [])
-
-  const validate = (): boolean => {
-    const newErrors: Record<string, string> = {}
-    if (!values.title) newErrors.title = 'Title is required'
-    if (!values.startTime) newErrors.startTime = 'Date & time is required'
-    if (!values.duration) newErrors.duration = 'Duration is required'
-    if (values.platform !== 'google_meet' && !values.meetingUrl) {
-      newErrors.meetingUrl = 'Meeting URL is required'
-    }
-    setErrors(newErrors)
-    return Object.keys(newErrors).length === 0
-  }
-
-  const utils = api.useUtils()
-  const createMeeting = api.recording.createMeeting.useMutation({
-    onSuccess: () => {
-      toastSuccess({ title: 'Meeting created' })
-      utils.recording.list.invalidate()
-      utils.calendar.getUpcoming.invalidate()
-      onOpenChange(false)
-    },
-    onError: (error) => {
-      toastError({ title: 'Error creating meeting', description: error.message })
-    },
-  })
-
-  const isPending = createMeeting.isPending
-
-  const handleSubmit = async () => {
-    if (!validate()) return
-
-    const isGoogleMeet = values.platform === 'google_meet'
-
-    createMeeting.mutate({
-      title: values.title,
-      startTime: values.startTime,
-      durationMinutes: Number.parseInt(values.duration, 10),
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      createGoogleMeet: isGoogleMeet,
-      meetingUrl: !isGoogleMeet && values.meetingUrl ? values.meetingUrl : undefined,
-      description: values.description || undefined,
-      contactRecordIds: values.participants as string[],
-    })
-  }
-
-  const isManualUrl = values.platform !== 'google_meet'
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className='sm:max-w-[500px]' position='tc'>
-        <DialogHeader>
-          <DialogTitle>Create Meeting</DialogTitle>
-          <DialogDescription>
-            Schedule a new meeting and optionally generate a video link.
-          </DialogDescription>
-        </DialogHeader>
-
-        <VarEditorField
-          orientation='responsive'
-          className='p-0 sm:[&_[data-slot=field-row-label]]:w-50'>
-          {/* Title */}
-          <VarEditorFieldRow
-            title='Title'
-            type={BaseType.STRING}
-            showIcon
-            isRequired
-            validationError={errors.title}
-            validationType='error'>
-            <ConstantInputAdapter
-              value={values.title}
-              onChange={(_, val) => handleChange('title', val)}
-              varType={BaseType.STRING}
-              placeholder='Meeting title'
-              disabled={isPending}
-            />
-          </VarEditorFieldRow>
-
-          {/* Platform */}
-          <VarEditorFieldRow title='Platform' type={BaseType.ENUM} showIcon>
-            <ConstantInputAdapter
-              value={values.platform}
-              onChange={(_, val) => handleChange('platform', val)}
-              varType={BaseType.ENUM}
-              disabled={isPending}
-              fieldOptions={{ enum: PLATFORM_OPTIONS }}
-            />
-          </VarEditorFieldRow>
-
-          {/* Date & Time */}
-          <VarEditorFieldRow
-            title='Date & Time'
-            type={BaseType.DATETIME}
-            showIcon
-            isRequired
-            validationError={errors.startTime}
-            validationType='error'>
-            <ConstantInputAdapter
-              value={values.startTime}
-              onChange={(_, val) => handleChange('startTime', val)}
-              varType={BaseType.DATETIME}
-              disabled={isPending}
-            />
-          </VarEditorFieldRow>
-
-          {/* Duration */}
-          <VarEditorFieldRow
-            title='Duration'
-            type={BaseType.ENUM}
-            showIcon
-            isRequired
-            validationError={errors.duration}
-            validationType='error'>
-            <ConstantInputAdapter
-              value={values.duration}
-              onChange={(_, val) => handleChange('duration', val)}
-              varType={BaseType.ENUM}
-              disabled={isPending}
-              fieldOptions={{ enum: DURATION_OPTIONS }}
-            />
-          </VarEditorFieldRow>
-
-          {/* Meeting URL — only for non-Google Meet */}
-          {isManualUrl && (
-            <VarEditorFieldRow
-              title='Meeting URL'
-              type={BaseType.URL}
-              showIcon
-              isRequired
-              validationError={errors.meetingUrl}
-              validationType='error'>
-              <ConstantInputAdapter
-                value={values.meetingUrl}
-                onChange={(_, val) => handleChange('meetingUrl', val)}
-                varType={BaseType.URL}
-                placeholder='https://zoom.us/j/...'
-                disabled={isPending}
-              />
-            </VarEditorFieldRow>
+        <MeetingForm
+          open={open}
+          onClose={() => onOpenChange(false)}
+          header={({ title }) => (
+            <DialogHeader>
+              <DialogTitle>{title}</DialogTitle>
+              <DialogDescription>
+                Schedule a new meeting and optionally generate a video link.
+              </DialogDescription>
+            </DialogHeader>
           )}
-
-          {/* Participants */}
-          <VarEditorFieldRow title='Participants' type={BaseType.RELATION} showIcon>
-            <ConstantInputAdapter
-              value={values.participants}
-              onChange={(_, val) => handleChange('participants', val)}
-              varType={BaseType.RELATION}
-              placeholder='Search contacts...'
-              disabled={isPending}
-              fieldOptions={{
-                relatedEntityDefinitionId: 'contact',
-                relationshipType: 'has_many',
-              }}
-            />
-          </VarEditorFieldRow>
-
-          {/* Description */}
-          <VarEditorFieldRow title='Description' type={BaseType.STRING} showIcon>
-            <ConstantInputAdapter
-              value={values.description}
-              onChange={(_, val) => handleChange('description', val)}
-              varType={BaseType.STRING}
-              placeholder='Optional meeting notes'
-              disabled={isPending}
-              fieldOptions={{ string: { multiline: true } }}
-            />
-          </VarEditorFieldRow>
-        </VarEditorField>
-
-        <DialogFooter>
-          <Button
-            type='button'
-            variant='ghost'
-            size='sm'
-            onClick={() => onOpenChange(false)}
-            disabled={isPending}>
-            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            variant='outline'
-            size='sm'
-            loading={isPending}
-            loadingText='Creating...'
-            data-dialog-submit>
-            Create Meeting <KbdSubmit variant='outline' size='sm' />
-          </Button>
-        </DialogFooter>
+        />
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/components/calls/ui/meeting-form.tsx
+++ b/apps/web/src/components/calls/ui/meeting-form.tsx
@@ -1,0 +1,290 @@
+// apps/web/src/components/calls/ui/meeting-form.tsx
+'use client'
+
+import type { RecordId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { toastError, toastSuccess } from '@auxx/ui/components/toast'
+import { type ReactNode, useCallback, useEffect, useState } from 'react'
+import { BaseType } from '~/components/workflow/types'
+import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
+import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+import { api } from '~/trpc/react'
+
+const PLATFORM_OPTIONS = [
+  { label: 'Google Meet', value: 'google_meet' },
+  { label: 'Zoom', value: 'zoom' },
+  { label: 'Teams', value: 'teams' },
+  { label: 'Other', value: 'other' },
+]
+
+const DURATION_OPTIONS = [
+  { label: '15 min', value: '15' },
+  { label: '30 min', value: '30' },
+  { label: '45 min', value: '45' },
+  { label: '60 min', value: '60' },
+  { label: '90 min', value: '90' },
+  { label: '120 min', value: '120' },
+]
+
+/**
+ * Get the next half-hour as default start time.
+ */
+function getDefaultStartTime(): string {
+  const now = new Date()
+  const minutes = now.getMinutes()
+  const roundedMinutes = minutes < 30 ? 30 : 60
+  now.setMinutes(roundedMinutes, 0, 0)
+  if (roundedMinutes === 60) {
+    now.setHours(now.getHours())
+  }
+  return now.toISOString()
+}
+
+/** Props for the shell-free meeting form core. */
+export interface MeetingFormProps {
+  /** Whether the form is "open" — drives the init/reset cycle. In a dialog this is
+   *  the dialog's open state; in the palette it's `page === 'create-meeting'`. */
+  open: boolean
+  /** Called after a successful create */
+  onSuccess?: () => void
+  /** Dismiss after a successful save / unrecoverable state (dialog closes; palette
+   *  closes). */
+  onClose: () => void
+  /** Cancel/back dismiss. Defaults to {@link onClose}; the palette routes it back
+   *  to the root action list instead of closing outright. */
+  onCancel?: () => void
+  /** Host-specific header. Dialogs render a `DialogHeader`; the palette omits it
+   *  (the breadcrumb supplies the title). */
+  header?: (ctx: { title: string }) => ReactNode
+}
+
+/**
+ * Shell-free meeting create form: all hooks/state, the field body, and the footer
+ * (Cancel / Create Meeting). The only host seams are the `header` slot and `onClose`.
+ * `create-meeting-dialog.tsx` wraps this in a `Dialog`; the command palette hosts it
+ * as a page. Create-only (no edit mode).
+ */
+export function MeetingForm({ open, onSuccess, onClose, onCancel, header }: MeetingFormProps) {
+  const cancel = onCancel ?? onClose
+  const title = 'Create Meeting'
+
+  const [values, setValues] = useState({
+    title: '',
+    platform: 'google_meet',
+    startTime: '',
+    duration: '30',
+    meetingUrl: '',
+    participants: [] as RecordId[],
+    description: '',
+  })
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  // Reset when the form opens
+  useEffect(() => {
+    if (open) {
+      setValues({
+        title: '',
+        platform: 'google_meet',
+        startTime: getDefaultStartTime(),
+        duration: '30',
+        meetingUrl: '',
+        participants: [],
+        description: '',
+      })
+      setErrors({})
+    }
+  }, [open])
+
+  const handleChange = useCallback((field: string, value: any) => {
+    setValues((prev) => ({ ...prev, [field]: value }))
+    setErrors((prev) => {
+      if (prev[field]) {
+        const next = { ...prev }
+        delete next[field]
+        return next
+      }
+      return prev
+    })
+  }, [])
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {}
+    if (!values.title) newErrors.title = 'Title is required'
+    if (!values.startTime) newErrors.startTime = 'Date & time is required'
+    if (!values.duration) newErrors.duration = 'Duration is required'
+    if (values.platform !== 'google_meet' && !values.meetingUrl) {
+      newErrors.meetingUrl = 'Meeting URL is required'
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const utils = api.useUtils()
+  const createMeeting = api.recording.createMeeting.useMutation({
+    onSuccess: () => {
+      toastSuccess({ title: 'Meeting created' })
+      utils.recording.list.invalidate()
+      utils.calendar.getUpcoming.invalidate()
+      onSuccess?.()
+      onClose()
+    },
+    onError: (error) => {
+      toastError({ title: 'Error creating meeting', description: error.message })
+    },
+  })
+
+  const isPending = createMeeting.isPending
+
+  const handleSubmit = async () => {
+    if (!validate()) return
+
+    const isGoogleMeet = values.platform === 'google_meet'
+
+    createMeeting.mutate({
+      title: values.title,
+      startTime: values.startTime,
+      durationMinutes: Number.parseInt(values.duration, 10),
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      createGoogleMeet: isGoogleMeet,
+      meetingUrl: !isGoogleMeet && values.meetingUrl ? values.meetingUrl : undefined,
+      description: values.description || undefined,
+      contactRecordIds: values.participants as string[],
+    })
+  }
+
+  const isManualUrl = values.platform !== 'google_meet'
+
+  return (
+    <>
+      {header?.({ title })}
+
+      <VarEditorField
+        orientation='responsive'
+        className='p-0 sm:[&_[data-slot=field-row-label]]:w-50'>
+        {/* Title */}
+        <VarEditorFieldRow
+          title='Title'
+          type={BaseType.STRING}
+          showIcon
+          isRequired
+          validationError={errors.title}
+          validationType='error'>
+          <ConstantInputAdapter
+            value={values.title}
+            onChange={(_, val) => handleChange('title', val)}
+            varType={BaseType.STRING}
+            placeholder='Meeting title'
+            disabled={isPending}
+          />
+        </VarEditorFieldRow>
+
+        {/* Platform */}
+        <VarEditorFieldRow title='Platform' type={BaseType.ENUM} showIcon>
+          <ConstantInputAdapter
+            value={values.platform}
+            onChange={(_, val) => handleChange('platform', val)}
+            varType={BaseType.ENUM}
+            disabled={isPending}
+            fieldOptions={{ enum: PLATFORM_OPTIONS }}
+          />
+        </VarEditorFieldRow>
+
+        {/* Date & Time */}
+        <VarEditorFieldRow
+          title='Date & Time'
+          type={BaseType.DATETIME}
+          showIcon
+          isRequired
+          validationError={errors.startTime}
+          validationType='error'>
+          <ConstantInputAdapter
+            value={values.startTime}
+            onChange={(_, val) => handleChange('startTime', val)}
+            varType={BaseType.DATETIME}
+            disabled={isPending}
+          />
+        </VarEditorFieldRow>
+
+        {/* Duration */}
+        <VarEditorFieldRow
+          title='Duration'
+          type={BaseType.ENUM}
+          showIcon
+          isRequired
+          validationError={errors.duration}
+          validationType='error'>
+          <ConstantInputAdapter
+            value={values.duration}
+            onChange={(_, val) => handleChange('duration', val)}
+            varType={BaseType.ENUM}
+            disabled={isPending}
+            fieldOptions={{ enum: DURATION_OPTIONS }}
+          />
+        </VarEditorFieldRow>
+
+        {/* Meeting URL — only for non-Google Meet */}
+        {isManualUrl && (
+          <VarEditorFieldRow
+            title='Meeting URL'
+            type={BaseType.URL}
+            showIcon
+            isRequired
+            validationError={errors.meetingUrl}
+            validationType='error'>
+            <ConstantInputAdapter
+              value={values.meetingUrl}
+              onChange={(_, val) => handleChange('meetingUrl', val)}
+              varType={BaseType.URL}
+              placeholder='https://zoom.us/j/...'
+              disabled={isPending}
+            />
+          </VarEditorFieldRow>
+        )}
+
+        {/* Participants */}
+        <VarEditorFieldRow title='Participants' type={BaseType.RELATION} showIcon>
+          <ConstantInputAdapter
+            value={values.participants}
+            onChange={(_, val) => handleChange('participants', val)}
+            varType={BaseType.RELATION}
+            placeholder='Search contacts...'
+            disabled={isPending}
+            fieldOptions={{
+              relatedEntityDefinitionId: 'contact',
+              relationshipType: 'has_many',
+            }}
+          />
+        </VarEditorFieldRow>
+
+        {/* Description */}
+        <VarEditorFieldRow title='Description' type={BaseType.STRING} showIcon>
+          <ConstantInputAdapter
+            value={values.description}
+            onChange={(_, val) => handleChange('description', val)}
+            varType={BaseType.STRING}
+            placeholder='Optional meeting notes'
+            disabled={isPending}
+            fieldOptions={{ string: { multiline: true } }}
+          />
+        </VarEditorFieldRow>
+      </VarEditorField>
+
+      <DialogFooter>
+        <Button type='button' variant='ghost' size='sm' onClick={cancel} disabled={isPending}>
+          Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant='outline'
+          size='sm'
+          loading={isPending}
+          loadingText='Creating...'
+          data-dialog-submit>
+          Create Meeting <KbdSubmit variant='outline' size='sm' />
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}

--- a/apps/web/src/components/datasets/create-dataset-dialog.tsx
+++ b/apps/web/src/components/datasets/create-dataset-dialog.tsx
@@ -2,73 +2,34 @@
 
 'use client'
 
-import { ModelType } from '@auxx/lib/ai/providers/types'
-import { EMBEDDING_DIMENSIONS, type EmbeddingDimension } from '@auxx/lib/datasets/types'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from '@auxx/ui/components/dialog'
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@auxx/ui/components/form'
-import { Input } from '@auxx/ui/components/input'
-import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
-import { Textarea } from '@auxx/ui/components/textarea'
-import { toastError } from '@auxx/ui/components/toast'
-import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { Plus } from 'lucide-react'
-import { useMemo, useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { z } from 'zod'
-import { AiModelPicker, type ModelPickerItem } from '~/components/pickers/ai-model-picker'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
-import { api } from '~/trpc/react'
-
-const createDatasetSchema = z.object({
-  name: z.string().min(1, 'Name is required').max(255, 'Name must be less than 255 characters'),
-  description: z.string().max(1000, 'Description must be less than 1000 characters').optional(),
-  embeddingModel: z.string().optional(),
-  vectorDimension: z.number().optional(),
-})
-
-type CreateDatasetForm = z.infer<typeof createDatasetSchema>
+import { useState } from 'react'
+import { DatasetForm } from './dataset-form'
 
 interface CreateDatasetDialogProps {
   trigger?: React.ReactNode
-  onSuccess?: (dataset: any) => void
+  onSuccess?: (dataset: unknown) => void
 }
 
 /**
- * Dialog for creating a new dataset
- * Provides form with name, description, and embedding model selection
+ * Thin modal wrapper around {@link DatasetForm}. Supplies the `Dialog` shell, the
+ * trigger button, and the header; all form logic lives in the core, which the
+ * command palette hosts directly as a page. Public API is unchanged.
  */
 export function CreateDatasetDialog({ trigger, onSuccess }: CreateDatasetDialogProps) {
   const [open, setOpen] = useState(false)
 
-  const handleOpenChange = (newOpen: boolean) => {
-    setOpen(newOpen)
-  }
-
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         {trigger || (
           <Button size='sm'>
@@ -78,242 +39,21 @@ export function CreateDatasetDialog({ trigger, onSuccess }: CreateDatasetDialogP
         )}
       </DialogTrigger>
       <DialogContent position='tc' size='sm'>
-        <CreateDatasetDialogContent onSuccess={onSuccess} onClose={() => setOpen(false)} />
+        {open && (
+          <DatasetForm
+            onSuccess={onSuccess}
+            onClose={() => setOpen(false)}
+            header={({ title }) => (
+              <DialogHeader>
+                <DialogTitle>{title}</DialogTitle>
+                <DialogDescription>
+                  Create a new dataset to organize and manage your documents.
+                </DialogDescription>
+              </DialogHeader>
+            )}
+          />
+        )}
       </DialogContent>
     </Dialog>
-  )
-}
-
-/** Inner content props */
-interface CreateDatasetDialogContentProps {
-  onSuccess?: (dataset: any) => void
-  onClose: () => void
-}
-
-/** Inner content component */
-function CreateDatasetDialogContent({ onSuccess, onClose }: CreateDatasetDialogContentProps) {
-  const form = useForm<CreateDatasetForm>({
-    resolver: standardSchemaResolver(createDatasetSchema),
-    defaultValues: {
-      name: '',
-      description: '',
-      embeddingModel: undefined,
-      vectorDimension: undefined,
-    },
-  })
-
-  const utils = api.useUtils()
-
-  const unifiedModelData = api.aiIntegration.getUnifiedModelData.useQuery({
-    includeDefaults: true,
-    modelTypes: [ModelType.TEXT_EMBEDDING],
-    includeUnconfigured: false,
-  })
-
-  const createDataset = api.dataset.create.useMutation({
-    onSuccess: (dataset) => {
-      // Reset form and close dialog
-      form.reset()
-      onClose()
-
-      // Invalidate datasets list to refresh UI
-      utils.dataset.list.invalidate()
-      utils.dataset.getOrganizationStats.invalidate()
-
-      // Call success callback
-      onSuccess?.(dataset)
-    },
-    onError: (error) => {
-      toastError({
-        title: 'Failed to create dataset',
-        description: error.message,
-      })
-    },
-  })
-
-  const currentModelId = form.watch('embeddingModel')
-
-  /** Get selected model to access its parameterRules */
-  const selectedModel = useMemo(() => {
-    if (!currentModelId || !unifiedModelData.data) return null
-    for (const provider of unifiedModelData.data.providers) {
-      const model = provider.models.find(
-        (m: { modelId: string }) => `${provider.provider}:${m.modelId}` === currentModelId
-      )
-      if (model) return model
-    }
-    return null
-  }, [currentModelId, unifiedModelData.data])
-
-  /** Extract dimension options from selected model's parameterRules */
-  const dimensionRule = selectedModel?.parameterRules?.find(
-    (rule: { name: string }) => rule.name === 'dimensions'
-  )
-
-  /** Get available options filtered to supported DB dimensions */
-  const availableDimensions = useMemo(() => {
-    if (!dimensionRule?.options) return null
-    const supported = (dimensionRule.options as (string | number)[])
-      .map((opt) => (typeof opt === 'string' ? Number(opt) : opt))
-      .filter((dim): dim is EmbeddingDimension =>
-        EMBEDDING_DIMENSIONS.includes(dim as EmbeddingDimension)
-      )
-    return supported.length > 1 ? supported : null
-  }, [dimensionRule])
-
-  const defaultDimension = dimensionRule?.default ? Number(dimensionRule.default) : 1536
-  const hasConfigurableDimensions = availableDimensions && availableDimensions.length > 1
-
-  /** Handle model selection change */
-  const handleModelChange = (model: ModelPickerItem | null) => {
-    form.setValue('embeddingModel', model?.id ?? undefined)
-
-    // Auto-select model's default dimension if available
-    if (model?.parameterRules) {
-      const dimRule = model.parameterRules.find((rule) => rule.name === 'dimensions')
-      if (dimRule?.default) {
-        const defaultDim = Number(dimRule.default)
-        if (EMBEDDING_DIMENSIONS.includes(defaultDim as EmbeddingDimension)) {
-          form.setValue('vectorDimension', defaultDim)
-        }
-      }
-    }
-  }
-
-  const onSubmit = (data: CreateDatasetForm) => {
-    createDataset.mutate({
-      name: data.name,
-      description: data.description || undefined,
-      embeddingModel: data.embeddingModel,
-      vectorDimension: data.vectorDimension,
-    })
-  }
-
-  return (
-    <>
-      <DialogHeader>
-        <DialogTitle>Create New Dataset</DialogTitle>
-        <DialogDescription>
-          Create a new dataset to organize and manage your documents.
-        </DialogDescription>
-      </DialogHeader>
-
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
-          <FormField
-            control={form.control}
-            name='name'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Dataset Name *</FormLabel>
-                <FormControl>
-                  <Input placeholder='Enter dataset name...' {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name='description'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Description</FormLabel>
-                <FormControl>
-                  <Textarea
-                    placeholder='Describe what this dataset will contain...'
-                    className='resize-none'
-                    rows={3}
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-30'>
-            <VarEditorFieldRow
-              title='Model'
-              description='Select a text embedding model from your configured providers'>
-              <FormField
-                control={form.control}
-                name='embeddingModel'
-                render={({ field }) => (
-                  <FormItem className='flex-1 space-y-0! mb-0'>
-                    <AiModelPicker
-                      data={unifiedModelData.data}
-                      value={field.value ?? null}
-                      onChange={handleModelChange}
-                      modelTypes={[ModelType.TEXT_EMBEDDING]}
-                      showUnconfigured={false}
-                      placeholder='Select embedding model...'
-                      triggerVariant='transparent'
-                      triggerClassName='w-full justify-between h-6'
-                      isUpdating={unifiedModelData.isLoading}
-                    />
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </VarEditorFieldRow>
-
-            {/* Dimension selector - only show if model supports configurable dimensions */}
-            {hasConfigurableDimensions && (
-              <VarEditorFieldRow
-                title='Dimensions'
-                description={
-                  dimensionRule?.help ||
-                  'Smaller dimensions use less storage but may reduce accuracy.'
-                }>
-                <FormField
-                  control={form.control}
-                  name='vectorDimension'
-                  render={({ field }) => (
-                    <FormItem className='flex-1 mb-0 space-y-0!'>
-                      <Select
-                        value={field.value?.toString() ?? defaultDimension.toString()}
-                        onValueChange={(v) => field.onChange(parseInt(v, 10))}>
-                        <SelectTrigger className='w-full' size='sm' variant='transparent'>
-                          <SelectValue placeholder='Select dimension' />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {availableDimensions.map((dim) => (
-                            <SelectItem key={dim} value={dim.toString()}>
-                              {dim} dimensions {dim === defaultDimension && '(default)'}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </VarEditorFieldRow>
-            )}
-          </VarEditorField>
-
-          <DialogFooter>
-            <Button
-              type='button'
-              variant='ghost'
-              size='sm'
-              onClick={onClose}
-              disabled={createDataset.isPending}>
-              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-            </Button>
-            <Button
-              variant='outline'
-              size='sm'
-              type='submit'
-              loading={createDataset.isPending}
-              loadingText='Creating...'>
-              Create Dataset <KbdSubmit variant='outline' size='sm' />
-            </Button>
-          </DialogFooter>
-        </form>
-      </Form>
-    </>
   )
 }

--- a/apps/web/src/components/datasets/dataset-form.tsx
+++ b/apps/web/src/components/datasets/dataset-form.tsx
@@ -1,0 +1,278 @@
+// apps/web/src/components/datasets/dataset-form.tsx
+'use client'
+
+import { ModelType } from '@auxx/lib/ai/providers/types'
+import { EMBEDDING_DIMENSIONS, type EmbeddingDimension } from '@auxx/lib/datasets/types'
+import { Button } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@auxx/ui/components/form'
+import { Input } from '@auxx/ui/components/input'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { Textarea } from '@auxx/ui/components/textarea'
+import { toastError } from '@auxx/ui/components/toast'
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
+import type { ReactNode } from 'react'
+import { useMemo } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { AiModelPicker, type ModelPickerItem } from '~/components/pickers/ai-model-picker'
+import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+import { api } from '~/trpc/react'
+
+const createDatasetSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(255, 'Name must be less than 255 characters'),
+  description: z.string().max(1000, 'Description must be less than 1000 characters').optional(),
+  embeddingModel: z.string().optional(),
+  vectorDimension: z.number().optional(),
+})
+
+type CreateDatasetForm = z.infer<typeof createDatasetSchema>
+
+/** Props for the shell-free dataset create form core. */
+export interface DatasetFormProps {
+  /** Called after a successful create (for auto-select / list refresh hooks). */
+  onSuccess?: (dataset: unknown) => void
+  /** Dismiss after a successful save (dialog closes; palette closes). */
+  onClose: () => void
+  /** Cancel/back dismiss. Defaults to {@link onClose}; the palette routes it to root. */
+  onCancel?: () => void
+  /** Host-specific header. Dialogs render a `DialogHeader`; the palette omits it. */
+  header?: (ctx: { title: string }) => ReactNode
+}
+
+/**
+ * Shell-free dataset create form: all hooks/state, the field body, and the footer
+ * (Cancel / Create). `create-dataset-dialog.tsx` wraps this in a `Dialog`; the
+ * command palette hosts it as a page. Owns its own mutation + cache invalidation.
+ */
+export function DatasetForm({ onSuccess, onClose, onCancel, header }: DatasetFormProps) {
+  const cancel = onCancel ?? onClose
+  const form = useForm<CreateDatasetForm>({
+    resolver: standardSchemaResolver(createDatasetSchema),
+    defaultValues: {
+      name: '',
+      description: '',
+      embeddingModel: undefined,
+      vectorDimension: undefined,
+    },
+  })
+
+  const utils = api.useUtils()
+
+  const unifiedModelData = api.aiIntegration.getUnifiedModelData.useQuery({
+    includeDefaults: true,
+    modelTypes: [ModelType.TEXT_EMBEDDING],
+    includeUnconfigured: false,
+  })
+
+  const createDataset = api.dataset.create.useMutation({
+    onSuccess: (dataset) => {
+      form.reset()
+      onClose()
+      utils.dataset.list.invalidate()
+      utils.dataset.getOrganizationStats.invalidate()
+      onSuccess?.(dataset)
+    },
+    onError: (error) => {
+      toastError({
+        title: 'Failed to create dataset',
+        description: error.message,
+      })
+    },
+  })
+
+  const currentModelId = form.watch('embeddingModel')
+
+  /** Get selected model to access its parameterRules */
+  const selectedModel = useMemo(() => {
+    if (!currentModelId || !unifiedModelData.data) return null
+    for (const provider of unifiedModelData.data.providers) {
+      const model = provider.models.find(
+        (m: { modelId: string }) => `${provider.provider}:${m.modelId}` === currentModelId
+      )
+      if (model) return model
+    }
+    return null
+  }, [currentModelId, unifiedModelData.data])
+
+  /** Extract dimension options from selected model's parameterRules */
+  const dimensionRule = selectedModel?.parameterRules?.find(
+    (rule: { name: string }) => rule.name === 'dimensions'
+  )
+
+  /** Get available options filtered to supported DB dimensions */
+  const availableDimensions = useMemo(() => {
+    if (!dimensionRule?.options) return null
+    const supported = (dimensionRule.options as (string | number)[])
+      .map((opt) => (typeof opt === 'string' ? Number(opt) : opt))
+      .filter((dim): dim is EmbeddingDimension =>
+        EMBEDDING_DIMENSIONS.includes(dim as EmbeddingDimension)
+      )
+    return supported.length > 1 ? supported : null
+  }, [dimensionRule])
+
+  const defaultDimension = dimensionRule?.default ? Number(dimensionRule.default) : 1536
+  const hasConfigurableDimensions = availableDimensions && availableDimensions.length > 1
+
+  /** Handle model selection change */
+  const handleModelChange = (model: ModelPickerItem | null) => {
+    form.setValue('embeddingModel', model?.id ?? undefined)
+
+    // Auto-select model's default dimension if available
+    if (model?.parameterRules) {
+      const dimRule = model.parameterRules.find((rule) => rule.name === 'dimensions')
+      if (dimRule?.default) {
+        const defaultDim = Number(dimRule.default)
+        if (EMBEDDING_DIMENSIONS.includes(defaultDim as EmbeddingDimension)) {
+          form.setValue('vectorDimension', defaultDim)
+        }
+      }
+    }
+  }
+
+  const onSubmit = (data: CreateDatasetForm) => {
+    createDataset.mutate({
+      name: data.name,
+      description: data.description || undefined,
+      embeddingModel: data.embeddingModel,
+      vectorDimension: data.vectorDimension,
+    })
+  }
+
+  return (
+    <>
+      {header?.({ title: 'Create New Dataset' })}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
+          <FormField
+            control={form.control}
+            name='name'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Dataset Name *</FormLabel>
+                <FormControl>
+                  <Input placeholder='Enter dataset name...' {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name='description'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder='Describe what this dataset will contain...'
+                    className='resize-none'
+                    rows={3}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-30'>
+            <VarEditorFieldRow
+              title='Model'
+              description='Select a text embedding model from your configured providers'>
+              <FormField
+                control={form.control}
+                name='embeddingModel'
+                render={({ field }) => (
+                  <FormItem className='flex-1 items-center space-y-0! mb-0'>
+                    <AiModelPicker
+                      data={unifiedModelData.data}
+                      value={field.value ?? null}
+                      onChange={handleModelChange}
+                      modelTypes={[ModelType.TEXT_EMBEDDING]}
+                      showUnconfigured={false}
+                      placeholder='Select embedding model...'
+                      triggerVariant='transparent'
+                      triggerClassName='w-full justify-between h-8'
+                      isUpdating={unifiedModelData.isLoading}
+                    />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </VarEditorFieldRow>
+
+            {/* Dimension selector - only show if model supports configurable dimensions */}
+            {hasConfigurableDimensions && (
+              <VarEditorFieldRow
+                title='Dimensions'
+                description={
+                  dimensionRule?.help ||
+                  'Smaller dimensions use less storage but may reduce accuracy.'
+                }>
+                <FormField
+                  control={form.control}
+                  name='vectorDimension'
+                  render={({ field }) => (
+                    <FormItem className='flex-1 mb-0 space-y-0!'>
+                      <Select
+                        value={field.value?.toString() ?? defaultDimension.toString()}
+                        onValueChange={(v) => field.onChange(parseInt(v, 10))}>
+                        <SelectTrigger className='w-full' size='sm' variant='transparent'>
+                          <SelectValue placeholder='Select dimension' />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {availableDimensions.map((dim) => (
+                            <SelectItem key={dim} value={dim.toString()}>
+                              {dim} dimensions {dim === defaultDimension && '(default)'}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </VarEditorFieldRow>
+            )}
+          </VarEditorField>
+
+          <DialogFooter>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              onClick={cancel}
+              disabled={createDataset.isPending}>
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+            </Button>
+            <Button
+              variant='outline'
+              size='sm'
+              type='submit'
+              loading={createDataset.isPending}
+              loadingText='Creating...'>
+              Create Dataset <KbdSubmit variant='outline' size='sm' />
+            </Button>
+          </DialogFooter>
+        </form>
+      </Form>
+    </>
+  )
+}

--- a/apps/web/src/components/fields/displays/display-rich-text.tsx
+++ b/apps/web/src/components/fields/displays/display-rich-text.tsx
@@ -12,6 +12,7 @@ export function DisplayRichText() {
   return (
     <DisplayWrapper copyValue={richText || null}>
       <div
+        data-slot='field-display-rich-text'
         className='prose max-w-none prose-sm dark:prose-invert prose-p:text-sm prose-p:leading-6 prose-p:mb-2 prose-p:mt-0 prose-p:text-muted-foreground prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline prose-img:rounded-lg prose-img:max-w-full'
         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(richText) }}
       />

--- a/apps/web/src/components/fields/displays/display-wrapper.tsx
+++ b/apps/web/src/components/fields/displays/display-wrapper.tsx
@@ -90,15 +90,17 @@ function DisplayWrapper({
   }, [buttons, copied, handleCopy, resolvedCopyValue])
 
   return (
-    <div className='relative flex-1 overflow-hidden '>
+    <div data-slot='field-display' className='relative flex-1 overflow-hidden '>
       <div className='group-hover/property-row:dark:bg-foreground/8 group-hover/property-row:bg-neutral-100 rounded-md flex items-start w-full gap-2 '>
         <div
+          data-slot='field-display-content'
           className={cn(
             'rounded-md px-1 w-full overflow-hidden h-auto min-h-[28px] flex items-center mask-[linear-gradient(to_right,black_0%,black_calc(100%-40px),transparent_calc(100%-20px),transparent_100%)] mask-size-[160%_100%] mask-position-[60%_0%] group-hover/property-row:mask-position-[100%_0%] transition-[mask-position] duration-200 ease', // group-hover:bg-neutral-200 group-hover:dark:bg-foreground/8
             className
           )}
           {...props}>
           <div
+            data-slot='field-display-value'
             className={cn(
               'content-center items-center h-fit flex  whitespace-nowrap py-[2px] text-ellipsis text-neutral-900 dark:text-neutral-50',
               innerClassName

--- a/apps/web/src/components/global/copy-input.tsx
+++ b/apps/web/src/components/global/copy-input.tsx
@@ -1,27 +1,48 @@
+// apps/web/src/components/global/copy-input.tsx
 'use client'
 
-import { Button } from '@auxx/ui/components/button'
-import { Input } from '@auxx/ui/components/input'
-import { CopyIcon } from 'lucide-react'
-import { useState } from 'react'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@auxx/ui/components/input-group'
+import { useCopy } from '@auxx/ui/hooks/use-copy'
+import { Check, Copy, KeyRound } from 'lucide-react'
+import { Tooltip } from '~/components/global/tooltip'
 
-export function CopyInput({ value }: { value: string }) {
-  const [copied, setCopied] = useState(false)
+interface CopyInputProps {
+  value: string
+  /** Toast message shown after a successful copy */
+  toastMessage?: string
+}
+
+export function CopyInput({ value, toastMessage = 'Copied to clipboard' }: CopyInputProps) {
+  const { copied, copy } = useCopy({ toastMessage })
 
   return (
-    <div className='flex w-full flex-1 items-center gap-1'>
-      <Input value={value} readOnly className='flex-1' disabled />
-      <Button
-        variant='outline'
-        onClick={() => {
-          if (value) {
-            navigator.clipboard.writeText(value)
-            setCopied(true)
-          }
-        }}>
-        <CopyIcon className='mr-2 size-4' />
-        {copied ? 'Copied!' : 'Copy'}
-      </Button>
-    </div>
+    <InputGroup>
+      <InputGroupAddon align='inline-start'>
+        <KeyRound />
+      </InputGroupAddon>
+      <InputGroupInput
+        type='text'
+        value={value}
+        readOnly
+        className='font-mono text-xs'
+        onFocus={(e) => e.target.select()}
+      />
+      <InputGroupAddon align='inline-end' className='gap-0.5'>
+        <Tooltip content='Copy'>
+          <InputGroupButton
+            aria-label='Copy'
+            className='rounded-full'
+            size='icon-xs'
+            onClick={() => copy(value)}>
+            {copied ? <Check /> : <Copy />}
+          </InputGroupButton>
+        </Tooltip>
+      </InputGroupAddon>
+    </InputGroup>
   )
 }

--- a/apps/web/src/components/inbox/inbox-dialog.tsx
+++ b/apps/web/src/components/inbox/inbox-dialog.tsx
@@ -1,35 +1,15 @@
 // apps/web/src/components/inbox/inbox-dialog.tsx
 'use client'
 
-import type { InboxVisibility } from '@auxx/lib/inboxes'
-import { parseRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
-import { Button } from '@auxx/ui/components/button'
+import type { RecordId } from '@auxx/lib/resources/client'
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@auxx/ui/components/dialog'
-import { Field, FieldGroup, FieldLabel } from '@auxx/ui/components/field'
-import { Form } from '@auxx/ui/components/form'
-import { Input } from '@auxx/ui/components/input'
-import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
-import { Label } from '@auxx/ui/components/label'
-import { RadioGroup, RadioGroupItem } from '@auxx/ui/components/radio-group'
-import { Textarea } from '@auxx/ui/components/textarea'
-import { toastError } from '@auxx/ui/components/toast'
-import { Trash2 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
-import { useForm } from 'react-hook-form'
-import { MemberGroupFormField } from '~/components/pickers/member-group-form-picker'
-import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
-import { FormColorTagPicker } from '~/components/tags/ui/color-tag-picker'
-import { useConfirm } from '~/hooks/use-confirm'
-import { useDirtyCheck } from '~/hooks/use-dirty-state'
-import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
-import { api } from '~/trpc/react'
+import { InboxForm } from './inbox-form'
 
 /** Props for InboxDialog */
 interface InboxDialogProps {
@@ -41,350 +21,35 @@ interface InboxDialogProps {
   onSuccess?: (inbox: { id: string; name: string; recordId: RecordId }) => void
 }
 
-/** Form data for inbox dialog */
-interface InboxFormData {
-  name: string
-  description: string
-  color: string
-  accessType: 'anyone' | 'restricted'
-  memberGroupSelection: {
-    memberIds: string[]
-    groupIds: string[]
-  }
-}
-
-/** Dialog for creating and editing inboxes */
+/**
+ * Thin modal wrapper around {@link InboxForm}. Supplies the `Dialog` shell and the
+ * header; all form logic (pickers, access radio, unsaved-changes guard, delete)
+ * lives in the core, which the command palette hosts directly as a page. Public API
+ * is unchanged.
+ */
 export function InboxDialog({ open, onOpenChange, recordId, onSuccess }: InboxDialogProps) {
-  // Determine if editing based on prop
   const isEditing = !!recordId
 
-  // Extract inboxId from recordId for mutations
-  const inboxId = recordId ? parseRecordId(recordId).entityInstanceId : null
-
-  // Fetch system field values for edit mode
-  const { values: fieldValues, isLoading: isLoadingValues } = useSystemValues(
-    recordId,
-    ['inbox_name', 'inbox_description', 'inbox_color', 'inbox_visibility'],
-    { autoFetch: true, enabled: isEditing && !!recordId }
-  )
-
-  // Save system values with optimistic updates
-  const { save: saveSystemValues, isPending: isSavingValues } = useSaveSystemValues(recordId)
-
-  // Track if form has been initialized this open cycle
-  const isInitialized = useRef(false)
-
-  // Form setup
-  const form = useForm<InboxFormData>({
-    defaultValues: {
-      name: '',
-      description: '',
-      color: 'indigo',
-      accessType: 'anyone',
-      memberGroupSelection: { memberIds: [], groupIds: [] },
-    },
-  })
-
-  // Watch form values
-  const colorValue = form.watch('color')
-  const accessType = form.watch('accessType')
-
-  // Combined form values for dirty checking
-  // biome-ignore lint/correctness/useExhaustiveDependencies: form.watch values are intentionally used as dependencies for dirty checking
-  const formValues = useMemo(
-    () => ({
-      name: form.watch('name'),
-      description: form.watch('description'),
-      color: colorValue,
-      accessType,
-    }),
-    [form.watch('name'), form.watch('description'), colorValue, accessType]
-  )
-
-  // Track dirty state for unsaved changes warning
-  const { isDirty, setInitial } = useDirtyCheck(formValues)
-
-  // Stable callback for closing the dialog
-  const handleConfirmedClose = useCallback(() => {
-    onOpenChange(false)
-  }, [onOpenChange])
-
-  // Guard against accidental close when dirty
-  const { guardProps, guardedClose, ConfirmDialog } = useUnsavedChangesGuard({
-    isDirty,
-    onConfirmedClose: handleConfirmedClose,
-  })
-
-  // Initialize form when dialog opens (only once per cycle)
-  useEffect(() => {
-    if (open) {
-      // Skip if already initialized
-      if (isInitialized.current) return
-
-      if (isEditing && recordId) {
-        // In edit mode, wait for values to load (inbox_name is required)
-        if (isLoadingValues || fieldValues.inbox_name === undefined) return
-
-        isInitialized.current = true
-
-        const name = (fieldValues.inbox_name as string) ?? ''
-        const description = (fieldValues.inbox_description as string) ?? ''
-        const color = (fieldValues.inbox_color as string) ?? 'indigo'
-        const visibility = fieldValues.inbox_visibility ?? 'org_members'
-        const accessType = visibility === 'org_members' ? 'anyone' : 'restricted'
-
-        form.reset({
-          name,
-          description,
-          color,
-          accessType,
-          memberGroupSelection: { memberIds: [], groupIds: [] },
-        })
-        setInitial({ name, description, color, accessType })
-      } else {
-        // Create mode: reset to defaults
-        isInitialized.current = true
-
-        form.reset({
-          name: '',
-          description: '',
-          color: 'indigo',
-          accessType: 'anyone',
-          memberGroupSelection: { memberIds: [], groupIds: [] },
-        })
-        setInitial({
-          name: '',
-          description: '',
-          color: 'indigo',
-          accessType: 'anyone',
-        })
-      }
-    } else {
-      // Reset flag when dialog closes
-      isInitialized.current = false
-    }
-  }, [open, isEditing, recordId, fieldValues, isLoadingValues, form, setInitial])
-
-  // Get tRPC utils for cache invalidation
-  const utils = api.useUtils()
-
-  // Confirmation dialog for delete
-  const [confirm, ConfirmDeleteDialog] = useConfirm()
-
-  /** Invalidate both inbox query caches (tRPC getAll + entity system listAll) */
-  const invalidateInboxes = () => {
-    utils.inbox.getAll.invalidate()
-    utils.record.listAll.invalidate({ entityDefinitionId: 'inbox' })
-  }
-
-  // Create inbox mutation
-  const createInbox = api.inbox.create.useMutation({
-    onSuccess: (data) => {
-      invalidateInboxes()
-      onOpenChange(false)
-      onSuccess?.({ id: data.id, name: data.name, recordId: toRecordId('inbox', data.id) })
-    },
-    onError: (error) => {
-      toastError({ title: 'Error creating inbox', description: error.message })
-    },
-  })
-
-  // Delete inbox mutation
-  const deleteInbox = api.inbox.delete.useMutation({
-    onSuccess: () => {
-      invalidateInboxes()
-      onOpenChange(false)
-    },
-    onError: (error) => {
-      toastError({ title: 'Error deleting inbox', description: error.message })
-    },
-  })
-
-  const isPending = createInbox.isPending || isSavingValues || deleteInbox.isPending
-
-  // Form validation
-  const isValid = (form.watch('name') ?? '').trim().length > 0
-
-  // Handle color change from the color picker
-  const handleColorChange = (color: string) => {
-    form.setValue('color', color)
-  }
-
-  // Handle delete with confirmation
-  const handleDelete = async () => {
-    if (!inboxId) return
-
-    const confirmed = await confirm({
-      title: 'Delete inbox?',
-      description:
-        'This will permanently delete this inbox and all its settings. This action cannot be undone.',
-      confirmText: 'Delete',
-      cancelText: 'Cancel',
-      destructive: true,
-    })
-
-    if (confirmed) {
-      deleteInbox.mutate({ inboxId })
-    }
-  }
-
-  // Handle form submission
-  const handleSubmit = async (data: InboxFormData) => {
-    if (!isValid) return
-
-    const visibility: InboxVisibility = data.accessType === 'anyone' ? 'org_members' : 'custom'
-
-    if (isEditing && recordId) {
-      // Save field values with optimistic updates
-      const success = await saveSystemValues({
-        inbox_name: data.name.trim(),
-        inbox_description: data.description,
-        inbox_color: data.color,
-        inbox_visibility: visibility,
-      })
-
-      if (success) {
-        // Field-value mutations don't invalidate inbox query caches, so picker
-        // rows and badges stay stale until the React Query staleTime expires.
-        // Flush both here so every dialog caller gets fresh data.
-        invalidateInboxes()
-        onOpenChange(false)
-        onSuccess?.({ id: inboxId!, name: data.name })
-      }
-    } else {
-      createInbox.mutate({
-        name: data.name.trim(),
-        description: data.description,
-        color: data.color,
-        status: 'ACTIVE',
-        visibility,
-      })
-    }
-  }
-
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent size='sm' position='tc' {...guardProps}>
-          <DialogHeader>
-            <DialogTitle>{isEditing ? 'Edit Inbox' : 'Create Inbox'}</DialogTitle>
-            <DialogDescription>
-              {isEditing
-                ? 'Update inbox settings.'
-                : 'Create a new inbox to organize your messages.'}
-            </DialogDescription>
-          </DialogHeader>
-
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(handleSubmit)}>
-              <FieldGroup className='gap-4'>
-                {/* Name field */}
-                <Field>
-                  <FieldLabel>Name</FieldLabel>
-                  <Input
-                    {...form.register('name', { required: 'Name is required' })}
-                    placeholder='Enter inbox name'
-                  />
-                  {form.formState.errors.name && (
-                    <p className='text-sm text-destructive'>{form.formState.errors.name.message}</p>
-                  )}
-                </Field>
-
-                {/* Description field */}
-                <Field>
-                  <FieldLabel>Description</FieldLabel>
-                  <Textarea
-                    {...form.register('description')}
-                    placeholder='Optional description'
-                    rows={3}
-                  />
-                </Field>
-
-                {/* Color field */}
-                <Field>
-                  <FieldLabel>Color</FieldLabel>
-                  <FormColorTagPicker value={colorValue} onChange={handleColorChange} />
-                </Field>
-
-                {/* Access fields */}
-                <Field>
-                  <FieldLabel>Access</FieldLabel>
-                  <RadioGroup
-                    value={accessType}
-                    onValueChange={(value) =>
-                      form.setValue('accessType', value as 'anyone' | 'restricted')
-                    }
-                    className='mt-2 flex flex-col space-y-2'>
-                    <div className='flex items-center space-x-2'>
-                      <RadioGroupItem value='anyone' id='anyone' />
-                      <Label htmlFor='anyone' className='cursor-pointer'>
-                        Anyone in the organization
-                      </Label>
-                    </div>
-                    <div className='flex items-center space-x-2'>
-                      <RadioGroupItem value='restricted' id='restricted' />
-                      <Label htmlFor='restricted' className='cursor-pointer'>
-                        Restricted
-                      </Label>
-                    </div>
-                  </RadioGroup>
-                </Field>
-
-                {accessType === 'restricted' && (
-                  <div className='pl-6'>
-                    <MemberGroupFormField
-                      name='memberGroupSelection'
-                      control={form.control}
-                      label='Select members or groups with access'
-                      description='Only selected members and groups will have access to this inbox'
-                      disabled={isPending}
-                    />
-                  </div>
-                )}
-              </FieldGroup>
-
-              <DialogFooter className='flex sm:justify-between!'>
-                {isEditing ? (
-                  <Button
-                    type='button'
-                    size='sm'
-                    variant='ghost'
-                    onClick={handleDelete}
-                    disabled={isPending}
-                    className='text-destructive hover:text-destructive'>
-                    <Trash2 /> Delete
-                  </Button>
-                ) : (
-                  <div />
-                )}
-                <div className='flex gap-2'>
-                  <Button
-                    type='button'
-                    size='sm'
-                    variant='ghost'
-                    onClick={guardedClose}
-                    disabled={isPending}>
-                    Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-                  </Button>
-                  <Button
-                    variant='outline'
-                    size='sm'
-                    type='submit'
-                    loading={isPending}
-                    loadingText='Saving...'
-                    disabled={!isValid || isPending}>
-                    {isEditing ? 'Update Inbox' : 'Create Inbox'}{' '}
-                    <KbdSubmit variant='outline' size='sm' />
-                  </Button>
-                </div>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-
-      <ConfirmDialog />
-      <ConfirmDeleteDialog />
-    </>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size='sm' position='tc'>
+        <InboxForm
+          open={open}
+          recordId={recordId}
+          onSuccess={onSuccess}
+          onClose={() => onOpenChange(false)}
+          header={({ title }) => (
+            <DialogHeader>
+              <DialogTitle>{title}</DialogTitle>
+              <DialogDescription>
+                {isEditing
+                  ? 'Update inbox settings.'
+                  : 'Create a new inbox to organize your messages.'}
+              </DialogDescription>
+            </DialogHeader>
+          )}
+        />
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -1,0 +1,396 @@
+// apps/web/src/components/inbox/inbox-form.tsx
+'use client'
+
+import type { InboxVisibility } from '@auxx/lib/inboxes'
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import { Button } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { Field, FieldGroup, FieldLabel } from '@auxx/ui/components/field'
+import { Form } from '@auxx/ui/components/form'
+import { Input } from '@auxx/ui/components/input'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { Label } from '@auxx/ui/components/label'
+import { RadioGroup, RadioGroupItem } from '@auxx/ui/components/radio-group'
+import { Textarea } from '@auxx/ui/components/textarea'
+import { toastError } from '@auxx/ui/components/toast'
+import { Trash2 } from 'lucide-react'
+import { type ReactNode, useEffect, useMemo, useRef } from 'react'
+import { useForm } from 'react-hook-form'
+import { MemberGroupFormField } from '~/components/pickers/member-group-form-picker'
+import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
+import { FormColorTagPicker } from '~/components/tags/ui/color-tag-picker'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useDirtyCheck } from '~/hooks/use-dirty-state'
+import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
+import { api } from '~/trpc/react'
+
+/** Form data for inbox form */
+interface InboxFormData {
+  name: string
+  description: string
+  color: string
+  accessType: 'anyone' | 'restricted'
+  memberGroupSelection: {
+    memberIds: string[]
+    groupIds: string[]
+  }
+}
+
+/** Props for the shell-free inbox form core. */
+export interface InboxFormProps {
+  /** Whether the form is "open" — drives the init/reset cycle. In a dialog this is
+   *  the dialog's open state; in the palette it's `page === 'create-inbox'`. */
+  open: boolean
+  /** RecordId for edit mode, null/undefined for create mode */
+  recordId?: RecordId | null
+  /** Called after successful save */
+  onSuccess?: (inbox: { id: string; name: string; recordId: RecordId }) => void
+  /** Dismiss after a successful save / unrecoverable state (dialog closes; palette
+   *  closes). */
+  onClose: () => void
+  /** Cancel/back dismiss. Defaults to {@link onClose}; the palette routes it back
+   *  to the root action list instead of closing outright. */
+  onCancel?: () => void
+  /** Host-specific header. Dialogs render a `DialogHeader`; the palette omits it
+   *  (the breadcrumb supplies the title). */
+  header?: (ctx: { title: string }) => ReactNode
+}
+
+/**
+ * Shell-free inbox create/edit form: all hooks/state/mutations, the member/group +
+ * color pickers, the access radio, the unsaved-changes guard, and the delete
+ * affordance. The only host seams are the `header` slot and `onClose`/`onCancel`.
+ * `inbox-dialog.tsx` wraps this in a `Dialog`; the command palette hosts it as a
+ * page. Behavior is unchanged from the original dialog.
+ */
+export function InboxForm({
+  open,
+  recordId,
+  onSuccess,
+  onClose,
+  onCancel,
+  header,
+}: InboxFormProps) {
+  const cancel = onCancel ?? onClose
+
+  // Determine if editing based on prop
+  const isEditing = !!recordId
+
+  // Extract inboxId from recordId for mutations
+  const inboxId = recordId ? parseRecordId(recordId).entityInstanceId : null
+
+  // Fetch system field values for edit mode
+  const { values: fieldValues, isLoading: isLoadingValues } = useSystemValues(
+    recordId,
+    ['inbox_name', 'inbox_description', 'inbox_color', 'inbox_visibility'],
+    { autoFetch: true, enabled: isEditing && !!recordId }
+  )
+
+  // Save system values with optimistic updates
+  const { save: saveSystemValues, isPending: isSavingValues } = useSaveSystemValues(recordId)
+
+  // Track if form has been initialized this open cycle
+  const isInitialized = useRef(false)
+
+  // Form setup
+  const form = useForm<InboxFormData>({
+    defaultValues: {
+      name: '',
+      description: '',
+      color: 'indigo',
+      accessType: 'anyone',
+      memberGroupSelection: { memberIds: [], groupIds: [] },
+    },
+  })
+
+  // Watch form values
+  const colorValue = form.watch('color')
+  const accessType = form.watch('accessType')
+
+  // Combined form values for dirty checking
+  // biome-ignore lint/correctness/useExhaustiveDependencies: form.watch values are intentionally used as dependencies for dirty checking
+  const formValues = useMemo(
+    () => ({
+      name: form.watch('name'),
+      description: form.watch('description'),
+      color: colorValue,
+      accessType,
+    }),
+    [form.watch('name'), form.watch('description'), colorValue, accessType]
+  )
+
+  // Track dirty state for unsaved changes warning
+  const { isDirty, setInitial } = useDirtyCheck(formValues)
+
+  // Guard against accidental close when dirty. The palette hosts this form without
+  // a Dialog, so the guard owns the form's own cancel/close path: the Cancel button
+  // routes through `guardedClose`, which (after confirming a discard) calls `cancel`.
+  const { guardedClose, ConfirmDialog } = useUnsavedChangesGuard({
+    isDirty,
+    onConfirmedClose: cancel,
+  })
+
+  // Initialize form when dialog opens (only once per cycle)
+  useEffect(() => {
+    if (open) {
+      // Skip if already initialized
+      if (isInitialized.current) return
+
+      if (isEditing && recordId) {
+        // In edit mode, wait for values to load (inbox_name is required)
+        if (isLoadingValues || fieldValues.inbox_name === undefined) return
+
+        isInitialized.current = true
+
+        const name = (fieldValues.inbox_name as string) ?? ''
+        const description = (fieldValues.inbox_description as string) ?? ''
+        const color = (fieldValues.inbox_color as string) ?? 'indigo'
+        const visibility = fieldValues.inbox_visibility ?? 'org_members'
+        const accessType = visibility === 'org_members' ? 'anyone' : 'restricted'
+
+        form.reset({
+          name,
+          description,
+          color,
+          accessType,
+          memberGroupSelection: { memberIds: [], groupIds: [] },
+        })
+        setInitial({ name, description, color, accessType })
+      } else {
+        // Create mode: reset to defaults
+        isInitialized.current = true
+
+        form.reset({
+          name: '',
+          description: '',
+          color: 'indigo',
+          accessType: 'anyone',
+          memberGroupSelection: { memberIds: [], groupIds: [] },
+        })
+        setInitial({
+          name: '',
+          description: '',
+          color: 'indigo',
+          accessType: 'anyone',
+        })
+      }
+    } else {
+      // Reset flag when dialog closes
+      isInitialized.current = false
+    }
+  }, [open, isEditing, recordId, fieldValues, isLoadingValues, form, setInitial])
+
+  // Get tRPC utils for cache invalidation
+  const utils = api.useUtils()
+
+  // Confirmation dialog for delete
+  const [confirm, ConfirmDeleteDialog] = useConfirm()
+
+  /** Invalidate both inbox query caches (tRPC getAll + entity system listAll) */
+  const invalidateInboxes = () => {
+    utils.inbox.getAll.invalidate()
+    utils.record.listAll.invalidate({ entityDefinitionId: 'inbox' })
+  }
+
+  // Create inbox mutation
+  const createInbox = api.inbox.create.useMutation({
+    onSuccess: (data) => {
+      invalidateInboxes()
+      onClose()
+      onSuccess?.({ id: data.id, name: data.name, recordId: toRecordId('inbox', data.id) })
+    },
+    onError: (error) => {
+      toastError({ title: 'Error creating inbox', description: error.message })
+    },
+  })
+
+  // Delete inbox mutation
+  const deleteInbox = api.inbox.delete.useMutation({
+    onSuccess: () => {
+      invalidateInboxes()
+      onClose()
+    },
+    onError: (error) => {
+      toastError({ title: 'Error deleting inbox', description: error.message })
+    },
+  })
+
+  const isPending = createInbox.isPending || isSavingValues || deleteInbox.isPending
+
+  // Form validation
+  const isValid = (form.watch('name') ?? '').trim().length > 0
+
+  // Handle color change from the color picker
+  const handleColorChange = (color: string) => {
+    form.setValue('color', color)
+  }
+
+  // Handle delete with confirmation
+  const handleDelete = async () => {
+    if (!inboxId) return
+
+    const confirmed = await confirm({
+      title: 'Delete inbox?',
+      description:
+        'This will permanently delete this inbox and all its settings. This action cannot be undone.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+
+    if (confirmed) {
+      deleteInbox.mutate({ inboxId })
+    }
+  }
+
+  // Handle form submission
+  const handleSubmit = async (data: InboxFormData) => {
+    if (!isValid) return
+
+    const visibility: InboxVisibility = data.accessType === 'anyone' ? 'org_members' : 'custom'
+
+    if (isEditing && recordId) {
+      // Save field values with optimistic updates
+      const success = await saveSystemValues({
+        inbox_name: data.name.trim(),
+        inbox_description: data.description,
+        inbox_color: data.color,
+        inbox_visibility: visibility,
+      })
+
+      if (success) {
+        // Field-value mutations don't invalidate inbox query caches, so picker
+        // rows and badges stay stale until the React Query staleTime expires.
+        // Flush both here so every caller gets fresh data.
+        invalidateInboxes()
+        onClose()
+        onSuccess?.({ id: inboxId!, name: data.name, recordId })
+      }
+    } else {
+      createInbox.mutate({
+        name: data.name.trim(),
+        description: data.description,
+        color: data.color,
+        status: 'ACTIVE',
+        visibility,
+      })
+    }
+  }
+
+  const title = isEditing ? 'Edit Inbox' : 'Create Inbox'
+
+  return (
+    <>
+      {header?.({ title })}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(handleSubmit)}>
+          <FieldGroup className='gap-4'>
+            {/* Name field */}
+            <Field>
+              <FieldLabel>Name</FieldLabel>
+              <Input
+                {...form.register('name', { required: 'Name is required' })}
+                placeholder='Enter inbox name'
+              />
+              {form.formState.errors.name && (
+                <p className='text-sm text-destructive'>{form.formState.errors.name.message}</p>
+              )}
+            </Field>
+
+            {/* Description field */}
+            <Field>
+              <FieldLabel>Description</FieldLabel>
+              <Textarea
+                {...form.register('description')}
+                placeholder='Optional description'
+                rows={3}
+              />
+            </Field>
+
+            {/* Color field */}
+            <Field>
+              <FieldLabel>Color</FieldLabel>
+              <FormColorTagPicker value={colorValue} onChange={handleColorChange} />
+            </Field>
+
+            {/* Access fields */}
+            <Field>
+              <FieldLabel>Access</FieldLabel>
+              <RadioGroup
+                value={accessType}
+                onValueChange={(value) =>
+                  form.setValue('accessType', value as 'anyone' | 'restricted')
+                }
+                className='mt-2 flex flex-col space-y-2'>
+                <div className='flex items-center space-x-2'>
+                  <RadioGroupItem value='anyone' id='anyone' />
+                  <Label htmlFor='anyone' className='cursor-pointer'>
+                    Anyone in the organization
+                  </Label>
+                </div>
+                <div className='flex items-center space-x-2'>
+                  <RadioGroupItem value='restricted' id='restricted' />
+                  <Label htmlFor='restricted' className='cursor-pointer'>
+                    Restricted
+                  </Label>
+                </div>
+              </RadioGroup>
+            </Field>
+
+            {accessType === 'restricted' && (
+              <div className='pl-6'>
+                <MemberGroupFormField
+                  name='memberGroupSelection'
+                  control={form.control}
+                  label='Select members or groups with access'
+                  description='Only selected members and groups will have access to this inbox'
+                  disabled={isPending}
+                />
+              </div>
+            )}
+          </FieldGroup>
+
+          <DialogFooter className='flex sm:justify-between!'>
+            {isEditing ? (
+              <Button
+                type='button'
+                size='sm'
+                variant='ghost'
+                onClick={handleDelete}
+                disabled={isPending}
+                className='text-destructive hover:text-destructive'>
+                <Trash2 /> Delete
+              </Button>
+            ) : (
+              <div />
+            )}
+            <div className='flex gap-2'>
+              <Button
+                type='button'
+                size='sm'
+                variant='ghost'
+                onClick={guardedClose}
+                disabled={isPending}>
+                Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+              </Button>
+              <Button
+                variant='outline'
+                size='sm'
+                type='submit'
+                loading={isPending}
+                loadingText='Saving...'
+                disabled={!isValid || isPending}>
+                {isEditing ? 'Update Inbox' : 'Create Inbox'}{' '}
+                <KbdSubmit variant='outline' size='sm' />
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </Form>
+
+      <ConfirmDialog />
+      <ConfirmDeleteDialog />
+    </>
+  )
+}

--- a/apps/web/src/components/kbar/actions/launchers.ts
+++ b/apps/web/src/components/kbar/actions/launchers.ts
@@ -1,0 +1,123 @@
+// apps/web/src/components/kbar/actions/launchers.ts
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useMemo } from 'react'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { useCommandPaletteStore } from '../store'
+import type { PaletteAction } from '../types'
+
+/**
+ * "Create …" actions for flows that live in standalone dialogs elsewhere. Their
+ * forms are shell-free cores (see e.g. `webhook-form.tsx`), so the palette hosts
+ * them as embedded pages with full back-nav — the action just drills into the
+ * matching `create-*` page. Team invite has no form core (its Card form is
+ * page-coupled), so it routes to the members page instead.
+ *
+ * Every action is gated to match where the feature is reachable today (the same
+ * flag/admin checks the sidebar + settings menu use); an action for a disabled
+ * feature or a non-admin must not appear.
+ */
+export function useLauncherActions(): PaletteAction[] {
+  const router = useRouter()
+  const { hasAccess } = useFeatureFlags()
+  const { isAdminOrOwner } = useUser()
+
+  return useMemo<PaletteAction[]>(() => {
+    const actions: PaletteAction[] = []
+
+    if (hasAccess('apiAccess')) {
+      actions.push({
+        id: 'create.apiKey',
+        label: 'Create API Key',
+        subtitle: 'New API secret key',
+        icon: 'key',
+        keywords: 'create new api key secret token',
+        perform: () => useCommandPaletteStore.getState().openCreateApiKey(),
+      })
+    }
+
+    if (isAdminOrOwner && hasAccess('webhooks')) {
+      actions.push({
+        id: 'create.webhook',
+        label: 'Create Webhook',
+        subtitle: 'New outgoing webhook',
+        icon: 'webhook',
+        keywords: 'create new webhook endpoint event',
+        perform: () => useCommandPaletteStore.getState().openCreateWebhook(),
+      })
+    }
+
+    if (isAdminOrOwner) {
+      actions.push({
+        id: 'create.inbox',
+        label: 'Create Inbox',
+        subtitle: 'New shared inbox',
+        icon: 'inbox',
+        keywords: 'create new inbox shared mailbox',
+        perform: () => useCommandPaletteStore.getState().openCreateInbox(),
+      })
+    }
+
+    actions.push({
+      id: 'create.mailView',
+      label: 'Create Mail View',
+      subtitle: 'New saved mail view',
+      icon: 'filter',
+      keywords: 'create new mail view saved filter',
+      perform: () => useCommandPaletteStore.getState().openCreateMailView(),
+    })
+
+    if (hasAccess('callRecordings')) {
+      actions.push({
+        id: 'create.meeting',
+        label: 'Create Meeting',
+        subtitle: 'Schedule a recorded meeting',
+        icon: 'video',
+        keywords: 'create new meeting call recording schedule',
+        perform: () => useCommandPaletteStore.getState().openCreateMeeting(),
+      })
+    }
+
+    if (isAdminOrOwner) {
+      actions.push({
+        id: 'create.group',
+        label: 'Create Group',
+        subtitle: 'New member group',
+        icon: 'layers',
+        keywords: 'create new group team members',
+        perform: () => useCommandPaletteStore.getState().openCreateGroup(),
+      })
+    }
+
+    if (hasAccess('datasets')) {
+      actions.push({
+        id: 'create.dataset',
+        label: 'Create Dataset',
+        subtitle: 'New vector dataset',
+        icon: 'database',
+        keywords: 'create new dataset embeddings vector',
+        perform: () => useCommandPaletteStore.getState().openCreateDataset(),
+      })
+    }
+
+    // Team invite has no shell-free form core — its invite form is a page-coupled
+    // Card (requires org context, routes on cancel). Route to the members page.
+    if (isAdminOrOwner && hasAccess('teammates')) {
+      actions.push({
+        id: 'create.invite',
+        label: 'Invite Teammate',
+        subtitle: 'Invite a member to your organization',
+        icon: 'user-plus',
+        keywords: 'invite teammate member user organization',
+        perform: () => {
+          router.push('/app/settings/members')
+          useCommandPaletteStore.getState().close()
+        },
+      })
+    }
+
+    return actions
+  }, [hasAccess, isAdminOrOwner, router])
+}

--- a/apps/web/src/components/kbar/command-palette.tsx
+++ b/apps/web/src/components/kbar/command-palette.tsx
@@ -8,16 +8,42 @@ import { useResources } from '~/components/resources/hooks/use-resources'
 import { preventTaskPickerEscape } from '~/components/tasks/ui/task-form'
 import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
 import { CreatePage } from './pages/create'
+import { CreateApiKeyPage } from './pages/create-api-key'
+import { CreateDatasetPage } from './pages/create-dataset'
+import { CreateGroupPage } from './pages/create-group'
+import { CreateInboxPage } from './pages/create-inbox'
+import { CreateMailViewPage } from './pages/create-mail-view'
+import { CreateMeetingPage } from './pages/create-meeting'
 import { CreateSignaturePage } from './pages/create-signature'
 import { CreateSnippetPage } from './pages/create-snippet'
 import { CreateTaskPage } from './pages/create-task'
+import { CreateWebhookPage } from './pages/create-webhook'
 import { RecordActionsPage } from './pages/record-actions'
 import { RootPage } from './pages/root'
 import { SearchPage } from './pages/search'
 import { useRecentsStore } from './recents-store'
 import { useCommandPaletteStore } from './store'
+import type { PalettePage } from './types'
 import { usePaletteActions } from './use-palette-actions'
 import { usePaletteHotkeys } from './use-palette-hotkeys'
+
+/**
+ * Simple create pages whose breadcrumb is just a single non-interactive crumb
+ * (title === crumb label, back goes to root). The entity `create` page is not
+ * here — it has a dynamic label and a dirty guard on its back button.
+ */
+const SIMPLE_CREATE_TITLES: Partial<Record<PalettePage, string>> = {
+  'create-snippet': 'Create Snippet',
+  'create-signature': 'Create Signature',
+  'create-task': 'Create Task',
+  'create-api-key': 'Create API Key',
+  'create-webhook': 'Create Webhook',
+  'create-inbox': 'Create Inbox',
+  'create-mail-view': 'Create Mail View',
+  'create-meeting': 'Create Meeting',
+  'create-group': 'Create Group',
+  'create-dataset': 'Create Dataset',
+}
 
 /**
  * The command palette (cmd+k). Mounted once at the app root — replaces the old
@@ -100,20 +126,12 @@ export function CommandPalette() {
               crumbs={[{ label: `Create ${createLabel ?? 'record'}` }]}
               onBack={guardedClose}
             />
-          ) : page === 'create-snippet' ? (
+          ) : SIMPLE_CREATE_TITLES[page] ? (
             <DialogNav
-              title='Create Snippet'
-              crumbs={[{ label: 'Create Snippet' }]}
+              title={SIMPLE_CREATE_TITLES[page] as string}
+              crumbs={[{ label: SIMPLE_CREATE_TITLES[page] as string }]}
               onBack={back}
             />
-          ) : page === 'create-signature' ? (
-            <DialogNav
-              title='Create Signature'
-              crumbs={[{ label: 'Create Signature' }]}
-              onBack={back}
-            />
-          ) : page === 'create-task' ? (
-            <DialogNav title='Create Task' crumbs={[{ label: 'Create Task' }]} onBack={back} />
           ) : null}
 
           <DialogNavPages value={page}>
@@ -137,6 +155,27 @@ export function CommandPalette() {
             </DialogNavPage>
             <DialogNavPage value='create-task' size='xl'>
               <CreateTaskPage />
+            </DialogNavPage>
+            <DialogNavPage value='create-api-key' size='md'>
+              <CreateApiKeyPage />
+            </DialogNavPage>
+            <DialogNavPage value='create-webhook' size='lg'>
+              <CreateWebhookPage />
+            </DialogNavPage>
+            <DialogNavPage value='create-inbox' size='lg'>
+              <CreateInboxPage />
+            </DialogNavPage>
+            <DialogNavPage value='create-mail-view' size='xl'>
+              <CreateMailViewPage />
+            </DialogNavPage>
+            <DialogNavPage value='create-meeting' size='lg'>
+              <CreateMeetingPage />
+            </DialogNavPage>
+            <DialogNavPage value='create-group' size='md'>
+              <CreateGroupPage />
+            </DialogNavPage>
+            <DialogNavPage value='create-dataset' size='md'>
+              <CreateDatasetPage />
             </DialogNavPage>
           </DialogNavPages>
         </DialogContent>

--- a/apps/web/src/components/kbar/pages/create-api-key.tsx
+++ b/apps/web/src/components/kbar/pages/create-api-key.tsx
@@ -1,0 +1,24 @@
+// apps/web/src/components/kbar/pages/create-api-key.tsx
+'use client'
+
+import { ApiKeyForm } from '~/app/(protected)/app/settings/apiKeys/_components/api-key-form'
+import { useCommandPaletteStore } from '../store'
+
+/**
+ * Hosts the shell-free {@link ApiKeyForm} as a palette page. The breadcrumb
+ * supplies the title. Unlike the other create pages this does NOT close on
+ * success — the form must stay mounted to reveal the one-time secret; its own
+ * "Done" button calls `onClose` (which closes the palette). Cancel / back returns
+ * to root.
+ */
+export function CreateApiKeyPage() {
+  const page = useCommandPaletteStore((s) => s.page)
+  const close = useCommandPaletteStore((s) => s.close)
+  const goTo = useCommandPaletteStore((s) => s.goTo)
+
+  return (
+    <div className='p-4'>
+      <ApiKeyForm open={page === 'create-api-key'} onClose={close} onCancel={() => goTo('root')} />
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/pages/create-dataset.tsx
+++ b/apps/web/src/components/kbar/pages/create-dataset.tsx
@@ -1,0 +1,21 @@
+// apps/web/src/components/kbar/pages/create-dataset.tsx
+'use client'
+
+import { DatasetForm } from '~/components/datasets/dataset-form'
+import { useCommandPaletteStore } from '../store'
+
+/**
+ * Hosts the shell-free {@link DatasetForm} as a palette page. The breadcrumb
+ * supplies the title (no header slot). On success the palette closes; cancel /
+ * back returns to root.
+ */
+export function CreateDatasetPage() {
+  const close = useCommandPaletteStore((s) => s.close)
+  const goTo = useCommandPaletteStore((s) => s.goTo)
+
+  return (
+    <div className='p-4'>
+      <DatasetForm onClose={close} onCancel={() => goTo('root')} />
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/pages/create-group.tsx
+++ b/apps/web/src/components/kbar/pages/create-group.tsx
@@ -1,0 +1,22 @@
+// apps/web/src/components/kbar/pages/create-group.tsx
+'use client'
+
+import { GroupDetailDialog } from '~/components/groups'
+import { useCommandPaletteStore } from '../store'
+
+/**
+ * Hosts the shell-free {@link GroupDetailDialog} (create mode) as a palette page.
+ * `GroupDetailDialog` is already shell-free content (its `Dialog` is supplied by
+ * the host), so the page renders it directly; the breadcrumb supplies the title.
+ * On success the palette closes; cancel / back returns to root.
+ */
+export function CreateGroupPage() {
+  const close = useCommandPaletteStore((s) => s.close)
+  const goTo = useCommandPaletteStore((s) => s.goTo)
+
+  return (
+    <div className='p-4'>
+      <GroupDetailDialog mode='create' onSuccess={close} onCancel={() => goTo('root')} />
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/pages/create-inbox.tsx
+++ b/apps/web/src/components/kbar/pages/create-inbox.tsx
@@ -1,0 +1,27 @@
+// apps/web/src/components/kbar/pages/create-inbox.tsx
+'use client'
+
+import { InboxForm } from '~/components/inbox/inbox-form'
+import { useCommandPaletteStore } from '../store'
+
+/**
+ * Hosts the shell-free {@link InboxForm} as a palette page (create mode only).
+ * The breadcrumb supplies the title (no header slot). On success / cancel the
+ * palette closes; back returns to root.
+ */
+export function CreateInboxPage() {
+  const page = useCommandPaletteStore((s) => s.page)
+  const close = useCommandPaletteStore((s) => s.close)
+  const goTo = useCommandPaletteStore((s) => s.goTo)
+
+  return (
+    <div className='p-4'>
+      <InboxForm
+        open={page === 'create-inbox'}
+        onSuccess={close}
+        onClose={close}
+        onCancel={() => goTo('root')}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/pages/create-mail-view.tsx
+++ b/apps/web/src/components/kbar/pages/create-mail-view.tsx
@@ -1,0 +1,27 @@
+// apps/web/src/components/kbar/pages/create-mail-view.tsx
+'use client'
+
+import { MailViewForm } from '~/components/mail-views/mail-view-form'
+import { useCommandPaletteStore } from '../store'
+
+/**
+ * Hosts the shell-free {@link MailViewForm} as a palette page (create mode only).
+ * The breadcrumb supplies the title (no header slot). On success / cancel the
+ * palette closes; back returns to root.
+ */
+export function CreateMailViewPage() {
+  const page = useCommandPaletteStore((s) => s.page)
+  const close = useCommandPaletteStore((s) => s.close)
+  const goTo = useCommandPaletteStore((s) => s.goTo)
+
+  return (
+    <div className='p-4'>
+      <MailViewForm
+        open={page === 'create-mail-view'}
+        onSuccess={close}
+        onClose={close}
+        onCancel={() => goTo('root')}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/pages/create-meeting.tsx
+++ b/apps/web/src/components/kbar/pages/create-meeting.tsx
@@ -1,0 +1,27 @@
+// apps/web/src/components/kbar/pages/create-meeting.tsx
+'use client'
+
+import { MeetingForm } from '~/components/calls/ui/meeting-form'
+import { useCommandPaletteStore } from '../store'
+
+/**
+ * Hosts the shell-free {@link MeetingForm} as a palette page (create mode only).
+ * The breadcrumb supplies the title (no header slot). On success / cancel the
+ * palette closes; back returns to root.
+ */
+export function CreateMeetingPage() {
+  const page = useCommandPaletteStore((s) => s.page)
+  const close = useCommandPaletteStore((s) => s.close)
+  const goTo = useCommandPaletteStore((s) => s.goTo)
+
+  return (
+    <div className='p-4'>
+      <MeetingForm
+        open={page === 'create-meeting'}
+        onSuccess={close}
+        onClose={close}
+        onCancel={() => goTo('root')}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/pages/create-webhook.tsx
+++ b/apps/web/src/components/kbar/pages/create-webhook.tsx
@@ -1,0 +1,27 @@
+// apps/web/src/components/kbar/pages/create-webhook.tsx
+'use client'
+
+import { WebhookForm } from '~/app/(protected)/app/settings/webhooks/_components/webhook-form'
+import { useCommandPaletteStore } from '../store'
+
+/**
+ * Hosts the shell-free {@link WebhookForm} as a palette page (create mode only).
+ * The breadcrumb supplies the title (no header slot). On success / cancel the
+ * palette closes; back returns to root.
+ */
+export function CreateWebhookPage() {
+  const page = useCommandPaletteStore((s) => s.page)
+  const close = useCommandPaletteStore((s) => s.close)
+  const goTo = useCommandPaletteStore((s) => s.goTo)
+
+  return (
+    <div className='p-4'>
+      <WebhookForm
+        open={page === 'create-webhook'}
+        onSuccess={close}
+        onClose={close}
+        onCancel={() => goTo('root')}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/pages/record-preview.tsx
+++ b/apps/web/src/components/kbar/pages/record-preview.tsx
@@ -8,6 +8,7 @@ import {
   type RecordPickerItem,
   type ResourceField,
 } from '@auxx/lib/resources/client'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { useMemo } from 'react'
@@ -112,20 +113,25 @@ export function RecordPreview({ recordId: rawRecordId, item }: RecordPreviewProp
             className='shrink-0 inset-shadow-xs inset-shadow-black/20'
           />
           <div className='min-w-0 flex-1'>
-            <div className='truncate font-medium text-sm'>{item.displayName}</div>
+            <div className='flex items-center gap-2'>
+              <div className='min-w-0 flex-1 truncate font-medium text-sm'>{item.displayName}</div>
+              {resource && (
+                <Badge
+                  variant={(resource.color || 'gray') as Variant}
+                  size='xs'
+                  className='shrink-0 uppercase tracking-wide'>
+                  {resource.label}
+                </Badge>
+              )}
+            </div>
             {item.secondaryInfo && (
               <div className='truncate text-muted-foreground text-xs'>{item.secondaryInfo}</div>
-            )}
-            {resource && (
-              <div className='mt-1 inline-flex rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground uppercase tracking-wide'>
-                {resource.label}
-              </div>
             )}
           </div>
         </div>
 
         {/* Fields */}
-        <div className='flex flex-col gap-3 px-4 pb-4'>
+        <div className='flex flex-col gap-1 px-4 pb-4'>
           {rows.length === 0 ? (
             <div className='space-y-2 pt-1'>
               <Skeleton className='h-3.5 w-2/3' />
@@ -136,7 +142,10 @@ export function RecordPreview({ recordId: rawRecordId, item }: RecordPreviewProp
             rows.map(({ field, value }) => (
               <div key={field.id} className='flex min-w-0 flex-col gap-0.5'>
                 <span className='text-[11px] text-muted-foreground'>{field.label}</span>
-                <div className='min-w-0 text-sm'>
+                {/* Strip the property-row chrome from FieldDisplay: the right-edge
+                    mask and single-line clamp are tuned for editable rows, not a
+                    read-only preview. Let values wrap and align to the top. */}
+                <div className='min-w-0 text-sm [&_[data-slot=field-display-content]]:mask-none [&_[data-slot=field-display-content]]:items-start [&_[data-slot=field-display-value]]:whitespace-normal'>
                   <FieldDisplay field={field} value={value} />
                 </div>
               </div>

--- a/apps/web/src/components/kbar/pages/search.tsx
+++ b/apps/web/src/components/kbar/pages/search.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { getDefinitionId, type RecordId, type RecordPickerItem } from '@auxx/lib/resources/client'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import {
   Command,
@@ -194,9 +195,12 @@ export function SearchPage() {
                         )}
                       </div>
                       {resource && (
-                        <span className='shrink-0 text-xs text-muted-foreground me-2'>
+                        <Badge
+                          variant={(resource.color || 'gray') as Variant}
+                          size='xs'
+                          className='me-2 shrink-0'>
                           {resource.label}
-                        </span>
+                        </Badge>
                       )}
                     </CommandItem>
                   ))}

--- a/apps/web/src/components/kbar/store.ts
+++ b/apps/web/src/components/kbar/store.ts
@@ -40,6 +40,13 @@ interface CommandPaletteState {
   openCreateSnippet: (folderId?: string) => void
   openCreateSignature: () => void
   openCreateTask: (ref?: RecordId) => void
+  openCreateApiKey: () => void
+  openCreateWebhook: () => void
+  openCreateInbox: () => void
+  openCreateMailView: () => void
+  openCreateMeeting: () => void
+  openCreateGroup: () => void
+  openCreateDataset: () => void
   /** `Meta+K`: open when closed; on the search page open the active record's
    *  actions; otherwise toggle closed. */
   metaK: () => void
@@ -54,6 +61,13 @@ const BACK_TARGET: Record<PalettePage, PalettePage> = {
   'create-snippet': 'root',
   'create-signature': 'root',
   'create-task': 'root',
+  'create-api-key': 'root',
+  'create-webhook': 'root',
+  'create-inbox': 'root',
+  'create-mail-view': 'root',
+  'create-meeting': 'root',
+  'create-group': 'root',
+  'create-dataset': 'root',
 }
 
 /**
@@ -83,6 +97,13 @@ export const useCommandPaletteStore = create<CommandPaletteState>((set, get) => 
     set({ open: true, createSnippetFolderId: folderId ?? null, page: 'create-snippet' }),
   openCreateSignature: () => set({ open: true, page: 'create-signature' }),
   openCreateTask: (ref) => set({ open: true, createTaskRef: ref ?? null, page: 'create-task' }),
+  openCreateApiKey: () => set({ open: true, page: 'create-api-key' }),
+  openCreateWebhook: () => set({ open: true, page: 'create-webhook' }),
+  openCreateInbox: () => set({ open: true, page: 'create-inbox' }),
+  openCreateMailView: () => set({ open: true, page: 'create-mail-view' }),
+  openCreateMeeting: () => set({ open: true, page: 'create-meeting' }),
+  openCreateGroup: () => set({ open: true, page: 'create-group' }),
+  openCreateDataset: () => set({ open: true, page: 'create-dataset' }),
   metaK: () => {
     const s = get()
     if (!s.open) return set({ open: true, page: 'root' })

--- a/apps/web/src/components/kbar/types.ts
+++ b/apps/web/src/components/kbar/types.ts
@@ -9,6 +9,13 @@ export type PalettePage =
   | 'create-snippet'
   | 'create-signature'
   | 'create-task'
+  | 'create-api-key'
+  | 'create-webhook'
+  | 'create-inbox'
+  | 'create-mail-view'
+  | 'create-meeting'
+  | 'create-group'
+  | 'create-dataset'
 
 /**
  * A single command-palette entry. The whole palette is built from plain arrays

--- a/apps/web/src/components/kbar/use-palette-actions.ts
+++ b/apps/web/src/components/kbar/use-palette-actions.ts
@@ -5,6 +5,7 @@ import { useMemo } from 'react'
 import { SIDEBAR_MENU } from '~/constants/menu'
 import { useCreateActions, useNonEntityCreateActions } from './actions/create'
 import { useGeneralActions } from './actions/general'
+import { useLauncherActions } from './actions/launchers'
 import { useNavigationActions } from './actions/navigation'
 import { useSettingsActions } from './actions/settings'
 import { useThemeActions } from './actions/theme'
@@ -75,6 +76,7 @@ export function usePaletteActions(): PaletteActionsResult {
   const navigation = useNavigationActions()
   const create = useCreateActions()
   const nonEntityCreate = useNonEntityCreateActions()
+  const launchers = useLauncherActions()
   const settings = useSettingsActions()
   const theme = useThemeActions()
 
@@ -82,7 +84,7 @@ export function usePaletteActions(): PaletteActionsResult {
     const sections: PaletteSection[] = [
       { label: 'Actions', actions: general },
       { label: 'Navigation', actions: navigation },
-      { label: 'Create', actions: [...create, ...nonEntityCreate] },
+      { label: 'Create', actions: [...create, ...nonEntityCreate, ...launchers] },
       { label: 'Settings', actions: settings },
       { label: 'Theme', actions: theme },
     ]
@@ -97,5 +99,5 @@ export function usePaletteActions(): PaletteActionsResult {
     }
 
     return { sections, byId }
-  }, [general, navigation, create, nonEntityCreate, settings, theme])
+  }, [general, navigation, create, nonEntityCreate, launchers, settings, theme])
 }

--- a/apps/web/src/components/mail-views/mail-view-dialog.tsx
+++ b/apps/web/src/components/mail-views/mail-view-dialog.tsx
@@ -1,62 +1,8 @@
 // apps/web/src/components/mail-views/mail-view-dialog.tsx
 'use client'
 
-import { Button } from '@auxx/ui/components/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
-import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
-import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
-import { toastError, toastSuccess } from '@auxx/ui/components/toast'
-import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
-import { FileText, Filter, Sliders, Trash2 } from 'lucide-react'
-import { usePathname, useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
-import { FormProvider, useForm } from 'react-hook-form'
-import * as z from 'zod'
-import type { ConditionGroup } from '~/components/conditions'
-import { useConfirm } from '~/hooks/use-confirm'
-import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
-import { api } from '~/trpc/react'
-import { MailViewDetailsForm } from './mail-view-details-form'
-import { MailViewFilterBuilder } from './mail-view-filter-builder'
-import { MailViewSharingOptions } from './mail-view-sharing-options'
-import { MailViewSortOptions } from './mail-view-sort-options'
-
-// Define the form schema using zod
-const mailViewFormSchema = z.object({
-  name: z.string().min(1, 'Name is required').max(100),
-  description: z.string().optional(),
-  isDefault: z.boolean().default(false),
-  isPinned: z.boolean().default(false),
-  isShared: z.boolean().default(false),
-  sortField: z.string().optional(),
-  sortDirection: z.enum(['asc', 'desc']).default('desc'),
-  filterGroups: z.any(), // ConditionGroup[] - complex nested structure handled separately
-})
-
-export type MailViewFormValues = z.infer<typeof mailViewFormSchema>
-
-const createDefaultGroup = (): ConditionGroup => ({
-  id: 'default',
-  conditions: [],
-  logicalOperator: 'AND',
-})
-
-const getCreateDefaults = (): MailViewFormValues => ({
-  name: '',
-  description: '',
-  isDefault: false,
-  isPinned: false,
-  isShared: false,
-  sortField: 'lastMessageAt',
-  sortDirection: 'desc',
-  filterGroups: [createDefaultGroup()],
-})
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@auxx/ui/components/dialog'
+import { MailViewForm } from './mail-view-form'
 
 interface MailViewDialogProps {
   isOpen: boolean
@@ -64,250 +10,26 @@ interface MailViewDialogProps {
   mailViewId?: string // If provided, we're editing an existing view
 }
 
+/**
+ * Thin modal wrapper around {@link MailViewForm}. Supplies the `Dialog` shell and
+ * the header; all form logic lives in the core, which the command palette hosts
+ * directly as a page. Public API is unchanged.
+ */
 export function MailViewDialog({ isOpen, onClose, mailViewId }: MailViewDialogProps) {
-  const [activeTab, setActiveTab] = useState<'details' | 'filters' | 'options'>('details')
-  const [confirm, DeleteConfirmDialog] = useConfirm()
-  const router = useRouter()
-  const pathname = usePathname()
-
-  // Setup form
-  const methods = useForm<MailViewFormValues>({
-    resolver: standardSchemaResolver(mailViewFormSchema),
-    defaultValues: getCreateDefaults(),
-  })
-
-  // Guard against accidental close with unsaved changes
-  const {
-    guardProps,
-    guardedClose,
-    ConfirmDialog: UnsavedChangesDialog,
-  } = useUnsavedChangesGuard({
-    isDirty: methods.formState.isDirty,
-    onConfirmedClose: onClose,
-    confirmOptions: {
-      title: 'Discard changes?',
-      description: 'You have unsaved changes. Are you sure you want to discard them?',
-      confirmText: 'Discard',
-      cancelText: 'Keep editing',
-    },
-  })
-
-  // Get mail view for editing
-  const { data: mailView, isLoading: isLoadingMailView } = api.mailView.getById.useQuery(
-    { id: mailViewId! },
-    { enabled: !!mailViewId, refetchOnWindowFocus: false }
-  )
-
-  // Create and update mutations
-  const createMailView = api.mailView.create.useMutation({
-    onSuccess: () => {
-      toastSuccess({
-        title: 'View created',
-        description: 'Your mail view has been created successfully',
-      })
-      onClose()
-      // Invalidate queries to refresh the list
-      utils.mailView.getUserMailViews.invalidate()
-      utils.mailView.getAllAccessibleMailViews.invalidate()
-    },
-    onError: (error) => {
-      toastError({ title: 'Error creating view', description: error.message })
-    },
-  })
-
-  const updateMailView = api.mailView.update.useMutation({
-    onSuccess: () => {
-      toastSuccess({
-        title: 'View updated',
-        description: 'Your mail view has been updated successfully',
-      })
-      onClose()
-      // Invalidate queries to refresh the list
-      utils.mailView.getUserMailViews.invalidate()
-      utils.mailView.getAllAccessibleMailViews.invalidate()
-      if (mailViewId) {
-        utils.mailView.getById.invalidate({ id: mailViewId })
-      }
-      if (methods.getValues('isShared')) {
-        utils.mailView.getSharedMailViews.invalidate()
-      }
-    },
-    onError: (error) => {
-      toastError({ title: 'Error updating view', description: error.message })
-    },
-  })
-
-  const deleteMailView = api.mailView.delete.useMutation({
-    onSuccess: () => {
-      // Clear dirty state so the unsaved-changes guard doesn't fire on close
-      methods.reset(methods.getValues())
-      // If the user is currently viewing the deleted view, send them back to inbox.
-      if (mailViewId && pathname?.startsWith(`/app/mail/views/${mailViewId}`)) {
-        router.push('/app/mail')
-      }
-      onClose()
-      utils.mailView.getUserMailViews.invalidate()
-      utils.mailView.getAllAccessibleMailViews.invalidate()
-    },
-    onError: (error) => {
-      toastError({ title: 'Error deleting view', description: error.message })
-    },
-  })
-
-  const utils = api.useUtils()
-
-  // Load mail view data when editing
-  useEffect(() => {
-    if (mailView) {
-      const savedGroups = (mailView.filters as ConditionGroup[]) || []
-      methods.reset({
-        name: mailView.name,
-        description: mailView.description || '',
-        isDefault: mailView.isDefault,
-        isPinned: mailView.isPinned,
-        isShared: mailView.isShared,
-        sortField: mailView.sortField || 'lastMessageAt',
-        sortDirection: (mailView.sortDirection as 'asc' | 'desc') || 'desc',
-        // Database stores filterGroups in 'filters' column (backwards compatible)
-        filterGroups: savedGroups.length > 0 ? savedGroups : [createDefaultGroup()],
-      })
-    }
-  }, [mailView, methods])
-
-  // Reset form to fresh defaults whenever the dialog opens in create mode.
-  // Without this, the previously-submitted values stick around when the
-  // user reopens the "New View" dialog after creating one.
-  useEffect(() => {
-    if (!isOpen || mailViewId) return
-    methods.reset(getCreateDefaults())
-    setActiveTab('details')
-  }, [isOpen, mailViewId, methods])
-
-  /** Handles the delete action with confirmation */
-  const handleDelete = async () => {
-    if (!mailViewId) return
-
-    const confirmed = await confirm({
-      title: 'Delete this view?',
-      description: 'This action cannot be undone. The view will be permanently deleted.',
-      confirmText: 'Delete',
-      cancelText: 'Cancel',
-      destructive: true,
-    })
-
-    if (confirmed) {
-      deleteMailView.mutate({ id: mailViewId })
-    }
-  }
-
-  const onSubmit = (data: MailViewFormValues) => {
-    if (mailViewId) {
-      updateMailView.mutate({
-        id: mailViewId,
-        data: {
-          name: data.name,
-          description: data.description,
-          isDefault: data.isDefault,
-          isPinned: data.isPinned,
-          isShared: data.isShared,
-          sortField: data.sortField,
-          sortDirection: data.sortDirection,
-          filterGroups: data.filterGroups,
-        },
-      })
-    } else {
-      createMailView.mutate({
-        name: data.name,
-        description: data.description,
-        isDefault: data.isDefault,
-        isPinned: data.isPinned,
-        isShared: data.isShared,
-        sortField: data.sortField,
-        sortDirection: data.sortDirection,
-        filterGroups: data.filterGroups,
-      })
-    }
-  }
-
-  // Compute disabled state for submit
-  const isSubmitDisabled = isLoadingMailView || createMailView.isPending || updateMailView.isPending
-
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && guardedClose()}>
-      <DialogContent size='xl' variant='default' position='tc' {...guardProps}>
-        <DialogHeader>
-          <DialogTitle>{mailViewId ? 'Edit Mail View' : 'Create Mail View'}</DialogTitle>
-        </DialogHeader>
-
-        <FormProvider {...methods}>
-          <form onSubmit={methods.handleSubmit(onSubmit)}>
-            <RadioTab
-              value={activeTab}
-              onValueChange={setActiveTab}
-              size='sm'
-              radioGroupClassName='grid w-full'
-              className='border border-primary-200 flex flex-1 w-full mb-4'>
-              <RadioTabItem value='details' size='sm'>
-                <FileText />
-                Details
-              </RadioTabItem>
-              <RadioTabItem value='filters' size='sm'>
-                <Filter />
-                Filters
-              </RadioTabItem>
-              <RadioTabItem value='options' size='sm'>
-                <Sliders />
-                Options
-              </RadioTabItem>
-            </RadioTab>
-
-            {activeTab === 'details' && (
-              <div className='space-y-4 '>
-                <MailViewDetailsForm />
-              </div>
-            )}
-
-            {activeTab === 'filters' && <MailViewFilterBuilder />}
-
-            {activeTab === 'options' && (
-              <div className='space-y-4'>
-                <MailViewSortOptions />
-                <MailViewSharingOptions />
-              </div>
-            )}
-
-            <DialogFooter className='mt-0'>
-              {mailViewId && (
-                <Button
-                  type='button'
-                  size='sm'
-                  variant='destructive-hover'
-                  onClick={handleDelete}
-                  loading={deleteMailView.isPending}
-                  loadingText='Deleting...'
-                  className='mr-auto'>
-                  <Trash2 />
-                  Delete View
-                </Button>
-              )}
-              <Button size='sm' variant='ghost' type='button' onClick={guardedClose}>
-                Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-              </Button>
-              <Button
-                type='submit'
-                size='sm'
-                variant='outline'
-                loadingText='Saving...'
-                loading={isLoadingMailView || createMailView.isPending || updateMailView.isPending}>
-                {mailViewId ? 'Update View' : 'Create View'}{' '}
-                <KbdSubmit variant='outline' size='sm' />
-              </Button>
-            </DialogFooter>
-          </form>
-        </FormProvider>
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent size='xl' variant='default' position='tc'>
+        <MailViewForm
+          open={isOpen}
+          mailViewId={mailViewId}
+          onClose={onClose}
+          header={({ title }) => (
+            <DialogHeader>
+              <DialogTitle>{title}</DialogTitle>
+            </DialogHeader>
+          )}
+        />
       </DialogContent>
-      <DeleteConfirmDialog />
-      <UnsavedChangesDialog />
     </Dialog>
   )
 }

--- a/apps/web/src/components/mail-views/mail-view-form.tsx
+++ b/apps/web/src/components/mail-views/mail-view-form.tsx
@@ -1,0 +1,328 @@
+// apps/web/src/components/mail-views/mail-view-form.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import { toastError, toastSuccess } from '@auxx/ui/components/toast'
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
+import { FileText, Filter, Sliders, Trash2 } from 'lucide-react'
+import { usePathname, useRouter } from 'next/navigation'
+import { type ReactNode, useEffect, useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import * as z from 'zod'
+import type { ConditionGroup } from '~/components/conditions'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
+import { api } from '~/trpc/react'
+import { MailViewDetailsForm } from './mail-view-details-form'
+import { MailViewFilterBuilder } from './mail-view-filter-builder'
+import { MailViewSharingOptions } from './mail-view-sharing-options'
+import { MailViewSortOptions } from './mail-view-sort-options'
+
+// Define the form schema using zod
+const mailViewFormSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  description: z.string().optional(),
+  isDefault: z.boolean().default(false),
+  isPinned: z.boolean().default(false),
+  isShared: z.boolean().default(false),
+  sortField: z.string().optional(),
+  sortDirection: z.enum(['asc', 'desc']).default('desc'),
+  filterGroups: z.any(), // ConditionGroup[] - complex nested structure handled separately
+})
+
+export type MailViewFormValues = z.infer<typeof mailViewFormSchema>
+
+const createDefaultGroup = (): ConditionGroup => ({
+  id: 'default',
+  conditions: [],
+  logicalOperator: 'AND',
+})
+
+const getCreateDefaults = (): MailViewFormValues => ({
+  name: '',
+  description: '',
+  isDefault: false,
+  isPinned: false,
+  isShared: false,
+  sortField: 'lastMessageAt',
+  sortDirection: 'desc',
+  filterGroups: [createDefaultGroup()],
+})
+
+/** Props for the shell-free mail view form core. */
+export interface MailViewFormProps {
+  /** Whether the form is "open" — drives the init/reset cycle. In a dialog this is
+   *  the dialog's open state; in the palette it's `page === 'create-mail-view'`. */
+  open: boolean
+  /** Mail view id for edit mode; null/undefined = create */
+  mailViewId?: string
+  /** Called after a successful save */
+  onSuccess?: () => void
+  /** Dismiss after a successful save / unrecoverable state (dialog closes; palette
+   *  closes). */
+  onClose: () => void
+  /** Cancel/back dismiss. Defaults to {@link onClose}; the palette routes it back
+   *  to the root action list instead of closing outright. */
+  onCancel?: () => void
+  /** Host-specific header. Dialogs render a `DialogHeader`; the palette omits it
+   *  (the breadcrumb supplies the title). */
+  header?: (ctx: { title: string }) => ReactNode
+}
+
+/**
+ * Shell-free mail view create/edit form: all hooks/state, the tabbed body
+ * (details / filters / options), and the footer (delete / cancel / save). The only
+ * host seams are the `header` slot and `onClose`/`onCancel`. `mail-view-dialog.tsx`
+ * wraps this in a `Dialog`; the command palette hosts it as a page. Behavior is
+ * unchanged from the original dialog (unsaved-changes guard, delete affordance, and
+ * router redirect when deleting the currently-viewed view).
+ */
+export function MailViewForm({
+  open,
+  mailViewId,
+  onSuccess,
+  onClose,
+  onCancel,
+  header,
+}: MailViewFormProps) {
+  const cancel = onCancel ?? onClose
+  const [activeTab, setActiveTab] = useState<'details' | 'filters' | 'options'>('details')
+  const [confirm, DeleteConfirmDialog] = useConfirm()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  // Setup form
+  const methods = useForm<MailViewFormValues>({
+    resolver: standardSchemaResolver(mailViewFormSchema),
+    defaultValues: getCreateDefaults(),
+  })
+
+  // Guard against accidental close with unsaved changes
+  const { guardedClose, ConfirmDialog: UnsavedChangesDialog } = useUnsavedChangesGuard({
+    isDirty: methods.formState.isDirty,
+    onConfirmedClose: cancel,
+    confirmOptions: {
+      title: 'Discard changes?',
+      description: 'You have unsaved changes. Are you sure you want to discard them?',
+      confirmText: 'Discard',
+      cancelText: 'Keep editing',
+    },
+  })
+
+  // Get mail view for editing
+  const { data: mailView, isLoading: isLoadingMailView } = api.mailView.getById.useQuery(
+    { id: mailViewId! },
+    { enabled: !!mailViewId, refetchOnWindowFocus: false }
+  )
+
+  // Create and update mutations
+  const createMailView = api.mailView.create.useMutation({
+    onSuccess: () => {
+      toastSuccess({
+        title: 'View created',
+        description: 'Your mail view has been created successfully',
+      })
+      onSuccess?.()
+      onClose()
+      // Invalidate queries to refresh the list
+      utils.mailView.getUserMailViews.invalidate()
+      utils.mailView.getAllAccessibleMailViews.invalidate()
+    },
+    onError: (error) => {
+      toastError({ title: 'Error creating view', description: error.message })
+    },
+  })
+
+  const updateMailView = api.mailView.update.useMutation({
+    onSuccess: () => {
+      toastSuccess({
+        title: 'View updated',
+        description: 'Your mail view has been updated successfully',
+      })
+      onSuccess?.()
+      onClose()
+      // Invalidate queries to refresh the list
+      utils.mailView.getUserMailViews.invalidate()
+      utils.mailView.getAllAccessibleMailViews.invalidate()
+      if (mailViewId) {
+        utils.mailView.getById.invalidate({ id: mailViewId })
+      }
+      if (methods.getValues('isShared')) {
+        utils.mailView.getSharedMailViews.invalidate()
+      }
+    },
+    onError: (error) => {
+      toastError({ title: 'Error updating view', description: error.message })
+    },
+  })
+
+  const deleteMailView = api.mailView.delete.useMutation({
+    onSuccess: () => {
+      // Clear dirty state so the unsaved-changes guard doesn't fire on close
+      methods.reset(methods.getValues())
+      // If the user is currently viewing the deleted view, send them back to inbox.
+      if (mailViewId && pathname?.startsWith(`/app/mail/views/${mailViewId}`)) {
+        router.push('/app/mail')
+      }
+      onClose()
+      utils.mailView.getUserMailViews.invalidate()
+      utils.mailView.getAllAccessibleMailViews.invalidate()
+    },
+    onError: (error) => {
+      toastError({ title: 'Error deleting view', description: error.message })
+    },
+  })
+
+  const utils = api.useUtils()
+
+  // Load mail view data when editing
+  useEffect(() => {
+    if (mailView) {
+      const savedGroups = (mailView.filters as ConditionGroup[]) || []
+      methods.reset({
+        name: mailView.name,
+        description: mailView.description || '',
+        isDefault: mailView.isDefault,
+        isPinned: mailView.isPinned,
+        isShared: mailView.isShared,
+        sortField: mailView.sortField || 'lastMessageAt',
+        sortDirection: (mailView.sortDirection as 'asc' | 'desc') || 'desc',
+        // Database stores filterGroups in 'filters' column (backwards compatible)
+        filterGroups: savedGroups.length > 0 ? savedGroups : [createDefaultGroup()],
+      })
+    }
+  }, [mailView, methods])
+
+  // Reset form to fresh defaults whenever the form opens in create mode.
+  // Without this, the previously-submitted values stick around when the
+  // user reopens the "New View" form after creating one.
+  useEffect(() => {
+    if (!open || mailViewId) return
+    methods.reset(getCreateDefaults())
+    setActiveTab('details')
+  }, [open, mailViewId, methods])
+
+  /** Handles the delete action with confirmation */
+  const handleDelete = async () => {
+    if (!mailViewId) return
+
+    const confirmed = await confirm({
+      title: 'Delete this view?',
+      description: 'This action cannot be undone. The view will be permanently deleted.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+
+    if (confirmed) {
+      deleteMailView.mutate({ id: mailViewId })
+    }
+  }
+
+  const onSubmit = (data: MailViewFormValues) => {
+    if (mailViewId) {
+      updateMailView.mutate({
+        id: mailViewId,
+        data: {
+          name: data.name,
+          description: data.description,
+          isDefault: data.isDefault,
+          isPinned: data.isPinned,
+          isShared: data.isShared,
+          sortField: data.sortField,
+          sortDirection: data.sortDirection,
+          filterGroups: data.filterGroups,
+        },
+      })
+    } else {
+      createMailView.mutate({
+        name: data.name,
+        description: data.description,
+        isDefault: data.isDefault,
+        isPinned: data.isPinned,
+        isShared: data.isShared,
+        sortField: data.sortField,
+        sortDirection: data.sortDirection,
+        filterGroups: data.filterGroups,
+      })
+    }
+  }
+
+  const title = mailViewId ? 'Edit Mail View' : 'Create Mail View'
+
+  return (
+    <>
+      {header?.({ title })}
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit(onSubmit)}>
+          <RadioTab
+            value={activeTab}
+            onValueChange={setActiveTab}
+            size='sm'
+            radioGroupClassName='grid w-full'
+            className='border border-primary-200 flex flex-1 w-full mb-4'>
+            <RadioTabItem value='details' size='sm'>
+              <FileText />
+              Details
+            </RadioTabItem>
+            <RadioTabItem value='filters' size='sm'>
+              <Filter />
+              Filters
+            </RadioTabItem>
+            <RadioTabItem value='options' size='sm'>
+              <Sliders />
+              Options
+            </RadioTabItem>
+          </RadioTab>
+
+          {activeTab === 'details' && (
+            <div className='space-y-4 '>
+              <MailViewDetailsForm />
+            </div>
+          )}
+
+          {activeTab === 'filters' && <MailViewFilterBuilder />}
+
+          {activeTab === 'options' && (
+            <div className='space-y-4'>
+              <MailViewSortOptions />
+              <MailViewSharingOptions />
+            </div>
+          )}
+
+          <DialogFooter className='mt-0'>
+            {mailViewId && (
+              <Button
+                type='button'
+                size='sm'
+                variant='destructive-hover'
+                onClick={handleDelete}
+                loading={deleteMailView.isPending}
+                loadingText='Deleting...'
+                className='mr-auto'>
+                <Trash2 />
+                Delete View
+              </Button>
+            )}
+            <Button size='sm' variant='ghost' type='button' onClick={guardedClose}>
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+            </Button>
+            <Button
+              type='submit'
+              size='sm'
+              variant='outline'
+              loadingText='Saving...'
+              loading={isLoadingMailView || createMailView.isPending || updateMailView.isPending}>
+              {mailViewId ? 'Update View' : 'Create View'} <KbdSubmit variant='outline' size='sm' />
+            </Button>
+          </DialogFooter>
+        </form>
+      </FormProvider>
+      <DeleteConfirmDialog />
+      <UnsavedChangesDialog />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
Continues the palette form-embedding work from #887. Extracts reusable form components from their dialogs and wires up new command-palette create pages so the dialogs and palette share a single form per resource.

- Extract `*-form.tsx` components for api-key, webhook, dataset, inbox, meeting, and mail-view
- Add palette create pages (`create-*`) plus a `create-group` page
- Add launcher actions (`kbar/actions/launchers.ts`) and supporting store/types/palette wiring
- Slim down the original dialogs to render the shared forms

## Test plan
- [ ] Open command palette and create each resource (api-key, webhook, dataset, inbox, meeting, mail-view, group)
- [ ] Verify the existing settings dialogs still create/edit correctly