### PR TITLE
feat(sync-core): async bulk-export engine seam (Step 7a)

### DIFF
--- a/packages/lib/src/data-connectors/async-export/index.ts
+++ b/packages/lib/src/data-connectors/async-export/index.ts
@@ -1,0 +1,23 @@
+// packages/lib/src/data-connectors/async-export/index.ts
+// Provider-neutral async bulk-export engine (Step 7). Drivers (Shopify Bulk Ops) plug
+// into `AsyncExportDriver`; the slice state machine + `__parentId` restitch are shared.
+
+export type { RestitchOptions } from './restitch'
+export { restitchByParentId } from './restitch'
+export type { RunAsyncExportSliceArgs } from './slice-loop'
+export { runAsyncExportSlice } from './slice-loop'
+export type {
+  AsyncExportArgs,
+  AsyncExportCapability,
+  AsyncExportDriver,
+  AsyncExportState,
+  AsyncExportStatus,
+} from './types'
+export {
+  decodeAsyncCursor,
+  encodeAsyncCursor,
+  MAX_REINITIATE,
+  POLL_BASE_MS,
+  POLL_MAX_MS,
+  pollDelayMs,
+} from './types'

--- a/packages/lib/src/data-connectors/async-export/restitch.test.ts
+++ b/packages/lib/src/data-connectors/async-export/restitch.test.ts
@@ -1,0 +1,72 @@
+// packages/lib/src/data-connectors/async-export/restitch.test.ts
+// The __parentId restitch helper: re-nest a flat, unordered bulk-export JSONL set.
+
+import { describe, expect, it } from 'vitest'
+import { restitchByParentId } from './restitch'
+
+describe('restitchByParentId', () => {
+  it('nests children under their parent (default __children key)', () => {
+    const tops = restitchByParentId([
+      { id: 'o1', name: 'Order 1' },
+      { id: 'li1', __parentId: 'o1', title: 'Widget' },
+      { id: 'li2', __parentId: 'o1', title: 'Gadget' },
+    ])
+    expect(tops).toEqual([
+      {
+        id: 'o1',
+        name: 'Order 1',
+        __children: [
+          { id: 'li1', __parentId: 'o1', title: 'Widget' },
+          { id: 'li2', __parentId: 'o1', title: 'Gadget' },
+        ],
+      },
+    ])
+  })
+
+  it('restitches regardless of order — a child can precede its parent', () => {
+    const tops = restitchByParentId([
+      { id: 'li1', __parentId: 'o1', title: 'Widget' },
+      { id: 'o1', name: 'Order 1' },
+    ])
+    expect(tops).toHaveLength(1)
+    expect((tops[0]!.__children as unknown[]).length).toBe(1)
+  })
+
+  it('groups children by a provider childKey (line items vs. fulfillments)', () => {
+    const childKey = (c: Record<string, unknown>) =>
+      String(c.id).includes('LineItem') ? 'lineItems' : 'fulfillments'
+    const tops = restitchByParentId(
+      [
+        { id: 'gid://shopify/Order/1' },
+        { id: 'gid://shopify/LineItem/1', __parentId: 'gid://shopify/Order/1' },
+        { id: 'gid://shopify/Fulfillment/1', __parentId: 'gid://shopify/Order/1' },
+      ],
+      { childKey }
+    )
+    expect(tops[0]!.lineItems).toHaveLength(1)
+    expect(tops[0]!.fulfillments).toHaveLength(1)
+  })
+
+  it('nests grandchildren (multi-level) via shared references', () => {
+    const tops = restitchByParentId([
+      { id: 'o1' },
+      { id: 'li1', __parentId: 'o1' },
+      { id: 'tax1', __parentId: 'li1' }, // grandchild of the order
+    ])
+    const order = tops[0]!
+    const lineItem = (order.__children as Record<string, unknown>[])[0]!
+    expect((lineItem.__children as unknown[]).length).toBe(1)
+    expect(tops).toHaveLength(1)
+  })
+
+  it('surfaces a child with a dangling parent ref as a top-level record (no data loss)', () => {
+    const tops = restitchByParentId([{ id: 'o1' }, { id: 'orphan', __parentId: 'missing' }])
+    expect(tops).toHaveLength(2)
+    expect(tops.map((t) => t.id)).toContain('orphan')
+  })
+
+  it('ignores non-object rows', () => {
+    const tops = restitchByParentId([{ id: 'o1' }, null, 42, 'nope'])
+    expect(tops).toEqual([{ id: 'o1' }])
+  })
+})

--- a/packages/lib/src/data-connectors/async-export/restitch.ts
+++ b/packages/lib/src/data-connectors/async-export/restitch.ts
@@ -1,0 +1,72 @@
+// packages/lib/src/data-connectors/async-export/restitch.ts
+// Re-nest a flattened bulk-export JSONL stream back into parent→children records.
+// Shopify Bulk Operations (and similar) emit a FLAT line-per-object file: a parent on
+// one line, each child on its own line carrying `__parentId` → the parent's `id`. Order
+// is NOT guaranteed (a child can precede its parent), so we buffer the whole set, index
+// by id, and attach each child onto its parent under a provider-chosen key. Because we
+// mutate the shared object references in the index, grandchildren nest correctly too
+// (a child attached to its parent already carries the grandchildren attached to it).
+//
+// Provider-neutral by design (large-dataset-sync §5.2): the connector/driver supplies
+// `childKey` to decide which array a given child nests under (e.g. line items vs.
+// fulfillments); the engine never branches on provider.
+
+/** How to read the id/parent links and group children. All optional with sane defaults. */
+export interface RestitchOptions {
+  /** Field carrying each record's own id. Default `'id'`. */
+  idField?: string
+  /** Field on a child pointing at its parent's id. Default `'__parentId'`. */
+  parentField?: string
+  /**
+   * Which parent-side array a child nests under, derived from the child. Default groups
+   * every child under `'__children'`. Shopify keys off the child's `id` gid type
+   * (e.g. `gid://shopify/LineItem/…` → `lineItems`).
+   */
+  childKey?: (child: Record<string, unknown>) => string
+}
+
+type Rec = Record<string, unknown>
+
+const isRecord = (v: unknown): v is Rec => typeof v === 'object' && v !== null && !Array.isArray(v)
+
+/**
+ * Re-nest a flat array of bulk-export rows into top-level records with their children
+ * grouped onto them. A row with no (or an unknown) `__parentId` is a top-level record;
+ * a row whose `__parentId` matches a known id is appended to that parent under
+ * `childKey(child)`. A child whose parent id is absent from the set is surfaced as a
+ * top-level record (defensive — no data loss) rather than silently dropped.
+ *
+ * Input order is irrelevant: the function indexes all rows first, then links them, so a
+ * child appearing before its parent (or grandchildren in any order) restitches correctly.
+ */
+export function restitchByParentId(rows: Iterable<unknown>, options: RestitchOptions = {}): Rec[] {
+  const idField = options.idField ?? 'id'
+  const parentField = options.parentField ?? '__parentId'
+  const childKey = options.childKey ?? (() => '__children')
+
+  const records = [...rows].filter(isRecord)
+
+  // Index by id so a child can find its parent regardless of arrival order.
+  const byId = new Map<string, Rec>()
+  for (const r of records) {
+    const id = r[idField]
+    if (typeof id === 'string') byId.set(id, r)
+  }
+
+  const tops: Rec[] = []
+  for (const r of records) {
+    const parentId = r[parentField]
+    const parent = typeof parentId === 'string' ? byId.get(parentId) : undefined
+    if (!parent) {
+      // No parent ref, or a dangling ref → treat as a top-level record.
+      tops.push(r)
+      continue
+    }
+    const key = childKey(r)
+    const bucket = parent[key]
+    if (Array.isArray(bucket)) bucket.push(r)
+    else parent[key] = [r]
+  }
+
+  return tops
+}

--- a/packages/lib/src/data-connectors/async-export/slice-loop.test.ts
+++ b/packages/lib/src/data-connectors/async-export/slice-loop.test.ts
@@ -1,0 +1,155 @@
+// packages/lib/src/data-connectors/async-export/slice-loop.test.ts
+// The async-export slice state machine (init → poll → download), driven by a fake
+// driver + in-memory sink. One runAsyncExportSlice call = one slice; we thread the
+// returned nextCursor into the next call to simulate the worker's continuation chain.
+
+import { describe, expect, it, vi } from 'vitest'
+import type { SyncCursor, SyncSliceCtx, ThrottleHandle } from '../../sync-core/contracts'
+import type { ConnectorRecord } from '../connectors/types'
+import { runAsyncExportSlice } from './slice-loop'
+import { type AsyncExportDriver, type AsyncExportStatus, decodeAsyncCursor } from './types'
+
+function ctx(cursor?: SyncCursor, aborted = false): SyncSliceCtx {
+  const ac = new AbortController()
+  if (aborted) ac.abort()
+  return {
+    phase: 'backfill',
+    cursor,
+    budget: { maxPages: 20, maxRecords: 5_000, maxMs: 25_000 },
+    throttle: {} as ThrottleHandle,
+    signal: ac.signal,
+  }
+}
+
+function rec(id: string): ConnectorRecord {
+  return { streamKey: 's1', fields: { id }, externalId: id }
+}
+
+/** A driver whose poll() walks a scripted status sequence; download() yields fixed records. */
+function fakeDriver(opts: {
+  statuses?: AsyncExportStatus[]
+  records?: ConnectorRecord[]
+  onDownload?: () => void
+}): AsyncExportDriver & { initiated: number; polled: number } {
+  const statuses = [...(opts.statuses ?? [])]
+  const d = {
+    id: 'fake',
+    initiated: 0,
+    polled: 0,
+    async initiate() {
+      d.initiated += 1
+      return { handle: `op${d.initiated}` }
+    },
+    async poll() {
+      d.polled += 1
+      return statuses.shift() ?? { state: 'running' as const }
+    },
+    async *download() {
+      opts.onDownload?.()
+      for (const r of opts.records ?? []) yield r
+    },
+  }
+  return d
+}
+
+describe('runAsyncExportSlice', () => {
+  it('runs the full lifecycle init → poll(running) → poll(completed) → download', async () => {
+    const driver = fakeDriver({
+      statuses: [{ state: 'running' }, { state: 'completed', url: 'https://x/file.jsonl' }],
+      records: [rec('a'), rec('b')],
+    })
+    const sunk: ConnectorRecord[] = []
+    const sink = (r: ConnectorRecord) => {
+      sunk.push(r)
+      return Promise.resolve()
+    }
+
+    // Slice 1 — initiate.
+    const s1 = await runAsyncExportSlice({ driver, sink, ctx: ctx() })
+    expect(driver.initiated).toBe(1)
+    expect(s1.hasMore).toBe(true)
+    expect(s1.recordsProcessed).toBe(0)
+    expect(s1.rateLimitWaitMs).toBe(5_000)
+    expect(decodeAsyncCursor(s1.nextCursor)).toMatchObject({
+      stage: 'poll',
+      handle: 'op1',
+      polls: 0,
+    })
+
+    // Slice 2 — poll, still running → backed-off re-enqueue.
+    const s2 = await runAsyncExportSlice({ driver, sink, ctx: ctx(s1.nextCursor) })
+    expect(s2.hasMore).toBe(true)
+    expect(s2.rateLimitWaitMs).toBe(10_000)
+    expect(decodeAsyncCursor(s2.nextCursor)).toMatchObject({ stage: 'poll', polls: 1 })
+
+    // Slice 3 — poll, completed → move to download (no delay).
+    const s3 = await runAsyncExportSlice({ driver, sink, ctx: ctx(s2.nextCursor) })
+    expect(s3.hasMore).toBe(true)
+    expect(s3.rateLimitWaitMs).toBe(0)
+    expect(decodeAsyncCursor(s3.nextCursor)).toMatchObject({
+      stage: 'download',
+      url: 'https://x/file.jsonl',
+    })
+    expect(sunk).toHaveLength(0) // download hasn't run yet
+
+    // Slice 4 — download → sink all, exhausted.
+    const s4 = await runAsyncExportSlice({ driver, sink, ctx: ctx(s3.nextCursor) })
+    expect(sunk.map((r) => r.externalId)).toEqual(['a', 'b'])
+    expect(s4.recordsProcessed).toBe(2)
+    expect(s4.hasMore).toBe(false)
+    expect(s4.nextCursor).toBeUndefined()
+  })
+
+  it('re-initiates a FAILED job (bounded), keeping an attempt count', async () => {
+    const driver = fakeDriver({ statuses: [{ state: 'failed', reason: 'boom' }] })
+    const sink = () => Promise.resolve()
+
+    // Poll returns failed → re-initiate: back to init with attempts bumped.
+    const pollCursor: SyncCursor = {
+      kind: 'token',
+      value: JSON.stringify({ stage: 'poll', handle: 'op1' }),
+    }
+    const out = await runAsyncExportSlice({ driver, sink, ctx: ctx(pollCursor) })
+    expect(out.hasMore).toBe(true)
+    expect(out.rateLimitWaitMs).toBe(0)
+    expect(decodeAsyncCursor(out.nextCursor)).toMatchObject({ stage: 'init', attempts: 1 })
+  })
+
+  it('re-initiates an EXPIRED result url', async () => {
+    const driver = fakeDriver({ statuses: [{ state: 'expired' }] })
+    const sink = () => Promise.resolve()
+    const pollCursor: SyncCursor = {
+      kind: 'token',
+      value: JSON.stringify({ stage: 'poll', handle: 'op1' }),
+    }
+    const out = await runAsyncExportSlice({ driver, sink, ctx: ctx(pollCursor) })
+    expect(decodeAsyncCursor(out.nextCursor)).toMatchObject({ stage: 'init', attempts: 1 })
+  })
+
+  it('fails the run permanently after exhausting the re-initiate budget', async () => {
+    const driver = fakeDriver({ statuses: [{ state: 'failed', reason: 'still broken' }] })
+    const sink = () => Promise.resolve()
+    // attempts already at the cap (3) → the next failure throws.
+    const pollCursor: SyncCursor = {
+      kind: 'token',
+      value: JSON.stringify({ stage: 'poll', handle: 'op1', attempts: 3 }),
+    }
+    await expect(runAsyncExportSlice({ driver, sink, ctx: ctx(pollCursor) })).rejects.toThrow(
+      /giving up after 3 re-initiates/
+    )
+  })
+
+  it('re-enqueues the download on graceful abort (idempotent re-download)', async () => {
+    const driver = fakeDriver({ records: [rec('a'), rec('b')] })
+    const sink = vi.fn(() => Promise.resolve())
+    const dlCursor: SyncCursor = {
+      kind: 'token',
+      value: JSON.stringify({ stage: 'download', url: 'https://x/file.jsonl' }),
+    }
+    // Signal pre-aborted → the loop yields before sinking, holding the download stage.
+    const out = await runAsyncExportSlice({ driver, sink, ctx: ctx(dlCursor, true) })
+    expect(sink).not.toHaveBeenCalled()
+    expect(out.hasMore).toBe(true)
+    expect(decodeAsyncCursor(out.nextCursor)).toMatchObject({ stage: 'download' })
+  })
+})

--- a/packages/lib/src/data-connectors/async-export/slice-loop.ts
+++ b/packages/lib/src/data-connectors/async-export/slice-loop.ts
@@ -1,0 +1,115 @@
+// packages/lib/src/data-connectors/async-export/slice-loop.ts
+// The provider-neutral async-export slice state machine (Step 7 / large-dataset §5.1).
+// One call = ONE slice = one worker job. A slice does exactly one phase of the async
+// job and returns a `SliceResult` the core runner acts on — the continuation chain is
+// the worker re-enqueueing on `hasMore`. Crucially, a poll slice does NO record work
+// and returns immediately (with a poll-delay), so "wait for the export to finish" never
+// holds a worker lock: it's spread across many tiny re-enqueued slices.
+//
+//   init      → kick off the job, checkpoint the handle, re-enqueue to poll.
+//   poll      → running ⇒ re-enqueue (capped backoff); completed ⇒ move to download;
+//               failed/expired ⇒ re-initiate (bounded) or fail the run.
+//   download  → stream the (already-restitched) records into the sink, then complete.
+//
+// Pure over an injected driver + sink + clock, so it unit-tests with fakes (no network).
+
+import type { SliceResult, SyncSliceCtx } from '../../sync-core/contracts'
+import type { SliceSink } from '../connector-slice-loop'
+import type { AsyncExportDriver } from './types'
+import {
+  type AsyncExportState,
+  decodeAsyncCursor,
+  encodeAsyncCursor,
+  MAX_REINITIATE,
+  pollDelayMs,
+} from './types'
+
+export interface RunAsyncExportSliceArgs {
+  driver: AsyncExportDriver
+  sink: SliceSink
+  ctx: SyncSliceCtx
+}
+
+/** A re-enqueue slice result that advances to `next` after `delayMs`, doing no record work. */
+function step(next: AsyncExportState, delayMs: number): Omit<SliceResult, 'counters'> {
+  return {
+    recordsProcessed: 0,
+    pagesProcessed: 0,
+    nextCursor: encodeAsyncCursor(next),
+    hasMore: true,
+    // The core surfaces `rateLimitWaitMs` as the re-enqueue delay (retryAfterMs). For an
+    // async export it's not a throttle wait but the poll/stage pacing — same channel.
+    rateLimitWaitMs: delayMs,
+    commit: 'all',
+  }
+}
+
+/**
+ * Run one async-export slice. Returns the `SliceResult` MINUS counters (the caller folds
+ * the sink's counter deltas, mirroring `runConnectorSlice`).
+ */
+export async function runAsyncExportSlice(
+  args: RunAsyncExportSliceArgs
+): Promise<Omit<SliceResult, 'counters'>> {
+  const { driver, sink, ctx } = args
+  const state = decodeAsyncCursor(ctx.cursor)
+
+  if (state.stage === 'init') {
+    const { handle } = await driver.initiate()
+    return step({ stage: 'poll', handle, polls: 0 }, pollDelayMs(0))
+  }
+
+  if (state.stage === 'poll') {
+    if (!state.handle) {
+      // Lost handle (shouldn't happen) — restart the job rather than poll nothing.
+      return step({ stage: 'init', attempts: state.attempts }, 0)
+    }
+    const status = await driver.poll(state.handle)
+
+    if (status.state === 'running') {
+      const polls = (state.polls ?? 0) + 1
+      return step({ ...state, polls }, pollDelayMs(polls))
+    }
+    if (status.state === 'completed') {
+      // Move to download on the next slice (don't chain a multi-minute download onto a
+      // poll slice). No delay — the file is ready.
+      return step({ stage: 'download', url: status.url }, 0)
+    }
+    // failed / expired → re-initiate, bounded. Past the budget, fail the run permanently.
+    const attempts = (state.attempts ?? 0) + 1
+    if (attempts > MAX_REINITIATE) {
+      const why = status.state === 'failed' ? (status.reason ?? 'failed') : 'result url expired'
+      throw new Error(
+        `async-export ${driver.id}: giving up after ${MAX_REINITIATE} re-initiates (${why})`
+      )
+    }
+    return step({ stage: 'init', attempts }, 0)
+  }
+
+  // download
+  if (!state.url) {
+    // Lost url — re-initiate rather than download nothing.
+    return step({ stage: 'init', attempts: state.attempts }, 0)
+  }
+  let recordsProcessed = 0
+  for await (const record of driver.download(state.url)) {
+    if (ctx.signal.aborted) {
+      // Graceful cancellation — re-enqueue the download. The signed URL re-fetches from
+      // the top; the sink dedupes already-written records on their content hash, so the
+      // re-download is idempotent (counters may slightly over-count fetched/skipped).
+      return {
+        recordsProcessed,
+        nextCursor: encodeAsyncCursor(state),
+        hasMore: true,
+        commit: 'all',
+        rateLimitWaitMs: 0,
+      }
+    }
+    await sink(record)
+    recordsProcessed += 1
+  }
+  // The whole file streamed — this phase is exhausted (the runner runs reconciliation
+  // and flips to steady). The budget is advisory here: restitch needs the full file, so
+  // a download isn't split mid-stream in v1 (resumable download deferred to Step 7b+).
+  return { recordsProcessed, nextCursor: undefined, hasMore: false, commit: 'all' }
+}

--- a/packages/lib/src/data-connectors/async-export/types.ts
+++ b/packages/lib/src/data-connectors/async-export/types.ts
@@ -1,0 +1,100 @@
+// packages/lib/src/data-connectors/async-export/types.ts
+// The provider-neutral async bulk-export seam (Step 7 / large-dataset-sync §5).
+// Some APIs (Shopify Bulk Operations, Salesforce Bulk API 2.0) don't paginate large
+// reads — you submit a query, they run it ASYNC on their side, and hand back a single
+// result file. We model that as a connector capability whose "slice" is a phase of the
+// job (initiate → poll → download), NOT a page of records — so polling re-enqueues a
+// continuation slice instead of blocking a worker lock for minutes. The driver below
+// is the only provider-specific piece; the state machine (`runAsyncExportSlice`) and
+// the `__parentId` restitch helper are shared and provider-neutral.
+
+import type { RuntimeConnectionData } from '../../connections/resolve-connection-for-runtime'
+import type { SyncCursor } from '../../sync-core/contracts'
+import type { ConnectorRecord, DataConnectorConfig, StreamRequestConfig } from '../types'
+
+/** Where one async export job is in its lifecycle, carried across slices. */
+export interface AsyncExportState {
+  stage: 'init' | 'poll' | 'download'
+  /** Opaque provider handle for the running job (Shopify bulk operation id). */
+  handle?: string
+  /** Signed result-file URL, set once the job reports COMPLETED. */
+  url?: string
+  /** Re-initiate count (a FAILED/EXPIRED job is retried up to {@link MAX_REINITIATE}). */
+  attempts?: number
+  /** Poll count — drives the capped poll backoff so a long job isn't polled every 5s forever. */
+  polls?: number
+}
+
+/** A provider's report of the job's current status (polled each slice). */
+export type AsyncExportStatus =
+  | { state: 'running' }
+  | { state: 'completed'; url: string }
+  /** Transient — the job failed; re-initiate (bounded). `reason` is surfaced on permanent give-up. */
+  | { state: 'failed'; reason?: string }
+  /** The result URL expired (7-day deadline) before download — re-initiate. */
+  | { state: 'expired' }
+
+/** Inputs a capability needs to build a provider driver for one stream's export. */
+export interface AsyncExportArgs {
+  streamKey: string
+  credential: RuntimeConnectionData | null
+  config: DataConnectorConfig
+  requestConfig?: StreamRequestConfig
+}
+
+/**
+ * The one provider-specific piece. Implementations (Shopify Bulk Ops — Step 7b) own
+ * the API I/O: kick off the job, report status, and stream the completed file as
+ * already-restitched {@link ConnectorRecord}s (the driver uses the shared
+ * `restitchByParentId` helper to re-nest the flat JSONL). Everything else — the slice
+ * state machine, re-initiate, checkpointing — is provider-neutral.
+ */
+export interface AsyncExportDriver {
+  readonly id: string
+  /** Kick off the async job; return the opaque handle to poll. */
+  initiate(): Promise<{ handle: string }>
+  /** Check the job's status by handle. */
+  poll(handle: string): Promise<AsyncExportStatus>
+  /** Stream the completed export as fully-formed, restitched records (lazy). */
+  download(url: string): AsyncIterable<ConnectorRecord>
+}
+
+/** A connector definition's optional async bulk-export capability. */
+export interface AsyncExportCapability {
+  createDriver(args: AsyncExportArgs): AsyncExportDriver
+}
+
+// ── Tuning ──────────────────────────────────────────────────────────────────────
+
+/** First poll delay; doubles each poll up to {@link POLL_MAX_MS}. */
+export const POLL_BASE_MS = 5_000
+/** Poll-delay ceiling — a long-running export is polled at most this often. */
+export const POLL_MAX_MS = 60_000
+/** Re-initiate budget for a FAILED/EXPIRED job before the run is failed permanently. */
+export const MAX_REINITIATE = 3
+
+/** Capped exponential poll backoff: 5s, 10s, 20s, 40s, 60s, 60s… */
+export function pollDelayMs(polls: number): number {
+  return Math.min(POLL_BASE_MS * 2 ** Math.max(0, polls), POLL_MAX_MS)
+}
+
+// ── Cursor codec ──────────────────────────────────────────────────────────────────
+// The async state rides the core's opaque `SyncCursor` (checkpointed by the
+// SyncStateStore, resumed each slice) — the core never interprets it, so we keep the
+// whole state machine inside the connector layer (no sync-core change).
+
+/** Encode the async-export state as the slice's resume cursor. */
+export function encodeAsyncCursor(state: AsyncExportState): SyncCursor {
+  return { kind: 'token', value: JSON.stringify(state) }
+}
+
+/** Decode the slice's resume cursor back to async-export state; absent/garbage ⇒ start at `init`. */
+export function decodeAsyncCursor(cursor?: SyncCursor): AsyncExportState {
+  if (!cursor?.value) return { stage: 'init' }
+  try {
+    const parsed = JSON.parse(cursor.value) as AsyncExportState
+    return parsed.stage ? parsed : { stage: 'init' }
+  } catch {
+    return { stage: 'init' }
+  }
+}

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -24,6 +24,7 @@ import type { RuntimeConnectionData } from '../connections/resolve-connection-fo
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { invalidateSnapshots } from '../snapshot'
 import type { SliceResult, SyncRunCounters, SyncSliceCtx, SyncSource } from '../sync-core/contracts'
+import { runAsyncExportSlice } from './async-export'
 import { runConnectorSlice } from './connector-slice-loop'
 import { reconcileOrphans } from './reconciliation'
 import { resolveRelationships } from './relationship-pass'
@@ -135,6 +136,24 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
     const syncCtx = await this.buildCtx(counters, this.deps.stream.mappings)
     const streamKey = this.deps.stream.streamKey
     if (!streamKey) throw new Error(`SyncSource ${this.id}: stream has no streamKey`)
+
+    // Async bulk export (Step 7): a large BACKFILL runs the initiate→poll→download
+    // lifecycle instead of synchronous paging. Steady deltas still page/webhook, so
+    // only the backfill phase branches here.
+    if (this.deps.definition.asyncExport && ctx.phase === 'backfill') {
+      const driver = this.deps.definition.asyncExport.createDriver({
+        streamKey,
+        credential: this.deps.credential,
+        config: this.deps.config,
+        requestConfig: this.deps.stream.requestConfig ?? undefined,
+      })
+      const result = await runAsyncExportSlice({
+        ctx,
+        driver,
+        sink: (record) => sinkSourceRecord(syncCtx, this.deps.stream.mappings, record),
+      })
+      return { ...result, counters: toSyncCounters(counters) }
+    }
 
     // Backfill paginates from the top/cursor (snapshot); steady incremental injects
     // the watermark delta floor (Step 5). The connector reads `state.backfillCursor`

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -13,6 +13,8 @@ import type { RuntimeConnectionData } from '../connections/resolve-connection-fo
 import type { RateLimitPolicy } from '../connections/transports/types'
 import { RateLimitError } from '../errors'
 import type { SyncCursor } from '../sync-core/contracts'
+// Type-only (erased at runtime) — no import cycle despite async-export importing back.
+import type { AsyncExportCapability } from './async-export/types'
 
 // ── Connector-level config (jsonb on DataConnector) ───────────────────────────
 
@@ -319,6 +321,13 @@ export interface DataConnectorDefinition {
   requestModel?: ConnectorRequestModel
   streams: ConnectorStreamDecl[]
   fetch(args: ConnectorFetchArgs): Promise<FetchResult>
+  /**
+   * Optional async bulk-export capability (Step 7). When present, a BACKFILL runs the
+   * initiate → poll → download lifecycle (rate-limit-exempt, the right tool for
+   * 100k+ reads) instead of synchronous paging; steady deltas still page/webhook.
+   * The capability builds a provider {@link AsyncExportDriver} per stream.
+   */
+  asyncExport?: AsyncExportCapability
   /** Map a provider delete event onto a (streamKey, externalId). */
   resolveDelete?(event: unknown): { streamKey: string; externalId: string } | null
 }


### PR DESCRIPTION
## Step 7a — Async bulk export, the provider-neutral engine (Phase E)

Some APIs don't paginate large reads — you submit a query, they run it **async** on their side, and hand back a single result file. Shopify Bulk Operations is the flagship (rate-limit-**exempt**, the recommended path for 100k+ reads); Salesforce Bulk 2.0 is the same shape. This PR builds the engine seam, fully unit-tested with a fake driver. **The real Shopify GraphQL driver is 7b.**

### The one load-bearing idea: a "slice" is a *phase of the job*, not a page

The naive implementation (`initiate(); while(!done) sleep+poll; download()`) holds a worker lock for minutes. Instead we map the async lifecycle onto the existing slice-continuation chain:

| Slice | Does | Returns | Worker effect |
|---|---|---|---|
| init | kick off job, checkpoint handle | `hasMore`, delay 5s, 0 records | re-enqueue, **lock released** |
| poll (running) | check status | `hasMore`, capped backoff 5s→60s, 0 records | re-enqueue, lock released |
| poll (completed) | got JSONL URL | move to download stage | re-enqueue immediately |
| download | stream restitched records → sink | records flow, then `complete` | normal slice |

A poll slice does **zero record work**, so waiting on a multi-minute export never starves the worker. It rides the existing runner / ledger / B1 latch / sink **unchanged** — the async job state is carried in the opaque `SyncCursor`, so there's **no sync-core change**.

### What's here (`packages/lib/src/data-connectors/async-export/`)
- **`AsyncExportDriver`** seam (`initiate`/`poll`/`download`) — the only provider-specific surface — hung off `DataConnectorDefinition.asyncExport`. Cursor codec keeps the whole state machine in the connector layer.
- **`runAsyncExportSlice`** — the init→poll→download state machine: capped poll backoff, re-initiate on `FAILED`/`EXPIRED` bounded by `MAX_REINITIATE=3` (then permanent-fail), idempotent abort re-download.
- **`restitchByParentId`** — re-nest the flat, unordered bulk JSONL (`__parentId` → parent `id`). Order-independent, multi-level (grandchildren via shared refs), provider `childKey` grouping, dangling-parent child → surfaced top-level (no data loss). The one genuinely new algorithm.
- **Wiring**: `ConnectorStreamSyncSource.fetchSlice` branches to the async loop when `definition.asyncExport && phase === 'backfill'` (steady deltas still page/webhook). Dormant until a driver sets the capability.

### Tests
**11 new** (6 restitch + 5 slice-loop: full lifecycle, re-initiate on failed/expired, max-attempts permanent fail, abort re-download). **62 green** across data-connectors + sync-core; biome clean.

### v1 limits (documented in code)
- Download + restitch is **one slice** — restitch needs the whole file, so it buffers it. Resumable mid-file download is deferred to 7b+ (the 7-day signed-URL deadline holds it).
- Graceful abort → full re-download, made safe by the sink's content-hash dedup.

### Out of scope
- **7b** — the real Shopify Bulk Ops driver (`bulkOperationRunQuery` + `bulkOperation(id)` poll + signed JSONL download) and the "large → bulk" template decision.
- **7c** — Salesforce Bulk API 2.0 (later, per the plan).