### PR TITLE
feat(data-connectors): live sync status over realtime

### DIFF
--- a/apps/web/src/components/data-connectors/hooks/use-connector-sync-realtime.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-connector-sync-realtime.ts
@@ -1,0 +1,81 @@
+// ~/components/data-connectors/hooks/use-connector-sync-realtime.ts
+
+'use client'
+
+import type { DataConnectorSyncEvent } from '@auxx/lib/realtime'
+import { useCallback } from 'react'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { useOrgChannel } from '~/realtime/hooks'
+import { api, type RouterOutputs } from '~/trpc/react'
+
+type ConnectorStatusData = RouterOutputs['dataConnector']['getStatus']
+
+/**
+ * Live connector-sync updates for one connector's detail view. Listens on the org
+ * channel for `dataConnector:sync` and:
+ *  - `progress` → patches the cached `getStatus` in place (instant counter motion,
+ *    no refetch).
+ *  - lifecycle (`run-started` / `run-finished`) → invalidates `getStatus` + `listRuns`
+ *    for the authoritative shape (new run row, freshness, schedule, resyncPending —
+ *    none of which the frame carries).
+ *
+ * Best-effort (realtime is never authoritative): the detail view keeps a slow
+ * safety poll while syncing so a dropped frame still converges.
+ */
+export function useConnectorSyncRealtime(connectorId: string) {
+  const { hasAccess } = useFeatureFlags()
+  const realtimeSyncEnabled = hasAccess('realtimeSync')
+  const utils = api.useUtils()
+
+  const onEvent = useCallback(
+    (event: string, payload: unknown) => {
+      if (!realtimeSyncEnabled) return
+      if (event !== 'dataConnector:sync') return
+      const data = payload as DataConnectorSyncEvent['data']
+      if (data.connectorId !== connectorId) return
+
+      if (data.kind === 'progress') {
+        const cached = utils.dataConnector.getStatus.getData({ id: connectorId })
+        // No run cached yet (progress raced ahead of the run-started refetch) — hydrate
+        // the authoritative shape instead of patching onto a null run.
+        if (!cached?.latestRun) {
+          utils.dataConnector.getStatus.invalidate({ id: connectorId })
+          return
+        }
+        utils.dataConnector.getStatus.setData({ id: connectorId }, (prev) =>
+          prev ? mergeProgress(prev, data) : prev
+        )
+        return
+      }
+
+      utils.dataConnector.getStatus.invalidate({ id: connectorId })
+      utils.dataConnector.listRuns.invalidate({ id: connectorId })
+    },
+    [realtimeSyncEnabled, connectorId, utils]
+  )
+
+  useOrgChannel({ onEvent })
+}
+
+/** Merge a `progress` frame onto the cached status — overwrite live counters, keep the rest. */
+function mergeProgress(
+  prev: ConnectorStatusData,
+  data: DataConnectorSyncEvent['data']
+): ConnectorStatusData {
+  return {
+    ...prev,
+    status: data.connectorStatus,
+    lastSyncedAt: data.lastSyncedAt ? new Date(data.lastSyncedAt) : prev.lastSyncedAt,
+    perStream: data.perStream,
+    latestRun: prev.latestRun
+      ? {
+          ...prev.latestRun,
+          status: data.runStatus ?? prev.latestRun.status,
+          phase: data.phase ?? prev.latestRun.phase,
+          recordsSeen: data.recordsSeen,
+          created: data.created,
+          updated: data.updated,
+        }
+      : prev.latestRun,
+  }
+}

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -24,6 +24,7 @@ import { useMedia } from '~/hooks/use-media'
 import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
 import { useConnectorMutations } from '../hooks/use-connector-mutations'
+import { useConnectorSyncRealtime } from '../hooks/use-connector-sync-realtime'
 import { resolveSyncStatus } from '../lib/resolve-sync-status'
 import { ConnectorDetailTabs } from './connector-detail-tabs'
 import { ConnectorResyncBanner } from './connector-resync-banner'
@@ -66,18 +67,22 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
   const isPaused = status === 'paused'
 
   // Live status for the freshness line + the derived "Action needed" reconnect CTA.
-  // Polls only while a sync is in flight (4s, matching the Runs panel — same query
-  // key, so the two share one request). The header Sync/Pause/Resume buttons stay on
-  // the optimistic getById `status` so their instant feedback is preserved.
+  // The `dataConnector:sync` realtime feed (below) drives the snappy updates; this
+  // poll is now just a SAFETY NET while a sync is in flight (realtime is best-effort
+  // with no missed-event replay — a dropped frame must still converge). 15s, matching
+  // the Runs panel — same query key, so the two share one request. The header
+  // Sync/Pause/Resume buttons stay on the optimistic getById `status`.
   const statusQuery = api.dataConnector.getStatus.useQuery(
     { id: connector.id },
     {
       refetchInterval: (query) => {
         const s = query.state.data?.status ?? connector.status
-        return s === 'syncing' || s === 'provisioning' ? 4000 : false
+        return s === 'syncing' || s === 'provisioning' ? 15000 : false
       },
     }
   )
+  // Push live run progress + lifecycle into the shared getStatus/listRuns caches.
+  useConnectorSyncRealtime(connector.id)
   const live = statusQuery.data
   const liveStatus = asConnectorStatus(live?.status ?? connector.status)
   // The run status is a free-text DB column; normalize it once for the resolver + status line.

--- a/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
@@ -16,6 +16,7 @@ import { ArchiveX, History, Plus, RefreshCw, SkipForward, Trash2, XCircle } from
 import { Fragment, useState } from 'react'
 import { VisualIcon } from '~/components/icons/ui/visual-icon'
 import { api, type RouterOutputs } from '~/trpc/react'
+import { useConnectorSyncRealtime } from '../hooks/use-connector-sync-realtime'
 import { ConnectorBackfillProgress } from './connector-backfill-progress'
 import { ConnectorFreshnessPanel } from './connector-freshness-panel'
 import { ConnectorRunErrors } from './connector-run-errors'
@@ -138,12 +139,17 @@ export function ConnectorRunsPanel({
   initialStatus,
   sourceLabel,
 }: ConnectorRunsPanelProps) {
+  // Live run progress + lifecycle via the `dataConnector:sync` feed (self-sufficient
+  // so the panel updates even when docked without the detail view). The polls below
+  // are a 15s safety net — realtime is best-effort with no missed-event replay.
+  useConnectorSyncRealtime(connectorId)
+
   const statusQuery = api.dataConnector.getStatus.useQuery(
     { id: connectorId },
     {
       refetchInterval: (query) => {
         const s = query.state.data?.status ?? initialStatus
-        return s === 'syncing' || s === 'provisioning' ? 4000 : false
+        return s === 'syncing' || s === 'provisioning' ? 15000 : false
       },
     }
   )
@@ -152,7 +158,7 @@ export function ConnectorRunsPanel({
 
   const runs = api.dataConnector.listRuns.useQuery(
     { id: connectorId, limit: 50 },
-    { refetchInterval: isSyncing ? 4000 : false }
+    { refetchInterval: isSyncing ? 15000 : false }
   )
 
   const rows = runs.data ?? []

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -114,6 +114,7 @@ export {
   provisionConnectorMappings,
   provisionTarget,
 } from './provisioning'
+export { type ConnectorSyncEventKind, publishConnectorSync } from './realtime'
 export { archiveExternalId, handleConnectorDelete, reconcileOrphans } from './reconciliation'
 export { resolveRelationships } from './relationship-pass'
 // Orchestrator + passes

--- a/packages/lib/src/data-connectors/realtime.ts
+++ b/packages/lib/src/data-connectors/realtime.ts
@@ -1,0 +1,103 @@
+// packages/lib/src/data-connectors/realtime.ts
+// Live connector-sync status over realtime (v2). One entry point —
+// `publishConnectorSync` — reads the current connector + latest run + per-stream
+// state and emits a `dataConnector:sync` snapshot so the detail view moves live
+// instead of on the 4s `getStatus` poll. Centralized here (not scattered across
+// the finalize sites) so every emitted payload matches exactly what `getStatus`
+// would return.
+
+import type { Database } from '@auxx/database'
+import type { DataConnectorSyncEvent } from '../realtime/events'
+import { getConnector, listRuns, listStreams } from './service'
+import type { ConnectorStreamState } from './types'
+
+/** Client routing hint — `progress` patches in place; lifecycle edges refetch. */
+export type ConnectorSyncEventKind = DataConnectorSyncEvent['data']['kind']
+
+/**
+ * Min interval between `progress` emits per connector. A slice (one page) is
+ * already coarse, but a backfill of thousands of tiny pages could fan out a lot
+ * of frames — coalesce to ≤1 progress emit / interval. Lifecycle edges bypass it.
+ */
+const PROGRESS_MIN_INTERVAL_MS = 750
+const lastProgressEmit = new Map<string, number>()
+
+/**
+ * Publish the connector's current sync status to its org channel. `progress` is
+ * throttled per-connector; `run-started` / `run-finished` always emit (and reset
+ * the throttle so a fast follow-up run's first progress isn't suppressed by a
+ * stale timestamp). Fire-and-forget — never throws into the sync job.
+ */
+export async function publishConnectorSync(
+  db: Database,
+  organizationId: string,
+  connectorId: string,
+  kind: ConnectorSyncEventKind
+): Promise<void> {
+  if (kind === 'progress') {
+    const now = Date.now()
+    if (now - (lastProgressEmit.get(connectorId) ?? 0) < PROGRESS_MIN_INTERVAL_MS) return
+    lastProgressEmit.set(connectorId, now)
+  } else {
+    lastProgressEmit.delete(connectorId)
+  }
+
+  const data = await buildSnapshot(db, organizationId, connectorId, kind)
+  if (!data) return
+
+  // Lazy-import the realtime barrel: a static import from a data-connectors module
+  // creates a load-time cycle (realtime → publish-helpers → cache → …) that breaks
+  // vi.mock interception in the connector smoke tests. Same pattern as
+  // `connector-sync-source.emitRecordsInvalidated`.
+  const { getRealtimeService, publishDataConnectorSync } = await import('../realtime')
+  await publishDataConnectorSync(getRealtimeService(), organizationId, data).catch(() => {})
+}
+
+/**
+ * Read the realtime-relevant subset of `getStatus` (connector lifecycle + latest
+ * run + per-stream progress) into a `dataConnector:sync` payload. Mirrors the
+ * `getStatus` router's aggregation so the client can patch its cache from this
+ * frame without a refetch. Returns null when the connector is gone.
+ */
+async function buildSnapshot(
+  db: Database,
+  organizationId: string,
+  connectorId: string,
+  kind: ConnectorSyncEventKind
+): Promise<DataConnectorSyncEvent['data'] | null> {
+  const result = await getConnector(db, organizationId, connectorId)
+  if (result.isErr()) return null
+  const connector = result.value
+
+  const [runs, streams] = await Promise.all([
+    listRuns(db, organizationId, connectorId, 1),
+    listStreams(db, organizationId, connectorId),
+  ])
+  const latest = runs[0] ?? null
+
+  const perStream = streams.map((s) => {
+    const st = (s.state ?? {}) as ConnectorStreamState
+    return {
+      streamKey: s.streamKey ?? '',
+      recordsSeen: st.recordsSeen ?? 0,
+      phase: st.phase ?? ('backfill' as const),
+      done: st.phase === 'steady',
+    }
+  })
+  const recordsSeen = perStream.reduce((n, s) => n + s.recordsSeen, 0)
+
+  return {
+    connectorId,
+    kind,
+    connectorStatus: connector.status,
+    lastSyncedAt: connector.lastSyncedAt ? connector.lastSyncedAt.toISOString() : null,
+    runId: latest?.id,
+    runStatus: latest?.status,
+    phase: (latest?.phase as 'backfill' | 'steady' | null) ?? null,
+    trigger: latest?.trigger,
+    recordsSeen,
+    created: latest?.created ?? 0,
+    updated: latest?.updated ?? 0,
+    perStream,
+  }
+}

--- a/packages/lib/src/data-connectors/slice-orchestrator.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator.ts
@@ -24,6 +24,7 @@ import {
   enqueueConnectorSync,
 } from './data-connector-queue'
 import { backfillProvisionedFieldRefs, provisionConnectorMappings } from './provisioning'
+import { publishConnectorSync } from './realtime'
 import {
   claimForSync,
   finalizeConnector,
@@ -262,6 +263,9 @@ export async function startConnectorSync(
     phase,
     streams: streams.length,
   })
+  // Light up every open detail view immediately — including for a webhook/scheduled
+  // run the 4s poll never armed for (it only polls when status already reads syncing).
+  await publishConnectorSync(db, organizationId, dataConnectorId, 'run-started')
   return true
 }
 
@@ -430,6 +434,7 @@ export async function runBackfillSlice(
           sampleLimit: run.sampleLimit,
           startedAt: run.startedAt,
         })
+        await publishConnectorSync(db, organizationId, connectorId, 'run-finished')
         return
       }
     }
@@ -454,6 +459,7 @@ export async function runBackfillSlice(
           ceiling: MAX_BACKFILL_RECORDS,
           startedAt: run.startedAt,
         })
+        await publishConnectorSync(db, organizationId, connectorId, 'run-finished')
         return
       }
     }
@@ -469,6 +475,9 @@ export async function runBackfillSlice(
       { connectorId, organizationId, streamId, runId },
       { delayMs: outcome.retryAfterMs }
     )
+    // Live counter motion — the slice folded its counts + persisted stream state, so
+    // the snapshot read reflects this slice. Throttled per-connector.
+    await publishConnectorSync(db, organizationId, connectorId, 'progress')
     return
   }
 
@@ -476,6 +485,7 @@ export async function runBackfillSlice(
     // The runner already failed the run; release the connector so it isn't stuck
     // 'syncing'. Sibling streams will see the run no longer 'running' and stop.
     await finalizeConnector(db, connectorId, { ok: false, error: outcome.error.message })
+    await publishConnectorSync(db, organizationId, connectorId, 'run-finished')
     return
   }
 
@@ -486,6 +496,10 @@ export async function runBackfillSlice(
   if (outcome.completedPhase === 'steady') {
     await source.finalizeSteady()
   }
+  // A stream finished. For the LAST stream the connector is now live/finalized; for
+  // an earlier one it's still syncing with this stream done. Either way the snapshot
+  // tells the truth — emit a lifecycle frame so the history panel + freshness refetch.
+  await publishConnectorSync(db, organizationId, connectorId, 'run-finished')
 }
 
 // ── Stale-run sweep (H5) ──────────────────────────────────────────────────────────
@@ -517,10 +531,12 @@ export async function sweepStaleConnectorRuns(
         ...(opts.dataConnectorId ? [eq(T.dataConnectorId, opts.dataConnectorId)] : [])
       )
     )
-    .returning({ id: T.id, dataConnectorId: T.dataConnectorId })
+    .returning({ id: T.id, dataConnectorId: T.dataConnectorId, organizationId: T.organizationId })
 
   for (const run of stale) {
     await finalizeConnector(db, run.dataConnectorId, { ok: false, error: 'sync stalled' })
+    // Unstick any open detail view that was watching the crashed chain.
+    await publishConnectorSync(db, run.organizationId, run.dataConnectorId, 'run-finished')
   }
   if (stale.length > 0) {
     logger.warn('sweepStaleConnectorRuns: failed stale runs + released connectors', {

--- a/packages/lib/src/realtime/client/index.ts
+++ b/packages/lib/src/realtime/client/index.ts
@@ -3,6 +3,7 @@
 export type {
   AiStatus,
   AiValueMetadata,
+  DataConnectorSyncEvent,
   FieldValuesUpdatedEvent,
   FieldValueUpdateEntry,
   InboxSyncCompletedEvent,

--- a/packages/lib/src/realtime/events.ts
+++ b/packages/lib/src/realtime/events.ts
@@ -48,6 +48,7 @@ export type ResourceSyncEvent =
   | RecordDeletedEvent
   | RecordArchivedEvent
   | RecordsInvalidatedEvent
+  | DataConnectorSyncEvent
 
 /** Field values changed (from mutations, triggers, cost recalc, etc.) */
 export interface FieldValuesUpdatedEvent {
@@ -135,6 +136,45 @@ export interface RecordsInvalidatedEvent {
   event: 'records:invalidated'
   data: {
     entityDefinitionId: string
+  }
+}
+
+/**
+ * Live data-connector sync signal on the org channel. Lets the connector detail
+ * view move WITHOUT the 4s `getStatus` poll (and lights up webhook/scheduled runs
+ * the poll never armed for). The payload mirrors the realtime-relevant subset of
+ * `getStatus` so the client can patch the cached query directly on the hot
+ * `progress` path; lifecycle edges (`run-started` / `run-finished`) refetch the
+ * authoritative shape (new run row, freshness, schedule, resyncPending).
+ *
+ * `kind` is purely a client routing hint — `progress` patches in place, the two
+ * lifecycle kinds invalidate. Fields are raw DB column values (free-text status /
+ * trigger) the client normalizes, matching how `getStatus` returns them.
+ */
+export interface DataConnectorSyncEvent {
+  event: 'dataConnector:sync'
+  data: {
+    connectorId: string
+    kind: 'run-started' | 'progress' | 'run-finished'
+    /** Connector lifecycle status: 'syncing' | 'provisioning' | 'live' | 'error' | 'paused' | … */
+    connectorStatus: string
+    /** ISO; advances on a successful finalize. Null when never synced. */
+    lastSyncedAt: string | null
+    /** Latest run snapshot (the connector's newest `DataConnectorRun`). */
+    runId?: string
+    runStatus?: string
+    phase?: 'backfill' | 'steady' | null
+    trigger?: string
+    /** Live aggregate records-seen across all streams (sum of per-stream state). */
+    recordsSeen: number
+    created: number
+    updated: number
+    perStream: {
+      streamKey: string
+      recordsSeen: number
+      phase: 'backfill' | 'steady'
+      done: boolean
+    }[]
   }
 }
 

--- a/packages/lib/src/realtime/index.ts
+++ b/packages/lib/src/realtime/index.ts
@@ -17,6 +17,7 @@ export type {
   AgentUpdatedEvent,
   AiStatus,
   AiValueMetadata,
+  DataConnectorSyncEvent,
   EvalCaseChangedEvent,
   FieldValuesUpdatedEvent,
   FieldValueUpdateEntry,
@@ -45,6 +46,7 @@ export type {
 export {
   flushMailBatch,
   publishAgentUpdated,
+  publishDataConnectorSync,
   publishEvalCaseChanged,
   publishFieldValueUpdates,
   publishInboxSyncCompleted,

--- a/packages/lib/src/realtime/publish-helpers.ts
+++ b/packages/lib/src/realtime/publish-helpers.ts
@@ -2,6 +2,7 @@
 
 import { getOrgCache } from '../cache'
 import type {
+  DataConnectorSyncEvent,
   FieldValueUpdateEntry,
   MailSyncEvent,
   MessageMeta,
@@ -85,6 +86,27 @@ export async function publishRecordsInvalidated(
       realtimeService.publish(roomKey, 'records:invalidated', { entityDefinitionId }, options)
     )
   )
+}
+
+/**
+ * Publish `dataConnector:sync` on the org channel — the live connector-sync status
+ * signal (see `DataConnectorSyncEvent`). Coarse + org-wide like `records:invalidated`.
+ * No `excludeSocketId`: sync runs in the worker (no originating browser socket), so
+ * every open tab — including the one that clicked "Sync now" — should light up.
+ *
+ * Gated on `realtimeSync`. Fire-and-forget: errors swallowed so a Pusher hiccup
+ * never blocks the sync job.
+ */
+export async function publishDataConnectorSync(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  data: DataConnectorSyncEvent['data']
+) {
+  const { features } = await getOrgCache().getOrRecompute(organizationId, ['features'])
+  if (!features?.realtimeSync) return
+  await realtimeService
+    .publish(rooms.orgPresence(organizationId), 'dataConnector:sync', data)
+    .catch(() => {})
 }
 
 // ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What

Replaces the 4s `getStatus` poll on the connector detail view with a push feed so syncs move **live** — run counters tick, the runs panel gains rows, and the freshness line refreshes without waiting on a poll. It also lights up **webhook/scheduled** runs that the old poll never armed for (it only polled once the cached status already read `syncing`, so a webhook-triggered run on a `live` connector was invisible until a manual refetch).

## Why

Today `connector-detail-view.tsx` runs `getStatus` on a 4s `refetchInterval` gated on `status === 'syncing' | 'provisioning'`. Two problems: up-to-4s latency/granularity, and webhook/scheduled runs never start the poll (the connector row the client holds still reads `live`) — the "didn't see that the data synced" class.

## How

**Server**
- New org-channel event `dataConnector:sync` in `realtime/events.ts` + `realtimeSync`-gated `publishDataConnectorSync` helper (`realtime/publish-helpers.ts`).
- `data-connectors/realtime.ts` (new): single entry point `publishConnectorSync(db, orgId, connectorId, kind)` reads a snapshot (connector + latest run + per-stream state, mirroring the `getStatus` router) and emits it. `progress` is throttled to 750ms/connector; lifecycle kinds (`run-started` / `run-finished`) bypass. Lazy `import('../realtime')` to dodge the vi.mock-breaking load cycle.
- Publish call-sites all in `slice-orchestrator.ts`: `run-started` on chain enqueue, `progress` per slice, `run-finished` on park / failed / complete, and on the stale-run sweep (unsticks crashed chains). No socket exclusion — sync runs in the worker, so every open tab (incl. the one that clicked "Sync now") updates.

**Client**
- `useConnectorSyncRealtime` hook: `progress` patches the `getStatus` cache in place (instant counter motion, no refetch); lifecycle invalidates `getStatus` + `listRuns`. Mounted in both the detail view and the independently-docked runs panel.
- The 4s polls drop to a **15s safety net** — realtime is best-effort with no missed-event replay, so a slow poll + focus-refetch remains the fallback.

## Testing

- Biome clean on all touched files.
- 169/169 `src/data-connectors` + `src/jobs/data-connector` tests pass, including the slice-orchestrator and connector-sync-source smoke tests that exercise the lazy realtime import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)