### PR TITLE
feat(data-connectors): per-stream request editors + humanized field picker

### DIFF
--- a/apps/web/src/components/data-connectors/hooks/use-source-paths.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-source-paths.ts
@@ -9,6 +9,8 @@ export interface SourcePath {
   path: string
   /** JSON-schema type at this path (`string` / `number` / `object` / `array`). */
   type: string
+  /** Detected JSON-schema string `format` (`email` / `uri` / `date` / `time` / `date-time`). */
+  format?: string
   /** Depth (for indenting the picker list). */
   depth: number
   /** True for object/array branches (not directly mappable as a value). */
@@ -17,6 +19,7 @@ export interface SourcePath {
 
 interface JsonSchemaNode {
   type?: string | string[]
+  format?: string
   properties?: Record<string, JsonSchemaNode>
   items?: JsonSchemaNode
 }
@@ -53,7 +56,7 @@ export function flattenSourceSchema(
         const childType = typeOf(child)
         const isBranch =
           childType === 'object' || (childType === 'array' && !!child.items?.properties)
-        out.push({ path: childPath, type: childType, depth, isBranch })
+        out.push({ path: childPath, type: childType, format: child.format, depth, isBranch })
         if (childType === 'object') {
           walk(child, childPath, depth + 1)
         } else if (childType === 'array' && child.items) {

--- a/apps/web/src/components/data-connectors/hooks/use-stream-mutations.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-stream-mutations.ts
@@ -9,6 +9,19 @@ import { api, type RouterOutputs } from '~/trpc/react'
 type Stream = RouterOutputs['dataConnector']['listStreams'][number]
 type Mapping = Stream['mappings'][number]
 
+/**
+ * The request fields the stream config UI edits and persists — a subset of the
+ * engine's `StreamRequestConfig`. Threaded whole through `saveRequestConfig` and
+ * `setSyncMode` so headers/params/body are never dropped on a partial write.
+ */
+export type UiRequestConfig = {
+  path?: string
+  method?: 'GET' | 'POST'
+  headers?: Record<string, string>
+  params?: Record<string, unknown>
+  body?: Record<string, unknown>
+}
+
 /** Per-field merge strategy. Folded into each binding entry (absent ⇒ 'overwrite'). */
 export type FieldMergeStrategy =
   | 'overwrite'
@@ -313,11 +326,7 @@ export function useStreamMutations(connectorId: string) {
 
   // ── Stream sync-mode toggle (atomic) ──────────────────────────────────────
   const setSyncMode = useCallback(
-    (
-      streamId: string,
-      syncMode: 'snapshot' | 'incremental',
-      requestConfig: { path?: string; method?: 'GET' | 'POST' }
-    ) =>
+    (streamId: string, syncMode: 'snapshot' | 'incremental', requestConfig: UiRequestConfig) =>
       patchStream(
         streamId,
         { syncMode } as Partial<Stream>,
@@ -329,7 +338,7 @@ export function useStreamMutations(connectorId: string) {
 
   // ── Deliberate / imperative wrappers (invalidate-based) ───────────────────
   const saveRequestConfig = useCallback(
-    (streamId: string, requestConfig: { path?: string; method?: 'GET' | 'POST' }) =>
+    (streamId: string, requestConfig: UiRequestConfig) =>
       saveRequestConfigM.mutateAsync({ streamId, requestConfig }),
     [saveRequestConfigM]
   )

--- a/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
@@ -3,36 +3,39 @@
 
 import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeType } from '@auxx/database/types'
+import { FIELD_TYPE_GROUPS, fieldTypeOptions } from '@auxx/lib/custom-fields/types'
 import { toResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
+import { EntityIcon } from '@auxx/ui/components/icons'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
-import { ChevronDown } from 'lucide-react'
-import { useState } from 'react'
+import { humanizeFieldPath } from '@auxx/utils'
+import { ChevronDown, ChevronLeft, ChevronsUpDown } from 'lucide-react'
+import { useMemo, useState } from 'react'
 import { useCustomFieldMutations } from '~/components/custom-fields/hooks/use-custom-field-mutations'
-import { FieldPicker } from '~/components/pickers/field-picker'
+import { ComboPicker, type Option, type OptionGroup } from '~/components/pickers/combo-picker'
+import { FieldPickerContent } from '~/components/pickers/field-picker'
+import { useResourceFields } from '~/components/resources'
 import { lastSegment } from '../hooks/use-source-paths'
 import { isSourceTargetCompatible, isWritableTarget } from './field-type-compat'
 
-/** Field types offered by the lightweight quick-create, seeded from the source type. */
-const QUICK_CREATE_TYPES: Array<{ value: FieldTypeType; label: string }> = [
-  { value: FieldType.TEXT, label: 'Text' },
-  { value: FieldType.NUMBER, label: 'Number' },
-  { value: FieldType.EMAIL, label: 'Email' },
-  { value: FieldType.URL, label: 'URL' },
-  { value: FieldType.DATE, label: 'Date' },
-  { value: FieldType.CHECKBOX, label: 'Checkbox' },
-  { value: FieldType.TAGS, label: 'Tags' },
-]
-
-/** Infer a sensible create-field type from the source node (last segment + JSON type). */
-function inferFieldType(path: string, sourceType: string): FieldTypeType {
+/**
+ * Infer a sensible create-field type from the source node. A detected string
+ * `format` (from the test-fetch values) wins over the segment-name heuristic,
+ * which only falls back when the format is absent.
+ */
+function inferFieldType(path: string, sourceType: string, format?: string): FieldTypeType {
+  switch (format) {
+    case 'email':
+      return FieldType.EMAIL
+    case 'uri':
+      return FieldType.URL
+    case 'date-time':
+      return FieldType.DATETIME
+    case 'date':
+      return FieldType.DATE
+    case 'time':
+      return FieldType.TIME
+  }
   if (sourceType === 'array') return FieldType.TAGS
   if (sourceType === 'number' || sourceType === 'integer') return FieldType.NUMBER
   if (sourceType === 'boolean') return FieldType.CHECKBOX
@@ -43,21 +46,14 @@ function inferFieldType(path: string, sourceType: string): FieldTypeType {
   return FieldType.TEXT
 }
 
-/** Title-case a source segment for the seeded field name (`total_price` → `Total Price`). */
-function humanize(path: string): string {
-  return lastSegment(path)
-    .replace(/\[\]$/, '')
-    .replace(/[_-]+/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase())
-    .trim()
-}
-
 interface MappingFieldPickerProps {
   /** The def whose fields are the binding targets. Null until a target is picked. */
   entityDefinitionId: string | null
   /** The source node being bound — drives the type filter + quick-create seed. */
   sourceType: string
   sourcePath: string
+  /** Detected source string `format` — seeds the quick-create field type (§2.2). */
+  sourceFormat?: string
   /** The currently-bound target field ref (`ResourceFieldId`), if any. */
   assignedKey: string | undefined
   /** Resolved label for the bound ref (for the chip), if known. */
@@ -73,15 +69,17 @@ interface MappingFieldPickerProps {
 }
 
 /**
- * The leaf-row target control (plan §5.2) — the canonical {@link FieldPicker}
- * replacing the old bare `<Select>`. Takes the selected `field.key` (relationship
- * drill is disabled in v1), filters targets by source-type compatibility, and on
- * owned defs offers a lightweight inline quick-create seeded from the source node.
+ * The leaf-row target control — a single self-managed {@link Popover} whose body
+ * swaps between the {@link FieldPickerContent} list and an inline quick-create
+ * form (a `view` flip, no stacked popovers). Filters targets by source-type
+ * compatibility, and on owned defs offers a quick-create seeded from the source
+ * node (friendly name + value-aware type).
  */
 export function MappingFieldPicker({
   entityDefinitionId,
   sourceType,
   sourcePath,
+  sourceFormat,
   assignedKey,
   assignedLabel,
   excludeKeys,
@@ -89,13 +87,13 @@ export function MappingFieldPicker({
   onAssign,
   onClear,
 }: MappingFieldPickerProps) {
-  const [pickerOpen, setPickerOpen] = useState(false)
-  const [creating, setCreating] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [view, setView] = useState<'pick' | 'create'>('pick')
 
   const chipLabel = assignedKey ? (assignedLabel ?? assignedKey) : 'Apply field…'
 
-  // No target def yet — the FieldPicker has nothing to resolve against. Show a
-  // disabled trigger; binding unlocks once a target def is picked (plan 08 §3.4).
+  // No target def yet — nothing to resolve against. Show a disabled trigger;
+  // binding unlocks once a target def is picked (plan 08 §3.4).
   if (!entityDefinitionId) {
     return (
       <Button
@@ -108,140 +106,235 @@ export function MappingFieldPicker({
     )
   }
 
-  return (
-    <>
-      <FieldPicker
-        open={pickerOpen}
-        onOpenChange={setPickerOpen}
-        entityDefinitionId={entityDefinitionId}
-        excludeFields={[FieldType.RELATIONSHIP]}
-        // Only fields the sync can actually write (creatable + updatable, not
-        // computed), whose type accepts this source value, and that no other entry
-        // already binds (uniqueness — the array allows dupes, the UI forbids them).
-        filterField={(f) =>
-          !excludeKeys?.has(f.resourceFieldId ?? toResourceFieldId(entityDefinitionId, f.id)) &&
-          isWritableTarget(f) &&
-          isSourceTargetCompatible(f.fieldType, sourceType)
-        }
-        mode='single'
-        searchPlaceholder='Search fields…'
-        onSelect={(_ref, field) =>
-          onAssign(field.resourceFieldId ?? toResourceFieldId(entityDefinitionId, field.id))
-        }
-        // Skip = unbind. Only offered once a field is bound (an unbound source
-        // node is already "not mapped").
-        onSkip={assignedKey ? onClear : undefined}
-        skipLabel="Don't map this field"
-        onCreateField={
-          canCreate
-            ? () => {
-                setPickerOpen(false)
-                setCreating(true)
-              }
-            : undefined
-        }
-        trigger={
-          <Button
-            variant='transparent'
-            className={`h-9 w-full justify-between rounded-none px-2 text-xs hover:bg-primary/5 ${
-              assignedKey ? '' : 'text-muted-foreground'
-            }`}>
-            <span className='truncate'>{chipLabel}</span>
-            <ChevronDown className='size-3 opacity-50' />
-          </Button>
-        }
-      />
+  // Reset to the list whenever the popover closes, so a re-open never lands on
+  // a stale create form.
+  const onOpenChange = (next: boolean) => {
+    setOpen(next)
+    if (!next) setView('pick')
+  }
 
-      {/* Lightweight inline quick-create (owned defs only). */}
-      <Popover open={creating} onOpenChange={setCreating}>
-        <PopoverTrigger asChild>
-          <span className='sr-only' />
-        </PopoverTrigger>
-        <PopoverContent align='end' className='w-64 p-3'>
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          variant='transparent'
+          className={`h-9 w-full justify-between rounded-none px-2 text-xs hover:bg-primary/5 ${
+            assignedKey ? '' : 'text-muted-foreground'
+          }`}>
+          <span className='truncate'>{chipLabel}</span>
+          <ChevronDown className='size-3 opacity-50' />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className='w-72 p-0' align='start'>
+        {view === 'pick' ? (
+          <FieldPickerContent
+            entityDefinitionId={entityDefinitionId}
+            excludeFields={[FieldType.RELATIONSHIP]}
+            // Only fields the sync can actually write (creatable + updatable, not
+            // computed), whose type accepts this source value, and that no other
+            // entry already binds (uniqueness — the array allows dupes, the UI
+            // forbids them).
+            filterField={(f) =>
+              !excludeKeys?.has(f.resourceFieldId ?? toResourceFieldId(entityDefinitionId, f.id)) &&
+              isWritableTarget(f) &&
+              isSourceTargetCompatible(f.fieldType, sourceType)
+            }
+            mode='single'
+            closeOnSelect
+            onClose={() => setOpen(false)}
+            searchPlaceholder='Search fields…'
+            onSelect={(_ref, field) =>
+              onAssign(field.resourceFieldId ?? toResourceFieldId(entityDefinitionId, field.id))
+            }
+            // Skip = unbind. Only offered once a field is bound (an unbound source
+            // node is already "not mapped").
+            onSkip={assignedKey ? onClear : undefined}
+            skipLabel="Don't map this field"
+            createLabel='Quick create'
+            onCreateField={canCreate ? () => setView('create') : undefined}
+          />
+        ) : (
           <QuickCreateFieldForm
             entityDefinitionId={entityDefinitionId}
-            seedName={humanize(sourcePath)}
-            seedType={inferFieldType(sourcePath, sourceType)}
-            onCancel={() => setCreating(false)}
+            sourceType={sourceType}
+            excludeKeys={excludeKeys}
+            seedName={humanizeFieldPath(sourcePath)}
+            seedType={inferFieldType(sourcePath, sourceType, sourceFormat)}
+            onBack={() => setView('pick')}
             onCreated={(fieldRef) => {
-              setCreating(false)
               onAssign(fieldRef)
+              onOpenChange(false)
             }}
           />
-        </PopoverContent>
-      </Popover>
-    </>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/** Build the ComboPicker groups for the field-type catalog, minus RELATIONSHIP. */
+function useFieldTypeGroups(): OptionGroup[] {
+  return useMemo(
+    () =>
+      Object.entries(FIELD_TYPE_GROUPS)
+        .map(([groupName, types]) => ({
+          label: groupName,
+          options: types
+            .filter((type) => type !== FieldType.RELATIONSHIP)
+            .map((type) => {
+              const opt = fieldTypeOptions[type]
+              if (!opt) return null
+              return { value: type, label: opt.label, iconId: opt.iconId }
+            })
+            .filter((o): o is Option => o !== null),
+        }))
+        .filter((g) => g.options.length > 0),
+    []
   )
 }
 
 /**
- * Inline "name + type" create form over the same {@link useCustomFieldMutations}
- * the dynamic-table create-field flow uses (plan decision 8). A custom field's
- * key equals its name, so the created field is bound immediately by name.
+ * Inline name + type quick-create over {@link useCustomFieldMutations} (the same
+ * mutation the full field editor uses). A custom field's key equals its name, so
+ * the created field binds immediately by its canonical `ResourceFieldId`. The
+ * type picker is the full {@link FIELD_TYPE_GROUPS} catalog (minus RELATIONSHIP),
+ * pre-seeded from the source node so the common path is two prefilled fields →
+ * Create. A pre-flight duplicate-name check steers the user to an existing field
+ * instead of a dead-end server error (plan §5.4).
  */
 function QuickCreateFieldForm({
   entityDefinitionId,
+  sourceType,
+  excludeKeys,
   seedName,
   seedType,
-  onCancel,
+  onBack,
   onCreated,
 }: {
   entityDefinitionId: string
+  sourceType: string
+  excludeKeys?: Set<string>
   seedName: string
   seedType: FieldTypeType
-  onCancel: () => void
+  onBack: () => void
   onCreated: (fieldRef: string) => void
 }) {
   const [name, setName] = useState(seedName)
   const [type, setType] = useState<FieldTypeType>(seedType)
+  const [typePickerOpen, setTypePickerOpen] = useState(false)
   const { create } = useCustomFieldMutations({ entityDefinitionId })
 
+  // Unfiltered field set for the pre-flight name check — the picker list is
+  // filtered, so a same-named field may be hidden from it; read it raw here.
+  const { fields } = useResourceFields(entityDefinitionId)
+  const groups = useFieldTypeGroups()
+
+  const trimmed = name.trim()
+
+  // Existing field whose label collides with the typed name (case-insensitive),
+  // and whether it's a usable binding target for this source value.
+  const conflict = useMemo(() => {
+    if (!trimmed) return null
+    const existing = fields.find((f) => f.label.trim().toLowerCase() === trimmed.toLowerCase())
+    if (!existing) return null
+    const ref = existing.resourceFieldId ?? toResourceFieldId(entityDefinitionId, existing.id)
+    const alreadyMapped = excludeKeys?.has(ref) ?? false
+    const bindable =
+      !alreadyMapped &&
+      isWritableTarget(existing) &&
+      isSourceTargetCompatible(existing.fieldType, sourceType)
+    return { existing, ref, bindable, alreadyMapped }
+  }, [trimmed, fields, entityDefinitionId, excludeKeys, sourceType])
+
+  const canSubmit = !!trimmed && !conflict && !create.isPending
+
   const submit = async () => {
-    const trimmed = name.trim()
-    if (!trimmed) return
+    if (!canSubmit) return
     const field = await create.mutateAsync({ entityDefinitionId, name: trimmed, type })
-    // Bind by the canonical ResourceFieldId of the just-created field.
     onCreated(toResourceFieldId(entityDefinitionId, field.id))
   }
 
+  const selectedTypeOption = fieldTypeOptions[type]
+  const selectedAsOption: Option | null = selectedTypeOption
+    ? { value: type, label: selectedTypeOption.label, iconId: selectedTypeOption.iconId }
+    : null
+
   return (
-    <div className='flex flex-col gap-2'>
-      <span className='text-xs font-medium uppercase text-muted-foreground'>New field</span>
+    <div className='flex flex-col gap-2 p-3'>
+      <button
+        type='button'
+        onClick={onBack}
+        className='-ml-1 flex w-fit items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground'>
+        <ChevronLeft className='size-3.5' />
+        Quick create
+      </button>
+
       <input
         autoFocus
         value={name}
         onChange={(e) => setName(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === 'Enter') void submit()
-          if (e.key === 'Escape') onCancel()
+          if (e.key === 'Escape') onBack()
         }}
         placeholder='Field name'
         className='w-full rounded-md border bg-background px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-ring'
       />
-      <Select value={type} onValueChange={(v) => setType(v as FieldTypeType)}>
-        <SelectTrigger size='sm' className='h-7 text-xs'>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {QUICK_CREATE_TYPES.map((t) => (
-            <SelectItem key={t.value} value={t.value}>
-              {t.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+
+      <ComboPicker
+        groups={groups}
+        selected={selectedAsOption}
+        multi={false}
+        className='w-[var(--radix-popover-trigger-width)]!'
+        open={typePickerOpen}
+        onOpen={() => setTypePickerOpen(true)}
+        onClose={() => setTypePickerOpen(false)}
+        onChange={(opt) => {
+          if (opt && !Array.isArray(opt)) setType(opt.value as FieldTypeType)
+          setTypePickerOpen(false)
+        }}
+        showSearch
+        searchPlaceholder='Search field types…'>
+        <Button variant='outline' size='sm' className='h-7 w-full justify-between text-xs'>
+          <span className='flex items-center gap-2'>
+            {selectedTypeOption && (
+              <EntityIcon iconId={selectedTypeOption.iconId} variant='default' size='xs' />
+            )}
+            {selectedTypeOption?.label ?? 'Select type'}
+          </span>
+          <ChevronsUpDown className='size-3.5 opacity-50' />
+        </Button>
+      </ComboPicker>
+
+      {conflict?.bindable && (
+        <p className='text-xs text-muted-foreground'>
+          A field “{conflict.existing.label}” already exists.
+        </p>
+      )}
+      {conflict && !conflict.bindable && (
+        <p className='text-xs text-destructive'>
+          “{conflict.existing.label}” already exists but{' '}
+          {conflict.alreadyMapped ? 'is already mapped' : "isn't compatible with this source value"}
+          .
+        </p>
+      )}
+
       <div className='flex justify-end gap-1.5'>
-        <Button variant='ghost' size='xs' onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button
-          variant='outline'
-          size='xs'
-          loading={create.isPending}
-          loadingText='Creating…'
-          onClick={() => void submit()}>
-          Create
-        </Button>
+        {conflict?.bindable ? (
+          <Button variant='outline' size='xs' onClick={() => onCreated(conflict.ref)}>
+            Use existing
+          </Button>
+        ) : (
+          <Button
+            variant='outline'
+            size='xs'
+            disabled={!canSubmit}
+            loading={create.isPending}
+            loadingText='Creating…'
+            onClick={() => void submit()}>
+            Create
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -552,7 +552,12 @@ function SourceNode(props: SourceNodeProps) {
       assignedLabel={assignedLabel}
       assignedTargetKey={assignedTargetKey}
       excludeKeys={excludeKeys}
-      canCreate={targetMode === 'owned'}
+      // Quick-create is available whenever a target def is set — both owned
+      // (the connector provisions the def) and contributing (adding a field to
+      // an existing def). The `customField.create` mutation is the backstop for
+      // a def that rejects new fields.
+      canCreate={!!mapping.entityDefinitionId}
+      isOwned={targetMode === 'owned'}
       isMatch={assignedTargetKey ? matchKeys.has(assignedTargetKey) : false}
       mergeStrategy={entry?.mergeStrategy ?? 'overwrite'}
       onAssign={(targetKey) => onAssign(node.path, targetKey)}

--- a/apps/web/src/components/data-connectors/ui/request-editors.tsx
+++ b/apps/web/src/components/data-connectors/ui/request-editors.tsx
@@ -1,0 +1,144 @@
+// apps/web/src/components/data-connectors/ui/request-editors.tsx
+'use client'
+
+import { generateId } from '@auxx/utils/generateId'
+import { useEffect, useRef, useState } from 'react'
+import {
+  HttpRequestFieldProvider,
+  type KeyValue,
+  KeyValueList,
+  keyValueToRecord,
+  PlainFieldEditor,
+  recordToKeyValue,
+} from '~/components/global/http-request'
+import CodeEditor, { CodeLanguage } from '~/components/workflow/ui/code-editor'
+
+/**
+ * Request sub-editors for a data-connector stream (headers / query params /
+ * body). They reuse the shared HTTP `KeyValueList` row config behind the plain
+ * (no-workflow-variable) field editor, and the workflow `CodeEditor` for the
+ * JSON body — but persist plain `Record`s (the connector's `requestConfig`
+ * shape), not the workflow node's serialized string format.
+ *
+ * Each editor keeps its own `KeyValue[]` / text state and re-seeds only on a
+ * genuine external change (mirrors `core/http/panel.tsx`) so row identity is
+ * stable across keystrokes and the parent's buffered draft stays keyed by the
+ * stored Record.
+ */
+
+const PLAIN_FIELD = { FieldEditor: PlainFieldEditor }
+
+/** Headers / query params — a Record-backed wrapper over the shared KeyValueList. */
+export function RecordKeyValueEditor({
+  record,
+  onChange,
+  readonly = false,
+}: {
+  record: Record<string, unknown> | undefined
+  onChange: (record: Record<string, string>) => void
+  readonly?: boolean
+}) {
+  const [list, setList] = useState<KeyValue[]>(() => recordToKeyValue(record))
+  // The serialized record we last emitted/seeded from — detects truly external
+  // changes (switching streams, a server move) vs. our own onChange echo.
+  const recordStringRef = useRef(JSON.stringify(keyValueToRecord(recordToKeyValue(record))))
+
+  useEffect(() => {
+    const current = JSON.stringify(record ?? {})
+    if (current !== recordStringRef.current) {
+      recordStringRef.current = current
+      setList(recordToKeyValue(record))
+    }
+  }, [record])
+
+  const emit = (next: KeyValue[]) => {
+    setList(next)
+    const rec = keyValueToRecord(next)
+    recordStringRef.current = JSON.stringify(rec)
+    onChange(rec)
+  }
+
+  return (
+    <HttpRequestFieldProvider value={PLAIN_FIELD}>
+      <KeyValueList
+        readonly={readonly}
+        list={list}
+        onChange={emit}
+        onAdd={() => emit([...list, { id: generateId(), key: '', value: '' }])}
+      />
+    </HttpRequestFieldProvider>
+  )
+}
+
+function recordToJsonText(record: Record<string, unknown> | undefined): string {
+  if (!record || Object.keys(record).length === 0) return ''
+  return JSON.stringify(record, null, 2)
+}
+
+/**
+ * JSON body editor — a `Record<string, unknown>` edited as JSON text. Emits the
+ * parsed object only while valid; an empty editor clears the body to `{}`. The
+ * `onValidChange` callback lets the parent disable Save on a parse error.
+ */
+export function JsonBodyEditor({
+  value,
+  onChange,
+  onValidChange,
+}: {
+  value: Record<string, unknown> | undefined
+  onChange: (body: Record<string, unknown>) => void
+  onValidChange?: (valid: boolean) => void
+}) {
+  const [text, setText] = useState(() => recordToJsonText(value))
+  const [error, setError] = useState<string | null>(null)
+  const emittedRef = useRef(JSON.stringify(value ?? {}))
+
+  useEffect(() => {
+    const current = JSON.stringify(value ?? {})
+    if (current !== emittedRef.current) {
+      emittedRef.current = current
+      setText(recordToJsonText(value))
+      setError(null)
+      onValidChange?.(true)
+    }
+  }, [value, onValidChange])
+
+  const handleChange = (next: string) => {
+    setText(next)
+    const trimmed = next.trim()
+    if (trimmed === '') {
+      setError(null)
+      onValidChange?.(true)
+      emittedRef.current = JSON.stringify({})
+      onChange({})
+      return
+    }
+    try {
+      const parsed = JSON.parse(trimmed)
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        setError('Body must be a JSON object')
+        onValidChange?.(false)
+        return
+      }
+      setError(null)
+      onValidChange?.(true)
+      emittedRef.current = JSON.stringify(parsed)
+      onChange(parsed as Record<string, unknown>)
+    } catch {
+      setError('Invalid JSON')
+      onValidChange?.(false)
+    }
+  }
+
+  return (
+    <div className='flex flex-col gap-1'>
+      <CodeEditor
+        language={CodeLanguage.json}
+        value={text}
+        onChange={handleChange}
+        minHeight={120}
+      />
+      {error && <p className='px-1 text-xs text-destructive'>{error}</p>}
+    </div>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
@@ -28,6 +28,29 @@ export const MERGE_OPTIONS: Array<{ value: string; label: string }> = [
   { value: 'connector_owned_only', label: 'owned-only' },
 ]
 
+/**
+ * Short type token for the leaf badge. Prefers a detected string `format`
+ * (`uri`/`email`/`date`/…) over the bare JSON type, so the badge matches what
+ * quick-create seeds — a `url`-valued string reads `URL`, not `STRING`. The
+ * badge's `uppercase` class handles casing.
+ */
+function sourceTypeLabel(node: SourcePath): string {
+  switch (node.format) {
+    case 'uri':
+      return 'url'
+    case 'email':
+      return 'email'
+    case 'date-time':
+      return 'datetime'
+    case 'date':
+      return 'date'
+    case 'time':
+      return 'time'
+    default:
+      return node.type
+  }
+}
+
 interface SourceLeafRowProps {
   depth: number
   node: SourcePath
@@ -39,8 +62,10 @@ interface SourceLeafRowProps {
   /** Target keys bound by other entries — excluded from this leaf's picker. */
   excludeKeys?: Set<string>
   mergeStrategy: string
-  /** Owned defs allow inline quick-create (plan decision 3). */
+  /** A target def is set, so inline quick-create can mint a new field. */
   canCreate: boolean
+  /** Owned mapping (the connector is the sole writer) — hides the merge picker. */
+  isOwned: boolean
   /** This bound field is a secondary identity-match key (external id stays primary). */
   isMatch: boolean
   onAssign: (targetKey: string) => void
@@ -65,6 +90,7 @@ export function SourceLeafRow({
   excludeKeys,
   mergeStrategy,
   canCreate,
+  isOwned,
   isMatch,
   onAssign,
   onClear,
@@ -84,7 +110,9 @@ export function SourceLeafRow({
           <span className={`font-mono text-sm ${isMapped ? '' : 'text-muted-foreground'}`}>
             {lastSegment(node.path)}
           </span>
-          <span className='text-[10px] uppercase text-muted-foreground/60'>{node.type}</span>
+          <span className='text-[10px] uppercase text-muted-foreground/60'>
+            {sourceTypeLabel(node)}
+          </span>
         </span>
       }
       cells={[
@@ -103,6 +131,7 @@ export function SourceLeafRow({
           entityDefinitionId={entityDefinitionId}
           sourceType={node.type}
           sourcePath={node.path}
+          sourceFormat={node.format}
           assignedKey={assignedTargetKey}
           assignedLabel={assignedLabel}
           excludeKeys={excludeKeys}
@@ -143,9 +172,9 @@ export function SourceLeafRow({
             )}
           </div>
           {/* Merge strategy only matters when the def is shared. An owned mapping
-              (canCreate) is the sole writer, so every field is an implicit
-              overwrite — no picker. Fixed width so it sits at a consistent x. */}
-          {isMapped && !canCreate && (
+              is the sole writer, so every field is an implicit overwrite — no
+              picker. Fixed width so it sits at a consistent x. */}
+          {isMapped && !isOwned && (
             <Select value={mergeStrategy} onValueChange={onMergeChange}>
               <SelectTrigger variant='transparent' size='sm' className='h-9 w-28 text-xs'>
                 <SelectValue />

--- a/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
@@ -19,7 +19,16 @@ import {
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { EmptySection, Section } from '@auxx/ui/components/section'
-import { ChevronDown, Database, FlaskConical, Pencil, RefreshCw, Waypoints } from 'lucide-react'
+import {
+  ChevronDown,
+  Database,
+  FlaskConical,
+  Minus,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Waypoints,
+} from 'lucide-react'
 import { type ReactNode, useState } from 'react'
 import {
   SchemaEditorDialog,
@@ -30,6 +39,7 @@ import { useBufferedConfig } from '../hooks/use-buffered-config'
 import { useSourcePaths } from '../hooks/use-source-paths'
 import { useStreamMutations } from '../hooks/use-stream-mutations'
 import { MappingTree } from './mapping-tree'
+import { JsonBodyEditor, RecordKeyValueEditor } from './request-editors'
 import { StreamSample } from './stream-sample'
 
 type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
@@ -109,15 +119,33 @@ export function StreamConfigPanel({ connector, stream }: StreamConfigPanelProps)
   const requestConfig = (stream.requestConfig ?? {}) as {
     path?: string
     method?: 'GET' | 'POST'
+    headers?: Record<string, string>
+    params?: Record<string, unknown>
+    body?: Record<string, unknown>
   }
   const request = useBufferedConfig(
     {
       path: requestConfig.path ?? '',
       method: requestConfig.method ?? 'GET',
+      headers: requestConfig.headers ?? {},
+      params: requestConfig.params ?? {},
+      body: requestConfig.body ?? {},
     },
-    (draft) => saveRequestConfig(stream.id, { path: draft.path, method: draft.method }),
+    (draft) => saveRequestConfig(stream.id, draft),
     { mode: 'manual' }
   )
+
+  // Progressive disclosure — each sub-editor stays hidden until revealed, but
+  // starts open when its config already has content (a saved request is never
+  // hidden). `bodyValid` gates Save on a JSON parse error.
+  const [showHeaders, setShowHeaders] = useState(
+    () => Object.keys(requestConfig.headers ?? {}).length > 0
+  )
+  const [showParams, setShowParams] = useState(
+    () => Object.keys(requestConfig.params ?? {}).length > 0
+  )
+  const [showBody, setShowBody] = useState(() => Object.keys(requestConfig.body ?? {}).length > 0)
+  const [bodyValid, setBodyValid] = useState(true)
   const rawSyncMode = (stream.syncMode as 'snapshot' | 'incremental' | 'webhook') ?? 'snapshot'
   // The picker only exposes snapshot/incremental; treat webhook as snapshot here.
   const syncMode: 'snapshot' | 'incremental' =
@@ -127,9 +155,7 @@ export function StreamConfigPanel({ connector, stream }: StreamConfigPanelProps)
     const result = await sampleFetch({
       id: connector.id,
       streamKey: stream.streamKey,
-      requestConfig: isGenericRest
-        ? { path: request.value.path, method: request.value.method }
-        : undefined,
+      requestConfig: isGenericRest ? request.value : undefined,
     })
     setSample(result)
     // Auto-set the inferred schema (the raw response shape) when none exists yet.
@@ -175,7 +201,7 @@ export function StreamConfigPanel({ connector, stream }: StreamConfigPanelProps)
             initialOpen
             collapsible={false}
             description='What to fetch from the source.'>
-            <div className='px-1'>
+            <div className='flex flex-col gap-2 px-1'>
               <InputGroup>
                 <InputGroupAddon align='inline-start'>
                   <DropdownMenu>
@@ -213,13 +239,63 @@ export function StreamConfigPanel({ connector, stream }: StreamConfigPanelProps)
                     size='xs'
                     variant='outline'
                     className='me-0.5'
-                    disabled={!request.isDirty || isSavingRequest}
+                    disabled={!request.isDirty || isSavingRequest || !bodyValid}
                     loading={isSavingRequest}
                     onClick={() => void request.commit()}>
                     Save request
                   </Button>
                 </InputGroupAddon>
               </InputGroup>
+
+              {/* Reveal chips — headers / query params / body stay hidden until clicked. */}
+              <div className='flex flex-wrap items-center gap-1.5'>
+                <RevealChip
+                  label='Headers'
+                  count={Object.keys(request.value.headers).length}
+                  active={showHeaders}
+                  onClick={() => setShowHeaders((v) => !v)}
+                />
+                <RevealChip
+                  label='Query params'
+                  count={Object.keys(request.value.params).length}
+                  active={showParams}
+                  onClick={() => setShowParams((v) => !v)}
+                />
+                {request.value.method === 'POST' && (
+                  <RevealChip
+                    label='Body'
+                    count={Object.keys(request.value.body).length > 0 ? 'JSON' : 0}
+                    active={showBody}
+                    onClick={() => setShowBody((v) => !v)}
+                  />
+                )}
+              </div>
+
+              {showHeaders && (
+                <RequestEditorBlock title='Headers'>
+                  <RecordKeyValueEditor
+                    record={request.value.headers}
+                    onChange={(headers) => request.set({ ...request.value, headers })}
+                  />
+                </RequestEditorBlock>
+              )}
+              {showParams && (
+                <RequestEditorBlock title='Query params'>
+                  <RecordKeyValueEditor
+                    record={request.value.params}
+                    onChange={(params) => request.set({ ...request.value, params })}
+                  />
+                </RequestEditorBlock>
+              )}
+              {request.value.method === 'POST' && showBody && (
+                <RequestEditorBlock title='Body'>
+                  <JsonBodyEditor
+                    value={request.value.body}
+                    onChange={(body) => request.set({ ...request.value, body })}
+                    onValidChange={setBodyValid}
+                  />
+                </RequestEditorBlock>
+              )}
             </div>
           </Section>
         )}
@@ -270,10 +346,9 @@ export function StreamConfigPanel({ connector, stream }: StreamConfigPanelProps)
             <RadioTab
               value={syncMode}
               onValueChange={(v) =>
-                setSyncMode(stream.id, v as 'snapshot' | 'incremental', {
-                  path: request.value.path,
-                  method: request.value.method,
-                })
+                // Pass the whole buffered request so toggling mode never drops
+                // saved headers/params/body (setStreamRequestConfig writes it whole).
+                setSyncMode(stream.id, v as 'snapshot' | 'incremental', request.value)
               }
               size='sm'>
               <RadioTabItem value='snapshot' size='sm'>
@@ -319,5 +394,41 @@ export function StreamConfigPanel({ connector, stream }: StreamConfigPanelProps)
         onSave={handleSaveSchema}
       />
     </ScrollArea>
+  )
+}
+
+/** A reveal toggle for one request sub-editor, with an optional content badge. */
+function RevealChip({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string
+  count: number | string
+  active: boolean
+  onClick: () => void
+}) {
+  const hasCount = typeof count === 'number' ? count > 0 : !!count
+  return (
+    <Button type='button' size='xs' variant={active ? 'secondary' : 'ghost'} onClick={onClick}>
+      {active ? <Minus /> : <Plus />}
+      {label}
+      {hasCount && (
+        <span className='ml-1 rounded-full bg-muted px-1.5 text-[10px] tabular-nums text-muted-foreground'>
+          {count}
+        </span>
+      )}
+    </Button>
+  )
+}
+
+/** A bordered, titled container for a revealed request sub-editor. */
+function RequestEditorBlock({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className='overflow-hidden rounded-lg border bg-card/40'>
+      <div className='border-b px-3 py-1.5 text-xs font-medium text-muted-foreground'>{title}</div>
+      {children}
+    </div>
   )
 }

--- a/apps/web/src/components/global/http-request/index.ts
+++ b/apps/web/src/components/global/http-request/index.ts
@@ -36,10 +36,12 @@ export {
   keyValueToBodyPayload,
   keyValueToHeaders,
   keyValueToParams,
+  keyValueToRecord,
   keyValueToString,
   parseBodyDataToKeyValue,
   parseHeadersToKeyValue,
   parseParamsToKeyValue,
+  recordToKeyValue,
   setBodyContent,
   setBodyFileReference,
 } from './utils'

--- a/apps/web/src/components/global/http-request/utils.test.ts
+++ b/apps/web/src/components/global/http-request/utils.test.ts
@@ -2,7 +2,12 @@
 
 import { describe, expect, it } from 'vitest'
 import type { KeyValue } from './types'
-import { keyValueToString, parseHeadersToKeyValue } from './utils'
+import {
+  keyValueToRecord,
+  keyValueToString,
+  parseHeadersToKeyValue,
+  recordToKeyValue,
+} from './utils'
 
 describe('HTTP utils serialization', () => {
   it('should handle plain text key-value pairs', () => {
@@ -124,5 +129,43 @@ describe('HTTP utils serialization', () => {
     expect(lines).toHaveLength(2)
     expect(lines[0]).toBe('Header1:Value1')
     expect(lines[1]).toBe('Header3:Value3')
+  })
+})
+
+describe('Record ⇄ KeyValue[] converters', () => {
+  it('keyValueToRecord drops blank keys and keeps the last duplicate', () => {
+    const list: KeyValue[] = [
+      { id: '1', key: 'Authorization', value: 'Bearer a' },
+      { id: '2', key: '  ', value: 'ignored' },
+      { id: '3', key: 'X-Env', value: 'dev' },
+      { id: '4', key: 'X-Env', value: 'prod' },
+    ]
+    expect(keyValueToRecord(list)).toEqual({ Authorization: 'Bearer a', 'X-Env': 'prod' })
+  })
+
+  it('keyValueToRecord trims keys but preserves values verbatim', () => {
+    const list: KeyValue[] = [{ id: '1', key: '  Accept  ', value: ' application/json ' }]
+    expect(keyValueToRecord(list)).toEqual({ Accept: ' application/json ' })
+  })
+
+  it('recordToKeyValue yields a row per entry plus a trailing blank', () => {
+    const rows = recordToKeyValue({ a: '1', b: 2 })
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toMatchObject({ key: 'a', value: '1' })
+    expect(rows[1]).toMatchObject({ key: 'b', value: '2' }) // non-string coerced
+    expect(rows[2]).toMatchObject({ key: '', value: '' })
+  })
+
+  it('recordToKeyValue returns a single blank row for empty / nullish input', () => {
+    for (const input of [undefined, null, {}]) {
+      const rows = recordToKeyValue(input)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toMatchObject({ key: '', value: '' })
+    }
+  })
+
+  it('round-trips a record through KeyValue[] and back', () => {
+    const rec = { Authorization: 'Bearer x', 'X-Api-Version': '2026-06' }
+    expect(keyValueToRecord(recordToKeyValue(rec))).toEqual(rec)
   })
 })

--- a/apps/web/src/components/global/http-request/utils.ts
+++ b/apps/web/src/components/global/http-request/utils.ts
@@ -88,6 +88,40 @@ export function keyValueToParams(list: KeyValue[]): string {
 }
 
 /**
+ * Convert KeyValue[] to a plain `Record<string, string>` — for callers that
+ * persist a record (e.g. data-connector `requestConfig.headers`/`params`)
+ * rather than the workflow node's serialized string format. Blank-key rows are
+ * dropped and later duplicate keys win.
+ */
+export function keyValueToRecord(list: KeyValue[]): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const { key, value } of list) {
+    const k = key.trim()
+    if (k) out[k] = value
+  }
+  return out
+}
+
+/**
+ * Convert a persisted `Record` back to KeyValue[] for editing — one row per
+ * entry plus a trailing blank row so the user can always add another. An empty
+ * / absent record yields a single blank row (matches `parseHeadersToKeyValue`).
+ */
+export function recordToKeyValue(rec: Record<string, unknown> | undefined | null): KeyValue[] {
+  const entries = Object.entries(rec ?? {})
+  if (entries.length === 0) {
+    return [{ id: generateId(), key: '', value: '' }]
+  }
+  const rows = entries.map(([key, value]) => ({
+    id: generateId(),
+    key,
+    value: value == null ? '' : String(value),
+  }))
+  rows.push({ id: generateId(), key: '', value: '' })
+  return rows
+}
+
+/**
  * Convert BodyPayload to KeyValue[] for form data and URL encoded body types
  */
 export function parseBodyDataToKeyValue(data: BodyPayload): KeyValue[] {

--- a/apps/web/src/components/pickers/field-picker/field-picker-content.tsx
+++ b/apps/web/src/components/pickers/field-picker/field-picker-content.tsx
@@ -78,6 +78,7 @@ export function FieldPickerInnerContent({
   closeOnSelect = mode === 'single',
   onClose,
   onCreateField,
+  createLabel = 'Create field',
   onSkip,
   skipLabel = 'Skip',
   searchPlaceholder = 'Search fields...',
@@ -352,7 +353,7 @@ export function FieldPickerInnerContent({
             <CommandGroup>
               <CommandItem onSelect={onCreateField}>
                 <Plus className='size-4' />
-                <span>Create field</span>
+                <span>{createLabel}</span>
               </CommandItem>
             </CommandGroup>
           </>

--- a/apps/web/src/components/pickers/field-picker/field-picker.tsx
+++ b/apps/web/src/components/pickers/field-picker/field-picker.tsx
@@ -27,6 +27,7 @@ export function FieldPicker({
   mode = 'single',
   closeOnSelect = mode === 'single',
   onCreateField,
+  createLabel,
   onSkip,
   skipLabel,
   searchPlaceholder,
@@ -76,6 +77,7 @@ export function FieldPicker({
           closeOnSelect={closeOnSelect}
           onClose={handleClose}
           onCreateField={onCreateField}
+          createLabel={createLabel}
           onSkip={onSkip}
           skipLabel={skipLabel}
           searchPlaceholder={searchPlaceholder}

--- a/apps/web/src/components/pickers/field-picker/types.ts
+++ b/apps/web/src/components/pickers/field-picker/types.ts
@@ -50,6 +50,9 @@ export interface FieldPickerContentProps {
   /** Optional: Show "Create field" button */
   onCreateField?: () => void
 
+  /** Label for the {@link onCreateField} row (default `Create field`). */
+  createLabel?: string
+
   /**
    * Optional: show a "skip / don't map" item at the top of the root list (e.g.
    * to clear a binding from within the picker). Selecting it runs this callback

--- a/packages/lib/src/json-schema/__tests__/infer.test.ts
+++ b/packages/lib/src/json-schema/__tests__/infer.test.ts
@@ -21,9 +21,21 @@ describe('inferJsonSchema — primitives', () => {
       type: 'string',
       format: 'date-time',
     })
-    // A bare date is not date-time — no format guessing beyond date-time.
-    expect(inferJsonSchema('2026-06-11')).toEqual({ type: 'string' })
-    expect(inferJsonSchema('not a date')).toEqual({ type: 'string' })
+  })
+
+  it('detects date / time / email / uri string formats', () => {
+    expect(inferJsonSchema('2026-06-19')).toEqual({ type: 'string', format: 'date' })
+    expect(inferJsonSchema('13:45:00')).toEqual({ type: 'string', format: 'time' })
+    expect(inferJsonSchema('13:45')).toEqual({ type: 'string', format: 'time' })
+    expect(inferJsonSchema('a@b.com')).toEqual({ type: 'string', format: 'email' })
+    expect(inferJsonSchema('https://x.com/y')).toEqual({ type: 'string', format: 'uri' })
+    expect(inferJsonSchema('http://x.com')).toEqual({ type: 'string', format: 'uri' })
+  })
+
+  it('stays formatless for non-matching strings (conservative)', () => {
+    expect(inferJsonSchema('hello')).toEqual({ type: 'string' })
+    // No http(s) scheme and no `x@y.z` email shape → not tagged.
+    expect(inferJsonSchema('foo:bar')).toEqual({ type: 'string' })
   })
 })
 
@@ -90,6 +102,30 @@ describe('inferJsonSchema — arrays', () => {
         },
       },
     })
+  })
+
+  it('preserves a shared string format across an array of record objects', () => {
+    const schema = inferJsonSchema([
+      { email: 'a@b.com', when: '2026-06-19' },
+      { email: 'c@d.com', when: '2026-06-20' },
+    ]) as { items: { properties: Record<string, { type: string; format?: string }> } }
+    expect(schema.items.properties.email).toEqual({ type: 'string', format: 'email' })
+    expect(schema.items.properties.when).toEqual({ type: 'string', format: 'date' })
+  })
+
+  it('drops format when samples disagree on it', () => {
+    // One email, one free-text → mixed string formats collapse to a bare type.
+    const schema = inferJsonSchema([{ v: 'a@b.com' }, { v: 'hello' }]) as {
+      items: { properties: Record<string, { type: string; format?: string }> }
+    }
+    expect(schema.items.properties.v).toEqual({ type: 'string' })
+  })
+
+  it('keeps a shared format nullable when null appears alongside', () => {
+    const schema = inferJsonSchema([{ v: 'a@b.com' }, { v: null }]) as {
+      items: { properties: Record<string, { type: string | string[]; format?: string }> }
+    }
+    expect(schema.items.properties.v).toEqual({ type: ['string', 'null'], format: 'email' })
   })
 
   it('collapses mixed scalar arrays to a type union', () => {

--- a/packages/lib/src/json-schema/infer.ts
+++ b/packages/lib/src/json-schema/infer.ts
@@ -13,8 +13,9 @@
  * - Arrays infer `items` from a shallow union of the first few elements.
  * - `null` collapses into a `['<seen>', 'null']` type union when mixed with a
  *   concrete type, or a bare `{ type: 'null' }` when that is all we saw.
- * - ISO date-time strings are detected as `format: 'date-time'`; no other
- *   format guessing.
+ * - String `format` is detected from the value: `date-time`, `date`, `time`,
+ *   `email`, and (http/https) `uri`. Conservative on purpose — false positives
+ *   only mis-seed an editable hint.
  *
  * Pure and dependency-free — safe to call from both server and client code via
  * the `@auxx/lib/json-schema/client` export.
@@ -26,8 +27,17 @@ export type JsonSchema = Record<string, unknown>
 /** How many array elements to sample when inferring `items`. */
 const ARRAY_SAMPLE = 5
 
-/** Strict ISO-8601 date-time matcher (the only format we auto-detect). */
+/**
+ * String `format` matchers, checked most-specific first. `uri` requires an
+ * explicit http(s) scheme (so `"foo:bar"` / `"mailto:…"` don't get tagged) and
+ * `email` requires `x@y.z` — conservative so a false positive only mis-seeds an
+ * editable hint, never the sync write path.
+ */
 const ISO_DATE_TIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$/
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+const ISO_TIME = /^\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:\d{2})?$/
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const HTTP_URL = /^https?:\/\/\S+$/i
 
 /**
  * Infer a JSON Schema from a single runtime value.
@@ -62,6 +72,10 @@ function inferNode(value: unknown): JsonSchema {
 
 function inferString(value: string): JsonSchema {
   if (ISO_DATE_TIME.test(value)) return { type: 'string', format: 'date-time' }
+  if (ISO_DATE.test(value)) return { type: 'string', format: 'date' }
+  if (ISO_TIME.test(value)) return { type: 'string', format: 'time' }
+  if (EMAIL.test(value)) return { type: 'string', format: 'email' }
+  if (HTTP_URL.test(value)) return { type: 'string', format: 'uri' }
   return { type: 'string' }
 }
 
@@ -102,6 +116,19 @@ function mergeNodes(nodes: JsonSchema[]): JsonSchema {
       .filter((i): i is JsonSchema => !!i && typeof i === 'object')
     const items = itemNodes.length > 0 ? mergeNodes(itemNodes) : {}
     return maybeNullable({ type: 'array', items }, hasNull)
+  }
+
+  // Same single scalar type sharing the same `format` → keep it (so an array of
+  // record objects preserves `{ type: 'string', format: 'email' }` per field
+  // after the merge, not just single-object responses).
+  const firstType = nonNull[0].type
+  const firstFormat = nonNull[0].format
+  if (
+    typeof firstType === 'string' &&
+    firstFormat !== undefined &&
+    nonNull.every((n) => n.type === firstType && n.format === firstFormat)
+  ) {
+    return maybeNullable({ type: firstType, format: firstFormat }, hasNull)
   }
 
   // Scalars / mixed → collapse to a `type` union (dropping per-node formats,

--- a/packages/utils/src/__tests__/strings.test.ts
+++ b/packages/utils/src/__tests__/strings.test.ts
@@ -1,0 +1,62 @@
+// packages/utils/src/__tests__/strings.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { humanizeFieldName, humanizeFieldPath } from '../strings'
+
+describe('humanizeFieldName', () => {
+  it('splits camelCase', () => {
+    expect(humanizeFieldName('totalPrice')).toBe('Total Price')
+    expect(humanizeFieldName('first.name')).toBe('First Name')
+  })
+
+  it('splits snake_case and kebab-case', () => {
+    expect(humanizeFieldName('total_price')).toBe('Total Price')
+    expect(humanizeFieldName('line-items')).toBe('Line Items')
+  })
+
+  it('preserves all-caps acronyms', () => {
+    expect(humanizeFieldName('customerID')).toBe('Customer ID')
+    expect(humanizeFieldName('URL')).toBe('URL')
+  })
+
+  it('drops the array marker', () => {
+    expect(humanizeFieldName('tags[]')).toBe('Tags')
+  })
+
+  it('returns empty string for empty / nullish input', () => {
+    expect(humanizeFieldName('')).toBe('')
+    expect(humanizeFieldName(null)).toBe('')
+    expect(humanizeFieldName(undefined)).toBe('')
+  })
+})
+
+describe('humanizeFieldPath', () => {
+  it('prepends ancestor object names', () => {
+    expect(humanizeFieldPath('owner.url')).toBe('Owner Url')
+    expect(humanizeFieldPath('owner.id')).toBe('Owner Id')
+    expect(humanizeFieldPath('a.b.c')).toBe('A B C')
+    expect(humanizeFieldPath('customer.totalPrice')).toBe('Customer Total Price')
+  })
+
+  it('does not prefix a root-level leaf', () => {
+    expect(humanizeFieldPath('url')).toBe('Url')
+  })
+
+  it('handles array markers per segment', () => {
+    expect(humanizeFieldPath('line_items[].sku')).toBe('Line Items Sku')
+    expect(humanizeFieldPath('owner.aliases[]')).toBe('Owner Aliases')
+  })
+
+  it('does not double a parent name the child restates', () => {
+    expect(humanizeFieldPath('owner.owner_id')).toBe('Owner Id')
+    expect(humanizeFieldPath('owner.owner')).toBe('Owner')
+    expect(humanizeFieldPath('order.order_line_id')).toBe('Order Line Id')
+    expect(humanizeFieldPath('owner.owner.id')).toBe('Owner Id')
+  })
+
+  it('returns empty string for empty / nullish input', () => {
+    expect(humanizeFieldPath('')).toBe('')
+    expect(humanizeFieldPath(null)).toBe('')
+    expect(humanizeFieldPath(undefined)).toBe('')
+  })
+})

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -141,6 +141,8 @@ export {
 export { withRetry } from './retry'
 // String utilities
 export {
+  humanizeFieldName,
+  humanizeFieldPath,
   incrementTitle,
   interpretEscapeSequences,
   pluralize,

--- a/packages/utils/src/strings.ts
+++ b/packages/utils/src/strings.ts
@@ -31,6 +31,62 @@ export function pluralize(count: number, singular: string, plural = `${singular}
 }
 
 /**
+ * Friendly-ify a machine field key into a human label.
+ * `totalPrice` → `Total Price`, `total_price` → `Total Price`,
+ * `line-items` → `Line Items`, `customerID` → `Customer ID`, `tags[]` → `Tags`.
+ *
+ * Splits camelCase / PascalCase boundaries, treats `_ - . /` and whitespace as
+ * separators, collapses runs, and title-cases — preserving existing all-caps
+ * acronyms (`ID`, `URL`) rather than lower-casing them to `Id`/`Url`.
+ */
+export function humanizeFieldName(key: string | null | undefined): string {
+  if (!key) return ''
+  return key
+    .replace(/\[\]$/, '') // drop array marker
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // fooBar → foo Bar
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2') // URLField → URL Field, customerID → customer ID
+    .replace(/[_\-./]+/g, ' ') // separators → space
+    .replace(/\s+/g, ' ') // collapse
+    .trim()
+    .split(' ')
+    .map((w) =>
+      w.length > 1 && w === w.toUpperCase() ? w : w.charAt(0).toUpperCase() + w.slice(1)
+    )
+    .join(' ')
+}
+
+/**
+ * Friendly-ify a dotted machine field PATH into a human label, prepending each
+ * ancestor segment. `owner.url` → `Owner Url`, `a.b.c` → `A B C`,
+ * `line_items[].sku` → `Line Items Sku`, `url` → `Url`.
+ *
+ * Each segment runs through {@link humanizeFieldName}. A leading run of a
+ * segment that repeats the tail of the accumulated label is dropped, so a child
+ * key that re-states its parent doesn't double it: `owner.owner_id` →
+ * `Owner Id` (not `Owner Owner Id`), `order.order_line` → `Order Line`.
+ */
+export function humanizeFieldPath(path: string | null | undefined): string {
+  if (!path) return ''
+  const words: string[] = []
+  for (const seg of path.split('.')) {
+    const segWords = humanizeFieldName(seg).split(' ').filter(Boolean)
+    if (segWords.length === 0) continue
+    // Find the longest overlap where the tail of `words` equals the head of this
+    // segment's words (case-insensitive), and skip that repeated prefix.
+    let overlap = 0
+    for (let k = Math.min(words.length, segWords.length); k > 0; k--) {
+      const tail = words.slice(words.length - k)
+      if (tail.every((w, i) => w.toLowerCase() === segWords[i].toLowerCase())) {
+        overlap = k
+        break
+      }
+    }
+    words.push(...segWords.slice(overlap))
+  }
+  return words.join(' ')
+}
+
+/**
  * Interprets common escape sequences in a string.
  * Converts literal escape sequences (e.g., typed "\n") into actual characters.
  *


### PR DESCRIPTION
## Summary
- Add Record-backed **headers / query-param / body editors** for a data-connector stream (`request-editors.tsx`), reusing the shared HTTP `KeyValueList` behind a plain (no-workflow-variable) field editor and the workflow `CodeEditor` for the JSON body. These persist plain `Record`s to match the connector's `requestConfig` shape rather than the workflow node's serialized string format.
- Add `keyValueToRecord` / `recordToKeyValue` helpers to the shared HTTP request utils, with stable row identity re-seeding only on genuine external change.
- Improve the **mapping field picker** with humanized labels via new `humanizeFieldName` / `humanizeFieldPath` helpers in `@auxx/utils` (camelCase/snake/kebab splitting, acronym preservation, parent-segment de-duplication).
- Richer **JSON-schema format inference** in `@auxx/lib/json-schema`: detect `date`, `time`, `email`, and (http/https) `uri` in addition to `date-time`, and preserve per-field `format` through array/record merges.

## Test plan
- [ ] Unit tests added for `humanizeFieldName` / `humanizeFieldPath` (`packages/utils`)
- [ ] Updated infer tests for new string formats (`packages/lib`)
- [ ] Updated HTTP request utils tests for Record conversions (`apps/web`)
- [ ] Manually edit a data-connector stream's headers/params/body and confirm round-trip persistence