### PR TITLE
feat(kbar): page-defined contextual actions in command palette

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/apiKeys/_components/apiKey-table.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apiKeys/_components/apiKey-table.tsx
@@ -60,7 +60,7 @@ function ApiKeyTable({ initialData }: Props) {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className='w-[200px]'>Name</TableHead>
+              <TableHead className='min-w-[200px]'>Name</TableHead>
               <TableHead>Created</TableHead>
               <TableHead className='text-right'></TableHead>
             </TableRow>
@@ -73,7 +73,7 @@ function ApiKeyTable({ initialData }: Props) {
                 <TableCell className='text-right'>
                   <RevokeAPIKeyButton
                     id={apiKey.id}
-                    buttonProps={{ variant: 'outline-solid', size: 'sm' }}
+                    buttonProps={{ variant: 'ghost', size: 'sm' }}
                   />
                 </TableCell>
               </TableRow>
@@ -99,7 +99,7 @@ function ApiKeyTable({ initialData }: Props) {
               variant='outline'
               disabled={isLoading}
               onClick={() => setIsOpen(true)}>
-              <PlusIcon className='h-4 w-4' />
+              <PlusIcon />
               Create Api Key
             </Button>
           }

--- a/apps/web/src/components/kbar/contextual/command-action.tsx
+++ b/apps/web/src/components/kbar/contextual/command-action.tsx
@@ -1,0 +1,105 @@
+// apps/web/src/components/kbar/contextual/command-action.tsx
+'use client'
+
+import { useEffect, useId, useRef } from 'react'
+import { useScopeGroupLabel } from './command-context'
+import { useContextualActionsStore } from './contextual-store'
+
+interface CommandActionProps {
+  /**
+   * Stable id. Optional — falls back to `useId()`. An explicit id helps when a
+   * surface conditionally remounts the same logical row.
+   */
+  id?: string
+  label: string
+  subtitle?: string
+  icon?: string
+  keywords?: string
+  /** Chord hint — rendered as a `Kbd` chip, bound to NO global hotkey. */
+  shortcut?: string[]
+  /** Group label override. Defaults to the enclosing scope, then `'Actions'`. */
+  group?: string
+  disabled?: boolean
+  /** Higher = listed first within its group. Default 0. */
+  priority?: number
+  perform: () => void
+}
+
+/**
+ * Distributed command-palette row contributor. Mount inside (or beside) a
+ * `<CommandContext>`; registers a slice while alive and clears it on unmount.
+ *
+ * **Stable perform via ref:** the latest `perform` closure is kept in a ref and
+ * the registered wrapper is `() => ref.current()`. `perform` is excluded from
+ * the effect deps so a fresh closure each parent render does NOT thrash
+ * register/clear — the row stays mounted while the page re-renders (e.g. typing
+ * in a search box) and still reads live state at fire time.
+ */
+export function CommandAction({
+  id: explicitId,
+  label,
+  subtitle,
+  icon,
+  keywords,
+  shortcut,
+  group,
+  disabled,
+  priority,
+  perform,
+}: CommandActionProps): null {
+  const generatedId = useId()
+  const id = explicitId ?? generatedId
+
+  const performRef = useRef(perform)
+  performRef.current = perform
+
+  const setSlice = useContextualActionsStore((s) => s.setActionSlice)
+  const clearSlice = useContextualActionsStore((s) => s.clearActionSlice)
+
+  const inheritedGroup = useScopeGroupLabel()
+  const resolvedGroup = group ?? inheritedGroup ?? 'Actions'
+
+  const shortcutKey = shortcut?.join('|')
+
+  // `perform` rides on `performRef` (excluded so a fresh closure each render
+  // doesn't thrash register/clear); `shortcut` is tracked via the stable
+  // `shortcutKey` to avoid array-identity churn; `explicitId` folds into `id`.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see note above
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && explicitId !== undefined) {
+      if (useContextualActionsStore.getState().actionSlices[id]) {
+        console.warn(
+          `[CommandAction] duplicate explicit id "${id}" — a surface is double-mounted; ` +
+            'the rows will clobber each other. Use a unique id per mount.'
+        )
+      }
+    }
+    setSlice(id, {
+      id,
+      label,
+      ...(subtitle ? { subtitle } : {}),
+      ...(icon ? { icon } : {}),
+      ...(keywords ? { keywords } : {}),
+      ...(shortcut ? { shortcut } : {}),
+      group: resolvedGroup,
+      ...(disabled ? { disabled } : {}),
+      ...(priority !== undefined ? { priority } : {}),
+      perform: () => performRef.current(),
+    })
+    return () => clearSlice(id)
+  }, [
+    id,
+    label,
+    subtitle,
+    icon,
+    keywords,
+    shortcutKey,
+    resolvedGroup,
+    disabled,
+    priority,
+    setSlice,
+    clearSlice,
+  ])
+
+  return null
+}

--- a/apps/web/src/components/kbar/contextual/command-context.tsx
+++ b/apps/web/src/components/kbar/contextual/command-context.tsx
@@ -1,0 +1,60 @@
+// apps/web/src/components/kbar/contextual/command-context.tsx
+'use client'
+
+import { createContext, type ReactNode, useContext, useEffect, useId } from 'react'
+import { useContextualActionsStore } from './contextual-store'
+import type { CommandScope } from './types'
+
+/**
+ * Internal React context carrying the enclosing scope's group label down to
+ * descendant `<CommandAction>`s. A flat sibling default can't disambiguate once
+ * two scopes coexist (record drawer over a live table), so group inheritance is
+ * provider-scoped rather than "active context wins".
+ */
+const ScopeContext = createContext<{ groupLabel: string } | null>(null)
+
+/** Read the enclosing scope's default group label (or `null` at the root). */
+export function useScopeGroupLabel(): string | null {
+  return useContext(ScopeContext)?.groupLabel ?? null
+}
+
+interface CommandContextProps extends CommandScope {
+  children?: ReactNode
+}
+
+/**
+ * Distributed command-palette scope contributor. Mount one (or many) on a
+ * surface; each mount registers a scope slice while alive and clears it on
+ * unmount. Descendant `<CommandAction>`s inherit its `label` as their default
+ * group and can read the payload via `useCommandScope()`.
+ *
+ * Props are primitives so React's default dep-comparison drives effect re-runs.
+ * Render self-closing to contribute only the payload (supplies no default group).
+ */
+export function CommandContext({
+  label,
+  kind,
+  recordId,
+  entityDefinitionId,
+  priority,
+  children,
+}: CommandContextProps) {
+  const id = useId()
+  const setSlice = useContextualActionsStore((s) => s.setContextSlice)
+  const clearSlice = useContextualActionsStore((s) => s.clearContextSlice)
+
+  useEffect(() => {
+    setSlice(id, {
+      id,
+      label,
+      kind,
+      ...(recordId ? { recordId } : {}),
+      ...(entityDefinitionId ? { entityDefinitionId } : {}),
+      ...(priority !== undefined ? { priority } : {}),
+    })
+    return () => clearSlice(id)
+  }, [id, label, kind, recordId, entityDefinitionId, priority, setSlice, clearSlice])
+
+  if (children === undefined) return null
+  return <ScopeContext.Provider value={{ groupLabel: label }}>{children}</ScopeContext.Provider>
+}

--- a/apps/web/src/components/kbar/contextual/contextual-store.ts
+++ b/apps/web/src/components/kbar/contextual/contextual-store.ts
@@ -1,0 +1,47 @@
+// apps/web/src/components/kbar/contextual/contextual-store.ts
+'use client'
+
+import { create } from 'zustand'
+import type { CommandActionSlice, CommandContextSlice } from './types'
+
+/**
+ * Distributed registry for page-defined command-palette rows. Mirrors the
+ * Kopilot slice pattern (`kopilot-store`): every `<CommandContext>` /
+ * `<CommandAction>` writes one slice keyed by its `useId()` on mount and clears
+ * it on unmount.
+ *
+ * Kept SEPARATE from `useCommandPaletteStore` so surface re-registration churn
+ * never touches the palette's open/page state (and vice-versa).
+ */
+interface ContextualState {
+  actionSlices: Record<string, CommandActionSlice>
+  contextSlices: Record<string, CommandContextSlice>
+  setActionSlice: (id: string, slice: CommandActionSlice) => void
+  clearActionSlice: (id: string) => void
+  setContextSlice: (id: string, slice: CommandContextSlice) => void
+  clearContextSlice: (id: string) => void
+}
+
+export const useContextualActionsStore = create<ContextualState>()((set) => ({
+  actionSlices: {},
+  contextSlices: {},
+
+  setActionSlice: (id, slice) => set((s) => ({ actionSlices: { ...s.actionSlices, [id]: slice } })),
+  clearActionSlice: (id) =>
+    set((s) => {
+      if (!(id in s.actionSlices)) return s
+      const next = { ...s.actionSlices }
+      delete next[id]
+      return { actionSlices: next }
+    }),
+
+  setContextSlice: (id, slice) =>
+    set((s) => ({ contextSlices: { ...s.contextSlices, [id]: slice } })),
+  clearContextSlice: (id) =>
+    set((s) => {
+      if (!(id in s.contextSlices)) return s
+      const next = { ...s.contextSlices }
+      delete next[id]
+      return { contextSlices: next }
+    }),
+}))

--- a/apps/web/src/components/kbar/contextual/index.ts
+++ b/apps/web/src/components/kbar/contextual/index.ts
@@ -1,0 +1,7 @@
+// apps/web/src/components/kbar/contextual/index.ts
+
+export { CommandAction } from './command-action'
+export { CommandContext } from './command-context'
+export { RecordCommandActions } from './record-command-actions'
+export { useCommandScope, useContextualSections } from './select-contextual'
+export type { CommandScope, CommandScopeKind } from './types'

--- a/apps/web/src/components/kbar/contextual/record-command-actions.tsx
+++ b/apps/web/src/components/kbar/contextual/record-command-actions.tsx
@@ -1,0 +1,87 @@
+// apps/web/src/components/kbar/contextual/record-command-actions.tsx
+'use client'
+
+import { CommandAction } from './command-action'
+import { useCommandScope } from './select-contextual'
+import { useRecordActions } from './use-record-actions'
+
+interface RecordCommandActionsProps {
+  /** Override the scope's record id (defaults to the active `useCommandScope()`). */
+  recordId?: string
+  /** Override the scope's display name. */
+  displayName?: string
+}
+
+/**
+ * The common record-action row set, packaged so any record surface can drop one
+ * component instead of re-declaring rows. Reads the active scope via
+ * `useCommandScope()` (record scopes should outrank table scopes by priority);
+ * the `perform`s come from the shared {@link useRecordActions} helper so the
+ * search-flow page and the mounted-surface flow can't drift.
+ *
+ * Mount inside a `<CommandContext kind="record" …>` so the rows inherit its
+ * group heading.
+ */
+export function RecordCommandActions({
+  recordId: recordIdProp,
+  displayName: displayNameProp,
+}: RecordCommandActionsProps = {}): React.ReactNode {
+  const scope = useCommandScope()
+  const recordId = recordIdProp ?? scope?.recordId ?? ''
+  const displayName = displayNameProp ?? scope?.label ?? ''
+
+  const handlers = useRecordActions(recordId, displayName)
+
+  if (!recordId) return null
+
+  return (
+    <>
+      <CommandAction
+        label='Open record'
+        icon='external-link'
+        keywords='open view go'
+        priority={10}
+        perform={handlers.open}
+      />
+      {handlers.absoluteHref && (
+        <CommandAction
+          label='Open in new tab'
+          icon='share'
+          keywords='open new tab window'
+          priority={9}
+          perform={handlers.openNewTab}
+        />
+      )}
+      <CommandAction
+        label='Create task'
+        icon='list-checks'
+        keywords='task todo'
+        priority={8}
+        perform={handlers.createTask}
+      />
+      <CommandAction
+        label='Ask Kopilot about this'
+        icon='sparkles'
+        keywords='kopilot ai ask summarize'
+        priority={7}
+        perform={handlers.askKopilot}
+      />
+      <CommandAction
+        label='Copy name'
+        icon='copy'
+        keywords='copy name clipboard'
+        priority={6}
+        perform={handlers.copyName}
+      />
+      {handlers.absoluteHref && (
+        <CommandAction
+          label='Copy link'
+          icon='link-2'
+          keywords='copy link url clipboard'
+          priority={5}
+          perform={handlers.copyLink}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/web/src/components/kbar/contextual/select-contextual.ts
+++ b/apps/web/src/components/kbar/contextual/select-contextual.ts
@@ -1,0 +1,101 @@
+// apps/web/src/components/kbar/contextual/select-contextual.ts
+'use client'
+
+import { useMemo } from 'react'
+import type { PaletteAction, PaletteSection } from '../types'
+import { useContextualActionsStore } from './contextual-store'
+import type { CommandActionSlice, CommandContextSlice, CommandScope } from './types'
+
+/**
+ * Build the contextual `PaletteSection[]` from the raw slice maps.
+ *
+ * - Group `actionSlices` by their resolved `group` label.
+ * - Order groups by the matching context slice's `priority` (desc). Groups with
+ *   no matching context slice sort last, stable by first-seen order.
+ * - Within a group, order actions by `priority` (desc) then registration order.
+ */
+export function selectContextualSections(
+  actions: Record<string, CommandActionSlice>,
+  contexts: Record<string, CommandContextSlice>
+): PaletteSection[] {
+  const actionList = Object.values(actions)
+  if (actionList.length === 0) return []
+
+  // Highest priority context per label (the group heading derives its order
+  // from the scope that owns it).
+  const contextByLabel = new Map<string, CommandContextSlice>()
+  for (const ctx of Object.values(contexts)) {
+    const existing = contextByLabel.get(ctx.label)
+    if (!existing || (ctx.priority ?? 0) > (existing.priority ?? 0)) {
+      contextByLabel.set(ctx.label, ctx)
+    }
+  }
+
+  // Group actions, preserving first-seen order for the group list.
+  const groups = new Map<string, CommandActionSlice[]>()
+  for (const action of actionList) {
+    const bucket = groups.get(action.group)
+    if (bucket) bucket.push(action)
+    else groups.set(action.group, [action])
+  }
+
+  const ordered = Array.from(groups.entries()).map(([label, slices], index) => ({
+    label,
+    slices,
+    priority: contextByLabel.get(label)?.priority ?? Number.NEGATIVE_INFINITY,
+    index,
+  }))
+
+  // Group order: priority desc, first-seen tiebreak.
+  ordered.sort((a, b) => b.priority - a.priority || a.index - b.index)
+
+  return ordered.map(({ label, slices }) => ({
+    label,
+    actions: slices
+      .slice()
+      .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
+      .map(sliceToAction),
+  }))
+}
+
+function sliceToAction(slice: CommandActionSlice): PaletteAction {
+  return {
+    id: slice.id,
+    label: slice.label,
+    ...(slice.subtitle ? { subtitle: slice.subtitle } : {}),
+    ...(slice.icon ? { icon: slice.icon } : {}),
+    ...(slice.keywords ? { keywords: slice.keywords } : {}),
+    ...(slice.shortcut ? { shortcut: slice.shortcut } : {}),
+    ...(slice.disabled ? { disabled: slice.disabled } : {}),
+    perform: slice.perform,
+  }
+}
+
+/**
+ * Read the raw slice maps and memoize the section build. `useShallow` on the
+ * result does NOT work here: `selectContextualSections` returns freshly built
+ * objects each call, so shallow equality always fails and `useSyncExternalStore`
+ * falls into a "snapshot not cached" update loop (the documented
+ * `kopilot/stores/select-context.ts:59` caveat). Memoize over the raw maps —
+ * their identity is stable until a slice is set/cleared.
+ */
+export const useContextualSections = (): PaletteSection[] => {
+  const actions = useContextualActionsStore((s) => s.actionSlices)
+  const contexts = useContextualActionsStore((s) => s.contextSlices)
+  return useMemo(() => selectContextualSections(actions, contexts), [actions, contexts])
+}
+
+/**
+ * The highest-priority active scope payload (or `null`), for shared action
+ * helpers that read the live scope (e.g. `<RecordCommandActions>`).
+ */
+export const useCommandScope = (): CommandScope | null => {
+  const contexts = useContextualActionsStore((s) => s.contextSlices)
+  return useMemo(() => {
+    let best: CommandContextSlice | null = null
+    for (const ctx of Object.values(contexts)) {
+      if (!best || (ctx.priority ?? 0) > (best.priority ?? 0)) best = ctx
+    }
+    return best
+  }, [contexts])
+}

--- a/apps/web/src/components/kbar/contextual/types.ts
+++ b/apps/web/src/components/kbar/contextual/types.ts
@@ -1,0 +1,41 @@
+// apps/web/src/components/kbar/contextual/types.ts
+
+export type CommandScopeKind = 'table' | 'record' | 'thread' | 'page'
+
+/** Structured scope payload a `<CommandContext>` contributes. */
+export interface CommandScope {
+  /** Group heading + default group key for descendant actions. */
+  label: string
+  kind: CommandScopeKind
+  /** "entityDefinitionId:instanceId" — present for record scopes. */
+  recordId?: string
+  entityDefinitionId?: string
+  /** Higher = listed first among contextual groups. Default 0. */
+  priority?: number
+}
+
+/** A registered scope slice, keyed by the contributing component's `useId()`. */
+export interface CommandContextSlice extends CommandScope {
+  id: string
+}
+
+/**
+ * One contextual row. Mirrors {@link PaletteAction} but adds `group`, `disabled`
+ * and `priority`. The `perform` stored here is a STABLE wrapper that reads the
+ * latest closure via a ref — see `command-action.tsx`.
+ */
+export interface CommandActionSlice {
+  id: string
+  label: string
+  subtitle?: string
+  icon?: string
+  keywords?: string
+  /** Chord hint — rendered as a `Kbd` chip but bound to NO global hotkey. */
+  shortcut?: string[]
+  /** Resolved group label (explicit prop or inherited context label). */
+  group: string
+  disabled?: boolean
+  priority?: number
+  /** Stable wrapper → latest perform. */
+  perform: () => void
+}

--- a/apps/web/src/components/kbar/contextual/use-record-actions.ts
+++ b/apps/web/src/components/kbar/contextual/use-record-actions.ts
@@ -1,0 +1,77 @@
+// apps/web/src/components/kbar/contextual/use-record-actions.ts
+'use client'
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import { useRouter } from 'next/navigation'
+import { useMemo } from 'react'
+import { useKopilotStore } from '~/components/kopilot/stores/kopilot-store'
+import { useResourceStore } from '~/components/resources/store/resource-store'
+import { recordHref } from '../record-href'
+import { useCommandPaletteStore } from '../store'
+
+/** The common record-action handler set, shared by the search-flow page and the
+ * mounted-surface flow (`<RecordCommandActions>`) so the two can't drift. */
+export interface RecordActionHandlers {
+  /** Resolved detail-page href (relative), or `null` if unresolvable. */
+  href: string | null
+  /** Absolute href (origin-prefixed), or `null`. */
+  absoluteHref: string | null
+  /** Navigate to the record and close the palette. */
+  open: () => void
+  /** Open the record in a new tab and close the palette. */
+  openNewTab: () => void
+  /** Drill into the embedded create-task page, pre-linked to the record. */
+  createTask: () => void
+  /** Copy the record's display name. */
+  copyName: () => void
+  /** Copy the record's absolute link. */
+  copyLink: () => void
+  /** Open the Kopilot dock — the record is already in scope via its mounted context. */
+  askKopilot: () => void
+}
+
+/**
+ * Build the record-action handlers for a given record. Reads the resource store
+ * for href resolution and drives both the command-palette store (navigation /
+ * create-task) and the Kopilot store (dock).
+ */
+export function useRecordActions(recordId: string, displayName: string): RecordActionHandlers {
+  const router = useRouter()
+  const getResourceById = useResourceStore((s) => s.getResourceById)
+
+  return useMemo(() => {
+    const href = recordHref(recordId as RecordId, getResourceById)
+    const absoluteHref =
+      href && typeof window !== 'undefined' ? `${window.location.origin}${href}` : href
+
+    const close = () => useCommandPaletteStore.getState().close()
+
+    return {
+      href,
+      absoluteHref,
+      open: () => {
+        if (href) {
+          router.push(href)
+          close()
+        }
+      },
+      openNewTab: () => {
+        if (absoluteHref) window.open(absoluteHref, '_blank', 'noopener,noreferrer')
+        close()
+      },
+      createTask: () => useCommandPaletteStore.getState().openCreateTask(recordId as RecordId),
+      copyName: () => {
+        void navigator.clipboard?.writeText(displayName)
+        close()
+      },
+      copyLink: () => {
+        if (absoluteHref) void navigator.clipboard?.writeText(absoluteHref)
+        close()
+      },
+      askKopilot: () => {
+        useKopilotStore.getState().setPanelOpen(true)
+        close()
+      },
+    }
+  }, [recordId, displayName, getResourceById, router])
+}

--- a/apps/web/src/components/kbar/pages/record-actions.tsx
+++ b/apps/web/src/components/kbar/pages/record-actions.tsx
@@ -1,83 +1,52 @@
 // apps/web/src/components/kbar/pages/record-actions.tsx
 'use client'
 
-import type { RecordId } from '@auxx/lib/resources/client'
 import { Command, CommandGroup, CommandItem, CommandList } from '@auxx/ui/components/command'
 import { Copy, ExternalLink, Link2, ListChecks, SquareArrowOutUpRight } from 'lucide-react'
-import { useRouter } from 'next/navigation'
-import { useResourceStore } from '~/components/resources/store/resource-store'
-import { recordHref } from '../record-href'
+import { useRecordActions } from '../contextual/use-record-actions'
 import { selectOnEnter } from '../select-on-enter'
 import { useCommandPaletteStore } from '../store'
 
 /**
  * Contextual actions for the record carried from the search page (`selectedRecord`).
  * Rendered as a nested page under the `… › Search › Actions` breadcrumb. The
- * current set is entity-agnostic (open / open-in-new-tab / copy / create task);
- * entity-specific actions (copy email, send email, create note) follow once the
- * preview surfaces the record's fields.
+ * handler bodies come from the shared {@link useRecordActions} hook — the same
+ * source the mounted-surface flow (`<RecordCommandActions>`) uses, so the two
+ * can't drift.
  */
 export function RecordActionsPage() {
-  const router = useRouter()
   const selected = useCommandPaletteStore((s) => s.selectedRecord)
-  const close = useCommandPaletteStore((s) => s.close)
-  const getResourceById = useResourceStore((s) => s.getResourceById)
+
+  // Hooks must run unconditionally — fall back to empty strings when no record
+  // is carried (the component early-returns null just below).
+  const handlers = useRecordActions(selected?.recordId ?? '', selected?.displayName ?? '')
 
   if (!selected) return null
-
-  const href = recordHref(selected.recordId as RecordId, getResourceById)
-  const absoluteHref =
-    href && typeof window !== 'undefined' ? `${window.location.origin}${href}` : href
-
-  const open = () => {
-    if (href) {
-      router.push(href)
-      close()
-    }
-  }
-
-  const openNewTab = () => {
-    if (absoluteHref) window.open(absoluteHref, '_blank', 'noopener,noreferrer')
-    close()
-  }
-
-  const copy = (text: string) => {
-    void navigator.clipboard?.writeText(text)
-    close()
-  }
-
-  const createTask = () => {
-    // Drill into the embedded task page with the record pre-linked (stays in-palette).
-    useCommandPaletteStore.getState().openCreateTask(selected.recordId as RecordId)
-  }
 
   return (
     <Command onKeyDown={selectOnEnter} className='flex flex-col'>
       <CommandList className='max-h-[min(360px,55vh)] p-1'>
         <CommandGroup heading={selected.displayName}>
-          <CommandItem value='open' onSelect={open} className='gap-2'>
+          <CommandItem value='open' onSelect={handlers.open} className='gap-2'>
             <ExternalLink />
             Open record
           </CommandItem>
-          {absoluteHref && (
-            <CommandItem value='open-new-tab' onSelect={openNewTab} className='gap-2'>
+          {handlers.absoluteHref && (
+            <CommandItem value='open-new-tab' onSelect={handlers.openNewTab} className='gap-2'>
               <SquareArrowOutUpRight />
               Open in new tab
             </CommandItem>
           )}
-          <CommandItem value='create-task' onSelect={createTask} className='gap-2'>
+          <CommandItem value='create-task' onSelect={handlers.createTask} className='gap-2'>
             <ListChecks />
             Create task
           </CommandItem>
-          <CommandItem
-            value='copy-name'
-            onSelect={() => copy(selected.displayName)}
-            className='gap-2'>
+          <CommandItem value='copy-name' onSelect={handlers.copyName} className='gap-2'>
             <Copy />
             Copy name
           </CommandItem>
-          {absoluteHref && (
-            <CommandItem value='copy-link' onSelect={() => copy(absoluteHref)} className='gap-2'>
+          {handlers.absoluteHref && (
+            <CommandItem value='copy-link' onSelect={handlers.copyLink} className='gap-2'>
               <Link2 />
               Copy link
             </CommandItem>

--- a/apps/web/src/components/kbar/pages/root.tsx
+++ b/apps/web/src/components/kbar/pages/root.tsx
@@ -9,6 +9,7 @@ import {
   CommandList,
 } from '@auxx/ui/components/command'
 import { useState } from 'react'
+import { useContextualSections } from '../contextual/select-contextual'
 import { PaletteActionItem } from '../palette-action-item'
 import { useRecentsStore } from '../recents-store'
 import { selectOnEnter } from '../select-on-enter'
@@ -32,6 +33,10 @@ export function RootPage({
   const goTo = useCommandPaletteStore((s) => s.goTo)
   const pushRecent = useRecentsStore((s) => s.push)
 
+  // Page-defined contextual groups (from mounted <CommandContext>/<CommandAction>).
+  // Lead the list, above the static "Search" group — page actions come first.
+  const contextualSections = useContextualSections()
+
   const onRun = (action: PaletteAction) => pushRecent(action.id)
   const showRecents = query.trim() === '' && recentActions.length > 0
 
@@ -45,6 +50,17 @@ export function RootPage({
       />
       <CommandList className='max-h-[min(420px,60vh)]'>
         <CommandEmpty>No results found.</CommandEmpty>
+
+        {/* Contextual groups — page-ephemeral, excluded from recents (unstable ids). */}
+        {contextualSections.map((section) =>
+          section.actions.length > 0 ? (
+            <CommandGroup key={`ctx:${section.label}`} heading={section.label}>
+              {section.actions.map((action) => (
+                <PaletteActionItem key={action.id} action={action} />
+              ))}
+            </CommandGroup>
+          ) : null
+        )}
 
         <CommandGroup heading='Search'>
           <PaletteActionItem

--- a/apps/web/src/components/kbar/palette-action-item.tsx
+++ b/apps/web/src/components/kbar/palette-action-item.tsx
@@ -40,12 +40,17 @@ export function PaletteActionItem({
   }, [action.label, action.subtitle, action.keywords])
 
   const handleSelect = () => {
+    if (action.disabled) return
     onRun?.(action)
     action.perform()
   }
 
   return (
-    <CommandItem value={action.id} keywords={keywords} onSelect={handleSelect}>
+    <CommandItem
+      value={action.id}
+      keywords={keywords}
+      disabled={action.disabled}
+      onSelect={handleSelect}>
       {action.icon && (
         <EntityIcon
           iconId={action.icon}

--- a/apps/web/src/components/kbar/types.ts
+++ b/apps/web/src/components/kbar/types.ts
@@ -36,6 +36,8 @@ export interface PaletteAction {
   keywords?: string
   /** Chord hint, lowercase as displayed (e.g. `['g', 'i']`). */
   shortcut?: string[]
+  /** Render a non-selectable, muted row (e.g. a selection-aware action with nothing selected). */
+  disabled?: boolean
   /** Run the action. */
   perform: () => void
 }

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -32,6 +32,7 @@ import { BaseEntityDrawer } from '~/components/drawers/base-entity-drawer'
 import { getHeaderActions } from '~/components/drawers/drawer-action-registry'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
 import { Tooltip } from '~/components/global/tooltip'
+import { CommandContext, RecordCommandActions } from '~/components/kbar/contextual'
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions'
 import { MergeDialog } from '~/components/merge'
@@ -245,6 +246,16 @@ export const RecordDrawer = React.memo(function RecordDrawer({
     <>
       <KopilotContext activeRecordId={recordId} activeRecordLabel={displayName ?? undefined} />
       <KopilotSuggestion text='Summarize this record' icon='sparkle' priority={10} autoSubmit />
+      {/* Command-palette record scope — priority outranks the table scope so the
+          record group leads cmd+k when a drawer is open over the live table. */}
+      <CommandContext
+        kind='record'
+        label={displayName ?? resource?.label ?? 'Record'}
+        recordId={recordId}
+        entityDefinitionId={entityDefinitionId || undefined}
+        priority={10}>
+        <RecordCommandActions recordId={recordId} displayName={displayName ?? undefined} />
+      </CommandContext>
       <KopilotSuggestion text='Show related records' icon='list' autoSubmit />
       <BaseEntityDrawer
         recordId={recordId}

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -21,6 +21,7 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { Archive, Combine, Database, FileText, Play, Plus, SquarePen, Trash2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { BulkUpdateEntityInstanceDialog } from '~/components/custom-fields/ui/bulk-update-entity-instance-dialog'
@@ -35,6 +36,8 @@ import { decodeColumnId } from '~/components/dynamic-table/utils/column-id'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
 import { EmptyState } from '~/components/global/empty-state'
 import { getCreateHotkey } from '~/components/global-create/system-hotkeys'
+import { CommandAction, CommandContext } from '~/components/kbar/contextual'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import { MergeDialog } from '~/components/merge'
 import { type RecordMeta, toRecordId, useResource } from '~/components/resources'
 import { useRunAiBulkGenerate } from '~/components/resources/hooks/run-ai-bulk-generate'
@@ -89,6 +92,7 @@ export function RecordsView({
   onEditRecord,
 }: RecordsViewProps) {
   const resolvedBasePath = basePath ?? `/app/custom/${slug}`
+  const router = useRouter()
 
   // Dock state
   const isDocked = useEffectiveDockState()
@@ -747,8 +751,87 @@ export function RecordsView({
     />
   )
 
+  const hasSelection = selectedRowIds.size > 0
+  const selectionCount = selectedRowIds.size
+  const selectedRows = () =>
+    Array.from(selectedRowIds).map((id) => ({ id }) as unknown as EntityRow)
+
   return (
     <>
+      {/* Command-palette table scope — surfaces the table's create + bulk
+          operations in cmd+k. Selection-aware rows render only when rows are
+          selected; their subtitles reflect the live count. */}
+      {entityDefinitionId && (
+        <CommandContext
+          kind='table'
+          label={resource.plural}
+          entityDefinitionId={entityDefinitionId}>
+          <CommandAction
+            label={`Create ${resource.label}`}
+            icon={resource.icon ?? 'plus'}
+            keywords='create new add record'
+            priority={10}
+            perform={() => useCommandPaletteStore.getState().openCreate(entityDefinitionId)}
+          />
+          <CommandAction
+            label='Import'
+            icon='database'
+            keywords='import upload csv'
+            priority={1}
+            perform={() => {
+              useCommandPaletteStore.getState().close()
+              router.push(`${resolvedBasePath}/import`)
+            }}
+          />
+          {hasSelection && (
+            <>
+              <CommandAction
+                label='Run workflow'
+                subtitle={`On ${selectionCount} selected`}
+                icon='git-branch'
+                keywords='run workflow trigger automation'
+                priority={9}
+                perform={() => setIsWorkflowDialogOpen(true)}
+              />
+              {selectionCount >= 2 && (
+                <CommandAction
+                  label='Merge'
+                  subtitle={`${selectionCount} selected`}
+                  icon='merge'
+                  keywords='merge combine dedupe'
+                  priority={8}
+                  perform={() => setIsMergeDialogOpen(true)}
+                />
+              )}
+              <CommandAction
+                label='Edit'
+                subtitle={`${selectionCount} selected`}
+                icon='edit'
+                keywords='edit bulk update fields'
+                priority={7}
+                perform={() => setIsBulkUpdateDialogOpen(true)}
+              />
+              <CommandAction
+                label='Archive'
+                subtitle={`${selectionCount} selected`}
+                icon='archive'
+                keywords='archive bulk'
+                priority={6}
+                perform={() => handleBulkArchive(selectedRows())}
+              />
+              <CommandAction
+                label='Delete'
+                subtitle={`${selectionCount} selected`}
+                icon='trash'
+                keywords='delete remove bulk'
+                priority={5}
+                perform={() => handleBulkDelete(selectedRows())}
+              />
+            </>
+          )}
+        </CommandContext>
+      )}
+
       {embedded ? (
         mainContent
       ) : (


### PR DESCRIPTION
## What

Adds **page-defined contextual actions** to the command palette: any surface can mount `<CommandContext>` / `<CommandAction>` to inject scope-aware rows into `cmd+k`, exactly the way `<KopilotContext>` / `<KopilotSuggestion>` feed the Kopilot composer today. Groups appear/disappear purely from which surfaces are mounted — no central per-page wiring.

Implements `plans/kbar/v2/contextual-actions-plan.md` (Phases 1–5 + the two proof surfaces).

## How

**Mechanism (`components/kbar/contextual/`)**
- `contextual-store.ts` — Zustand slice registry, separate from the palette open/page store so surface re-registration never touches palette state. Writers subscribe only to stable setters → a slice write never re-renders other registrars.
- `select-contextual.ts` — `useContextualSections()` builds `PaletteSection[]` memoized over the **raw maps** (not `useShallow` on the fresh array — the documented `select-context.ts:59` trap). Groups ordered by owning-context priority; rows by priority then registration order. Plus `useCommandScope()`.
- `command-context.tsx` — registers a scope slice (`useId`, primitive deps) and provides group inheritance via React context (chosen over an "active context wins" race so a record drawer over a live table is unambiguous).
- `command-action.tsx` — **stable `perform` via ref** (excluded from effect deps so a fresh closure each parent render doesn't thrash register/clear); dev-only duplicate-id guard.

**Render**
- `pages/root.tsx` renders contextual groups at the top, above "Search". Excluded from recents (page-ephemeral, unstable ids).
- `PaletteAction` gains `disabled`; `palette-action-item.tsx` renders a non-selectable row.

**Proof surfaces**
- Shared `useRecordActions` hook backs both the search-flow `record-actions.tsx` page and the new `<RecordCommandActions>` mounted-surface flow — single source so they can't drift.
- **Records table** (`records-view.tsx`): `<CommandContext kind="table">` with Create / Import + selection-aware Run workflow / Merge / Edit / Archive / Delete (subtitles reflect live count, wired to existing bulk handlers).
- **Record drawer** (`record-drawer.tsx`): `<CommandContext kind="record" priority={10}>` beside its `KopilotContext`, rendering `<RecordCommandActions>`.

## Performance

Verified: registrars decouple from slice data (stable setters), `RootPage` is the only data subscriber and is unmounted while the palette is closed, and the consumer memoizes over raw maps. Typing/selection don't thrash registration. No changes needed.

## Notes
- Mail thread / contact drawer / KB editor / agent detail are intent-level in the plan and **not** wired here — they follow the same recipe.
- Includes one small unrelated tweak to `apiKey-table.tsx` (button variants / column width) that was in the working tree.

## Test plan
- [ ] `cmd+k` on a records table → table group leads with Create + bulk ops; selecting rows updates subtitles to `N selected`; navigating away removes the group.
- [ ] Open a record drawer → record group appears (Open record / Create task / Ask Kopilot / Copy…); Create task drills into the embedded page pre-linked; Open record navigates + closes.
- [ ] Search still fuzzy-matches contextual rows; contextual rows not recorded in recents.