### PR TITLE
feat(data-connectors): allow custom values in tool-backed dynamic-select config fields

### DIFF
--- a/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
@@ -14,6 +14,7 @@ import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapte
 import { type FieldEntry, readFieldNodes, seedDefaults } from '~/components/global/schema-form'
 import { BaseType } from '~/components/workflow/types'
 import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+import { useDebounce } from '~/hooks/use-debounced-value'
 import { api } from '~/trpc/react'
 import { useRegisterSaver } from '../hooks/use-connector-edits'
 import { RecordKeyValueEditor, RequestEditorBlock, RevealChip } from './request-editors'
@@ -189,6 +190,7 @@ function AppConfigSource({
                 key={entry.key}
                 connectorId={connector.id}
                 entry={entry}
+                hint={hint}
                 value={values[entry.key]}
                 onChange={onChange}
               />
@@ -271,25 +273,43 @@ function ConfigFieldRow({
 function ToolBackedSelectRow({
   connectorId,
   entry,
+  hint,
   value,
   onChange,
 }: {
   connectorId: string
   entry: FieldEntry
+  hint: ActionInputHint
   value: unknown
   onChange: (next: unknown) => void
 }) {
+  // `allowCustom` turns the closed single-select into a creatable combobox: the
+  // tool options become suggestions, and a typed value commits as the raw string.
+  const allowCustom = hint.kind === 'dynamic-select' && hint.dynamicSelect.allowCustom === true
+
+  // Typeahead — feed the picker's debounced search text to the resolver as
+  // `query` so suggestions narrow as you type. Gated on `allowCustom` so closed
+  // selects keep their byte-for-byte (query-less) behavior.
+  const [search, setSearch] = useState('')
+  const debouncedSearch = useDebounce(search, 250)
+  const query = allowCustom && debouncedSearch.trim() ? debouncedSearch.trim() : undefined
+
   const optionsQuery = api.apps.resolveToolOptions.useQuery(
-    { source: { kind: 'connector', connectorId }, fieldKey: entry.key },
+    { source: { kind: 'connector', connectorId }, fieldKey: entry.key, query },
     { staleTime: 60_000, refetchOnWindowFocus: false }
   )
-  const fieldOptions: FieldOptions = {
-    options: (optionsQuery.data?.options ?? []).map((o) => ({
-      value: o.value,
-      label: o.sublabel ? `${o.label} — ${o.sublabel}` : o.label,
-    })),
-  }
+  const options = (optionsQuery.data?.options ?? []).map((o) => ({
+    value: o.value,
+    label: o.sublabel ? `${o.label} — ${o.sublabel}` : o.label,
+  }))
   const selected = typeof value === 'string' && value ? [value] : []
+  // A persisted custom value won't appear in the resolved suggestions (it's a
+  // repo the token can't list); surface it as its own option so the trigger
+  // renders the label rather than a blank.
+  if (allowCustom && selected[0] && !options.some((o) => o.value === selected[0])) {
+    options.unshift({ value: selected[0], label: selected[0] })
+  }
+  const fieldOptions: FieldOptions = { options }
 
   return (
     <VarEditorFieldRow
@@ -310,7 +330,12 @@ function ToolBackedSelectRow({
               entry.meta.placeholder ??
               `Select ${entry.meta.label ?? entry.key}…`)
         }
+        // Only block while loading — a `disabledHint` (e.g. no connection) still
+        // leaves the field typeable when `allowCustom`, so a known value works.
         disabled={optionsQuery.isLoading}
+        canAdd={allowCustom}
+        useValueAsLabel={allowCustom}
+        onSearchChange={allowCustom ? setSearch : undefined}
         triggerProps={ROW_TRIGGER_PROPS}
       />
     </VarEditorFieldRow>

--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -88,6 +88,19 @@ export interface FieldInputAdapterProps {
   onOptionsChange?: (options: SelectOption[]) => void
   /** Override multi-select behavior (for operators like "in"/"not in") */
   allowMultiple?: boolean
+  /**
+   * Override `canAdd` on select fields — lets a SINGLE_SELECT become a creatable
+   * combobox (e.g. a tool-backed `dynamic-select` with `allowCustom`). Defaults
+   * to the field type's `getSelectConfig`.
+   */
+  canAdd?: boolean
+  /**
+   * When a created select value should be the typed text rather than a UUID
+   * (free-text identifier fields). Forwarded to `SelectFieldInput`.
+   */
+  useValueAsLabel?: boolean
+  /** Called when the select picker's search text changes (for live typeahead). */
+  onSearchChange?: (value: string) => void
   /** Trigger customization options for picker-based inputs */
   triggerProps?: PickerTriggerOptions
   /** Controlled open state for picker-based inputs */
@@ -129,6 +142,9 @@ export function FieldInputAdapter({
   disabled = false,
   onOptionsChange,
   allowMultiple,
+  canAdd,
+  useValueAsLabel,
+  onSearchChange,
   triggerProps,
   open,
   onOpenChange,
@@ -293,9 +309,12 @@ export function FieldInputAdapter({
     case FieldType.TAGS: {
       const options = fieldOptions?.options ?? []
       const baseConfig = getSelectConfig(fieldType)
-      // Override multi if allowMultiple is explicitly set
-      const config =
-        allowMultiple !== undefined ? { ...baseConfig, multi: allowMultiple } : baseConfig
+      // Override multi/canAdd when explicitly set (operators, creatable selects)
+      const config = {
+        ...baseConfig,
+        ...(allowMultiple !== undefined ? { multi: allowMultiple } : {}),
+        ...(canAdd !== undefined ? { canAdd } : {}),
+      }
 
       const selectedValues = Array.isArray(value) ? value : value ? [value] : []
 
@@ -312,6 +331,8 @@ export function FieldInputAdapter({
           open={open}
           onOpenChange={onOpenChange}
           shouldPreventDismiss={shouldPreventDismiss}
+          useValueAsLabel={useValueAsLabel}
+          onSearchChange={onSearchChange}
         />
       )
     }

--- a/apps/web/src/components/fields/inputs/select-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/select-input-field.tsx
@@ -257,6 +257,14 @@ export interface SelectFieldInputProps {
   onOpenChange?: (open: boolean) => void
   /** Callback to check if a dismiss event should be prevented. Return true to prevent closing. */
   shouldPreventDismiss?: (target: HTMLElement) => boolean
+  /**
+   * When a value is created (only with `config.canAdd`), use the typed text as
+   * the stored value instead of a generated UUID. Needed for free-text identifier
+   * fields like a `<owner>/<repo>` full-name. Forwarded to the picker.
+   */
+  useValueAsLabel?: boolean
+  /** Called when the picker's search text changes (for live typeahead). */
+  onSearchChange?: (value: string) => void
 }
 
 /**
@@ -277,6 +285,8 @@ export function SelectFieldInput({
   open: controlledOpen,
   onOpenChange,
   shouldPreventDismiss,
+  useValueAsLabel = false,
+  onSearchChange,
 }: SelectFieldInputProps) {
   // Normalize value — callers may pass a single string when switching operators
   const normalizedValue = Array.isArray(value) ? value : value ? [value] : []
@@ -362,6 +372,8 @@ export function SelectFieldInput({
           multi={config.multi}
           canAdd={config.canAdd}
           canManage={config.canManage}
+          useValueAsLabel={useValueAsLabel}
+          onSearchChange={onSearchChange}
           placeholder={config.placeholder}
           manageLabel={config.manageLabel}
           disabled={disabled}

--- a/apps/web/src/components/pickers/multi-select-picker.tsx
+++ b/apps/web/src/components/pickers/multi-select-picker.tsx
@@ -285,9 +285,12 @@ export function MultiSelectPicker({
     const newValue = useValueAsLabel ? newLabel : generateId()
     const newOption: SelectOption = { label: newLabel, value: newValue }
 
-    // Update options and auto-select the new option
+    // Update options and auto-select the new option. In single-select mode,
+    // replace the selection (mirror `handleSelect`) so a pre-existing value
+    // isn't left behind as `[old, new][0]`; in multi mode, append.
     updateOptions([...localOptions, newOption])
-    updateSelected([...localSelected, newValue])
+    updateSelected(multi ? [...localSelected, newValue] : [newValue])
+    if (!multi) onSelectSingle?.(newValue)
 
     setSearchValue('')
   }, [
@@ -295,6 +298,8 @@ export function MultiSelectPicker({
     searchValue,
     localOptions,
     localSelected,
+    multi,
+    onSelectSingle,
     updateOptions,
     updateSelected,
     useValueAsLabel,

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -95,6 +95,7 @@ export interface DynamicSelectHint {
   labelTemplate: string
   sublabelTemplate?: string
   emptyHint?: string
+  allowCustom?: boolean
 }
 
 export interface CatalogAction {

--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -219,6 +219,14 @@ export interface DynamicSelectHint {
   readonly sublabelTemplate?: string
   /** Text shown disabled when no options resolve. */
   readonly emptyHint?: string
+  /**
+   * When true, the resolved tool options are treated as **suggestions** rather
+   * than a whitelist: the field also commits a free-text value the resolver
+   * never returned (a *creatable* select). Use for open identifiers like an
+   * `owner/repo` full-name; leave off for closed pickers that must match a real
+   * remote record (e.g. a Shopify collection).
+   */
+  readonly allowCustom?: boolean
 }
 
 /**


### PR DESCRIPTION
## What

Tool-backed `dynamic-select` connector config fields render as a **closed** single-select fed by options from running an app tool through the connector's own connection. For GitHub that's only the repos the token can list — so you can't point the connector at an arbitrary public repo like `facebook/react`.

This makes the tool's option list **suggestions** instead of a whitelist, via an opt-in `allowCustom` flag on the hint.

## Changes

- **types** — add `allowCustom?: boolean` to `DynamicSelectHint` in both mirror copies (`packages/sdk/src/root/tools/types.ts` + `packages/database/src/db/schema/app-deployment.ts`). Carried verbatim through catalog extraction; no extraction/resolver change.
- **`multi-select-picker.tsx`** — single-select `createOption` now **replaces** the selection (`[newValue]`) instead of appending `[old, new]`, and fires `onSelectSingle` to close.
- **`select-input-field.tsx` / `field-input-adapter.tsx`** — thread `canAdd`, `useValueAsLabel`, and `onSearchChange` overrides down to the picker.
- **`source-config-panel.tsx`** — `ToolBackedSelectRow` honors `allowCustom`: creatable + value-as-label, surfaces a persisted custom value as its own option, debounced typeahead `query`, and stays typeable when option resolution is disabled (e.g. no connection).

Consumer wiring (`allowCustom: true` on the GitHub Issues `repo` field) is in a companion PR on **auxxai-apps**.

## Notes

- No schema migration.
- Closed `dynamic-select` fields (no `allowCustom`) are byte-for-byte unchanged.
- Kept the single combined `owner/repo` string (server already splits on `/`); no pre-validation of a typed repo — a bad value surfaces as a 404 through the existing backfill error counters.

Plan: `plans/data-connectors/v4/allow-custom-dynamic-select-plan.md`