### PR TITLE
fix(data-connectors): re-assert overwrite fields on destination drift

### DIFF
--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -14,7 +14,7 @@ import type { FieldId, ResourceFieldId } from '@auxx/types/field'
 import { getFieldId } from '@auxx/types/field'
 import type { TypedFieldValue } from '@auxx/types/field-value'
 import { stableHash } from '@auxx/utils/hash'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull, ne, or } from 'drizzle-orm'
 import { resolveConnectorFieldRef } from '../../agents/bindings/resolve'
 import { toRecordId } from '../../resources/resource-id'
 import { buildWriteKeyToFieldId } from '../field-id-resolver'
@@ -259,6 +259,83 @@ async function stampContributingProvenance(
     )
 }
 
+/**
+ * The set of bound instance ids for `mapping` whose `overwrite` cells have
+ * DRIFTED — i.e. a `FieldValue.managedByConnectorId` that this connector stamped
+ * on write is now cleared (someone hand-edited the cell in the grid) or owned by
+ * a different connector. The content-hash skip must NOT skip these, because an
+ * `overwrite` field is connector-owned and has to re-assert the source value (the
+ * write re-stamps the marker, so a healed record drops out of this set next run).
+ *
+ * Computed ONCE per mapping per slice (one bulk query), memoized on `ctx` as a
+ * Promise so records processed concurrently share it — never a per-record read.
+ * Contributing-mode only: owned fields are `isUpdatable:false` (the grid can't
+ * edit them) and owned writes don't stamp the marker, so there's nothing to
+ * detect. A mapping with no `overwrite` field (all conservative strategies) pays
+ * nothing — it short-circuits to an empty set before querying.
+ */
+function driftedInstances(ctx: SyncCtx, mapping: DecodedMapping): Promise<Set<string>> {
+  const memo = (ctx.driftByMapping ??= new Map())
+  let pending = memo.get(mapping.row.id)
+  if (!pending) {
+    pending = computeDriftedInstances(ctx, mapping)
+    memo.set(mapping.row.id, pending)
+  }
+  return pending
+}
+
+async function computeDriftedInstances(
+  ctx: SyncCtx,
+  mapping: DecodedMapping
+): Promise<Set<string>> {
+  if (mapping.targetMode !== 'contributing') return new Set()
+
+  // `overwrite` is the default when a binding carries no explicit mergeStrategy
+  // (mirrors `strategyFor` in buildWriteSet), so an unset strategy counts here.
+  const overwriteRefs = mapping.fieldMappings
+    .filter(
+      (fm) =>
+        fm.targetFieldRef != null && (fm.mergeStrategy == null || fm.mergeStrategy === 'overwrite')
+    )
+    .map((fm) => fm.targetFieldRef as ResourceFieldId)
+  if (overwriteRefs.length === 0) return new Set()
+
+  // Resolve each ref to the concrete CustomField uuid `FieldValue.fieldId` carries
+  // (refs may be the late-bound `@app:` form; system fields key by systemAttribute).
+  const connectionId = ctx.connector.credentialId ?? undefined
+  const keyToId = await buildWriteKeyToFieldId(ctx.orgId, mapping.entityDefinitionId)
+  const fieldIds = new Set<string>()
+  for (const ref of overwriteRefs) {
+    const concrete = await resolveConnectorFieldRef(ref, ctx.orgId, connectionId)
+    if (!concrete) continue
+    const uuid = keyToId.get(getFieldId(concrete))
+    if (uuid) fieldIds.add(uuid)
+  }
+  if (fieldIds.size === 0) return new Set()
+
+  // One query: bound instances of this mapping holding an overwrite cell no longer
+  // stamped by this connector (NULL = hand-edited, or a different connector took over).
+  const rows = await ctx.db
+    .selectDistinct({ entityId: schema.FieldValue.entityId })
+    .from(schema.FieldValue)
+    .innerJoin(
+      schema.DataConnectorItem,
+      eq(schema.DataConnectorItem.entityInstanceId, schema.FieldValue.entityId)
+    )
+    .where(
+      and(
+        eq(schema.DataConnectorItem.dataConnectorId, ctx.connector.id),
+        eq(schema.DataConnectorItem.mappingId, mapping.row.id),
+        inArray(schema.FieldValue.fieldId, Array.from(fieldIds)),
+        or(
+          isNull(schema.FieldValue.managedByConnectorId),
+          ne(schema.FieldValue.managedByConnectorId, ctx.connector.id)
+        )
+      )
+    )
+  return new Set(rows.map((r) => r.entityId))
+}
+
 export const entitySink: EntitySink = {
   async upsertRecord(ctx, mapping, record) {
     ctx.counters.fetched += 1
@@ -276,21 +353,31 @@ export const entitySink: EntitySink = {
       instanceId = resolved.instanceId
     }
 
-    // 2. Content hash — skip unchanged + already bound.
+    // 2. Content hash — skip unchanged + already bound, UNLESS an overwrite cell
+    //    has drifted (hand-edited in the grid). The hash is computed over the
+    //    SOURCE only, so a destination edit is invisible to it; without the drift
+    //    guard an `overwrite` field silently never re-asserts the source value
+    //    while the source is stable. Drift is detected in bulk, once per mapping.
     const contentHash = stableHash({ fields: record.fields, displayName: record.displayName })
     if (bound?.entityInstanceId && bound.contentHash === contentHash) {
-      await touchItem(ctx.db, bound.id, ctx.runId)
-      ctx.counters.skipped += 1
-      // Still re-register pending relations so a later-arriving target resolves.
-      if (record.pendingRelations.length > 0) {
-        await mergePendingRelations(
-          ctx,
-          bound.id,
-          bound.pendingRelations ?? [],
-          record.pendingRelations
-        )
+      // Source is unchanged — skip, unless an overwrite cell drifted (hand-edited),
+      // in which case fall through to re-assert the source value. Drift is only
+      // queried here, when we'd otherwise skip, so a create-only backfill pays nothing.
+      const drifted = await driftedInstances(ctx, mapping)
+      if (!drifted.has(bound.entityInstanceId)) {
+        await touchItem(ctx.db, bound.id, ctx.runId)
+        ctx.counters.skipped += 1
+        // Still re-register pending relations so a later-arriving target resolves.
+        if (record.pendingRelations.length > 0) {
+          await mergePendingRelations(
+            ctx,
+            bound.id,
+            bound.pendingRelations ?? [],
+            record.pendingRelations
+          )
+        }
+        return
       }
-      return
     }
 
     // 3. Build the write set with per-field merge strategy.

--- a/packages/lib/src/data-connectors/sinks/types.ts
+++ b/packages/lib/src/data-connectors/sinks/types.ts
@@ -56,6 +56,15 @@ export interface SyncCtx {
    * because the crawl is complete-by-construction) — still gated on the FINAL slice.
    */
   sweep?: boolean
+  /**
+   * Per-mapping drift cache (entity-sink). Maps a mapping id → the set of bound
+   * instance ids whose `overwrite` cells were edited by someone other than this
+   * connector (detected via a cleared/foreign `FieldValue.managedByConnectorId`).
+   * The content-hash skip must NOT skip these — `overwrite` has to re-assert the
+   * source value. Computed once per mapping per slice (one query, memoized as a
+   * Promise so concurrent records share it), never per record.
+   */
+  driftByMapping?: Map<string, Promise<Set<string>>>
 }
 
 /** The entity sink contract (04 §1b). */

--- a/packages/lib/src/data-connectors/webhooks/fixture.ts
+++ b/packages/lib/src/data-connectors/webhooks/fixture.ts
@@ -1,61 +1,20 @@
 // packages/lib/src/data-connectors/webhooks/fixture.ts
 // Provider-neutral webhook capability — proves the ingress spine with no external
-// dependency (mirrors fixtureConnector). Used by tests + as the reference driver.
-// `verify` is a plain timing-safe secret-header compare; `resolveWebhook` maps a
-// self-describing payload straight onto sink actions.
+// dependency (mirrors fixtureConnector). Used by tests + as the reference driver. The
+// read path is declared in `fixtureSpec` (a shared-token verify, or unsigned in tests,
+// over a self-describing payload); register/unregister are deterministic no-ops.
 
-import { fixturePreset, verifyWebhook } from '../../webhooks/inbound'
-import type { WebhookAction, WebhookCapability } from '../types'
+import { compileWebhookSpec, fixtureSpec } from '../../webhooks/inbound'
+import type { WebhookCapability } from '../types'
 
-/** A fixture webhook payload — already shaped as one action's worth of data. */
-interface FixturePayload {
-  topic?: string
-  streamKey: string
-  externalId: string
-  fields?: Record<string, unknown>
-  displayName?: string
-  deleted?: boolean
-}
-
-export const fixtureWebhookCapability: WebhookCapability = {
+export const fixtureWebhookCapability: WebhookCapability = compileWebhookSpec(fixtureSpec, {
   topics: ['fixture/upsert', 'fixture/delete'],
-
-  verify({ rawBody, headers, secret }) {
-    if (!secret) return true // an unsecured fixture endpoint (tests)
-    return verifyWebhook(fixturePreset, { rawBody, headers, secret })
-  },
-
-  eventId({ headers }) {
-    return headers['x-fixture-event-id'] ?? null
-  },
-
-  resolveWebhook({ payload }): WebhookAction[] {
-    const p = payload as FixturePayload | null
-    if (!p?.streamKey || !p?.externalId) return []
-    if (p.deleted) {
-      return [{ kind: 'delete', streamKey: p.streamKey, externalId: p.externalId }]
-    }
-    return [
-      {
-        kind: 'upsert',
-        streamKey: p.streamKey,
-        record: {
-          streamKey: p.streamKey,
-          externalId: p.externalId,
-          displayName: p.displayName,
-          fields: p.fields ?? {},
-        },
-      },
-    ]
-  },
-
   // The fixture has no real provider — register/unregister are deterministic no-ops
   // that still return a subscription so the registration round-trip is exercisable.
   async register({ topics }) {
     return topics.map((topic) => ({ topic, externalId: `fixture-sub:${topic}` }))
   },
-
   async unregister() {
     /* no-op */
   },
-}
+})

--- a/packages/lib/src/data-connectors/webhooks/shopify.ts
+++ b/packages/lib/src/data-connectors/webhooks/shopify.ts
@@ -1,20 +1,17 @@
 // packages/lib/src/data-connectors/webhooks/shopify.ts
-// Shopify webhook capability (Step 8). HMAC-SHA256 over the RAW body (base64), the
-// `x-shopify-event-id` idempotency key, topic from `x-shopify-topic`, and
-// webhookSubscriptionCreate/Delete over the Admin GraphQL API for registration.
-//
-// A Shopify topic is `<resource>/<verb>` (e.g. `orders/delete`). The connector's
-// stream key is the resource (`orders`); a `*/delete` verb archives by the payload
-// `id`, every other verb upserts the payload.
+// Shopify webhook capability (Step 8). The read path (verify / event-id / topic→action)
+// is declared as data in `shopifySpec` and compiled into the capability; only the
+// registration half — webhookSubscriptionCreate/Delete over the Admin GraphQL API — is
+// coded here, because GraphQL construction + shop auth is genuinely provider-specific.
 
 import { createScopedLogger } from '@auxx/logger'
 import type { RuntimeConnectionData } from '../../connections/resolve-connection-for-runtime'
-import { shopifyPreset, verifyWebhook } from '../../webhooks/inbound'
+import { compileWebhookSpec, shopifySpec } from '../../webhooks/inbound'
 import type {
-  WebhookAction,
   WebhookCapability,
   WebhookRegisterInput,
   WebhookSubscription,
+  WebhookUnregisterInput,
 } from '../types'
 
 const logger = createScopedLogger('data-connector-webhook-shopify')
@@ -69,87 +66,61 @@ async function shopifyGraphql(
   return res.json()
 }
 
-export const shopifyWebhookCapability: WebhookCapability = {
-  topics: DEFAULT_TOPICS,
-
-  verify({ rawBody, headers, secret }) {
-    return verifyWebhook(shopifyPreset, { rawBody, headers, secret })
-  },
-
-  eventId({ headers }) {
-    return headers['x-shopify-event-id'] ?? null
-  },
-
-  resolveWebhook({ headers, payload }): WebhookAction[] {
-    const topic = headers['x-shopify-topic']
-    if (!topic) return []
-    const [resource, verb] = topic.split('/')
-    const streamKey = resource ?? topic
-    const body = payload as { id?: string | number } | null
-    const externalId = body?.id != null ? String(body.id) : null
-    if (!externalId) return []
-    if (verb === 'delete') {
-      return [{ kind: 'delete', streamKey, externalId }]
-    }
-    return [
-      {
-        kind: 'upsert',
-        streamKey,
-        record: { streamKey, externalId, fields: payload ?? {} },
-      },
-    ]
-  },
-
-  async register(input: WebhookRegisterInput): Promise<WebhookSubscription[]> {
-    const topics = input.topics.length > 0 ? input.topics : DEFAULT_TOPICS
-    const mutation = `
-      mutation webhookSubscriptionCreate($topic: WebhookSubscriptionTopic!, $sub: WebhookSubscriptionInput!) {
-        webhookSubscriptionCreate(topic: $topic, webhookSubscription: $sub) {
-          webhookSubscription { id }
-          userErrors { field message }
-        }
-      }`
-    const subs: WebhookSubscription[] = []
-    for (const topic of topics) {
-      try {
-        const json = await shopifyGraphql(input.credential, mutation, {
-          topic: topicToGraphqlEnum(topic),
-          sub: { callbackUrl: input.callbackUrl, format: 'JSON' },
-        })
-        const result = json?.data?.webhookSubscriptionCreate
-        const id = result?.webhookSubscription?.id
-        if (id) {
-          subs.push({ topic, externalId: id })
-        } else {
-          logger.warn('Shopify webhook subscribe returned no id', {
-            topic,
-            userErrors: result?.userErrors,
-          })
-        }
-      } catch (error) {
-        logger.warn('Shopify webhook subscribe failed', {
+async function shopifyRegister(input: WebhookRegisterInput): Promise<WebhookSubscription[]> {
+  const topics = input.topics.length > 0 ? input.topics : DEFAULT_TOPICS
+  const mutation = `
+    mutation webhookSubscriptionCreate($topic: WebhookSubscriptionTopic!, $sub: WebhookSubscriptionInput!) {
+      webhookSubscriptionCreate(topic: $topic, webhookSubscription: $sub) {
+        webhookSubscription { id }
+        userErrors { field message }
+      }
+    }`
+  const subs: WebhookSubscription[] = []
+  for (const topic of topics) {
+    try {
+      const json = await shopifyGraphql(input.credential, mutation, {
+        topic: topicToGraphqlEnum(topic),
+        sub: { callbackUrl: input.callbackUrl, format: 'JSON' },
+      })
+      const result = json?.data?.webhookSubscriptionCreate
+      const id = result?.webhookSubscription?.id
+      if (id) {
+        subs.push({ topic, externalId: id })
+      } else {
+        logger.warn('Shopify webhook subscribe returned no id', {
           topic,
-          error: error instanceof Error ? error.message : String(error),
+          userErrors: result?.userErrors,
         })
       }
+    } catch (error) {
+      logger.warn('Shopify webhook subscribe failed', {
+        topic,
+        error: error instanceof Error ? error.message : String(error),
+      })
     }
-    return subs
-  },
-
-  async unregister(input) {
-    const mutation = `
-      mutation webhookSubscriptionDelete($id: ID!) {
-        webhookSubscriptionDelete(id: $id) { userErrors { field message } }
-      }`
-    for (const id of input.externalIds) {
-      try {
-        await shopifyGraphql(input.credential, mutation, { id })
-      } catch (error) {
-        logger.warn('Shopify webhook unsubscribe failed', {
-          id,
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
-  },
+  }
+  return subs
 }
+
+async function shopifyUnregister(input: WebhookUnregisterInput): Promise<void> {
+  const mutation = `
+    mutation webhookSubscriptionDelete($id: ID!) {
+      webhookSubscriptionDelete(id: $id) { userErrors { field message } }
+    }`
+  for (const id of input.externalIds) {
+    try {
+      await shopifyGraphql(input.credential, mutation, { id })
+    } catch (error) {
+      logger.warn('Shopify webhook unsubscribe failed', {
+        id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+}
+
+export const shopifyWebhookCapability: WebhookCapability = compileWebhookSpec(shopifySpec, {
+  topics: DEFAULT_TOPICS,
+  register: shopifyRegister,
+  unregister: shopifyUnregister,
+})

--- a/packages/lib/src/data-connectors/webhooks/stripe.ts
+++ b/packages/lib/src/data-connectors/webhooks/stripe.ts
@@ -1,72 +1,43 @@
 // packages/lib/src/data-connectors/webhooks/stripe.ts
-// Stripe webhook capability (Step 8). Verifies the `Stripe-Signature` scheme
-// (`t=<ts>,v1=<hmac>` over `${t}.${rawBody}` with the `whsec_` signing secret),
-// dedupes by the event `id`, and resolves an event onto an upsert/delete by its
-// `type`. Registration uses the Stripe REST API (`/v1/webhook_endpoints`).
-//
-// A Stripe event's object (`data.object`) carries `object: 'customer'` etc.; the
-// stream key is that object name pluralized-by-convention is avoided — we use the
-// raw object name as the stream key, and `*.deleted` event types archive.
+// Stripe webhook capability (Step 8). The read path (verify / event-id / topic→action)
+// is declared as data in `stripeSpec` and compiled into the capability; only the
+// registration half — the Stripe REST API (`/v1/webhook_endpoints`) — is coded here.
 
 import { createScopedLogger } from '@auxx/logger'
 import type { RuntimeConnectionData } from '../../connections/resolve-connection-for-runtime'
-import { stripePreset, verifyWebhook } from '../../webhooks/inbound'
-import type { WebhookAction, WebhookCapability, WebhookSubscription } from '../types'
+import { compileWebhookSpec, stripeSpec } from '../../webhooks/inbound'
+import type {
+  WebhookCapability,
+  WebhookRegisterInput,
+  WebhookSubscription,
+  WebhookUnregisterInput,
+} from '../types'
 
 const logger = createScopedLogger('data-connector-webhook-stripe')
 
 /** Default Stripe event types a connector subscribes to. */
 const DEFAULT_EVENTS = ['customer.created', 'customer.updated', 'customer.deleted']
 
-interface StripeEvent {
-  id?: string
-  type?: string
-  data?: { object?: { id?: string; object?: string } }
+async function stripeRegister(input: WebhookRegisterInput): Promise<WebhookSubscription[]> {
+  const events = input.topics.length > 0 ? input.topics : DEFAULT_EVENTS
+  const id = await stripeRequest(input.credential, 'POST', '/v1/webhook_endpoints', {
+    url: input.callbackUrl,
+    ...Object.fromEntries(events.map((e, i) => [`enabled_events[${i}]`, e])),
+  })
+  return id ? [{ topic: 'stripe-endpoint', externalId: id }] : []
 }
 
-export const stripeWebhookCapability: WebhookCapability = {
+async function stripeUnregister(input: WebhookUnregisterInput): Promise<void> {
+  for (const id of input.externalIds) {
+    await stripeRequest(input.credential, 'DELETE', `/v1/webhook_endpoints/${id}`)
+  }
+}
+
+export const stripeWebhookCapability: WebhookCapability = compileWebhookSpec(stripeSpec, {
   topics: DEFAULT_EVENTS,
-
-  verify({ rawBody, headers, secret }) {
-    return verifyWebhook(stripePreset, { rawBody, headers, secret })
-  },
-
-  eventId({ rawBody }) {
-    try {
-      return (JSON.parse(rawBody) as StripeEvent).id ?? null
-    } catch {
-      return null
-    }
-  },
-
-  resolveWebhook({ payload }): WebhookAction[] {
-    const event = payload as StripeEvent | null
-    const type = event?.type
-    const object = event?.data?.object
-    if (!type || !object?.id) return []
-    const streamKey = object.object ?? type.split('.')[0] ?? 'event'
-    const externalId = String(object.id)
-    if (type.endsWith('.deleted')) {
-      return [{ kind: 'delete', streamKey, externalId }]
-    }
-    return [{ kind: 'upsert', streamKey, record: { streamKey, externalId, fields: object } }]
-  },
-
-  async register(input): Promise<WebhookSubscription[]> {
-    const events = input.topics.length > 0 ? input.topics : DEFAULT_EVENTS
-    const id = await stripeRequest(input.credential, 'POST', '/v1/webhook_endpoints', {
-      url: input.callbackUrl,
-      ...Object.fromEntries(events.map((e, i) => [`enabled_events[${i}]`, e])),
-    })
-    return id ? [{ topic: 'stripe-endpoint', externalId: id }] : []
-  },
-
-  async unregister(input) {
-    for (const id of input.externalIds) {
-      await stripeRequest(input.credential, 'DELETE', `/v1/webhook_endpoints/${id}`)
-    }
-  },
-}
+  register: stripeRegister,
+  unregister: stripeUnregister,
+})
 
 /** Make a form-encoded Stripe API call; returns the response `id` (POST) or null. */
 async function stripeRequest(

--- a/packages/lib/src/webhooks/inbound/index.ts
+++ b/packages/lib/src/webhooks/inbound/index.ts
@@ -14,6 +14,15 @@ export {
   stripePreset,
 } from './presets'
 export { resolveWebhookSecret } from './secret/resolve'
+export {
+  compileWebhookSpec,
+  resolveWebhookActions,
+  topicGlob,
+  type WebhookSource,
+  type WebhookSpec,
+  type WebhookSpecHooks,
+} from './spec'
+export { fixtureSpec, shopifySpec, stripeSpec } from './specs'
 export type {
   HmacAlgo,
   HmacEncoding,

--- a/packages/lib/src/webhooks/inbound/spec.test.ts
+++ b/packages/lib/src/webhooks/inbound/spec.test.ts
@@ -1,0 +1,158 @@
+// packages/lib/src/webhooks/inbound/spec.test.ts
+// Unit tests for the WebhookSpec compiler + helpers: topic glob, stream-key fallback,
+// missing-id drops, topic-segment derivation, and body-flag deletes. The per-provider
+// parity vectors live in data-connectors/webhooks/webhook-capability.test.ts.
+
+import { describe, expect, it } from 'vitest'
+import type { WebhookSpec } from './spec'
+import { compileWebhookSpec, resolveWebhookActions, topicGlob } from './spec'
+
+const noHooks = {
+  topics: [],
+  register: async () => [],
+  unregister: async () => {},
+}
+
+describe('topicGlob', () => {
+  it('matches a leading-* suffix glob', () => {
+    expect(topicGlob('*/delete', 'orders/delete')).toBe(true)
+    expect(topicGlob('*/delete', 'products/update')).toBe(false)
+    expect(topicGlob('*.deleted', 'customer.deleted')).toBe(true)
+    expect(topicGlob('*.deleted', 'customer.updated')).toBe(false)
+  })
+
+  it('matches an exact pattern with no wildcard', () => {
+    expect(topicGlob('orders/create', 'orders/create')).toBe(true)
+    expect(topicGlob('orders/create', 'orders/update')).toBe(false)
+  })
+})
+
+describe('resolveWebhookActions', () => {
+  const resolve: WebhookSpec['resolve'] = {
+    topic: { from: 'header', name: 'x-topic' },
+    streamKey: { from: 'topicSegment', index: 0 },
+    externalId: { from: 'body', path: 'id' },
+    fields: { from: 'body', path: '' },
+    deleteWhen: { topicMatches: '*/delete' },
+  }
+
+  it('derives the stream key from the first topic segment', () => {
+    const actions = resolveWebhookActions(
+      resolve,
+      { 'x-topic': 'orders/create' },
+      { id: 1, n: 'a' }
+    )
+    expect(actions).toEqual([
+      {
+        kind: 'upsert',
+        streamKey: 'orders',
+        record: { streamKey: 'orders', externalId: '1', fields: { id: 1, n: 'a' } },
+      },
+    ])
+  })
+
+  it('drops a delivery with no external id', () => {
+    expect(resolveWebhookActions(resolve, { 'x-topic': 'orders/create' }, { n: 'a' })).toEqual([])
+  })
+
+  it('drops a delivery with no resolvable stream key', () => {
+    expect(resolveWebhookActions(resolve, {}, { id: 1 })).toEqual([])
+  })
+
+  it('keeps an id of 0 (faithful != null rule), drops an empty-string id', () => {
+    expect(
+      resolveWebhookActions(resolve, { 'x-topic': 'orders/create' }, { id: 0 })[0]
+    ).toMatchObject({ kind: 'upsert', record: { externalId: '0' } })
+    expect(resolveWebhookActions(resolve, { 'x-topic': 'orders/create' }, { id: '' })).toEqual([])
+  })
+
+  it('applies a stream-key fallback then a literal default', () => {
+    const withFallback: WebhookSpec['resolve'] = {
+      ...resolve,
+      topic: { from: 'body', path: 'type' },
+      streamKey: {
+        from: 'body',
+        path: 'data.object.object',
+        fallback: { from: 'topicSegment', index: 0, separator: '.' },
+        default: 'event',
+      },
+      externalId: { from: 'body', path: 'data.object.id' },
+      fields: { from: 'body', path: 'data.object' },
+      deleteWhen: { topicMatches: '*.deleted' },
+    }
+    // Primary present.
+    expect(
+      resolveWebhookActions(
+        withFallback,
+        {},
+        { type: 'x.y', data: { object: { id: 'a', object: 'cust' } } }
+      )[0]
+    ).toMatchObject({ streamKey: 'cust' })
+    // Primary absent → topic-segment fallback.
+    expect(
+      resolveWebhookActions(
+        withFallback,
+        {},
+        { type: 'invoice.paid', data: { object: { id: 'b' } } }
+      )[0]
+    ).toMatchObject({ streamKey: 'invoice' })
+  })
+
+  it('resolves a body flag to a delete', () => {
+    const flagResolve: WebhookSpec['resolve'] = {
+      ...resolve,
+      topic: { from: 'body', path: 'topic' },
+      streamKey: { from: 'body', path: 'streamKey' },
+      externalId: { from: 'body', path: 'externalId' },
+      fields: { from: 'body', path: 'fields' },
+      deleteWhen: { bodyFlag: { path: 'deleted' } },
+    }
+    expect(
+      resolveWebhookActions(flagResolve, {}, { streamKey: 's', externalId: 'e', deleted: true })
+    ).toEqual([{ kind: 'delete', streamKey: 's', externalId: 'e' }])
+  })
+})
+
+describe('compileWebhookSpec', () => {
+  const spec: WebhookSpec = {
+    verify: { scheme: 'shared-token', header: 'x-token' },
+    unsignedOk: true,
+    eventId: { from: 'body', path: 'id' },
+    resolve: {
+      topic: { from: 'body', path: 'type' },
+      streamKey: { from: 'body', path: 'stream' },
+      externalId: { from: 'body', path: 'ref' },
+      fields: { from: 'body', path: '' },
+      deleteWhen: { topicMatches: '*.gone' },
+    },
+  }
+
+  it('treats a missing secret as verified when unsignedOk', () => {
+    const cap = compileWebhookSpec(spec, noHooks)
+    expect(cap.verify({ rawBody: '{}', headers: {}, secret: null })).toBe(true)
+  })
+
+  it('extracts the event id from the parsed body, null on bad JSON', () => {
+    const cap = compileWebhookSpec(spec, noHooks)
+    expect(cap.eventId({ rawBody: JSON.stringify({ id: 'evt_9' }), headers: {} })).toBe('evt_9')
+    expect(cap.eventId({ rawBody: 'not json', headers: {} })).toBe(null)
+  })
+
+  it('exposes the coded registration hooks unchanged', async () => {
+    const cap = compileWebhookSpec(spec, {
+      topics: ['t1'],
+      register: async ({ topics }) => topics.map((t) => ({ topic: t, externalId: `s:${t}` })),
+      unregister: async () => {},
+    })
+    expect(cap.topics).toEqual(['t1'])
+    expect(
+      await cap.register({
+        callbackUrl: 'u',
+        secret: 's',
+        topics: ['t1'],
+        credential: null,
+        config: {},
+      })
+    ).toEqual([{ topic: 't1', externalId: 's:t1' }])
+  })
+})

--- a/packages/lib/src/webhooks/inbound/spec.ts
+++ b/packages/lib/src/webhooks/inbound/spec.ts
@@ -1,0 +1,186 @@
+// packages/lib/src/webhooks/inbound/spec.ts
+// Declarative per-delivery webhook behavior (Direction 1). A WebhookSpec describes a
+// provider's verify → event-id → topic→action mapping as DATA, extending the shipped
+// WebhookVerifyPreset. `compileWebhookSpec` turns one (plus coded registration hooks)
+// into the runtime WebhookCapability — the contract stays, the authoring becomes config.
+//
+// Registration (register/unregister) is NOT declarative: GraphQL/REST construction +
+// provider auth is genuinely code, passed in as `hooks`. See webhookspec-build-plan.md.
+
+import { getByPath } from '@auxx/utils'
+import type {
+  WebhookAction,
+  WebhookCapability,
+  WebhookRegisterInput,
+  WebhookSubscription,
+  WebhookUnregisterInput,
+} from '../../data-connectors/types'
+import type { WebhookVerifyPreset } from './types'
+import { verifyWebhook } from './verify'
+
+/** Where a scalar is read from on a verified delivery. */
+export type WebhookSource =
+  /** A (lowercased) request header. */
+  | { from: 'header'; name: string }
+  /** A dot-path into the parsed JSON body (`''` = the whole body). */
+  | { from: 'body'; path: string }
+  /** A segment of the resolved topic, split on `separator` (default `'/'`). */
+  | { from: 'topicSegment'; index: number; separator?: string }
+
+/** A source that reads from a header or the body (no topic context — used for ids/topics). */
+type FieldSource = { from: 'header'; name: string } | { from: 'body'; path: string }
+
+/**
+ * A provider's per-delivery webhook behavior as data. The `verify` block is the
+ * already-shipped {@link WebhookVerifyPreset}; the rest describes idempotency and the
+ * topic → sink-action mapping that each driver used to hand-write.
+ */
+export interface WebhookSpec {
+  /** Signature verification — the shipped preset, reused verbatim. */
+  verify: WebhookVerifyPreset
+  /** Treat a missing secret as verified (unsecured fixture endpoints in tests). */
+  unsignedOk?: boolean
+  /** Idempotency key for receiver dedupe. Missing at runtime ⇒ caller hashes the body. */
+  eventId: FieldSource
+  /** Topic → action mapping. */
+  resolve: {
+    /** The provider topic for this delivery (`orders/delete`, `customer.deleted`). */
+    topic: FieldSource
+    /** The stream this delivery belongs to (Shopify: a topic segment; Stripe: a body path). */
+    streamKey: WebhookSource & { fallback?: WebhookSource; default?: string }
+    /** The external record id. */
+    externalId: { from: 'body'; path: string }
+    /** The fields to sink on upsert (`''` = whole body; `data.object` = Stripe). */
+    fields: { from: 'body'; path: string }
+    /** Optional human label. */
+    displayName?: { from: 'body'; path: string }
+    /** Delete-detection: a glob the topic matches, or a truthy/equality body flag. */
+    deleteWhen: { topicMatches: string } | { bodyFlag: { path: string; equals?: unknown } }
+  }
+}
+
+/** The coded escape hatch — registration stays per-provider. */
+export interface WebhookSpecHooks {
+  topics: string[]
+  register(input: WebhookRegisterInput): Promise<WebhookSubscription[]>
+  unregister(input: WebhookUnregisterInput): Promise<void>
+}
+
+/**
+ * Match a topic against a leading-`*` glob (`*​/delete` ⇒ ends with `/delete`,
+ * `*.deleted` ⇒ ends with `.deleted`). A glob without `*` is an exact match.
+ */
+export function topicGlob(pattern: string, topic: string): boolean {
+  if (pattern.startsWith('*')) return topic.endsWith(pattern.slice(1))
+  return topic === pattern
+}
+
+/** Resolve a header/body field to its raw value. */
+function readField(
+  source: FieldSource,
+  headers: Record<string, string>,
+  payload: unknown
+): unknown {
+  return source.from === 'header' ? headers[source.name] : getByPath(payload, source.path)
+}
+
+/** Resolve any source (incl. topic segments) given the already-resolved topic. */
+function readSource(
+  source: WebhookSource,
+  headers: Record<string, string>,
+  payload: unknown,
+  topic: string
+): unknown {
+  if (source.from === 'topicSegment') {
+    return topic.split(source.separator ?? '/')[source.index]
+  }
+  return readField(source, headers, payload)
+}
+
+/** Normalize a resolved id to a non-empty string, or null. Faithful to the driver rule. */
+function toExternalId(raw: unknown): string {
+  if (raw == null) return ''
+  return String(raw)
+}
+
+/**
+ * Map one verified delivery onto sink actions from a spec's `resolve` block. Pure.
+ * Bails (`[]`) when the stream key or external id is missing — the union of every
+ * driver's guard. Exported for direct unit testing.
+ */
+export function resolveWebhookActions(
+  resolve: WebhookSpec['resolve'],
+  headers: Record<string, string>,
+  payload: unknown
+): WebhookAction[] {
+  const topicRaw = readField(resolve.topic, headers, payload)
+  const topic = topicRaw == null ? '' : String(topicRaw)
+
+  // Stream key: primary source, then optional fallback, then optional literal default.
+  let streamKeyRaw = readSource(resolve.streamKey, headers, payload, topic)
+  if (streamKeyRaw == null && resolve.streamKey.fallback) {
+    streamKeyRaw = readSource(resolve.streamKey.fallback, headers, payload, topic)
+  }
+  if (streamKeyRaw == null && resolve.streamKey.default != null) {
+    streamKeyRaw = resolve.streamKey.default
+  }
+  const streamKey = streamKeyRaw == null ? '' : String(streamKeyRaw)
+
+  const externalId = toExternalId(getByPath(payload, resolve.externalId.path))
+  if (!streamKey || !externalId) return []
+
+  const isDelete =
+    'topicMatches' in resolve.deleteWhen
+      ? topicGlob(resolve.deleteWhen.topicMatches, topic)
+      : matchesBodyFlag(resolve.deleteWhen.bodyFlag, payload)
+
+  if (isDelete) return [{ kind: 'delete', streamKey, externalId }]
+
+  const fields = getByPath(payload, resolve.fields.path) ?? {}
+  const record = resolve.displayName
+    ? {
+        streamKey,
+        externalId,
+        displayName: getByPath(payload, resolve.displayName.path) as string | undefined,
+        fields,
+      }
+    : { streamKey, externalId, fields }
+  return [{ kind: 'upsert', streamKey, record }]
+}
+
+/** A truthy (default) or strict-equality test on a body flag. */
+function matchesBodyFlag(flag: { path: string; equals?: unknown }, payload: unknown): boolean {
+  const value = getByPath(payload, flag.path)
+  return flag.equals === undefined ? Boolean(value) : value === flag.equals
+}
+
+/** Compile a declarative spec + coded registration hooks into a runtime WebhookCapability. */
+export function compileWebhookSpec(spec: WebhookSpec, hooks: WebhookSpecHooks): WebhookCapability {
+  return {
+    topics: hooks.topics,
+
+    verify({ rawBody, headers, secret }) {
+      if (spec.unsignedOk && !secret) return true
+      return verifyWebhook(spec.verify, { rawBody, headers, secret })
+    },
+
+    eventId({ rawBody, headers }) {
+      if (spec.eventId.from === 'header') return headers[spec.eventId.name] ?? null
+      let payload: unknown
+      try {
+        payload = rawBody ? JSON.parse(rawBody) : null
+      } catch {
+        return null
+      }
+      const value = getByPath(payload, spec.eventId.path)
+      return value == null ? null : (value as string)
+    },
+
+    resolveWebhook({ headers, payload }) {
+      return resolveWebhookActions(spec.resolve, headers, payload)
+    },
+
+    register: hooks.register,
+    unregister: hooks.unregister,
+  }
+}

--- a/packages/lib/src/webhooks/inbound/specs.ts
+++ b/packages/lib/src/webhooks/inbound/specs.ts
@@ -1,0 +1,64 @@
+// packages/lib/src/webhooks/inbound/specs.ts
+// Per-provider WebhookSpecs — the read-path (verify / event-id / topic→action) as data.
+// Each spec is exactly the column of behavior the old hand-written driver implemented;
+// the driver now compiles this with `compileWebhookSpec` + its coded registration hooks.
+
+import { fixturePreset, shopifyPreset, stripePreset } from './presets'
+import type { WebhookSpec } from './spec'
+
+/**
+ * Shopify: HMAC base64 verify, `x-shopify-event-id` idempotency, topic from
+ * `x-shopify-topic`. A topic is `<resource>/<verb>` — the stream key is the resource
+ * (first segment) and a `*​/delete` verb archives by the payload `id`.
+ */
+export const shopifySpec: WebhookSpec = {
+  verify: shopifyPreset,
+  eventId: { from: 'header', name: 'x-shopify-event-id' },
+  resolve: {
+    topic: { from: 'header', name: 'x-shopify-topic' },
+    streamKey: { from: 'topicSegment', index: 0 },
+    externalId: { from: 'body', path: 'id' },
+    fields: { from: 'body', path: '' }, // the whole payload
+    deleteWhen: { topicMatches: '*/delete' },
+  },
+}
+
+/**
+ * Stripe: the `t=,v1=` signature verify, event `id` from the body, topic from the event
+ * `type`. The stream key is the object name (`data.object.object`), falling back to the
+ * first `type` segment; `*.deleted` types archive. Upserts sink `data.object`.
+ */
+export const stripeSpec: WebhookSpec = {
+  verify: stripePreset,
+  eventId: { from: 'body', path: 'id' },
+  resolve: {
+    topic: { from: 'body', path: 'type' },
+    streamKey: {
+      from: 'body',
+      path: 'data.object.object',
+      fallback: { from: 'topicSegment', index: 0, separator: '.' },
+      default: 'event',
+    },
+    externalId: { from: 'body', path: 'data.object.id' },
+    fields: { from: 'body', path: 'data.object' },
+    deleteWhen: { topicMatches: '*.deleted' },
+  },
+}
+
+/**
+ * Provider-neutral fixture: a shared-token verify (or unsigned in tests) over a
+ * self-describing payload that already carries `streamKey` / `externalId` / `deleted`.
+ */
+export const fixtureSpec: WebhookSpec = {
+  verify: fixturePreset,
+  unsignedOk: true,
+  eventId: { from: 'header', name: 'x-fixture-event-id' },
+  resolve: {
+    topic: { from: 'body', path: 'topic' },
+    streamKey: { from: 'body', path: 'streamKey' },
+    externalId: { from: 'body', path: 'externalId' },
+    fields: { from: 'body', path: 'fields' },
+    displayName: { from: 'body', path: 'displayName' },
+    deleteWhen: { bodyFlag: { path: 'deleted' } },
+  },
+}


### PR DESCRIPTION
## Summary

Fixes a correctness bug where an `overwrite` ("always update") contributing field silently stopped re-asserting the source value once a destination cell was hand-edited.

The content-hash skip in the entity sink is computed over the **source** record only:

```ts
const contentHash = stableHash({ fields: record.fields, displayName: record.displayName })
if (bound?.entityInstanceId && bound.contentHash === contentHash) return // skip
```

So a destination edit is invisible to it. With the source unchanged, the skip short-circuits **before** `buildWriteSet`, and the `overwrite` write never runs — the manual edit survives and the connector never heals the drift, violating the `overwrite` contract.

### Repro (found in dev)

A GitHub-repos connector synced 100 rows. The `mojombo/god` row's `Private` cell was hand-edited; the next sync reported **100 skipped** and left the edit in place even though the field's strategy is `overwrite`.

## Fix

Before skipping an unchanged-by-hash record, detect drift in **bulk** — one query per mapping per slice (memoized on `SyncCtx`) for bound instances whose `overwrite` cells carry a `NULL`/foreign `managedByConnectorId` (the marker a contributing write stamps; a manual grid edit clears it). Drifted records fall through to `buildWriteSet`, which re-asserts the source value and re-stamps the marker → self-healing.

### Cost
- Create-only backfill: **zero** extra queries (nothing skips, so drift is never computed).
- Steady re-sync of N unchanged records: **one** `SELECT DISTINCT` per mapping, writing only genuinely drifted rows.
- All-conservative mapping (no `overwrite` field) or owned mode: short-circuits with no query.

### Scope
- `overwrite` only. `fill_blank` / `connector_owned_only` / `ignore` still tolerate manual edits (their contract). Owned fields are protected by `isUpdatable:false`.
- ⚠️ The drift signal depends on a manual edit *clearing* `managedByConnectorId` — currently incidental behavior, and the open question in the field-lock provenance plan recommends the opposite ("keep marker"). If that lands, this heal must switch to a per-cell write-version comparison. (Noted in the v4 plan.)

## Commits
1. `fix(data-connectors)` — the drift heal (`entity-sink.ts`, `sinks/types.ts`)
2. `chore(webhooks)` — unrelated in-progress inbound webhook spec plumbing, bundled in at request

## Testing
Verified the drift-detection SQL against dev data: it returns exactly the one hand-edited instance and leaves the 99 correctly-synced rows alone. (No vitest DB harness exists for an automated sink test.)