### PR TITLE
feat(sync-core): enriched PaginationSpec — next-url, has_more, last-record cursor, offset base

### DIFF
--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -15,14 +15,30 @@ import type { FieldType } from '../../types'
  */
 export type DataConnectorType = 'generic-rest' | `app:${string}`
 
-/** Pagination contract for a generic-REST endpoint. Refined in sub-plan 05a. */
+/**
+ * Pagination contract for a generic-REST endpoint. Refined in sub-plan 05a.
+ * Structural mirror of `PaginationSpec` in `@auxx/lib/data-connectors/types`
+ * (this package can't import tier-3 lib) — keep the two byte-compatible.
+ */
 export interface PaginationSpec {
-  kind: 'cursor' | 'page' | 'offset' | 'link-header' | 'none'
-  /** Where the next cursor/page token lives in the response. */
-  cursorPath?: string
+  kind: 'cursor' | 'page' | 'offset' | 'link-header' | 'next-url' | 'none'
   /** Query/body param name carrying the cursor/page token. */
   cursorParam?: string
+  /** Where the next cursor/page token lives in the response (cursor-in-body). */
+  cursorPath?: string
+  /** `'response'` (default) reads cursorPath; `'lastRecord'` derives it from the last record (Stripe). */
+  cursorFrom?: 'response' | 'lastRecord'
+  /** With `lastRecord`: which field of the last record is the cursor (Stripe: `id`). */
+  cursorRecordField?: string
+  /** Dotted path to the page's record array (read last record + detect empty); auto-found if omitted. */
+  recordsPath?: string
+  /** Boolean body field that says "more pages exist" (Stripe/Notion `has_more`); falsy terminates. */
+  hasMorePath?: string
+  /** Dotted body path to a full next-page URL the server hands back (Salesforce `nextRecordsUrl`). */
+  nextUrlPath?: string
   pageParam?: string
+  /** Offset base for `kind: 'offset'` — `0` (default) or `1` (QuickBooks `STARTPOSITION`). */
+  offsetBase?: 0 | 1
   limitParam?: string
   pageSize?: number
 }

--- a/packages/lib/src/data-connectors/connectors/generic-rest-slicing.test.ts
+++ b/packages/lib/src/data-connectors/connectors/generic-rest-slicing.test.ts
@@ -10,6 +10,7 @@ import {
   ConnectorRateLimitError,
   type ConnectorYield,
   isConnectorCheckpoint,
+  type PaginationSpec,
 } from './types'
 
 const fetchMock = vi.fn()
@@ -160,5 +161,90 @@ describe('generic-rest steady mode (G2)', () => {
     )
     // Single page (no pagination) → terminal checkpoint carries the max updated_at.
     expect(yields.at(-1)).toEqual({ __checkpoint: true, watermark: '2026-06-15' })
+  })
+})
+
+describe('generic-rest enriched pagination (Step 6)', () => {
+  function paged(pagination: PaginationSpec, over: Partial<ConnectorFetchArgs> = {}) {
+    return args({
+      config: { endpoint: { baseUrl: 'https://api.example.com', auth: 'none', pagination } },
+      requestConfig: { path: 'query' },
+      ...over,
+    })
+  }
+
+  it('next-url: GETs the body next URL verbatim, terminates when absent', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        json({ done: false, nextRecordsUrl: '/query/01g-2000', records: [{ id: 1 }] })
+      )
+      .mockResolvedValueOnce(json({ done: true, records: [{ id: 2 }] })) // no nextRecordsUrl → done
+
+    const yields = await collect(
+      paged({ kind: 'next-url', nextUrlPath: 'nextRecordsUrl', recordsPath: 'records' })
+    )
+
+    // Page 2 is the server-handed URL, joined onto the base origin and GET as-is.
+    const [secondUrl] = fetchMock.mock.calls[1]!
+    expect(String(secondUrl)).toBe('https://api.example.com/query/01g-2000')
+    expect(yields[1]).toEqual({
+      __checkpoint: true,
+      cursor: { kind: 'token', value: '/query/01g-2000' },
+    })
+    expect(yields.at(-1)).toEqual({ __checkpoint: true }) // exhausted, no cursor
+  })
+
+  it('cursor lastRecord + has_more: cursor = last record id, has_more:false stops', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json({ has_more: true, data: [{ id: 'a' }, { id: 'b' }] }))
+      .mockResolvedValueOnce(json({ has_more: false, data: [{ id: 'c' }] }))
+
+    const yields = await collect(
+      paged({
+        kind: 'cursor',
+        cursorFrom: 'lastRecord',
+        cursorRecordField: 'id',
+        cursorParam: 'starting_after',
+        recordsPath: 'data',
+        hasMorePath: 'has_more',
+      })
+    )
+
+    // Page 2 carries the LAST record id of page 1 as the cursor.
+    const [secondUrl] = fetchMock.mock.calls[1]!
+    expect(String(secondUrl)).toContain('starting_after=b')
+    expect(yields[1]).toEqual({ __checkpoint: true, cursor: { kind: 'token', value: 'b' } })
+    // has_more:false on page 2 terminates the loop (only two fetches).
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(yields.at(-1)).toEqual({ __checkpoint: true })
+  })
+
+  it('has_more:false terminates even when a next token is present', async () => {
+    fetchMock.mockResolvedValueOnce(json({ next_cursor: 'c1', has_more: false, data: [{}] }))
+
+    const yields = await collect(
+      paged({
+        kind: 'cursor',
+        cursorPath: 'next_cursor',
+        cursorParam: 'cursor',
+        hasMorePath: 'has_more',
+      })
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1) // stopped despite next_cursor present
+    expect(yields.at(-1)).toEqual({ __checkpoint: true })
+  })
+
+  it('offsetBase:1 starts the offset at 1 (QuickBooks STARTPOSITION)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json({ items: [{}] })) // non-empty → keep going
+      .mockResolvedValueOnce(json({ items: [] })) // empty → exhausted
+
+    await collect(
+      paged({ kind: 'offset', pageParam: 'STARTPOSITION', pageSize: 1000, offsetBase: 1 })
+    )
+
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('STARTPOSITION=1')
+    expect(String(fetchMock.mock.calls[1]![0])).toContain('STARTPOSITION=1001')
   })
 })

--- a/packages/lib/src/data-connectors/connectors/generic-rest.ts
+++ b/packages/lib/src/data-connectors/connectors/generic-rest.ts
@@ -59,6 +59,19 @@ function countRecords(body: unknown, depth = 0): number {
 }
 
 /**
+ * The page's record array per the pagination spec: `recordsPath` when declared
+ * (Stripe `data`, HubSpot `results`), else best-effort auto-find. Used to read the
+ * last record (`lastRecord` cursor) and detect an empty page.
+ */
+function selectRecords(body: unknown, recordsPath?: string): unknown[] {
+  if (recordsPath) {
+    const at = getByPath(body, recordsPath)
+    return Array.isArray(at) ? at : []
+  }
+  return findRecords(body)
+}
+
+/**
  * Best-effort records array in a payload — the first array found (depth-first),
  * mirroring `countRecords`. Used only to extract the steady-mode watermark; the
  * mapping's `rootPath` remains the authoritative records selector for the sink.
@@ -174,6 +187,8 @@ function toSyncCursor(
     case 'link-header':
       return { kind: 'headerLocator', value: nextToken }
     default:
+      // cursor / next-url both resume from the token (body cursor, last-record id,
+      // or a verbatim next URL) on the next slice.
       return { kind: 'token', value: nextToken }
   }
 }
@@ -187,8 +202,21 @@ function nextPageToken(
 ): string | undefined {
   if (!pagination || pagination.kind === 'none') return undefined
   switch (pagination.kind) {
-    case 'cursor':
+    case 'cursor': {
+      // Stripe-style: the next cursor is a field of the LAST record on the page,
+      // not a fixed body path. Empty page ⇒ no last record ⇒ stop.
+      if (pagination.cursorFrom === 'lastRecord') {
+        const records = selectRecords(body, pagination.recordsPath)
+        const last = records[records.length - 1]
+        const value = getByPath(last, pagination.cursorRecordField)
+        return value === undefined || value === null ? undefined : String(value)
+      }
       return getByPath(body, pagination.cursorPath) as string | undefined
+    }
+    case 'next-url':
+      // Server hands back a full next-page URL in the body (Salesforce
+      // `nextRecordsUrl`); absent ⇒ exhausted.
+      return getByPath(body, pagination.nextUrlPath) as string | undefined
     case 'link-header': {
       const link = headers.link ?? ''
       const match = link.match(/<([^>]+)>;\s*rel="next"/)
@@ -265,7 +293,9 @@ async function* fetchRecords(args: ConnectorFetchArgs): AsyncIterable<ConnectorY
       params[pagination.pageParam] = pageIndex + 1
     }
     if (pagination?.kind === 'offset' && pagination.pageParam) {
-      params[pagination.pageParam] = pageIndex * (pagination.pageSize ?? 0)
+      // offsetBase shifts the first page's offset (QuickBooks STARTPOSITION is 1-based).
+      params[pagination.pageParam] =
+        (pagination.offsetBase ?? 0) + pageIndex * (pagination.pageSize ?? 0)
     }
     if (pagination?.limitParam && pagination.pageSize) {
       params[pagination.limitParam] = pagination.pageSize
@@ -276,8 +306,17 @@ async function* fetchRecords(args: ConnectorFetchArgs): AsyncIterable<ConnectorY
       params[incremental.sinceParam] = args.state.watermark
     }
 
-    const url =
-      pagination?.kind === 'link-header' && cursor ? cursor : buildUrl(baseUrl, path, params)
+    // link-header hands back an absolute next URL (GET as-is); next-url hands back
+    // a body URL that is often relative (Salesforce `nextRecordsUrl`) — join it onto
+    // the base origin and GET it verbatim, without re-appending our paging params.
+    let url: string
+    if (pagination?.kind === 'link-header' && cursor) {
+      url = cursor
+    } else if (pagination?.kind === 'next-url' && cursor) {
+      url = buildUrl(baseUrl, cursor)
+    } else {
+      url = buildUrl(baseUrl, path, params)
+    }
 
     // The HTTP transport applies the resolved connection's declarative auth
     // (header/basic/query), sends the request, handles rate limits (429 +
@@ -313,8 +352,15 @@ async function* fetchRecords(args: ConnectorFetchArgs): AsyncIterable<ConnectorY
     yield { streamKey: args.streamKey, fields: body }
 
     const next = nextPageToken(pagination, body, response.headers, pageIndex)
-    // Stop when there's no next token, or a page/offset run returned an empty page.
+    // An explicit `has_more: false` terminates regardless of token presence
+    // (Stripe/Notion); when absent we fall back to token/empty-page detection.
+    const hasMore = pagination?.hasMorePath
+      ? Boolean(getByPath(body, pagination.hasMorePath))
+      : undefined
+    // Stop when has_more says so, there's no next token, or a page/offset run
+    // returned an empty page.
     if (
+      hasMore === false ||
       !next ||
       (countRecords(body) === 0 && (pagination?.kind === 'page' || pagination?.kind === 'offset'))
     ) {

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -18,12 +18,38 @@ import type { SyncCursor } from '../sync-core/contracts'
 
 /** Pagination contract for a generic-REST endpoint. */
 export interface PaginationSpec {
-  kind: 'cursor' | 'page' | 'offset' | 'link-header' | 'none'
-  /** Where the next cursor/page token lives in the response. */
-  cursorPath?: string
+  kind: 'cursor' | 'page' | 'offset' | 'link-header' | 'next-url' | 'none'
   /** Query/body param name carrying the cursor/page token. */
   cursorParam?: string
+  /** Where the next cursor/page token lives in the response (cursor-in-body). */
+  cursorPath?: string
+  /**
+   * Where the next cursor comes from. `'response'` (default) reads {@link cursorPath};
+   * `'lastRecord'` derives it from the last record on the page (Stripe `starting_after`).
+   */
+  cursorFrom?: 'response' | 'lastRecord'
+  /** With `cursorFrom: 'lastRecord'`: which field of the last record is the cursor (Stripe: `id`). */
+  cursorRecordField?: string
+  /**
+   * Dotted path to the page's record array (HubSpot `results`, Stripe `data`).
+   * Used to read the last record (`lastRecord` cursor) and detect an empty page;
+   * omit to auto-find the first array in the body.
+   */
+  recordsPath?: string
+  /**
+   * Boolean body field that says "more pages exist" (Stripe/Notion `has_more`).
+   * When set, a falsy value terminates the loop regardless of token presence.
+   */
+  hasMorePath?: string
+  /**
+   * Dotted body path to a full next-page URL the server hands back (Salesforce
+   * `nextRecordsUrl`); the URL is GET verbatim. Only read for `kind: 'next-url'`.
+   * (`link-header` covers the same idea when the URL is in a response header.)
+   */
+  nextUrlPath?: string
   pageParam?: string
+  /** Offset base for `kind: 'offset'` — `0` (default) or `1` (QuickBooks `STARTPOSITION`). */
+  offsetBase?: 0 | 1
   limitParam?: string
   pageSize?: number
 }


### PR DESCRIPTION
## Step 6 — Pagination breadth (Phase D)

Teaches the generic-rest page loop four real-provider pagination dialects it couldn't express before. **Additive, jsonb-only — no migration.** Picking a dialect stays a human authoring decision (template config); this PR is the engine vocabulary only.

### What's new on `PaginationSpec`

| Addition | Unlocks | Behavior |
|---|---|---|
| `kind: 'next-url'` + `nextUrlPath` | **Salesforce** `nextRecordsUrl` | server hands back a full next-page URL in the body → joined onto the base origin and GET verbatim (no re-appended paging params) |
| `cursorFrom: 'lastRecord'` + `cursorRecordField` + `recordsPath` | **Stripe** `starting_after` | next cursor = a field of the *last record* on the page, not a fixed body path; empty page ⇒ stop |
| `hasMorePath` | **Stripe / Notion** `has_more` | a falsy value terminates the loop **regardless** of token presence |
| `offsetBase: 0 \| 1` | **QuickBooks** `STARTPOSITION` | `offset = offsetBase + pageIndex * pageSize` (fixes the 1-based off-by-one) |

### Files
- `packages/lib/src/data-connectors/types.ts` — canonical `PaginationSpec` extended
- `packages/database/src/db/schema/data-connector-types.ts` — DB mirror, kept byte-compatible
- `packages/lib/src/data-connectors/connectors/generic-rest.ts` — `nextPageToken` (lastRecord + next-url), `selectRecords` (honors `recordsPath`), URL selection for next-url, `hasMorePath` terminator, `offsetBase` math
- `generic-rest-slicing.test.ts` — +4 tests

Resume/checkpoint and watermark paths are untouched — next-url and cursor both resume from the existing `token` `SyncCursor`, so sliced backfill and steady mode keep working unchanged.

### Out of scope (by design)
Async bulk export (Shopify Bulk Ops, Salesforce Bulk 2.0) is **not** a pagination kind — it's a different fetch lifecycle (initiate → poll → download) and lives in Step 7. No provider templates are wired here; this PR just makes them expressible.

### Tests
- **51 green** across `data-connectors` + `sync-core` (+4 new): next-url verbatim-GET + terminate-when-absent, Stripe lastRecord cursor + `has_more:false` stop, `has_more:false` overrides a present token, `offsetBase:1` → `STARTPOSITION=1` then `1001`.
- Biome clean.