### PR TITLE
feat(data-connectors): sync robustness — stale recovery, rate-limit signal, ingest ceiling

### DIFF
--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -238,6 +238,24 @@ export async function setupSchedules() {
     }
   )
 
+  // Data-connector stale-run sweep — every 5 minutes. Fails connector runs whose
+  // checkpoint heartbeat went cold (STALE_RUN_MS) and releases the connector claim,
+  // so a crashed/restarted continuation chain can't strand a connector 'syncing'
+  // forever. Global (no connectorId) — the scoped sweep at startConnectorSync only
+  // heals the one connector being re-synced.
+  await maintenanceQueue.upsertJobScheduler(
+    'dataConnectorStaleSweepJob',
+    { pattern: '*/5 * * * *' },
+    {
+      opts: {
+        attempts: 1,
+        priority: 8,
+        removeOnComplete: { count: 30 },
+        removeOnFail: { count: 50 },
+      },
+    }
+  )
+
   // Every day at 8 AM
   await maintenanceQueue.upsertJobScheduler(
     'requestDocumentSuggestionsJob',

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -1,4 +1,5 @@
 import { isSelfHosted } from '@auxx/deployment'
+import { dataConnectorStaleSweepJob } from '@auxx/lib/data-connectors'
 import { isDemoEnabled } from '@auxx/lib/demo'
 import { evalRunWatchdog } from '@auxx/lib/evals/worker'
 import {
@@ -170,6 +171,10 @@ const jobMappings = {
 
   // Data migrations runner (enqueued at boot + from the superadmin panel)
   dataMigrationsJob,
+
+  // Global data-connector stale-run sweep (every 5 min; fails cold runs + releases
+  // their connector claim so a crashed continuation chain can't strand a connector)
+  dataConnectorStaleSweepJob,
 }
 
 export function startMaintenanceWorker() {

--- a/packages/lib/src/data-connectors/connectors/app-connector-adapter.ts
+++ b/packages/lib/src/data-connectors/connectors/app-connector-adapter.ts
@@ -13,12 +13,13 @@ import type { CatalogDataConnector, Database } from '@auxx/database'
 import { createScopedLogger } from '../../logger'
 import type { SyncCursor } from '../../sync-core/contracts'
 import { decodeCursor, encodeCursor } from './app-connector-state'
-import type {
-  ConnectorRecord,
-  ConnectorStreamDecl,
-  ConnectorYield,
-  DataConnectorDefinition,
-  FetchResult,
+import {
+  ConnectorRateLimitError,
+  type ConnectorRecord,
+  type ConnectorStreamDecl,
+  type ConnectorYield,
+  type DataConnectorDefinition,
+  type FetchResult,
 } from './types'
 
 /** What an app's `execute` returns per page (the SDK's flat `ConnectorFetchResult`). */
@@ -31,6 +32,16 @@ interface AppExecuteResult {
     updatedSince?: string
     /** Set on the last page — flips the stream to steady / finishes the snapshot. */
     backfillComplete?: boolean
+  }
+  /**
+   * Upstream throttle signal (mirrors the SDK `ConnectorFetchResult.rateLimited`).
+   * The signal crosses the sandbox boundary as plain DATA; the adapter re-throws it
+   * as a real `ConnectorRateLimitError` (in-realm) so the slice loop's existing
+   * back-off handling can pace the re-enqueue. Cross-realm `instanceof` from inside
+   * the sandbox would never match — this is why the app returns data, not an error.
+   */
+  rateLimited?: {
+    retryAfterMs?: number
   }
 }
 
@@ -281,8 +292,19 @@ export function appConnectorAdapter(
       return {
         records: (async function* (): AsyncGenerator<ConnectorYield> {
           while (true) {
-            const { records = [], nextState = {} } = await invokePage(flat)
+            const { records = [], nextState = {}, rateLimited } = await invokePage(flat)
             for (const record of records) yield record
+
+            // Upstream throttle (§2): the app couldn't fetch this page and asked us to
+            // back off. Re-throw as the in-realm lib error so the slice loop folds
+            // `retryAfterMs` into the re-enqueue delay. Records yielded above (earlier
+            // pages this slice) are kept; the throttled page is retried after the wait.
+            if (rateLimited) {
+              throw new ConnectorRateLimitError(
+                `App connector '${slug}' rate-limited by upstream`,
+                rateLimited.retryAfterMs
+              )
+            }
 
             const watermark = nextState.updatedSince
             logger.info('app connector page complete', {

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -176,6 +176,7 @@ export type { EntitySink, ProjectedRecord, SyncCtx } from './sinks/types'
 export {
   backfillPendingChange,
   freshBackfillState,
+  MAX_BACKFILL_RECORDS,
   runBackfillSlice,
   SLICE_BUDGET,
   SLICE_LOCK_DURATION_MS,
@@ -183,6 +184,11 @@ export {
   startConnectorSync,
   sweepStaleConnectorRuns,
 } from './slice-orchestrator'
+// §1 global stale-run sweep — maintenance-schedule handler
+export {
+  DATA_CONNECTOR_STALE_SWEEP_JOB_NAME,
+  dataConnectorStaleSweepJob,
+} from './stale-sweep-job'
 // Tier 2 mapping suggester (create-sync-flow §3.2) — heuristic source→field proposals
 export type { SourceLeaf } from './suggest-mappings'
 export { collectSchemaLeaves, suggestFieldMappings } from './suggest-mappings'

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -354,6 +354,49 @@ export async function finalizeConnector(
   }
 }
 
+/** Current run-level fetched count (the per-run ingest total folded by the ledger). */
+export async function getRunFetched(db: Database, runId: string): Promise<number> {
+  const row = await db.query.DataConnectorRun.findFirst({
+    where: eq(schema.DataConnectorRun.id, runId),
+    columns: { fetched: true },
+  })
+  return row?.fetched ?? 0
+}
+
+/**
+ * Park a backfill that crossed the per-run ingest ceiling (§3). Marks the run
+ * `partial` (NOT `failed` — it's a clean stop, not an error) with a `paused` note for
+ * the status line, and releases the connector to `paused` (NOT left `syncing` — that's
+ * the §1 strand trap). The stream cursor is left checkpointed, so a later "resume"
+ * (re-trigger after bumping the ceiling) continues mid-chain instead of from page 1.
+ */
+export async function parkBackfillAtCeiling(
+  db: Database,
+  input: {
+    runId: string
+    dataConnectorId: string
+    fetched: number
+    ceiling: number
+    startedAt: Date
+  }
+): Promise<void> {
+  const message = `Backfill paused at ${input.fetched} records (limit ${input.ceiling}). Raise the limit or narrow the source, then resume.`
+  const T = schema.DataConnectorRun
+  await db
+    .update(T)
+    .set({
+      status: 'partial',
+      finishedAt: new Date(),
+      durationMs: Date.now() - input.startedAt.getTime(),
+      progress: sql`jsonb_set(coalesce(${T.progress}, '{}'::jsonb), '{paused}', jsonb_build_object('reason', 'ingest-ceiling', 'atRecords', ${input.fetched}::int, 'ceiling', ${input.ceiling}::int), true)`,
+    })
+    .where(eq(T.id, input.runId))
+  await db
+    .update(schema.DataConnector)
+    .set({ status: 'paused', error: message, updatedAt: new Date() })
+    .where(eq(schema.DataConnector.id, input.dataConnectorId))
+}
+
 /** Persist a stream's incremental cursor after the stream completes. */
 export async function persistStreamState(
   db: Database,

--- a/packages/lib/src/data-connectors/slice-orchestrator.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator.ts
@@ -27,9 +27,11 @@ import { backfillProvisionedFieldRefs, provisionConnectorMappings } from './prov
 import {
   claimForSync,
   finalizeConnector,
+  getRunFetched,
   initConnectorBackfillLatch,
   loadConnector,
   openRun,
+  parkBackfillAtCeiling,
   persistStreamState,
   setRunRateLimited,
 } from './service'
@@ -49,6 +51,17 @@ export const SLICE_BUDGET = { maxPages: 20, maxRecords: 5_000, maxMs: 25_000 } a
 
 /** BullMQ `lockDuration` for the slice job — 2–3× the realistic slice wall-clock. */
 export const SLICE_LOCK_DURATION_MS = 90_000
+
+/**
+ * Per-run ingest ceiling (§3). A backfill stops re-enqueuing once its run-level
+ * `fetched` count crosses this, so a mis-targeted or unexpectedly huge source can't
+ * ingest unbounded volume + flood downstream jobs on shared infra. SOFT bound: the
+ * check runs at slice (page) boundaries, so the actual stop overshoots by up to one
+ * slice's worth of records — it's a guardrail, not an exact cap. The run parks
+ * `partial` and the connector goes `paused`; "resume" (re-trigger) continues from the
+ * checkpoint. NOT to be confused with `SLICE_BUDGET.maxRecords` (per-slice, not per-run).
+ */
+export const MAX_BACKFILL_RECORDS = 9_000
 
 /**
  * A run is presumed dead once its checkpoint heartbeat (`heartbeatAt`, bumped every
@@ -362,6 +375,30 @@ export async function runBackfillSlice(
     if (signal?.aborted) {
       logger.info('runBackfillSlice: cancelled, not re-enqueuing', { runId, streamId })
       return
+    }
+
+    // §3 ingest ceiling: park the backfill before re-enqueuing once the run crosses
+    // the per-run record cap. Backfill phase only — steady deltas are naturally
+    // bounded by the watermark. Parking releases the connector to `paused` and keeps
+    // the cursor, so a later resume continues mid-chain (NOT page 1).
+    if (run.phase === 'backfill') {
+      const fetched = await getRunFetched(db, runId)
+      if (fetched >= MAX_BACKFILL_RECORDS) {
+        logger.warn('runBackfillSlice: ingest ceiling reached, parking run', {
+          runId,
+          connectorId,
+          fetched,
+          ceiling: MAX_BACKFILL_RECORDS,
+        })
+        await parkBackfillAtCeiling(db, {
+          runId,
+          dataConnectorId: connectorId,
+          fetched,
+          ceiling: MAX_BACKFILL_RECORDS,
+          startedAt: run.startedAt,
+        })
+        return
+      }
     }
     // Surface the throttle to the status line: set `rateLimited.until` when the next
     // slice is delayed on a 429, clear it on a clean re-enqueue (Step 9 §3.1).

--- a/packages/lib/src/data-connectors/stale-sweep-job.ts
+++ b/packages/lib/src/data-connectors/stale-sweep-job.ts
@@ -1,0 +1,26 @@
+// packages/lib/src/data-connectors/stale-sweep-job.ts
+// §1 — global periodic stale-run sweep. Runs on the maintenance schedule (every
+// 5 min) and fails any connector run whose checkpoint heartbeat went cold
+// (STALE_RUN_MS), releasing its connector claim. The scoped sweep at
+// `startConnectorSync` only heals the one connector being re-synced; this covers
+// every connector with no human trigger, so a crashed/restarted continuation chain
+// can never strand a connector `syncing` forever.
+
+import { database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { JobContext } from '../jobs/types'
+import { sweepStaleConnectorRuns } from './slice-orchestrator'
+
+const logger = createScopedLogger('data-connector-stale-sweep')
+
+export const DATA_CONNECTOR_STALE_SWEEP_JOB_NAME = 'dataConnectorStaleSweepJob'
+
+/** Global stale-run sweep handler. Idempotent + cheap — touches only cold runs. */
+export async function dataConnectorStaleSweepJob(
+  ctx: JobContext<{ staleMs?: number } | undefined>
+): Promise<void> {
+  const swept = await sweepStaleConnectorRuns(database, { staleMs: ctx.data?.staleMs })
+  if (swept > 0) {
+    logger.warn('Swept stale connector runs', { count: swept })
+  }
+}

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -74,6 +74,20 @@ export interface ConnectorFetchResult {
   records: ConnectorRecord[] | AsyncIterable<ConnectorRecord>
   /** Cursor + watermark to persist; the next page / incremental run resumes from here. */
   nextState: ConnectorStreamState
+  /**
+   * Upstream throttle signal. When the source rate-limits a page (HTTP 429, or a
+   * provider-specific 403/cost throttle), **return** this instead of throwing or
+   * sleeping — the platform pauses the chain and re-enqueues the next slice after
+   * `retryAfterMs`, so the connector never burns its sandbox budget waiting.
+   *
+   * Return the cursor you want to resume from in `nextState.cursor` alongside this
+   * (typically the SAME page that was throttled). Records already collected this page
+   * are still sinked; the throttled page is retried after the wait.
+   */
+  rateLimited?: {
+    /** Server-hinted wait before the next attempt, in ms (`Retry-After` / reset header). */
+    retryAfterMs?: number
+  }
 }
 
 /** Field capabilities surfaced on a declared source field. */


### PR DESCRIPTION
## What

Four durable guardrails so a data-connector backfill can't strand a connector, overload the app, or silently ingest the wrong data. Turns the one-off symptoms of a recent incident (a `github.issues` connector that synced `facebook/react` and then froze) into permanent fixes.

### §1 — Auto-recover stuck syncs
A crashed/restarted continuation chain left the run `running` and the connector `syncing` **forever** — the stale-run reaper (`sweepStaleConnectorRuns`) was only ever called scoped to one connector at `startConnectorSync`, with no global cron. Now a **global sweep runs on the maintenance schedule every 5 min** (mirrors `evalRunWatchdog`), failing cold-heartbeat runs and releasing the connector claim. Worst-case recovery ~10 min (5-min staleness + 5-min interval), no human trigger needed.

### §2 — App connectors can signal upstream rate limits
The back-off path keyed entirely on `error instanceof ConnectorRateLimitError`, but app connectors can't construct that lib class and it can't cross the app-runtime sandbox via `instanceof` — so for app connectors the throttle path was **dead code** and a 429 hard-failed the run. Now:
- SDK `ConnectorFetchResult` gains an optional `rateLimited?: { retryAfterMs }` field (returned as data, survives the sandbox).
- The adapter re-throws it as an in-realm `ConnectorRateLimitError`, so the existing slice-loop back-off paces the re-enqueue.

### §3 — Per-run ingest ceiling (9000)
No cap existed on how many records one backfill could ingest. A backfill now **parks** once its run-level `fetched` crosses `MAX_BACKFILL_RECORDS = 9000`: run → `partial`, connector → `paused`, cursor preserved so a re-trigger resumes mid-chain. Soft bound (checked at slice boundaries, so it overshoots by ~one slice — a guardrail, not an exact cap).

## Notes
- **§4** (remove the `github.issues` default-repo fallback → throw on empty config) and the **github connector's rate-limit emit** land in the **`auxxai-apps`** repo (separate PR).
- The SDK was rebuilt so the new `rateLimited` type propagates to the linked apps workspace.
- The **realtime event-flood suppression** is a separate plan/PR (another agent) and is intentionally **not** included here.

## Test plan
- [ ] **Stale recovery:** start a backfill, kill the worker mid-chain, restart — the global sweep flips the cold run to `failed` and releases the connector within ~10 min without a manual re-sync; a fresh sync resumes from the checkpoint cursor.
- [ ] **Rate limit:** point a connector at a 403/429 — confirm it backs off + re-enqueues with a delay (status line shows `rateLimited.until`) instead of hard-failing.
- [ ] **Ceiling:** backfill a large source — confirm the run parks `partial`, connector goes `paused`, downstream job volume stops, and re-trigger continues.