### PR TITLE
feat(kbar): in-palette thread reader on Search threads page

### DIFF
--- a/apps/web/src/components/kbar/command-palette.tsx
+++ b/apps/web/src/components/kbar/command-palette.tsx
@@ -21,6 +21,7 @@ import { CreateWebhookPage } from './pages/create-webhook'
 import { RecordActionsPage } from './pages/record-actions'
 import { RootPage } from './pages/root'
 import { SearchPage } from './pages/search'
+import { SearchThreadsPage } from './pages/search-threads'
 import { useRecentsStore } from './recents-store'
 import { useCommandPaletteStore } from './store'
 import type { PalettePage } from './types'
@@ -111,6 +112,12 @@ export function CommandPalette() {
             </DialogHeader>
           ) : page === 'search' ? (
             <DialogNav title='Search records' crumbs={[{ label: 'Search' }]} onBack={back} />
+          ) : page === 'search-threads' ? (
+            <DialogNav
+              title='Search threads'
+              crumbs={[{ label: 'Search threads' }]}
+              onBack={back}
+            />
           ) : page === 'record-actions' ? (
             <DialogNav
               title='Record actions'
@@ -140,6 +147,9 @@ export function CommandPalette() {
             </DialogNavPage>
             <DialogNavPage value='search' size='xxl'>
               <SearchPage />
+            </DialogNavPage>
+            <DialogNavPage value='search-threads' size='3xl'>
+              <SearchThreadsPage />
             </DialogNavPage>
             <DialogNavPage value='record-actions' size='sm'>
               <RecordActionsPage />

--- a/apps/web/src/components/kbar/pages/root.tsx
+++ b/apps/web/src/components/kbar/pages/root.tsx
@@ -73,6 +73,16 @@ export function RootPage({
               perform: () => goTo('search'),
             }}
           />
+          <PaletteActionItem
+            action={{
+              id: 'search-threads',
+              label: 'Search threads',
+              subtitle: 'Read mail across every inbox',
+              icon: 'mail',
+              keywords: 'search threads mail email read inbox conversation',
+              perform: () => goTo('search-threads'),
+            }}
+          />
         </CommandGroup>
 
         {showRecents && (

--- a/apps/web/src/components/kbar/pages/search-threads.tsx
+++ b/apps/web/src/components/kbar/pages/search-threads.tsx
@@ -1,0 +1,282 @@
+// apps/web/src/components/kbar/pages/search-threads.tsx
+'use client'
+
+import { buildConditionGroups } from '@auxx/lib/mail-query/client'
+import { Button } from '@auxx/ui/components/button'
+import { Kbd, KbdGroup } from '@auxx/ui/components/kbd'
+import { ScrollArea, scrollElementIntoViewport } from '@auxx/ui/components/scroll-area'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { useHotkeys } from '@tanstack/react-hotkeys'
+import { Loader2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useInView } from 'react-intersection-observer'
+import { useThreadList } from '~/components/threads/hooks/use-thread-list'
+import { useCommandPaletteStore } from '../store'
+import { threadHref } from '../thread-href'
+import { PaletteThreadRow } from '../thread-search/palette-thread-row'
+import { PaletteThreadSearchBar } from '../thread-search/palette-thread-search-bar'
+import { usePaletteThreadSearchStore } from '../thread-search/store'
+import { ThreadPreview } from './thread-preview'
+
+/**
+ * Thread reader page: the inbox's reading experience inside the command palette.
+ * The left pane is the real mail searchbar (isolated palette store) above a
+ * thread results list across *all* inboxes/statuses; the right pane renders the
+ * selected thread's messages read-only via {@link ThreadPreview}. Selection is
+ * click-driven; Enter (when the searchbar didn't consume it) or "Open in mail"
+ * navigates to the thread in the inbox and closes the palette.
+ */
+export function SearchThreadsPage() {
+  const router = useRouter()
+  const close = useCommandPaletteStore((s) => s.close)
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const resultsViewportRef = useRef<HTMLDivElement>(null)
+
+  // Searchbar conditions drive the list reactively (field conditions live;
+  // free-text lands as a `freeText` condition on Enter — shell behavior).
+  const conditions = usePaletteThreadSearchStore((s) => s.conditions)
+  const filter = useMemo(
+    // Scope = "all": contextType 'all' + no status yields only the default
+    // TRASH/SPAM/IGNORED exclusion, so every inbox/status is in range.
+    () => buildConditionGroups({ contextType: 'all', statusSlug: undefined }, conditions),
+    [conditions]
+  )
+
+  const { threads, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } = useThreadList({
+    filter,
+    sort: { field: 'lastMessageAt', direction: 'desc' },
+  })
+
+  // Focus the searchbar on entry — DialogNav swaps pages without re-running
+  // Radix's open autofocus, so the input is otherwise unfocused and ↑/↓ / typing
+  // do nothing until the user clicks. Defer past the page transition.
+  useEffect(() => {
+    const id = setTimeout(() => containerRef.current?.querySelector('input')?.focus(), 60)
+    return () => clearTimeout(id)
+  }, [])
+
+  // Auto-select the first result so the right pane is never blank. Keep the
+  // current selection if it's still in the results; otherwise fall back to first.
+  useEffect(() => {
+    if (threads.length === 0) return
+    if (!selectedThreadId || !threads.some((t) => t.id === selectedThreadId)) {
+      setSelectedThreadId(threads[0]!.id)
+    }
+  }, [threads, selectedThreadId])
+
+  // Infinite scroll: a bottom sentinel auto-loads the next page when it scrolls
+  // into view, same as the inbox list (IntersectionObserver clips through the
+  // ScrollArea's overflow, so no explicit root is needed).
+  const { ref: sentinelRef, inView } = useInView({ threshold: 0 })
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  const openInMail = useCallback(
+    (threadId: string) => {
+      router.push(threadHref({ id: threadId }))
+      close()
+    },
+    [router, close]
+  )
+
+  // Move keyboard focus to the row at `index`, which selects it (the row's
+  // onFocus drives the preview), scrolls it into view, and pre-fetches the next
+  // page as the cursor approaches the end of the list.
+  const focusRowAt = useCallback(
+    (index: number) => {
+      const thread = threads[index]
+      if (!thread) return
+      const el = document.getElementById(`palette-thread-${thread.id}`)
+      el?.focus({ preventScroll: true })
+      if (el && resultsViewportRef.current) {
+        scrollElementIntoViewport(el, resultsViewportRef.current, {
+          behavior: 'smooth',
+          padding: 96,
+        })
+      }
+      if (index >= threads.length - 3 && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage()
+      }
+    },
+    [threads, hasNextPage, isFetchingNextPage, fetchNextPage]
+  )
+
+  // Index of the currently focused row, or -1 when focus is elsewhere (e.g. the
+  // searchbar input) — the entry point for `↓` to step into the list.
+  const focusedRowIndex = useCallback(() => {
+    const activeId = document.activeElement?.id
+    if (!activeId?.startsWith('palette-thread-')) return -1
+    return threads.findIndex((t) => `palette-thread-${t.id}` === activeId)
+  }, [threads])
+
+  /** Return the SearchBarShell currently holding focus inside this palette page. */
+  const focusedSearchbar = useCallback(() => {
+    const activeElement = document.activeElement
+    if (!(activeElement instanceof HTMLElement)) return null
+
+    const searchbar = activeElement.closest<HTMLElement>('[data-searchbar-shell]')
+    if (!searchbar || !containerRef.current?.contains(searchbar)) return null
+
+    return searchbar
+  }, [])
+
+  // TanStack hotkeys attach native listeners, which may run before React's input
+  // keydown handler. Read SearchBarShell's data attributes instead of relying
+  // only on `defaultPrevented` so suggestions keep ownership while the user is
+  // actively typing/filtering, but an empty focused searchbar can hand ↓ to rows.
+  const shouldLetSearchbarOwnArrow = useCallback(() => {
+    const searchbar = focusedSearchbar()
+    if (!searchbar) return false
+
+    const isOpen = searchbar.dataset.searchbarOpen === 'true'
+    const inputIsEmpty = searchbar.dataset.searchbarInputEmpty === 'true'
+    const suggestionsCount = Number(searchbar.dataset.searchbarSuggestionsCount ?? 0)
+    const highlightedIndex = Number(searchbar.dataset.searchbarHighlightedIndex ?? -1)
+
+    return isOpen && suggestionsCount > 0 && (!inputIsEmpty || highlightedIndex >= 0)
+  }, [focusedSearchbar])
+
+  /** Move the palette result cursor up or down from scoped TanStack hotkeys. */
+  const handleArrowNavigation = useCallback(
+    (event: KeyboardEvent, direction: 'up' | 'down') => {
+      if (event.defaultPrevented || shouldLetSearchbarOwnArrow()) return
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      const idx = focusedRowIndex()
+      if (direction === 'down') {
+        focusRowAt(idx < 0 ? 0 : Math.min(idx + 1, threads.length - 1))
+        return
+      }
+
+      if (idx <= 0) {
+        // From the top of the list, hand focus back to the searchbar input.
+        containerRef.current?.querySelector('input')?.focus()
+      } else {
+        focusRowAt(idx - 1)
+      }
+    },
+    [focusedRowIndex, focusRowAt, shouldLetSearchbarOwnArrow, threads.length]
+  )
+
+  useHotkeys(
+    [
+      {
+        hotkey: 'ArrowDown',
+        callback: (event: KeyboardEvent) => handleArrowNavigation(event, 'down'),
+      },
+      {
+        hotkey: 'ArrowUp',
+        callback: (event: KeyboardEvent) => handleArrowNavigation(event, 'up'),
+      },
+      {
+        hotkey: 'Enter',
+        callback: (event: KeyboardEvent) => {
+          if (event.defaultPrevented || focusedSearchbar() || !selectedThreadId) return
+          event.preventDefault()
+          event.stopPropagation()
+          openInMail(selectedThreadId)
+        },
+      },
+    ],
+    {
+      target: containerRef,
+      enabled: threads.length > 0,
+      ignoreInputs: false,
+      preventDefault: false,
+      stopPropagation: false,
+      conflictBehavior: 'allow',
+    }
+  )
+
+  return (
+    <div ref={containerRef} className='flex flex-col'>
+      <div className='border-b border-border/50 p-2 dark:border-[#323842]/80'>
+        <PaletteThreadSearchBar onSearch={() => {}} isLoading={isLoading} />
+      </div>
+
+      <div className='flex h-[min(420px,60vh)]'>
+        {/* Left: thread results */}
+        <div className='flex w-full flex-col overflow-hidden border-border/50 md:w-[22rem] md:flex-none md:border-r dark:border-[#323842]/80'>
+          <ScrollArea
+            viewportRef={resultsViewportRef}
+            className='min-h-0 flex-1'
+            scrollbarClassName='w-1!'>
+            <div className='flex flex-col gap-1 p-2 pe-4'>
+              {isLoading && threads.length === 0 ? (
+                <>
+                  <ThreadRowSkeleton />
+                  <ThreadRowSkeleton />
+                  <ThreadRowSkeleton />
+                </>
+              ) : threads.length === 0 ? (
+                <div className='p-6 text-center text-sm text-primary-400'>No threads found.</div>
+              ) : (
+                <>
+                  {threads.map((thread) => (
+                    <PaletteThreadRow
+                      key={thread.id}
+                      thread={thread}
+                      isSelected={thread.id === selectedThreadId}
+                      onSelect={() => setSelectedThreadId(thread.id)}
+                    />
+                  ))}
+                  {(hasNextPage || isFetchingNextPage) && (
+                    <div ref={sentinelRef} className='flex h-8 w-full items-center justify-center'>
+                      {isFetchingNextPage && (
+                        <Loader2 className='size-4 animate-spin text-muted-foreground' />
+                      )}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* Right: read-only message view */}
+        <ThreadPreview threadId={selectedThreadId} />
+      </div>
+
+      <div className='flex h-11 items-center gap-4 border-t border-border/50 px-3 text-xs text-muted-foreground dark:border-[#323842]/80'>
+        <span className='flex items-center gap-1'>
+          <KbdGroup variant='ghost' size='sm'>
+            <Kbd>↑</Kbd>
+            <Kbd>↓</Kbd>
+          </KbdGroup>
+          Navigate
+        </span>
+        {selectedThreadId && (
+          <Button
+            variant='default'
+            size='xs'
+            className='ml-auto'
+            onClick={() => openInMail(selectedThreadId)}>
+            Open in mail
+            <Kbd shortcut='enter' variant='default' size='sm' />
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Lightweight loading skeleton for a palette thread row. */
+function ThreadRowSkeleton() {
+  return (
+    <div className='flex w-full flex-col gap-2 rounded-lg border bg-background px-3 py-2.5'>
+      <div className='flex items-center justify-between'>
+        <Skeleton className='h-4 w-1/3' />
+        <Skeleton className='h-3 w-10' />
+      </div>
+      <Skeleton className='h-3 w-2/3' />
+      <Skeleton className='h-3 w-full' />
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/pages/thread-preview.tsx
+++ b/apps/web/src/components/kbar/pages/thread-preview.tsx
@@ -1,0 +1,69 @@
+// apps/web/src/components/kbar/pages/thread-preview.tsx
+'use client'
+
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { ReadOnlyThreadProvider } from '~/components/mail/read-only-thread-provider'
+import { ThreadMessages } from '~/components/mail/thread-messages'
+import { useThread } from '~/components/threads/hooks'
+import type { ThreadStatus } from '~/components/threads/store'
+
+/** Badge variant per thread status — muted greys for terminal states. */
+const STATUS_VARIANT: Record<ThreadStatus, Variant> = {
+  OPEN: 'blue',
+  ARCHIVED: 'green',
+  SPAM: 'amber',
+  TRASH: 'gray',
+}
+
+const STATUS_LABEL: Record<ThreadStatus, string> = {
+  OPEN: 'Open',
+  ARCHIVED: 'Done',
+  SPAM: 'Spam',
+  TRASH: 'Trash',
+}
+
+/**
+ * Read-only preview of a thread's messages on the right pane of the palette's
+ * thread reader. Reuses {@link ThreadMessages} (email + chat, scheduled + system
+ * lines) under a {@link ReadOnlyThreadProvider} so no reply box or per-message
+ * action affordances render. Loading falls out of `ThreadMessages`' own skeleton.
+ */
+export function ThreadPreview({ threadId }: { threadId: string | null }) {
+  const { thread } = useThread({ threadId, enabled: !!threadId })
+
+  if (!threadId) {
+    return (
+      <div className='hidden min-w-0 items-center justify-center p-6 text-center text-sm text-primary-400 md:flex'>
+        Select a thread to read.
+      </div>
+    )
+  }
+
+  const status = thread?.status
+
+  return (
+    <div className='hidden min-w-0 flex-col overflow-hidden md:flex'>
+      <ScrollArea className='min-h-0 flex-1'>
+        {/* Sticky header — subject + status badge */}
+        <div className='sticky top-0 z-10 flex items-start gap-2.5 bg-background/90 px-4 pt-4 pb-3 backdrop-blur-lg'>
+          <div className='min-w-0 flex-1 truncate font-medium text-sm'>
+            {thread?.subject || '(no subject)'}
+          </div>
+          {status && (
+            <Badge
+              variant={STATUS_VARIANT[status] ?? 'gray'}
+              size='xs'
+              className='shrink-0 uppercase tracking-wide'>
+              {STATUS_LABEL[status] ?? status}
+            </Badge>
+          )}
+        </div>
+
+        <ReadOnlyThreadProvider threadId={threadId}>
+          <ThreadMessages />
+        </ReadOnlyThreadProvider>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/apps/web/src/components/kbar/store.ts
+++ b/apps/web/src/components/kbar/store.ts
@@ -56,6 +56,7 @@ interface CommandPaletteState {
 const BACK_TARGET: Record<PalettePage, PalettePage> = {
   root: 'root',
   search: 'root',
+  'search-threads': 'root',
   'record-actions': 'search',
   create: 'root',
   'create-snippet': 'root',

--- a/apps/web/src/components/kbar/thread-href.ts
+++ b/apps/web/src/components/kbar/thread-href.ts
@@ -1,0 +1,15 @@
+// apps/web/src/components/kbar/thread-href.ts
+'use client'
+
+import type { ThreadMeta } from '~/components/threads/store'
+
+/**
+ * Resolve the inbox route that opens a thread, mirroring how the inbox itself
+ * selects a thread: the all-inboxes mailbox (`inboxes/all`) at the `all` status
+ * shows every thread across all inboxes, and the open thread is carried in the
+ * `tid` query param (see `mail-box.tsx`, which reads `?tid=` into the active
+ * thread). The thread renders in the right pane regardless of list membership.
+ */
+export function threadHref(thread: Pick<ThreadMeta, 'id'>): string {
+  return `/app/mail/inboxes/all/all?tid=${encodeURIComponent(thread.id)}`
+}

--- a/apps/web/src/components/kbar/thread-search/palette-thread-row.tsx
+++ b/apps/web/src/components/kbar/thread-search/palette-thread-row.tsx
@@ -1,0 +1,102 @@
+// apps/web/src/components/kbar/thread-search/palette-thread-row.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { formatDistanceToNowStrict } from 'date-fns'
+import DOMPurify from 'dompurify'
+import { memo, useMemo } from 'react'
+import { getIntegrationIcon } from '~/components/mail/mail-status-config'
+import { useMessage, useMessageParticipants } from '~/components/threads/hooks'
+import type { ThreadMeta } from '~/components/threads/store'
+
+interface PaletteThreadRowProps {
+  thread: ThreadMeta
+  isSelected: boolean
+  onSelect: () => void
+}
+
+/**
+ * Lightweight, presentation-only thread row for the palette's thread reader
+ * (friction #2 in the plan). Unlike the inbox's `MailThreadItem`, it pulls in
+ * none of the selection store / keyboard-nav / mutations / drag machinery —
+ * none of which belong in the palette. It reads the same batched, store-cached
+ * data hooks the inbox row uses (`useMessage` + `useMessageParticipants`), so
+ * the per-row cost matches the inbox's existing cost.
+ */
+export const PaletteThreadRow = memo(function PaletteThreadRow({
+  thread,
+  isSelected,
+  onSelect,
+}: PaletteThreadRowProps) {
+  const { message: latestMessage } = useMessage({
+    messageId: thread.latestMessageId,
+    enabled: !!thread.latestMessageId,
+  })
+  const { from: sender } = useMessageParticipants(latestMessage?.participants ?? [])
+
+  const senderName = sender?.displayName ?? 'Unknown'
+
+  const formattedDate = useMemo(
+    () =>
+      thread.lastMessageAt
+        ? formatDistanceToNowStrict(new Date(thread.lastMessageAt), { addSuffix: false })
+        : '',
+    [thread.lastMessageAt]
+  )
+
+  const snippet = useMemo(() => {
+    if (typeof window !== 'undefined' && latestMessage?.snippet) {
+      return DOMPurify.sanitize(latestMessage.snippet, { USE_PROFILES: { html: true } })
+    }
+    return latestMessage?.snippet ?? ''
+  }, [latestMessage?.snippet])
+
+  return (
+    <button
+      type='button'
+      id={`palette-thread-${thread.id}`}
+      onClick={onSelect}
+      onFocus={onSelect}
+      aria-selected={isSelected}
+      className={cn(
+        'group relative flex w-full flex-col items-start gap-1 rounded-lg border bg-background px-3 py-2.5 text-left text-sm transition-colors',
+        'hover:bg-accent hover:text-accent-foreground dark:bg-[#2c313c] dark:border-[#1e2227]',
+        isSelected &&
+          'bg-info text-background hover:bg-info-100! border-info/50 dark:bg-info dark:hover:bg-info-100'
+      )}>
+      {thread.isUnread && (
+        <span
+          className={cn(
+            'absolute left-1.5 top-3.5 size-2 rounded-full bg-blue-500',
+            isSelected && 'bg-white'
+          )}
+          aria-label='Unread message'
+        />
+      )}
+      <div className='flex w-full items-center gap-2'>
+        <div
+          className={cn(
+            'flex-none rounded-full border p-0.5 text-blue-500',
+            isSelected && 'border-background/40 text-background'
+          )}>
+          {getIntegrationIcon(thread.integrationProvider)}
+        </div>
+        <div className='min-w-0 flex-1 truncate font-semibold group-aria-selected:text-white'>
+          {senderName}
+        </div>
+        <span className='shrink-0 whitespace-nowrap text-xs text-muted-foreground group-aria-selected:text-background/60'>
+          {formattedDate}
+        </span>
+      </div>
+      <div className='w-full truncate text-xs font-medium group-aria-selected:text-background/80'>
+        {thread.subject || '(no subject)'}
+      </div>
+      {snippet && (
+        <div
+          className='line-clamp-1 w-full break-words text-xs text-muted-foreground group-aria-selected:text-background/50'
+          dangerouslySetInnerHTML={{ __html: snippet }}
+        />
+      )}
+    </button>
+  )
+})

--- a/apps/web/src/components/kbar/thread-search/palette-thread-search-bar.tsx
+++ b/apps/web/src/components/kbar/thread-search/palette-thread-search-bar.tsx
@@ -1,0 +1,160 @@
+// apps/web/src/components/kbar/thread-search/palette-thread-search-bar.tsx
+'use client'
+
+import {
+  getDefaultOperatorForField,
+  getMailViewFieldDefinition,
+  MAIL_VIEW_FIELD_DEFINITIONS,
+  SEARCH_SCOPE_FIELD_ID,
+} from '@auxx/lib/mail-views/client'
+import { useCallback } from 'react'
+import { v4 as generateId } from 'uuid'
+import { useShallow } from 'zustand/react/shallow'
+import { ConditionProvider } from '~/components/conditions/condition-context'
+import {
+  useDeleteRecentSearch,
+  useSearchSuggestions,
+} from '~/components/mail/searchbar/_hooks/use-search-suggestions'
+import { AdvancedFilterMode } from '~/components/mail/searchbar/advanced-filter-mode'
+import { RecentSearchDisplay } from '~/components/mail/searchbar/recent-search-display'
+import { SearchBarShell } from '~/components/searchbar/searchbar-shell'
+import type { SearchSuggestion } from '~/components/searchbar/types'
+import { selectDisplayText, selectHasActiveConditions, usePaletteThreadSearchStore } from './store'
+
+const MAIL_HIDDEN_FIELD_IDS = new Set([SEARCH_SCOPE_FIELD_ID])
+
+interface PaletteThreadSearchBarProps {
+  /** Callback when search is executed (Enter pressed or filter applied). */
+  onSearch: (query: string) => void
+  /** Additional CSS classes. */
+  className?: string
+  /** Loading state indicator. */
+  isLoading?: boolean
+}
+
+/**
+ * Isolated copy of `MailSearchBar` bound to {@link usePaletteThreadSearchStore}
+ * instead of the inbox singleton (friction #1 in the thread-reader plan). The
+ * only real differences from the original are the store import and a hardcoded
+ * `showScopeBadge={false}` (the palette mounts outside `MailFilterProvider`, so
+ * the original's lone `useMailFilter()` read is dropped). The
+ * `ConditionProvider` + `SearchBarShell` body and the suggestions hooks are
+ * unchanged, so this tracks the original closely.
+ */
+export function PaletteThreadSearchBar({
+  onSearch,
+  className,
+  isLoading = false,
+}: PaletteThreadSearchBarProps) {
+  const conditions = usePaletteThreadSearchStore((s) => s.conditions)
+  const highlightedIndex = usePaletteThreadSearchStore((s) => s.highlightedIndex)
+  const hasActiveConditions = usePaletteThreadSearchStore(selectHasActiveConditions)
+  const displayText = usePaletteThreadSearchStore(selectDisplayText)
+  const actions = usePaletteThreadSearchStore(
+    useShallow((s) => ({
+      addCondition: s.addCondition,
+      updateCondition: s.updateCondition,
+      removeCondition: s.removeCondition,
+      clearConditions: s.clearConditions,
+      setConditions: s.setConditions,
+      setHighlightedIndex: s.setHighlightedIndex,
+    }))
+  )
+
+  const deleteRecentSearch = useDeleteRecentSearch()
+
+  const { suggestions, isLoading: suggestionsLoading } = useSearchSuggestions({
+    query: '',
+    enabled: true,
+  })
+
+  const handleSuggestionSelect = useCallback(
+    (suggestion: SearchSuggestion) => {
+      if (suggestion.type === 'recent' && suggestion.conditions) {
+        const conditionsWithIds = suggestion.conditions.map((c) => ({
+          ...c,
+          id: c.id || generateId(),
+        }))
+        actions.setConditions(conditionsWithIds)
+        setTimeout(() => {
+          onSearch(displayText)
+        }, 0)
+        return
+      }
+
+      if (suggestion.type === 'field' && suggestion.fieldId) {
+        const defaultOperator = getDefaultOperatorForField(suggestion.fieldId)
+        actions.addCondition(suggestion.fieldId, defaultOperator, undefined)
+        return
+      }
+    },
+    [actions, onSearch, displayText]
+  )
+
+  const handleConditionsChange = useCallback(
+    (newConditions: any[]) => {
+      actions.setConditions(
+        newConditions.map((c) => ({
+          id: c.id,
+          fieldId: c.fieldId,
+          operator: c.operator,
+          value: c.value,
+          displayLabel: c.displayLabel,
+        }))
+      )
+    },
+    [actions]
+  )
+
+  const renderRecentItem = useCallback((suggestion: SearchSuggestion) => {
+    if (suggestion.conditions) {
+      return <RecentSearchDisplay conditions={suggestion.conditions} />
+    }
+    return <span className='truncate text-primary-700'>{suggestion.label}</span>
+  }, [])
+
+  return (
+    <ConditionProvider
+      conditions={conditions}
+      config={{
+        mode: 'resource',
+        fields: MAIL_VIEW_FIELD_DEFINITIONS.filter((f) => f.id !== SEARCH_SCOPE_FIELD_ID),
+        showGrouping: false,
+        compactMode: true,
+      }}
+      getFieldDefinition={(fieldId) =>
+        typeof fieldId === 'string' ? (getMailViewFieldDefinition(fieldId) as any) : undefined
+      }
+      onConditionsChange={handleConditionsChange}>
+      <SearchBarShell
+        conditions={conditions}
+        hiddenFieldIds={MAIL_HIDDEN_FIELD_IDS}
+        actions={actions}
+        highlightedIndex={highlightedIndex}
+        hasActiveConditions={hasActiveConditions}
+        displayText={displayText}
+        suggestions={suggestions}
+        suggestionsLoading={suggestionsLoading}
+        onSuggestionSelect={handleSuggestionSelect}
+        onDeleteRecentSuggestion={deleteRecentSearch}
+        renderRecentItem={renderRecentItem}
+        onSearch={() => onSearch(displayText)}
+        freeTextField='freeText'
+        renderAdvancedFilter={({ conditions: advConditions, onApply, onCancel }) => (
+          <AdvancedFilterMode
+            initialConditions={advConditions}
+            onApply={onApply}
+            onCancel={onCancel}
+          />
+        )}
+        pinnedFieldIds={MAIL_HIDDEN_FIELD_IDS}
+        pinnedBadgeClassName='bg-accent/30 border-accent/40'
+        placeholder='Search all threads…'
+        className={className}
+        isLoading={isLoading}
+        showScopeBadge={false}
+        openOnFocus={false}
+      />
+    </ConditionProvider>
+  )
+}

--- a/apps/web/src/components/kbar/thread-search/store.ts
+++ b/apps/web/src/components/kbar/thread-search/store.ts
@@ -1,0 +1,36 @@
+// apps/web/src/components/kbar/thread-search/store.ts
+'use client'
+
+import { getMailViewFieldDefinition, SEARCH_SCOPE_FIELD_ID } from '@auxx/lib/mail-views/client'
+import {
+  createSearchSelectors,
+  createSearchStore,
+} from '~/components/searchbar/create-search-store'
+
+/**
+ * An isolated mail-search store instance for the command palette's "Search
+ * threads" page. It mirrors the inbox's `mail-search-store-v2` (same field
+ * labels, same selectors) but is a *second, independent* store so palette
+ * searches never read or write the inbox's live conditions.
+ *
+ * Differences from the inbox store (friction #1 in the plan):
+ * - No `this_mailbox` scope pin — palette scope is "all" (driven by
+ *   `contextType: 'all'` passed to `buildConditionGroups`, not the searchbar).
+ * - `persistRecent: false` — palette searches aren't saved to localStorage.
+ */
+export const usePaletteThreadSearchStore = createSearchStore({
+  name: 'palette-thread-search',
+  getFieldLabel: (fieldId) => getMailViewFieldDefinition(fieldId)?.label,
+  persistRecent: false,
+  pinnedConditions: [],
+  pinnedFieldIds: new Set(),
+})
+
+const paletteSelectors = createSearchSelectors(
+  new Set([SEARCH_SCOPE_FIELD_ID]),
+  (fieldId) => getMailViewFieldDefinition(fieldId)?.label
+)
+
+export const selectHasActiveConditions = paletteSelectors.selectHasActiveConditions
+export const selectConditionCount = paletteSelectors.selectConditionCount
+export const selectDisplayText = paletteSelectors.selectDisplayText

--- a/apps/web/src/components/kbar/types.ts
+++ b/apps/web/src/components/kbar/types.ts
@@ -4,6 +4,7 @@
 export type PalettePage =
   | 'root'
   | 'search'
+  | 'search-threads'
   | 'record-actions'
   | 'create'
   | 'create-snippet'

--- a/apps/web/src/components/mail/chat-message-display.tsx
+++ b/apps/web/src/components/mail/chat-message-display.tsx
@@ -77,6 +77,10 @@ const ChatMessageDisplay = ({
   const senderInitials = sender?.initials ?? senderName.charAt(0).toUpperCase()
   const content = message.textPlain ?? message.snippet ?? ''
 
+  // Read-only seam: an empty `messageActions` (e.g. the palette's
+  // ReadOnlyThreadProvider) hides the floating action dropdown entirely.
+  const hasActions = typeof messageActions?.onDelete === 'function'
+
   // Open the sender in the shared mail drawer. A linked contact opens the
   // richer contact drawer; an unlinked participant opens the participant
   // drawer (which offers "Create Contact"). Mirrors ThreadParticipantButton.
@@ -172,12 +176,14 @@ const ChatMessageDisplay = ({
             </div>
           ) : null}
         </div>
-        <FloatingDropdown
-          message={message}
-          emailActions={messageActions}
-          onMarkUnread={markAsUnread}
-          popoverClassName={popoverClassName}
-        />
+        {hasActions && (
+          <FloatingDropdown
+            message={message}
+            emailActions={messageActions}
+            onMarkUnread={markAsUnread}
+            popoverClassName={popoverClassName}
+          />
+        )}
       </div>
       {showFooter && (
         <div className='flex items-center gap-2 px-1'>

--- a/apps/web/src/components/mail/email-display.tsx
+++ b/apps/web/src/components/mail/email-display.tsx
@@ -224,6 +224,11 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
   const isMe = !message.isInbound
   const senderInitials = from?.displayName?.charAt(0)?.toUpperCase() ?? '?'
 
+  // Read-only seam: a populated `messageActions` always carries `onReply`. When
+  // it's empty (e.g. the palette's ReadOnlyThreadProvider) hide every action
+  // affordance — the dropdown and the inline reply/forward buttons.
+  const hasActions = typeof messageActions?.onReply === 'function'
+
   return (
     <div
       className={cn(
@@ -285,17 +290,19 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
           </div>
           <div className='flex shrink-0 grow-0 items-start gap-2'>
             <div className='flex flex-col items-end'>
-              <div className='flex items-center flex-row justify-end'>
-                <DropdownMenuDemo
-                  message={message}
-                  editorMessage={editorMessage}
-                  emailActions={messageActions}
-                  onMarkUnread={markAsUnread}
-                />
-                <Button variant='ghost' size='icon-sm' onClick={handleReply}>
-                  <Reply />
-                </Button>
-              </div>
+              {hasActions && (
+                <div className='flex items-center flex-row justify-end'>
+                  <DropdownMenuDemo
+                    message={message}
+                    editorMessage={editorMessage}
+                    emailActions={messageActions}
+                    onMarkUnread={markAsUnread}
+                  />
+                  <Button variant='ghost' size='icon-sm' onClick={handleReply}>
+                    <Reply />
+                  </Button>
+                </div>
+              )}
               <div className='text-xs text-muted-foreground'>
                 <Tooltip
                   content={message.sentAt ? new Date(message.sentAt).toString() : ''}
@@ -368,29 +375,31 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
                   </div>
                 </div>
               )}
-              <div className='flex items-center flex-row gap-2 p-4'>
-                <Button
-                  variant='info'
-                  className='rounded-full'
-                  size='sm'
-                  onClick={handleDirectReplyClick}>
-                  <Reply className='opacity-70' />
-                  Reply
-                </Button>
-                <Button
-                  variant='info'
-                  className='rounded-full pr-3!'
-                  size='sm'
-                  onClick={handleDirectReplyAllClick}>
-                  <ReplyAll className='opacity-70' />
-                  Reply All
-                  {isLastMessage && (
-                    <Kbd variant='default' size='sm'>
-                      R
-                    </Kbd>
-                  )}
-                </Button>
-              </div>
+              {hasActions && (
+                <div className='flex items-center flex-row gap-2 p-4'>
+                  <Button
+                    variant='info'
+                    className='rounded-full'
+                    size='sm'
+                    onClick={handleDirectReplyClick}>
+                    <Reply className='opacity-70' />
+                    Reply
+                  </Button>
+                  <Button
+                    variant='info'
+                    className='rounded-full pr-3!'
+                    size='sm'
+                    onClick={handleDirectReplyAllClick}>
+                    <ReplyAll className='opacity-70' />
+                    Reply All
+                    {isLastMessage && (
+                      <Kbd variant='default' size='sm'>
+                        R
+                      </Kbd>
+                    )}
+                  </Button>
+                </div>
+              )}
             </div>
           </motion.div>
         )}

--- a/apps/web/src/components/mail/mail-status-config.tsx
+++ b/apps/web/src/components/mail/mail-status-config.tsx
@@ -77,8 +77,11 @@ export const sendStatusConfig = {
     color: 'text-yellow-600',
     bgColor: 'bg-yellow-100',
     borderColor: 'border-yellow-200',
+    // RecordBadge-style classes (ring + bg + text) with dark-mode variants
+    badgeClass:
+      'bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-900',
     icon: Clock,
-    label: 'Sending...',
+    label: 'Sending…',
     description: 'Message is being sent',
     animate: true,
   },
@@ -86,6 +89,8 @@ export const sendStatusConfig = {
     color: 'text-green-600',
     bgColor: 'bg-green-100',
     borderColor: 'border-green-200',
+    badgeClass:
+      'bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-900',
     icon: CheckCircle,
     label: 'Sent',
     description: 'Message sent successfully',
@@ -95,6 +100,8 @@ export const sendStatusConfig = {
     color: 'text-red-600',
     bgColor: 'bg-red-100',
     borderColor: 'border-red-200',
+    badgeClass:
+      'bg-red-50 text-red-700 ring-red-200 dark:bg-red-950/40 dark:text-red-300 dark:ring-red-900',
     icon: XCircle,
     label: 'Failed to send',
     description: 'Failed to send message',

--- a/apps/web/src/components/mail/mail-thread-list.tsx
+++ b/apps/web/src/components/mail/mail-thread-list.tsx
@@ -24,6 +24,7 @@ import { useQueryState } from 'nuqs'
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 // import { useAutoAnimate } from '@formkit/auto-animate/react'
 // NEW: Import selection hooks from threads module
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import { ActorPicker } from '~/components/pickers/actor-picker'
 import { useThreadTags } from '~/components/tags/hooks/use-thread-tags'
 import { TagPicker } from '~/components/tags/ui/tag-picker'
@@ -106,9 +107,13 @@ export const ThreadList = memo(function ThreadList({
   }, [threadIds, setListThreadIds])
 
   // Keyboard navigation - handles arrow keys, Home/End, Cmd+A, Escape, etc.
+  // Suspend it while the command palette is open so its own thread reader owns
+  // the arrow keys (otherwise the inbox behind the dialog navigates instead —
+  // the manager listens on `document` and fires regardless of dialog focus).
+  const paletteOpen = useCommandPaletteStore((s) => s.open)
   useThreadKeyboardNav({
     threadIds,
-    enabled: true,
+    enabled: !paletteOpen,
     mode: variant === 'compact' ? 'focus' : 'navigate',
     onNavigateToEnd: () => {
       if (hasNextPage && !isFetchingNextPage) {

--- a/apps/web/src/components/mail/message-display.tsx
+++ b/apps/web/src/components/mail/message-display.tsx
@@ -131,6 +131,10 @@ const MessageDisplay = ({ messageId, messageActions, isOpen }: MessageDisplayPro
     return null
   }
 
+  // Read-only seam: an empty `messageActions` (e.g. the palette's
+  // ReadOnlyThreadProvider) hides the action dropdown entirely.
+  const hasActions = typeof messageActions?.onReply === 'function'
+
   const isInbound = message.isInbound
   const senderName = sender?.displayName ?? 'Unknown'
   const senderInitials = sender?.initials ?? senderName.charAt(0).toUpperCase()
@@ -170,15 +174,17 @@ const MessageDisplay = ({ messageId, messageActions, isOpen }: MessageDisplayPro
                   />
                 </div>
               </div>
-              <div className='pr-2 pt-2'>
-                <div className='flex items-center'>
-                  <MessageDropdownMenu
-                    message={message}
-                    emailActions={messageActions}
-                    onMarkUnread={markAsUnread}
-                  />
+              {hasActions && (
+                <div className='pr-2 pt-2'>
+                  <div className='flex items-center'>
+                    <MessageDropdownMenu
+                      message={message}
+                      emailActions={messageActions}
+                      onMarkUnread={markAsUnread}
+                    />
+                  </div>
                 </div>
-              </div>
+              )}
             </div>
 
             <div className='px-4 pb-3'>

--- a/apps/web/src/components/mail/read-only-thread-provider.tsx
+++ b/apps/web/src/components/mail/read-only-thread-provider.tsx
@@ -1,0 +1,52 @@
+// apps/web/src/components/mail/read-only-thread-provider.tsx
+'use client'
+
+import type React from 'react'
+import { useMemo } from 'react'
+import type { EmailActions } from './email-actions'
+import { ThreadContext } from './thread-provider'
+
+/**
+ * Empty actions object. `ThreadMessages` and its display children read only
+ * `emailActions` (passed down as `messageActions`) — when it's empty they hide
+ * every action affordance (dropdown + inline reply/forward), giving a read-only
+ * render for free. The full `ThreadProvider` already returns `{}` for
+ * `emailActions` when there's no thread, so an empty actions object is precedented.
+ */
+const NOOP_ACTIONS = {} as EmailActions
+
+/**
+ * Lightweight, read-only alternative to {@link ThreadProvider} for previewing a
+ * thread's messages (e.g. inside the command palette's thread reader).
+ *
+ * It supplies {@link ThreadContext} with just `threadId` + a no-op
+ * `emailActions`, skipping the full provider's per-mount weight: `useReplyBox`,
+ * `api.ticket.create`, `api.participant.ensureContact`, and the entire
+ * mutations/handlers graph. That machinery is never used in a passive preview,
+ * and the right pane remounts on every row swap — so this avoids real per-click
+ * cost. `ThreadMessages`'s display children consume only `threadId` +
+ * `emailActions` from the context; everything else they need comes from store
+ * hooks, independent of the provider.
+ */
+export function ReadOnlyThreadProvider({
+  threadId,
+  children,
+}: {
+  threadId: string
+  children: React.ReactNode
+}) {
+  const value = useMemo(
+    () =>
+      ({
+        threadId,
+        emailActions: NOOP_ACTIONS,
+        replyBox: {},
+        mutations: {},
+        handlers: {},
+        contactId: null,
+      }) as unknown as React.ContextType<typeof ThreadContext>,
+    [threadId]
+  )
+
+  return <ThreadContext.Provider value={value}>{children}</ThreadContext.Provider>
+}

--- a/apps/web/src/components/mail/send-status-indicator.tsx
+++ b/apps/web/src/components/mail/send-status-indicator.tsx
@@ -1,12 +1,14 @@
 // apps/web/src/components/mail/send-status-indicator.tsx
 'use client'
 import { SendStatus } from '@auxx/database/enums'
-import { Button } from '@auxx/ui/components/button'
 import { cn } from '@auxx/ui/lib/utils'
+import type { VariantProps } from 'class-variance-authority'
+import { RotateCw } from 'lucide-react'
 import { Tooltip } from '~/components/global/tooltip'
+import { recordBadgeVariants } from '~/components/resources/ui/record-badge'
 import { sendStatusConfig } from './mail-status-config'
 
-interface SendStatusIndicatorProps {
+interface SendStatusIndicatorProps extends VariantProps<typeof recordBadgeVariants> {
   status?: SendStatus | null
   error?: string | null
   attempts?: number
@@ -14,14 +16,17 @@ interface SendStatusIndicatorProps {
   onRetry?: () => void
 }
 /**
- * Component to display the send status of a message with optional retry functionality
- * Uses the centralized mail status configuration for consistent styling
+ * Displays the send status of a message as a RecordBadge-style chip with an
+ * optional retry button. Reuses `recordBadgeVariants` and the `record-display`
+ * / `record-remove` data-slots so it matches `RecordBadge`/`TicketBadge` and
+ * renders correctly in dark mode.
  */
 export function SendStatusIndicator({
   status,
   error,
   attempts,
   className,
+  size,
   onRetry,
 }: SendStatusIndicatorProps) {
   // Don't show indicator for successfully sent messages
@@ -32,6 +37,7 @@ export function SendStatusIndicator({
   const config = sendStatusConfig[status]
   if (!config) return null
   const Icon = config.icon
+  const canRetry = status === SendStatus.FAILED && !!onRetry
   // Build tooltip content for additional details
   const tooltipContent =
     error || (attempts && attempts > 1) ? (
@@ -43,32 +49,37 @@ export function SendStatusIndicator({
         )}
       </div>
     ) : undefined
-  // Full mode display with status badge and optional retry button
   return (
-    <div className={cn('flex items-center gap-1', className)}>
-      <Tooltip
-        contentComponent={tooltipContent}
-        content={!tooltipContent ? config.description : undefined}>
-        <div
+    <Tooltip
+      contentComponent={tooltipContent}
+      content={!tooltipContent ? config.description : undefined}>
+      <div
+        data-slot='record-badge'
+        className={cn(recordBadgeVariants({ size }), config.badgeClass, className)}>
+        <Icon
           className={cn(
-            'inline-flex items-center ps-2 h-6 rounded-md text-xs',
-            config.bgColor,
-            config.borderColor,
-            'border',
-            !(status === SendStatus.FAILED && onRetry) && 'pe-2'
-          )}>
-          <Icon className={cn('h-3 w-3', config.animate && 'animate-spin')} />
-          {status === SendStatus.FAILED && onRetry && (
-            <Button
-              size='xs'
-              variant='ghost'
-              className='rounded-l-none py-0 hover:bg-black/10'
-              onClick={onRetry}>
-              Retry
-            </Button>
+            'shrink-0',
+            size === 'sm' ? 'size-3' : 'size-3.5',
+            config.animate && 'animate-spin'
           )}
-        </div>
-      </Tooltip>
-    </div>
+        />
+        <span data-slot='record-display' className='truncate'>
+          {config.label}
+        </span>
+        {canRetry && (
+          <button
+            type='button'
+            data-slot='record-remove'
+            aria-label='Retry sending'
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onRetry?.()
+            }}>
+            <RotateCw />
+          </button>
+        )}
+      </div>
+    </Tooltip>
   )
 }

--- a/apps/web/src/components/mail/thread-provider.tsx
+++ b/apps/web/src/components/mail/thread-provider.tsx
@@ -86,8 +86,10 @@ interface ThreadContextValue {
   contactId: string | null
 }
 
-// Create context
-const ThreadContext = createContext<ThreadContextValue | null>(null)
+// Create context. Exported so the lightweight `ReadOnlyThreadProvider` can
+// supply a minimal value (threadId + no-op actions) without running the full
+// provider's reply-box / mutation machinery on every mount.
+export const ThreadContext = createContext<ThreadContextValue | null>(null)
 
 /**
  * Signals that a `ThreadProvider` subtree is rendered *inside* another view that

--- a/apps/web/src/components/searchbar/searchbar-shell.tsx
+++ b/apps/web/src/components/searchbar/searchbar-shell.tsx
@@ -82,6 +82,8 @@ export interface SearchBarShellProps {
   showFilterButton?: boolean
   /** Whether to show the scope badge. Passed through to SearchFilterInput's visibility logic. */
   showScopeBadge?: boolean
+  /** Whether focusing the input opens suggestions immediately. Defaults to true. */
+  openOnFocus?: boolean
 }
 
 /**
@@ -113,9 +115,10 @@ export function SearchBarShell({
   isLoading = false,
   showFilterButton = true,
   showScopeBadge,
+  openOnFocus = true,
 }: SearchBarShellProps) {
   const inputRef = useRef<AutosizeInputRef>(null)
-  const filterButtonRef = useRef<HTMLButtonElement>(null)
+  const filterButtonRef = useRef<HTMLSpanElement>(null)
   const searchBarContainerRef = useRef<HTMLDivElement>(null)
   const searchInputRowRef = useRef<HTMLDivElement>(null)
 
@@ -158,13 +161,15 @@ export function SearchBarShell({
   /** Handle input keydown for suggestion navigation and condition creation */
   const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // Arrow navigation in suggestions
-      if (e.key === 'ArrowDown' && suggestions.length > 0) {
+      // Arrow navigation in suggestions — only while the dropdown is actually
+      // open. When it's closed, let the arrows bubble so a host (e.g. the
+      // palette thread reader) can move focus from the input into its list.
+      if (e.key === 'ArrowDown' && isOpen && suggestions.length > 0) {
         e.preventDefault()
         setHighlightedSuggestionIndex((prev) => Math.min(prev + 1, suggestions.length - 1))
         return
       }
-      if (e.key === 'ArrowUp' && suggestions.length > 0) {
+      if (e.key === 'ArrowUp' && isOpen && suggestions.length > 0) {
         e.preventDefault()
         setHighlightedSuggestionIndex((prev) => Math.max(prev - 1, -1))
         return
@@ -201,6 +206,7 @@ export function SearchBarShell({
       }
     },
     [
+      isOpen,
       suggestions,
       highlightedSuggestionIndex,
       inputValue,
@@ -214,8 +220,21 @@ export function SearchBarShell({
 
   /** Handle input focus */
   const handleInputFocus = useCallback(() => {
-    setIsOpen(true)
-  }, [])
+    if (openOnFocus) {
+      setIsOpen(true)
+    }
+  }, [openOnFocus])
+
+  /** Handle input value changes and optionally open suggestions once the user types. */
+  const handleInputChange = useCallback(
+    (value: string) => {
+      setInputValue(value)
+      if (!openOnFocus && value.trim()) {
+        setIsOpen(true)
+      }
+    },
+    [openOnFocus]
+  )
 
   /** Clear all conditions and input */
   const handleClear = useCallback(
@@ -254,7 +273,14 @@ export function SearchBarShell({
   }, [showAdvanced])
 
   return (
-    <div ref={searchBarContainerRef} className={cn('w-full min-w-[20rem]', className)}>
+    <div
+      ref={searchBarContainerRef}
+      data-searchbar-shell=''
+      data-searchbar-open={isOpen ? 'true' : 'false'}
+      data-searchbar-input-empty={inputValue.trim() ? 'false' : 'true'}
+      data-searchbar-suggestions-count={suggestions.length}
+      data-searchbar-highlighted-index={highlightedSuggestionIndex}
+      className={cn('w-full min-w-[20rem]', className)}>
       {/* Search input row - always visible, outside popover */}
       <div
         ref={searchInputRowRef}
@@ -275,7 +301,7 @@ export function SearchBarShell({
           onHighlightChange={actions.setHighlightedIndex}
           inputRef={inputRef}
           inputValue={inputValue}
-          onInputChange={setInputValue}
+          onInputChange={handleInputChange}
           onInputKeyDown={handleInputKeyDown}
           onFocus={handleInputFocus}
           placeholder={placeholder}
@@ -303,14 +329,15 @@ export function SearchBarShell({
 
         {/* Filter button */}
         {showFilterButton && (
-          <Button
-            ref={filterButtonRef}
-            variant='ghost'
-            aria-selected={showAdvanced ? 'true' : 'false'}
-            className={cn('size-6 rounded-full aria-[selected=true]:bg-primary-200')}
-            onClick={handleFilterClick}>
-            <Filter className='size-4 shrink-0 opacity-50' />
-          </Button>
+          <span ref={filterButtonRef} className='shrink-0'>
+            <Button
+              variant='ghost'
+              aria-selected={showAdvanced ? 'true' : 'false'}
+              className={cn('size-6 rounded-full aria-[selected=true]:bg-primary-200')}
+              onClick={handleFilterClick}>
+              <Filter className='size-4 shrink-0 opacity-50' />
+            </Button>
+          </span>
         )}
       </div>
 

--- a/apps/web/src/components/templates/ui/template-gallery-dialog.tsx
+++ b/apps/web/src/components/templates/ui/template-gallery-dialog.tsx
@@ -278,7 +278,7 @@ export function TemplateGalleryDialog<T extends TemplateGalleryItem>({
       <div className='flex w-full min-h-0 flex-col justify-start sm:flex-row'>
         {/* Category sidebar */}
         <div className='hidden w-56 flex-col border-r bg-muted/30 sm:flex'>
-          <ScrollArea className='max-h-[440px]'>
+          <ScrollArea viewportClassName='max-h-[440px]'>
             <h3 className='sticky top-0 p-3 pb-0 text-sm font-semibold text-muted-foreground'>
               Categories
             </h3>
@@ -337,7 +337,7 @@ export function TemplateGalleryDialog<T extends TemplateGalleryItem>({
               </div>
             )
           ) : filteredItems.length > 0 ? (
-            <ScrollArea className='max-h-[400px]'>
+            <ScrollArea viewportClassName='max-h-[400px]'>
               {layout === 'cards' ? (
                 <div className='grid gap-3 p-3 pt-0 pb-5 pe-5 sm:grid-cols-2'>
                   {filteredItems.map((item) => renderCard(item))}

--- a/packages/ui/src/components/dialog-nav.tsx
+++ b/packages/ui/src/components/dialog-nav.tsx
@@ -177,7 +177,10 @@ export function DialogNavPages({ value, children, className }: DialogNavPagesPro
       animate={{ width: `${widthRem}rem`, height }}
       transition={{ width: SPRING, height: measuredOnce.current ? SPRING : { duration: 0 } }}
       style={{ maxWidth: '95vw' }}
-      className={cn('relative overflow-hidden', className)}>
+      // On mobile, override the JS-driven rem width / 95vw cap so the body fills
+      // the full-width `content` shell edge-to-edge. The bang beats the inline
+      // `width`/`maxWidth` above; desktop (sm+) keeps the width spring.
+      className={cn('relative overflow-hidden max-sm:w-full! max-sm:max-w-full!', className)}>
       {/* Stable measuring wrapper: the keyed page below remounts on every change,
           so the ResizeObserver can't live on it. The exiting page is positioned
           absolutely, so this wrapper's height tracks the active page. */}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -88,7 +88,8 @@ const dialogVariants = cva(
         fullscreen: 'w-screen h-screen',
         // Shrink-wraps to the widest child (capped at 95vw). Use for dialogs whose
         // width is driven by their content — e.g. an animated `DialogNavPages` body.
-        content: 'w-fit max-w-[95vw]',
+        // On mobile it spans full-width (edge-to-edge) like the fixed-size tokens.
+        content: 'w-fit max-w-[95vw] max-sm:w-full! max-sm:max-w-full!',
       },
     },
     defaultVariants: { variant: 'default', position: 'default', size: 'default' },

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -5,6 +5,13 @@ import { cn } from '@auxx/ui/lib/utils'
 import { ScrollArea as BaseScrollArea } from '@base-ui-components/react/scroll-area'
 import type * as React from 'react'
 
+interface ScrollElementIntoViewportOptions {
+  /** Smooth or instant scroll. Defaults to `auto`. */
+  behavior?: ScrollBehavior
+  /** Extra room to keep between the element and viewport edges. Defaults to 0. */
+  padding?: number
+}
+
 interface ScrollAreaProps {
   children: React.ReactNode
   /** Scroll orientation: vertical (default), horizontal, or both */
@@ -28,6 +35,32 @@ interface ScrollAreaProps {
   noFade?: boolean
   /** Allow scroll chaining to parent scroll containers. Disables overscroll-contain so events propagate when at scroll boundaries. */
   allowScrollChaining?: boolean
+}
+
+function scrollElementIntoViewport(
+  element: HTMLElement,
+  viewport: HTMLElement,
+  { behavior = 'auto', padding = 0 }: ScrollElementIntoViewportOptions = {}
+) {
+  const elementRect = element.getBoundingClientRect()
+  const viewportRect = viewport.getBoundingClientRect()
+  const topOverflow = elementRect.top - viewportRect.top - padding
+  const bottomOverflow = elementRect.bottom - viewportRect.bottom + padding
+
+  if (topOverflow < 0) {
+    viewport.scrollTo({
+      top: viewport.scrollTop + topOverflow,
+      behavior,
+    })
+    return
+  }
+
+  if (bottomOverflow > 0) {
+    viewport.scrollTo({
+      top: viewport.scrollTop + bottomOverflow,
+      behavior,
+    })
+  }
 }
 
 function ScrollArea({
@@ -111,4 +144,4 @@ function ScrollArea({
   )
 }
 
-export { ScrollArea }
+export { ScrollArea, scrollElementIntoViewport }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1150,9 +1150,6 @@ importers:
       jwks-rsa:
         specifier: ^3.2.0
         version: 3.2.2
-      kbar:
-        specifier: 0.1.0-beta.48
-        version: 0.1.0-beta.48(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       libphonenumber-js:
         specifier: 'catalog:'
         version: 1.12.38
@@ -6180,19 +6177,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-portal@1.1.10':
-    resolution: {integrity: sha512-4kY9IVa6+9nJPsYmngK5Uk2kUmZnv7ChhHAFeQ5oaj8jrR1bIi3xww8nH71pz1/Ve4d/cXO3YxT8eikt1B0a8w==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-portal@1.1.6':
     resolution: {integrity: sha512-XmsIl2z1n/TsYFLIdYam2rmFwf9OC/Sh2avkbmVMDuBZIe7hSpM0cYnWPAo7nHOVx8zTuwDZGByfcqLdnzp3Vw==}
     peerDependencies:
@@ -6667,9 +6651,6 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
-
-  '@reach/observe-rect@1.2.0':
-    resolution: {integrity: sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==}
 
   '@react-email/body@0.1.0':
     resolution: {integrity: sha512-o1bcSAmDYNNHECbkeyceCVPGmVsYvT+O3sSO/Ct7apKUu3JphTi31hu+0Nwqr/pgV5QFqdoT5vdS3SW5DJFHgQ==}
@@ -10198,9 +10179,6 @@ packages:
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
-  fast-equals@2.0.4:
-    resolution: {integrity: sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w==}
-
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
@@ -10485,10 +10463,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  fuse.js@6.6.2:
-    resolution: {integrity: sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==}
-    engines: {node: '>=10'}
 
   gaxios@6.7.1:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
@@ -11219,12 +11193,6 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
-
-  kbar@0.1.0-beta.48:
-    resolution: {integrity: sha512-HD5A1dqfK6XGeoH4fRWTmRt4y76sDbtGxY4Dh2xNa5MYtvtKsqfz+nRZ0tKgcrjjGYN4rf5TLXMJuiE7Pb8rXg==}
-    peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -13057,11 +13025,6 @@ packages:
     peerDependencies:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
-
-  react-virtual@2.10.4:
-    resolution: {integrity: sha512-Ir6+oPQZTVHfa6+JL9M7cvMILstFZH/H3jqeYeKI4MSUX+rIruVwFC6nGVXw9wqAw8L0Kg2KvfXxI85OvYQdpQ==}
-    peerDependencies:
-      react: ^16.6.3 || ^17.0.0
 
   react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
@@ -19038,16 +19001,6 @@ snapshots:
       '@types/react': 19.2.3
       '@types/react-dom': 19.2.3(@types/react@19.2.3)
 
-  '@radix-ui/react-portal@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.3)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.3
-      '@types/react-dom': 19.2.3(@types/react@19.2.3)
-
   '@radix-ui/react-portal@1.1.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.0(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -19574,8 +19527,6 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.3)
 
   '@radix-ui/rect@1.1.1': {}
-
-  '@reach/observe-rect@1.2.0': {}
 
   '@react-email/body@0.1.0(react@19.2.3)':
     dependencies:
@@ -23403,8 +23354,6 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
-  fast-equals@2.0.4: {}
-
   fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
@@ -23696,8 +23645,6 @@ snapshots:
       - waku
 
   function-bind@1.1.2: {}
-
-  fuse.js@6.6.2: {}
 
   gaxios@6.7.1:
     dependencies:
@@ -24521,19 +24468,6 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
-
-  kbar@0.1.0-beta.48(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@radix-ui/react-portal': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      fast-equals: 2.0.4
-      fuse.js: 6.6.2
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-virtual: 2.10.4(react@19.2.3)
-      tiny-invariant: 1.3.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
 
   keyv@4.5.4:
     dependencies:
@@ -26735,11 +26669,6 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-
-  react-virtual@2.10.4(react@19.2.3):
-    dependencies:
-      '@reach/observe-rect': 1.2.0
-      react: 19.2.3
 
   react@19.0.0: {}
 


### PR DESCRIPTION
## Summary

Adds a **Search threads** page to the command palette — a read-only mail reading experience across every inbox and status, without leaving the palette.

- **Left pane**: an isolated copy of the mail searchbar (its own palette-scoped store, no recent-search persistence) above an infinite-scroll thread list scoped to `all` inboxes/statuses.
- **Right pane**: the selected thread's messages rendered read-only. Selection is click/keyboard-driven; Enter or "Open in mail" navigates to the thread in the inbox and closes the palette.

## How it works

- **Read-only rendering** — new `ReadOnlyThreadProvider` supplies `ThreadContext` with just `threadId` + a no-op `emailActions`, skipping the full provider's reply-box / mutation machinery (which the right pane remounts on every row swap). The email/chat/message displays hide every action affordance (dropdown + inline reply/forward) when `messageActions` is empty.
- **Keyboard nav** — scoped TanStack hotkeys move the cursor between the searchbar input and the results list. The inbox's `document`-level keyboard nav is suspended while the palette is open so it doesn't navigate behind the dialog. `SearchBarShell` now exposes `data-searchbar-*` attributes and an `openOnFocus` flag so the host can decide ownership of arrow keys.
- **Supporting UI changes** — `scrollElementIntoViewport` helper added to `ScrollArea`; the `content` dialog variant and `DialogNavPages` span full-width on mobile; `SendStatusIndicator` restyled as a `RecordBadge` chip with dark-mode support.

## Test plan

- [ ] Open palette → **Search threads**, confirm results load across inboxes
- [ ] Arrow up/down moves between searchbar and rows; typing filters; suggestions keep arrow ownership while active
- [ ] Right pane shows the selected thread read-only (no reply box / action menus)
- [ ] Enter / "Open in mail" navigates to the thread and closes the palette
- [ ] Infinite scroll loads more threads at the bottom
- [ ] Mobile: dialog spans full width