### PR TITLE
feat(data-connectors): run-history retention + webhook freshness + runs panel redesign

### DIFF
--- a/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
@@ -1,9 +1,11 @@
 // apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
 'use client'
 
+import { Alert } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { ButtonGroup, ButtonGroupSeparator } from '@auxx/ui/components/button-group'
+import { AnimatedCollapsibleContent } from '@auxx/ui/components/collapsible'
 import { DrawerHeader } from '@auxx/ui/components/drawer'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { LastUpdated } from '@auxx/ui/components/last-updated'
@@ -65,7 +67,7 @@ function RunCounts({ run, className }: { run: ConnectorRun; className?: string }
               title={f.label}
               className={cn('text-[11px] font-normal', f.className)}>
               <Icon />
-              <span className='hidden @md/runs:inline'>{f.label}</span>
+              <span className='hidden @lg/runs:inline'>{f.label}</span>
               {run[f.key]}
             </Button>
           </Fragment>
@@ -99,31 +101,71 @@ function RunRow({ run, sourceLabel }: { run: ConnectorRun; sourceLabel: string }
       title={meta.label}
       description={metaParts.join(' · ')}
       rowClassName='hover:bg-primary-100'
-      secondary={<RunCounts run={run} className='ms-2' />}
-      actions={
-        <div className='flex items-center gap-2 whitespace-nowrap text-xs text-muted-foreground'>
+      secondary={
+        <div className='ms-2 flex items-center gap-2 whitespace-nowrap text-xs text-muted-foreground'>
+          <LastUpdated timestamp={new Date(run.startedAt)} />
           {run.relationshipWarnings > 0 && (
             <span className='text-amber-600'>
               {run.relationshipWarnings} {pluralize(run.relationshipWarnings, 'warning')}
             </span>
           )}
-          <LastUpdated timestamp={new Date(run.startedAt)} />
         </div>
       }
+      actions={<RunCounts run={run} />}
       expandable={hasErrors}
       isOpen={hasErrors ? open : undefined}
       onToggleOpen={hasErrors ? () => setOpen((v) => !v) : undefined}>
       {hasErrors && (
-        <div className='mt-1 me-2 ms-8 flex flex-col gap-1 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-700'>
+        <Alert variant='destructive' className='mt-1 me-2 ms-8 flex flex-col gap-1 text-xs'>
           {errors.slice(0, 3).map((e, i) => (
-            <div key={i} className='truncate'>
-              <span className='font-mono'>{e.externalId}</span>: {e.error}
+            <div key={i} className='break-words'>
+              {e.error}
             </div>
           ))}
           <ConnectorRunErrors errors={errors} connectorLabel={sourceLabel} runId={run.id} />
-        </div>
+        </Alert>
       )}
     </TreeRow>
+  )
+}
+
+/** How many runs render before the "Show more" row collapses the rest. */
+const VISIBLE_RUN_LIMIT = 7
+
+/**
+ * The run history list: the latest {@link VISIBLE_RUN_LIMIT} runs, then a
+ * "Show more" tree row that reveals the remainder in an animated collapse. The
+ * extra runs are siblings of the toggle row (not its children) so they keep the
+ * flat-list indentation.
+ */
+function RunHistoryList({ rows, sourceLabel }: { rows: ConnectorRun[]; sourceLabel: string }) {
+  const [showAll, setShowAll] = useState(false)
+  const visible = rows.slice(0, VISIBLE_RUN_LIMIT)
+  const hidden = rows.slice(VISIBLE_RUN_LIMIT)
+
+  return (
+    <div className='@container/runs flex flex-col ps-2 pe-4'>
+      {visible.map((run) => (
+        <RunRow key={run.id} run={run} sourceLabel={sourceLabel} />
+      ))}
+      {hidden.length > 0 && (
+        <>
+          <AnimatedCollapsibleContent open={showAll} className='flex flex-col'>
+            {hidden.map((run) => (
+              <RunRow key={run.id} run={run} sourceLabel={sourceLabel} />
+            ))}
+          </AnimatedCollapsibleContent>
+          <TreeRow
+            icon={<History className='size-4' />}
+            title={showAll ? 'Show less' : `Show ${hidden.length} more`}
+            rowClassName='hover:bg-primary-100'
+            expandable
+            isOpen={showAll}
+            onToggleOpen={() => setShowAll((v) => !v)}
+          />
+        </>
+      )}
+    </div>
   )
 }
 
@@ -232,11 +274,7 @@ export function ConnectorRunsPanel({
               />
             </div>
           ) : (
-            <div className='@container/runs flex flex-col ps-2 pe-4'>
-              {rows.map((run) => (
-                <RunRow key={run.id} run={run} sourceLabel={sourceLabel} />
-              ))}
-            </div>
+            <RunHistoryList rows={rows} sourceLabel={sourceLabel} />
           )}
         </Section>
       </ScrollArea>

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -256,6 +256,22 @@ export async function setupSchedules() {
     }
   )
 
+  // Data-connector run-history retention — nightly at 03:30. Trims each connector
+  // active in the last 25h back to its newest 200 finished runs so the run table
+  // stays bounded under a 15-min sync cadence (~96 runs/day/connector otherwise).
+  await maintenanceQueue.upsertJobScheduler(
+    'dataConnectorRunRetentionJob',
+    { pattern: '30 3 * * *' },
+    {
+      opts: {
+        attempts: 1,
+        priority: 10,
+        removeOnComplete: { count: 14 },
+        removeOnFail: { count: 30 },
+      },
+    }
+  )
+
   // Every day at 8 AM
   await maintenanceQueue.upsertJobScheduler(
     'requestDocumentSuggestionsJob',

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -1,5 +1,5 @@
 import { isSelfHosted } from '@auxx/deployment'
-import { dataConnectorStaleSweepJob } from '@auxx/lib/data-connectors'
+import { dataConnectorRunRetentionJob, dataConnectorStaleSweepJob } from '@auxx/lib/data-connectors'
 import { isDemoEnabled } from '@auxx/lib/demo'
 import { evalRunWatchdog } from '@auxx/lib/evals/worker'
 import {
@@ -175,6 +175,10 @@ const jobMappings = {
   // Global data-connector stale-run sweep (every 5 min; fails cold runs + releases
   // their connector claim so a crashed continuation chain can't strand a connector)
   dataConnectorStaleSweepJob,
+
+  // Nightly data-connector run-history retention (trims each recently-active
+  // connector back to its newest 200 finished runs so the table stays bounded)
+  dataConnectorRunRetentionJob,
 }
 
 export function startMaintenanceWorker() {

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -122,6 +122,11 @@ export { resolveRelationships } from './relationship-pass'
 // Orchestrator + passes
 export type { ResolveConnectorConfigOptionsInput } from './resolve-config-options'
 export { resolveConnectorConfigOptions } from './resolve-config-options'
+// Nightly run-history retention — maintenance-schedule handler
+export {
+  DATA_CONNECTOR_RUN_RETENTION_JOB_NAME,
+  dataConnectorRunRetentionJob,
+} from './run-retention-job'
 // Status-line schedule derivation (Step 9 §3.3)
 export type { ConnectorScheduleInfo, DeriveScheduleInput } from './schedule-info'
 export { deriveConnectorScheduleInfo } from './schedule-info'
@@ -157,6 +162,7 @@ export {
   listStreams,
   loadConnector,
   markItemArchived,
+  markWebhookEventReceived,
   newRunCounters,
   openRun,
   persistStreamState,

--- a/packages/lib/src/data-connectors/run-retention-job.ts
+++ b/packages/lib/src/data-connectors/run-retention-job.ts
@@ -1,0 +1,70 @@
+// packages/lib/src/data-connectors/run-retention-job.ts
+// Nightly run-history retention. `DataConnectorRun` rows accumulate forever (a
+// 15-min-cadence connector adds ~96/day), so this trims each connector back to
+// its newest RUN_RETENTION_KEEP finished runs. Global (all orgs), pure count.
+//
+// Efficiency: a connector only GAINS runs when it syncs, and every sync ends in
+// `finalizeConnector`, which bumps `DataConnector.updatedAt`. So only connectors
+// touched since the last sweep can have crossed the threshold — we gate the
+// window function to those active in the last RUN_RETENTION_ACTIVE_HOURS, instead
+// of re-ranking every connector's full partition every night.
+
+import { database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { JobContext } from '../jobs/types'
+
+const logger = createScopedLogger('data-connector-run-retention')
+
+export const DATA_CONNECTOR_RUN_RETENTION_JOB_NAME = 'dataConnectorRunRetentionJob'
+
+/** Finished runs to keep per connector. Matches the `listRuns` API ceiling (max 200). */
+const RUN_RETENTION_KEEP = 200
+
+/**
+ * Only sweep connectors whose `updatedAt` falls in this window. 25h gives a 1h
+ * margin over the nightly schedule so a slightly-late run never skips a day.
+ */
+const RUN_RETENTION_ACTIVE_HOURS = 25
+
+interface RunRetentionJobData {
+  /** Override the per-connector keep count (default {@link RUN_RETENTION_KEEP}). */
+  keep?: number
+  /** Override the active-connector window in hours (default {@link RUN_RETENTION_ACTIVE_HOURS}). */
+  activeHours?: number
+}
+
+/**
+ * Trim each recently-active connector's run history to its newest `keep` finished
+ * runs. In-flight runs (`finishedAt IS NULL`) are never eligible, so a syncing
+ * connector can't lose its live run mid-flight. One windowed DELETE, backed by
+ * `DataConnectorRun_dataConnectorId_startedAt_idx`.
+ */
+export async function dataConnectorRunRetentionJob(
+  ctx: JobContext<RunRetentionJobData | undefined>
+): Promise<void> {
+  const keep = ctx.data?.keep ?? RUN_RETENTION_KEEP
+  const activeHours = ctx.data?.activeHours ?? RUN_RETENTION_ACTIVE_HOURS
+
+  const result = await database.execute(sql`
+    WITH active AS (
+      SELECT id FROM "DataConnector"
+      WHERE "updatedAt" >= now() - (${activeHours} * interval '1 hour')
+    ),
+    ranked AS (
+      SELECT id, row_number() OVER (
+        PARTITION BY "dataConnectorId" ORDER BY "startedAt" DESC
+      ) AS rn
+      FROM "DataConnectorRun"
+      WHERE "dataConnectorId" IN (SELECT id FROM active)
+        AND "finishedAt" IS NOT NULL
+    )
+    DELETE FROM "DataConnectorRun"
+    WHERE id IN (SELECT id FROM ranked WHERE rn > ${keep})
+  `)
+
+  const deleted = result.rowCount ?? 0
+  if (deleted > 0) {
+    logger.info('Pruned old connector runs', { deleted, keep, activeHours })
+  }
+}

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -369,6 +369,31 @@ export async function finalizeConnector(
   }
 }
 
+/**
+ * Stamp `lastWebhookEventAt = now()` on each connector a verified webhook delivery
+ * just matched. This is the liveness signal the freshness panel's "Last event" cell
+ * reads for webhook-sync connectors — it advances on every delivery, independent of
+ * whether the delivery routed to a steered partial run or a full sync (those update
+ * `lastSyncedAt` via `finalizeConnector` only once their run finalizes). Org-scoped;
+ * a no-op on an empty id list.
+ */
+export async function markWebhookEventReceived(
+  db: Database,
+  organizationId: string,
+  dataConnectorIds: string[]
+): Promise<void> {
+  if (dataConnectorIds.length === 0) return
+  await db
+    .update(schema.DataConnector)
+    .set({ lastWebhookEventAt: new Date() })
+    .where(
+      and(
+        eq(schema.DataConnector.organizationId, organizationId),
+        inArray(schema.DataConnector.id, dataConnectorIds)
+      )
+    )
+}
+
 /** Current run-level fetched count (the per-run ingest total folded by the ledger). */
 export async function getRunFetched(db: Database, runId: string): Promise<number> {
   const row = await db.query.DataConnectorRun.findFirst({

--- a/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.ts
+++ b/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.ts
@@ -14,6 +14,7 @@ import { getRedisClient } from '@auxx/redis'
 import { and, eq, inArray, ne } from 'drizzle-orm'
 import { matchesFilter } from '../../agents/agent-trigger-queries'
 import { enqueueConnectorSync } from '../../data-connectors/data-connector-queue'
+import { markWebhookEventReceived } from '../../data-connectors/service'
 import { createScopedLogger } from '../../logger'
 import { getQueue, Queues } from '../queues'
 import type { JobContext } from '../types'
@@ -119,6 +120,13 @@ export async function dispatchAppTriggerToConnectors(
       steerable: (wt.paths?.length ?? 0) > 0,
     })
   }
+
+  // Advance the "Last event" liveness stamp for every connector this delivery touched,
+  // regardless of how it routes below — the run-based paths only refresh `lastSyncedAt`
+  // once their run finalizes, which can lag a busy delivery.
+  await markWebhookEventReceived(db, organizationId, [
+    ...new Set(matched.map((m) => m.connectorId)),
+  ])
 
   const fullSyncConnectors = new Set(matched.filter((m) => !m.steerable).map((m) => m.connectorId))
   const queue = getQueue(Queues.appTriggerQueue)

--- a/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
@@ -17,6 +17,7 @@ import { getRedisClient } from '@auxx/redis'
 import { and, eq, inArray, ne } from 'drizzle-orm'
 import { matchesFilter } from '../../agents/agent-trigger-queries'
 import { enqueueConnectorSync } from '../../data-connectors/data-connector-queue'
+import { markWebhookEventReceived } from '../../data-connectors/service'
 import { createScopedLogger } from '../../logger'
 import { getQueue, Queues } from '../queues'
 import type { JobContext } from '../types'
@@ -119,6 +120,13 @@ export async function dispatchWebhookEndpointToConnectors(
       steerable: (wt.paths?.length ?? 0) > 0,
     })
   }
+
+  // Advance the "Last event" liveness stamp for every connector this delivery touched,
+  // regardless of how it routes below — the run-based paths only refresh `lastSyncedAt`
+  // once their run finalizes, which can lag a busy delivery.
+  await markWebhookEventReceived(db, organizationId, [
+    ...new Set(matched.map((m) => m.connectorId)),
+  ])
 
   const fullSyncConnectors = new Set(matched.filter((m) => !m.steerable).map((m) => m.connectorId))
   const queue = getQueue(Queues.appTriggerQueue)


### PR DESCRIPTION
## Summary

Three related changes to the connector **runs / freshness** surface. Independent of the in-progress relationship-linking work (no overlap — see below).

### 1. Runs panel redesign (`connector-runs-panel.tsx`)
- Relative start time + relationship-warning moved into the row **secondary**.
- Per-run created/updated/… counts moved into the **actions** slot.
- Error sample now renders in an `<Alert variant="destructive">` instead of a hand-rolled div; long error text wraps (`break-words`) instead of truncating.
- History collapses to the **latest 7 runs** with a "Show N more" / "Show less" `TreeRow` toggle rendered **below** the rows; the extra runs reveal via `AnimatedCollapsibleContent` as flat siblings.

### 2. Nightly run-history retention (new `run-retention-job.ts`)
`DataConnectorRun` was **unbounded** — a 15-min-cadence connector adds ~96 rows/day forever, with no pruning anywhere. New maintenance-worker job (nightly **03:30**) trims each connector to its newest **200 finished runs** (matches the `listRuns` API ceiling) via one windowed `DELETE`.

Efficiency: gated by a `WITH active AS (...)` CTE to connectors whose `updatedAt` is within the last **25h** — every sync ends in `finalizeConnector`, which bumps `updatedAt`, so only connectors that could have gained runs get re-ranked. In-flight runs (`finishedAt IS NULL`) are never eligible. Backed by the existing `DataConnectorRun_dataConnectorId_startedAt_idx`. No migration.

### 3. Webhook freshness fix (`markWebhookEventReceived`)
`DataConnector.lastWebhookEventAt` was declared in the schema and read by the freshness panel's **"Last event"** cell, but **nothing ever wrote it** — so for webhook-sync connectors it was always null and silently fell back to `lastSyncedAt`, lagging actual deliveries (the "history says 10 min ago, freshness says 2h" symptom). Now stamped on every verified delivery in **both** dispatch legs (`dispatchAppTriggerToConnectors`, `dispatchWebhookEndpointToConnectors`), batched across all matched connectors, before routing — so it advances independent of whether the delivery becomes a steered partial run or a full sync.

## Overlap with other in-flight work
This branch was carved out of a working tree that also contains a large **relationship-linking** feature. Only `service.ts` and `index.ts` are shared files; this PR stages **only** its own hunks (`markWebhookEventReceived` + two exports) and leaves all relationship-linking changes (incl. the `0241` migration, `relationship-link-row.tsx`, new tests) untouched. No logical dependency between the two.

## Test plan
- [ ] Runs panel renders: time/warning in secondary, counts in actions, Alert errors wrap, show-more reveals runs 8+.
- [ ] Retention job trims a connector with >200 finished runs to 200; leaves dormant + in-flight runs alone.
- [ ] A webhook delivery advances the freshness "Last event" timestamp immediately.