### PR TITLE
feat(data-connectors): materialize owned default-mappings at app setup

### DIFF
--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -218,6 +218,8 @@ export interface CatalogConnectorDefaultMapping {
 export interface CatalogConnectorStream {
   key: string
   displayFieldKey: string
+  /** Stream scheduling — `incremental` backfills once then runs deltas. */
+  syncMode?: 'snapshot' | 'incremental'
   fields: CatalogConnectorField[]
   defaultMappings?: CatalogConnectorDefaultMapping[]
   exampleRecord?: Record<string, unknown>

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -6,6 +6,7 @@
 // through update) so a cadence or lifecycle change is reflected in BullMQ immediately.
 
 import { type CatalogDataConnector, type Database, schema } from '@auxx/database'
+import type { FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { getFieldDefinitionId, getFieldId, toResourceFieldId } from '@auxx/types/field'
 import { generateId } from '@auxx/utils'
@@ -18,6 +19,7 @@ import {
   unregisterConnectorWebhooks,
 } from './connector-webhook-registration'
 import { removeConnectorScheduler, syncConnectorScheduler } from './data-connector-scheduler'
+import { type ProvisionFieldSpec, provisionTarget } from './provisioning'
 import type { DataConnectorMappingRow, DataConnectorRow, DataConnectorStreamRow } from './service'
 import type {
   ConnectorTemplate,
@@ -266,11 +268,13 @@ async function buildTemplateFieldMappings(
  * stamped `catalog`. The request is baked into the app (`fixed` model), so streams
  * carry no `requestConfig`.
  *
- * Default *mappings* are intentionally NOT materialized here: the first-party app
- * declarations are owned-mode + relationship fan-outs, and owned-mode provisioning
- * at setup is deferred (plan §6 / target-provisioning v1 is contributing-only). The
- * user maps in the stepper against the now-populated schema — assisted by the Tier 2
- * `suggestMappings` suggester, which works because the schema is present.
+ * Each stream's `owned` default-mappings ARE materialized here (step-11 gap 2): the
+ * owned `EntityDefinition` + its fields are provisioned up front from the declared
+ * stream schema, and a `DataConnectorMapping` carrying concrete field refs is created
+ * — the connector fully owns the def, so no `@app:` late-binding / stepper authoring
+ * is needed for the happy path. `contributing` default-mappings are still left to the
+ * stepper (they carry no field bindings — the Tier 2 `suggestMappings` suggester fills
+ * them against the now-populated schema).
  */
 export async function createConnectorFromAppCatalog(
   db: Database,
@@ -283,13 +287,101 @@ export async function createConnectorFromAppCatalog(
     definitionKind: 'app',
   })
   for (const stream of catalog.streams) {
-    await addStream(db, organizationId, connector.id, {
+    const streamRow = await addStream(db, organizationId, connector.id, {
       streamKey: stream.key,
       ...appCatalogStreamSchema(stream),
-      syncMode: 'snapshot',
+      syncMode: stream.syncMode ?? 'snapshot',
     })
+    await materializeAppOwnedMappings(db, organizationId, connector.id, streamRow.id, stream)
   }
   return connector
+}
+
+/**
+ * Materialize a catalog stream's `owned` default-mappings into provisioned defs +
+ * `DataConnectorMapping` rows. The declared stream fields ARE the owned def's schema,
+ * so we provision the def + a field per declaration, then bind concrete
+ * `${defId}:${fieldId}` refs (no `@app:` late-binding — the connector owns the def).
+ * `contributing` targets are skipped (left to the stepper).
+ */
+async function materializeAppOwnedMappings(
+  db: Database,
+  organizationId: string,
+  dataConnectorId: string,
+  streamId: string,
+  stream: CatalogDataConnector['streams'][number]
+): Promise<void> {
+  for (const mapping of stream.defaultMappings ?? []) {
+    if (mapping.target.mode !== 'owned') continue
+    const { entity } = mapping.target
+
+    // The declared stream fields become the owned def's schema.
+    const { entityDefinitionId, fieldIdByKey } = await provisionTarget(
+      db,
+      organizationId,
+      dataConnectorId,
+      {
+        targetMode: 'owned',
+        entityDefinitionId: null,
+        ownedDef: { apiSlug: entity.apiSlug, singular: entity.singular, plural: entity.plural },
+        fields: ownedProvisionSpecs(stream.fields),
+      }
+    )
+
+    await addMapping(db, organizationId, {
+      dataConnectorStreamId: streamId,
+      rootPath: mapping.rootPath,
+      linkMode: mapping.linkMode ?? ('upsert' as LinkMode),
+      targetMode: 'owned' as TargetMode,
+      entityDefinitionId,
+      relationshipFieldKey: mapping.relationshipFieldKey ?? null,
+      fieldMappings: buildOwnedFieldMappings(entityDefinitionId, fieldIdByKey, stream.fields),
+      // Incremental connectors only see the delta each run, so unseen ≠ deleted —
+      // never archive owned orphans automatically. Full-snapshot sweeps can still
+      // reconcile; v1 keeps it safe.
+      orphanBehavior: 'ignore' as OrphanBehavior,
+    })
+  }
+}
+
+/** Owned-def schema = the declared stream fields, provisioned connector-read-only. */
+export function ownedProvisionSpecs(
+  fields: CatalogDataConnector['streams'][number]['fields']
+): ProvisionFieldSpec[] {
+  return fields.map((f) => ({
+    appFieldKey: f.fieldKey,
+    name: f.name,
+    type: f.type as FieldType,
+    isHidden: f.capabilities?.hidden ?? false,
+    isUpdatable: false,
+    isCreatable: false,
+  }))
+}
+
+/**
+ * Bind each declared field to its provisioned column with a concrete
+ * `${defId}:${fieldId}` ref. The expression mirrors the manual editor —
+ * `{<sourcePath>}` over an identity `sourceFields` map (the connector's
+ * `ConnectorRecord.fields` is keyed by `sourcePath`). A field that collided with a
+ * pre-existing user field (no id in `fieldIdByKey`) is skipped.
+ */
+export function buildOwnedFieldMappings(
+  entityDefinitionId: string,
+  fieldIdByKey: Record<string, string>,
+  fields: CatalogDataConnector['streams'][number]['fields']
+): FieldMapping[] {
+  return fields.flatMap((f) => {
+    const fieldId = fieldIdByKey[f.fieldKey]
+    if (!fieldId) return []
+    return [
+      {
+        id: generateId(),
+        targetFieldRef: toResourceFieldId(entityDefinitionId, fieldId),
+        expression: `{${f.sourcePath}}`,
+        sourceFields: { [f.sourcePath]: f.sourcePath },
+      },
+    ]
+  })
 }
 
 export interface UpdateConnectorInput {

--- a/packages/lib/src/data-connectors/owned-mappings.test.ts
+++ b/packages/lib/src/data-connectors/owned-mappings.test.ts
@@ -1,0 +1,96 @@
+// packages/lib/src/data-connectors/owned-mappings.test.ts
+// Pure-helper coverage for owned-mode app default-mapping materialization
+// (step-11 gap 2). The DB orchestration in `createConnectorFromAppCatalog` has no
+// vitest harness; these cover the ref-binding logic that's easy to get wrong.
+
+import { toResourceFieldId } from '@auxx/types/field'
+import { describe, expect, it } from 'vitest'
+import { buildOwnedFieldMappings, ownedProvisionSpecs } from './mutations'
+
+type CatalogField = Parameters<typeof ownedProvisionSpecs>[0][number]
+
+const FIELDS: CatalogField[] = [
+  { fieldKey: 'id', sourcePath: 'id', type: 'TEXT', name: 'GitHub ID' },
+  { fieldKey: 'title', sourcePath: 'title', type: 'TEXT', name: 'Title' },
+  // fieldKey differs from sourcePath — the provisioned column keys on fieldKey,
+  // the projection expression keys on sourcePath.
+  { fieldKey: 'author', sourcePath: 'user_login', type: 'TEXT', name: 'Author' },
+  {
+    fieldKey: 'secret',
+    sourcePath: 'secret',
+    type: 'TEXT',
+    name: 'Secret',
+    capabilities: { hidden: true },
+  },
+]
+
+describe('ownedProvisionSpecs', () => {
+  it('derives one connector-read-only spec per declared field, hidden honoring capabilities', () => {
+    const specs = ownedProvisionSpecs(FIELDS)
+    expect(specs).toEqual([
+      {
+        appFieldKey: 'id',
+        name: 'GitHub ID',
+        type: 'TEXT',
+        isHidden: false,
+        isUpdatable: false,
+        isCreatable: false,
+      },
+      {
+        appFieldKey: 'title',
+        name: 'Title',
+        type: 'TEXT',
+        isHidden: false,
+        isUpdatable: false,
+        isCreatable: false,
+      },
+      {
+        appFieldKey: 'author',
+        name: 'Author',
+        type: 'TEXT',
+        isHidden: false,
+        isUpdatable: false,
+        isCreatable: false,
+      },
+      {
+        appFieldKey: 'secret',
+        name: 'Secret',
+        type: 'TEXT',
+        isHidden: true,
+        isUpdatable: false,
+        isCreatable: false,
+      },
+    ])
+  })
+})
+
+describe('buildOwnedFieldMappings', () => {
+  const defId = 'def_issues'
+  const fieldIdByKey: Record<string, string> = {
+    id: 'f_id',
+    title: 'f_title',
+    author: 'f_author',
+    // `secret` intentionally absent — simulates a name collision with a user field.
+  }
+
+  it('binds concrete refs and keys the projection expression on sourcePath', () => {
+    const mappings = buildOwnedFieldMappings(defId, fieldIdByKey, FIELDS)
+
+    // `secret` (no provisioned id) is dropped.
+    expect(mappings).toHaveLength(3)
+
+    const author = mappings.find((m) => m.targetFieldRef === toResourceFieldId(defId, 'f_author'))
+    expect(author).toBeDefined()
+    // Expression reads `source.fields[sourcePath]`, not the fieldKey.
+    expect(author?.expression).toBe('{user_login}')
+    expect(author?.sourceFields).toEqual({ user_login: 'user_login' })
+    expect(author?.id).toBeTruthy()
+  })
+
+  it('points every ref at the owned def', () => {
+    const mappings = buildOwnedFieldMappings(defId, fieldIdByKey, FIELDS)
+    for (const m of mappings) {
+      expect(m.targetFieldRef?.startsWith(`${defId}:`)).toBe(true)
+    }
+  })
+})

--- a/packages/lib/src/data-connectors/provisioning.ts
+++ b/packages/lib/src/data-connectors/provisioning.ts
@@ -53,6 +53,12 @@ export interface ProvisionTarget {
 export interface ProvisionResult {
   entityDefinitionId: string
   provisionedFieldKeys: string[]
+  /**
+   * `appFieldKey` → concrete `CustomField` id for every resolved field (created
+   * OR pre-existing). Lets the caller build concrete `targetFieldRef`s without a
+   * follow-up query — used by the app-catalog owned materializer (step-11 gap 2).
+   */
+  fieldIdByKey: Record<string, string>
 }
 
 /**
@@ -115,9 +121,12 @@ export async function provisionTarget(
 
   // ── 2. Provision each mapped field idempotently ──────────────────────────────
   const provisionedFieldKeys: string[] = []
+  const fieldIdByKey: Record<string, string> = {}
   for (const field of target.fields) {
-    const created = await provisionField(db, organizationId, dataConnectorId, defId, field)
-    if (created) provisionedFieldKeys.push(field.appFieldKey)
+    const result = await provisionField(db, organizationId, dataConnectorId, defId, field)
+    if (!result) continue
+    fieldIdByKey[field.appFieldKey] = result.id
+    if (result.created) provisionedFieldKeys.push(field.appFieldKey)
   }
 
   if (provisionedFieldKeys.length > 0) {
@@ -131,13 +140,15 @@ export async function provisionTarget(
     provisioned: provisionedFieldKeys.length,
   })
 
-  return { entityDefinitionId: defId, provisionedFieldKeys }
+  return { entityDefinitionId: defId, provisionedFieldKeys, fieldIdByKey }
 }
 
 /**
  * Provision one field if absent. Idempotent per `(dataConnectorId, appFieldKey,
  * entityDefinitionId)` and additionally guarded against an existing display-name
- * collision (a field the user already owns). Returns true if it created the field.
+ * collision (a field the user already owns). Returns the field's concrete id +
+ * whether it was created this call, or `null` when a name collision left it
+ * unresolvable (contributing mode never touches an existing user field).
  */
 async function provisionField(
   db: Database,
@@ -145,7 +156,7 @@ async function provisionField(
   dataConnectorId: string,
   entityDefinitionId: string,
   field: ProvisionFieldSpec
-): Promise<boolean> {
+): Promise<{ id: string; created: boolean } | null> {
   // Already provisioned by this connector?
   const existing = await db.query.CustomField.findFirst({
     where: and(
@@ -156,7 +167,7 @@ async function provisionField(
     ),
     columns: { id: true },
   })
-  if (existing) return false
+  if (existing) return { id: existing.id, created: false }
 
   // Create via the app-field path. DUPLICATE_FIELD_NAME (a user/system field of the
   // same name already exists) is a benign no-op — contributing mode never touches
@@ -173,7 +184,7 @@ async function provisionField(
     isHidden: field.isHidden ?? false,
   })
   if (result.isErr()) {
-    if (result.error.code === 'DUPLICATE_FIELD_NAME') return false
+    if (result.error.code === 'DUPLICATE_FIELD_NAME') return null
     throw new Error(result.error.message)
   }
 
@@ -183,7 +194,7 @@ async function provisionField(
     .set({ dataConnectorId, updatedAt: new Date() })
     .where(eq(schema.CustomField.id, result.value.id))
 
-  return true
+  return { id: result.value.id, created: true }
 }
 
 /**

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -137,6 +137,12 @@ export interface ConnectorStreamDecl {
   key: string
   /** Field-key that holds the record's display name. */
   displayFieldKey: string
+  /**
+   * How the platform schedules this stream. `incremental` runs the backfill once
+   * then steady `updatedSince`-floored delta runs; `snapshot` (default) re-crawls
+   * in full every run. Drives the `mode` handed to `execute`.
+   */
+  syncMode?: 'snapshot' | 'incremental'
   /** Source field declarations (Layer A) keyed by stable `fieldKey`. */
   fields: Record<string, ConnectorFieldDecl>
   /** Recommended fan-out — root + embedded branches + id-only refs. */

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -209,6 +209,8 @@ export interface CatalogConnectorDefaultMapping {
 export interface CatalogConnectorStream {
   key: string
   displayFieldKey: string
+  /** Stream scheduling — `incremental` backfills once then runs deltas. */
+  syncMode?: 'snapshot' | 'incremental'
   fields: CatalogConnectorField[]
   defaultMappings?: CatalogConnectorDefaultMapping[]
   exampleRecord?: Record<string, unknown>
@@ -647,6 +649,7 @@ export async function compileAndExtractCatalog(): Promise<
     const streams: CatalogConnectorStream[] = (connector.streams ?? []).map((stream) => ({
       key: stream.key,
       displayFieldKey: stream.displayFieldKey,
+      syncMode: stream.syncMode,
       // Flatten the `fieldKey → decl` map into an array, carrying the key.
       fields: Object.entries(stream.fields ?? {}).map(([fieldKey, decl]) => ({
         fieldKey,
@@ -796,6 +799,7 @@ interface RawConnectorFieldDecl {
 interface RawConnectorStream {
   key: string
   displayFieldKey: string
+  syncMode?: 'snapshot' | 'incremental'
   fields: Record<string, RawConnectorFieldDecl>
   defaultMappings?: CatalogConnectorDefaultMapping[]
   exampleRecord?: Record<string, unknown>


### PR DESCRIPTION
## What

App-catalog connectors that declare `owned`-mode default-mappings now get their target schema and mappings materialized up front at connector setup, instead of leaving everything to the stepper.

For each stream's `owned` default-mapping:
- Provision the owned `EntityDefinition` + a field per declared stream field (connector-read-only).
- Create a `DataConnectorMapping` carrying concrete `${defId}:${fieldId}` field refs — no `@app:` late-binding or stepper authoring needed for the happy path.
- `orphanBehavior: 'ignore'` so incremental connectors never auto-archive owned records (unseen ≠ deleted on a delta run).

`contributing` default-mappings are still left to the stepper (they carry no field bindings; the Tier 2 `suggestMappings` suggester fills them against the now-populated schema).

## How

- `provisionTarget` now returns `fieldIdByKey` (`appFieldKey` → concrete `CustomField` id, created or pre-existing), so the caller can bind concrete `targetFieldRef`s without a follow-up query. `provisionField` returns `{ id, created } | null` (null on benign name collision).
- New pure helpers `ownedProvisionSpecs` + `buildOwnedFieldMappings` extracted and unit-tested (the DB orchestration has no vitest harness; these cover the ref-binding logic that's easy to get wrong).
- Threads stream `syncMode` (`snapshot` | `incremental`) through the SDK `ConnectorStreamDecl`, catalog extraction, and `CatalogConnectorStream` schema types.

## Test

- `packages/lib/src/data-connectors/owned-mappings.test.ts` — covers spec derivation (hidden honoring capabilities) and ref binding (sourcePath-keyed expression, dropped collisions, refs pointing at the owned def).