### PR TITLE
feat(data-connectors): canonical ResourceFieldId field refs

### DIFF
--- a/apps/web/src/components/data-connectors/hooks/use-stream-mutations.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-stream-mutations.ts
@@ -18,13 +18,14 @@ export type FieldMergeStrategy =
   | 'ignore'
 
 /**
- * One binding entry. Identity is the stable `id`; `targetFieldKey` is nullable
- * (`null` = an unassigned draft formula the runtime skips). `match` flags the
- * bound field as a secondary identity key (external id stays primary).
+ * One binding entry. Identity is the stable `id`; `targetFieldRef` is a canonical
+ * `ResourceFieldId` (`${entityDefinitionId}:${fieldId}`), nullable (`null` = an
+ * unassigned draft formula the runtime skips). `match` flags the bound field as a
+ * secondary identity key (external id stays primary).
  */
 export type FieldMapping = {
   id: string
-  targetFieldKey: string | null
+  targetFieldRef: string | null
   expression: string
   sourceFields: Record<string, string>
   match?: { normalize?: 'email' | 'phone' | 'domain' | 'none' }

--- a/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
@@ -3,6 +3,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeType } from '@auxx/database/types'
+import { toResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import {
@@ -57,16 +58,16 @@ interface MappingFieldPickerProps {
   /** The source node being bound — drives the type filter + quick-create seed. */
   sourceType: string
   sourcePath: string
-  /** The currently-bound target field key, if any. */
+  /** The currently-bound target field ref (`ResourceFieldId`), if any. */
   assignedKey: string | undefined
-  /** Resolved label for the bound key (for the chip), if known. */
+  /** Resolved label for the bound ref (for the chip), if known. */
   assignedLabel: string | undefined
-  /** Target keys already bound by other entries — hidden from the list (uniqueness). */
+  /** Target field refs already bound by other entries — hidden (uniqueness). */
   excludeKeys?: Set<string>
   /** Quick-create is wired only for owned defs (plan decision 3). */
   canCreate: boolean
-  /** Bind this source node to the chosen target field key. */
-  onAssign: (fieldKey: string) => void
+  /** Bind this source node to the chosen target field (canonical `ResourceFieldId`). */
+  onAssign: (fieldRef: string) => void
   /** Unbind this source node — surfaced as the in-picker "Don't map" option. */
   onClear: () => void
 }
@@ -118,13 +119,15 @@ export function MappingFieldPicker({
         // computed), whose type accepts this source value, and that no other entry
         // already binds (uniqueness — the array allows dupes, the UI forbids them).
         filterField={(f) =>
-          !excludeKeys?.has(f.key) &&
+          !excludeKeys?.has(f.resourceFieldId ?? toResourceFieldId(entityDefinitionId, f.id)) &&
           isWritableTarget(f) &&
           isSourceTargetCompatible(f.fieldType, sourceType)
         }
         mode='single'
         searchPlaceholder='Search fields…'
-        onSelect={(_ref, field) => onAssign(field.key)}
+        onSelect={(_ref, field) =>
+          onAssign(field.resourceFieldId ?? toResourceFieldId(entityDefinitionId, field.id))
+        }
         // Skip = unbind. Only offered once a field is bound (an unbound source
         // node is already "not mapped").
         onSkip={assignedKey ? onClear : undefined}
@@ -160,9 +163,9 @@ export function MappingFieldPicker({
             seedName={humanize(sourcePath)}
             seedType={inferFieldType(sourcePath, sourceType)}
             onCancel={() => setCreating(false)}
-            onCreated={(fieldKey) => {
+            onCreated={(fieldRef) => {
               setCreating(false)
-              onAssign(fieldKey)
+              onAssign(fieldRef)
             }}
           />
         </PopoverContent>
@@ -187,7 +190,7 @@ function QuickCreateFieldForm({
   seedName: string
   seedType: FieldTypeType
   onCancel: () => void
-  onCreated: (fieldKey: string) => void
+  onCreated: (fieldRef: string) => void
 }) {
   const [name, setName] = useState(seedName)
   const [type, setType] = useState<FieldTypeType>(seedType)
@@ -197,8 +200,8 @@ function QuickCreateFieldForm({
     const trimmed = name.trim()
     if (!trimmed) return
     const field = await create.mutateAsync({ entityDefinitionId, name: trimmed, type })
-    // Custom-field key === name (see useCustomFieldMutations serverField).
-    onCreated(field.name)
+    // Bind by the canonical ResourceFieldId of the just-created field.
+    onCreated(toResourceFieldId(entityDefinitionId, field.id))
   }
 
   return (

--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import type { ResourceField } from '@auxx/lib/resources/client'
+import { toResourceFieldId } from '@auxx/types/field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { EntityIcon } from '@auxx/ui/components/icons'
@@ -120,21 +121,29 @@ export function MappingNode({
   const targetMode = mapping.targetMode as 'owned' | 'contributing'
   const fieldMappings = (mapping.fieldMappings ?? []) as FieldMapping[]
 
+  // Canonical `ResourceFieldId` for a target field — what bindings store. Prefer
+  // the field's own `resourceFieldId`, else compose it from the mapping's def.
+  const refOf = (f: ResourceField): string =>
+    f.resourceFieldId ?? toResourceFieldId(mapping.entityDefinitionId ?? '', f.id)
+  // Find the target field a stored ref points at (label/normalize resolution).
+  const fieldByRef = (ref: string | null | undefined): ResourceField | undefined =>
+    ref ? targetFields.find((f) => refOf(f) === ref) : undefined
+
   // Persist a new entry array (the single mapping field-write surface).
   const writeEntries = (next: FieldMapping[]) => setFieldMappings(streamId, mapping.id, next)
   // Patch one entry in place by its stable id (used by every per-entry mutation).
   const patchEntry = (id: string, patch: Partial<FieldMapping>) =>
     writeEntries(fieldMappings.map((e) => (e.id === id ? { ...e, ...patch } : e)))
 
-  // Target field keys flagged as secondary identity-match keys (external id is
+  // Target field refs flagged as secondary identity-match keys (external id is
   // always the primary). The blue "Match" badges on leaves reflect this set.
   const matchKeys = new Set(
-    fieldMappings.filter((e) => e.match && e.targetFieldKey != null).map((e) => e.targetFieldKey!)
+    fieldMappings.filter((e) => e.match && e.targetFieldRef != null).map((e) => e.targetFieldRef!)
   )
   // Every target field already bound by SOME entry — the pickers exclude these so
   // two entries can't fight over one field (an array allows it; the UI forbids it).
   const usedTargetKeys = new Set(
-    fieldMappings.map((e) => e.targetFieldKey).filter((k): k is string => k != null)
+    fieldMappings.map((e) => e.targetFieldRef).filter((k): k is string => k != null)
   )
 
   // Slice this mapping's subtree by its FULL absolute prefix (not the bare,
@@ -163,13 +172,13 @@ export function MappingNode({
   }
 
   // Formula rows = computed entries (a multi-source formula has no single leaf to
-  // anchor on) PLUS unassigned drafts (`targetFieldKey: null`), which are persisted
+  // anchor on) PLUS unassigned drafts (`targetFieldRef: null`), which are persisted
   // half-authored formulas with nowhere to live on the source tree yet.
   const formulaEntries = fieldMappings.filter(
-    (e) => !isBareToken(e.expression) || e.targetFieldKey == null
+    (e) => !isBareToken(e.expression) || e.targetFieldRef == null
   )
 
-  const assignTarget = (sourcePath: string, targetKey: string) => {
+  const assignTarget = (sourcePath: string, targetRef: string) => {
     // Drop any prior bare-token entry bound to this source (1 source → 1 target),
     // then append a fresh entry with a stable id.
     const next = fieldMappings.filter(
@@ -177,7 +186,7 @@ export function MappingNode({
     )
     next.push({
       id: generateId(),
-      targetFieldKey: targetKey,
+      targetFieldRef: targetRef,
       expression: `{${sourcePath}}`,
       sourceFields: { [sourcePath]: sourcePath },
     })
@@ -187,12 +196,12 @@ export function MappingNode({
 
   // Re-point a formula at a different target field. Identity is the entry id, so
   // this is a single field set — merge/match ride along, no re-key.
-  const retargetEntry = (id: string, newKey: string) => patchEntry(id, { targetFieldKey: newKey })
+  const retargetEntry = (id: string, newRef: string) => patchEntry(id, { targetFieldRef: newRef })
 
   // Normalizer for a match key, derived from the target field's storage type so
   // the toggle stays one-click (no normalize selector).
-  const deriveNormalize = (targetKey: string): 'email' | 'phone' | 'domain' | 'none' => {
-    const ft = targetFields.find((f) => f.key === targetKey)?.fieldType
+  const deriveNormalize = (targetRef: string): 'email' | 'phone' | 'domain' | 'none' => {
+    const ft = fieldByRef(targetRef)?.fieldType
     if (ft === 'EMAIL') return 'email'
     if (ft === 'PHONE_INTL') return 'phone'
     if (ft === 'URL') return 'domain'
@@ -203,14 +212,14 @@ export function MappingNode({
     const e = fieldMappings.find((x) => x.id === id)
     if (!e) return
     patchEntry(id, {
-      match: e.match ? undefined : { normalize: deriveNormalize(e.targetFieldKey ?? '') },
+      match: e.match ? undefined : { normalize: deriveNormalize(e.targetFieldRef ?? '') },
     })
   }
 
   // Append a persisted draft formula (no target yet) and open the dialog on it.
   const addFormula = () => {
     const id = generateId()
-    writeEntries([...fieldMappings, { id, targetFieldKey: null, expression: '', sourceFields: {} }])
+    writeEntries([...fieldMappings, { id, targetFieldRef: null, expression: '', sourceFields: {} }])
     setCalcEntryId(id)
   }
 
@@ -353,20 +362,17 @@ export function MappingNode({
                 key={e.id}
                 depth={depth + 1}
                 entityDefinitionId={mapping.entityDefinitionId}
-                targetKey={e.targetFieldKey ?? ''}
+                targetKey={e.targetFieldRef ?? ''}
                 label={
-                  e.targetFieldKey
-                    ? (targetFields.find((f) => f.key === e.targetFieldKey)?.label ??
-                      e.targetFieldKey)
-                    : ''
+                  e.targetFieldRef ? (fieldByRef(e.targetFieldRef)?.label ?? e.targetFieldRef) : ''
                 }
                 expression={e.expression}
                 mergeStrategy={e.mergeStrategy ?? 'overwrite'}
                 // Exclude keys other entries already bind, so a formula can't be
                 // retargeted onto a field already in use.
                 excludeKeys={
-                  e.targetFieldKey
-                    ? new Set([...usedTargetKeys].filter((k) => k !== e.targetFieldKey))
+                  e.targetFieldRef
+                    ? new Set([...usedTargetKeys].filter((k) => k !== e.targetFieldRef))
                     : usedTargetKeys
                 }
                 onEdit={() => setCalcEntryId(e.id)}
@@ -422,9 +428,8 @@ export function MappingNode({
         open={calcEntryId !== null}
         onOpenChange={(o) => !o && setCalcEntryId(null)}
         targetLabel={
-          calcEntry?.targetFieldKey
-            ? (targetFields.find((f) => f.key === calcEntry.targetFieldKey)?.label ??
-              calcEntry.targetFieldKey)
+          calcEntry?.targetFieldRef
+            ? (fieldByRef(calcEntry.targetFieldRef)?.label ?? calcEntry.targetFieldRef)
             : ''
         }
         expression={calcEntry?.expression ?? ''}
@@ -527,9 +532,13 @@ function SourceNode(props: SourceNodeProps) {
   }
 
   const entry = sourceToEntry.get(node.path)
-  const assignedTargetKey = entry?.targetFieldKey ?? undefined
+  const assignedTargetKey = entry?.targetFieldRef ?? undefined
   const assignedLabel = assignedTargetKey
-    ? targetFields.find((f) => f.key === assignedTargetKey)?.label
+    ? targetFields.find(
+        (f) =>
+          (f.resourceFieldId ?? toResourceFieldId(mapping.entityDefinitionId ?? '', f.id)) ===
+          assignedTargetKey
+      )?.label
     : undefined
   // Exclude target keys bound elsewhere (keep this leaf's own key selectable).
   const excludeKeys = assignedTargetKey

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -31,6 +31,7 @@ import {
   updateMapping,
   updateStream,
 } from '@auxx/lib/data-connectors'
+import { resourceFieldIdSchema } from '@auxx/types/field'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { adminProcedure, createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
@@ -109,12 +110,13 @@ const mergeStrategySchema = z.enum([
   'ignore',
 ])
 
-// One binding entry. Identity is the stable `id`; `targetFieldKey` is nullable
-// (a null entry is an unassigned draft the runtime skips). `mergeStrategy` is
-// folded in (no parallel map).
+// One binding entry. Identity is the stable `id`; `targetFieldRef` is a canonical
+// `ResourceFieldId` (concrete or the late-bound `@app:` form), nullable (a null
+// entry is an unassigned draft / provisioned field awaiting its ref — the runtime
+// skips it). `mergeStrategy` is folded in (no parallel map).
 const fieldMappingSchema = z.object({
   id: z.string(),
-  targetFieldKey: z.string().nullable(),
+  targetFieldRef: resourceFieldIdSchema.nullable(),
   expression: z.string(),
   sourceFields: z.record(z.string(), z.string()),
   // Present → this bound field is also a secondary identity-match key.

--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -5,7 +5,11 @@ import { getCachedResource } from '@auxx/lib/cache'
 import { conditionGroupSchema } from '@auxx/lib/conditions'
 import { BadRequestError } from '@auxx/lib/errors'
 import { getDescendantIds } from '@auxx/lib/field-values'
-import { RESOURCE_TABLE_REGISTRY, UnifiedCrudHandler } from '@auxx/lib/resources'
+import {
+  type LookupCandidate,
+  RESOURCE_TABLE_REGISTRY,
+  UnifiedCrudHandler,
+} from '@auxx/lib/resources'
 import { type FieldId, parseResourceFieldId, resourceFieldIdSchema } from '@auxx/types/field'
 import {
   ENTITY_DEFINITION_TYPES,
@@ -87,28 +91,30 @@ const createInputSchema = z.object({
 /**
  * Input for `record.lookupByField`.
  *
- * Priority-ordered equality lookup by (systemAttribute, value). v1 only
- * accepts `systemAttribute` — no `fieldId` support yet; we'll add it when
- * a custom-field caller lands, to avoid dead API surface on the client.
+ * Priority-ordered equality lookup. A candidate references its field either by
+ * `systemAttribute` (system fields) or by `fieldId` (custom fields, whose
+ * `systemAttribute` is null — e.g. connector-provisioned fields). Data Connectors
+ * are the custom-field caller this `fieldId` variant was always meant for.
  *
  * `limit` caps distinct recordIds across ALL candidates combined (not
  * per-candidate). Default 1 ("exists or not" — the 90% case). Cap at 25
  * so callers can't turn this into a listing endpoint through the side
  * door — beyond 25 the UX should be "search in Auxx".
  */
+const lookupValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.union([z.string(), z.number(), z.boolean()])),
+])
 const lookupByFieldInputSchema = z.object({
   entityDefinitionId: entityDefinitionIdSchema,
   candidates: z
     .array(
-      z.object({
-        systemAttribute: z.string().min(1),
-        value: z.union([
-          z.string(),
-          z.number(),
-          z.boolean(),
-          z.array(z.union([z.string(), z.number(), z.boolean()])),
-        ]),
-      })
+      z.union([
+        z.object({ systemAttribute: z.string().min(1), value: lookupValueSchema }),
+        z.object({ fieldId: z.string().min(1), value: lookupValueSchema }),
+      ])
     )
     .min(1)
     .max(5),
@@ -256,7 +262,8 @@ export const recordRouter = createTRPCRouter({
         const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
         return await handler.lookupByField({
           entityDefinitionId: input.entityDefinitionId,
-          candidates: input.candidates,
+          // `fieldId` arrives as a plain string from zod; the handler brands it.
+          candidates: input.candidates as LookupCandidate[],
           limit: input.limit,
         })
       } catch (error: unknown) {

--- a/packages/database/src/db/schema/data-connector-mapping.ts
+++ b/packages/database/src/db/schema/data-connector-mapping.ts
@@ -57,7 +57,8 @@ export const DataConnectorMapping = pgTable(
     }),
 
     // Array of binding entries. Each carries a stable `id` (identity) + a nullable
-    // `targetFieldKey` (a null entry is an unassigned draft the runtime skips), the
+    // `targetFieldRef` (a canonical `ResourceFieldId`; a null entry is an unassigned
+    // draft / provisioned field awaiting its ref, both skipped by the runtime), the
     // CALC shape, its `mergeStrategy`, and `match`/`provision` flags. An array (not
     // a Record) so identity is independent of the target and nothing keys by it;
     // a one-click row is the degenerate single-token `{source}` expression. Empty

--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -96,8 +96,14 @@ export interface StreamRequestConfig {
 export interface FieldMapping {
   /** Stable entry id (generateId). React key + dialog/patch handle; never reused. */
   id: string
-  /** Target field key this binding writes into; `null` = unassigned draft → runtime skips it. */
-  targetFieldKey: string | null
+  /**
+   * Canonical `ResourceFieldId` reference to the target field — concrete
+   * (`${entityDefinitionId}:${fieldId}`) or the late-bound `@app:` form. `null` =
+   * unassigned draft / provisioned field awaiting its concrete ref. Branded
+   * `ResourceFieldId` in the engine `FieldMapping` (`@auxx/lib/data-connectors/types`);
+   * a plain string here (this package can't import tier-1 `@auxx/types`).
+   */
+  targetFieldRef: string | null
   expression: string
   sourceFields: Record<string, string>
   /**

--- a/packages/lib/src/agents/bindings/resolve.ts
+++ b/packages/lib/src/agents/bindings/resolve.ts
@@ -201,6 +201,24 @@ export async function resolveAppFieldValue(params: {
 }
 
 /**
+ * Resolve a Data Connector's stored `targetFieldRef` to a concrete
+ * `ResourceFieldId`. A plain `${defId}:${fieldId}` passes through unchanged; the
+ * late-bound `@app:<slug>:<key>` form is resolved against the connector's bound
+ * connection (its `credentialId`). Returns `null` when an `@app:` segment can't
+ * resolve (no bound connection / no provisioned field) — the caller skips that
+ * field/candidate and records a run error. The connection-explicit twin of
+ * {@link resolveAppFieldValue}, decoupled from `ToolContext`/`Subject`.
+ */
+export async function resolveConnectorFieldRef(
+  ref: ResourceFieldId,
+  orgId: string,
+  connectionId: string | undefined
+): Promise<ResourceFieldId | null> {
+  const resolved = await resolveAppSegmentsWith(ref as VarRef, orgId, () => connectionId)
+  return (resolved as ResourceFieldId | null) ?? null
+}
+
+/**
  * Resolve an app field (`@app:<slug>:<key>`) to the org's `CustomField` id.
  *
  * Among the entity's custom fields, pick the app-owned field whose `appFieldKey`

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -78,7 +78,11 @@ export type {
   ProvisionTarget,
 } from './provisioning'
 // Schema provisioning (owned + contributing, 01 §5)
-export { provisionConnectorMappings, provisionTarget } from './provisioning'
+export {
+  backfillProvisionedFieldRefs,
+  provisionConnectorMappings,
+  provisionTarget,
+} from './provisioning'
 // Orchestrator + passes
 export { handleConnectorDelete, reconcileOrphans } from './reconciliation'
 export { resolveRelationships } from './relationship-pass'

--- a/packages/lib/src/data-connectors/map-record.test.ts
+++ b/packages/lib/src/data-connectors/map-record.test.ts
@@ -37,7 +37,7 @@ describe('mapRecord', () => {
       fieldMappings: [
         {
           id: 'e1',
-          targetFieldKey: 'total',
+          targetFieldRef: 'def1:total',
           expression: '{total_price}',
           sourceFields: { total_price: 'total_price' },
         },
@@ -47,7 +47,7 @@ describe('mapRecord', () => {
     const writes = mapRecord([m], source({ total_price: '49.99', customer: { email: 'a@b.com' } }))
 
     expect(writes).toHaveLength(1)
-    expect(writes[0]?.projected?.fields).toEqual({ total: '49.99' })
+    expect(writes[0]?.projected?.fields).toEqual({ 'def1:total': '49.99' })
     expect(writes[0]?.projected?.externalId).toBe('o1')
     // No field flagged `match` → no identity candidates (external-id only).
     expect(writes[0]?.projected?.identityCandidates).toEqual([])
@@ -58,7 +58,7 @@ describe('mapRecord', () => {
       id: 'li',
       rootPath: 'line_items[]',
       fieldMappings: [
-        { id: 'e1', targetFieldKey: 'sku', expression: '{sku}', sourceFields: { sku: 'sku' } },
+        { id: 'e1', targetFieldRef: 'def1:sku', expression: '{sku}', sourceFields: { sku: 'sku' } },
       ],
     })
 
@@ -73,7 +73,7 @@ describe('mapRecord', () => {
     )
 
     expect(writes).toHaveLength(2)
-    expect(writes.map((w) => w.projected?.fields.sku)).toEqual(['A', 'B'])
+    expect(writes.map((w) => w.projected?.fields['def1:sku'])).toEqual(['A', 'B'])
     // No natural id on the element → synthetic `${parentExternalId}:${index}`.
     expect(writes.map((w) => w.projected?.externalId)).toEqual(['o1:0', 'o1:1'])
   })
@@ -88,7 +88,7 @@ describe('mapRecord', () => {
         // rootPath 'customer') → target field 'contact_email', flagged `match`.
         {
           id: 'e1',
-          targetFieldKey: 'contact_email',
+          targetFieldRef: 'def1:contact_email',
           expression: '{email}',
           sourceFields: { email: 'email' },
           match: { normalize: 'email' },
@@ -100,7 +100,7 @@ describe('mapRecord', () => {
 
     expect(writes).toHaveLength(1)
     expect(writes[0]?.projected?.identityCandidates).toEqual([
-      { targetFieldId: 'contact_email', value: 'a@b.com', normalize: 'email' },
+      { targetFieldRef: 'def1:contact_email', value: 'a@b.com', normalize: 'email' },
     ])
   })
 
@@ -112,7 +112,7 @@ describe('mapRecord', () => {
       fieldMappings: [
         {
           id: 'e1',
-          targetFieldKey: 'title',
+          targetFieldRef: 'def1:title',
           expression: '{title}',
           sourceFields: { title: 'title' },
         },
@@ -128,7 +128,7 @@ describe('mapRecord', () => {
     )
 
     expect(writes).toHaveLength(2)
-    expect(writes.map((w) => w.projected?.fields.title)).toEqual(['a', 'b'])
+    expect(writes.map((w) => w.projected?.fields['def1:title'])).toEqual(['a', 'b'])
     // Each element's own `id` becomes the externalId (no parent hint needed).
     expect(writes.map((w) => w.projected?.externalId)).toEqual(['1', '2'])
   })
@@ -141,7 +141,7 @@ describe('mapRecord', () => {
       parentMappingId: 'order',
       relationshipFieldKey: 'line_items',
       fieldMappings: [
-        { id: 'e1', targetFieldKey: 'sku', expression: '{sku}', sourceFields: { sku: 'sku' } },
+        { id: 'e1', targetFieldRef: 'def1:sku', expression: '{sku}', sourceFields: { sku: 'sku' } },
       ],
     })
 
@@ -151,7 +151,7 @@ describe('mapRecord', () => {
     )
 
     const lineItems = writes.filter((w) => w.mapping.row.id === 'li')
-    expect(lineItems.map((w) => w.projected?.fields.sku)).toEqual(['A', 'B'])
+    expect(lineItems.map((w) => w.projected?.fields['def1:sku'])).toEqual(['A', 'B'])
     // Children attach to the specific parent instance (o1) they nest under.
     expect(lineItems.every((w) => w.parentRelation?.parentExternalId === 'o1')).toBe(true)
   })

--- a/packages/lib/src/data-connectors/map-record.ts
+++ b/packages/lib/src/data-connectors/map-record.ts
@@ -87,7 +87,7 @@ function evaluateFields(mapping: DecodedMapping, subtree: unknown): Record<strin
 
   for (const fm of mapping.fieldMappings) {
     // Unassigned draft (no target yet) — projected nowhere, skip.
-    if (fm.targetFieldKey == null) continue
+    if (fm.targetFieldRef == null) continue
     // Build the placeholder → value context for this expression.
     const ctx: Record<string, unknown> = {}
     for (const [placeholder, sourcePath] of Object.entries(fm.sourceFields ?? {})) {
@@ -99,10 +99,10 @@ function evaluateFields(mapping: DecodedMapping, subtree: unknown): Record<strin
     // Degenerate one-click case: an id-only subtree (e.g. a scalar) with a single
     // {source} token mapping to the whole subtree.
     if (Object.keys(ctx).length === 0 && fm.expression.trim() === '{source}') {
-      out[fm.targetFieldKey] = subtree
+      out[fm.targetFieldRef] = subtree
       continue
     }
-    out[fm.targetFieldKey] = evaluateCalcExpression(fm.expression, ctx)
+    out[fm.targetFieldRef] = evaluateCalcExpression(fm.expression, ctx)
   }
   return out
 }
@@ -121,11 +121,11 @@ function identityCandidates(
 ): ProjectedRecord['identityCandidates'] {
   const candidates: ProjectedRecord['identityCandidates'] = []
   for (const fm of mapping.fieldMappings) {
-    if (!fm.match || fm.targetFieldKey == null) continue
+    if (!fm.match || fm.targetFieldRef == null) continue
     const sourcePath = Object.values(fm.sourceFields)[0]
     if (!sourcePath) continue
     candidates.push({
-      targetFieldId: fm.targetFieldKey,
+      targetFieldRef: fm.targetFieldRef,
       value: getByPath(subtree, sourcePath),
       normalize: fm.match.normalize,
     })

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -7,9 +7,10 @@
 
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { getFieldDefinitionId, getFieldId, toResourceFieldId } from '@auxx/types/field'
 import { generateId } from '@auxx/utils'
 import { and, eq } from 'drizzle-orm'
-import { getCachedEntityDefId } from '../cache'
+import { getCachedCustomFields, getCachedEntityDefId } from '../cache'
 import { BadRequestError, NotFoundError } from '../errors'
 import { removeConnectorScheduler, syncConnectorScheduler } from './data-connector-scheduler'
 import type { DataConnectorMappingRow, DataConnectorRow, DataConnectorStreamRow } from './service'
@@ -136,6 +137,29 @@ export async function createConnectorFromTemplate(
 }
 
 /**
+ * Assert every concrete `targetFieldRef` belongs to the mapping's own entity def
+ * (a wrong-def ref is unrepresentable past this boundary). The late-bound `@app:`
+ * form carries the app slug in its first segment (resolved at sync time), so it
+ * skips the def-match check; `null` (draft / provisioned-awaiting-ref) is allowed.
+ */
+function assertFieldRefsMatchDef(
+  entityDefinitionId: string | null | undefined,
+  fieldMappings: FieldMapping[] | undefined
+): void {
+  if (!entityDefinitionId || !fieldMappings) return
+  for (const fm of fieldMappings) {
+    const ref = fm.targetFieldRef
+    if (ref == null) continue
+    if (getFieldId(ref).startsWith('@app:')) continue
+    if (getFieldDefinitionId(ref) !== entityDefinitionId) {
+      throw new BadRequestError(
+        `Field mapping targetFieldRef '${ref}' does not belong to entity definition '${entityDefinitionId}'`
+      )
+    }
+  }
+}
+
+/**
  * Materialize a stream's declared template mappings into rows. Streams are no
  * longer auto-seeded with a blank root, so every declared mapping is a fresh
  * insert. v1: contributing targets only — the `@system:*` ref resolves to a real
@@ -152,7 +176,11 @@ async function seedTemplateMappings(
       organizationId,
       mapping.target.entityRef
     )
-    const fieldMappings = buildTemplateFieldMappings(mapping.fields)
+    const fieldMappings = await buildTemplateFieldMappings(
+      organizationId,
+      entityDefinitionId,
+      mapping.fields
+    )
     await addMapping(db, organizationId, {
       dataConnectorStreamId: streamId,
       rootPath: mapping.rootPath,
@@ -188,20 +216,38 @@ async function resolveTemplateEntityRef(
  * as `{path}` (single-brace) — so `source: 'email'` becomes `{ expression: '{email}',
  * sourceFields: { email: 'email' } }`. Explicit `expression`/`sourceFields` pass
  * through verbatim for transforms (e.g. `{created} * 1000`).
+ *
+ * Target resolution: a **reused** field (no `provision` hint) resolves its
+ * template `key` (a systemAttribute or display name) to a concrete
+ * `ResourceFieldId` against the target def now. A **provisioned** field (`provision`
+ * hint) doesn't exist yet → `targetFieldRef: null`; the sync-time provisioning
+ * write-back fills the concrete ref once the field is created.
  */
-function buildTemplateFieldMappings(fields: ConnectorTemplateFieldMapping[]): FieldMapping[] {
+async function buildTemplateFieldMappings(
+  organizationId: string,
+  entityDefinitionId: string,
+  fields: ConnectorTemplateFieldMapping[]
+): Promise<FieldMapping[]> {
+  const defFields = await getCachedCustomFields(organizationId, entityDefinitionId)
+  const fieldIdByKey = new Map<string, string>()
+  for (const fld of defFields) {
+    if (fld.systemAttribute) fieldIdByKey.set(fld.systemAttribute, fld.id)
+    fieldIdByKey.set(fld.name, fld.id)
+  }
+
   return fields.map((f) => {
     const expression = f.expression ?? (f.source ? `{${f.source}}` : '')
     const sourceFields = f.sourceFields ?? (f.source ? { [f.source]: f.source } : {})
+    const reusedFieldId = f.provision ? undefined : fieldIdByKey.get(f.key)
     const mapping: FieldMapping = {
       id: generateId(),
-      targetFieldKey: f.key,
+      targetFieldRef: reusedFieldId ? toResourceFieldId(entityDefinitionId, reusedFieldId) : null,
       expression,
       sourceFields,
     }
     if (f.match) mapping.match = typeof f.match === 'object' ? f.match : {}
-    // Provisioned field's name = its key (provisioned fields carry no
-    // systemAttribute, so the crud layer resolves writes by name).
+    // Provisioned field's name = its key (the stable appFieldKey the sync-time
+    // provisioning + ref write-back match on).
     if (f.provision) mapping.provision = { name: f.key, ...f.provision }
     return mapping
   })
@@ -464,6 +510,7 @@ export async function addMapping(
   input: AddMappingInput
 ): Promise<DataConnectorMappingRow> {
   await loadStreamRow(db, organizationId, input.dataConnectorStreamId)
+  assertFieldRefsMatchDef(input.entityDefinitionId, input.fieldMappings)
   const [row] = await db
     .insert(schema.DataConnectorMapping)
     .values({
@@ -518,7 +565,11 @@ export async function updateMapping(
   mappingId: string,
   patch: UpdateMappingInput
 ): Promise<DataConnectorMappingRow> {
-  await loadMappingRow(db, organizationId, mappingId)
+  const existing = await loadMappingRow(db, organizationId, mappingId)
+  // Validate refs against the EFFECTIVE def (a same-call def change applies first).
+  const effectiveDefId =
+    patch.entityDefinitionId !== undefined ? patch.entityDefinitionId : existing.entityDefinitionId
+  assertFieldRefsMatchDef(effectiveDefId, patch.fieldMappings)
   const [row] = await db
     .update(schema.DataConnectorMapping)
     .set({

--- a/packages/lib/src/data-connectors/provisioning.ts
+++ b/packages/lib/src/data-connectors/provisioning.ts
@@ -16,6 +16,7 @@ import type { FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { createCustomField } from '@auxx/services/custom-fields'
 import { createEntityDefinition } from '@auxx/services/entity-definitions'
+import { getFieldId, toResourceFieldId } from '@auxx/types/field'
 import { and, eq } from 'drizzle-orm'
 import { onCacheEvent } from '../cache/invalidate'
 import { NotFoundError } from '../errors'
@@ -213,12 +214,11 @@ export async function provisionConnectorMappings(
 
     const fields: ProvisionFieldSpec[] = []
     for (const fm of mapping.fieldMappings) {
-      // Unassigned draft (no target yet) — nothing to provision, skip.
-      const key = fm.targetFieldKey
-      if (!key) continue
       if (fm.provision) {
+        // Provisioned field — `targetFieldRef` is null until the post-provision
+        // write-back; the stable `appFieldKey` is the provision name.
         fields.push({
-          appFieldKey: key,
+          appFieldKey: fm.provision.name,
           name: fm.provision.name,
           type: fm.provision.type,
           icon: fm.provision.icon,
@@ -226,11 +226,17 @@ export async function provisionConnectorMappings(
           isUpdatable: false,
           isCreatable: false,
         })
-      } else if (mapping.targetMode === 'owned') {
+        continue
+      }
+      // Unassigned draft (no target yet) — nothing to provision, skip.
+      const ref = fm.targetFieldRef
+      if (!ref) continue
+      if (mapping.targetMode === 'owned') {
+        const fieldId = getFieldId(ref)
         fields.push({
-          appFieldKey: key,
-          name: key,
-          type: fieldTypeFor(mapping.row.id, key),
+          appFieldKey: fieldId,
+          name: fieldId,
+          type: fieldTypeFor(mapping.row.id, fieldId),
           isUpdatable: false,
           isCreatable: false,
         })
@@ -248,4 +254,44 @@ export async function provisionConnectorMappings(
     results.push(result)
   }
   return results
+}
+
+/**
+ * Fill the concrete `ResourceFieldId` on each provisioned field mapping after its
+ * field has been created (the generic-rest provision case — app connectors resolve
+ * their `@app:` refs live in the sink, no write-back). Resolves the field by
+ * `(dataConnectorId, entityDefinitionId, appFieldKey = provision.name)`, stamps
+ * `fm.targetFieldRef`, and persists the mutated `fieldMappings`. Mutates the
+ * decoded mappings in place so the current run's sink sees the resolved refs.
+ */
+export async function backfillProvisionedFieldRefs(
+  db: Database,
+  organizationId: string,
+  dataConnectorId: string,
+  mappings: DecodedMapping[]
+): Promise<void> {
+  for (const mapping of mappings) {
+    let changed = false
+    for (const fm of mapping.fieldMappings) {
+      if (!fm.provision || fm.targetFieldRef != null) continue
+      const field = await db.query.CustomField.findFirst({
+        where: and(
+          eq(schema.CustomField.organizationId, organizationId),
+          eq(schema.CustomField.entityDefinitionId, mapping.entityDefinitionId),
+          eq(schema.CustomField.dataConnectorId, dataConnectorId),
+          eq(schema.CustomField.appFieldKey, fm.provision.name)
+        ),
+        columns: { id: true },
+      })
+      if (!field) continue
+      fm.targetFieldRef = toResourceFieldId(mapping.entityDefinitionId, field.id)
+      changed = true
+    }
+    if (changed) {
+      await db
+        .update(schema.DataConnectorMapping)
+        .set({ fieldMappings: mapping.fieldMappings, updatedAt: new Date() })
+        .where(eq(schema.DataConnectorMapping.id, mapping.row.id))
+    }
+  }
 }

--- a/packages/lib/src/data-connectors/run-data-connector-sync.ts
+++ b/packages/lib/src/data-connectors/run-data-connector-sync.ts
@@ -11,7 +11,7 @@ import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { invalidateSnapshots } from '../snapshot'
 import { prepareConnectorFetch } from './connector-runtime'
 import { mapRecord } from './map-record'
-import { provisionConnectorMappings } from './provisioning'
+import { backfillProvisionedFieldRefs, provisionConnectorMappings } from './provisioning'
 import { reconcileOrphans } from './reconciliation'
 import { resolveRelationships } from './relationship-pass'
 import {
@@ -77,6 +77,11 @@ export async function runDataConnectorSync(
     const targetedMappings = streams.flatMap((s) => s.mappings)
     if (targetedMappings.length > 0) {
       await provisionConnectorMappings(db, organizationId, dataConnectorId, targetedMappings)
+      // Stamp the concrete `ResourceFieldId` onto each just-provisioned field
+      // mapping (mutates the decoded mappings in place so this run's sink resolves
+      // them; persists for subsequent runs). App connectors resolve `@app:` refs
+      // live in the sink, so they're excluded by the `!== 'app'` guard above.
+      await backfillProvisionedFieldRefs(db, organizationId, dataConnectorId, targetedMappings)
     }
   }
 

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -9,9 +9,11 @@
 // importer, events are NOT skipped — workflows/agents react.
 
 import { createScopedLogger } from '@auxx/logger'
+import type { FieldId, ResourceFieldId } from '@auxx/types/field'
+import { getFieldId } from '@auxx/types/field'
 import type { TypedFieldValue } from '@auxx/types/field-value'
 import { stableHash } from '@auxx/utils/hash'
-import { getCachedCustomFields } from '../../cache'
+import { resolveConnectorFieldRef } from '../../agents/bindings/resolve'
 import { toRecordId } from '../../resources/resource-id'
 import {
   type DecodedMapping,
@@ -54,24 +56,67 @@ function isBlank(value: unknown): boolean {
 }
 
 /**
+ * Resolve every distinct `targetFieldRef` a record references (write fields +
+ * identity candidates) to a concrete `ResourceFieldId`. Concrete refs pass
+ * through; the late-bound `@app:` form resolves against the connector's bound
+ * connection (its `credentialId`). An unresolved ref (no bound connection / no
+ * provisioned field) is dropped from the map + recorded as a run error — the
+ * caller skips that field/candidate rather than writing a garbage field id.
+ */
+async function resolveFieldRefs(
+  ctx: SyncCtx,
+  record: ProjectedRecord
+): Promise<Map<string, ResourceFieldId>> {
+  const refs = new Set<string>()
+  for (const k of Object.keys(record.fields)) refs.add(k)
+  for (const c of record.identityCandidates) refs.add(c.targetFieldRef)
+
+  const connectionId = ctx.connector.credentialId ?? undefined
+  const out = new Map<string, ResourceFieldId>()
+  for (const ref of refs) {
+    const resolved = await resolveConnectorFieldRef(ref as ResourceFieldId, ctx.orgId, connectionId)
+    if (resolved) {
+      out.set(ref, resolved)
+      continue
+    }
+    logger.warn('targetFieldRef did not resolve — skipping field/candidate', {
+      connectorId: ctx.connector.id,
+      mappingExternalId: record.externalId,
+      ref,
+    })
+    if (ctx.counters.errorSample.length < 50) {
+      ctx.counters.errorSample.push({
+        externalId: record.externalId,
+        error: `unresolved targetFieldRef: ${ref}`,
+      })
+    }
+  }
+  return out
+}
+
+/**
  * Resolve the entity instance an upstream record binds to via its SECONDARY
  * match keys (the external-id binding is resolved first by the caller). Returns
  * `{ instanceId }`; null ⇒ no match → caller creates. Match candidates were
  * resolved from the source record by the mapping layer (flagged `match`
- * bindings → identityCandidates); the crud lookup keys candidates by
- * systemAttribute (= the target field), which lookupByField accepts directly.
+ * bindings → identityCandidates); each candidate's `targetFieldRef` is resolved
+ * to a concrete field id via `refToConcrete`, then keyed by `fieldId` so
+ * `lookupByField` matches connector-provisioned fields (systemAttribute null).
  */
 async function resolveIdentity(
   ctx: SyncCtx,
   mapping: DecodedMapping,
-  record: ProjectedRecord
+  record: ProjectedRecord,
+  refToConcrete: Map<string, ResourceFieldId>
 ): Promise<{ instanceId: string | null }> {
   const candidates = record.identityCandidates
     .map((c) => {
       if (isBlank(c.value)) return null
-      return { systemAttribute: c.targetFieldId, value: normalizeMatch(c.value, c.normalize) }
+      const concrete = refToConcrete.get(c.targetFieldRef)
+      if (!concrete) return null
+      return { fieldId: getFieldId(concrete), value: normalizeMatch(c.value, c.normalize) }
     })
-    .filter((c): c is { systemAttribute: string; value: string } => c !== null)
+    .filter((c): c is { fieldId: FieldId; value: string } => c !== null)
 
   if (candidates.length === 0) return { instanceId: null } // external-id only → create
 
@@ -104,17 +149,22 @@ async function buildWriteSet(
   mapping: DecodedMapping,
   record: ProjectedRecord,
   existingInstanceId: string | null,
-  fieldKeyToId: Map<string, string>
+  refToConcrete: Map<string, ResourceFieldId>
 ): Promise<{ writeSet: Record<string, unknown>; managedFields: string[] }> {
+  // managedFields stay keyed by the raw `targetFieldRef` — the same key space as
+  // `record.fields`, `mergeByKey`, and the prior runs' stored `managedFields`
+  // (used by the `connector_owned_only` ownership check below).
   const managedFields = Object.keys(record.fields)
+  // Write-set keys are concrete field ids (`getFieldId(resolvedRef)`) — what
+  // `setFieldValues`/`createEntity` expect (a bare uuid or systemAttribute).
   const writeSet: Record<string, unknown> = {}
 
   // Per-field merge strategy, derived from the binding entries (folded in from the
-  // old parallel column). Keyed by target field key; unassigned drafts are skipped.
+  // old parallel column). Keyed by raw `targetFieldRef`; unassigned drafts skipped.
   const mergeByKey = new Map<string, FieldMergeStrategy>()
   for (const fm of mapping.fieldMappings) {
-    if (fm.targetFieldKey != null && fm.mergeStrategy) {
-      mergeByKey.set(fm.targetFieldKey, fm.mergeStrategy)
+    if (fm.targetFieldRef != null && fm.mergeStrategy) {
+      mergeByKey.set(fm.targetFieldRef, fm.mergeStrategy)
     }
   }
   const strategyFor = (key: string): FieldMergeStrategy => mergeByKey.get(key) ?? 'overwrite'
@@ -130,25 +180,28 @@ async function buildWriteSet(
     current = await ctx.crud.getFieldValues(recordId)
   }
 
-  for (const [key, value] of Object.entries(record.fields)) {
-    const strategy = strategyFor(key)
+  for (const [rawRef, value] of Object.entries(record.fields)) {
+    const strategy = strategyFor(rawRef)
     if (strategy === 'ignore') continue
 
+    const concrete = refToConcrete.get(rawRef)
+    if (!concrete) continue // unresolved @app: ref — already recorded in resolveFieldRefs
+    const fieldId = getFieldId(concrete)
+
     if (strategy === 'overwrite') {
-      writeSet[key] = value
+      writeSet[fieldId] = value
       continue
     }
     if (strategy === 'connector_owned_only') {
       // Write only if this connector created/owns the field on this record.
       const item = await findItem(ctx.db, ctx.connector.id, mapping.row.id, record.externalId)
-      const owns = !item || (item.managedFields ?? []).includes(key)
-      if (owns) writeSet[key] = value
+      const owns = !item || (item.managedFields ?? []).includes(rawRef)
+      if (owns) writeSet[fieldId] = value
       continue
     }
     if (strategy === 'fill_blank') {
-      const fieldId = fieldKeyToId.get(key)
-      const cur = current && fieldId ? rawOf(current.get(fieldId)) : undefined
-      if (isBlank(cur)) writeSet[key] = value
+      const cur = current ? rawOf(current.get(fieldId)) : undefined
+      if (isBlank(cur)) writeSet[fieldId] = value
       continue
     }
     if (strategy === 'manual_review') {
@@ -156,7 +209,7 @@ async function buildWriteSet(
       logger.info('manual_review merge — conflict logged, not written', {
         mappingId: mapping.row.id,
         externalId: record.externalId,
-        field: key,
+        field: rawRef,
       })
     }
   }
@@ -169,20 +222,15 @@ export const entitySink: EntitySink = {
     ctx.counters.fetched += 1
     ctx.touchedDefs.add(mapping.entityDefinitionId)
 
-    // Field key → id map (for current-value reads under merge strategies).
-    const fields = await getCachedCustomFields(ctx.orgId, mapping.entityDefinitionId)
-    const fieldKeyToId = new Map<string, string>()
-    for (const f of fields) {
-      if (f.systemAttribute) fieldKeyToId.set(f.systemAttribute, f.id)
-      fieldKeyToId.set(f.name, f.id)
-      fieldKeyToId.set(f.id, f.id)
-    }
+    // Resolve every mapped `targetFieldRef` to a concrete field id once — both the
+    // identity lookup and the write set key off this table (§3.3).
+    const refToConcrete = await resolveFieldRefs(ctx, record)
 
     // 1. Resolve identity — exact bind, else strategy bootstrap.
     const bound = await findItem(ctx.db, ctx.connector.id, mapping.row.id, record.externalId)
     let instanceId: string | null = bound?.entityInstanceId ?? null
     if (!instanceId) {
-      const resolved = await resolveIdentity(ctx, mapping, record)
+      const resolved = await resolveIdentity(ctx, mapping, record, refToConcrete)
       instanceId = resolved.instanceId
     }
 
@@ -209,7 +257,7 @@ export const entitySink: EntitySink = {
       mapping,
       record,
       instanceId,
-      fieldKeyToId
+      refToConcrete
     )
 
     // 4. Write — owned uses the bypass handler + provenance; contributing uses

--- a/packages/lib/src/data-connectors/sinks/types.ts
+++ b/packages/lib/src/data-connectors/sinks/types.ts
@@ -2,6 +2,7 @@
 // Shared sync context + sink contract. The sink is the ONLY entity writer.
 
 import type { Database } from '@auxx/database'
+import type { ResourceFieldId } from '@auxx/types/field'
 import type { UnifiedCrudHandler } from '../../resources/crud/unified-handler'
 import type { DataConnectorRow, DecodedMapping, PendingRelation, RunCounters } from '../service'
 
@@ -9,17 +10,22 @@ import type { DataConnectorRow, DecodedMapping, PendingRelation, RunCounters } f
 export interface ProjectedRecord {
   externalId: string
   displayName: string
-  /** Mapped to TARGET field keys (the mapping layer already evaluated CALC). */
+  /**
+   * Mapped values keyed by the binding's `targetFieldRef` (a `ResourceFieldId`,
+   * possibly the `@app:` form). The sink resolves each key to a concrete field id
+   * before writing — see entity-sink's ref pre-pass. The mapping layer already
+   * evaluated CALC.
+   */
   fields: Record<string, unknown>
   /**
    * Secondary identity match values resolved from the SOURCE record (each bound
-   * field flagged `match`), pairing a target field with the source value it must
-   * equal. Pre-resolved by the mapping layer because the sink has no access to the
-   * source subtree. Empty when no field is flagged → the record matches by its
-   * external id only.
+   * field flagged `match`), pairing a target field ref with the source value it
+   * must equal. Pre-resolved by the mapping layer because the sink has no access
+   * to the source subtree. Empty when no field is flagged → the record matches by
+   * its external id only.
    */
   identityCandidates: Array<{
-    targetFieldId: string
+    targetFieldRef: ResourceFieldId
     value: unknown
     normalize?: 'email' | 'phone' | 'domain' | 'none'
   }>

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -8,6 +8,7 @@
 // the service layer casts at the read/write boundary.
 
 import type { FieldType } from '@auxx/database/types'
+import type { ResourceFieldId } from '@auxx/types/field'
 import type { RuntimeConnectionData } from '../connections/resolve-connection-for-runtime'
 
 // ── Connector-level config (jsonb on DataConnector) ───────────────────────────
@@ -219,8 +220,15 @@ export type FieldMergeStrategy =
 export interface FieldMapping {
   /** Stable entry id (generateId). React key + dialog/patch handle; never reused. */
   id: string
-  /** Target field key this binding writes into; `null` = unassigned draft → runtime skips it. */
-  targetFieldKey: string | null
+  /**
+   * Canonical reference to the target field this binding writes into — a
+   * single-segment `VarRef`. Concrete (`${entityDefinitionId}:${fieldId}`) for a
+   * bind-to-existing field, or the connection-late-bound `${slug}:@app:${slug}:${key}`
+   * form for an app-declared field (resolved at sync time against the connector's
+   * connection). `null` = unassigned draft (runtime skips it) or a generic-rest
+   * provisioned field awaiting its concrete ref (see {@link FieldMapping.provision}).
+   */
+  targetFieldRef: ResourceFieldId | null
   expression: string
   sourceFields: Record<string, string>
   /**

--- a/packages/lib/src/resources/crud/index.ts
+++ b/packages/lib/src/resources/crud/index.ts
@@ -12,7 +12,12 @@ export type {
   TransformedData,
   UpdateRecordOptions,
 } from './types'
-export type { CrudOptions } from './unified-handler'
+export type {
+  CrudOptions,
+  LookupByFieldResult,
+  LookupCandidate,
+  LookupMatch,
+} from './unified-handler'
 // Main handler
 export { UnifiedCrudHandler } from './unified-handler'
 // Mutation utilities (for advanced use cases)

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -7,11 +7,12 @@ import { createScopedLogger } from '@auxx/logger'
 import { checkUniqueValue } from '@auxx/services/custom-fields'
 import { getEntityInstance, listEntityInstances } from '@auxx/services/entity-instances'
 import { ModelTypes } from '@auxx/types/custom-field'
+import type { FieldId } from '@auxx/types/field'
 import { createTypedValueInput } from '@auxx/types/field-value'
 import { isEntityDefinitionType } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { type AnyColumn, and, eq, type SQL } from 'drizzle-orm'
-import { findCachedResource, getCachedCustomFields } from '../../cache'
+import { findCachedResource, getCachedCustomFields, getCachedFieldMap } from '../../cache'
 import { type ConditionGroup, resolveConditionContext } from '../../conditions'
 import { BadRequestError } from '../../errors'
 import { publisher } from '../../events/publisher'
@@ -63,24 +64,28 @@ type EntityInstanceEntity = typeof schema.EntityInstance.$inferSelect
 const lookupLogger = createScopedLogger('unified-handler-lookup')
 
 /**
- * Candidate for `lookupByField` — one `(systemAttribute, value)` pair to try.
+ * Candidate for `lookupByField` — one field reference + value to try. Two shapes,
+ * resolved through the same `customFields` org-cache:
+ *  - `{ systemAttribute }` → matched by `CustomField.systemAttribute` (system
+ *    fields / legacy callers: extension, `record.lookupByField`, `findByField`).
+ *  - `{ fieldId }` → matched by `CustomField.id` directly — the only path that
+ *    resolves connector-provisioned custom fields, whose `systemAttribute` is null.
  */
-export type LookupCandidate = {
-  systemAttribute: string
-  value: unknown
-}
+export type LookupCandidate =
+  | { systemAttribute: string; value: unknown }
+  | { fieldId: FieldId; value: unknown }
 
 /**
- * Single match returned by `lookupByField`. `matchedBy` records which
- * candidate hit this record (useful when callers want to know whether
- * dedup succeeded via externalId vs. primary_email). The denormalized
- * display columns from EntityInstance ride along so list-style consumers
- * (e.g. the extension's "N similar found" view) can render an avatar +
+ * Single match returned by `lookupByField`. `matchedBy` echoes the candidate that
+ * hit this record (its `systemAttribute` or `fieldId`), useful when callers want
+ * to know whether dedup succeeded via externalId vs. primary_email. The
+ * denormalized display columns from EntityInstance ride along so list-style
+ * consumers (e.g. the extension's "N similar found" view) can render an avatar +
  * name + subtitle without a second round-trip.
  */
 export type LookupMatch = {
   recordId: RecordId
-  matchedBy: { systemAttribute: string; value: unknown }
+  matchedBy: { systemAttribute?: string; fieldId?: FieldId; value: unknown }
   displayName: string | null
   secondaryDisplayValue: string | null
   avatarUrl: string | null
@@ -339,10 +344,29 @@ export class UnifiedCrudHandler {
     let anyValid = false
     const skipped: Array<{ candidate: LookupCandidate; reason: string }> = []
 
+    // `{ fieldId }` candidates resolve through the same `customFields` cache
+    // `getFieldBySystemAttribute` reads — fetched once here, not per candidate.
+    // Keyed by `CustomField.id` (every DB-backed field, incl. system fields whose
+    // ResourceFieldId carries the UUID); a systemAttribute fallback covers the
+    // pure-static-field edge so a `{ fieldId }` candidate never silently misses.
+    const hasFieldIdCandidate = params.candidates.some((c) => 'fieldId' in c)
+    const fieldMap = hasFieldIdCandidate
+      ? await getCachedFieldMap(this.organizationId, entityDef.id)
+      : null
+    const resolveByFieldId = (fieldId: FieldId): CustomFieldEntity | null => {
+      const byId = fieldMap!.get(fieldId)
+      if (byId) return byId
+      for (const f of fieldMap!.values()) if (f.systemAttribute === fieldId) return f
+      return null
+    }
+
     for (const candidate of params.candidates) {
       if (items.length >= params.limit) break
 
-      const field = await this.getFieldBySystemAttribute(entityDef.id, candidate.systemAttribute)
+      const field =
+        'fieldId' in candidate
+          ? resolveByFieldId(candidate.fieldId)
+          : await this.getFieldBySystemAttribute(entityDef.id, candidate.systemAttribute)
       if (!field) {
         skipped.push({ candidate, reason: 'field not found' })
         continue
@@ -390,7 +414,10 @@ export class UnifiedCrudHandler {
         seen.add(recordId)
         items.push({
           recordId,
-          matchedBy: { systemAttribute: candidate.systemAttribute, value: candidate.value },
+          matchedBy:
+            'fieldId' in candidate
+              ? { fieldId: candidate.fieldId, value: candidate.value }
+              : { systemAttribute: candidate.systemAttribute, value: candidate.value },
           displayName: row.displayName,
           secondaryDisplayValue: row.secondaryDisplayValue,
           avatarUrl: row.avatarUrl,

--- a/packages/lib/src/resources/index.ts
+++ b/packages/lib/src/resources/index.ts
@@ -19,6 +19,9 @@ export type {
   CrudResultSuccess,
   FieldChange,
   FindByFieldOptions,
+  LookupByFieldResult,
+  LookupCandidate,
+  LookupMatch,
   TransformedData,
   UpdateRecordOptions,
 } from './crud'


### PR DESCRIPTION
## Summary

Migrates the Data Connector binding model from `targetFieldKey` (a fuzzy systemAttribute / display-name string) to **`targetFieldRef`**, a canonical `ResourceFieldId` (`${entityDefinitionId}:${fieldId}`, or the late-bound `@app:` form). Refs can now address connector-provisioned custom fields — whose `systemAttribute` is `null` — which the key-based lookup could never resolve.

## What changed

**Schema / types**
- `FieldMapping.targetFieldRef` replaces `targetFieldKey` across the engine type, the db jsonb shape, and the tRPC input (`resourceFieldIdSchema`).
- Mapping writes (`addMapping` / `updateMapping`) assert every concrete ref belongs to the mapping's own entity def; `@app:` refs skip the check (resolved at sync), `null` (draft) is allowed.

**Sink (`entity-sink`)**
- Resolves every distinct ref a record touches (write fields + identity candidates) to a concrete field id once per record, including live `@app:` resolution via the new `resolveConnectorFieldRef`.
- An unresolved ref drops that field/candidate and records a run error rather than writing a garbage field id.

**Provisioning**
- Provisioned fields persist `targetFieldRef: null` until `backfillProvisionedFieldRefs` stamps the concrete ref after the field is created (mutated in place so the current run's sink sees it).
- Template seeding resolves reused (non-provisioned) fields to concrete refs up front.

**`lookupByField`**
- `LookupCandidate` gains a `{ fieldId }` shape (matched by `CustomField.id` via the field-map cache) alongside `{ systemAttribute }`, so identity dedup works for provisioned fields. `LookupCandidate` / `LookupMatch` / `LookupByFieldResult` re-exported from `@auxx/lib/resources`.

**UI**
- Field pickers and mapping nodes bind/resolve by `ResourceFieldId` (`toResourceFieldId`), including quick-create.

## Test plan
- [x] `map-record.test.ts` updated to assert ref-keyed projections + identity candidates.
- [ ] `pnpm test` green on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)