### PR TITLE
feat(connections): rename connections + shared connection display

### DIFF
--- a/apps/web/src/components/apps/ui/connection-display.ts
+++ b/apps/web/src/components/apps/ui/connection-display.ts
@@ -1,0 +1,35 @@
+// apps/web/src/components/apps/ui/connection-display.ts
+import type { useAppsContext } from '~/components/apps/providers/apps-context'
+import type { PickerConnection } from './connection-picker'
+
+type AppInstallations = ReturnType<typeof useAppsContext>['appInstallations']
+
+/** Fallback icons when a connection carries no resolved icon. */
+const APP_FALLBACK_ICON = 'package'
+const KEY_FALLBACK_ICON = 'key-round'
+
+/**
+ * Resolve a connection row to its display identity (icon + title).
+ *
+ * App rows get their installed app's logo + title (hydrated client-side, since
+ * `avatarUrl` isn't a credential column); non-app rows use the provider brand
+ * mark `connections.list` resolved on `icon`, else a neutral key fallback.
+ * Title prefers the user-set `label`, then the app title, then the raw `name`.
+ *
+ * Shared by the connection picker, its popover trigger, and the data-connector
+ * connection section so every surface renders the same icon/name.
+ */
+export function resolveConnectionDisplay(
+  connection: PickerConnection,
+  appInstallations: AppInstallations
+): { iconId: string; title: string } {
+  const inst = connection.appId
+    ? appInstallations.find((i) => i.app.id === connection.appId)
+    : undefined
+  const fallback =
+    connection.kind === 'app' ? APP_FALLBACK_ICON : (connection.icon ?? KEY_FALLBACK_ICON)
+  return {
+    iconId: inst?.app.avatarUrl ?? fallback,
+    title: connection.label ?? inst?.app.title ?? connection.name,
+  }
+}

--- a/apps/web/src/components/apps/ui/connection-picker.tsx
+++ b/apps/web/src/components/apps/ui/connection-picker.tsx
@@ -14,6 +14,7 @@ import { useMemo } from 'react'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
 import type { RouterOutputs } from '~/trpc/react'
 import { AppWithStatusIcon } from './app-with-status-icon'
+import { resolveConnectionDisplay } from './connection-display'
 
 /** A single bindable connection as projected by `connections.list`. */
 export type PickerConnection = RouterOutputs['connections']['list'][number]
@@ -23,10 +24,6 @@ export type PickerConnection = RouterOutputs['connections']['list'][number]
  * MCP creds are server-bound, not a fetch credential.
  */
 export type PickerKind = 'app' | 'integration' | 'workflow'
-
-/** Fallback icons when a connection carries no resolved icon. */
-const APP_FALLBACK_ICON = 'package'
-const KEY_FALLBACK_ICON = 'key-round'
 
 interface ConnectionPickerProps {
   /** Currently-bound credentialId. */
@@ -73,17 +70,7 @@ export function ConnectionPicker({
     [connections]
   )
 
-  // app row → app logo + title (hydrated client-side; `avatarUrl` isn't a
-  // credential column); non-app row → the provider brand mark `credentials.list`
-  // resolved on `icon`, else a neutral key fallback.
-  const resolve = (c: PickerConnection) => {
-    const inst = c.appId ? appInstallations.find((i) => i.app.id === c.appId) : undefined
-    const fallback = c.kind === 'app' ? APP_FALLBACK_ICON : (c.icon ?? KEY_FALLBACK_ICON)
-    return {
-      iconId: inst?.app.avatarUrl ?? fallback,
-      title: c.label ?? inst?.app.title ?? c.name,
-    }
-  }
+  const resolve = (c: PickerConnection) => resolveConnectionDisplay(c, appInstallations)
 
   const isEmpty = connections.length === 0
 

--- a/apps/web/src/components/connections/ui/connection-card.tsx
+++ b/apps/web/src/components/connections/ui/connection-card.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/connections/ui/connection-card.tsx
 'use client'
 
-import { Pencil, RefreshCw, Trash, TriangleAlert } from 'lucide-react'
+import { Pencil, PencilLine, RefreshCw, Trash, TriangleAlert } from 'lucide-react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { AppListCard, type AppListCardMenuItem } from '~/components/apps/ui/app-list-card'
 import type { RouterOutputs } from '~/trpc/react'
@@ -19,6 +19,8 @@ interface ConnectionCardProps {
   onAction?: () => void
   /** Label for the primary action — "Reconnect" (oauth) or "Edit" (secret). */
   actionLabel?: string
+  /** Rename the connection (writes its display label). Hidden when absent. */
+  onRename?: () => void
   /** Remove the connection. */
   onDelete: () => void
 }
@@ -34,6 +36,7 @@ export function ConnectionCard({
   subtitle,
   onAction,
   actionLabel = 'Reconnect',
+  onRename,
   onDelete,
 }: ConnectionCardProps) {
   const title = connection.label ?? connection.name
@@ -50,6 +53,9 @@ export function ConnectionCard({
       icon: actionLabel === 'Edit' ? <Pencil /> : <RefreshCw />,
       onClick: onAction,
     })
+  }
+  if (onRename) {
+    menuItems.push({ label: 'Rename', icon: <PencilLine />, onClick: onRename })
   }
   menuItems.push({ label: 'Delete', icon: <Trash />, onClick: onDelete, destructive: true })
 

--- a/apps/web/src/components/connections/ui/connection-rename-dialog.tsx
+++ b/apps/web/src/components/connections/ui/connection-rename-dialog.tsx
@@ -1,0 +1,94 @@
+// apps/web/src/components/connections/ui/connection-rename-dialog.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Field, FieldLabel } from '@auxx/ui/components/field'
+import { Input } from '@auxx/ui/components/input'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { useEffect, useState } from 'react'
+
+interface ConnectionRenameDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Current display name, used to seed the input. */
+  currentName: string
+  pending?: boolean
+  /** Persist the new name. Only called when non-empty and changed. */
+  onSubmit: (name: string) => void
+}
+
+/**
+ * Minimal single-field dialog for renaming a connection. Writes the user-facing
+ * `label` via `connections.update` (the card title shows `label ?? name`).
+ */
+export function ConnectionRenameDialog({
+  open,
+  onOpenChange,
+  currentName,
+  pending,
+  onSubmit,
+}: ConnectionRenameDialogProps) {
+  const [value, setValue] = useState(currentName)
+
+  useEffect(() => {
+    if (open) setValue(currentName)
+  }, [open, currentName])
+
+  const trimmed = value.trim()
+  const canSave = trimmed.length > 0 && trimmed !== currentName && !pending
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSave) return
+    onSubmit(trimmed)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size='sm' position='tc'>
+        <DialogHeader>
+          <DialogTitle>Rename connection</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSave}>
+          <Field>
+            <FieldLabel>Name</FieldLabel>
+            <Input
+              placeholder='Connection name'
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              disabled={pending}
+              autoComplete='off'
+              autoFocus
+            />
+          </Field>
+          <DialogFooter>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              onClick={() => onOpenChange(false)}
+              disabled={pending}>
+              Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+            </Button>
+            <Button
+              type='submit'
+              variant='outline'
+              size='sm'
+              disabled={!canSave}
+              loading={pending}
+              loadingText='Saving...'>
+              Save <KbdSubmit variant='outline' size='sm' />
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/connections/ui/connections-section.tsx
+++ b/apps/web/src/components/connections/ui/connections-section.tsx
@@ -16,6 +16,7 @@ import { AddConnectionDialog } from './add-connection-dialog'
 import { ConnectionCard, type ConnectionRow } from './connection-card'
 import { ConnectionDetailDialog } from './connection-detail-dialog'
 import type { DetailMethod } from './connection-detail-page'
+import { ConnectionRenameDialog } from './connection-rename-dialog'
 import { appTarget, platformTarget } from './connection-targets'
 
 /**
@@ -37,6 +38,7 @@ export function ConnectionsSection() {
 
   const [addOpen, setAddOpen] = useState(false)
   const [editRow, setEditRow] = useState<ConnectionRow | null>(null)
+  const [renameRow, setRenameRow] = useState<ConnectionRow | null>(null)
   const [search, setSearch] = useState('')
   const [confirm, ConfirmDialog] = useConfirm()
 
@@ -138,6 +140,21 @@ export function ConnectionsSection() {
     )
   }
 
+  const handleRenameSubmit = (name: string) => {
+    if (!renameRow) return
+    updateCredential.mutate(
+      { id: renameRow.id, label: name },
+      {
+        onSuccess: () => {
+          setRenameRow(null)
+          invalidate()
+        },
+        onError: (error) =>
+          toastError({ title: 'Error renaming connection', description: error.message }),
+      }
+    )
+  }
+
   const handleDelete = async (row: ConnectionRow) => {
     const ok = await confirm({
       title: 'Delete connection?',
@@ -222,6 +239,7 @@ export function ConnectionsSection() {
                     : 'Edit'
                 }
                 onAction={() => (isPlainSecret(row) ? setEditRow(row) : handleReconnect(row))}
+                onRename={() => setRenameRow(row)}
                 onDelete={() => void handleDelete(row)}
               />
             ))}
@@ -253,6 +271,19 @@ export function ConnectionsSection() {
           pending={updateCredential.isPending}
           submitLabel='Save'
           onSubmit={(payload) => handleEditSubmit(payload.secret ?? '')}
+        />
+      )}
+
+      {/* Rename — writes the connection's display label via connections.update. */}
+      {renameRow && (
+        <ConnectionRenameDialog
+          open={!!renameRow}
+          onOpenChange={(next) => {
+            if (!next) setRenameRow(null)
+          }}
+          currentName={renameRow.label ?? renameRow.name}
+          pending={updateCredential.isPending}
+          onSubmit={handleRenameSubmit}
         />
       )}
 

--- a/apps/web/src/components/data-connectors/ui/connection-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/connection-section.tsx
@@ -6,6 +6,8 @@ import { Section } from '@auxx/ui/components/section'
 import { Plug } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
+import { AppWithStatusIcon } from '~/components/apps/ui/app-with-status-icon'
+import { resolveConnectionDisplay } from '~/components/apps/ui/connection-display'
 import { ConnectionList } from '~/components/apps/ui/connection-list'
 import { ConnectionPickerPopover } from '~/components/apps/ui/connection-picker-popover'
 import { ConnectionRow, type ConnectionStatus } from '~/components/apps/ui/connection-row'
@@ -13,10 +15,10 @@ import {
   AddConnectionDialog,
   type ConnectionRestriction,
 } from '~/components/connections/ui/add-connection-dialog'
-import { api } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 import { SourceConfigPanel } from './source-config-panel'
 
-type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
+type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
 
 interface ConnectionSectionProps {
   connector: Connector
@@ -84,6 +86,18 @@ export function ConnectionSection({ connector }: ConnectionSectionProps) {
     update.mutate({ id: connector.id, credentialId, appInstallationId })
 
   const connected = !!connector.credentialId
+
+  // Resolve the bound connection to surface its real icon + name (e.g. "Gmail")
+  // instead of a generic "bound credential" line. Shares the picker popover's
+  // query (same input) so this adds no extra fetch.
+  const { data: connections = [] } = api.connections.list.useQuery(
+    { kind: ['app', 'integration', 'workflow'], orgScopedOnly: true },
+    { refetchOnWindowFocus: false }
+  )
+  const bound = connector.credentialId
+    ? connections.find((c) => c.id === connector.credentialId)
+    : undefined
+  const boundDisplay = bound ? resolveConnectionDisplay(bound, appInstallations) : null
   const status: ConnectionStatus = connected ? 'connected' : 'disconnected'
 
   return (
@@ -98,7 +112,16 @@ export function ConnectionSection({ connector }: ConnectionSectionProps) {
           <ConnectionList>
             <ConnectionRow
               status={status}
-              title={connected ? 'Connected account' : 'Not connected'}
+              statusIcon={
+                boundDisplay ? (
+                  <AppWithStatusIcon
+                    iconId={boundDisplay.iconId}
+                    size='sm'
+                    status={bound?.status ?? 'connected'}
+                  />
+                ) : undefined
+              }
+              title={boundDisplay?.title ?? (connected ? 'Connected account' : 'Not connected')}
               subtitle={
                 connected
                   ? 'This connector is using a bound credential.'

--- a/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
@@ -4,7 +4,7 @@
 import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeType } from '@auxx/database/types'
 import { FIELD_TYPE_GROUPS, fieldTypeOptions } from '@auxx/lib/custom-fields/types'
-import { toResourceFieldId } from '@auxx/types/field'
+import { type ResourceFieldId, toResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
@@ -129,6 +129,8 @@ export function MappingFieldPicker({
         {view === 'pick' ? (
           <FieldPickerContent
             entityDefinitionId={entityDefinitionId}
+            // Mark the currently-bound field with a check.
+            fieldReferences={assignedKey ? [assignedKey as ResourceFieldId] : []}
             excludeFields={[FieldType.RELATIONSHIP]}
             // Only fields the sync can actually write (creatable + updatable, not
             // computed), whose type accepts this source value, and that no other

--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -6,13 +6,6 @@ import { toResourceFieldId } from '@auxx/types/field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { EntityIcon } from '@auxx/ui/components/icons'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
 import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { generateId } from '@auxx/utils'
@@ -34,7 +27,8 @@ import { BranchRow } from './branch-row'
 import { FieldCalcDialog } from './field-calc-dialog'
 import { MAPPING_COLS } from './mapping-columns'
 import { MappingFieldPicker } from './mapping-field-picker'
-import { MERGE_OPTIONS, SourceLeafRow } from './source-leaf-row'
+import { MergeStrategySelect } from './merge-strategy-select'
+import { SourceLeafRow } from './source-leaf-row'
 
 type Mapping = RouterOutputs['dataConnector']['listStreams'][number]['mappings'][number]
 
@@ -647,23 +641,16 @@ function FormulaRow({
           onAssign={onRetarget}
           onClear={onClear}
         />,
-        <div key='actions' className='flex w-full items-center gap-2 px-2'>
-          {/* Spacer aligns the merge picker with the leaf rows' (which reserve an
-              Identifier slot here). */}
-          <div className='w-20 shrink-0' />
-          <Select value={mergeStrategy} onValueChange={onMergeChange}>
-            <SelectTrigger variant='transparent' size='sm' className='h-9 w-28 text-xs'>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {MERGE_OPTIONS.map((o) => (
-                <SelectItem key={o.value} value={o.value}>
-                  {o.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <TreeRowButton tooltipText='Remove formula' onClick={onClear}>
+        <div key='actions' className='flex w-full items-center gap-2 pl-2 pr-1'>
+          {/* Merge on the left; the trash floats right (ml-auto) so it lines up
+              with the leaf/header rows' clear. No Identifier — a formula has no
+              single source path to match identity on. */}
+          <MergeStrategySelect value={mergeStrategy} onValueChange={onMergeChange} />
+          <TreeRowButton
+            variant='destructive'
+            className='ml-auto'
+            tooltipText='Remove formula'
+            onClick={onClear}>
             <X />
           </TreeRowButton>
         </div>,

--- a/apps/web/src/components/data-connectors/ui/merge-strategy-select.tsx
+++ b/apps/web/src/components/data-connectors/ui/merge-strategy-select.tsx
@@ -1,0 +1,49 @@
+// apps/web/src/components/data-connectors/ui/merge-strategy-select.tsx
+'use client'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+
+/**
+ * Per-field merge strategies offered once a target is bound. `manual_review` and
+ * `ignore` stay in the schema/runtime (`FieldMergeStrategy`) but are not yet
+ * surfaced — `manual_review` has no conflict-review queue and `ignore` has no
+ * use until then. Re-add here when those land.
+ */
+export const MERGE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'overwrite', label: 'overwrite' },
+  { value: 'fill_blank', label: 'fill-blank' },
+  { value: 'connector_owned_only', label: 'owned-only' },
+]
+
+/**
+ * The fixed-width merge-strategy picker shared by leaf and formula rows. A single
+ * control so both surfaces stay visually identical and at a consistent x.
+ */
+export function MergeStrategySelect({
+  value,
+  onValueChange,
+}: {
+  value: string
+  onValueChange: (value: string) => void
+}) {
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger variant='transparent' size='sm' className='h-9 w-28 text-xs'>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {MERGE_OPTIONS.map((o) => (
+          <SelectItem key={o.value} value={o.value}>
+            {o.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/request-editors.tsx
+++ b/apps/web/src/components/data-connectors/ui/request-editors.tsx
@@ -26,7 +26,12 @@ import CodeEditor, { CodeLanguage } from '~/components/workflow/ui/code-editor'
  * stored Record.
  */
 
-const PLAIN_FIELD = { FieldEditor: PlainFieldEditor }
+// No workflow variables here, so override the variable-insert hint placeholders.
+export const PLAIN_FIELD = {
+  FieldEditor: PlainFieldEditor,
+  keyPlaceholder: 'Enter key...',
+  valuePlaceholder: 'Enter value...',
+}
 
 /** Headers / query params — a Record-backed wrapper over the shared KeyValueList. */
 export function RecordKeyValueEditor({

--- a/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
@@ -8,10 +8,16 @@ import { Section } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
 import { Globe, Plus, Settings2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { generateId, type KeyValue, KeyValueList } from '~/components/global/http-request'
+import {
+  generateId,
+  HttpRequestFieldProvider,
+  type KeyValue,
+  KeyValueList,
+} from '~/components/global/http-request'
 import { readFieldNodes, SchemaField, seedDefaults } from '~/components/global/schema-form'
 import { api } from '~/trpc/react'
 import { useRegisterSaver } from '../hooks/use-connector-edits'
+import { PLAIN_FIELD } from './request-editors'
 
 /** Order-independent serialization for dirty comparison (header order is cosmetic). */
 function canonRecord(record: Record<string, string>): string {
@@ -141,7 +147,9 @@ function GenericRestSource({
           </Button>
         }>
         <div className='px-1'>
-          <KeyValueList readonly={false} list={headers} onChange={setHeaders} onAdd={addRow} />
+          <HttpRequestFieldProvider value={PLAIN_FIELD}>
+            <KeyValueList readonly={false} list={headers} onChange={setHeaders} onAdd={addRow} />
+          </HttpRequestFieldProvider>
         </div>
       </Section>
     </div>

--- a/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
@@ -2,31 +2,13 @@
 'use client'
 
 import { Badge } from '@auxx/ui/components/badge'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
 import { SimpleTooltip } from '@auxx/ui/components/tooltip'
-import { GridTreeRow } from '@auxx/ui/components/tree-row'
-import { ArrowRight, Brackets, Hash } from 'lucide-react'
+import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { ArrowRight, Brackets, Hash, Trash2 } from 'lucide-react'
 import { lastSegment, type SourcePath } from '../hooks/use-source-paths'
 import { MAPPING_COLS } from './mapping-columns'
 import { MappingFieldPicker } from './mapping-field-picker'
-
-/**
- * Per-field merge strategies offered once a leaf is bound. `manual_review` and
- * `ignore` stay in the schema/runtime (`FieldMergeStrategy`) but are not yet
- * surfaced — `manual_review` has no conflict-review queue and `ignore` has no
- * use until then. Re-add here when those land.
- */
-export const MERGE_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: 'overwrite', label: 'overwrite' },
-  { value: 'fill_blank', label: 'fill-blank' },
-  { value: 'connector_owned_only', label: 'owned-only' },
-]
+import { MergeStrategySelect } from './merge-strategy-select'
 
 /**
  * Short type token for the leaf badge. Prefers a detected string `format`
@@ -139,13 +121,19 @@ export function SourceLeafRow({
           onAssign={onAssign}
           onClear={onClear}
         />,
-        // Actions — match toggle + merge picker, available once the leaf is bound.
-        <div key='actions' className='flex w-full items-center gap-2 px-2'>
-          {/* Secondary identifier toggle: subtle text → filled blue badge.
-              Reserves its slot whether shown or not, so the merge picker stays at
-              a fixed location across rows. */}
-          <div className='flex w-20 shrink-0 items-center'>
-            {isMapped && (
+        // Actions — merge picker (left), then a right-aligned identifier badge +
+        // hover-reveal clear, mirroring the header row's badge → trash so they
+        // line up at one x. The clear reuses `onClear` (the "Don't map" path).
+        <div key='actions' className='flex w-full items-center gap-2 pl-2 pr-1'>
+          {/* Merge strategy only matters when the def is shared. An owned mapping
+              is the sole writer, so every field is an implicit overwrite — no
+              picker. */}
+          {isMapped && !isOwned && (
+            <MergeStrategySelect value={mergeStrategy} onValueChange={onMergeChange} />
+          )}
+          {isMapped && (
+            <div className='ml-auto flex items-center gap-1'>
+              {/* Secondary identifier toggle: subtle text → filled blue badge. */}
               <SimpleTooltip
                 side='left'
                 delayDuration={500}
@@ -169,24 +157,13 @@ export function SourceLeafRow({
                   )}
                 </button>
               </SimpleTooltip>
-            )}
-          </div>
-          {/* Merge strategy only matters when the def is shared. An owned mapping
-              is the sole writer, so every field is an implicit overwrite — no
-              picker. Fixed width so it sits at a consistent x. */}
-          {isMapped && !isOwned && (
-            <Select value={mergeStrategy} onValueChange={onMergeChange}>
-              <SelectTrigger variant='transparent' size='sm' className='h-9 w-28 text-xs'>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {MERGE_OPTIONS.map((o) => (
-                  <SelectItem key={o.value} value={o.value}>
-                    {o.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              <TreeRowButton
+                variant='destructive'
+                tooltipText="Don't map this field"
+                onClick={onClear}>
+                <Trash2 />
+              </TreeRowButton>
+            </div>
           )}
         </div>,
       ]}

--- a/apps/web/src/components/global/http-request/field-editor.tsx
+++ b/apps/web/src/components/global/http-request/field-editor.tsx
@@ -50,6 +50,13 @@ export interface HttpRequestFieldContextValue {
   FieldEditor: HttpFieldEditor
   /** Optional; absent ⇒ file/binary body + file key-value branches are hidden. */
   FilePicker?: HttpFilePicker
+  /**
+   * Placeholder for the key/value inputs. Defaults to the workflow variable
+   * hint (`type '{' to insert variable...`); the plain connector surface
+   * overrides these since it has no workflow variables.
+   */
+  keyPlaceholder?: string
+  valuePlaceholder?: string
 }
 
 /**

--- a/apps/web/src/components/global/http-request/key-value-item.tsx
+++ b/apps/web/src/components/global/http-request/key-value-item.tsx
@@ -47,7 +47,13 @@ const KeyValueItem: FC<Props> = ({
   insertVarTipToLeft,
   itemIndex = 0,
 }) => {
-  const { FieldEditor, FilePicker } = useHttpRequestField()
+  const { FieldEditor, FilePicker, keyPlaceholder, valuePlaceholder } = useHttpRequestField()
+
+  // Falls back to the workflow variable hint; the plain connector surface
+  // overrides these via the field-editor context.
+  const VAR_HINT = "type '{' to insert variable..."
+  const resolvedKeyPlaceholder = keyPlaceholder ?? VAR_HINT
+  const resolvedValuePlaceholder = valuePlaceholder ?? VAR_HINT
 
   // File rows only make sense when a FilePicker is injected.
   const supportFile = isSupportFile && !!FilePicker
@@ -170,7 +176,7 @@ const KeyValueItem: FC<Props> = ({
             value={localKey}
             onChange={handleLocalChange('key')}
             onBlur={syncToParent}
-            placeholder="type '{' to insert variable..."
+            placeholder={resolvedKeyPlaceholder}
             className='p-1 h-full focus-within:bg-primary-150/60 focus-within:hover:bg-primary-150/60 hover:bg-primary-100'
             disabled={readonly}
           />
@@ -221,7 +227,7 @@ const KeyValueItem: FC<Props> = ({
             value={localValue}
             onChange={handleLocalChange('value')}
             onBlur={syncToParent}
-            placeholder="type '{' to insert variable..."
+            placeholder={resolvedValuePlaceholder}
             className={cn(
               'p-1 h-full',
               'focus-within:bg-primary-150/60',

--- a/apps/web/src/components/pickers/field-picker/field-item.tsx
+++ b/apps/web/src/components/pickers/field-picker/field-item.tsx
@@ -39,10 +39,6 @@ export const FieldItem = memo(function FieldItem({
 
   // Determine icon based on field type
   const getIcon = () => {
-    if (isSelected) {
-      return <Check className='size-4' />
-    }
-
     if (isRelationship && targetResourceProps) {
       return (
         <EntityIcon iconId={targetResourceProps.icon} color={targetResourceProps.color} size='xs' />
@@ -77,7 +73,16 @@ export const FieldItem = memo(function FieldItem({
         {getIcon()}
         <span>{field.label}</span>
       </div>
-      {canDrillDown && <ChevronRight className='size-4 opacity-50' />}
+      <div className='flex shrink-0 items-center gap-1.5'>
+        {/* Blue rounded check (right) — the selected-row convention shared with the
+            record/resource pickers. */}
+        {isSelected && (
+          <div className='flex size-4 items-center justify-center rounded-full border border-blue-800 bg-info'>
+            <Check className='size-2.5! text-white' strokeWidth={4} />
+          </div>
+        )}
+        {canDrillDown && <ChevronRight className='size-4 opacity-50' />}
+      </div>
     </CommandItem>
   )
 })

--- a/apps/web/src/components/pickers/field-picker/field-picker-content.tsx
+++ b/apps/web/src/components/pickers/field-picker/field-picker-content.tsx
@@ -337,7 +337,7 @@ export function FieldPickerInnerContent({
               <FieldItem
                 key={field.id}
                 field={field}
-                isSelected={mode === 'multi' && isFieldSelected(field)}
+                isSelected={isFieldSelected(field)}
                 canDrillDown={!!field.relationship}
                 onSelect={() => handleSelectField(field)}
                 onDrillDown={field.relationship ? () => handleDrillInto(field) : undefined}

--- a/apps/web/src/server/api/routers/connections.ts
+++ b/apps/web/src/server/api/routers/connections.ts
@@ -14,7 +14,7 @@ import {
   refreshCredentialTokens,
   saveConnection,
 } from '@auxx/lib/connections'
-import { getAllProviders } from '@auxx/lib/connections/providers'
+import { getAllProviders, getProviderByKey } from '@auxx/lib/connections/providers'
 import { isAdminOrOwner } from '@auxx/lib/members'
 import { getChannelProviderIcon } from '@auxx/lib/providers'
 import { CredentialTestingService, isCredentialInUse } from '@auxx/lib/workflow-engine'
@@ -98,10 +98,16 @@ export const connectionsRouter = createTRPCRouter({
           type: record.type ?? '',
           kind: record.kind,
           label: record.label,
-          // Visual-ref for non-app rows: channel/integration creds store the provider
-          // as `type` ('google', 'outlook', …) → resolve its brand mark. App rows leave
-          // this null and hydrate the app's avatar client-side.
-          icon: record.type ? getChannelProviderIcon(record.type) : null,
+          // Visual-ref for non-app rows: resolve the provider brand mark from `type`.
+          // Channel creds use a ChannelProviderType ('google', 'outlook', …); platform
+          // integration creds (incl. AI keys like 'openaiApi') use a providerKey, whose
+          // icon lives on the platform provider catalog. App rows leave this null and
+          // hydrate the app's avatar client-side.
+          icon: record.type
+            ? (getChannelProviderIcon(record.type) ??
+              getProviderByKey(record.type)?.uiMetadata?.icon ??
+              null)
+            : null,
           appId: record.appId,
           appInstallationId: record.appInstallationId,
           connectionDefinitionId: record.connectionDefinitionId,
@@ -293,15 +299,16 @@ export const connectionsRouter = createTRPCRouter({
       z.object({
         id: z.string().min(1, 'Connection ID is required'),
         name: z.string().min(1).optional(),
+        label: z.string().min(1).optional(),
         data: z.record(z.string(), z.any()).optional(),
       })
     )
     .use(notDemo('update connection'))
     .mutation(async ({ ctx, input }) => {
-      if (!input.name && !input.data) {
+      if (!input.name && !input.label && !input.data) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
-          message: 'At least one field (name or data) must be provided for update',
+          message: 'At least one field (name, label, or data) must be provided for update',
         })
       }
 
@@ -318,6 +325,7 @@ export const connectionsRouter = createTRPCRouter({
 
       const updateResult = await updateCredential(input.id, organizationId, {
         name: input.name,
+        label: input.label,
         metadata,
       })
       if (updateResult.isErr()) {


### PR DESCRIPTION
## Summary

Connections + data-connector UI polish, centered on a shared connection-display resolver and a rename flow.

- **Rename connections** — new `ConnectionRenameDialog` writes the display `label` via `connections.update` (router now accepts `label`); the connection card menu gains a **Rename** item.
- **Shared connection display** — extract `resolveConnectionDisplay` (icon + title), now used by the connection picker, its popover trigger, and the data-connector connection section so every surface renders the same brand mark/name. The connector header shows the bound connection's real icon + name (e.g. "Gmail") instead of a generic "Connected account" line — reusing the picker's existing `connections.list` query, no extra fetch.
- **Router icon resolution** — falls back to the platform provider catalog so integration/AI keys (e.g. `openaiApi`) resolve their brand mark.
- **Field picker** — blue rounded selected-check matching the record/resource pickers; the check now shows in single-select mode too.
- **Merge strategy** — extract `MergeStrategySelect` shared by leaf and formula rows; rework row actions (right-aligned identifier badge + hover-reveal clear/trash).
- **Plain connector key/value editor** — overrides the workflow-variable hint placeholders since the connector surface has no workflow variables.

## Test plan

- [ ] Rename a connection and confirm the card title updates (label ?? name).
- [ ] Bound data-connector connection shows the real provider icon + name.
- [ ] Field picker shows the blue check in both single- and multi-select.
- [ ] Merge-strategy picker renders identically on leaf and formula rows.