### PR TITLE
fix(data-connectors): don't auto-skip Connect step for app connectors

### DIFF
--- a/apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
@@ -25,15 +25,33 @@ export function deriveStreamReadiness(stream: Stream): StreamReadiness {
 }
 
 export interface SetupProgress {
-  /** Connection is optional, but a generic-rest connector needs an endpoint base URL. */
+  /** Connect is satisfied — gating only (the Continue button). */
   connect: boolean
+  /**
+   * Connect has genuinely nothing to do (app connector with no required connection AND
+   * no config form). Only then is it safe to auto-skip the step instead of opening on
+   * it — a credential to bind or any config field (required or not) keeps the user here.
+   */
+  connectTrivial: boolean
   /** At least one stream has a source schema (a successful sample → "use as schema"). */
   sample: boolean
   /** EVERY stream is `ready` (≥1 mapping with a bound `targetFieldRef`). */
   map: boolean
   /** Map satisfied → the terminal "Run first sync" CTA is enabled
-   *  (Sample is implied by Map; Schedule defaults to Manual; Connect is optional). */
+   *  (Sample is implied by Map; Schedule defaults to Manual). */
   canRun: boolean
+}
+
+/** App-connector Connect requirements — the stepper resolves these from the apps
+ *  context + the connector's declared config schema (not available to a pure
+ *  connector+streams read), then hands them in. Ignored for generic-rest. */
+export interface ConnectRequirements {
+  /** The app exposes a connection definition ⇒ a bound credential is required. */
+  requiresConnection: boolean
+  /** The connector declares ≥1 config field (required or optional). */
+  hasConfigForm: boolean
+  /** Every *required* config field has a value. */
+  requiredConfigSatisfied: boolean
 }
 
 /**
@@ -41,17 +59,37 @@ export interface SetupProgress {
  * `step` column, no client wizard state. Every predicate reads persisted data the
  * detail view already queries (`getById` + `listStreams`). See plan §2.2.
  */
-export function deriveSetupProgress(connector: Connector, streams: Stream[]): SetupProgress {
-  // Connection is optional, but a generic-rest connector still needs an endpoint to
-  // fetch from. App connectors get their endpoint from the catalog, so they're exempt.
+export function deriveSetupProgress(
+  connector: Connector,
+  streams: Stream[],
+  connectReqs: ConnectRequirements
+): SetupProgress {
   const isGenericRest = connector.definitionKind !== 'app'
-  const baseUrl = (connector.config as { endpoint?: { baseUrl?: string } } | null)?.endpoint
-    ?.baseUrl
-  const connect = !isGenericRest || !!baseUrl?.trim()
+
+  let connect: boolean
+  let connectTrivial: boolean
+  if (isGenericRest) {
+    // Generic-rest: the connection itself is optional, but it still needs an endpoint
+    // base URL to fetch from. Never trivial — it always has the endpoint form to fill.
+    const baseUrl = (connector.config as { endpoint?: { baseUrl?: string } } | null)?.endpoint
+      ?.baseUrl
+    connect = !!baseUrl?.trim()
+    connectTrivial = false
+  } else {
+    // App connector: the catalog supplies the endpoint, but the connection still has to
+    // be authorized and any declared settings still have to be set. Only auto-skip when
+    // there's nothing to authorize AND nothing to configure.
+    const { requiresConnection, hasConfigForm, requiredConfigSatisfied } = connectReqs
+    connectTrivial = !requiresConnection && !hasConfigForm
+    connect =
+      connectTrivial ||
+      ((!requiresConnection || !!connector.credentialId) && requiredConfigSatisfied)
+  }
+
   const sample = streams.some((s) => s.sourceSchema != null)
   // Every stream must be mapped — an app connector that fans out to N streams (or
   // carries a draft contributing mapping) can't finish setup with a half-authored
   // fan-out (multi-stream-setup-plan §4.2).
   const map = streams.length > 0 && streams.every((s) => deriveStreamReadiness(s) === 'ready')
-  return { connect, sample, map, canRun: map }
+  return { connect, connectTrivial, sample, map, canRun: map }
 }

--- a/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
@@ -25,6 +25,8 @@ import {
 import { toastError } from '@auxx/ui/components/toast'
 import { Check, Clock, FlaskConical, Layers, Play, Plug, Waypoints } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { useAppsContext } from '~/components/apps/providers/apps-context'
+import { isMissing, readFieldNodes } from '~/components/global/schema-form'
 import { api, type RouterOutputs } from '~/trpc/react'
 import { useConnectorMutations } from '../hooks/use-connector-mutations'
 import {
@@ -122,7 +124,38 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
   )
   const stepOrder = useMemo(() => steps.map((s) => s.id), [steps])
 
-  const progress = deriveSetupProgress(connector, streams)
+  // Connect requirements for an app connector (generic-rest ignores these): a credential
+  // is required when the app exposes a connection definition, and the declared config
+  // schema decides whether there's a settings form to fill. Both come from sources a pure
+  // connector+streams read can't see, so we resolve them here and hand them to the hook.
+  const { appInstallations } = useAppsContext()
+  const requiresConnection = useMemo(() => {
+    if (connector.definitionKind !== 'app') return false
+    const slug = connector.type.startsWith('app:') ? connector.type.slice('app:'.length) : null
+    const inst = appInstallations.find(
+      (i) => i.installationId === connector.appInstallationId || i.app.slug === slug
+    )
+    return !!(inst?.connectionDefinitions?.user || inst?.connectionDefinitions?.organization)
+  }, [connector.definitionKind, connector.type, connector.appInstallationId, appInstallations])
+
+  const schemaQuery = api.dataConnector.connectorSchema.useQuery(
+    { id: connector.id },
+    { enabled: connector.definitionKind === 'app' }
+  )
+  const configFields = useMemo(
+    () => readFieldNodes(schemaQuery.data?.configJsonSchema as Record<string, unknown> | null),
+    [schemaQuery.data]
+  )
+  const requiredConfigSatisfied = useMemo(() => {
+    const cfg = (connector.config ?? {}) as Record<string, unknown>
+    return configFields.filter((f) => f.required).every((f) => !isMissing(cfg[f.key]))
+  }, [configFields, connector.config])
+
+  const progress = deriveSetupProgress(connector, streams, {
+    requiresConnection,
+    hasConfigForm: configFields.length > 0,
+    requiredConfigSatisfied,
+  })
 
   // Per-stream readiness drives the Map step's overview badges + its `every`-stream gate.
   const readinessById = useMemo<Record<string, StreamReadiness>>(
@@ -143,9 +176,12 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
   // Visual completion (filled indicator + check + filled rail). Distinct from
   // gating: Schedule isn't shown completed until the user actually reaches it —
   // otherwise it renders as a dark, done-looking step while still on step 1.
+  // Connect is only pre-completed when it's trivial (nothing to authorize/configure);
+  // otherwise it's the opening step and the passing rule (`idx < activeIdx`) marks it
+  // done once the user advances past it — never a pre-filled check they didn't earn.
   // Passing-completed (`idx < activeIdx`) is added per-step in the render.
   const completedById: Record<SetupStepId, boolean> = {
-    connect: progress.connect,
+    connect: progress.connectTrivial,
     sample: progress.sample,
     map: progress.map,
     schedule: false,
@@ -165,10 +201,12 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
     onError: (e) => toastError({ title: 'Could not add stream', description: e.message }),
   })
 
-  // Active (expanded) step. Defaults to the first incomplete step; the user can
-  // click any unlocked step header to jump back to it.
-  const [active, setActive] = useState<SetupStepId>(
-    () => stepOrder.find((id) => !doneById[id]) ?? 'run'
+  // Active (expanded) step. Opens on Connect unless it's trivially nothing-to-do
+  // (then the first incomplete step) — so a connector that still needs a connection
+  // or has settings to set never silently skips straight to "Run". The user can
+  // click any unlocked step header to jump back.
+  const [active, setActive] = useState<SetupStepId>(() =>
+    progress.connectTrivial ? (stepOrder.find((id) => !doneById[id]) ?? 'run') : 'connect'
   )
 
   // Guard: if the active step was filtered out (sample drops once streams load),


### PR DESCRIPTION
## Problem

In the connector setup stepper, an app-based connection marked a bunch of steps complete and jumped straight to **Run first sync** — skipping **Connect** even though the connection still needs authorizing and the connector may have settings to set.

### Root cause

`deriveSetupProgress` hard-coded `connect = true` for app connectors (it only required a base URL for generic-rest). Combined with the catalog schema satisfying `sample`, pre-bound owned mappings satisfying `map`, and `schedule` always done, `doneById` was all-true except `run`. So the stepper opened on the last step, and the passing-completion rule (`idx < activeIdx`) drew a check on every earlier step.

## Fix

Derive `connect` from real requirements and add a `connectTrivial` flag:

- **Auto-skip Connect only when** there's nothing to authorize **and** no config form — the sole case it's pre-completed.
- Otherwise Connect is the **opening step**, gated by a bound credential (when the app exposes a connection definition) **and** all *required* config fields filled.
- A config form with only optional fields still keeps the user on Connect (not skipped), while `Continue` stays enabled.

Signals are resolved in the stepper: `requiresConnection` from the apps context (`connectionDefinitions`), and `hasConfigForm` / `requiredConfigSatisfied` from the `dataConnector.connectorSchema` query via `readFieldNodes` + `isMissing`.

## Notes

- `canRun` still equals `map` — the Run step is locked by `isUnlocked` until Connect is done, so an app connector can't reach Run without a bound connection.
- `deriveSetupProgress` now takes a required third arg; the stepper is its only caller.