### PR TITLE
feat(webhooks): live WebhookEndpoint delivery inspector + TreeRow trigger source rows

### DIFF
--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -235,7 +235,9 @@ async function pushWebhookEndpointEvent(
   try {
     const redis = await getRedisClient(false)
     if (!redis) return
-    const redisKey = `webhook-endpoint:${endpointId}:${topic}:events`
+    // Topic-agnostic key so the delivery inspector sees EVERY delivery to this endpoint
+    // (the per-delivery topic stays in the event payload for client-side filtering).
+    const redisKey = `webhook-endpoint:${endpointId}:events`
     const event = {
       id: randomUUID(),
       timestamp: new Date().toISOString(),

--- a/apps/web/src/app/api/webhook-endpoints/[endpointId]/events/route.ts
+++ b/apps/web/src/app/api/webhook-endpoints/[endpointId]/events/route.ts
@@ -1,0 +1,22 @@
+// apps/web/src/app/api/webhook-endpoints/[endpointId]/events/route.ts
+// SSE stream of live deliveries for a generic inbound WebhookEndpoint, read from the
+// topic-agnostic Redis list the ingress writes (`webhook-endpoint:<id>:events`). Mirrors
+// the app-trigger events route — a thin config over `createSsePollRoute`.
+
+import { WebhookEndpoint } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { createSsePollRoute } from '~/lib/sse/create-sse-poll-route'
+
+export const GET = createSsePollRoute({
+  getRedisKey: ({ endpointId }) => `webhook-endpoint:${endpointId}:events`,
+  authorize: async (session, params, db) => {
+    const endpoint = await db.query.WebhookEndpoint.findFirst({
+      where: and(
+        eq(WebhookEndpoint.id, params.endpointId),
+        eq(WebhookEndpoint.organizationId, session.user.defaultOrganizationId)
+      ),
+      columns: { id: true },
+    })
+    return !!endpoint
+  },
+})

--- a/apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
@@ -47,7 +47,9 @@ import {
   seedDefaults,
 } from '~/components/global/schema-form'
 import { ResourcePicker } from '~/components/pickers/resource-picker'
+import { TriggerSourceRow } from '~/components/pickers/trigger-source'
 import { useResources } from '~/components/resources/hooks/use-resources'
+import { WebhookEndpointInspector } from '~/components/webhooks/ui/webhook-endpoint-inspector'
 import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api, type RouterOutputs } from '~/trpc/react'
@@ -139,6 +141,8 @@ interface AgentTriggerDialogProps {
     hasTopicSource: boolean
   }
   onSuccess?: () => void
+  /** Re-pick the source (app trigger / webhook endpoint) — closes the dialog and re-opens the picker. */
+  onRepick?: () => void
 }
 
 interface EventState {
@@ -192,6 +196,7 @@ export function AgentTriggerDialog({
   appSelection,
   webhookSelection,
   onSuccess,
+  onRepick,
 }: AgentTriggerDialogProps) {
   const isEditMode = !!trigger
   const effectiveKind: Kind = isEditMode && trigger ? (trigger.kind as Kind) : kind
@@ -329,6 +334,15 @@ export function AgentTriggerDialog({
     })
     if (confirmed) destroy.mutate({ id: trigger.id })
   }
+
+  // The source chip's Trash2 removes the binding: delete the row when editing, otherwise
+  // abandon the in-progress selection (close the dialog). When the chip is shown it owns
+  // delete, so the footer's Delete button steps aside for app / webhook kinds.
+  const handleSourceRemove = () => {
+    if (isEditMode) void handleDelete()
+    else onOpenChange(false)
+  }
+  const chipHandlesDelete = (isAppKind && !!appContext) || (isWebhookKind && !!webhookContext)
 
   const fieldNodes = useMemo(
     () => readFieldNodes(appContext?.inputsJsonSchema),
@@ -480,23 +494,13 @@ export function AgentTriggerDialog({
               <>
                 <Field orientation='vertical'>
                   <FieldLabel>Trigger</FieldLabel>
-                  <div className='flex items-center gap-3 rounded-md border bg-muted/30 px-3 py-2'>
-                    <AppIcon
-                      iconId={appContext.appAvatarUrl ?? 'package'}
-                      size='lg'
-                      className='border border-foreground/5'
-                    />
-                    <div className='flex min-w-0 flex-col'>
-                      <span className='truncate text-sm font-medium'>
-                        {appContext.appTitle} · {appContext.triggerLabel}
-                      </span>
-                      {appContext.triggerDescription && (
-                        <span className='truncate text-xs text-muted-foreground'>
-                          {appContext.triggerDescription}
-                        </span>
-                      )}
-                    </div>
-                  </div>
+                  <TriggerSourceRow
+                    icon={<AppIcon iconId={appContext.appAvatarUrl ?? 'package'} size='sm' />}
+                    title={`${appContext.appTitle} · ${appContext.triggerLabel}`}
+                    secondary={appContext.triggerDescription}
+                    onEdit={!isEditMode ? onRepick : undefined}
+                    onDelete={handleSourceRemove}
+                  />
                 </Field>
 
                 <Field orientation='vertical'>
@@ -574,17 +578,13 @@ export function AgentTriggerDialog({
               <>
                 <Field orientation='vertical'>
                   <FieldLabel>Trigger</FieldLabel>
-                  <div className='flex items-center gap-3 rounded-md border bg-muted/30 px-3 py-2'>
-                    <AppIcon iconId='webhook' size='lg' className='border border-foreground/5' />
-                    <div className='flex min-w-0 flex-col'>
-                      <span className='truncate text-sm font-medium'>
-                        {webhookContext.endpointName}
-                      </span>
-                      <span className='truncate text-xs text-muted-foreground'>
-                        {webhookContext.endpointUrl}
-                      </span>
-                    </div>
-                  </div>
+                  <TriggerSourceRow
+                    icon={<AppIcon iconId='webhook' size='sm' />}
+                    title={webhookContext.endpointName}
+                    secondary={webhookContext.endpointUrl}
+                    onEdit={!isEditMode ? onRepick : undefined}
+                    onDelete={handleSourceRemove}
+                  />
                 </Field>
                 <Field orientation='vertical'>
                   <FieldLabel>Topic {webhookContext.hasTopicSource ? '' : '(optional)'}</FieldLabel>
@@ -598,6 +598,11 @@ export function AgentTriggerDialog({
                     onChange={(e) => setWebhookTopic(e.target.value)}
                   />
                 </Field>
+                <WebhookEndpointInspector
+                  endpointId={webhookContext.webhookEndpointId}
+                  topic={webhookTopic}
+                  description='Live deliveries to this endpoint matching this trigger.'
+                />
               </>
             ) : null}
 
@@ -620,7 +625,7 @@ export function AgentTriggerDialog({
           </div>
 
           <DialogFooter className='flex sm:justify-between!'>
-            {isEditMode && !isBuiltinKind ? (
+            {isEditMode && !isBuiltinKind && !chipHandlesDelete ? (
               <Button
                 type='button'
                 size='sm'

--- a/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/triggers-section-content.tsx
@@ -224,6 +224,13 @@ export function TriggersSectionContent({
         appSelection={appSelectionForDialog}
         webhookSelection={webhookSelectionForDialog}
         onSuccess={invalidateList}
+        onRepick={() => {
+          setEditingTrigger(null)
+          setCreatingBuiltinKind(null)
+          setPendingAppSelection(null)
+          setPendingWebhookSelection(null)
+          onAddingKindChange('source')
+        }}
       />
 
       {triggers.isLoading ? (

--- a/apps/web/src/components/data-connectors/hooks/use-connector-edits.tsx
+++ b/apps/web/src/components/data-connectors/hooks/use-connector-edits.tsx
@@ -22,6 +22,8 @@ interface Saver {
 }
 
 interface EditsStore {
+  /** When true, registered sections persist their drafts automatically (setup mode). */
+  autoSave: boolean
   subscribe: (cb: () => void) => () => void
   snapshot: () => { isDirty: boolean; isSaving: boolean }
   set: (id: string, saver: Saver) => void
@@ -36,7 +38,7 @@ interface EditsStore {
  * latest `set` while the cached snapshot stays referentially stable between flips
  * (required by `useSyncExternalStore`).
  */
-function createStore(): EditsStore {
+function createStore(autoSave: boolean): EditsStore {
   const savers = new Map<string, Saver>()
   const listeners = new Set<() => void>()
   let cached = { isDirty: false, isSaving: false }
@@ -55,6 +57,7 @@ function createStore(): EditsStore {
   }
 
   return {
+    autoSave,
     subscribe(cb) {
       listeners.add(cb)
       return () => void listeners.delete(cb)
@@ -77,9 +80,19 @@ function createStore(): EditsStore {
 
 const EditsContext = createContext<EditsStore | null>(null)
 
-/** Scopes one shared save buffer over the sections it wraps. */
-export function ConnectorEditsProvider({ children }: { children: ReactNode }) {
-  const store = useMemo(() => createStore(), [])
+/**
+ * Scopes one shared save buffer over the sections it wraps. Pass `autoSave` (setup
+ * mode) to have sections persist their drafts automatically — no manual save click
+ * before the stepper's gated "Continue".
+ */
+export function ConnectorEditsProvider({
+  children,
+  autoSave = false,
+}: {
+  children: ReactNode
+  autoSave?: boolean
+}) {
+  const store = useMemo(() => createStore(autoSave), [autoSave])
   return <EditsContext.Provider value={store}>{children}</EditsContext.Provider>
 }
 
@@ -103,7 +116,19 @@ export function useRegisterSaver(
   }, [store, id, isDirty, isSaving])
 
   useEffect(() => () => store?.remove(id), [store, id])
+
+  // Auto-save (setup mode): debounce a commit while the section is dirty. The effect
+  // re-runs on every render, so continuous edits keep clearing and re-arming the
+  // timer (a draft change re-renders the section); once edits settle for `DEBOUNCE_MS`
+  // it fires once. A save in flight or a clean section arms nothing.
+  useEffect(() => {
+    if (!store?.autoSave || !isDirty || isSaving) return
+    const timer = setTimeout(() => void commitRef.current(), DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  })
 }
+
+const DEBOUNCE_MS = 700
 
 const EMPTY = { isDirty: false, isSaving: false }
 
@@ -117,6 +142,7 @@ export function useConnectorEdits() {
   )
   return {
     ...snapshot,
+    autoSave: store?.autoSave ?? false,
     commitAll: store?.commitAll ?? (async () => {}),
   }
 }

--- a/apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
@@ -25,14 +25,14 @@ export function deriveStreamReadiness(stream: Stream): StreamReadiness {
 }
 
 export interface SetupProgress {
-  /** A credential is bound, or the endpoint declares no auth. */
+  /** Connection is optional, but a generic-rest connector needs an endpoint base URL. */
   connect: boolean
   /** At least one stream has a source schema (a successful sample → "use as schema"). */
   sample: boolean
   /** EVERY stream is `ready` (≥1 mapping with a bound `targetFieldRef`). */
   map: boolean
-  /** Connect + Map satisfied → the terminal "Run first sync" CTA is enabled
-   *  (Sample is implied by Map; Schedule defaults to Manual). */
+  /** Map satisfied → the terminal "Run first sync" CTA is enabled
+   *  (Sample is implied by Map; Schedule defaults to Manual; Connect is optional). */
   canRun: boolean
 }
 
@@ -42,12 +42,16 @@ export interface SetupProgress {
  * detail view already queries (`getById` + `listStreams`). See plan §2.2.
  */
 export function deriveSetupProgress(connector: Connector, streams: Stream[]): SetupProgress {
-  const auth = (connector.config as { endpoint?: { auth?: string } } | null)?.endpoint?.auth
-  const connect = connector.credentialId != null || auth === 'none'
+  // Connection is optional, but a generic-rest connector still needs an endpoint to
+  // fetch from. App connectors get their endpoint from the catalog, so they're exempt.
+  const isGenericRest = connector.definitionKind !== 'app'
+  const baseUrl = (connector.config as { endpoint?: { baseUrl?: string } } | null)?.endpoint
+    ?.baseUrl
+  const connect = !isGenericRest || !!baseUrl?.trim()
   const sample = streams.some((s) => s.sourceSchema != null)
   // Every stream must be mapped — an app connector that fans out to N streams (or
   // carries a draft contributing mapping) can't finish setup with a half-authored
   // fan-out (multi-stream-setup-plan §4.2).
   const map = streams.length > 0 && streams.every((s) => deriveStreamReadiness(s) === 'ready')
-  return { connect, sample, map, canRun: connect && map }
+  return { connect, sample, map, canRun: map }
 }

--- a/apps/web/src/components/data-connectors/ui/connection-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/connection-section.tsx
@@ -3,7 +3,7 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { Section } from '@auxx/ui/components/section'
-import { Plug } from 'lucide-react'
+import { Plug, Trash2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
 import { AppWithStatusIcon } from '~/components/apps/ui/app-with-status-icon'
@@ -97,6 +97,11 @@ export function ConnectionSection({ connector }: ConnectionSectionProps) {
   const bindCredential = (credentialId: string, appInstallationId: string | null = null) =>
     update.mutate({ id: connector.id, credentialId, appInstallationId })
 
+  // Connections are optional (public endpoints need none) — clear the binding by
+  // writing null for both the credential and its app installation.
+  const unbindCredential = () =>
+    update.mutate({ id: connector.id, credentialId: null, appInstallationId: null })
+
   const connected = !!connector.credentialId
 
   // Resolve the bound connection to surface its real icon + name (e.g. "Gmail")
@@ -158,25 +163,38 @@ export function ConnectionSection({ connector }: ConnectionSectionProps) {
                       : 'Connect an account to authorize this connector.'
               }
               actions={() => (
-                <ConnectionPickerPopover
-                  value={connector.credentialId ?? undefined}
-                  onPick={(credentialId, row) =>
-                    bindCredential(credentialId, row.appInstallationId)
-                  }
-                  onCreateNew={() => setAddOpen(true)}
-                  preferredCredentialIds={preferredCredentialIds}
-                  preferredLabel={preferredLabel ?? undefined}
-                  trigger={
-                    <Button variant='outline' size='sm'>
-                      <Plug />
-                      {connected
-                        ? 'Switch connection'
-                        : preferredLabel
-                          ? `Connect ${preferredLabel}`
-                          : 'Connect'}
+                <div className='flex items-center gap-1.5'>
+                  <ConnectionPickerPopover
+                    value={connector.credentialId ?? undefined}
+                    onPick={(credentialId, row) =>
+                      bindCredential(credentialId, row.appInstallationId)
+                    }
+                    onCreateNew={() => setAddOpen(true)}
+                    preferredCredentialIds={preferredCredentialIds}
+                    preferredLabel={preferredLabel ?? undefined}
+                    trigger={
+                      <Button variant='outline' size='sm'>
+                        <Plug />
+                        {connected
+                          ? 'Switch connection'
+                          : preferredLabel
+                            ? `Connect ${preferredLabel}`
+                            : 'Connect'}
+                      </Button>
+                    }
+                  />
+                  {/* Connections are optional — clear the binding for public endpoints. */}
+                  {connected && (
+                    <Button
+                      variant='outline'
+                      size='sm'
+                      aria-label='Remove connection'
+                      loading={update.isPending}
+                      onClick={() => unbindCredential()}>
+                      <Trash2 />
                     </Button>
-                  }
-                />
+                  )}
+                </div>
               )}
             />
           </ConnectionList>

--- a/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
@@ -42,6 +42,8 @@ interface ConnectorDetailTabsProps {
   connector: Connector
   /** On mobile (no dock) the Runs panel is appended as a tab/section. */
   mobileRunsPanel?: React.ReactNode
+  /** Pending mapping-edit re-sync banner — pinned directly under the tabs strip. */
+  resyncBanner?: React.ReactNode
 }
 
 /**
@@ -53,7 +55,11 @@ interface ConnectorDetailTabsProps {
  * and shares the `useScrollSpy` hook.
  * See plans/data-connectors/claude/05-frontend.md §2.
  */
-export function ConnectorDetailTabs({ connector, mobileRunsPanel }: ConnectorDetailTabsProps) {
+export function ConnectorDetailTabs({
+  connector,
+  mobileRunsPanel,
+  resyncBanner,
+}: ConnectorDetailTabsProps) {
   const [tab, setTab] = useQueryState('tab', { defaultValue: 'connection' })
   const [selectedStreamId, setSelectedStreamId] = useQueryState('stream')
 
@@ -106,7 +112,7 @@ export function ConnectorDetailTabs({ connector, mobileRunsPanel }: ConnectorDet
   // section components against the identical mutations (create-sync-flow-plan §2).
   if (asConnectorStatus(connector.status) === 'pending') {
     return (
-      <ConnectorEditsProvider>
+      <ConnectorEditsProvider autoSave>
         <ConnectorSetupStepper connector={connector} />
       </ConnectorEditsProvider>
     )
@@ -139,30 +145,33 @@ export function ConnectorDetailTabs({ connector, mobileRunsPanel }: ConnectorDet
                   </TabsList>
                 </Tabs>
               }>
-              <div className='relative h-full'>
-                <ScrollArea
-                  viewportRef={scrollContainerRef}
-                  className='h-full'
-                  scrollbarClassName='w-1.5 z-20'
-                  noFade>
-                  <div ref={assignRef('connection')}>
-                    <ConnectionSection connector={connector} />
-                  </div>
-                  <div ref={assignRef('streams')}>
-                    <StreamsSection
-                      connector={connector}
-                      onSelect={(id) => setSelectedStreamId(id)}
-                    />
-                  </div>
-                  <div ref={assignRef('schedule')}>
-                    <ScheduleSection connector={connector} />
-                  </div>
+              <div className='flex h-full flex-col'>
+                {resyncBanner}
+                <div className='relative min-h-0 flex-1'>
+                  <ScrollArea
+                    viewportRef={scrollContainerRef}
+                    className='h-full'
+                    scrollbarClassName='w-1.5 z-20'
+                    noFade>
+                    <div ref={assignRef('connection')}>
+                      <ConnectionSection connector={connector} />
+                    </div>
+                    <div ref={assignRef('streams')}>
+                      <StreamsSection
+                        connector={connector}
+                        onSelect={(id) => setSelectedStreamId(id)}
+                      />
+                    </div>
+                    <div ref={assignRef('schedule')}>
+                      <ScheduleSection connector={connector} />
+                    </div>
 
-                  {mobileRunsPanel && <div className='h-[60vh]'>{mobileRunsPanel}</div>}
+                    {mobileRunsPanel && <div className='h-[60vh]'>{mobileRunsPanel}</div>}
 
-                  <div className='h-[40vh]' />
-                </ScrollArea>
-                <ConnectorSaveBar />
+                    <div className='h-[40vh]' />
+                  </ScrollArea>
+                  <ConnectorSaveBar />
+                </div>
               </div>
             </NavStackPanel>
 

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -238,14 +238,6 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
         isSyncing={isSyncPending}
       />
 
-      {/* Pinned between header and content by the flex layout — surfaces a pending
-          mapping-edit re-sync; the actual safety already ran at save time. */}
-      <ConnectorResyncBanner
-        pending={live?.resyncPending}
-        onBackfill={() => backfillPending(connector.id)}
-        isBackfilling={isBackfilling}
-      />
-
       <MainPageContent
         dockedPanels={
           isDesktop
@@ -264,6 +256,13 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
         <ConnectorDetailTabs
           connector={connector}
           mobileRunsPanel={!isDesktop ? runsPanel : null}
+          resyncBanner={
+            <ConnectorResyncBanner
+              pending={live?.resyncPending}
+              onBackfill={() => backfillPending(connector.id)}
+              isBackfilling={isBackfilling}
+            />
+          }
         />
       </MainPageContent>
     </MainPage>

--- a/apps/web/src/components/data-connectors/ui/connector-resync-banner.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-resync-banner.tsx
@@ -21,8 +21,8 @@ interface ConnectorResyncBannerProps {
  * Advisory banner surfacing a pending mapping-edit re-sync (Layer 3). The actual
  * safety already ran at save time; this only offers to run the deferred re-crawl that
  * repopulates history. `rebackfill` reads as info ("records don't reflect the change
- * yet"); `rebind` reads as a warning ("records will be re-linked"). Pinned between the
- * page header and content by the flex layout — never scrolls away. Dismiss hides it
+ * yet"); `rebind` reads as a warning ("records will be re-linked"). Pinned directly
+ * under the Connection/Streams/Schedule tabs strip — never scrolls away. Dismiss hides it
  * for the session; it reappears on reload until the backfill clears `resyncPending`.
  */
 export function ConnectorResyncBanner({

--- a/apps/web/src/components/data-connectors/ui/connector-save-bar.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-save-bar.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
+import { Loader2 } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import { useConnectorEdits } from '../hooks/use-connector-edits'
 
@@ -14,9 +15,33 @@ const SPRING = { type: 'spring', stiffness: 420, damping: 26 } as const
  * wrapped section (source config, schedule) is dirty and springs back down when it
  * isn't. Overlays the scroll content (doesn't take layout), and commits every
  * dirty section at once. Replaces the per-section Save buttons.
+ *
+ * In auto-save mode (setup) there's no manual commit — drafts persist on a debounce —
+ * so the bar degrades to a passive "Saving…" pill shown only while a save is in flight.
  */
 export function ConnectorSaveBar() {
-  const { isDirty, isSaving, commitAll } = useConnectorEdits()
+  const { isDirty, isSaving, autoSave, commitAll } = useConnectorEdits()
+
+  // Setup mode: no button, just transient save feedback.
+  if (autoSave) {
+    return (
+      <div className='pointer-events-none absolute inset-x-0 bottom-0 flex justify-end px-5 pb-4'>
+        <AnimatePresence>
+          {isSaving && (
+            <motion.div
+              initial={{ opacity: 0, y: 24 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 24 }}
+              transition={SPRING}
+              className='flex items-center gap-2 rounded-md border bg-background px-3 py-1.5 text-xs text-muted-foreground shadow-lg'>
+              <Loader2 className='size-3.5 animate-spin' />
+              Saving…
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    )
+  }
 
   return (
     <div className='pointer-events-none absolute inset-x-0 bottom-0 flex justify-end px-5 pb-4'>

--- a/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
@@ -295,7 +295,7 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
     if (id === 'run') return null
     const blocked = !doneById[id]
     const hint: Partial<Record<SetupStepId, string>> = {
-      connect: 'Connect an account to continue.',
+      connect: 'Add the endpoint base URL to continue (a connection is optional).',
       sample: 'Run a test fetch and use its shape as the schema to continue.',
       map: 'Map at least one field to continue.',
     }

--- a/apps/web/src/components/data-connectors/ui/webhook-trigger-binding-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/webhook-trigger-binding-section.tsx
@@ -13,14 +13,16 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { toastError } from '@auxx/ui/components/toast'
-import { Pencil, Plus, Webhook, X } from 'lucide-react'
+import { Plus, Webhook, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
 import {
   type TriggerSource,
   TriggerSourcePicker,
+  TriggerSourceRow,
   useTriggerSources,
 } from '~/components/pickers/trigger-source'
+import { WebhookEndpointInspector } from '~/components/webhooks/ui/webhook-endpoint-inspector'
 import { AppTriggerTestSection } from '~/components/workflow/apps/trigger/app-trigger-test-section'
 import { api, type RouterOutputs } from '~/trpc/react'
 
@@ -138,6 +140,16 @@ export function WebhookTriggerBindingSection({
     [selectedAppTrigger]
   )
 
+  // Scope the live inspector to the bound topic when the binding targets exactly one;
+  // multiple (or none) ⇒ show every delivery to the endpoint.
+  const singleTopic = useMemo(() => {
+    const list = topics
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+    return list.length === 1 ? list[0] : undefined
+  }, [topics])
+
   const handlePick = (picked: TriggerSource) => {
     if (picked.kind === 'app') setSource({ kind: 'app', triggerId: picked.trigger.triggerId })
     else setSource({ kind: 'webhook-endpoint', webhookEndpointId: picked.endpoint.id })
@@ -206,24 +218,18 @@ export function WebhookTriggerBindingSection({
       <div className='flex flex-col gap-4 px-1'>
         <div className='flex flex-col gap-1.5'>
           <Label>Trigger</Label>
-          {sourceLabel ? (
-            <div className='flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2'>
-              <Webhook className='size-4 text-muted-foreground' />
-              <span className='flex-1 truncate text-sm font-medium'>{sourceLabel}</span>
-              <Button variant='ghost' size='icon-sm' onClick={() => setPickerOpen(true)}>
-                <Pencil />
-              </Button>
-            </div>
+          {source && sourceLabel ? (
+            <TriggerSourceRow
+              icon={<Webhook className='size-4 text-muted-foreground' />}
+              title={sourceLabel}
+              secondary={selectedEndpoint?.url ?? selectedAppTrigger?.description}
+              onEdit={() => setPickerOpen(true)}
+              onDelete={() => setSource(null)}
+            />
           ) : (
             <Button variant='outline' className='self-start' onClick={() => setPickerOpen(true)}>
               Select a trigger…
             </Button>
-          )}
-          {selectedAppTrigger?.description && (
-            <p className='text-xs text-muted-foreground'>{selectedAppTrigger.description}</p>
-          )}
-          {selectedEndpoint && (
-            <p className='text-xs text-muted-foreground'>{selectedEndpoint.url}</p>
           )}
         </div>
 
@@ -338,6 +344,16 @@ export function WebhookTriggerBindingSection({
         {source?.kind === 'app' && installationId && (
           <div className='border-t pt-3'>
             <AppTriggerTestSection installationId={installationId} triggerId={source.triggerId} />
+          </div>
+        )}
+
+        {source?.kind === 'webhook-endpoint' && (
+          <div className='border-t pt-3'>
+            <WebhookEndpointInspector
+              endpointId={source.webhookEndpointId}
+              topic={singleTopic}
+              description='Live deliveries to this endpoint matching this binding.'
+            />
           </div>
         )}
       </div>

--- a/apps/web/src/components/pickers/trigger-source/index.ts
+++ b/apps/web/src/components/pickers/trigger-source/index.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/pickers/trigger-source/index.ts
 export { TriggerSourcePicker } from './trigger-source-picker'
+export { TriggerSourceRow } from './trigger-source-row'
 export {
   type AppTriggerSource,
   type TriggerSource,

--- a/apps/web/src/components/pickers/trigger-source/trigger-source-row.tsx
+++ b/apps/web/src/components/pickers/trigger-source/trigger-source-row.tsx
@@ -1,0 +1,60 @@
+// apps/web/src/components/pickers/trigger-source/trigger-source-row.tsx
+// The "selected trigger source" row — an icon + name + (truncated) secondary, with
+// hover-revealed Edit (Pencil) and Remove (Trash2) actions. A thin TreeRow so every
+// surface that shows a chosen app trigger / webhook endpoint (agent trigger dialog,
+// data-connector binding) renders it identically. Pass only the handlers that apply —
+// each button renders only when its handler is supplied.
+
+'use client'
+
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { Pencil, Trash2 } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+interface TriggerSourceRowProps {
+  icon: ReactNode
+  title: ReactNode
+  /** Secondary text shown after the title (e.g. the endpoint URL or trigger description). */
+  secondary?: ReactNode
+  /** Edit — re-open the picker to re-pick the source. Pencil hidden when omitted. */
+  onEdit?: () => void
+  /** Remove — clear the selection / delete the trigger. Trash2 hidden when omitted. */
+  onDelete?: () => void
+}
+
+export function TriggerSourceRow({
+  icon,
+  title,
+  secondary,
+  onEdit,
+  onDelete,
+}: TriggerSourceRowProps) {
+  return (
+    <TreeRow
+      icon={icon}
+      title={title}
+      secondary={secondary}
+      secondaryFill
+      actions={
+        onEdit || onDelete ? (
+          <>
+            {onEdit && (
+              <TreeRowButton tooltipText='Edit' aria-label='Edit' onClick={onEdit}>
+                <Pencil />
+              </TreeRowButton>
+            )}
+            {onDelete && (
+              <TreeRowButton
+                variant='destructive'
+                tooltipText='Remove'
+                aria-label='Remove'
+                onClick={onDelete}>
+                <Trash2 />
+              </TreeRowButton>
+            )}
+          </>
+        ) : undefined
+      }
+    />
+  )
+}

--- a/apps/web/src/components/webhooks/hooks/use-webhook-endpoint-events.ts
+++ b/apps/web/src/components/webhooks/hooks/use-webhook-endpoint-events.ts
@@ -1,0 +1,30 @@
+// apps/web/src/components/webhooks/hooks/use-webhook-endpoint-events.ts
+// Live-delivery listener for a generic inbound WebhookEndpoint. The event shape mirrors
+// what the ingress writes to Redis (`pushWebhookEndpointEvent` in apps/api webhooks.ts):
+// the per-delivery topic travels on the payload so binding-scoped views can filter on it.
+// Thin configs over the shared SSE test-event primitives.
+
+'use client'
+
+import {
+  type BaseTestEvent,
+  createTestEventStore,
+  useTestEventListener,
+} from '~/components/workflow/shared/test-events'
+
+export interface WebhookEndpointTestEvent extends BaseTestEvent {
+  source: 'webhook'
+  /** The topic extracted from this delivery ('' when the endpoint declares no topic source). */
+  topic: string
+  triggerData: Record<string, unknown>
+  eventId?: string
+}
+
+const useWebhookEndpointTestStore = createTestEventStore<WebhookEndpointTestEvent>(
+  (endpointId) => `/api/webhook-endpoints/${endpointId}/events`
+)
+
+/** Subscribe to the live delivery stream for one endpoint (listen/stop/clear + events). */
+export function useWebhookEndpointTestListener(endpointId: string) {
+  return useTestEventListener<WebhookEndpointTestEvent>(useWebhookEndpointTestStore, endpointId)
+}

--- a/apps/web/src/components/webhooks/ui/webhook-endpoint-dialog.tsx
+++ b/apps/web/src/components/webhooks/ui/webhook-endpoint-dialog.tsx
@@ -15,7 +15,7 @@ import {
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { Label } from '@auxx/ui/components/label'
 import { useCopy } from '@auxx/ui/hooks/use-copy'
-import { Check, Copy, KeyRound, Link, TriangleAlert } from 'lucide-react'
+import { Check, Copy, KeyRound, Link, Radio, TriangleAlert } from 'lucide-react'
 import { type ReactNode, useEffect, useState } from 'react'
 import { ConnectionVariableFields } from '~/components/connections/ui/connection-variable-fields'
 import {
@@ -25,6 +25,7 @@ import {
 import { Tooltip } from '~/components/global/tooltip'
 import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
 import { useWebhookEndpoint, type WebhookEndpointRow } from '../hooks/use-webhook-endpoint'
+import { WebhookEndpointInspector } from './webhook-endpoint-inspector'
 
 interface WebhookEndpointDialogProps {
   open: boolean
@@ -170,7 +171,7 @@ export function WebhookEndpointDialog({ open, onClose, endpoint }: WebhookEndpoi
   const isEdit = !!endpoint
   const { create, update, rotateSecret } = useWebhookEndpoint()
 
-  const [page, setPage] = useState<'configure' | 'created'>('configure')
+  const [page, setPage] = useState<'configure' | 'created' | 'deliveries'>('configure')
   const [values, setValues] = useState<Record<string, string>>(() => seedValues(endpoint))
   const [errors, setErrors] = useState<Record<string, string>>({})
   /** The reveal shown on `created`: the endpoint URL + the one-time plaintext secret. */
@@ -249,6 +250,7 @@ export function WebhookEndpointDialog({ open, onClose, endpoint }: WebhookEndpoi
           crumbs={[
             { label: isEdit ? endpoint.name : 'New endpoint' },
             ...(page === 'created' ? [{ label: revealed?.title ?? 'Created' }] : []),
+            ...(page === 'deliveries' ? [{ label: 'Deliveries' }] : []),
           ]}
         />
 
@@ -260,7 +262,20 @@ export function WebhookEndpointDialog({ open, onClose, endpoint }: WebhookEndpoi
                 handleSubmit()
               }}
               className='flex flex-col gap-4 p-4'>
-              {isEdit && <CopyRow label='Webhook URL' value={endpoint.url} icon={<Link />} />}
+              {isEdit && (
+                <div className='space-y-2'>
+                  <CopyRow label='Webhook URL' value={endpoint.url} icon={<Link />} />
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    type='button'
+                    className='self-start'
+                    onClick={() => setPage('deliveries')}>
+                    <Radio />
+                    View deliveries
+                  </Button>
+                </div>
+              )}
 
               <div className='flex flex-col gap-2'>
                 <div className='text-xs font-medium text-muted-foreground'>Configuration</div>
@@ -346,6 +361,28 @@ export function WebhookEndpointDialog({ open, onClose, endpoint }: WebhookEndpoi
                 </Button>
               </DialogFooter>
             </form>
+          </DialogNavPage>
+
+          <DialogNavPage value='deliveries' size='md'>
+            <div className='flex flex-col gap-4 p-4'>
+              {isEdit && (
+                <WebhookEndpointInspector
+                  endpointId={endpoint.id}
+                  title='Deliveries'
+                  description='Live deliveries to this endpoint (kept for ~5 minutes).'
+                  initialOpen
+                />
+              )}
+              <DialogFooter>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  type='button'
+                  onClick={() => setPage('configure')}>
+                  Back
+                </Button>
+              </DialogFooter>
+            </div>
           </DialogNavPage>
         </DialogNavPages>
       </DialogContent>

--- a/apps/web/src/components/webhooks/ui/webhook-endpoint-inspector.tsx
+++ b/apps/web/src/components/webhooks/ui/webhook-endpoint-inspector.tsx
@@ -1,0 +1,105 @@
+// apps/web/src/components/webhooks/ui/webhook-endpoint-inspector.tsx
+// Live delivery inspector for a generic inbound WebhookEndpoint. Listen-only (no synthetic
+// send — the endpoint's public URL is the test path): toggle listening, watch deliveries
+// land, inspect raw payloads. Endpoint-scoped by default; pass `topic` to scope a binding
+// view to matching deliveries, with a muted hint counting deliveries on other topics so a
+// topic typo is visible.
+
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { useMemo } from 'react'
+import { TestEventList, TriggerEventInspector } from '~/components/workflow/shared/test-events'
+import {
+  useWebhookEndpointTestListener,
+  type WebhookEndpointTestEvent,
+} from '../hooks/use-webhook-endpoint-events'
+
+interface WebhookEndpointInspectorProps {
+  endpointId: string
+  /** When set, only deliveries whose extracted topic matches are shown (binding-scoped). */
+  topic?: string
+  title?: string
+  description?: string
+  initialOpen?: boolean
+}
+
+export function WebhookEndpointInspector({
+  endpointId,
+  topic,
+  title = 'Deliveries',
+  description = 'Listen for live deliveries to this endpoint.',
+  initialOpen = false,
+}: WebhookEndpointInspectorProps) {
+  const listener = useWebhookEndpointTestListener(endpointId)
+  const scopedTopic = topic?.trim() || null
+
+  return (
+    <TriggerEventInspector<WebhookEndpointTestEvent>
+      listener={listener}
+      title={title}
+      description={description}
+      initialOpen={initialOpen}
+      renderEvents={(events, onClear) => (
+        <WebhookEndpointEventList events={events} onClear={onClear} scopedTopic={scopedTopic} />
+      )}
+    />
+  )
+}
+
+function WebhookEndpointEventList({
+  events,
+  onClear,
+  scopedTopic,
+}: {
+  events: WebhookEndpointTestEvent[]
+  onClear: () => void
+  scopedTopic: string | null
+}) {
+  const { shown, otherCount } = useMemo(() => {
+    if (!scopedTopic) return { shown: events, otherCount: 0 }
+    const shown = events.filter((e) => e.topic === scopedTopic)
+    return { shown, otherCount: events.length - shown.length }
+  }, [events, scopedTopic])
+
+  return (
+    <div className='space-y-2'>
+      <TestEventList<WebhookEndpointTestEvent>
+        events={shown}
+        onClear={onClear}
+        emptyTitle={
+          scopedTopic ? `No deliveries on "${scopedTopic}" yet` : 'No deliveries captured yet'
+        }
+        emptyDescription='Deliveries to this endpoint will appear here in real time.'
+        renderEventBadges={(event) => (
+          <>
+            {event.topic ? (
+              <Badge variant='secondary' className='text-xs'>
+                {event.topic}
+              </Badge>
+            ) : null}
+            {event.eventId && (
+              <span className='text-xs text-muted-foreground font-mono truncate max-w-32'>
+                {event.eventId}
+              </span>
+            )}
+          </>
+        )}
+        renderEventDetail={(event) => (
+          <div>
+            <h5 className='text-xs font-medium mb-1'>Payload</h5>
+            <pre className='text-xs bg-muted p-2 rounded overflow-x-auto max-h-48 overflow-y-auto'>
+              {JSON.stringify(event.triggerData, null, 2)}
+            </pre>
+          </div>
+        )}
+      />
+      {scopedTopic && otherCount > 0 && (
+        <p className='text-xs text-muted-foreground'>
+          {otherCount} other {otherCount === 1 ? 'delivery' : 'deliveries'} to this endpoint on
+          other topics (not matching <code>{scopedTopic}</code>).
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/workflow/apps/trigger/app-trigger-test-section.tsx
+++ b/apps/web/src/components/workflow/apps/trigger/app-trigger-test-section.tsx
@@ -2,15 +2,10 @@
 
 'use client'
 
-import { Button } from '@auxx/ui/components/button'
-import { toastError } from '@auxx/ui/components/toast'
-import { cn } from '@auxx/ui/lib/utils'
-import { Play, Radio } from 'lucide-react'
-import { useCallback, useState } from 'react'
-import { CodeEditor } from '~/components/schema-editor/ui/code-editor'
+import { useMemo } from 'react'
 import { useAppTriggerTestListener } from '~/components/workflow/hooks/use-app-trigger-test-listener'
+import { TriggerEventInspector } from '~/components/workflow/shared/test-events'
 import type { WorkflowBlockOutput } from '~/components/workflow/types/block-types'
-import Section from '~/components/workflow/ui/section'
 import { AppTriggerTestEvents } from './app-trigger-test-events'
 
 function buildSampleData(outputs?: Record<string, WorkflowBlockOutput>): Record<string, unknown> {
@@ -46,118 +41,38 @@ interface AppTriggerTestSectionProps {
   schema?: { outputs?: Record<string, WorkflowBlockOutput> }
 }
 
+/**
+ * App-trigger delivery inspector — live listen + synthetic "Send test event" (seeded from the
+ * trigger's declared output schema). A thin wrapper over the shared {@link TriggerEventInspector}.
+ */
 export function AppTriggerTestSection({
   installationId,
   triggerId,
   schema,
 }: AppTriggerTestSectionProps) {
-  const { events, isListening, connectionStatus, startListening, stopListening, clearEvents } =
-    useAppTriggerTestListener(installationId, triggerId)
-
-  const [showTestEditor, setShowTestEditor] = useState(false)
-  const [testData, setTestData] = useState(() =>
-    JSON.stringify(buildSampleData(schema?.outputs), null, 2)
+  const listener = useAppTriggerTestListener(installationId, triggerId)
+  const sampleData = useMemo(
+    () => JSON.stringify(buildSampleData(schema?.outputs), null, 2),
+    [schema?.outputs]
   )
-  const [isSending, setIsSending] = useState(false)
-
-  const handleSendTest = useCallback(async () => {
-    let parsed: Record<string, unknown>
-    try {
-      parsed = JSON.parse(testData)
-    } catch {
-      toastError({ title: 'Invalid JSON', description: 'Please enter valid JSON data' })
-      return
-    }
-
-    setIsSending(true)
-    try {
-      const res = await fetch(`/api/app-triggers/${installationId}/${triggerId}/test`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ triggerData: parsed }),
-      })
-      if (!res.ok) {
-        const text = await res.text()
-        toastError({ title: 'Failed to send test event', description: text })
-      }
-    } catch (error: any) {
-      toastError({ title: 'Failed to send test event', description: error.message })
-    } finally {
-      setIsSending(false)
-    }
-  }, [testData, installationId, triggerId])
 
   return (
-    <Section
+    <TriggerEventInspector
+      listener={listener}
       title='Test Trigger'
       description='Listen for incoming trigger events or send a manual test.'
-      actions={
-        <div className='flex items-center gap-2'>
-          <div
-            className={cn(
-              'size-2 rounded-full',
-              connectionStatus === 'connected'
-                ? 'bg-green-500'
-                : connectionStatus === 'connecting'
-                  ? 'bg-yellow-500 animate-pulse'
-                  : 'bg-gray-400'
-            )}
-          />
-          <span className='text-xs text-muted-foreground'>
-            {connectionStatus === 'connected'
-              ? 'Listening'
-              : connectionStatus === 'connecting'
-                ? 'Connecting...'
-                : 'Disconnected'}
-          </span>
-        </div>
-      }>
-      <div className='space-y-3'>
-        <div className='flex items-center gap-2'>
-          <Button
-            variant='outline'
-            size='sm'
-            className={cn(
-              isListening &&
-                'bg-bad-200 hover:bg-bad-200 text-bad-500 hover:text-bad-500 border-bad-300'
-            )}
-            onClick={() => (isListening ? stopListening() : startListening())}>
-            {isListening ? (
-              <span className='size-2.5 rounded-full bg-bad-500 animate-pulse' />
-            ) : (
-              <Radio />
-            )}
-            {isListening ? 'Listening...' : 'Listen for Events'}
-          </Button>
-
-          <Button variant='outline' size='sm' onClick={() => setShowTestEditor(!showTestEditor)}>
-            <Play />
-            Send Test Event
-          </Button>
-        </div>
-
-        {showTestEditor && (
-          <div className='space-y-2'>
-            <CodeEditor
-              value={testData}
-              onUpdate={setTestData}
-              className='h-40 rounded-lg border'
-            />
-            <Button
-              variant='default'
-              size='sm'
-              onClick={handleSendTest}
-              loading={isSending}
-              loadingText='Sending...'>
-              Send
-            </Button>
-          </div>
-        )}
-
-        {(isListening || events.length > 0) && (
-          <AppTriggerTestEvents events={events} onClear={clearEvents} />
-        )}
-      </div>
-    </Section>
+      renderEvents={(events, onClear) => <AppTriggerTestEvents events={events} onClear={onClear} />}
+      send={{
+        sampleData,
+        onSend: async (parsed) => {
+          const res = await fetch(`/api/app-triggers/${installationId}/${triggerId}/test`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ triggerData: parsed }),
+          })
+          if (!res.ok) throw new Error(await res.text())
+        },
+      }}
+    />
   )
 }

--- a/apps/web/src/components/workflow/nodes/core/webhook-trigger/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/webhook-trigger/panel.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import React, { useMemo } from 'react'
+import { WebhookEndpointInspector } from '~/components/webhooks/ui/webhook-endpoint-inspector'
 import { useNodeCrud, useReadOnly } from '~/components/workflow/hooks'
 import { BasePanel } from '~/components/workflow/nodes/shared/base/base-panel'
 import Field from '~/components/workflow/ui/field'
@@ -106,6 +107,14 @@ const WebhookTriggerPanelComponent: React.FC<WebhookTriggerPanelProps> = ({ node
           )}
         </div>
       </Section>
+
+      {nodeData.webhookEndpointId && (
+        <WebhookEndpointInspector
+          endpointId={nodeData.webhookEndpointId}
+          topic={nodeData.topic}
+          description='Live deliveries to this endpoint matching this trigger.'
+        />
+      )}
 
       <OutputVariablesDisplay
         outputVariables={webhookTriggerDefinition.outputVariables?.(nodeData, nodeId) || []}

--- a/apps/web/src/components/workflow/shared/test-events/index.ts
+++ b/apps/web/src/components/workflow/shared/test-events/index.ts
@@ -2,5 +2,9 @@
 
 export { createTestEventStore } from './create-test-event-store'
 export { TestEventList } from './test-event-list'
+export {
+  TriggerEventInspector,
+  type TriggerEventListenerState,
+} from './trigger-event-inspector'
 export type { BaseTestEvent, ConnectionStatus, TestEventListener, TestEventStore } from './types'
 export { useTestEventListener } from './use-test-event-listener'

--- a/apps/web/src/components/workflow/shared/test-events/trigger-event-inspector.tsx
+++ b/apps/web/src/components/workflow/shared/test-events/trigger-event-inspector.tsx
@@ -1,0 +1,154 @@
+// apps/web/src/components/workflow/shared/test-events/trigger-event-inspector.tsx
+// Shared live-delivery inspector shell: a listen toggle + connection indicator + event
+// list, optionally with a synthetic "Send test event" editor. Both the app-trigger
+// inspector (with send) and the generic WebhookEndpoint inspector (listen-only) render
+// through this — the shell is source-agnostic, the caller wires the listener + renderer.
+
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Section } from '@auxx/ui/components/section'
+import { toastError } from '@auxx/ui/components/toast'
+import { cn } from '@auxx/ui/lib/utils'
+import { Play, Radio } from 'lucide-react'
+import { type ReactNode, useCallback, useState } from 'react'
+import { CodeEditor } from '~/components/schema-editor/ui/code-editor'
+import type { BaseTestEvent, ConnectionStatus } from './types'
+
+/** The slice of `useTestEventListener`'s return this shell needs. */
+export interface TriggerEventListenerState<T extends BaseTestEvent> {
+  events: T[]
+  isListening: boolean
+  connectionStatus: ConnectionStatus
+  startListening: () => void
+  stopListening: () => void
+  clearEvents: () => void
+}
+
+interface TriggerEventInspectorProps<T extends BaseTestEvent> {
+  listener: TriggerEventListenerState<T>
+  title?: string
+  description?: string
+  initialOpen?: boolean
+  /** Renders the captured events (e.g. the shared `TestEventList`). */
+  renderEvents: (events: T[], onClear: () => void) => ReactNode
+  /**
+   * Synthetic test-send affordance. OMIT for listen-only sources (generic webhook
+   * endpoints — the real URL is the test path). When present, shows a JSON editor seeded
+   * with `sampleData` and POSTs the parsed payload through `onSend`.
+   */
+  send?: {
+    sampleData: string
+    onSend: (parsed: Record<string, unknown>) => Promise<void>
+  }
+}
+
+export function TriggerEventInspector<T extends BaseTestEvent>({
+  listener,
+  title = 'Deliveries',
+  description = 'Listen for incoming events in real time.',
+  initialOpen = true,
+  renderEvents,
+  send,
+}: TriggerEventInspectorProps<T>) {
+  const { events, isListening, connectionStatus, startListening, stopListening, clearEvents } =
+    listener
+
+  const [showTestEditor, setShowTestEditor] = useState(false)
+  const [testData, setTestData] = useState(() => send?.sampleData ?? '{}')
+  const [isSending, setIsSending] = useState(false)
+
+  const handleSendTest = useCallback(async () => {
+    if (!send) return
+    let parsed: Record<string, unknown>
+    try {
+      parsed = JSON.parse(testData)
+    } catch {
+      toastError({ title: 'Invalid JSON', description: 'Please enter valid JSON data' })
+      return
+    }
+    setIsSending(true)
+    try {
+      await send.onSend(parsed)
+    } catch (error: any) {
+      toastError({ title: 'Failed to send test event', description: error.message })
+    } finally {
+      setIsSending(false)
+    }
+  }, [send, testData])
+
+  return (
+    <Section
+      title={title}
+      description={description}
+      initialOpen={initialOpen}
+      actions={
+        <div className='flex items-center gap-2'>
+          <div
+            className={cn(
+              'size-2 rounded-full',
+              connectionStatus === 'connected'
+                ? 'bg-green-500'
+                : connectionStatus === 'connecting'
+                  ? 'bg-yellow-500 animate-pulse'
+                  : 'bg-gray-400'
+            )}
+          />
+          <span className='text-xs text-muted-foreground'>
+            {connectionStatus === 'connected'
+              ? 'Listening'
+              : connectionStatus === 'connecting'
+                ? 'Connecting...'
+                : 'Disconnected'}
+          </span>
+        </div>
+      }>
+      <div className='space-y-3'>
+        <div className='flex items-center gap-2'>
+          <Button
+            variant='outline'
+            size='sm'
+            className={cn(
+              isListening &&
+                'bg-bad-200 hover:bg-bad-200 text-bad-500 hover:text-bad-500 border-bad-300'
+            )}
+            onClick={() => (isListening ? stopListening() : startListening())}>
+            {isListening ? (
+              <span className='size-2.5 rounded-full bg-bad-500 animate-pulse' />
+            ) : (
+              <Radio />
+            )}
+            {isListening ? 'Listening...' : 'Listen for Events'}
+          </Button>
+
+          {send && (
+            <Button variant='outline' size='sm' onClick={() => setShowTestEditor(!showTestEditor)}>
+              <Play />
+              Send Test Event
+            </Button>
+          )}
+        </div>
+
+        {send && showTestEditor && (
+          <div className='space-y-2'>
+            <CodeEditor
+              value={testData}
+              onUpdate={setTestData}
+              className='h-40 rounded-lg border'
+            />
+            <Button
+              variant='default'
+              size='sm'
+              onClick={handleSendTest}
+              loading={isSending}
+              loadingText='Sending...'>
+              Send
+            </Button>
+          </div>
+        )}
+
+        {(isListening || events.length > 0) && renderEvents(events, clearEvents)}
+      </div>
+    </Section>
+  )
+}

--- a/packages/lib/src/jobs/data-connector/app-trigger-sync-stream-job.ts
+++ b/packages/lib/src/jobs/data-connector/app-trigger-sync-stream-job.ts
@@ -117,9 +117,10 @@ async function deadLetter(job: Job<ConnectorAppTriggerStreamJobData>, err: unkno
     const redis = await getRedisClient(false)
     if (!redis) return
     // Sit the DLQ beside whichever inspector list fed the event: app triggers use
-    // `app-trigger-test:<inst>:<triggerId>:*`, generic endpoints `webhook-endpoint:<id>:<topic>:*`.
+    // `app-trigger-test:<inst>:<triggerId>:dlq`, generic endpoints `webhook-endpoint:<id>:dlq`
+    // (topic-agnostic, mirroring the events key — the topic is kept on the entry).
     const key = webhookEndpointId
-      ? `webhook-endpoint:${webhookEndpointId}:${topic ?? ''}:dlq`
+      ? `webhook-endpoint:${webhookEndpointId}:dlq`
       : `app-trigger-test:${appInstallationId}:${triggerId}:dlq`
     const entry = {
       id: eventId,
@@ -128,6 +129,7 @@ async function deadLetter(job: Job<ConnectorAppTriggerStreamJobData>, err: unkno
       connectorId,
       streamKey,
       eventId,
+      topic,
       error: err instanceof Error ? err.message : String(err),
       triggerData,
     }

--- a/packages/ui/src/components/tree-row.tsx
+++ b/packages/ui/src/components/tree-row.tsx
@@ -17,6 +17,11 @@ export interface TreeRowProps {
   description?: string
   /** Secondary text rendered to the right of the description. */
   secondary?: React.ReactNode
+  /**
+   * Let the `title` keep its natural width and have `secondary` fill the remaining space
+   * (truncating). Default: both size to content, so a long `secondary` can crowd the title.
+   */
+  secondaryFill?: boolean
   /** Right-side slot — switch, badge cluster, count text, etc. */
   actions?: React.ReactNode
   /** Escape hatch — full custom trailing content; if set, replaces `actions` + chevron. */
@@ -188,6 +193,7 @@ export function TreeRow({
   title,
   description,
   secondary,
+  secondaryFill = false,
   actions,
   trailing,
   depth = 0,
@@ -209,6 +215,7 @@ export function TreeRow({
     <span
       className={cn(
         'truncate px-1 py-1.5 text-foreground text-sm',
+        secondaryFill && 'shrink-0',
         onTitleClick && 'cursor-pointer'
       )}
       onClick={
@@ -246,7 +253,15 @@ export function TreeRow({
           {description && (
             <TooltipExplanation text={description} className='text-primary-400 shrink-0' />
           )}
-          {secondary && <span className='ml-1 truncate text-primary-400 text-sm'>{secondary}</span>}
+          {secondary && (
+            <span
+              className={cn(
+                'ml-1 truncate text-primary-400 text-sm',
+                secondaryFill && 'min-w-0 flex-1'
+              )}>
+              {secondary}
+            </span>
+          )}
 
           {/* Trailing chevron — omitted when the icon doubles as the hover chevron. */}
           {expandable && !chevronOnHover && (


### PR DESCRIPTION
## Live WebhookEndpoint delivery inspector

Closes the deferred item from `unified-trigger-picker-plan.md` §7.5. Plan: `plans/data-connectors/v6/webhook-endpoint-inspector-plan.md`.

- **Producer fix** — topic-agnostic Redis events key (`webhook-endpoint:<id>:events`) so an endpoint-level listener sees *every* delivery (the per-delivery topic stays on the payload for client-side filtering). Connector-sync DLQ key aligned to match.
- **Shared shell** — extracted `TriggerEventInspector` from `AppTriggerTestSection` (listen toggle + connection dot + optional synthetic "Send test event" + event list). App-trigger inspector refactored onto it — **behavior-identical**. Synthetic send is an optional prop; endpoints are listen-only (the real URL is the test path).
- **Endpoint wiring** — SSE route (`/api/webhook-endpoints/[endpointId]/events`), store + `useWebhookEndpointTestListener`, and `WebhookEndpointInspector` with optional `topic` scoping + an "N other deliveries on other topics" hint (surfaces topic typos).
- **Shown in 4 surfaces:** webhook management dialog (new **Deliveries** page), data-connector binding, agent trigger dialog, workflow webhook node panel.

## TreeRow trigger source rows

- New **`TriggerSourceRow`** (`TreeRow` + hover `Pencil`/`Trash2` via `TreeRowButton`) replaces the bespoke bordered chips in the agent trigger dialog (app + webhook) and the data-connector binding. **Edit** re-opens the picker; **Delete** clears the selection / removes the trigger. Agent dialog footer "Delete" steps aside for app/webhook kinds so there's one delete affordance.
- Opt-in **`TreeRow.secondaryFill`** — title keeps natural width, secondary fills remaining space and truncates. Default off → **no other TreeRow usage changes**.

## Also bundled
In-progress **data-connector detail/setup UI** changes from a concurrent agent (connector detail tabs/view, save bar, setup stepper, `use-connector-edits`/`use-setup-progress` hooks, connection + resync sections). Included per request to commit everything.

## Notes / deferred
- **DLQ view** deferred — failed connector syncs land on `:dlq` but the inspector shows only the success stream (a failing binding can read as "no deliveries").
- **No persistence** — events are Redis-only (~5 min TTL), same as the app-trigger inspector.
- Agent-dialog chip **Edit (re-pick) is create-only** — re-picking an existing trigger's source isn't a supported op (delete + recreate).
- Did **not** run full `pnpm test` / `tsc` (per repo guidance); biome lint clean on all changed files.