### PR TITLE
fix(data-connectors): reflect ingested count on failed/parked syncs

### DIFF
--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -347,9 +347,21 @@ export async function finalizeConnector(
       })
       .where(eq(schema.DataConnector.id, dataConnectorId))
   } else {
+    // A crashed/swept/failed run never ran the success bookkeeping, so the connector
+    // would report `itemCount: 0` / "never synced" even when records DID land (a stale
+    // sweep after a partial backfill). Refresh the count from the bound items so the
+    // connector tells the truth, and stamp `lastSyncedAt` when anything was ingested
+    // (kept null on a zero-ingest failure → still shows "never synced").
+    const itemCount = await countConnectorItems(db, dataConnectorId)
     await db
       .update(schema.DataConnector)
-      .set({ status: 'error', error: input.error ?? 'Unknown error', updatedAt: new Date() })
+      .set({
+        status: 'error',
+        error: input.error ?? 'Unknown error',
+        itemCount,
+        ...(itemCount > 0 ? { lastSyncedAt: new Date() } : {}),
+        updatedAt: new Date(),
+      })
       .where(eq(schema.DataConnector.id, dataConnectorId))
   }
 }
@@ -391,9 +403,18 @@ export async function parkBackfillAtCeiling(
       progress: sql`jsonb_set(coalesce(${T.progress}, '{}'::jsonb), '{paused}', jsonb_build_object('reason', 'ingest-ceiling', 'atRecords', ${input.fetched}::int, 'ceiling', ${input.ceiling}::int), true)`,
     })
     .where(eq(T.id, input.runId))
+  // A parked backfill has ingested records (it hit the ceiling), so reflect the real
+  // count + stamp `lastSyncedAt` — don't leave the connector showing "0 / never synced".
+  const itemCount = await countConnectorItems(db, input.dataConnectorId)
   await db
     .update(schema.DataConnector)
-    .set({ status: 'paused', error: message, updatedAt: new Date() })
+    .set({
+      status: 'paused',
+      error: message,
+      itemCount,
+      ...(itemCount > 0 ? { lastSyncedAt: new Date() } : {}),
+      updatedAt: new Date(),
+    })
     .where(eq(schema.DataConnector.id, input.dataConnectorId))
 }
 


### PR DESCRIPTION
## What

A crashed/swept/parked backfill never ran the success bookkeeping, so the connector reported **`itemCount: 0`** and **"never synced"** even when records actually landed.

Concretely, after the stale-sweep fired on the recent incident's run:

| Connector field | Was | Reality |
|---|---|---|
| `itemCount` | `0` | **8644** bound `DataConnectorItem` rows |
| `lastSyncedAt` | `null` ("never synced") | 7967 records created |

Root cause: `itemCount` / `lastSyncedAt` were written **only** on a clean backfill finalize (`finalizeConnector(ok:true)`). The `ok:false` branch (and the §3 park path) left them untouched.

## Fix

- `finalizeConnector`'s failure branch and `parkBackfillAtCeiling` now refresh `itemCount` from the bound items (cheap O(1) `count()`).
- `lastSyncedAt` is stamped when anything was ingested; a genuine **zero-ingest** failure still shows "never synced" (left null).

## Notes
- The already-stuck connector row won't retroactively update from this change — the MCP DB connection is read-only and the run is already terminal. It self-corrects on the **next** sync (success → `ok:true`, or failure → the new `ok:false` path). Re-triggering it (now safe: §4 fails fast on empty repo, §3 parks at ~9000) will set the right count.

## Test plan
- [ ] Start a backfill, kill the worker mid-chain → stale-sweep fails the run → connector shows the real ingested count (not 0) and a `lastSyncedAt`.
- [ ] Park a backfill at the ceiling → connector `paused` with the real count.
- [ ] A connector that fails before ingesting anything → still shows `itemCount: 0` / "never synced".