### PR TITLE
feat(connections): server-minted client_credentials grant

### DIFF
--- a/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
+++ b/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
@@ -71,7 +71,7 @@ const connectionFormSchema = z
       .min(1, 'Key is required')
       .regex(KEY_PATTERN, 'Use lowercase letters, digits, and underscores'),
     global: z.boolean(),
-    connectionType: z.enum(['none', 'secret', 'oauth2-code']),
+    connectionType: z.enum(['none', 'secret', 'oauth2-code', 'client-credentials']),
     label: z.string().min(1, 'Label is required'),
     description: z.string().optional().or(z.literal('')),
 
@@ -173,7 +173,7 @@ const connectionFormSchema = z
   })
   .refine(
     (data) => {
-      // If oauth2-code is selected, required OAuth2 fields (except scopes)
+      // oauth2-code needs the full browser flow (authorize URL + token mint).
       if (data.connectionType === 'oauth2-code') {
         return (
           data.oauth2AuthorizeUrl &&
@@ -183,10 +183,19 @@ const connectionFormSchema = z
           data.oauth2TokenRequestAuthMethod
         )
       }
+      // client-credentials mints with no browser step — same fields minus the authorize URL.
+      if (data.connectionType === 'client-credentials') {
+        return (
+          data.oauth2AccessTokenUrl &&
+          data.oauth2ClientId &&
+          data.oauth2ClientSecret &&
+          data.oauth2TokenRequestAuthMethod
+        )
+      }
       return true
     },
     {
-      message: 'Required OAuth2 fields must be filled when OAuth2 is selected',
+      message: 'Required OAuth2 fields must be filled when an OAuth2 method is selected',
       path: ['connectionType'],
     }
   )
@@ -236,6 +245,7 @@ function formatScopesArray(scopes: string[] | null | undefined): string {
 
 const TYPE_LABELS: Record<string, string> = {
   'oauth2-code': 'OAuth 2.0',
+  'client-credentials': 'OAuth 2.0 (Machine-to-machine)',
   secret: 'Secret',
   none: 'None',
 }
@@ -407,7 +417,11 @@ function MethodEditor({
   useEffect(() => {
     if (connection && !hasLoadedConnection.current) {
       const scheduleValue = convertSecondsToSchedule(connection.oauth2RefreshTokenIntervalSeconds)
-      const connectionTypeValue = connection.connectionType as 'none' | 'secret' | 'oauth2-code'
+      const connectionTypeValue = connection.connectionType as
+        | 'none'
+        | 'secret'
+        | 'oauth2-code'
+        | 'client-credentials'
       const features = (connection.oauth2Features as Record<string, unknown>) ?? {}
 
       maskedSecretPrefill.current = connection.oauth2ClientSecret || ''
@@ -505,7 +519,11 @@ function MethodEditor({
   })
 
   const isOAuth2 = connectionType === 'oauth2-code'
+  const isClientCredentials = connectionType === 'client-credentials'
   const isSecret = connectionType === 'secret'
+  // Both OAuth2 grants mint a token (and thus show the token URL / client id+secret / scopes
+  // fields); only oauth2-code additionally drives the browser redirect (authorize URL, PKCE…).
+  const mintsToken = isOAuth2 || isClientCredentials
   const authApplyMode = watch('authApplyMode') || 'none'
 
   const authorizeUrl = watch('oauth2AuthorizeUrl') || ''
@@ -519,12 +537,13 @@ function MethodEditor({
   const secretRegister = register('oauth2ClientSecret')
 
   const detectedPlaceholders = useMemo(() => {
-    const allFields = [authorizeUrl, tokenUrl, clientId, clientSecret].join(' ')
+    // client-credentials interpolates the token URL + client id/secret (no authorize URL).
+    const allFields = [mintsToken ? authorizeUrl : '', tokenUrl, clientId, clientSecret].join(' ')
     const matches = allFields.match(/\{([^}]+)\}/g)
     if (!matches) return []
     const keys = [...new Set(matches.map((m) => m.slice(1, -1)))]
     return keys.filter((k) => !connectionVariables.some((v) => v.key === k))
-  }, [authorizeUrl, tokenUrl, clientId, clientSecret, connectionVariables])
+  }, [mintsToken, authorizeUrl, tokenUrl, clientId, clientSecret, connectionVariables])
 
   const handleVariablesChange = (vars: ConnectionVariable[]) => {
     setConnectionVariables(vars)
@@ -534,6 +553,8 @@ function MethodEditor({
   const onSubmit = async (data: ConnectionFormData) => {
     const scopesArray = parseScopesString(data.oauth2Scopes || '')
     const refreshSeconds = convertScheduleToSeconds(data.oauth2RefreshSchedule)
+    const mintsTokenType =
+      data.connectionType === 'oauth2-code' || data.connectionType === 'client-credentials'
 
     // Fields shared by create + update (everything except identity).
     const fields = {
@@ -542,18 +563,17 @@ function MethodEditor({
       label: data.label,
       description: data.description,
 
-      // Connection variables, request auth, and base-URL template apply to both
-      // oauth2-code (interpolation) and secret (connect form). `none` methods omit them
-      // → the router stores null.
-      ...((data.connectionType === 'oauth2-code' || data.connectionType === 'secret') && {
+      // Connection variables, request auth, and base-URL template apply to every connecting
+      // method (oauth2-code interpolation, client-credentials id/secret, secret connect form).
+      // `none` methods omit them → the router stores null.
+      ...(data.connectionType !== 'none' && {
         connectionVariables,
         authApply: formToAuthApply(data, loadedAuthApply.current),
         baseUrlTemplate: data.baseUrlTemplate || undefined,
       }),
 
-      // Only include OAuth2 fields if connectionType is oauth2-code
-      ...(data.connectionType === 'oauth2-code' && {
-        oauth2AuthorizeUrl: data.oauth2AuthorizeUrl,
+      // Token-minting fields — written for both oauth2-code and client-credentials.
+      ...(mintsTokenType && {
         oauth2AccessTokenUrl: data.oauth2AccessTokenUrl,
         oauth2RefreshUrl: data.oauth2RefreshUrl,
         oauth2ClientId: data.oauth2ClientId,
@@ -564,6 +584,11 @@ function MethodEditor({
         oauth2Scopes: scopesArray,
         oauth2TokenRequestAuthMethod: data.oauth2TokenRequestAuthMethod,
         oauth2RefreshTokenIntervalSeconds: refreshSeconds,
+      }),
+
+      // Browser-redirect fields — oauth2-code only (client-credentials has no authorize step).
+      ...(data.connectionType === 'oauth2-code' && {
+        oauth2AuthorizeUrl: data.oauth2AuthorizeUrl,
         oauth2Features: {
           ...(data.oauth2Pkce && { pkce: true }),
           ...(data.oauth2CallbackBaseUrl && { callbackBaseUrl: data.oauth2CallbackBaseUrl }),
@@ -697,6 +722,9 @@ function MethodEditor({
                           <SelectItem value='none'>None</SelectItem>
                           <SelectItem value='secret'>Secret</SelectItem>
                           <SelectItem value='oauth2-code'>OAuth 2.0</SelectItem>
+                          <SelectItem value='client-credentials'>
+                            OAuth 2.0 (Machine-to-machine)
+                          </SelectItem>
                         </SelectContent>
                       </Select>
                     )}
@@ -707,15 +735,15 @@ function MethodEditor({
                 </Field>
               </FieldGroup>
 
-              {(isOAuth2 || isSecret) && (
+              {(mintsToken || isSecret) && (
                 <FieldGroup>
                   <Field>
                     <FieldLabel className='flex items-center gap-1'>
                       Dynamic Variables
                       <TooltipExplanation
                         text={
-                          isOAuth2
-                            ? 'Define variables that organizations must provide when connecting. Use {variable_name} placeholders in the Authorize URL, Token URL, Client ID, or Client Secret fields below.'
+                          mintsToken
+                            ? 'Define variables that organizations must provide when connecting. Use {variable_name} placeholders in the Token URL, Client ID, or Client Secret fields below (oauth2-code also supports the Authorize URL).'
                             : 'Define the fields organizations fill in when connecting (e.g. client ID, client secret, account number). Secret-flagged fields are masked and stored encrypted.'
                         }
                         side='right'
@@ -736,14 +764,14 @@ function MethodEditor({
                           <div className='flex flex-wrap items-center gap-1'>
                             {connectionVariables.map((v) => (
                               <Badge key={v.key} variant='zinc' size='sm'>
-                                {isOAuth2 ? `{${v.key}}` : v.key}
+                                {mintsToken ? `{${v.key}}` : v.key}
                               </Badge>
                             ))}
                           </div>
                         </>
                       )}
                     </div>
-                    {isOAuth2 && (
+                    {mintsToken && (
                       <FieldDescription>
                         Use these as placeholders in the fields below (e.g.{' '}
                         <code className='text-xs'>
@@ -761,7 +789,7 @@ function MethodEditor({
                     )}
                   </Field>
 
-                  {isOAuth2 && detectedPlaceholders.length > 0 && (
+                  {mintsToken && detectedPlaceholders.length > 0 && (
                     <div className='flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800'>
                       <AlertTriangle className='size-4 shrink-0' />
                       <span>
@@ -779,7 +807,7 @@ function MethodEditor({
                 </FieldGroup>
               )}
 
-              {(isOAuth2 || isSecret) && (
+              {(mintsToken || isSecret) && (
                 <div
                   role='button'
                   tabIndex={0}
@@ -802,28 +830,32 @@ function MethodEditor({
                 </div>
               )}
 
-              {isOAuth2 && (
+              {mintsToken && (
                 <FieldGroup>
-                  <Field>
-                    <FieldLabel htmlFor='app-organization-authorize-url'>Authorize URL</FieldLabel>
-                    <InputGroup>
-                      <InputGroupInput
-                        id='app-organization-authorize-url'
-                        placeholder='https://auth-server.com/oauth/authorize'
-                        aria-invalid={!!errors.oauth2AuthorizeUrl}
-                        {...register('oauth2AuthorizeUrl')}
-                      />
-                      <InputGroupAddon align='inline-end'>
-                        {errors.oauth2AuthorizeUrl && (
-                          <TooltipError text={errors.oauth2AuthorizeUrl.message ?? ''} />
-                        )}
-                        <TooltipExplanation
-                          text='The URL where users are redirected to grant authorization to your app.'
-                          side='right'
+                  {isOAuth2 && (
+                    <Field>
+                      <FieldLabel htmlFor='app-organization-authorize-url'>
+                        Authorize URL
+                      </FieldLabel>
+                      <InputGroup>
+                        <InputGroupInput
+                          id='app-organization-authorize-url'
+                          placeholder='https://auth-server.com/oauth/authorize'
+                          aria-invalid={!!errors.oauth2AuthorizeUrl}
+                          {...register('oauth2AuthorizeUrl')}
                         />
-                      </InputGroupAddon>
-                    </InputGroup>
-                  </Field>
+                        <InputGroupAddon align='inline-end'>
+                          {errors.oauth2AuthorizeUrl && (
+                            <TooltipError text={errors.oauth2AuthorizeUrl.message ?? ''} />
+                          )}
+                          <TooltipExplanation
+                            text='The URL where users are redirected to grant authorization to your app.'
+                            side='right'
+                          />
+                        </InputGroupAddon>
+                      </InputGroup>
+                    </Field>
+                  )}
                   <Field>
                     <FieldLabel htmlFor='app-organization-token-url'>Access token URL</FieldLabel>
                     <InputGroup>
@@ -966,146 +998,153 @@ function MethodEditor({
                       </p>
                     )}
                   </Field>
-                  <FieldSet>
-                    <div className='flex items-center gap-3'>
-                      <Switch
-                        id='app-organization-advanced'
-                        checked={showAdvanced}
-                        onCheckedChange={setShowAdvanced}
-                      />
-                      <FieldLabel htmlFor='app-organization-advanced'>Advanced settings</FieldLabel>
-                    </div>
+                  {isOAuth2 && (
+                    <FieldSet>
+                      <div className='flex items-center gap-3'>
+                        <Switch
+                          id='app-organization-advanced'
+                          checked={showAdvanced}
+                          onCheckedChange={setShowAdvanced}
+                        />
+                        <FieldLabel htmlFor='app-organization-advanced'>
+                          Advanced settings
+                        </FieldLabel>
+                      </div>
 
-                    {showAdvanced && (
-                      <FieldGroup>
-                        <Field>
-                          <div className='flex items-center gap-3'>
-                            <Controller
-                              name='oauth2Pkce'
-                              control={control}
-                              render={({ field }) => (
-                                <Switch
-                                  id='app-organization-pkce'
-                                  checked={field.value ?? false}
-                                  onCheckedChange={field.onChange}
-                                />
-                              )}
+                      {showAdvanced && (
+                        <FieldGroup>
+                          <Field>
+                            <div className='flex items-center gap-3'>
+                              <Controller
+                                name='oauth2Pkce'
+                                control={control}
+                                render={({ field }) => (
+                                  <Switch
+                                    id='app-organization-pkce'
+                                    checked={field.value ?? false}
+                                    onCheckedChange={field.onChange}
+                                  />
+                                )}
+                              />
+                              <FieldLabel htmlFor='app-organization-pkce'>
+                                Use PKCE (S256)
+                              </FieldLabel>
+                            </div>
+                            <FieldDescription>
+                              Enable Proof Key for Code Exchange (RFC 7636). Required by Airtable,
+                              Zoom, Twitter/X, Linear, Figma, and other providers.
+                            </FieldDescription>
+                          </Field>
+                          <Field>
+                            <FieldLabel htmlFor='app-organization-callback-base-url'>
+                              Callback base URL
+                            </FieldLabel>
+                            <Input
+                              id='app-organization-callback-base-url'
+                              placeholder='https://example.ngrok-free.app'
+                              {...register('oauth2CallbackBaseUrl')}
                             />
-                            <FieldLabel htmlFor='app-organization-pkce'>Use PKCE (S256)</FieldLabel>
-                          </div>
-                          <FieldDescription>
-                            Enable Proof Key for Code Exchange (RFC 7636). Required by Airtable,
-                            Zoom, Twitter/X, Linear, Figma, and other providers.
-                          </FieldDescription>
-                        </Field>
-                        <Field>
-                          <FieldLabel htmlFor='app-organization-callback-base-url'>
-                            Callback base URL
-                          </FieldLabel>
-                          <Input
-                            id='app-organization-callback-base-url'
-                            placeholder='https://example.ngrok-free.app'
-                            {...register('oauth2CallbackBaseUrl')}
-                          />
-                          <FieldDescription>
-                            Override the callback redirect URL base. Falls back to WEBAPP_URL if
-                            empty.
-                          </FieldDescription>
-                          {errors.oauth2CallbackBaseUrl && (
-                            <p className='text-sm text-red-600 mt-1'>
-                              {errors.oauth2CallbackBaseUrl.message}
-                            </p>
-                          )}
-                        </Field>
-                        <Field>
-                          <FieldLabel htmlFor='app-organization-refresh-url'>
-                            Refresh URL
-                          </FieldLabel>
-                          <Input
-                            id='app-organization-refresh-url'
-                            placeholder='https://auth-server.com/oauth/refresh'
-                            {...register('oauth2RefreshUrl')}
-                          />
-                          <FieldDescription>
-                            Endpoint used to refresh the access token. Defaults to the Access token
-                            URL when empty. Supports {'{variable}'} placeholders.
-                          </FieldDescription>
-                          {errors.oauth2RefreshUrl && (
-                            <p className='text-sm text-red-600 mt-1'>
-                              {errors.oauth2RefreshUrl.message}
-                            </p>
-                          )}
-                        </Field>
-                        <Field>
-                          <FieldLabel htmlFor='app-organization-scope-separator'>
-                            Scope separator
-                          </FieldLabel>
-                          <Input
-                            id='app-organization-scope-separator'
-                            placeholder='(space by default)'
-                            {...register('oauth2ScopeSeparator')}
-                          />
-                          <FieldDescription>
-                            Character used to separate scopes in the authorize URL. Defaults to a
-                            space if empty.
-                          </FieldDescription>
-                        </Field>
-                        <Field>
-                          <FieldLabel htmlFor='app-organization-additional-authorize-params'>
-                            Additional authorize params
-                          </FieldLabel>
-                          <Textarea
-                            id='app-organization-additional-authorize-params'
-                            placeholder='{"prompt": "consent"}'
-                            rows={3}
-                            {...register('oauth2AdditionalAuthorizeParams')}
-                          />
-                          <FieldDescription>
-                            JSON object of extra query params appended to the authorize URL.
-                          </FieldDescription>
-                          {errors.oauth2AdditionalAuthorizeParams && (
-                            <p className='text-sm text-red-600 mt-1'>
-                              {errors.oauth2AdditionalAuthorizeParams.message}
-                            </p>
-                          )}
-                        </Field>
-                        <Field>
-                          <FieldLabel htmlFor='app-organization-additional-token-params'>
-                            Additional token params
-                          </FieldLabel>
-                          <Textarea
-                            id='app-organization-additional-token-params'
-                            placeholder='{"audience": "https://api.example.com"}'
-                            rows={3}
-                            {...register('oauth2AdditionalTokenParams')}
-                          />
-                          <FieldDescription>
-                            JSON object of extra params appended to the token exchange request body.
-                          </FieldDescription>
-                          {errors.oauth2AdditionalTokenParams && (
-                            <p className='text-sm text-red-600 mt-1'>
-                              {errors.oauth2AdditionalTokenParams.message}
-                            </p>
-                          )}
-                        </Field>
-                        <Field>
-                          <FieldLabel htmlFor='app-organization-callback-metadata-params'>
-                            Callback metadata params
-                          </FieldLabel>
-                          <Input
-                            id='app-organization-callback-metadata-params'
-                            placeholder='realmId, tenantId'
-                            {...register('oauth2CallbackMetadataParams')}
-                          />
-                          <FieldDescription>
-                            Comma-separated list of callback URL query params to capture and store
-                            as connection metadata. These are available at runtime via
-                            connection.metadata.
-                          </FieldDescription>
-                        </Field>
-                      </FieldGroup>
-                    )}
-                  </FieldSet>
+                            <FieldDescription>
+                              Override the callback redirect URL base. Falls back to WEBAPP_URL if
+                              empty.
+                            </FieldDescription>
+                            {errors.oauth2CallbackBaseUrl && (
+                              <p className='text-sm text-red-600 mt-1'>
+                                {errors.oauth2CallbackBaseUrl.message}
+                              </p>
+                            )}
+                          </Field>
+                          <Field>
+                            <FieldLabel htmlFor='app-organization-refresh-url'>
+                              Refresh URL
+                            </FieldLabel>
+                            <Input
+                              id='app-organization-refresh-url'
+                              placeholder='https://auth-server.com/oauth/refresh'
+                              {...register('oauth2RefreshUrl')}
+                            />
+                            <FieldDescription>
+                              Endpoint used to refresh the access token. Defaults to the Access
+                              token URL when empty. Supports {'{variable}'} placeholders.
+                            </FieldDescription>
+                            {errors.oauth2RefreshUrl && (
+                              <p className='text-sm text-red-600 mt-1'>
+                                {errors.oauth2RefreshUrl.message}
+                              </p>
+                            )}
+                          </Field>
+                          <Field>
+                            <FieldLabel htmlFor='app-organization-scope-separator'>
+                              Scope separator
+                            </FieldLabel>
+                            <Input
+                              id='app-organization-scope-separator'
+                              placeholder='(space by default)'
+                              {...register('oauth2ScopeSeparator')}
+                            />
+                            <FieldDescription>
+                              Character used to separate scopes in the authorize URL. Defaults to a
+                              space if empty.
+                            </FieldDescription>
+                          </Field>
+                          <Field>
+                            <FieldLabel htmlFor='app-organization-additional-authorize-params'>
+                              Additional authorize params
+                            </FieldLabel>
+                            <Textarea
+                              id='app-organization-additional-authorize-params'
+                              placeholder='{"prompt": "consent"}'
+                              rows={3}
+                              {...register('oauth2AdditionalAuthorizeParams')}
+                            />
+                            <FieldDescription>
+                              JSON object of extra query params appended to the authorize URL.
+                            </FieldDescription>
+                            {errors.oauth2AdditionalAuthorizeParams && (
+                              <p className='text-sm text-red-600 mt-1'>
+                                {errors.oauth2AdditionalAuthorizeParams.message}
+                              </p>
+                            )}
+                          </Field>
+                          <Field>
+                            <FieldLabel htmlFor='app-organization-additional-token-params'>
+                              Additional token params
+                            </FieldLabel>
+                            <Textarea
+                              id='app-organization-additional-token-params'
+                              placeholder='{"audience": "https://api.example.com"}'
+                              rows={3}
+                              {...register('oauth2AdditionalTokenParams')}
+                            />
+                            <FieldDescription>
+                              JSON object of extra params appended to the token exchange request
+                              body.
+                            </FieldDescription>
+                            {errors.oauth2AdditionalTokenParams && (
+                              <p className='text-sm text-red-600 mt-1'>
+                                {errors.oauth2AdditionalTokenParams.message}
+                              </p>
+                            )}
+                          </Field>
+                          <Field>
+                            <FieldLabel htmlFor='app-organization-callback-metadata-params'>
+                              Callback metadata params
+                            </FieldLabel>
+                            <Input
+                              id='app-organization-callback-metadata-params'
+                              placeholder='realmId, tenantId'
+                              {...register('oauth2CallbackMetadataParams')}
+                            />
+                            <FieldDescription>
+                              Comma-separated list of callback URL query params to capture and store
+                              as connection metadata. These are available at runtime via
+                              connection.metadata.
+                            </FieldDescription>
+                          </Field>
+                        </FieldGroup>
+                      )}
+                    </FieldSet>
+                  )}
                 </FieldGroup>
               )}
             </FieldSet>

--- a/apps/build/src/lib/publish-checks.ts
+++ b/apps/build/src/lib/publish-checks.ts
@@ -85,17 +85,22 @@ export interface ConnectionForPublishCheck {
 }
 
 /**
- * Check if all oauth2-code connections have complete configuration.
- * Connections with type 'secret' or 'none' require no validation.
- * @returns true if no oauth2-code connections exist, or all are properly configured
+ * Check that all token-minting connections (oauth2-code, client-credentials) are fully configured.
+ * Connections with type 'secret' or 'none' require no validation. `client-credentials` mints with
+ * no browser step, so it needs the same fields as oauth2-code minus the Authorize URL.
+ * @returns true if no minting connections exist, or all are properly configured
  */
 export function isConnectionsConfigComplete(connections: ConnectionForPublishCheck[]): boolean {
-  const oauthConnections = connections.filter((c) => c.connectionType === 'oauth2-code')
-  if (oauthConnections.length === 0) return true
+  const mintingConnections = connections.filter(
+    (c) => c.connectionType === 'oauth2-code' || c.connectionType === 'client-credentials'
+  )
+  if (mintingConnections.length === 0) return true
 
-  return oauthConnections.every((c) => {
+  return mintingConnections.every((c) => {
     const checks = {
-      oauth2AuthorizeUrl: isValidStringField(c.oauth2AuthorizeUrl),
+      // Authorize URL is required only for the browser-redirect grant.
+      oauth2AuthorizeUrl:
+        c.connectionType === 'client-credentials' || isValidStringField(c.oauth2AuthorizeUrl),
       oauth2AccessTokenUrl: isValidStringField(c.oauth2AccessTokenUrl),
       oauth2ClientId: c.hasClientId,
       oauth2ClientSecret: c.hasClientSecret,

--- a/apps/build/src/server/api/routers/connections.ts
+++ b/apps/build/src/server/api/routers/connections.ts
@@ -109,7 +109,7 @@ function redactConnection<
 /** Editable method fields shared by create + update (everything except identity: appId/key/major). */
 const methodFields = {
   global: z.boolean(),
-  connectionType: z.enum(['oauth2-code', 'secret', 'none']),
+  connectionType: z.enum(['oauth2-code', 'client-credentials', 'secret', 'none']),
   label: z.string(),
   description: z.string().optional(),
   oauth2AuthorizeUrl: z.string().optional(),

--- a/apps/web/src/components/apps/hooks/use-connect-flow.tsx
+++ b/apps/web/src/components/apps/hooks/use-connect-flow.tsx
@@ -289,7 +289,9 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
         return
       }
       setArgs(next)
-      if (def.connectionType === 'secret') {
+      // `client-credentials` has no browser step — the org enters its id/secret in the same
+      // field form as a secret connection; the runtime mints the bearer lazily on first use.
+      if (def.connectionType === 'secret' || def.connectionType === 'client-credentials') {
         // The one dialog handles both shapes — `ConnectionDetailPage` renders the token row for a
         // bare API key, or one row per connection variable when the def declares them.
         setFormOpen(true)
@@ -354,7 +356,7 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
         setError(new Error('Connection not available for this scope'))
         return
       }
-      if (def.connectionType === 'secret') {
+      if (def.connectionType === 'secret' || def.connectionType === 'client-credentials') {
         saveSecretForOwner(a, payload)
         return
       }
@@ -373,7 +375,7 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
   const saveOrOauth = useCallback(
     (a: ConnectFlowArgs, payload: { values?: Record<string, string>; secret?: string }) => {
       const def = pickDef(a)
-      if (def?.connectionType === 'secret') {
+      if (def?.connectionType === 'secret' || def?.connectionType === 'client-credentials') {
         saveSecretForOwner(a, payload)
         return
       }

--- a/apps/web/src/components/connections/ui/add-connection-dialog.tsx
+++ b/apps/web/src/components/connections/ui/add-connection-dialog.tsx
@@ -383,6 +383,8 @@ function defaultProviderDescription(provider: ProviderRow): string {
   switch (provider.connectionType) {
     case 'oauth2-code':
       return 'Connect with OAuth.'
+    case 'client-credentials':
+      return 'Connect with a client ID and secret.'
     case 'secret':
       return 'Connect with an API key or credentials.'
     default:

--- a/apps/web/src/components/connections/ui/connection-detail-page.tsx
+++ b/apps/web/src/components/connections/ui/connection-detail-page.tsx
@@ -43,6 +43,7 @@ interface ConnectionDetailPageProps {
 /** Short type label shown in parentheses next to the method name. */
 const TYPE_LABEL: Record<string, string> = {
   'oauth2-code': 'OAuth',
+  'client-credentials': 'OAuth (M2M)',
   secret: 'API key',
 }
 
@@ -95,7 +96,7 @@ export function ConnectionDetailPage({
               <RadioGroupItemCard
                 key={method.id}
                 value={method.id}
-                icon={method.connectionType === 'secret' ? <KeyRound /> : <Plug />}
+                icon={method.connectionType === 'oauth2-code' ? <Plug /> : <KeyRound />}
                 label={method.label}
                 sublabel={TYPE_LABEL[method.connectionType]}
                 description={

--- a/apps/web/src/server/api/routers/apps.ts
+++ b/apps/web/src/server/api/routers/apps.ts
@@ -10,6 +10,7 @@ import {
   saveAppConnection,
 } from '@auxx/lib/apps'
 import { getCachedAppBySlug, getOrgCache, onCacheEvent } from '@auxx/lib/cache'
+import { mintClientCredentialToken } from '@auxx/lib/connections'
 import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import {
@@ -459,6 +460,19 @@ export const appsRouter = createTRPCRouter({
           code: 'INTERNAL_SERVER_ERROR',
           message: result.error.message || 'Failed to save connection',
         })
+      }
+
+      // Connection test for the no-browser `client-credentials` grant: mint once now so a bad
+      // client id/secret surfaces immediately rather than on first runtime use. The minted token
+      // is cached on the credential for reuse.
+      if (def.connectionType === 'client-credentials') {
+        const minted = await mintClientCredentialToken(result.value, organizationId)
+        if (!minted.success) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: `Couldn't authenticate with these credentials: ${minted.error ?? 'mint failed'}`,
+          })
+        }
       }
 
       return { success: true, credentialId: result.value }

--- a/apps/web/src/server/api/routers/connections.ts
+++ b/apps/web/src/server/api/routers/connections.ts
@@ -9,12 +9,15 @@ import {
   splitSensitiveFields,
   updateCredential,
 } from '@auxx/credentials/store'
-import { saveConnection } from '@auxx/lib/connections'
+import {
+  mintClientCredentialToken,
+  refreshCredentialTokens,
+  saveConnection,
+} from '@auxx/lib/connections'
 import { getAllProviders } from '@auxx/lib/connections/providers'
 import { isAdminOrOwner } from '@auxx/lib/members'
 import { getChannelProviderIcon } from '@auxx/lib/providers'
 import { CredentialTestingService, isCredentialInUse } from '@auxx/lib/workflow-engine'
-import { refreshCredentialTokens } from '@auxx/lib/workflows'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
@@ -264,6 +267,19 @@ export const connectionsRouter = createTRPCRouter({
 
       if (result.isErr()) {
         throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: result.error.message })
+      }
+
+      // Connection test for the no-browser grant: mint once now so a bad client id/secret
+      // surfaces immediately rather than on first runtime use (mirrors the oauth2 flow's
+      // validate-on-connect). The minted token is cached on the credential for reuse.
+      if (def.connectionType === 'client-credentials') {
+        const minted = await mintClientCredentialToken(result.value, organizationId)
+        if (!minted.success) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: `Couldn't authenticate with these credentials: ${minted.error ?? 'mint failed'}`,
+          })
+        }
       }
 
       return { credentialId: result.value }

--- a/apps/web/src/server/api/routers/shopify.ts
+++ b/apps/web/src/server/api/routers/shopify.ts
@@ -570,7 +570,7 @@ export const shopifyRouter = createTRPCRouter({
             scope: claim.scope,
             shopDomain: claim.shop,
             // The hourly token refresh interpolates {shop} in the ConnectionDefinition's
-            // access-token URL from `connectionVariables` (oauth2-workflow.ts).
+            // access-token URL from `connectionVariables` (oauth2-token-grants.ts).
             // Without this the App-Store-saved credential refreshes against a literal
             // `https://{shop}.myshopify.com/...` URL and the connection dies an hour after
             // install — store the subdomain exactly as the in-app OAuth callback does.

--- a/packages/database/src/db/schema/connection-definition.ts
+++ b/packages/database/src/db/schema/connection-definition.ts
@@ -165,7 +165,9 @@ export const ConnectionDefinition = pgTable(
     key: text(),
     major: integer().notNull(), // Version major
 
-    // Connection type: oauth2-code, secret, none
+    // Connection type: oauth2-code, client-credentials, secret, none.
+    // `client-credentials` is the server-minted M2M OAuth2 grant — same minting columns as
+    // oauth2-code (sans the browser-redirect fields), downstream an ordinary bearer connection.
     connectionType: text().notNull(),
     label: text().notNull(),
     description: text(),

--- a/packages/lib/scripts/check-credential-refresh-roundtrip.ts
+++ b/packages/lib/scripts/check-credential-refresh-roundtrip.ts
@@ -24,7 +24,7 @@ const { eq } = await import('drizzle-orm')
 const { getCredential, revealSecrets, updateCredential } = await import('@auxx/credentials/store')
 const { encryptValue } = await import('@auxx/credentials/crypto')
 const { saveMcpConnection, resolveMcpConnectionForRuntime } = await import('../src/ai/mcp')
-const { refreshCredentialTokens } = await import('../src/workflows/oauth2-workflow')
+const { refreshCredentialTokens } = await import('../src/connections/oauth2-token-grants')
 
 const organizationId = process.argv[2] ?? 'abgwpa1l81reht2zmwrcihfu' // DemoOrg
 

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -444,7 +444,7 @@ export interface CachedMcpServer {
   endpoint: string
   isCustom: boolean // organizationId != null
   toolsetSlug: string // `mcp:<serverId>`
-  connectionType: 'oauth2-code' | 'secret' | 'none' | null // null = no definition yet
+  connectionType: 'oauth2-code' | 'client-credentials' | 'secret' | 'none' | null // null = no definition yet
   connectionPresent: boolean
   connectionExpiresAt: string | null
   /** Circuit breaker tripped (consecutiveRefreshFailures >= 5) — surfaces a reconnect pill. */

--- a/packages/lib/src/cache/providers/mcp-servers-provider.ts
+++ b/packages/lib/src/cache/providers/mcp-servers-provider.ts
@@ -47,7 +47,7 @@ export const mcpServersProvider: CacheProvider<CachedMcpServer[]> = {
         .filter((d) => d.mcpServerId)
         .map((d) => [
           d.mcpServerId as string,
-          d.connectionType as 'oauth2-code' | 'secret' | 'none',
+          d.connectionType as 'oauth2-code' | 'client-credentials' | 'secret' | 'none',
         ])
     )
 

--- a/packages/lib/src/connections/__tests__/auth-apply.test.ts
+++ b/packages/lib/src/connections/__tests__/auth-apply.test.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/connections/__tests__/auth-apply.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { applyAuth } from '../auth-apply'
+import { applyAuth, BEARER_AUTH, defaultAuthApply } from '../auth-apply'
 
 const req = () => ({ headers: {} as Record<string, string>, url: 'https://api.example.com/v1' })
 
@@ -62,6 +62,20 @@ describe('applyAuth', () => {
       { in: 'header', name: 'Authorization', format: 'Bearer {value}' }
     )
     expect(input.headers).toEqual({})
+  })
+
+  describe('defaultAuthApply', () => {
+    it('defaults oauth2-code to a bearer token', () => {
+      expect(defaultAuthApply('oauth2-code')).toEqual(BEARER_AUTH)
+    })
+
+    it('defaults a server-minted client-credentials token to a bearer token', () => {
+      expect(defaultAuthApply('client-credentials')).toEqual(BEARER_AUTH)
+    })
+
+    it('has no default for secret connections (they declare their own)', () => {
+      expect(defaultAuthApply('secret')).toBeNull()
+    })
   })
 
   describe('superset — multi-insertion + static headers', () => {

--- a/packages/lib/src/connections/__tests__/client-credentials-request.test.ts
+++ b/packages/lib/src/connections/__tests__/client-credentials-request.test.ts
@@ -1,0 +1,115 @@
+// packages/lib/src/connections/__tests__/client-credentials-request.test.ts
+//
+// Covers `makeClientCredentialsRequest`: the `grant_type=client_credentials` body, scope joining,
+// `request-body` vs `basic-auth` client authentication, and non-2xx error surfacing. The heavy
+// module graph oauth2-token-grants pulls in is mocked wholesale (mirrors oauth2-refresh-request);
+// the request itself is asserted via a fetch stub.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/config/server', () => ({ WEBAPP_URL: 'https://app.example.com' }))
+vi.mock('@auxx/credentials', () => ({
+  CredentialTypeRegistry: class {},
+  configService: { get: () => null },
+}))
+vi.mock('@auxx/workflow-nodes/server', () => ({ URLTemplateService: {} }))
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+}))
+vi.mock('@auxx/credentials/store', () => ({
+  recordRefreshFailure: async () => undefined,
+  recordRefreshSuccess: async () => undefined,
+  revealSecrets: async () => undefined,
+  rotateSecrets: async () => undefined,
+}))
+vi.mock('@auxx/database', () => ({ database: { query: {} }, schema: {} }))
+vi.mock('@auxx/services/app-connections', () => ({
+  interpolateConnectionFields: () => ({}),
+  mergeConnectionVariables: () => ({}),
+}))
+
+import { makeClientCredentialsRequest } from '../oauth2-token-grants'
+
+const fetchCalls: { url: string; headers: Record<string, string>; body: URLSearchParams }[] = []
+
+function stubFetch(ok: boolean, payload: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    async (url: string, init: { headers: Record<string, string>; body: string }) => {
+      fetchCalls.push({ url, headers: init.headers, body: new URLSearchParams(init.body) })
+      return {
+        ok,
+        status: ok ? 200 : 401,
+        json: async () => payload,
+        text: async () => (typeof payload === 'string' ? payload : JSON.stringify(payload)),
+      }
+    }
+  )
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0
+  stubFetch(true, { access_token: 'minted-token', expires_in: 3600 })
+})
+
+describe('makeClientCredentialsRequest', () => {
+  it('posts grant_type=client_credentials with joined scope (request-body auth)', async () => {
+    const result = await makeClientCredentialsRequest(
+      'https://as.example.com/token',
+      'client-123',
+      'secret-xyz',
+      ['scope.a', 'scope.b'],
+      'request-body'
+    )
+
+    expect(result.access_token).toBe('minted-token')
+    const call = fetchCalls[0]
+    expect(call?.url).toBe('https://as.example.com/token')
+    expect(call?.body.get('grant_type')).toBe('client_credentials')
+    expect(call?.body.get('scope')).toBe('scope.a scope.b')
+    expect(call?.body.get('client_id')).toBe('client-123')
+    expect(call?.body.get('client_secret')).toBe('secret-xyz')
+    expect(call?.headers.Authorization).toBeUndefined()
+  })
+
+  it('omits the scope param entirely when no scopes are configured', async () => {
+    await makeClientCredentialsRequest('https://as.example.com/token', 'c', 's', [], 'request-body')
+    expect(fetchCalls[0]?.body.has('scope')).toBe(false)
+  })
+
+  it('puts id/secret in the Authorization header and omits them from the body (basic-auth)', async () => {
+    await makeClientCredentialsRequest(
+      'https://as.example.com/token',
+      'client-123',
+      'secret-xyz',
+      ['scope.a'],
+      'basic-auth'
+    )
+
+    const call = fetchCalls[0]
+    const expected = Buffer.from('client-123:secret-xyz').toString('base64')
+    expect(call?.headers.Authorization).toBe(`Basic ${expected}`)
+    expect(call?.body.has('client_id')).toBe(false)
+    expect(call?.body.has('client_secret')).toBe(false)
+    expect(call?.body.get('grant_type')).toBe('client_credentials')
+  })
+
+  it('omits client_secret from the body when none is supplied (request-body)', async () => {
+    await makeClientCredentialsRequest(
+      'https://as.example.com/token',
+      'c',
+      undefined,
+      [],
+      'request-body'
+    )
+    expect(fetchCalls[0]?.body.has('client_secret')).toBe(false)
+  })
+
+  it('throws with the response body text on a non-2xx response', async () => {
+    stubFetch(false, 'invalid_client')
+    await expect(
+      makeClientCredentialsRequest('https://as.example.com/token', 'c', 's', [], 'request-body')
+    ).rejects.toThrow(/Client credentials grant failed: 401 invalid_client/)
+  })
+})

--- a/packages/lib/src/connections/__tests__/oauth2-refresh-request.test.ts
+++ b/packages/lib/src/connections/__tests__/oauth2-refresh-request.test.ts
@@ -92,7 +92,7 @@ vi.mock('@auxx/services/app-connections', () => ({
   ) => ({ ...(metadata?.connectionVariables ?? {}), ...(secrets?.fields ?? {}) }),
 }))
 
-import { refreshCredentialTokens } from '../oauth2-workflow'
+import { refreshCredentialTokens } from '../oauth2-token-grants'
 
 const fetchCalls: { url: string; body: URLSearchParams }[] = []
 

--- a/packages/lib/src/connections/auth-apply.ts
+++ b/packages/lib/src/connections/auth-apply.ts
@@ -18,13 +18,18 @@ export const BEARER_AUTH: AuthApply = {
 
 /**
  * The default auth application for a connection type when none is declared on
- * its definition. An `oauth2-code` access token is always a bearer token, so app
- * authors needn't restate it (platform defs set it explicitly; app-authored defs
- * often omit it). Secret connections have no universal default — they must
- * declare how their secret is applied.
+ * its definition. An `oauth2-code` access token — and a server-minted
+ * `client-credentials` token — is always a bearer token, so app authors needn't
+ * restate it (platform defs set it explicitly; app-authored defs often omit it).
+ * Secret connections have no universal default — they must declare how their
+ * secret is applied.
  */
-export function defaultAuthApply(connectionType: 'oauth2-code' | 'secret'): AuthApply | null {
-  return connectionType === 'oauth2-code' ? BEARER_AUTH : null
+export function defaultAuthApply(
+  connectionType: 'oauth2-code' | 'client-credentials' | 'secret'
+): AuthApply | null {
+  return connectionType === 'oauth2-code' || connectionType === 'client-credentials'
+    ? BEARER_AUTH
+    : null
 }
 
 /** A resolved connection, narrowed to what applyAuth reads. */

--- a/packages/lib/src/connections/index.ts
+++ b/packages/lib/src/connections/index.ts
@@ -10,6 +10,12 @@ export {
   type RuntimeConnectionAuthData,
 } from './auth-apply'
 export {
+  makeClientCredentialsRequest,
+  mintClientCredentialToken,
+  type RefreshTokensResult,
+  refreshCredentialTokens,
+} from './oauth2-token-grants'
+export {
   type ConnectionDefinitionForRefresh,
   type CredentialOwner,
   loadDefinitionForCredential,

--- a/packages/lib/src/connections/oauth2-token-grants.ts
+++ b/packages/lib/src/connections/oauth2-token-grants.ts
@@ -1,4 +1,10 @@
-// packages/lib/src/workflows/oauth2-workflow.ts
+// packages/lib/src/connections/oauth2-token-grants.ts
+//
+// OAuth2 token production for a credential — the two grants that mint/renew its access token:
+// `refresh_token` (refresh an existing token) and `client_credentials` (mint server-side, no user
+// or browser). Shared by the lazy resolve-on-use seam, the scheduled refresh job, and the connect
+// surface. Lives beside `resolve-connection-definition.ts` because both grants resolve their
+// provider config the same way (by ConnectionDefinition).
 
 import {
   recordRefreshFailure,
@@ -13,9 +19,9 @@ import { eq } from 'drizzle-orm'
 import {
   loadDefinitionForCredential,
   resolveOAuth2RefreshConfig,
-} from '../connections/resolve-connection-definition'
+} from './resolve-connection-definition'
 
-const logger = createScopedLogger('oauth2-workflow')
+const logger = createScopedLogger('oauth2-token-grants')
 
 /** Circuit-breaker threshold mirrored from the store (a permanent failure jumps straight here). */
 const CIRCUIT_OPEN_THRESHOLD = 5
@@ -169,23 +175,118 @@ export async function refreshCredentialTokens(
   }
 }
 
-/** Make a refresh-token request to the provider, handling basic-auth vs request-body. */
-async function makeTokenRefreshRequest(
+/**
+ * Mint a fresh access token for a `client-credentials` credential. There is no user, no browser,
+ * and no refresh token: the org's `client_id`/`client_secret` (stored as secret connection
+ * variables, resolved via the same `resolveOAuth2RefreshConfig` fallback as refresh) are POSTed
+ * straight to the token endpoint. The minted token is rotated onto the credential as
+ * `secrets.accessToken` — `secrets.fields` (the id/secret) are preserved by the spread — and
+ * `expiresAt` is stamped. Shares the breaker + success/failure recording with the refresh path.
+ * Called lazily by the runtime (on first use / near expiry) through `ensureFreshCredentialToken`.
+ */
+export async function mintClientCredentialToken(
+  credentialId: string,
+  organizationId: string
+): Promise<RefreshTokensResult> {
+  const revealed = await revealSecrets<OAuth2Secrets>(credentialId, organizationId)
+  if (revealed.isErr()) {
+    return { success: false, error: revealed.error.message }
+  }
+
+  const { record, secrets } = revealed.value
+  const previousFailureCount = record.consecutiveRefreshFailures
+
+  try {
+    const connDef = await loadDefinitionForCredential({
+      connectionDefinitionId: record.connectionDefinitionId,
+      appId: record.appId,
+      mcpServerId: record.mcpServerId,
+      type: record.type,
+    })
+    if (!connDef) {
+      return { success: false, error: 'ConnectionDefinition not found' }
+    }
+
+    const variables = mergeConnectionVariables(record.metadata, secrets)
+    const oauth = resolveOAuth2RefreshConfig(connDef, variables)
+    if (!oauth.accessTokenUrl) {
+      return { success: false, error: 'ConnectionDefinition not found' }
+    }
+
+    const tokenData = await makeClientCredentialsRequest(
+      oauth.accessTokenUrl,
+      oauth.clientId,
+      oauth.clientSecret,
+      oauth.scopes,
+      oauth.authMethod
+    )
+
+    const newExpiresAt = tokenData.expires_in
+      ? new Date(Date.now() + tokenData.expires_in * 1000)
+      : null
+
+    // No refreshToken written — client_credentials re-mints from the id/secret on expiry.
+    const rotated = await rotateSecrets(credentialId, organizationId, {
+      ...secrets,
+      accessToken: tokenData.access_token,
+    })
+    if (rotated.isErr()) {
+      return { success: false, error: rotated.error.message }
+    }
+
+    await recordRefreshSuccess(credentialId, organizationId, { expiresAt: newExpiresAt })
+
+    logger.info('Client credentials token minted', {
+      credentialId,
+      kind: record.kind,
+      expiresAt: newExpiresAt,
+      previousFailures: previousFailureCount,
+    })
+
+    return { success: true, expiresAt: newExpiresAt }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    logger.error('Client credentials mint failed', { credentialId, error: errorMessage })
+
+    await recordRefreshFailure(credentialId, organizationId)
+
+    const newFailureCount = previousFailureCount + 1
+    return {
+      success: false,
+      error: errorMessage,
+      newFailureCount,
+      circuitOpened: newFailureCount >= CIRCUIT_OPEN_THRESHOLD,
+    }
+  }
+}
+
+/** Token response shape shared by the refresh and client-credentials grants. */
+interface TokenResponse {
+  access_token: string
+  refresh_token?: string
+  expires_in?: number
+}
+
+/**
+ * POST a form-encoded OAuth2 token request, applying `basic-auth` vs `request-body` client
+ * authentication uniformly. Shared by the refresh-token and client-credentials grants so the two
+ * never drift on header/auth handling. `body` carries the grant-specific params; the client
+ * id/secret are placed in the body (request-body) or the `Authorization` header (basic-auth).
+ */
+async function postOAuth2TokenRequest(
   tokenUrl: string,
+  body: Record<string, string>,
   clientId: string,
   clientSecret: string | null | undefined,
-  refreshToken: string,
   authMethod: string,
-  resource?: string
-): Promise<{ access_token: string; refresh_token?: string; expires_in?: number }> {
+  failureLabel: string
+): Promise<TokenResponse> {
   const tokenRequestBody: Record<string, string> = {
-    grant_type: 'refresh_token',
-    refresh_token: refreshToken,
+    ...body,
     client_id: clientId,
     // Public clients (e.g. DCR-minted MCP clients, PKCE-only) have no secret — omit the field
     // rather than sending an empty value some ASes reject.
     ...(clientSecret ? { client_secret: clientSecret } : {}),
-    ...(resource ? { resource } : {}),
   }
 
   const headers: Record<string, string> = {
@@ -208,8 +309,57 @@ async function makeTokenRefreshRequest(
 
   if (!response.ok) {
     const errorText = await response.text()
-    throw new Error(`Token refresh failed: ${response.status} ${errorText}`)
+    throw new Error(`${failureLabel}: ${response.status} ${errorText}`)
   }
 
   return response.json()
+}
+
+/** Make a refresh-token request to the provider, handling basic-auth vs request-body. */
+async function makeTokenRefreshRequest(
+  tokenUrl: string,
+  clientId: string,
+  clientSecret: string | null | undefined,
+  refreshToken: string,
+  authMethod: string,
+  resource?: string
+): Promise<TokenResponse> {
+  return postOAuth2TokenRequest(
+    tokenUrl,
+    {
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      ...(resource ? { resource } : {}),
+    },
+    clientId,
+    clientSecret,
+    authMethod,
+    'Token refresh failed'
+  )
+}
+
+/**
+ * Make a `client_credentials` token request — the no-user, no-browser grant: POST the client
+ * id/secret straight to the token endpoint to mint a short-lived bearer (no refresh token).
+ * `basic-auth` vs `request-body` is handled identically to {@link makeTokenRefreshRequest}.
+ */
+export async function makeClientCredentialsRequest(
+  tokenUrl: string,
+  clientId: string,
+  clientSecret: string | null | undefined,
+  scopes: string[],
+  authMethod: string
+): Promise<TokenResponse> {
+  return postOAuth2TokenRequest(
+    tokenUrl,
+    {
+      grant_type: 'client_credentials',
+      // Scope is optional per RFC 6749 §4.4.2 — omit the param entirely when none are configured.
+      ...(scopes.length > 0 ? { scope: scopes.join(' ') } : {}),
+    },
+    clientId,
+    clientSecret,
+    authMethod,
+    'Client credentials grant failed'
+  )
 }

--- a/packages/lib/src/connections/resolve-connection-definition.ts
+++ b/packages/lib/src/connections/resolve-connection-definition.ts
@@ -16,6 +16,7 @@ export interface ConnectionDefinitionForRefresh {
   oauth2AuthorizeUrl: string | null
   oauth2AccessTokenUrl: string | null
   oauth2RefreshUrl: string | null
+  oauth2Scopes: string[] | null
   oauth2ClientId: string | null
   oauth2ClientSecret: string | null
   oauth2TokenRequestAuthMethod: string | null
@@ -38,6 +39,7 @@ const REFRESH_COLUMNS = {
   oauth2AuthorizeUrl: true,
   oauth2AccessTokenUrl: true,
   oauth2RefreshUrl: true,
+  oauth2Scopes: true,
   oauth2ClientId: true,
   oauth2ClientSecret: true,
   oauth2TokenRequestAuthMethod: true,
@@ -111,6 +113,7 @@ export function resolveOAuth2RefreshConfig(
   clientId: string
   clientSecret: string
   authMethod: string
+  scopes: string[]
 } {
   const resolved = interpolateConnectionFields(def, variables)
 
@@ -127,5 +130,6 @@ export function resolveOAuth2RefreshConfig(
     clientId,
     clientSecret,
     authMethod: def.oauth2TokenRequestAuthMethod || 'request-body',
+    scopes: def.oauth2Scopes ?? [],
   }
 }

--- a/packages/lib/src/connections/resolve-connection-for-runtime.ts
+++ b/packages/lib/src/connections/resolve-connection-for-runtime.ts
@@ -19,6 +19,13 @@ import { defaultAuthApply } from './auth-apply'
 
 const logger = createScopedLogger('resolve-connection-for-runtime')
 
+/**
+ * The runtime connection types. `client-credentials` is a server-minted bearer (no user, no
+ * browser) — downstream it behaves exactly like `oauth2-code`; only the token-production path
+ * (mint vs refresh) differs.
+ */
+type ConnectionType = 'oauth2-code' | 'client-credentials' | 'secret'
+
 /** Secrets no longer carry expiry/metadata — those come from the record columns. */
 type ConnectionSecrets = Pick<
   DecryptedConnectionData,
@@ -32,7 +39,7 @@ type ConnectionSecrets = Pick<
  */
 export interface RuntimeConnectionData {
   id: string
-  type: 'oauth2-code' | 'secret'
+  type: ConnectionType
   value: string
   fields?: Record<string, string>
   /** Declarative spec for putting this connection on an outgoing HTTP request (§3); null for DB/email/none. */
@@ -86,18 +93,29 @@ function connectionFields(
 }
 
 /**
- * Lazy refresh: for an `oauth2-code` connection with a stored refresh token, refresh the access
- * token if it is at/near expiry (single-flight, never throws) and re-reveal the rotated secrets.
- * The hot path (fresh token, or `secret`-type, or `ensureFresh: false`) stays at one reveal.
+ * Lazily produce a fresh token before use, then re-reveal the rotated secrets:
+ *  - `oauth2-code`: refresh against the stored refresh token if it's at/near expiry.
+ *  - `client-credentials`: mint from the org's id/secret when no token has been minted yet
+ *    (`!expiresAt`) or it's near expiry — there is no refresh token to gate on.
+ * Single-flight and never-throwing (see `ensureFreshCredentialToken`). The hot path (fresh token,
+ * or `secret`-type, or `ensureFresh: false`) stays at one reveal.
  */
 async function refreshIfNeeded(
   revealed: RevealedConnection,
   organizationId: string,
-  connectionType: 'oauth2-code' | 'secret',
+  connectionType: ConnectionType,
   ensureFresh: boolean
 ): Promise<RevealedConnection> {
   const { record, secrets } = revealed
-  if (!ensureFresh || connectionType !== 'oauth2-code' || !secrets.refreshToken) {
+  if (!ensureFresh) return revealed
+
+  const isClientCredentials = connectionType === 'client-credentials'
+  // Only the token-minting types do any work here: oauth2-code needs a stored refresh token,
+  // client-credentials always mints from the org's id/secret. Everything else (secret/none/db…)
+  // is a one-reveal hot path.
+  if (connectionType === 'oauth2-code') {
+    if (!secrets.refreshToken) return revealed
+  } else if (!isClientCredentials) {
     return revealed
   }
 
@@ -107,7 +125,8 @@ async function refreshIfNeeded(
     expiresAt: record.expiresAt,
     lastRefreshAt: record.lastRefreshAt,
     createdAt: record.createdAt,
-    hasRefreshToken: true,
+    hasRefreshToken: !!secrets.refreshToken,
+    grant: isClientCredentials ? 'client-credentials' : 'refresh_token',
   })
   if (!changed) return revealed
 
@@ -119,7 +138,7 @@ async function refreshIfNeeded(
 async function shapeFromRevealed(
   revealed: RevealedConnection,
   organizationId: string,
-  connectionType: 'oauth2-code' | 'secret',
+  connectionType: ConnectionType,
   ensureFresh: boolean,
   def: DefinitionRuntime = {}
 ): Promise<RuntimeConnectionData> {
@@ -156,7 +175,7 @@ async function shapeFromRevealed(
 async function toRuntimeConnection(
   credentialId: string,
   organizationId: string,
-  connectionType: 'oauth2-code' | 'secret',
+  connectionType: ConnectionType,
   ensureFresh: boolean,
   def: DefinitionRuntime = {}
 ): Promise<Result<RuntimeConnectionData, ResolveConnectionError>> {
@@ -199,7 +218,7 @@ async function resolveAppCredential(
       cred.connectionDefinitionId ? eq(d.id, cred.connectionDefinitionId) : eq(d.appId, appId),
     columns: { connectionType: true, authApply: true, baseUrlTemplate: true },
   })
-  const connectionType = (def?.connectionType ?? 'secret') as 'oauth2-code' | 'secret'
+  const connectionType = (def?.connectionType ?? 'secret') as ConnectionType
   return toRuntimeConnection(cred.id, organizationId, connectionType, ensureFresh, {
     authApply: def?.authApply ?? null,
     baseUrlTemplate: def?.baseUrlTemplate,
@@ -268,7 +287,7 @@ export async function resolveConnectionForRuntime(
       columns: { connectionType: true, authApply: true, baseUrlTemplate: true },
     })
     const connectionType = (def?.connectionType ??
-      (revealed.value.secrets.accessToken ? 'oauth2-code' : 'secret')) as 'oauth2-code' | 'secret'
+      (revealed.value.secrets.accessToken ? 'oauth2-code' : 'secret')) as ConnectionType
     const resolved = await shapeFromRevealed(
       revealed.value,
       organizationId,
@@ -310,7 +329,7 @@ export async function resolveConnectionForRuntime(
     const resolved = await toRuntimeConnection(
       found.value.id,
       organizationId,
-      (def?.connectionType ?? 'secret') as 'oauth2-code' | 'secret',
+      (def?.connectionType ?? 'secret') as ConnectionType,
       ensureFresh,
       { authApply: def?.authApply ?? null, baseUrlTemplate: def?.baseUrlTemplate }
     )
@@ -339,7 +358,7 @@ export async function resolveConnectionForRuntime(
     const resolved = await toRuntimeConnection(
       found.value.id,
       organizationId,
-      def.connectionType as 'oauth2-code' | 'secret',
+      def.connectionType as ConnectionType,
       ensureFresh,
       { authApply: def.authApply, baseUrlTemplate: def.baseUrlTemplate }
     )

--- a/packages/lib/src/credentials/__tests__/ensure-fresh-credential-token.test.ts
+++ b/packages/lib/src/credentials/__tests__/ensure-fresh-credential-token.test.ts
@@ -1,11 +1,12 @@
 // packages/lib/src/credentials/__tests__/ensure-fresh-credential-token.test.ts
 //
-// Redis and the (lazily imported) oauth2-workflow are mocked wholesale; the tests assert the
+// Redis and the (lazily imported) oauth2-token-grants are mocked wholesale; the tests assert the
 // skip/refresh/lock decisions and the adaptive expiry skew.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const refreshCalls: { credentialId: string; organizationId: string }[] = []
+const mintCalls: { credentialId: string; organizationId: string }[] = []
 const redisState = {
   available: true,
   /** Lock value returned by `set NX` — null simulates "already held". */
@@ -33,9 +34,13 @@ vi.mock('@auxx/redis', () => ({
   },
 }))
 
-vi.mock('../../workflows/oauth2-workflow', () => ({
+vi.mock('../../connections/oauth2-token-grants', () => ({
   refreshCredentialTokens: async (credentialId: string, organizationId: string) => {
     refreshCalls.push({ credentialId, organizationId })
+    return { success: true, expiresAt: new Date(Date.now() + 3600_000) }
+  },
+  mintClientCredentialToken: async (credentialId: string, organizationId: string) => {
+    mintCalls.push({ credentialId, organizationId })
     return { success: true, expiresAt: new Date(Date.now() + 3600_000) }
   },
 }))
@@ -50,6 +55,7 @@ const base = {
 
 beforeEach(() => {
   refreshCalls.length = 0
+  mintCalls.length = 0
   redisState.available = true
   redisState.setResult = 'OK'
   redisState.getResults = []
@@ -144,5 +150,44 @@ describe('ensureFreshCredentialToken', () => {
     })
     expect(changed).toBe(true)
     expect(refreshCalls).toHaveLength(1)
+  })
+
+  describe('client-credentials grant', () => {
+    const cc = { ...base, hasRefreshToken: false, grant: 'client-credentials' as const }
+
+    it('mints when no token has been minted yet (!expiresAt)', async () => {
+      const changed = await ensureFreshCredentialToken({ ...cc, expiresAt: null })
+      expect(changed).toBe(true)
+      expect(mintCalls).toEqual([{ credentialId: 'cred-1', organizationId: 'org-1' }])
+      expect(refreshCalls).toHaveLength(0)
+    })
+
+    it('mints when the token is near expiry', async () => {
+      const changed = await ensureFreshCredentialToken({
+        ...cc,
+        expiresAt: new Date(Date.now() + 60_000),
+        lastRefreshAt: new Date(Date.now() - 3540_000), // 1h lifetime → 120s skew applies
+      })
+      expect(changed).toBe(true)
+      expect(mintCalls).toHaveLength(1)
+    })
+
+    it('does not mint a comfortably fresh token', async () => {
+      const changed = await ensureFreshCredentialToken({
+        ...cc,
+        expiresAt: new Date(Date.now() + 3600_000),
+        createdAt: new Date(),
+      })
+      expect(changed).toBe(false)
+      expect(mintCalls).toHaveLength(0)
+    })
+
+    it('reports a possible rotation under lock contention without minting', async () => {
+      redisState.setResult = null // lock held elsewhere
+      redisState.getResults = ['1', null]
+      const changed = await ensureFreshCredentialToken({ ...cc, expiresAt: null })
+      expect(changed).toBe(true)
+      expect(mintCalls).toHaveLength(0)
+    })
   })
 })

--- a/packages/lib/src/credentials/ensure-fresh-credential-token.ts
+++ b/packages/lib/src/credentials/ensure-fresh-credential-token.ts
@@ -35,14 +35,20 @@ function expirySkewMs(input: {
 }
 
 /**
- * If the credential's access token is expired or within the refresh-ahead window of expiry and a
- * refresh token exists, refresh it — single-flight per credential via a Redis NX lock (refresh
- * tokens may rotate; concurrent refreshes would persist a dead rotation). Kind-agnostic: routes
- * through `refreshCredentialTokens`, which branches on `record.kind` (`mcp` / `app`) itself.
- * Returns `true` when the stored secrets may have changed (a refresh ran here, or another process
- * held the lock) so the caller knows to re-reveal; `false` means the token was fresh and nothing
- * happened. Never throws: a failed refresh leaves the stored token in place for the caller's 401
- * path, and `refreshCredentialTokens` already stamps the breaker.
+ * Ensure the credential carries a fresh access token, producing one when it's expired/near expiry
+ * (single-flight per credential via a Redis NX lock — concurrent mints/refreshes would persist a
+ * dead rotation). Two grants share this seam:
+ *
+ * - `refresh_token` (default): refresh only when a refresh token exists and the token is at/near
+ *   expiry. `!expiresAt` means "can't tell" → leave it to the caller's 401 path.
+ * - `client-credentials`: there is no refresh token and no browser — re-mint from the org's
+ *   id/secret. The trigger inverts: `!expiresAt` (no token minted yet) means "**mint now**", and a
+ *   stored expiry near the skew window re-mints.
+ *
+ * Routes through `refreshCredentialTokens` / `mintClientCredentialToken` accordingly. Returns
+ * `true` when the stored secrets may have changed (work ran here, or another process held the
+ * lock) so the caller knows to re-reveal; `false` means nothing happened. Never throws: a failure
+ * leaves the stored token in place for the caller's 401 path, and the workflow stamps the breaker.
  */
 export async function ensureFreshCredentialToken(input: {
   credentialId: string
@@ -51,20 +57,28 @@ export async function ensureFreshCredentialToken(input: {
   lastRefreshAt?: Date | null
   createdAt?: Date
   hasRefreshToken: boolean
+  /** Which grant produces the fresh token. Default `refresh_token`. */
+  grant?: 'refresh_token' | 'client-credentials'
   /** Skip the expiry check — used by the 401 retry path where the token just failed live. */
   force?: boolean
 }): Promise<boolean> {
   const { credentialId, organizationId, expiresAt, hasRefreshToken, force } = input
+  const grant = input.grant ?? 'refresh_token'
 
-  if (!hasRefreshToken) return false
+  // refresh_token can't proceed without a refresh token; client-credentials always can (it mints).
+  if (grant === 'refresh_token' && !hasRefreshToken) return false
   if (!force) {
-    if (!expiresAt) return false // can't tell — leave it to the 401 path
-    const skew = expirySkewMs({
-      expiresAt,
-      lastRefreshAt: input.lastRefreshAt,
-      createdAt: input.createdAt,
-    })
-    if (expiresAt.getTime() - Date.now() > skew) return false
+    if (!expiresAt) {
+      // refresh: can't tell → 401 path owns it. client-credentials: no token yet → mint now.
+      if (grant === 'refresh_token') return false
+    } else {
+      const skew = expirySkewMs({
+        expiresAt,
+        lastRefreshAt: input.lastRefreshAt,
+        createdAt: input.createdAt,
+      })
+      if (expiresAt.getTime() - Date.now() > skew) return false
+    }
   }
 
   let redis: Awaited<ReturnType<typeof getRedisClient>> | null = null
@@ -92,12 +106,15 @@ export async function ensureFreshCredentialToken(input: {
   }
 
   try {
-    // Lazy import: oauth2-workflow pulls in the heavy workflow-nodes/services graph, which a
+    // Lazy import: oauth2-token-grants pulls in the heavy workflow-nodes/services graph, which a
     // low-level credentials module must not load statically (breaks test mock interception too).
-    const { refreshCredentialTokens } = await import('../workflows/oauth2-workflow')
-    const result = await refreshCredentialTokens(credentialId, organizationId)
+    const grants = await import('../connections/oauth2-token-grants')
+    const result =
+      grant === 'client-credentials'
+        ? await grants.mintClientCredentialToken(credentialId, organizationId)
+        : await grants.refreshCredentialTokens(credentialId, organizationId)
     if (!result.success) {
-      logger.warn('Credential token refresh failed', { credentialId, error: result.error })
+      logger.warn('Credential token refresh failed', { credentialId, grant, error: result.error })
     }
   } catch (error) {
     logger.warn('Credential token refresh threw', {

--- a/packages/lib/src/jobs/oauth2-refresh/oauth2-token-refresh-job.ts
+++ b/packages/lib/src/jobs/oauth2-refresh/oauth2-token-refresh-job.ts
@@ -2,7 +2,7 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { refreshCredentialTokens } from '../../workflows/oauth2-workflow'
+import { refreshCredentialTokens } from '../../connections/oauth2-token-grants'
 
 const logger = createScopedLogger('oauth2-token-refresh-job')
 

--- a/packages/lib/src/workflows/index.ts
+++ b/packages/lib/src/workflows/index.ts
@@ -1,7 +1,6 @@
 // packages/lib/src/workflows/index.ts
 
 export { normalizeTemplateGraph } from './normalize-template-graph'
-export { type RefreshTokensResult, refreshCredentialTokens } from './oauth2-workflow'
 export type { WorkflowGraph } from './template-graph-transformer'
 export { TemplateGraphTransformer } from './template-graph-transformer'
 export {


### PR DESCRIPTION
## What

Adds the OAuth2 **`client_credentials`** grant — the no-user, no-browser flow where the app POSTs a `client_id`/`client_secret` to the token endpoint to mint a short-lived bearer (no refresh token). This unblocks FedEx-style machine-to-machine APIs through declarative **World B** with zero per-provider code: a connection becomes a row of data.

Implements **steps 1–5** of `plans/connections/v2/client-credentials-grant.md`. The FedEx migration onto this capability is a separate follow-on PR.

## How

**Platform (`@auxx/lib`)**
- **`oauth2-token-grants`** — new `mintClientCredentialToken` + `makeClientCredentialsRequest`, factored onto a shared `postOAuth2TokenRequest` helper so the refresh and cc grants no longer drift on header/basic-auth handling. Mint writes **no** refreshToken, preserves `secrets.fields`, and shares the breaker/success/failure path. `resolveOAuth2RefreshConfig` now exposes `oauth2Scopes`.
- **`ensure-fresh-credential-token`** — new `grant` param. For `client-credentials` it drops the `hasRefreshToken` gate and inverts the trigger (`!expiresAt` ⇒ *mint now*), routing through the **same Redis single-flight lock**.
- **`resolve-connection-for-runtime`** — widened the `connectionType` union; `refreshIfNeeded` mints lazily on resolve. `defaultAuthApply` treats a minted token as a bearer.

**Authoring (`apps/build`)** — connection form + build router enum + publish gate learn the new type. Token-minting fields render for both grants; browser-redirect fields stay `oauth2-code`-only. `hasOAuthConnections` (browser-OAuth check) left `oauth2-code`-only.

**Consume (`apps/web`)** — the connect surface routes `client-credentials` through the secret field form (org enters its id/secret). A connect-time **mint-once test** surfaces a bad id/secret immediately rather than on first runtime use.

**Refactor** — relocated the token module out of `workflows/` (it has nothing to do with the workflow engine):
`workflows/oauth2-workflow.ts` → `connections/oauth2-token-grants.ts`, now exported from `@auxx/lib/connections`.

## Test plan
- New `makeClientCredentialsRequest` unit tests (grant body, scope joining, request-body vs basic-auth, error surfacing).
- Extended `ensureFreshCredentialToken` (cc branch: mint-on-empty / near-expiry / fresh-noop / lock contention) and `defaultAuthApply` tests.
- `@auxx/lib` rebuilds; **56/56** tests across `connections` + `credentials/__tests__` pass; lint clean.
- No schema column / migration (new grant rides existing columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)