### PR TITLE
fix(data-connectors): allow connector-config option resolver through lambda validator

### DIFF
--- a/apps/lambda/src/validator.ts
+++ b/apps/lambda/src/validator.ts
@@ -170,6 +170,8 @@ const PollingTriggerExecutionSchema = AppEventSchema.extend({
  * `invocationContext.kind` discriminates the surface the call came from:
  *   - 'agent'  — Kopilot bridge invocation (LLM tool call).
  *   - 'action' — action button invocation (ticket / email editor).
+ *   - 'data-connector-config' — a tool-backed connector config option resolver
+ *     (e.g. the GitHub repo picker), via the shared `invokeAppToolForOptions` core.
  *
  * See plans/kopilot/agents/triggers/app-surface-implementation-plan.md §7.
  */
@@ -187,9 +189,15 @@ const ActionInvocationContextSchema = z.object({
   ticketId: z.string().optional(),
 })
 
+const ConnectorConfigInvocationContextSchema = z.object({
+  kind: z.literal('data-connector-config'),
+  connectorId: z.string().optional(),
+})
+
 const InvocationContextSchema = z.discriminatedUnion('kind', [
   AgentInvocationContextSchema,
   ActionInvocationContextSchema,
+  ConnectorConfigInvocationContextSchema,
 ])
 
 const ToolExecutionSchema = AppEventSchema.extend({

--- a/packages/lib/src/apps/tool-options.ts
+++ b/packages/lib/src/apps/tool-options.ts
@@ -113,11 +113,6 @@ export async function invokeAppToolForOptions(
     },
   })
   if (lambdaResult.isErr()) {
-    logger.warn('Options resolver lambda invocation failed', {
-      optionsFrom: hint.optionsFrom,
-      code: lambdaResult.error.code,
-      error: lambdaResult.error.message,
-    })
     // A missing/expired connection is the one actionable case for the user.
     return disabled(
       lambdaResult.error.code === 'CONNECTION_REQUIRED'
@@ -127,11 +122,6 @@ export async function invokeAppToolForOptions(
   }
   const result = lambdaResult.value
   if (result.metadata?.runtime_error || result.metadata?.validation_error) {
-    logger.warn('Options resolver tool errored', {
-      optionsFrom: hint.optionsFrom,
-      runtimeError: result.metadata?.runtime_error?.message,
-      validationError: result.metadata?.validation_error?.message,
-    })
     return disabled("Couldn't load options — the resolver errored")
   }
   const data = result.execution_result?.data ?? result.execution_result ?? {}


### PR DESCRIPTION
## What

The tool-backed connector **config option picker** (e.g. the GitHub Issues connector's `repo` dropdown) was showing no options for a connected account.

## Why

Resolving the picker runs the app's resolver tool through the connector's own connection via the shared `invokeAppToolForOptions` core. That call was failing at **two lambda gates**:

1. **Caller allowlist** — the core signs as `app-tool-options`, which wasn't in `CALLER_TYPE_ALLOWLIST` → `403 CALLER_TYPE_DENIED`. *(Already landed on `main` via #949.)*
2. **Payload validator** *(this PR)* — the picker sends `invocationContext: { kind: 'data-connector-config', connectorId }`, but `InvocationContextSchema` only accepted `'agent' | 'action'` → `VALIDATION_ERROR`.

Both failures were swallowed into the resolver's empty/disabled state, so the dropdown just looked empty.

## Change

- Add `ConnectorConfigInvocationContextSchema` (`kind: 'data-connector-config'`) to the lambda validator's `InvocationContextSchema` discriminated union. The tool executor already falls back gracefully for non-agent/action kinds.
- Drop the temporary resolver-failure `logger.warn`s added while diagnosing. The user-facing `disabledHint` messages (so a failed resolve explains *why* in the picker instead of looking like "no results") are kept.

## Verification

Reproduced live with the GitHub Issues connector: before, the `repo` combobox showed `Couldn't load options — the resolver failed`; the lambda logs showed the caller accepted but the payload rejected with `VALIDATION_ERROR`. After adding the schema, repos load from the connected account.

> Note: `apps/lambda` is the Deno service — needs a deploy for this to take effect in prod.