### PR TITLE
feat(data-connectors): field-type-aware mapping with compatibility guards

### DIFF
--- a/apps/web/src/components/custom-fields/hooks/use-custom-field-mutations.tsx
+++ b/apps/web/src/components/custom-fields/hooks/use-custom-field-mutations.tsx
@@ -1,7 +1,10 @@
 // apps/web/src/components/custom-fields/hooks/use-custom-field-mutations.tsx
 
 import type { FieldType, FieldType as FieldTypeEnum } from '@auxx/database/types'
-import { PRIMARY_DISPLAY_ELIGIBLE_TYPES } from '@auxx/lib/custom-fields/client'
+import {
+  getEffectiveFieldType,
+  PRIMARY_DISPLAY_ELIGIBLE_TYPES,
+} from '@auxx/lib/custom-fields/client'
 import type { FieldCapabilities, ResourceField } from '@auxx/lib/resources/client'
 import { mapFieldTypeToBaseType } from '@auxx/lib/workflow-engine/client'
 import {
@@ -60,8 +63,13 @@ export function useCustomFieldMutations({ entityDefinitionId }: UseCustomFieldMu
       const tempId = `temp_${Date.now()}`
       const tempKey = toResourceFieldId(effectiveEntityDefId, toFieldId(tempId))
 
-      // Determine base type from field type
-      const baseType = mapFieldTypeToBaseType(variables.type)
+      // Determine base type from field type. For CALC the workflow base type
+      // follows the result type (CALC itself isn't modeled by
+      // mapFieldTypeToBaseType); getEffectiveFieldType returns resultFieldType
+      // for CALC and the field type itself for everything else.
+      const baseType = mapFieldTypeToBaseType(
+        getEffectiveFieldType({ fieldType: variables.type, options: variables.options })
+      )
 
       // Build capabilities (defaults for custom fields)
       const capabilities: FieldCapabilities = {
@@ -135,8 +143,11 @@ export function useCustomFieldMutations({ entityDefinitionId }: UseCustomFieldMu
       // Build the server field's key
       const serverKey = toResourceFieldId(effectiveEntityDefId, toFieldId(result.id))
 
-      // Determine base type from field type
-      const baseType = mapFieldTypeToBaseType(result.type)
+      // Determine base type from field type — CALC follows its result type
+      // (see the create-onMutate note above).
+      const baseType = mapFieldTypeToBaseType(
+        getEffectiveFieldType({ fieldType: result.type, options: result.options })
+      )
 
       // Build capabilities from server response
       const capabilities: FieldCapabilities = {

--- a/apps/web/src/components/custom-fields/ui/ai-prompt-editor/ai-prompt-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/ai-prompt-editor/ai-prompt-editor.tsx
@@ -8,7 +8,8 @@ import { type FieldReference, fieldRefToKey } from '@auxx/types/field'
 import { CommandNavigation } from '@auxx/ui/components/command'
 import { Field, FieldDescription, FieldLabel } from '@auxx/ui/components/field'
 import { EditorContent } from '@tiptap/react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo } from 'react'
+import { InlinePickerPopover, useActivePicker } from '~/components/editor/inline-picker'
 import {
   type ExcludeFilter,
   FieldPickerInnerContent,
@@ -44,15 +45,15 @@ export function AiPromptEditor({
   currentFieldId,
   excludeFieldIds,
 }: AiPromptEditorProps) {
-  const editorContainerRef = useRef<HTMLDivElement>(null)
-  const pickerRef = useRef<HTMLDivElement>(null)
-  const [popoverPosition, setPopoverPosition] = useState<{ top: number; left: number } | null>(null)
-
-  const { editor, suggestionState, insertField, closeSuggestion } = useAiPrompt({
+  const { editor, insertField, closePicker } = useAiPrompt({
     initialPrompt: prompt,
     onChange,
     entityDefinitionId,
   })
+
+  // Drive the picker popover off the open `{` chip.
+  const activePicker = useActivePicker(editor)
+  const pickerOpen = !!activePicker && activePicker.trigger === '{'
 
   // Encode the picker's FieldReference (ResourceFieldId or FieldPath) as a
   // single string key via `fieldRefToKey`. The server's reference-resolver
@@ -76,64 +77,36 @@ export function AiPromptEditor({
     [entityDefinitionId, currentFieldId, excludeFieldIds]
   )
 
-  useEffect(() => {
-    if (suggestionState.isOpen && suggestionState.clientRect && editorContainerRef.current) {
-      const containerRect = editorContainerRef.current.getBoundingClientRect()
-      const cursorRect = suggestionState.clientRect
-      setPopoverPosition({
-        top: cursorRect.bottom - containerRect.top,
-        left: cursorRect.left - containerRect.left,
-      })
-    }
-  }, [suggestionState.isOpen, suggestionState.clientRect])
-
-  useEffect(() => {
-    if (!suggestionState.isOpen) return
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (pickerRef.current && !pickerRef.current.contains(event.target as Node)) {
-        closeSuggestion()
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [suggestionState.isOpen, closeSuggestion])
-
   return (
     <Field>
       <FieldLabel>Prompt</FieldLabel>
-      <div ref={editorContainerRef} className='relative rounded-md border bg-background'>
+      <div className='relative rounded-md border bg-background'>
         <EditorContent editor={editor} className='min-h-[80px]' />
-
-        {suggestionState.isOpen && popoverPosition && (
-          <div
-            ref={pickerRef}
-            className='absolute z-50'
-            style={{ top: popoverPosition.top, left: popoverPosition.left }}>
-            <div
-              className='w-[320px] rounded-lg border bg-popover shadow-lg'
-              onMouseDown={(e) => e.preventDefault()}
-              onKeyDown={(e) => {
-                if (e.key === 'Escape') {
-                  e.stopPropagation()
-                  closeSuggestion()
-                }
-              }}>
-              <CommandNavigation<FieldPickerNavigationItem>>
-                <FieldPickerInnerContent
-                  entityDefinitionId={entityDefinitionId}
-                  excludeFields={excludeFilters}
-                  onSelect={handleSelectField}
-                  onClose={closeSuggestion}
-                  closeOnSelect
-                  showBreadcrumb={false}
-                  searchPlaceholder='Search fields...'
-                />
-              </CommandNavigation>
-            </div>
-          </div>
-        )}
       </div>
+
+      {editor && (
+        <InlinePickerPopover
+          state={{
+            isOpen: pickerOpen,
+            query: activePicker?.query ?? '',
+            range: null,
+            clientRect: activePicker?.clientRect ?? null,
+          }}
+          width={320}
+          onClose={closePicker}>
+          <CommandNavigation<FieldPickerNavigationItem>>
+            <FieldPickerInnerContent
+              entityDefinitionId={entityDefinitionId}
+              excludeFields={excludeFilters}
+              onSelect={handleSelectField}
+              onClose={closePicker}
+              closeOnSelect
+              showBreadcrumb={false}
+              searchPlaceholder='Search fields...'
+            />
+          </CommandNavigation>
+        </InlinePickerPopover>
+      )}
       <FieldDescription>
         Type <kbd className='rounded bg-muted px-1 text-xs'>{'{'}</kbd> to insert a field reference.
       </FieldDescription>

--- a/apps/web/src/components/custom-fields/ui/ai-prompt-editor/use-ai-prompt.tsx
+++ b/apps/web/src/components/custom-fields/ui/ai-prompt-editor/use-ai-prompt.tsx
@@ -6,11 +6,11 @@ import { extractFieldIdsFromPrompt, type RichReferencePrompt } from '@auxx/types
 import Placeholder from '@tiptap/extension-placeholder'
 import { type Editor, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import {
   createInlineNode,
-  createInlinePickerExtension,
-  type InlinePickerState,
+  getOpenPickerRange,
+  ReferencePickerNode,
 } from '~/components/editor/inline-picker'
 import { FieldBadge } from '~/components/resources/ui'
 
@@ -34,17 +34,14 @@ export interface UseAiPromptOptions {
   placeholder?: string
 }
 
-const closedSuggestionState: InlinePickerState = {
-  isOpen: false,
-  query: '',
-  range: null,
-  clientRect: null,
-}
-
 /**
  * TipTap hook for the AI prompt editor. Mirrors `useCalcFormula` but drops
  * the calc-expression validation and function-picker affordances: an AI
  * prompt is free text with inline `{fieldId}` references, nothing more.
+ *
+ * The `{`-triggered field picker rides on the shared `ReferencePickerNode`
+ * chip; the consumer mounts the popover via `useActivePicker` +
+ * `InlinePickerPopover` and commits selections through `insertField`.
  */
 export function useAiPrompt({
   initialPrompt,
@@ -52,33 +49,13 @@ export function useAiPrompt({
   entityDefinitionId,
   placeholder = 'Type { to insert a field, e.g., "Write a one-line intro for {fullName} who works at {company}."',
 }: UseAiPromptOptions) {
-  const [suggestionState, setSuggestionState] = useState<InlinePickerState>(closedSuggestionState)
   const onChangeRef = useRef(onChange)
-  const suggestionRangeRef = useRef<{ from: number; to: number } | null>(null)
 
   useEffect(() => {
     onChangeRef.current = onChange
   }, [onChange])
 
-  useEffect(() => {
-    suggestionRangeRef.current = suggestionState.range
-  }, [suggestionState.range])
-
   const initialContent = useMemo(() => initialPrompt ?? emptyPromptDoc(), [initialPrompt])
-
-  const handleSuggestionStateChange = useCallback((state: InlinePickerState) => {
-    setSuggestionState(state)
-  }, [])
-
-  const pickerExtension = useMemo(
-    () =>
-      createInlinePickerExtension({
-        type: 'field',
-        trigger: '{',
-        onStateChange: handleSuggestionStateChange,
-      }),
-    [handleSuggestionStateChange]
-  )
 
   const fieldNode = useMemo(
     () =>
@@ -112,11 +89,18 @@ export function useAiPrompt({
           horizontalRule: false,
         }),
         fieldNode,
-        pickerExtension,
+        // `{` fires mid-word (allowedPrefixes: null) — authors write prose like
+        // "intro for {fullName}" where the `{` follows non-space text.
+        ReferencePickerNode.configure({
+          triggers: [{ char: '{', kind: 'command', allowedPrefixes: null }],
+        }),
         Placeholder.configure({ placeholder, showOnlyWhenEditable: true }),
       ],
       content: initialContent,
       onUpdate: ({ editor }: { editor: Editor }) => {
+        // Skip while the `{` picker chip is open — the transient chip must
+        // never be persisted into the saved prompt doc.
+        if (getOpenPickerRange(editor.state)) return
         const json = editor.getJSON() as RichReferencePrompt
         const referencedFieldIds = extractFieldIdsFromPrompt(json)
         onChangeRef.current?.(json, referencedFieldIds)
@@ -129,44 +113,35 @@ export function useAiPrompt({
       immediatelyRender: false,
       shouldRerenderOnTransaction: false,
     }),
-    [initialContent, fieldNode, pickerExtension, placeholder]
+    [initialContent, fieldNode, placeholder]
   )
 
   const editor = useEditor(editorConfig)
 
+  /** Insert a field badge node, replacing the open `{` picker chip. */
   const insertField = useCallback(
     (fieldId: string) => {
-      if (!editor || !suggestionRangeRef.current) return
-
-      const range = suggestionRangeRef.current
-      suggestionRangeRef.current = null
-
+      if (!editor) return
+      const range = getOpenPickerRange(editor.state)
+      if (!range) return
       editor
         .chain()
         .focus()
-        .deleteRange({ from: range.from, to: range.to })
+        .deleteRange(range)
         .insertContent({ type: 'field', attrs: { id: fieldId } })
         .run()
-
-      setSuggestionState(closedSuggestionState)
     },
     [editor]
   )
 
-  const closeSuggestion = useCallback(() => {
-    if (editor && suggestionRangeRef.current) {
-      const range = suggestionRangeRef.current
-      suggestionRangeRef.current = null
-      editor.chain().focus().deleteRange({ from: range.from, to: range.to }).run()
-    }
-    setSuggestionState(closedSuggestionState)
-    editor?.commands.focus()
+  /** Close the picker, removing the transient `{` trigger. */
+  const closePicker = useCallback(() => {
+    editor?.commands.closeReferencePicker({ keepText: false })
   }, [editor])
 
   return {
     editor,
-    suggestionState,
     insertField,
-    closeSuggestion,
+    closePicker,
   }
 }

--- a/apps/web/src/components/custom-fields/ui/calc-editor/calc-field-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/calc-editor/calc-field-editor.tsx
@@ -3,7 +3,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeType } from '@auxx/database/types'
-import { getFieldOutputKey, type ResourceField } from '@auxx/lib/resources/client'
+import type { ResourceField } from '@auxx/lib/resources/client'
 import type { FieldReference } from '@auxx/types/field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
@@ -27,7 +27,8 @@ import { cn } from '@auxx/ui/lib/utils'
 import { getAvailableFunctions } from '@auxx/utils/calc-expression'
 import { EditorContent } from '@tiptap/react'
 import { AlertCircle, HelpCircle } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { InlinePickerPopover, useActivePicker } from '~/components/editor/inline-picker'
 import {
   FieldPickerInnerContent,
   type FieldPickerNavigationItem,
@@ -37,7 +38,7 @@ import { useCalcFormula } from './use-calc-formula'
 /** Options for a CALC field stored in field.options.calc */
 export interface CalcEditorOptions {
   expression: string
-  sourceFields: Record<string, string> // Record<placeholderKey, ResourceFieldId>
+  sourceFields: Record<string, string> // Record<placeholderKey, FieldId>
   resultFieldType: FieldTypeType
   disabled?: boolean
   disabledReason?: string
@@ -70,8 +71,6 @@ export function CalcFieldEditor({
 }: CalcFieldEditorProps) {
   const [showFunctions, setShowFunctions] = useState(false)
   const functions = useMemo(() => getAvailableFunctions(), [])
-  const editorContainerRef = useRef<HTMLDivElement>(null)
-  const pickerRef = useRef<HTMLDivElement>(null)
 
   // Build a mapping from field key to field id for storage
   const fieldKeyToId = useMemo(() => {
@@ -83,36 +82,33 @@ export function CalcFieldEditor({
   }, [availableFields])
 
   // Use the calc formula hook
-  const {
-    editor,
-    validation,
-    sourceFields,
-    suggestionState,
-    insertField,
-    insertFunction,
-    closeSuggestion,
-  } = useCalcFormula({
-    initialExpression: options.expression,
-    onExpressionChange: (expression, extractedFields) => {
-      // Build sourceFields mapping from field keys to field IDs
-      const sourceFieldsMap: Record<string, string> = {}
-      for (const key of extractedFields) {
-        if (fieldKeyToId[key]) {
-          sourceFieldsMap[key] = `${entityDefinitionId}:${fieldKeyToId[key]}`
+  const { editor, validation, sourceFields, insertField, insertFunction, closePicker } =
+    useCalcFormula({
+      initialExpression: options.expression,
+      onExpressionChange: (expression, extractedFields) => {
+        // Build sourceFields mapping: placeholder key → bare field id (UUID).
+        // Both calc consumers — the client `calc-value-computer` dependency
+        // graph and the server `calc-resolver` (which wraps with
+        // `toResourceFieldId`) — expect the value to be a plain field id, NOT
+        // a `entityDef:fieldId` ResourceFieldId.
+        const sourceFieldsMap: Record<string, string> = {}
+        for (const key of extractedFields) {
+          if (fieldKeyToId[key]) {
+            sourceFieldsMap[key] = fieldKeyToId[key]
+          }
         }
-      }
 
-      onChange({
-        ...options,
-        expression,
-        sourceFields: sourceFieldsMap,
-      })
-    },
-    entityDefinitionId,
-    currentFieldId,
-    availableFields: availableFields.map((f) => ({ key: f.key, label: f.label, type: f.type })),
-    placeholder: 'Type { to insert a field, e.g., concat({firstName}, " ", {lastName})',
-  })
+        onChange({
+          ...options,
+          expression,
+          sourceFields: sourceFieldsMap,
+        })
+      },
+      entityDefinitionId,
+      currentFieldId,
+      availableFields: availableFields.map((f) => ({ key: f.key, label: f.label, type: f.type })),
+      placeholder: 'Type { to insert a field, e.g., concat({firstName}, " ", {lastName})',
+    })
 
   /** Insert function at cursor */
   const handleInsertFunction = (funcName: string) => {
@@ -125,7 +121,11 @@ export function CalcFieldEditor({
   /** Handle selecting a field from the picker */
   const handleSelectField = useCallback(
     (_fieldReference: FieldReference, field: ResourceField) => {
-      insertField(getFieldOutputKey(field))
+      // Insert the field's `key` (e.g. `lastName`) — the token the FieldBadge
+      // pill resolves (fieldMap aliases `<entity>:<key>`) and what
+      // `availableFields` / `fieldKeyToId` are keyed by. The output key
+      // (`systemAttribute`, e.g. `last_name`) is NOT fieldMap-resolvable.
+      insertField(field.key || field.id)
     },
     [insertField]
   )
@@ -183,33 +183,10 @@ export function CalcFieldEditor({
     [functions, handleSelectFunction]
   )
 
-  // Calculate popover position relative to editor container
-  const [popoverPosition, setPopoverPosition] = useState<{ top: number; left: number } | null>(null)
-
-  useEffect(() => {
-    if (suggestionState.isOpen && suggestionState.clientRect && editorContainerRef.current) {
-      const containerRect = editorContainerRef.current.getBoundingClientRect()
-      const cursorRect = suggestionState.clientRect
-      setPopoverPosition({
-        top: cursorRect.bottom - containerRect.top,
-        left: cursorRect.left - containerRect.left,
-      })
-    }
-  }, [suggestionState.isOpen, suggestionState.clientRect])
-
-  // Close picker when clicking outside
-  useEffect(() => {
-    if (!suggestionState.isOpen) return
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (pickerRef.current && !pickerRef.current.contains(event.target as Node)) {
-        closeSuggestion()
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [suggestionState.isOpen, closeSuggestion])
+  // Drive the picker popover off the open `{` chip (positioning, query,
+  // outside-click + Escape are all owned by InlinePickerPopover).
+  const activePicker = useActivePicker(editor)
+  const pickerOpen = !!activePicker && activePicker.trigger === '{'
 
   return (
     <FieldGroup className='space-y-4'>
@@ -249,7 +226,6 @@ export function CalcFieldEditor({
 
         {/* TipTap Editor with Field Picker Popover */}
         <div
-          ref={editorContainerRef}
           className={cn(
             'relative border rounded-md bg-background',
             !validation.isValid &&
@@ -258,41 +234,33 @@ export function CalcFieldEditor({
               'border-destructive'
           )}>
           <EditorContent editor={editor} className='min-h-[80px]' />
-
-          {/* Field Picker - positioned at cursor */}
-          {suggestionState.isOpen && popoverPosition && (
-            <div
-              ref={pickerRef}
-              className='absolute z-50'
-              style={{
-                top: popoverPosition.top,
-                left: popoverPosition.left,
-              }}>
-              <div
-                className='rounded-lg border bg-popover shadow-lg w-[320px]'
-                onMouseDown={(e) => e.preventDefault()}
-                onKeyDown={(e) => {
-                  if (e.key === 'Escape') {
-                    e.stopPropagation()
-                    closeSuggestion()
-                  }
-                }}>
-                <CommandNavigation<FieldPickerNavigationItem>>
-                  <FieldPickerInnerContent
-                    entityDefinitionId={entityDefinitionId}
-                    excludeFields={excludeFilters}
-                    onSelect={handleSelectField}
-                    onClose={closeSuggestion}
-                    closeOnSelect
-                    showBreadcrumb={false}
-                    searchPlaceholder='Search fields or functions...'
-                    renderAdditionalContent={renderFunctionsInPicker}
-                  />
-                </CommandNavigation>
-              </div>
-            </div>
-          )}
         </div>
+
+        {/* Field + function picker, anchored at the open `{` chip */}
+        {editor && (
+          <InlinePickerPopover
+            state={{
+              isOpen: pickerOpen,
+              query: activePicker?.query ?? '',
+              range: null,
+              clientRect: activePicker?.clientRect ?? null,
+            }}
+            width={320}
+            onClose={closePicker}>
+            <CommandNavigation<FieldPickerNavigationItem>>
+              <FieldPickerInnerContent
+                entityDefinitionId={entityDefinitionId}
+                excludeFields={excludeFilters}
+                onSelect={handleSelectField}
+                onClose={closePicker}
+                closeOnSelect
+                showBreadcrumb={false}
+                searchPlaceholder='Search fields or functions...'
+                renderAdditionalContent={renderFunctionsInPicker}
+              />
+            </CommandNavigation>
+          </InlinePickerPopover>
+        )}
 
         {/* Validation Error - only show for actual syntax errors, not empty state */}
         {!validation.isValid &&

--- a/apps/web/src/components/custom-fields/ui/calc-editor/use-calc-formula.tsx
+++ b/apps/web/src/components/custom-fields/ui/calc-editor/use-calc-formula.tsx
@@ -9,8 +9,8 @@ import StarterKit from '@tiptap/starter-kit'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   createInlineNode,
-  createInlinePickerExtension,
-  type InlinePickerState,
+  getOpenPickerRange,
+  ReferencePickerNode,
 } from '~/components/editor/inline-picker'
 import { FieldBadge } from '~/components/resources/ui'
 import { extractFieldIds, formulaToString, stringToFormula } from './formula-converters'
@@ -31,17 +31,16 @@ export interface UseCalcFormulaOptions {
   placeholder?: string
 }
 
-/** Initial closed state for suggestion */
-const initialSuggestionState: InlinePickerState = {
-  isOpen: false,
-  query: '',
-  range: null,
-  clientRect: null,
-}
-
 /**
  * Hook for managing the CALC formula TipTap editor state.
  * Handles expression parsing, validation, and conversion.
+ *
+ * The `{`-triggered field/function picker rides on the shared
+ * `ReferencePickerNode` chip (the same primitive used by the snippet /
+ * greeting editors): typing `{` opens an inert chip and the consumer mounts
+ * the picker popover via `useActivePicker` + `InlinePickerPopover`. Selection
+ * is committed here through `getOpenPickerRange` — fields collapse to a
+ * `field` badge node, functions insert their literal `name(` text.
  */
 export function useCalcFormula({
   initialExpression = '',
@@ -51,43 +50,17 @@ export function useCalcFormula({
   placeholder = 'Type { to insert a field or function...',
 }: UseCalcFormulaOptions) {
   const [expression, setExpression] = useState(initialExpression)
-  const [suggestionState, setSuggestionState] = useState<InlinePickerState>(initialSuggestionState)
   const contentRef = useRef(initialExpression)
   const onChangeRef = useRef(onExpressionChange)
-  const suggestionRangeRef = useRef<{ from: number; to: number } | null>(null)
 
-  // Update refs when values change
   useEffect(() => {
     onChangeRef.current = onExpressionChange
   }, [onExpressionChange])
 
-  // Track suggestion range for insertion
-  useEffect(() => {
-    suggestionRangeRef.current = suggestionState.range
-  }, [suggestionState.range])
-
   // Convert initial expression to TipTap content
-  const initialContent = useMemo(() => {
-    return stringToFormula(initialExpression)
-  }, [initialExpression])
+  const initialContent = useMemo(() => stringToFormula(initialExpression), [initialExpression])
 
-  // Memoize onStateChange callback
-  const handleSuggestionStateChange = useCallback((state: InlinePickerState) => {
-    setSuggestionState(state)
-  }, [])
-
-  // Create picker extension
-  const pickerExtension = useMemo(
-    () =>
-      createInlinePickerExtension({
-        type: 'field',
-        trigger: '{',
-        onStateChange: handleSuggestionStateChange,
-      }),
-    [handleSuggestionStateChange]
-  )
-
-  // Create field node with base factory
+  // Create field node with base factory — serializes to `{id}`.
   const fieldNode = useMemo(
     () =>
       createInlineNode(
@@ -121,7 +94,11 @@ export function useCalcFormula({
           horizontalRule: false,
         }),
         fieldNode,
-        pickerExtension,
+        // `{` fires mid-word (allowedPrefixes: null) — formula authors type
+        // `concat({first}, {last})` where `{` directly follows `(` or `,`.
+        ReferencePickerNode.configure({
+          triggers: [{ char: '{', kind: 'command', allowedPrefixes: null }],
+        }),
         Placeholder.configure({
           placeholder,
           showOnlyWhenEditable: true,
@@ -129,6 +106,9 @@ export function useCalcFormula({
       ],
       content: initialContent,
       onUpdate: ({ editor }: { editor: Editor }) => {
+        // Don't emit while the `{` picker chip is open — the trigger char is
+        // transient and would otherwise land an invalid `{` in the expression.
+        if (getOpenPickerRange(editor.state)) return
         const json = editor.getJSON()
         const newExpression = formulaToString(json)
         const sourceFields = extractFieldIds(json)
@@ -147,7 +127,7 @@ export function useCalcFormula({
       immediatelyRender: false,
       shouldRerenderOnTransaction: false,
     }),
-    [initialContent, fieldNode, pickerExtension, placeholder]
+    [initialContent, fieldNode, placeholder]
   )
 
   const editor = useEditor(editorConfig)
@@ -170,8 +150,7 @@ export function useCalcFormula({
   const setContent = useCallback(
     (newExpression: string) => {
       if (editor && newExpression !== expression) {
-        const tiptapContent = stringToFormula(newExpression)
-        editor.commands.setContent(tiptapContent)
+        editor.commands.setContent(stringToFormula(newExpression))
         contentRef.current = newExpression
         setExpression(newExpression)
       }
@@ -179,63 +158,36 @@ export function useCalcFormula({
     [editor, expression]
   )
 
-  /** Insert a field node at the suggestion trigger position */
+  /** Insert a field badge node, replacing the open `{` picker chip. */
   const insertField = useCallback(
     (fieldId: string) => {
-      if (!editor || !suggestionRangeRef.current) return
-
-      const range = suggestionRangeRef.current
-      // Clear the ref immediately to prevent closeSuggestion from deleting again
-      suggestionRangeRef.current = null
-
+      if (!editor) return
+      const range = getOpenPickerRange(editor.state)
+      if (!range) return
       editor
         .chain()
         .focus()
-        .deleteRange({ from: range.from, to: range.to })
-        .insertContent({
-          type: 'field',
-          attrs: { id: fieldId },
-        })
+        .deleteRange(range)
+        .insertContent({ type: 'field', attrs: { id: fieldId } })
         .run()
-
-      // Close the suggestion
-      setSuggestionState(initialSuggestionState)
     },
     [editor]
   )
 
-  /** Insert a function name at the suggestion trigger position */
+  /** Insert a function call (`name(`), replacing the open `{` picker chip. */
   const insertFunction = useCallback(
     (funcName: string) => {
-      if (!editor || !suggestionRangeRef.current) return
-
-      const range = suggestionRangeRef.current
-      // Clear the ref immediately to prevent closeSuggestion from deleting again
-      suggestionRangeRef.current = null
-
-      editor
-        .chain()
-        .focus()
-        .deleteRange({ from: range.from, to: range.to })
-        .insertContent(`${funcName}(`)
-        .run()
-
-      // Close the suggestion
-      setSuggestionState(initialSuggestionState)
+      if (!editor) return
+      const range = getOpenPickerRange(editor.state)
+      if (!range) return
+      editor.chain().focus().deleteRange(range).insertContent(`${funcName}(`).run()
     },
     [editor]
   )
 
-  /** Close the suggestion picker and remove the trigger character */
-  const closeSuggestion = useCallback(() => {
-    // Delete the trigger character and any query text
-    if (editor && suggestionRangeRef.current) {
-      const range = suggestionRangeRef.current
-      suggestionRangeRef.current = null
-      editor.chain().focus().deleteRange({ from: range.from, to: range.to }).run()
-    }
-    setSuggestionState(initialSuggestionState)
-    editor?.commands.focus()
+  /** Close the picker, removing the transient `{` trigger. */
+  const closePicker = useCallback(() => {
+    editor?.commands.closeReferencePicker({ keepText: false })
   }, [editor])
 
   return {
@@ -245,10 +197,8 @@ export function useCalcFormula({
     missingFields,
     sourceFields: validation.extractedFields,
     setContent,
-    // Suggestion state and actions for external picker UI
-    suggestionState,
     insertField,
     insertFunction,
-    closeSuggestion,
+    closePicker,
   }
 }

--- a/apps/web/src/components/custom-fields/ui/custom-field-dialog.tsx
+++ b/apps/web/src/components/custom-fields/ui/custom-field-dialog.tsx
@@ -218,6 +218,10 @@ export function CustomFieldDialog({
       })
       .map((f) => ({
         id: f.id,
+        // Key by `f.key` (e.g. `lastName`) — the token the calc editor inserts
+        // and the form the FieldBadge pill resolves (fieldMap aliases
+        // `<entity>:<key>`). Falls back to the row id for custom fields whose
+        // key already equals the id.
         key: f.key || f.id,
         label: f.label,
         type: f.fieldType ?? 'TEXT',

--- a/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
@@ -14,6 +14,7 @@ import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
 import { ChevronLeft, ChevronRight, Clock, Layers, Plug } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useCallback, useMemo } from 'react'
+import { useResourceFields } from '~/components/resources'
 import { useScrollSpy } from '~/hooks/use-scroll-spy'
 import { api } from '~/trpc/react'
 import { absolutePrefix, leafPathsUnder, useSourcePaths } from '../hooks/use-source-paths'
@@ -161,6 +162,10 @@ export function ConnectorDetailTabs({ connector, mobileRunsPanel }: ConnectorDet
     (fieldMapping?.fieldMappings as Record<string, { expression: string }> | undefined)?.[
       fieldKey ?? ''
     ]?.expression ?? ''
+  // Target fields the formula can write into — the same store the mapping tree
+  // reads. Called unconditionally (the hook tolerates a null def id) so it never
+  // trips rules-of-hooks when no field drill is open.
+  const { fields: targetFields } = useResourceFields(fieldMapping?.entityDefinitionId ?? null)
   // Optimistic field-mapping write against listStreams (shared with the tree).
   const { setFieldMappings } = useStreamMutations(connector.id)
 
@@ -249,13 +254,20 @@ export function ConnectorDetailTabs({ connector, mobileRunsPanel }: ConnectorDet
             value='field'
             className='h-full bg-neutral-100 dark:bg-background'
             bar={fieldBar}>
-            {fieldMapping && fieldKey ? (
+            {fieldMapping ? (
               <FieldCalcPanel
-                fieldLabel={fieldKey}
+                entityDefinitionId={fieldMapping.entityDefinitionId ?? null}
+                targetKey={fieldKey ?? ''}
+                targetLabel={targetFields.find((f) => f.key === fieldKey)?.label ?? ''}
+                // Fields already bound (leaf or formula) elsewhere — can't double-map.
+                // The current target stays selectable so editing keeps its own field.
+                excludeKeys={Object.keys(fieldMapping.fieldMappings ?? {}).filter(
+                  (k) => k !== fieldKey
+                )}
                 expression={fieldExpression}
                 // Scoped + relative to the mapping's subtree, matching the runtime.
                 sourcePaths={leafPathsUnder(sourcePaths, absolutePrefix(fieldMapping, mappingById))}
-                onSave={(expression, sourceFields) => {
+                onSave={(targetKey, expression, sourceFields) => {
                   const existing = (fieldMapping.fieldMappings ?? {}) as Record<
                     string,
                     { expression: string; sourceFields: Record<string, string> }
@@ -263,7 +275,7 @@ export function ConnectorDetailTabs({ connector, mobileRunsPanel }: ConnectorDet
                   if (selectedStreamId)
                     void setFieldMappings(selectedStreamId, fieldMapping.id, {
                       ...existing,
-                      [fieldKey]: { expression, sourceFields },
+                      [targetKey]: { expression, sourceFields },
                     })
                   void setField(null)
                 }}

--- a/apps/web/src/components/data-connectors/ui/field-calc-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/field-calc-panel.tsx
@@ -1,31 +1,43 @@
 // apps/web/src/components/data-connectors/ui/field-calc-panel.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Field, FieldDescription, FieldLabel } from '@auxx/ui/components/field'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { getAvailableFunctions, validateCalcExpression } from '@auxx/utils/calc-expression'
-import { AlertCircle, FunctionSquare } from 'lucide-react'
+import { AlertCircle, ChevronDown, FunctionSquare } from 'lucide-react'
 import { useMemo, useRef, useState } from 'react'
+import { FieldPicker } from '~/components/pickers/field-picker'
 import type { SourcePath } from '../hooks/use-source-paths'
+import { isSourceTargetCompatible } from './field-type-compat'
 
 interface FieldCalcPanelProps {
-  /** The target field label this expression produces. */
-  fieldLabel: string
+  /** The mapping's def — the source of selectable target fields. Null only if unset. */
+  entityDefinitionId: string | null
+  /** The target field this expression writes into (`''` while creating). */
+  targetKey: string
+  /** Resolved label for the current target field (for the trigger chip). */
+  targetLabel: string
+  /** Target field keys already bound elsewhere (leaf or formula) — excluded from the picker. */
+  excludeKeys: string[]
   /** Current calc expression (over source tokens, e.g. `concat({a}," ",{b})`). */
   expression: string
   /** Source schema paths offered as `{token}` inserts. */
   sourcePaths: SourcePath[]
-  /** Persist the expression + the source fields it references. */
-  onSave: (expression: string, sourceFields: Record<string, string>) => void
+  /** Persist the chosen target field + expression + the source fields it references. */
+  onSave: (targetKey: string, expression: string, sourceFields: Record<string, string>) => void
 }
 
 /**
- * The lone mapping drill — the calc expression editor (05 §4). A value row's `ƒ`
- * promotes here. The token picker lists SOURCE-schema paths (not target fields),
- * the function set comes from `@auxx/utils/calc-expression`, and output is the
- * target field. Stored uniformly as `{ expression, sourceFields }`.
+ * The lone mapping drill — the calc expression editor (05 §4). A formula row (or
+ * the "+ Add formula" row) opens this. The canonical {@link FieldPicker} picks
+ * which target field the expression writes into (so the panel handles both
+ * create and retarget), excluding fields already bound by another leaf/formula;
+ * the token picker lists SOURCE-schema paths (not target fields), the function
+ * set comes from `@auxx/utils/calc-expression`, and output is the target field.
+ * Stored uniformly as `{ expression, sourceFields }` keyed by the target field.
  *
  * Implementation note: this uses a plain textarea + insert buttons (not the
  * entity-coupled TipTap `CalcFieldEditor`/`FieldBadge`, which resolves tokens
@@ -33,14 +45,21 @@ interface FieldCalcPanelProps {
  * field-picker coupling while reusing the shared calc function set + validator.
  */
 export function FieldCalcPanel({
-  fieldLabel,
+  entityDefinitionId,
+  targetKey,
+  targetLabel,
+  excludeKeys,
   expression,
   sourcePaths,
   onSave,
 }: FieldCalcPanelProps) {
   const [value, setValue] = useState(expression)
+  const [target, setTarget] = useState(targetKey)
+  const [targetChip, setTargetChip] = useState(targetLabel)
+  const [pickerOpen, setPickerOpen] = useState(false)
   const taRef = useRef<HTMLTextAreaElement>(null)
   const functions = useMemo(() => getAvailableFunctions(), [])
+  const excludeSet = useMemo(() => new Set(excludeKeys), [excludeKeys])
 
   const validation = useMemo(() => {
     if (!value.trim()) return { isValid: true, extractedFields: [] as string[], error: undefined }
@@ -63,17 +82,49 @@ export function FieldCalcPanel({
     })
   }
 
+  const canSave = !!target && validation.isValid && !!value.trim()
   const handleSave = () => {
+    if (!canSave) return
     const fields: Record<string, string> = {}
     for (const path of validation.extractedFields) fields[path] = path
-    onSave(value, fields)
+    onSave(target, value, fields)
   }
 
   return (
     <ScrollArea className='h-full' scrollbarClassName='w-1.5'>
       <div className='flex flex-col gap-5 p-4'>
         <Field>
-          <FieldLabel>Expression for “{fieldLabel}”</FieldLabel>
+          <FieldLabel>Writes into</FieldLabel>
+          <FieldPicker
+            open={pickerOpen}
+            onOpenChange={setPickerOpen}
+            entityDefinitionId={entityDefinitionId}
+            excludeFields={[FieldType.RELATIONSHIP]}
+            // A formula yields a scalar (string/number) — exclude already-bound
+            // targets and any field type a computed value can't populate.
+            filterField={(f) =>
+              !excludeSet.has(f.key) && isSourceTargetCompatible(f.fieldType, 'string')
+            }
+            mode='single'
+            searchPlaceholder='Search fields…'
+            onSelect={(_ref, field) => {
+              setTarget(field.key)
+              setTargetChip(field.label)
+            }}
+            trigger={
+              <Button
+                variant='outline'
+                size='sm'
+                className={`justify-between ${target ? '' : 'text-muted-foreground'}`}>
+                <span className='truncate'>{target ? targetChip : 'Pick a target field…'}</span>
+                <ChevronDown className='size-4 opacity-50' />
+              </Button>
+            }
+          />
+        </Field>
+
+        <Field>
+          <FieldLabel>Expression</FieldLabel>
           <textarea
             ref={taRef}
             value={value}
@@ -143,7 +194,7 @@ export function FieldCalcPanel({
           </div>
         )}
 
-        <Button className='self-start' onClick={handleSave}>
+        <Button className='self-start' disabled={!canSave} onClick={handleSave}>
           Save expression
         </Button>
       </div>

--- a/apps/web/src/components/data-connectors/ui/field-type-compat.ts
+++ b/apps/web/src/components/data-connectors/ui/field-type-compat.ts
@@ -1,0 +1,42 @@
+// apps/web/src/components/data-connectors/ui/field-type-compat.ts
+
+import { FieldType } from '@auxx/database/enums'
+import type { FieldType as FieldTypeType } from '@auxx/database/types'
+import { isFieldTypeCompatible } from '@auxx/lib/custom-fields/client'
+
+/**
+ * A connector source leaf's JSON-schema type → the representative
+ * {@link FieldType} its values carry, so it can be checked against a target
+ * field via the shared {@link isFieldTypeCompatible} matrix.
+ */
+function jsonSourceFieldType(jsonType: string): FieldTypeType {
+  switch (jsonType) {
+    case 'number':
+    case 'integer':
+      return FieldType.NUMBER
+    case 'boolean':
+      return FieldType.CHECKBOX
+    case 'array':
+      return FieldType.TAGS
+    case 'object':
+      return FieldType.JSON
+    default:
+      return FieldType.TEXT
+  }
+}
+
+/**
+ * Can a source value be written into a `target` field? Returns `true` for a
+ * null/unknown target type (don't hide a field we can't classify).
+ *
+ * `jsonType` is a source leaf's JSON-schema type. A computed formula has no
+ * single source type — it produces a scalar string/number, so pass `'string'`
+ * (→ TEXT) for formula targets.
+ */
+export function isSourceTargetCompatible(
+  target: FieldTypeType | null | undefined,
+  jsonType: string
+): boolean {
+  if (!target) return true
+  return isFieldTypeCompatible(target, jsonSourceFieldType(jsonType))
+}

--- a/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
@@ -3,7 +3,6 @@
 
 import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeType } from '@auxx/database/types'
-import type { ResourceField } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import {
@@ -18,21 +17,7 @@ import { useState } from 'react'
 import { useCustomFieldMutations } from '~/components/custom-fields/hooks/use-custom-field-mutations'
 import { FieldPicker } from '~/components/pickers/field-picker'
 import { lastSegment } from '../hooks/use-source-paths'
-
-/** Target field types that hold many values — the only valid sink for an array-of-scalars source. */
-const MULTI_VALUE_FIELD_TYPES = new Set<FieldTypeType>([FieldType.TAGS, FieldType.MULTI_SELECT])
-
-/**
- * Permissive source→target type gate (plan §8.2). Block only the impossible
- * bindings: an array-of-scalars source needs a multi-value target; everything
- * else (scalar → any) is allowed and tightened later if real schemas need it.
- */
-function isTypeCompatible(field: ResourceField, sourceType: string): boolean {
-  if (sourceType === 'array') {
-    return field.fieldType ? MULTI_VALUE_FIELD_TYPES.has(field.fieldType) : false
-  }
-  return true
-}
+import { isSourceTargetCompatible } from './field-type-compat'
 
 /** Field types offered by the lightweight quick-create, seeded from the source type. */
 const QUICK_CREATE_TYPES: Array<{ value: FieldTypeType; label: string }> = [
@@ -80,6 +65,8 @@ interface MappingFieldPickerProps {
   canCreate: boolean
   /** Bind this source node to the chosen target field key. */
   onAssign: (fieldKey: string) => void
+  /** Unbind this source node — surfaced as the in-picker "Don't map" option. */
+  onClear: () => void
 }
 
 /**
@@ -96,6 +83,7 @@ export function MappingFieldPicker({
   assignedLabel,
   canCreate,
   onAssign,
+  onClear,
 }: MappingFieldPickerProps) {
   const [pickerOpen, setPickerOpen] = useState(false)
   const [creating, setCreating] = useState(false)
@@ -124,10 +112,14 @@ export function MappingFieldPicker({
         onOpenChange={setPickerOpen}
         entityDefinitionId={entityDefinitionId}
         excludeFields={[FieldType.RELATIONSHIP]}
-        filterField={(f) => isTypeCompatible(f, sourceType)}
+        filterField={(f) => isSourceTargetCompatible(f.fieldType, sourceType)}
         mode='single'
         searchPlaceholder='Search fields…'
         onSelect={(_ref, field) => onAssign(field.key)}
+        // Skip = unbind. Only offered once a field is bound (an unbound source
+        // node is already "not mapped").
+        onSkip={assignedKey ? onClear : undefined}
+        skipLabel="Don't map this field"
         onCreateField={
           canCreate
             ? () => {

--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -11,7 +11,7 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import TreeRow, { TreeRowButton } from '@auxx/ui/components/tree-row'
-import { Trash2 } from 'lucide-react'
+import { FunctionSquare, Plus, Trash2, X } from 'lucide-react'
 import { useState } from 'react'
 import { ResourcePicker } from '~/components/pickers/resource-picker'
 import { useResourceFields, useResourceProperty } from '~/components/resources'
@@ -25,7 +25,7 @@ import {
 } from '../hooks/use-source-paths'
 import type { useStreamMutations } from '../hooks/use-stream-mutations'
 import { BranchRow } from './branch-row'
-import { SourceLeafRow } from './source-leaf-row'
+import { MERGE_OPTIONS, SourceLeafRow } from './source-leaf-row'
 
 /** Sentinel for the whole-payload root (`''`) — Radix Select forbids empty values. */
 const ROOT_SENTINEL = '__root__'
@@ -165,6 +165,12 @@ export function MappingNode({
     if (isBareToken(fm.expression))
       sourceToTarget.set(fm.expression.replace(/^\{|\}$/g, ''), targetKey)
   }
+
+  // Non-bare entries are computed target fields — they get their own rows below
+  // the source leaves (a multi-source formula has no single leaf to anchor on).
+  const formulaEntries = Object.entries(fieldMappings).filter(
+    ([, fm]) => !isBareToken(fm.expression)
+  )
 
   const assignTarget = (sourcePath: string, targetKey: string) => {
     const next = { ...fieldMappings }
@@ -329,7 +335,6 @@ export function MappingNode({
               setMergeStrategies(streamId, mapping.id, { ...mergeStrategies, [targetKey]: value })
             }
             onToggleMatch={toggleMatch}
-            onPromote={(targetKey) => onPromoteField(mapping.id, targetKey)}
             onFanOut={materializeChild}
             // Child-mapping recursion context.
             streamId={streamId}
@@ -342,6 +347,35 @@ export function MappingNode({
             onPromoteField={onPromoteField}
           />
         ))
+      )}
+
+      {/* Formula rows — one per non-bare field mapping (a computed target field),
+          plus an add row. Reference-mode mappings only link, so no formulas. */}
+      {linkMode !== 'reference' && (
+        <>
+          {formulaEntries.map(([targetKey, fm]) => (
+            <FormulaRow
+              key={targetKey}
+              depth={depth + 1}
+              label={targetFields.find((f) => f.key === targetKey)?.label ?? targetKey}
+              expression={fm.expression}
+              mergeStrategy={mergeStrategies[targetKey] ?? 'overwrite'}
+              onEdit={() => onPromoteField(mapping.id, targetKey)}
+              onMergeChange={(value) =>
+                setMergeStrategies(streamId, mapping.id, { ...mergeStrategies, [targetKey]: value })
+              }
+              onClear={() => clearTarget(targetKey)}
+            />
+          ))}
+          {mapping.entityDefinitionId != null && (
+            <TreeRow
+              depth={depth + 1}
+              icon={<Plus className='size-3.5 text-muted-foreground/50' />}
+              title={<span className='text-sm text-muted-foreground'>Add formula</span>}
+              onToggleOpen={() => onPromoteField(mapping.id, '')}
+            />
+          )}
+        </>
       )}
 
       {/* Child mappings whose branch isn't in the current schema — appended so
@@ -383,7 +417,6 @@ interface SourceNodeProps {
   onClear: (targetKey: string) => void
   onMergeChange: (targetKey: string, value: string) => void
   onToggleMatch: (targetKey: string) => void
-  onPromote: (targetKey: string) => void
   onFanOut: (node: SourceTreeNode, entityDefinitionId: string) => void
   // Child-mapping recursion context (forwarded to a nested MappingNode).
   streamId: string
@@ -417,7 +450,6 @@ function SourceNode(props: SourceNodeProps) {
     onClear,
     onMergeChange,
     onToggleMatch,
-    onPromote,
     onFanOut,
   } = props
   const [open, setOpen] = useState(true)
@@ -476,7 +508,66 @@ function SourceNode(props: SourceNodeProps) {
       onClear={() => assignedTargetKey && onClear(assignedTargetKey)}
       onMergeChange={(value) => assignedTargetKey && onMergeChange(assignedTargetKey, value)}
       onToggleMatch={() => assignedTargetKey && onToggleMatch(assignedTargetKey)}
-      onPromote={() => assignedTargetKey && onPromote(assignedTargetKey)}
+    />
+  )
+}
+
+// ── Formula row (a computed target field) ──────────────────────────────────────
+
+interface FormulaRowProps {
+  depth: number
+  /** Target field label this formula writes into. */
+  label: string
+  /** The calc expression (shown as a preview; click the row to edit). */
+  expression: string
+  mergeStrategy: string
+  onEdit: () => void
+  onMergeChange: (value: string) => void
+  onClear: () => void
+}
+
+/**
+ * A computed target field (plan 10 §3.2) — a non-bare `fieldMappings` entry that
+ * can reference many source fields, so it lives on its own row rather than on a
+ * source leaf. Clicking the row opens the calc editor; it carries a merge
+ * strategy (it writes a target field) but no Match toggle (no single source path
+ * to match identity on).
+ */
+function FormulaRow({
+  depth,
+  label,
+  expression,
+  mergeStrategy,
+  onEdit,
+  onMergeChange,
+  onClear,
+}: FormulaRowProps) {
+  return (
+    <TreeRow
+      depth={depth}
+      icon={<FunctionSquare className='size-3.5' />}
+      title={<span className='text-sm'>{label}</span>}
+      secondary={<span className='font-mono text-xs'>← {expression}</span>}
+      onToggleOpen={onEdit}
+      trailing={
+        <div className='flex items-center gap-1'>
+          <Select value={mergeStrategy} onValueChange={onMergeChange}>
+            <SelectTrigger size='sm' className='h-6 min-w-[96px] text-xs'>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MERGE_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <TreeRowButton tooltipText='Remove formula' onClick={onClear}>
+            <X />
+          </TreeRowButton>
+        </div>
+      }
     />
   )
 }

--- a/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
@@ -9,18 +9,21 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@auxx/ui/components/select'
-import TreeRow, { TreeRowButton } from '@auxx/ui/components/tree-row'
-import { Brackets, FunctionSquare, Hash, X } from 'lucide-react'
+import TreeRow from '@auxx/ui/components/tree-row'
+import { Brackets, Hash } from 'lucide-react'
 import { lastSegment, type SourcePath } from '../hooks/use-source-paths'
 import { MappingFieldPicker } from './mapping-field-picker'
 
-/** Per-field merge strategies offered once a leaf is bound. */
+/**
+ * Per-field merge strategies offered once a leaf is bound. `manual_review` and
+ * `ignore` stay in the schema/runtime (`FieldMergeStrategy`) but are not yet
+ * surfaced — `manual_review` has no conflict-review queue and `ignore` has no
+ * use until then. Re-add here when those land.
+ */
 export const MERGE_OPTIONS: Array<{ value: string; label: string }> = [
   { value: 'overwrite', label: 'overwrite' },
   { value: 'fill_blank', label: 'fill-blank' },
   { value: 'connector_owned_only', label: 'owned-only' },
-  { value: 'manual_review', label: 'review' },
-  { value: 'ignore', label: 'ignore' },
 ]
 
 interface SourceLeafRowProps {
@@ -40,14 +43,14 @@ interface SourceLeafRowProps {
   onClear: () => void
   onMergeChange: (value: string) => void
   onToggleMatch: () => void
-  onPromote: () => void
 }
 
 /**
  * A source-schema leaf (plan §3.1). The label is the source field; the
  * {@link MappingFieldPicker} "applies" a target field to it. Once bound, the
- * merge picker + `ƒ` (calc) promote + clear appear. A source value maps to at
- * most one target field. Array-of-scalars leaves get the multi-value icon.
+ * merge picker + clear appear. A source value maps to at most one target field
+ * (a strict bare-token bind); computed/multi-source values live on their own
+ * formula rows, not here. Array-of-scalars leaves get the multi-value icon.
  */
 export function SourceLeafRow({
   depth,
@@ -62,7 +65,6 @@ export function SourceLeafRow({
   onClear,
   onMergeChange,
   onToggleMatch,
-  onPromote,
 }: SourceLeafRowProps) {
   const isMapped = !!assignedTargetKey
   const isArray = node.type === 'array'
@@ -89,22 +91,24 @@ export function SourceLeafRow({
           assignedLabel={assignedLabel}
           canCreate={canCreate}
           onAssign={onAssign}
+          onClear={onClear}
         />
       }
       trailing={
         isMapped ? (
-          <div className='flex items-center gap-1'>
+          <div className='flex shrink-0 items-center gap-1'>
             {/* Secondary identity-match toggle: subtle text → filled blue badge. */}
             <button
               type='button'
               onClick={onToggleMatch}
+              className='inline-flex shrink-0 items-center'
               title={
                 isMatch
                   ? 'Used as a secondary identity match. Click to stop matching on this field.'
                   : 'Also match existing records by this field (external id stays the primary key).'
               }>
               {isMatch ? (
-                <Badge variant='blue' className='h-5 px-1.5 text-[10px]'>
+                <Badge variant='blue' size='xs'>
                   Match
                 </Badge>
               ) : (
@@ -113,24 +117,23 @@ export function SourceLeafRow({
                 </span>
               )}
             </button>
-            <Select value={mergeStrategy} onValueChange={onMergeChange}>
-              <SelectTrigger size='sm' className='h-6 min-w-[96px] text-xs'>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {MERGE_OPTIONS.map((o) => (
-                  <SelectItem key={o.value} value={o.value}>
-                    {o.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <TreeRowButton tooltipText='Edit as a formula' onClick={onPromote}>
-              <FunctionSquare />
-            </TreeRowButton>
-            <TreeRowButton tooltipText='Clear mapping' onClick={onClear}>
-              <X />
-            </TreeRowButton>
+            {/* Merge strategy only matters when the def is shared. An owned
+                mapping (canCreate) is the sole writer, so every field is an
+                implicit overwrite — no picker. Contributing mappings choose. */}
+            {!canCreate && (
+              <Select value={mergeStrategy} onValueChange={onMergeChange}>
+                <SelectTrigger variant='transparent' size='sm' className='h-6 min-w-[96px] text-xs'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MERGE_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
           </div>
         ) : undefined
       }

--- a/apps/web/src/components/pickers/field-picker/field-picker-content.tsx
+++ b/apps/web/src/components/pickers/field-picker/field-picker-content.tsx
@@ -22,7 +22,7 @@ import {
   useCommandNavigation,
 } from '@auxx/ui/components/command'
 import { EntityIcon } from '@auxx/ui/components/icons'
-import { Plus } from 'lucide-react'
+import { Ban, Plus } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useResourceFields, useResourceProperty } from '~/components/resources'
 import { FieldItem } from './field-item'
@@ -78,6 +78,8 @@ export function FieldPickerInnerContent({
   closeOnSelect = mode === 'single',
   onClose,
   onCreateField,
+  onSkip,
+  skipLabel = 'Skip',
   searchPlaceholder = 'Search fields...',
   onBackFromRoot,
   externalNavigation,
@@ -294,6 +296,24 @@ export function FieldPickerInnerContent({
 
         {/* Header content (e.g. anchor self rows for the binding picker) */}
         {renderHeaderContent?.(search)}
+
+        {/* Skip / don't-map option (root only) */}
+        {onSkip && isAtRoot && (
+          <>
+            <CommandGroup>
+              <CommandItem
+                onSelect={() => {
+                  onSkip()
+                  if (closeOnSelect && onClose) onClose()
+                }}
+                className='text-muted-foreground'>
+                <Ban className='size-4' />
+                <span>{skipLabel}</span>
+              </CommandItem>
+            </CommandGroup>
+            <CommandSeparator />
+          </>
+        )}
 
         {/* When drilled into a relationship, show entity selector first */}
         {!isAtRoot && current && entityProps && (

--- a/apps/web/src/components/pickers/field-picker/field-picker.tsx
+++ b/apps/web/src/components/pickers/field-picker/field-picker.tsx
@@ -27,6 +27,8 @@ export function FieldPicker({
   mode = 'single',
   closeOnSelect = mode === 'single',
   onCreateField,
+  onSkip,
+  skipLabel,
   searchPlaceholder,
 }: FieldPickerProps) {
   // Support both controlled and uncontrolled modes
@@ -74,6 +76,8 @@ export function FieldPicker({
           closeOnSelect={closeOnSelect}
           onClose={handleClose}
           onCreateField={onCreateField}
+          onSkip={onSkip}
+          skipLabel={skipLabel}
           searchPlaceholder={searchPlaceholder}
         />
       </PopoverContent>

--- a/apps/web/src/components/pickers/field-picker/types.ts
+++ b/apps/web/src/components/pickers/field-picker/types.ts
@@ -50,6 +50,16 @@ export interface FieldPickerContentProps {
   /** Optional: Show "Create field" button */
   onCreateField?: () => void
 
+  /**
+   * Optional: show a "skip / don't map" item at the top of the root list (e.g.
+   * to clear a binding from within the picker). Selecting it runs this callback
+   * and closes the picker per {@link closeOnSelect}.
+   */
+  onSkip?: () => void
+
+  /** Optional: label for the {@link onSkip} item (default "Skip"). */
+  skipLabel?: string
+
   /** Optional: Search placeholder */
   searchPlaceholder?: string
 

--- a/packages/lib/src/custom-fields/client.ts
+++ b/packages/lib/src/custom-fields/client.ts
@@ -38,7 +38,11 @@ export {
   formulaToString,
   stringToFormula,
 } from './formula-converters'
-export { PRIMARY_DISPLAY_ELIGIBLE_TYPES } from './types'
+export {
+  FIELD_TYPE_COMPATIBILITY_MAP,
+  isFieldTypeCompatible,
+  PRIMARY_DISPLAY_ELIGIBLE_TYPES,
+} from './types'
 
 import type { SelectOptionColor } from '@auxx/types/custom-field'
 

--- a/packages/lib/src/custom-fields/types.ts
+++ b/packages/lib/src/custom-fields/types.ts
@@ -45,6 +45,99 @@ export const FIELD_TYPE_GROUPS: Record<string, FieldType[]> = {
 }
 
 /**
+ * Source→target field-type compatibility for value mapping.
+ *
+ * Keyed by the **target** {@link FieldType} → the set of **source** field types
+ * whose values can be written into it (a target always accepts its own type —
+ * that's implicit in {@link isFieldTypeCompatible}, not repeated here). Blocks
+ * the impossible coercions: a boolean can't populate a DATE, an array (TAGS/
+ * MULTI_SELECT) can't populate a scalar TEXT, etc. Targets with an empty list
+ * (RELATIONSHIP, ACTOR, CALC) are never a write sink for another type's value.
+ *
+ * Used by connector mappings and any flow that binds a typed source value to a
+ * field. A raw JSON source type is first reduced to its representative field
+ * type (string→TEXT, number→NUMBER, boolean→CHECKBOX, array→TAGS, object→JSON)
+ * before checking against this map.
+ */
+export const FIELD_TYPE_COMPATIBILITY_MAP: Record<FieldType, FieldType[]> = {
+  // Text-like sinks accept most stringifiable scalars.
+  [FieldTypeEnum.TEXT]: [
+    FieldTypeEnum.NAME,
+    FieldTypeEnum.RICH_TEXT,
+    FieldTypeEnum.EMAIL,
+    FieldTypeEnum.URL,
+    FieldTypeEnum.PHONE_INTL,
+    FieldTypeEnum.NUMBER,
+    FieldTypeEnum.CURRENCY,
+    FieldTypeEnum.CHECKBOX,
+    FieldTypeEnum.SINGLE_SELECT,
+    FieldTypeEnum.DATE,
+    FieldTypeEnum.DATETIME,
+    FieldTypeEnum.TIME,
+  ],
+  [FieldTypeEnum.RICH_TEXT]: [FieldTypeEnum.TEXT, FieldTypeEnum.NAME],
+  [FieldTypeEnum.NAME]: [FieldTypeEnum.TEXT],
+  [FieldTypeEnum.EMAIL]: [FieldTypeEnum.TEXT],
+  [FieldTypeEnum.URL]: [FieldTypeEnum.TEXT],
+  [FieldTypeEnum.PHONE_INTL]: [FieldTypeEnum.TEXT],
+  // Numeric sinks.
+  [FieldTypeEnum.NUMBER]: [FieldTypeEnum.CURRENCY, FieldTypeEnum.TEXT],
+  [FieldTypeEnum.CURRENCY]: [FieldTypeEnum.NUMBER, FieldTypeEnum.TEXT],
+  // Boolean.
+  [FieldTypeEnum.CHECKBOX]: [FieldTypeEnum.TEXT],
+  // Selects.
+  [FieldTypeEnum.SINGLE_SELECT]: [FieldTypeEnum.TEXT, FieldTypeEnum.NUMBER, FieldTypeEnum.CHECKBOX],
+  [FieldTypeEnum.MULTI_SELECT]: [FieldTypeEnum.TAGS],
+  [FieldTypeEnum.TAGS]: [FieldTypeEnum.MULTI_SELECT, FieldTypeEnum.TEXT],
+  // Date/time (numbers accepted as epoch timestamps).
+  [FieldTypeEnum.DATE]: [FieldTypeEnum.DATETIME, FieldTypeEnum.TEXT, FieldTypeEnum.NUMBER],
+  [FieldTypeEnum.DATETIME]: [FieldTypeEnum.DATE, FieldTypeEnum.TEXT, FieldTypeEnum.NUMBER],
+  [FieldTypeEnum.TIME]: [FieldTypeEnum.TEXT],
+  // Complex.
+  [FieldTypeEnum.ADDRESS]: [FieldTypeEnum.ADDRESS_STRUCT, FieldTypeEnum.TEXT],
+  [FieldTypeEnum.ADDRESS_STRUCT]: [FieldTypeEnum.JSON],
+  [FieldTypeEnum.FILE]: [FieldTypeEnum.TEXT],
+  // JSON is an opaque sink — accepts any other type.
+  [FieldTypeEnum.JSON]: [
+    FieldTypeEnum.TEXT,
+    FieldTypeEnum.NAME,
+    FieldTypeEnum.RICH_TEXT,
+    FieldTypeEnum.EMAIL,
+    FieldTypeEnum.URL,
+    FieldTypeEnum.PHONE_INTL,
+    FieldTypeEnum.NUMBER,
+    FieldTypeEnum.CURRENCY,
+    FieldTypeEnum.CHECKBOX,
+    FieldTypeEnum.SINGLE_SELECT,
+    FieldTypeEnum.MULTI_SELECT,
+    FieldTypeEnum.TAGS,
+    FieldTypeEnum.DATE,
+    FieldTypeEnum.DATETIME,
+    FieldTypeEnum.TIME,
+    FieldTypeEnum.ADDRESS,
+    FieldTypeEnum.ADDRESS_STRUCT,
+    FieldTypeEnum.FILE,
+    FieldTypeEnum.RELATIONSHIP,
+    FieldTypeEnum.ACTOR,
+    FieldTypeEnum.CALC,
+  ],
+  // Never a sink for a different type's value.
+  [FieldTypeEnum.RELATIONSHIP]: [],
+  [FieldTypeEnum.ACTOR]: [],
+  [FieldTypeEnum.CALC]: [],
+}
+
+/**
+ * Can a `source` field type's value be written into a `target` field type? A
+ * target always accepts its own type; otherwise it must be listed in
+ * {@link FIELD_TYPE_COMPATIBILITY_MAP}.
+ */
+export function isFieldTypeCompatible(target: FieldType, source: FieldType): boolean {
+  if (target === source) return true
+  return FIELD_TYPE_COMPATIBILITY_MAP[target]?.includes(source) ?? false
+}
+
+/**
  * FieldTypeOption interface
  * Describes the metadata associated with each custom field type option
  */


### PR DESCRIPTION
## Summary

- Add a source→target field-type **compatibility map** (`FIELD_TYPE_COMPATIBILITY_MAP` + `isFieldTypeCompatible`) in `@auxx/lib/custom-fields`, exported via the `/client` subpath so the mapping UI can use it.
- Surface compatibility across the connector mapping UI — mapping field picker, mapping node, source-leaf rows, and the field calc panel now respect which source value types can be written into a given target field.
- Field picker gains an optional **skip / don't-map** item (`onSkip` + `skipLabel`) to clear a binding from within the picker.
- Refactor the custom-field AI-prompt editor and calc field editor / hooks.

## Notes

- `FIELD_TYPE_COMPATIBILITY_MAP` blocks impossible coercions (e.g. boolean → DATE, array → scalar TEXT); a target always implicitly accepts its own type.
- `RELATIONSHIP`, `ACTOR`, and `CALC` are never write sinks for another type's value.