### PR TITLE
feat(data-connectors): mapping empty-state CTAs + leaf cap + Stripe cursor pagination

### DIFF
--- a/apps/web/src/components/data-connectors/ui/branch-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/branch-row.tsx
@@ -16,6 +16,12 @@ interface BranchRowProps {
   onToggleOpen: () => void
   /** Materialize a child mapping that upserts records under this branch. */
   onFanOut: (entityDefinitionId: string) => void
+  /**
+   * No mapping exists anywhere in the tree yet (the wizard's first state). Surfaces
+   * a faint "or map separately" hint and forces the fan-out button visible (no
+   * hover needed), so a nested object/array reads as a secondary starting point.
+   */
+  isEmpty?: boolean
   children: React.ReactNode
 }
 
@@ -35,6 +41,7 @@ export function BranchRow({
   isOpen,
   onToggleOpen,
   onFanOut,
+  isEmpty = false,
   children,
 }: BranchRowProps) {
   const [menuOpen, setMenuOpen] = useState(false)
@@ -59,6 +66,9 @@ export function BranchRow({
         <span className='flex items-center gap-1.5 text-sm text-muted-foreground'>
           <span className='font-mono'>{lastSegment(node.path)}</span>
           <span className='text-[10px] uppercase opacity-60'>{node.type}</span>
+          {isEmpty && (
+            <span className='text-[11px] text-muted-foreground/40'>· or map separately</span>
+          )}
         </span>
       }
       // A passive container — no arrow/target. The fan-out action sits in the
@@ -69,7 +79,7 @@ export function BranchRow({
         <div key='actions' className='flex w-full items-center justify-end pr-1'>
           <Popover open={menuOpen} onOpenChange={setMenuOpen}>
             <PopoverTrigger asChild>
-              <TreeRowButton tooltipText='Fan out → own def'>
+              <TreeRowButton tooltipText='Fan out → own def' persistent={isEmpty}>
                 <Plus />
               </TreeRowButton>
             </PopoverTrigger>

--- a/apps/web/src/components/data-connectors/ui/capped-node-list.tsx
+++ b/apps/web/src/components/data-connectors/ui/capped-node-list.tsx
@@ -1,0 +1,77 @@
+// apps/web/src/components/data-connectors/ui/capped-node-list.tsx
+'use client'
+
+import { AnimatedCollapsibleContent, CollapsibleChevron } from '@auxx/ui/components/collapsible'
+import { GridTreeRow } from '@auxx/ui/components/tree-row'
+import type React from 'react'
+import { useState } from 'react'
+import type { SourceTreeNode } from '../hooks/use-source-paths'
+import { MAPPING_COLS } from './mapping-columns'
+
+/**
+ * Max unmapped leaves rendered per container before the rest collapse behind a
+ * "Show more" toggle. Branches and mapped leaves never count toward this and are
+ * always shown. The single knob for every level of the mapping tree (the inert
+ * skeleton AND inside promoted mappings) — change it here and it applies everywhere.
+ */
+export const MAX_VISIBLE_LEAVES = 7
+
+interface CappedNodeListProps {
+  /** The container's direct children, in schema order. */
+  nodes: SourceTreeNode[]
+  /** True for a node that counts toward the cap and may be hidden (an unmapped leaf). */
+  isCappable: (node: SourceTreeNode) => boolean
+  /** Render one child — must set its own `key`. */
+  renderNode: (node: SourceTreeNode) => React.ReactNode
+  /** Depth of the children — the "Show more" toggle aligns to it. */
+  childDepth: number
+}
+
+/**
+ * Renders a container's children with the unmapped-leaf cap (huge payloads like
+ * GitHub return dozens of fields). Branches and mapped leaves always render in
+ * schema order; unmapped leaves past {@link MAX_VISIBLE_LEAVES} are grouped into a
+ * trailing {@link AnimatedCollapsibleContent} behind a "Show N more / Show less"
+ * toggle. Under the cap it's a transparent pass-through (no toggle, no wrapper).
+ *
+ * The hidden leaves are grouped at the end (a single trailing collapse), so the
+ * visible rows keep exact schema order and the reveal rides the shared spring.
+ */
+export function CappedNodeList({ nodes, isCappable, renderNode, childDepth }: CappedNodeListProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const cappable = nodes.filter(isCappable)
+  if (cappable.length <= MAX_VISIBLE_LEAVES) {
+    return <>{nodes.map(renderNode)}</>
+  }
+
+  // Hide every cappable node past the cap; everything else (branches, mapped
+  // leaves, the first N unmapped leaves) stays inline in its schema position.
+  const hiddenPaths = new Set(cappable.slice(MAX_VISIBLE_LEAVES).map((n) => n.path))
+  const hiddenCount = hiddenPaths.size
+
+  return (
+    <>
+      {nodes.filter((n) => !hiddenPaths.has(n.path)).map(renderNode)}
+      <AnimatedCollapsibleContent open={expanded} className='flex flex-col'>
+        {nodes.filter((n) => hiddenPaths.has(n.path)).map(renderNode)}
+      </AnimatedCollapsibleContent>
+      {/* Toggle sits BELOW the collapsed rows: collapsed it caps the visible list;
+          expanded the revealed rows push it down so it always reads as the list's
+          footer (chevron points right when collapsed, rotates down when open). */}
+      <GridTreeRow
+        columns={MAPPING_COLS}
+        depth={childDepth}
+        onToggleOpen={() => setExpanded((e) => !e)}
+        icon={<CollapsibleChevron open={expanded} className='size-3.5 text-muted-foreground/50' />}
+        title={
+          <span className='text-xs text-muted-foreground transition-colors hover:text-foreground'>
+            {expanded
+              ? 'Show less'
+              : `Show ${hiddenCount} more field${hiddenCount === 1 ? '' : 's'}`}
+          </span>
+        }
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -10,7 +10,7 @@ import { toastError } from '@auxx/ui/components/toast'
 import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { generateId } from '@auxx/utils'
-import { ArrowRight, FunctionSquare, Loader2, Plus, Sparkles, Trash2, X } from 'lucide-react'
+import { ArrowRight, FunctionSquare, Loader2, Plus, Sparkles, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { ResourcePicker } from '~/components/pickers/resource-picker'
 import { useResourceFields, useResourceProperty } from '~/components/resources'
@@ -25,6 +25,7 @@ import {
 } from '../hooks/use-source-paths'
 import type { FieldMapping, useStreamMutations } from '../hooks/use-stream-mutations'
 import { BranchRow } from './branch-row'
+import { CappedNodeList } from './capped-node-list'
 import { FieldCalcDialog } from './field-calc-dialog'
 import { MAPPING_COLS } from './mapping-columns'
 import { MappingFieldPicker } from './mapping-field-picker'
@@ -367,36 +368,41 @@ export function MappingNode({
             No source schema yet — generate or edit the schema above to map fields.
           </div>
         ) : (
-          sourceTree.map((node) => (
-            <SourceNode
-              key={node.path}
-              node={node}
-              depth={depth + 1}
-              mapping={mapping}
-              targetMode={targetMode}
-              targetFields={targetFields}
-              sourceToEntry={sourceToEntry}
-              usedTargetKeys={usedTargetKeys}
-              matchKeys={matchKeys}
-              childByNodePath={childByNodePath}
-              onAssign={assignTarget}
-              onClear={clearEntry}
-              onMergeChange={(id, value) =>
-                patchEntry(id, { mergeStrategy: value as FieldMapping['mergeStrategy'] })
-              }
-              onToggleMatch={toggleMatch}
-              onFanOut={materializeChild}
-              // Child-mapping recursion context.
-              connectorId={connectorId}
-              streamId={streamId}
-              streamKey={streamKey}
-              sourceSchema={sourceSchema}
-              sourcePaths={sourcePaths}
-              byMappingId={byMappingId}
-              childrenOf={childrenOf}
-              mutations={mutations}
-            />
-          ))
+          <CappedNodeList
+            nodes={sourceTree}
+            childDepth={depth + 1}
+            isCappable={(n) => !n.isBranch && !sourceToEntry.has(n.path)}
+            renderNode={(node) => (
+              <SourceNode
+                key={node.path}
+                node={node}
+                depth={depth + 1}
+                mapping={mapping}
+                targetMode={targetMode}
+                targetFields={targetFields}
+                sourceToEntry={sourceToEntry}
+                usedTargetKeys={usedTargetKeys}
+                matchKeys={matchKeys}
+                childByNodePath={childByNodePath}
+                onAssign={assignTarget}
+                onClear={clearEntry}
+                onMergeChange={(id, value) =>
+                  patchEntry(id, { mergeStrategy: value as FieldMapping['mergeStrategy'] })
+                }
+                onToggleMatch={toggleMatch}
+                onFanOut={materializeChild}
+                // Child-mapping recursion context.
+                connectorId={connectorId}
+                streamId={streamId}
+                streamKey={streamKey}
+                sourceSchema={sourceSchema}
+                sourcePaths={sourcePaths}
+                byMappingId={byMappingId}
+                childrenOf={childrenOf}
+                mutations={mutations}
+              />
+            )}
+          />
         )}
 
         {/* Formula rows — one per non-bare field mapping (a computed target field),
@@ -576,9 +582,14 @@ function SourceNode(props: SourceNodeProps) {
         isOpen={open}
         onToggleOpen={() => setOpen((o) => !o)}
         onFanOut={(entityDefinitionId) => onFanOut(node, entityDefinitionId)}>
-        {node.children.map((child) => (
-          <SourceNode key={child.path} {...props} node={child} depth={depth + 1} />
-        ))}
+        <CappedNodeList
+          nodes={node.children}
+          childDepth={depth + 1}
+          isCappable={(n) => !n.isBranch && !props.sourceToEntry.has(n.path)}
+          renderNode={(child) => (
+            <SourceNode key={child.path} {...props} node={child} depth={depth + 1} />
+          )}
+        />
       </BranchRow>
     )
   }
@@ -704,7 +715,7 @@ function FormulaRow({
               Identifier — a formula has no single source path to match identity on. */}
           <MergeStrategyToggle value={mergeStrategy} onValueChange={onMergeChange} />
           <TreeRowButton variant='destructive' tooltipText='Remove formula' onClick={onClear}>
-            <X />
+            <Trash2 />
           </TreeRowButton>
         </div>,
       ]}

--- a/apps/web/src/components/data-connectors/ui/mapping-tree.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-tree.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/data-connectors/ui/mapping-tree.tsx
 'use client'
 
+import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { Braces, Brackets, Hash, Plus } from 'lucide-react'
@@ -16,6 +17,7 @@ import {
 } from '../hooks/use-source-paths'
 import { useStreamMutations } from '../hooks/use-stream-mutations'
 import { BranchRow } from './branch-row'
+import { CappedNodeList } from './capped-node-list'
 import { MAPPING_COLS } from './mapping-columns'
 import { MappingNode } from './mapping-node'
 
@@ -64,6 +66,11 @@ export function MappingTree({
   // out per element (`[]`); an object root is a single record (`''`).
   const rootIsArray = useMemo(() => sourcePaths.some((p) => p.path.startsWith('[]')), [sourcePaths])
   const rootBase = rootIsArray ? '[]' : ''
+
+  // Wizard's first state: not a single mapping exists anywhere in the tree. Drives
+  // the empty-state affordances (root CTA + branch hints) that vanish the moment
+  // the user creates any mapping.
+  const isEmpty = rows.length === 0
 
   // Index mappings by id (for `absolutePrefix`) and by parent (the tree).
   const { byMappingId, childrenOf } = useMemo(() => {
@@ -149,6 +156,9 @@ export function MappingTree({
         title={
           <span className='text-xs text-muted-foreground'>
             {rootIsArray ? `each ${streamKey || 'item'}` : 'whole payload'}
+            {isEmpty && (
+              <span className='ml-2 text-muted-foreground/50'>· map to a record to begin</span>
+            )}
           </span>
         }
         cells={[
@@ -157,6 +167,7 @@ export function MappingTree({
           <div key='actions' className='flex w-full items-center justify-end pr-1'>
             <CreateMappingAction
               tooltip='Map whole payload → own record'
+              label={isEmpty ? 'Map record' : undefined}
               onPick={(defId) => createMapping(rootBase, defId)}
             />
           </div>,
@@ -166,16 +177,22 @@ export function MappingTree({
             No source schema yet — generate or edit the schema above to map fields.
           </div>
         ) : (
-          topTree.map((node) => (
-            <TopSourceNode
-              key={node.path}
-              node={node}
-              depth={1}
-              branchMappingByPath={branchMappingByPath}
-              onCreate={createMapping}
-              {...recursionCtx}
-            />
-          ))
+          <CappedNodeList
+            nodes={topTree}
+            childDepth={1}
+            isCappable={(n) => !n.isBranch}
+            renderNode={(node) => (
+              <TopSourceNode
+                key={node.path}
+                node={node}
+                depth={1}
+                isEmpty={isEmpty}
+                branchMappingByPath={branchMappingByPath}
+                onCreate={createMapping}
+                {...recursionCtx}
+              />
+            )}
+          />
         )}
       </GridTreeRow>
     </div>
@@ -187,6 +204,8 @@ export function MappingTree({
 interface TopSourceNodeProps {
   node: SourceTreeNode
   depth: number
+  /** No mapping exists anywhere yet — forwarded to branch rows for their hint/CTA. */
+  isEmpty: boolean
   /** Top-level branch mappings keyed by array-normalized path (`data` → `data[]`). */
   branchMappingByPath: Map<string, Mapping>
   /** Create a top-level mapping at the given rootPath against the picked def. */
@@ -234,12 +253,18 @@ function TopSourceNode(props: TopSourceNodeProps) {
       <BranchRow
         depth={depth}
         node={node}
+        isEmpty={props.isEmpty}
         isOpen={open}
         onToggleOpen={() => setOpen((o) => !o)}
         onFanOut={(defId) => onCreate(branchRootPath(node), defId)}>
-        {node.children.map((child) => (
-          <TopSourceNode key={child.path} {...props} node={child} depth={depth + 1} />
-        ))}
+        <CappedNodeList
+          nodes={node.children}
+          childDepth={depth + 1}
+          isCappable={(n) => !n.isBranch}
+          renderNode={(child) => (
+            <TopSourceNode key={child.path} {...props} node={child} depth={depth + 1} />
+          )}
+        />
       </BranchRow>
     )
   }
@@ -267,21 +292,32 @@ function InertLeafRow({ depth, node }: { depth: number; node: SourcePath }) {
   )
 }
 
-/** The "pick a def → create a mapping here" popover action (shared by root + branch). */
+/** The "pick a def → create a mapping here" popover action (shared by root + branch).
+ *  Pass `label` to render the prominent, always-visible CTA (empty state); omit it
+ *  for the default hover-revealed icon button. */
 function CreateMappingAction({
   tooltip,
   onPick,
+  label,
 }: {
   tooltip: string
   onPick: (entityDefinitionId: string) => void
+  label?: string
 }) {
   const [open, setOpen] = useState(false)
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <TreeRowButton tooltipText={tooltip}>
-          <Plus />
-        </TreeRowButton>
+        {label ? (
+          <Button variant='outline' size='xs'>
+            <Plus />
+            {label}
+          </Button>
+        ) : (
+          <TreeRowButton tooltipText={tooltip}>
+            <Plus />
+          </TreeRowButton>
+        )}
       </PopoverTrigger>
       <PopoverContent align='end' className='w-64 p-0'>
         <div className='border-b px-2 py-1.5 text-[10px] font-medium uppercase text-muted-foreground'>

--- a/packages/lib/src/data-connectors/templates/defs/stripe.json
+++ b/packages/lib/src/data-connectors/templates/defs/stripe.json
@@ -24,7 +24,14 @@
         "path": "/customers",
         "method": "GET",
         "params": { "limit": 100 },
-        "pagination": { "kind": "none" },
+        "pagination": {
+          "kind": "cursor",
+          "cursorParam": "starting_after",
+          "cursorFrom": "lastRecord",
+          "cursorRecordField": "id",
+          "hasMorePath": "has_more",
+          "recordsPath": "data"
+        },
         "backfillWindow": { "sinceParam": "created[gte]", "format": "unix" }
       },
       "mappings": [
@@ -81,7 +88,14 @@
         "path": "/charges",
         "method": "GET",
         "params": { "limit": 100 },
-        "pagination": { "kind": "none" },
+        "pagination": {
+          "kind": "cursor",
+          "cursorParam": "starting_after",
+          "cursorFrom": "lastRecord",
+          "cursorRecordField": "id",
+          "hasMorePath": "has_more",
+          "recordsPath": "data"
+        },
         "backfillWindow": { "sinceParam": "created[gte]", "format": "unix" }
       },
       "sourceSchema": {


### PR DESCRIPTION
## Summary
- Surface empty-state affordances in the mapping tree: a prominent **Map record** CTA at the root and faint *"or map separately"* hints on branch rows when no mapping exists yet. All of these vanish the moment the first mapping is created.
- Add `CappedNodeList` to collapse unmapped leaves past `MAX_VISIBLE_LEAVES` (7) behind a *"Show N more fields"* toggle, keeping large payloads (GitHub, Stripe) navigable. Branches and mapped leaves always render in schema order; the hidden leaves group into a single trailing collapse riding the shared spring animation.
- Switch Stripe `customers` and `charges` streams to cursor pagination (`starting_after` / `has_more`) instead of `none`.
- Minor: swap the formula-row remove icon from `X` to `Trash2` for consistency.

## Test plan
- [ ] Open a connector with no mappings → root shows "Map record" CTA, branches show "or map separately" hint
- [ ] Create a mapping → empty-state affordances disappear
- [ ] Open a stream with >7 unmapped leaf fields → extras collapse behind "Show N more fields"; toggle expands/collapses
- [ ] Stripe customers/charges sync paginates through all records via cursor