### PR TITLE
feat(data-connectors): connector progress UX (Step 9)

### DIFF
--- a/apps/web/src/components/data-connectors/lib/resolve-sync-status.test.ts
+++ b/apps/web/src/components/data-connectors/lib/resolve-sync-status.test.ts
@@ -1,0 +1,116 @@
+// apps/web/src/components/data-connectors/lib/resolve-sync-status.test.ts
+import { describe, expect, it } from 'vitest'
+import { classifyConnectorError, resolveSyncStatus } from './resolve-sync-status'
+
+const NOW = Date.parse('2026-06-22T12:00:00.000Z')
+
+describe('classifyConnectorError', () => {
+  it('flags auth/connection failures as reconnect', () => {
+    for (const msg of [
+      'Request failed: 401 Unauthorized',
+      'Forbidden (403)',
+      'invalid api key',
+      'OAuth token expired',
+      'authentication failed',
+      'permission denied',
+    ]) {
+      expect(classifyConnectorError(msg)).toBe('auth')
+    }
+  })
+
+  it('treats generic failures as retry', () => {
+    expect(classifyConnectorError('ECONNRESET')).toBe('generic')
+    expect(classifyConnectorError('sync stalled — checkpoint heartbeat went cold')).toBe('generic')
+    expect(classifyConnectorError(null)).toBe('generic')
+    expect(classifyConnectorError(undefined)).toBe('generic')
+  })
+})
+
+describe('resolveSyncStatus', () => {
+  it('maps pending → idle', () => {
+    const r = resolveSyncStatus({ status: 'pending' }, NOW)
+    expect(r.state).toBe('idle')
+    expect(r.primaryAction).toBe('sync')
+  })
+
+  it('maps paused → paused with resume', () => {
+    const r = resolveSyncStatus({ status: 'paused' }, NOW)
+    expect(r).toMatchObject({ state: 'paused', primaryAction: 'resume' })
+  })
+
+  it('maps an auth error → action-needed/reconnect', () => {
+    const r = resolveSyncStatus({ status: 'error', error: '401 Unauthorized' }, NOW)
+    expect(r).toMatchObject({ state: 'action-needed', primaryAction: 'reconnect' })
+  })
+
+  it('maps a generic error → error/retry and surfaces the message', () => {
+    const r = resolveSyncStatus({ status: 'error', error: 'upstream 500' }, NOW)
+    expect(r).toMatchObject({ state: 'error', primaryAction: 'retry', detail: 'upstream 500' })
+  })
+
+  it('derives rate-limited from a future rateLimitedUntil while syncing', () => {
+    const until = new Date(NOW + 28_000).toISOString()
+    const r = resolveSyncStatus(
+      { status: 'syncing', latestRun: { status: 'running', rateLimitedUntil: until } },
+      NOW
+    )
+    expect(r.state).toBe('rate-limited')
+    expect(r.countdownUntil).toBe(until)
+    expect(r.primaryAction).toBeUndefined()
+  })
+
+  it('falls through to plain syncing once the rate-limit window passes', () => {
+    const until = new Date(NOW - 1_000).toISOString() // already elapsed
+    const r = resolveSyncStatus(
+      {
+        status: 'syncing',
+        latestRun: { status: 'running', rateLimitedUntil: until, recordsSeen: 0 },
+      },
+      NOW
+    )
+    expect(r.state).toBe('syncing')
+  })
+
+  it('shows live backfill counts with the active stream noun', () => {
+    const r = resolveSyncStatus(
+      {
+        status: 'syncing',
+        latestRun: {
+          status: 'running',
+          phase: 'backfill',
+          recordsSeen: 3250,
+          primaryStreamLabel: 'orders',
+        },
+      },
+      NOW
+    )
+    expect(r).toMatchObject({ state: 'syncing', primaryAction: 'pause' })
+    expect(r.detail).toBe('Importing orders — 3,250 records so far')
+  })
+
+  it('does not show "records so far" for a steady run', () => {
+    const r = resolveSyncStatus(
+      { status: 'syncing', latestRun: { status: 'running', phase: 'steady', recordsSeen: 9999 } },
+      NOW
+    )
+    expect(r.detail).toBe('Syncing…')
+  })
+
+  it('labels provisioning distinctly', () => {
+    expect(resolveSyncStatus({ status: 'provisioning' }, NOW).label).toBe('Provisioning')
+  })
+
+  it('maps live → synced with a per-run delta', () => {
+    const r = resolveSyncStatus(
+      { status: 'live', latestRun: { status: 'completed', created: 3, updated: 12 } },
+      NOW
+    )
+    expect(r).toMatchObject({ state: 'synced', primaryAction: 'sync' })
+    expect(r.detail).toBe('Last run: +12 updated, +3 new')
+  })
+
+  it('maps live with no changes → "Up to date."', () => {
+    const r = resolveSyncStatus({ status: 'live', latestRun: { status: 'completed' } }, NOW)
+    expect(r.detail).toBe('Up to date.')
+  })
+})

--- a/apps/web/src/components/data-connectors/lib/resolve-sync-status.ts
+++ b/apps/web/src/components/data-connectors/lib/resolve-sync-status.ts
@@ -1,0 +1,166 @@
+// apps/web/src/components/data-connectors/lib/resolve-sync-status.ts
+// The pure, client-safe status resolver (Step 9 §3.2). Maps the raw connector
+// lifecycle status + its latest run onto the freshness-first vocabulary the status
+// line / list card / detail pill all render: Synced · Syncing · Rate-limited ·
+// Paused · Action needed · Error (+ Idle for a not-yet-configured source). Two of
+// the live states are DERIVED, not raw enum values:
+//   • Rate-limited = syncing AND the run's `rateLimited.until` is set + in the future.
+//   • Action needed = error AND the message classifies as an auth/connection failure
+//     (reconnect) vs. a generic retryable Error.
+// No server imports, no time-relative formatting — freshness ("4 min ago", the live
+// "0:28" countdown) is composed by the component from `countdownUntil` + the status
+// payload's lastSyncedAt/nextSyncAt. Keep this dependency-light so it can't pull a
+// server-only module into a client bundle (CLAUDE.md client rule).
+
+import type { ConnectorStatus } from '../ui/connector-status'
+
+/**
+ * The resolved status vocabulary. The first six are the plan's live states; `idle`
+ * covers a `pending` connector (no mappings / never synced) so it isn't miscolored
+ * as one of the active states.
+ */
+export type SyncStatusState =
+  | 'synced'
+  | 'syncing'
+  | 'rate-limited'
+  | 'paused'
+  | 'action-needed'
+  | 'error'
+  | 'idle'
+
+/**
+ * The header CTA the state implies. `pause` is included (the plan's §3.2 list omits
+ * it, but the §10.1 mock shows [Pause] while syncing — the resolver is the source of
+ * truth for which action a state offers).
+ */
+export type SyncPrimaryAction = 'sync' | 'pause' | 'resume' | 'reconnect' | 'retry'
+
+/** The slice of the latest `DataConnectorRun` the resolver reads (from `getStatus`). */
+export interface SyncStatusRunInfo {
+  /** 'running' | 'completed' | 'partial' | 'failed'. */
+  status: string
+  /** Engine lifecycle phase; absent/null on legacy single-shot runs. */
+  phase?: 'backfill' | 'steady' | null
+  /** Live aggregate records-seen across the connector's streams (backfill counts). */
+  recordsSeen?: number
+  /** ISO time the next slice is throttled until, or null/absent when not rate-limited. */
+  rateLimitedUntil?: string | null
+  /** Per-run delta for the steady freshness line. */
+  created?: number
+  updated?: number
+  /** The actively-importing stream's key (e.g. "orders"), for the backfill detail noun. */
+  primaryStreamLabel?: string | null
+}
+
+export interface SyncStatusInput {
+  status: ConnectorStatus
+  /** The connector's last error message (free text — no code is persisted). */
+  error?: string | null
+  latestRun?: SyncStatusRunInfo | null
+}
+
+export interface ResolvedSyncStatus {
+  state: SyncStatusState
+  /** Short label for the pill/dot ("Syncing", "Action needed"). */
+  label: string
+  /** One-line description WITHOUT relative time (counts + static copy only). */
+  detail: string
+  /** ISO instant a live countdown ticks toward ("retrying in 0:28"); rate-limited only. */
+  countdownUntil?: string
+  primaryAction?: SyncPrimaryAction
+}
+
+// Auth/connection failures the user must act on (reconnect) vs. a generic retryable
+// error. We only have the persisted message string to go on, so match the common
+// shapes AuxxError messages and provider 401/403s produce.
+const AUTH_ERROR_HINTS =
+  /\b(unauthor|forbidden|401|403|invalid[\s_-]*(token|credential|api[\s_-]*key)|token[\s_-]*expired|expired[\s_-]*token|reconnect|authentication|permission[\s_-]*denied|access[\s_-]*denied|credential)\b/i
+
+/** Classify a connector error message into the "reconnect" vs. "retry" bucket. */
+export function classifyConnectorError(error?: string | null): 'auth' | 'generic' {
+  return error && AUTH_ERROR_HINTS.test(error) ? 'auth' : 'generic'
+}
+
+/**
+ * Resolve the connector's display status. Pure — pass `now` (ms) to make the
+ * rate-limited countdown deterministic in tests; defaults to `Date.now()`.
+ */
+export function resolveSyncStatus(
+  input: SyncStatusInput,
+  now: number = Date.now()
+): ResolvedSyncStatus {
+  const { status, error, latestRun } = input
+
+  if (status === 'pending') {
+    return {
+      state: 'idle',
+      label: 'Not set up',
+      detail: 'Add a source and field mappings to start syncing.',
+      primaryAction: 'sync',
+    }
+  }
+
+  if (status === 'paused') {
+    return {
+      state: 'paused',
+      label: 'Paused',
+      detail: 'Syncing is paused.',
+      primaryAction: 'resume',
+    }
+  }
+
+  if (status === 'error') {
+    if (classifyConnectorError(error) === 'auth') {
+      return {
+        state: 'action-needed',
+        label: 'Action needed',
+        detail: 'Reconnect the source — the connection expired.',
+        primaryAction: 'reconnect',
+      }
+    }
+    return {
+      state: 'error',
+      label: 'Error',
+      detail: error?.trim() || 'Last sync failed.',
+      primaryAction: 'retry',
+    }
+  }
+
+  if (status === 'syncing' || status === 'provisioning') {
+    // Rate-limited is derived: a throttled slice stamped `rateLimited.until` in the
+    // future. Once it passes (the next slice ran), fall through to plain syncing.
+    const until = latestRun?.rateLimitedUntil
+    if (until && new Date(until).getTime() > now) {
+      return {
+        state: 'rate-limited',
+        label: 'Rate-limited',
+        detail: 'Waiting for the source — too many requests. Auto-resumes.',
+        countdownUntil: until,
+        // No CTA: it self-heals. (Pause is still available elsewhere on the page.)
+      }
+    }
+
+    const records = latestRun?.recordsSeen ?? 0
+    // "records so far" is a backfill concept; steady deltas use the run +n/+n line.
+    const isBackfill = !latestRun || latestRun.phase !== 'steady'
+    const noun = latestRun?.primaryStreamLabel?.trim() || 'records'
+    const detail =
+      isBackfill && records > 0
+        ? `Importing ${noun} — ${records.toLocaleString()} records so far`
+        : 'Syncing…'
+    return {
+      state: 'syncing',
+      label: status === 'provisioning' ? 'Provisioning' : 'Syncing',
+      detail,
+      primaryAction: 'pause',
+    }
+  }
+
+  // status === 'live' → Synced. Detail carries the per-run delta when there was one;
+  // freshness ("last synced 4 min ago · next in 11 min") is composed by the component.
+  const created = latestRun?.created ?? 0
+  const updated = latestRun?.updated ?? 0
+  const detail =
+    created > 0 || updated > 0 ? `Last run: +${updated} updated, +${created} new` : 'Up to date.'
+  return { state: 'synced', label: 'Synced', detail, primaryAction: 'sync' }
+}

--- a/apps/web/src/components/data-connectors/ui/connector-backfill-progress.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-backfill-progress.tsx
@@ -1,0 +1,113 @@
+// apps/web/src/components/data-connectors/ui/connector-backfill-progress.tsx
+'use client'
+
+import { LastUpdated } from '@auxx/ui/components/last-updated'
+import { cn } from '@auxx/ui/lib/utils'
+import { ArrowRight } from 'lucide-react'
+
+/** One stream's live import progress, projected from `getStatus.perStream`. */
+export interface BackfillStreamProgress {
+  streamKey: string
+  recordsSeen: number
+  phase: 'backfill' | 'steady'
+  done: boolean
+}
+
+interface ConnectorBackfillProgressProps {
+  /** The source being imported from (the connector name). */
+  sourceLabel: string
+  /** When the current backfill run started (latestRun.startedAt). */
+  startedAt?: Date | string | null
+  perStream: BackfillStreamProgress[]
+}
+
+/**
+ * The initial-backfill progress card (Step 9 §10.2) — live per-stream counts + a
+ * Fetch→Map→Save flow indicator, shown only while a backfill is in flight. Counts are
+ * the real signal; bars encode STATE (working vs. done), never a percent-of-total —
+ * upstream totals are unknown, so we never fake a denominator (§1). Mirrors Airbyte's
+ * per-stream counts + Stitch's pipeline metaphor.
+ */
+export function ConnectorBackfillProgress({
+  sourceLabel,
+  startedAt,
+  perStream,
+}: ConnectorBackfillProgressProps) {
+  const total = perStream.reduce((n, s) => n + s.recordsSeen, 0)
+
+  return (
+    <div className='flex flex-col gap-3 border-b bg-muted/30 px-4 py-3'>
+      <div className='text-xs font-semibold text-muted-foreground'>
+        Importing from {sourceLabel}
+      </div>
+
+      <div className='flex flex-col gap-2'>
+        {perStream.map((s) => (
+          <StreamRow key={s.streamKey || '∅'} stream={s} />
+        ))}
+      </div>
+
+      <PipelineFlow />
+
+      <div className='text-[11px] text-muted-foreground'>
+        {startedAt && (
+          <>
+            <LastUpdated timestamp={startedAt} prefix='Started' className='text-[11px]' />
+            {' · '}
+          </>
+        )}
+        {total.toLocaleString()} records so far
+      </div>
+    </div>
+  )
+}
+
+/** A stream's row: name, an activity bar (state color, not %), count, and status word. */
+function StreamRow({ stream }: { stream: BackfillStreamProgress }) {
+  return (
+    <div className='flex items-center gap-2 text-xs'>
+      <span className='w-24 shrink-0 truncate capitalize' title={stream.streamKey}>
+        {stream.streamKey || 'Records'}
+      </span>
+      <div className='h-1.5 flex-1 overflow-hidden rounded-full bg-foreground/10'>
+        <div
+          className={cn(
+            'h-full w-full rounded-full',
+            stream.done ? 'bg-green-500/70' : 'animate-pulse bg-amber-500/70'
+          )}
+        />
+      </div>
+      <span className='w-20 shrink-0 text-right tabular-nums text-muted-foreground'>
+        {stream.recordsSeen.toLocaleString()}
+      </span>
+      <span
+        className={cn(
+          'w-16 shrink-0 text-right',
+          stream.done ? 'text-green-600' : 'text-amber-600'
+        )}>
+        {stream.done ? 'done' : 'fetching…'}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * The Fetch → Map → Save flow metaphor (Stitch). Our engine streams records through
+ * all three continuously, so during a backfill all three read as active — it conveys
+ * "data is flowing", not staged percentages.
+ */
+function PipelineFlow() {
+  return (
+    <div className='flex items-center gap-1.5 text-[11px] text-muted-foreground'>
+      {['Fetch', 'Map', 'Save'].map((label, i) => (
+        <span key={label} className='inline-flex items-center gap-1.5'>
+          {i > 0 && <ArrowRight className='size-3 opacity-50' />}
+          <span className='inline-flex items-center gap-1'>
+            <span className='size-1.5 animate-pulse rounded-full bg-amber-500' />
+            {label}
+          </span>
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -15,17 +15,20 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { ChevronDown, Pause, Play, RefreshCw, Trash } from 'lucide-react'
+import { ChevronDown, Pause, Play, Plug, RefreshCw, Trash } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { useQueryState } from 'nuqs'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useMedia } from '~/hooks/use-media'
 import { useDockStore } from '~/stores/dock-store'
-import type { api } from '~/trpc/react'
+import { api } from '~/trpc/react'
 import { useConnectorMutations } from '../hooks/use-connector-mutations'
+import { resolveSyncStatus } from '../lib/resolve-sync-status'
 import { ConnectorDetailTabs } from './connector-detail-tabs'
 import { ConnectorRunsPanel } from './connector-runs-panel'
-import { asConnectorStatus, ConnectorStatusPill } from './connector-status'
+import { asConnectorStatus } from './connector-status'
+import { ConnectorStatusLine } from './connector-status-line'
 
 type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
 
@@ -54,10 +57,32 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
   const maxWidth = useDockStore((state) => state.maxWidth)
 
   const [confirm, ConfirmDialog] = useConfirm()
+  const [, setTab] = useQueryState('tab')
 
   const status = asConnectorStatus(connector.status)
   const isSyncing = status === 'syncing' || status === 'provisioning'
   const isPaused = status === 'paused'
+
+  // Live status for the freshness line + the derived "Action needed" reconnect CTA.
+  // Polls only while a sync is in flight (4s, matching the Runs panel — same query
+  // key, so the two share one request). The header Sync/Pause/Resume buttons stay on
+  // the optimistic getById `status` so their instant feedback is preserved.
+  const statusQuery = api.dataConnector.getStatus.useQuery(
+    { id: connector.id },
+    {
+      refetchInterval: (query) => {
+        const s = query.state.data?.status ?? connector.status
+        return s === 'syncing' || s === 'provisioning' ? 4000 : false
+      },
+    }
+  )
+  const live = statusQuery.data
+  const liveStatus = asConnectorStatus(live?.status ?? connector.status)
+  const resolved = resolveSyncStatus({
+    status: liveStatus,
+    error: live?.error ?? connector.error,
+    latestRun: live?.latestRun ?? null,
+  })
 
   const {
     syncNow,
@@ -86,7 +111,13 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
     if (ok && (await remove(connector.id, syncedData))) router.push('/app/connectors')
   }
 
-  const runsPanel = <ConnectorRunsPanel connectorId={connector.id} initialStatus={status} />
+  const runsPanel = (
+    <ConnectorRunsPanel
+      connectorId={connector.id}
+      initialStatus={status}
+      sourceLabel={connector.name}
+    />
+  )
 
   return (
     <MainPage>
@@ -104,6 +135,12 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
               <RefreshCw />
               Sync now
             </Button>
+            {resolved.state === 'action-needed' && (
+              <Button variant='outline' size='sm' onClick={() => void setTab('connection')}>
+                <Plug />
+                Reconnect
+              </Button>
+            )}
             {isPaused ? (
               <Button
                 variant='outline'
@@ -154,7 +191,13 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
             }
             last
           />
-          <ConnectorStatusPill status={status} className='ml-2' />
+          <ConnectorStatusLine
+            status={liveStatus}
+            error={live?.error ?? connector.error}
+            lastSyncedAt={live?.lastSyncedAt ?? connector.lastSyncedAt}
+            latestRun={live?.latestRun ?? null}
+            className='ml-2'
+          />
         </MainPageBreadcrumb>
       </MainPageHeader>
 

--- a/apps/web/src/components/data-connectors/ui/connector-freshness-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-freshness-panel.tsx
@@ -1,0 +1,71 @@
+// apps/web/src/components/data-connectors/ui/connector-freshness-panel.tsx
+'use client'
+
+import { LastUpdated } from '@auxx/ui/components/last-updated'
+
+interface ConnectorFreshnessPanelProps {
+  lastSyncedAt: Date | string | null
+  /** Derived next-sync ISO (scheduled only); null for manual/webhook/custom-cron. */
+  nextSyncAt: string | null
+  /** Human cadence, e.g. "every 15 minutes". */
+  cadenceLabel: string | null
+  /** 'manual' | 'scheduled' | 'webhook'. */
+  syncBehavior: string
+  latestRun?: { created?: number; updated?: number } | null
+}
+
+/**
+ * The steady-phase freshness panel (Step 9 §10.3) — a non-programmer's "is this up to
+ * date?" at a glance: last/next synced, the latest run's delta, and how it keeps fresh.
+ * Shown between runs (not during a backfill — that's the import card). All relative
+ * times self-update via `LastUpdated`; nothing here is a cursor or a percent.
+ */
+export function ConnectorFreshnessPanel({
+  lastSyncedAt,
+  nextSyncAt,
+  cadenceLabel,
+  syncBehavior,
+  latestRun,
+}: ConnectorFreshnessPanelProps) {
+  const created = latestRun?.created ?? 0
+  const updated = latestRun?.updated ?? 0
+  const delta = created > 0 || updated > 0 ? `+${updated} updated, +${created} new` : 'No changes'
+
+  return (
+    <div className='grid grid-cols-2 gap-x-4 gap-y-2 border-b bg-muted/30 px-4 py-3 text-xs'>
+      <Cell label='Last synced'>
+        {lastSyncedAt ? <LastUpdated timestamp={lastSyncedAt} className='text-xs' /> : '—'}
+      </Cell>
+      <Cell label='Synced this run'>{delta}</Cell>
+
+      <Cell label='Next sync'>{nextSync(nextSyncAt, syncBehavior, cadenceLabel)}</Cell>
+      <Cell label='Keeping up to date'>{cadence(syncBehavior, cadenceLabel)}</Cell>
+    </div>
+  )
+}
+
+/** The "Next sync" value — a relative time when scheduled, else the trigger model. */
+function nextSync(nextSyncAt: string | null, syncBehavior: string, cadenceLabel: string | null) {
+  if (nextSyncAt) return <LastUpdated timestamp={nextSyncAt} className='text-xs' />
+  if (syncBehavior === 'webhook') return 'On changes'
+  if (syncBehavior === 'manual') return 'On demand'
+  // Scheduled but no derivable next-time (custom cron).
+  return cadenceLabel ?? 'Not scheduled'
+}
+
+/** The freshness-source subtitle. */
+function cadence(syncBehavior: string, cadenceLabel: string | null): string {
+  if (syncBehavior === 'webhook') return 'Live via webhooks'
+  if (syncBehavior === 'manual') return 'Syncs when you run it'
+  return cadenceLabel ?? 'Not scheduled'
+}
+
+/** A labeled value cell (muted label over the value). */
+function Cell({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className='flex flex-col gap-0.5'>
+      <span className='text-[11px] text-muted-foreground'>{label}</span>
+      <span className='text-foreground'>{children}</span>
+    </div>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
@@ -17,11 +17,15 @@ import {
   XCircle,
 } from 'lucide-react'
 import { api } from '~/trpc/react'
+import { ConnectorBackfillProgress } from './connector-backfill-progress'
+import { ConnectorFreshnessPanel } from './connector-freshness-panel'
 import type { ConnectorStatus } from './connector-status'
 
 interface ConnectorRunsPanelProps {
   connectorId: string
   initialStatus: ConnectorStatus
+  /** The source name, shown on the live "Importing from …" backfill card. */
+  sourceLabel: string
 }
 
 const RUN_STATUS_META: Record<
@@ -64,7 +68,11 @@ function CountChip({
  * warnings, durations, cursor + error samples. Reuses execution-progress styling.
  * See plans/data-connectors/claude/05-frontend.md §6.
  */
-export function ConnectorRunsPanel({ connectorId, initialStatus }: ConnectorRunsPanelProps) {
+export function ConnectorRunsPanel({
+  connectorId,
+  initialStatus,
+  sourceLabel,
+}: ConnectorRunsPanelProps) {
   const statusQuery = api.dataConnector.getStatus.useQuery(
     { id: connectorId },
     {
@@ -84,6 +92,17 @@ export function ConnectorRunsPanel({ connectorId, initialStatus }: ConnectorRuns
 
   const rows = runs.data ?? []
 
+  // Live initial-backfill card (Step 9 §10.2): only while a backfill chain is in
+  // flight. Steady runs use the per-run counts below; this is the "first import" view.
+  const latestRun = statusQuery.data?.latestRun
+  const perStream = statusQuery.data?.perStream ?? []
+  const showBackfill = isSyncing && latestRun?.phase === 'backfill' && perStream.length > 0
+
+  // Steady freshness summary (Step 9 §10.3): once the source has synced and isn't
+  // mid-backfill, show last/next synced + the latest run's delta instead of the card.
+  const lastSyncedAt = statusQuery.data?.lastSyncedAt ?? null
+  const showFreshness = !showBackfill && !!lastSyncedAt
+
   return (
     <div className='flex h-full flex-col bg-background'>
       <div className='flex shrink-0 items-center justify-between border-b px-4 py-3'>
@@ -99,6 +118,24 @@ export function ConnectorRunsPanel({ connectorId, initialStatus }: ConnectorRuns
           </Badge>
         )}
       </div>
+
+      {showBackfill && (
+        <ConnectorBackfillProgress
+          sourceLabel={sourceLabel}
+          startedAt={latestRun?.startedAt}
+          perStream={perStream}
+        />
+      )}
+
+      {showFreshness && (
+        <ConnectorFreshnessPanel
+          lastSyncedAt={lastSyncedAt}
+          nextSyncAt={statusQuery.data?.nextSyncAt ?? null}
+          cadenceLabel={statusQuery.data?.cadenceLabel ?? null}
+          syncBehavior={statusQuery.data?.syncBehavior ?? 'manual'}
+          latestRun={latestRun}
+        />
+      )}
 
       <ScrollArea className='flex-1' scrollbarClassName='w-1.5'>
         <div className='flex flex-col divide-y'>

--- a/apps/web/src/components/data-connectors/ui/connector-status-line.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-status-line.tsx
@@ -1,0 +1,130 @@
+// apps/web/src/components/data-connectors/ui/connector-status-line.tsx
+'use client'
+
+import { LastUpdated } from '@auxx/ui/components/last-updated'
+import { cn } from '@auxx/ui/lib/utils'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  PauseCircle,
+  RefreshCw,
+  Wrench,
+  XCircle,
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  resolveSyncStatus,
+  type SyncStatusRunInfo,
+  type SyncStatusState,
+} from '../lib/resolve-sync-status'
+import type { ConnectorStatus } from './connector-status'
+
+/** Per-state icon + text color for the status-line chip. */
+const STATE_META: Record<
+  SyncStatusState,
+  { icon: React.ComponentType<{ className?: string }>; className: string; spin?: boolean }
+> = {
+  synced: { icon: CheckCircle2, className: 'text-green-600' },
+  syncing: { icon: RefreshCw, className: 'text-amber-600', spin: true },
+  'rate-limited': { icon: Clock, className: 'text-amber-600' },
+  paused: { icon: PauseCircle, className: 'text-muted-foreground' },
+  'action-needed': { icon: AlertTriangle, className: 'text-amber-600' },
+  error: { icon: XCircle, className: 'text-red-600' },
+  idle: { icon: Wrench, className: 'text-muted-foreground' },
+}
+
+interface ConnectorStatusLineProps {
+  /** Live connector status (polled `getStatus`, falling back to the row value). */
+  status: ConnectorStatus
+  error?: string | null
+  lastSyncedAt?: Date | string | null
+  latestRun?: SyncStatusRunInfo | null
+  className?: string
+}
+
+/**
+ * The at-a-glance, freshness-first status line for the connector detail header
+ * (Step 9 §10.1) — replaces `ConnectorStatusPill`. A state chip (icon + label) plus a
+ * concise secondary line: live import counts while syncing, a self-healing countdown
+ * while rate-limited, or "last synced …" when idle. Honest copy only — never a fake
+ * percent. Actions (Sync / Pause / Reconnect) live in the header, not here.
+ */
+export function ConnectorStatusLine({
+  status,
+  error,
+  lastSyncedAt,
+  latestRun,
+  className,
+}: ConnectorStatusLineProps) {
+  const resolved = resolveSyncStatus({ status, error, latestRun })
+  const meta = STATE_META[resolved.state]
+  const Icon = meta.icon
+
+  return (
+    <span className={cn('inline-flex min-w-0 items-center gap-2 text-xs', className)}>
+      <span className={cn('inline-flex shrink-0 items-center gap-1 font-medium', meta.className)}>
+        <Icon className={cn('size-3.5', meta.spin && 'animate-spin')} />
+        {resolved.label}
+      </span>
+      <SecondaryLine
+        state={resolved.state}
+        detail={resolved.detail}
+        countdownUntil={resolved.countdownUntil}
+        lastSyncedAt={lastSyncedAt}
+      />
+    </span>
+  )
+}
+
+/** The muted secondary copy — composed per state so the live countdown can interleave. */
+function SecondaryLine({
+  state,
+  detail,
+  countdownUntil,
+  lastSyncedAt,
+}: {
+  state: SyncStatusState
+  detail: string
+  countdownUntil?: string
+  lastSyncedAt?: Date | string | null
+}) {
+  if (state === 'rate-limited' && countdownUntil) {
+    return (
+      <span className='truncate text-muted-foreground'>
+        Waiting for the source · retrying in <Countdown until={countdownUntil} /> (auto-resumes)
+      </span>
+    )
+  }
+
+  // Synced → freshness ("last synced 4 min ago"); the per-run delta + "next in …"
+  // line is the steady-freshness panel (Step 9 Phase 3), not this compact line.
+  if (state === 'synced' && lastSyncedAt) {
+    return (
+      <LastUpdated className='truncate text-xs' timestamp={lastSyncedAt} prefix='Last synced' />
+    )
+  }
+
+  return <span className='truncate text-muted-foreground'>{detail}</span>
+}
+
+/** A 1s-ticking "m:ss" countdown toward `until`; clamps at 0:00 (pure client, no fetch). */
+function Countdown({ until }: { until: string }) {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const target = new Date(until).getTime()
+    if (Number.isNaN(target)) return
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(timer)
+  }, [until])
+
+  const remainingMs = Math.max(0, new Date(until).getTime() - now)
+  const totalSeconds = Math.ceil(remainingMs / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return (
+    <span className='tabular-nums'>
+      {minutes}:{String(seconds).padStart(2, '0')}
+    </span>
+  )
+}

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -14,6 +14,7 @@ import {
   type DataConnectorType,
   decodeMapping,
   deleteConnector,
+  deriveConnectorScheduleInfo,
   enqueueConnectorSync,
   getAllConnectorTemplates,
   getConnector,
@@ -211,7 +212,15 @@ export const dataConnectorRouter = createTRPCRouter({
     return { ...connector, connectionHint }
   }),
 
-  /** Lightweight status poll (in-flight sync UI). */
+  /**
+   * Status poll for the in-flight sync UI (4s while syncing). Beyond the raw
+   * lifecycle fields it carries everything the client `resolveSyncStatus` resolver +
+   * status line need in one round-trip (Step 9 §3.3): the derived next-sync time +
+   * human cadence, a projection of the latest run (incl. the transient
+   * `rateLimitedUntil` for the live countdown), and per-stream live counts for the
+   * backfill view. Per-stream `recordsSeen`/`phase` come straight off the stream
+   * states (the source of truth) rather than denormalized onto the run.
+   */
   getStatus: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
@@ -220,11 +229,67 @@ export const dataConnectorRouter = createTRPCRouter({
         throw new TRPCError({ code: 'NOT_FOUND', message: result.error.message })
       }
       const c = result.value
+
+      const [runs, streams] = await Promise.all([
+        listRuns(ctx.db, ctx.session.organizationId, input.id, 1),
+        listStreams(ctx.db, ctx.session.organizationId, input.id),
+      ])
+      const latest = runs[0] ?? null
+
+      // Per-stream live progress, read off each stream's durable state jsonb. `done`
+      // = the stream has flipped to steady (its backfill exhausted).
+      const perStream = streams.map((s) => {
+        const st = (s.state ?? {}) as { recordsSeen?: number; phase?: 'backfill' | 'steady' }
+        return {
+          streamKey: s.streamKey ?? '',
+          recordsSeen: st.recordsSeen ?? 0,
+          phase: st.phase ?? ('backfill' as const),
+          done: st.phase === 'steady',
+        }
+      })
+      const recordsSeen = perStream.reduce((n, s) => n + s.recordsSeen, 0)
+      // The actively-importing stream (most records this run) names the backfill detail.
+      const top = perStream.reduce<(typeof perStream)[number] | null>(
+        (a, b) => (a && a.recordsSeen >= b.recordsSeen ? a : b),
+        null
+      )
+
+      const { nextSyncAt, cadenceLabel } = deriveConnectorScheduleInfo({
+        syncBehavior: c.syncBehavior,
+        status: c.status,
+        scheduleConfig: c.scheduleConfig,
+        lastSyncedAt: c.lastSyncedAt,
+      })
+
+      const latestRun = latest
+        ? {
+            id: latest.id,
+            status: latest.status,
+            phase: latest.phase as 'backfill' | 'steady' | null,
+            trigger: latest.trigger,
+            mode: latest.mode,
+            recordsSeen,
+            created: latest.created,
+            updated: latest.updated,
+            startedAt: latest.startedAt,
+            finishedAt: latest.finishedAt,
+            rateLimitedUntil:
+              (latest.progress as { rateLimited?: { until?: string } } | null)?.rateLimited
+                ?.until ?? null,
+            primaryStreamLabel: top?.streamKey || null,
+          }
+        : null
+
       return {
         status: c.status,
+        syncBehavior: c.syncBehavior,
         lastSyncedAt: c.lastSyncedAt,
         itemCount: c.itemCount,
         error: c.error,
+        nextSyncAt,
+        cadenceLabel,
+        latestRun,
+        perStream,
       }
     }),
 


### PR DESCRIPTION
## Step 9 — Connector progress UX

The human surface for the sync engine, grounded in the real UI. Consumes the `schedule-info` helper + barrel exports that landed in #928 (now on `main`).

### What's in it
- **`resolve-sync-status`** — shared 6-state status resolver (Synced / Syncing / Rate-limited / Paused / Action needed / Error) + tests.
- **`connector-status-line`** — the connector status pill.
- **`connector-backfill-progress`** — backfill counts + Fetch→Map→Save pipeline (no fake percent bar).
- **`connector-freshness-panel`** — steady freshness (last/next synced, per-run delta).
- **`connector-detail-view` / `connector-runs-panel`** — wired to the new surfaces + the engine's `recordsSeen`/`phase`/`progress`.
- **`data-connectors` router** — exposes the schedule/status derivation (`deriveConnectorScheduleInfo`).

### Notes
- These are pre-existing working-tree changes bundled here per request; **not authored or validated in the Step 8 session**.
- Was originally stacked on #928; rebased onto `main` after that merged, so the diff is the 8 `apps/web` files only.