### PR TITLE
feat(apps): capability badges on app About page

### DIFF
--- a/apps/web/src/components/apps/ui/app-about.tsx
+++ b/apps/web/src/components/apps/ui/app-about.tsx
@@ -4,8 +4,46 @@ import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Item, ItemContent, ItemGroup, ItemHeader } from '@auxx/ui/components/item'
 import { format } from 'date-fns'
-import { Code, Globe, LucideGitGraph, Mail } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { Blocks, Code, Globe, Link2, LucideGitGraph, Mail, Plug, Wrench, Zap } from 'lucide-react'
+import { Tooltip } from '~/components/global/tooltip'
 import type { RouterOutputs } from '~/trpc/react'
+
+type CapabilityGroup = RouterOutputs['apps']['getBySlug']['capabilities']['tools']
+
+/**
+ * A capability count badge ("8 Tools") with a hover tooltip listing the item
+ * names and a "+N more" line when the list is capped.
+ */
+function CapabilityBadge({
+  group,
+  icon: Icon,
+  singular,
+  plural,
+}: {
+  group: CapabilityGroup
+  icon: LucideIcon
+  singular: string
+  plural: string
+}) {
+  const hidden = group.count - group.names.length
+  return (
+    <Tooltip
+      contentComponent={
+        <ul className='space-y-0.5 text-xs'>
+          {group.names.map((name) => (
+            <li key={name}>{name}</li>
+          ))}
+          {hidden > 0 && <li className='text-muted-foreground'>+{hidden} more</li>}
+        </ul>
+      }>
+      <Badge variant='secondary' className='gap-1'>
+        <Icon className='size-3' />
+        {group.count} {group.count === 1 ? singular : plural}
+      </Badge>
+    </Tooltip>
+  )
+}
 
 /**
  * Props for AppAbout component
@@ -93,6 +131,53 @@ function AppAbout({ app }: Props) {
               </ItemContent>
             </Item>
           )}
+          {(() => {
+            const caps = app.capabilities
+            const groups = [
+              { group: caps.tools, icon: Wrench, singular: 'Tool', plural: 'Tools' },
+              {
+                group: caps.quickActions,
+                icon: Zap,
+                singular: 'Quick action',
+                plural: 'Quick actions',
+              },
+              {
+                group: caps.workflowBlocks,
+                icon: Blocks,
+                singular: 'Workflow block',
+                plural: 'Workflow blocks',
+              },
+              {
+                group: caps.dataConnectors,
+                icon: Plug,
+                singular: 'Data connector',
+                plural: 'Data connectors',
+              },
+            ].filter((g) => g.group.count > 0)
+            if (groups.length === 0 && !caps.connection) return null
+            return (
+              <Item className='p-0 gap-1'>
+                <ItemHeader className='text-xs text-primary-400'>Includes</ItemHeader>
+                <ItemContent className='flex flex-row flex-wrap gap-1 items-start'>
+                  {groups.map((g) => (
+                    <CapabilityBadge
+                      key={g.plural}
+                      group={g.group}
+                      icon={g.icon}
+                      singular={g.singular}
+                      plural={g.plural}
+                    />
+                  ))}
+                  {caps.connection && (
+                    <Badge variant='secondary' className='gap-1'>
+                      <Link2 className='size-3' />
+                      {caps.connection.label}
+                    </Badge>
+                  )}
+                </ItemContent>
+              </Item>
+            )
+          })()}
           {/* {latestVersion && (
             <Item className="p-0 gap-1">
               <ItemHeader className="text-xs text-primary-400">Current version</ItemHeader>

--- a/packages/lib/src/apps/get-app-details.ts
+++ b/packages/lib/src/apps/get-app-details.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/apps/get-app-details.ts
 
-import type { Database } from '@auxx/database'
+import type { CatalogPayload, Database } from '@auxx/database'
 import {
   type ConnectionDefinitionSummary,
   type ConnectionMethod,
@@ -16,6 +16,30 @@ export interface GetAppWithStatusInput {
   appSlug: string
   organizationId: string
   db: Database
+}
+
+/**
+ * One capability category for the About-page "Includes" badges. `names` is capped
+ * (see NAME_CAP) for payload size; `count` is the true total so the badge can show
+ * "+N more" beyond the listed names.
+ */
+export interface CapabilityGroup {
+  count: number
+  names: string[]
+}
+
+/**
+ * Compact, client-safe summary of what an app's latest deployment defines.
+ * Computed from `AppDeployment.catalog` — no server-only catalog types cross the wire.
+ */
+export interface AppCapabilitySummary {
+  tools: CapabilityGroup
+  quickActions: CapabilityGroup
+  /** Workflow blocks + workflow triggers, combined. */
+  workflowBlocks: CapabilityGroup
+  dataConnectors: CapabilityGroup
+  /** Derived connection descriptor, or null when the app needs no connection. */
+  connection: { label: string } | null
 }
 
 /**
@@ -68,6 +92,8 @@ export interface AppWithStatusOutput {
     status: string
     createdAt: Date
   }>
+  /** What the latest deployment defines — surfaced as "Includes" badges on the About page. */
+  capabilities: AppCapabilitySummary
 }
 
 /**
@@ -140,21 +166,29 @@ export async function getAppWithInstallationStatus(
     columns: { title: true, logoUrl: true },
   })
 
-  // Fetch connection methods (+ derived two-slot view) if app is installed
+  // Connection methods are app-keyed (not installation-scoped), so fetch them regardless of
+  // installation — the About page needs them to derive the connection badge for not-yet-installed
+  // apps. The per-scope two-slot view stays installed-only (only meaningful once connected).
   const connectionDefinitions: AppWithStatusOutput['installation']['connectionDefinitions'] = {}
-  let methods: ConnectionMethod[] = []
+  const methodsResult = await listAppConnectionDefinitions(cachedApp.id)
+  const methods: ConnectionMethod[] = methodsResult.isOk() ? methodsResult.value : []
   if (installation) {
-    const [userConnDef, orgConnDef, methodsResult] = await Promise.all([
+    const [userConnDef, orgConnDef] = await Promise.all([
       getAppConnectionDefinition(cachedApp.id, false),
       getAppConnectionDefinition(cachedApp.id, true),
-      listAppConnectionDefinitions(cachedApp.id),
     ])
     if (userConnDef.isOk() && userConnDef.value) connectionDefinitions.user = userConnDef.value
     if (orgConnDef.isOk() && orgConnDef.value) {
       connectionDefinitions.organization = orgConnDef.value
     }
-    if (methodsResult.isOk()) methods = methodsResult.value
   }
+
+  // Summarize the latest accessible deployment's catalog into client-safe count + name groups.
+  const capabilities = summarizeCapabilities(
+    deployments[0]?.catalog ?? null,
+    methods,
+    cachedApp.hasOauth
+  )
 
   return {
     ok: true,
@@ -202,6 +236,48 @@ export async function getAppWithInstallationStatus(
         status: d.status,
         createdAt: d.createdAt,
       })),
+      capabilities,
     },
   }
+}
+
+/** Max item names projected per category — the tooltip shows "+N more" beyond this. */
+const CAPABILITY_NAME_CAP = 20
+
+/** Build a {count, names} group, capping the names list while keeping the true total. */
+function toCapabilityGroup(names: string[]): CapabilityGroup {
+  return { count: names.length, names: names.slice(0, CAPABILITY_NAME_CAP) }
+}
+
+/**
+ * Project the latest deployment's catalog into a compact, client-safe summary.
+ * Defensive against null catalogs (bundle-less apps) and optional catalog keys
+ * (`workflow`, `dataConnectors`) that older catalogs omit.
+ */
+function summarizeCapabilities(
+  catalog: CatalogPayload | null,
+  methods: ConnectionMethod[],
+  hasOauth: boolean
+): AppCapabilitySummary {
+  return {
+    tools: toCapabilityGroup((catalog?.tools ?? []).map((t) => t.name)),
+    quickActions: toCapabilityGroup((catalog?.actions ?? []).map((a) => a.label)),
+    workflowBlocks: toCapabilityGroup([
+      ...(catalog?.workflow?.blocks ?? []).map((b) => b.label),
+      ...(catalog?.workflow?.triggers ?? []).map((t) => t.label),
+    ]),
+    dataConnectors: toCapabilityGroup((catalog?.dataConnectors ?? []).map((c) => c.label)),
+    connection: deriveConnectionDescriptor(methods, hasOauth),
+  }
+}
+
+/** Pick a short label for the connection badge, or null when the app needs no connection. */
+function deriveConnectionDescriptor(
+  methods: ConnectionMethod[],
+  hasOauth: boolean
+): { label: string } | null {
+  if (methods.length === 1) return { label: methods[0].label }
+  if (methods.length > 1) return { label: 'Connection' }
+  if (hasOauth) return { label: 'OAuth connection' }
+  return null
 }


### PR DESCRIPTION
## What

Surfaces what a published app *defines* on its About page — **tools**, **quick actions**, **workflow blocks/triggers**, and **data connectors**, plus a derived **connection** descriptor — as compact count badges in the left meta column ("Includes"). Each capability badge lists its item names in a hover tooltip with "+N more" truncation.

This page renders for *not-yet-installed* apps (installed apps redirect to the tabbed installed view), so the data is projected from the latest deployment's catalog rather than the installed-apps org cache.

## How

**`packages/lib/src/apps/get-app-details.ts`**
- New `CapabilityGroup` (`{ count, names[] }`) + `AppCapabilitySummary` types; added `capabilities` to `AppWithStatusOutput`.
- `summarizeCapabilities()` projects `deployments[0].catalog` into counts + capped name lists (cap 20, tooltip shows "+N more"). Defensive against null catalogs and optional `workflow`/`dataConnectors` keys.
- Lifted the connection-method fetch (`listAppConnectionDefinitions`, app-keyed) out of the installed-only guard so the connection descriptor works for not-yet-installed apps. Falls back to `hasOauth` → "OAuth connection".
- Counts + plain name strings only — no server-only `Catalog*` types cross the wire.

**`apps/web/src/components/apps/ui/app-about.tsx`**
- `CapabilityBadge`: secondary `Badge` wrapped in the global `Tooltip`, content lists item names + "+N more".
- New "Includes" `Item` in the left meta `ItemGroup`; renders one badge per non-empty category + the connection badge; hidden when nothing is defined.

No DB schema change, no new tRPC procedure (`getBySlug` returns the value verbatim).

## Test plan
- [ ] Open a published app with a catalog → "Includes" shows correct counts, tooltips list names.
- [ ] App with >20 of a category → tooltip shows "+N more".
- [ ] App with no bundle/catalog → "Includes" section hidden.
- [ ] Connection badge shows for OAuth/secret apps, absent for connection-less apps.