### PR TITLE
feat(data-connectors): generic connection picker + source-relative identity

### DIFF
--- a/apps/web/src/components/apps/ui/connection-picker-popover.tsx
+++ b/apps/web/src/components/apps/ui/connection-picker-popover.tsx
@@ -1,0 +1,224 @@
+// apps/web/src/components/apps/ui/connection-picker-popover.tsx
+'use client'
+
+import { Popover, PopoverContentDialogAware, PopoverTrigger } from '@auxx/ui/components/popover'
+import { toastError } from '@auxx/ui/components/toast'
+import { type ReactNode, useMemo, useState } from 'react'
+import { useAppsContext } from '~/components/apps/providers/apps-context'
+import { PickerTrigger } from '~/components/ui/picker-trigger'
+import { api } from '~/trpc/react'
+import { useConnectFlow } from '../hooks/use-connect-flow'
+import { AppIcon } from './app-icon'
+import { ConnectionPicker, type PickerConnection, type PickerKind } from './connection-picker'
+import { SecretConnectionForm } from './secret-connection-form'
+
+interface ConnectionPickerPopoverProps {
+  /** Currently-bound credentialId. */
+  value: string | undefined
+  /** Fires when an existing connection is picked (row carries `appInstallationId`). */
+  onPick: (credentialId: string, connection: PickerConnection) => void
+  /** Credential families to list. Defaults to all bindable kinds. */
+  kinds?: PickerKind[]
+  /**
+   * Restrict to org-scoped (workspace) connections, excluding personal/user
+   * creds. Defaults to true — background resources must bind org-scoped creds.
+   */
+  orgScopedOnly?: boolean
+  /**
+   * When set, a "+ New connection" footer mints an `integration` secret of this
+   * type and calls `onCreated` with the new credentialId.
+   */
+  createConnection?: { type: string; label: string }
+  /** Fires with the new credentialId after "+ New connection" succeeds. */
+  onCreated?: (credentialId: string) => void
+  /**
+   * Enable per-row actions: Reconnect (app rows) + Edit (integration secrets).
+   * Defaults to true. Set false for a pure read-only picker (05c §4).
+   */
+  enableActions?: boolean
+  /** Trigger placeholder when nothing is bound. */
+  placeholder?: string
+  /** Override the trigger button. */
+  trigger?: ReactNode
+  /** Match the popover width to the trigger (for full-width form fields). */
+  matchTriggerWidth?: boolean
+}
+
+const DEFAULT_KINDS: PickerKind[] = ['app', 'integration', 'workflow']
+
+/**
+ * Popover-wrapped {@link ConnectionPicker}. Owns the `credentials.list` query,
+ * the trigger label, and the "+ New connection" mint flow. The cross-feature
+ * replacement for `AppAccountPopover` — see
+ * plans/data-connectors/claude/05b-connection-picker.md.
+ */
+export function ConnectionPickerPopover({
+  value,
+  onPick,
+  kinds = DEFAULT_KINDS,
+  orgScopedOnly = true,
+  createConnection,
+  onCreated,
+  enableActions = true,
+  placeholder = 'Choose connection',
+  trigger,
+  matchTriggerWidth = false,
+}: ConnectionPickerPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const [formOpen, setFormOpen] = useState(false)
+  const [editRow, setEditRow] = useState<PickerConnection | null>(null)
+  const utils = api.useUtils()
+  const { appInstallations } = useAppsContext()
+
+  const listInput = { kind: kinds, orgScopedOnly }
+  const { data: connections = [] } = api.credentials.list.useQuery(listInput, {
+    refetchOnWindowFocus: false,
+  })
+
+  // Reconnect (app rows): re-authorize via the shared connect flow, which does a
+  // silent token refresh → OAuth popup, or the secret/variable re-entry form.
+  const flow = useConnectFlow({
+    onConnected: () => void utils.credentials.list.invalidate(listInput),
+  })
+
+  const handleReconnect = (row: PickerConnection) => {
+    const inst = row.appId ? appInstallations.find((i) => i.app.id === row.appId) : undefined
+    if (!inst) {
+      toastError({
+        title: 'App not installed',
+        description: 'Reconnect this account from the app’s settings instead.',
+      })
+      return
+    }
+    setOpen(false)
+    flow.start({
+      target: {
+        appId: inst.app.id,
+        appSlug: inst.app.slug,
+        appTitle: inst.app.title,
+        installationId: inst.installationId,
+        connectionDefinitions: inst.connectionDefinitions ?? {},
+      },
+      scope: row.scope,
+      connectionId: row.id, // reconnect the existing cred, not a fresh connect
+    })
+  }
+
+  // Edit (integration secrets): re-enter the API key. `mergeSecrets` keeps any
+  // other stored fields untouched.
+  const updateCredential = api.credentials.update.useMutation()
+  const handleEditSubmit = (secret: string) => {
+    if (!editRow) return
+    updateCredential.mutate(
+      { id: editRow.id, data: { apiKey: secret } },
+      {
+        onSuccess: () => {
+          setEditRow(null)
+          void utils.credentials.list.invalidate(listInput)
+        },
+        onError: (error) =>
+          toastError({ title: 'Error updating connection', description: error.message }),
+      }
+    )
+  }
+
+  const selected = useMemo(() => connections.find((c) => c.id === value), [connections, value])
+  const triggerIconId = useMemo(() => {
+    if (!selected?.appId) return null
+    return appInstallations.find((i) => i.app.id === selected.appId)?.app.avatarUrl ?? null
+  }, [appInstallations, selected])
+  const triggerLabel = selected?.label ?? selected?.name ?? null
+
+  const createCredential = api.credentials.create.useMutation()
+
+  const handleCreate = (secret: string) => {
+    if (!createConnection) return
+    createCredential.mutate(
+      {
+        type: createConnection.type,
+        name: createConnection.label,
+        kind: 'integration',
+        data: { apiKey: secret },
+      },
+      {
+        onSuccess: ({ id }) => {
+          setFormOpen(false)
+          setOpen(false)
+          void utils.credentials.list.invalidate(listInput)
+          onCreated?.(id)
+        },
+        onError: (error) =>
+          toastError({ title: 'Error creating connection', description: error.message }),
+      }
+    )
+  }
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          {trigger ?? (
+            <PickerTrigger
+              open={open}
+              hasValue={!!triggerLabel}
+              placeholder={placeholder}
+              size='default'
+              variant='outline'>
+              {triggerIconId && <AppIcon iconId={triggerIconId} size='sm' />}
+              <span className='truncate'>{triggerLabel}</span>
+            </PickerTrigger>
+          )}
+        </PopoverTrigger>
+        <PopoverContentDialogAware
+          className={matchTriggerWidth ? 'w-[var(--radix-popover-trigger-width)] p-0' : 'w-80 p-0'}
+          align='start'>
+          <ConnectionPicker
+            value={value}
+            connections={connections}
+            onPick={(credentialId, connection) => {
+              onPick(credentialId, connection)
+              setOpen(false)
+            }}
+            onCreateNew={createConnection ? () => setFormOpen(true) : undefined}
+            onReconnect={enableActions ? handleReconnect : undefined}
+            onEdit={
+              enableActions
+                ? (row) => {
+                    setOpen(false)
+                    setEditRow(row)
+                  }
+                : undefined
+            }
+          />
+        </PopoverContentDialogAware>
+      </Popover>
+
+      {createConnection && (
+        <SecretConnectionForm
+          open={formOpen}
+          onOpenChange={setFormOpen}
+          connectionLabel={createConnection.label}
+          connectionType='organization'
+          pending={createCredential.isPending}
+          onSubmit={handleCreate}
+        />
+      )}
+
+      {editRow && (
+        <SecretConnectionForm
+          open={!!editRow}
+          onOpenChange={(next) => {
+            if (!next) setEditRow(null)
+          }}
+          connectionLabel={editRow.label ?? editRow.name}
+          connectionType='organization'
+          pending={updateCredential.isPending}
+          onSubmit={handleEditSubmit}
+        />
+      )}
+
+      {/* Reconnect dialogs (secret / variable re-entry) owned by the connect flow. */}
+      {flow.Dialogs}
+    </>
+  )
+}

--- a/apps/web/src/components/apps/ui/connection-picker.tsx
+++ b/apps/web/src/components/apps/ui/connection-picker.tsx
@@ -1,0 +1,211 @@
+// apps/web/src/components/apps/ui/connection-picker.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@auxx/ui/components/command'
+import { Check, Pencil, Plus, TriangleAlert } from 'lucide-react'
+import { useMemo } from 'react'
+import { useAppsContext } from '~/components/apps/providers/apps-context'
+import type { RouterOutputs } from '~/trpc/react'
+import { AppWithStatusIcon } from './app-with-status-icon'
+
+/** A single bindable connection as projected by `credentials.list`. */
+export type PickerConnection = RouterOutputs['credentials']['list'][number]
+
+/**
+ * Credential families this picker can bind. `mcp` is intentionally excluded —
+ * MCP creds are server-bound, not a fetch credential.
+ */
+export type PickerKind = 'app' | 'integration' | 'workflow'
+
+/** Fallback icons when a connection has no app logo to resolve. */
+const APP_FALLBACK_ICON = 'package'
+const KEY_FALLBACK_ICON = 'key-round'
+
+interface ConnectionPickerProps {
+  /** Currently-bound credentialId. */
+  value: string | undefined
+  /** Fires once per pick with the credentialId and the whole row (carries `appInstallationId`). */
+  onPick: (credentialId: string, connection: PickerConnection) => void
+  /** Connections to list (already fetched + filtered by the host/popover). */
+  connections: PickerConnection[]
+  /** When set, renders a "+ New connection" footer row. */
+  onCreateNew?: () => void
+  /** App rows only: re-authorize / re-enter the connection (05c §3). */
+  onReconnect?: (connection: PickerConnection) => void
+  /** Non-app rows only: change the stored secret / rename (05c §3). */
+  onEdit?: (connection: PickerConnection) => void
+  /** Empty-state hint shown when there are no connections to list. */
+  emptyHint?: string
+}
+
+/**
+ * Generic, credential-agnostic connection picker. Lists *any* bindable org
+ * connection (app OAuth, integration, workflow API-key) grouped by family and
+ * binds its `credentialId`. The cross-feature superset of `AppAccountPicker` —
+ * see plans/data-connectors/claude/05b-connection-picker.md.
+ */
+export function ConnectionPicker({
+  value,
+  onPick,
+  connections,
+  onCreateNew,
+  onReconnect,
+  onEdit,
+  emptyHint,
+}: ConnectionPickerProps) {
+  const { appInstallations } = useAppsContext()
+
+  const { apps, keys } = useMemo(
+    () => ({
+      apps: connections.filter((c) => c.kind === 'app'),
+      keys: connections.filter((c) => c.kind === 'integration' || c.kind === 'workflow'),
+    }),
+    [connections]
+  )
+
+  // app row → app logo + title (hydrated client-side; `avatarUrl` isn't a
+  // credential column); non-app row → neutral fallback icon + label/name.
+  const resolve = (c: PickerConnection) => {
+    const inst = c.appId ? appInstallations.find((i) => i.app.id === c.appId) : undefined
+    return {
+      iconId: inst?.app.avatarUrl ?? (c.kind === 'app' ? APP_FALLBACK_ICON : KEY_FALLBACK_ICON),
+      title: c.label ?? inst?.app.title ?? c.name,
+    }
+  }
+
+  const isEmpty = connections.length === 0
+
+  return (
+    <Command className='w-full'>
+      <CommandList scrollAreaClassName='max-h-none'>
+        {isEmpty && (
+          <div className='px-3 py-6 text-center text-sm text-muted-foreground'>
+            {emptyHint ?? 'No connections yet — add one to authorize this connector.'}
+          </div>
+        )}
+
+        {apps.length > 0 && (
+          <CommandGroup heading='Apps'>
+            {apps.map((c) => (
+              <ConnectionItem
+                key={c.id}
+                connection={c}
+                selected={value === c.id}
+                onSelect={() => onPick(c.id, c)}
+                onReconnect={onReconnect}
+                onEdit={onEdit}
+                {...resolve(c)}
+              />
+            ))}
+          </CommandGroup>
+        )}
+
+        {keys.length > 0 && (
+          <CommandGroup heading='API keys & integrations'>
+            {keys.map((c) => (
+              <ConnectionItem
+                key={c.id}
+                connection={c}
+                selected={value === c.id}
+                onSelect={() => onPick(c.id, c)}
+                onReconnect={onReconnect}
+                onEdit={onEdit}
+                {...resolve(c)}
+              />
+            ))}
+          </CommandGroup>
+        )}
+
+        {onCreateNew && (
+          <>
+            {!isEmpty && <CommandSeparator />}
+            <CommandGroup>
+              <CommandItem onSelect={onCreateNew} className='cursor-pointer h-7.5'>
+                <Plus className='text-muted-foreground' />
+                <span>New connection</span>
+              </CommandItem>
+            </CommandGroup>
+          </>
+        )}
+      </CommandList>
+    </Command>
+  )
+}
+
+function ConnectionItem({
+  connection,
+  selected,
+  iconId,
+  title,
+  onSelect,
+  onReconnect,
+  onEdit,
+}: {
+  connection: PickerConnection
+  selected: boolean
+  iconId: string
+  title: string
+  onSelect: () => void
+  onReconnect?: (connection: PickerConnection) => void
+  onEdit?: (connection: PickerConnection) => void
+}) {
+  const isApp = connection.kind === 'app'
+  const expired = connection.status === 'expired'
+  // App rows re-authorize (covers OAuth + secret re-entry); non-app secret rows
+  // edit the stored key. See 05c §1.
+  const canReconnect = isApp && !!onReconnect
+  const canEdit = !isApp && !!onEdit
+
+  return (
+    <CommandItem value={title} onSelect={onSelect} className='cursor-pointer h-7.5'>
+      {/* `status` ('connected' | 'expired') is a subset of AppConnectionStatus. */}
+      <AppWithStatusIcon iconId={iconId} size='sm' status={connection.status} />
+      <span className='truncate'>{title}</span>
+      {connection.type && (
+        <span className='truncate text-xs text-muted-foreground'>{connection.type}</span>
+      )}
+      {expired && canReconnect && <TriangleAlert className='size-3.5 shrink-0 text-amber-600' />}
+      <div className='ml-auto flex items-center gap-1.5'>
+        {selected && (
+          <div className='flex size-4 items-center justify-center rounded-full border border-blue-800 bg-info'>
+            <Check className='size-2.5! text-white' strokeWidth={4} />
+          </div>
+        )}
+        {canReconnect && (
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            className={expired ? 'h-6 px-2 text-amber-600 hover:text-amber-700' : 'h-6 px-2'}
+            onClick={(e) => {
+              e.stopPropagation()
+              onReconnect(connection)
+            }}>
+            Reconnect
+          </Button>
+        )}
+        {canEdit && (
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            className='h-6 px-2'
+            onClick={(e) => {
+              e.stopPropagation()
+              onEdit(connection)
+            }}>
+            <Pencil />
+            Edit
+          </Button>
+        )}
+      </div>
+    </CommandItem>
+  )
+}

--- a/apps/web/src/components/data-connectors/hooks/use-source-paths.test.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-source-paths.test.ts
@@ -1,0 +1,52 @@
+// apps/web/src/components/data-connectors/hooks/use-source-paths.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { flattenSourceSchema, leafPathsUnder } from './use-source-paths'
+
+const SCHEMA = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    customer: {
+      type: 'object',
+      properties: { email: { type: 'string' }, name: { type: 'string' } },
+    },
+    line_items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { sku: { type: 'string' }, price: { type: 'number' } },
+      },
+    },
+  },
+}
+
+describe('flattenSourceSchema', () => {
+  it('emits dotted leaf + branch paths, arrays under `[]`', () => {
+    const paths = flattenSourceSchema(SCHEMA).map((p) => p.path)
+    expect(paths).toContain('customer.email')
+    expect(paths).toContain('line_items[].sku')
+    expect(paths).toContain('line_items[].price')
+  })
+})
+
+describe('leafPathsUnder', () => {
+  it('returns root leaves unchanged (relative == absolute)', () => {
+    const leaves = leafPathsUnder(flattenSourceSchema(SCHEMA), '').map((p) => p.path)
+    expect(leaves).toContain('id')
+    expect(leaves).toContain('customer.email')
+    // branches are excluded
+    expect(leaves).not.toContain('customer')
+    expect(leaves).not.toContain('line_items')
+  })
+
+  it('strips an object rootPath prefix', () => {
+    const leaves = leafPathsUnder(flattenSourceSchema(SCHEMA), 'customer').map((p) => p.path)
+    expect(leaves.sort()).toEqual(['email', 'name'])
+  })
+
+  it('strips an array rootPath prefix (the `[]` segment too)', () => {
+    const leaves = leafPathsUnder(flattenSourceSchema(SCHEMA), 'line_items[]').map((p) => p.path)
+    expect(leaves.sort()).toEqual(['price', 'sku'])
+  })
+})

--- a/apps/web/src/components/data-connectors/hooks/use-source-paths.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-source-paths.ts
@@ -65,12 +65,24 @@ export function useSourcePaths(schema: Record<string, unknown> | null | undefine
   return useMemo(() => flattenSourceSchema(schema), [schema])
 }
 
-/** Leaf (value) paths only, optionally scoped to a `rootPath` subtree. */
+/**
+ * Leaf (value) paths under a mapping's `rootPath`, returned RELATIVE to that
+ * subtree. This matches the sync runtime, which descends into the subtree
+ * (`extractSubtrees(source.fields, rootPath)`) before resolving each field path
+ * (`getByPath(subtree, relativePath)`) — so a `line_items[]` mapping references
+ * `price`, not `line_items[].price`. The root mapping (`''`) returns its leaves
+ * unchanged (relative == absolute).
+ */
 export function leafPathsUnder(paths: SourcePath[], rootPath: string): SourcePath[] {
-  const prefix = rootPath ? `${rootPath.replace(/\[\]$/, '')}` : ''
-  return paths.filter((p) => {
-    if (p.isBranch) return false
-    if (!prefix) return true
-    return p.path === prefix || p.path.startsWith(`${prefix}.`) || p.path.startsWith(`${prefix}[]`)
-  })
+  if (!rootPath) return paths.filter((p) => !p.isBranch)
+  const base = rootPath.replace(/\[\]$/, '')
+  const out: SourcePath[] = []
+  for (const p of paths) {
+    if (p.isBranch) continue
+    let rel: string | null = null
+    if (p.path.startsWith(`${base}[].`)) rel = p.path.slice(base.length + 3)
+    else if (p.path.startsWith(`${base}.`)) rel = p.path.slice(base.length + 1)
+    if (rel) out.push({ ...p, path: rel })
+  }
+  return out
 }

--- a/apps/web/src/components/data-connectors/hooks/use-target-defs.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-target-defs.ts
@@ -32,19 +32,27 @@ export function useTargetDefs() {
 
   const defs = useMemo<TargetDef[]>(() => {
     const rows = resources.data ?? []
-    return rows.map((r) => ({
-      entityDefinitionId: r.entityDefinitionId,
-      label: r.label,
-      icon: r.icon,
-      color: r.color,
-      fields: (r.fields ?? []).map((f) => ({
-        id: f.id,
-        key: f.key,
-        label: f.label,
-        type: String(f.fieldType ?? f.type),
-        isIdentifier: f.isIdentifier === true,
-      })),
-    }))
+    // Only EntityDefinition-backed resources are valid sink targets: their
+    // `entityDefinitionId` is a real `EntityDefinition.id` (the column the mapping
+    // FKs to) and they store records as EntityInstances. Old static system types
+    // (thread, user, …) surface as `type: 'system'` with the type slug as their
+    // `entityDefinitionId` and live in their own legacy tables — not EntityInstances —
+    // so a mapping can neither FK to them nor write into them.
+    return rows
+      .filter((r) => r.type === 'custom')
+      .map((r) => ({
+        entityDefinitionId: r.entityDefinitionId,
+        label: r.label,
+        icon: r.icon,
+        color: r.color,
+        fields: (r.fields ?? []).map((f) => ({
+          id: f.id,
+          key: f.key,
+          label: f.label,
+          type: String(f.fieldType ?? f.type),
+          isIdentifier: f.isIdentifier === true,
+        })),
+      }))
   }, [resources.data])
 
   const byId = useMemo(() => {

--- a/apps/web/src/components/data-connectors/ui/connection-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/connection-section.tsx
@@ -4,9 +4,8 @@
 import { Button } from '@auxx/ui/components/button'
 import { Section } from '@auxx/ui/components/section'
 import { ChevronRight, Globe, Plug, Settings2 } from 'lucide-react'
-import { useAppsContext } from '~/components/apps/providers/apps-context'
-import { AppAccountPopover } from '~/components/apps/ui/app-account-popover'
 import { ConnectionList } from '~/components/apps/ui/connection-list'
+import { ConnectionPickerPopover } from '~/components/apps/ui/connection-picker-popover'
 import { ConnectionRow, type ConnectionStatus } from '~/components/apps/ui/connection-row'
 import { api } from '~/trpc/react'
 
@@ -26,27 +25,17 @@ interface ConnectionSectionProps {
  */
 export function ConnectionSection({ connector, onOpenSource }: ConnectionSectionProps) {
   const utils = api.useUtils()
-  const { appInstallations } = useAppsContext()
   const isGenericRest = !connector.type.startsWith('app:')
-  // app:<slug> connectors borrow the installed app's credential; generic-rest binds a
-  // secret connection. The connector type stores the app *slug*, but the account picker
-  // keys off App.id — so resolve the installation by slug and feed the picker its id.
-  const slug = connector.type.startsWith('app:') ? connector.type.slice('app:'.length) : null
-  const installation = slug ? (appInstallations.find((i) => i.app.slug === slug) ?? null) : null
-  const appId = installation?.app.id ?? null
 
   const update = api.dataConnector.update.useMutation({
     onSuccess: () => void utils.dataConnector.getById.invalidate({ id: connector.id }),
   })
 
-  // Borrowing an app credential also records the installation (token refresh + lifecycle
-  // live on the app connection — DataConnector.appInstallationId, 01 §1).
-  const bindCredential = (credentialId: string) =>
-    update.mutate({
-      id: connector.id,
-      credentialId,
-      appInstallationId: installation?.installationId ?? null,
-    })
+  // The picker lists across kinds; the picked row carries `appInstallationId`
+  // (set for app creds so token refresh + lifecycle stay wired — 01 §1). A
+  // freshly-minted "+ New connection" integration secret has none.
+  const bindCredential = (credentialId: string, appInstallationId: string | null = null) =>
+    update.mutate({ id: connector.id, credentialId, appInstallationId })
 
   const connected = !!connector.credentialId
   const status: ConnectionStatus = connected ? 'connected' : 'disconnected'
@@ -71,15 +60,15 @@ export function ConnectionSection({ connector, onOpenSource }: ConnectionSection
                   : 'Connect an account to authorize this connector.'
             }
             actions={() => (
-              <AppAccountPopover
-                appId={appId}
+              <ConnectionPickerPopover
                 value={connector.credentialId ?? undefined}
-                onPick={bindCredential}
-                onConnected={bindCredential}
+                onPick={(credentialId, row) => bindCredential(credentialId, row.appInstallationId)}
+                onCreated={(credentialId) => bindCredential(credentialId, null)}
+                createConnection={{ type: connector.type, label: `${connector.name} API key` }}
                 trigger={
                   <Button variant='outline' size='sm'>
                     <Plug />
-                    {connected ? 'Switch account' : 'Connect'}
+                    {connected ? 'Switch connection' : 'Connect'}
                   </Button>
                 }
               />

--- a/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
@@ -16,7 +16,7 @@ import { useQueryState } from 'nuqs'
 import { useCallback, useMemo } from 'react'
 import { useScrollSpy } from '~/hooks/use-scroll-spy'
 import { api } from '~/trpc/react'
-import { useSourcePaths } from '../hooks/use-source-paths'
+import { leafPathsUnder, useSourcePaths } from '../hooks/use-source-paths'
 import { useStreamMutations } from '../hooks/use-stream-mutations'
 import { ConnectionSection } from './connection-section'
 import { FieldCalcPanel } from './field-calc-panel'
@@ -242,7 +242,8 @@ export function ConnectorDetailTabs({ connector, mobileRunsPanel }: ConnectorDet
               <FieldCalcPanel
                 fieldLabel={fieldKey}
                 expression={fieldExpression}
-                sourcePaths={sourcePaths}
+                // Scoped + relative to the mapping's subtree, matching the runtime.
+                sourcePaths={leafPathsUnder(sourcePaths, fieldMapping.rootPath)}
                 onSave={(expression, sourceFields) => {
                   const existing = (fieldMapping.fieldMappings ?? {}) as Record<
                     string,

--- a/apps/web/src/components/data-connectors/ui/mapping-tree.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-tree.tsx
@@ -376,17 +376,26 @@ function IdentityChip({
       | { kind: 'manualReview' }
   ) => void
 }) {
-  const identity = mapping.identityStrategy as { kind: string; connectorFieldKey?: string }
+  const identity = mapping.identityStrategy as {
+    kind: string
+    connectorFieldKey?: string
+    targetFieldId?: string
+    normalize?: 'email' | 'phone' | 'domain' | 'none'
+  }
+
+  // matchField pairs a SOURCE field (relative leaf) with a TARGET field to match
+  // against — identifier fields first, else any field.
+  const identifierFields = def?.fields.filter((f) => f.isIdentifier) ?? []
+  const targetFields = identifierFields.length > 0 ? identifierFields : (def?.fields ?? [])
+
   const label =
     identity.kind === 'matchField'
-      ? `id: ${identity.connectorFieldKey}`
+      ? `id: ${identity.connectorFieldKey || 'field'}`
       : identity.kind === 'connectorExternalId'
         ? 'id: external'
         : identity.kind === 'manualReview'
           ? 'id: review'
           : 'id'
-
-  const identifierFields = def?.fields.filter((f) => f.isIdentifier) ?? []
 
   return (
     <Popover>
@@ -410,7 +419,7 @@ function IdentityChip({
                 onSave({
                   kind: 'matchField',
                   connectorFieldKey: leaves[0]?.path ?? '',
-                  targetFieldId: identifierFields[0]?.id ?? '',
+                  targetFieldId: targetFields[0]?.id ?? '',
                   normalize: 'none',
                 })
               }
@@ -426,34 +435,56 @@ function IdentityChip({
           </Select>
 
           {identity.kind === 'matchField' && (
-            <div className='flex flex-col gap-2'>
-              <span className='text-xs text-muted-foreground'>Source field</span>
-              <Select
-                value={identity.connectorFieldKey ?? ''}
-                onValueChange={(connectorFieldKey) => {
-                  const current = identity as {
-                    targetFieldId?: string
-                    normalize?: 'email' | 'phone' | 'domain' | 'none'
-                  }
-                  onSave({
-                    kind: 'matchField',
-                    connectorFieldKey,
-                    targetFieldId: current.targetFieldId ?? identifierFields[0]?.id ?? '',
-                    normalize: current.normalize ?? 'none',
-                  })
-                }}>
-                <SelectTrigger size='sm'>
-                  <SelectValue placeholder='Source field…' />
-                </SelectTrigger>
-                <SelectContent>
-                  {leaves.map((p) => (
-                    <SelectItem key={p.path} value={p.path}>
-                      {p.path}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            <>
+              <div className='flex flex-col gap-2'>
+                <span className='text-xs text-muted-foreground'>Source field</span>
+                <Select
+                  value={identity.connectorFieldKey ?? ''}
+                  onValueChange={(connectorFieldKey) =>
+                    onSave({
+                      kind: 'matchField',
+                      connectorFieldKey,
+                      targetFieldId: identity.targetFieldId ?? targetFields[0]?.id ?? '',
+                      normalize: identity.normalize ?? 'none',
+                    })
+                  }>
+                  <SelectTrigger size='sm'>
+                    <SelectValue placeholder='Source field…' />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {leaves.map((p) => (
+                      <SelectItem key={p.path} value={p.path}>
+                        {p.path}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className='flex flex-col gap-2'>
+                <span className='text-xs text-muted-foreground'>Target field</span>
+                <Select
+                  value={identity.targetFieldId ?? ''}
+                  onValueChange={(targetFieldId) =>
+                    onSave({
+                      kind: 'matchField',
+                      connectorFieldKey: identity.connectorFieldKey ?? leaves[0]?.path ?? '',
+                      targetFieldId,
+                      normalize: identity.normalize ?? 'none',
+                    })
+                  }>
+                  <SelectTrigger size='sm'>
+                    <SelectValue placeholder='Target field…' />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {targetFields.map((f) => (
+                      <SelectItem key={f.id} value={f.id}>
+                        {f.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </>
           )}
         </div>
       </PopoverContent>

--- a/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
@@ -334,7 +334,7 @@ export function StreamConfigPanel({ connector, stream, onPromoteField }: StreamC
         onOpenChange={(open) => !open && setSeed(null)}
         title={stream.streamKey}
         initial={seed ?? { schema: EMPTY_SCHEMA, seededFrom: 'empty' }}
-        policy={{ emitRequired: false, root: 'any' }}
+        policy={{ emitRequired: false, root: 'any', rootLabel: 'record', freeformNames: true }}
         onSave={handleSaveSchema}
       />
     </ScrollArea>

--- a/apps/web/src/components/schema-editor/schema-draft.ts
+++ b/apps/web/src/components/schema-editor/schema-draft.ts
@@ -40,7 +40,7 @@ export interface SchemaFieldDraft {
   raw?: Record<string, unknown>
 }
 
-/** Editor policy — the only fork between MCP and workflow modes. */
+/** Editor policy — the per-mode fork (workflow / MCP / data source). */
 export interface SchemaPolicy {
   /** Workflow mode emits the `required` array; MCP mode never does. */
   emitRequired: boolean
@@ -52,6 +52,19 @@ export interface SchemaPolicy {
    * top-level arrays.
    */
   root?: 'object' | 'any'
+  /**
+   * Label on the synthetic root row in the Visual tab. Defaults to
+   * `structured_output` (the editor's workflow origin); other consumers pass a
+   * domain term (e.g. data sources use `record`).
+   */
+  rootLabel?: string
+  /**
+   * Allow arbitrary JSON Schema property names. The default (false) requires
+   * identifier-shaped names so workflow variable paths (`structured_output.x`)
+   * stay clean; data sources / general JSON schemas set this to permit any key
+   * (`Total Price`, `line-items`, …).
+   */
+  freeformNames?: boolean
 }
 
 /**

--- a/apps/web/src/components/schema-editor/ui/schema-editor-dialog.tsx
+++ b/apps/web/src/components/schema-editor/ui/schema-editor-dialog.tsx
@@ -222,7 +222,9 @@ function SchemaEditorBody({
               rows={rows}
               onChange={setRows}
               policy={policy}
-              rootTypeLabel={rootKind === 'array-of-objects' ? 'array of objects' : 'object'}
+              rootKind={rootKind}
+              // Editable root only under `root: 'any'`; workflow's object root is fixed.
+              onRootKindChange={rootPolicy === 'any' ? setRootKind : undefined}
             />
           )
         ) : (

--- a/apps/web/src/components/schema-editor/ui/schema-field-card.tsx
+++ b/apps/web/src/components/schema-editor/ui/schema-field-card.tsx
@@ -5,8 +5,9 @@ import type { SchemaFieldDraft } from '../schema-draft'
 
 /**
  * Compact read row in SOG's plain-text style: bold name, lowercase type, a red
- * "Required" tag, and the description on a muted second line. No chips, no
- * icons — the visual language stays identical to the original editor.
+ * "Required" tag, and an inline (truncated) description. Single-line, so it's the
+ * same height as the edit card — hovering swaps in place without shifting rows.
+ * No chips, no icons — the visual language stays identical to the original editor.
  */
 export function SchemaFieldCard({ row }: { row: SchemaFieldDraft }) {
   const typeLabel = typeLabelOf(pickerValueOf(row))
@@ -14,20 +15,24 @@ export function SchemaFieldCard({ row }: { row: SchemaFieldDraft }) {
   return (
     <div className='flex flex-col py-0.5'>
       <div className='flex h-7 items-center gap-x-1 pl-1 pr-0.5'>
-        <div className='truncate border border-transparent px-1 py-px font-semibold text-sm text-primary-800'>
+        <div className='shrink-0 border border-transparent px-1 py-px font-semibold text-sm text-primary-800'>
           {row.name || 'field'}
         </div>
-        <div className='px-1 py-0.5 text-xs text-muted-foreground'>{typeLabel}</div>
+        <div className='shrink-0 px-1 py-0.5 text-xs text-muted-foreground'>{typeLabel}</div>
         {row.nullable && (
-          <div className='px-1 py-0.5 text-[10px] text-muted-foreground'>nullable</div>
+          <div className='shrink-0 px-1 py-0.5 text-[10px] text-muted-foreground'>nullable</div>
         )}
         {row.required && (
-          <div className='px-1 py-0.5 font-medium text-[10px] text-bad-500 uppercase'>Required</div>
+          <div className='shrink-0 px-1 py-0.5 font-medium text-[10px] text-bad-500 uppercase'>
+            Required
+          </div>
+        )}
+        {row.description && (
+          <div className='min-w-0 truncate px-1 text-xs text-muted-foreground'>
+            {row.description}
+          </div>
         )}
       </div>
-      {row.description && (
-        <div className='truncate px-2 pb-1 text-xs text-muted-foreground'>{row.description}</div>
-      )}
     </div>
   )
 }

--- a/apps/web/src/components/schema-editor/ui/schema-field-edit-card.tsx
+++ b/apps/web/src/components/schema-editor/ui/schema-field-edit-card.tsx
@@ -51,7 +51,7 @@ export function SchemaFieldEditCard({
   onAddChild,
   onFocusEditing,
 }: SchemaFieldEditCardProps) {
-  const nameError = validateFieldName(row.name, siblingNames)
+  const nameError = validateFieldName(row.name, siblingNames, policy.freeformNames)
   const isSelect =
     row.fieldType === FieldType.SINGLE_SELECT || row.fieldType === FieldType.MULTI_SELECT
   const isRaw = !!row.raw
@@ -60,7 +60,7 @@ export function SchemaFieldEditCard({
   return (
     <div className='flex flex-col rounded-lg bg-background py-0.5 shadow-sm'>
       <div className='flex h-7 items-center pl-1 pr-0.5'>
-        <div className='flex grow items-center gap-x-1'>
+        <div className='flex min-w-0 grow items-center gap-x-1'>
           <AutosizeInput
             value={row.name}
             placeholder='Field name'
@@ -87,7 +87,22 @@ export function SchemaFieldEditCard({
             />
           )}
 
-          {nameError && <span className='px-1 text-[10px] text-bad-500'>{nameError}</span>}
+          {/* Description sits inline (same autosize input as the name) so the row
+              stays a single line — hovering never grows it past its read height. */}
+          {!isRaw && (
+            <AutosizeInput
+              value={row.description ?? ''}
+              placeholder='Description'
+              minWidth={80}
+              maxWidth={260}
+              onChange={(e) => onChange({ ...row, description: e.target.value || undefined })}
+              onFocus={() => onFocusEditing(true)}
+              onBlur={() => onFocusEditing(false)}
+              inputClassName='text-xs h-5 rounded-[5px] border border-transparent px-1 py-px text-primary-500 outline-none placeholder:text-primary-400 hover:bg-state-base-hover focus:border-components-input-border-active focus:bg-components-input-bg-active focus:shadow-xs'
+            />
+          )}
+
+          {nameError && <span className='shrink-0 px-1 text-[10px] text-bad-500'>{nameError}</span>}
         </div>
 
         {policy.emitRequired && (
@@ -119,21 +134,9 @@ export function SchemaFieldEditCard({
         </button>
       </div>
 
-      {isRaw ? (
+      {isRaw && (
         <div className='px-2 pb-1 text-[11px] text-muted-foreground italic'>
           Complex schema — edit it in the JSON tab.
-        </div>
-      ) : (
-        <div className='px-2 pb-1'>
-          <input
-            value={row.description ?? ''}
-            placeholder='Description'
-            className='h-4 w-full p-0 text-xs text-primary-500 outline-none placeholder:text-primary-400'
-            onFocus={() => onFocusEditing(true)}
-            onBlur={() => onFocusEditing(false)}
-            onChange={(e) => onChange({ ...row, description: e.target.value || undefined })}
-            onKeyUp={(e) => e.key === 'Enter' && e.currentTarget.blur()}
-          />
         </div>
       )}
 

--- a/apps/web/src/components/schema-editor/ui/schema-field-tree.tsx
+++ b/apps/web/src/components/schema-editor/ui/schema-field-tree.tsx
@@ -1,12 +1,22 @@
 // apps/web/src/components/schema-editor/ui/schema-field-tree.tsx
 
+import { BaseType } from '@auxx/lib/workflow-engine/client'
 import { Button } from '@auxx/ui/components/button'
 import { Separator } from '@auxx/ui/components/separator'
 import { cn } from '@auxx/ui/lib/utils'
 import { ChevronDown, ChevronRight, PlusCircle } from 'lucide-react'
 import { type ReactNode, useCallback, useState } from 'react'
-import { addField, removeRow, siblingNames, updateRow } from '../draft-ops'
-import type { SchemaFieldDraft, SchemaPolicy } from '../schema-draft'
+import { VariableTypePicker } from '~/components/workflow/ui/variable-type-picker'
+import {
+  addField,
+  removeRow,
+  STRUCTURAL_ARRAY,
+  STRUCTURAL_OBJECT,
+  siblingNames,
+  typeLabelOf,
+  updateRow,
+} from '../draft-ops'
+import type { SchemaFieldDraft, SchemaPolicy, SchemaRootKind } from '../schema-draft'
 import { SchemaFieldCard } from './schema-field-card'
 import { SchemaFieldEditCard } from './schema-field-edit-card'
 
@@ -17,9 +27,12 @@ interface SchemaFieldTreeProps {
   rows: SchemaFieldDraft[]
   onChange: (rows: SchemaFieldDraft[]) => void
   policy: SchemaPolicy
-  /** Type annotation on the synthetic root (e.g. `array of objects` for an
-   *  array-of-objects root). Defaults to `object`. */
-  rootTypeLabel?: string
+  /** Current root kind — drives the root type label / picker. The tree only
+   *  renders for object / array-of-objects roots ('other' is JSON-tab only). */
+  rootKind?: SchemaRootKind
+  /** When provided, the root type becomes an editable object ⇄ array-of-objects
+   *  picker; omitted (workflow's fixed object root) renders a static label. */
+  onRootKindChange?: (kind: SchemaRootKind) => void
 }
 
 /**
@@ -35,8 +48,10 @@ export function SchemaFieldTree({
   rows,
   onChange,
   policy,
-  rootTypeLabel = 'object',
+  rootKind = 'object',
+  onRootKindChange,
 }: SchemaFieldTreeProps) {
+  const rootLabel = policy.rootLabel ?? 'structured_output'
   const [hoveredId, setHoveredId] = useState<string | null>(null)
   const [focusedId, setFocusedId] = useState<string | null>(null)
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
@@ -117,12 +132,10 @@ export function SchemaFieldTree({
           </div>
         </div>
 
-        {/* Vertical connector down the left of this node's subtree. */}
+        {/* Vertical connector down the left of this node's subtree. Rows are a
+            single line (description is inline), so the offset is uniform. */}
         <div
-          className={cn(
-            'absolute z-0 flex w-5 justify-center',
-            row.description ? 'top-12 h-[calc(100%-3rem)]' : 'top-7 h-[calc(100%-1.75rem)]'
-          )}
+          className='absolute top-7 z-0 flex h-[calc(100%-1.75rem)] w-5 justify-center'
           style={{ left: depth * INDENT }}>
           <Separator
             orientation='vertical'
@@ -146,9 +159,17 @@ export function SchemaFieldTree({
         <div className='relative z-10'>
           <div className='flex h-7 items-center gap-x-1 pl-1 pr-0.5'>
             <span className='border border-transparent px-1 py-px font-semibold text-sm text-primary-800'>
-              structured_output
+              {rootLabel}
             </span>
-            <span className='px-1 py-0.5 text-xs text-muted-foreground'>{rootTypeLabel}</span>
+            {onRootKindChange ? (
+              <RootTypeSelector rootKind={rootKind} onChange={onRootKindChange} />
+            ) : (
+              <span className='px-1 py-0.5 text-xs text-muted-foreground'>
+                {typeLabelOf(
+                  rootKind === 'array-of-objects' ? STRUCTURAL_ARRAY : STRUCTURAL_OBJECT
+                )}
+              </span>
+            )}
           </div>
         </div>
         <div className='absolute top-7 z-0 flex h-[calc(100%-1.75rem)] w-5 justify-center left-0'>
@@ -158,6 +179,48 @@ export function SchemaFieldTree({
         <AddField depth={1} onClick={() => handleAdd(null)} />
       </div>
     </div>
+  )
+}
+
+/** Every `BaseType` except `object` — the root picker offers object only,
+ *  with the Array toggle flipping object ⇄ array-of-objects. */
+const ROOT_EXCLUDED_TYPES: BaseType[] = Object.values(BaseType).filter(
+  (type) => type !== BaseType.OBJECT
+)
+
+/**
+ * The root type control — the same `VariableTypePicker` the field edit card uses,
+ * behind the same ghost trigger. The base type is pinned to `object`; the picker's
+ * Array toggle is the real control, mapping to `array-of-objects`. Search is
+ * hidden (a single base type), so the popover is just the toggle.
+ */
+function RootTypeSelector({
+  rootKind,
+  onChange,
+}: {
+  rootKind: SchemaRootKind
+  onChange: (kind: SchemaRootKind) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const isArray = rootKind === 'array-of-objects'
+  return (
+    <VariableTypePicker
+      value={{ baseType: BaseType.OBJECT, isArray }}
+      onChange={(next) => onChange(next.isArray ? 'array-of-objects' : 'object')}
+      excludeTypes={ROOT_EXCLUDED_TYPES}
+      includeArrayToggle
+      showSearch={false}
+      open={open}
+      onOpenChange={setOpen}
+      align='start'
+      popoverWidth={208}>
+      <Button variant='ghost' size='xs' className={cn(open && 'bg-state-base-hover')}>
+        <span className='system-xs-medium text-primary-500'>
+          {typeLabelOf(isArray ? STRUCTURAL_ARRAY : STRUCTURAL_OBJECT)}
+        </span>
+        <ChevronDown className='size-4 text-primary-500' />
+      </Button>
+    </VariableTypePicker>
   )
 }
 

--- a/apps/web/src/components/schema-editor/validation.ts
+++ b/apps/web/src/components/schema-editor/validation.ts
@@ -101,12 +101,17 @@ export function checkJsonSchemaDepth(schema: unknown, depth = 0): number {
 
 /**
  * Validate a field (property) name against its siblings. Returns an error
- * string, or null when valid. JSON Schema keys can be arbitrary strings, but we
- * require identifier-shaped names so generated variable paths stay clean.
+ * string, or null when valid. JSON Schema keys can be arbitrary strings; the
+ * identifier-shaped rule keeps generated workflow variable paths clean, so it's
+ * skipped under `freeformNames` (data sources / general JSON schemas).
  */
-export function validateFieldName(name: string, siblingNames: string[] = []): string | null {
+export function validateFieldName(
+  name: string,
+  siblingNames: string[] = [],
+  freeformNames = false
+): string | null {
   if (!name || name.trim() === '') return 'Field name is required'
-  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+  if (!freeformNames && !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
     return 'Use letters, numbers, and underscores; must start with a letter or underscore'
   }
   if (siblingNames.includes(name)) return 'Field name already exists'

--- a/apps/web/src/server/api/routers/credentials.ts
+++ b/apps/web/src/server/api/routers/credentials.ts
@@ -23,6 +23,14 @@ const credentialRegistry = new CredentialTypeRegistry()
 /** The four credential families (mirrors `CredentialKind` in @auxx/credentials). */
 const credentialKindSchema = z.enum(['app', 'mcp', 'integration', 'workflow'])
 
+/**
+ * Consecutive refresh failures at which a connection's circuit breaker is
+ * "open" — mirrors `CONNECTION_CIRCUIT_OPEN_THRESHOLD` in
+ * `@auxx/services/app-connections`. At or above this, the credential is
+ * surfaced as `expired` so a uniform status applies to every kind.
+ */
+const CONNECTION_CIRCUIT_OPEN_THRESHOLD = 5
+
 export const credentialsRouter = createTRPCRouter({
   /**
    * Create a new workflow credential
@@ -33,6 +41,12 @@ export const credentialsRouter = createTRPCRouter({
         type: z.string().min(1, 'Credential type is required'),
         name: z.string().min(1, 'Credential name is required'),
         data: z.record(z.string(), z.any()).describe('Credential data (API keys, tokens, etc.)'),
+        /**
+         * Credential family to create under. Defaults to `workflow` so the
+         * workflow-credentials UI keeps minting workflow creds; data connectors
+         * pass `integration` for app-less sync secrets.
+         */
+        kind: credentialKindSchema.optional(),
       })
     )
     .use(notDemo('create credentials'))
@@ -48,7 +62,7 @@ export const credentialsRouter = createTRPCRouter({
       const result = await insertCredential({
         organizationId: ctx.session.user.defaultOrganizationId,
         createdById: ctx.session.user.id,
-        kind: 'workflow',
+        kind: input.kind ?? 'workflow',
         type: input.type,
         name: input.name,
         secrets,
@@ -83,6 +97,13 @@ export const credentialsRouter = createTRPCRouter({
             .union([credentialKindSchema, credentialKindSchema.array().min(1)])
             .optional()
             .describe('Filter by credential family'),
+          /**
+           * When true, only org-scoped (workspace) connections are returned —
+           * personal/user-scoped creds are excluded. Background resources like
+           * data connectors must bind org-scoped creds so they don't break for
+           * other users.
+           */
+          orgScopedOnly: z.boolean().optional(),
         })
         .optional()
     )
@@ -98,6 +119,9 @@ export const credentialsRouter = createTRPCRouter({
         organizationId: ctx.session.user.defaultOrganizationId,
         kind: input?.kind ?? 'workflow',
         type: input?.type,
+        // `userId: null` filters to org-scoped rows; omitting the key entirely
+        // leaves user scope unfiltered (the workflow-credentials default).
+        ...(input?.orgScopedOnly ? { userId: null } : {}),
         withCreatedBy: true,
       })
 
@@ -108,13 +132,27 @@ export const credentialsRouter = createTRPCRouter({
         })
       }
 
-      return result.value.map((record) => ({
-        id: record.id,
-        name: record.name,
-        type: record.type ?? '',
-        createdAt: record.createdAt,
-        createdBy: { name: record.createdByName },
-      }))
+      const now = new Date()
+      return result.value.map((record) => {
+        const expired =
+          record.consecutiveRefreshFailures >= CONNECTION_CIRCUIT_OPEN_THRESHOLD ||
+          (record.expiresAt !== null && record.expiresAt < now)
+        return {
+          id: record.id,
+          name: record.name,
+          type: record.type ?? '',
+          kind: record.kind,
+          label: record.label,
+          appId: record.appId,
+          appInstallationId: record.appInstallationId,
+          // user-scoped vs org-scoped — reconnect picks the matching connection
+          // definition by scope (05c §2).
+          scope: record.userId ? ('user' as const) : ('organization' as const),
+          status: expired ? ('expired' as const) : ('connected' as const),
+          createdAt: record.createdAt,
+          createdBy: { name: record.createdByName },
+        }
+      })
     }),
 
   /**

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -296,8 +296,12 @@ export const dataConnectorRouter = createTRPCRouter({
   // ── Stream setup (admin) ──────────────────────────────────────────────────
 
   /**
-   * Live test-fetch → raw JSON records for schema inference + mapping preview.
-   * Capped small. App connectors aren't wired yet (phase 4) — guarded.
+   * Live test-fetch → the RAW source records (each `ConnectorRecord.fields`, not
+   * the envelope). The source schema and all mapping paths are expressed against
+   * the raw record, so inference + the picker must see the raw record — the
+   * connector's derived `externalId`/`displayName` are sync-time lineage, not
+   * part of the authored source shape. Capped small. App connectors aren't wired
+   * yet (phase 4) — guarded.
    */
   sampleFetch: adminProcedure
     .input(
@@ -331,7 +335,7 @@ export const dataConnectorRouter = createTRPCRouter({
       const sample: unknown[] = []
       try {
         for await (const record of records) {
-          sample.push(record)
+          sample.push(record.fields)
           if (sample.length >= SAMPLE_FETCH_CAP) break
         }
       } catch (error) {

--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -97,19 +97,42 @@ export interface FieldMapping {
 
 /**
  * Per-field write behavior (jsonb on {@link DataConnectorMapping}, keyed by
- * target field key). Decision #13. Refined in sub-plan 02.
+ * target field key). MUST mirror the engine `FieldMergeStrategy` in
+ * `@auxx/lib/data-connectors/types` (this package can't import tier-3 lib).
  */
-export type FieldMergeStrategy = 'overwrite' | 'fill_if_empty' | 'append' | 'ignore'
+export type FieldMergeStrategy =
+  | 'overwrite'
+  | 'fill_blank'
+  | 'connector_owned_only'
+  | 'manual_review'
+  | 'ignore'
+
+/**
+ * Identity match normalizers — mirror of the engine union.
+ */
+export type IdentityNormalize = 'email' | 'phone' | 'domain' | 'none'
 
 /**
  * How upstream records match existing records (jsonb on
- * {@link DataConnectorMapping}). Decision #12. Refined in sub-plan 02.
+ * {@link DataConnectorMapping}). MUST mirror the engine `IdentityStrategy` in
+ * `@auxx/lib/data-connectors/types` (this package can't import tier-3 lib):
+ *  - `matchField`/`composite` pair a subtree-relative source path
+ *    (`connectorFieldKey`) with the target field it must equal (`targetFieldId`).
  */
-export interface IdentityStrategy {
-  /** 'external-id' (default) | 'field-match' | 'composite'. */
-  kind: 'external-id' | 'field-match' | 'composite'
-  /** Source path(s) forming the upstream stable id / match key. */
-  sourceIdPath?: string
-  /** Target field keys used for field-match / composite identity. */
-  matchFields?: string[]
-}
+export type IdentityStrategy =
+  | { kind: 'connectorExternalId' }
+  | {
+      kind: 'matchField'
+      connectorFieldKey: string
+      targetFieldId: string
+      normalize?: IdentityNormalize
+    }
+  | {
+      kind: 'composite'
+      rules: Array<{
+        connectorFieldKey: string
+        targetFieldId: string
+        normalize?: IdentityNormalize
+      }>
+    }
+  | { kind: 'manualReview' }

--- a/packages/lib/src/data-connectors/map-record.test.ts
+++ b/packages/lib/src/data-connectors/map-record.test.ts
@@ -1,0 +1,114 @@
+// packages/lib/src/data-connectors/map-record.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { ConnectorRecord } from './connectors/types'
+import { mapRecord } from './map-record'
+import type { DecodedMapping } from './service'
+
+/** Build a DecodedMapping with sensible defaults; override what the test cares about. */
+function mapping(over: Partial<DecodedMapping> & { id?: string }): DecodedMapping {
+  const { id = 'm1', ...rest } = over
+  return {
+    row: { id } as DecodedMapping['row'],
+    rootPath: '',
+    linkMode: 'upsert',
+    targetMode: 'owned',
+    entityDefinitionId: 'def1',
+    parentMappingId: null,
+    relationshipFieldKey: null,
+    orphanBehavior: 'ignore',
+    identityStrategy: { kind: 'connectorExternalId' },
+    fieldMappings: {},
+    mergeStrategies: {},
+    ...rest,
+  }
+}
+
+function source(fields: Record<string, unknown>): ConnectorRecord {
+  return { streamKey: 'order', externalId: 'o1', displayName: 'Order', fields }
+}
+
+describe('mapRecord', () => {
+  it('resolves a root mapping field path relative to the whole record', () => {
+    const m = mapping({
+      fieldMappings: {
+        total: { expression: '{total_price}', sourceFields: { total_price: 'total_price' } },
+      },
+    })
+
+    const writes = mapRecord([m], source({ total_price: '49.99', customer: { email: 'a@b.com' } }))
+
+    expect(writes).toHaveLength(1)
+    expect(writes[0]?.projected?.fields).toEqual({ total: '49.99' })
+    expect(writes[0]?.projected?.externalId).toBe('o1')
+    // connectorExternalId contributes no identity candidates.
+    expect(writes[0]?.projected?.identityCandidates).toEqual([])
+  })
+
+  it('fans out an array mapping, resolving field paths relative to each element', () => {
+    const m = mapping({
+      id: 'li',
+      rootPath: 'line_items[]',
+      fieldMappings: { sku: { expression: '{sku}', sourceFields: { sku: 'sku' } } },
+    })
+
+    const writes = mapRecord(
+      [m],
+      source({
+        line_items: [
+          { sku: 'A', price: 1 },
+          { sku: 'B', price: 2 },
+        ],
+      })
+    )
+
+    expect(writes).toHaveLength(2)
+    expect(writes.map((w) => w.projected?.fields.sku)).toEqual(['A', 'B'])
+    // No natural id on the element → synthetic `${parentExternalId}:${index}`.
+    expect(writes.map((w) => w.projected?.externalId)).toEqual(['o1:0', 'o1:1'])
+  })
+
+  it('resolves matchField identity from the subtree via a relative connectorFieldKey', () => {
+    const m = mapping({
+      id: 'cust',
+      rootPath: 'customer',
+      targetMode: 'contributing',
+      identityStrategy: {
+        kind: 'matchField',
+        connectorFieldKey: 'email', // relative to rootPath 'customer'
+        targetFieldId: 'contact_email',
+        normalize: 'email',
+      },
+      fieldMappings: {
+        contact_email: { expression: '{email}', sourceFields: { email: 'email' } },
+      },
+    })
+
+    const writes = mapRecord([m], source({ customer: { email: 'a@b.com', name: 'Acme' } }))
+
+    expect(writes).toHaveLength(1)
+    expect(writes[0]?.projected?.identityCandidates).toEqual([
+      { targetFieldId: 'contact_email', value: 'a@b.com', normalize: 'email' },
+    ])
+  })
+
+  it('orders the root mapping first and wires child parentRelations', () => {
+    const root = mapping({ id: 'root', rootPath: '' })
+    const child = mapping({
+      id: 'child',
+      rootPath: 'customer',
+      parentMappingId: 'root',
+      relationshipFieldKey: 'customer',
+    })
+
+    const writes = mapRecord([child, root], source({ customer: { id: 'c1' } }))
+
+    expect(writes[0]?.mapping.row.id).toBe('root')
+    const childWrite = writes.find((w) => w.mapping.row.id === 'child')
+    expect(childWrite?.parentRelation).toMatchObject({
+      parentMappingId: 'root',
+      fieldKey: 'customer',
+      targetExternalId: 'c1',
+    })
+  })
+})

--- a/packages/lib/src/data-connectors/map-record.ts
+++ b/packages/lib/src/data-connectors/map-record.ts
@@ -101,6 +101,36 @@ function evaluateFields(mapping: DecodedMapping, subtree: unknown): Record<strin
   return out
 }
 
+/**
+ * Resolve a mapping's identity match values from the source subtree. matchField/
+ * composite read a subtree-relative source path (`connectorFieldKey`) and pair it
+ * with the target field it must equal; the sink normalizes + looks up. Other
+ * strategies (connectorExternalId / manualReview) contribute no candidates.
+ */
+function identityCandidates(
+  mapping: DecodedMapping,
+  subtree: unknown
+): ProjectedRecord['identityCandidates'] {
+  const strategy = mapping.identityStrategy
+  const rules =
+    strategy.kind === 'matchField'
+      ? [
+          {
+            connectorFieldKey: strategy.connectorFieldKey,
+            targetFieldId: strategy.targetFieldId,
+            normalize: strategy.normalize,
+          },
+        ]
+      : strategy.kind === 'composite'
+        ? strategy.rules
+        : []
+  return rules.map((r) => ({
+    targetFieldId: r.targetFieldId,
+    value: getByPath(subtree, r.connectorFieldKey),
+    normalize: r.normalize,
+  }))
+}
+
 /** Derive the external id of a subtree (its own id, falling back to index). */
 function subtreeExternalId(
   parentExternalId: string,
@@ -183,6 +213,7 @@ export function mapRecord(mappings: DecodedMapping[], source: ConnectorRecord): 
           externalId,
           displayName,
           fields,
+          identityCandidates: identityCandidates(mapping, subtree),
           pendingRelations: [],
         },
         parentRelation,

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -329,7 +329,7 @@ export async function addMapping(
       entityDefinitionId: input.entityDefinitionId,
       parentMappingId: input.parentMappingId ?? null,
       relationshipFieldKey: input.relationshipFieldKey ?? null,
-      identityStrategy: input.identityStrategy as unknown as Record<string, unknown>,
+      identityStrategy: input.identityStrategy,
       fieldMappings: input.fieldMappings ?? {},
       mergeStrategies: input.mergeStrategies ?? {},
       orphanBehavior: input.orphanBehavior ?? 'ignore',
@@ -450,7 +450,7 @@ export async function setIdentityStrategy(
   const [row] = await db
     .update(schema.DataConnectorMapping)
     .set({
-      identityStrategy: identityStrategy as unknown as Record<string, unknown>,
+      identityStrategy,
       updatedAt: new Date(),
     })
     .where(eq(schema.DataConnectorMapping.id, mappingId))

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -67,9 +67,9 @@ export function decodeMapping(row: DataConnectorMappingRow): DecodedMapping {
     parentMappingId: row.parentMappingId ?? null,
     relationshipFieldKey: row.relationshipFieldKey ?? null,
     orphanBehavior: row.orphanBehavior as OrphanBehavior,
-    identityStrategy: row.identityStrategy as unknown as IdentityStrategy,
-    fieldMappings: (row.fieldMappings as Record<string, FieldMapping>) ?? {},
-    mergeStrategies: (row.mergeStrategies as Record<string, FieldMergeStrategy>) ?? {},
+    identityStrategy: row.identityStrategy,
+    fieldMappings: row.fieldMappings ?? {},
+    mergeStrategies: row.mergeStrategies ?? {},
   }
 }
 

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -23,7 +23,6 @@ import {
   touchItem,
   upsertItem,
 } from '../service'
-import type { IdentityStrategy } from '../types'
 import type { EntitySink, ProjectedRecord, SyncCtx } from './types'
 
 const logger = createScopedLogger('data-connector-entity-sink')
@@ -77,29 +76,13 @@ async function resolveIdentity(
     return { instanceId: null }
   }
 
-  const rules =
-    strategy.kind === 'composite'
-      ? strategy.rules
-      : [
-          {
-            connectorFieldKey: (strategy as Extract<IdentityStrategy, { kind: 'matchField' }>)
-              .connectorFieldKey,
-            targetFieldId: (strategy as Extract<IdentityStrategy, { kind: 'matchField' }>)
-              .targetFieldId,
-            normalize: (strategy as Extract<IdentityStrategy, { kind: 'matchField' }>).normalize,
-          },
-        ]
-
-  // Build lookup candidates from the projected (target-keyed) fields. The
-  // connectorFieldKey/targetFieldId both address a target field key here because
-  // the mapping layer already projected source → target keys.
-  const candidates = rules
-    .map((r) => {
-      const value = record.fields[r.targetFieldId] ?? record.fields[r.connectorFieldKey]
-      if (isBlank(value)) return null
-      // The crud lookup keys candidates by systemAttribute; resolve id → systemAttribute
-      // is unnecessary because lookupByField accepts systemAttribute directly.
-      return { systemAttribute: r.targetFieldId, value: normalizeMatch(value, r.normalize) }
+  // Match values were resolved from the SOURCE record by the mapping layer
+  // (matchField/composite → identityCandidates). The crud lookup keys candidates
+  // by systemAttribute (= the target field), which lookupByField accepts directly.
+  const candidates = record.identityCandidates
+    .map((c) => {
+      if (isBlank(c.value)) return null
+      return { systemAttribute: c.targetFieldId, value: normalizeMatch(c.value, c.normalize) }
     })
     .filter((c): c is { systemAttribute: string; value: string } => c !== null)
 

--- a/packages/lib/src/data-connectors/sinks/types.ts
+++ b/packages/lib/src/data-connectors/sinks/types.ts
@@ -11,6 +11,17 @@ export interface ProjectedRecord {
   displayName: string
   /** Mapped to TARGET field keys (the mapping layer already evaluated CALC). */
   fields: Record<string, unknown>
+  /**
+   * Identity match values resolved from the SOURCE record (matchField/composite),
+   * each pairing a target field with the source value it must equal. Pre-resolved
+   * by the mapping layer because the sink has no access to the source subtree.
+   * Empty for connectorExternalId / manualReview.
+   */
+  identityCandidates: Array<{
+    targetFieldId: string
+    value: unknown
+    normalize?: 'email' | 'phone' | 'domain' | 'none'
+  }>
   /** Pending relations to register on this record's item (resolved in the two-pass). */
   pendingRelations: PendingRelation[]
   /** Upstream last-modified, if the source carries one. */

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -161,7 +161,12 @@ export interface DataConnectorDefinition {
 
 /**
  * How an incoming upstream record is matched to an existing entity record.
- * Stored on DataConnectorMapping.identityStrategy (jsonb).
+ * Stored on DataConnectorMapping.identityStrategy (jsonb). `matchField`/
+ * `composite` match a SOURCE field's value against a TARGET field on the entity:
+ *  - `connectorFieldKey` — a subtree-relative source path (like `sourceFields`),
+ *    read straight from the source record.
+ *  - `targetFieldId` — the entity field whose value must equal it (often an
+ *    app-`defineField`'d field, e.g. `email`).
  */
 export type IdentityStrategy =
   | { kind: 'connectorExternalId' }

--- a/packages/sdk/__fixtures__/connector-app/src/shopify-core.connector.ts
+++ b/packages/sdk/__fixtures__/connector-app/src/shopify-core.connector.ts
@@ -80,8 +80,9 @@ export const shopifyCoreDataConnector = defineDataConnector({
             mode: 'contributing',
             entityKind: 'contact',
             identity: {
+              // connectorFieldKey is subtree-relative to rootPath ('customer').
               kind: 'matchField',
-              connectorFieldKey: 'customer.email',
+              connectorFieldKey: 'email',
               targetFieldId: 'email',
               normalize: 'email',
             },

--- a/packages/sdk/src/util/__tests__/compile-and-extract-catalog-connectors.test.ts
+++ b/packages/sdk/src/util/__tests__/compile-and-extract-catalog-connectors.test.ts
@@ -80,7 +80,7 @@ describe('compileAndExtractCatalog — data connectors', () => {
       target: {
         mode: 'contributing',
         entityKind: 'contact',
-        identity: { kind: 'matchField', connectorFieldKey: 'customer.email', normalize: 'email' },
+        identity: { kind: 'matchField', connectorFieldKey: 'email', normalize: 'email' },
       },
     })
     expect(mappings[3]).toMatchObject({


### PR DESCRIPTION
## Summary

Continues the data-connectors work (#893, #894). Two main threads: a reusable connection picker that replaces the app-only account popover, and identity matching that resolves match values from the source record at the mapping layer.

### Connection picker
- New `ConnectionPicker` / `ConnectionPickerPopover` (`apps/web/src/components/apps/ui/`): credential-agnostic, lists any bindable org connection (app OAuth, integration secret, workflow API key) grouped by family, with per-row **Reconnect** (app rows) / **Edit** (integration secrets) and a **+ New connection** mint flow.
- The connector connection section now uses it; binding records `appInstallationId` when present so token refresh + lifecycle stay wired.

### Credentials router
- `create` accepts a `kind` — data connectors mint `integration` secrets instead of always `workflow`.
- `list` gains `orgScopedOnly` (background resources bind org-scoped creds only) and surfaces `kind` / `label` / `appId` / `appInstallationId` / `scope` plus a uniform `connected | expired` status (expiry or circuit-breaker open).

### Identity matching
- matchField/composite values are now resolved from the **source** subtree at the mapping layer (`ProjectedRecord.identityCandidates`); the entity sink consumes pre-resolved candidates instead of re-deriving from target fields.
- `connectorFieldKey` is subtree-relative to `rootPath` (e.g. a `customer` mapping references `email`, not `customer.email`).
- `leafPathsUnder` returns subtree-relative paths to match the sync runtime; field-calc + identity pickers use them.
- `sampleFetch` returns the raw `record.fields` (the authored source shape), not the connector envelope.
- Tightened `IdentityStrategy` / `FieldMergeStrategy` schema types to mirror the engine union; dropped unsafe jsonb casts.

### Schema editor (data-source mode)
- Freeform property names, editable object ⇄ array-of-objects root, configurable root label, and inline single-line description rows.

## Test plan
- `packages/lib/src/data-connectors/map-record.test.ts` — identity resolution from source subtree.
- `apps/web/src/components/data-connectors/hooks/use-source-paths.test.ts` — `leafPathsUnder` relative paths.
- SDK catalog fixture/test updated for subtree-relative `connectorFieldKey`.