### PR TITLE
feat(data-connectors): tool-backed dynamic-select for connector config fields

### DIFF
--- a/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
@@ -1,13 +1,19 @@
 // apps/web/src/components/data-connectors/ui/source-config-panel.tsx
 'use client'
 
+import type { ActionInputHint } from '@auxx/database'
+import { FieldType } from '@auxx/database/enums'
+import type { FieldOptions } from '@auxx/lib/field-values/client'
 import { Field, FieldLabel } from '@auxx/ui/components/field'
 import { Input } from '@auxx/ui/components/input'
 import { Section } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
 import { Globe, Settings2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { readFieldNodes, SchemaField, seedDefaults } from '~/components/global/schema-form'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { type FieldEntry, readFieldNodes, seedDefaults } from '~/components/global/schema-form'
+import { BaseType } from '~/components/workflow/types'
+import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 import { useRegisterSaver } from '../hooks/use-connector-edits'
 import { RecordKeyValueEditor, RequestEditorBlock, RevealChip } from './request-editors'
@@ -139,6 +145,8 @@ function AppConfigSource({
     (data?.configJsonSchema as Record<string, unknown> | null) ??
     (connector.config as { _schema?: Record<string, unknown> })?._schema ??
     null
+  // Per-field dynamic-select hints (tool-backed dropdowns). Keyed by config field.
+  const optionHints = (data?.configOptionHints ?? null) as Record<string, ActionInputHint> | null
   const fields = useMemo(() => readFieldNodes(schema), [schema])
   const baseline = useMemo(
     () => ({ ...seedDefaults(fields), ...(connector.config ?? {}) }) as Record<string, unknown>,
@@ -170,17 +178,141 @@ function AppConfigSource({
         initialOpen
         collapsible={false}
         description='Options declared by this connector.'>
-        <div className='flex flex-col gap-4 px-1'>
-          {fields.map((entry) => (
-            <SchemaField
-              key={entry.key}
-              entry={entry}
-              value={values[entry.key]}
-              onChange={(next) => setValues((v) => ({ ...v, [entry.key]: next }))}
-            />
-          ))}
-        </div>
+        <VarEditorField
+          orientation='responsive'
+          className='p-0 sm:[&_[data-slot=field-row-label]]:w-70!'>
+          {fields.map((entry) => {
+            const hint = optionHints?.[entry.key]
+            const onChange = (next: unknown) => setValues((v) => ({ ...v, [entry.key]: next }))
+            return hint?.kind === 'dynamic-select' ? (
+              <ToolBackedSelectRow
+                key={entry.key}
+                connectorId={connector.id}
+                entry={entry}
+                value={values[entry.key]}
+                onChange={onChange}
+              />
+            ) : (
+              <ConfigFieldRow
+                key={entry.key}
+                entry={entry}
+                value={values[entry.key]}
+                onChange={onChange}
+              />
+            )
+          })}
+        </VarEditorField>
       </Section>
     </div>
+  )
+}
+
+/** Map a JSON-Schema config node to the platform `FieldType` that renders it. */
+function fieldTypeFor(entry: FieldEntry): FieldType {
+  switch (entry.node.type) {
+    case 'boolean':
+      return FieldType.CHECKBOX
+    case 'number':
+    case 'integer':
+      return FieldType.NUMBER
+    default:
+      return FieldType.TEXT
+  }
+}
+
+/** The row-label icon's base type for a given field type. */
+function baseTypeFor(fieldType: FieldType): BaseType {
+  if (fieldType === FieldType.CHECKBOX) return BaseType.BOOLEAN
+  if (fieldType === FieldType.NUMBER) return BaseType.NUMBER
+  return BaseType.STRING
+}
+
+const ROW_TRIGGER_PROPS = { className: 'w-full ps-0 pe-1' }
+
+/**
+ * A plain connector-config field rendered as a `VarEditorFieldRow` + matching
+ * `FieldInputAdapter` control (mirrors `ConnectionVariableFields`). Text / number /
+ * checkbox by the field's JSON-Schema type.
+ */
+function ConfigFieldRow({
+  entry,
+  value,
+  onChange,
+}: {
+  entry: FieldEntry
+  value: unknown
+  onChange: (next: unknown) => void
+}) {
+  const fieldType = fieldTypeFor(entry)
+  return (
+    <VarEditorFieldRow
+      title={entry.meta.label ?? entry.key}
+      description={entry.meta.description}
+      type={baseTypeFor(fieldType)}
+      showIcon
+      isRequired={entry.required}>
+      <FieldInputAdapter
+        fieldType={fieldType}
+        value={value ?? (fieldType === FieldType.CHECKBOX ? false : '')}
+        onChange={onChange}
+        placeholder={entry.meta.placeholder}
+        triggerProps={ROW_TRIGGER_PROPS}
+      />
+    </VarEditorFieldRow>
+  )
+}
+
+/**
+ * A config field whose options are fetched live by running an app tool through
+ * the connector's own connection (e.g. a repo picker backed by `list_repos`).
+ * Renders a `SINGLE_SELECT` via `FieldInputAdapter`, fed by the generic
+ * `apps.resolveToolOptions` resolver (connector source).
+ */
+function ToolBackedSelectRow({
+  connectorId,
+  entry,
+  value,
+  onChange,
+}: {
+  connectorId: string
+  entry: FieldEntry
+  value: unknown
+  onChange: (next: unknown) => void
+}) {
+  const optionsQuery = api.apps.resolveToolOptions.useQuery(
+    { source: { kind: 'connector', connectorId }, fieldKey: entry.key },
+    { staleTime: 60_000, refetchOnWindowFocus: false }
+  )
+  const fieldOptions: FieldOptions = {
+    options: (optionsQuery.data?.options ?? []).map((o) => ({
+      value: o.value,
+      label: o.sublabel ? `${o.label} — ${o.sublabel}` : o.label,
+    })),
+  }
+  const selected = typeof value === 'string' && value ? [value] : []
+
+  return (
+    <VarEditorFieldRow
+      title={entry.meta.label ?? entry.key}
+      description={entry.meta.description}
+      type={BaseType.STRING}
+      showIcon
+      isRequired={entry.required}>
+      <FieldInputAdapter
+        fieldType={FieldType.SINGLE_SELECT}
+        fieldOptions={fieldOptions}
+        value={selected}
+        onChange={(next) => onChange(Array.isArray(next) ? (next[0] ?? '') : (next ?? ''))}
+        placeholder={
+          optionsQuery.isLoading
+            ? 'Loading…'
+            : (optionsQuery.data?.disabledHint ??
+              entry.meta.placeholder ??
+              `Select ${entry.meta.label ?? entry.key}…`)
+        }
+        disabled={optionsQuery.isLoading}
+        triggerProps={ROW_TRIGGER_PROPS}
+      />
+    </VarEditorFieldRow>
   )
 }

--- a/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
+++ b/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
@@ -558,7 +558,7 @@ function QuickActionField({
 }
 
 /**
- * A select whose options are loaded at open time from `quickAction.resolveOptions`
+ * A select whose options are loaded at open time from `apps.resolveToolOptions`
  * — the app's resolver tool run against the thread's contact. When no contact is
  * linked or zero options resolve, the control renders disabled with the hint
  * (decision 6 — show, don't hide). See plans/actions/09-dynamic-action-inputs.md.
@@ -597,13 +597,16 @@ function QuickActionDynamicSelectField({
   // (so we can render its label). Cached for the compose session — charges don't
   // change mid-compose, so re-opening doesn't re-invoke the lambda.
   const enabled = !!contactRecordId && (opened || !!value)
-  const optionsQuery = api.quickAction.resolveOptions.useQuery(
+  const optionsQuery = api.apps.resolveToolOptions.useQuery(
     {
-      appId,
-      installationId,
-      actionId,
+      source: {
+        kind: 'entity',
+        appId,
+        installationId,
+        actionId,
+        recordId: contactRecordId ?? '',
+      },
       fieldKey,
-      recordId: contactRecordId ?? '',
     },
     { enabled, staleTime: 60_000, refetchOnWindowFocus: false }
   )

--- a/apps/web/src/server/api/routers/apps.ts
+++ b/apps/web/src/server/api/routers/apps.ts
@@ -11,7 +11,9 @@ import {
 } from '@auxx/lib/apps'
 import { getCachedAppBySlug, getOrgCache, onCacheEvent } from '@auxx/lib/cache'
 import { mintClientCredentialToken } from '@auxx/lib/connections'
+import { resolveConnectorConfigOptions } from '@auxx/lib/data-connectors'
 import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
+import { resolveQuickActionOptions } from '@auxx/lib/quick-actions'
 import { createScopedLogger } from '@auxx/logger'
 import {
   getAppConnectionDefinition,
@@ -88,6 +90,86 @@ export const appsRouter = createTRPCRouter({
       }))
 
       return { installations }
+    }),
+
+  /**
+   * Resolve the live options for a tool-backed `dynamic-select` field by running
+   * an app tool in the sandbox and mapping its output. One generic procedure for
+   * every option-picker surface — discriminated by `source`:
+   *  - `entity`    → a quick-action input, scoped to a subject record (binds args
+   *                  off the record's fields).
+   *  - `connector` → a data-connector config field, scoped to the connector's own
+   *                  bound connection (e.g. a repo picker).
+   * Both share the generic app-tool resolver core in `@auxx/lib`.
+   */
+  resolveToolOptions: protectedProcedure
+    .input(
+      z.object({
+        source: z.discriminatedUnion('kind', [
+          z.object({
+            kind: z.literal('entity'),
+            appId: z.string(),
+            installationId: z.string(),
+            actionId: z.string(),
+            recordId: z.string(),
+          }),
+          z.object({ kind: z.literal('connector'), connectorId: z.string() }),
+        ]),
+        fieldKey: z.string(),
+        query: z.string().optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { organizationId, userId } = ctx.session
+      const organization = await ctx.db.query.Organization.findFirst({
+        where: (orgs, { eq }) => eq(orgs.id, organizationId),
+      })
+      if (!organization?.handle) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Organization not found' })
+      }
+
+      if (input.source.kind === 'connector') {
+        return resolveConnectorConfigOptions({
+          db: ctx.db,
+          organizationId,
+          organizationHandle: organization.handle,
+          connectorId: input.source.connectorId,
+          fieldKey: input.fieldKey,
+          query: input.query,
+        })
+      }
+
+      // entity (quick-action): validate the subject record belongs to the org
+      // before binding args against it.
+      const { recordId } = input.source
+      const [, entityInstanceId] = recordId.split(':')
+      if (!entityInstanceId) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid recordId' })
+      }
+      const instance = await ctx.db.query.EntityInstance.findFirst({
+        where: (rows, { eq, and }) =>
+          and(eq(rows.id, entityInstanceId), eq(rows.organizationId, organizationId)),
+        columns: { id: true },
+      })
+      if (!instance) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Record not found' })
+      }
+      const user = await ctx.db.query.User.findFirst({
+        where: (users, { eq }) => eq(users.id, userId),
+      })
+      return resolveQuickActionOptions({
+        appId: input.source.appId,
+        installationId: input.source.installationId,
+        actionId: input.source.actionId,
+        fieldKey: input.fieldKey,
+        recordId,
+        query: input.query,
+        organizationId,
+        organizationHandle: organization.handle,
+        userId,
+        userEmail: user?.email ?? '',
+        userName: user?.name ?? '',
+      })
     }),
 
   /**

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -203,7 +203,7 @@ export const dataConnectorRouter = createTRPCRouter({
       }
       const connector = result.value
       if (!connector.type.startsWith('app:')) {
-        return { requestModel: 'builder' as const, configJsonSchema: null }
+        return { requestModel: 'builder' as const, configJsonSchema: null, configOptionHints: null }
       }
       const slug = connector.type.replace(/^app:/, '')
       const installedApps = await getCachedInstalledApps(ctx.session.organizationId)
@@ -214,6 +214,7 @@ export const dataConnectorRouter = createTRPCRouter({
       return {
         requestModel: dc?.requestModel ?? ('fixed' as const),
         configJsonSchema: dc?.configJsonSchema ?? null,
+        configOptionHints: dc?.configOptionHints ?? null,
       }
     }),
 

--- a/apps/web/src/server/api/routers/quick-actions.ts
+++ b/apps/web/src/server/api/routers/quick-actions.ts
@@ -1,6 +1,6 @@
 // apps/web/src/server/api/routers/quick-actions.ts
 
-import { QuickActionExecutor, resolveQuickActionOptions } from '@auxx/lib/quick-actions'
+import { QuickActionExecutor } from '@auxx/lib/quick-actions'
 import { TicketEventType, TimelineActorType, TimelineEntityType } from '@auxx/lib/timeline'
 import { createScopedLogger } from '@auxx/logger'
 import { createTimelineEvent } from '@auxx/services/timeline'
@@ -104,63 +104,5 @@ export const quickActionRouter = createTRPCRouter({
       }
 
       return results
-    }),
-
-  /**
-   * Resolve the live options for a quick-action `dynamic-select` input (e.g. the
-   * Stripe charges for the thread's contact). Read-only — runs the app's resolver
-   * tool, scoped to `recordId`. See plans/actions/09-dynamic-action-inputs.md.
-   */
-  resolveOptions: protectedProcedure
-    .input(
-      z.object({
-        appId: z.string(),
-        installationId: z.string(),
-        actionId: z.string(),
-        fieldKey: z.string(),
-        recordId: z.string(),
-        query: z.string().optional(),
-      })
-    )
-    .query(async ({ ctx, input }) => {
-      const { organizationId, userId } = ctx.session
-
-      // Validate the subject record belongs to the caller's org before binding.
-      const [entityDefinitionId, entityInstanceId] = input.recordId.split(':')
-      if (!entityDefinitionId || !entityInstanceId) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid recordId' })
-      }
-      const instance = await ctx.db.query.EntityInstance.findFirst({
-        where: (rows, { eq, and }) =>
-          and(eq(rows.id, entityInstanceId), eq(rows.organizationId, organizationId)),
-        columns: { id: true },
-      })
-      if (!instance) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Record not found' })
-      }
-
-      const organization = await ctx.db.query.Organization.findFirst({
-        where: (orgs, { eq }) => eq(orgs.id, organizationId),
-      })
-      if (!organization?.handle) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Organization not found' })
-      }
-      const user = await ctx.db.query.User.findFirst({
-        where: (users, { eq }) => eq(users.id, userId),
-      })
-
-      return resolveQuickActionOptions({
-        appId: input.appId,
-        installationId: input.installationId,
-        actionId: input.actionId,
-        fieldKey: input.fieldKey,
-        recordId: input.recordId,
-        query: input.query,
-        organizationId,
-        organizationHandle: organization.handle,
-        userId,
-        userEmail: user?.email ?? '',
-        userName: user?.name ?? '',
-      })
     }),
 })

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -245,6 +245,13 @@ export interface CatalogDataConnector {
   requestModel?: 'builder' | 'fixed'
   /** Connector-level config schema (JSON Schema, from the `config` zod schema). */
   configJsonSchema: Record<string, unknown>
+  /**
+   * Per-config-field presentation overrides — same `dynamic-select` shape as a
+   * quick-action's `inputHints`, carried separately because `configJsonSchema`
+   * is bare JSON Schema (metadata is stripped). Lets a config field render as a
+   * live dropdown backed by an app tool (`optionsFrom`). Keyed by config field.
+   */
+  configOptionHints?: Record<string, ActionInputHint>
   streams: CatalogConnectorStream[]
 }
 

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -728,14 +728,24 @@ export const WorkflowShareAccessModeValues = ['public', 'organization'] as const
 // EntityDefinition string constants (not database enums - stored as text)
 export const EntityTypeValues = [
   'standard',
+  'article',
+  'company',
   'contact',
-  'user',
+  'entity_group',
+  'inbox',
+  'meeting',
+  'part',
+  'signature',
+  'stock_movement',
+  'subpart',
+  'tag',
   'thread',
   'ticket',
-  'entity_group',
+  'user',
+  'vendor_part',
 ] as const
 
-export const StandardTypeValues = ['company', 'task', 'deal', 'custom'] as const
+export const StandardTypeValues = ['task', 'deal', 'custom'] as const
 
 // ============================================================================
 // ENUM OBJECTS - Can be used both as types and values on client-side
@@ -1449,15 +1459,24 @@ export const WorkflowShareAccessMode = {
 // EntityDefinition type objects (not database enums - stored as text fields)
 export const EntityType = {
   STANDARD: 'standard',
+  ARTICLE: 'article',
+  COMPANY: 'company',
   CONTACT: 'contact',
-  USER: 'user',
+  ENTITY_GROUP: 'entity_group',
+  INBOX: 'inbox',
+  MEETING: 'meeting',
+  PART: 'part',
+  SIGNATURE: 'signature',
+  STOCK_MOVEMENT: 'stock_movement',
+  SUBPART: 'subpart',
+  TAG: 'tag',
   THREAD: 'thread',
   TICKET: 'ticket',
-  ENTITY_GROUP: 'entity_group',
+  USER: 'user',
+  VENDOR_PART: 'vendor_part',
 } as const
 
 export const StandardType = {
-  COMPANY: 'company',
   TASK: 'task',
   DEAL: 'deal',
   CUSTOM: 'custom',

--- a/packages/lib/src/apps/tool-options.ts
+++ b/packages/lib/src/apps/tool-options.ts
@@ -1,0 +1,194 @@
+// packages/lib/src/apps/tool-options.ts
+
+import type { DynamicSelectHint } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+
+const logger = createScopedLogger('app-tool-options')
+
+/**
+ * Generic "run an app tool, shape its output into selectable options" core.
+ *
+ * Both the quick-action dynamic-select resolver (scoped to a thread's contact)
+ * and the data-connector config picker (scoped to a connector's connection) call
+ * this with the connection + bound args already resolved by their caller-specific
+ * front. The only thing this layer owns is: locate the deployment bundle, invoke
+ * the resolver tool in the lambda, and map the output via {@link mapToolOutputToOptions}.
+ *
+ * Lazy-imports the app-runtime cluster (a static import pulls billing/dist into
+ * vitest — project memory). The pure mapper below has no such deps.
+ */
+
+export interface ToolOption {
+  value: string
+  label: string
+  sublabel?: string
+}
+
+export interface ResolveToolOptionsResult {
+  options: ToolOption[]
+  /** Hint shown disabled when no options resolve; null when there are options. */
+  disabledHint: string | null
+}
+
+/** Identifiers + already-resolved connection/args needed to run the resolver tool. */
+export interface InvokeToolForOptionsInput {
+  appId: string
+  installationId: string
+  organizationId: string
+  organizationHandle: string
+  userId?: string
+  userEmail?: string | null
+  userName?: string | null
+  /** Decrypted runtime connections (resolved by the caller-specific front). */
+  userConnection?: unknown
+  organizationConnection?: unknown
+  /** The dynamic-select hint (`optionsFrom`, value/label paths, constant `args`). */
+  hint: DynamicSelectHint
+  /** Args bound from the surrounding context (empty for connector config). */
+  boundArgs?: Record<string, unknown>
+  /** Passed through to the sandbox for telemetry/scoping; shape is caller-defined. */
+  invocationContext?: Record<string, unknown>
+  /** Search term — filters the resolved list locally. */
+  query?: string
+}
+
+/**
+ * Locate the deployment bundle, invoke `hint.optionsFrom` in the lambda with the
+ * resolved connection + args, and map its output to options. Returns the
+ * disabled/empty state (never throws) on any resolution failure.
+ */
+export async function invokeAppToolForOptions(
+  input: InvokeToolForOptionsInput
+): Promise<ResolveToolOptionsResult> {
+  const { hint } = input
+  const disabled = (): ResolveToolOptionsResult => ({
+    options: [],
+    disabledHint: hint.emptyHint ?? null,
+  })
+
+  const { getInstallationDeployment } = await import('./installations/get-installation-deployment')
+  const { prepareLambdaContext, invokeLambdaExecutor } = await import('./lambda')
+
+  const installationResult = await getInstallationDeployment({
+    installationId: input.installationId,
+    organizationHandle: input.organizationHandle,
+    appId: input.appId,
+  })
+  if (installationResult.isErr()) {
+    logger.warn('Failed to get installation deployment', {
+      installationId: input.installationId,
+      error: installationResult.error.message,
+    })
+    return disabled()
+  }
+  const { serverBundleSha, installation: inst } = installationResult.value
+  if (!serverBundleSha) return disabled()
+
+  const baseContext = prepareLambdaContext({
+    appId: input.appId,
+    installationId: inst.id,
+    organizationId: input.organizationId,
+    organizationHandle: input.organizationHandle,
+    userId: input.userId,
+    userEmail: input.userEmail ?? null,
+    userName: input.userName ?? null,
+    userConnection: input.userConnection,
+    organizationConnection: input.organizationConnection,
+  })
+
+  const lambdaResult = await invokeLambdaExecutor({
+    caller: 'app-tool-options',
+    payload: {
+      type: 'tool',
+      serverBundleSha,
+      toolId: hint.optionsFrom,
+      inputs: { ...hint.args, ...input.boundArgs },
+      context: baseContext,
+      invocationContext: input.invocationContext,
+      timeout: 30000,
+    },
+  })
+  if (lambdaResult.isErr()) {
+    logger.warn('Options resolver lambda invocation failed', {
+      optionsFrom: hint.optionsFrom,
+      error: lambdaResult.error.message,
+    })
+    return disabled()
+  }
+  const result = lambdaResult.value
+  if (result.metadata?.runtime_error || result.metadata?.validation_error) {
+    return disabled()
+  }
+  const data = result.execution_result?.data ?? result.execution_result ?? {}
+  return mapToolOutputToOptions(data, hint, input.query)
+}
+
+/**
+ * Pure mapping from a resolver tool's raw output to the option list. Selects
+ * items at `itemsPath` (or the first array found), projects each via
+ * `valuePath`/`labelTemplate`/`sublabelTemplate`, drops valueless rows, and
+ * locally filters by `query`.
+ */
+export function mapToolOutputToOptions(
+  data: unknown,
+  hint: DynamicSelectHint,
+  query?: string
+): ResolveToolOptionsResult {
+  const items = selectItems(data, hint.itemsPath)
+  const options: ToolOption[] = []
+  for (const item of items) {
+    const value = getPath(item, hint.valuePath)
+    if (value === undefined || value === null || value === '') continue
+    options.push({
+      value: String(value),
+      label: renderTemplate(hint.labelTemplate, item) || String(value),
+      sublabel: hint.sublabelTemplate ? renderTemplate(hint.sublabelTemplate, item) : undefined,
+    })
+  }
+
+  const filtered = filterOptions(options, query)
+  return { options: filtered, disabledHint: filtered.length ? null : (hint.emptyHint ?? null) }
+}
+
+/** Pull the option array out of the resolver output via `itemsPath`, else the first array found. */
+function selectItems(data: unknown, itemsPath?: string): Array<Record<string, unknown>> {
+  if (Array.isArray(data)) return data as Array<Record<string, unknown>>
+  if (itemsPath) {
+    const at = getPath(data, itemsPath)
+    return Array.isArray(at) ? (at as Array<Record<string, unknown>>) : []
+  }
+  // No itemsPath and not an array — take the first array-valued top-level field.
+  if (data && typeof data === 'object') {
+    for (const value of Object.values(data as Record<string, unknown>)) {
+      if (Array.isArray(value)) return value as Array<Record<string, unknown>>
+    }
+  }
+  return []
+}
+
+/** Read a dotted path (`a.b.c`) off an object. */
+function getPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === 'object') return (acc as Record<string, unknown>)[key]
+    return undefined
+  }, obj)
+}
+
+/** Substitute `{field}` / `{a.b}` placeholders in a template from an item. */
+function renderTemplate(template: string, item: Record<string, unknown>): string {
+  return template
+    .replace(/\{([^}]+)\}/g, (_, key: string) => {
+      const value = getPath(item, key.trim())
+      return value === undefined || value === null ? '' : String(value)
+    })
+    .trim()
+}
+
+/** Case-insensitive substring filter over value + label + sublabel. */
+function filterOptions(options: ToolOption[], query?: string): ToolOption[] {
+  const q = query?.trim().toLowerCase()
+  if (!q) return options
+  return options.filter((o) =>
+    `${o.value} ${o.label} ${o.sublabel ?? ''}`.toLowerCase().includes(q)
+  )
+}

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -121,9 +121,11 @@ export {
   provisionConnectorMappings,
   provisionTarget,
 } from './provisioning'
-// Orchestrator + passes
 export { archiveExternalId, handleConnectorDelete, reconcileOrphans } from './reconciliation'
 export { resolveRelationships } from './relationship-pass'
+// Orchestrator + passes
+export type { ResolveConnectorConfigOptionsInput } from './resolve-config-options'
+export { resolveConnectorConfigOptions } from './resolve-config-options'
 // Status-line schedule derivation (Step 9 §3.3)
 export type { ConnectorScheduleInfo, DeriveScheduleInput } from './schedule-info'
 export { deriveConnectorScheduleInfo } from './schedule-info'

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -446,7 +446,12 @@ async function materializeAppOwnedMappings(
       {
         targetMode: 'owned',
         entityDefinitionId: null,
-        ownedDef: { apiSlug: entity.apiSlug, singular: entity.singular, plural: entity.plural },
+        ownedDef: {
+          apiSlug: entity.apiSlug,
+          singular: entity.singular,
+          plural: entity.plural,
+          primaryDisplayFieldKey: entity.primaryDisplayField,
+        },
         fields: ownedProvisionSpecs(stream.fields),
       }
     )

--- a/packages/lib/src/data-connectors/provisioning.ts
+++ b/packages/lib/src/data-connectors/provisioning.ts
@@ -47,7 +47,15 @@ export interface ProvisionTarget {
   /** Existing def id, or the owned-def declaration to create if absent. */
   entityDefinitionId?: string | null
   /** Owned-def declaration (used only when entityDefinitionId is absent + owned). */
-  ownedDef?: { apiSlug: string; singular: string; plural: string; icon?: string; color?: string }
+  ownedDef?: {
+    apiSlug: string
+    singular: string
+    plural: string
+    icon?: string
+    color?: string
+    /** `appFieldKey` of the field to wire as the def's primary display field. */
+    primaryDisplayFieldKey?: string
+  }
   fields: ProvisionFieldSpec[]
 }
 
@@ -87,10 +95,14 @@ export async function provisionTarget(
       apiSlug: target.ownedDef.apiSlug,
       singular: target.ownedDef.singular,
       plural: target.ownedDef.plural,
-      icon: target.ownedDef.icon ?? 'Box',
+      // Icon is a lowercase lucide iconId (e.g. 'box'), never the PascalCase
+      // component name — match what the UI's create path stores.
+      icon: target.ownedDef.icon ?? 'box',
       color: target.ownedDef.color ?? 'blue',
-      entityType: 'standard',
-      standardType: 'custom',
+      // A connector-owned def is a CUSTOM entity, exactly like one a user creates
+      // in the UI: entityType/standardType stay null. Setting 'standard'/'custom'
+      // here misclassifies it (e.g. escapes the custom-entity quota, which counts
+      // `isNull(entityType)`) and diverges from every user-created entity.
     })
     if (created.isErr()) {
       // SLUG_ALREADY_EXISTS → the user (or a prior run) already owns this slug; adopt it.
@@ -132,6 +144,22 @@ export async function provisionTarget(
 
   if (provisionedFieldKeys.length > 0) {
     await onCacheEvent('custom-field.created', { orgId: organizationId })
+  }
+
+  // Wire the declared primary display field once its column exists (the UI sets this
+  // for user-created entities; owned defs were landing with null display pointers).
+  // The def is fresh with no records, so a direct pointer write is enough — no
+  // display-value recalculation needed.
+  const primaryDisplayFieldId =
+    target.targetMode === 'owned' && target.ownedDef?.primaryDisplayFieldKey
+      ? fieldIdByKey[target.ownedDef.primaryDisplayFieldKey]
+      : undefined
+  if (primaryDisplayFieldId) {
+    await db
+      .update(schema.EntityDefinition)
+      .set({ primaryDisplayFieldId, updatedAt: new Date() })
+      .where(eq(schema.EntityDefinition.id, defId))
+    await onCacheEvent('entity-def.updated', { orgId: organizationId })
   }
 
   logger.info('Provisioned connector target', {

--- a/packages/lib/src/data-connectors/resolve-config-options.ts
+++ b/packages/lib/src/data-connectors/resolve-config-options.ts
@@ -1,0 +1,95 @@
+// packages/lib/src/data-connectors/resolve-config-options.ts
+
+import type { Database } from '@auxx/database'
+import { invokeAppToolForOptions, type ResolveToolOptionsResult } from '../apps/tool-options'
+import { getCachedInstalledApps } from '../cache/org-cache-helpers'
+import { getConnector } from './service'
+
+/** Input for {@link resolveConnectorConfigOptions}. */
+export interface ResolveConnectorConfigOptionsInput {
+  db: Database
+  organizationId: string
+  organizationHandle: string
+  /** The `DataConnector` row id whose config field declares the dynamic select. */
+  connectorId: string
+  /** Which config field's `configOptionHints` entry to resolve. */
+  fieldKey: string
+  query?: string
+}
+
+/**
+ * Resolve the live options for a data-connector config `dynamic-select` field
+ * (e.g. the repos for the connected GitHub account). Runs the app tool named by
+ * the field's `configOptionHints[fieldKey].dynamicSelect.optionsFrom` through the
+ * connector's OWN bound connection — the same credential the sync uses — and
+ * shapes its output into options. Read-only; returns the disabled/empty state on
+ * any failure (never throws on resolution gaps).
+ *
+ * Shares the generic {@link invokeAppToolForOptions} core with the quick-action
+ * resolver; the only connector-specific work is resolving the connection from the
+ * connector's `credentialId` (no surrounding entity to bind args against).
+ */
+export async function resolveConnectorConfigOptions(
+  input: ResolveConnectorConfigOptionsInput
+): Promise<ResolveToolOptionsResult> {
+  const connectorResult = await getConnector(input.db, input.organizationId, input.connectorId)
+  if (connectorResult.isErr()) {
+    throw new Error(`Connector not found: ${input.connectorId}`)
+  }
+  const connector = connectorResult.value
+  const slug = connector.type.replace(/^app:/, '')
+
+  // Locate the installed app + its catalogued connector (mirrors the
+  // `connectorSchema` procedure / the app-connector adapter resolution).
+  const installedApps = await getCachedInstalledApps(input.organizationId)
+  const installedApp =
+    installedApps.find((a) => a.installationId === connector.appInstallationId) ??
+    installedApps.find((a) => a.app.slug === slug)
+  if (!installedApp) {
+    throw new Error(`Installed app not found for connector ${input.connectorId}`)
+  }
+  const catalogConnector =
+    installedApp.dataConnectors?.find((c) => c.configOptionHints?.[input.fieldKey]) ??
+    installedApp.dataConnectors?.[0]
+  const hintEntry = catalogConnector?.configOptionHints?.[input.fieldKey]
+  if (!hintEntry || hintEntry.kind !== 'dynamic-select') {
+    throw new Error(
+      `No dynamic-select hint for connector "${input.connectorId}" config "${input.fieldKey}"`
+    )
+  }
+  const hint = hintEntry.dynamicSelect
+  const disabled = (): ResolveToolOptionsResult => ({
+    options: [],
+    disabledHint: hint.emptyHint ?? null,
+  })
+
+  // Resolve the connector's bound connection — the SAME credential the sync
+  // borrows (credentialId on the connector row), decrypted into the runtime
+  // connection shape. Lazy-import the runtime cluster (vitest/billing-dist).
+  const { resolveAppConnectionForRuntime } = await import(
+    '../apps/connections/resolve-app-connection-for-runtime'
+  )
+  const resolveInput = connector.credentialId
+    ? {
+        appId: installedApp.app.id,
+        organizationId: input.organizationId,
+        userId: '',
+        connectionId: connector.credentialId,
+      }
+    : { appId: installedApp.app.id, organizationId: input.organizationId, userId: '' }
+  const connections = await resolveAppConnectionForRuntime(resolveInput)
+  if (connections.isErr()) return disabled()
+  const { userConnection, organizationConnection } = connections.value
+
+  return invokeAppToolForOptions({
+    appId: installedApp.app.id,
+    installationId: installedApp.installationId,
+    organizationId: input.organizationId,
+    organizationHandle: input.organizationHandle,
+    userConnection,
+    organizationConnection,
+    hint,
+    invocationContext: { kind: 'data-connector-config', connectorId: input.connectorId },
+    query: input.query,
+  })
+}

--- a/packages/lib/src/quick-actions/resolve-options.ts
+++ b/packages/lib/src/quick-actions/resolve-options.ts
@@ -1,12 +1,21 @@
 // packages/lib/src/quick-actions/resolve-options.ts
 
 import type { DynamicSelectHint } from '@auxx/database'
-import { createScopedLogger } from '@auxx/logger'
 import type { RecordId } from '@auxx/types/resource'
 import { resolveAppFieldValue } from '../agents/bindings'
+import {
+  invokeAppToolForOptions,
+  mapToolOutputToOptions,
+  type ResolveToolOptionsResult,
+  type ToolOption,
+} from '../apps/tool-options'
 import { getCachedInstalledApps } from '../cache/org-cache-helpers'
 
-const logger = createScopedLogger('quick-action-resolve-options')
+/**
+ * Back-compat re-export — the pure output→options mapper now lives in the
+ * generic app-tool-options core (shared with the data-connector config picker).
+ */
+export const mapResolverOutputToOptions = mapToolOutputToOptions
 
 /** Input for {@link resolveQuickActionOptions}. */
 export interface ResolveQuickActionOptionsInput {
@@ -27,17 +36,8 @@ export interface ResolveQuickActionOptionsInput {
   userName: string
 }
 
-export interface QuickActionOption {
-  value: string
-  label: string
-  sublabel?: string
-}
-
-export interface ResolveQuickActionOptionsResult {
-  options: QuickActionOption[]
-  /** Hint shown disabled when no options resolve; null when there are options. */
-  disabledHint: string | null
-}
+export type QuickActionOption = ToolOption
+export type ResolveQuickActionOptionsResult = ResolveToolOptionsResult
 
 /**
  * Resolve the live options for a quick-action `dynamic-select` input. Runs the
@@ -97,30 +97,10 @@ export async function resolveQuickActionOptions(
     boundArgs[argName] = value
   }
 
-  // 4. Invoke the resolver tool in the lambda — mirror QuickActionExecutor.
-  const { getInstallationDeployment } = await import(
-    '../apps/installations/get-installation-deployment'
-  )
-  const { prepareLambdaContext, invokeLambdaExecutor } = await import('../apps/lambda')
-
-  const installationResult = await getInstallationDeployment({
+  // 4-5. Invoke the resolver tool + map its output via the shared core.
+  return invokeAppToolForOptions({
+    appId: input.appId,
     installationId: input.installationId,
-    organizationHandle: input.organizationHandle,
-    appId: input.appId,
-  })
-  if (installationResult.isErr()) {
-    logger.warn('Failed to get installation deployment', {
-      installationId: input.installationId,
-      error: installationResult.error.message,
-    })
-    return disabled()
-  }
-  const { serverBundleSha, installation: inst } = installationResult.value
-  if (!serverBundleSha) return disabled()
-
-  const baseContext = prepareLambdaContext({
-    appId: input.appId,
-    installationId: inst.id,
     organizationId: input.organizationId,
     organizationHandle: input.organizationHandle,
     userId: input.userId,
@@ -128,103 +108,9 @@ export async function resolveQuickActionOptions(
     userName: input.userName,
     userConnection,
     organizationConnection,
+    hint: ds,
+    boundArgs,
+    invocationContext: { kind: 'action', recordId: input.recordId },
+    query: input.query,
   })
-
-  const lambdaResult = await invokeLambdaExecutor({
-    caller: 'quick-action',
-    payload: {
-      type: 'tool',
-      serverBundleSha,
-      toolId: ds.optionsFrom,
-      inputs: { ...ds.args, ...boundArgs },
-      context: baseContext,
-      invocationContext: { kind: 'action', recordId: input.recordId },
-      timeout: 30000,
-    },
-  })
-  if (lambdaResult.isErr()) {
-    logger.warn('Resolver lambda invocation failed', {
-      optionsFrom: ds.optionsFrom,
-      error: lambdaResult.error.message,
-    })
-    return disabled()
-  }
-  const result = lambdaResult.value
-  if (result.metadata?.runtime_error || result.metadata?.validation_error) {
-    return disabled()
-  }
-  const data = result.execution_result?.data ?? result.execution_result ?? {}
-
-  // 5. Map output → options, then local-filter by query.
-  return mapResolverOutputToOptions(data, ds, input.query)
-}
-
-/**
- * Pure mapping from a resolver tool's raw output to the option list — the
- * testable core of step 5. Selects items at `itemsPath`, projects each via
- * `valuePath`/`labelTemplate`/`sublabelTemplate`, drops valueless rows, and
- * locally filters by `query`.
- */
-export function mapResolverOutputToOptions(
-  data: unknown,
-  ds: DynamicSelectHint,
-  query?: string
-): ResolveQuickActionOptionsResult {
-  const items = selectItems(data, ds.itemsPath)
-  const options: QuickActionOption[] = []
-  for (const item of items) {
-    const value = getPath(item, ds.valuePath)
-    if (value === undefined || value === null || value === '') continue
-    options.push({
-      value: String(value),
-      label: renderTemplate(ds.labelTemplate, item) || String(value),
-      sublabel: ds.sublabelTemplate ? renderTemplate(ds.sublabelTemplate, item) : undefined,
-    })
-  }
-
-  const filtered = filterOptions(options, query)
-  return { options: filtered, disabledHint: filtered.length ? null : (ds.emptyHint ?? null) }
-}
-
-/** Pull the option array out of the resolver output via `itemsPath`, else the first array found. */
-function selectItems(data: unknown, itemsPath?: string): Array<Record<string, unknown>> {
-  if (Array.isArray(data)) return data as Array<Record<string, unknown>>
-  if (itemsPath) {
-    const at = getPath(data, itemsPath)
-    return Array.isArray(at) ? (at as Array<Record<string, unknown>>) : []
-  }
-  // No itemsPath and not an array — take the first array-valued top-level field.
-  if (data && typeof data === 'object') {
-    for (const value of Object.values(data as Record<string, unknown>)) {
-      if (Array.isArray(value)) return value as Array<Record<string, unknown>>
-    }
-  }
-  return []
-}
-
-/** Read a dotted path (`a.b.c`) off an object. */
-function getPath(obj: unknown, path: string): unknown {
-  return path.split('.').reduce<unknown>((acc, key) => {
-    if (acc && typeof acc === 'object') return (acc as Record<string, unknown>)[key]
-    return undefined
-  }, obj)
-}
-
-/** Substitute `{field}` / `{a.b}` placeholders in a template from an item. */
-function renderTemplate(template: string, item: Record<string, unknown>): string {
-  return template
-    .replace(/\{([^}]+)\}/g, (_, key: string) => {
-      const value = getPath(item, key.trim())
-      return value === undefined || value === null ? '' : String(value)
-    })
-    .trim()
-}
-
-/** Case-insensitive substring filter over value + label + sublabel. */
-function filterOptions(options: QuickActionOption[], query?: string): QuickActionOption[] {
-  const q = query?.trim().toLowerCase()
-  if (!q) return options
-  return options.filter((o) =>
-    `${o.value} ${o.label} ${o.sublabel ?? ''}`.toLowerCase().includes(q)
-  )
 }

--- a/packages/lib/src/recording/calendar/participant-resolver.ts
+++ b/packages/lib/src/recording/calendar/participant-resolver.ts
@@ -87,10 +87,7 @@ export async function findCompanyByDomain(
       .where(
         and(
           eq(schema.EntityDefinition.organizationId, organizationId),
-          or(
-            eq(schema.EntityDefinition.standardType, 'company'),
-            eq(schema.EntityDefinition.entityType, 'company')
-          )!
+          eq(schema.EntityDefinition.entityType, 'company')
         )
       )
       .limit(1)

--- a/packages/sdk/__fixtures__/connector-app/src/app.ts
+++ b/packages/sdk/__fixtures__/connector-app/src/app.ts
@@ -4,13 +4,29 @@
 // Connector via `defineDataConnector`. Consumed by
 // `src/util/__tests__/compile-and-extract-catalog.test.ts` to pin the
 // `catalog.dataConnectors` projection (streams, fields, defaultMappings,
-// exampleRecord, requiresConnection, config JSON Schema).
+// exampleRecord, requiresConnection, config JSON Schema, configOptionHints).
 //
 // Unannotated `app` export (NOT `: App`) so the connector literals survive on
 // `typeof app`.
 
+import { z } from 'zod/v4'
+import listOptions from './list-options.tool.server'
 import { shopifyCoreDataConnector } from './shopify-core.connector'
 
 export const app = {
+  // A resolver tool backing the connector's `configOptions.collection` picker —
+  // its id must match `configOptions.collection.dynamicSelect.optionsFrom`.
+  tools: [
+    {
+      id: 'list_shopify_collections',
+      name: 'List Shopify collections',
+      description: 'Internal — lists collections to back a connector config dropdown.',
+      inputs: z.object({}),
+      outputs: z.object({
+        collections: z.array(z.object({ handle: z.string() })),
+      }),
+      execute: listOptions,
+    },
+  ],
   dataConnectors: [shopifyCoreDataConnector],
 }

--- a/packages/sdk/__fixtures__/connector-app/src/list-options.tool.server.ts
+++ b/packages/sdk/__fixtures__/connector-app/src/list-options.tool.server.ts
@@ -1,0 +1,9 @@
+// packages/sdk/__fixtures__/connector-app/src/list-options.tool.server.ts
+//
+// Stub resolver tool backing the connector's `configOptions.collection` dynamic
+// select. Server code is stubbed by the catalog extractor — this just satisfies
+// the `execute` import.
+
+export default async function listOptions(): Promise<{ collections: { handle: string }[] }> {
+  return { collections: [{ handle: 'summer' }, { handle: 'winter' }] }
+}

--- a/packages/sdk/__fixtures__/connector-app/src/shopify-core.connector.ts
+++ b/packages/sdk/__fixtures__/connector-app/src/shopify-core.connector.ts
@@ -21,7 +21,21 @@ export const shopifyCoreDataConnector = defineDataConnector({
   iconKey: 'shopping-bag',
   config: z.object({
     includeDraftProducts: z.boolean().default(false),
+    collection: z.string().optional(),
   }),
+  // `collection` renders as a dropdown backed by the `list_shopify_collections`
+  // tool (must be a tool in this app — validated at extraction).
+  configOptions: {
+    collection: {
+      kind: 'dynamic-select',
+      dynamicSelect: {
+        optionsFrom: 'list_shopify_collections',
+        itemsPath: 'collections',
+        valuePath: 'handle',
+        labelTemplate: '{handle}',
+      },
+    },
+  },
   streams: [
     {
       key: 'order',

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -21,6 +21,7 @@
 
 import type { z } from 'zod/v4'
 import type { FieldType } from '../fields/field-types.js'
+import type { ActionInputHint } from '../tools/types.js'
 
 /**
  * One normalized, SOURCE-shaped record produced by a connector's `execute`. Not
@@ -204,6 +205,15 @@ export interface DataConnectorDefinition<TConfigSchema extends z.ZodTypeAny = z.
   requiresConnection: boolean
   /** Connector-level config schema (filters, toggles). */
   config: TConfigSchema
+  /**
+   * Per-config-field presentation overrides keyed by config field, reusing the
+   * quick-action `ActionInputHint` shape. A `dynamic-select` hint renders the
+   * field as a live dropdown whose options come from an app tool
+   * (`optionsFrom`) invoked through the connector's own connection — e.g. a
+   * repo picker backed by a `list_repos` tool. `optionsFrom` must name a tool in
+   * the same app. Absent fields render from the JSON Schema as usual.
+   */
+  configOptions?: Record<string, ActionInputHint>
   /** Stream (fetch) declarations. */
   streams: ConnectorStreamDecl[]
   /** Optional icon key for the connector card. */

--- a/packages/sdk/src/util/__tests__/compile-and-extract-catalog-connectors.test.ts
+++ b/packages/sdk/src/util/__tests__/compile-and-extract-catalog-connectors.test.ts
@@ -48,6 +48,19 @@ describe('compileAndExtractCatalog — data connectors', () => {
       properties: { includeDraftProducts: { type: 'boolean' } },
     })
 
+    // Tool-backed config-field hints projected beside the bare JSON Schema.
+    expect(connector?.configOptionHints).toEqual({
+      collection: {
+        kind: 'dynamic-select',
+        dynamicSelect: {
+          optionsFrom: 'list_shopify_collections',
+          itemsPath: 'collections',
+          valuePath: 'handle',
+          labelTemplate: '{handle}',
+        },
+      },
+    })
+
     // One stream, with the source fields flattened (fieldKey carried).
     expect(connector?.streams).toHaveLength(1)
     const stream = connector?.streams[0]

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -229,6 +229,12 @@ export interface CatalogDataConnector {
   iconKey: string | null
   /** Connector-level config schema (JSON Schema, from the `config` zod schema). */
   configJsonSchema: Record<string, unknown>
+  /**
+   * Per-config-field presentation overrides (same `dynamic-select` shape as a
+   * quick-action's `inputHints`), carried beside the bare JSON Schema so a config
+   * field can render as a tool-backed dropdown. Keyed by config field.
+   */
+  configOptionHints?: Record<string, ActionInputHint>
   streams: CatalogConnectorStream[]
 }
 
@@ -646,6 +652,26 @@ export async function compileAndExtractCatalog(): Promise<
       ? zodToProviderToolSchema(connector.config as never).jsonSchema
       : {}
 
+    // Validate each config-field dynamic-select hint against this app's tools —
+    // same rules as action `inputHints` (optionsFrom must be a local tool;
+    // valuePath + labelTemplate are required to render an option).
+    for (const [fieldKey, hint] of Object.entries(connector.configOptions ?? {})) {
+      if (hint.kind !== 'dynamic-select') continue
+      const ds = hint.dynamicSelect
+      if (!toolIds.has(ds.optionsFrom)) {
+        return errored({
+          code: 'CATALOG_VALIDATION_FAILED',
+          message: `Connector "${connector.id}" config "${fieldKey}": optionsFrom "${ds.optionsFrom}" is not a tool in this app`,
+        })
+      }
+      if (!ds.valuePath || !ds.labelTemplate) {
+        return errored({
+          code: 'CATALOG_VALIDATION_FAILED',
+          message: `Connector "${connector.id}" config "${fieldKey}": dynamic-select requires valuePath and labelTemplate`,
+        })
+      }
+    }
+
     const streams: CatalogConnectorStream[] = (connector.streams ?? []).map((stream) => ({
       key: stream.key,
       displayFieldKey: stream.displayFieldKey,
@@ -669,6 +695,7 @@ export async function compileAndExtractCatalog(): Promise<
       requiresConnection: Boolean(connector.requiresConnection),
       iconKey: connector.iconKey ?? null,
       configJsonSchema,
+      ...(connector.configOptions ? { configOptionHints: connector.configOptions } : {}),
       streams,
     })
   }
@@ -812,6 +839,8 @@ interface RawDataConnector {
   iconKey?: string
   /** zod schema — projected to JSON Schema via zodToProviderToolSchema. */
   config?: unknown
+  /** Per-config-field presentation overrides (tool-backed dynamic selects). */
+  configOptions?: Record<string, ActionInputHint>
   streams: RawConnectorStream[]
 }
 


### PR DESCRIPTION
## Summary

Lets a data-connector **config field** render as a live dropdown backed by an app tool (e.g. a repo / collection picker) instead of a bare text input.

- New `configOptions` map on `DataConnectorDefinition` reuses the quick-action `ActionInputHint` / `dynamic-select` shape. Validated at catalog compile time against the app's own tools (`optionsFrom` must be a local tool; `valuePath` + `labelTemplate` required) and projected onto the catalog as `configOptionHints`.
- Extracted the option-resolution core into `@auxx/lib/apps/tool-options` (`invokeAppToolForOptions` + `mapToolOutputToOptions`), now shared by both resolvers. `quick-actions/resolve-options.ts` keeps a back-compat re-export.
- `resolveConnectorConfigOptions` runs the tool through the connector's **own bound connection** — the same credential the sync borrows.
- Collapsed `quickAction.resolveOptions` into one generic `apps.resolveToolOptions` procedure, discriminated by `source` (`entity` quick-action vs `connector` config). Both UI call sites updated.
- Config fields now render via `VarEditorFieldRow` + `FieldInputAdapter`, with a `ToolBackedSelectRow` for dynamic-select fields.

## Also in this PR

- **EntityType enum**: expanded values (article, company, meeting, part, tag, vendor_part, …); removed `company` from `StandardType`. Calendar participant resolver now resolves companies by `entityType` only.
- **Owned-def provisioning**: connector-owned defs are now classified as CUSTOM entities (entityType/standardType null, matching user-created entities), store the lowercase lucide iconId, and wire the declared `primaryDisplayFieldKey`.

## Test plan

- [ ] SDK catalog fixtures (`compile-and-extract-catalog-connectors.test.ts`) cover `configOptionHints` projection + validation
- [ ] Connector config picker resolves options through the connector's connection
- [ ] Quick-action dynamic-select still works via the generic `apps.resolveToolOptions`