### PR TITLE
refactor(calc): share the TipTap calc editor across custom-fields and connectors

### DIFF
--- a/apps/web/src/components/custom-fields/ui/calc-editor/calc-field-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/calc-editor/calc-field-editor.tsx
@@ -5,17 +5,8 @@ import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeType } from '@auxx/database/types'
 import type { ResourceField } from '@auxx/lib/resources/client'
 import type { FieldReference } from '@auxx/types/field'
-import { Badge } from '@auxx/ui/components/badge'
-import { Button } from '@auxx/ui/components/button'
-import {
-  CommandGroup,
-  CommandItem,
-  CommandNavigation,
-  CommandSeparator,
-} from '@auxx/ui/components/command'
+import { CommandNavigation } from '@auxx/ui/components/command'
 import { Field, FieldDescription, FieldGroup, FieldLabel } from '@auxx/ui/components/field'
-import { EntityIcon } from '@auxx/ui/components/icons'
-import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import {
   Select,
   SelectContent,
@@ -23,17 +14,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@auxx/ui/components/select'
-import { cn } from '@auxx/ui/lib/utils'
-import { getAvailableFunctions } from '@auxx/utils/calc-expression'
-import { EditorContent } from '@tiptap/react'
-import { AlertCircle, HelpCircle } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
-import { InlinePickerPopover, useActivePicker } from '~/components/editor/inline-picker'
+import { useCallback, useMemo } from 'react'
+import {
+  CalcFormulaInput,
+  type CalcTokenSource,
+  CalcTokensUsed,
+  extractFieldIdsFromString,
+  FunctionsPickerGroup,
+} from '~/components/global/calc-formula'
 import {
   FieldPickerInnerContent,
   type FieldPickerNavigationItem,
 } from '~/components/pickers/field-picker'
-import { useCalcFormula } from './use-calc-formula'
+import { FieldBadge } from '~/components/resources/ui'
 
 /** Options for a CALC field stored in field.options.calc */
 export interface CalcEditorOptions {
@@ -59,8 +52,11 @@ interface CalcFieldEditorProps {
 }
 
 /**
- * Editor component for CALC field configuration.
- * Uses TipTap editor with field picker for formula input.
+ * Editor component for CALC field configuration. A thin wrapper over the shared
+ * {@link CalcFormulaInput}: its token source is the entity definition's fields
+ * (badge = {@link FieldBadge}, picker = {@link FieldPickerInnerContent}). Adds
+ * the custom-field-only "Result Format" selector and stores `sourceFields` as
+ * `placeholderKey → field UUID`.
  */
 export function CalcFieldEditor({
   options,
@@ -69,9 +65,6 @@ export function CalcFieldEditor({
   currentFieldId,
   availableFields,
 }: CalcFieldEditorProps) {
-  const [showFunctions, setShowFunctions] = useState(false)
-  const functions = useMemo(() => getAvailableFunctions(), [])
-
   // Build a mapping from field key to field id for storage
   const fieldKeyToId = useMemo(() => {
     const map: Record<string, string> = {}
@@ -80,63 +73,6 @@ export function CalcFieldEditor({
     }
     return map
   }, [availableFields])
-
-  // Use the calc formula hook
-  const { editor, validation, sourceFields, insertField, insertFunction, closePicker } =
-    useCalcFormula({
-      initialExpression: options.expression,
-      onExpressionChange: (expression, extractedFields) => {
-        // Build sourceFields mapping: placeholder key → bare field id (UUID).
-        // Both calc consumers — the client `calc-value-computer` dependency
-        // graph and the server `calc-resolver` (which wraps with
-        // `toResourceFieldId`) — expect the value to be a plain field id, NOT
-        // a `entityDef:fieldId` ResourceFieldId.
-        const sourceFieldsMap: Record<string, string> = {}
-        for (const key of extractedFields) {
-          if (fieldKeyToId[key]) {
-            sourceFieldsMap[key] = fieldKeyToId[key]
-          }
-        }
-
-        onChange({
-          ...options,
-          expression,
-          sourceFields: sourceFieldsMap,
-        })
-      },
-      entityDefinitionId,
-      currentFieldId,
-      availableFields: availableFields.map((f) => ({ key: f.key, label: f.label, type: f.type })),
-      placeholder: 'Type { to insert a field, e.g., concat({firstName}, " ", {lastName})',
-    })
-
-  /** Insert function at cursor */
-  const handleInsertFunction = (funcName: string) => {
-    if (editor) {
-      editor.chain().focus().insertContent(`${funcName}(`).run()
-      setShowFunctions(false)
-    }
-  }
-
-  /** Handle selecting a field from the picker */
-  const handleSelectField = useCallback(
-    (_fieldReference: FieldReference, field: ResourceField) => {
-      // Insert the field's `key` (e.g. `lastName`) — the token the FieldBadge
-      // pill resolves (fieldMap aliases `<entity>:<key>`) and what
-      // `availableFields` / `fieldKeyToId` are keyed by. The output key
-      // (`systemAttribute`, e.g. `last_name`) is NOT fieldMap-resolvable.
-      insertField(field.key || field.id)
-    },
-    [insertField]
-  )
-
-  /** Handle selecting a function from the picker */
-  const handleSelectFunction = useCallback(
-    (funcName: string) => {
-      insertFunction(funcName)
-    },
-    [insertFunction]
-  )
 
   // Build exclude filters: exclude RELATIONSHIP and CALC types, plus current field
   const excludeFilters = useMemo(() => {
@@ -150,152 +86,81 @@ export function CalcFieldEditor({
     return filters
   }, [entityDefinitionId, currentFieldId])
 
-  /** Render functions section filtered by search */
-  const renderFunctionsInPicker = useCallback(
-    (search: string) => {
-      const filteredFunctions = search
-        ? functions.filter(
-            (f) =>
-              f.name.toLowerCase().includes(search.toLowerCase()) ||
-              f.description.toLowerCase().includes(search.toLowerCase())
-          )
-        : functions
-
-      if (filteredFunctions.length === 0) return null
-
-      return (
-        <>
-          <CommandSeparator />
-          <CommandGroup heading='Functions'>
-            {filteredFunctions.map((fn) => (
-              <CommandItem key={fn.name} onSelect={() => handleSelectFunction(fn.name)}>
-                <EntityIcon iconId='function' size='xs' className='text-muted-foreground' />
-                <div className='flex flex-col'>
-                  <span className='font-mono text-sm'>{fn.signature}</span>
-                  <span className='text-xs text-muted-foreground'>{fn.description}</span>
-                </div>
-              </CommandItem>
-            ))}
-          </CommandGroup>
-        </>
-      )
+  /** Handle selecting a field from the picker */
+  const handleSelectField = useCallback(
+    (onSelect: (tokenId: string) => void) => (_ref: FieldReference, field: ResourceField) => {
+      // Insert the field's `key` (e.g. `lastName`) — the token the FieldBadge
+      // pill resolves (fieldMap aliases `<entity>:<key>`) and what
+      // `availableFields` / `fieldKeyToId` are keyed by. The output key
+      // (`systemAttribute`, e.g. `last_name`) is NOT fieldMap-resolvable.
+      onSelect(field.key || field.id)
     },
-    [functions, handleSelectFunction]
+    []
   )
 
-  // Drive the picker popover off the open `{` chip (positioning, query,
-  // outside-click + Escape are all owned by InlinePickerPopover).
-  const activePicker = useActivePicker(editor)
-  const pickerOpen = !!activePicker && activePicker.trigger === '{'
+  // The token source: entity fields. Badge resolves a key against the resource
+  // store; the picker is the self-contained field navigation widget, with the
+  // shared functions group nested via its `renderAdditionalContent` slot.
+  const tokenSource: CalcTokenSource = useMemo(
+    () => ({
+      renderBadge: (id, selected) => (
+        <FieldBadge id={id} entityDefinitionId={entityDefinitionId} selected={selected} />
+      ),
+      renderPickerItems: ({ onSelect, insertFunction, onClose }) => (
+        <CommandNavigation<FieldPickerNavigationItem>>
+          <FieldPickerInnerContent
+            entityDefinitionId={entityDefinitionId}
+            excludeFields={excludeFilters}
+            onSelect={handleSelectField(onSelect)}
+            onClose={onClose}
+            closeOnSelect
+            showBreadcrumb={false}
+            searchPlaceholder='Search fields or functions...'
+            renderAdditionalContent={(search) => (
+              <FunctionsPickerGroup search={search} onSelect={insertFunction} />
+            )}
+          />
+        </CommandNavigation>
+      ),
+    }),
+    [entityDefinitionId, excludeFilters, handleSelectField]
+  )
+
+  // Build sourceFields mapping: placeholder key → bare field id (UUID). Both
+  // calc consumers — the client `calc-value-computer` dependency graph and the
+  // server `calc-resolver` (which wraps with `toResourceFieldId`) — expect a
+  // plain field id, NOT a `entityDef:fieldId` ResourceFieldId.
+  const handleExpressionChange = useCallback(
+    (expression: string, extractedTokens: string[]) => {
+      const sourceFieldsMap: Record<string, string> = {}
+      for (const key of extractedTokens) {
+        if (fieldKeyToId[key]) {
+          sourceFieldsMap[key] = fieldKeyToId[key]
+        }
+      }
+      onChange({ ...options, expression, sourceFields: sourceFieldsMap })
+    },
+    [fieldKeyToId, onChange, options]
+  )
+
+  // Tokens currently referenced, for the "Fields used" strip.
+  const usedTokens = useMemo(
+    () => extractFieldIdsFromString(options.expression),
+    [options.expression]
+  )
 
   return (
     <FieldGroup className='space-y-4'>
-      {/* Formula Expression Editor */}
-      <Field>
-        <div className='flex items-center justify-between'>
-          <FieldLabel>Formula Expression</FieldLabel>
-          <Popover open={showFunctions} onOpenChange={setShowFunctions}>
-            <PopoverTrigger asChild>
-              <Button variant='ghost' size='sm'>
-                <HelpCircle className='size-4 mr-1' />
-                Functions
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className='w-96 max-h-80 overflow-y-auto' align='end'>
-              <div className='space-y-2'>
-                <h4 className='font-medium text-sm'>Available Functions</h4>
-                <p className='text-xs text-muted-foreground mb-2'>
-                  Click to insert at cursor position
-                </p>
-                {functions.map((fn) => (
-                  <div
-                    key={fn.name}
-                    className='p-2 border rounded hover:bg-muted cursor-pointer'
-                    onClick={() => handleInsertFunction(fn.name)}>
-                    <div className='font-mono text-sm text-primary-900'>{fn.signature}</div>
-                    <div className='text-xs text-muted-foreground'>{fn.description}</div>
-                    <div className='text-xs text-muted-foreground mt-1'>
-                      Example: <code className='bg-muted px-1 rounded'>{fn.example}</code>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </PopoverContent>
-          </Popover>
-        </div>
+      <CalcFormulaInput
+        expression={options.expression}
+        onChange={handleExpressionChange}
+        tokenSource={tokenSource}
+        label='Formula Expression'
+        showFunctionsHelp
+        placeholder='Type { to insert a field, e.g., concat({firstName}, " ", {lastName})'
+      />
 
-        {/* TipTap Editor with Field Picker Popover */}
-        <div
-          className={cn(
-            'relative border rounded-md bg-background',
-            !validation.isValid &&
-              options.expression.trim() &&
-              validation.error !== 'Expression is required' &&
-              'border-destructive'
-          )}>
-          <EditorContent editor={editor} className='min-h-[80px]' />
-        </div>
-
-        {/* Field + function picker, anchored at the open `{` chip */}
-        {editor && (
-          <InlinePickerPopover
-            state={{
-              isOpen: pickerOpen,
-              query: activePicker?.query ?? '',
-              range: null,
-              clientRect: activePicker?.clientRect ?? null,
-            }}
-            width={320}
-            onClose={closePicker}>
-            <CommandNavigation<FieldPickerNavigationItem>>
-              <FieldPickerInnerContent
-                entityDefinitionId={entityDefinitionId}
-                excludeFields={excludeFilters}
-                onSelect={handleSelectField}
-                onClose={closePicker}
-                closeOnSelect
-                showBreadcrumb={false}
-                searchPlaceholder='Search fields or functions...'
-                renderAdditionalContent={renderFunctionsInPicker}
-              />
-            </CommandNavigation>
-          </InlinePickerPopover>
-        )}
-
-        {/* Validation Error - only show for actual syntax errors, not empty state */}
-        {!validation.isValid &&
-          options.expression.trim() &&
-          validation.error !== 'Expression is required' && (
-            <div className='flex items-center gap-1 text-sm text-destructive mt-1'>
-              <AlertCircle className='size-4' />
-              {validation.error}
-            </div>
-          )}
-
-        <FieldDescription>
-          Type <kbd className='px-1 bg-muted rounded text-xs'>{'{'}</kbd> to insert a field
-          reference. Use functions like concat(), add(), multiply().
-        </FieldDescription>
-      </Field>
-
-      {/* Source Fields Display - only show when there are actual field references */}
-      {sourceFields.length > 0 && (
-        <Field>
-          <FieldLabel>Fields Used</FieldLabel>
-          <div className='flex flex-wrap gap-1'>
-            {sourceFields.map((fieldKey) => {
-              const field = availableFields.find((f) => f.key === fieldKey)
-              const isMissing = !field
-              return (
-                <Badge key={fieldKey} variant={isMissing ? 'destructive' : 'secondary'}>
-                  {field?.label ?? fieldKey}
-                  {isMissing && ' (not found)'}
-                </Badge>
-              )
-            })}
-          </div>
-        </Field>
-      )}
+      <CalcTokensUsed tokens={usedTokens} tokenSource={tokenSource} />
 
       {/* Result Field Type */}
       <Field>

--- a/apps/web/src/components/custom-fields/ui/calc-editor/index.ts
+++ b/apps/web/src/components/custom-fields/ui/calc-editor/index.ts
@@ -1,15 +1,18 @@
 // apps/web/src/components/custom-fields/ui/calc-editor/index.ts
 
+// Re-exported from the shared calc-formula home (moved there so both the
+// custom-fields and data-connectors editors can use them).
+export {
+  extractFieldIds,
+  extractFieldIdsFromString,
+  formulaToString,
+  stringToFormula,
+  type UseCalcFormulaOptions,
+  useCalcFormula,
+} from '~/components/global/calc-formula'
 export {
   type CalcEditorOptions,
   CalcFieldEditor,
   formatCalcOptions,
   parseCalcOptions,
 } from './calc-field-editor'
-export {
-  extractFieldIds,
-  extractFieldIdsFromString,
-  formulaToString,
-  stringToFormula,
-} from './formula-converters'
-export { type UseCalcFormulaOptions, useCalcFormula } from './use-calc-formula'

--- a/apps/web/src/components/data-connectors/ui/field-calc-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/field-calc-panel.tsx
@@ -2,16 +2,30 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
-import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { Field, FieldDescription, FieldLabel } from '@auxx/ui/components/field'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@auxx/ui/components/command'
+import { Field, FieldLabel } from '@auxx/ui/components/field'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { getAvailableFunctions, validateCalcExpression } from '@auxx/utils/calc-expression'
-import { AlertCircle, ChevronDown, FunctionSquare } from 'lucide-react'
-import { useMemo, useRef, useState } from 'react'
+import { validateCalcExpression } from '@auxx/utils/calc-expression'
+import { ChevronDown, Hash } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import {
+  CalcFormulaInput,
+  type CalcTokenSource,
+  CalcTokensUsed,
+  FunctionsPickerGroup,
+} from '~/components/global/calc-formula'
 import { FieldPicker } from '~/components/pickers/field-picker'
 import type { SourcePath } from '../hooks/use-source-paths'
 import { isSourceTargetCompatible } from './field-type-compat'
+import { SourcePathBadge } from './source-path-badge'
 
 interface FieldCalcPanelProps {
   /** The mapping's def — the source of selectable target fields. Null only if unset. */
@@ -24,7 +38,7 @@ interface FieldCalcPanelProps {
   excludeKeys: string[]
   /** Current calc expression (over source tokens, e.g. `concat({a}," ",{b})`). */
   expression: string
-  /** Source schema paths offered as `{token}` inserts. */
+  /** Source schema paths offered as `{token}` inserts (subtree-relative). */
   sourcePaths: SourcePath[]
   /** Persist the chosen target field + expression + the source fields it references. */
   onSave: (targetKey: string, expression: string, sourceFields: Record<string, string>) => void
@@ -34,15 +48,14 @@ interface FieldCalcPanelProps {
  * The lone mapping drill — the calc expression editor (05 §4). A formula row (or
  * the "+ Add formula" row) opens this. The canonical {@link FieldPicker} picks
  * which target field the expression writes into (so the panel handles both
- * create and retarget), excluding fields already bound by another leaf/formula;
- * the token picker lists SOURCE-schema paths (not target fields), the function
- * set comes from `@auxx/utils/calc-expression`, and output is the target field.
- * Stored uniformly as `{ expression, sourceFields }` keyed by the target field.
+ * create and retarget), excluding fields already bound by another leaf/formula.
  *
- * Implementation note: this uses a plain textarea + insert buttons (not the
- * entity-coupled TipTap `CalcFieldEditor`/`FieldBadge`, which resolves tokens
- * against an entity def). That keeps the connector route free of the entity
- * field-picker coupling while reusing the shared calc function set + validator.
+ * The expression itself uses the shared {@link CalcFormulaInput} (the same TipTap
+ * editor as custom-fields CALC fields) backed by a **source-path** token source:
+ * tokens are subtree-relative schema paths (`customer.email`), not entity fields,
+ * so the chip resolves nothing and the `{` picker lists source paths. Stored
+ * uniformly as `{ expression, sourceFields }` keyed by the target field, with
+ * `sourceFields` an identity `path → path` map.
  */
 export function FieldCalcPanel({
   entityDefinitionId,
@@ -57,34 +70,54 @@ export function FieldCalcPanel({
   const [target, setTarget] = useState(targetKey)
   const [targetChip, setTargetChip] = useState(targetLabel)
   const [pickerOpen, setPickerOpen] = useState(false)
-  const taRef = useRef<HTMLTextAreaElement>(null)
-  const functions = useMemo(() => getAvailableFunctions(), [])
   const excludeSet = useMemo(() => new Set(excludeKeys), [excludeKeys])
 
   const validation = useMemo(() => {
-    if (!value.trim()) return { isValid: true, extractedFields: [] as string[], error: undefined }
+    if (!value.trim()) return { isValid: true, extractedFields: [] as string[] }
     return validateCalcExpression(value)
   }, [value])
 
-  const insertAtCursor = (text: string) => {
-    const ta = taRef.current
-    if (!ta) {
-      setValue((v) => v + text)
-      return
-    }
-    const start = ta.selectionStart
-    const end = ta.selectionEnd
-    const next = value.slice(0, start) + text + value.slice(end)
-    setValue(next)
-    requestAnimationFrame(() => {
-      ta.focus()
-      ta.selectionStart = ta.selectionEnd = start + text.length
-    })
-  }
+  // The token source: source-schema paths. Badge is purely presentational; the
+  // `{` picker is a flat path list followed by the shared functions group.
+  const tokenSource: CalcTokenSource = useMemo(
+    () => ({
+      renderBadge: (id, selected) => <SourcePathBadge path={id} selected={selected} />,
+      renderPickerItems: ({ onSelect, insertFunction, onClose }) => (
+        <Command>
+          <CommandInput placeholder='Search source fields or functions…' />
+          <CommandList>
+            <CommandEmpty>No source fields.</CommandEmpty>
+            {sourcePaths.length > 0 && (
+              <CommandGroup heading='Source fields'>
+                {sourcePaths.map((p) => (
+                  <CommandItem
+                    key={p.path}
+                    value={p.path}
+                    onSelect={() => {
+                      onSelect(p.path)
+                      onClose()
+                    }}>
+                    <Hash className='size-3.5 text-muted-foreground' />
+                    <span className='font-mono text-sm'>{p.path}</span>
+                    <span className='ml-auto text-[10px] uppercase text-muted-foreground/60'>
+                      {p.type}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            <FunctionsPickerGroup search='' onSelect={insertFunction} />
+          </CommandList>
+        </Command>
+      ),
+    }),
+    [sourcePaths]
+  )
 
   const canSave = !!target && validation.isValid && !!value.trim()
   const handleSave = () => {
     if (!canSave) return
+    // Connectors store sourceFields as an identity map (token path → source path).
     const fields: Record<string, string> = {}
     for (const path of validation.extractedFields) fields[path] = path
     onSave(target, value, fields)
@@ -98,7 +131,7 @@ export function FieldCalcPanel({
           <FieldPicker
             open={pickerOpen}
             onOpenChange={setPickerOpen}
-            entityDefinitionId={entityDefinitionId}
+            entityDefinitionId={entityDefinitionId ?? ''}
             excludeFields={[FieldType.RELATIONSHIP]}
             // A formula yields a scalar (string/number) — exclude already-bound
             // targets and any field type a computed value can't populate.
@@ -123,76 +156,25 @@ export function FieldCalcPanel({
           />
         </Field>
 
-        <Field>
-          <FieldLabel>Expression</FieldLabel>
-          <textarea
-            ref={taRef}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            placeholder='concat({first_name}, " ", {last_name})'
-            className='min-h-[88px] w-full rounded-md border bg-background p-2 font-mono text-sm outline-none focus:ring-1 focus:ring-ring'
-          />
-          {!validation.isValid && value.trim() && (
-            <div className='mt-1 flex items-center gap-1 text-sm text-destructive'>
-              <AlertCircle className='size-4' />
-              {validation.error}
-            </div>
-          )}
-          <FieldDescription>
-            Reference source fields with <code className='rounded bg-muted px-1'>{'{path}'}</code>{' '}
-            and combine them with functions.
-          </FieldDescription>
-        </Field>
+        <CalcFormulaInput
+          expression={expression}
+          onChange={(expr) => setValue(expr)}
+          tokenSource={tokenSource}
+          label='Expression'
+          placeholder='concat({first_name}, " ", {last_name})'
+        />
 
-        <div className='flex flex-col gap-1.5'>
-          <span className='text-xs font-medium uppercase text-muted-foreground'>Source fields</span>
-          <div className='flex flex-wrap gap-1'>
-            {sourcePaths.length === 0 ? (
-              <span className='text-xs text-muted-foreground'>
-                No source schema yet — generate one in the stream first.
-              </span>
-            ) : (
-              sourcePaths.map((p) => (
-                <Button
-                  key={p.path}
-                  variant='outline'
-                  size='xs'
-                  onClick={() => insertAtCursor(`{${p.path}}`)}>
-                  {p.path}
-                </Button>
-              ))
-            )}
-          </div>
-        </div>
-
-        <div className='flex flex-col gap-1.5'>
-          <span className='flex items-center gap-1 text-xs font-medium uppercase text-muted-foreground'>
-            <FunctionSquare className='size-3.5' />
-            Functions
+        {sourcePaths.length === 0 && (
+          <span className='text-xs text-muted-foreground'>
+            No source schema yet — generate one in the stream first.
           </span>
-          <div className='flex flex-wrap gap-1'>
-            {functions.map((fn) => (
-              <Button
-                key={fn.name}
-                variant='ghost'
-                size='xs'
-                title={`${fn.signature} — ${fn.description}`}
-                onClick={() => insertAtCursor(`${fn.name}(`)}>
-                {fn.name}
-              </Button>
-            ))}
-          </div>
-        </div>
-
-        {validation.extractedFields.length > 0 && (
-          <div className='flex flex-wrap gap-1'>
-            {validation.extractedFields.map((f) => (
-              <Badge key={f} variant='secondary'>
-                {f}
-              </Badge>
-            ))}
-          </div>
         )}
+
+        <CalcTokensUsed
+          tokens={validation.extractedFields}
+          tokenSource={tokenSource}
+          label='Source fields used'
+        />
 
         <Button className='self-start' disabled={!canSave} onClick={handleSave}>
           Save expression

--- a/apps/web/src/components/data-connectors/ui/source-path-badge.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-path-badge.tsx
@@ -1,0 +1,50 @@
+// apps/web/src/components/data-connectors/ui/source-path-badge.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { Hash, X } from 'lucide-react'
+import { recordBadgeVariants } from '~/components/resources/ui'
+import { lastSegment } from '../hooks/use-source-paths'
+
+interface SourcePathBadgeProps {
+  /** The source-schema path token, e.g. `customer.email`. */
+  path: string
+  selected?: boolean
+  /** When set, renders a trailing X button. */
+  onRemove?: () => void
+}
+
+/**
+ * Presentational chip for a source-path `{token}` inside the connector calc
+ * editor. Unlike {@link FieldBadge}, it resolves nothing — the path IS the
+ * label. Shares {@link recordBadgeVariants} so it sits visually next to field
+ * chips. Shows the last path segment, with the full path on hover.
+ */
+export function SourcePathBadge({ path, selected, onRemove }: SourcePathBadgeProps) {
+  return (
+    <span
+      data-slot='field-badge'
+      title={path}
+      className={cn(
+        recordBadgeVariants({}),
+        'font-mono font-normal',
+        selected && 'ring-2 ring-primary ring-offset-1'
+      )}>
+      <Hash className='size-3 text-muted-foreground' />
+      <span className='truncate'>{lastSegment(path)}</span>
+      {onRemove && (
+        <button
+          type='button'
+          data-slot='record-remove'
+          aria-label='Remove'
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            onRemove()
+          }}>
+          <X />
+        </button>
+      )}
+    </span>
+  )
+}

--- a/apps/web/src/components/global/calc-formula/calc-formula-input.tsx
+++ b/apps/web/src/components/global/calc-formula/calc-formula-input.tsx
@@ -1,0 +1,154 @@
+// apps/web/src/components/global/calc-formula/calc-formula-input.tsx
+
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Field, FieldDescription, FieldLabel } from '@auxx/ui/components/field'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { cn } from '@auxx/ui/lib/utils'
+import { getAvailableFunctions } from '@auxx/utils/calc-expression'
+import { EditorContent } from '@tiptap/react'
+import { AlertCircle, HelpCircle } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { InlinePickerPopover, useActivePicker } from '~/components/editor/inline-picker'
+import type { CalcTokenSource } from './token-source'
+import { useCalcFormula } from './use-calc-formula'
+
+interface CalcFormulaInputProps {
+  /** Initial expression (the editor is uncontrolled after mount; changes flow via onChange). */
+  expression: string
+  /** Emits the new expression + the tokens it references on every edit. */
+  onChange: (expression: string, extractedTokens: string[]) => void
+  /** The single consumer-specific seam (badge + `{` picker body). */
+  tokenSource: CalcTokenSource
+  placeholder?: string
+  /** Optional header label above the editor (rendered with the functions-help button). */
+  label?: string
+  /** Show a "Functions" help popover button in the header (default false). */
+  showFunctionsHelp?: boolean
+}
+
+/**
+ * The reusable calc-formula editor heart: a TipTap box whose `{` opens an inline
+ * token + functions picker, with inline validation. Everything consumer-specific
+ * (what a token is, how its chip renders, what the picker lists) is supplied via
+ * {@link CalcTokenSource}; the surrounding chrome (a target picker, a result-type
+ * selector, a Save button) is composed by the consumer around this component.
+ */
+export function CalcFormulaInput({
+  expression,
+  onChange,
+  tokenSource,
+  placeholder = 'Type { to insert a field, e.g., concat({firstName}, " ", {lastName})',
+  label,
+  showFunctionsHelp = false,
+}: CalcFormulaInputProps) {
+  const [showFunctions, setShowFunctions] = useState(false)
+  const functions = useMemo(() => getAvailableFunctions(), [])
+
+  const { editor, validation, insertField, insertFunction, closePicker } = useCalcFormula({
+    initialExpression: expression,
+    onExpressionChange: onChange,
+    renderBadge: tokenSource.renderBadge,
+    placeholder,
+  })
+
+  /** Insert a function from the header help popover (not the `{` picker). */
+  const handleInsertFunction = (funcName: string) => {
+    if (editor) {
+      editor.chain().focus().insertContent(`${funcName}(`).run()
+      setShowFunctions(false)
+    }
+  }
+
+  // Drive the picker popover off the open `{` chip.
+  const activePicker = useActivePicker(editor)
+  const pickerOpen = !!activePicker && activePicker.trigger === '{'
+  const query = activePicker?.query ?? ''
+
+  // Show syntax errors, but not the empty-state "Expression is required". The
+  // hook's validation is live (driven by the editor), and it returns the
+  // "required" sentinel for an empty expression — so that one check covers both
+  // the empty gate and the live-vs-initial staleness the prop can't.
+  const showError = !validation.isValid && validation.error !== 'Expression is required'
+
+  return (
+    <Field>
+      {(label || showFunctionsHelp) && (
+        <div className='flex items-center justify-between'>
+          {label ? <FieldLabel>{label}</FieldLabel> : <span />}
+          {showFunctionsHelp && (
+            <Popover open={showFunctions} onOpenChange={setShowFunctions}>
+              <PopoverTrigger asChild>
+                <Button variant='ghost' size='sm'>
+                  <HelpCircle className='size-4 mr-1' />
+                  Functions
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className='w-96 max-h-80 overflow-y-auto' align='end'>
+                <div className='space-y-2'>
+                  <h4 className='font-medium text-sm'>Available Functions</h4>
+                  <p className='text-xs text-muted-foreground mb-2'>
+                    Click to insert at cursor position
+                  </p>
+                  {functions.map((fn) => (
+                    <div
+                      key={fn.name}
+                      className='p-2 border rounded hover:bg-muted cursor-pointer'
+                      onClick={() => handleInsertFunction(fn.name)}>
+                      <div className='font-mono text-sm text-primary-900'>{fn.signature}</div>
+                      <div className='text-xs text-muted-foreground'>{fn.description}</div>
+                      <div className='text-xs text-muted-foreground mt-1'>
+                        Example: <code className='bg-muted px-1 rounded'>{fn.example}</code>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </PopoverContent>
+            </Popover>
+          )}
+        </div>
+      )}
+
+      {/* TipTap editor with the `{` picker popover */}
+      <div
+        className={cn(
+          'relative border rounded-md bg-background',
+          showError && 'border-destructive'
+        )}>
+        <EditorContent editor={editor} className='min-h-[80px]' />
+      </div>
+
+      {editor && (
+        <InlinePickerPopover
+          state={{
+            isOpen: pickerOpen,
+            query,
+            range: null,
+            clientRect: activePicker?.clientRect ?? null,
+          }}
+          width={320}
+          onClose={closePicker}>
+          {tokenSource.renderPickerItems({
+            query,
+            onSelect: insertField,
+            insertFunction,
+            onClose: closePicker,
+          })}
+        </InlinePickerPopover>
+      )}
+
+      {showError && (
+        <div className='flex items-center gap-1 text-sm text-destructive mt-1'>
+          <AlertCircle className='size-4' />
+          {validation.error}
+        </div>
+      )}
+
+      <FieldDescription>
+        Type <kbd className='px-1 bg-muted rounded text-xs'>{'{'}</kbd> to insert a field reference.
+        Use functions like concat(), add(), multiply().
+      </FieldDescription>
+    </Field>
+  )
+}

--- a/apps/web/src/components/global/calc-formula/calc-tokens-used.tsx
+++ b/apps/web/src/components/global/calc-formula/calc-tokens-used.tsx
@@ -1,0 +1,39 @@
+// apps/web/src/components/global/calc-formula/calc-tokens-used.tsx
+
+'use client'
+
+import { Field, FieldLabel } from '@auxx/ui/components/field'
+import type { CalcTokenSource } from './token-source'
+
+interface CalcTokensUsedProps {
+  /** The tokens referenced by the expression (validation.extractedFields). */
+  tokens: string[]
+  /** Renders each token's chip — reuses the same badge as the editor. */
+  tokenSource: CalcTokenSource
+  /** Section label (default "Fields used"). */
+  label?: string
+}
+
+/**
+ * The "tokens used" chip strip below a calc editor. Renders each referenced
+ * token via the token source's badge, so unknown/unresolved tokens surface the
+ * same way they do inside the editor (e.g. a destructive "not found" chip). Used
+ * by both calc-formula consumers.
+ */
+export function CalcTokensUsed({
+  tokens,
+  tokenSource,
+  label = 'Fields used',
+}: CalcTokensUsedProps) {
+  if (tokens.length === 0) return null
+  return (
+    <Field>
+      <FieldLabel>{label}</FieldLabel>
+      <div className='flex flex-wrap gap-1'>
+        {tokens.map((token) => (
+          <span key={token}>{tokenSource.renderBadge(token, false)}</span>
+        ))}
+      </div>
+    </Field>
+  )
+}

--- a/apps/web/src/components/global/calc-formula/formula-converters.ts
+++ b/apps/web/src/components/global/calc-formula/formula-converters.ts
@@ -1,4 +1,4 @@
-// apps/web/src/components/custom-fields/ui/calc-editor/formula-converters.ts
+// apps/web/src/components/global/calc-formula/formula-converters.ts
 
 import {
   extractFieldIdsFromString as extractFieldIdsFromStringLib,

--- a/apps/web/src/components/global/calc-formula/functions-picker-group.tsx
+++ b/apps/web/src/components/global/calc-formula/functions-picker-group.tsx
@@ -1,0 +1,51 @@
+// apps/web/src/components/global/calc-formula/functions-picker-group.tsx
+
+'use client'
+
+import { CommandGroup, CommandItem, CommandSeparator } from '@auxx/ui/components/command'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { getAvailableFunctions } from '@auxx/utils/calc-expression'
+import { useMemo } from 'react'
+
+interface FunctionsPickerGroupProps {
+  /** Current picker search query — filters the function list. */
+  search: string
+  /** Insert a function call (`name(`) at the cursor. */
+  onSelect: (funcName: string) => void
+}
+
+/**
+ * The shared Functions group for the `{`-picker, rendered after a token source's
+ * items. Both calc-formula consumers (custom-fields, data-connectors) render it,
+ * so the `getAvailableFunctions()` + search-filter logic lives once.
+ */
+export function FunctionsPickerGroup({ search, onSelect }: FunctionsPickerGroupProps) {
+  const functions = useMemo(() => getAvailableFunctions(), [])
+
+  const filtered = search
+    ? functions.filter(
+        (f) =>
+          f.name.toLowerCase().includes(search.toLowerCase()) ||
+          f.description.toLowerCase().includes(search.toLowerCase())
+      )
+    : functions
+
+  if (filtered.length === 0) return null
+
+  return (
+    <>
+      <CommandSeparator />
+      <CommandGroup heading='Functions'>
+        {filtered.map((fn) => (
+          <CommandItem key={fn.name} onSelect={() => onSelect(fn.name)}>
+            <EntityIcon iconId='function' size='xs' className='text-muted-foreground' />
+            <div className='flex flex-col'>
+              <span className='font-mono text-sm'>{fn.signature}</span>
+              <span className='text-xs text-muted-foreground'>{fn.description}</span>
+            </div>
+          </CommandItem>
+        ))}
+      </CommandGroup>
+    </>
+  )
+}

--- a/apps/web/src/components/global/calc-formula/index.ts
+++ b/apps/web/src/components/global/calc-formula/index.ts
@@ -1,0 +1,13 @@
+// apps/web/src/components/global/calc-formula/index.ts
+
+export { CalcFormulaInput } from './calc-formula-input'
+export { CalcTokensUsed } from './calc-tokens-used'
+export {
+  extractFieldIds,
+  extractFieldIdsFromString,
+  formulaToString,
+  stringToFormula,
+} from './formula-converters'
+export { FunctionsPickerGroup } from './functions-picker-group'
+export type { CalcTokenSource } from './token-source'
+export { type UseCalcFormulaOptions, useCalcFormula } from './use-calc-formula'

--- a/apps/web/src/components/global/calc-formula/token-source.ts
+++ b/apps/web/src/components/global/calc-formula/token-source.ts
@@ -1,0 +1,33 @@
+// apps/web/src/components/global/calc-formula/token-source.ts
+
+import type React from 'react'
+
+/**
+ * The single seam that varies between calc-formula consumers (custom-fields vs
+ * data-connectors). A *token source* is the whole of what a `{token}` means: how
+ * its chip renders, how the `{`-picker lists selectable tokens, and a human
+ * label for the "tokens used" strip.
+ *
+ * - custom-fields builds one from an entity definition (tokens = field keys).
+ * - data-connectors builds one from a source schema (tokens = source paths).
+ *
+ * Adding a future consumer is implementing this interface, not rewiring props.
+ */
+export interface CalcTokenSource {
+  /** Render a token chip from its serialized id (the `{id}` payload). */
+  renderBadge: (id: string, selected: boolean) => React.ReactNode
+  /**
+   * The full `{` picker popover body — must be Command-rooted (the popover
+   * provides no Command context). Render the token list plus the shared
+   * `<FunctionsPickerGroup onSelect={insertFunction} />` wherever it fits the
+   * widget (a self-contained field picker nests it via its own slot; a flat
+   * source list renders it as a sibling group). `onSelect(tokenId)` inserts the
+   * token; `insertFunction(name)` inserts a function call; `onClose` dismisses.
+   */
+  renderPickerItems: (ctx: {
+    query: string
+    onSelect: (tokenId: string) => void
+    insertFunction: (funcName: string) => void
+    onClose: () => void
+  }) => React.ReactNode
+}

--- a/apps/web/src/components/global/calc-formula/use-calc-formula.tsx
+++ b/apps/web/src/components/global/calc-formula/use-calc-formula.tsx
@@ -1,4 +1,4 @@
-// apps/web/src/components/custom-fields/ui/calc-editor/use-calc-formula.tsx
+// apps/web/src/components/global/calc-formula/use-calc-formula.tsx
 
 'use client'
 
@@ -12,41 +12,38 @@ import {
   getOpenPickerRange,
   ReferencePickerNode,
 } from '~/components/editor/inline-picker'
-import { FieldBadge } from '~/components/resources/ui'
 import { extractFieldIds, formulaToString, stringToFormula } from './formula-converters'
+import type { CalcTokenSource } from './token-source'
 
 /** Options for the useCalcFormula hook */
 export interface UseCalcFormulaOptions {
   /** Initial expression string */
   initialExpression?: string
   /** Callback when expression changes */
-  onExpressionChange?: (expression: string, sourceFields: string[]) => void
-  /** Entity definition ID for field picker */
-  entityDefinitionId: string
-  /** Current field ID to exclude from picker (prevent self-reference) */
-  currentFieldId?: string
-  /** Available fields for display and validation */
-  availableFields: Array<{ key: string; label: string; type: string }>
+  onExpressionChange?: (expression: string, extractedTokens: string[]) => void
+  /** Renders the token chips inside the editor (the only consumer-specific seam). */
+  renderBadge: CalcTokenSource['renderBadge']
   /** Placeholder text for empty editor */
   placeholder?: string
 }
 
 /**
- * Hook for managing the CALC formula TipTap editor state.
- * Handles expression parsing, validation, and conversion.
+ * Hook for managing the CALC formula TipTap editor state. Token-source-agnostic:
+ * the only thing it knows about a `{token}` is how to render its chip
+ * (`renderBadge`) — custom-fields resolves it against an entity def, connectors
+ * against a source schema. Handles expression parsing, validation, and conversion.
  *
- * The `{`-triggered field/function picker rides on the shared
- * `ReferencePickerNode` chip (the same primitive used by the snippet /
- * greeting editors): typing `{` opens an inert chip and the consumer mounts
- * the picker popover via `useActivePicker` + `InlinePickerPopover`. Selection
- * is committed here through `getOpenPickerRange` — fields collapse to a
- * `field` badge node, functions insert their literal `name(` text.
+ * The `{`-triggered picker rides on the shared `ReferencePickerNode` chip (the
+ * same primitive used by the snippet / greeting editors): typing `{` opens an
+ * inert chip and the consumer mounts the picker popover via `useActivePicker` +
+ * `InlinePickerPopover`. Selection is committed here through `getOpenPickerRange`
+ * — tokens collapse to a `field` badge node, functions insert their literal
+ * `name(` text.
  */
 export function useCalcFormula({
   initialExpression = '',
   onExpressionChange,
-  entityDefinitionId,
-  availableFields,
+  renderBadge,
   placeholder = 'Type { to insert a field or function...',
 }: UseCalcFormulaOptions) {
   const [expression, setExpression] = useState(initialExpression)
@@ -60,7 +57,9 @@ export function useCalcFormula({
   // Convert initial expression to TipTap content
   const initialContent = useMemo(() => stringToFormula(initialExpression), [initialExpression])
 
-  // Create field node with base factory — serializes to `{id}`.
+  // Create field node with base factory — serializes to `{id}`. The input rule
+  // accepts any non-brace token (`[^{}]+`) so hand-typed dotted/`[]` source
+  // paths (`{customer.email}`) auto-chip, not just `[\w-]` field keys.
   const fieldNode = useMemo(
     () =>
       createInlineNode(
@@ -71,13 +70,11 @@ export function useCalcFormula({
             pattern: /\{([^{}]+)\}/,
             getId: (match) => match[1]!,
           },
-          inputRules: [{ find: /\{([\w-]+)\}$/, getId: (match) => match[1]! }],
+          inputRules: [{ find: /\{([^{}]+)\}$/, getId: (match) => match[1]! }],
         },
-        ({ id, selected }) => (
-          <FieldBadge id={id} entityDefinitionId={entityDefinitionId} selected={selected} />
-        )
+        ({ id, selected }) => renderBadge(id, selected)
       ),
-    [entityDefinitionId]
+    [renderBadge]
   )
 
   // Build editor configuration
@@ -140,12 +137,6 @@ export function useCalcFormula({
     return validateCalcExpression(expression)
   }, [expression])
 
-  // Check for missing fields
-  const missingFields = useMemo(() => {
-    const availableKeys = new Set(availableFields.map((f) => f.key))
-    return validation.extractedFields.filter((f) => !availableKeys.has(f))
-  }, [validation.extractedFields, availableFields])
-
   // Set content programmatically
   const setContent = useCallback(
     (newExpression: string) => {
@@ -194,7 +185,6 @@ export function useCalcFormula({
     editor,
     expression,
     validation,
-    missingFields,
     sourceFields: validation.extractedFields,
     setContent,
     insertField,

--- a/apps/web/src/components/global/schedule/cron-editor.tsx
+++ b/apps/web/src/components/global/schedule/cron-editor.tsx
@@ -357,7 +357,7 @@ export const CronEditor: React.FC<CronEditorProps> = ({
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
               disabled={disabled}
-              className='h-[20px] min-h-0 resize-none border-0 bg-transparent px-2 py-0 font-mono text-sm shadow-none focus-visible:outline-none focus-visible:ring-0'
+              className='h-[20px] min-h-0 resize-none border-0 bg-transparent dark:bg-transparent px-2 py-0 font-mono text-sm shadow-none focus-visible:outline-none focus-visible:ring-0'
               rows={2}
             />
             {!localValue && !isFocused && placeholder && (


### PR DESCRIPTION
## What

The data-connectors calc drill (`field-calc-panel.tsx`) was a from-scratch `textarea` + insert-button reimplementation of a formula editor, while custom-fields CALC fields already had the polished TipTap version — inline token chips, a `{`-triggered picker, function help. Both produce the identical `{ expression, sourceFields }` shape over the same `@auxx/utils/calc-expression` function set; the only real difference is what a `{token}` points at.

This extracts the token-agnostic core into a shared home and reuses it on both sides, **reversing the earlier decision to keep the connector editor separate** (it was only separate because the TipTap editor was coupled to an entity definition — that coupling is now removed).

## How

New shared module `apps/web/src/components/global/calc-formula/` behind a single `CalcTokenSource` seam (`renderBadge` + `renderPickerItems`), backed by two token sources:

- **custom-fields** → entity-definition fields (`FieldBadge` + `FieldPickerInnerContent`)
- **data-connectors** → source-schema paths (new `SourcePathBadge` + a flat path list)

Now shared between both: the editor input, the `{`-picker functions group, the "tokens used" strip, the TipTap converters, the validator, and the hook. Each consumer keeps only its own outer chrome — custom-fields its **Result Format** selector, connectors its **"Writes into"** target picker — plus its token-source implementation. The outer panels are deliberately *not* merged (different layout/lifecycle).

## Result

- Connectors gain inline token chips, source-path autocomplete, and "tokens used" feedback they lacked.
- The stored shape and runtime (`mapRecord`) are unchanged; `connector-detail-tabs.tsx` wiring is untouched.
- The shared validator already tokenizes dotted/`[]` source paths; the auto-chip input rule was widened to match.

## Notes

- Custom-fields' load-bearing `field.key || field.id` token-insert contract is preserved.
- Includes one unrelated dark-mode `bg-transparent` fix in the cron editor (was already in the working tree).

## Testing

- Biome clean across the changeset. No `tsc` (project rule).
- Not yet exercised at runtime — recommended manual pass: a custom-fields CALC field (regression: chips, `{`-picker, functions, Result Format, round-trip) and a connector formula row (source paths in the `{`-picker, chip render, save → reopen rehydrates as chips).