### PR TITLE
feat(kbar): full-height mobile sheet for command palette

### DIFF
--- a/apps/web/src/components/apps/ui/app-account-picker.tsx
+++ b/apps/web/src/components/apps/ui/app-account-picker.tsx
@@ -100,7 +100,7 @@ export function AppAccountPicker({
   return (
     <>
       <Command className='w-full'>
-        <CommandList className='max-h-none'>
+        <CommandList scrollAreaClassName='max-h-none'>
           {allowPersonal && userDef && options.personal.length > 0 && (
             <CommandGroup heading='Personal'>
               {options.personal.map((c) => (

--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -276,7 +276,7 @@ export function BaseEntityDrawer({
               <div className='flex flex-1 overflow-hidden'>
                 {/* Base tabs - static */}
                 <TabsContent value='overview' className='w-full'>
-                  <ScrollArea className='flex-1'>
+                  <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
                     <TabCards
                       tab='overview'
                       position='before'
@@ -288,6 +288,7 @@ export function BaseEntityDrawer({
                     />
                     <Section
                       title='Details'
+                      className='[&>[data-slot=section]>[data-slot=section-content]]:pe-4'
                       initialOpen
                       collapsible={false}
                       icon={<HouseIcon className='size-4' />}>
@@ -312,7 +313,7 @@ export function BaseEntityDrawer({
                 </TabsContent>
 
                 <TabsContent value='timeline' className='w-full h-full mt-0'>
-                  <ScrollArea className='flex-1'>
+                  <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
                     <div className='p-3 flex-1 flex-col flex'>
                       <TimelineTab recordId={recordId} />
                     </div>
@@ -320,7 +321,7 @@ export function BaseEntityDrawer({
                 </TabsContent>
 
                 <TabsContent value='comments' className='w-full h-full mt-0'>
-                  <ScrollArea className='flex-1'>
+                  <ScrollArea className='flex-1' scrollbarClassName='w-1!'>
                     <DrawerComments
                       recordId={recordId}
                       focusComposerTrigger={focusComposerTrigger}

--- a/apps/web/src/components/kbar/command-palette.tsx
+++ b/apps/web/src/components/kbar/command-palette.tsx
@@ -97,6 +97,7 @@ export function CommandPalette() {
           size='content'
           position='tc'
           innerClassName='p-0'
+          mobileFullHeight
           showClose={false}
           // The palette pages supply their own titles (DialogNav / sr-only) but
           // no description; opt out explicitly so Radix doesn't warn.
@@ -141,7 +142,7 @@ export function CommandPalette() {
             />
           ) : null}
 
-          <DialogNavPages value={page}>
+          <DialogNavPages value={page} className='max-sm:min-h-0 max-sm:flex-1'>
             <DialogNavPage value='root' size='md'>
               <RootPage sections={sections} recentActions={recentActions} />
             </DialogNavPage>

--- a/apps/web/src/components/kbar/pages/create-api-key.tsx
+++ b/apps/web/src/components/kbar/pages/create-api-key.tsx
@@ -17,7 +17,7 @@ export function CreateApiKeyPage() {
   const goTo = useCommandPaletteStore((s) => s.goTo)
 
   return (
-    <div className='p-4'>
+    <div className='p-4 max-sm:flex max-sm:min-h-0 max-sm:flex-1 max-sm:flex-col max-sm:overflow-y-auto'>
       <ApiKeyForm open={page === 'create-api-key'} onClose={close} onCancel={() => goTo('root')} />
     </div>
   )

--- a/apps/web/src/components/kbar/pages/create-dataset.tsx
+++ b/apps/web/src/components/kbar/pages/create-dataset.tsx
@@ -14,7 +14,7 @@ export function CreateDatasetPage() {
   const goTo = useCommandPaletteStore((s) => s.goTo)
 
   return (
-    <div className='p-4'>
+    <div className='p-4 max-sm:flex max-sm:min-h-0 max-sm:flex-1 max-sm:flex-col max-sm:overflow-y-auto'>
       <DatasetForm onClose={close} onCancel={() => goTo('root')} />
     </div>
   )

--- a/apps/web/src/components/kbar/pages/create-group.tsx
+++ b/apps/web/src/components/kbar/pages/create-group.tsx
@@ -15,7 +15,7 @@ export function CreateGroupPage() {
   const goTo = useCommandPaletteStore((s) => s.goTo)
 
   return (
-    <div className='p-4'>
+    <div className='p-4 max-sm:flex max-sm:min-h-0 max-sm:flex-1 max-sm:flex-col max-sm:overflow-y-auto'>
       <GroupDetailDialog mode='create' onSuccess={close} onCancel={() => goTo('root')} />
     </div>
   )

--- a/apps/web/src/components/kbar/pages/create-inbox.tsx
+++ b/apps/web/src/components/kbar/pages/create-inbox.tsx
@@ -15,7 +15,7 @@ export function CreateInboxPage() {
   const goTo = useCommandPaletteStore((s) => s.goTo)
 
   return (
-    <div className='p-4'>
+    <div className='p-4 max-sm:flex max-sm:min-h-0 max-sm:flex-1 max-sm:flex-col max-sm:overflow-y-auto'>
       <InboxForm
         open={page === 'create-inbox'}
         onSuccess={close}

--- a/apps/web/src/components/kbar/pages/create-mail-view.tsx
+++ b/apps/web/src/components/kbar/pages/create-mail-view.tsx
@@ -15,7 +15,7 @@ export function CreateMailViewPage() {
   const goTo = useCommandPaletteStore((s) => s.goTo)
 
   return (
-    <div className='p-4'>
+    <div className='p-4 max-sm:flex max-sm:min-h-0 max-sm:flex-1 max-sm:flex-col max-sm:overflow-y-auto'>
       <MailViewForm
         open={page === 'create-mail-view'}
         onSuccess={close}

--- a/apps/web/src/components/kbar/pages/create-meeting.tsx
+++ b/apps/web/src/components/kbar/pages/create-meeting.tsx
@@ -15,7 +15,7 @@ export function CreateMeetingPage() {
   const goTo = useCommandPaletteStore((s) => s.goTo)
 
   return (
-    <div className='p-4'>
+    <div className='p-4 max-sm:flex max-sm:min-h-0 max-sm:flex-1 max-sm:flex-col max-sm:overflow-y-auto'>
       <MeetingForm
         open={page === 'create-meeting'}
         onSuccess={close}

--- a/apps/web/src/components/kbar/pages/create-signature.tsx
+++ b/apps/web/src/components/kbar/pages/create-signature.tsx
@@ -15,7 +15,7 @@ export function CreateSignaturePage() {
   const goTo = useCommandPaletteStore((s) => s.goTo)
 
   return (
-    <div className='p-4'>
+    <div className='p-4 max-sm:flex max-sm:min-h-0 max-sm:flex-1 max-sm:flex-col max-sm:overflow-y-auto'>
       <SignatureForm
         open={page === 'create-signature'}
         onSuccess={close}

--- a/apps/web/src/components/kbar/pages/create-snippet.tsx
+++ b/apps/web/src/components/kbar/pages/create-snippet.tsx
@@ -16,7 +16,7 @@ export function CreateSnippetPage() {
   const goTo = useCommandPaletteStore((s) => s.goTo)
 
   return (
-    <div className='p-4'>
+    <div className='p-4 max-sm:flex max-sm:min-h-0 max-sm:flex-1 max-sm:flex-col max-sm:overflow-y-auto'>
       <SnippetForm
         initialValues={{ folderId: folderId ?? undefined }}
         onSuccess={close}

--- a/apps/web/src/components/kbar/pages/create-webhook.tsx
+++ b/apps/web/src/components/kbar/pages/create-webhook.tsx
@@ -15,7 +15,7 @@ export function CreateWebhookPage() {
   const goTo = useCommandPaletteStore((s) => s.goTo)
 
   return (
-    <div className='p-4'>
+    <div className='p-4 max-sm:flex max-sm:min-h-0 max-sm:flex-1 max-sm:flex-col max-sm:overflow-y-auto'>
       <WebhookForm
         open={page === 'create-webhook'}
         onSuccess={close}

--- a/apps/web/src/components/kbar/pages/create.tsx
+++ b/apps/web/src/components/kbar/pages/create.tsx
@@ -28,7 +28,7 @@ export function CreatePage({
   if (!entityDefinitionId) return null
 
   return (
-    <div className='flex flex-col gap-4 p-4'>
+    <div className='flex flex-col gap-4 p-4 max-sm:min-h-0 max-sm:flex-1 max-sm:overflow-y-auto'>
       <EntityInstanceForm
         open={page === 'create'}
         entityDefinitionId={entityDefinitionId}

--- a/apps/web/src/components/kbar/pages/record-actions.tsx
+++ b/apps/web/src/components/kbar/pages/record-actions.tsx
@@ -24,8 +24,10 @@ export function RecordActionsPage() {
   if (!selected) return null
 
   return (
-    <Command onKeyDown={selectOnEnter} className='flex flex-col'>
-      <CommandList className='max-h-[min(360px,55vh)] p-1'>
+    <Command onKeyDown={selectOnEnter} className='flex min-h-0 flex-col'>
+      <CommandList
+        className='p-1'
+        scrollAreaClassName='max-h-[min(360px,55vh)] max-sm:min-h-0 max-sm:flex-1 max-sm:max-h-none'>
         <CommandGroup heading={selected.displayName}>
           <CommandItem value='open' onSelect={handlers.open} className='gap-2'>
             <ExternalLink />

--- a/apps/web/src/components/kbar/pages/root.tsx
+++ b/apps/web/src/components/kbar/pages/root.tsx
@@ -41,14 +41,14 @@ export function RootPage({
   const showRecents = query.trim() === '' && recentActions.length > 0
 
   return (
-    <Command loop onKeyDown={selectOnEnter}>
+    <Command loop onKeyDown={selectOnEnter} className='min-h-0'>
       <CommandInput
         value={query}
         onValueChange={setQuery}
         autoFocus
         placeholder='Type a command or search…'
       />
-      <CommandList className='max-h-[min(420px,60vh)]'>
+      <CommandList scrollAreaClassName='max-h-[min(420px,60vh)] max-sm:min-h-0 max-sm:flex-1 max-sm:max-h-none'>
         <CommandEmpty>No results found.</CommandEmpty>
 
         {/* Contextual groups — page-ephemeral, excluded from recents (unstable ids). */}

--- a/apps/web/src/components/kbar/pages/search-threads.tsx
+++ b/apps/web/src/components/kbar/pages/search-threads.tsx
@@ -196,12 +196,12 @@ export function SearchThreadsPage() {
   )
 
   return (
-    <div ref={containerRef} className='flex flex-col'>
+    <div ref={containerRef} className='flex min-h-0 flex-col max-sm:h-full'>
       <div className='border-b border-border/50 p-2 dark:border-[#323842]/80'>
         <PaletteThreadSearchBar onSearch={() => {}} isLoading={isLoading} />
       </div>
 
-      <div className='flex h-[min(420px,60vh)]'>
+      <div className='flex h-[min(420px,60vh)] max-sm:h-auto max-sm:min-h-0 max-sm:flex-1'>
         {/* Left: thread results */}
         <div className='flex w-full flex-col overflow-hidden border-border/50 md:w-[22rem] md:flex-none md:border-r dark:border-[#323842]/80'>
           <ScrollArea

--- a/apps/web/src/components/kbar/pages/search.tsx
+++ b/apps/web/src/components/kbar/pages/search.tsx
@@ -149,7 +149,7 @@ export function SearchPage() {
       onPointerMoveCapture={() => {
         hoverActiveRef.current = true
       }}
-      className='flex flex-col'>
+      className='flex min-h-0 flex-col'>
       <CommandInput
         value={query}
         onValueChange={setQuery}
@@ -157,9 +157,9 @@ export function SearchPage() {
         loading={isFetching}
         placeholder='Search records…'
       />
-      <div className='grid h-[min(300px,55vh)] grid-cols-1 md:grid-cols-2'>
-        <div className='flex min-w-0 flex-col overflow-hidden border-border/50 md:border-r dark:border-[#323842]/80 [&_[data-slot=command-list]]:h-full [&_[data-slot=command-list]]:max-h-none'>
-          <CommandList className='min-w-0'>
+      <div className='grid h-[min(300px,55vh)] grid-cols-1 md:grid-cols-2 max-sm:h-auto max-sm:min-h-0 max-sm:flex-1'>
+        <div className='flex min-w-0 flex-col overflow-hidden border-border/50 md:border-r dark:border-[#323842]/80'>
+          <CommandList className='min-w-0' scrollAreaClassName='h-full max-h-none'>
             {isFetching && items.length === 0 && <CommandLoading>Searching…</CommandLoading>}
             {!isFetching && items.length === 0 && (
               <CommandPlaceholder>No records found.</CommandPlaceholder>

--- a/apps/web/src/components/workflow/ui/block-selector/index.tsx
+++ b/apps/web/src/components/workflow/ui/block-selector/index.tsx
@@ -185,7 +185,7 @@ export const BlockSelector = memo(
             placeholder={isSearching ? 'Search all...' : `Search ${activeTab}...`}
             onValueChange={setSearchValue}
           />
-          <CommandList className='max-h-[700px]'>
+          <CommandList scrollAreaClassName='max-h-[700px]'>
             {!isSearching && activeTab === 'apps' && appNodes.length === 0 ? (
               <div className='p-6 text-center'>
                 <div className='text-sm text-gray-500 mb-2'>No apps available</div>

--- a/apps/web/src/components/workflow/ui/variables/variable-explorer-enhanced.tsx
+++ b/apps/web/src/components/workflow/ui/variables/variable-explorer-enhanced.tsx
@@ -545,7 +545,7 @@ export const VariableExplorerEnhanced: React.FC<VariableExplorerEnhancedProps> =
         {/* Variable List */}
         <CommandList
           className='flex-1 overflow-y-auto min-h-[200px] outline-none'
-          style={{ maxHeight }}>
+          scrollAreaStyle={{ maxHeight }}>
           {getCurrentLevelItems.length === 0 ? (
             <CommandEmpty className='py-8 flex flex-col items-center'>
               <Search className='size-8 mx-auto mb-2 opacity-50' />

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -370,7 +370,7 @@ function CommandInput({
   }, [onValueChange])
   return (
     <div
-      className='flex items-center border-b border-border/50 dark:border-[#323842]/80 ps-3 pe-1'
+      className='flex shrink-0 items-center border-b border-border/50 dark:border-[#323842]/80 ps-3 pe-1'
       cmdk-input-wrapper=''>
       {loading ? (
         <Loader2 className='mr-2 size-4 shrink-0 opacity-50 animate-spin' />
@@ -471,21 +471,40 @@ function CommandInputWithSubmit({
   )
 }
 
-function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+interface CommandListProps extends React.ComponentProps<typeof CommandPrimitive.List> {
+  /**
+   * Classes for the ScrollArea Root that owns sizing/clipping. Use this to
+   * override the default `max-h-[300px]` height cap — `className` lands on the
+   * inner cmdk list, where height utilities are a dead letter.
+   */
+  scrollAreaClassName?: string
+  /** Styles for the ScrollArea Root. Use this for dynamic `maxHeight` values. */
+  scrollAreaStyle?: React.CSSProperties
+}
+
+function CommandList({
+  className,
+  scrollAreaClassName,
+  scrollAreaStyle,
+  style,
+  ...props
+}: CommandListProps) {
   // `data-slot='command-list'` is on the outer scroll-area Root so a parent can
   // target it from a Tailwind className with a descendant selector, e.g.
   // `[&_[data-slot=command-list]]:h-[288px]` to pin the list to a fixed height.
+  // The default cap is `max-h-[300px]`; raise/drop it via `scrollAreaClassName`.
   return (
     <BaseScrollArea.Root
       data-slot='command-list'
-      className='relative max-h-[300px] overflow-hidden'>
+      className={cn('relative max-h-[300px] overflow-hidden', scrollAreaClassName)}
+      style={scrollAreaStyle}>
       <BaseScrollArea.Viewport
-        className='h-full max-h-[300px] w-full overscroll-contain scroll-area-fade outline-none'
+        className='h-full max-h-[inherit] w-full overscroll-contain scroll-area-fade outline-none'
         style={{ overflowX: 'hidden' }}>
         <BaseScrollArea.Content style={{ minWidth: undefined }}>
           <CommandPrimitive.List
             className={cn('outline-none', className)}
-            style={{ overflow: 'visible', maxHeight: 'none' }}
+            style={{ overflow: 'visible', maxHeight: 'none', ...style }}
             {...props}
           />
         </BaseScrollArea.Content>

--- a/packages/ui/src/components/dialog-nav.tsx
+++ b/packages/ui/src/components/dialog-nav.tsx
@@ -71,7 +71,8 @@ export function DialogNav({
       className={cn(
         // space-y-0 cancels DialogHeader's space-y-1.5, which would otherwise
         // push the actions slot down (margin-top on the second flex-row child).
-        'mb-0 flex h-10 flex-row items-center justify-between space-y-0 border-b px-3',
+        // shrink-0 keeps the bar from compressing when the body becomes a flex child.
+        'mb-0 flex h-10 shrink-0 flex-row items-center justify-between space-y-0 border-b px-3',
         className
       )}>
       <div className='flex items-center gap-1'>
@@ -178,17 +179,22 @@ export function DialogNavPages({ value, children, className }: DialogNavPagesPro
       transition={{ width: SPRING, height: measuredOnce.current ? SPRING : { duration: 0 } }}
       style={{ maxWidth: '95vw' }}
       // On mobile, override the JS-driven rem width / 95vw cap so the body fills
-      // the full-width `content` shell edge-to-edge. The bang beats the inline
-      // `width`/`maxWidth` above; desktop (sm+) keeps the width spring.
-      className={cn('relative overflow-hidden max-sm:w-full! max-sm:max-w-full!', className)}>
+      // the full-width `content` shell edge-to-edge, and override the animated
+      // height so it fills the full-height shell instead of measuring to content.
+      // The bang beats the inline `width`/`maxWidth`/`height`; desktop (sm+) keeps
+      // the width + height springs.
+      className={cn(
+        'relative overflow-hidden max-sm:w-full! max-sm:max-w-full! max-sm:h-full! max-sm:min-h-0',
+        className
+      )}>
       {/* Stable measuring wrapper: the keyed page below remounts on every change,
           so the ResizeObserver can't live on it. The exiting page is positioned
           absolutely, so this wrapper's height tracks the active page. */}
-      <div ref={ref}>
+      <div ref={ref} className='max-sm:h-full max-sm:min-h-0'>
         <AnimatePresence mode='popLayout' initial={false}>
           <motion.div
             key={value}
-            className='w-full'
+            className='w-full max-sm:flex max-sm:h-full max-sm:min-h-0 max-sm:flex-col'
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0, position: 'absolute', inset: 0 }}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -121,6 +121,14 @@ export interface DialogContentProps
   /** Whether to show the close button. Defaults to true */
   showClose?: boolean
   innerClassName?: string
+  /**
+   * Opt in to a full-height mobile sheet: on `max-sm` the dialog fills the
+   * viewport (`100dvh`) with the footer pinned to the bottom and the body
+   * scrolling between a fixed header and footer. The opted-in dialog must mark
+   * its own scrolling body `flex-1 min-h-0 overflow-y-auto` (the `{children}`
+   * are arbitrary). Desktop (`sm+`) is unchanged. Defaults to false.
+   */
+  mobileFullHeight?: boolean
 }
 
 function DialogContent({
@@ -130,6 +138,7 @@ function DialogContent({
   size,
   position,
   showClose = true,
+  mobileFullHeight = false,
   children,
   ...props
 }: DialogContentProps) {
@@ -199,12 +208,20 @@ function DialogContent({
     <DialogPortal>
       <DialogOverlay />
       <div
-        className='z-50 pb-6 sm:pb-20 overflow-y-auto absolute inset-0 max-sm:flex max-sm:flex-col max-sm:items-center'
+        className={cn(
+          'z-50 sm:pb-20 overflow-y-auto absolute inset-0 max-sm:flex max-sm:flex-col',
+          // Full-height sheets reach the true bottom edge (no pb) and stretch the
+          // full-width card instead of centering it; otherwise keep the gutter.
+          mobileFullHeight ? 'pb-6 max-sm:pb-0' : 'pb-6 max-sm:items-center'
+        )}
         onWheel={(e) => e.stopPropagation()}>
         <DialogPrimitive.Content
           className={cn(
             dialogVariants({ variant, size, position, className }),
-            'max-sm:inset-auto max-sm:translate-x-0 max-sm:translate-y-0'
+            'max-sm:inset-auto max-sm:translate-x-0 max-sm:translate-y-0',
+            // Flip grid→flex on mobile so the card stretches to a taller container
+            // (a grid child with h-full won't stretch unless the row is 1fr).
+            mobileFullHeight && 'max-sm:h-[100dvh] max-sm:flex max-sm:p-0'
           )}
           {...props}>
           <DialogContext.Provider value={{ isInsideDialog: true, portalContainerRef }}>
@@ -212,7 +229,13 @@ function DialogContent({
               ref={contentRef}
               className={cn(
                 'bg-background ring-1 ring-ring/20 dark:bg-primary-100/80 p-4 relative rounded-[16px] flex flex-col min-h-0',
-                innerClassName
+                mobileFullHeight && 'max-sm:flex-1 max-sm:rounded-none',
+                innerClassName,
+                // Full-height sheet reaches the screen edges, so keep its content
+                // clear of the notch / Dynamic Island / home-indicator. The card
+                // paints its own bg, so it stays filled under the inset. Placed
+                // after innerClassName so the safe insets win over its padding.
+                mobileFullHeight && 'max-sm:pt-safe max-sm:pb-safe max-sm:pl-safe max-sm:pr-safe'
               )}>
               {children}
               {showClose && (
@@ -270,7 +293,9 @@ function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
   return (
     <div
       className={cn(
-        'pt-4 flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+        // `max-sm:mt-auto` pins the footer to the bottom of a full-height flex
+        // card; in a content-height card there's no free space, so it's a no-op.
+        'pt-4 flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 max-sm:mt-auto',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Makes the command palette a full-height sheet on mobile (`max-sm`), filling the viewport (`100dvh`) with a fixed header, a scrolling body, and a pinned footer — instead of the centered content-height card that was awkward on small screens. Desktop (`sm+`) is unchanged.

## Changes

- **`DialogContent`** — new `mobileFullHeight` opt-in: stretches the card to `100dvh` on `max-sm`, flips grid→flex so the card fills the taller container, drops the bottom gutter, and applies safe-area insets (notch / Dynamic Island / home-indicator).
- **`DialogFooter`** — `max-sm:mt-auto` pins the footer to the bottom of a full-height flex card (no-op in a content-height card).
- **`DialogNav` / `DialogNavPages`** — `shrink-0` header bar; pages stretch to fill and allow their body to scroll inside the flex column.
- **`CommandList`** — new `scrollAreaClassName` / `scrollAreaStyle` props to override the default `max-h-[300px]` cap on the ScrollArea root (height utilities on `className` land on the inner cmdk list and are a dead letter).
- **kbar pages** — opt the palette into `mobileFullHeight` and wire root/search/create pages to stretch + scroll correctly.

## Test plan

- [ ] Open the command palette on a mobile viewport — fills the screen, header pinned top, footer pinned bottom, body scrolls between them.
- [ ] Safe-area insets keep content clear of notch / home indicator.
- [ ] Desktop palette is visually unchanged.