### PR TITLE
feat(logger): searchable dev log history via OpenObserve

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,23 @@ REDIS_PORT=6379
 # APP_NAME=auxx-ai
 
 # ------------------------------------
+# Log history (OpenObserve) — dev only
+# ------------------------------------
+# `pnpm dev` starts the openobserve container and apps ship logs to it
+# automatically in dev. UI: http://localhost:5080 (stream `auxx`).
+# Credentials below must match the docker-compose `openobserve` service.
+OPENOBSERVE_EMAIL=root@auxx.dev
+# Quoted because Node's --env-file (used by the worker) treats an unquoted # as a comment.
+OPENOBSERVE_PASSWORD="Complexpass#123"
+# Turn log shipping off entirely:
+# OPENOBSERVE_DISABLE=true
+# Override the target (e.g. a remote collector):
+# OPENOBSERVE_URL=http://localhost:5080
+# OPENOBSERVE_ORG=default
+# OPENOBSERVE_STREAM=auxx
+# OPENOBSERVE_PORT=5080
+
+# ------------------------------------
 # Storage (S3 / S3-compatible)
 # ------------------------------------
 FILE_STORAGE_TYPE=s3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,19 @@ npx dotenv -- npx tsx path/to/script.ts
 
 ---
 
+# Viewing Logs (dev)
+
+`@auxx/logger` prints to the console AND ships structured logs to a local **OpenObserve** instance that `pnpm dev` starts automatically (dev-only). Use it to search/review log history instead of scrolling the terminal.
+
+- **UI**: http://localhost:5080 → _Logs_ → stream `auxx`
+- **Login**: `root@auxx.dev` / `Complexpass#123` (local dev only — not a secret)
+- Every entry has `level`, `scope`, `app` (`@auxx/web` / `@auxx/worker` / …), `message`, plus any `.with({...})` fields. Filter with SQL, e.g. `level='error'`, `scope='billing'`, `app='@auxx/worker'`, or full-text `match_all('stripe')`.
+- Querying the API directly (Basic auth): `POST http://localhost:5080/api/default/_search?type=logs` with a SQL body.
+
+Full details (how it works, turning it off): `docs/log-history.md`.
+
+---
+
 # Ops Reference (Railway, AWS)
 
 For Railway (production) and AWS (dev) commands — log tailing, service status, RDS, ECS — read `docs/ops-reference.md`. Pull it in when the user asks about deploys, prod logs, or infrastructure debugging.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,7 @@
 // apps/api/src/index.ts
 
+// Side-effect import: registers the OpenObserve log sink when OPENOBSERVE_URL is set.
+import '@auxx/logger/openobserve'
 import { configService } from '@auxx/credentials'
 import { initGeo } from '@auxx/lib/geo'
 import { createScopedLogger } from '@auxx/logger'

--- a/apps/web/src/server/bootstrap.ts
+++ b/apps/web/src/server/bootstrap.ts
@@ -2,6 +2,8 @@
 
 import 'server-only'
 
+// Side-effect import: registers the OpenObserve log sink when OPENOBSERVE_URL is set.
+import '@auxx/logger/openobserve'
 import { configService } from '@auxx/credentials'
 import { registerChannelHooks } from '@auxx/lib/channels'
 import { createScopedLogger } from '@auxx/logger'

--- a/apps/worker/src/server.ts
+++ b/apps/worker/src/server.ts
@@ -1,5 +1,7 @@
 // apps/worker/src/server.ts
 
+// Side-effect import: registers the OpenObserve log sink when OPENOBSERVE_URL is set.
+import '@auxx/logger/openobserve'
 import { getDevPort } from '@auxx/config/server'
 import { configService } from '@auxx/credentials'
 import { closePools } from '@auxx/database'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,21 @@ services:
       timeout: 5s
       retries: 5
 
+  # Searchable log history UI. Apps ship structured logs here via
+  # @auxx/logger/openobserve when OPENOBSERVE_URL is set. UI at http://localhost:5080
+  openobserve:
+    image: public.ecr.aws/zinclabs/openobserve:latest
+    restart: unless-stopped
+    environment:
+      ZO_ROOT_USER_EMAIL: ${OPENOBSERVE_EMAIL:-root@auxx.dev}
+      ZO_ROOT_USER_PASSWORD: ${OPENOBSERVE_PASSWORD:-Complexpass#123}
+      ZO_DATA_DIR: /data
+    ports:
+      - "${OPENOBSERVE_PORT:-5080}:5080"
+    volumes:
+      - openobserve_data:/data
+
 volumes:
   postgres_data:
   redis_data:
+  openobserve_data:

--- a/docs/log-history.md
+++ b/docs/log-history.md
@@ -1,0 +1,59 @@
+# Log history (OpenObserve)
+
+`@auxx/logger` writes to the console for live debugging. To **review and search
+older logs** in a browser, we ship the same structured records to a local
+[OpenObserve](https://openobserve.ai) instance.
+
+This is a **dev-only** setup that's **on by default** — it works the same way
+postgres and redis do. `pnpm dev` runs `docker compose up -d`, which starts the
+`openobserve` container alongside the rest of the stack, and the apps ship logs
+to it automatically in development.
+
+## Usage
+
+1. `pnpm dev` (from the repo root) — starts the collector and apps. Make sure
+   the `OPENOBSERVE_*` block from `.env.example` is present in your `.env`.
+
+2. Open the UI: **http://localhost:5080** → _Logs_ → stream `auxx`. Log in with
+   `OPENOBSERVE_EMAIL` / `OPENOBSERVE_PASSWORD` (defaults
+   `root@auxx.dev` / `Complexpass#123`).
+
+Logs from `web`, `worker`, and `api` all flow into the `auxx` stream, tagged by
+`app`.
+
+### Turning it off
+
+Set `OPENOBSERVE_DISABLE=true` in your `.env` to stop shipping logs (the console
+output is unchanged). The container still starts with `pnpm dev`; run
+`docker compose stop openobserve` if you don't want it running at all.
+
+In **production** the sink stays inactive unless `OPENOBSERVE_URL` is set
+explicitly.
+
+## Searching
+
+Each entry is structured, so you can filter instead of grepping:
+
+- `level='error'`
+- `scope='billing'`
+- `app='@auxx/worker'`
+- free-text match on `message`
+- any field added via `logger.with({ ... })` becomes a queryable column
+- time-range picker for "what happened recently"
+
+## How it works
+
+- `packages/logger/src/index.ts` emits a structured `LogRecord`
+  (`time`, `level`, `scope`, `message`, `args`, `fields`) to every registered
+  sink, in addition to the console line.
+- `packages/logger/src/openobserve.ts` is a side-effect module that registers an
+  HTTP sink. Outside production it defaults to `http://localhost:5080`
+  (override with `OPENOBSERVE_URL`, disable with `OPENOBSERVE_DISABLE=true`). It
+  batches records and POSTs them to OpenObserve's ingest endpoint; failures are
+  swallowed so a down collector never affects the app.
+- The long-running processes import it once at startup:
+  `apps/worker/src/server.ts`, `apps/api/src/index.ts`, and
+  `apps/web/src/server/bootstrap.ts`.
+
+Sensitive fields (password/secret/token/apikey) are already redacted by the
+logger's `sanitizeLogValue` before they reach any sink.

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -15,6 +15,12 @@
       "source": "./src/run-log.ts",
       "import": "./dist/run-log.mjs",
       "default": "./src/run-log.ts"
+    },
+    "./openobserve": {
+      "types": "./src/openobserve.ts",
+      "source": "./src/openobserve.ts",
+      "import": "./dist/openobserve.mjs",
+      "default": "./src/openobserve.ts"
     }
   },
   "scripts": {

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,7 +1,8 @@
 // packages/logger/src/index.ts
 
 // ---------------------------------------------------------------------------
-// Run-scoped file sink hook (set by @auxx/logger/run-log on import)
+// Log sinks (registered by side-effect modules like `@auxx/logger/run-log`
+// and `@auxx/logger/openobserve` on import)
 // ---------------------------------------------------------------------------
 
 export interface RunLogEntryMeta {
@@ -9,20 +10,48 @@ export interface RunLogEntryMeta {
   level: LogLevel
 }
 
-type WriteToRunLogFn = (message: string, meta: RunLogEntryMeta) => void
-
-let _writeToRunLog: WriteToRunLogFn | undefined
-
-/**
- * Register the run-log writer. Called by `@auxx/logger/run-log` on import.
- * Keeps the main entry point free of Node.js imports (browser-safe).
- */
-export function _registerRunLogWriter(fn: WriteToRunLogFn): void {
-  _writeToRunLog = fn
+/** Structured record handed to every registered sink alongside the formatted line. */
+export interface LogRecord extends RunLogEntryMeta {
+  /** ISO-8601 timestamp for when the entry was emitted. */
+  time: string
+  /** Raw (unformatted) log message. */
+  message: string
+  /** Sanitized positional args passed after the message. */
+  args: unknown[]
+  /** Sanitized contextual fields accumulated via `.with()`. */
+  fields: Record<string, unknown>
 }
 
-function writeToRunLog(message: string, meta: RunLogEntryMeta): void {
-  _writeToRunLog?.(message, meta)
+/** A sink receives both the human-formatted line and the structured record. */
+export type LogSink = (formatted: string, record: LogRecord) => void
+
+const sinks: LogSink[] = []
+
+/**
+ * Register a log sink. Called by side-effect modules (`@auxx/logger/run-log`,
+ * `@auxx/logger/openobserve`) on import. Lives in the main entry point, which
+ * stays free of Node.js imports so it remains browser-safe.
+ */
+export function registerLogSink(sink: LogSink): void {
+  sinks.push(sink)
+}
+
+/**
+ * Back-compat shim for the run-log file sink, which only needs the formatted
+ * line + scope/level. Prefer `registerLogSink` for new sinks.
+ */
+export function _registerRunLogWriter(fn: (message: string, meta: RunLogEntryMeta) => void): void {
+  sinks.push((formatted, record) => fn(formatted, record))
+}
+
+function emitToSinks(formatted: string, record: LogRecord): void {
+  for (const sink of sinks) {
+    try {
+      sink(formatted, record)
+    } catch {
+      // A misbehaving sink must never break logging.
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -183,15 +212,11 @@ export function createScopedLogger(scope: string, options?: { color?: ColorName 
    * Builds a logger with contextual fields that are appended to each message.
    */
   const createLogger = (fields: Record<string, unknown> = {}): Logger => {
-    const formatMessage = (level: LogLevel, message: string, args: unknown[]) => {
-      const allArgs = [...args]
-      if (Object.keys(fields).length > 0) {
-        allArgs.push(fields)
-      }
-
-      const formattedArgs = allArgs
-        .map((arg) => sanitizeLogValue(arg))
-        .map((arg) => (typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)))
+    const formatMessage = (level: LogLevel, message: string, sanitizedArgs: unknown[]) => {
+      const formattedArgs = sanitizedArgs
+        .map((arg) =>
+          typeof arg === 'object' && arg !== null ? JSON.stringify(arg, null, 2) : String(arg)
+        )
         .join(' ')
 
       const nowDate = new Date()
@@ -213,9 +238,27 @@ export function createScopedLogger(scope: string, options?: { color?: ColorName 
       message: string,
       args: unknown[]
     ) => {
-      const formatted = formatMessage(level, message, args)
+      const sanitizedArgs = args.map((arg) => sanitizeLogValue(arg))
+      const sanitizedFields = sanitizeLogValue(fields) as Record<string, unknown>
+      const hasFields = Object.keys(fields).length > 0
+
+      const formatted = formatMessage(
+        level,
+        message,
+        hasFields ? [...sanitizedArgs, sanitizedFields] : sanitizedArgs
+      )
       consoleFn(formatted)
-      writeToRunLog(formatted, { scope, level })
+
+      if (sinks.length > 0) {
+        emitToSinks(formatted, {
+          time: new Date().toISOString(),
+          scope,
+          level,
+          message,
+          args: sanitizedArgs,
+          fields: sanitizedFields,
+        })
+      }
     }
 
     return {

--- a/packages/logger/src/openobserve.ts
+++ b/packages/logger/src/openobserve.ts
@@ -1,0 +1,93 @@
+// packages/logger/src/openobserve.ts
+
+import { type LogRecord, registerLogSink } from './index'
+
+/**
+ * Ships structured log records to a local OpenObserve instance over HTTP.
+ *
+ * Dev-focused and on by default: `pnpm dev` starts the `openobserve` container
+ * (docker-compose), so outside production the sink defaults to the local
+ * instance at http://localhost:5080. Override the target with `OPENOBSERVE_URL`,
+ * or turn it off entirely with `OPENOBSERVE_DISABLE=true`. In production the sink
+ * stays inactive unless `OPENOBSERVE_URL` is set explicitly.
+ *
+ * Import this module once per long-running process (worker, api, web bootstrap)
+ * for its side effect of registering the sink. Records are batched and flushed
+ * on a short interval so logging stays non-blocking; failures are swallowed so a
+ * missing/down collector never affects the app.
+ */
+
+const IS_PRODUCTION = process.env.NODE_ENV === 'production'
+const DISABLED =
+  process.env.OPENOBSERVE_DISABLE === 'true' || process.env.OPENOBSERVE_DISABLE === '1'
+
+// Explicit URL always wins; otherwise default to the local container in dev.
+const RESOLVED_URL = DISABLED
+  ? undefined
+  : (process.env.OPENOBSERVE_URL ?? (IS_PRODUCTION ? undefined : 'http://localhost:5080'))
+
+const BASE_URL = RESOLVED_URL?.replace(/\/$/, '')
+const ORG = process.env.OPENOBSERVE_ORG ?? 'default'
+const STREAM = process.env.OPENOBSERVE_STREAM ?? 'auxx'
+// Defaults mirror the docker-compose `openobserve` service root credentials.
+const EMAIL = process.env.OPENOBSERVE_EMAIL ?? 'root@auxx.dev'
+const PASSWORD = process.env.OPENOBSERVE_PASSWORD ?? 'Complexpass#123'
+const APP =
+  process.env.APP_NAME ?? process.env.SERVICE_NAME ?? process.env.npm_package_name ?? 'app'
+
+const MAX_BATCH = 100
+const FLUSH_MS = 2000
+
+if (BASE_URL) {
+  const endpoint = `${BASE_URL}/api/${ORG}/${STREAM}/_json`
+  const auth = `Basic ${Buffer.from(`${EMAIL}:${PASSWORD}`).toString('base64')}`
+
+  const queue: Record<string, unknown>[] = []
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let flushing = false
+
+  const flush = async (): Promise<void> => {
+    if (flushing || queue.length === 0) return
+    flushing = true
+    const batch = queue.splice(0, queue.length)
+    try {
+      await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: auth },
+        body: JSON.stringify(batch),
+      })
+    } catch {
+      // Dev-only sink: drop the batch rather than crash or block on a down collector.
+    } finally {
+      flushing = false
+    }
+  }
+
+  const schedule = (): void => {
+    if (timer) return
+    timer = setTimeout(() => {
+      timer = undefined
+      void flush()
+    }, FLUSH_MS)
+    // Don't keep the event loop alive just to flush logs.
+    timer.unref?.()
+  }
+
+  registerLogSink((_formatted: string, record: LogRecord) => {
+    queue.push({
+      // OpenObserve reads the entry time from `_timestamp` (microseconds since epoch).
+      _timestamp: new Date(record.time).getTime() * 1000,
+      level: record.level,
+      scope: record.scope,
+      app: APP,
+      message: record.message,
+      ...record.fields,
+      ...(record.args.length > 0 ? { args: record.args } : {}),
+    })
+    if (queue.length >= MAX_BATCH) void flush()
+    else schedule()
+  })
+
+  // Best-effort final flush so the last lines before exit aren't lost.
+  process.once('beforeExit', () => void flush())
+}

--- a/packages/logger/tsdown.config.ts
+++ b/packages/logger/tsdown.config.ts
@@ -2,7 +2,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/run-log.ts'],
+  entry: ['src/index.ts', 'src/run-log.ts', 'src/openobserve.ts'],
   format: 'esm',
   target: 'es2022',
   platform: 'node',

--- a/setup.sh
+++ b/setup.sh
@@ -116,6 +116,10 @@ if [ "$FILL_MODE" = true ]; then
   fill_if_empty "LOGIN_TOKEN_PRIVATE_KEY" "$LOGIN_TOKEN_PRIVATE_KEY"
   fill_if_empty "LOGIN_TOKEN_PUBLIC_KEY" "$LOGIN_TOKEN_PUBLIC_KEY"
   fill_if_empty "BUILD_SESSION_SECRET" "$BUILD_SESSION_SECRET"
+  # Log history (OpenObserve) — must match the docker-compose `openobserve` service
+  fill_if_empty "OPENOBSERVE_EMAIL" "root@auxx.dev"
+  # Quoted: Node's --env-file (worker) treats an unquoted # as a comment.
+  fill_if_empty "OPENOBSERVE_PASSWORD" '"Complexpass#123"'
 
   # Rebuild DATABASE_URL if it contains a stale password
   DB_PASS=$(grep "^DATABASE_PASSWORD=" .env | cut -d'=' -f2- | tr -d '"')


### PR DESCRIPTION
## What

Adds a browser-searchable history of our logs for dev debugging, layered on top of the existing console output. `@auxx/logger` still prints to the console exactly as before, and now also ships structured records to a local **OpenObserve** instance you can browse at **http://localhost:5080**.

## Why

The console is great for live debugging but useless for reviewing older logs or searching for something that happened recently. This gives us filtering by `level` / `scope` / `app`, full-text search, and a time-range picker — without changing how logging is called.

## How it works

- `@auxx/logger` now emits a structured `LogRecord` (`time`, `level`, `scope`, `app`, `message`, `args`, `fields`) to a sink registry (`registerLogSink`), alongside the console line. The old single run-log writer is refactored onto this with a back-compat shim.
- New `@auxx/logger/openobserve` side-effect module batches records and POSTs them to OpenObserve. **On by default outside production** (defaults to `http://localhost:5080`); `OPENOBSERVE_DISABLE=true` opts out, `OPENOBSERVE_URL` overrides the target. Flush failures are swallowed so a down collector can never affect the app.
- `docker-compose.yml` adds the `openobserve` service (UI on `:5080`), brought up automatically by `pnpm dev` the same way postgres/redis are.
- Wired into the long-running processes: `apps/worker`, `apps/api`, `apps/web` bootstrap (one side-effect import each).
- `.env.example` / `setup.sh` seed the `OPENOBSERVE_*` creds.

## Notes

- **Dev-only.** In production the sink stays inactive unless `OPENOBSERVE_URL` is set explicitly.
- The password is **quoted** in env files because Node's `--env-file` (used by the worker) truncates an unquoted value at `#` — this was why the worker initially shipped nothing while web worked.
- Login for the local UI: `root@auxx.dev` / `Complexpass#123` (local dev only).
- Existing devs need to copy the `OPENOBSERVE_*` block into their `.env` (or run `./setup.sh --fill`) and restart `pnpm dev`.

See `docs/log-history.md` and the new "Viewing Logs" section in `CLAUDE.md`.