### PR TITLE
feat(data-connectors): webhook deliveries steer a targeted partial run

### DIFF
--- a/apps/worker/src/workers/worker-definitions/app-trigger-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/app-trigger-worker.ts
@@ -7,6 +7,8 @@ import {
   dispatchWebhookEndpoint,
   dispatchWebhookEndpointToAgents,
   dispatchWebhookEndpointToConnectors,
+  runConnectorWebhookSteer,
+  WEBHOOK_STEER_JOB,
 } from '@auxx/lib/jobs'
 import { Queues } from '@auxx/lib/jobs/queues'
 import { createWorker } from '../utils/createWorker'
@@ -14,13 +16,15 @@ import { createWorker } from '../utils/createWorker'
 const jobMappings = {
   dispatchAppTrigger,
   dispatchAppTriggerToAgents,
-  // Sync bridge: third consumer of the app-trigger fan-out. A relevant delivery steers a
-  // full run-based sync (enqueueConnectorSync), so there's no per-stream child job.
+  // Sync bridge: third consumer of the app-trigger fan-out. The dispatch routes each matched
+  // stream to either the steer job (steerable → targeted partial run) or a full sync.
   dispatchAppTriggerToConnectors,
   dispatchWebhookEndpoint,
   dispatchWebhookEndpointToAgents,
   // Connector-sink leg of the generic WebhookEndpoint fan-out.
   dispatchWebhookEndpointToConnectors,
+  // Per-stream child: steers the connector fetch with a webhook payload → targeted PARTIAL run.
+  [WEBHOOK_STEER_JOB]: runConnectorWebhookSteer,
 }
 
 export function startAppTriggerWorker() {

--- a/packages/lib/src/data-connectors/connector-webhook.test.ts
+++ b/packages/lib/src/data-connectors/connector-webhook.test.ts
@@ -1,0 +1,216 @@
+// packages/lib/src/data-connectors/connector-webhook.test.ts
+// Guards the webhook-steered PARTIAL run. A `fetch` steer opens a run, steers the connector
+// fetch with the resolved `triggerContext`, sinks the result, and closes the run as `partial`
+// (never `completed` — a single steered record is a SUBSET, so no orphan reconciliation) while
+// still stamping `lastSyncedAt` via finalizeConnector. A `delete` steer archives by externalId
+// and never fetches. A throttle drops the run row (no panel spam) and re-throws. Heavy deps faked.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  loadConnector,
+  resolveWebhookSteer,
+  openRun,
+  finalizeRun,
+  finalizeConnector,
+  countConnectorItems,
+  prepareConnectorFetch,
+  sinkSourceRecord,
+  archiveExternalId,
+  invalidateSnapshots,
+  ConnectorRateLimitError,
+  fetchFn,
+  deleteWhere,
+} = vi.hoisted(() => {
+  class ConnectorRateLimitError extends Error {
+    retryAfterMs?: number
+    constructor(retryAfterMs?: number) {
+      super('throttled')
+      this.name = 'ConnectorRateLimitError'
+      this.retryAfterMs = retryAfterMs
+    }
+  }
+  return {
+    loadConnector: vi.fn(),
+    resolveWebhookSteer: vi.fn(),
+    openRun: vi.fn(),
+    finalizeRun: vi.fn(),
+    finalizeConnector: vi.fn(),
+    countConnectorItems: vi.fn(),
+    prepareConnectorFetch: vi.fn(),
+    sinkSourceRecord: vi.fn(),
+    archiveExternalId: vi.fn(),
+    invalidateSnapshots: vi.fn(),
+    ConnectorRateLimitError,
+    fetchFn: vi.fn(),
+    deleteWhere: vi.fn(),
+  }
+})
+
+const db = { delete: vi.fn(() => ({ where: (...a: unknown[]) => deleteWhere(...a) })) }
+vi.mock('@auxx/database', () => ({
+  schema: { DataConnectorRun: { id: 'id-col' } },
+}))
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: () => {}, warn: () => {}, error: () => {} }),
+}))
+vi.mock('../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    async warmCache() {}
+  },
+}))
+vi.mock('../snapshot', () => ({
+  invalidateSnapshots: (...a: unknown[]) => invalidateSnapshots(...a),
+}))
+vi.mock('./connector-runtime', () => ({
+  prepareConnectorFetch: (...a: unknown[]) => prepareConnectorFetch(...a),
+}))
+vi.mock('./connectors', () => ({ ConnectorRateLimitError }))
+vi.mock('./connectors/types', () => ({ isConnectorCheckpoint: () => false }))
+vi.mock('./reconciliation', () => ({
+  archiveExternalId: (...a: unknown[]) => archiveExternalId(...a),
+}))
+vi.mock('./service', () => ({
+  loadConnector: (...a: unknown[]) => loadConnector(...a),
+  openRun: (...a: unknown[]) => openRun(...a),
+  finalizeRun: (...a: unknown[]) => finalizeRun(...a),
+  finalizeConnector: (...a: unknown[]) => finalizeConnector(...a),
+  countConnectorItems: (...a: unknown[]) => countConnectorItems(...a),
+  newRunCounters: () => ({ created: 0, updated: 0, deleted: 0, archived: 0 }),
+}))
+vi.mock('./sink-source-record', () => ({
+  sinkSourceRecord: (ctx: { touchedDefs: Set<string> }, ...a: unknown[]) => {
+    ctx.touchedDefs.add('def1')
+    return sinkSourceRecord(ctx, ...a)
+  },
+}))
+vi.mock('./webhook-steer', () => ({
+  resolveWebhookSteer: (...a: unknown[]) => resolveWebhookSteer(...a),
+}))
+
+import { runWebhookSteeredRun } from './connector-webhook'
+
+async function* oneRecord() {
+  yield { externalId: '123', data: {} }
+}
+
+const loaded = {
+  connector: { id: 'dc1', createdById: 'u1', config: {} },
+  streams: [
+    {
+      stream: {
+        streamKey: 'orders',
+        requestConfig: {
+          webhookTrigger: { paths: ['id'] },
+          incremental: { watermarkField: 'updatedAt' },
+        },
+      },
+      mappings: [{ entityDefinitionId: 'def1' }],
+    },
+  ],
+}
+
+const data = {
+  connectorId: 'dc1',
+  organizationId: 'org1',
+  streamKey: 'orders',
+  triggerData: { id: '123', topic: 'orders/create' },
+  eventId: 'evt1',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  loadConnector.mockResolvedValue(loaded)
+  openRun.mockResolvedValue({ id: 'run1', startedAt: new Date(0) })
+  finalizeRun.mockResolvedValue(undefined)
+  finalizeConnector.mockResolvedValue(undefined)
+  countConnectorItems.mockResolvedValue(5)
+  prepareConnectorFetch.mockResolvedValue({ definition: { fetch: fetchFn }, credential: {} })
+  fetchFn.mockResolvedValue({ records: oneRecord() })
+})
+
+describe('runWebhookSteeredRun', () => {
+  it('opens a run, steers the fetch, sinks, and closes it PARTIAL (no reconcile)', async () => {
+    resolveWebhookSteer.mockReturnValue({ kind: 'fetch', triggerContext: { id: '123' } })
+
+    await runWebhookSteeredRun(db as never, data)
+
+    expect(openRun).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ trigger: 'webhook', mode: 'incremental' })
+    )
+    // steered: the resolved triggerContext is threaded into the fetch
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.objectContaining({ streamKey: 'orders', triggerContext: { id: '123' } })
+    )
+    expect(sinkSourceRecord).toHaveBeenCalledTimes(1)
+    expect(archiveExternalId).not.toHaveBeenCalled()
+    // closes PARTIAL — the load-bearing bit: a subset run must NOT reconcile/archive the rest
+    expect(finalizeRun).toHaveBeenCalledWith(
+      db,
+      'run1',
+      expect.objectContaining({ status: 'partial' })
+    )
+    // still stamps lastSyncedAt so header freshness advances
+    expect(finalizeConnector).toHaveBeenCalledWith(
+      db,
+      'dc1',
+      expect.objectContaining({ ok: true, itemCount: 5 })
+    )
+    expect(invalidateSnapshots).toHaveBeenCalledWith({
+      organizationId: 'org1',
+      resourceType: 'def1',
+    })
+  })
+
+  it('archives by externalId on a delete steer and never fetches', async () => {
+    resolveWebhookSteer.mockReturnValue({ kind: 'delete', externalId: '123' })
+
+    await runWebhookSteeredRun(db as never, data)
+
+    expect(archiveExternalId).toHaveBeenCalledWith(
+      expect.anything(),
+      loaded.streams[0]?.mappings,
+      '123'
+    )
+    expect(prepareConnectorFetch).not.toHaveBeenCalled()
+    expect(fetchFn).not.toHaveBeenCalled()
+    expect(finalizeRun).toHaveBeenCalledWith(
+      db,
+      'run1',
+      expect.objectContaining({ status: 'partial' })
+    )
+  })
+
+  it('drops the run row and re-throws on a throttle (no panel spam)', async () => {
+    resolveWebhookSteer.mockReturnValue({ kind: 'fetch', triggerContext: { id: '123' } })
+    fetchFn.mockRejectedValue(new ConnectorRateLimitError(2000))
+
+    await expect(runWebhookSteeredRun(db as never, data)).rejects.toBeInstanceOf(
+      ConnectorRateLimitError
+    )
+    expect(db.delete).toHaveBeenCalledTimes(1)
+    expect(deleteWhere).toHaveBeenCalledTimes(1)
+    expect(finalizeRun).not.toHaveBeenCalled()
+  })
+
+  it('marks the run failed (not dropped) on a non-throttle error and re-throws', async () => {
+    resolveWebhookSteer.mockReturnValue({ kind: 'fetch', triggerContext: { id: '123' } })
+    fetchFn.mockRejectedValue(new Error('boom'))
+
+    await expect(runWebhookSteeredRun(db as never, data)).rejects.toThrow('boom')
+    expect(db.delete).not.toHaveBeenCalled()
+    expect(finalizeRun).toHaveBeenCalledWith(
+      db,
+      'run1',
+      expect.objectContaining({ status: 'failed' })
+    )
+  })
+
+  it('is a no-op when the connector is gone (never opens a run)', async () => {
+    loadConnector.mockResolvedValue(null)
+    await runWebhookSteeredRun(db as never, data)
+    expect(openRun).not.toHaveBeenCalled()
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/data-connectors/connector-webhook.ts
+++ b/packages/lib/src/data-connectors/connector-webhook.ts
@@ -1,0 +1,202 @@
+// packages/lib/src/data-connectors/connector-webhook.ts
+// The webhook-steered PARTIAL run. A verified inbound delivery (app trigger or generic
+// WebhookEndpoint) STEERS the regular connector fetch into the SAME entity sink the
+// backfill/steady paths use — but fetches only the changed record (`{path}` steering,
+// e.g. `GET /orders/{id}`) instead of re-crawling the collection. Unlike a full sync it
+// opens a run marked `partial`: the run observed a SUBSET of the collection, so it must
+// NOT reconcile/archive the rest (a one-record run that reconciled would archive every
+// other record). It never advances the watermark/cursor (W3 — webhook events are
+// out-of-band of the steady delta floor) and is idempotent via the sink's content-hash
+// dedupe + the receiver's event-id dedupe. The full-sync path (enqueueConnectorSync) still
+// handles cursor streams that have no `{path}` to steer — see the dispatch jobs.
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { eq } from 'drizzle-orm'
+import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import { invalidateSnapshots } from '../snapshot'
+import { prepareConnectorFetch } from './connector-runtime'
+import { ConnectorRateLimitError } from './connectors'
+import { isConnectorCheckpoint } from './connectors/types'
+import { publishConnectorSync } from './realtime'
+import { archiveExternalId } from './reconciliation'
+import {
+  countConnectorItems,
+  finalizeConnector,
+  finalizeRun,
+  loadConnector,
+  newRunCounters,
+  openRun,
+  type RunCounters,
+  type StreamWithMappings,
+} from './service'
+import { sinkSourceRecord } from './sink-source-record'
+import type { SyncCtx } from './sinks/types'
+import { resolveWebhookSteer } from './webhook-steer'
+
+const logger = createScopedLogger('data-connector-webhook')
+
+/**
+ * App-trigger / WebhookEndpoint sync bridge — drive ONE stream off one webhook delivery
+ * as a PARTIAL run. STEERS the regular connector fetch: reads the stream's `webhookTrigger`
+ * config, resolves `{token}` values out of `triggerData`, runs the normal fetch seeded with
+ * that context (so auth/baseUrl/pagination/mappings are identical to a bulk sync), and sinks
+ * the FETCH result. A delete event skips the fetch and archives by externalId.
+ *
+ * Opens a real `DataConnectorRun` (`trigger:'webhook'`, `mode:'incremental'`) so the delivery
+ * shows in the Runs panel and refreshes `lastSyncedAt` — but closes it as `partial` and runs
+ * NO orphan reconciliation (the run saw a single record, not the whole collection). A throttle
+ * surfaces as `ConnectorRateLimitError` (the fetch sets `maxRetries: 0`) for the caller to
+ * re-enqueue — the run row is dropped on a throttle deferral so retries don't spam the panel.
+ * A no-op when the connector/stream is gone or unmapped.
+ */
+export async function runWebhookSteeredRun(
+  db: Database,
+  data: {
+    connectorId: string
+    organizationId: string
+    streamKey: string
+    triggerData: Record<string, unknown>
+    eventId: string
+  }
+): Promise<void> {
+  const { connectorId, organizationId, streamKey, triggerData, eventId } = data
+
+  const loaded = await loadConnector(db, organizationId, connectorId)
+  if (!loaded) {
+    logger.info('runWebhookSteeredRun: connector gone/unmapped, dropping', { connectorId })
+    return
+  }
+  const { connector, streams } = loaded
+  const stream = streams.find((s) => s.stream.streamKey === streamKey)
+  const webhookTrigger = stream?.stream.requestConfig?.webhookTrigger
+  if (!stream || !webhookTrigger) {
+    logger.info('runWebhookSteeredRun: stream unmapped or not webhook-bound, dropping', {
+      connectorId,
+      streamKey,
+    })
+    return
+  }
+
+  const steer = resolveWebhookSteer(webhookTrigger, triggerData)
+  const counters = newRunCounters()
+
+  // Open a real run. `incremental` mode + no `phase`/cursor reset: a steered point-fetch,
+  // never a (re)backfill. The run id flows into the sink ctx — legit now that a row exists.
+  const run = await openRun(db, {
+    dataConnectorId: connectorId,
+    organizationId,
+    trigger: 'webhook',
+    mode: 'incremental',
+  })
+
+  try {
+    const ctx = await buildWebhookCtx(db, organizationId, connector, streams, run.id, counters)
+
+    if (steer.kind === 'delete') {
+      if (steer.externalId) await archiveExternalId(ctx, stream.mappings, steer.externalId)
+    } else {
+      const { definition, credential } = await prepareConnectorFetch(
+        db,
+        organizationId,
+        connector,
+        connector.createdById ?? 'system'
+      )
+      const { records } = await definition.fetch({
+        streamKey,
+        mode: 'snapshot',
+        state: {},
+        credential,
+        config: connector.config,
+        requestConfig: stream.stream.requestConfig ?? undefined,
+        triggerContext: steer.triggerContext,
+        // H1 — never sleep on a throttle; surface it for the caller to re-enqueue.
+        rateLimitOverride: { maxRetries: 0 },
+      })
+      // Drain the fetch (1 page for `single`, the full pagination loop for `collection`),
+      // sinking each raw page through the SAME mappings as bulk sync. Seed
+      // `upstreamUpdatedAt` from the fetched record's `watermarkField` so concurrent events
+      // for one externalId can't regress to older data (the guard lives in the sink).
+      const updatedAtPath = stream.stream.requestConfig?.incremental?.watermarkField
+      for await (const record of records) {
+        if (isConnectorCheckpoint(record)) continue
+        await sinkSourceRecord(ctx, stream.mappings, record, updatedAtPath)
+      }
+    }
+
+    for (const defId of ctx.touchedDefs) {
+      await invalidateSnapshots({ organizationId, resourceType: defId })
+    }
+
+    // Close the run PARTIAL — it observed a single steered record, so the connector
+    // finalize must NOT reconcile orphans (that would archive the rest of the collection).
+    // `finalizeConnector` still stamps `lastSyncedAt` so header freshness advances.
+    await finalizeRun(db, run.id, { status: 'partial', counters, startedAt: run.startedAt })
+    await finalizeConnector(db, connectorId, {
+      ok: true,
+      itemCount: await countConnectorItems(db, connectorId),
+    })
+    // A steered run is a fast point-fetch that never sets the connector to `syncing`
+    // (no claimForSync), so there's no live "syncing" phase to animate — this single
+    // emit invalidates getStatus + listRuns so the new partial run row appears and
+    // freshness advances instantly, instead of waiting on the 15s safety poll.
+    await publishConnectorSync(db, organizationId, connectorId, 'run-finished')
+    logger.info('runWebhookSteeredRun applied', {
+      connectorId,
+      streamKey,
+      eventId,
+      runId: run.id,
+      kind: steer.kind,
+      created: counters.created,
+      updated: counters.updated,
+      deleted: counters.deleted,
+      archived: counters.archived,
+    })
+  } catch (err) {
+    // A throttle is a "try again later", not an attempt worth recording — drop the run row
+    // so a deferred-then-succeeded delivery leaves one clean run, not a trail of failures.
+    // The fetch throttles at initiation (before any sink) for the common `single` shape, so
+    // nothing is lost; a mid-pagination throttle re-sinks idempotently on retry.
+    if (err instanceof ConnectorRateLimitError) {
+      await db.delete(schema.DataConnectorRun).where(eq(schema.DataConnectorRun.id, run.id))
+    } else {
+      await finalizeRun(db, run.id, { status: 'failed', counters, startedAt: run.startedAt }).catch(
+        () => {}
+      )
+      // Surface the failed run row live too — a throttle (run dropped above) emits nothing.
+      await publishConnectorSync(db, organizationId, connectorId, 'run-finished')
+    }
+    throw err
+  }
+}
+
+/** Build a one-shot sink context for a webhook delivery, bound to the real run id. */
+async function buildWebhookCtx(
+  db: Database,
+  organizationId: string,
+  connector: SyncCtx['connector'],
+  streams: StreamWithMappings[],
+  runId: string,
+  counters: RunCounters
+): Promise<SyncCtx> {
+  const userId = connector.createdById ?? 'system'
+  const crud = new UnifiedCrudHandler(organizationId, userId, db)
+  const ownedCrud = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+    bypassFieldGuards: new Set<never>(),
+  })
+  const defs = new Set(streams.flatMap((s) => s.mappings.map((m) => m.entityDefinitionId)))
+  for (const defId of defs) {
+    await crud.warmCache(defId)
+    await ownedCrud.warmCache(defId)
+  }
+  return {
+    db,
+    orgId: organizationId,
+    connector,
+    runId,
+    crud,
+    ownedCrud,
+    counters,
+    touchedDefs: new Set<string>(),
+  }
+}

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -33,6 +33,8 @@ export type {
   SyncSourceStream,
 } from './connector-sync-source'
 export { createConnectorStreamSyncSource } from './connector-sync-source'
+// Webhook-steered PARTIAL run (plans/data-connectors/v2/webhook-steered-partial-run-plan)
+export { runWebhookSteeredRun } from './connector-webhook'
 export type {
   AppConnectorContext,
   ConnectorCheckpoint,

--- a/packages/lib/src/data-connectors/realtime.ts
+++ b/packages/lib/src/data-connectors/realtime.ts
@@ -42,15 +42,22 @@ export async function publishConnectorSync(
     lastProgressEmit.delete(connectorId)
   }
 
-  const data = await buildSnapshot(db, organizationId, connectorId, kind)
-  if (!data) return
+  // Wholly fire-and-forget: the snapshot read + publish must NEVER throw into a sync
+  // run or webhook job — a realtime hiccup is not a sync failure. Callers `await` this
+  // without their own try/catch, so the guarantee has to live here.
+  try {
+    const data = await buildSnapshot(db, organizationId, connectorId, kind)
+    if (!data) return
 
-  // Lazy-import the realtime barrel: a static import from a data-connectors module
-  // creates a load-time cycle (realtime → publish-helpers → cache → …) that breaks
-  // vi.mock interception in the connector smoke tests. Same pattern as
-  // `connector-sync-source.emitRecordsInvalidated`.
-  const { getRealtimeService, publishDataConnectorSync } = await import('../realtime')
-  await publishDataConnectorSync(getRealtimeService(), organizationId, data).catch(() => {})
+    // Lazy-import the realtime barrel: a static import from a data-connectors module
+    // creates a load-time cycle (realtime → publish-helpers → cache → …) that breaks
+    // vi.mock interception in the connector smoke tests. Same pattern as
+    // `connector-sync-source.emitRecordsInvalidated`.
+    const { getRealtimeService, publishDataConnectorSync } = await import('../realtime')
+    await publishDataConnectorSync(getRealtimeService(), organizationId, data)
+  } catch {
+    // swallowed — realtime is best-effort
+  }
 }
 
 /**

--- a/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.test.ts
+++ b/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.test.ts
@@ -1,8 +1,9 @@
 // packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.test.ts
 // The connector app-trigger matcher (v7): a delivery matches webhook-sync connectors on the
 // delivering connection whose CONNECTOR-level `config.webhookTrigger.triggerId` matches, then
-// steers a full run-based sync for each connector with ≥1 stream whose `filter` passes.
-// DB/redis/enqueue faked.
+// routes each matched stream by mode — steerable (`{path}` set) → a per-stream steer job
+// (targeted PARTIAL run); non-steerable cursor stream → the full `enqueueConnectorSync`.
+// DB/redis/queue/enqueue faked.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -23,9 +24,16 @@ vi.mock('../../data-connectors/data-connector-queue', () => ({
   enqueueConnectorSync: (...a: unknown[]) => enqueueConnectorSync(...a),
 }))
 
+const queueAdd = vi.fn()
+vi.mock('../queues', () => ({
+  getQueue: () => ({ add: (...a: unknown[]) => queueAdd(...a) }),
+  Queues: { appTriggerQueue: 'app-trigger-queue' },
+}))
+
 vi.mock('@auxx/redis', () => ({ getRedisClient: async () => null }))
 
 import { dispatchAppTriggerToConnectors } from './app-trigger-sync-dispatch-job'
+import { WEBHOOK_STEER_JOB } from './webhook-steer-job'
 
 function job(data: Record<string, unknown>) {
   // Shaped like a JobContext: handlers read the real job off `ctx.job`.
@@ -47,7 +55,7 @@ beforeEach(() => {
 })
 
 describe('dispatchAppTriggerToConnectors', () => {
-  it('steers a webhook sync for a connector whose signal + a stream filter match', async () => {
+  it('enqueues a steer job for a steerable stream (paths set)', async () => {
     findManyConnectors.mockResolvedValue([
       { id: 'dc1', config: { webhookTrigger: { triggerId: 'shopify.shopify-trigger' } } },
     ])
@@ -55,11 +63,39 @@ describe('dispatchAppTriggerToConnectors', () => {
       {
         dataConnectorId: 'dc1',
         streamKey: 'orders',
-        requestConfig: { webhookTrigger: { tokens: {} } },
+        requestConfig: { webhookTrigger: { paths: ['resourceId'] } },
       },
     ])
     const result = await dispatchAppTriggerToConnectors(job(base))
-    expect(result).toEqual({ connectorsSynced: 1 })
+    expect(result).toEqual({ steerJobs: 1, connectorsFullSynced: 0 })
+    expect(enqueueConnectorSync).not.toHaveBeenCalled()
+    expect(queueAdd).toHaveBeenCalledTimes(1)
+    expect(queueAdd.mock.calls[0]?.[0]).toBe(WEBHOOK_STEER_JOB)
+    expect(queueAdd.mock.calls[0]?.[1]).toMatchObject({
+      connectorId: 'dc1',
+      streamKey: 'orders',
+      organizationId: 'org1',
+      triggerId: 'shopify.shopify-trigger',
+      eventId: 'evt1',
+    })
+    // No jobId opts ⇒ steered runs never coalesce (each delivery is a distinct record).
+    expect(queueAdd.mock.calls[0]?.[2]).toBeUndefined()
+  })
+
+  it('full-syncs a non-steerable cursor stream (no paths)', async () => {
+    findManyConnectors.mockResolvedValue([
+      { id: 'dc1', config: { webhookTrigger: { triggerId: 'shopify.shopify-trigger' } } },
+    ])
+    findManyStreams.mockResolvedValue([
+      {
+        dataConnectorId: 'dc1',
+        streamKey: 'orders',
+        requestConfig: { webhookTrigger: { paths: [] } },
+      },
+    ])
+    const result = await dispatchAppTriggerToConnectors(job(base))
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 1 })
+    expect(queueAdd).not.toHaveBeenCalled()
     expect(enqueueConnectorSync).toHaveBeenCalledTimes(1)
     expect(enqueueConnectorSync.mock.calls[0]?.[0]).toMatchObject({
       connectorId: 'dc1',
@@ -68,24 +104,55 @@ describe('dispatchAppTriggerToConnectors', () => {
     })
   })
 
-  it('syncs a connector once even when several of its streams match', async () => {
+  it('full-syncs a connector with ANY non-steerable matched stream (superset wins)', async () => {
     findManyConnectors.mockResolvedValue([
       { id: 'dc1', config: { webhookTrigger: { triggerId: 'shopify.shopify-trigger' } } },
     ])
     findManyStreams.mockResolvedValue([
-      { dataConnectorId: 'dc1', streamKey: 'orders', requestConfig: { webhookTrigger: {} } },
-      { dataConnectorId: 'dc1', streamKey: 'customers', requestConfig: { webhookTrigger: {} } },
+      {
+        dataConnectorId: 'dc1',
+        streamKey: 'orders',
+        requestConfig: { webhookTrigger: { paths: ['resourceId'] } },
+      },
+      {
+        dataConnectorId: 'dc1',
+        streamKey: 'customers',
+        requestConfig: { webhookTrigger: { paths: [] } },
+      },
     ])
     const result = await dispatchAppTriggerToConnectors(job(base))
-    expect(result).toEqual({ connectorsSynced: 1 })
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 1 })
+    expect(queueAdd).not.toHaveBeenCalled()
     expect(enqueueConnectorSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('enqueues a steer job per matched steerable stream of a connector', async () => {
+    findManyConnectors.mockResolvedValue([
+      { id: 'dc1', config: { webhookTrigger: { triggerId: 'shopify.shopify-trigger' } } },
+    ])
+    findManyStreams.mockResolvedValue([
+      {
+        dataConnectorId: 'dc1',
+        streamKey: 'orders',
+        requestConfig: { webhookTrigger: { paths: ['resourceId'] } },
+      },
+      {
+        dataConnectorId: 'dc1',
+        streamKey: 'lineItems',
+        requestConfig: { webhookTrigger: { paths: ['resourceId'] } },
+      },
+    ])
+    const result = await dispatchAppTriggerToConnectors(job(base))
+    expect(result).toEqual({ steerJobs: 2, connectorsFullSynced: 0 })
+    expect(queueAdd).toHaveBeenCalledTimes(2)
   })
 
   it('returns early when the delivery carries no connection', async () => {
     const result = await dispatchAppTriggerToConnectors(job({ ...base, connectionId: undefined }))
-    expect(result).toEqual({ connectorsSynced: 0 })
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 0 })
     expect(findManyConnectors).not.toHaveBeenCalled()
     expect(enqueueConnectorSync).not.toHaveBeenCalled()
+    expect(queueAdd).not.toHaveBeenCalled()
   })
 
   it('skips connectors bound to a different trigger on the same connection', async () => {
@@ -93,8 +160,9 @@ describe('dispatchAppTriggerToConnectors', () => {
       { id: 'dc1', config: { webhookTrigger: { triggerId: 'other.trigger' } } },
     ])
     const result = await dispatchAppTriggerToConnectors(job(base))
-    expect(result).toEqual({ connectorsSynced: 0 })
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 0 })
     expect(findManyStreams).not.toHaveBeenCalled()
     expect(enqueueConnectorSync).not.toHaveBeenCalled()
+    expect(queueAdd).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.ts
+++ b/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.ts
@@ -1,13 +1,13 @@
 // packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.ts
 // The THIRD consumer of the app-trigger fan-out (sync bridge §5.2). Sibling to
 // `dispatchAppTrigger` (workflows) and `dispatchAppTriggerToAgents` (agents): one
-// verified app-webhook delivery → a full run-based sync of every webhook-sync
-// DataConnector bound to this `(connection, triggerId)` with ≥1 stream whose `filter`
-// matches the payload. THIN by design — it only dedups + matches + steers a sync via
-// `enqueueConnectorSync({ trigger: 'webhook' })` (same path as "Sync now"), so the
-// delivery produces a `DataConnectorRun` history row, refreshes `lastSyncedAt`, and
-// runs orphan reconciliation. `enqueueConnectorSync`'s per-connector `jobId` coalesces
-// a burst of deliveries into one run.
+// verified app-webhook delivery → a sync of every webhook-sync DataConnector bound to this
+// `(connection, triggerId)` with ≥1 stream whose `filter` matches the payload. THIN by
+// design — it dedups + matches + routes by mode (webhook-steered-partial-run-plan):
+//   • steerable stream (`webhookTrigger.paths` set) → a targeted PARTIAL run via the steer
+//     job (fetches only the changed record via `{path}`, marks the run `partial`).
+//   • non-steerable cursor stream → the full run-based sync (`enqueueConnectorSync`).
+// Either way the delivery yields a `DataConnectorRun` history row + refreshed `lastSyncedAt`.
 
 import { database as db, schema } from '@auxx/database'
 import { getRedisClient } from '@auxx/redis'
@@ -15,7 +15,9 @@ import { and, eq, inArray, ne } from 'drizzle-orm'
 import { matchesFilter } from '../../agents/agent-trigger-queries'
 import { enqueueConnectorSync } from '../../data-connectors/data-connector-queue'
 import { createScopedLogger } from '../../logger'
+import { getQueue, Queues } from '../queues'
 import type { JobContext } from '../types'
+import { type ConnectorWebhookSteerJobData, WEBHOOK_STEER_JOB } from './webhook-steer-job'
 
 const logger = createScopedLogger('data-connector-app-trigger-dispatch-job')
 
@@ -37,11 +39,9 @@ export type ConnectorAppTriggerDispatchJobData = {
  * `webhookTrigger.filter` + `matchesFilter` discriminates topics (Shopify multiplexes
  * 22 topics through one triggerId, on `triggerData.topic`).
  *
- * A relevant delivery (≥1 of a connector's streams matches the payload) STEERS a full
- * run-based sync via `enqueueConnectorSync({ trigger: 'webhook' })` — same path as
- * "Sync now", so the delivery yields a `DataConnectorRun` history row, refreshes
- * `lastSyncedAt`, and runs orphan reconciliation. `enqueueConnectorSync`'s per-connector
- * `jobId` coalesces a burst of deliveries into one run. Fan-to-all across connectors.
+ * Each matched stream routes by mode: steerable (`{path}` set) → a per-stream steer job
+ * (targeted PARTIAL run); non-steerable cursor stream → `enqueueConnectorSync` (full run).
+ * Fan-to-all across connectors.
  */
 export async function dispatchAppTriggerToConnectors(
   ctx: JobContext<ConnectorAppTriggerDispatchJobData>
@@ -58,7 +58,7 @@ export async function dispatchAppTriggerToConnectors(
       const setResult = await redis.set(dedupKey, '1', 'EX', 300, 'NX')
       if (!setResult) {
         logger.warn('Duplicate connector app-trigger event, skipping', { dedupKey, eventId })
-        return { connectorsSynced: 0 }
+        return { steerJobs: 0, connectorsFullSynced: 0 }
       }
     }
   } catch (err) {
@@ -71,7 +71,7 @@ export async function dispatchAppTriggerToConnectors(
   // Webhook-sync connectors are keyed by the connection. No connection ⇒ nothing binds.
   if (!connectionId) {
     logger.debug('App trigger carried no connectionId — no connector match', { triggerId, eventId })
-    return { connectorsSynced: 0 }
+    return { steerJobs: 0, connectorsFullSynced: 0 }
   }
 
   // Signal is connector-level since v7 (`config.webhookTrigger.triggerId`) — match the
@@ -89,7 +89,7 @@ export async function dispatchAppTriggerToConnectors(
     columns: { id: true, config: true },
   })
   const connectors = candidates.filter((c) => c.config?.webhookTrigger?.triggerId === triggerId)
-  if (connectors.length === 0) return { connectorsSynced: 0 }
+  if (connectors.length === 0) return { steerJobs: 0, connectorsFullSynced: 0 }
 
   const streams = await db.query.DataConnectorStream.findMany({
     where: and(
@@ -102,25 +102,51 @@ export async function dispatchAppTriggerToConnectors(
     columns: { dataConnectorId: true, streamKey: true, requestConfig: true },
   })
 
-  // A connector is relevant when ≥1 of its enabled streams' `webhookTrigger.filter`
-  // matches this payload (topic discrimination). One full sync per relevant connector —
-  // the run covers all its streams, so we don't fan per-stream.
-  const relevant = new Set<string>()
+  // Match streams by `webhookTrigger.filter` (topic discrimination), then SPLIT by mode:
+  //  • steerable (`{path}` set) → a targeted PARTIAL run that fetches only the changed
+  //    record (the steer job, per-stream so retries stay isolated).
+  //  • non-steerable (cursor stream, no `{path}`) → the full run-based sync (enqueueConnectorSync).
+  // A connector with ANY non-steerable matched stream full-syncs; the full crawl is a superset
+  // that covers its steerable streams too, so we skip their steer jobs (no double-ingest).
+  const matched: { connectorId: string; streamKey: string; steerable: boolean }[] = []
   for (const stream of streams) {
     const wt = stream.requestConfig?.webhookTrigger
     if (!stream.streamKey || !wt) continue
     if (!matchesFilter(wt.filter, triggerData)) continue
-    relevant.add(stream.dataConnectorId)
+    matched.push({
+      connectorId: stream.dataConnectorId,
+      streamKey: stream.streamKey,
+      steerable: (wt.paths?.length ?? 0) > 0,
+    })
   }
 
-  for (const connectorId of relevant) {
+  const fullSyncConnectors = new Set(matched.filter((m) => !m.steerable).map((m) => m.connectorId))
+  const queue = getQueue(Queues.appTriggerQueue)
+  let steerJobs = 0
+  for (const m of matched) {
+    if (!m.steerable || fullSyncConnectors.has(m.connectorId)) continue
+    // No `jobId` — each delivery is a distinct record, so steered runs must NOT coalesce
+    // (the dispatch-level redis dedup already drops duplicate deliveries of one eventId).
+    await queue.add(WEBHOOK_STEER_JOB, {
+      connectorId: m.connectorId,
+      streamKey: m.streamKey,
+      organizationId,
+      appInstallationId,
+      triggerId,
+      triggerData,
+      eventId,
+    } satisfies ConnectorWebhookSteerJobData)
+    steerJobs++
+  }
+  for (const connectorId of fullSyncConnectors) {
     await enqueueConnectorSync({ connectorId, organizationId, trigger: 'webhook' })
   }
 
   logger.debug('Dispatched connector app trigger', {
     triggerId,
     eventId,
-    connectorsSynced: relevant.size,
+    steerJobs,
+    connectorsFullSynced: fullSyncConnectors.size,
   })
-  return { connectorsSynced: relevant.size }
+  return { steerJobs, connectorsFullSynced: fullSyncConnectors.size }
 }

--- a/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.test.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.test.ts
@@ -1,8 +1,8 @@
 // packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.test.ts
 // The connector webhook-endpoint matcher (v7): a delivery matches webhook-sync connectors
-// whose CONNECTOR-level `config.webhookTrigger.webhookEndpointId` matches, then steers a full
-// run-based sync for each connector with ≥1 stream whose `webhookTrigger.filter` passes.
-// DB + redis + enqueue faked.
+// whose CONNECTOR-level `config.webhookTrigger.webhookEndpointId` matches, then routes each
+// matched stream by mode — steerable (`{path}` set) → a per-stream steer job (targeted PARTIAL
+// run); non-steerable cursor stream → the full `enqueueConnectorSync`. DB/redis/queue faked.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -24,9 +24,16 @@ vi.mock('../../data-connectors/data-connector-queue', () => ({
   enqueueConnectorSync: (...a: unknown[]) => enqueueConnectorSync(...a),
 }))
 
+const queueAdd = vi.fn()
+vi.mock('../queues', () => ({
+  getQueue: () => ({ add: (...a: unknown[]) => queueAdd(...a) }),
+  Queues: { appTriggerQueue: 'app-trigger-queue' },
+}))
+
 vi.mock('@auxx/redis', () => ({ getRedisClient: async () => null }))
 
 import { dispatchWebhookEndpointToConnectors } from './webhook-endpoint-sync-dispatch-job'
+import { WEBHOOK_STEER_JOB } from './webhook-steer-job'
 
 function job(data: Record<string, unknown>) {
   // Shaped like a JobContext: handlers read the real job off `ctx.job`.
@@ -46,7 +53,7 @@ beforeEach(() => {
 })
 
 describe('dispatchWebhookEndpointToConnectors', () => {
-  it('steers a webhook sync for a connector whose signal matches the endpoint', async () => {
+  it('enqueues a steer job for a steerable stream (paths set), with the folded topic', async () => {
     findManyConnectors.mockResolvedValue([
       { id: 'dc1', config: { webhookTrigger: { webhookEndpointId: 'ep1' } } },
     ])
@@ -54,11 +61,40 @@ describe('dispatchWebhookEndpointToConnectors', () => {
       {
         dataConnectorId: 'dc1',
         streamKey: 'orders',
-        requestConfig: { webhookTrigger: { tokens: {} } },
+        requestConfig: { webhookTrigger: { paths: ['id'] } },
       },
     ])
     const result = await dispatchWebhookEndpointToConnectors(job(base))
-    expect(result).toEqual({ connectorsSynced: 1 })
+    expect(result).toEqual({ steerJobs: 1, connectorsFullSynced: 0 })
+    expect(enqueueConnectorSync).not.toHaveBeenCalled()
+    expect(queueAdd).toHaveBeenCalledTimes(1)
+    expect(queueAdd.mock.calls[0]?.[0]).toBe(WEBHOOK_STEER_JOB)
+    expect(queueAdd.mock.calls[0]?.[1]).toMatchObject({
+      connectorId: 'dc1',
+      streamKey: 'orders',
+      organizationId: 'org1',
+      webhookEndpointId: 'ep1',
+      topic: 'orders/create',
+      eventId: 'evt1',
+      // the steer job receives the topic-folded payload so `resolveWebhookSteer` sees it
+      triggerData: { id: 1, topic: 'orders/create' },
+    })
+  })
+
+  it('full-syncs a non-steerable cursor stream (no paths)', async () => {
+    findManyConnectors.mockResolvedValue([
+      { id: 'dc1', config: { webhookTrigger: { webhookEndpointId: 'ep1' } } },
+    ])
+    findManyStreams.mockResolvedValue([
+      {
+        dataConnectorId: 'dc1',
+        streamKey: 'orders',
+        requestConfig: { webhookTrigger: { paths: [] } },
+      },
+    ])
+    const result = await dispatchWebhookEndpointToConnectors(job(base))
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 1 })
+    expect(queueAdd).not.toHaveBeenCalled()
     expect(enqueueConnectorSync).toHaveBeenCalledTimes(1)
     expect(enqueueConnectorSync.mock.calls[0]?.[0]).toMatchObject({
       connectorId: 'dc1',
@@ -73,9 +109,10 @@ describe('dispatchWebhookEndpointToConnectors', () => {
       { id: 'dc2', config: { webhookTrigger: undefined } },
     ])
     const result = await dispatchWebhookEndpointToConnectors(job(base))
-    expect(result).toEqual({ connectorsSynced: 0 })
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 0 })
     expect(findManyStreams).not.toHaveBeenCalled()
     expect(enqueueConnectorSync).not.toHaveBeenCalled()
+    expect(queueAdd).not.toHaveBeenCalled()
   })
 
   it('matches a topic-scoped stream when the topic is only in the separate field (header/path source)', async () => {
@@ -97,7 +134,7 @@ describe('dispatchWebhookEndpointToConnectors', () => {
     const result = await dispatchWebhookEndpointToConnectors(
       job({ ...base, triggerData: { id: 1 } }) // no `topic` in the body
     )
-    expect(result).toEqual({ connectorsSynced: 1 })
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 1 })
     expect(enqueueConnectorSync).toHaveBeenCalledTimes(1)
   })
 
@@ -117,8 +154,9 @@ describe('dispatchWebhookEndpointToConnectors', () => {
     const result = await dispatchWebhookEndpointToConnectors(
       job({ ...base, triggerData: { id: 1 } })
     )
-    expect(result).toEqual({ connectorsSynced: 0 })
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 0 })
     expect(enqueueConnectorSync).not.toHaveBeenCalled()
+    expect(queueAdd).not.toHaveBeenCalled()
   })
 
   it('skips streams with no steering block and streams whose filter rejects the payload', async () => {
@@ -130,11 +168,12 @@ describe('dispatchWebhookEndpointToConnectors', () => {
       {
         dataConnectorId: 'dc1',
         streamKey: 'b',
-        requestConfig: { webhookTrigger: { tokens: {}, filter: { topic: 'orders/delete' } } },
+        requestConfig: { webhookTrigger: { paths: [], filter: { topic: 'orders/delete' } } },
       },
     ])
     const result = await dispatchWebhookEndpointToConnectors(job(base))
-    expect(result).toEqual({ connectorsSynced: 0 })
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 0 })
     expect(enqueueConnectorSync).not.toHaveBeenCalled()
+    expect(queueAdd).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
@@ -1,11 +1,12 @@
 // packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
 // The connector-sink leg of the generic WebhookEndpoint fan-out (unified-trigger-picker
 // §4.4). Sibling to `dispatchAppTriggerToConnectors` (the APP-trigger leg) and to the
-// workflow/agent `dispatchWebhookEndpoint*` jobs: one verified endpoint delivery → a full
-// run-based sync of every webhook-sync DataConnector bound to this `webhookEndpointId`
-// with ≥1 stream whose `filter` matches the payload. THIN — dedup + match + steer a sync
-// via `enqueueConnectorSync({ trigger: 'webhook' })` (same path as "Sync now"), so the
-// delivery gets a `DataConnectorRun` history row + refreshed `lastSyncedAt` + reconciliation.
+// workflow/agent `dispatchWebhookEndpoint*` jobs: one verified endpoint delivery → a sync of
+// every webhook-sync DataConnector bound to this `webhookEndpointId` with ≥1 stream whose
+// `filter` matches the payload. THIN — dedup + match + route by mode: steerable streams
+// (`{path}` set) get a per-stream steer job (targeted PARTIAL run), non-steerable cursor
+// streams get the full `enqueueConnectorSync`. Either way the delivery yields a
+// `DataConnectorRun` history row + refreshed `lastSyncedAt`.
 // Match key is `webhookEndpointId`, NOT `credentialId`: generic endpoints aren't
 // connection-bound, so a connector opts in via its connector-level
 // `config.webhookTrigger.webhookEndpointId` (v7 — one signal per connector); each of its
@@ -17,7 +18,9 @@ import { and, eq, inArray, ne } from 'drizzle-orm'
 import { matchesFilter } from '../../agents/agent-trigger-queries'
 import { enqueueConnectorSync } from '../../data-connectors/data-connector-queue'
 import { createScopedLogger } from '../../logger'
+import { getQueue, Queues } from '../queues'
 import type { JobContext } from '../types'
+import { type ConnectorWebhookSteerJobData, WEBHOOK_STEER_JOB } from './webhook-steer-job'
 
 const logger = createScopedLogger('data-connector-webhook-endpoint-dispatch-job')
 
@@ -62,7 +65,7 @@ export async function dispatchWebhookEndpointToConnectors(
       const setResult = await redis.set(dedupKey, '1', 'EX', 300, 'NX')
       if (!setResult) {
         logger.warn('Duplicate connector webhook-endpoint event, skipping', { dedupKey, eventId })
-        return { connectorsSynced: 0 }
+        return { steerJobs: 0, connectorsFullSynced: 0 }
       }
     }
   } catch (err) {
@@ -87,7 +90,7 @@ export async function dispatchWebhookEndpointToConnectors(
   const connectors = candidates.filter(
     (c) => c.config?.webhookTrigger?.webhookEndpointId === endpointId
   )
-  if (connectors.length === 0) return { connectorsSynced: 0 }
+  if (connectors.length === 0) return { steerJobs: 0, connectorsFullSynced: 0 }
 
   const streams = await db.query.DataConnectorStream.findMany({
     where: and(
@@ -100,25 +103,49 @@ export async function dispatchWebhookEndpointToConnectors(
     columns: { dataConnectorId: true, streamKey: true, requestConfig: true },
   })
 
-  // A connector is relevant when ≥1 of its enabled streams' `webhookTrigger.filter`
-  // matches this payload (topic discrimination). One full sync per relevant connector —
-  // the run covers all its streams, so we don't fan per-stream.
-  const relevant = new Set<string>()
+  // Match streams by `webhookTrigger.filter` (topic discrimination), then SPLIT by mode —
+  // same routing as the app-trigger leg (webhook-steered-partial-run-plan):
+  //  • steerable (`{path}` set) → a targeted PARTIAL run via the per-stream steer job.
+  //  • non-steerable cursor stream → the full run-based sync (`enqueueConnectorSync`).
+  // A connector with ANY non-steerable matched stream full-syncs (superset covers the rest).
+  const matched: { connectorId: string; streamKey: string; steerable: boolean }[] = []
   for (const stream of streams) {
     const wt = stream.requestConfig?.webhookTrigger
     if (!stream.streamKey || !wt) continue
     if (!matchesFilter(wt.filter, matchData)) continue
-    relevant.add(stream.dataConnectorId)
+    matched.push({
+      connectorId: stream.dataConnectorId,
+      streamKey: stream.streamKey,
+      steerable: (wt.paths?.length ?? 0) > 0,
+    })
   }
 
-  for (const connectorId of relevant) {
+  const fullSyncConnectors = new Set(matched.filter((m) => !m.steerable).map((m) => m.connectorId))
+  const queue = getQueue(Queues.appTriggerQueue)
+  let steerJobs = 0
+  for (const m of matched) {
+    if (!m.steerable || fullSyncConnectors.has(m.connectorId)) continue
+    // No `jobId` — each delivery is a distinct record, so steered runs must NOT coalesce.
+    await queue.add(WEBHOOK_STEER_JOB, {
+      connectorId: m.connectorId,
+      streamKey: m.streamKey,
+      organizationId,
+      webhookEndpointId: endpointId,
+      topic,
+      triggerData: matchData,
+      eventId,
+    } satisfies ConnectorWebhookSteerJobData)
+    steerJobs++
+  }
+  for (const connectorId of fullSyncConnectors) {
     await enqueueConnectorSync({ connectorId, organizationId, trigger: 'webhook' })
   }
 
   logger.debug('Dispatched connector webhook endpoint', {
     endpointId,
     eventId,
-    connectorsSynced: relevant.size,
+    steerJobs,
+    connectorsFullSynced: fullSyncConnectors.size,
   })
-  return { connectorsSynced: relevant.size }
+  return { steerJobs, connectorsFullSynced: fullSyncConnectors.size }
 }

--- a/packages/lib/src/jobs/data-connector/webhook-steer-job.test.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-steer-job.test.ts
@@ -1,0 +1,119 @@
+// packages/lib/src/jobs/data-connector/webhook-steer-job.test.ts
+// Guards the per-(connector, stream) webhook-steered PARTIAL-run handler. The worker passes a
+// JobContext (whose `.job` is the real BullMQ Job); the handler must read native fields
+// (`opts.attempts`, `attemptsMade`) off `ctx.job`, NOT off the context — reading them off the
+// context yields `undefined` and a "Cannot read properties of undefined (reading 'attempts')"
+// crash that would mask the real fetch error. DB/queue/redis/data-connectors faked.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runWebhookSteeredRun, ConnectorRateLimitError, queueAdd, redis } = vi.hoisted(() => {
+  class ConnectorRateLimitError extends Error {
+    retryAfterMs?: number
+    constructor(retryAfterMs?: number) {
+      super('throttled')
+      this.name = 'ConnectorRateLimitError'
+      this.retryAfterMs = retryAfterMs
+    }
+  }
+  return {
+    runWebhookSteeredRun: vi.fn(),
+    ConnectorRateLimitError,
+    queueAdd: vi.fn(),
+    redis: { lpush: vi.fn(), ltrim: vi.fn(), expire: vi.fn() },
+  }
+})
+
+vi.mock('@auxx/database', () => ({ database: {} }))
+vi.mock('@auxx/redis', () => ({ getRedisClient: async () => redis }))
+vi.mock('../../data-connectors', () => ({ runWebhookSteeredRun, ConnectorRateLimitError }))
+vi.mock('../queues', () => ({
+  getQueue: () => ({ add: (...a: unknown[]) => queueAdd(...a) }),
+  Queues: { appTriggerQueue: 'appTriggerQueue' },
+}))
+vi.mock('../../logger', () => ({
+  createScopedLogger: () => ({ info: () => {}, warn: () => {}, error: () => {} }),
+}))
+
+import { runConnectorWebhookSteer, WEBHOOK_STEER_JOB } from './webhook-steer-job'
+
+const baseData = {
+  connectorId: 'dc1',
+  streamKey: 'orders',
+  organizationId: 'org1',
+  triggerData: { topic: 'orders/create' },
+  eventId: 'evt1',
+  appInstallationId: 'inst1',
+  triggerId: 'shopify.shopify-trigger',
+}
+
+/** A JobContext (has `throwIfCancelled`) whose `.job` carries the native fields. */
+function ctx(opts?: { attempts?: number; attemptsMade?: number; data?: Record<string, unknown> }) {
+  const data = { ...baseData, ...opts?.data }
+  return {
+    throwIfCancelled: () => {},
+    data,
+    job: { data, opts: { attempts: opts?.attempts ?? 5 }, attemptsMade: opts?.attemptsMade ?? 0 },
+  } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('runConnectorWebhookSteer', () => {
+  it('runs the steered run and returns ok on success', async () => {
+    runWebhookSteeredRun.mockResolvedValue(undefined)
+    const result = await runConnectorWebhookSteer(ctx())
+    expect(result).toEqual({ ok: true })
+    expect(runWebhookSteeredRun).toHaveBeenCalledOnce()
+    expect(queueAdd).not.toHaveBeenCalled()
+  })
+
+  it('re-enqueues with the Retry-After delay on a rate-limit error', async () => {
+    runWebhookSteeredRun.mockRejectedValue(new ConnectorRateLimitError(2000))
+    const result = await runConnectorWebhookSteer(ctx())
+    expect(result).toMatchObject({ deferred: true })
+    expect(queueAdd).toHaveBeenCalledOnce()
+    const [name, payload, options] = queueAdd.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+      { delay: number },
+    ]
+    expect(name).toBe(WEBHOOK_STEER_JOB)
+    expect(payload).toMatchObject({ connectorId: 'dc1', rateLimitRetries: 1 })
+    expect(options.delay).toBe(2000)
+    expect(redis.lpush).not.toHaveBeenCalled()
+  })
+
+  it('dead-letters and re-throws a generic error on the final attempt', async () => {
+    // Final attempt: attemptsMade (4) >= opts.attempts (5) - 1. Reads both off ctx.job —
+    // if the unwrap regressed this would throw a TypeError instead of "boom".
+    runWebhookSteeredRun.mockRejectedValue(new Error('boom'))
+    await expect(runConnectorWebhookSteer(ctx({ attempts: 5, attemptsMade: 4 }))).rejects.toThrow(
+      'boom'
+    )
+    expect(redis.lpush).toHaveBeenCalledOnce()
+    const [key] = redis.lpush.mock.calls[0] as [string, string]
+    expect(key).toBe('app-trigger-test:inst1:shopify.shopify-trigger:dlq')
+  })
+
+  it('re-throws without dead-lettering when attempts remain', async () => {
+    runWebhookSteeredRun.mockRejectedValue(new Error('boom'))
+    await expect(runConnectorWebhookSteer(ctx({ attempts: 5, attemptsMade: 0 }))).rejects.toThrow(
+      'boom'
+    )
+    expect(redis.lpush).not.toHaveBeenCalled()
+  })
+
+  it('routes the dead-letter to the WebhookEndpoint list when present', async () => {
+    runWebhookSteeredRun.mockRejectedValue(new Error('boom'))
+    await expect(
+      runConnectorWebhookSteer(
+        ctx({ attempts: 1, attemptsMade: 0, data: { webhookEndpointId: 'whe1' } })
+      )
+    ).rejects.toThrow('boom')
+    const [key] = redis.lpush.mock.calls[0] as [string, string]
+    expect(key).toBe('webhook-endpoint:whe1:dlq')
+  })
+})

--- a/packages/lib/src/jobs/data-connector/webhook-steer-job.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-steer-job.ts
@@ -1,0 +1,156 @@
+// packages/lib/src/jobs/data-connector/webhook-steer-job.ts
+// The per-(connector, stream) child of the webhook dispatch jobs. Steers the connector's
+// regular fetch with the webhook payload and sinks the result as a PARTIAL run
+// (runWebhookSteeredRun). Owns the WHOLE failure policy so the thin dispatch jobs stay cheap:
+//   • 429 → the fetch sets `maxRetries: 0`, so a throttle surfaces as
+//     `ConnectorRateLimitError` immediately; we re-enqueue with `delay = retryAfterMs`
+//     instead of burning a BullMQ attempt sleeping under the lock (H1).
+//   • other 4xx/5xx → BullMQ's default bounded retries (5, exponential). On the final
+//     attempt we capture context to the inspector dead-letter before `removeOnFail`
+//     discards the job, then re-throw.
+// Split out from the dispatch job (rather than fetching inline) because the dispatch holds a
+// redis dedup key under retry — an inline fetch's BullMQ retry would self-suppress on the
+// already-claimed key and never re-run. A separate child gets clean, isolated retries.
+// Runs on `appTriggerQueue` (concurrency 10) — a higher lane than the 2-slot backfill queue —
+// so webhook latency isn't stuck behind bulk syncs.
+
+import { getRedisClient } from '@auxx/redis'
+import type { Job } from 'bullmq'
+import { createScopedLogger } from '../../logger'
+import { getQueue, Queues } from '../queues'
+import type { JobContext } from '../types'
+
+const logger = createScopedLogger('data-connector-webhook-steer-job')
+
+/** Job name on `appTriggerQueue` (registered in app-trigger-worker.ts). */
+export const WEBHOOK_STEER_JOB = 'data-connector-webhook-steer'
+
+/** Stop re-enqueuing a perpetually-throttled event after this many rate-limit deferrals. */
+const MAX_RATE_LIMIT_REENQUEUES = 10
+
+export type ConnectorWebhookSteerJobData = {
+  connectorId: string
+  streamKey: string
+  organizationId: string
+  triggerData: Record<string, unknown>
+  eventId: string
+  /** Present when the steering signal is an APP trigger (DLQ labels off these). */
+  appInstallationId?: string
+  triggerId?: string
+  /** Present when the steering signal is a generic WebhookEndpoint instead. */
+  webhookEndpointId?: string
+  topic?: string
+  /** How many times this event has been deferred for a throttle (re-enqueue guard). */
+  rateLimitRetries?: number
+}
+
+export async function runConnectorWebhookSteer(
+  ctx: JobContext<ConnectorWebhookSteerJobData> | Job<ConnectorWebhookSteerJobData>
+) {
+  // The worker passes a JobContext whose `.job` is the real BullMQ Job; tolerate a raw Job
+  // too. Unwrap so the native fields this handler needs (`opts.attempts`, `attemptsMade`)
+  // read off the real job — reading them off the context yields undefined.
+  const job = 'throwIfCancelled' in ctx ? ctx.job : ctx
+  const { connectorId, streamKey, organizationId, triggerData, eventId } = job.data
+
+  // Lazy-import the heavy data-connectors barrel at call time (it pulls the sink / crud
+  // spine) — keeps this job file light and side-effect-free for vitest.
+  const { database: db } = await import('@auxx/database')
+  const { runWebhookSteeredRun, ConnectorRateLimitError } = await import('../../data-connectors')
+
+  try {
+    await runWebhookSteeredRun(db, {
+      connectorId,
+      organizationId,
+      streamKey,
+      triggerData,
+      eventId,
+    })
+    return { ok: true }
+  } catch (err) {
+    if (err instanceof ConnectorRateLimitError) {
+      return await deferForThrottle(job, err.retryAfterMs)
+    }
+    // Last attempt → dead-letter before `removeOnFail` discards the job, then re-throw so
+    // BullMQ records the terminal failure.
+    const maxAttempts = job.opts.attempts ?? 5
+    if (job.attemptsMade >= maxAttempts - 1) {
+      await deadLetter(job, err)
+    }
+    throw err
+  }
+}
+
+/** Re-enqueue the event after the provider's Retry-After, capped to avoid a hot loop. */
+async function deferForThrottle(job: Job<ConnectorWebhookSteerJobData>, retryAfterMs?: number) {
+  const retries = (job.data.rateLimitRetries ?? 0) + 1
+  if (retries > MAX_RATE_LIMIT_REENQUEUES) {
+    await deadLetter(job, new Error('rate-limited beyond re-enqueue cap'))
+    logger.warn('Connector webhook steer gave up after throttle cap', {
+      connectorId: job.data.connectorId,
+      streamKey: job.data.streamKey,
+      eventId: job.data.eventId,
+    })
+    return { ok: false, throttledOut: true }
+  }
+  const delay = Math.max(retryAfterMs ?? 1_000, 1_000)
+  await getQueue(Queues.appTriggerQueue).add(
+    WEBHOOK_STEER_JOB,
+    { ...job.data, rateLimitRetries: retries },
+    { delay }
+  )
+  logger.info('Connector webhook steer throttled — re-enqueued', {
+    connectorId: job.data.connectorId,
+    streamKey: job.data.streamKey,
+    eventId: job.data.eventId,
+    delay,
+    retries,
+  })
+  return { ok: true, deferred: true }
+}
+
+/**
+ * Capture failure context to the inspector dead-letter list (mirrors the success inspector
+ * list shape) before BullMQ discards the job on `removeOnFail`.
+ */
+async function deadLetter(job: Job<ConnectorWebhookSteerJobData>, err: unknown) {
+  const {
+    appInstallationId,
+    triggerId,
+    webhookEndpointId,
+    topic,
+    eventId,
+    connectorId,
+    streamKey,
+    triggerData,
+  } = job.data
+  try {
+    const redis = await getRedisClient(false)
+    if (!redis) return
+    // Sit the DLQ beside whichever inspector list fed the event: app triggers use
+    // `app-trigger-test:<inst>:<triggerId>:dlq`, generic endpoints `webhook-endpoint:<id>:dlq`
+    // (topic-agnostic, mirroring the events key — the topic is kept on the entry).
+    const key = webhookEndpointId
+      ? `webhook-endpoint:${webhookEndpointId}:dlq`
+      : `app-trigger-test:${appInstallationId}:${triggerId}:dlq`
+    const entry = {
+      id: eventId,
+      timestamp: new Date().toISOString(),
+      source: 'connector-sync',
+      connectorId,
+      streamKey,
+      eventId,
+      topic,
+      error: err instanceof Error ? err.message : String(err),
+      triggerData,
+    }
+    await redis.lpush(key, JSON.stringify(entry))
+    await redis.ltrim(key, 0, 49)
+    await redis.expire(key, 86_400)
+  } catch (redisErr) {
+    logger.warn('Failed to write connector webhook steer dead-letter', {
+      eventId,
+      error: redisErr instanceof Error ? redisErr.message : String(redisErr),
+    })
+  }
+}

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -79,6 +79,12 @@ export {
   type ConnectorWebhookEndpointDispatchJobData,
   dispatchWebhookEndpointToConnectors,
 } from './data-connector/webhook-endpoint-sync-dispatch-job'
+// Webhook-steered PARTIAL run child job (plans/data-connectors/v2/webhook-steered-partial-run-plan)
+export {
+  type ConnectorWebhookSteerJobData,
+  runConnectorWebhookSteer,
+  WEBHOOK_STEER_JOB,
+} from './data-connector/webhook-steer-job'
 // Datasets
 export {
   batchOperationJob,


### PR DESCRIPTION
## What & why

#969 routed every webhook delivery to a **full** run-based sync — that gave a `DataConnectorRun` history row, refreshed `lastSyncedAt`, and orphan reconciliation, but it drained the **whole collection** on every delivery. This brings back the **targeted `{path}` fetch** (`GET /orders/{id}`) while still producing a run — marked **`partial`**.

## The design: one shared spine, `partial` is the only fork

The record-handling spine is shared with the full-sync path: `prepareConnectorFetch` → `definition.fetch({ triggerContext })` → `sinkSourceRecord` / `archiveExternalId`. The only difference is `partial`:

> The run observed a **single steered record** — a subset of the collection — so it must **NOT reconcile orphans**. A one-record run that reconciled would archive every *other* record.

It also never advances the watermark/cursor (W3 — webhook events are out-of-band of the steady delta floor) and still stamps `lastSyncedAt` via `finalizeConnector` so header freshness advances.

| | Full sync (#969) | Targeted (this PR) |
|---|---|---|
| Fetch | paginate the collection | one steered `{path}` fetch |
| Sink | `sinkSourceRecord` | **same** |
| Run row + `lastSyncedAt` | yes | **same** |
| Orphan reconciliation | yes | **skipped** |
| Run status | `completed` | `partial` |

## Changes

- **`connector-webhook.ts`** — revived as `runWebhookSteeredRun`: `openRun(trigger:'webhook', mode:'incremental')` → steered fetch+sink (or archive on a delete steer) → `finalizeRun('partial')` → `finalizeConnector`. A throttle drops the run row (no Runs-panel spam); other errors mark the run `failed`.
- **`webhook-steer-job.ts`** — per-(connector, stream) child on `appTriggerQueue` with the proven 429-defer + dead-letter policy.
- **both dispatch jobs** — route each matched stream by mode: steerable (`webhookTrigger.paths` set) → steer job (per-delivery, no coalescing); non-steerable cursor stream → the existing `enqueueConnectorSync` full sync. A connector with any non-steerable matched stream full-syncs (superset). Return shape: `{ steerJobs, connectorsFullSynced }`.
- **`realtime.ts`** — make `publishConnectorSync` wholly fire-and-forget so a realtime hiccup can never throw into a sync/webhook job.

## Notes

- **No migration** — `partial` is already a `DataConnectorRun.status` value.
- Coexists with #969: cursor streams (no `{path}`) keep the full sync; nothing regresses for them.

## Testing

- **182 tests green** across `src/jobs/data-connector` + `src/data-connectors` (4 test files written/revived).
- Biome clean.