### PR TITLE
fix(connections): clear reauth/sync state on reconnect; overage count fixes

### DIFF
--- a/apps/web/src/components/apps/hooks/use-oauth-return.ts
+++ b/apps/web/src/components/apps/hooks/use-oauth-return.ts
@@ -34,6 +34,9 @@ export function useOAuthReturn() {
       })
       void utils.apps.listConnections.invalidate()
       void utils.apps.listInstalled.invalidate()
+      // Channel reconnects (Gmail/Outlook) ride the same return path — refresh their list so a
+      // cleared `requiresReauth` drops the "Auth required" badge without waiting out the staleTime.
+      void utils.channel.list.invalidate()
     }
 
     if (oauthError === 'true') {

--- a/apps/web/src/components/connections/ui/connections-section.tsx
+++ b/apps/web/src/components/connections/ui/connections-section.tsx
@@ -56,6 +56,7 @@ export function ConnectionsSection() {
   const flow = useConnectFlow({ onConnected: invalidate })
 
   const updateCredential = api.connections.update.useMutation()
+  const saveConnection = api.connections.save.useMutation()
   const deleteCredential = api.connections.delete.useMutation()
 
   // Installed apps that actually expose a connection (have a scoped definition).
@@ -116,24 +117,62 @@ export function ConnectionsSection() {
   // rotate their key through the flow's Reconnect button.
   const isPlainSecret = (row: ConnectionRow) => row.kind !== 'app' && !providerByKey.get(row.type)
 
-  // Synthetic method backing the unified edit dialog. Plain secrets expose their single API-key
-  // row; every other row is name-only here (re-auth / key rotation routes through Reconnect), so
-  // they carry a fieldless oauth-shaped method. Cheap to recompute, so no memo.
+  // The platform provider backing this row (if any). Secret providers (e.g. AI API keys) edit
+  // their credential fields inline; OAuth providers re-authorize through Reconnect.
+  const editProvider = editRow ? providerByKey.get(editRow.type) : undefined
+  // A row whose credentials are edited inline: a plain secret (bare API-key) or a provider-backed
+  // secret (the provider's connection-variable form). OAuth/app rows stay name-only + Reconnect.
+  const editInlineSecret = editRow
+    ? isPlainSecret(editRow) || editProvider?.connectionType === 'secret'
+    : false
+
+  // Synthetic method backing the unified edit dialog. Plain secrets expose a bare API-key row;
+  // provider secrets expose the provider's fields (apiKey, base URL, …), seeded masked from
+  // `getForEdit`; OAuth/app rows are fieldless (name-only). Cheap to recompute, so no memo.
   const editMethod: DetailMethod | null = editRow
     ? {
         id: editRow.connectionDefinitionId ?? editRow.id,
         label: editRow.label ?? editRow.name,
         description: null,
-        connectionType: isPlainSecret(editRow) ? 'secret' : 'oauth2-code',
+        connectionType: editInlineSecret ? 'secret' : 'oauth2-code',
         global: editRow.scope !== 'user',
-        connectionVariables: [],
+        connectionVariables:
+          editProvider?.connectionType === 'secret' ? (editProvider.connectionVariables ?? []) : [],
       }
     : null
 
-  // One Save persists a rename (label) and, for a plain secret, a rotated API key — both via
-  // `connections.update`. A no-op (nothing changed) just closes.
-  const handleEditSubmit = (payload: { name?: string; secret?: string }) => {
+  const onEditSaved = () => {
+    setEditRow(null)
+    invalidate()
+  }
+  const onEditError = (error: { message: string }) =>
+    toastError({ title: 'Error updating connection', description: error.message })
+
+  // One Save persists a rename and the connection's credentials. Provider-backed secrets (e.g. AI
+  // API keys, multi-field forms) route through `connections.save`, which splits values by the
+  // def's secret flags and merges unchanged secrets on reconnect (no metadata wipe). Plain secrets
+  // and name-only rows use `connections.update`. A no-op just closes.
+  const handleEditSubmit = (payload: {
+    name?: string
+    secret?: string
+    values?: Record<string, string>
+  }) => {
     if (!editRow) return
+
+    if (editProvider?.connectionType === 'secret') {
+      saveConnection.mutate(
+        {
+          connectionDefinitionId: editRow.connectionDefinitionId ?? editRow.type,
+          name: payload.name?.trim() || editRow.label || editRow.name,
+          ...(payload.values && { values: payload.values }),
+          ...(payload.secret && { secret: payload.secret }),
+          connectionId: editRow.id,
+        },
+        { onSuccess: onEditSaved, onError: onEditError }
+      )
+      return
+    }
+
     const currentName = editRow.label ?? editRow.name
     const newLabel = payload.name?.trim()
     const labelChanged = !!newLabel && newLabel !== currentName
@@ -148,14 +187,7 @@ export function ConnectionsSection() {
         ...(labelChanged && { label: newLabel }),
         ...(newSecret && { data: { apiKey: newSecret } }),
       },
-      {
-        onSuccess: () => {
-          setEditRow(null)
-          invalidate()
-        },
-        onError: (error) =>
-          toastError({ title: 'Error updating connection', description: error.message }),
-      }
+      { onSuccess: onEditSaved, onError: onEditError }
     )
   }
 
@@ -376,20 +408,20 @@ export function ConnectionsSection() {
           }}
           title={`Edit ${editRow.label ?? editRow.name}`}
           method={editMethod}
-          // Plain secrets seed their masked key; name-only rows skip the load.
-          connectionId={isPlainSecret(editRow) ? editRow.id : undefined}
-          pending={updateCredential.isPending}
+          // Inline-secret rows seed their masked credentials; name-only rows skip the load.
+          connectionId={editInlineSecret ? editRow.id : undefined}
+          pending={updateCredential.isPending || saveConnection.isPending}
           submitLabel='Save'
           loadingText='Saving...'
           showName
           initialName={editRow.label ?? editRow.name}
           description={
-            isPlainSecret(editRow)
-              ? 'Rename this connection or update its API key.'
+            editInlineSecret
+              ? 'Rename this connection or update its credentials.'
               : 'Rename this connection, or use Reconnect to re-authorize or update its credentials.'
           }
           onReconnect={
-            isPlainSecret(editRow)
+            editInlineSecret
               ? undefined
               : () => {
                   const row = editRow

--- a/apps/web/src/server/api/routers/connections.ts
+++ b/apps/web/src/server/api/routers/connections.ts
@@ -9,6 +9,7 @@ import {
   splitSensitiveFields,
   updateCredential,
 } from '@auxx/credentials/store'
+import type { ConnectionVariable } from '@auxx/database'
 import { getOrgCache } from '@auxx/lib/cache'
 import {
   mintClientCredentialToken,
@@ -47,10 +48,10 @@ const BYO_CLIENT_KEYS = new Set(['clientId', 'clientSecret'])
  * fields required when the connection must bring its own. Non-OAuth defs pass through.
  */
 function gateConnectionVariables(
-  provider: { connectionType: string; connectionVariables?: unknown },
+  provider: { connectionType: string; connectionVariables?: ConnectionVariable[] },
   requiresOwnClient: boolean
-) {
-  const vars = (provider.connectionVariables ?? []) as Array<{ key: string; required?: boolean }>
+): ConnectionVariable[] {
+  const vars = provider.connectionVariables ?? []
   if (provider.connectionType !== 'oauth2-code') return vars
   if (requiresOwnClient) {
     return vars.map((v) => (BYO_CLIENT_KEYS.has(v.key) ? { ...v, required: true } : v))

--- a/docs/realtime-architecture-guide.md
+++ b/docs/realtime-architecture-guide.md
@@ -1,0 +1,494 @@
+# Realtime Architecture Guide
+
+How Auxx pushes live updates to the browser: field values, records, mail
+threads/messages, agent/procedure/eval admin state, presence, and the customer
+chat widget. There is exactly **one transport today — [Pusher](https://pusher.com)
+Channels** — but the code is wrapped behind provider-agnostic seams so a second
+backend (Ably, raw WebSocket, etc.) could drop in without touching consumers.
+
+> TL;DR — Servers publish domain events to opaque **room keys** through a
+> `RealtimeService`. Room keys map to Pusher channels (`private-` / `presence-` /
+> raw public) via a shared key-helper module. The admin app (`apps/web`) runs one
+> refcounted `PusherRealtimeAdapter` that fans channel events out to React hooks,
+> which patch Zustand stores or invalidate React Query. The customer chat widget
+> (`packages/chat`) runs a **separate, dependency-free** Pusher client. Every
+> mutation carries the publisher's `socket_id` so the originator is excluded from
+> its own echo.
+
+---
+
+## 1. Why an abstraction at all
+
+Pusher is never imported directly by feature code. Two thin interfaces sit in
+front of it:
+
+| Interface | Side | File | Implemented by |
+| --- | --- | --- | --- |
+| `RealtimeProvider` | server | `packages/lib/src/realtime/types.ts` | `PusherRealtimeProvider` |
+| `RealtimeAdapter` | client | `packages/lib/src/realtime/client/types.ts` | `PusherRealtimeAdapter` |
+
+`RealtimeProvider` is two methods — `publish(channel, event, data, opts)` and
+`authenticate(socketId, channel, userData)`. `RealtimeAdapter` is the browser
+counterpart: `connect` / `subscribe` / `subscribePresence` / `updateSelf` plus
+`useSyncExternalStore` plumbing. Swapping providers means writing one new class on
+each side; the ~40 publish call-sites and ~20 consumer hooks never change.
+
+The seam exists for portability, but pragmatically it also keeps the Pusher SDK
+(and its 10KB-per-message limit, channel-name prefix rules, auth handshake) out of
+business logic. The 10KB limit in particular leaks into helper design — see
+chunking (§5) and lazy attachment URLs (§9).
+
+---
+
+## 2. Rooms — the addressing scheme
+
+Consumers and publishers never type a Pusher channel name. They build an **opaque
+room key** with a typed helper, and the transport layer maps it to a channel.
+
+```
+rooms.orgPresence(orgId)          → org-{orgId}                         (presence)
+rooms.orgEvents(orgId)            → org-{orgId}-events                  (plain)
+rooms.orgInbox(orgId, inboxSlug)  → org-{orgId}-inbox-{inboxSlug}       (plain)
+rooms.user(userId)               → user-{userId}                       (plain)
+rooms.chatThread(threadId)       → thread-{threadId}                   (plain)
+rooms.chatSession(sessionId)     → chat-{sessionId}                    (public)
+rooms.visitor(participantId)     → visitor-{participantId}             (plain)
+```
+
+A room has one of three **kinds** (`RoomKind`), which decides the Pusher prefix:
+
+| Kind | Pusher channel | Auth signing | Used for |
+| --- | --- | --- | --- |
+| `plain` | `private-{key}` | yes (`/api/pusher/auth`) | most admin rooms, widget visitor/thread channels |
+| `presence` | `presence-{key}` | yes + member roster | org presence (who's online) |
+| `public` | `{key}` (raw) | none | visitor chat session — widget has no session cookie at bootstrap |
+
+The mapping is split across two files **on purpose**:
+
+- **`room-keys.ts`** — client-safe. Key builders (`rooms`), `roomKindFor`,
+  `toPusherChannel`, `fromPusherChannel`. No DB imports, so the browser bundle can
+  pull it in.
+- **`rooms.ts`** — server-only. Re-exports the key helpers and adds the
+  **authorization registry**: one `RoomDef` per room family with a `match(key)`
+  predicate and an `authorize(key, ctx)` ACL function.
+
+> ⚠️ **Registry order matters.** `findRoom` is greedy first-match. The specific
+> `-inbox-` and `-events` patterns must precede the catch-all `org-` presence
+> entry, and `roomKindFor` in `room-keys.ts` must stay in lockstep with the
+> registry ordering in `rooms.ts`. They are two hand-synced copies of the same
+> precedence.
+
+### Authorization (`AuthorizeCtx`)
+
+```ts
+interface AuthorizeCtx {
+  session?: { userId; organizationId } | null   // admin app
+  visitor?: { participantId; threadId? }         // widget passport
+}
+```
+
+Each `RoomDef.authorize` enforces its own rule:
+
+- **inbox** — caller is an org member **and** has access to that inbox (via
+  `InboxService.hasUserAccess`); the `none` triage slug is open to all members.
+- **events / presence** — caller is an org member.
+- **user** — `ctx.session.userId === userId`.
+- **thread** (admin) — any authenticated session (org scoping handled upstream).
+- **chat session** (`chat-*`) — public, always allowed; channel name is an
+  unguessable random session id, the `authorize` hook is unreachable because Pusher
+  never asks the server to sign public channels.
+- **visitor** — `ctx.visitor.participantId === participantId`.
+
+There is a dev-mode bypass (`NODE_ENV === 'development'`) that lets membership/inbox
+checks pass on DB errors, so local work isn't blocked by seed gaps.
+
+---
+
+## 3. Server side — publishing
+
+### The service
+
+`RealtimeService` (`realtime-service.ts`) is the single server entry point,
+constructed once as a singleton via `getRealtimeService()` wrapping
+`PusherRealtimeProvider`. Key methods:
+
+- `publish(roomKey, event, data, { excludeSocketId })` — maps key → channel and
+  forwards to the provider. Returns `false` (never throws) if the room is unknown
+  or Pusher isn't configured.
+- `publishMemberUpdate(roomKey, member)` — presence-only; emits a `member-update`
+  event (used by `updateSelf`).
+- `authorize(socketId, channelName, ctx, userData)` — the auth-route path: resolve
+  key, run the registry ACL, then sign.
+- `authenticateChannel(...)` — raw signing with **no** registry ACL, used by the
+  widget auth route which does its own passport check upstream.
+
+`PusherRealtimeProvider` lazily reads `PUSHER_APP_ID/KEY/SECRET/CLUSTER` from
+`configService`. If any are missing it logs a warning and every `publish` becomes a
+silent no-op — **realtime degrades to "off," it never errors**.
+
+### Publish helpers
+
+`publish-helpers.ts` is the typed catalogue of "what the server can announce."
+Every helper:
+
+1. Looks up the org **feature flag** (`realtimeSync` or `realtimeMail`) from the
+   per-org cache and bails early if disabled.
+2. Builds the room key.
+3. Fires-and-forgets the publish (errors swallowed — a Pusher hiccup must never
+   block the underlying DB mutation).
+
+| Helper | Room | Event | Flag |
+| --- | --- | --- | --- |
+| `publishFieldValueUpdates` | orgPresence | `fieldValues:updated` | `realtimeSync` |
+| `publishRecordsInvalidated` | orgPresence | `records:invalidated` | `realtimeSync` |
+| `publishThreadCreated/Updated/Deleted` | orgInbox | `thread:*` | `realtimeMail` |
+| `publishMessageCreated/Updated/Deleted` | orgInbox | `message:*` | `realtimeMail` |
+| `publishParticipantUpdated` | orgPresence | `participant:updated` | `realtimeMail` |
+| `publishInboxSyncCompleted` | orgInbox | `inbox:syncCompleted` | `realtimeMail` |
+| `flushMailBatch` | orgInbox | `mail:batch` | `realtimeMail` |
+| `publishAgentUpdated` | orgPresence | `agent:updated` | `realtimeSync` |
+| `publishProcedureUpdated` | orgPresence | `procedure:updated` | `realtimeSync` |
+| `publishEvalCaseChanged` | orgPresence | `eval:case-changed` | `realtimeSync` |
+
+Record lifecycle events (`record:created/updated/deleted/archived`) are published
+inline from the entity CRUD layer
+(`packages/lib/src/resources/crud/unified-handler-mutations.ts`) and from
+`maybeUpdateDisplayValue` in `field-value-helpers.ts`, all on the **orgPresence**
+room with `excludeSocketId`.
+
+### Event payload contract
+
+All event shapes live in `events.ts` (server) and are re-exported from
+`client/index.ts` so both sides share one type. The pervasive convention is
+**partial-by-design patches**:
+
+- Missing key = "don't touch this field."
+- Explicit `null` = "clear this field."
+- Present value = "set this field."
+
+This is what lets, e.g., `record:updated` carry just the one denormalized column
+that changed, or a `fieldValues:updated` entry carry an AI-status transition with
+no value (`{ key, aiStatus: 'generating' }`).
+
+---
+
+## 4. Server side — authorization & socket-id echo suppression
+
+### Auth endpoints
+
+Two HTTP endpoints sign Pusher channel subscriptions (Pusher's JS client needs an
+`authEndpoint`; routing it through tRPC would be friction with no benefit):
+
+1. **`apps/web/src/app/api/pusher/auth/route.ts`** — admin app. Reads
+   `socket_id` + `channel_name`, loads the Better-auth session, builds an
+   `AuthorizeCtx` from it, and delegates to `RealtimeService.authorize`, which runs
+   the registry ACL before signing.
+2. **`apps/api/src/routes/chat/pusher-auth.ts`** — chat widget (Hono, on
+   `apps/api`). Verifies the channel belongs to the **passport's** visitor
+   (`private-visitor-{id}` exact match, or `private-thread-{id}` gated by
+   `buildVisitorThreadOwnership`), then signs via `authenticateChannel` (no
+   registry — passport already vouched). Public `chat-*` channels skip this
+   entirely.
+
+### Client-mediated publish (`realtimeRouter`)
+
+Clients can publish a **narrow allow-list** of ephemeral events through the
+`realtime.publish` tRPC mutation — only `typing:` and `presence:` prefixes. The
+guard rationale is explicit in the router: authoritative server events
+(`thread:*`, `record:*`, `fieldValues:*`, …) must **never** be client-publishable,
+or a logged-in peer could forge deletions/updates into any room they pass ACL on.
+`realtime.updateSelf` is the only path for presence meta and emits a
+server-mediated `member-update` (no Pusher client-events anywhere in the system).
+
+### Echo suppression (the socket-id loop)
+
+The originator of a mutation should not receive its own realtime echo — it already
+applied the change optimistically. The mechanism:
+
+1. The browser's live Pusher `socket_id` is read non-reactively via
+   `getRealtimeSocketId()` and attached as the **`x-realtime-socket-id`** header on
+   every tRPC request (`apps/web/src/trpc/react.tsx`, `trpc/vanilla.ts`).
+2. The server threads it into the mutation context (`ctx.socketId`).
+3. Every publish passes `{ excludeSocketId: ctx.socketId }`, which becomes Pusher's
+   `socket_id` exclusion param → the originating socket is skipped.
+
+A second, finer-grained echo guard exists in the client stores: `setValues`
+**skips keys with pending optimistic updates**, so even a racing inbound event
+can't clobber an in-flight local write before the mutation confirms.
+
+---
+
+## 5. Server side — scale controls
+
+Realtime at sync/backfill scale would trivially blow Pusher's per-message size and
+rate limits. Three patterns guard against it:
+
+- **Chunking.** `publishFieldValueUpdates` and `flushMailBatch` split entries at
+  `CHUNK_SIZE = 50` per frame to stay under the 10KB limit; field-value chunks
+  carry `{ index, total }` metadata.
+- **Coarse invalidation over per-record firehose.** Bulk writes (data-connector
+  slice sync) suppress the thousands of per-record `record:created` /
+  `fieldValues:updated` events and instead emit a **single `records:invalidated`
+  per touched entity def per slice**. The client responds with one refetch of the
+  def's visible list. Same idea for mail: `inbox:syncCompleted` replaces
+  per-message events during a sync cycle, and the client invalidates
+  `thread.listIds` once.
+- **Batch frames.** `mail:batch` bundles many `MailSyncEvent`s into one Pusher
+  publish for initial-/polling-sync; the client unpacks and re-dispatches each
+  inner event through the same handlers.
+
+---
+
+## 6. Client side — the admin adapter (`apps/web`)
+
+### One adapter, lives outside React
+
+`apps/web/src/realtime/adapter.ts` instantiates a single module-level
+`PusherRealtimeAdapter`. Its lifecycle is driven by `useRealtimeLifecycle()`
+(mounted once in the app layout):
+
+- On auth ready → `connect({ key, cluster, authEndpoint: '/api/pusher/auth' })`.
+  The `key`/`cluster` reach the browser via the dehydrated env payload
+  (`dehydration/service.ts` exposes `pusher: { key, cluster }`; consumed through
+  `useEnv()`).
+- On **org switch** → `unsubscribeMatching` tears down every room scoped to the old
+  org (`org-{old}`, `org-{old}-*`, and `thread-*`). The `user-{userId}` channel is
+  intentionally **kept** across org switches since the same user spans orgs.
+- On logout/unmount → `disconnect()`.
+
+### Refcounting & fan-out
+
+The adapter is the heart of the client design. Properties worth knowing:
+
+- **Refcounted rooms.** Many components can subscribe to the same room; the
+  adapter keeps one Pusher channel with a `refCount` and only tears it down on the
+  last `unsubscribe`.
+- **Single global listener per channel.** It binds one `bind_global` handler that
+  fans out to every registered consumer's `onEvent`, filtering Pusher-internal
+  `pusher:*` events. Presence built-ins (`member_added/removed`) are bound
+  explicitly and routed to presence handlers.
+- **Pending-subscription buffer.** Subscriptions requested before `connect()` ran
+  (React fires child effects before the parent lifecycle) are queued and replayed
+  on connect.
+- **`onSubscribed` catch-up.** Fired on `pusher:subscription_succeeded` and again on
+  every reconnect — Pusher does **not** replay events sent during the
+  subscribe/reconnect window, so consumers use this hook to refetch and catch up.
+  Late-joining handlers get an async `onSubscribed` / roster replay via
+  `queueMicrotask`.
+- **`useSyncExternalStore` plumbing.** All `subscribeToX`/`getXSnapshot` are
+  arrow-field class members returning identity-stable snapshots, so React doesn't
+  thrash.
+
+### React hooks (`apps/web/src/realtime/hooks.ts`)
+
+| Hook | Subscribes to | Notes |
+| --- | --- | --- |
+| `useRealtimeRoom(key, handlers)` | any plain room | base primitive; returns "bound?" |
+| `usePresence(key, self, handlers)` | presence room | + member tracking |
+| `useOrgChannel(handlers)` | `orgPresence(orgId)` | the org firehose |
+| `useInboxChannel(slug, handlers)` | one `orgInbox` | |
+| `useInboxChannels(slugs, handlers)` | many `orgInbox` | returns stable subscribed-key set |
+| `useRealtimeConnected()` | connection state | |
+
+Handlers are held in a ref so re-renders don't re-bind the channel; the effect
+re-subscribes only when the room key itself changes.
+
+---
+
+## 7. Consumer domains (admin app)
+
+### A. Field values & records
+
+- **`useResourceSync`** subscribes to `useOrgChannel` and handles
+  `fieldValues:updated`, `record:created/updated/deleted/archived`, and
+  `records:invalidated`.
+- Patches **Zustand** stores (`useFieldValueStore`, `useRecordStore`) for value /
+  AI-state / denormalized-column changes, and **invalidates React Query**
+  (`record.listFiltered`) for list membership.
+- **AI generation lifecycle** rides on `fieldValues:updated` entries:
+  `aiStatus: 'generating'` (stage-1 enqueue) → `'result'` (commit, with value) →
+  `'error'`. `useSaveFieldValue` sets the marker optimistically; the realtime commit
+  resolves it. Markers are a parallel store slice (`aiStates`) so a status change
+  needn't carry a value.
+- Supporting machinery: `field-value-fetch-queue` debounces/​chunks on-demand value
+  fetches (50ms, 100 recordIds/batch); `field-value-store` recomputes dependent
+  CALC fields on every write and skips keys with pending optimistic updates.
+
+### B. Mail — threads & messages
+
+- **`useMailSync`** is the mail brain. It subscribes to `useInboxChannels` (all
+  accessible inboxes + `none` triage) for `thread:*` / `message:*` / `mail:batch` /
+  `inbox:syncCompleted`, and to `useOrgChannel` for `participant:updated`.
+- It patches a thread/message Zustand store and invalidates `thread.listIds` on
+  membership changes. `mail:batch` is recursively unpacked into the same handlers.
+- **Batch drain** (`thread-data-provider` + `use-batch-drain`): realtime events that
+  reference not-yet-loaded entities enqueue ids into a per-resource pending set; a
+  150ms-coalesced **serial** drainer calls `*.getByIds`, preventing a burst of
+  events from fanning into concurrent mutations that trip the tRPC rate limiter.
+  Five drainers run in parallel (thread/message/participant/task/draft).
+- `useMessageArrivalCue` coalesces inbound `message:created` over a 1s window into a
+  single toast/chime/favicon cue, suppressing outbound sends and the
+  actively-viewed thread.
+- **`useThreadEvents`** (chat panel) subscribes to `chatThread(threadId)` for
+  lifecycle events (`thread:taken_over`, `returned_to_ai`, `archived`, …), merging
+  persisted (`thread.listEvents`) with live, deduped by event id.
+
+### C. Agent / procedure / eval admin state
+
+`agent:updated`, `procedure:updated`, `eval:case-changed` are pure **refresh
+signals** on the org channel — the payload carries only ids. `useAgentRealtime` and
+`useEvalCasesRealtime` just invalidate the relevant React Query keys. These fire
+from server-origin writes (notably Kopilot authoring tools) that happen outside an
+editor's own save path. The editor's own autosave passes `excludeSocketId` (or
+simply omits the publish) so it never invalidates the author's in-flight editing.
+
+> An open seed-once TipTap editor needs a remount on top of the invalidation; that
+> lives in `useProcedureRealtime`/`usePersonaRealtime`, keyed by a reload key.
+
+### D. Presence
+
+`useOrgPresence` + `usePresenceHeartbeat` share one refcounted presence
+subscription via a module-level store keyed by org. The heartbeat flips a
+`meta.idle` flag through `realtimeAdapter.updateSelf` → `realtime.updateSelf` tRPC →
+server `member-update` publish. Going fully offline needs no message — Pusher's
+`member_removed` fires when the socket drops.
+
+### E. Notifications & user channel
+
+The `user-{userId}` private channel carries personal events
+(`notification-center.tsx`, server side `notification-service.ts`) and survives org
+switches.
+
+---
+
+## 8. The chat widget — a separate stack by design
+
+The customer-facing widget in **`packages/chat`** runs its **own** Pusher client
+with **zero `@auxx/*` dependencies**, so the embeddable bundle stays standalone and
+small. It does **not** use `PusherRealtimeAdapter` or `@auxx/lib/realtime/client`.
+
+| Aspect | Admin (`apps/web`) | Widget (`packages/chat`) |
+| --- | --- | --- |
+| Client | `PusherRealtimeAdapter` (`@auxx/lib`) | bespoke `realtime-client.ts` |
+| Auth endpoint | `/api/pusher/auth` (session) | `/api/chat/pusher/auth` (passport bearer) |
+| Message stream | `message:created` on inbox channel | `new-message` on public `chat-{sessionId}` |
+| Cross-thread | `thread:updated` on inbox | `thread-updated` on `private-visitor-{id}` |
+| Lifecycle | `thread:*` on `thread-{id}` | same `thread-{id}` **plus** redundant `visitor-{id}` |
+| Dependencies | full `@auxx/lib` | none |
+
+Widget specifics:
+
+- One shared, refcounted Pusher socket per widget instance; launcher badge and
+  conversation view share channels.
+- Auth reads the **live passport** at call time (token refresh) and posts to the
+  `apps/api` chat auth route.
+- The visitor channel (`private-visitor-{participantId}`) connects **eagerly**
+  (before the widget is opened) so the unread badge updates while closed; it
+  survives identity rotation via an epoch bump.
+- Event type definitions are **duplicated locally** (`transport/thread-events.ts`)
+  rather than imported, kept in sync by hand with `apps/api`'s
+  `WIDGET_THREAD_EVENT_TYPES`.
+
+This is a deliberate "two clients" decision (bundle isolation) — don't try to DRY
+the widget client and the admin adapter into one.
+
+---
+
+## 9. Dual-publish — how an agent and a visitor see the same chat live
+
+A single chat message must reach **three** audiences. `publishChatMessageCreated`
+(`packages/lib/src/chat/realtime.ts`) does the fan-out:
+
+1. **`message:created` on the inbox channel** → the admin agent's mail view (via
+   `publishMessageCreated`; `excludeSocketId` on the outbound path).
+2. **`new-message` on `chat-{sessionId}`** → the visitor's open conversation.
+3. **`thread-updated` on `visitor-{participantId}`** → the visitor's other
+   (backgrounded) threads + unread badge.
+
+Inbound (visitor → agent) flows through `ChatProvider.receiveMessage`; outbound
+(agent → visitor) through `ChatProvider.sendMessage` with
+`skipInboxMessagePublish: true` (the `MessageSenderService` already published the
+inbox event). Agent replies are composed in `process-chat-turn.ts`.
+
+**Thread lifecycle** events (takeover, archive, reopen, assignee change, visitor
+identified) are persisted then fanned out by
+`events/handlers/publish-thread-event-to-realtime.ts` to **both** `thread-{id}`
+(admin + open widget) and `visitor-{id}` (widget in any state, deduped by event id
+client-side).
+
+> Pusher frames never carry attachment URLs (10KB limit). The widget resolves them
+> lazily via `/api/chat/attachments/{id}/url` with a short TTL.
+
+---
+
+## 10. Failure modes & guarantees
+
+- **Realtime is best-effort, never authoritative.** Every publish is fire-and-forget
+  with swallowed errors; React Query stale-time / focus-refetch is the fallback for
+  orgs with the flag off or during a Pusher outage.
+- **No missed-event replay from Pusher.** Events sent during a subscribe/reconnect
+  gap are lost by the transport — the `onSubscribed` catch-up refetch closes that
+  gap on the consumer side.
+- **Feature-flag gated.** `realtimeSync` (records/fields/agents) and `realtimeMail`
+  (threads/messages) gate publishing per org.
+- **Misconfiguration degrades silently.** Missing Pusher creds → provider logs a
+  warning and every publish no-ops; the app stays functional, just not live.
+
+---
+
+## 11. Extending the system
+
+**Add a new event on an existing room:** add the type to `events.ts`, re-export from
+`client/index.ts`, add a `publishX` helper (with its flag gate), and handle it in
+the relevant consumer hook's `onEvent` switch.
+
+**Add a new room family:** one helper on `rooms` (`room-keys.ts`), one
+`roomKindFor` branch (same file), and one `RoomDef` with its `authorize` ACL in the
+`rooms.ts` registry — minding the greedy match ordering.
+
+**Add a second transport (e.g. Ably):** implement `RealtimeProvider` (server) and
+`RealtimeAdapter` (client). Swap the singleton construction in
+`realtime/index.ts` and the adapter instance in `apps/web/src/realtime/adapter.ts`.
+Consumers, helpers, room registry, and event types are all transport-agnostic and
+stay untouched.
+
+---
+
+## Appendix — file map
+
+**Core (`packages/lib/src/realtime/`)**
+- `index.ts` — `getRealtimeService()` singleton + barrel exports
+- `types.ts` — `RealtimeProvider` server interface
+- `realtime-service.ts` — `RealtimeService` (publish / authorize)
+- `providers/pusher.ts` — `PusherRealtimeProvider`
+- `events.ts` — all event payload types
+- `publish-helpers.ts` — typed publish catalogue (flag-gated)
+- `room-keys.ts` — client-safe key/kind/prefix helpers
+- `rooms.ts` — server auth registry (`RoomDef`, `findRoom`, ACLs)
+- `client/types.ts` — `RealtimeAdapter` client interface
+- `client/adapters/pusher.ts` — `PusherRealtimeAdapter` (refcount, fan-out, presence)
+- `client/index.ts` — client barrel
+
+**Admin app (`apps/web/src/`)**
+- `realtime/adapter.ts` — singleton adapter instance
+- `realtime/use-realtime-lifecycle.ts` — connect/disconnect, org-switch teardown
+- `realtime/hooks.ts` — `useRealtimeRoom`, `useOrgChannel`, `useInboxChannels`, …
+- `app/api/pusher/auth/route.ts` — admin channel auth
+- `server/api/routers/realtime.ts` — client-mediated publish / updateSelf
+- `hooks/use-org-presence.ts`, `hooks/use-presence-heartbeat.ts` — presence
+- `trpc/react.tsx`, `trpc/vanilla.ts` — socket-id header injection
+- `components/resources/**` — field-value / record consumers
+- `components/threads/**`, `components/mail/**` — mail consumers + batch drain
+- `components/agents/hooks/use-agent-realtime.ts`, `components/evals/hooks/use-eval-cases-realtime.ts`
+
+**Chat widget (`packages/chat/src/`)**
+- `transport/realtime-client.ts` — bespoke shared Pusher socket
+- `transport/visitor-channel.ts`, `transport/thread-events.ts`, `transport/config.ts`, `transport/chat-api.ts`
+- `views/conversation/**`, `widget.tsx`
+
+**Server chat publishing**
+- `packages/lib/src/chat/realtime.ts` — `publishChatMessageCreated`, `publishVisitorThreadCreated`
+- `packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts` — lifecycle dual fan-out
+- `packages/lib/src/chat/agent/process-chat-turn.ts` — agent reply composition
+- `apps/api/src/routes/chat/pusher-auth.ts` — widget channel auth
+- `apps/api/src/routes/chat/{threads,initialize}.ts` — message POST / bootstrap

--- a/packages/credentials/src/store/record-refresh.ts
+++ b/packages/credentials/src/store/record-refresh.ts
@@ -10,8 +10,11 @@ import type { CredentialStoreError } from './types'
 const PERMANENT_FAILURE_THRESHOLD = 5
 
 /**
- * Record a successful token refresh: reset the failure breaker and stamp `lastRefreshAt`.
- * The only writer (with {@link recordRefreshFailure}) of the breaker fields. Org-scoped.
+ * Record a successful token refresh: reset the failure breaker, clear any classified auth-error
+ * state (`requiresReauth` / `lastAuthError` / `lastAuthErrorAt`), and stamp `lastRefreshAt`. A
+ * fresh token means the credential is healthy again, so this is also the reconnect recovery path —
+ * without clearing the reauth flags the UI keeps surfacing "Auth required". The only writer (with
+ * {@link recordRefreshFailure}) of the breaker fields. Org-scoped.
  */
 export async function recordRefreshSuccess(
   id: string,
@@ -24,6 +27,9 @@ export async function recordRefreshSuccess(
       .update(schema.Credential)
       .set({
         consecutiveRefreshFailures: 0,
+        requiresReauth: false,
+        lastAuthError: null,
+        lastAuthErrorAt: null,
         lastRefreshAt: now,
         expiresAt: options.expiresAt,
         updatedAt: now,

--- a/packages/lib/src/channels/provisioning-hook.ts
+++ b/packages/lib/src/channels/provisioning-hook.ts
@@ -102,6 +102,11 @@ function mergeMetadata(existing: unknown, patch: Record<string, unknown>): Recor
  * Create the Integration row, or relink the credential onto the existing one (reauth / reconnect /
  * calendar grant). On relink the metadata patch is MERGED so domain blobs (watch expiration, cached
  * user emails, calendar sync flags) survive.
+ *
+ * A relink also clears the sync breaker (`syncStatus` / `syncStage` / `throttle*`). The credential
+ * is healthy again, so a prior `FAILED` must not stick: it both shows a stale "Sync Error" badge
+ * and — for webhook-mode channels, which the polling relaunch job skips — would never recover on
+ * its own. Reset to the clean `NOT_SYNCED` / `IDLE` baseline so the next push or poll resumes.
  */
 async function upsertIntegration(args: {
   organizationId: string
@@ -132,6 +137,11 @@ async function upsertIntegration(args: {
         email,
         enabled: true,
         metadata: mergeMetadata(existing.metadata, metadataPatch) as any,
+        syncStatus: 'NOT_SYNCED',
+        syncStage: 'IDLE',
+        syncStageStartedAt: null,
+        throttleFailureCount: 0,
+        throttleRetryAfter: null,
         updatedAt: new Date(),
       })
       .where(eq(schema.Integration.id, existing.id))

--- a/packages/lib/src/permissions/overage-detection-service.ts
+++ b/packages/lib/src/permissions/overage-detection-service.ts
@@ -12,6 +12,15 @@ import { FEATURE_REGISTRY_MAP, FeatureKey, parseFeatureLimits } from './types'
 
 const logger = createScopedLogger('overage-detection-service')
 
+/**
+ * Static-typed features that are NOT standing, countable resources.
+ * These are metered monthly pools (tracked via OrganizationAiQuota and the
+ * quota webhook handlers), so they must be excluded from resource-count
+ * overage detection — there is nothing to count, and treating them here would
+ * report a count of 0 and mask real usage.
+ */
+const NON_COUNTABLE_STATIC_KEYS = new Set<string>([FeatureKey.monthlyAiCredits])
+
 /** Overage detected for a single feature */
 export interface Overage {
   key: string
@@ -178,6 +187,7 @@ export class OverageDetectionService {
     for (const def of featureDefs) {
       const meta = FEATURE_REGISTRY_MAP.get(def.key as FeatureKey)
       if (meta?.type !== 'static') continue
+      if (NON_COUNTABLE_STATIC_KEYS.has(def.key)) continue // metered pools, not standing resources
       if (meta.perOperation) continue // per-operation caps aren't standing resources
       if (typeof def.limit !== 'number' || def.limit === -1) continue // skip '+', boolean, and -1 (unlimited)
       limits.set(def.key, def.limit)
@@ -193,6 +203,7 @@ export class OverageDetectionService {
       for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
         const meta = FEATURE_REGISTRY_MAP.get(key as FeatureKey)
         if (meta?.type !== 'static') continue
+        if (NON_COUNTABLE_STATIC_KEYS.has(key)) continue
         if (meta.perOperation) continue
         if (typeof value === 'number') {
           if (value === -1) {
@@ -310,6 +321,17 @@ export class OverageDetectionService {
               isNull(schema.EntityDefinition.entityType),
               isNull(schema.EntityDefinition.archivedAt)
             )
+          )
+        return result?.value ?? 0
+      }
+
+      case FeatureKey.agentsLimit: {
+        // Count non-archived agents (drafts included), matching listAgents() enforcement.
+        const [result] = await this.db
+          .select({ value: count() })
+          .from(schema.Agent)
+          .where(
+            and(eq(schema.Agent.organizationId, organizationId), isNull(schema.Agent.archivedAt))
           )
         return result?.value ?? 0
       }


### PR DESCRIPTION
Bundles independent local changes that were pending in the working tree. They're unrelated and can be split if preferred.

## Connection / channel reconnect recovery
- **`recordRefreshSuccess`** now clears `requiresReauth` / `lastAuthError` / `lastAuthErrorAt` on a successful token refresh. A fresh token means the credential is healthy again, so this is the reconnect recovery path — without it the UI keeps surfacing "Auth required".
- **Channel relink** (`upsertIntegration`) resets the sync breaker (`syncStatus` / `syncStage` / `throttle*`) to the clean `NOT_SYNCED` / `IDLE` baseline. A prior `FAILED` otherwise shows a stale "Sync Error" badge and — for webhook-mode channels, which the polling relaunch job skips — would never recover on its own.
- **OAuth return** invalidates `channel.list` so a cleared `requiresReauth` drops the badge without waiting out the React Query `staleTime`.
- `gateConnectionVariables` typed against `ConnectionVariable[]` instead of `unknown` casts.
- Connections UI updates to reflect the reauth/badge state.

## Overage detection
- Exclude metered monthly pools (`monthlyAiCredits`) from resource-count overage detection — there is nothing to count, and treating it here reports 0 and masks real usage.
- Count `agentsLimit` (non-archived agents, drafts included) to match `listAgents()` enforcement.

## Docs
- Add `docs/realtime-architecture-guide.md`.