### PR TITLE
feat(data-connectors): progress UX + mapping suggester + slicing

### DIFF
--- a/apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
@@ -1,0 +1,37 @@
+// apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
+'use client'
+
+import type { RouterOutputs } from '~/trpc/react'
+
+type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
+type Stream = RouterOutputs['dataConnector']['listStreams'][number]
+
+/** The setup stepper's ordered steps (create-sync-flow-plan §2.1). */
+export type SetupStepId = 'connect' | 'sample' | 'map' | 'schedule' | 'run'
+
+export interface SetupProgress {
+  /** A credential is bound, or the endpoint declares no auth. */
+  connect: boolean
+  /** At least one stream has a source schema (a successful sample → "use as schema"). */
+  sample: boolean
+  /** At least one stream has ≥1 field mapping with a bound `targetFieldRef`. */
+  map: boolean
+  /** Connect + Map satisfied → the terminal "Run first sync" CTA is enabled
+   *  (Sample is implied by Map; Schedule defaults to Manual). */
+  canRun: boolean
+}
+
+/**
+ * Derive each setup step's "done" state from the connector + its streams — no new
+ * `step` column, no client wizard state. Every predicate reads persisted data the
+ * detail view already queries (`getById` + `listStreams`). See plan §2.2.
+ */
+export function deriveSetupProgress(connector: Connector, streams: Stream[]): SetupProgress {
+  const auth = (connector.config as { endpoint?: { auth?: string } } | null)?.endpoint?.auth
+  const connect = connector.credentialId != null || auth === 'none'
+  const sample = streams.some((s) => s.sourceSchema != null)
+  const map = streams.some((s) =>
+    s.mappings.some((m) => m.fieldMappings?.some((fm) => fm.targetFieldRef != null))
+  )
+  return { connect, sample, map, canRun: connect && map }
+}

--- a/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
@@ -12,6 +12,8 @@ import { api } from '~/trpc/react'
 import { ConnectorEditsProvider } from '../hooks/use-connector-edits'
 import { ConnectionSection } from './connection-section'
 import { ConnectorSaveBar } from './connector-save-bar'
+import { ConnectorSetupStepper } from './connector-setup-stepper'
+import { asConnectorStatus } from './connector-status'
 import { ScheduleSection } from './schedule-section'
 import { StreamConfigPanel } from './stream-config-panel'
 import { StreamDetailBar } from './stream-detail-bar'
@@ -98,6 +100,17 @@ export function ConnectorDetailTabs({ connector, mobileRunsPanel }: ConnectorDet
       streamKey={selectedStream.streamKey}
     />
   ) : null
+
+  // A `pending` connector is in first-run setup → render the guided stepper. Any
+  // other status renders today's flat tabbed editor. Both mount the identical
+  // section components against the identical mutations (create-sync-flow-plan §2).
+  if (asConnectorStatus(connector.status) === 'pending') {
+    return (
+      <ConnectorEditsProvider>
+        <ConnectorSetupStepper connector={connector} />
+      </ConnectorEditsProvider>
+    )
+  }
 
   return (
     <ConnectorEditsProvider>

--- a/apps/web/src/components/data-connectors/ui/connector-freshness-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-freshness-panel.tsx
@@ -2,6 +2,8 @@
 'use client'
 
 import { LastUpdated } from '@auxx/ui/components/last-updated'
+import { MetricCell, MetricGrid } from '@auxx/ui/components/metric-grid'
+import { ArrowDownUp, CalendarClock, History, RefreshCw } from 'lucide-react'
 
 interface ConnectorFreshnessPanelProps {
   lastSyncedAt: Date | string | null
@@ -17,8 +19,10 @@ interface ConnectorFreshnessPanelProps {
 /**
  * The steady-phase freshness panel (Step 9 §10.3) — a non-programmer's "is this up to
  * date?" at a glance: last/next synced, the latest run's delta, and how it keeps fresh.
- * Shown between runs (not during a backfill — that's the import card). All relative
- * times self-update via `LastUpdated`; nothing here is a cursor or a percent.
+ * Rendered with the shared `MetricGrid` widget (matching the document/file/ticket detail
+ * drawers) as a 2×2 grid. Shown between runs (not during a backfill — that's the import
+ * card). All relative times self-update via `LastUpdated`; nothing here is a cursor or a
+ * percent.
  */
 export function ConnectorFreshnessPanel({
   lastSyncedAt,
@@ -32,21 +36,34 @@ export function ConnectorFreshnessPanel({
   const delta = created > 0 || updated > 0 ? `+${updated} updated, +${created} new` : 'No changes'
 
   return (
-    <div className='grid grid-cols-2 gap-x-4 gap-y-2 border-b bg-muted/30 px-4 py-3 text-xs'>
-      <Cell label='Last synced'>
-        {lastSyncedAt ? <LastUpdated timestamp={lastSyncedAt} className='text-xs' /> : '—'}
-      </Cell>
-      <Cell label='Synced this run'>{delta}</Cell>
-
-      <Cell label='Next sync'>{nextSync(nextSyncAt, syncBehavior, cadenceLabel)}</Cell>
-      <Cell label='Keeping up to date'>{cadence(syncBehavior, cadenceLabel)}</Cell>
-    </div>
+    <MetricGrid columns={2}>
+      <MetricCell
+        label='Last synced'
+        icon={<History className='size-4 text-muted-foreground' />}
+        value={lastSyncedAt ? <LastUpdated timestamp={lastSyncedAt} className='text-sm' /> : '—'}
+      />
+      <MetricCell
+        label='Synced this run'
+        icon={<ArrowDownUp className='size-4 text-muted-foreground' />}
+        value={delta}
+      />
+      <MetricCell
+        label='Next sync'
+        icon={<CalendarClock className='size-4 text-muted-foreground' />}
+        value={nextSync(nextSyncAt, syncBehavior, cadenceLabel)}
+      />
+      <MetricCell
+        label='Keeping up to date'
+        icon={<RefreshCw className='size-4 text-muted-foreground' />}
+        value={cadence(syncBehavior, cadenceLabel)}
+      />
+    </MetricGrid>
   )
 }
 
 /** The "Next sync" value — a relative time when scheduled, else the trigger model. */
 function nextSync(nextSyncAt: string | null, syncBehavior: string, cadenceLabel: string | null) {
-  if (nextSyncAt) return <LastUpdated timestamp={nextSyncAt} className='text-xs' />
+  if (nextSyncAt) return <LastUpdated timestamp={nextSyncAt} className='text-sm' />
   if (syncBehavior === 'webhook') return 'On changes'
   if (syncBehavior === 'manual') return 'On demand'
   // Scheduled but no derivable next-time (custom cron).
@@ -58,14 +75,4 @@ function cadence(syncBehavior: string, cadenceLabel: string | null): string {
   if (syncBehavior === 'webhook') return 'Live via webhooks'
   if (syncBehavior === 'manual') return 'Syncs when you run it'
   return cadenceLabel ?? 'Not scheduled'
-}
-
-/** A labeled value cell (muted label over the value). */
-function Cell({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className='flex flex-col gap-0.5'>
-      <span className='text-[11px] text-muted-foreground'>{label}</span>
-      <span className='text-foreground'>{children}</span>
-    </div>
-  )
 }

--- a/apps/web/src/components/data-connectors/ui/connector-run-errors.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-run-errors.tsx
@@ -1,0 +1,138 @@
+// apps/web/src/components/data-connectors/ui/connector-run-errors.tsx
+'use client'
+
+import { Badge, type BadgeProps } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@auxx/ui/components/dialog'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { toCsv } from '@auxx/utils/csv'
+import { Download } from 'lucide-react'
+import { downloadCsv } from '~/lib/csv'
+
+/** The two-tier error sample carried on a run row (Step 9 §1.1 / §2). */
+export interface ConnectorRunError {
+  externalId: string
+  error: string
+  /** 'invalid' = dropped before the write; 'rejected' = the write threw; absent = engine-level. */
+  tier?: 'invalid' | 'rejected'
+}
+
+/** errorSample is capped server-side (`service.ts` finalizeRun → `.slice(0, 50)`). */
+const ERROR_SAMPLE_CAP = 50
+
+const TIER_META: Record<string, { label: string; variant: BadgeProps['variant'] }> = {
+  invalid: { label: 'Invalid', variant: 'amber' },
+  rejected: { label: 'Rejected', variant: 'red' },
+}
+const UNTAGGED_TIER = { label: 'Error', variant: 'gray' as const }
+
+function tierMeta(tier?: string) {
+  return (tier && TIER_META[tier]) || UNTAGGED_TIER
+}
+
+function slugify(label: string): string {
+  return (
+    label
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'connector'
+  )
+}
+
+/**
+ * The drill-in for a run's failures (Step 9 §2). A "N errors" affordance opens a
+ * dialog rendering the run's `errorSample` as a Reason / Record / Type table with a
+ * tier badge, plus a "Download rows with errors" CSV. The sample is capped at 50, so
+ * the dialog says so rather than implying the export is every failed row.
+ */
+export function ConnectorRunErrors({
+  errors,
+  connectorLabel,
+  runId,
+}: {
+  errors: ConnectorRunError[]
+  connectorLabel: string
+  runId: string
+}) {
+  if (errors.length === 0) return null
+  const capped = errors.length >= ERROR_SAMPLE_CAP
+
+  const handleDownload = () => {
+    const rows = errors.map((e) => ({
+      tier: e.tier ?? 'error',
+      externalId: e.externalId,
+      error: e.error,
+    }))
+    downloadCsv(
+      toCsv(rows, ['tier', 'externalId', 'error']),
+      `${slugify(connectorLabel)}-errors-${runId}.csv`
+    )
+  }
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type='button'
+          className='self-start text-xs font-medium text-red-600 underline-offset-2 hover:underline'>
+          {errors.length} error{errors.length === 1 ? '' : 's'}
+        </button>
+      </DialogTrigger>
+      <DialogContent size='lg'>
+        <DialogHeader>
+          <DialogTitle>Sync errors</DialogTitle>
+          <DialogDescription>
+            {capped
+              ? `Showing the first ${ERROR_SAMPLE_CAP} errors from this run — there may be more.`
+              : `${errors.length} record${errors.length === 1 ? '' : 's'} couldn’t be synced in this run.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className='max-h-[50vh]'>
+          <table className='w-full text-left text-sm'>
+            <thead className='sticky top-0 bg-background'>
+              <tr className='border-b text-xs text-muted-foreground'>
+                <th className='py-2 pr-3 font-medium'>Reason</th>
+                <th className='py-2 pr-3 font-medium'>Record</th>
+                <th className='py-2 font-medium'>Type</th>
+              </tr>
+            </thead>
+            <tbody>
+              {errors.map((e, i) => {
+                const tier = tierMeta(e.tier)
+                return (
+                  <tr key={i} className='border-b last:border-0 align-top'>
+                    <td className='py-2 pr-3 text-foreground'>{e.error}</td>
+                    <td className='py-2 pr-3 font-mono text-xs text-muted-foreground'>
+                      {e.externalId || '—'}
+                    </td>
+                    <td className='py-2'>
+                      <Badge variant={tier.variant} size='xs'>
+                        {tier.label}
+                      </Badge>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </ScrollArea>
+
+        <DialogFooter>
+          <Button variant='outline' onClick={handleDownload}>
+            <Download />
+            Download rows with errors
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
@@ -2,6 +2,8 @@
 'use client'
 
 import { Badge } from '@auxx/ui/components/badge'
+import { DrawerHeader } from '@auxx/ui/components/drawer'
+import { EntityIcon } from '@auxx/ui/components/icons'
 import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
@@ -19,6 +21,7 @@ import {
 import { api } from '~/trpc/react'
 import { ConnectorBackfillProgress } from './connector-backfill-progress'
 import { ConnectorFreshnessPanel } from './connector-freshness-panel'
+import { ConnectorRunErrors } from './connector-run-errors'
 import type { ConnectorStatus } from './connector-status'
 
 interface ConnectorRunsPanelProps {
@@ -105,19 +108,22 @@ export function ConnectorRunsPanel({
 
   return (
     <div className='flex h-full flex-col bg-background'>
-      <div className='flex shrink-0 items-center justify-between border-b px-4 py-3'>
-        <span className='text-sm font-semibold'>Runs</span>
-        {isSyncing ? (
-          <Badge variant='outline' size='sm' className='text-amber-600'>
-            <RefreshCw className='size-3 animate-spin' />
-            Syncing
-          </Badge>
-        ) : (
-          <Badge variant='outline' size='sm'>
-            {statusQuery.data?.itemCount ?? 0} records
-          </Badge>
-        )}
-      </div>
+      <DrawerHeader
+        icon={<EntityIcon iconId='history' color='gray' className='size-6' />}
+        title='Runs'
+        actions={
+          isSyncing ? (
+            <Badge variant='outline' size='sm' className='text-amber-600'>
+              <RefreshCw className='size-3 animate-spin' />
+              Syncing
+            </Badge>
+          ) : (
+            <Badge variant='outline' size='sm'>
+              {statusQuery.data?.itemCount ?? 0} records
+            </Badge>
+          )
+        }
+      />
 
       {showBackfill && (
         <ConnectorBackfillProgress
@@ -208,15 +214,17 @@ export function ConnectorRunsPanel({
                   </div>
 
                   {run.errorSample && run.errorSample.length > 0 && (
-                    <div className='mt-1 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-700'>
+                    <div className='mt-1 flex flex-col gap-1 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-700'>
                       {run.errorSample.slice(0, 3).map((e, i) => (
                         <div key={i} className='truncate'>
                           <span className='font-mono'>{e.externalId}</span>: {e.error}
                         </div>
                       ))}
-                      {run.errorSample.length > 3 && (
-                        <div className='text-red-500'>+{run.errorSample.length - 3} more</div>
-                      )}
+                      <ConnectorRunErrors
+                        errors={run.errorSample}
+                        connectorLabel={sourceLabel}
+                        runId={run.id}
+                      />
                     </div>
                   )}
                 </div>

--- a/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
@@ -1,0 +1,291 @@
+// apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { EmptySection } from '@auxx/ui/components/section'
+import { toastError } from '@auxx/ui/components/toast'
+import { cn } from '@auxx/ui/lib/utils'
+import { Check, Clock, FlaskConical, Layers, Play, Plug, Waypoints } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { api, type RouterOutputs } from '~/trpc/react'
+import { useConnectorMutations } from '../hooks/use-connector-mutations'
+import { deriveSetupProgress, type SetupStepId } from '../hooks/use-setup-progress'
+import { ConnectionSection } from './connection-section'
+import { ConnectorSaveBar } from './connector-save-bar'
+import { ScheduleSection } from './schedule-section'
+import { StreamConfigPanel } from './stream-config-panel'
+
+type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
+
+interface StepDef {
+  id: SetupStepId
+  title: string
+  description: string
+  icon: React.ComponentType<{ className?: string }>
+}
+
+const STEPS: StepDef[] = [
+  {
+    id: 'connect',
+    title: 'Connect',
+    description: 'Authorize the connection this connector uses to make requests.',
+    icon: Plug,
+  },
+  {
+    id: 'sample',
+    title: 'Pull a sample',
+    description: 'Fetch a few real records to see what the source returns.',
+    icon: FlaskConical,
+  },
+  {
+    id: 'map',
+    title: 'Map fields',
+    description: 'Choose where each source field lands in your entities.',
+    icon: Waypoints,
+  },
+  {
+    id: 'schedule',
+    title: 'Schedule',
+    description: 'Sync manually or on a schedule — you can change this anytime.',
+    icon: Clock,
+  },
+  {
+    id: 'run',
+    title: 'Run first sync',
+    description: 'Start the first import. Live progress shows in the runs panel.',
+    icon: Play,
+  },
+]
+
+const STEP_ORDER = STEPS.map((s) => s.id)
+
+interface ConnectorSetupStepperProps {
+  connector: Connector
+}
+
+/**
+ * Guided first-run setup — the `pending` render mode of the connector detail view
+ * (create-sync-flow-plan §2). A gated vertical stepper that mounts the SAME section
+ * components the flat editor uses (`ConnectionSection`, `StreamConfigPanel`,
+ * `ScheduleSection`) against the live connector, so there is zero duplicate save
+ * logic. Each step's "done" is derived from persisted state (no `step` column); the
+ * terminal "Run first sync" CTA fires `syncNow`, flipping the connector out of
+ * `pending` so the view collapses to the flat tabbed editor and the loop closes.
+ */
+export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps) {
+  const utils = api.useUtils()
+  const streamsQuery = api.dataConnector.listStreams.useQuery({ id: connector.id })
+  const streams = useMemo(() => streamsQuery.data ?? [], [streamsQuery.data])
+  const primaryStream = streams[0] ?? null
+
+  const progress = deriveSetupProgress(connector, streams)
+  const doneById: Record<SetupStepId, boolean> = {
+    connect: progress.connect,
+    sample: progress.sample,
+    map: progress.map,
+    schedule: true, // Manual is a valid terminal state — always satisfiable.
+    run: false, // Terminal action, never "done" while still pending.
+  }
+
+  const { syncNow, isSyncing } = useConnectorMutations()
+
+  const addStream = api.dataConnector.addStream.useMutation({
+    onSuccess: () => void utils.dataConnector.listStreams.invalidate({ id: connector.id }),
+    onError: (e) => toastError({ title: 'Could not add stream', description: e.message }),
+  })
+
+  // Active (expanded) step. Defaults to the first incomplete step; the user can
+  // click any unlocked step header to jump back to it.
+  const [active, setActive] = useState<SetupStepId>(
+    () => STEP_ORDER.find((id) => !doneById[id]) ?? 'run'
+  )
+
+  // A step is unlocked once every step before it is done.
+  const isUnlocked = (id: SetupStepId) => {
+    const idx = STEP_ORDER.indexOf(id)
+    return STEP_ORDER.slice(0, idx).every((prior) => doneById[prior])
+  }
+
+  const goNext = (id: SetupStepId) => {
+    const next = STEP_ORDER[STEP_ORDER.indexOf(id) + 1]
+    if (next) setActive(next)
+  }
+
+  const renderBody = (id: SetupStepId) => {
+    switch (id) {
+      case 'connect':
+        return <ConnectionSection connector={connector} />
+      case 'sample':
+        if (!primaryStream)
+          return <NoStreamPrompt addStream={addStream} connectorId={connector.id} />
+        return (
+          <StreamConfigPanel
+            connector={connector}
+            stream={primaryStream}
+            view='configure'
+            scroll={false}
+          />
+        )
+      case 'map':
+        if (!primaryStream)
+          return (
+            <p className='px-1 py-3 text-sm text-muted-foreground'>
+              Pull a sample first — the source schema is what you map against.
+            </p>
+          )
+        return (
+          <StreamConfigPanel
+            connector={connector}
+            stream={primaryStream}
+            view='map'
+            scroll={false}
+          />
+        )
+      case 'schedule':
+        return <ScheduleSection connector={connector} />
+      case 'run':
+        return (
+          <div className='flex flex-col gap-3 px-1 py-2'>
+            <EmptySection
+              icon={<Play />}
+              title='Ready to sync'
+              description={
+                progress.canRun
+                  ? 'Run the first import now. You can keep editing while it runs.'
+                  : 'Finish Connect and Map fields above to enable the first sync.'
+              }
+            />
+            <div>
+              <Button
+                loading={isSyncing}
+                loadingText='Starting…'
+                disabled={!progress.canRun}
+                onClick={() => void syncNow(connector.id)}>
+                <Play />
+                Run first sync
+              </Button>
+            </div>
+          </div>
+        )
+    }
+  }
+
+  // The footer advance control for a step (Run uses the body CTA instead).
+  const renderFooter = (id: SetupStepId) => {
+    if (id === 'run') return null
+    const blocked = !doneById[id]
+    const hint: Partial<Record<SetupStepId, string>> = {
+      connect: 'Connect an account to continue.',
+      sample: 'Run a test fetch and use its shape as the schema to continue.',
+      map: 'Map at least one field to continue.',
+    }
+    return (
+      <div className='mt-3 flex items-center gap-3'>
+        <Button size='sm' variant='outline' disabled={blocked} onClick={() => goNext(id)}>
+          Continue
+        </Button>
+        {blocked && hint[id] && <span className='text-xs text-muted-foreground'>{hint[id]}</span>}
+      </div>
+    )
+  }
+
+  return (
+    <div className='relative flex min-h-0 flex-1 flex-col'>
+      <ScrollArea className='h-full' scrollbarClassName='w-1.5' noFade>
+        <div className='mx-auto flex max-w-2xl flex-col gap-1 px-4 py-6'>
+          {STEPS.map((step, idx) => {
+            const done = doneById[step.id]
+            const unlocked = isUnlocked(step.id)
+            const isActive = active === step.id
+            const Icon = step.icon
+            const isLast = idx === STEPS.length - 1
+            return (
+              <div key={step.id} className='flex gap-3'>
+                {/* Rail — number/check badge + connecting line. */}
+                <div className='flex flex-col items-center'>
+                  <button
+                    type='button'
+                    disabled={!unlocked}
+                    onClick={() => unlocked && setActive(step.id)}
+                    className={cn(
+                      'flex size-8 shrink-0 items-center justify-center rounded-full border text-sm font-medium transition-colors',
+                      done
+                        ? 'border-good-500 bg-good-500 text-white'
+                        : isActive
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : unlocked
+                            ? 'border-border bg-background text-muted-foreground hover:border-primary'
+                            : 'border-border bg-muted text-muted-foreground/50',
+                      unlocked ? 'cursor-pointer' : 'cursor-not-allowed'
+                    )}>
+                    {done ? <Check className='size-4' /> : <Icon className='size-4' />}
+                  </button>
+                  {!isLast && <div className='my-1 w-px flex-1 bg-border' />}
+                </div>
+
+                {/* Step content. */}
+                <div className={cn('flex-1 pb-6', !isActive && 'pt-1')}>
+                  <button
+                    type='button'
+                    disabled={!unlocked}
+                    onClick={() => unlocked && setActive(step.id)}
+                    className={cn(
+                      'flex flex-col items-start text-left',
+                      unlocked ? 'cursor-pointer' : 'cursor-not-allowed'
+                    )}>
+                    <span
+                      className={cn(
+                        'text-sm font-semibold',
+                        !unlocked && 'text-muted-foreground/60'
+                      )}>
+                      {step.title}
+                    </span>
+                    <span className='text-xs text-muted-foreground'>{step.description}</span>
+                  </button>
+
+                  {isActive && (
+                    <div className='mt-3 rounded-lg border bg-background p-1'>
+                      {renderBody(step.id)}
+                      <div className='px-1 pb-1'>{renderFooter(step.id)}</div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </ScrollArea>
+      <ConnectorSaveBar />
+    </div>
+  )
+}
+
+/** Custom REST starts with no streams — create the first one to pull a sample. */
+function NoStreamPrompt({
+  addStream,
+  connectorId,
+}: {
+  addStream: ReturnType<typeof api.dataConnector.addStream.useMutation>
+  connectorId: string
+}) {
+  return (
+    <div className='flex flex-col gap-3 px-1 py-2'>
+      <EmptySection
+        icon={<Layers />}
+        title='No stream yet'
+        description='A stream is one fetch (e.g. /orders). Add one to pull a sample and map its fields.'
+      />
+      <div>
+        <Button
+          size='sm'
+          variant='outline'
+          loading={addStream.isPending}
+          onClick={() => addStream.mutate({ id: connectorId })}>
+          <Layers />
+          Add a stream
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -6,14 +6,15 @@ import { toResourceFieldId } from '@auxx/types/field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { EntityIcon } from '@auxx/ui/components/icons'
+import { toastError } from '@auxx/ui/components/toast'
 import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { generateId } from '@auxx/utils'
-import { ArrowRight, FunctionSquare, Plus, Trash2, X } from 'lucide-react'
+import { ArrowRight, FunctionSquare, Loader2, Plus, Sparkles, Trash2, X } from 'lucide-react'
 import { useState } from 'react'
 import { ResourcePicker } from '~/components/pickers/resource-picker'
 import { useResourceFields, useResourceProperty } from '~/components/resources'
-import type { RouterOutputs } from '~/trpc/react'
+import { api, type RouterOutputs } from '~/trpc/react'
 import {
   absolutePrefix,
   buildSourceTree,
@@ -71,9 +72,13 @@ function branchRootPath(node: SourceTreeNode): string {
 export interface MappingNodeProps {
   mapping: Mapping
   depth: number
+  /** The connector id — for the Tier 2 `suggestMappings` call. */
+  connectorId: string
   streamId: string
   /** The stream key — the record noun for the unnamed array root (`[]`). */
   streamKey: string
+  /** The stream's raw source schema (Layer A) — fed to the suggester so it needn't re-fetch. */
+  sourceSchema?: Record<string, unknown> | null
   /** Payload-absolute source paths (Layer A schema), shared by the whole tree. */
   sourcePaths: SourcePath[]
   /** All mappings indexed by id — for `absolutePrefix` + child lookup. */
@@ -94,8 +99,10 @@ export interface MappingNodeProps {
 export function MappingNode({
   mapping,
   depth,
+  connectorId,
   streamId,
   streamKey,
+  sourceSchema,
   sourcePaths,
   byMappingId,
   childrenOf,
@@ -125,6 +132,33 @@ export function MappingNode({
 
   // Persist a new entry array (the single mapping field-write surface).
   const writeEntries = (next: FieldMapping[]) => setFieldMappings(streamId, mapping.id, next)
+
+  // Tier 2 suggester (create-sync-flow §3.2) — only offered on a root-record
+  // mapping (whole payload / each item), where the suggester's record-relative
+  // leaves match this mapping's subtree. Merges proposals in as editable rows,
+  // skipping any source path or target field that's already bound.
+  const canSuggest =
+    mapping.parentMappingId == null &&
+    (mapping.rootPath === '' || mapping.rootPath === '[]') &&
+    mapping.entityDefinitionId != null
+  const suggestMappings = api.dataConnector.suggestMappings.useMutation({
+    onSuccess: (data) => {
+      const boundSources = new Set(
+        fieldMappings
+          .filter((e) => isBareToken(e.expression))
+          .map((e) => e.expression.replace(/^\{|\}$/g, ''))
+      )
+      const boundTargets = new Set(
+        fieldMappings.map((e) => e.targetFieldRef).filter((r): r is string => r != null)
+      )
+      const fresh = (data.proposals as FieldMapping[]).filter((p) => {
+        const src = Object.values(p.sourceFields)[0]
+        return !!src && !boundSources.has(src) && !boundTargets.has(p.targetFieldRef ?? '')
+      })
+      if (fresh.length > 0) writeEntries([...fieldMappings, ...fresh])
+    },
+    onError: (e) => toastError({ title: 'Could not suggest mappings', description: e.message }),
+  })
   // Patch one entry in place by its stable id (used by every per-entry mutation).
   const patchEntry = (id: string, patch: Partial<FieldMapping>) =>
     writeEntries(fieldMappings.map((e) => (e.id === id ? { ...e, ...patch } : e)))
@@ -300,6 +334,22 @@ export function MappingNode({
                 </Badge>
               </button>
             </SimpleTooltip>
+            {canSuggest && (
+              <TreeRowButton
+                persistent
+                tooltipText='Suggest field mappings from the source'
+                disabled={suggestMappings.isPending}
+                onClick={() =>
+                  suggestMappings.mutate({
+                    id: connectorId,
+                    streamKey: streamKey || undefined,
+                    entityDefinitionId: mapping.entityDefinitionId!,
+                    sourceSchema: sourceSchema ?? undefined,
+                  })
+                }>
+                {suggestMappings.isPending ? <Loader2 className='animate-spin' /> : <Sparkles />}
+              </TreeRowButton>
+            )}
             {/* Every mapping is removable now — no auto-seeded spine. Deleting a
               mapping drops back to the passive source row it was created from. */}
             <TreeRowButton
@@ -337,8 +387,10 @@ export function MappingNode({
               onToggleMatch={toggleMatch}
               onFanOut={materializeChild}
               // Child-mapping recursion context.
+              connectorId={connectorId}
               streamId={streamId}
               streamKey={streamKey}
+              sourceSchema={sourceSchema}
               sourcePaths={sourcePaths}
               byMappingId={byMappingId}
               childrenOf={childrenOf}
@@ -405,7 +457,9 @@ export function MappingNode({
             key={child.id}
             mapping={child}
             depth={depth + 1}
+            connectorId={connectorId}
             streamId={streamId}
+            sourceSchema={sourceSchema}
             sourcePaths={sourcePaths}
             byMappingId={byMappingId}
             childrenOf={childrenOf}
@@ -460,8 +514,10 @@ interface SourceNodeProps {
   onToggleMatch: (entryId: string) => void
   onFanOut: (node: SourceTreeNode, entityDefinitionId: string) => void
   // Child-mapping recursion context (forwarded to a nested MappingNode).
+  connectorId: string
   streamId: string
   streamKey: string
+  sourceSchema?: Record<string, unknown> | null
   sourcePaths: SourcePath[]
   byMappingId: Map<string, Mapping>
   childrenOf: Map<string | null, Mapping[]>
@@ -500,8 +556,10 @@ function SourceNode(props: SourceNodeProps) {
       <MappingNode
         mapping={childMapping}
         depth={depth}
+        connectorId={props.connectorId}
         streamId={props.streamId}
         streamKey={props.streamKey}
+        sourceSchema={props.sourceSchema}
         sourcePaths={props.sourcePaths}
         byMappingId={props.byMappingId}
         childrenOf={props.childrenOf}

--- a/apps/web/src/components/data-connectors/ui/mapping-tree.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-tree.tsx
@@ -29,6 +29,8 @@ interface MappingTreeProps {
   /** The stream's mappings (loaded with the stream — plan 08 §3). */
   mappings: Mapping[]
   sourcePaths: SourcePath[]
+  /** The stream's raw source schema (Layer A) — fed to the Tier 2 suggester. */
+  sourceSchema?: Record<string, unknown> | null
 }
 
 /** The fan-out rootPath for a branch node — arrays keep their `[]` suffix. */
@@ -52,6 +54,7 @@ export function MappingTree({
   streamKey,
   mappings: rows,
   sourcePaths,
+  sourceSchema,
 }: MappingTreeProps) {
   const mutations = useStreamMutations(connectorId)
   const { fanOut } = mutations
@@ -107,8 +110,10 @@ export function MappingTree({
     })
 
   const recursionCtx = {
+    connectorId,
     streamId,
     streamKey,
+    sourceSchema,
     sourcePaths,
     byMappingId,
     childrenOf,
@@ -187,8 +192,10 @@ interface TopSourceNodeProps {
   /** Create a top-level mapping at the given rootPath against the picked def. */
   onCreate: (rootPath: string, entityDefinitionId: string) => void
   // Recursion context forwarded to a promoted MappingNode.
+  connectorId: string
   streamId: string
   streamKey: string
+  sourceSchema?: Record<string, unknown> | null
   sourcePaths: SourcePath[]
   byMappingId: Map<string, Mapping>
   childrenOf: Map<string | null, Mapping[]>
@@ -212,8 +219,10 @@ function TopSourceNode(props: TopSourceNodeProps) {
         <MappingNode
           mapping={mapping}
           depth={depth}
+          connectorId={props.connectorId}
           streamId={props.streamId}
           streamKey={props.streamKey}
+          sourceSchema={props.sourceSchema}
           sourcePaths={props.sourcePaths}
           byMappingId={props.byMappingId}
           childrenOf={props.childrenOf}

--- a/apps/web/src/components/data-connectors/ui/merge-strategy-toggle.tsx
+++ b/apps/web/src/components/data-connectors/ui/merge-strategy-toggle.tsx
@@ -20,21 +20,21 @@ const MERGE_STRATEGIES: Array<{
 }> = [
   {
     value: 'overwrite',
-    label: 'overwrite',
+    label: 'Always update',
     variant: 'default',
-    description: 'Always replace the target value with the synced value.',
+    description: 'Always replace the current value with the latest synced value.',
   },
   {
     value: 'fill_blank',
-    label: 'fill-blank',
+    label: 'Only if empty',
     variant: 'sky',
-    description: 'Only write when the target is empty; never replace an existing value.',
+    description: 'Only fill this in when the field is empty; never replace an existing value.',
   },
   {
     value: 'connector_owned_only',
-    label: 'owned-only',
+    label: 'Keep manual edits',
     variant: 'emerald',
-    description: 'Only update values this connector wrote; leave manually-edited values untouched.',
+    description: 'Only update values this sync created; leave manually-edited values untouched.',
   },
 ]
 
@@ -63,7 +63,7 @@ export function MergeStrategyToggle({
       delayDuration={500}
       contentComponent={
         <div className='max-w-xs'>
-          <div className='font-semibold capitalize'>{current.label}</div>
+          <div className='font-semibold'>{current.label}</div>
           <div className='text-muted-foreground'>{current.description}</div>
         </div>
       }>

--- a/apps/web/src/components/data-connectors/ui/schedule-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/schedule-section.tsx
@@ -9,6 +9,8 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
+import { Label } from '@auxx/ui/components/label'
+import { RadioGroup, RadioGroupItem } from '@auxx/ui/components/radio-group'
 import { EmptySection, Section } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
 import { ChevronDown, Clock } from 'lucide-react'
@@ -25,6 +27,13 @@ import { useRegisterSaver } from '../hooks/use-connector-edits'
 type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
 
 type SyncBehavior = 'manual' | 'scheduled' | 'webhook'
+type BackfillWindowSpan = 'all' | 'last_90_days' | 'last_12_months'
+
+const WINDOW_OPTIONS: Array<{ value: BackfillWindowSpan; label: string }> = [
+  { value: 'all', label: 'Import all history' },
+  { value: 'last_12_months', label: 'Last 12 months' },
+  { value: 'last_90_days', label: 'Last 90 days' },
+]
 
 interface ScheduleSectionProps {
   connector: Connector
@@ -45,16 +54,39 @@ export function ScheduleSection({ connector }: ScheduleSectionProps) {
     onError: (e) => toastError({ title: 'Could not save schedule', description: e.message }),
   })
 
-  // Behavior + schedule fields are one buffered draft behind a single Save —
-  // flip mode to 'auto' for autosave (plan §6). Both edits dirty the same draft.
+  // The window radio only makes sense when a stream declares which param carries the
+  // backfill floor (templates do; bare generic-rest doesn't — Step 9 §1.2/§3.2). We
+  // can't filter a param we don't know, so hide the choice otherwise.
+  const streams = api.dataConnector.listStreams.useQuery({ id: connector.id })
+  const supportsWindow = (streams.data ?? []).some(
+    (s) => (s.requestConfig as { backfillWindow?: { sinceParam?: string } } | null)?.backfillWindow
+  )
+  const persistedSpan = ((connector.config as { backfillWindowSpan?: BackfillWindowSpan } | null)
+    ?.backfillWindowSpan ?? 'all') as BackfillWindowSpan
+
+  // Behavior + schedule + backfill window are one buffered draft behind a single Save
+  // — flip mode to 'auto' for autosave (plan §6). All edits dirty the same draft.
   const draft = useBufferedConfig(
     {
       behavior: (connector.syncBehavior as SyncBehavior) ?? 'manual',
       schedule: scheduledStateFromConfig(
         connector.scheduleConfig as Record<string, unknown> | null
       ),
+      windowSpan: persistedSpan,
     },
     (value) => {
+      // `update` replaces config wholesale, so merge the span into the existing
+      // config — and only send it when it changed, to avoid clobbering a concurrent
+      // config edit on a pure schedule save.
+      const windowChanged = value.windowSpan !== persistedSpan
+      const configPatch = windowChanged
+        ? {
+            config: {
+              ...((connector.config as Record<string, unknown> | null) ?? {}),
+              backfillWindowSpan: value.windowSpan,
+            },
+          }
+        : {}
       if (value.behavior === 'scheduled') {
         const config = scheduledConfigFromState(value.schedule)
         if (!config) {
@@ -68,17 +100,19 @@ export function ScheduleSection({ connector }: ScheduleSectionProps) {
           id: connector.id,
           syncBehavior: 'scheduled',
           scheduleConfig: config,
+          ...configPatch,
         })
       }
       return update.mutateAsync({
         id: connector.id,
         syncBehavior: value.behavior,
         scheduleConfig: null,
+        ...configPatch,
       })
     },
     { mode: 'manual' }
   )
-  const { behavior, schedule } = draft.value
+  const { behavior, schedule, windowSpan } = draft.value
 
   // Feeds the connector-wide save bar; no per-section Save button.
   useRegisterSaver('schedule', draft.isDirty, update.isPending, draft.commit)
@@ -130,6 +164,30 @@ export function ScheduleSection({ connector }: ScheduleSectionProps) {
             <p className='text-xs text-muted-foreground'>
               Minimum cadence is 5 minutes — connectors don’t sync more often than that.
             </p>
+          </div>
+        )}
+
+        {supportsWindow && (
+          <div className='flex flex-col gap-2 border-t pt-4'>
+            <div className='text-sm font-medium'>How much history to import</div>
+            <p className='text-xs text-muted-foreground'>
+              Applies to the first full import. Changing this takes effect on the next import.
+            </p>
+            <RadioGroup
+              value={windowSpan}
+              onValueChange={(v) =>
+                draft.set({ ...draft.value, windowSpan: v as BackfillWindowSpan })
+              }
+              className='gap-2 pt-1'>
+              {WINDOW_OPTIONS.map((opt) => (
+                <div key={opt.value} className='flex items-center gap-2'>
+                  <RadioGroupItem value={opt.value} id={`window-${opt.value}`} />
+                  <Label htmlFor={`window-${opt.value}`} className='cursor-pointer font-normal'>
+                    {opt.label}
+                  </Label>
+                </div>
+              ))}
+            </RadioGroup>
           </div>
         )}
       </div>

--- a/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
@@ -76,6 +76,14 @@ const SYNC_MODE_COPY: Record<
 interface StreamConfigPanelProps {
   connector: Connector
   stream: Stream
+  /**
+   * Which sections to render. `all` (default, the flat-editor drill) shows the
+   * whole panel; the setup stepper splits it into `configure` (request → sample →
+   * schema → sync mode) and `map` (mappings only) so each becomes its own step.
+   */
+  view?: 'all' | 'configure' | 'map'
+  /** Wrap in a full-height `ScrollArea` (default). The stepper supplies its own scroll. */
+  scroll?: boolean
 }
 
 const EMPTY_SCHEMA = { type: 'object', properties: {} }
@@ -86,7 +94,14 @@ const EMPTY_SCHEMA = { type: 'object', properties: {} }
  * The schema is derived from the sample ("Use this shape as the schema") or
  * hand-edited; the mapping fan-out tree projects subtrees onto target defs.
  */
-export function StreamConfigPanel({ connector, stream }: StreamConfigPanelProps) {
+export function StreamConfigPanel({
+  connector,
+  stream,
+  view = 'all',
+  scroll = true,
+}: StreamConfigPanelProps) {
+  const showConfigure = view !== 'map'
+  const showMappings = view !== 'configure'
   // Branch on the persisted definitionKind (05c §7), not a `type` prefix sniff.
   const isGenericRest = connector.definitionKind !== 'app'
 
@@ -186,11 +201,11 @@ export function StreamConfigPanel({ connector, stream }: StreamConfigPanelProps)
     ? (SCHEMA_SOURCE_SENTENCE[stream.schemaSource] ?? SCHEMA_SOURCE_SENTENCE.manual)
     : SCHEMA_SOURCE_NONE
 
-  return (
-    <ScrollArea className='h-full' scrollbarClassName='w-1.5'>
+  const body = (
+    <>
       <div className='flex flex-col'>
         {/* 1. Request — what to fetch (generic-rest only) */}
-        {isGenericRest && (
+        {isGenericRest && showConfigure && (
           <Section
             title='Request'
             icon={<Database className='size-4' />}
@@ -297,88 +312,95 @@ export function StreamConfigPanel({ connector, stream }: StreamConfigPanelProps)
         )}
 
         {/* 2. Sample — the single live test-fetch; feeds the schema below */}
-        <Section
-          title='Sample'
-          icon={<FlaskConical className='size-4' />}
-          initialOpen
-          collapsible={false}
-          description='Pull a few real records to see what the source returns.'
-          actions={
-            <Button
-              variant='outline'
-              size='xs'
-              loading={isSampling}
-              loadingText='Fetching...'
-              onClick={() => void handleTestFetch()}>
-              <FlaskConical />
-              Test fetch
-            </Button>
-          }>
-          <StreamSample sample={sample} onUseShape={handleUseShape} />
-        </Section>
+        {showConfigure && (
+          <>
+            <Section
+              title='Sample'
+              icon={<FlaskConical className='size-4' />}
+              initialOpen
+              collapsible={false}
+              description='Pull a few real records to see what the source returns.'
+              actions={
+                <Button
+                  variant='outline'
+                  size='xs'
+                  loading={isSampling}
+                  loadingText='Fetching...'
+                  onClick={() => void handleTestFetch()}>
+                  <FlaskConical />
+                  Test fetch
+                </Button>
+              }>
+              <StreamSample sample={sample} onUseShape={handleUseShape} />
+            </Section>
 
-        {/* 3. Schema — derived from the sample or hand-edited */}
-        <Section
-          title='Source schema'
-          icon={<Database className='size-4' />}
-          initialOpen
-          collapsible={false}
-          actions={
-            <Button variant='ghost' size='xs' onClick={openEdit}>
-              <Pencil />
-              Edit
-            </Button>
-          }>
-          <p className='px-1 pb-2 text-xs text-muted-foreground'>{schemaSentence}</p>
-        </Section>
+            {/* 3. Schema — derived from the sample or hand-edited */}
+            <Section
+              title='Source schema'
+              icon={<Database className='size-4' />}
+              initialOpen
+              collapsible={false}
+              actions={
+                <Button variant='ghost' size='xs' onClick={openEdit}>
+                  <Pencil />
+                  Edit
+                </Button>
+              }>
+              <p className='px-1 pb-2 text-xs text-muted-foreground'>{schemaSentence}</p>
+            </Section>
 
-        {/* 4. Sync mode */}
-        <Section
-          title='Sync mode'
-          icon={<Database className='size-4' />}
-          initialOpen
-          collapsible={false}
-          actions={
-            <RadioTab
-              value={syncMode}
-              onValueChange={(v) =>
-                // Pass the whole buffered request so toggling mode never drops
-                // saved headers/params/body (setStreamRequestConfig writes it whole).
-                setSyncMode(stream.id, v as 'snapshot' | 'incremental', request.value)
-              }
-              size='sm'>
-              <RadioTabItem value='snapshot' size='sm'>
-                Snapshot
-              </RadioTabItem>
-              <RadioTabItem value='incremental' size='sm'>
-                Incremental
-              </RadioTabItem>
-            </RadioTab>
-          }>
-          <div className='px-1'>
-            <EmptySection
-              icon={SYNC_MODE_COPY[syncMode].icon}
-              title={SYNC_MODE_COPY[syncMode].title}
-              description={SYNC_MODE_COPY[syncMode].description}
-            />
-          </div>
-        </Section>
+            {/* 4. Sync mode */}
+            <Section
+              title='Sync mode'
+              icon={<Database className='size-4' />}
+              initialOpen
+              collapsible={false}
+              actions={
+                <RadioTab
+                  value={syncMode}
+                  onValueChange={(v) =>
+                    // Pass the whole buffered request so toggling mode never drops
+                    // saved headers/params/body (setStreamRequestConfig writes it whole).
+                    setSyncMode(stream.id, v as 'snapshot' | 'incremental', request.value)
+                  }
+                  size='sm'>
+                  <RadioTabItem value='snapshot' size='sm'>
+                    Snapshot
+                  </RadioTabItem>
+                  <RadioTabItem value='incremental' size='sm'>
+                    Incremental
+                  </RadioTabItem>
+                </RadioTab>
+              }>
+              <div className='px-1'>
+                <EmptySection
+                  icon={SYNC_MODE_COPY[syncMode].icon}
+                  title={SYNC_MODE_COPY[syncMode].title}
+                  description={SYNC_MODE_COPY[syncMode].description}
+                />
+              </div>
+            </Section>
+          </>
+        )}
 
         {/* 5. Mappings */}
-        <Section
-          title='Mappings'
-          icon={<Database className='size-4' />}
-          initialOpen
-          collapsible={false}
-          description='Project subtrees of the source onto target definitions.'>
-          <MappingTree
-            connectorId={connector.id}
-            streamId={stream.id}
-            streamKey={stream.streamKey ?? ''}
-            mappings={stream.mappings}
-            sourcePaths={sourcePaths}
-          />
-        </Section>
+        {showMappings && (
+          <Section
+            title='Mappings'
+            icon={<Database className='size-4' />}
+            initialOpen
+            collapsible={false}
+            description='Project subtrees of the source onto target definitions.'>
+            <MappingTree
+              connectorId={connector.id}
+              streamId={stream.id}
+              streamKey={stream.streamKey ?? ''}
+              mappings={stream.mappings}
+              sourcePaths={sourcePaths}
+              sourceSchema={stream.sourceSchema as Record<string, unknown> | null}
+            />
+          </Section>
+        )}
       </div>
 
       <SchemaEditorDialog
@@ -389,7 +411,15 @@ export function StreamConfigPanel({ connector, stream }: StreamConfigPanelProps)
         policy={{ emitRequired: false, root: 'any', rootLabel: 'record', freeformNames: true }}
         onSave={handleSaveSchema}
       />
+    </>
+  )
+
+  return scroll ? (
+    <ScrollArea className='h-full' scrollbarClassName='w-1.5'>
+      {body}
     </ScrollArea>
+  ) : (
+    body
   )
 }
 

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -5,7 +5,7 @@
 // The backend engine (queue/scheduler/orchestrator/provisioning) lives in
 // @auxx/lib/data-connectors — this router is a thin, validated edge over it.
 
-import { getCachedInstalledApps } from '@auxx/lib/cache'
+import { getCachedInstalledApps, getCachedResourceFields } from '@auxx/lib/cache'
 import {
   addMapping,
   addStream,
@@ -28,10 +28,12 @@ import {
   sampleConnectorFetch,
   setStreamRequestConfig,
   setStreamSchema,
+  suggestFieldMappings,
   updateConnector,
   updateMapping,
   updateStream,
 } from '@auxx/lib/data-connectors'
+import { inferJsonSchema } from '@auxx/lib/json-schema/client'
 import { resourceFieldIdSchema } from '@auxx/types/field'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
@@ -67,6 +69,8 @@ const connectorConfigSchema = z
       })
       .optional(),
     filters: z.record(z.string(), z.unknown()).optional(),
+    // How far back a backfill crawls (Step 9 §1.2) — plain-language window radio.
+    backfillWindowSpan: z.enum(['all', 'last_90_days', 'last_12_months']).optional(),
   })
   .passthrough()
 
@@ -102,6 +106,11 @@ const requestConfigSchema = z.object({
   body: z.record(z.string(), z.unknown()).optional(),
   headers: z.record(z.string(), z.string()).optional(),
   pagination: paginationSchema.optional(),
+  // Declares which param carries the backfill-window floor (Step 9 §1.2); set by
+  // templates, preserved across stream edits. Distinct from `incremental.sinceParam`.
+  backfillWindow: z
+    .object({ sinceParam: z.string(), format: z.enum(['iso', 'unix']).optional() })
+    .optional(),
 })
 
 const mergeStrategySchema = z.enum([
@@ -471,6 +480,61 @@ export const dataConnectorRouter = createTRPCRouter({
           message: error instanceof Error ? error.message : 'Test-fetch failed',
         })
       }
+    }),
+
+  /**
+   * Tier 2 mapping suggestions for a bare custom-REST stream (create-sync-flow §3.2).
+   * Reuses the stream's already-detected `sourceSchema` (the setup stepper's Map step
+   * runs after Sample, so a schema exists) — else falls back to a live `sampleFetch`
+   * + inference — then heuristically proposes source→field bindings against the target
+   * entity def's fields (read from the org cache). Returns the editable `FieldMapping`
+   * entry shape; the UI drops them in as pre-checked rows the user confirms/edits.
+   */
+  suggestMappings: adminProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        streamKey: z.string().min(1).nullish(),
+        entityDefinitionId: z.string(),
+        // The stream's detected source schema (Layer A). Passed by the UI to avoid a
+        // redundant live fetch; when omitted, a sample fetch infers it.
+        sourceSchema: z.record(z.string(), z.unknown()).nullish(),
+        requestConfig: requestConfigSchema.optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const result = await getConnector(ctx.db, ctx.session.organizationId, input.id)
+      if (result.isErr()) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: result.error.message })
+      }
+
+      let schema = input.sourceSchema ?? null
+      if (!schema) {
+        try {
+          const sample = await sampleConnectorFetch(
+            ctx.db,
+            ctx.session.organizationId,
+            ctx.session.userId,
+            result.value,
+            { streamKey: input.streamKey, requestConfig: input.requestConfig }
+          )
+          const record = Array.isArray(sample.response) ? sample.response[0] : sample.response
+          schema = record != null ? (inferJsonSchema(record) as Record<string, unknown>) : null
+        } catch (error) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: error instanceof Error ? error.message : 'Could not sample the source',
+          })
+        }
+      }
+      if (!schema) return { proposals: [] }
+
+      const targetFields = await getCachedResourceFields(
+        ctx.session.organizationId,
+        input.entityDefinitionId
+      )
+      const proposals = suggestFieldMappings(input.entityDefinitionId, schema, targetFields)
+      return { proposals }
     }),
 
   addStream: adminProcedure

--- a/packages/database/src/db/schema/data-connector-run.ts
+++ b/packages/database/src/db/schema/data-connector-run.ts
@@ -43,7 +43,11 @@ export const DataConnectorRun = pgTable(
     pagesProcessed: integer().default(0).notNull(),
     // Cumulative wall-clock spent waiting on rate limits (honest "Rate-limited" UX).
     rateLimitWaitMs: integer().default(0).notNull(),
-    errorSample: jsonb().$type<Array<{ externalId: string; error: string }>>(),
+    // `tier` (Step 9 §1.1): 'invalid' (bad shape, pre-write drop) | 'rejected'
+    // (the entity write threw). Omitted ⇒ engine-level error → neutral "Error".
+    // Mirror of `RunCounters.errorSample` in lib service.ts (hand-synced).
+    errorSample:
+      jsonb().$type<Array<{ externalId: string; error: string; tier?: 'invalid' | 'rejected' }>>(),
     // Optional progress snapshot for the live status line (counts + per-stream phase).
     progress: jsonb().$type<Record<string, unknown>>(),
     // B2 — the decoded stream+mapping snapshot the continuation chain is PINNED to.

--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -69,6 +69,8 @@ export interface DataConnectorConfig {
   filters?: Record<string, unknown>
   /** Provider webhook capability selector (Step 8). Mirror of lib `DataConnectorConfig.webhook`. */
   webhook?: { provider: 'shopify' | 'stripe' }
+  /** Backfill crawl span (Step 9 §1.2). Mirror of lib `DataConnectorConfig.backfillWindowSpan`. */
+  backfillWindowSpan?: 'all' | 'last_90_days' | 'last_12_months'
 }
 
 /**
@@ -109,6 +111,9 @@ export interface ConnectorStreamState {
   recordsSeen?: number
   /** Steady-phase delta floor; the source returns a monotonic max each slice. */
   watermark?: string
+  /** Backfill-window floor (Step 9 §1.2), pinned once at fresh-backfill reset.
+   *  Mirror of lib `ConnectorStreamState.backfillFloor`. */
+  backfillFloor?: string
   /** Legacy single-shot incremental cursor (snapshot-first generic-rest path). */
   cursor?: string
   /** Set by a connector's terminal `nextState` when its backfill is exhausted. */
@@ -145,6 +150,9 @@ export interface StreamRequestConfig {
     /** Dotted path on each event to the embedded object to sink (Stripe `data.object`). */
     objectPath?: string
   }
+  /** Backfill-window floor param declaration (Step 9 §1.2). Mirror of lib
+   *  `StreamRequestConfig.backfillWindow`. */
+  backfillWindow?: { sinceParam: string; format?: 'iso' | 'unix' }
 }
 
 /**

--- a/packages/lib/src/data-connectors/connectors/generic-rest-slicing.test.ts
+++ b/packages/lib/src/data-connectors/connectors/generic-rest-slicing.test.ts
@@ -248,3 +248,60 @@ describe('generic-rest enriched pagination (Step 6)', () => {
     expect(String(fetchMock.mock.calls[1]![0])).toContain('STARTPOSITION=1001')
   })
 })
+
+describe('generic-rest backfill window (Step 9 §1.2)', () => {
+  const backfillWindow = { sinceParam: 'created[gte]', format: 'unix' as const }
+
+  it('injects the pinned floor on EVERY page of a snapshot run (page pagination)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(json({ items: [{}] })) // page 1 → keep going
+      .mockResolvedValueOnce(json({ items: [] })) // page 2 → exhausted
+
+    await collect(
+      args({
+        mode: 'snapshot',
+        state: { backfillFloor: '1700000000' },
+        config: {
+          endpoint: {
+            baseUrl: 'https://api.example.com',
+            auth: 'none',
+            pagination: { kind: 'page', pageParam: 'page' },
+          },
+        },
+        requestConfig: { path: 'charges', backfillWindow },
+      })
+    )
+
+    // Pinned floor is re-sent on both pages — not first-page-only.
+    expect(decodeURIComponent(String(fetchMock.mock.calls[0]![0]))).toContain(
+      'created[gte]=1700000000'
+    )
+    expect(decodeURIComponent(String(fetchMock.mock.calls[1]![0]))).toContain(
+      'created[gte]=1700000000'
+    )
+  })
+
+  it('does NOT inject the floor on an incremental (steady) run', async () => {
+    fetchMock.mockResolvedValueOnce(json([{}]))
+    await collect(
+      args({
+        mode: 'incremental',
+        state: { backfillFloor: '1700000000' },
+        requestConfig: { path: 'charges', pagination: { kind: 'none' }, backfillWindow },
+      })
+    )
+    expect(decodeURIComponent(String(fetchMock.mock.calls[0]![0]))).not.toContain('created[gte]')
+  })
+
+  it('does NOT inject when no floor is pinned (span all)', async () => {
+    fetchMock.mockResolvedValueOnce(json([{}]))
+    await collect(
+      args({
+        mode: 'snapshot',
+        state: {}, // no backfillFloor
+        requestConfig: { path: 'charges', pagination: { kind: 'none' }, backfillWindow },
+      })
+    )
+    expect(decodeURIComponent(String(fetchMock.mock.calls[0]![0]))).not.toContain('created[gte]')
+  })
+})

--- a/packages/lib/src/data-connectors/connectors/generic-rest.ts
+++ b/packages/lib/src/data-connectors/connectors/generic-rest.ts
@@ -342,6 +342,15 @@ async function* fetchRecords(args: ConnectorFetchArgs): AsyncIterable<ConnectorY
     if (incremental && args.mode === 'incremental' && args.state.watermark) {
       params[incremental.sinceParam] = args.state.watermark
     }
+    // Backfill-window floor (Step 9 §1.2) — inject the pinned floor on EVERY page of a
+    // snapshot run. `params` is rebuilt per page, and page/offset/cursor pagination
+    // re-sends filters every request, so this must not be first-page-only. For
+    // next-url/link-header the url-selection below GETs the server URL verbatim and
+    // ignores `params`, so the floor (baked into that URL) is applied page 1 only —
+    // exactly right. The pinned floor is stable across the whole chain (no drift).
+    if (request.backfillWindow && args.mode === 'snapshot' && args.state.backfillFloor) {
+      params[request.backfillWindow.sinceParam] = args.state.backfillFloor
+    }
 
     // link-header hands back an absolute next URL (GET as-is); next-url hands back
     // a body URL that is often relative (Salesforce `nextRecordsUrl`) — join it onto

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -177,6 +177,9 @@ export {
   startConnectorSync,
   sweepStaleConnectorRuns,
 } from './slice-orchestrator'
+// Tier 2 mapping suggester (create-sync-flow §3.2) — heuristic source→field proposals
+export type { SourceLeaf } from './suggest-mappings'
+export { collectSchemaLeaves, suggestFieldMappings } from './suggest-mappings'
 // Sync-core adapters (Step 3) — DC implementations of the shared seams
 export {
   applySyncStateToStream,

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -213,7 +213,11 @@ export interface RunCounters {
   deleted: number
   failed: number
   relationshipWarnings: number
-  errorSample: Array<{ externalId: string; error: string }>
+  // `tier` classifies the failure for the two-tier error UI (Step 9 §1.1):
+  // 'invalid' = bad shape / missing identity, dropped before the write;
+  // 'rejected' = the entity write itself threw. Omitted ⇒ engine-level error
+  // (stale sweep / ledger fail), rendered under a neutral "Error" bucket.
+  errorSample: Array<{ externalId: string; error: string; tier?: 'invalid' | 'rejected' }>
 }
 
 export function newRunCounters(): RunCounters {

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -88,6 +88,7 @@ async function resolveFieldRefs(
       ctx.counters.errorSample.push({
         externalId: record.externalId,
         error: `unresolved targetFieldRef: ${ref}`,
+        tier: 'invalid', // caught before the write — bad shape / missing identity
       })
     }
   }
@@ -283,7 +284,11 @@ export const entitySink: EntitySink = {
       const message = error instanceof Error ? error.message : String(error)
       ctx.counters.failed += 1
       if (ctx.counters.errorSample.length < 50) {
-        ctx.counters.errorSample.push({ externalId: record.externalId, error: message })
+        ctx.counters.errorSample.push({
+          externalId: record.externalId,
+          error: message,
+          tier: 'rejected', // the entity write itself failed
+        })
       }
       logger.warn('upsertRecord failed', {
         mappingId: mapping.row.id,

--- a/packages/lib/src/data-connectors/slice-orchestrator.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator.ts
@@ -74,7 +74,8 @@ interface ChainSnapshot {
 /** Reset a stream's durable state to a fresh backfill (re-backfill / first run). */
 function freshBackfillState(
   prev: ConnectorStreamState,
-  startedAtIso: string
+  startedAtIso: string,
+  backfillFloor?: string
 ): ConnectorStreamState {
   return {
     ...prev,
@@ -84,7 +85,29 @@ function freshBackfillState(
     recordsSeen: 0,
     watermark: undefined,
     backfillComplete: false,
+    // Step 9 §1.2 — pin the window floor ONCE so every slice injects the same value
+    // (no per-slice `now` drift). Undefined ⇒ span 'all' / no window ⇒ full history.
+    backfillFloor,
   }
+}
+
+type BackfillWindowSpan = 'all' | 'last_90_days' | 'last_12_months'
+
+/**
+ * Compute the pinned backfill-window floor (Step 9 §1.2). `span` is the connector's
+ * plain-language choice; `format` comes from the stream's `backfillWindow`. Computed
+ * ONCE per fresh backfill so the whole chain shares one floor. `'all'`/absent ⇒ no
+ * floor (crawl full history — current behavior).
+ */
+function computeBackfillFloor(
+  span: BackfillWindowSpan | undefined,
+  format: 'iso' | 'unix' = 'iso'
+): string | undefined {
+  if (!span || span === 'all') return undefined
+  const floor = new Date()
+  if (span === 'last_90_days') floor.setDate(floor.getDate() - 90)
+  else floor.setMonth(floor.getMonth() - 12) // last_12_months
+  return format === 'unix' ? String(Math.floor(floor.getTime() / 1000)) : floor.toISOString()
 }
 
 // ── Start a connector sync (backfill or steady) ──────────────────────────────────
@@ -149,11 +172,16 @@ export async function startConnectorSync(
   // (keep its cursor) or running steady (keep its watermark).
   const startedAtIso = new Date().toISOString()
   if (phase === 'backfill') {
+    const span = connector.config?.backfillWindowSpan
     for (const [i, s] of streams.entries()) {
       const st = streamStates[i] ?? {}
       const resumable = incrementalConnector && st.phase === 'backfill' && !!st.backfillCursor
-      if (!resumable)
-        await persistStreamState(db, s.stream.id, freshBackfillState(st, startedAtIso))
+      if (resumable) continue
+      // Pin the floor per stream — the param is connector-level but the format is
+      // declared per stream; streams without a `backfillWindow` get no floor.
+      const window = s.stream.requestConfig?.backfillWindow
+      const floor = window ? computeBackfillFloor(span, window.format) : undefined
+      await persistStreamState(db, s.stream.id, freshBackfillState(st, startedAtIso, floor))
     }
   }
 

--- a/packages/lib/src/data-connectors/suggest-mappings.test.ts
+++ b/packages/lib/src/data-connectors/suggest-mappings.test.ts
@@ -1,0 +1,122 @@
+// packages/lib/src/data-connectors/suggest-mappings.test.ts
+// Tier 2 mapping suggester (create-sync-flow §3.2): scalar-leaf extraction from a
+// source schema + the name/type heuristic that proposes source→field bindings.
+
+import { describe, expect, it } from 'vitest'
+import type { ResourceField } from '../resources'
+import { collectSchemaLeaves, suggestFieldMappings } from './suggest-mappings'
+
+/** Minimal writable target field; override `capabilities`/`fieldType` per case. */
+function field(partial: Partial<ResourceField> & { id: string; key: string }): ResourceField {
+  return {
+    label: partial.key,
+    type: 'string',
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: true,
+    },
+    ...partial,
+  } as ResourceField
+}
+
+describe('collectSchemaLeaves', () => {
+  it('collects scalar leaves, recurses objects, skips arrays', () => {
+    const leaves = collectSchemaLeaves({
+      type: 'object',
+      properties: {
+        email: { type: 'string' },
+        age: { type: 'number' },
+        tags: { type: 'array', items: { type: 'string' } },
+        customer: { type: 'object', properties: { city: { type: 'string' } } },
+      },
+    })
+    expect(leaves).toEqual([
+      { path: 'email', jsonType: 'string' },
+      { path: 'age', jsonType: 'number' },
+      { path: 'customer.city', jsonType: 'string' },
+    ])
+  })
+
+  it('descends an array-root schema into its element shape (record-relative paths)', () => {
+    const leaves = collectSchemaLeaves({
+      type: 'array',
+      items: { type: 'object', properties: { id: { type: 'string' } } },
+    })
+    expect(leaves).toEqual([{ path: 'id', jsonType: 'string' }])
+  })
+})
+
+describe('suggestFieldMappings', () => {
+  const DEF = 'def_contact'
+
+  it('matches snake/camel-normalized names and emits one-click bindings', () => {
+    const targets = [
+      field({ id: 'email', key: 'email', label: 'Email' }),
+      field({ id: 'fld_first', key: 'firstName', label: 'First name' }),
+    ]
+    const proposals = suggestFieldMappings(
+      DEF,
+      { type: 'object', properties: { email: { type: 'string' }, first_name: { type: 'string' } } },
+      targets
+    )
+    expect(proposals).toHaveLength(2)
+    const byRef = Object.fromEntries(proposals.map((p) => [p.targetFieldRef, p]))
+    expect(byRef[`${DEF}:email`]).toMatchObject({
+      expression: '{email}',
+      sourceFields: { email: 'email' },
+    })
+    expect(byRef[`${DEF}:fld_first`]).toMatchObject({
+      expression: '{first_name}',
+      sourceFields: { first_name: 'first_name' },
+    })
+  })
+
+  it('skips non-writable target fields', () => {
+    const targets = [
+      field({
+        id: 'rid',
+        key: 'recordId',
+        capabilities: {
+          filterable: true,
+          sortable: true,
+          creatable: false,
+          updatable: false,
+          configurable: false,
+          computed: true,
+        },
+      }),
+    ]
+    const proposals = suggestFieldMappings(
+      DEF,
+      { type: 'object', properties: { record_id: { type: 'string' } } },
+      targets
+    )
+    expect(proposals).toEqual([])
+  })
+
+  it('rejects a name match when the target type is incompatible', () => {
+    // RELATIONSHIP never sinks a foreign type, so a string source can't bind.
+    const targets = [field({ id: 'fld_owner', key: 'owner', fieldType: 'RELATIONSHIP' })]
+    const proposals = suggestFieldMappings(
+      DEF,
+      { type: 'object', properties: { owner: { type: 'string' } } },
+      targets
+    )
+    expect(proposals).toEqual([])
+  })
+
+  it('binds at most one source per target field', () => {
+    const targets = [field({ id: 'email', key: 'email', label: 'Email' })]
+    const proposals = suggestFieldMappings(
+      DEF,
+      // Two source leaves normalize to "email" — only the first wins the target.
+      { type: 'object', properties: { email: { type: 'string' }, e_mail: { type: 'string' } } },
+      targets
+    )
+    expect(proposals).toHaveLength(1)
+    expect(proposals[0]?.sourceFields).toEqual({ email: 'email' })
+  })
+})

--- a/packages/lib/src/data-connectors/suggest-mappings.ts
+++ b/packages/lib/src/data-connectors/suggest-mappings.ts
@@ -1,0 +1,137 @@
+// packages/lib/src/data-connectors/suggest-mappings.ts
+// Tier 2 mapping suggester (create-sync-flow-plan §3.2) — propose field bindings
+// for a bare custom-REST stream that has no template/app declarations to draw from.
+// Pure + server-safe: given the stream's source schema (Layer A) and the target
+// entity def's fields, it heuristically matches source leaves onto writable target
+// fields by normalized name + type compatibility and emits ready-to-edit
+// `FieldMapping` entries — the SAME one-click binding shape the mapping editor
+// produces (`expression: '{path}'`, `sourceFields: { path: path }`). v2 (LLM-assisted
+// proposal for the un-matched tail) rides behind the same procedure signature.
+
+import { FieldType } from '@auxx/database/enums'
+import type { FieldType as FieldTypeValue } from '@auxx/database/types'
+import { toResourceFieldId } from '@auxx/types/field'
+import { generateId } from '@auxx/utils'
+import { isFieldTypeCompatible } from '../custom-fields/types'
+import type { ResourceField } from '../resources'
+import type { FieldMapping } from './types'
+
+/** A scalar source leaf extracted from the Layer-A source schema. */
+export interface SourceLeaf {
+  /** Record-relative dotted path, e.g. `email` / `customer.email`. */
+  path: string
+  /** JSON-schema scalar type at this path (`string` / `number` / `boolean` / …). */
+  jsonType: string
+}
+
+interface JsonSchemaNode {
+  type?: string | string[]
+  format?: string
+  properties?: Record<string, JsonSchemaNode>
+  items?: JsonSchemaNode
+}
+
+function nodeType(node: JsonSchemaNode): string {
+  const t = node.type
+  if (Array.isArray(t)) return t.find((x) => x !== 'null') ?? 'string'
+  return t ?? 'object'
+}
+
+/**
+ * Flatten a source JSON schema into scalar leaves, RECORD-relative (an array-root
+ * schema descends into its element shape so paths read `email`, not `[].email` —
+ * matching a root mapping's subtree). Object branches recurse with a dotted prefix;
+ * array branches are skipped (they become their own fan-out mappings, not fields).
+ */
+export function collectSchemaLeaves(schema: Record<string, unknown>): SourceLeaf[] {
+  const root = schema as JsonSchemaNode
+  const start = nodeType(root) === 'array' && root.items ? root.items : root
+  const out: SourceLeaf[] = []
+  const walk = (node: JsonSchemaNode, prefix: string) => {
+    if (nodeType(node) !== 'object' || !node.properties) return
+    for (const [key, child] of Object.entries(node.properties)) {
+      const path = prefix ? `${prefix}.${key}` : key
+      const t = nodeType(child)
+      if (t === 'object') walk(child, path)
+      else if (t === 'array')
+        continue // a collection → its own mapping, not a field
+      else out.push({ path, jsonType: t })
+    }
+  }
+  walk(start, '')
+  return out
+}
+
+/** Canonical name form so `first_name` ↔ `firstName` ↔ `First Name` all collide. */
+function normalizeName(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+/** Last segment of a dotted path (`customer.email` → `email`). */
+function lastSegment(path: string): string {
+  return path.split('.').pop() ?? path
+}
+
+/** The representative {@link FieldType} a source leaf's values carry. */
+function jsonToFieldType(jsonType: string): FieldTypeValue {
+  switch (jsonType) {
+    case 'number':
+    case 'integer':
+      return FieldType.NUMBER
+    case 'boolean':
+      return FieldType.CHECKBOX
+    default:
+      return FieldType.TEXT
+  }
+}
+
+/**
+ * Can an ongoing sync reliably write this target field? Mirrors the UI's
+ * `isWritableTarget` rule — the sink drops non-creatable/non-updatable/computed
+ * values, so those fields can never be kept in sync and aren't worth suggesting.
+ */
+function isWritable(field: ResourceField): boolean {
+  const c = field.capabilities
+  return c.creatable && c.updatable && !c.computed && !c.hidden
+}
+
+/**
+ * Propose field bindings from a source schema onto an entity def's fields.
+ * Heuristic v1: a source leaf binds to the first writable target whose normalized
+ * `key` or `label` equals the leaf's normalized last segment AND whose type is
+ * compatible (when the target carries a concrete `fieldType`; system fields with no
+ * declared type are accepted by name alone). One target per proposal (1 source → 1
+ * field). Returns the entry-array shape the editor stores directly.
+ */
+export function suggestFieldMappings(
+  entityDefinitionId: string,
+  sourceSchema: Record<string, unknown>,
+  targetFields: ResourceField[]
+): FieldMapping[] {
+  const leaves = collectSchemaLeaves(sourceSchema)
+  const writable = targetFields.filter(isWritable)
+  const used = new Set<string>()
+  const out: FieldMapping[] = []
+
+  for (const leaf of leaves) {
+    const leafName = normalizeName(lastSegment(leaf.path))
+    if (!leafName) continue
+    const match = writable.find((f) => {
+      if (used.has(f.id)) return false
+      if (![normalizeName(f.key), normalizeName(f.label)].includes(leafName)) return false
+      if (f.fieldType && !isFieldTypeCompatible(f.fieldType, jsonToFieldType(leaf.jsonType))) {
+        return false
+      }
+      return true
+    })
+    if (!match) continue
+    used.add(match.id)
+    out.push({
+      id: generateId(),
+      targetFieldRef: toResourceFieldId(entityDefinitionId, match.id),
+      expression: `{${leaf.path}}`,
+      sourceFields: { [leaf.path]: leaf.path },
+    })
+  }
+  return out
+}

--- a/packages/lib/src/data-connectors/templates/defs/stripe.json
+++ b/packages/lib/src/data-connectors/templates/defs/stripe.json
@@ -24,7 +24,8 @@
         "path": "/customers",
         "method": "GET",
         "params": { "limit": 100 },
-        "pagination": { "kind": "none" }
+        "pagination": { "kind": "none" },
+        "backfillWindow": { "sinceParam": "created[gte]", "format": "unix" }
       },
       "mappings": [
         {
@@ -80,7 +81,8 @@
         "path": "/charges",
         "method": "GET",
         "params": { "limit": 100 },
-        "pagination": { "kind": "none" }
+        "pagination": { "kind": "none" },
+        "backfillWindow": { "sinceParam": "created[gte]", "format": "unix" }
       },
       "sourceSchema": {
         "type": "object",

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -78,6 +78,14 @@ export interface DataConnectorConfig {
    * binds the matching verify/resolve/register driver.
    */
   webhook?: { provider: 'shopify' | 'stripe' }
+  /**
+   * How far back a BACKFILL crawls (Step 9 §1.2, plain-language UX). Connector-level
+   * (applies to every stream). `'all'` (default) crawls full history. A bounded span
+   * injects a `created`-style floor on the first backfill request — but only on streams
+   * whose {@link StreamRequestConfig.backfillWindow} declares WHICH param carries it
+   * (templates do; bare generic-rest doesn't, so the UI hides the choice).
+   */
+  backfillWindowSpan?: 'all' | 'last_90_days' | 'last_12_months'
 }
 
 /**
@@ -125,6 +133,14 @@ export interface StreamRequestConfig {
   pagination?: PaginationSpec
   /** Steady-phase delta config (absent ⇒ every steady run re-crawls in full). */
   incremental?: StreamIncrementalConfig
+  /**
+   * Declares WHICH request param carries the backfill-window floor (Step 9 §1.2),
+   * e.g. Shopify `created_at_min` / Stripe `created[gte]`. Present ⇒ the connector
+   * can honor {@link DataConnectorConfig.backfillWindowSpan} on this stream (and the
+   * UI offers the window radio). Distinct from `incremental.sinceParam`, which is the
+   * STEADY delta floor (`updated_at`); this one bounds the initial BACKFILL crawl.
+   */
+  backfillWindow?: { sinceParam: string; format?: 'iso' | 'unix' }
 }
 
 // ── Stream state / connector output (03 §1) ───────────────────────────────────
@@ -152,6 +168,14 @@ export interface ConnectorStreamState {
   recordsSeen?: number
   /** Steady-phase delta floor; the source returns a monotonic max each slice. */
   watermark?: string
+  /**
+   * Backfill-window floor (Step 9 §1.2) — the already-formatted value injected on
+   * every page of a snapshot run (Shopify `created_at_min` / Stripe `created[gte]`).
+   * PINNED ONCE when the backfill resets to fresh (`freshBackfillState`), so it stays
+   * stable across every slice of the chain (no per-slice `now` drift). Absent ⇒ span
+   * `'all'` or no `backfillWindow` declared ⇒ crawl full history.
+   */
+  backfillFloor?: string
   /** Legacy single-shot incremental cursor (snapshot-first generic-rest path). */
   cursor?: string
   /** Set by a connector's terminal `nextState` when its backfill is exhausted. */


### PR DESCRIPTION
## Summary

Builds on the connector progress work (Step 9) with setup UX, a field-mapping suggester, and backfill slicing refinements.

- **Setup progress UX** — connector setup stepper, run-errors panel (CSV export), freshness panel, and `use-setup-progress` hook.
- **Mapping suggester** — heuristic `suggestFieldMappings` wired through the tRPC router, plus backfill-window controls.
- **Slicing/orchestration** — backfill slicing refinements in `generic-rest` + slice orchestrator and entity sink; schema additions on `data-connector-run` / `data-connector-types`.

## Stacking

> [!IMPORTANT]
> Based on `feat/ui-metric-grid-csv-primitives` (#930), which it depends on (`MetricGrid` + `@auxx/utils/csv`). Merge #930 first; this base will retarget to `main` automatically once #930 lands.