### PR TITLE
feat(data-connectors): pagination transparency + auto-detect (Step 10)

### DIFF
--- a/apps/web/src/components/apps/ui/connection-row.tsx
+++ b/apps/web/src/components/apps/ui/connection-row.tsx
@@ -128,9 +128,9 @@ export function ConnectionRow({
 }
 
 function StatusIcon({ status }: { status: ConnectionStatus }) {
-  if (status === 'connected') return <CheckCircle className='h-4 w-4 text-green-500' />
-  if (status === 'expired') return <Clock className='h-4 w-4 text-yellow-500' />
-  return <XCircle className='h-4 w-4 text-gray-400' />
+  if (status === 'connected') return <CheckCircle className='h-4 w-4 text-green-500 shrink-0' />
+  if (status === 'expired') return <Clock className='h-4 w-4 text-yellow-500 shrink-0' />
+  return <XCircle className='h-4 w-4 text-gray-400 shrink-0' />
 }
 
 function InlineRenameForm({

--- a/apps/web/src/components/data-connectors/hooks/use-stream-mutations.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-stream-mutations.ts
@@ -357,6 +357,17 @@ export function useStreamMutations(connectorId: string) {
     [sampleFetchM]
   )
 
+  // Persist a detected pagination spec by merging it onto the stream's whole
+  // request config (path/method/headers/params/body preserved). Powers the hidden
+  // "Use this" action (Step 10 §3.4); reuses the normal setStreamRequestConfig.
+  const applyPagination = useCallback(
+    (
+      streamId: string,
+      requestConfig: Parameters<typeof saveRequestConfigM.mutateAsync>[0]['requestConfig']
+    ) => saveRequestConfigM.mutateAsync({ streamId, requestConfig }),
+    [saveRequestConfigM]
+  )
+
   return {
     // Optimistic instant toggles
     setMappingTarget,
@@ -370,6 +381,7 @@ export function useStreamMutations(connectorId: string) {
     saveRequestConfig,
     setStreamSchema,
     sampleFetch,
+    applyPagination,
     // Pending flags
     isSavingRequest: saveRequestConfigM.isPending,
     isSampling: sampleFetchM.isPending,

--- a/apps/web/src/components/data-connectors/lib/describe-pagination.test.ts
+++ b/apps/web/src/components/data-connectors/lib/describe-pagination.test.ts
@@ -1,0 +1,66 @@
+// apps/web/src/components/data-connectors/lib/describe-pagination.test.ts
+import { describe, expect, it } from 'vitest'
+import { describePagination } from './describe-pagination'
+
+describe('describePagination', () => {
+  it('renders the blunt single-page copy for kind:none (and undefined)', () => {
+    for (const spec of [undefined, { kind: 'none' as const }]) {
+      const d = describePagination(spec)
+      expect(d.badge).toBe('Single page')
+      expect(d.summary).toMatch(/no further pages/)
+      // none has no stop condition / page size rows.
+      expect(d.details).toEqual([])
+    }
+  })
+
+  it('describes a Stripe-style last-record cursor', () => {
+    const d = describePagination({
+      kind: 'cursor',
+      cursorFrom: 'lastRecord',
+      cursorRecordField: 'id',
+      hasMorePath: 'has_more',
+      recordsPath: 'data',
+      pageSize: 100,
+    })
+    expect(d.badge).toBe('Cursor')
+    const byLabel = Object.fromEntries(d.details.map((r) => [r.label, r.value]))
+    expect(byLabel['Next page from']).toMatch(/“id” of the last record/)
+    expect(byLabel['Stops when']).toMatch(/has_more = false/)
+    expect(byLabel['Page size']).toMatch(/100 records/)
+  })
+
+  it('describes a response-field cursor', () => {
+    const d = describePagination({
+      kind: 'cursor',
+      cursorFrom: 'response',
+      cursorPath: 'paging.next.after',
+    })
+    const byLabel = Object.fromEntries(d.details.map((r) => [r.label, r.value]))
+    expect(byLabel['Next page from']).toMatch(/“paging.next.after” field/)
+    expect(byLabel['Stops when']).toMatch(/no next token/)
+  })
+
+  it('describes link-header, next-url, page and offset', () => {
+    expect(describePagination({ kind: 'link-header' }).badge).toBe('Link header')
+    expect(describePagination({ kind: 'next-url', nextUrlPath: 'nextRecordsUrl' }).summary).toMatch(
+      /next-page URL/
+    )
+    expect(describePagination({ kind: 'page' }).details[0].value).toMatch(/empty/)
+    expect(describePagination({ kind: 'offset' }).details[0].value).toMatch(/fewer records/)
+  })
+
+  it('adds the history-window row from the backfill span', () => {
+    const d = describePagination(
+      { kind: 'cursor', cursorPath: 'next' },
+      { backfillWindowSpan: 'last_12_months' }
+    )
+    const byLabel = Object.fromEntries(d.details.map((r) => [r.label, r.value]))
+    expect(byLabel['History window']).toBe('Last 12 months')
+  })
+
+  it('falls back to a stream page-size when the spec omits one', () => {
+    const d = describePagination({ kind: 'page' }, { pageSizeFallback: 250 })
+    const byLabel = Object.fromEntries(d.details.map((r) => [r.label, r.value]))
+    expect(byLabel['Page size']).toMatch(/250 records/)
+  })
+})

--- a/apps/web/src/components/data-connectors/lib/describe-pagination.ts
+++ b/apps/web/src/components/data-connectors/lib/describe-pagination.ts
@@ -1,0 +1,122 @@
+// apps/web/src/components/data-connectors/lib/describe-pagination.ts
+// Pure, client-safe translator: a stream's `PaginationSpec` → plain-language copy
+// for the read-only "How this paginates" display (Step 10 §3.2). Mirrors how the
+// engine actually pages (generic-rest.ts) so the words never lie about behaviour —
+// notably `none` is rendered bluntly ("Single page · no further pages") so a capped
+// fetch can't hide. No server imports; a local `PaginationSpec` (the few fields we
+// read) avoids pulling a server-only module into the client bundle (CLAUDE.md rule).
+
+/** The pagination fields the display reads — a structural subset of the engine spec. */
+export interface PaginationSpec {
+  kind: 'cursor' | 'page' | 'offset' | 'link-header' | 'next-url' | 'none'
+  cursorParam?: string
+  cursorPath?: string
+  cursorFrom?: 'response' | 'lastRecord'
+  cursorRecordField?: string
+  recordsPath?: string
+  hasMorePath?: string
+  nextUrlPath?: string
+  pageParam?: string
+  offsetBase?: 0 | 1
+  limitParam?: string
+  pageSize?: number
+}
+
+/** Matches `schedule-section.tsx` — the connector-level backfill window span. */
+export type BackfillWindowSpan = 'all' | 'last_90_days' | 'last_12_months'
+
+const WINDOW_LABEL: Record<BackfillWindowSpan, string> = {
+  all: 'All history',
+  last_12_months: 'Last 12 months',
+  last_90_days: 'Last 90 days',
+}
+
+export interface PaginationDescription {
+  /** Short chip label — the collapsed view shows only this. */
+  badge: string
+  /** One plain-language line describing how it advances. */
+  summary: string
+  /** Expanded detail rows: how it advances, when it stops, page size, history window. */
+  details: { label: string; value: string }[]
+}
+
+interface DescribeOpts {
+  /** Set when the connector has a backfill-window span configured. */
+  backfillWindowSpan?: BackfillWindowSpan
+  /** A stream-level page-size fallback (e.g. a `limit` query param) for the size row. */
+  pageSizeFallback?: number
+}
+
+/**
+ * Describe a `PaginationSpec` in end-user language. Reads only the spec — the same
+ * object already returned on the stream — so it needs no fetch.
+ */
+export function describePagination(
+  pagination: PaginationSpec | undefined,
+  opts: DescribeOpts = {}
+): PaginationDescription {
+  const kind = pagination?.kind ?? 'none'
+  const details: { label: string; value: string }[] = []
+
+  const stops = stopCondition(pagination)
+  if (stops && kind !== 'none') details.push({ label: 'Stops when', value: stops })
+
+  // "Next page from" — only meaningful for cursor pagination.
+  if (kind === 'cursor') {
+    const from =
+      pagination?.cursorFrom === 'lastRecord'
+        ? `the “${pagination.cursorRecordField ?? 'id'}” of the last record`
+        : pagination?.cursorPath
+          ? `the “${pagination.cursorPath}” field of the response`
+          : 'a token returned by the response'
+    details.push({ label: 'Next page from', value: from })
+  }
+
+  const pageSize = pagination?.pageSize ?? opts.pageSizeFallback
+  if (pageSize && kind !== 'none') {
+    details.push({ label: 'Page size', value: `${pageSize.toLocaleString()} records per request` })
+  }
+
+  if (opts.backfillWindowSpan) {
+    details.push({ label: 'History window', value: WINDOW_LABEL[opts.backfillWindowSpan] })
+  }
+
+  return { badge: BADGE[kind], summary: SUMMARY[kind], details }
+}
+
+const BADGE: Record<PaginationSpec['kind'], string> = {
+  cursor: 'Cursor',
+  'link-header': 'Link header',
+  'next-url': 'Next URL',
+  page: 'Page number',
+  offset: 'Offset',
+  none: 'Single page',
+}
+
+const SUMMARY: Record<PaginationSpec['kind'], string> = {
+  cursor: 'Follows a token from each response to fetch the next page.',
+  'link-header': 'Follows the next-page link in the response headers.',
+  'next-url': 'Follows a next-page URL the API returns in each response.',
+  page: 'Requests numbered pages (1, 2, 3…) until one comes back empty.',
+  offset: 'Steps through records by position (offset + limit).',
+  none: 'Makes one request and imports that response — no further pages are fetched.',
+}
+
+function stopCondition(pagination: PaginationSpec | undefined): string | undefined {
+  switch (pagination?.kind) {
+    case 'cursor':
+      return pagination.hasMorePath
+        ? `the API reports no more results (${pagination.hasMorePath} = false)`
+        : 'the response returns no next token'
+    case 'link-header':
+      return 'there is no “next” link in the response headers'
+    case 'next-url':
+      return 'the response has no next-page URL'
+    case 'page':
+      return 'a page comes back empty'
+    case 'offset':
+      return 'a page returns fewer records than the limit'
+    default:
+      return undefined
+  }
+}

--- a/apps/web/src/components/data-connectors/lib/detect-pagination.test.ts
+++ b/apps/web/src/components/data-connectors/lib/detect-pagination.test.ts
@@ -1,0 +1,79 @@
+// apps/web/src/components/data-connectors/lib/detect-pagination.test.ts
+import { describe, expect, it } from 'vitest'
+import { detectPagination } from './detect-pagination'
+
+describe('detectPagination', () => {
+  it('detects a GitHub-style link header', () => {
+    const r = detectPagination({
+      body: [{ id: 1 }],
+      headers: { link: '<https://api.github.com/x?page=2>; rel="next"' },
+      pageRecordCount: 1,
+    })
+    expect(r.spec.kind).toBe('link-header')
+    expect(r.confidence).toBe('high')
+  })
+
+  it('detects a Stripe-style has_more + last-record id cursor', () => {
+    const r = detectPagination({
+      body: { object: 'list', has_more: true, data: [{ id: 'cus_1' }, { id: 'cus_2' }] },
+      pageRecordCount: 2,
+    })
+    expect(r.spec).toMatchObject({
+      kind: 'cursor',
+      cursorFrom: 'lastRecord',
+      cursorRecordField: 'id',
+      hasMorePath: 'has_more',
+      recordsPath: 'data',
+    })
+  })
+
+  it('prefers a body cursor field when has_more carries one', () => {
+    const r = detectPagination({
+      body: { has_more: true, results: [{ x: 1 }], next_cursor: 'abc' },
+      pageRecordCount: 1,
+    })
+    expect(r.spec).toMatchObject({
+      kind: 'cursor',
+      cursorFrom: 'response',
+      cursorPath: 'next_cursor',
+    })
+  })
+
+  it('detects a HubSpot-style paging.next.after cursor without has_more', () => {
+    const r = detectPagination({
+      body: { results: [{ id: '1' }], paging: { next: { after: '10' } } },
+      pageRecordCount: 1,
+    })
+    expect(r.spec).toMatchObject({ kind: 'cursor', cursorPath: 'paging.next.after' })
+  })
+
+  it('detects a Salesforce-style next-url in the body', () => {
+    const r = detectPagination({
+      body: { done: false, nextRecordsUrl: '/services/data/v60.0/query/01g-2000', records: [{}] },
+      pageRecordCount: 1,
+    })
+    expect(r.spec).toMatchObject({ kind: 'next-url', nextUrlPath: 'nextRecordsUrl' })
+  })
+
+  it('detects a QuickBooks-style 1-based offset', () => {
+    const r = detectPagination({
+      body: { startPosition: 1, totalCount: 50, Invoice: [{}] },
+      pageRecordCount: 1,
+    })
+    expect(r.spec).toMatchObject({ kind: 'offset', offsetBase: 1 })
+  })
+
+  it('falls back to none, warning when the page looks full (the truncation case)', () => {
+    const full = detectPagination({
+      body: [{ id: 1 }, { id: 2 }],
+      pageRecordCount: 2,
+      pageLimit: 2,
+    })
+    expect(full.spec.kind).toBe('none')
+    expect(full.note).toMatch(/likely more pages/)
+
+    const short = detectPagination({ body: [{ id: 1 }], pageRecordCount: 1, pageLimit: 100 })
+    expect(short.spec.kind).toBe('none')
+    expect(short.note).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/data-connectors/lib/detect-pagination.ts
+++ b/apps/web/src/components/data-connectors/lib/detect-pagination.ts
@@ -1,0 +1,142 @@
+// apps/web/src/components/data-connectors/lib/detect-pagination.ts
+// Pure, client-safe inference: given a Test Fetch's raw body + allowlisted response
+// headers, propose a `PaginationSpec` (Step 10 §3.3). Inform-only — the result feeds
+// the same read-only display labeled "Detected from test fetch". Priority-ordered;
+// first match wins. No server imports.
+
+import type { PaginationSpec } from './describe-pagination'
+
+export interface PaginationDetection {
+  spec: PaginationSpec
+  /** `high` = a strong signal (link header / has_more / known cursor field); `guess` = fallback. */
+  confidence: 'high' | 'guess'
+  /** Optional caveat shown under the proposal (e.g. the full-page → likely-truncated warning). */
+  note?: string
+}
+
+interface DetectInput {
+  body: unknown
+  /** Allowlisted response headers (lowercased keys) from `sampleFetch`. */
+  headers?: Record<string, string>
+  /** Records on the sampled page (the source's collection size). */
+  pageRecordCount: number
+  /** The configured page size / limit, if any, to flag a full (likely-truncated) page. */
+  pageLimit?: number
+}
+
+/**
+ * Infer how a source paginates from one sampled page. Returns `kind:'none'` when
+ * nothing matches — with a warning when the page is full, since that's the
+ * silent-truncation case (a `none` spec stops after page one).
+ */
+export function detectPagination(input: DetectInput): PaginationDetection {
+  const { body, headers, pageRecordCount, pageLimit } = input
+  const obj = isRecord(body) ? body : undefined
+
+  // 1. Link header with rel="next" (GitHub, Salesforce REST sometimes). Mirrors the
+  //    engine's parse in generic-rest.ts nextPageToken().
+  const link = headers?.link
+  if (link && /<[^>]+>;\s*rel="next"/.test(link)) {
+    return { spec: { kind: 'link-header' }, confidence: 'high' }
+  }
+
+  if (obj) {
+    const recordsPath = findRecordArrayPath(obj)
+    const hasMore = typeof obj.has_more === 'boolean'
+
+    // 2. has_more + a record array → Stripe/Notion-shaped cursor.
+    if (hasMore && recordsPath) {
+      const bodyCursor = firstPath(obj, ['next_cursor', 'paging.next.after', 'nextPageToken'])
+      if (bodyCursor) {
+        return {
+          spec: {
+            kind: 'cursor',
+            cursorFrom: 'response',
+            cursorPath: bodyCursor.path,
+            hasMorePath: 'has_more',
+            recordsPath,
+          },
+          confidence: 'high',
+        }
+      }
+      // Stripe: next cursor = the last record's id; termination via has_more.
+      const records = getByPath(obj, recordsPath)
+      if (
+        Array.isArray(records) &&
+        records.length > 0 &&
+        isRecord(records[0]) &&
+        'id' in records[0]
+      ) {
+        return {
+          spec: {
+            kind: 'cursor',
+            cursorParam: 'starting_after',
+            cursorFrom: 'lastRecord',
+            cursorRecordField: 'id',
+            hasMorePath: 'has_more',
+            recordsPath,
+          },
+          confidence: 'high',
+        }
+      }
+    }
+
+    // 3. A body cursor field without has_more (HubSpot / Notion / Google).
+    const cursor = firstPath(obj, ['paging.next.after', 'next_cursor', 'nextPageToken'])
+    if (cursor) {
+      return {
+        spec: { kind: 'cursor', cursorFrom: 'response', cursorPath: cursor.path },
+        confidence: 'high',
+      }
+    }
+
+    // 4. Server next-URL in the body (Salesforce nextRecordsUrl).
+    const nextUrl = firstPath(obj, ['nextRecordsUrl', 'next'])
+    if (nextUrl && typeof getByPath(obj, nextUrl.path) === 'string') {
+      return { spec: { kind: 'next-url', nextUrlPath: nextUrl.path }, confidence: 'high' }
+    }
+
+    // 5. Offset/limit (QuickBooks STARTPOSITION → startPosition + totalCount).
+    if ('startPosition' in obj && 'totalCount' in obj) {
+      return { spec: { kind: 'offset', offsetBase: 1 }, confidence: 'guess' }
+    }
+  }
+
+  // 6. Nothing matched → single page. Warn when the page is full: there are likely
+  //    more pages this fetch won't reach (the Stripe-cap case).
+  const truncated = pageLimit !== undefined && pageRecordCount >= pageLimit && pageRecordCount > 0
+  return {
+    spec: { kind: 'none' },
+    confidence: 'guess',
+    note: truncated
+      ? "This page is full — there are likely more pages this fetch won't reach."
+      : undefined,
+  }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** The first dotted path (from the candidates) whose value is present + truthy. */
+function firstPath(obj: Record<string, unknown>, paths: string[]): { path: string } | undefined {
+  for (const path of paths) {
+    const value = getByPath(obj, path)
+    if (value !== undefined && value !== null && value !== '') return { path }
+  }
+  return undefined
+}
+
+/** First top-level key whose value is an array — the page's record collection. */
+function findRecordArrayPath(obj: Record<string, unknown>): string | undefined {
+  for (const [key, value] of Object.entries(obj)) {
+    if (Array.isArray(value)) return key
+  }
+  return undefined
+}
+
+function getByPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, seg) => (isRecord(acc) ? acc[seg] : undefined), obj)
+}

--- a/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
@@ -4,8 +4,16 @@
 import { Button } from '@auxx/ui/components/button'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { EmptySection } from '@auxx/ui/components/section'
+import {
+  Stepper,
+  StepperDescription,
+  StepperIndicator,
+  StepperItem,
+  StepperSeparator,
+  StepperTitle,
+  StepperTrigger,
+} from '@auxx/ui/components/stepper'
 import { toastError } from '@auxx/ui/components/toast'
-import { cn } from '@auxx/ui/lib/utils'
 import { Check, Clock, FlaskConical, Layers, Play, Plug, Waypoints } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { api, type RouterOutputs } from '~/trpc/react'
@@ -80,12 +88,27 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
   const primaryStream = streams[0] ?? null
 
   const progress = deriveSetupProgress(connector, streams)
+
+  // Gating: can the user advance past this step? Schedule is always satisfiable
+  // (Manual is a valid terminal state), so it never blocks the flow.
   const doneById: Record<SetupStepId, boolean> = {
     connect: progress.connect,
     sample: progress.sample,
     map: progress.map,
-    schedule: true, // Manual is a valid terminal state — always satisfiable.
+    schedule: true,
     run: false, // Terminal action, never "done" while still pending.
+  }
+
+  // Visual completion (filled indicator + check + filled rail). Distinct from
+  // gating: Schedule isn't shown completed until the user actually reaches it —
+  // otherwise it renders as a dark, done-looking step while still on step 1.
+  // Passing-completed (`idx < activeIdx`) is added per-step in the render.
+  const completedById: Record<SetupStepId, boolean> = {
+    connect: progress.connect,
+    sample: progress.sample,
+    map: progress.map,
+    schedule: false,
+    run: false,
   }
 
   const { syncNow, isSyncing } = useConnectorMutations()
@@ -190,71 +213,58 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
     )
   }
 
+  const activeNumber = STEP_ORDER.indexOf(active) + 1
+
   return (
     <div className='relative flex min-h-0 flex-1 flex-col'>
       <ScrollArea className='h-full' scrollbarClassName='w-1.5' noFade>
-        <div className='mx-auto flex max-w-2xl flex-col gap-1 px-4 py-6'>
+        <Stepper
+          value={activeNumber}
+          orientation='vertical'
+          onValueChange={(n) => {
+            const id = STEP_ORDER[n - 1]
+            if (id && isUnlocked(id)) setActive(id)
+          }}
+          className='mx-auto flex w-full max-w-3xl flex-col px-4 py-6'>
           {STEPS.map((step, idx) => {
-            const done = doneById[step.id]
-            const unlocked = isUnlocked(step.id)
+            // Visually completed = genuinely done, or already passed (an earlier step).
+            const completed = completedById[step.id] || idx < STEP_ORDER.indexOf(active)
             const isActive = active === step.id
             const Icon = step.icon
             const isLast = idx === STEPS.length - 1
             return (
-              <div key={step.id} className='flex gap-3'>
-                {/* Rail — number/check badge + connecting line. */}
-                <div className='flex flex-col items-center'>
-                  <button
-                    type='button'
-                    disabled={!unlocked}
-                    onClick={() => unlocked && setActive(step.id)}
-                    className={cn(
-                      'flex size-8 shrink-0 items-center justify-center rounded-full border text-sm font-medium transition-colors',
-                      done
-                        ? 'border-good-500 bg-good-500 text-white'
-                        : isActive
-                          ? 'border-primary bg-primary text-primary-foreground'
-                          : unlocked
-                            ? 'border-border bg-background text-muted-foreground hover:border-primary'
-                            : 'border-border bg-muted text-muted-foreground/50',
-                      unlocked ? 'cursor-pointer' : 'cursor-not-allowed'
-                    )}>
-                    {done ? <Check className='size-4' /> : <Icon className='size-4' />}
-                  </button>
-                  {!isLast && <div className='my-1 w-px flex-1 bg-border' />}
-                </div>
+              <StepperItem
+                key={step.id}
+                step={idx + 1}
+                completed={completed}
+                disabled={!isUnlocked(step.id)}
+                className='w-full not-last:pb-6'>
+                <StepperTrigger className='items-start gap-3 text-left'>
+                  <StepperIndicator
+                    asChild
+                    className='bg-primary-100 text-primary-500 data-[state=active]:bg-primary-700 data-[state=active]:text-primary-50 data-[state=completed]:bg-primary-700 data-[state=completed]:text-primary-50'>
+                    {completed ? <Check className='size-4' /> : <Icon className='size-4' />}
+                  </StepperIndicator>
+                  <div className='mt-0.5 flex flex-col items-start'>
+                    <StepperTitle className='font-semibold'>{step.title}</StepperTitle>
+                    <StepperDescription className='text-xs'>{step.description}</StepperDescription>
+                  </div>
+                </StepperTrigger>
 
-                {/* Step content. */}
-                <div className={cn('flex-1 pb-6', !isActive && 'pt-1')}>
-                  <button
-                    type='button'
-                    disabled={!unlocked}
-                    onClick={() => unlocked && setActive(step.id)}
-                    className={cn(
-                      'flex flex-col items-start text-left',
-                      unlocked ? 'cursor-pointer' : 'cursor-not-allowed'
-                    )}>
-                    <span
-                      className={cn(
-                        'text-sm font-semibold',
-                        !unlocked && 'text-muted-foreground/60'
-                      )}>
-                      {step.title}
-                    </span>
-                    <span className='text-xs text-muted-foreground'>{step.description}</span>
-                  </button>
+                {!isLast && (
+                  <StepperSeparator className='bg-primary-200 group-data-[state=completed]/step:bg-primary-700' />
+                )}
 
-                  {isActive && (
-                    <div className='mt-3 rounded-lg border bg-background p-1'>
-                      {renderBody(step.id)}
-                      <div className='px-1 pb-1'>{renderFooter(step.id)}</div>
-                    </div>
-                  )}
-                </div>
-              </div>
+                {isActive && (
+                  <div className='mt-3 ml-9 w-[calc(100%-2.25rem)] rounded-lg border bg-background p-1'>
+                    {renderBody(step.id)}
+                    <div className='px-1 pb-1'>{renderFooter(step.id)}</div>
+                  </div>
+                )}
+              </StepperItem>
             )
           })}
-        </div>
+        </Stepper>
       </ScrollArea>
       <ConnectorSaveBar />
     </div>

--- a/apps/web/src/components/data-connectors/ui/pagination-summary.tsx
+++ b/apps/web/src/components/data-connectors/ui/pagination-summary.tsx
@@ -1,0 +1,82 @@
+// apps/web/src/components/data-connectors/ui/pagination-summary.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import {
+  AnimatedCollapsibleContent,
+  Collapsible,
+  CollapsibleChevron,
+  CollapsibleTrigger,
+} from '@auxx/ui/components/collapsible'
+import { useState } from 'react'
+import type { PaginationDescription } from '../lib/describe-pagination'
+
+/**
+ * Read-only "How this paginates" display (Step 10 §3.2). Collapsed shows only the
+ * `kind` badge; expanded reveals the plain-language mechanics + stop condition. One
+ * renderer for both the stream's *configured* pagination and an auto-*detected*
+ * proposal — the only difference is the heading + the (hidden) "Use this" action.
+ */
+
+/**
+ * Reveal the one-click "Use this" apply on a detected proposal. The write path is
+ * fully wired (Step 10 §3.4) — flip this to `true` to expose it. Inform-only for now.
+ */
+export const SHOW_USE_DETECTED_PAGINATION = true
+
+interface PaginationSummaryProps {
+  description: PaginationDescription
+  /** `configured` = the stream's saved spec; `detected` = a test-fetch proposal. */
+  variant?: 'configured' | 'detected'
+  /** Caveat shown under a detected proposal (e.g. the likely-truncated warning). */
+  note?: string
+  /** Persist the detected spec. Rendered behind {@link SHOW_USE_DETECTED_PAGINATION}. */
+  onUse?: () => void
+  useLoading?: boolean
+}
+
+export function PaginationSummary({
+  description,
+  variant = 'configured',
+  note,
+  onUse,
+  useLoading,
+}: PaginationSummaryProps) {
+  const [open, setOpen] = useState(false)
+  const heading = variant === 'detected' ? 'Detected from test fetch' : 'Pagination'
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className='flex flex-col gap-2 px-1'>
+      <CollapsibleTrigger className='flex items-center gap-2 text-left'>
+        <CollapsibleChevron open={open} className='text-muted-foreground' />
+        <span className='text-xs text-muted-foreground'>{heading}</span>
+        <Badge variant='secondary' size='sm'>
+          {description.badge}
+        </Badge>
+      </CollapsibleTrigger>
+
+      <AnimatedCollapsibleContent open={open} className='flex flex-col gap-2 pl-6'>
+        <p className='text-xs text-muted-foreground'>{description.summary}</p>
+        {description.details.length > 0 && (
+          <dl className='flex flex-col gap-1'>
+            {description.details.map((d) => (
+              <div key={d.label} className='flex gap-2 text-xs'>
+                <dt className='w-28 shrink-0 text-muted-foreground'>{d.label}</dt>
+                <dd className='text-foreground'>{d.value}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
+        {note && <p className='text-xs text-amber-600 dark:text-amber-500'>{note}</p>}
+        {variant === 'detected' && SHOW_USE_DETECTED_PAGINATION && onUse && (
+          <div>
+            <Button variant='outline' size='xs' loading={useLoading} onClick={onUse}>
+              Use this pagination
+            </Button>
+          </div>
+        )}
+      </AnimatedCollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
@@ -29,7 +29,14 @@ import type { RouterOutputs } from '~/trpc/react'
 import { useBufferedConfig } from '../hooks/use-buffered-config'
 import { useSourcePaths } from '../hooks/use-source-paths'
 import { useStreamMutations } from '../hooks/use-stream-mutations'
+import {
+  type BackfillWindowSpan,
+  describePagination,
+  type PaginationSpec,
+} from '../lib/describe-pagination'
+import { detectPagination } from '../lib/detect-pagination'
 import { MappingTree } from './mapping-tree'
+import { PaginationSummary } from './pagination-summary'
 import {
   JsonBodyEditor,
   RecordKeyValueEditor,
@@ -109,7 +116,11 @@ export function StreamConfigPanel({
     schema: Record<string, unknown>
     seededFrom: SeededFrom
   } | null>(null)
-  const [sample, setSample] = useState<{ response: unknown; recordCount: number } | null>(null)
+  const [sample, setSample] = useState<{
+    response: unknown
+    recordCount: number
+    responseHeaders?: Record<string, string>
+  } | null>(null)
 
   const sourcePaths = useSourcePaths(stream.sourceSchema as Record<string, unknown> | null)
   const hasSchema = !!stream.sourceSchema
@@ -123,6 +134,7 @@ export function StreamConfigPanel({
     saveRequestConfig,
     setStreamSchema,
     sampleFetch,
+    applyPagination,
     isSavingRequest,
     isSampling,
   } = useStreamMutations(connector.id)
@@ -200,6 +212,39 @@ export function StreamConfigPanel({
   const schemaSentence = hasSchema
     ? (SCHEMA_SOURCE_SENTENCE[stream.schemaSource] ?? SCHEMA_SOURCE_SENTENCE.manual)
     : SCHEMA_SOURCE_NONE
+
+  // Pagination transparency (Step 10): describe the stream's configured spec and,
+  // after a test fetch, an inform-only detected proposal. Read-only — both render
+  // through PaginationSummary. The "Use this" apply is wired but hidden (§3.4).
+  const pagination = (stream.requestConfig as { pagination?: PaginationSpec } | null)?.pagination
+  const backfillWindowSpan = (
+    connector.config as { backfillWindowSpan?: BackfillWindowSpan } | null
+  )?.backfillWindowSpan
+  const pageSizeFallback = numericParam(requestConfig.params)
+  const configuredPagination = describePagination(pagination, {
+    backfillWindowSpan,
+    pageSizeFallback,
+  })
+  const detected = sample
+    ? detectPagination({
+        body: sample.response,
+        headers: sample.responseHeaders,
+        pageRecordCount: sample.recordCount,
+        pageLimit: pagination?.pageSize ?? pageSizeFallback,
+      })
+    : null
+  const detectedPagination = detected
+    ? describePagination(detected.spec, { pageSizeFallback })
+    : null
+
+  const handleUsePagination = () => {
+    if (!detected) return
+    const merged = {
+      ...((stream.requestConfig as Record<string, unknown>) ?? {}),
+      pagination: detected.spec,
+    }
+    void applyPagination(stream.id, merged as Parameters<typeof applyPagination>[1])
+  }
 
   const body = (
     <>
@@ -334,6 +379,29 @@ export function StreamConfigPanel({
               <StreamSample sample={sample} onUseShape={handleUseShape} />
             </Section>
 
+            {/* 2b. Pagination — read-only "how this fetch paginates" (generic-rest) */}
+            {isGenericRest && (
+              <Section
+                title='Pagination'
+                icon={<Waypoints className='size-4' />}
+                initialOpen
+                collapsible={false}
+                description='How this fetch reads through multiple pages.'>
+                <div className='flex flex-col gap-3'>
+                  <PaginationSummary description={configuredPagination} variant='configured' />
+                  {detectedPagination && detected && (
+                    <PaginationSummary
+                      description={detectedPagination}
+                      variant='detected'
+                      note={detected.note}
+                      onUse={handleUsePagination}
+                      useLoading={isSavingRequest}
+                    />
+                  )}
+                </div>
+              </Section>
+            )}
+
             {/* 3. Schema — derived from the sample or hand-edited */}
             <Section
               title='Source schema'
@@ -423,4 +491,12 @@ export function StreamConfigPanel({
   )
 }
 
-/** A reveal toggle for one request sub-editor, with an optional content badge. */
+/** Pull a numeric page-size from common limit-style query params, for the size row. */
+function numericParam(params?: Record<string, unknown>): number | undefined {
+  for (const key of ['limit', 'per_page', 'page_size', 'maxResults', 'pageSize']) {
+    const value = params?.[key]
+    if (typeof value === 'number') return value
+    if (typeof value === 'string' && /^\d+$/.test(value)) return Number(value)
+  }
+  return undefined
+}

--- a/apps/web/src/components/data-import/import-step-cards.tsx
+++ b/apps/web/src/components/data-import/import-step-cards.tsx
@@ -107,7 +107,7 @@ export function ImportStepCards({
               </div>
             </StepperTrigger>
             {index < stepsToRender.length - 1 && (
-              <StepperSeparator className='mx-4 bg-primary-200' />
+              <StepperSeparator className='sm:mx-4 bg-primary-200' />
             )}
           </StepperItem>
         )

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -10,6 +10,7 @@ import {
   addMapping,
   addStream,
   createConnector,
+  createConnectorFromAppCatalog,
   createConnectorFromTemplate,
   type DataConnectorType,
   decodeMapping,
@@ -49,11 +50,20 @@ const connectorTypeSchema = z
     message: 'Unknown connector type',
   })
 
+// Faithful mirror of the engine `PaginationSpec` (@auxx/lib/data-connectors/types).
+// Keep the field set in sync — a narrower schema silently strips the enriched
+// cursor/next-url fields a detected (Stripe/Salesforce-shaped) spec carries.
 const paginationSchema = z.object({
-  kind: z.enum(['cursor', 'page', 'offset', 'link-header', 'none']),
-  cursorPath: z.string().optional(),
+  kind: z.enum(['cursor', 'page', 'offset', 'link-header', 'next-url', 'none']),
   cursorParam: z.string().optional(),
+  cursorPath: z.string().optional(),
+  cursorFrom: z.enum(['response', 'lastRecord']).optional(),
+  cursorRecordField: z.string().optional(),
+  recordsPath: z.string().optional(),
+  hasMorePath: z.string().optional(),
+  nextUrlPath: z.string().optional(),
   pageParam: z.string().optional(),
+  offsetBase: z.union([z.literal(0), z.literal(1)]).optional(),
   limitParam: z.string().optional(),
   pageSize: z.number().int().positive().optional(),
 })
@@ -359,6 +369,36 @@ export const dataConnectorRouter = createTRPCRouter({
           template
         )
       }
+
+      // App connector (`app:<slug>`) — seed its streams from the installed app's
+      // catalog declaration (create-sync-flow §3.1, Tier 1) so setup arrives with
+      // the source schema pre-filled, like a template. Falls through to a bare
+      // connector if the app declares no data connector.
+      if (input.type.startsWith('app:')) {
+        const slug = input.type.slice('app:'.length)
+        const installedApps = await getCachedInstalledApps(ctx.session.organizationId)
+        const app =
+          installedApps.find((a) => a.installationId === input.appInstallationId) ??
+          installedApps.find((a) => a.app.slug === slug)
+        const catalog = app?.dataConnectors?.[0] ?? null
+        if (catalog) {
+          return createConnectorFromAppCatalog(
+            ctx.db,
+            ctx.session.organizationId,
+            {
+              name: input.name,
+              type: input.type as DataConnectorType,
+              credentialId: input.credentialId,
+              appInstallationId: input.appInstallationId,
+              syncBehavior: input.syncBehavior,
+              scheduleConfig: input.scheduleConfig,
+              createdById: ctx.session.userId,
+            },
+            catalog
+          )
+        }
+      }
+
       return createConnector(ctx.db, ctx.session.organizationId, {
         name: input.name,
         type: input.type as DataConnectorType,

--- a/packages/lib/src/data-connectors/app-catalog.test.ts
+++ b/packages/lib/src/data-connectors/app-catalog.test.ts
@@ -1,0 +1,70 @@
+// packages/lib/src/data-connectors/app-catalog.test.ts
+// App-catalog → setup materialization (create-sync-flow §3.1, Tier 1): building a
+// Layer-A source schema from declared field paths, and preferring an exampleRecord.
+
+import { describe, expect, it } from 'vitest'
+import { appCatalogStreamSchema, buildSchemaFromFieldPaths } from './app-catalog'
+
+describe('buildSchemaFromFieldPaths', () => {
+  it('nests dotted + array paths into an object/array schema with scalar leaf types', () => {
+    const schema = buildSchemaFromFieldPaths([
+      { sourcePath: 'id', type: 'TEXT' },
+      { sourcePath: 'total_price', type: 'CURRENCY' },
+      { sourcePath: 'paid', type: 'CHECKBOX' },
+      { sourcePath: 'customer.email', type: 'EMAIL' },
+      { sourcePath: 'line_items[].sku', type: 'TEXT' },
+      { sourcePath: 'line_items[].qty', type: 'NUMBER' },
+    ])
+    expect(schema).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        total_price: { type: 'number' },
+        paid: { type: 'boolean' },
+        customer: { type: 'object', properties: { email: { type: 'string' } } },
+        line_items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { sku: { type: 'string' }, qty: { type: 'number' } },
+          },
+        },
+      },
+    })
+  })
+
+  it('handles an array of scalars (trailing []) as a leaf', () => {
+    const schema = buildSchemaFromFieldPaths([{ sourcePath: 'tags[]', type: 'TEXT' }])
+    expect(schema).toEqual({
+      type: 'object',
+      properties: { tags: { type: 'array', items: { type: 'string' } } },
+    })
+  })
+})
+
+describe('appCatalogStreamSchema', () => {
+  it('prefers exampleRecord (inferred) over field paths', () => {
+    const result = appCatalogStreamSchema({
+      key: 'order',
+      displayFieldKey: 'name',
+      fields: [{ fieldKey: 'id', sourcePath: 'id', type: 'TEXT', name: 'ID' }],
+      exampleRecord: { id: 'o1', customer: { email: 'a@b.com' } },
+    })
+    expect(result.schemaSource).toBe('catalog')
+    // Inferred from the sample → carries the nested customer object.
+    const props = (result.sourceSchema as { properties: Record<string, unknown> }).properties
+    expect(props).toHaveProperty('customer')
+  })
+
+  it('falls back to field paths when there is no exampleRecord', () => {
+    const result = appCatalogStreamSchema({
+      key: 'order',
+      displayFieldKey: 'name',
+      fields: [{ fieldKey: 'name', sourcePath: 'name', type: 'TEXT', name: 'Name' }],
+    })
+    expect(result.sourceSchema).toEqual({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    })
+  })
+})

--- a/packages/lib/src/data-connectors/app-catalog.ts
+++ b/packages/lib/src/data-connectors/app-catalog.ts
@@ -1,0 +1,79 @@
+// packages/lib/src/data-connectors/app-catalog.ts
+// Pure helpers for materializing an installed app's catalog data-connector into the
+// setup surface (create-sync-flow §3.1, Tier 1). Kept dependency-light (no
+// drizzle/bullmq) so it's unit-testable in isolation; `mutations.ts` composes these
+// with the DB write helpers in `createConnectorFromAppCatalog`.
+
+import type { CatalogDataConnector } from '@auxx/database'
+import { inferJsonSchema } from '../json-schema'
+
+/** A catalog source field's declared type → the JSON-schema scalar type it carries. */
+function jsonTypeForCatalogField(type: string | undefined): string {
+  switch (type) {
+    case 'NUMBER':
+    case 'CURRENCY':
+      return 'number'
+    case 'CHECKBOX':
+      return 'boolean'
+    default:
+      return 'string'
+  }
+}
+
+/**
+ * Build a Layer-A source JSON schema from an app connector's declared source
+ * fields when it ships no `exampleRecord`. Each `sourcePath` (`total_price`,
+ * `customer.email`, `line_items[].sku`) is walked into a nested object/array
+ * shape — the same shape `inferJsonSchema(exampleRecord)` would produce — so the
+ * setup mapping tree + the Tier 2 suggester have a schema to work against.
+ */
+export function buildSchemaFromFieldPaths(
+  fields: Array<{ sourcePath: string; type?: string }>
+): Record<string, unknown> {
+  const root: Record<string, unknown> = { type: 'object', properties: {} }
+  for (const f of fields) {
+    const segs = f.sourcePath.split('.').filter(Boolean)
+    let node: Record<string, unknown> = root
+    segs.forEach((rawSeg, i) => {
+      const isLast = i === segs.length - 1
+      const isArray = rawSeg.endsWith('[]')
+      const seg = isArray ? rawSeg.slice(0, -2) : rawSeg
+      const props = (node.properties ??= {}) as Record<string, Record<string, unknown>>
+      const leafType = jsonTypeForCatalogField(f.type)
+      if (isArray) {
+        let arr = props[seg]
+        if (!arr || arr.type !== 'array') {
+          arr = {
+            type: 'array',
+            items: isLast ? { type: leafType } : { type: 'object', properties: {} },
+          }
+          props[seg] = arr
+        }
+        // Descend into the element shape for deeper segments; an array of scalars
+        // (the leaf case) has nothing further to walk into.
+        if (!isLast) node = arr.items as Record<string, unknown>
+      } else if (isLast) {
+        props[seg] = { type: leafType }
+      } else {
+        let obj = props[seg]
+        if (!obj || obj.type !== 'object') {
+          obj = { type: 'object', properties: {} }
+          props[seg] = obj
+        }
+        node = obj
+      }
+    })
+  }
+  return root
+}
+
+/** The source schema for an app catalog stream — prefer its canonical sample. */
+export function appCatalogStreamSchema(stream: CatalogDataConnector['streams'][number]): {
+  sourceSchema: Record<string, unknown>
+  schemaSource: 'catalog'
+} {
+  const sourceSchema = stream.exampleRecord
+    ? (inferJsonSchema(stream.exampleRecord) as Record<string, unknown>)
+    : buildSchemaFromFieldPaths(stream.fields)
+  return { sourceSchema, schemaSource: 'catalog' }
+}

--- a/packages/lib/src/data-connectors/connector-runtime.ts
+++ b/packages/lib/src/data-connectors/connector-runtime.ts
@@ -94,10 +94,19 @@ export interface SampleConnectorFetchInput {
   requestConfig?: StreamRequestConfig
 }
 
+/**
+ * Response headers (lowercased keys) the test-fetch forwards to the client for
+ * pagination detection. Allowlisted — we never dump the whole header bag to the
+ * browser (avoids leaking rate-limit/infra headers). Extend as detection grows.
+ */
+const SAMPLE_HEADER_ALLOWLIST = ['link'] as const
+
 /** The first raw page of a connector fetch, for schema inference + preview. */
 export interface SampleConnectorFetchResult {
   response: unknown
   recordCount: number
+  /** Allowlisted first-page response headers (lowercased keys); `link` for now. */
+  responseHeaders?: Record<string, string>
 }
 
 /**
@@ -119,6 +128,11 @@ export async function sampleConnectorFetch(
     connector,
     userId
   )
+  // Capture the first page's headers via the opt-in callback (closure). `fetch` is
+  // a lazy generator, so the loop runs past the transport call + `onPageMeta`
+  // before the first record reaches the `for await` below — `firstHeaders` is set
+  // by the time we read it.
+  let firstHeaders: Record<string, string> | undefined
   const { records } = await definition.fetch({
     streamKey: input.streamKey ?? '',
     mode: 'snapshot',
@@ -126,6 +140,9 @@ export async function sampleConnectorFetch(
     credential,
     config: connector.config,
     requestConfig: input.requestConfig,
+    onPageMeta: (meta) => {
+      if (meta.pageIndex === 0) firstHeaders = meta.headers
+    },
   })
   // The connector yields the RAW response body per page; sample the first one so
   // schema inference + the field pickers see exactly what the source returns (an
@@ -138,5 +155,17 @@ export async function sampleConnectorFetch(
     break
   }
   const recordCount = Array.isArray(response) ? response.length : response ? 1 : 0
-  return { response, recordCount }
+  return { response, recordCount, responseHeaders: pickAllowlisted(firstHeaders) }
+}
+
+/** Keep only the allowlisted headers (lowercased keys) before crossing to the client. */
+function pickAllowlisted(
+  headers: Record<string, string> | undefined
+): Record<string, string> | undefined {
+  if (!headers) return undefined
+  const picked: Record<string, string> = {}
+  for (const key of SAMPLE_HEADER_ALLOWLIST) {
+    if (headers[key] !== undefined) picked[key] = headers[key]
+  }
+  return Object.keys(picked).length > 0 ? picked : undefined
 }

--- a/packages/lib/src/data-connectors/connectors/generic-rest.ts
+++ b/packages/lib/src/data-connectors/connectors/generic-rest.ts
@@ -390,6 +390,10 @@ async function* fetchRecords(args: ConnectorFetchArgs): AsyncIterable<ConnectorY
     }
     const body = response.json()
 
+    // Sample/test-fetch only — surface this page's transport headers so the
+    // builder can detect `link-header` pagination. No-op for the scheduled sync.
+    args.onPageMeta?.({ pageIndex, headers: response.headers })
+
     // Advance the watermark over this page's records (before any content-hash skip).
     // For event-feed the watermark field is the EVENT's `created`, found the same way.
     watermark = maxWatermark(watermark, pageWatermark(body, incremental))

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -3,6 +3,8 @@
 // See plans/data-connectors/. Server-only (BullMQ, crypto): never import this
 // barrel from client code.
 
+// App-catalog → setup materialization (create-sync-flow §3.1, Tier 1)
+export { appCatalogStreamSchema, buildSchemaFromFieldPaths } from './app-catalog'
 // Connector runtime — the shared definition+credential seam + test-fetch
 export type {
   PreparedConnectorFetch,
@@ -97,6 +99,7 @@ export {
   addMapping,
   addStream,
   createConnector,
+  createConnectorFromAppCatalog,
   createConnectorFromTemplate,
   deleteConnector,
   removeMapping,

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -5,13 +5,14 @@
 // re-registration is driven from create/update (pause/resume is a `status` patch
 // through update) so a cadence or lifecycle change is reflected in BullMQ immediately.
 
-import { type Database, schema } from '@auxx/database'
+import { type CatalogDataConnector, type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { getFieldDefinitionId, getFieldId, toResourceFieldId } from '@auxx/types/field'
 import { generateId } from '@auxx/utils'
 import { and, eq } from 'drizzle-orm'
 import { getCachedCustomFields, getCachedEntityDefId } from '../cache'
 import { BadRequestError, NotFoundError } from '../errors'
+import { appCatalogStreamSchema } from './app-catalog'
 import {
   registerConnectorWebhooks,
   unregisterConnectorWebhooks,
@@ -255,6 +256,40 @@ async function buildTemplateFieldMappings(
     if (f.provision) mapping.provision = { name: f.key, ...f.provision }
     return mapping
   })
+}
+
+/**
+ * Create a connector from an installed app's catalog declaration (create-sync-flow
+ * §3.1, Tier 1). Mirrors {@link createConnectorFromTemplate}: an `app:<slug>`
+ * connector + one pre-filled stream per declared catalog stream, each with the
+ * declared source schema (from `exampleRecord`, else built from the field paths)
+ * stamped `catalog`. The request is baked into the app (`fixed` model), so streams
+ * carry no `requestConfig`.
+ *
+ * Default *mappings* are intentionally NOT materialized here: the first-party app
+ * declarations are owned-mode + relationship fan-outs, and owned-mode provisioning
+ * at setup is deferred (plan §6 / target-provisioning v1 is contributing-only). The
+ * user maps in the stepper against the now-populated schema — assisted by the Tier 2
+ * `suggestMappings` suggester, which works because the schema is present.
+ */
+export async function createConnectorFromAppCatalog(
+  db: Database,
+  organizationId: string,
+  input: Omit<CreateConnectorInput, 'definitionKind' | 'templateId' | 'config'>,
+  catalog: CatalogDataConnector
+): Promise<DataConnectorRow> {
+  const connector = await createConnector(db, organizationId, {
+    ...input,
+    definitionKind: 'app',
+  })
+  for (const stream of catalog.streams) {
+    await addStream(db, organizationId, connector.id, {
+      streamKey: stream.key,
+      ...appCatalogStreamSchema(stream),
+      syncMode: 'snapshot',
+    })
+  }
+  return connector
 }
 
 export interface UpdateConnectorInput {

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -347,6 +347,15 @@ export interface ConnectorFetchArgs {
    * Absent for the single-shot path, which keeps the default retry-and-sleep.
    */
   rateLimitOverride?: Partial<RateLimitPolicy>
+  /**
+   * Sample/test-fetch only: invoked once per fetched page with the transport's
+   * normalized response headers (lowercased keys). Lets the builder's test-fetch
+   * surface `link-header` pagination without putting transport metadata on
+   * {@link ConnectorRecord} (which flows through the whole sink/mapping spine on
+   * every real sync). The scheduled sync never passes this; connectors that have
+   * no HTTP headers simply never call it.
+   */
+  onPageMeta?: (meta: { pageIndex: number; headers: Record<string, string> }) => void
 }
 
 /**

--- a/packages/ui/src/components/stepper.tsx
+++ b/packages/ui/src/components/stepper.tsx
@@ -116,7 +116,7 @@ function StepperItem({
       <div
         data-slot='stepper-item'
         className={cn(
-          'group/step flex items-center group-data-[orientation=horizontal]/stepper:flex-row group-data-[orientation=vertical]/stepper:flex-col group-data-[orientation=vertical]/stepper:items-start',
+          'group/step relative flex items-center group-data-[orientation=horizontal]/stepper:flex-row group-data-[orientation=vertical]/stepper:flex-col group-data-[orientation=vertical]/stepper:items-start',
           className
         )}
         data-state={state}
@@ -230,7 +230,14 @@ function StepperSeparator({ className, ...props }: React.HTMLAttributes<HTMLDivE
     <div
       data-slot='stepper-separator'
       className={cn(
-        'bg-muted group-data-[state=completed]/step:bg-info m-0.5 group-data-[orientation=horizontal]/stepper:h-0.5 group-data-[orientation=horizontal]/stepper:w-full group-data-[orientation=horizontal]/stepper:flex-1 group-data-[orientation=vertical]/stepper:h-4 group-data-[orientation=vertical]/stepper:w-0.5 group-data-[orientation=vertical]/stepper:ml-[11px]',
+        'bg-muted group-data-[state=completed]/step:bg-info',
+        // Horizontal: a thin bar that flexes to fill the gap between indicators.
+        'group-data-[orientation=horizontal]/stepper:m-0.5 group-data-[orientation=horizontal]/stepper:h-0.5 group-data-[orientation=horizontal]/stepper:w-full group-data-[orientation=horizontal]/stepper:flex-1',
+        // Vertical: an absolutely-positioned rail spanning from below this step's
+        // indicator down to the next step, so it stretches across tall/inline step
+        // bodies instead of a fixed-height stub. Centered on the default size-6
+        // indicator (left-3); resize the indicator → override `left` to match.
+        'group-data-[orientation=vertical]/stepper:absolute group-data-[orientation=vertical]/stepper:top-7 group-data-[orientation=vertical]/stepper:bottom-0 group-data-[orientation=vertical]/stepper:left-3 group-data-[orientation=vertical]/stepper:w-0.5 group-data-[orientation=vertical]/stepper:-translate-x-1/2 group-data-[orientation=vertical]/stepper:rounded-full',
         className
       )}
       {...props}


### PR DESCRIPTION
## What

Makes a stream's pagination **legible** in the connector UI and **one-click configurable** from a Test Fetch. Closes the gap where pagination was template-JSON-only and invisible in the app.

### Read-only "How this paginates" display
- Collapsed = a `kind` badge; expand = plain-language mechanics, stop condition, page size, history window (`describePagination` + `PaginationSummary`).
- `kind:none` renders bluntly as **"Single page — no further pages fetched"** so a capped fetch can't hide (this is how we caught Stripe + GitHub `/repositories` under-fetching).

### Auto-detect from Test Fetch
- `detectPagination` infers `link-header` / `cursor` (response field **and** Stripe last-record id) / `next-url` / `offset` from one sampled page; falls back to `none` with a "page looks full — likely more pages" warning.
- **`onPageMeta` seam**: an opt-in callback on `ConnectorFetchArgs` surfaces the first page's response headers (allowlisted to `link`) through `sampleConnectorFetch` — so the header-only `link-header` case is detectable. No `ConnectorRecord`/spine change, no new endpoint, no migration.

### Apply it
- **"Use this pagination"** writes the detected spec via the existing `setStreamRequestConfig` (merge, not replace). Enabled (`SHOW_USE_DETECTED_PAGINATION = true`).
- Widened the router `paginationSchema` to mirror the enriched engine `PaginationSpec` (`next-url` + `cursorFrom`/`cursorRecordField`/`recordsPath`/`hasMorePath`/`nextUrlPath`/`offsetBase`) so detected specs round-trip instead of being silently stripped.

## Testing
- 13 new unit tests (`describe-pagination`, `detect-pagination`) — Stripe/HubSpot/GitHub/Salesforce/QBO shapes + truncation warning.
- Existing `generic-rest-slicing` (14) unaffected; `onPageMeta` is a no-op for the scheduled sync.
- Verified end-to-end against GitHub `https://api.github.com` + `/repositories` (Link-header-only pagination): Detected panel reads **Link header**, "Use this" flips the configured spec.

## Notes
- **Bundles adjacent in-progress changes** beyond pagination (`app-catalog`, `stepper`, `connector-setup-stepper`, `import-step-cards`, `connection-row`, lib `index`/`mutations`) — included per request to commit the full working tree.
- **Follow-up (not in this PR):** `stripe.json` is still `kind:'none'` (imports only the first 100 customers). The new display now surfaces this honestly; switching it to a `lastRecord` cursor is a separate change.