### PR TITLE
feat(data-connectors): templates seed contributing target mappings + provision at sync

### DIFF
--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -5,6 +5,8 @@
 // data-connectors sub-plans (02/03/05a); these are structurally-compatible
 // placeholders kept in sync. Drift between the two is reconciled in code review.
 
+import type { FieldType } from '../../types'
+
 /**
  * Connector kind — text-backed (not a pgEnum) so new connectors ship without an
  * enum-alter migration. Built-in ids plus the `app:${slug}` template literal, so
@@ -97,6 +99,12 @@ export interface FieldMapping {
    * in `@auxx/lib/data-connectors/types`.
    */
   match?: { normalize?: IdentityNormalize }
+  /**
+   * Provisioning hint for a connector-introduced target field (05d). Mirrors the
+   * engine `FieldMapping.provision` in `@auxx/lib/data-connectors/types` — used to
+   * create a missing target field with the declared type/name at sync time.
+   */
+  provision?: { name: string; type: FieldType; icon?: string; isHidden?: boolean }
 }
 
 /**

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -8,10 +8,15 @@
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
+import { getCachedEntityDefId } from '../cache'
 import { BadRequestError, NotFoundError } from '../errors'
 import { removeConnectorScheduler, syncConnectorScheduler } from './data-connector-scheduler'
 import type { DataConnectorMappingRow, DataConnectorRow, DataConnectorStreamRow } from './service'
-import type { ConnectorTemplate } from './templates'
+import type {
+  ConnectorTemplate,
+  ConnectorTemplateFieldMapping,
+  ConnectorTemplateMapping,
+} from './templates'
 import type {
   DataConnectorConfig,
   DataConnectorType,
@@ -95,9 +100,12 @@ export async function createConnector(
  *   - the connector's `config` (base URL + shared headers + pagination) and
  *   - each stream's source schema + request config, pre-filled and editable.
  *
- * v1 seeds config + streams only; entity mappings stay user-authored (the root
- * mapping `addStream` seeds is the spine, exactly as for a blank connector). The
- * `templateId` stamp is provenance — seed-and-forget, no live link back.
+ * When a stream declares `mappings` (05d), they're materialized into real
+ * `DataConnectorMapping` rows — the same rows the manual editor produces — so the
+ * connector is fully wired (target def + field mappings) on install. Streams
+ * without declared mappings keep the 05c behaviour (the seeded root stays
+ * untargeted; the user authors the mapping). The `templateId` stamp is provenance
+ * — seed-and-forget, no live link back.
  */
 export async function createConnectorFromTemplate(
   db: Database,
@@ -113,15 +121,96 @@ export async function createConnectorFromTemplate(
     config: template.config,
   })
   for (const stream of template.streams) {
-    await addStream(db, organizationId, connector.id, {
+    const s = await addStream(db, organizationId, connector.id, {
       streamKey: stream.streamKey,
       sourceSchema: stream.sourceSchema ?? null,
       schemaSource: 'catalog',
       syncMode: stream.syncMode,
       requestConfig: stream.requestConfig,
     })
+    if (stream.mappings?.length) {
+      await seedTemplateMappings(db, organizationId, s.id, stream.mappings)
+    }
   }
   return connector
+}
+
+/**
+ * Materialize a stream's declared template mappings into rows. `addStream` already
+ * seeded one blank root mapping, so the first declared mapping patches that root
+ * (avoiding an orphan untargeted row) and the rest are added. v1: contributing
+ * targets only — the `@system:*` ref resolves to a real def id at install.
+ */
+async function seedTemplateMappings(
+  db: Database,
+  organizationId: string,
+  streamId: string,
+  mappings: ConnectorTemplateMapping[]
+): Promise<void> {
+  const seededRoot = await db.query.DataConnectorMapping.findFirst({
+    where: eq(schema.DataConnectorMapping.dataConnectorStreamId, streamId),
+  })
+  for (const [i, mapping] of mappings.entries()) {
+    const entityDefinitionId = await resolveTemplateEntityRef(
+      organizationId,
+      mapping.target.entityRef
+    )
+    const fieldMappings = buildTemplateFieldMappings(mapping.fields)
+    const shared = {
+      rootPath: mapping.rootPath,
+      linkMode: mapping.linkMode ?? ('upsert' as LinkMode),
+      targetMode: 'contributing' as TargetMode,
+      entityDefinitionId,
+      fieldMappings,
+      orphanBehavior: mapping.orphanBehavior ?? ('ignore' as OrphanBehavior),
+    }
+    if (i === 0 && seededRoot) {
+      await updateMapping(db, organizationId, seededRoot.id, shared)
+    } else {
+      await addMapping(db, organizationId, { dataConnectorStreamId: streamId, ...shared })
+    }
+  }
+}
+
+/** Resolve a template `@system:<entityType>` ref to a real def id (v1: system only). */
+async function resolveTemplateEntityRef(
+  organizationId: string,
+  entityRef: string
+): Promise<string> {
+  if (!entityRef.startsWith('@system:')) {
+    throw new BadRequestError(`Unsupported connector-template entityRef: ${entityRef}`)
+  }
+  const entityType = entityRef.slice('@system:'.length)
+  const id = await getCachedEntityDefId(organizationId, entityType)
+  if (!id) {
+    throw new NotFoundError(`System entity "${entityType}" not found for organization`)
+  }
+  return id
+}
+
+/**
+ * Build the CALC `fieldMappings` jsonb from a template mapping's field bindings.
+ * Matches the shape the manual mapping editor produces: `sourceFields` is an
+ * identity map (token = source path), and the expression references those tokens
+ * as `{path}` (single-brace) — so `source: 'email'` becomes `{ expression: '{email}',
+ * sourceFields: { email: 'email' } }`. Explicit `expression`/`sourceFields` pass
+ * through verbatim for transforms (e.g. `{created} * 1000`).
+ */
+function buildTemplateFieldMappings(
+  fields: ConnectorTemplateFieldMapping[]
+): Record<string, FieldMapping> {
+  const out: Record<string, FieldMapping> = {}
+  for (const f of fields) {
+    const expression = f.expression ?? (f.source ? `{${f.source}}` : '')
+    const sourceFields = f.sourceFields ?? (f.source ? { [f.source]: f.source } : {})
+    const mapping: FieldMapping = { expression, sourceFields }
+    if (f.match) mapping.match = typeof f.match === 'object' ? f.match : {}
+    // Provisioned field's name = its key (provisioned fields carry no
+    // systemAttribute, so the crud layer resolves writes by name).
+    if (f.provision) mapping.provision = { name: f.key, ...f.provision }
+    out[f.key] = mapping
+  }
+  return out
 }
 
 export interface UpdateConnectorInput {

--- a/packages/lib/src/data-connectors/provisioning.ts
+++ b/packages/lib/src/data-connectors/provisioning.ts
@@ -187,11 +187,18 @@ async function provisionField(
 
 /**
  * Provision schema for every owned/contributing mapping of a connector. Derives the
- * field specs from each mapping's `fieldMappings` keys (the target field keys the
- * connector writes). `reference` mappings write nothing, so they need no provisioning.
- * Owned-def declarations come from the caller (the tRPC layer, sourced from the
- * connector's catalog declaration); a mapping that already carries an
- * `entityDefinitionId` provisions onto it directly.
+ * field specs from each mapping's `fieldMappings`. `reference` mappings write
+ * nothing, so they need no provisioning. A mapping carrying an `entityDefinitionId`
+ * provisions onto it directly.
+ *
+ * Field-type resolution (05d): a `FieldMapping.provision` hint (set by the template
+ * installer) declares the field's type/name, so connector-introduced fields land
+ * with the right type instead of defaulting to TEXT. Without a hint:
+ *   - owned mode   → create the field with the `fieldTypeFor` type (the def is
+ *                    fresh; manual owned mappings declare no hint). Backward-compat.
+ *   - contributing → SKIP. A no-hint contributing field is one reused from the
+ *                    existing def (email/name) — never re-created (the UI only
+ *                    allows new fields in owned mode), so provisioning leaves it be.
  */
 export async function provisionConnectorMappings(
   db: Database,
@@ -203,16 +210,32 @@ export async function provisionConnectorMappings(
   const results: ProvisionResult[] = []
   for (const mapping of mappings) {
     if (mapping.linkMode === 'reference') continue
-    const fieldKeys = Object.keys(mapping.fieldMappings)
-    if (fieldKeys.length === 0 && mapping.targetMode === 'contributing') continue
 
-    const fields: ProvisionFieldSpec[] = fieldKeys.map((key) => ({
-      appFieldKey: key,
-      name: key,
-      type: fieldTypeFor(mapping.row.id, key),
-      isUpdatable: false,
-      isCreatable: false,
-    }))
+    const fields: ProvisionFieldSpec[] = []
+    for (const [key, fm] of Object.entries(mapping.fieldMappings)) {
+      if (fm.provision) {
+        fields.push({
+          appFieldKey: key,
+          name: fm.provision.name,
+          type: fm.provision.type,
+          icon: fm.provision.icon,
+          isHidden: fm.provision.isHidden,
+          isUpdatable: false,
+          isCreatable: false,
+        })
+      } else if (mapping.targetMode === 'owned') {
+        fields.push({
+          appFieldKey: key,
+          name: key,
+          type: fieldTypeFor(mapping.row.id, key),
+          isUpdatable: false,
+          isCreatable: false,
+        })
+      }
+      // contributing + no hint → reused existing field; skip.
+    }
+    // Contributing needs at least one field to do; owned still creates the def.
+    if (fields.length === 0 && mapping.targetMode === 'contributing') continue
 
     const result = await provisionTarget(db, organizationId, dataConnectorId, {
       targetMode: mapping.targetMode,

--- a/packages/lib/src/data-connectors/run-data-connector-sync.ts
+++ b/packages/lib/src/data-connectors/run-data-connector-sync.ts
@@ -15,6 +15,7 @@ import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { invalidateSnapshots } from '../snapshot'
 import { connectorFor } from './connectors'
 import { mapRecord } from './map-record'
+import { provisionConnectorMappings } from './provisioning'
 import { reconcileOrphans } from './reconciliation'
 import { resolveRelationships } from './relationship-pass'
 import {
@@ -98,6 +99,17 @@ export async function runDataConnectorSync(
   if (!claimed) {
     logger.info('runDataConnectorSync: already syncing, skipping', { dataConnectorId })
     return
+  }
+
+  // Provision target schema before fetching so the sink has fields to write into
+  // (05d). Idempotent — runs every sync, self-healing. App connectors provision
+  // their own schema at install (app-field namespace), so we scope this to
+  // non-app connectors to avoid double-provisioning in the connector namespace.
+  if (connector.definitionKind !== 'app') {
+    const targetedMappings = streams.flatMap((s) => s.mappings)
+    if (targetedMappings.length > 0) {
+      await provisionConnectorMappings(db, organizationId, dataConnectorId, targetedMappings)
+    }
   }
 
   // A connector run is incremental if ALL its enabled streams are incremental;

--- a/packages/lib/src/data-connectors/templates/connector-template-registry.ts
+++ b/packages/lib/src/data-connectors/templates/connector-template-registry.ts
@@ -40,6 +40,33 @@ for (const template of allTemplates) {
         `Connector template "${template.id}": stream "${stream.streamKey}" needs requestConfig.path`
       )
     }
+    // Layer B (05d) — validate declared mappings if present.
+    for (const mapping of stream.mappings ?? []) {
+      if (!mapping.target) {
+        throw new Error(
+          `Connector template "${template.id}": stream "${stream.streamKey}" mapping needs a target`
+        )
+      }
+      if (mapping.target.mode !== 'contributing') {
+        throw new Error(
+          `Connector template "${template.id}": stream "${stream.streamKey}" — only 'contributing' targets are supported (got '${mapping.target.mode}')`
+        )
+      }
+      if (!mapping.target.entityRef?.startsWith('@system:')) {
+        throw new Error(
+          `Connector template "${template.id}": stream "${stream.streamKey}" — entityRef must be '@system:<entityType>' (got '${mapping.target.entityRef}')`
+        )
+      }
+      for (const field of mapping.fields) {
+        const hasSource = field.source != null
+        const hasExpression = field.expression != null
+        if (hasSource === hasExpression) {
+          throw new Error(
+            `Connector template "${template.id}": stream "${stream.streamKey}" field "${field.key}" needs exactly one of source / expression`
+          )
+        }
+      }
+    }
   }
   templateMap.set(template.id, template)
 }

--- a/packages/lib/src/data-connectors/templates/defs/stripe.json
+++ b/packages/lib/src/data-connectors/templates/defs/stripe.json
@@ -25,6 +25,29 @@
         "params": { "limit": 100 },
         "pagination": { "kind": "none" }
       },
+      "mappings": [
+        {
+          "rootPath": "data[]",
+          "linkMode": "upsert",
+          "target": { "mode": "contributing", "entityRef": "@system:contact" },
+          "fields": [
+            { "key": "primary_email", "source": "email", "match": { "normalize": "email" } },
+            { "key": "full_name", "source": "name" },
+            { "key": "phone", "source": "phone" },
+            {
+              "key": "Stripe Customer ID",
+              "source": "id",
+              "provision": { "type": "TEXT", "isHidden": true }
+            },
+            {
+              "key": "Stripe Created",
+              "expression": "{created} * 1000",
+              "sourceFields": { "created": "created" },
+              "provision": { "type": "DATETIME" }
+            }
+          ]
+        }
+      ],
       "sourceSchema": {
         "type": "object",
         "properties": {

--- a/packages/lib/src/data-connectors/templates/index.ts
+++ b/packages/lib/src/data-connectors/templates/index.ts
@@ -8,6 +8,9 @@ export {
 export type {
   ConnectorTemplate,
   ConnectorTemplateConnection,
+  ConnectorTemplateFieldMapping,
+  ConnectorTemplateMapping,
   ConnectorTemplateStream,
   ConnectorTemplateSummary,
+  ConnectorTemplateTarget,
 } from './types'

--- a/packages/lib/src/data-connectors/templates/types.ts
+++ b/packages/lib/src/data-connectors/templates/types.ts
@@ -5,7 +5,15 @@
 // composition over the existing `createConnector` / `addStream` helpers. Mirrors
 // `entity-templates/` one-to-one.
 
-import type { DataConnectorConfig, StreamRequestConfig, SyncMode } from '../types'
+import type { FieldType } from '@auxx/database/types'
+import type {
+  DataConnectorConfig,
+  IdentityNormalize,
+  LinkMode,
+  OrphanBehavior,
+  StreamRequestConfig,
+  SyncMode,
+} from '../types'
 
 /**
  * Connection hint surfaced at setup (05c §8). The template only *declares* that
@@ -36,6 +44,78 @@ export interface ConnectorTemplateStream {
   /** Per-stream generic-rest request: path/method/params/pagination. */
   requestConfig: StreamRequestConfig
   syncMode?: SyncMode
+  /**
+   * Layer B (05d) — where this stream lands + how source fields map onto target
+   * fields. Omit to leave the stream untargeted (05c behaviour: the user authors
+   * the mapping in the editor). v1 supports `contributing` targets only.
+   */
+  mappings?: ConnectorTemplateMapping[]
+}
+
+/**
+ * One target a stream's records land in (05d). Materialized into a real
+ * `DataConnectorMapping` row by the installer — the same row the manual mapping
+ * editor produces, so the runtime treats a template instance identically to a
+ * hand-built connector.
+ */
+export interface ConnectorTemplateMapping {
+  /** '' = whole record, else a path into the response (e.g. 'data[]' for a Stripe list). */
+  rootPath: string
+  /** 'upsert' (default) projects records; 'reference' wires a relationship only. */
+  linkMode?: LinkMode
+  /** Orphan handling. Defaults to 'ignore' (contributing never archives a co-owned def). */
+  orphanBehavior?: OrphanBehavior
+  /** Where the records land. v1: contributing into an existing def. */
+  target: ConnectorTemplateTarget
+  /** Target field key → binding. Identity (`match`) is derived from these. */
+  fields: ConnectorTemplateFieldMapping[]
+}
+
+/**
+ * Target for a template mapping. v1 ships `contributing` only — owned-mode def
+ * creation is deferred (05d §9). Kept a discriminated union so the owned variant
+ * slots in without touching call sites.
+ */
+export type ConnectorTemplateTarget = {
+  mode: 'contributing'
+  /**
+   * Symbolic reference to an existing def, resolved to a real `entityDefinitionId`
+   * at install time. v1 supports `@system:<entityType>` (e.g. '@system:contact',
+   * '@system:company') — every org has its system defs.
+   */
+  entityRef: string
+}
+
+/** One target-field binding in a template mapping (05d). */
+export interface ConnectorTemplateFieldMapping {
+  /**
+   * Target field identifier — what the connector writes into. For a field reused
+   * from an existing def this is its `systemAttribute` (e.g. 'primary_email',
+   * 'full_name', 'phone'). For a connector-introduced field (carrying `provision`)
+   * this is the field's display name (provisioned fields have no systemAttribute,
+   * so the crud layer resolves the write by name). The runtime resolves writes by
+   * `systemAttribute ?? name`, so `key` must equal one of those on the target def.
+   */
+  key: string
+  /** Source path in the record. Sugar for an identity CALC expression. */
+  source?: string
+  /** Full CALC expression for transforms (epoch→ms, cents→units). Use with `sourceFields`. */
+  expression?: string
+  /** Token → source path map for `expression`. */
+  sourceFields?: Record<string, string>
+  /**
+   * Flag this bound field a secondary identity-match key (first-link dedup), e.g.
+   * email. `true` = match with no normalization; pass `{ normalize: 'email' }` to
+   * canonicalize before lookup (recommended for email/phone/domain match keys).
+   */
+  match?: boolean | { normalize?: IdentityNormalize }
+  /**
+   * Provisioning hint for a connector-introduced field — set the type/icon/hidden
+   * of the field the connector creates (its name = `key`). Omit for fields already
+   * present on the target def (email/name/phone): those are reused as-is and never
+   * re-created.
+   */
+  provision?: { type: FieldType; icon?: string; isHidden?: boolean }
 }
 
 /** A first-party connector template — a pre-filled `generic-rest` preset. */

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -222,6 +222,14 @@ export interface FieldMapping {
    * toggle time (email/phone/domain), else 'none'.
    */
   match?: { normalize?: IdentityNormalize }
+  /**
+   * Provisioning hint for a connector-introduced target field (05d). Consumed by
+   * `provisionConnectorMappings` to create the field with the declared type/name
+   * when the target def is missing it; ignored when the field already exists
+   * (e.g. `email`/`name` reused from a system def). Absent on hand-authored UI
+   * mappings — those bind to fields that already exist.
+   */
+  provision?: { name: string; type: FieldType; icon?: string; isHidden?: boolean }
 }
 
 export type LinkMode = 'upsert' | 'reference'


### PR DESCRIPTION
## What

Extends first-party connector templates (05c) so a template also declares **where each stream lands** — a target entity definition + field mappings — not just the source request/schema. Installing the Stripe template now produces a **fully-wired** connector instead of a half-configured shell.

**v1 is contributing-only:** a template maps records into an *existing* def (e.g. Stripe customers → the org's **Contact**), enriching it and deduping on a secondary match key (email). No new entity definitions are created, and **no DB migration** is needed — the new `provision` hint rides the existing `fieldMappings` jsonb column.

## How

- **Types** — add `FieldMapping.provision` (engine + db-package mirror); add `mappings` to the stream template (`ConnectorTemplateMapping` / `ConnectorTemplateFieldMapping` / contributing-only `ConnectorTemplateTarget`), with import-time registry validation.
- **Installer** — `createConnectorFromTemplate` materializes declared mappings into real `DataConnectorMapping` rows (patches the seeded root + adds the rest), resolving `@system:*` → a real def id via the org cache and building CALC `fieldMappings` (matching the manual editor's shape).
- **Provisioning** — `provisionConnectorMappings` reads the `provision` type hint instead of defaulting every field to `TEXT`. Contributing provisions only connector-introduced fields; reused system fields (email/name/phone) are left as-is (the UI only creates fields in owned mode, so this can't regress manual flows).
- **Sync** — provision target schema at the start of a run (idempotent, **non-app connectors only** — app connectors provision via their own install path), so the sink has fields to write into. The manual `provision` route is no longer the only trigger.
- **Template** — Stripe `customers` maps into Contact (match on `primary_email`, plus a hidden `Stripe Customer ID` and `Stripe Created` field). Stripe `charges` / GitHub `repositories` stay untargeted (no system def fits; owned-mode is deferred).

## Identity / matching

External id (Stripe customer id) is the durable primary key via `DataConnectorItem`. On first link, the `match`-flagged `primary_email` field bootstraps dedup — normalized lowercase email lookup against existing Contacts, merging rather than creating a duplicate. Matching is email-only by design; a customer with no/non-matching email becomes a new Contact.

## Scope / deferred

Owned-mode def creation, cross-stream relationships, and the connect-dialog "lands in Contacts" hint + authoring helper are **not** in this PR (deferred — owned mode needs an `ownedDef` column + migration).

## Test plan

- [x] `vitest run src/data-connectors` — 11/11 pass
- [x] Registry import-time validation passes with the updated Stripe template
- [x] Biome lint + IDE type diagnostics clean on all touched files
- [ ] Manual: install Stripe template against a real org, bind a key, sync → Contacts enriched + `Stripe Customer ID` field created