### PR TITLE
refactor(credentials): consolidate the credential-entry surfaces

### DIFF
--- a/apps/web/src/components/ai/ui/credential-configuration-dialog.tsx
+++ b/apps/web/src/components/ai/ui/credential-configuration-dialog.tsx
@@ -1,7 +1,6 @@
 // apps/web/src/components/ai/ui/credential-configuration-dialog.tsx
 'use client'
 
-import { HIDDEN_VALUE } from '@auxx/credentials/crypto/client'
 import { ModelType } from '@auxx/lib/ai/providers/types'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -22,11 +21,8 @@ import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { PlusIcon, Trash2 } from 'lucide-react'
 import type React from 'react'
 import { type FormEvent, useEffect, useMemo, useState } from 'react'
+import { useCredentialForm } from '~/components/connections/hooks/use-credential-form'
 import { ConnectionVariableFields } from '~/components/connections/ui/connection-variable-fields'
-import {
-  seedValue,
-  validateConnectionVariables,
-} from '~/components/connections/ui/connection-variable-validation'
 import { AiProviderPicker } from '~/components/pickers/ai-provider-picker'
 import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
 import { useConfirm } from '~/hooks/use-confirm'
@@ -91,8 +87,6 @@ export function CredentialConfigurationDialog({
   providers,
 }: CredentialConfigurationDialogProps) {
   const [selectedProvider, setSelectedProvider] = useState<string | null>(provider ?? null)
-  const [values, setValues] = useState<Record<string, string>>({})
-  const [errors, setErrors] = useState<Record<string, string>>({})
   const [modelIdValue, setModelIdValue] = useState(modelId ?? '')
   const [modelTypeValue, setModelTypeValue] = useState<ModelType>(ModelType.LLM)
   const [confirmDelete, ConfirmDialog] = useConfirm()
@@ -137,14 +131,15 @@ export function CredentialConfigurationDialog({
     )
   }, [providerCapabilities])
 
-  // Secret keys that arrived already set (seeded as the sentinel) get a masked Replace/Cancel
-  // affordance instead of an editable box.
-  const savedSecrets = useMemo(() => {
-    const keys = Object.entries(existingCredentials ?? {})
-      .filter(([, v]) => v === HIDDEN_VALUE)
-      .map(([k]) => k)
-    return new Set(keys)
-  }, [existingCredentials])
+  // Shared form lifecycle — field values/errors, seed-on-open, set-secret derivation, validation.
+  // `visibleFields` is already scope-filtered (provider vs model), so the hook stays AI-agnostic.
+  const needsLoad = operation === 'edit' && !!selectedProvider
+  const { values, setValue, errors, setErrors, savedSecrets, validate } = useCredentialForm({
+    open,
+    variables: visibleFields,
+    existingValues: existingCredentials,
+    loading: needsLoad && !existingCredentials,
+  })
 
   // Keep selectedProvider in sync with the prop when it changes.
   // biome-ignore lint/correctness/useExhaustiveDependencies: selectedProvider excluded to avoid a loop.
@@ -152,20 +147,14 @@ export function CredentialConfigurationDialog({
     if (provider && provider !== selectedProvider) setSelectedProvider(provider)
   }, [provider])
 
-  // Seed the form on open (and, for an edit, once the masked credentials load). Stored values win
-  // over declared defaults; secrets seed as the sentinel so an untouched key round-trips intact.
-  const needsLoad = operation === 'edit' && !!selectedProvider
-  // biome-ignore lint/correctness/useExhaustiveDependencies: seeds on open / provider / load.
+  // The custom-model id/type chrome is AI-only, so it seeds alongside the shared values effect on
+  // open / load.
   useEffect(() => {
-    if (!open || !providerCapabilities) return
+    if (!open) return
     if (needsLoad && !existingCredentials) return
-    const seeded: Record<string, string> = {}
-    for (const v of visibleFields) seeded[v.key] = seedValue(v, existingCredentials)
-    setValues(seeded)
     setModelIdValue(modelId ?? '')
     setModelTypeValue(availableModelTypes[0]?.value ?? ModelType.LLM)
-    setErrors({})
-  }, [open, providerCapabilities, visibleFields, needsLoad, existingCredentials, modelId])
+  }, [open, needsLoad, existingCredentials, modelId, availableModelTypes])
 
   const saveProviderConfiguration = api.aiIntegration.saveProviderConfiguration.useMutation({
     onSuccess: async (result) => {
@@ -241,13 +230,13 @@ export function CredentialConfigurationDialog({
     e.preventDefault()
     if (!selectedProvider || !providerCapabilities) return
 
-    const next = validateConnectionVariables({ variables: visibleFields, values })
+    const next = validate()
     if (mode === 'custom-model') {
       if (!modelIdValue.trim()) next.__modelId = 'Model ID is required'
       else if (!MODEL_ID_PATTERN.test(modelIdValue))
         next.__modelId = 'Only letters, numbers, hyphens, and underscores allowed'
+      setErrors(next)
     }
-    setErrors(next)
     if (Object.keys(next).length > 0) return
 
     const credentials = collectCredentials()
@@ -391,9 +380,7 @@ export function CredentialConfigurationDialog({
                       <ConnectionVariableFields
                         variables={visibleFields}
                         values={values}
-                        onValueChange={(key, value) =>
-                          setValues((prev) => ({ ...prev, [key]: value }))
-                        }
+                        onValueChange={setValue}
                         errors={errors}
                         savedSecrets={savedSecrets}
                       />

--- a/apps/web/src/components/connections/hooks/use-credential-form.ts
+++ b/apps/web/src/components/connections/hooks/use-credential-form.ts
@@ -1,0 +1,102 @@
+// apps/web/src/components/connections/hooks/use-credential-form.ts
+'use client'
+
+import { HIDDEN_VALUE } from '@auxx/credentials/crypto/client'
+import type { ConnectionVariable } from '@auxx/database'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  seedValue,
+  validateConnectionVariables,
+} from '~/components/connections/ui/connection-variable-validation'
+
+interface UseCredentialFormArgs {
+  /** Dialog open state — seeding only runs while open. */
+  open: boolean
+  /**
+   * The fields to render/seed/validate, already filtered to the currently-visible set (the AI
+   * provider-vs-model scoping stays in the AI wrapper, so the shared hook never sees it).
+   */
+  variables: ConnectionVariable[]
+  /**
+   * Masked stored values for an edit — secrets as the `HIDDEN_VALUE` sentinel, plain vars real
+   * (from `connections.getForEdit` / `aiIntegration.getCredentials`). Undefined for a fresh create.
+   */
+  existingValues?: Record<string, string>
+  /** True while an edit's stored values are still loading; seeding waits so it never flashes blank. */
+  loading?: boolean
+  /** Extra plain values to seed under `existingValues` (reconnect prefill). */
+  prefill?: Record<string, string>
+}
+
+interface UseCredentialFormResult {
+  /** Current field values (every visible variable, seeded then user-edited). */
+  values: Record<string, string>
+  /** Set a single field value. */
+  setValue: (key: string, value: string) => void
+  /** Replace the whole values bag (rarely needed; prefer `setValue`). */
+  setValues: React.Dispatch<React.SetStateAction<Record<string, string>>>
+  /** Field → message map (empty = valid). */
+  errors: Record<string, string>
+  setErrors: React.Dispatch<React.SetStateAction<Record<string, string>>>
+  /** Keys that arrived already set (seeded as the sentinel) — drive the masked Replace/Cancel UI. */
+  savedSecrets: Set<string>
+  /**
+   * Validate the visible fields with the shared rich ruleset, store the result, and return it.
+   * Pass `{ requireToken, token }` for a bare-secret method's token row.
+   */
+  validate: (extra?: { requireToken?: boolean; token?: string }) => Record<string, string>
+}
+
+/**
+ * Headless credential-form lifecycle shared by every credential edit surface (connections panel,
+ * AI page). Owns the field `values`/`errors` state, seeds it on open (declared defaults + reconnect
+ * prefill + masked stored values, waiting for the edit load), derives the set-secret `savedSecrets`,
+ * and validates with the one shared validator. Surface-specific chrome (a bare-secret token row, a
+ * connection name, the AI custom-model id/type) stays in the wrapping dialog.
+ */
+export function useCredentialForm({
+  open,
+  variables,
+  existingValues,
+  loading = false,
+  prefill,
+}: UseCredentialFormArgs): UseCredentialFormResult {
+  const [values, setValues] = useState<Record<string, string>>({})
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const setValue = useCallback((key: string, value: string) => {
+    setValues((prev) => ({ ...prev, [key]: value }))
+  }, [])
+
+  // Seed when the dialog opens (and, for an edit, once the masked values have loaded so we don't
+  // flash blank then clobber keystrokes). Stored values win over the caller's prefill; declared
+  // defaults fill anything neither supplies, and secrets seed as the sentinel so an untouched key
+  // round-trips intact.
+  useEffect(() => {
+    if (!open || loading) return
+    const merged = { ...prefill, ...existingValues }
+    const seeded: Record<string, string> = {}
+    for (const v of variables) seeded[v.key] = seedValue(v, merged)
+    setValues(seeded)
+    setErrors({})
+  }, [open, loading, variables, existingValues, prefill])
+
+  // Secret keys that arrived already set (seeded as the sentinel) can be reverted to "keep existing".
+  const savedSecrets = useMemo(() => {
+    const keys = Object.entries(existingValues ?? {})
+      .filter(([, v]) => v === HIDDEN_VALUE)
+      .map(([k]) => k)
+    return new Set(keys)
+  }, [existingValues])
+
+  const validate = useCallback(
+    (extra?: { requireToken?: boolean; token?: string }) => {
+      const next = validateConnectionVariables({ variables, values, ...extra })
+      setErrors(next)
+      return next
+    },
+    [variables, values]
+  )
+
+  return { values, setValue, setValues, errors, setErrors, savedSecrets, validate }
+}

--- a/apps/web/src/components/connections/ui/connection-detail-dialog.tsx
+++ b/apps/web/src/components/connections/ui/connection-detail-dialog.tsx
@@ -14,13 +14,13 @@ import {
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import type { FormEvent } from 'react'
 import { useEffect, useMemo, useState } from 'react'
+import { useCredentialForm } from '~/components/connections/hooks/use-credential-form'
 import { api } from '~/trpc/react'
 import {
   ConnectionDetailPage,
   type DetailMethod,
   methodIsBareSecret,
 } from './connection-detail-page'
-import { seedValue, validateConnectionVariables } from './connection-variable-validation'
 
 interface ConnectionDetailDialogProps {
   open: boolean
@@ -83,10 +83,8 @@ export function ConnectionDetailDialog({
   reconnectLabel = 'Reconnect',
   onSubmit,
 }: ConnectionDetailDialogProps) {
-  const [values, setValues] = useState<Record<string, string>>({})
   const [token, setToken] = useState('')
   const [name, setName] = useState('')
-  const [errors, setErrors] = useState<Record<string, string>>({})
 
   // Stable across renders so the seed effect only fires on open / method change, not every render
   // (a bare method's `?? []` would otherwise re-seed and wipe input on each render).
@@ -99,47 +97,35 @@ export function ConnectionDetailDialog({
     { connectionId: connectionId ?? '' },
     { enabled: open && needsLoad }
   )
-
-  // Seed the form when the dialog opens (and, for an edit, once the masked values have loaded so we
-  // don't first flash blank then clobber the user's keystrokes). `getForEdit` values win over the
-  // caller's `prefill`; declared defaults fill anything neither supplies.
   const loaded = editLoad.data
+
+  // Shared form lifecycle — field values/errors, seed-on-open, set-secret derivation, validation.
+  const { values, setValue, errors, savedSecrets, validate } = useCredentialForm({
+    open,
+    variables,
+    existingValues: loaded?.values,
+    loading: needsLoad && !loaded,
+    prefill,
+  })
+
+  // Token + name are connection-specific (a bare API-key row, the editable connection name), so
+  // they seed alongside the shared values effect on open / load.
   useEffect(() => {
     if (!open) return
     if (needsLoad && !loaded) return
-    const merged = { ...prefill, ...(loaded?.values ?? {}) }
-    const seeded: Record<string, string> = {}
-    for (const v of variables) seeded[v.key] = seedValue(v, merged)
-    setValues(seeded)
     setToken(loaded?.tokenSet ? HIDDEN_VALUE : '')
     setName(initialName ?? method.label)
-    setErrors({})
-  }, [open, prefill, variables, needsLoad, loaded, initialName, method.label])
+  }, [open, needsLoad, loaded, initialName, method.label])
 
   const bareSecret = methodIsBareSecret(method)
   const formPending = pending || (needsLoad && !loaded)
-
-  // Secret fields that arrived already set (seeded as the sentinel) can be reverted to "keep
-  // existing" after the user starts editing them.
-  const savedSecrets = useMemo(() => {
-    const keys = Object.entries(loaded?.values ?? {})
-      .filter(([, v]) => v === HIDDEN_VALUE)
-      .map(([k]) => k)
-    return new Set(keys)
-  }, [loaded])
 
   // A bare-OAuth method has neither a token row nor variables — its edit dialog is name-only.
   const hasFields = bareSecret || variables.length > 0
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
-    const next = validateConnectionVariables({
-      variables,
-      values,
-      requireToken: bareSecret,
-      token,
-    })
-    setErrors(next)
+    const next = validate({ requireToken: bareSecret, token })
     if (Object.keys(next).length > 0) return
     const payload: { values?: Record<string, string>; secret?: string; name?: string } = {}
     if (showName) payload.name = name.trim()
@@ -175,7 +161,7 @@ export function ConnectionDetailDialog({
             selectedMethodId={method.id}
             onMethodChange={() => {}}
             values={values}
-            onValueChange={(key, value) => setValues((prev) => ({ ...prev, [key]: value }))}
+            onValueChange={setValue}
             token={token}
             onTokenChange={setToken}
             errors={errors}

--- a/apps/web/src/server/api/routers/apps.ts
+++ b/apps/web/src/server/api/routers/apps.ts
@@ -1,6 +1,6 @@
 // apps/web/src/server/api/routers/apps.ts
 
-import { isMasked, type MaskField, resolveForWrite } from '@auxx/credentials/crypto'
+import { isMasked, splitConnectionValues } from '@auxx/credentials/crypto'
 import { setDefaultCredential } from '@auxx/credentials/store'
 import {
   deleteAppConnection,
@@ -487,15 +487,14 @@ export const appsRouter = createTRPCRouter({
         // submitted as the sentinel) so editing one field never overwrites the others.
         const trimmed: Record<string, string> = {}
         for (const [key, value] of Object.entries(provided)) trimmed[key] = value?.trim() ?? ''
-        const fields: MaskField[] = variableDefs.map((v) => ({ key: v.key, secret: !!v.secret }))
-        const resolved = resolveForWrite(trimmed, fields)
+        const resolved = splitConnectionValues(variableDefs, trimmed)
 
         const secretFields: Record<string, string> = {}
-        for (const [key, value] of Object.entries(resolved.secrets)) {
+        for (const [key, value] of Object.entries(resolved.secretFields)) {
           if (value !== '') secretFields[key] = value
         }
         const plainValues: Record<string, string> = {}
-        for (const [key, value] of Object.entries(resolved.plain)) {
+        for (const [key, value] of Object.entries(resolved.plainVariables)) {
           if (value !== '') plainValues[key] = value
         }
 

--- a/apps/web/src/server/api/routers/connections.ts
+++ b/apps/web/src/server/api/routers/connections.ts
@@ -1,6 +1,6 @@
 // apps/web/src/server/api/routers/connections.ts
 
-import { isMasked, type MaskField, maskForEdit, resolveForWrite } from '@auxx/credentials/crypto'
+import { isMasked, projectCredentialForEdit, splitConnectionValues } from '@auxx/credentials/crypto'
 import {
   deleteCredential,
   listCredentials,
@@ -317,12 +317,8 @@ export const connectionsRouter = createTRPCRouter({
         const metadata = (record.metadata ?? {}) as Record<string, unknown>
         const plainVars = (metadata.connectionVariables ?? {}) as Record<string, unknown>
         const secretFields = (secrets.fields ?? {}) as Record<string, unknown>
-        const fields: MaskField[] = vars.map((v) => ({ key: v.key, secret: !!v.secret }))
-        const stored: Record<string, unknown> = {}
-        for (const field of fields) {
-          stored[field.key] = field.secret ? secretFields[field.key] : plainVars[field.key]
-        }
-        return { values: maskForEdit(fields, stored), tokenSet: false }
+        const values = projectCredentialForEdit(vars, { plain: plainVars, secrets: secretFields })
+        return { values, tokenSet: false }
       }
 
       // Bare API-key (or definition-less): report only whether some secret is stored — a boolean,
@@ -374,13 +370,9 @@ export const connectionsRouter = createTRPCRouter({
       // encrypt under `secrets.fields`, plain ones ride in plaintext metadata. `resolveForWrite`
       // drops any masked echo (an unchanged secret submitted as the `HIDDEN_VALUE` sentinel) so the
       // edit/reconnect merge keeps the stored value instead of overwriting it.
-      const fields: MaskField[] = (def.connectionVariables ?? []).map((v) => ({
-        key: v.key,
-        secret: !!v.secret,
-      }))
-      const { secrets: secretFields, plain: plainVariables } = resolveForWrite(
-        input.values ?? {},
-        fields
+      const { secretFields, plainVariables } = splitConnectionValues(
+        def.connectionVariables ?? [],
+        input.values ?? {}
       )
       // Bare API-key definitions (no connection variables): drop an unchanged sentinel the same way.
       const secret =

--- a/packages/credentials/src/crypto/__tests__/secret-mask.test.ts
+++ b/packages/credentials/src/crypto/__tests__/secret-mask.test.ts
@@ -1,7 +1,15 @@
 // packages/credentials/src/crypto/__tests__/secret-mask.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { HIDDEN_VALUE, isMasked, type MaskField, maskForEdit, resolveForWrite } from '../client'
+import {
+  HIDDEN_VALUE,
+  isMasked,
+  type MaskField,
+  maskForEdit,
+  projectCredentialForEdit,
+  resolveForWrite,
+  splitConnectionValues,
+} from '../client'
 
 const FIELDS: MaskField[] = [
   { key: 'host', secret: false },
@@ -49,5 +57,50 @@ describe('resolveForWrite', () => {
     const { secrets, plain } = resolveForWrite({ rogue: 'x', apiKey: 'k' }, FIELDS)
     expect(secrets).toEqual({ apiKey: 'k' })
     expect(plain).toEqual({})
+  })
+})
+
+const VARS = [
+  { key: 'host', secret: false },
+  { key: 'apiKey', secret: true },
+]
+
+describe('splitConnectionValues', () => {
+  it('splits by the definition flags, dropping a masked secret echo and undeclared keys', () => {
+    const { secretFields, plainVariables } = splitConnectionValues(VARS, {
+      host: 'new-host',
+      apiKey: HIDDEN_VALUE,
+      rogue: 'leak',
+    })
+    expect(secretFields).toEqual({}) // unchanged secret → dropped → store merge keeps existing
+    expect(plainVariables).toEqual({ host: 'new-host' })
+
+    const changed = splitConnectionValues(VARS, { host: 'h', apiKey: 'rotated' })
+    expect(changed.secretFields).toEqual({ apiKey: 'rotated' })
+    expect(changed.plainVariables).toEqual({ host: 'h' })
+  })
+})
+
+describe('projectCredentialForEdit', () => {
+  it('masks set secrets, returns plain values real, and excludes undeclared keys', () => {
+    const values = projectCredentialForEdit(VARS, {
+      plain: { host: 'db.example.com', rogue: 'leak' },
+      secrets: { apiKey: 'super-secret' },
+    })
+    expect(values).toEqual({ host: 'db.example.com', apiKey: HIDDEN_VALUE })
+    expect('rogue' in values).toBe(false)
+  })
+
+  it('accepts one merged bag for both plain and secret sources', () => {
+    const merged = { host: 'db.example.com', apiKey: 'super-secret' }
+    const values = projectCredentialForEdit(VARS, { plain: merged, secrets: merged })
+    expect(values).toEqual({ host: 'db.example.com', apiKey: HIDDEN_VALUE })
+  })
+
+  it('emits empty string for an unset secret and a missing plain value', () => {
+    expect(projectCredentialForEdit(VARS, { plain: {}, secrets: {} })).toEqual({
+      host: '',
+      apiKey: '',
+    })
   })
 })

--- a/packages/credentials/src/crypto/client.ts
+++ b/packages/credentials/src/crypto/client.ts
@@ -77,3 +77,44 @@ export function resolveForWrite(
   }
   return { secrets, plain }
 }
+
+/** A connection definition's variable, reduced to what the split/projection core needs. */
+export type ConnectionVariableFlag = { key: string; secret?: boolean }
+
+/**
+ * The single secret-split primitive for every credential-saving surface (connections, AI,
+ * apps, MCP): split a submitted form bag into the secret-flagged and plain values to persist,
+ * keyed by a connection definition's variable flags. A thin convenience over `resolveForWrite`
+ * that takes `ConnectionVariable[]` directly so callers don't hand-build `MaskField[]`.
+ *
+ * Masked echoes are dropped (the store merge keeps the existing secret) and only declared
+ * variables are emitted, so undeclared/system keys are structurally excluded.
+ */
+export function splitConnectionValues(
+  variables: ConnectionVariableFlag[],
+  values: Record<string, string>
+): { secretFields: Record<string, string>; plainVariables: Record<string, string> } {
+  const fields: MaskField[] = variables.map((v) => ({ key: v.key, secret: !!v.secret }))
+  const { secrets, plain } = resolveForWrite(values, fields)
+  return { secretFields: secrets, plainVariables: plain }
+}
+
+/**
+ * The single masked read-projection for every credential edit form (connections, AI): project a
+ * credential's stored bag into the shape the edit form seeds with — secret fields become the
+ * `HIDDEN_VALUE` "is set" sentinel (the real secret never leaves the server), plain fields come
+ * back real. `stored` carries the plain and secret sources separately (e.g. plain vars from
+ * `metadata.connectionVariables`, secrets from the revealed `secrets.fields` bag); pass the same
+ * flat bag for both when callers already hold a merged record. Only declared variables are emitted.
+ */
+export function projectCredentialForEdit(
+  variables: ConnectionVariableFlag[],
+  stored: { plain: Record<string, unknown>; secrets: Record<string, unknown> }
+): Record<string, string> {
+  const fields: MaskField[] = variables.map((v) => ({ key: v.key, secret: !!v.secret }))
+  const merged: Record<string, unknown> = {}
+  for (const field of fields) {
+    merged[field.key] = field.secret ? stored.secrets[field.key] : stored.plain[field.key]
+  }
+  return maskForEdit(fields, merged)
+}

--- a/packages/credentials/src/crypto/index.ts
+++ b/packages/credentials/src/crypto/index.ts
@@ -1,11 +1,14 @@
 // packages/credentials/src/crypto/index.ts
 
 export {
+  type ConnectionVariableFlag,
   HIDDEN_VALUE,
   isMasked,
   type MaskField,
   maskForEdit,
+  projectCredentialForEdit,
   resolveForWrite,
+  splitConnectionValues,
 } from './client'
 export {
   decryptSecrets,

--- a/packages/lib/src/ai/providers/config/byo-store.ts
+++ b/packages/lib/src/ai/providers/config/byo-store.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/ai/providers/config/byo-store.ts
 
-import { isMasked } from '@auxx/credentials/crypto'
+import { splitConnectionValues } from '@auxx/credentials/crypto'
 import {
   deleteCredential,
   findCredential,
@@ -42,29 +42,24 @@ export async function resolveConnectionDefinition(
 }
 
 /**
- * Split canonical AI credentials into secret-flagged vs plain variables (per the
- * blueprint's connectionVariables), dropping empty and masked echoes so an unchanged
- * secret never overwrites the stored value.
+ * Split canonical AI credentials into secret-flagged vs plain variables. A thin adapter over the
+ * shared `splitConnectionValues` primitive that resolves the provider's blueprint
+ * connectionVariables first (the AI-specific part) and normalizes/drops empty values before the
+ * shared def-flag split — the secret/plain decision and masked-echo dropping are single-sourced.
  */
 export function splitAiCredentials(
   providerKey: string,
   credentials: Record<string, any>
 ): { secretFields: Record<string, string>; plainVariables: Record<string, string> } {
   const def = getProviderByKey(providerKey)
-  const secretKeys = new Set(
-    (def?.connectionVariables ?? []).filter((v) => v.secret).map((v) => v.key)
-  )
-  const secretFields: Record<string, string> = {}
-  const plainVariables: Record<string, string> = {}
+  // Normalize to strings and drop empties so a blank field never overwrites a stored value with
+  // '' (AI-specific; the connections/apps surfaces drop empties at their own call sites).
+  const values: Record<string, string> = {}
   for (const [key, value] of Object.entries(credentials)) {
     if (value === undefined || value === null || value === '') continue
-    const str = String(value)
-    // Never persist a masked echo (HIDDEN_VALUE or the legacy '[**HIDDEN**]' sentinel).
-    if (isMasked(str) || str === '[**HIDDEN**]') continue
-    if (secretKeys.has(key)) secretFields[key] = str
-    else plainVariables[key] = str
+    values[key] = String(value)
   }
-  return { secretFields, plainVariables }
+  return splitConnectionValues(def?.connectionVariables ?? [], values)
 }
 
 /** Reveal a credential's canonical field bag (plain connectionVariables + secret fields). */

--- a/packages/lib/src/ai/providers/config/cache.ts
+++ b/packages/lib/src/ai/providers/config/cache.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/ai/providers/config/cache.ts
 
-import { maskForEdit } from '@auxx/credentials/crypto'
+import { projectCredentialForEdit } from '@auxx/credentials/crypto'
 import { getOrgCache } from '../../../cache/singletons'
 import { createScopedLogger } from '../../../logger'
 import { ProviderRegistry } from '../provider-registry'
@@ -130,11 +130,15 @@ async function obfuscateResult(
 ): Promise<CredentialsResponse> {
   const providerCaps = await ProviderRegistry.getProviderCapabilities(provider)
   if (providerCaps?.connectionVariables) {
-    const fields = providerCaps.connectionVariables.map((field) => ({
-      key: field.key,
-      secret: !!field.secret,
-    }))
-    return { ...result, credentials: maskForEdit(fields, result.credentials) }
+    // The cached result is an already-merged flat bag (plain + secret), so it serves as both the
+    // plain and secret source for the shared edit projection.
+    return {
+      ...result,
+      credentials: projectCredentialForEdit(providerCaps.connectionVariables, {
+        plain: result.credentials,
+        secrets: result.credentials,
+      }),
+    }
   }
   return result
 }


### PR DESCRIPTION
Implements §2–§4 of `plans/data-connectors/v5/credential-surfaces-consolidation-plan.md`. Secret storage was already single-sourced; this collapses the duplicated *orchestration* around it.

## Changes

**§2 — one secret-split primitive**
- Add `splitConnectionValues(variables, values)` to `@auxx/credentials/crypto` (thin convenience over `resolveForWrite`, exported from the crypto index).
- `splitAiCredentials` becomes a thin adapter over it (keeps only the AI-specific provider→blueprint resolution + empty-drop).
- Route the connections `save` router and apps `saveSecretConnection` router through it, dropping their hand-built `MaskField[]`.

**§3 — one masked read-projection**
- Add `projectCredentialForEdit(variables, { plain, secrets })`.
- Re-point `connections.getForEdit` and the AI `obfuscateResult` (cache.ts) at it.

**§4.A — shared `useCredentialForm` hook**
- New `apps/web/src/components/connections/hooks/use-credential-form.ts` owns the duplicated lifecycle (`values`/`errors` state, seed-on-open, `savedSecrets`, validation).
- `ConnectionDetailDialog` and the AI `CredentialConfigurationDialog` both consume it; each keeps only its surface-specific chrome (token/name vs custom-model id/type + provider-vs-model scoping).

## Tests
- Extended `secret-mask.test.ts` with cases for both new primitives.
- `@auxx/credentials` (81) and the connections/apps lib suites (63) pass; Biome clean.

## Notes / deviations
- **§2.3 was partly outdated:** the plan lists `pickSecrets` as a secret-split helper, but in current code it's a token-bag *assembler* receiving already-split fields — the real app-side split lived in `apps.ts` (now routed through `splitConnectionValues`). The three identical `pickSecrets` bag-assemblers are a separate, out-of-scope triplication and were left alone.
- **§5 deferred:** designating a single canonical edit surface (AI page deep-links to the connections editor) is a user-visible UX change the plan gates on a product decision. §2–§4 already make both surfaces byte-identical, so §5 is purely cosmetic and not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)