### PR TITLE
feat(connections): block deleting a connection in use by a channel

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-table.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-table.tsx
@@ -116,7 +116,6 @@ const getProviderName = (provider: string) => {
 const isClickOnInteractiveElement = (event: React.MouseEvent): boolean => {
   // Get the clicked element
   const target = event.target as HTMLElement
-  console.log(target)
   // Check if the element or any of its parents have the data-clickable attribute
   const isClickable = (element: HTMLElement | null): boolean => {
     if (!element) return false
@@ -309,7 +308,12 @@ export default function IntegrationTable({ integrations, inboxes }: IntegrationT
                         onCheckedChange={() => handleToggle(integration.id, integration.enabled)}
                       />
                     </TableCell>
-                    <TableCell className='text-right' data-clickable='true'>
+                    {/* Menu content is portaled, but React events bubble through the React tree —
+                        stop here so selecting an item never triggers the row's navigate. */}
+                    <TableCell
+                      className='text-right'
+                      data-clickable='true'
+                      onClick={(e) => e.stopPropagation()}>
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <Button variant='ghost' size='icon'>
@@ -319,7 +323,8 @@ export default function IntegrationTable({ integrations, inboxes }: IntegrationT
                         <DropdownMenuContent align='end'>
                           <DropdownMenuLabel>Actions</DropdownMenuLabel>
                           <DropdownMenuSeparator />
-                          <DropdownMenuItem onClick={() => handleEdit(integration.id)}>
+                          <DropdownMenuItem
+                            onClick={() => router.push(`/app/settings/channels/${integration.id}`)}>
                             <Pencil />
                             Edit Settings
                           </DropdownMenuItem>

--- a/apps/web/src/components/connections/ui/connection-card.tsx
+++ b/apps/web/src/components/connections/ui/connection-card.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/connections/ui/connection-card.tsx
 'use client'
 
-import { Pencil, RefreshCw, Trash, TriangleAlert } from 'lucide-react'
+import { Link2, Pencil, RefreshCw, Trash, TriangleAlert } from 'lucide-react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { AppListCard, type AppListCardMenuItem } from '~/components/apps/ui/app-list-card'
 import type { RouterOutputs } from '~/trpc/react'
@@ -38,6 +38,8 @@ export function ConnectionCard({
 }: ConnectionCardProps) {
   const title = connection.label ?? connection.name
   const expired = connection.status === 'expired'
+  // A channel binds this credential — deleting it would orphan the channel, so delete is blocked.
+  const usedByChannel = connection.usedByChannel
   const scopeLabel = connection.scope === 'user' ? 'Personal' : 'Workspace'
   const description = connection.createdBy?.name
     ? `${scopeLabel} · added by ${connection.createdBy.name}`
@@ -51,7 +53,20 @@ export function ConnectionCard({
       onClick: onAction,
     })
   }
-  menuItems.push({ label: 'Delete', icon: <Trash />, onClick: onDelete, destructive: true })
+  menuItems.push({
+    label: usedByChannel ? 'In use by a channel' : 'Delete',
+    icon: <Trash />,
+    onClick: onDelete,
+    destructive: true,
+    disabled: Boolean(usedByChannel),
+  })
+
+  const badges = [
+    ...(usedByChannel ? [{ label: 'In use', icon: <Link2 className='size-3' /> }] : []),
+    ...(expired
+      ? [{ label: 'Expired', icon: <TriangleAlert className='size-3 text-amber-600' /> }]
+      : []),
+  ]
 
   return (
     <AppListCard
@@ -59,11 +74,7 @@ export function ConnectionCard({
       subtitle={subtitle}
       description={description}
       icon={<AppIcon iconId={iconId} size='sm' />}
-      badges={
-        expired
-          ? [{ label: 'Expired', icon: <TriangleAlert className='size-3 text-amber-600' /> }]
-          : undefined
-      }
+      badges={badges.length > 0 ? badges : undefined}
       onClick={onAction}
       menuItems={menuItems}
     />

--- a/apps/web/src/components/connections/ui/connections-section.tsx
+++ b/apps/web/src/components/connections/ui/connections-section.tsx
@@ -160,6 +160,8 @@ export function ConnectionsSection() {
   }
 
   const handleDelete = async (row: ConnectionRow) => {
+    // Guarded server-side too, but the menu item is disabled — bail before the confirm/mutation.
+    if (row.usedByChannel) return
     const ok = await confirm({
       title: 'Delete connection?',
       description: `Remove "${row.label ?? row.name}"? This cannot be undone.`,

--- a/apps/web/src/server/api/routers/connections.ts
+++ b/apps/web/src/server/api/routers/connections.ts
@@ -9,6 +9,7 @@ import {
   splitSensitiveFields,
   updateCredential,
 } from '@auxx/credentials/store'
+import { getOrgCache } from '@auxx/lib/cache'
 import {
   mintClientCredentialToken,
   refreshCredentialTokens,
@@ -110,8 +111,16 @@ export const connectionsRouter = createTRPCRouter({
         throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: result.error.message })
       }
 
+      // Channels bind a connection credential — flag those rows so the UI can disable delete.
+      // Sourced from the `channels` org cache (no extra query); keyed by the credential FK.
+      const channels = await getOrgCache().get(organizationId, 'channels')
+      const channelByCred = new Map(
+        channels.flatMap((c) => (c.credentialId ? [[c.credentialId, c] as const] : []))
+      )
+
       const now = new Date()
       return result.value.map((record) => {
+        const channel = channelByCred.get(record.id)
         const expired =
           record.consecutiveRefreshFailures >= CONNECTION_CIRCUIT_OPEN_THRESHOLD ||
           (record.expiresAt !== null && record.expiresAt < now)
@@ -140,6 +149,9 @@ export const connectionsRouter = createTRPCRouter({
           // Fresh-connect verify polls for a new id; reconnect verify watches this stamp move.
           updatedAt: record.updatedAt,
           createdBy: { name: record.createdByName },
+          // Set when a channel binds this credential — the UI disables delete and shows an "In use"
+          // badge. Deleting would orphan the channel (FK is set-null), so block it here too.
+          usedByChannel: channel ? { provider: channel.provider, email: channel.email } : null,
         }
       })
     }),
@@ -427,6 +439,17 @@ export const connectionsRouter = createTRPCRouter({
         throw new TRPCError({
           code: 'CONFLICT',
           message: 'Cannot delete connection: it is currently being used in workflows',
+        })
+      }
+
+      // A channel binding this credential would be orphaned by the delete (FK is set-null), losing
+      // its only token source. Block it — disconnect the channel first. Sourced from the cache.
+      const channels = await getOrgCache().get(organizationId, 'channels')
+      if (channels.some((c) => c.credentialId === input.id)) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message:
+            'Cannot delete connection: it is in use by a channel. Disconnect the channel first.',
         })
       }
 

--- a/packages/lib/scripts/flush-channels-cache.ts
+++ b/packages/lib/scripts/flush-channels-cache.ts
@@ -1,0 +1,16 @@
+// packages/lib/scripts/flush-channels-cache.ts
+//
+// Dev util: bust the `channels` org cache for all orgs so it recomputes with the
+// latest CachedChannel shape (e.g. after adding `credentialId`). Next read per org
+// lazily recomputes. Run with the source condition so it picks up src, not stale dist:
+//   npx dotenv -- node --conditions source --import tsx/esm packages/lib/scripts/flush-channels-cache.ts
+
+import { getOrgCache } from '../src/cache'
+
+async function main() {
+  await getOrgCache().flushKeyForAllOrgs(['channels'])
+  console.log('Flushed `channels` cache for all orgs — next read recomputes.')
+  process.exit(0)
+}
+
+void main()

--- a/packages/lib/src/cache/providers/channels-provider.ts
+++ b/packages/lib/src/cache/providers/channels-provider.ts
@@ -19,6 +19,8 @@ type ChatWidgetRow = typeof schema.ChatWidget.$inferSelect
  */
 export interface CachedChannel {
   id: string
+  /** Linked connection credential (FK). Null once the credential is unlinked/deleted. */
+  credentialId: string | null
   provider: IntegrationProviderType
   displayName: string
   name: string | null
@@ -67,6 +69,7 @@ export const channelsProvider: CacheProvider<CachedChannel[]> = {
       const settings = (metadata?.settings as ChannelSettings | undefined) ?? {}
       return {
         id: i.id,
+        credentialId: i.credentialId,
         provider: i.provider,
         displayName: i.name ?? i.email ?? i.provider,
         name: i.name,


### PR DESCRIPTION
Deleting a connection whose credential is bound by a channel would orphan the channel (the FK is `set-null`), leaving it with no token source. Block it.

## Changes
- **`connectionsRouter`**: `list` flags rows whose credential is bound by a channel (sourced from the `channels` org cache — no extra query, keyed by the credential FK); `delete` throws `CONFLICT` with a "disconnect the channel first" message.
- **`ConnectionCard`**: shows an "In use" badge and disables the delete menu item; `connections-section` bails before the confirm/mutation (server-guarded too).
- **`channels-provider`**: caches `credentialId` on `CachedChannel` for the FK lookup.
- **`integration-table`**: row-action menu stops propagation so selecting an item never triggers the row navigate; Edit routes to channel settings; drops a stray `console.log`.
- Adds a `flush-channels-cache` dev script.

## Notes
- One pre-existing Biome **warning** (unused `displayIdentifier` in `integration-table.tsx`) — warning-level, doesn't fail CI; left as-is.