### PR TITLE
feat(web): add Quick Actions button to sidebar header

### DIFF
--- a/apps/web/src/app/admin/_components/app-sidebar.tsx
+++ b/apps/web/src/app/admin/_components/app-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
+  SidebarMenu,
   SidebarRail,
 } from '@auxx/ui/components/sidebar'
 import type * as React from 'react'
@@ -47,7 +48,9 @@ export function AdminAppSidebar({ user, ...props }: AdminAppSidebarProps) {
   return (
     <Sidebar collapsible='icon' {...props}>
       <SidebarHeader>
-        <NavUser user={user} />
+        <SidebarMenu>
+          <NavUser user={user} />
+        </SidebarMenu>
       </SidebarHeader>
       <SidebarContent className='gap-0'>
         <AdminNavMain />

--- a/apps/web/src/components/global/sidebar/index.tsx
+++ b/apps/web/src/components/global/sidebar/index.tsx
@@ -6,6 +6,7 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
+  SidebarMenu,
   SidebarRail,
 } from '@auxx/ui/components/sidebar'
 import type * as React from 'react'
@@ -16,6 +17,7 @@ import { EntitySidebarNav } from './entity-sidebar-nav'
 import { FavoritesSidebar } from './favorites-sidebar'
 import { NavMain } from './nav-main'
 import { NavUser } from './nav-user'
+import { QuickActionsNav } from './quick-actions-nav'
 import { useSidebarItemActions } from './sidebar-item-actions'
 import { SidebarStateProvider } from './sidebar-state-context'
 
@@ -40,7 +42,10 @@ export default function AppSidebar({ user, ...props }: Prop) {
     <SidebarStateProvider>
       <Sidebar collapsible='icon' {...props}>
         <SidebarHeader>
-          <NavUser user={user} />
+          <SidebarMenu>
+            <NavUser user={user} />
+            <QuickActionsNav />
+          </SidebarMenu>
         </SidebarHeader>
         <SidebarContent className='gap-0'>
           <MailSidebar />

--- a/apps/web/src/components/global/sidebar/nav-user.tsx
+++ b/apps/web/src/components/global/sidebar/nav-user.tsx
@@ -17,12 +17,7 @@ import {
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
-import {
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  useSidebar,
-} from '@auxx/ui/components/sidebar'
+import { SidebarMenuButton, SidebarMenuItem, useSidebar } from '@auxx/ui/components/sidebar'
 import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
 import { getInitialsFromName } from '@auxx/utils'
@@ -145,222 +140,220 @@ export function NavUser({ user }: Prop) {
     <>
       <CreateOrganizationDialog open={showNewOrgDialog} onOpenChange={setShowNewOrgDialog} />
 
-      <SidebarMenu>
-        <SidebarMenuItem className='flex items-center justify-between gap-1'>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <SidebarMenuButton
-                size='lg'
-                className='ps-1 w-auto pe-1.5  h-8 rounded-2xl ring-0 ring-ring/20  data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:pe-0'>
-                <span className='relative inline-flex shrink-0 group-data-[collapsible=icon]:mx-auto'>
-                  <Avatar className='size-6 rounded-full ring-1 ring-ring/20'>
+      <SidebarMenuItem className='flex items-center justify-between gap-1'>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size='lg'
+              className='ps-1 w-auto pe-1.5  h-8 rounded-2xl ring-0 ring-ring/20  data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:pe-0'>
+              <span className='relative inline-flex shrink-0 group-data-[collapsible=icon]:mx-auto'>
+                <Avatar className='size-6 rounded-full ring-1 ring-ring/20'>
+                  <AvatarImage src={displayImage!} alt={displayName} />
+                  <AvatarFallback className='rounded-lg'>{initials}</AvatarFallback>
+                </Avatar>
+                <PresenceDot
+                  state={myPresence}
+                  className='absolute -bottom-0.5 -right-0.5 size-2'
+                />
+              </span>
+              <div className='grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden pe-2'>
+                <span className='truncate'>{displayName}</span>
+              </div>
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className='w-(--radix-dropdown-menu-trigger-width) min-w-56'
+            // side={isMobile ? 'bottom' : 'right'}
+            align='start'
+            sideOffset={-32}>
+            <DropdownMenuLabel className='p-0 font-normal'>
+              <div className='flex items-center gap-2 px-1 py-1.5 text-left text-sm'>
+                <span className='relative inline-flex shrink-0'>
+                  <Avatar className='size-7 rounded-full ring-1 ring-ring/20'>
                     <AvatarImage src={displayImage!} alt={displayName} />
                     <AvatarFallback className='rounded-lg'>{initials}</AvatarFallback>
                   </Avatar>
                   <PresenceDot
                     state={myPresence}
-                    className='absolute -bottom-0.5 -right-0.5 size-2'
+                    className='absolute -bottom-0.5 -right-0.5 size-2.5'
                   />
                 </span>
-                <div className='grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden pe-2'>
-                  <span className='truncate'>{displayName}</span>
-                </div>
-              </SidebarMenuButton>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              className='w-(--radix-dropdown-menu-trigger-width) min-w-56'
-              // side={isMobile ? 'bottom' : 'right'}
-              align='start'
-              sideOffset={-32}>
-              <DropdownMenuLabel className='p-0 font-normal'>
-                <div className='flex items-center gap-2 px-1 py-1.5 text-left text-sm'>
-                  <span className='relative inline-flex shrink-0'>
-                    <Avatar className='size-7 rounded-full ring-1 ring-ring/20'>
-                      <AvatarImage src={displayImage!} alt={displayName} />
-                      <AvatarFallback className='rounded-lg'>{initials}</AvatarFallback>
-                    </Avatar>
-                    <PresenceDot
-                      state={myPresence}
-                      className='absolute -bottom-0.5 -right-0.5 size-2.5'
-                    />
+                <div className='grid flex-1 text-left text-sm leading-tight'>
+                  <span className='truncate font-semibold'>{displayName}</span>
+                  <span className='truncate text-xs text-muted-foreground'>
+                    {presenceLabel} · {displayEmail}
                   </span>
-                  <div className='grid flex-1 text-left text-sm leading-tight'>
-                    <span className='truncate font-semibold'>{displayName}</span>
-                    <span className='truncate text-xs text-muted-foreground'>
-                      {presenceLabel} · {displayEmail}
-                    </span>
-                  </div>
                 </div>
-              </DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {!selfHosted && (
-                <>
-                  <DropdownMenuGroup>
-                    <DropdownMenuItem asChild>
-                      <Link href='/app/settings/plans'>
-                        <Sparkles className='text-comparison-500' />
-                        Upgrade to Pro
-                      </Link>
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
-                  <DropdownMenuSeparator />
-                </>
-              )}
-              <DropdownMenuGroup>
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>
-                    <Building2 />
-                    Switch Organization
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent className='min-w-56'>
-                      <DropdownMenuLabel className='text-xs text-muted-foreground'>
-                        Organizations
-                      </DropdownMenuLabel>
-
-                      <DropdownMenuRadioGroup
-                        value={activeOrgId!}
-                        onValueChange={handleClickOrganization}>
-                        {isLoading
-                          ? ''
-                          : userData?.memberships.map((membership) => (
-                              <DropdownMenuRadioItem
-                                value={membership.organization.id}
-                                key={membership.organization.id}
-                                className='gap-2 p-1 pr-3'>
-                                <div className='flex size-5 items-center justify-center rounded-full border'>
-                                  <Building2 className='size-3 shrink-0' />
-                                </div>
-                                {membership.organization.name}
-                              </DropdownMenuRadioItem>
-                            ))}
-                      </DropdownMenuRadioGroup>
-                      <DropdownMenuSeparator />
-                      <Link href='/app/settings/organization'>
-                        <DropdownMenuItem>
-                          <div className='flex size-5 -ml-1 items-center justify-center rounded-full border bg-background'>
-                            <Building2 className='size-3' />
-                          </div>
-                          <div className=''>View all</div>
-                        </DropdownMenuItem>
-                      </Link>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem onClick={() => setShowNewOrgDialog(true)}>
-                        <div className='flex size-5 -ml-1 items-center justify-center rounded-full border bg-background'>
-                          <Plus className='size-3' />
-                        </div>
-                        <div className='font-medium text-muted-foreground'>Add Organization</div>
-                      </DropdownMenuItem>
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-              </DropdownMenuGroup>
-              <DropdownMenuSeparator />
-
-              <DropdownMenuGroup>
-                <Link href='/app/settings/general'>
-                  <DropdownMenuItem>
-                    <BadgeCheck />
-                    Account
-                  </DropdownMenuItem>
-                </Link>
-                <Link
-                  href='/login?callbackApp=build&returnTo=/'
-                  target='_blank'
-                  rel='noopener noreferrer'>
-                  <DropdownMenuItem>
-                    <Code />
-                    Developer Portal
-                  </DropdownMenuItem>
-                </Link>
-                {isSuperAdmin && (
-                  <Link href='/admin' target='_blank' rel='noopener noreferrer'>
-                    <DropdownMenuItem>
-                      <Shield />
-                      Admin
-                    </DropdownMenuItem>
-                  </Link>
-                )}
-                {!selfHosted && (
+              </div>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {!selfHosted && (
+              <>
+                <DropdownMenuGroup>
                   <DropdownMenuItem asChild>
                     <Link href='/app/settings/plans'>
-                      <CreditCard />
-                      Billing
+                      <Sparkles className='text-comparison-500' />
+                      Upgrade to Pro
                     </Link>
                   </DropdownMenuItem>
-                )}
-                {orgHasActiveChatQuery.data && (
-                  <DropdownMenuItem
-                    onSelect={(e) => e.preventDefault()}
-                    onClick={(e) => e.preventDefault()}>
-                    <Headset />
-                    Chat duty
-                    <Switch
-                      className='ml-auto'
-                      checked={isOnDuty}
-                      disabled={setSelfDuty.isPending}
-                      onCheckedChange={handleToggleDuty}
-                    />
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                  <SunMoon />
-                  Theme
-                  <RadioTab
-                    value={theme}
-                    onValueChange={setTheme}
-                    size='sm'
-                    radioGroupClassName='grid w-16'
-                    className='border h-6 border-primary-200 flex ml-auto '>
-                    <RadioTabItem value='light' size='sm' className=''>
-                      <Sun />
-                    </RadioTabItem>
-                    <RadioTabItem value='dark' size='sm' className=''>
-                      <Moon />
-                    </RadioTabItem>
-                  </RadioTab>
-                </DropdownMenuItem>
+                </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+              </>
+            )}
+            <DropdownMenuGroup>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <Building2 />
+                  Switch Organization
+                </DropdownMenuSubTrigger>
+                <DropdownMenuPortal>
+                  <DropdownMenuSubContent className='min-w-56'>
+                    <DropdownMenuLabel className='text-xs text-muted-foreground'>
+                      Organizations
+                    </DropdownMenuLabel>
 
-                {/* <DropdownMenuItem>
+                    <DropdownMenuRadioGroup
+                      value={activeOrgId!}
+                      onValueChange={handleClickOrganization}>
+                      {isLoading
+                        ? ''
+                        : userData?.memberships.map((membership) => (
+                            <DropdownMenuRadioItem
+                              value={membership.organization.id}
+                              key={membership.organization.id}
+                              className='gap-2 p-1 pr-3'>
+                              <div className='flex size-5 items-center justify-center rounded-full border'>
+                                <Building2 className='size-3 shrink-0' />
+                              </div>
+                              {membership.organization.name}
+                            </DropdownMenuRadioItem>
+                          ))}
+                    </DropdownMenuRadioGroup>
+                    <DropdownMenuSeparator />
+                    <Link href='/app/settings/organization'>
+                      <DropdownMenuItem>
+                        <div className='flex size-5 -ml-1 items-center justify-center rounded-full border bg-background'>
+                          <Building2 className='size-3' />
+                        </div>
+                        <div className=''>View all</div>
+                      </DropdownMenuItem>
+                    </Link>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onClick={() => setShowNewOrgDialog(true)}>
+                      <div className='flex size-5 -ml-1 items-center justify-center rounded-full border bg-background'>
+                        <Plus className='size-3' />
+                      </div>
+                      <div className='font-medium text-muted-foreground'>Add Organization</div>
+                    </DropdownMenuItem>
+                  </DropdownMenuSubContent>
+                </DropdownMenuPortal>
+              </DropdownMenuSub>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+
+            <DropdownMenuGroup>
+              <Link href='/app/settings/general'>
+                <DropdownMenuItem>
+                  <BadgeCheck />
+                  Account
+                </DropdownMenuItem>
+              </Link>
+              <Link
+                href='/login?callbackApp=build&returnTo=/'
+                target='_blank'
+                rel='noopener noreferrer'>
+                <DropdownMenuItem>
+                  <Code />
+                  Developer Portal
+                </DropdownMenuItem>
+              </Link>
+              {isSuperAdmin && (
+                <Link href='/admin' target='_blank' rel='noopener noreferrer'>
+                  <DropdownMenuItem>
+                    <Shield />
+                    Admin
+                  </DropdownMenuItem>
+                </Link>
+              )}
+              {!selfHosted && (
+                <DropdownMenuItem asChild>
+                  <Link href='/app/settings/plans'>
+                    <CreditCard />
+                    Billing
+                  </Link>
+                </DropdownMenuItem>
+              )}
+              {orgHasActiveChatQuery.data && (
+                <DropdownMenuItem
+                  onSelect={(e) => e.preventDefault()}
+                  onClick={(e) => e.preventDefault()}>
+                  <Headset />
+                  Chat duty
+                  <Switch
+                    className='ml-auto'
+                    checked={isOnDuty}
+                    disabled={setSelfDuty.isPending}
+                    onCheckedChange={handleToggleDuty}
+                  />
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                <SunMoon />
+                Theme
+                <RadioTab
+                  value={theme}
+                  onValueChange={setTheme}
+                  size='sm'
+                  radioGroupClassName='grid w-16'
+                  className='border h-6 border-primary-200 flex ml-auto '>
+                  <RadioTabItem value='light' size='sm' className=''>
+                    <Sun />
+                  </RadioTabItem>
+                  <RadioTabItem value='dark' size='sm' className=''>
+                    <Moon />
+                  </RadioTabItem>
+                </RadioTab>
+              </DropdownMenuItem>
+
+              {/* <DropdownMenuItem>
                   <Bell />
                   Notifications
                 </DropdownMenuItem> */}
-              </DropdownMenuGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onClick={() => {
-                  client.signOut({
-                    fetchOptions: {
-                      onSuccess: () => {
-                        posthog?.reset()
-                        router.push('/') // redirect to login page
-                      },
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => {
+                client.signOut({
+                  fetchOptions: {
+                    onSuccess: () => {
+                      posthog?.reset()
+                      router.push('/') // redirect to login page
                     },
-                  })
-                }}>
-                <LogOut />
-                Sign Out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          {kopilotEnabled && (
-            <Tooltip content='Kopilot' shortcut={['⌘', '⇧', 'K']}>
-              <button
-                type='button'
-                className='relative shrink-0 flex items-center justify-center size-8 rounded-2xl text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors group-data-[collapsible=icon]:hidden'
-                onClick={toggleKopilot}>
-                <Sparkles className='size-4' />
-                {hasUnreadNotification && (
-                  <span
-                    aria-label='Unread Kopilot notification'
-                    className='absolute right-1 top-1 size-2 rounded-full bg-primary'
-                  />
-                )}
-              </button>
-            </Tooltip>
-          )}
-        </SidebarMenuItem>
-      </SidebarMenu>
+                  },
+                })
+              }}>
+              <LogOut />
+              Sign Out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {kopilotEnabled && (
+          <Tooltip content='Kopilot' shortcut={['⌘', '⇧', 'K']}>
+            <button
+              type='button'
+              className='relative shrink-0 flex items-center justify-center size-8 rounded-2xl text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors group-data-[collapsible=icon]:hidden'
+              onClick={toggleKopilot}>
+              <Sparkles className='size-4' />
+              {hasUnreadNotification && (
+                <span
+                  aria-label='Unread Kopilot notification'
+                  className='absolute right-1 top-1 size-2 rounded-full bg-primary'
+                />
+              )}
+            </button>
+          </Tooltip>
+        )}
+      </SidebarMenuItem>
     </>
   )
 }

--- a/apps/web/src/components/global/sidebar/quick-actions-nav.tsx
+++ b/apps/web/src/components/global/sidebar/quick-actions-nav.tsx
@@ -1,0 +1,35 @@
+// apps/web/src/components/global/sidebar/quick-actions-nav.tsx
+'use client'
+
+import { Kbd, KbdGroup } from '@auxx/ui/components/kbd'
+import { SidebarMenuButton, SidebarMenuItem } from '@auxx/ui/components/sidebar'
+import { Zap } from 'lucide-react'
+import { useCommandPaletteStore } from '~/components/kbar/store'
+
+/**
+ * Sidebar-header entry that opens the command palette. Sits directly below
+ * {@link NavUser} inside the shared `SidebarMenu`. The `⌘K` hint is hidden when
+ * the sidebar collapses to icon-only mode.
+ */
+export function QuickActionsNav() {
+  const openPalette = useCommandPaletteStore((s) => s.openPalette)
+
+  return (
+    <SidebarMenuItem className='mt-2'>
+      <SidebarMenuButton
+        onClick={openPalette}
+        tooltip='Quick Actions'
+        className='h-7 shadow-[inset_0_0_0_1px_rgba(255,255,255,0),0_0_2px_0_rgba(28,40,64,0.18),0_1px_3px_0_rgba(24,41,75,0.04)] transition-colors hover:bg-sidebar-accent active:bg-sidebar-accent dark:shadow-[inset_0_0_0_1px_#2f3033,0_0_2px_0_#000,0_1px_3px_0_rgba(0,0,0,0.08)]'>
+        <Zap />
+        <span className='group-data-[collapsible=icon]:hidden'>Quick Actions</span>
+        <KbdGroup
+          size='sm'
+          className='ml-auto group-data-[collapsible=icon]:hidden'
+          variant='outline'>
+          <Kbd shortcut='cmd' />
+          <Kbd>K</Kbd>
+        </KbdGroup>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a **Quick Actions** button to the sidebar header, directly below `NavUser`, that opens the command palette.

- New `QuickActionsNav` component: a `SidebarMenuButton` with a `Zap` icon, "Quick Actions" label, and a `⌘K` `KbdGroup` hint. Opens the palette via `useCommandPaletteStore`'s `openPalette`.
- Label + `⌘K` hint are hidden in collapsed (icon-only) mode; a tooltip covers the collapsed state.
- `NavUser` no longer wraps itself in `<SidebarMenu>` — it now returns just its `<SidebarMenuItem>`, so `NavUser` and `QuickActionsNav` share a single `<SidebarMenu>` in the main app sidebar header.
- The admin sidebar (`admin/_components/app-sidebar.tsx`) wraps `NavUser` in its own `<SidebarMenu>` (no Quick Actions button there, since the command palette isn't mounted in the admin layout).

## Styling

The button uses theme-aware, Attio-inspired box-shadows:
- Light: transparent inset ring + soft ambient/drop shadow.
- Dark: `#2F3033` 1px inset ring + black ambient/drop shadows.

Hover/active use `bg-sidebar-accent` to adapt to the theme.

## Notes

- The large diff in `nav-user.tsx` is mostly re-indentation from removing the `<SidebarMenu>` wrapper.