### PR TITLE
feat(data-connectors): pagination stall guard + webhook steering token fields

### DIFF
--- a/apps/web/src/components/data-connectors/lib/resolve-sync-status.test.ts
+++ b/apps/web/src/components/data-connectors/lib/resolve-sync-status.test.ts
@@ -66,9 +66,11 @@ describe('resolveSyncStatus', () => {
     expect(r).toMatchObject({ state: 'action-needed', primaryAction: 'reconnect' })
   })
 
-  it('maps a generic error → error/retry and surfaces the message', () => {
+  it('maps a generic error → error/retry with static detail (raw message goes to a tooltip)', () => {
     const r = resolveSyncStatus({ status: 'error', error: 'upstream 500' }, NOW)
-    expect(r).toMatchObject({ state: 'error', primaryAction: 'retry', detail: 'upstream 500' })
+    // The header detail stays short/static; the raw error is surfaced separately by the
+    // status-line tooltip, not dumped into `detail`.
+    expect(r).toMatchObject({ state: 'error', primaryAction: 'retry', detail: 'Last sync failed.' })
   })
 
   it('derives rate-limited from a future rateLimitedUntil while syncing', () => {

--- a/apps/web/src/components/data-connectors/lib/resolve-sync-status.ts
+++ b/apps/web/src/components/data-connectors/lib/resolve-sync-status.ts
@@ -146,7 +146,9 @@ export function resolveSyncStatus(
     return {
       state: 'error',
       label: 'Error',
-      detail: error?.trim() || 'Last sync failed.',
+      // Static copy only — the raw (often long, technical) error message is surfaced
+      // separately behind a tooltip in the status line, not dumped into the header.
+      detail: 'Last sync failed.',
       primaryAction: 'retry',
     }
   }

--- a/apps/web/src/components/data-connectors/ui/connector-status-line.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-status-line.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { LastUpdated } from '@auxx/ui/components/last-updated'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
 import {
   AlertTriangle,
@@ -70,6 +71,7 @@ export function ConnectorStatusLine({
       <SecondaryLine
         state={resolved.state}
         detail={resolved.detail}
+        error={error}
         countdownUntil={resolved.countdownUntil}
         lastSyncedAt={lastSyncedAt}
       />
@@ -81,11 +83,13 @@ export function ConnectorStatusLine({
 function SecondaryLine({
   state,
   detail,
+  error,
   countdownUntil,
   lastSyncedAt,
 }: {
   state: SyncStatusState
   detail: string
+  error?: string | null
   countdownUntil?: string
   lastSyncedAt?: Date | string | null
 }) {
@@ -102,6 +106,19 @@ function SecondaryLine({
   if (state === 'synced' && lastSyncedAt) {
     return (
       <LastUpdated className='truncate text-xs' timestamp={lastSyncedAt} prefix='Last synced' />
+    )
+  }
+
+  // Error / action-needed → keep the inline copy short and static; the raw error
+  // message (often a long, technical sync failure) lives behind a hover tooltip
+  // instead of stretching the header.
+  if ((state === 'error' || state === 'action-needed') && error?.trim()) {
+    return (
+      <SimpleTooltip content={error.trim()}>
+        <span className='cursor-help truncate text-muted-foreground underline decoration-dotted underline-offset-2'>
+          {detail}
+        </span>
+      </SimpleTooltip>
     )
   }
 

--- a/apps/web/src/components/data-connectors/ui/request-editors.tsx
+++ b/apps/web/src/components/data-connectors/ui/request-editors.tsx
@@ -6,6 +6,7 @@ import { generateId } from '@auxx/utils/generateId'
 import { Minus, Plus } from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
 import {
+  type HttpRequestFieldContextValue,
   HttpRequestFieldProvider,
   type KeyValue,
   KeyValueList,
@@ -35,15 +36,24 @@ export const PLAIN_FIELD = {
   valuePlaceholder: 'Enter value...',
 }
 
-/** Headers / query params — a Record-backed wrapper over the shared KeyValueList. */
+/**
+ * Headers / query params — a Record-backed wrapper over the shared KeyValueList.
+ *
+ * `fieldContext` overrides the value editor (default: plain inputs). Webhook-sync
+ * streams pass a token-aware context so values gain `{path}` steering inserts; the
+ * key column stays a plain input (`keyNotSupportVar`) since header/param names are
+ * static.
+ */
 export function RecordKeyValueEditor({
   record,
   onChange,
   readonly = false,
+  fieldContext = PLAIN_FIELD,
 }: {
   record: Record<string, unknown> | undefined
   onChange: (record: Record<string, string>) => void
   readonly?: boolean
+  fieldContext?: HttpRequestFieldContextValue
 }) {
   const [list, setList] = useState<KeyValue[]>(() => recordToKeyValue(record))
   // The serialized record we last emitted/seeded from — detects truly external
@@ -66,12 +76,13 @@ export function RecordKeyValueEditor({
   }
 
   return (
-    <HttpRequestFieldProvider value={PLAIN_FIELD}>
+    <HttpRequestFieldProvider value={fieldContext}>
       <KeyValueList
         readonly={readonly}
         list={list}
         onChange={emit}
         onAdd={() => emit([...list, { id: generateId(), key: '', value: '' }])}
+        keyNotSupportVar
       />
     </HttpRequestFieldProvider>
   )

--- a/apps/web/src/components/data-connectors/ui/steering-token-source.tsx
+++ b/apps/web/src/components/data-connectors/ui/steering-token-source.tsx
@@ -1,0 +1,87 @@
+// apps/web/src/components/data-connectors/ui/steering-token-source.tsx
+'use client'
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@auxx/ui/components/command'
+import { cn } from '@auxx/ui/lib/utils'
+import { Hash } from 'lucide-react'
+import type { TokenSource } from '~/components/global/token-field'
+import { recordBadgeVariants } from '~/components/resources/ui'
+import { lastSegment } from '../hooks/use-source-paths'
+
+/**
+ * A {@link TokenSource} over a stream's declared webhook-steering `{path}`
+ * placeholders (`requestConfig.webhookTrigger.paths`). The picker offers only the
+ * declared paths — the source of truth is the Webhook steering section's
+ * checklist, so a path shows up here once it's declared there. A token typed by
+ * hand that isn't declared renders as an "unknown" chip (it won't resolve at
+ * fetch time) so the gap is visible.
+ */
+export function makeSteeringTokenSource(paths: string[]): TokenSource {
+  const declared = new Set(paths)
+  return {
+    renderBadge: (id, selected) => (
+      <SteeringPathBadge path={id} selected={selected} known={declared.has(id)} />
+    ),
+    renderPickerItems: ({ onSelect, onClose }) => (
+      <Command>
+        <CommandInput placeholder='Search payload fields…' />
+        <CommandList>
+          <CommandEmpty>
+            {paths.length === 0
+              ? 'Declare payload fields in Webhook steering first.'
+              : 'No matching fields.'}
+          </CommandEmpty>
+          {paths.length > 0 && (
+            <CommandGroup heading='Payload fields'>
+              {paths.map((path) => (
+                <CommandItem
+                  key={path}
+                  value={path}
+                  onSelect={() => {
+                    onSelect(path)
+                    onClose()
+                  }}>
+                  <Hash className='size-3.5 text-muted-foreground' />
+                  <span className='font-mono text-sm'>{path}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    ),
+  }
+}
+
+/** Inline chip for a steering `{path}` token; flags an undeclared (unknown) path. */
+function SteeringPathBadge({
+  path,
+  selected,
+  known,
+}: {
+  path: string
+  selected?: boolean
+  known: boolean
+}) {
+  return (
+    <span
+      data-slot='field-badge'
+      title={known ? path : `${path} — not a declared payload field`}
+      className={cn(
+        recordBadgeVariants({}),
+        'font-mono font-normal',
+        selected && 'ring-2 ring-primary ring-offset-1',
+        !known && 'text-destructive ring-1 ring-destructive/40'
+      )}>
+      <Hash className={cn('size-3', known ? 'text-muted-foreground' : 'text-destructive')} />
+      <span className='truncate'>{lastSegment(path)}</span>
+    </span>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
@@ -20,7 +20,9 @@ import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { EmptySection, Section } from '@auxx/ui/components/section'
 import { ChevronDown, Database, FlaskConical, Pencil, RefreshCw, Waypoints } from 'lucide-react'
-import { type ReactNode, useState } from 'react'
+import { type ReactNode, useMemo, useState } from 'react'
+import type { HttpRequestFieldContextValue } from '~/components/global/http-request'
+import { makeTokenFieldEditor } from '~/components/global/token-field'
 import {
   SchemaEditorDialog,
   type SeededFrom,
@@ -38,6 +40,7 @@ import {
   RequestEditorBlock,
   RevealChip,
 } from './request-editors'
+import { makeSteeringTokenSource } from './steering-token-source'
 import { StreamSample } from './stream-sample'
 
 type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
@@ -178,6 +181,24 @@ export function StreamConfigPanel({
   const syncMode: 'snapshot' | 'incremental' =
     rawSyncMode === 'incremental' ? 'incremental' : 'snapshot'
 
+  // Webhook streams steer the fetch with `{path}` placeholders declared in the
+  // Webhook steering section. Token-enable the request fields (URL + header/param
+  // values) so those paths are insertable via the `{` picker, not hand-typed.
+  const isWebhook = rawSyncMode === 'webhook'
+  const steeringPaths = useMemo<string[]>(() => {
+    const wt = (stream.requestConfig as { webhookTrigger?: { paths?: string[] } } | null)
+      ?.webhookTrigger
+    return wt?.paths ?? []
+  }, [stream.requestConfig])
+  const tokenFieldContext = useMemo<HttpRequestFieldContextValue>(() => {
+    const tokenSource = makeSteeringTokenSource(steeringPaths)
+    return {
+      FieldEditor: makeTokenFieldEditor(tokenSource),
+      keyPlaceholder: 'Enter key…',
+      valuePlaceholder: 'Type { to insert a field…',
+    }
+  }, [steeringPaths])
+
   const handleTestFetch = async () => {
     const result = await sampleFetch({
       id: connector.id,
@@ -256,11 +277,21 @@ export function StreamConfigPanel({
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </InputGroupAddon>
-                <InputGroupInput
-                  value={request.value.path}
-                  onChange={(e) => request.set({ ...request.value, path: e.target.value })}
-                  placeholder='/orders or full URL'
-                />
+                {isWebhook ? (
+                  <div className='flex-1'>
+                    <tokenFieldContext.FieldEditor
+                      value={request.value.path}
+                      onChange={(path) => request.set({ ...request.value, path })}
+                      placeholder='/orders/{id}.json'
+                    />
+                  </div>
+                ) : (
+                  <InputGroupInput
+                    value={request.value.path}
+                    onChange={(e) => request.set({ ...request.value, path: e.target.value })}
+                    placeholder='/orders or full URL'
+                  />
+                )}
               </InputGroup>
 
               {/* Reveal chips — headers / query params / body stay hidden until clicked. */}
@@ -292,6 +323,7 @@ export function StreamConfigPanel({
                   <RecordKeyValueEditor
                     record={request.value.headers}
                     onChange={(headers) => request.set({ ...request.value, headers })}
+                    fieldContext={isWebhook ? tokenFieldContext : undefined}
                   />
                 </RequestEditorBlock>
               )}
@@ -300,6 +332,7 @@ export function StreamConfigPanel({
                   <RecordKeyValueEditor
                     record={request.value.params}
                     onChange={(params) => request.set({ ...request.value, params })}
+                    fieldContext={isWebhook ? tokenFieldContext : undefined}
                   />
                 </RequestEditorBlock>
               )}

--- a/apps/web/src/components/global/token-field/index.ts
+++ b/apps/web/src/components/global/token-field/index.ts
@@ -1,0 +1,5 @@
+// apps/web/src/components/global/token-field/index.ts
+
+export { makeTokenFieldEditor } from './token-field-editor'
+export type { TokenSource } from './token-source'
+export { type UseTokenFieldOptions, useTokenField } from './use-token-field'

--- a/apps/web/src/components/global/token-field/token-field-editor.tsx
+++ b/apps/web/src/components/global/token-field/token-field-editor.tsx
@@ -1,0 +1,87 @@
+// apps/web/src/components/global/token-field/token-field-editor.tsx
+
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { EditorContent } from '@tiptap/react'
+import { InlinePickerPopover, useActivePicker } from '~/components/editor/inline-picker'
+import type { HttpFieldEditor, HttpFieldEditorProps } from '~/components/global/http-request'
+import type { TokenSource } from './token-source'
+import { useTokenField } from './use-token-field'
+
+/**
+ * A `{token}`-aware {@link HttpFieldEditor}: a single-line (or multiline) TipTap
+ * field whose `{` opens the inline token picker. Drop-in replacement for
+ * `PlainFieldEditor` in the shared HTTP request builder — wire it through
+ * `HttpRequestFieldProvider` so header / param values gain token insertion with
+ * no changes to the key-value rows.
+ *
+ * Bind a {@link TokenSource} via {@link makeTokenFieldEditor}; the resulting
+ * component matches the `HttpFieldEditor` contract exactly.
+ */
+function TokenFieldEditor({
+  value,
+  onChange,
+  onBlur,
+  placeholder,
+  disabled,
+  multiline,
+  className,
+  tokenSource,
+}: HttpFieldEditorProps & { tokenSource: TokenSource }) {
+  const { editor, insertField, closePicker } = useTokenField({
+    initialValue: value,
+    onChange,
+    renderBadge: tokenSource.renderBadge,
+    placeholder,
+    multiline,
+    editable: !disabled,
+  })
+
+  const activePicker = useActivePicker(editor)
+  const pickerOpen = !!activePicker && activePicker.trigger === '{'
+  const query = activePicker?.query ?? ''
+
+  return (
+    // The incoming `className` (e.g. `p-1 h-full focus-within:bg-…` from the
+    // key-value cell) rides the OUTER box so the background + height cover the
+    // whole cell. `onBlur` rides it too — focusout bubbles from the contenteditable,
+    // and `EditorContent` doesn't forward arbitrary handlers. Single-line content is
+    // vertically centered so a token row matches a plain key row's height.
+    <div
+      className={cn('relative flex w-full', multiline ? 'items-start' : 'items-center', className)}
+      onBlur={onBlur}>
+      <EditorContent
+        editor={editor}
+        className='w-full text-sm [&_.ProseMirror]:min-h-[1.25rem] [&_.ProseMirror]:pl-2 [&_.ProseMirror]:outline-none [&_p]:m-0'
+      />
+      {editor && (
+        <InlinePickerPopover
+          state={{
+            isOpen: pickerOpen,
+            query,
+            range: null,
+            clientRect: activePicker?.clientRect ?? null,
+          }}
+          width={300}
+          onClose={closePicker}>
+          {tokenSource.renderPickerItems({
+            query,
+            onSelect: (id) => {
+              insertField(id)
+              closePicker()
+            },
+            onClose: closePicker,
+          })}
+        </InlinePickerPopover>
+      )}
+    </div>
+  )
+}
+
+/** Bind a {@link TokenSource} into an `HttpFieldEditor` for the request-field seam. */
+export function makeTokenFieldEditor(tokenSource: TokenSource): HttpFieldEditor {
+  return function BoundTokenFieldEditor(props: HttpFieldEditorProps) {
+    return <TokenFieldEditor {...props} tokenSource={tokenSource} />
+  }
+}

--- a/apps/web/src/components/global/token-field/token-source.ts
+++ b/apps/web/src/components/global/token-field/token-source.ts
@@ -1,0 +1,27 @@
+// apps/web/src/components/global/token-field/token-source.ts
+
+import type React from 'react'
+
+/**
+ * The single seam that varies between token-field consumers — the leaner cousin
+ * of {@link CalcTokenSource} (no functions: a URL/header/param value is a value,
+ * not a formula). A *token source* is the whole of what a `{token}` means: how its
+ * chip renders, and how the `{`-picker lists selectable tokens.
+ *
+ * The first consumer is data-connectors webhook steering, where tokens are the
+ * declared payload `{path}` placeholders.
+ */
+export interface TokenSource {
+  /** Render a token chip from its serialized id (the `{id}` payload). */
+  renderBadge: (id: string, selected: boolean) => React.ReactNode
+  /**
+   * The full `{` picker popover body — must be Command-rooted (the popover
+   * provides no Command context). `onSelect(tokenId)` inserts the token;
+   * `onClose` dismisses the picker.
+   */
+  renderPickerItems: (ctx: {
+    query: string
+    onSelect: (tokenId: string) => void
+    onClose: () => void
+  }) => React.ReactNode
+}

--- a/apps/web/src/components/global/token-field/use-token-field.tsx
+++ b/apps/web/src/components/global/token-field/use-token-field.tsx
@@ -1,0 +1,170 @@
+// apps/web/src/components/global/token-field/use-token-field.tsx
+
+'use client'
+
+import { formulaToString, stringToFormula } from '@auxx/lib/custom-fields/client'
+import type { JSONContent } from '@tiptap/core'
+import Placeholder from '@tiptap/extension-placeholder'
+import { type Editor, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  createInlineNode,
+  getOpenPickerRange,
+  ReferencePickerNode,
+} from '~/components/editor/inline-picker'
+import type { TokenSource } from './token-source'
+
+export interface UseTokenFieldOptions {
+  /** Initial interpolated string, e.g. `orders/{id}.json`. */
+  initialValue?: string
+  /** Emits the new interpolated string on every edit. */
+  onChange?: (value: string) => void
+  /** Renders the `{token}` chips inside the editor. */
+  renderBadge: TokenSource['renderBadge']
+  placeholder?: string
+  /** Single-line by default; multiline allows wrapping (body editors). */
+  multiline?: boolean
+  editable?: boolean
+}
+
+/**
+ * The lean sibling of {@link useCalcFormula}: a `{token}`-aware TipTap field with
+ * no calc functions, no expression validation, single-line by default. Typing `{`
+ * opens the inline token picker; selection collapses to a `field` chip that
+ * serializes back to `{id}`. Used for HTTP request fields (URL / header / param
+ * values) where the tokens are webhook-steering payload paths.
+ *
+ * Reuses the shared `{id}` ↔ TipTap converters (`stringToFormula`/`formulaToString`)
+ * — they are token-source-agnostic despite the calc-field naming.
+ */
+export function useTokenField({
+  initialValue = '',
+  onChange,
+  renderBadge,
+  placeholder = 'Type { to insert a field…',
+  multiline = false,
+  editable = true,
+}: UseTokenFieldOptions) {
+  const [value, setValue] = useState(initialValue)
+  const contentRef = useRef(initialValue)
+  const onChangeRef = useRef(onChange)
+
+  useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  const initialContent = useMemo(() => stringToFormula(initialValue) as JSONContent, [initialValue])
+
+  // Any non-brace token auto-chips (`{customer.email}`, `{id}`), mirroring the
+  // calc field node — so hand-typed dotted paths collapse to a chip too.
+  const fieldNode = useMemo(
+    () =>
+      createInlineNode(
+        {
+          type: 'field',
+          serialize: (id) => `{${id}}`,
+          pastePattern: { pattern: /\{([^{}]+)\}/, getId: (match) => match[1]! },
+          inputRules: [{ find: /\{([^{}]+)\}$/, getId: (match) => match[1]! }],
+        },
+        ({ id, selected }) => renderBadge(id, selected)
+      ),
+    [renderBadge]
+  )
+
+  const editorConfig = useMemo(
+    () => ({
+      editable,
+      extensions: [
+        StarterKit.configure({
+          heading: false,
+          blockquote: false,
+          bulletList: false,
+          orderedList: false,
+          listItem: false,
+          codeBlock: false,
+          horizontalRule: false,
+        }),
+        fieldNode,
+        ReferencePickerNode.configure({
+          triggers: [{ char: '{', kind: 'command', allowedPrefixes: null }],
+        }),
+        Placeholder.configure({ placeholder, showOnlyWhenEditable: true }),
+      ],
+      content: initialContent,
+      onUpdate: ({ editor }: { editor: Editor }) => {
+        // Don't emit while the `{` picker chip is open — the transient `{` would
+        // otherwise land in the value.
+        if (getOpenPickerRange(editor.state)) return
+        const next = formulaToString(editor.getJSON() as JSONContent)
+        if (next !== contentRef.current) {
+          contentRef.current = next
+          setValue(next)
+          onChangeRef.current?.(next)
+        }
+      },
+      editorProps: {
+        attributes: {
+          class: `token-field-content text-sm focus:outline-none ${
+            multiline ? 'whitespace-pre-wrap break-words' : 'whitespace-nowrap overflow-x-auto'
+          }`,
+        },
+        // Single-line: swallow Enter so the value never gains a newline. (When the
+        // picker is open, focus is in the popover, not the editor, so this won't
+        // interfere with picker navigation.)
+        handleKeyDown: multiline
+          ? undefined
+          : (_view: unknown, event: KeyboardEvent) => {
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                return true
+              }
+              return false
+            },
+      },
+      immediatelyRender: false,
+      shouldRerenderOnTransaction: false,
+    }),
+    [initialContent, fieldNode, placeholder, multiline, editable]
+  )
+
+  const editor = useEditor(editorConfig)
+
+  // `editable` can flip after mount (a stream goes read-only); useEditor won't
+  // rebuild from config, so push it imperatively.
+  useEffect(() => {
+    editor?.setEditable(editable)
+  }, [editor, editable])
+
+  // Reseed only on a genuine external change (switching streams, a server move) —
+  // never echo our own onChange back into the editor (would jump the cursor).
+  useEffect(() => {
+    if (initialValue !== contentRef.current) {
+      contentRef.current = initialValue
+      setValue(initialValue)
+      editor?.commands.setContent(stringToFormula(initialValue) as JSONContent)
+    }
+  }, [initialValue, editor])
+
+  /** Insert a token chip, replacing the open `{` picker chip. */
+  const insertField = useCallback(
+    (id: string) => {
+      if (!editor) return
+      const range = getOpenPickerRange(editor.state)
+      if (!range) return
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent({ type: 'field', attrs: { id } })
+        .run()
+    },
+    [editor]
+  )
+
+  const closePicker = useCallback(() => {
+    editor?.commands.closeReferencePicker({ keepText: false })
+  }, [editor])
+
+  return { editor, value, insertField, closePicker }
+}

--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -144,6 +144,9 @@ export interface ConnectorStreamState {
   cursor?: string
   /** Set by a connector's terminal `nextState` when its backfill is exhausted. */
   backfillComplete?: boolean
+  /** Consecutive no-progress slices (pagination stall guard). Mirror of lib
+   *  `ConnectorStreamState.noProgressStrikes`. */
+  noProgressStrikes?: number
   [key: string]: unknown
 }
 

--- a/packages/lib/src/data-connectors/connector-slice-loop.test.ts
+++ b/packages/lib/src/data-connectors/connector-slice-loop.test.ts
@@ -5,7 +5,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { SliceBudget, SyncSliceCtx } from '../sync-core/contracts'
 import { runConnectorSlice } from './connector-slice-loop'
-import { ConnectorRateLimitError, type ConnectorYield } from './connectors/types'
+import {
+  ConnectorRateLimitError,
+  type ConnectorYield,
+  PaginationStalledError,
+} from './connectors/types'
 
 const BIG_BUDGET: SliceBudget = { maxPages: 1_000, maxRecords: 1_000_000, maxMs: 1_000_000 }
 
@@ -168,6 +172,19 @@ describe('runConnectorSlice', () => {
         now: () => 0,
       })
     ).rejects.toThrow('boom')
+  })
+
+  it('propagates a PaginationStalledError (not swallowed like a rate-limit/abort)', async () => {
+    // A non-advancing-cursor stall is permanent — it must surface to fail the run, not
+    // get treated as a retriable throttle.
+    await expect(
+      runConnectorSlice({
+        fetch: fakeFetch([rec('a'), checkpoint('c1')], new PaginationStalledError('stuck')),
+        sink: async () => {},
+        ctx: ctx(),
+        now: () => 0,
+      })
+    ).rejects.toBeInstanceOf(PaginationStalledError)
   })
 
   it('a cancelled signal yields gracefully (not a failure)', async () => {

--- a/packages/lib/src/data-connectors/connectors/generic-rest.test.ts
+++ b/packages/lib/src/data-connectors/connectors/generic-rest.test.ts
@@ -6,7 +6,7 @@
 import type { AuthApply } from '@auxx/database'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { genericRestConnector } from './generic-rest'
-import type { ConnectorFetchArgs } from './types'
+import { type ConnectorFetchArgs, PaginationStalledError } from './types'
 
 const fetchMock = vi.fn()
 
@@ -91,5 +91,70 @@ describe('genericRestConnector — applyAuth', () => {
 
     const [, init] = fetchMock.mock.calls[0]!
     expect(init.headers.Authorization).toBeUndefined()
+  })
+})
+
+describe('genericRestConnector — pagination stall guard', () => {
+  it('throws PaginationStalledError when the cursor token does not advance', async () => {
+    // The endpoint ignores `starting_after` and replays the same page (same last-record
+    // id) with has_more:true — the frozen-cursor loop. Page 1 yields a record + a cursor
+    // checkpoint; page 2 sees the SAME next token it just sent and bails.
+    // Fresh Response per call — a Response body can only be read once.
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ orders: [{ id: 'frozen' }], has_more: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    )
+    const a: ConnectorFetchArgs = {
+      ...args(),
+      requestConfig: {
+        path: 'orders',
+        pagination: {
+          kind: 'cursor',
+          cursorFrom: 'lastRecord',
+          cursorParam: 'starting_after',
+          cursorRecordField: 'id',
+          recordsPath: 'orders',
+          hasMorePath: 'has_more',
+        },
+      },
+    }
+
+    const seen: unknown[] = []
+    await expect(
+      (async () => {
+        const { records } = await genericRestConnector.fetch(a)
+        for await (const y of records) seen.push(y)
+      })()
+    ).rejects.toBeInstanceOf(PaginationStalledError)
+    // Page 1's record was emitted before the stall was detected on page 2.
+    expect(seen.some((y) => !(y as { __checkpoint?: true }).__checkpoint)).toBe(true)
+  })
+
+  it('does NOT trip on a clean terminal page (has_more:false ends first)', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ orders: [{ id: 'only' }], has_more: false }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const a: ConnectorFetchArgs = {
+      ...args(),
+      requestConfig: {
+        path: 'orders',
+        pagination: {
+          kind: 'cursor',
+          cursorFrom: 'lastRecord',
+          cursorParam: 'starting_after',
+          cursorRecordField: 'id',
+          recordsPath: 'orders',
+          hasMorePath: 'has_more',
+        },
+      },
+    }
+    // Drains without throwing — the terminal branch returns before the stall check.
+    await expect(drain(a)).resolves.toBeUndefined()
   })
 })

--- a/packages/lib/src/data-connectors/connectors/generic-rest.ts
+++ b/packages/lib/src/data-connectors/connectors/generic-rest.ts
@@ -22,6 +22,7 @@ import {
   type DataConnectorDefinition,
   type FetchResult,
   type PaginationSpec,
+  PaginationStalledError,
   type StreamIncrementalConfig,
   type StreamRequestConfig,
 } from './types'
@@ -509,6 +510,20 @@ async function* fetchRecords(args: ConnectorFetchArgs): AsyncIterable<ConnectorY
       // Final checkpoint with no cursor ⇒ this phase is exhausted. Carry the watermark.
       yield { __checkpoint: true, watermark }
       return
+    }
+    // Stall guard (inner, precise — the token is in hand). A next token EQUAL to the one
+    // we just sent, while `has_more` was not false, means pagination is stuck (an endpoint
+    // that ignores the cursor param and replays a page). page/offset tokens are monotonic
+    // indices and never trip this; only value-carried tokens (cursor / next-url /
+    // link-header) can freeze. Fail loudly — silently completing would mark a backfill
+    // "done" having seen only page 1, under-syncing real data. See
+    // pagination-stall-guard-plan.md §1.
+    if (next === cursor) {
+      throw new PaginationStalledError(
+        `generic-rest: ${method} ${url} returned a non-advancing ${pagination?.kind} cursor ` +
+          `(${JSON.stringify(next)}) while has_more was not false — check the pagination config ` +
+          `(cursorPath / cursorRecordField) against the endpoint.`
+      )
     }
     cursor = next
     pageIndex += 1

--- a/packages/lib/src/data-connectors/connectors/types.ts
+++ b/packages/lib/src/data-connectors/connectors/types.ts
@@ -22,4 +22,4 @@ export type {
   StreamIncrementalConfig,
   StreamRequestConfig,
 } from '../types'
-export { ConnectorRateLimitError, isConnectorCheckpoint } from '../types'
+export { ConnectorRateLimitError, isConnectorCheckpoint, PaginationStalledError } from '../types'

--- a/packages/lib/src/data-connectors/sync-core-adapters.ts
+++ b/packages/lib/src/data-connectors/sync-core-adapters.ts
@@ -27,6 +27,7 @@ export function syncStateFromStream(state: ConnectorStreamState): SyncState {
     watermark: state.watermark,
     recordsSeen: state.recordsSeen,
     backfillStartedAt: state.backfillStartedAt,
+    noProgressStrikes: state.noProgressStrikes,
   }
 }
 
@@ -47,6 +48,7 @@ export function applySyncStateToStream(
     watermark: sync.watermark,
     recordsSeen: sync.recordsSeen,
     backfillStartedAt: sync.backfillStartedAt,
+    noProgressStrikes: sync.noProgressStrikes,
   }
 }
 

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -234,6 +234,8 @@ export interface ConnectorStreamState {
   cursor?: string
   /** Set by a connector's terminal `nextState` when its backfill is exhausted. */
   backfillComplete?: boolean
+  /** Consecutive no-progress slices (stall guard) — see the core `SyncState`. */
+  noProgressStrikes?: number
   [key: string]: unknown
 }
 
@@ -308,6 +310,22 @@ export class ConnectorRateLimitError extends RateLimitError {
     public readonly retryAfterMs?: number
   ) {
     super(message, retryAfterMs !== undefined ? Math.ceil(retryAfterMs / 1_000) : undefined)
+  }
+}
+
+/**
+ * Thrown by a connector fetch when pagination stops making progress — the upstream
+ * hands back the SAME resume token it was just given while still signalling more
+ * pages (an endpoint that ignores the cursor param and replays a page). Unlike
+ * {@link ConnectorRateLimitError} this is NOT retriable: re-fetching just re-freezes.
+ * It is neither a rate-limit nor an abort, so it propagates out of `runConnectorSlice`
+ * and the slice-runner closes the run `failed` with this message — surfacing the real
+ * cause instead of silently completing a backfill that only ever saw page 1.
+ */
+export class PaginationStalledError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PaginationStalledError'
   }
 }
 

--- a/packages/lib/src/jobs/data-connector/app-trigger-sync-stream-job.ts
+++ b/packages/lib/src/jobs/data-connector/app-trigger-sync-stream-job.ts
@@ -16,6 +16,7 @@ import { getRedisClient } from '@auxx/redis'
 import type { Job } from 'bullmq'
 import { createScopedLogger } from '../../logger'
 import { getQueue, Queues } from '../queues'
+import type { JobContext } from '../types'
 import { APP_TRIGGER_SYNC_STREAM_JOB } from './app-trigger-sync-dispatch-job'
 
 const logger = createScopedLogger('data-connector-app-trigger-sync-stream-job')
@@ -39,7 +40,15 @@ export type ConnectorAppTriggerStreamJobData = {
   rateLimitRetries?: number
 }
 
-export async function runConnectorAppTriggerStream(job: Job<ConnectorAppTriggerStreamJobData>) {
+export async function runConnectorAppTriggerStream(
+  ctx: JobContext<ConnectorAppTriggerStreamJobData> | Job<ConnectorAppTriggerStreamJobData>
+) {
+  // The worker passes a JobContext whose `.job` is the real BullMQ Job; tolerate a raw
+  // Job too. Unwrap so the native fields this handler needs (`opts.attempts`,
+  // `attemptsMade`) read off the real job — reading them off the context yields undefined
+  // (the "Cannot read properties of undefined (reading 'attempts')" crash that masked the
+  // real fetch error).
+  const job = 'throwIfCancelled' in ctx ? ctx.job : ctx
   const { connectorId, streamKey, organizationId, triggerData, eventId } = job.data
 
   // Lazy-import the heavy data-connectors barrel at call time (it pulls the sink /

--- a/packages/lib/src/sync-core/contracts.ts
+++ b/packages/lib/src/sync-core/contracts.ts
@@ -86,6 +86,15 @@ export interface SyncState {
   backfillStartedAt?: string
   /** Cross-run throttle hard-gate (ported from the channel side). */
   throttle?: { failureCount: number; retryAfter?: string }
+  /**
+   * Consecutive slices that advanced and claimed more pages but moved NEITHER the
+   * cursor NOR the record count — the signature of a stuck pagination loop (an
+   * upstream that replays a page while signalling `has_more`). Reset to 0 on real
+   * progress; the runner fails the run past a small strike limit so a frozen cursor
+   * can't spin a continuation chain forever (the heartbeat stays warm, so the
+   * stale-sweep never catches it). See pagination-stall-guard-plan.md §2.
+   */
+  noProgressStrikes?: number
 }
 
 /**

--- a/packages/lib/src/sync-core/slice-runner.test.ts
+++ b/packages/lib/src/sync-core/slice-runner.test.ts
@@ -252,6 +252,74 @@ describe('runSyncSlice', () => {
     expect(ledger.calls).not.toContain('finalize')
   })
 
+  it('fails a stalled chain after consecutive no-progress slices (stall guard)', async () => {
+    // The source advances + claims more every slice but moves NOTHING — no records, the
+    // cursor never changes (a frozen pagination token). The runner tolerates a couple of
+    // strikes, then fails rather than spinning the continuation chain forever.
+    const stuck = { kind: 'token', value: 'frozen' } as const
+    const state = fakeStateStore({ phase: 'backfill', cursor: stuck })
+    const ledger = fakeLedger()
+    const stalledSource = source({
+      slice: { recordsProcessed: 0, nextCursor: stuck, hasMore: true, commit: 'all' },
+    })
+    const run = () =>
+      runSyncSlice({
+        source: stalledSource,
+        stateStore: state.store,
+        ledger: ledger.ledger,
+        throttle: THROTTLE,
+        budget: BUDGET,
+        signal: new AbortController().signal,
+      })
+
+    // Strikes climb 1 → 2 (re-enqueued), then the 3rd consecutive stall fails the run.
+    expect((await run()).action).toBe('reenqueue')
+    expect(state.current.noProgressStrikes).toBe(1)
+    expect((await run()).action).toBe('reenqueue')
+    expect(state.current.noProgressStrikes).toBe(2)
+    expect((await run()).action).toBe('failed')
+    expect(state.current.noProgressStrikes).toBe(3)
+    expect(ledger.calls).toContain('fail')
+  })
+
+  it('resets the stall strike count when a slice makes real progress', async () => {
+    const stuck = { kind: 'token', value: 'frozen' } as const
+    const state = fakeStateStore({ phase: 'backfill', cursor: stuck })
+    const ledger = fakeLedger()
+    // First slice stalls (strike 1)…
+    await runSyncSlice({
+      source: source({
+        slice: { recordsProcessed: 0, nextCursor: stuck, hasMore: true, commit: 'all' },
+      }),
+      stateStore: state.store,
+      ledger: ledger.ledger,
+      throttle: THROTTLE,
+      budget: BUDGET,
+      signal: new AbortController().signal,
+    })
+    expect(state.current.noProgressStrikes).toBe(1)
+
+    // …then one that processes records + advances the cursor resets the count to 0.
+    const out = await runSyncSlice({
+      source: source({
+        slice: {
+          recordsProcessed: 7,
+          nextCursor: { kind: 'token', value: 'moved' },
+          hasMore: true,
+          commit: 'all',
+        },
+      }),
+      stateStore: state.store,
+      ledger: ledger.ledger,
+      throttle: THROTTLE,
+      budget: BUDGET,
+      signal: new AbortController().signal,
+    })
+    expect(out.action).toBe('reenqueue')
+    expect(state.current.noProgressStrikes).toBe(0)
+    expect(ledger.calls).not.toContain('fail')
+  })
+
   it('fails the run when fetchSlice throws', async () => {
     const state = fakeStateStore({ phase: 'backfill' })
     const ledger = fakeLedger()

--- a/packages/lib/src/sync-core/slice-runner.ts
+++ b/packages/lib/src/sync-core/slice-runner.ts
@@ -21,6 +21,11 @@ import type {
 
 const logger = createScopedLogger('sync-core-slice-runner')
 
+/** Consecutive no-progress slices tolerated before the runner fails a stalled chain
+ *  (fails on strike `STALL_STRIKE_LIMIT + 1`). Tiny on purpose — bail within a few
+ *  slices, not thousands of pages. */
+const STALL_STRIKE_LIMIT = 2
+
 /** Directive returned to the worker after one slice. */
 export type SliceOutcome =
   | {
@@ -94,6 +99,34 @@ export async function runSyncSlice(args: RunSliceArgs): Promise<SliceOutcome> {
       ? (result.nextCursor ?? state.cursor)
       : state.cursor
 
+  // Stall guard (provider-agnostic backstop — protects app connectors / future channel
+  // sync that drive their own pagination, where generic-rest's inner token check can't
+  // reach). A full slice that advanced and still claims more, yet moved NOTHING (no
+  // records, cursor unchanged), is a stall candidate. One blip (a graceful abort, a
+  // transient empty page) is tolerated; STALL_STRIKE_LIMIT+1 consecutive ones fail the
+  // run — far cheaper than spinning a continuation chain to the page ceiling.
+  const noProgress =
+    advance &&
+    result.hasMore &&
+    result.recordsProcessed === 0 &&
+    cursorKey(nextCursor) === cursorKey(state.cursor)
+  const strikes = noProgress ? (state.noProgressStrikes ?? 0) + 1 : 0
+  if (strikes > STALL_STRIKE_LIMIT) {
+    const err = new Error(
+      `sync stalled: ${strikes} consecutive slices made no progress ` +
+        `(cursor ${cursorKey(state.cursor) ?? 'none'} unchanged) — failing to avoid an infinite chain.`
+    )
+    logger.error('pagination stalled', {
+      sourceId: source.id,
+      phase,
+      cursor: cursorKey(state.cursor),
+      strikes,
+    })
+    await stateStore.save({ ...state, noProgressStrikes: strikes }) // persist for observability
+    await ledger.fail(err)
+    return { action: 'failed', error: err }
+  }
+
   const next: SyncState = {
     ...state,
     phase,
@@ -101,6 +134,7 @@ export async function runSyncSlice(args: RunSliceArgs): Promise<SliceOutcome> {
     // The source returns a monotonic max watermark; the core just stores it on advance.
     watermark: advance ? (result.watermark ?? state.watermark) : state.watermark,
     recordsSeen: (state.recordsSeen ?? 0) + result.recordsProcessed,
+    noProgressStrikes: strikes,
   }
 
   // Checkpoint AFTER the slice — a crash/restart resumes here, never from page 1.


### PR DESCRIPTION
Two related data-connector hardening threads, committed together.

## Pagination stall guard

A frozen cursor — an endpoint that ignores the cursor param and replays a page while still signalling `has_more` — was a real failure mode with two bad outcomes: silently marking a backfill *done* after page 1 (under-syncing), or spinning a continuation chain forever with a warm heartbeat the stale-sweep never catches. Guarded at two layers:

- **Inner, precise** (`generic-rest`): throws the new non-retriable `PaginationStalledError` when the next token equals the one just sent. Only value-carried tokens (cursor / next-url / link-header) can freeze; page/offset indices are monotonic and never trip it. Failing loudly beats a phantom-complete backfill.
- **Outer, provider-agnostic** (`slice-runner`): tracks consecutive no-progress slices (`noProgressStrikes` on `SyncState` / `ConnectorStreamState`) and fails the run past a small strike limit (`STALL_STRIKE_LIMIT = 2`). A backstop for app connectors and future channel sync that drive their own pagination, where the inner token check can't reach. One blip is tolerated; the strike count resets on real progress.

### Also in this thread
- **Error tooltip**: the raw (often long, technical) sync error now lives behind a hover tooltip in the status line; the header `detail` stays short and static (`Last sync failed.`).
- **Job-context unwrap**: `runConnectorAppTriggerStream` now tolerates a `JobContext` or a raw `Job`, unwrapping so `opts.attempts` / `attemptsMade` read off the real BullMQ job — fixes the `Cannot read properties of undefined (reading 'attempts')` crash that was masking the real fetch error.

## Webhook steering token fields

Webhook streams steer their fetch with `{path}` placeholders. New shared `components/global/token-field` component — a lean TipTap `{token}` editor over the existing `HttpFieldEditor` seam, reusing the inline picker and the `{id}`↔TipTap converters — token-enables the request **URL, header and param values** so declared payload paths are insertable via the `{` picker instead of hand-typed.

A steering `TokenSource` lists the stream's declared `webhookTrigger.paths` and flags any undeclared/hand-typed token as an "unknown" chip (it won't resolve at fetch time, so the gap stays visible). Non-webhook streams keep plain inputs unchanged.

## Tests
- `generic-rest`: stall trips on a frozen cursor + replayed page; does NOT trip on a clean terminal page (`has_more:false`).
- `connector-slice-loop`: `PaginationStalledError` propagates (not swallowed like rate-limit/abort).
- `slice-runner`: strike count climbs and fails the chain on the 3rd consecutive stall; resets to 0 on real progress.
- `resolve-sync-status`: header detail stays static; raw error goes to the tooltip.

No schema migration — `noProgressStrikes` is a field on the jsonb-stored `ConnectorStreamState` interface, not a column.