### PR TITLE
feat(ui): shared MetricGrid + CSV utils + full-bleed drawer cards

### DIFF
--- a/apps/web/src/components/config/config-drawer.tsx
+++ b/apps/web/src/components/config/config-drawer.tsx
@@ -2,7 +2,6 @@
 'use client'
 
 import { Alert, AlertDescription } from '@auxx/ui/components/alert'
-import { CardContent, CardHeader, CardTitle } from '@auxx/ui/components/card'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
 import { DrawerHeader } from '@auxx/ui/components/drawer'
 import { EntityIcon } from '@auxx/ui/components/icons'
@@ -12,6 +11,7 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from '@auxx/ui/components/input-group'
+import { MetricCell, MetricGrid } from '@auxx/ui/components/metric-grid'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Field } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
@@ -181,57 +181,24 @@ export function ConfigDrawer({ variableKey, open, onOpenChange, isDbEnabled }: C
 
         {/* Metrics grid */}
         {variable && definition && (
-          <div className='grid grid-cols-2 border-b'>
-            {/* Source */}
-            <div className='border-r border-b'>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>Source</CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <SourceBadge source={variable.source} />
-              </CardContent>
-            </div>
-
-            {/* Type */}
-            <div className='border-b'>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>Type</CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <TypeBadge type={definition.type} />
-              </CardContent>
-            </div>
-
-            {/* Group */}
-            <div className='border-r'>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>Group</CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <div className='flex items-center gap-2'>
-                  <Folder className='h-4 w-4 text-muted-foreground' />
-                  <span className='text-sm font-semibold'>{definition.group}</span>
-                </div>
-              </CardContent>
-            </div>
-
-            {/* Sensitive */}
-            <div>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>
-                  Sensitive
-                </CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <div className='flex items-center gap-2'>
-                  <Lock className='h-4 w-4 text-muted-foreground' />
-                  <span className='text-sm font-semibold'>
-                    {definition.isSensitive ? 'Yes' : 'No'}
-                  </span>
-                </div>
-              </CardContent>
-            </div>
-          </div>
+          <MetricGrid columns={2}>
+            <MetricCell label='Source'>
+              <SourceBadge source={variable.source} />
+            </MetricCell>
+            <MetricCell label='Type'>
+              <TypeBadge type={definition.type} />
+            </MetricCell>
+            <MetricCell
+              label='Group'
+              icon={<Folder className='size-4 text-muted-foreground' />}
+              value={definition.group}
+            />
+            <MetricCell
+              label='Sensitive'
+              icon={<Lock className='size-4 text-muted-foreground' />}
+              value={definition.isSensitive ? 'Yes' : 'No'}
+            />
+          </MetricGrid>
         )}
 
         <ScrollArea className='flex-1'>

--- a/apps/web/src/components/connections/ui/connections-section.tsx
+++ b/apps/web/src/components/connections/ui/connections-section.tsx
@@ -229,42 +229,54 @@ export function ConnectionsSection() {
                 return <ConnectionStackCard key={group.key} group={group} onToggle={toggle} />
               }
               // Expanded: a self-contained block (header + nested cards) so it reads as the stack,
-              // not loose top-level cards detached from a narrow tile.
+              // not loose top-level cards detached from a narrow tile. It claims its own row
+              // (`col-span-full`) so its height never stretches the sibling cards, but a nested grid
+              // mirroring the column template caps the block to a single tile's width.
               return (
-                <div
-                  key={group.key}
-                  className='col-span-full flex flex-col gap-2 rounded-2xl border bg-muted/40 p-2'>
-                  <button
-                    type='button'
-                    onClick={toggle}
-                    className='flex w-full items-center gap-2 rounded-xl px-1 py-1 text-left hover:bg-muted/60'>
-                    <div className='flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-xl border bg-background'>
-                      <AppIcon iconId={group.iconId} size='sm' />
+                <div key={group.key} className='col-span-full'>
+                  <div className='grid w-full gap-2 @sm:grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3'>
+                    <div className='flex flex-col gap-2 rounded-2xl border bg-muted/40 p-2'>
+                      {/* Header mirrors the collapsed face: icon, then title + "N connections" on a
+                          second row, so toggling open/closed reads as the same card. */}
+                      <button
+                        type='button'
+                        onClick={toggle}
+                        className='flex w-full items-start gap-2 rounded-xl px-1 py-1 text-left hover:bg-muted/60'>
+                        <div className='flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-xl border bg-background'>
+                          <AppIcon iconId={group.iconId} size='sm' />
+                        </div>
+                        <div className='flex flex-1 flex-col'>
+                          <div className='flex items-center justify-between gap-1'>
+                            <span className='text-sm font-semibold'>{group.label}</span>
+                            <div className='flex items-center gap-1'>
+                              {group.expiredCount > 0 && (
+                                <span className='flex items-center gap-1 rounded-lg border bg-primary-100 px-1.5 py-0.5 text-xs text-amber-700'>
+                                  <TriangleAlert className='size-3 text-amber-600' />
+                                  Needs attention
+                                </span>
+                              )}
+                              <ChevronUp className='size-4 shrink-0 text-muted-foreground' />
+                            </div>
+                          </div>
+                          <span className='text-xs text-muted-foreground'>
+                            {group.rows.length} connections
+                          </span>
+                        </div>
+                      </button>
+                      <div className='flex flex-col gap-2'>
+                        {group.rows.map(renderCard)}
+                        {canAdd && (
+                          <Button
+                            variant='outline'
+                            size='sm'
+                            className='w-full border-dashed'
+                            onClick={() => handleAddToGroup(group)}>
+                            <Plus />
+                            Add {group.label}
+                          </Button>
+                        )}
+                      </div>
                     </div>
-                    <span className='text-sm font-semibold'>{group.label}</span>
-                    {group.expiredCount > 0 && (
-                      <span className='flex items-center gap-1 rounded-lg border bg-primary-100 px-1.5 py-0.5 text-xs text-amber-700'>
-                        <TriangleAlert className='size-3 text-amber-600' />
-                        Needs attention
-                      </span>
-                    )}
-                    <span className='ml-auto text-xs text-muted-foreground'>
-                      {group.rows.length} connections
-                    </span>
-                    <ChevronUp className='size-4 shrink-0 text-muted-foreground' />
-                  </button>
-                  <div className='flex flex-col gap-2'>
-                    {group.rows.map(renderCard)}
-                    {canAdd && (
-                      <Button
-                        variant='outline'
-                        size='sm'
-                        className='w-full border-dashed'
-                        onClick={() => handleAddToGroup(group)}>
-                        <Plus />
-                        Add {group.label}
-                      </Button>
-                    )}
                   </div>
                 </div>
               )

--- a/apps/web/src/components/datasets/documents/document-detail-drawer.tsx
+++ b/apps/web/src/components/datasets/documents/document-detail-drawer.tsx
@@ -3,7 +3,6 @@
 import type { DocumentEntity as Document } from '@auxx/database/types'
 import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
-import { CardContent, CardHeader, CardTitle } from '@auxx/ui/components/card'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
 import { DrawerHeader } from '@auxx/ui/components/drawer'
 import {
@@ -14,6 +13,7 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { Input } from '@auxx/ui/components/input'
+import { MetricCell, MetricGrid } from '@auxx/ui/components/metric-grid'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
 import { toastError, toastInfo } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
@@ -309,91 +309,38 @@ export function DocumentDetailDrawer({
           />
 
           {/* Metrics */}
-          <div className='grid grid-cols-2 border-b'>
-            {/* File Size */}
-            <div className='border-r border-b'>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>
-                  File Size
-                </CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <div className='flex items-center gap-2'>
-                  <Database className='size-4 text-muted-foreground' />
-                  <span className='text-lg font-semibold'>
-                    {formatBytes(Number(displayDocument.size))}
-                  </span>
-                </div>
-              </CardContent>
-            </div>
-
-            {/* Segments */}
-            <div className='border-b'>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>
-                  Segments
-                </CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <div className='flex items-center gap-2'>
-                  <Hash className='size-4 text-muted-foreground' />
-                  <span className='text-lg font-semibold'>{segmentCount}</span>
-                </div>
-                {displayDocument.status === 'PROCESSING' && segmentCount > 0 && (
-                  <p className='text-xs text-muted-foreground mt-1'>Processing</p>
-                )}
-              </CardContent>
-            </div>
-
-            {/* Upload Date */}
-            <div className='border-r'>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>
-                  Uploaded
-                </CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <div className='flex items-center gap-2'>
-                  <Calendar className='size-4 text-muted-foreground' />
-                  <div>
-                    <div className='text-sm font-medium'>
-                      {formatDistanceToNow(new Date(displayDocument.createdAt), {
-                        addSuffix: true,
-                      })}
-                    </div>
-                    <div className='text-xs text-muted-foreground'>
-                      {format(new Date(displayDocument.createdAt), 'MMM d, yyyy HH:mm')}
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </div>
-
-            {/* File Type */}
-            <div>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>
-                  File Type
-                </CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <div className='flex items-center gap-2'>
-                  <FileText className='size-4 text-muted-foreground' />
-                  <span className='text-sm font-medium'>
-                    {getStandardFileType(
-                      displayDocument.mimeType ?? undefined,
-                      displayDocument.filename
-                        ? getFileExtension(displayDocument.filename)
-                        : undefined
-                    )}
-                  </span>
-                </div>
-                <p className='text-xs text-muted-foreground mt-1'>
-                  {displayDocument.mimeType || 'Unknown MIME type'}
-                </p>
-              </CardContent>
-            </div>
-          </div>
+          <MetricGrid columns={2}>
+            <MetricCell
+              label='File Size'
+              icon={<Database className='size-4 text-muted-foreground' />}
+              value={formatBytes(Number(displayDocument.size))}
+            />
+            <MetricCell
+              label='Segments'
+              icon={<Hash className='size-4 text-muted-foreground' />}
+              value={segmentCount}
+              description={
+                displayDocument.status === 'PROCESSING' && segmentCount > 0
+                  ? 'Processing'
+                  : undefined
+              }
+            />
+            <MetricCell
+              label='Uploaded'
+              icon={<Calendar className='size-4 text-muted-foreground' />}
+              value={formatDistanceToNow(new Date(displayDocument.createdAt), { addSuffix: true })}
+              description={format(new Date(displayDocument.createdAt), 'MMM d, yyyy HH:mm')}
+            />
+            <MetricCell
+              label='File Type'
+              icon={<FileText className='size-4 text-muted-foreground' />}
+              value={getStandardFileType(
+                displayDocument.mimeType ?? undefined,
+                displayDocument.filename ? getFileExtension(displayDocument.filename) : undefined
+              )}
+              description={displayDocument.mimeType || 'Unknown MIME type'}
+            />
+          </MetricGrid>
 
           {/* Tabs */}
           <Tabs defaultValue='preview' className='flex-1 flex flex-col min-h-0'>

--- a/apps/web/src/components/detail-view/detail-view-sidebar.tsx
+++ b/apps/web/src/components/detail-view/detail-view-sidebar.tsx
@@ -4,6 +4,7 @@
 import { parseRecordId } from '@auxx/lib/field-values/client'
 import type { DrawerTabCardDefinition } from '@auxx/lib/resources/client'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
+import { cn } from '@auxx/ui/lib/utils'
 import React from 'react'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { getTabCardComponent } from '~/components/drawers/drawer-tab-registry'
@@ -104,8 +105,8 @@ function SidebarCards({
   return (
     <>
       {cards.map((card) => (
-        <div key={card.value} className='space-y-1 p-4'>
-          <h4 className='text-sm'>{card.label}</h4>
+        <div key={card.value} className={cn('space-y-1', card.fullBleed ? 'pt-4' : 'p-4')}>
+          <h4 className={cn('text-sm', card.fullBleed && 'px-4')}>{card.label}</h4>
           <LazySidebarCard
             entityType={entityType}
             cardValue={card.value}

--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -421,7 +421,16 @@ function TabCards({
   return (
     <>
       {cards.map((card) => (
-        <Section key={card.value} title={card.label} initialOpen collapsible={false}>
+        <Section
+          key={card.value}
+          title={card.label}
+          initialOpen
+          collapsible={false}
+          className={
+            card.fullBleed
+              ? '[&>[data-slot=section]>[data-slot=section-content]]:-mx-3 [&>[data-slot=section]>[data-slot=section-content]]:-mb-4'
+              : undefined
+          }>
           <LazyTabCard
             entityType={entityType}
             cardValue={card.value}

--- a/apps/web/src/components/drawers/cards/ticket-metrics-card.tsx
+++ b/apps/web/src/components/drawers/cards/ticket-metrics-card.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import type { ActorId } from '@auxx/types/actor'
-import { CardContent, CardHeader, CardTitle } from '@auxx/ui/components/card'
+import { MetricCell, MetricGrid } from '@auxx/ui/components/metric-grid'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { format, formatDistanceToNow } from 'date-fns'
 import { Calendar, CircleDot, Clock, Flag, Tags, Users } from 'lucide-react'
@@ -41,94 +41,77 @@ export function TicketMetricsCard({ recordId }: DrawerTabProps) {
   const isClosed = statusStr === 'CLOSED'
 
   return (
-    <div className='grid grid-cols-2'>
+    <MetricGrid columns={2}>
       {/* Status, Type & Priority */}
-      <div className='border-r border-b'>
-        <CardContent className='py-2'>
-          <div className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <Tags className='size-4 text-muted-foreground' />
-              {isLoading ? (
-                <Skeleton className='h-5 w-16' />
-              ) : (
-                <TicketStatusBadge status={statusStr ?? ''} />
-              )}
-            </div>
-            <div className='flex items-center gap-2'>
-              <CircleDot className='size-4 text-muted-foreground' />
-              {isLoading ? (
-                <Skeleton className='h-5 w-16' />
-              ) : (
-                <TicketTypeBadge type={typeStr ?? ''} closed={isClosed} />
-              )}
-            </div>
-            <div className='flex items-center gap-2'>
-              <Flag className='size-4 text-muted-foreground' />
-              {isLoading ? (
-                <Skeleton className='h-5 w-16' />
-              ) : (
-                <TicketPriorityBadge priority={priorityStr ?? ''} closed={isClosed} />
-              )}
-            </div>
+      <MetricCell>
+        <div className='flex flex-col gap-2'>
+          <div className='flex items-center gap-2'>
+            <Tags className='size-4 text-muted-foreground' />
+            {isLoading ? (
+              <Skeleton className='h-5 w-16' />
+            ) : (
+              <TicketStatusBadge status={statusStr ?? ''} />
+            )}
           </div>
-        </CardContent>
-      </div>
+          <div className='flex items-center gap-2'>
+            <CircleDot className='size-4 text-muted-foreground' />
+            {isLoading ? (
+              <Skeleton className='h-5 w-16' />
+            ) : (
+              <TicketTypeBadge type={typeStr ?? ''} closed={isClosed} />
+            )}
+          </div>
+          <div className='flex items-center gap-2'>
+            <Flag className='size-4 text-muted-foreground' />
+            {isLoading ? (
+              <Skeleton className='h-5 w-16' />
+            ) : (
+              <TicketPriorityBadge priority={priorityStr ?? ''} closed={isClosed} />
+            )}
+          </div>
+        </div>
+      </MetricCell>
 
       {/* Assignee */}
-      <div className='border-b'>
-        <CardHeader className='pb-2 pt-3'>
-          <CardTitle className='text-sm font-medium text-muted-foreground'>Assigned To</CardTitle>
-        </CardHeader>
-        <CardContent className='pb-3'>
-          <div className='flex items-start gap-2'>
-            <Users className='h-4 w-4 text-muted-foreground mt-0.5' />
-            <div className='flex-1'>
-              {isLoading ? (
-                <Skeleton className='h-5 w-24' />
-              ) : assigneeId ? (
-                <ActorBadge actorId={assigneeId} />
-              ) : (
-                <span className='text-sm text-muted-foreground'>Unassigned</span>
-              )}
-            </div>
+      <MetricCell label='Assigned To'>
+        <div className='flex items-start gap-2'>
+          <Users className='size-4 text-muted-foreground mt-0.5' />
+          <div className='flex-1'>
+            {isLoading ? (
+              <Skeleton className='h-5 w-24' />
+            ) : assigneeId ? (
+              <ActorBadge actorId={assigneeId} />
+            ) : (
+              <span className='text-sm text-muted-foreground'>Unassigned</span>
+            )}
           </div>
-        </CardContent>
-      </div>
+        </div>
+      </MetricCell>
 
       {/* Created Date */}
-      <div className='border-r'>
-        <CardHeader className='pb-2 pt-3'>
-          <CardTitle className='text-sm font-medium text-muted-foreground'>Created</CardTitle>
-        </CardHeader>
-        <CardContent className='pb-3'>
-          <div className='flex items-center gap-2'>
-            <Calendar className='h-4 w-4 text-muted-foreground' />
-            {isLoading ? (
-              <Skeleton className='h-8 w-24' />
-            ) : (
-              <DateDisplay value={values.ticket_created_at} />
-            )}
-          </div>
-        </CardContent>
-      </div>
+      <MetricCell label='Created'>
+        <div className='flex items-center gap-2'>
+          <Calendar className='size-4 text-muted-foreground' />
+          {isLoading ? (
+            <Skeleton className='h-8 w-24' />
+          ) : (
+            <DateDisplay value={values.ticket_created_at} />
+          )}
+        </div>
+      </MetricCell>
 
       {/* Updated Date */}
-      <div>
-        <CardHeader className='pb-2 pt-3'>
-          <CardTitle className='text-sm font-medium text-muted-foreground'>Last Updated</CardTitle>
-        </CardHeader>
-        <CardContent className='pb-3'>
-          <div className='flex items-center gap-2'>
-            <Clock className='h-4 w-4 text-muted-foreground' />
-            {isLoading ? (
-              <Skeleton className='h-8 w-24' />
-            ) : (
-              <DateDisplay value={values.ticket_updated_at} />
-            )}
-          </div>
-        </CardContent>
-      </div>
-    </div>
+      <MetricCell label='Last Updated'>
+        <div className='flex items-center gap-2'>
+          <Clock className='size-4 text-muted-foreground' />
+          {isLoading ? (
+            <Skeleton className='h-8 w-24' />
+          ) : (
+            <DateDisplay value={values.ticket_updated_at} />
+          )}
+        </div>
+      </MetricCell>
+    </MetricGrid>
   )
 }
 

--- a/apps/web/src/components/files/file-detail-drawer.tsx
+++ b/apps/web/src/components/files/file-detail-drawer.tsx
@@ -16,6 +16,7 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { Input } from '@auxx/ui/components/input'
+import { MetricCell, MetricGrid } from '@auxx/ui/components/metric-grid'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
 import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
@@ -331,88 +332,31 @@ export function FileDetailDrawer({ file, onOpenChange, setSelectedFile }: FileDe
           />
 
           {/* Metrics */}
-          <div className='grid grid-cols-2 border-b bg-background'>
-            {/* File Size */}
-            <div className='border-r border-b'>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>
-                  File Size
-                </CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <div className='flex items-center gap-2'>
-                  <Database className='h-4 w-4 text-muted-foreground' />
-                  <span className='text-lg font-semibold'>{formatBytes(file.displaySize)}</span>
-                </div>
-              </CardContent>
-            </div>
-
-            {/* File Type */}
-            <div className='border-b'>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>
-                  File Type
-                </CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <div className='flex items-center gap-2'>
-                  <FileText className='h-4 w-4 text-muted-foreground' />
-                  <span className='text-lg font-semibold'>
-                    {getStandardFileType(file.mimeType || undefined, file.ext || undefined)}
-                  </span>
-                </div>
-                {file.mimeType && (
-                  <p className='text-xs text-muted-foreground mt-1'>{file.mimeType}</p>
-                )}
-              </CardContent>
-            </div>
-
-            {/* Created Date */}
-            <div className='border-r'>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>Created</CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <div className='flex items-center gap-2'>
-                  <Calendar className='h-4 w-4 text-muted-foreground' />
-                  <div>
-                    <div className='text-sm font-medium'>
-                      {formatDistanceToNow(new Date(file.createdAt), {
-                        addSuffix: true,
-                      })}
-                    </div>
-                    <div className='text-xs text-muted-foreground'>
-                      {format(new Date(file.createdAt), 'MMM d, yyyy HH:mm')}
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </div>
-
-            {/* Modified Date */}
-            <div>
-              <CardHeader className='pb-2 pt-3'>
-                <CardTitle className='text-sm font-medium text-muted-foreground'>
-                  Modified
-                </CardTitle>
-              </CardHeader>
-              <CardContent className='pb-3'>
-                <div className='flex items-center gap-2'>
-                  <Calendar className='h-4 w-4 text-muted-foreground' />
-                  <div>
-                    <div className='text-sm font-medium'>
-                      {formatDistanceToNow(new Date(file.updatedAt), {
-                        addSuffix: true,
-                      })}
-                    </div>
-                    <div className='text-xs text-muted-foreground'>
-                      {format(new Date(file.updatedAt), 'MMM d, yyyy HH:mm')}
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </div>
-          </div>
+          <MetricGrid columns={2}>
+            <MetricCell
+              label='File Size'
+              icon={<Database className='size-4 text-muted-foreground' />}
+              value={formatBytes(file.displaySize)}
+            />
+            <MetricCell
+              label='File Type'
+              icon={<FileText className='size-4 text-muted-foreground' />}
+              value={getStandardFileType(file.mimeType || undefined, file.ext || undefined)}
+              description={file.mimeType || undefined}
+            />
+            <MetricCell
+              label='Created'
+              icon={<Calendar className='size-4 text-muted-foreground' />}
+              value={formatDistanceToNow(new Date(file.createdAt), { addSuffix: true })}
+              description={format(new Date(file.createdAt), 'MMM d, yyyy HH:mm')}
+            />
+            <MetricCell
+              label='Modified'
+              icon={<Calendar className='size-4 text-muted-foreground' />}
+              value={formatDistanceToNow(new Date(file.updatedAt), { addSuffix: true })}
+              description={format(new Date(file.updatedAt), 'MMM d, yyyy HH:mm')}
+            />
+          </MetricGrid>
 
           {/* Tabs */}
           <Tabs

--- a/apps/web/src/lib/csv.ts
+++ b/apps/web/src/lib/csv.ts
@@ -1,0 +1,16 @@
+// apps/web/src/lib/csv.ts
+// Browser-only CSV download (Step 9 §2.2). The framework-agnostic serializer lives
+// in `@auxx/utils/csv` (`toCsv`/`csvCell`, shared server + client); this is the
+// `Blob → createObjectURL → <a download> → revokeObjectURL` half, which can only run
+// in the browser. Pair them: `downloadCsv(toCsv(rows, columns), filename)`.
+
+/** Trigger a client-side download of `content` as a CSV file named `filename`. */
+export function downloadCsv(content: string, filename: string): void {
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -57,7 +57,7 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     defaultTab: 'conversation',
     defaultSidebarTab: 'overview',
     sidebarCards: [
-      { value: 'metrics', label: 'Metrics', position: 'before' },
+      { value: 'metrics', label: 'Metrics', position: 'before', fullBleed: true },
       { value: 'customer', label: 'Customer' },
       { value: 'relationships', label: 'Related Tickets' },
     ],

--- a/packages/lib/src/resources/registry/drawer-config-types.ts
+++ b/packages/lib/src/resources/registry/drawer-config-types.ts
@@ -39,6 +39,11 @@ export interface DrawerTabCardDefinition {
   label: string
   /** Position relative to default tab content */
   position?: 'before' | 'after'
+  /**
+   * Render the card edge-to-edge by cancelling the wrapping Section's horizontal
+   * padding (and bottom gap). Use for full-bleed strips like the metrics grid.
+   */
+  fullBleed?: boolean
 }
 
 /**

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -41,7 +41,7 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     },
     tabCards: {
       overview: [
-        { value: 'metrics', label: 'Metrics', position: 'before' },
+        { value: 'metrics', label: 'Metrics', position: 'before', fullBleed: true },
         { value: 'customer', label: 'Customer' },
         { value: 'relationships', label: 'Related Tickets' },
       ],

--- a/packages/ui/src/components/metric-grid.tsx
+++ b/packages/ui/src/components/metric-grid.tsx
@@ -1,0 +1,92 @@
+// packages/ui/src/components/metric-grid.tsx
+
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
+import type * as React from 'react'
+
+/** Props for a single MetricCell. */
+interface MetricCellProps {
+  /** Muted label above the value. Omit for a label-less cell (e.g. stacked badges). */
+  label?: React.ReactNode
+  /** Icon shown left of the value. */
+  icon?: React.ReactNode
+  /** Primary value. Ignored when `children` is provided. */
+  value?: React.ReactNode
+  /** Small muted subtitle under the value. */
+  description?: React.ReactNode
+  /** Skeleton in place of the value while loading. */
+  loading?: boolean
+  /** Custom body — overrides icon/value/description (badge stacks, ActorBadge, dates). */
+  children?: React.ReactNode
+  className?: string
+}
+
+/**
+ * A single metric cell: a muted label over an icon + value (+ optional subtitle).
+ * Pass `children` for a custom body (badge stacks, actor badges, two-line dates).
+ * Always render inside a {@link MetricGrid}, which draws the dividers.
+ */
+export function MetricCell({
+  label,
+  icon,
+  value,
+  description,
+  loading = false,
+  children,
+  className,
+}: MetricCellProps) {
+  return (
+    <div className={cn('bg-background', className)}>
+      {label && (
+        <div className='px-3 pt-3 pb-1.5 text-sm font-medium text-muted-foreground'>{label}</div>
+      )}
+      <div className={cn('px-3 pb-3', !label && 'pt-3')}>
+        {children ?? (
+          <div className='flex items-center gap-2'>
+            {icon}
+            {loading ? (
+              <Skeleton className='h-5 w-20' />
+            ) : (
+              <div className='min-w-0'>
+                <div className='truncate text-sm font-semibold'>{value}</div>
+                {description && (
+                  <div className='truncate text-xs text-muted-foreground'>{description}</div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const COLUMN_CLASS: Record<2 | 3 | 4, string> = {
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-4',
+}
+
+/** Props for the MetricGrid container. */
+interface MetricGridProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Number of columns (default 2). */
+  columns?: 2 | 3 | 4
+  /** MetricCell children. */
+  children: React.ReactNode
+}
+
+/**
+ * The detail-drawer metrics strip: a bordered grid of {@link MetricCell}s. Dividers are
+ * drawn with a 1px gap over a `bg-border` backdrop, so they're column-count-agnostic.
+ * Expects cells to fill complete rows; a partial last row leaves a divider-colored gap.
+ * Defaults to a bottom edge (`border-b`); override via `className`.
+ */
+export function MetricGrid({ columns = 2, className, children, ...props }: MetricGridProps) {
+  return (
+    <div
+      className={cn('grid gap-px border-b bg-border', COLUMN_CLASS[columns], className)}
+      {...props}>
+      {children}
+    </div>
+  )
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,6 +34,12 @@
       "import": "./dist/counter.js",
       "default": "./src/counter.ts"
     },
+    "./csv": {
+      "types": "./src/csv.ts",
+      "source": "./src/csv.ts",
+      "import": "./dist/csv.js",
+      "default": "./src/csv.ts"
+    },
     "./currency": {
       "types": "./src/currency.ts",
       "source": "./src/currency.ts",

--- a/packages/utils/src/__tests__/csv.test.ts
+++ b/packages/utils/src/__tests__/csv.test.ts
@@ -1,0 +1,52 @@
+// packages/utils/src/__tests__/csv.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { csvCell, toCsv } from '../csv'
+
+describe('csvCell', () => {
+  it('passes simple values through unquoted', () => {
+    expect(csvCell('hello')).toBe('hello')
+    expect(csvCell(42)).toBe('42')
+    expect(csvCell(true)).toBe('true')
+  })
+
+  it('renders null/undefined as empty', () => {
+    expect(csvCell(null)).toBe('')
+    expect(csvCell(undefined)).toBe('')
+  })
+
+  it('quotes values containing a comma, quote, or newline', () => {
+    expect(csvCell('a,b')).toBe('"a,b"')
+    expect(csvCell('line1\nline2')).toBe('"line1\nline2"')
+    expect(csvCell('carriage\rreturn')).toBe('"carriage\rreturn"')
+  })
+
+  it('doubles embedded quotes', () => {
+    expect(csvCell('he said "hi"')).toBe('"he said ""hi"""')
+  })
+
+  it('serializes Date as ISO and objects as JSON', () => {
+    expect(csvCell(new Date('2026-06-22T00:00:00.000Z'))).toBe('2026-06-22T00:00:00.000Z')
+    // JSON contains a comma → quoted, inner quotes doubled.
+    expect(csvCell({ a: 1, b: 2 })).toBe('"{""a"":1,""b"":2}"')
+  })
+})
+
+describe('toCsv', () => {
+  it('emits a header row then one line per row, selecting by column', () => {
+    const rows = [
+      { tier: 'invalid', externalId: 'cus_1', error: 'bad shape' },
+      { tier: 'rejected', externalId: 'cus_2', error: 'write failed' },
+    ]
+    expect(toCsv(rows, ['tier', 'externalId', 'error'])).toBe(
+      'tier,externalId,error\ninvalid,cus_1,bad shape\nrejected,cus_2,write failed'
+    )
+  })
+
+  it('quotes cells that need it and blanks missing columns', () => {
+    const rows = [{ externalId: 'id,1', error: 'a "quoted" reason' }]
+    expect(toCsv(rows, ['tier', 'externalId', 'error'])).toBe(
+      'tier,externalId,error\n,"id,1","a ""quoted"" reason"'
+    )
+  })
+})

--- a/packages/utils/src/csv.ts
+++ b/packages/utils/src/csv.ts
@@ -1,0 +1,32 @@
+// packages/utils/src/csv.ts
+// Framework-agnostic CSV serialization (Step 9 §2.2). Quoting follows RFC 4180:
+// a cell containing a comma, double-quote, or newline is wrapped in double quotes
+// and embedded quotes are doubled. Lifted from the audit-log exporter so the
+// server (@auxx/lib) and client (apps/web) share one correct serializer. The
+// browser-only download helper can't live here — see apps/web/src/lib/csv.ts.
+
+/**
+ * Serialize one cell value. `null`/`undefined` → empty string; `Date` → ISO;
+ * objects → JSON; everything else → `String()`. The result is quoted only when it
+ * contains a comma, double-quote, CR, or LF (embedded quotes doubled).
+ */
+export function csvCell(value: unknown): string {
+  if (value == null) return ''
+  const str =
+    value instanceof Date
+      ? value.toISOString()
+      : typeof value === 'object'
+        ? JSON.stringify(value)
+        : String(value)
+  return /[",\n\r]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str
+}
+
+/**
+ * Serialize `rows` into CSV text. The header line is `columns` verbatim; each row
+ * emits `columns.map((col) => csvCell(row[col]))`. Lines are joined with `\n`.
+ */
+export function toCsv(rows: Array<Record<string, unknown>>, columns: string[]): string {
+  const header = columns.join(',')
+  const lines = rows.map((row) => columns.map((col) => csvCell(row[col])).join(','))
+  return [header, ...lines].join('\n')
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -30,6 +30,8 @@ export {
 } from './contact'
 // Counter utilities
 export { createCounter, createIdAllocator } from './counter'
+// CSV serialization (framework-agnostic; browser download lives in apps/web)
+export { csvCell, toCsv } from './csv'
 // Currency utilities
 export {
   type CurrencyDisplayOptions,


### PR DESCRIPTION
## Summary

Extracts reusable presentation primitives and adopts them across the app. No feature logic — pure UI/shared-util refactor.

- **MetricGrid / MetricCell** (`@auxx/ui`) — replaces hand-rolled metric layouts in the document, file, ticket, and config drawers.
- **`fullBleed` card flag** on drawer / detail-view card configs so the metrics strip renders edge-to-edge; honored by `base-entity-drawer` and `detail-view-sidebar`.
- **Framework-agnostic CSV serializer** (`@auxx/utils/csv`: `toCsv`/`csvCell`) plus a browser-only `downloadCsv` helper in `apps/web`.
- **Connections section** — expanded app stack claims its own row and caps to a single tile width.

## Notes

`feat/data-connectors-progress-mapping` is stacked on this branch and consumes `MetricGrid` + the CSV utils — merge this one first.