### PR TITLE
fix(data-connectors): delete/archive connector-created records on connector delete

### DIFF
--- a/apps/web/src/components/data-connectors/ui/branch-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/branch-row.tsx
@@ -3,15 +3,14 @@
 
 import type { ResourceField } from '@auxx/lib/resources/client'
 import type { FieldReference } from '@auxx/types/field'
-import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
-import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
-import { Braces, Brackets, ChevronDown, Link2, Plus } from 'lucide-react'
+import { TreeRowButton } from '@auxx/ui/components/tree-row'
+import { Braces, Brackets, Plus } from 'lucide-react'
 import { useState } from 'react'
-import { FieldPickerContent } from '~/components/pickers/field-picker'
 import { ResourcePickerContent } from '~/components/pickers/resource-picker'
 import { lastSegment, type SourceTreeNode } from '../hooks/use-source-paths'
-import { MAPPING_COLS } from './mapping-columns'
+import { MappingFieldPicker } from './mapping-field-picker'
+import { MappingRow } from './mapping-row'
 
 interface BranchRowProps {
   depth: number
@@ -42,12 +41,14 @@ interface BranchRowProps {
 
 /**
  * An object/array source branch (relationship-linking v3 §11). A passive container
- * by default — its scalar leaves bind onto the enclosing mapping. The `⊕` action
- * fans the branch out into its own child `DataConnectorMapping`:
- *  - INSIDE a mapping ({@link parentEntityDefinitionId} set) → **drill a relationship**
- *    off the parent def; the related def is derived, the edge is the drilled
- *    relationship, the mode is forced contributing. This is the core inversion that
- *    makes a null `relationshipFieldKey` unrepresentable (§9.2).
+ * by default — its scalar leaves bind onto the enclosing mapping. Fanning it out
+ * materializes its own child `DataConnectorMapping`:
+ *  - INSIDE a mapping ({@link parentEntityDefinitionId} set) → the TARGET cell carries
+ *    the SAME unified {@link MappingFieldPicker} every leaf uses (in 'branch' mode):
+ *    drill a relationship off the parent def and select it; the related def is derived,
+ *    the edge is the drilled relationship, the mode is forced contributing. This makes
+ *    a null `relationshipFieldKey` unrepresentable (§9.2) — and the cell now reads
+ *    identically to every other row (unified picker §2).
  *  - at the payload ROOT (no enclosing mapping) → a free def pick (the entry def).
  * Once promoted the branch re-renders as a `MappingNode`; this row is the un-promoted
  * state.
@@ -71,8 +72,7 @@ export function BranchRow({
   const drillMode = !!parentEntityDefinitionId && !!onFanOutRelationship
 
   return (
-    <GridTreeRow
-      columns={MAPPING_COLS}
+    <MappingRow
       depth={depth}
       expandable
       chevronOnHover
@@ -88,79 +88,50 @@ export function BranchRow({
           )}
         </span>
       }
-      // Inside a mapping the TARGET cell carries a visible relationship picker (the
-      // same `FieldPickerContent` every leaf uses, drill-down ON) — you drill into a
-      // relationship and click it to link, no separate `+` affordance. At the payload
-      // ROOT (no def to drill off) the only action is the free-def fan-out, kept in
-      // the last column.
-      cells={[
-        <span key='arrow' />,
+      // Inside a mapping the TARGET cell carries the unified picker (drill a
+      // relationship → fan out a related record), with the arrow filled like every
+      // other row. At the payload ROOT (no def to drill off) the only action is the
+      // free-def fan-out, kept in the last column.
+      arrow={drillMode ? 'dim' : 'none'}
+      target={
         drillMode ? (
-          <Popover key='target' open={menuOpen} onOpenChange={setMenuOpen}>
+          <MappingFieldPicker
+            kind='branch'
+            entityDefinitionId={parentEntityDefinitionId!}
+            allowRelationships
+            placeholder='Link a record…'
+            onSelectRelationship={(field, ref) => onFanOutRelationship?.(field, ref)}
+          />
+        ) : undefined
+      }
+      actions={
+        !drillMode &&
+        onFanOut && (
+          <Popover open={menuOpen} onOpenChange={setMenuOpen}>
             <PopoverTrigger asChild>
-              <Button
-                variant='transparent'
-                className='h-9 w-full justify-between rounded-none px-2 text-xs text-muted-foreground hover:bg-primary/5'>
-                <span className='flex items-center gap-1.5 truncate'>
-                  <Link2 className='size-3.5 opacity-60' />
-                  Link via relationship…
-                </span>
-                <ChevronDown className='size-3 opacity-50' />
-              </Button>
+              <TreeRowButton tooltipText='Fan out → own def' persistent={isEmpty}>
+                <Plus />
+              </TreeRowButton>
             </PopoverTrigger>
-            <PopoverContent align='start' className='w-72 p-0'>
+            <PopoverContent align='end' className='w-72 p-0'>
               <div className='border-b px-2 py-1.5 text-[10px] font-medium uppercase text-muted-foreground'>
-                Link via a relationship
+                Fan out → own def
               </div>
-              {/* Drill the parent def's relationship graph and click the relationship
-                  to link (drill into it, then select its header row). The related def
-                  is derived from the picked relationship — never freely chosen. */}
-              <FieldPickerContent
-                entityDefinitionId={parentEntityDefinitionId!}
-                filterField={(f) => !!f.relationship}
-                mode='single'
-                closeOnSelect
-                onClose={() => setMenuOpen(false)}
-                searchPlaceholder='Search relationships…'
-                onSelect={(ref, field) => {
-                  if (!field.relationship) return
-                  onFanOutRelationship?.(field, ref)
+              <ResourcePickerContent
+                value={[]}
+                onChange={() => {}}
+                onSelectSingle={(entityDefinitionId) => {
+                  onFanOut?.(entityDefinitionId)
                   setMenuOpen(false)
                 }}
+                entityDefinedOnly
+                placeholder='Search entity definitions…'
               />
             </PopoverContent>
           </Popover>
-        ) : (
-          <span key='target' />
-        ),
-        <div key='actions' className='flex w-full items-center justify-end pr-1'>
-          {!drillMode && onFanOut && (
-            <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-              <PopoverTrigger asChild>
-                <TreeRowButton tooltipText='Fan out → own def' persistent={isEmpty}>
-                  <Plus />
-                </TreeRowButton>
-              </PopoverTrigger>
-              <PopoverContent align='end' className='w-72 p-0'>
-                <div className='border-b px-2 py-1.5 text-[10px] font-medium uppercase text-muted-foreground'>
-                  Fan out → own def
-                </div>
-                <ResourcePickerContent
-                  value={[]}
-                  onChange={() => {}}
-                  onSelectSingle={(entityDefinitionId) => {
-                    onFanOut?.(entityDefinitionId)
-                    setMenuOpen(false)
-                  }}
-                  entityDefinedOnly
-                  placeholder='Search entity definitions…'
-                />
-              </PopoverContent>
-            </Popover>
-          )}
-        </div>,
-      ]}>
+        )
+      }>
       {children}
-    </GridTreeRow>
+    </MappingRow>
   )
 }

--- a/apps/web/src/components/data-connectors/ui/connector-list.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-list.tsx
@@ -25,7 +25,7 @@ export function ConnectorList({ onConnect }: ConnectorListProps) {
   const rows = connectors.data ?? []
 
   return (
-    <div className='flex flex-col gap-4 p-4'>
+    <div className='flex flex-1 flex-col gap-4 p-4'>
       {connectors.isLoading ? (
         <div className='grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3'>
           {[0, 1, 2].map((i) => (

--- a/apps/web/src/components/data-connectors/ui/field-mapping-edits.test.ts
+++ b/apps/web/src/components/data-connectors/ui/field-mapping-edits.test.ts
@@ -1,0 +1,137 @@
+// apps/web/src/components/data-connectors/ui/field-mapping-edits.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { FieldMapping } from '../hooks/use-stream-mutations'
+import {
+  bareTokenSource,
+  bindingFor,
+  isBareToken,
+  removeBindingForSource,
+  retargetFormulaEntry,
+  setEntryIdentityRole,
+  upsertBinding,
+} from './field-mapping-edits'
+
+describe('isBareToken / bareTokenSource', () => {
+  it('detects a single-token expression', () => {
+    expect(isBareToken('{email}')).toBe(true)
+    expect(isBareToken('{customer.email}')).toBe(true)
+    expect(isBareToken('{a}-{b}')).toBe(false)
+    expect(isBareToken('{a} {b}')).toBe(false)
+  })
+  it('extracts the source path', () => {
+    expect(bareTokenSource('{customer.email}')).toBe('customer.email')
+  })
+})
+
+describe('bindingFor', () => {
+  it('builds an identity-mapped bare-token binding', () => {
+    const b = bindingFor('email', 'contact:email')
+    expect(b.expression).toBe('{email}')
+    expect(b.sourceFields).toEqual({ email: 'email' })
+    expect(b.targetFieldRef).toBe('contact:email')
+    expect(b.id).toBeTruthy()
+  })
+})
+
+describe('upsertBinding', () => {
+  it('replaces a prior bare-token binding on the same source (1 source → 1 target)', () => {
+    const entries: FieldMapping[] = [
+      {
+        id: '1',
+        targetFieldRef: 'contact:first_name',
+        expression: '{email}',
+        sourceFields: { email: 'email' },
+      },
+      {
+        id: '2',
+        targetFieldRef: 'order:total',
+        expression: '{total}',
+        sourceFields: { total: 'total' },
+      },
+    ]
+    const next = upsertBinding(entries, 'email', 'contact:email')
+    // the `{email}` row is replaced, `{total}` untouched
+    expect(next.filter((e) => bareTokenSource(e.expression) === 'email')).toHaveLength(1)
+    expect(next.find((e) => bareTokenSource(e.expression) === 'email')?.targetFieldRef).toBe(
+      'contact:email'
+    )
+    expect(next.find((e) => e.id === '2')).toBeTruthy()
+  })
+})
+
+describe('removeBindingForSource', () => {
+  it('drops only the matching bare-token entry', () => {
+    const entries: FieldMapping[] = [
+      {
+        id: '1',
+        targetFieldRef: 'contact:email',
+        expression: '{email}',
+        sourceFields: { email: 'email' },
+      },
+      {
+        id: '2',
+        targetFieldRef: 'order:total',
+        expression: '{total}',
+        sourceFields: { total: 'total' },
+      },
+    ]
+    expect(removeBindingForSource(entries, 'email')).toEqual([entries[1]])
+  })
+})
+
+describe('retargetFormulaEntry', () => {
+  it('swaps the target but preserves expression, sourceFields, id, and role', () => {
+    const entry: FieldMapping = {
+      id: 'f1',
+      targetFieldRef: 'order:full_name',
+      expression: 'concat({first}, " ", {last})',
+      sourceFields: { first: 'first', last: 'last' },
+      mergeStrategy: 'overwrite',
+    }
+    const next = retargetFormulaEntry(entry, 'contact:full_name')
+    expect(next.targetFieldRef).toBe('contact:full_name')
+    expect(next.id).toBe('f1')
+    expect(next.expression).toBe('concat({first}, " ", {last})')
+    expect(next.sourceFields).toEqual({ first: 'first', last: 'last' })
+    expect(next.mergeStrategy).toBe('overwrite')
+  })
+})
+
+describe('setEntryIdentityRole', () => {
+  const entries: FieldMapping[] = [
+    {
+      id: 'a',
+      targetFieldRef: 'contact:email',
+      expression: '{email}',
+      sourceFields: { email: 'email' },
+    },
+    {
+      id: 'b',
+      targetFieldRef: 'contact:external_id',
+      expression: '{cid}',
+      sourceFields: { cid: 'cid' },
+      identityRole: { kind: 'externalId' },
+    },
+  ]
+
+  it('makes External ID a radio — picking it clears the prior one', () => {
+    const next = setEntryIdentityRole(entries, 'a', 'externalId')
+    expect(next.find((e) => e.id === 'a')?.identityRole).toEqual({ kind: 'externalId' })
+    expect(next.find((e) => e.id === 'b')?.identityRole).toBeUndefined()
+  })
+
+  it('sets a match role with normalize and leaves External ID alone', () => {
+    const next = setEntryIdentityRole(entries, 'a', 'match', 'email')
+    expect(next.find((e) => e.id === 'a')?.identityRole).toEqual({
+      kind: 'match',
+      normalize: 'email',
+    })
+    expect(next.find((e) => e.id === 'b')?.identityRole).toEqual({ kind: 'externalId' })
+  })
+
+  it('clears a role with null', () => {
+    const next = setEntryIdentityRole(entries, 'b', null)
+    expect(next.find((e) => e.id === 'b')?.identityRole).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/data-connectors/ui/field-mapping-edits.ts
+++ b/apps/web/src/components/data-connectors/ui/field-mapping-edits.ts
@@ -1,0 +1,90 @@
+// apps/web/src/components/data-connectors/ui/field-mapping-edits.ts
+// Pure transforms over a mapping's `fieldMappings` array (relationship-linking v3
+// — unified picker). Shared by the M-level (direct) and drilled-child binding
+// paths so both produce identical entry shapes. No React / no I/O — unit-testable.
+
+import { generateId } from '@auxx/utils'
+import type { FieldMapping } from '../hooks/use-stream-mutations'
+
+/** A degenerate single-token `{path}` expression (one-click row, not a calc). */
+export function isBareToken(expression: string): boolean {
+  return /^\{[^{}]+\}$/.test(expression.trim())
+}
+
+/** The source path inside a bare-token expression (`{customer.email}` → `customer.email`). */
+export function bareTokenSource(expression: string): string {
+  return expression.replace(/^\{|\}$/g, '')
+}
+
+/** A fresh bare-token binding for `sourcePath` → `targetFieldRef` (null = unassigned). */
+export function bindingFor(sourcePath: string, targetFieldRef: string | null): FieldMapping {
+  return {
+    id: generateId(),
+    targetFieldRef,
+    expression: `{${sourcePath}}`,
+    sourceFields: { [sourcePath]: sourcePath },
+  }
+}
+
+/**
+ * Replace any prior bare-token binding on `sourcePath`, then append the new one
+ * (1 source → 1 target). Mirrors the inline logic the direct-bind path uses; the
+ * drilled-child path reuses it so a drilled binding is byte-identical.
+ */
+export function upsertBinding(
+  entries: FieldMapping[],
+  sourcePath: string,
+  targetFieldRef: string
+): FieldMapping[] {
+  return [...removeBindingForSource(entries, sourcePath), bindingFor(sourcePath, targetFieldRef)]
+}
+
+/** Drop the bare-token binding on `sourcePath` (if any). */
+export function removeBindingForSource(
+  entries: FieldMapping[],
+  sourcePath: string
+): FieldMapping[] {
+  return entries.filter(
+    (e) => !(isBareToken(e.expression) && bareTokenSource(e.expression) === sourcePath)
+  )
+}
+
+/**
+ * Re-home a formula entry onto a new target field, preserving its `expression`,
+ * `sourceFields`, `id`, and any identity role. Used when a formula's target picker
+ * moves the entry between the parent mapping (a root scalar) and a flat drilled
+ * child (a field across a relationship) — only the target pointer changes.
+ */
+export function retargetFormulaEntry(entry: FieldMapping, targetFieldRef: string): FieldMapping {
+  return { ...entry, targetFieldRef }
+}
+
+/**
+ * Set/clear an entry's identity role, keeping External ID a radio WITHIN this entry
+ * list (picking it clears any other External ID first). `null` clears the role. The
+ * entry must already exist (the drilled-child path always binds a field before it
+ * can be keyed). `normalize` is the match normalizer when role === 'match'.
+ */
+export function setEntryIdentityRole(
+  entries: FieldMapping[],
+  entryId: string,
+  role: 'externalId' | 'match' | null,
+  normalize: 'email' | 'phone' | 'domain' | 'none' = 'none'
+): FieldMapping[] {
+  return entries.map((e) => {
+    if (e.id === entryId) {
+      const identityRole =
+        role == null
+          ? undefined
+          : role === 'externalId'
+            ? ({ kind: 'externalId' } as const)
+            : ({ kind: 'match', normalize } as const)
+      return { ...e, identityRole }
+    }
+    // Radio: only one primary External ID per mapping.
+    if (role === 'externalId' && e.identityRole?.kind === 'externalId') {
+      return { ...e, identityRole: undefined }
+    }
+    return e
+  })
+}

--- a/apps/web/src/components/data-connectors/ui/identity-role-control.tsx
+++ b/apps/web/src/components/data-connectors/ui/identity-role-control.tsx
@@ -1,0 +1,99 @@
+// apps/web/src/components/data-connectors/ui/identity-role-control.tsx
+'use client'
+
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
+import { cn } from '@auxx/ui/lib/utils'
+import { Check, KeyRound } from 'lucide-react'
+
+/** The identity role a binding plays (relationship-linking v3 §9.4). */
+export type IdentityRole = 'externalId' | 'match' | null
+
+/**
+ * The unified identity-role control (relationship-linking v3 §9.4) — one `KeyRound`
+ * icon that replaces both the old silent external-id guess and the separate "Match"
+ * badge. State is conveyed by visibility + color (the glyph never changes):
+ *   • none → hover-reveal, muted;  • External ID → always-on, primary/blue;
+ *   • Match → always-on, amber. Click opens a tiny context-aware popover.
+ *
+ * Shared by source-leaf rows (keyed by source path) and formula rows (keyed by entry
+ * id), so the affordance reads identically wherever an identifier can be designated.
+ */
+export function IdentityRoleControl({
+  role,
+  canMatch,
+  onChange,
+}: {
+  role: IdentityRole
+  /** Show the "Match existing" option (needs a bound target to compare against). */
+  canMatch: boolean
+  onChange: (role: IdentityRole) => void
+}) {
+  const tooltip =
+    role === 'externalId'
+      ? 'External ID — the upstream key that dedups this record and anchors its links.'
+      : role === 'match'
+        ? 'Match — a secondary key used to adopt an existing record (external id stays primary).'
+        : 'Mark as an identifier (External ID or Match).'
+  return (
+    <Popover>
+      <SimpleTooltip side='top' delayDuration={500} content={tooltip}>
+        <PopoverTrigger asChild>
+          <button
+            type='button'
+            className={cn(
+              'inline-flex size-4 shrink-0 items-center justify-center rounded-sm transition-colors',
+              role === 'externalId' && 'text-primary',
+              role === 'match' && 'text-amber-500',
+              !role &&
+                'text-muted-foreground/0 group-hover/tree-row:text-muted-foreground/50 hover:text-muted-foreground'
+            )}>
+            <KeyRound className='size-3.5' />
+          </button>
+        </PopoverTrigger>
+      </SimpleTooltip>
+      <PopoverContent align='start' className='w-52 p-1'>
+        <RoleOption label='Not an identifier' active={!role} onClick={() => onChange(null)} />
+        <RoleOption
+          label='External ID'
+          hint='Primary upstream key'
+          active={role === 'externalId'}
+          onClick={() => onChange('externalId')}
+        />
+        {canMatch && (
+          <RoleOption
+            label='Match existing'
+            hint='Secondary adoption key'
+            active={role === 'match'}
+            onClick={() => onChange('match')}
+          />
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function RoleOption({
+  label,
+  hint,
+  active,
+  onClick,
+}: {
+  label: string
+  hint?: string
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className='flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs hover:bg-muted'>
+      <Check className={cn('size-3.5 shrink-0', active ? 'opacity-100' : 'opacity-0')} />
+      <span className='flex flex-col'>
+        <span>{label}</span>
+        {hint && <span className='text-[10px] text-muted-foreground'>{hint}</span>}
+      </span>
+    </button>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
@@ -5,8 +5,13 @@ import { FieldType } from '@auxx/database/enums'
 import type { FieldType as FieldTypeType } from '@auxx/database/types'
 import { FIELD_TYPE_GROUPS, fieldTypeOptions } from '@auxx/lib/custom-fields/types'
 import type { ResourceField } from '@auxx/lib/resources/client'
-import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
-import { type FieldReference, type ResourceFieldId, toResourceFieldId } from '@auxx/types/field'
+import {
+  type FieldPath,
+  type FieldReference,
+  getFieldDefinitionId,
+  isFieldPath,
+  toResourceFieldId,
+} from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
@@ -49,77 +54,96 @@ function inferFieldType(path: string, sourceType: string, format?: string): Fiel
 }
 
 interface MappingFieldPickerProps {
-  /** The def whose fields are the binding targets. Null until a target is picked. */
+  /**
+   * Whether this picker binds a scalar leaf ('leaf') or fans out a related record
+   * from an object/array branch ('branch'). Both drill the same relationship graph;
+   * 'branch' only ever selects a relationship (the fan-out target).
+   */
+  kind?: 'leaf' | 'branch'
+  /** The def the picker drills/binds FROM (the enclosing mapping's def). Null = no def yet. */
   entityDefinitionId: string | null
-  /** The source node being bound — drives the type filter + quick-create seed. */
-  sourceType: string
-  sourcePath: string
+  /** The source node being bound — drives the type filter + quick-create seed ('leaf'). */
+  sourceType?: string
+  sourcePath?: string
   /** Detected source string `format` — seeds the quick-create field type (§2.2). */
   sourceFormat?: string
-  /** The currently-bound target field ref (`ResourceFieldId`), if any. */
-  assignedKey: string | undefined
-  /** Resolved label for the bound ref (for the chip), if known. */
-  assignedLabel: string | undefined
-  /** Target field refs already bound by other entries — hidden (uniqueness). */
+  /** The currently-bound DIRECT target field ref (`ResourceFieldId`), if any. */
+  assignedKey?: string | undefined
+  /** Resolved label for the bound ref/path (for the chip), if known. */
+  assignedLabel?: string | undefined
+  /**
+   * Resolved icon id for the applied field — mirrors the field icon the picker list
+   * shows ({@link FieldItem}), so the trigger chip matches the row you picked.
+   */
+  assignedIconId?: string | undefined
+  /**
+   * Set when this leaf is bound ACROSS a relationship (a drilled `FieldPath`, e.g.
+   * `order:email → ["order:contact","contact:email"]`). Drives the in-list selected
+   * check on the far field; the chip shows {@link assignedLabel}.
+   */
+  drilledRef?: FieldReference
+  /** Target field refs already bound by other entries on the ROOT def — hidden (uniqueness). */
   excludeKeys?: Set<string>
   /** Quick-create is wired only for owned defs (plan decision 3). */
-  canCreate: boolean
-  /** Bind this source node to the chosen target field (canonical `ResourceFieldId`). */
-  onAssign: (fieldRef: string) => void
+  canCreate?: boolean
+  /** Trigger placeholder when nothing is assigned (default "Apply field…"). */
+  placeholder?: string
+  /** Bind this source node to a DIRECT field on the current def (canonical `ResourceFieldId`). */
+  onAssign?: (fieldRef: string) => void
+  /** Bind this source node ACROSS a relationship — a drilled `FieldPath` (§2 unified model). */
+  onDrilledAssign?: (field: ResourceField, ref: FieldPath) => void
   /** Unbind this source node — surfaced as the in-picker "Don't map" option. */
-  onClear: () => void
+  onClear?: () => void
   /**
-   * Flat-FK relationship linking (Approach B). When set, the picker ALSO lists the
-   * parent def's existing RELATIONSHIP fields (the inversion of the default
-   * exclusion): selecting one links this FK leaf to that relationship. The link is
-   * INDEPENDENT of any scalar binding on the same leaf (a leaf can be both) — it's
-   * surfaced on its own sub-row, not in this cell. Only relationships whose related
-   * def this connector syncs are offered (`syncedDefIds`).
+   * Whether RELATIONSHIP fields are shown (and so drillable). Off for formula rows
+   * and array leaves. Always on for a 'branch'.
    */
   allowRelationships?: boolean
-  /** Entity defs this connector syncs (upsert) — gates which relationships resolve. */
-  syncedDefIds?: Set<string>
   /** The currently-linked relationship field's ref, for the in-list selected check. */
   linkedFieldRef?: string
-  /** Link this FK leaf to the chosen relationship (desugars to an id-only reference branch). */
-  onLinkRelationship?: (field: ResourceField, ref: FieldReference) => void
-}
-
-/** A relationship field whose related def is synced — i.e. a valid link target. */
-function isLinkableRelationship(field: ResourceField, syncedDefIds?: Set<string>): boolean {
-  if (!field.relationship) return false
-  if (!syncedDefIds) return true
-  const relatedDefId = getRelatedEntityDefinitionId(field.relationship as RelationshipConfig)
-  return !!relatedDefId && syncedDefIds.has(relatedDefId)
+  /**
+   * A relationship was selected (not drilled past). 'leaf' → id-only link the FK to it;
+   * 'branch' → fan the branch out into a related child record. The handler decides which.
+   */
+  onSelectRelationship?: (field: ResourceField, ref: FieldReference) => void
 }
 
 /**
- * The leaf-row target control — a single self-managed {@link Popover} whose body
- * swaps between the {@link FieldPickerContent} list and an inline quick-create
- * form (a `view` flip, no stacked popovers). Filters targets by source-type
- * compatibility, and on owned defs offers a quick-create seeded from the source
- * node (friendly name + value-aware type).
+ * The unified target control (relationship-linking v3 — unified picker). One
+ * self-managed {@link Popover} that drills the relationship graph from
+ * {@link entityDefinitionId}: select a scalar at root → bind it directly; drill a
+ * relationship and select a scalar → bind ACROSS the relationship (a `FieldPath`);
+ * select a relationship itself → link/fan-out a related record. The same control
+ * renders on leaf rows AND branch rows so nothing reads as a different cell.
  */
 export function MappingFieldPicker({
+  kind = 'leaf',
   entityDefinitionId,
-  sourceType,
-  sourcePath,
+  sourceType = 'string',
+  sourcePath = '',
   sourceFormat,
   assignedKey,
   assignedLabel,
+  assignedIconId,
+  drilledRef,
   excludeKeys,
-  canCreate,
+  canCreate = false,
+  placeholder,
   onAssign,
+  onDrilledAssign,
   onClear,
   allowRelationships = false,
-  syncedDefIds,
   linkedFieldRef,
-  onLinkRelationship,
+  onSelectRelationship,
 }: MappingFieldPickerProps) {
   const [open, setOpen] = useState(false)
   const [view, setView] = useState<'pick' | 'create'>('pick')
 
-  const chipLabel = assignedKey ? (assignedLabel ?? assignedKey) : 'Apply field…'
+  const isBranch = kind === 'branch'
+  const showRelationships = isBranch || allowRelationships
+  const isAssigned = !!assignedKey || !!drilledRef
+  const chipLabel =
+    assignedLabel ?? (isAssigned ? (assignedKey ?? 'Linked') : (placeholder ?? 'Apply field…'))
 
   // No target def yet — nothing to resolve against. Show a disabled trigger;
   // binding unlocks once a target def is picked (plan 08 §3.4).
@@ -147,56 +171,75 @@ export function MappingFieldPicker({
       <PopoverTrigger asChild>
         <Button
           variant='transparent'
-          className={`h-9 w-full justify-between rounded-none px-2 text-xs hover:bg-primary/5 ${
-            assignedKey ? '' : 'text-muted-foreground'
+          className={`h-9 w-full justify-between rounded-none px-2 text-xs hover:bg-primary-200/20 ${
+            isAssigned ? '' : 'text-primary-400'
           }`}>
-          <span className='truncate'>{chipLabel}</span>
-          <ChevronDown className='size-3 opacity-50' />
+          <span className='flex min-w-0 items-center gap-1.5'>
+            {isAssigned && assignedIconId && (
+              <EntityIcon
+                iconId={assignedIconId}
+                size='sm'
+                className='inset-shadow-xs inset-shadow-black/20 shrink-0 bg-primary-300'
+              />
+            )}
+            <span className='truncate'>{chipLabel}</span>
+          </span>
+          <ChevronDown className='size-3 shrink-0 opacity-50' />
         </Button>
       </PopoverTrigger>
       <PopoverContent className='w-72 p-0' align='start'>
         {view === 'pick' ? (
           <FieldPickerContent
             entityDefinitionId={entityDefinitionId}
-            // Mark the bound scalar AND the linked relationship (independent) with a
-            // check — a leaf can carry both.
+            // Check the bound DIRECT scalar, the drilled FieldPath, and any id-only
+            // link — a leaf can carry both a value bind and a link.
             fieldReferences={
-              [assignedKey, linkedFieldRef].filter((r): r is string => !!r) as ResourceFieldId[]
+              [assignedKey, linkedFieldRef, drilledRef].filter(
+                (r): r is FieldReference => !!r
+              ) as FieldReference[]
             }
-            // Approach B: list the parent def's RELATIONSHIP fields too (the
-            // inversion of the default exclusion) so a flat FK can link to one.
-            excludeFields={allowRelationships ? [] : [FieldType.RELATIONSHIP]}
-            // A scalar target must be writable + type-compatible + not already bound.
-            // A relationship is a link target instead — kept only when its related
-            // def is synced by this connector (so the edge can resolve).
-            filterField={(f) =>
-              f.relationship
-                ? allowRelationships && isLinkableRelationship(f, syncedDefIds)
-                : !excludeKeys?.has(
-                    f.resourceFieldId ?? toResourceFieldId(entityDefinitionId, f.id)
-                  ) &&
-                  isWritableTarget(f) &&
-                  isSourceTargetCompatible(f.fieldType, sourceType)
-            }
-            // Relationship rows are select-only here (link the FK), never drilled.
-            disableDrillDown={allowRelationships}
+            // Show relationships (so they're drillable) for leaves that allow them and
+            // for every branch; otherwise hide them (formula rows / array leaves).
+            excludeFields={showRelationships ? [] : [FieldType.RELATIONSHIP]}
+            // Relationships are always shown (drillable). A scalar target must be
+            // writable + type-compatible; the no-double-bind exclusion only applies to
+            // the ROOT def (a drilled-into related def has its own keyspace). A branch
+            // binds no scalar — only its relationships are selectable.
+            filterField={(f) => {
+              if (f.relationship) return showRelationships
+              if (isBranch) return false
+              const rfid = f.resourceFieldId ?? toResourceFieldId(entityDefinitionId, f.id)
+              const notExcluded =
+                getFieldDefinitionId(rfid) === entityDefinitionId ? !excludeKeys?.has(rfid) : true
+              return (
+                notExcluded &&
+                isWritableTarget(f) &&
+                isSourceTargetCompatible(f.fieldType, sourceType)
+              )
+            }}
             mode='single'
             closeOnSelect
             onClose={() => setOpen(false)}
-            searchPlaceholder='Search fields…'
+            searchPlaceholder={isBranch ? 'Search relationships…' : 'Search fields…'}
             onSelect={(ref, field) => {
+              // Relationship picked → link (leaf) / fan out (branch).
               if (field.relationship) {
-                onLinkRelationship?.(field, ref)
+                onSelectRelationship?.(field, ref)
                 return
               }
-              onAssign(field.resourceFieldId ?? toResourceFieldId(entityDefinitionId, field.id))
+              // Scalar reached by drilling → bind across the relationship.
+              if (isFieldPath(ref)) {
+                onDrilledAssign?.(field, ref)
+                return
+              }
+              // Scalar at root → bind directly on the current def.
+              onAssign?.(field.resourceFieldId ?? toResourceFieldId(entityDefinitionId, field.id))
             }}
-            // Skip = unbind the SCALAR. Unlinking a relationship lives on the link
-            // sub-row, not here. Only offered once a scalar is bound.
-            onSkip={assignedKey ? onClear : undefined}
+            // Skip = unbind whatever is currently bound on this leaf (direct or drilled).
+            onSkip={!isBranch && isAssigned ? onClear : undefined}
             skipLabel="Don't map this field"
             createLabel='Quick create'
-            onCreateField={canCreate ? () => setView('create') : undefined}
+            onCreateField={!isBranch && canCreate ? () => setView('create') : undefined}
           />
         ) : (
           <QuickCreateFieldForm

--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -1,17 +1,30 @@
 // apps/web/src/components/data-connectors/ui/mapping-node.tsx
 'use client'
 
+import type { FieldType } from '@auxx/database/types'
+import { fieldTypeOptions } from '@auxx/lib/custom-fields/types'
 import type { ResourceField } from '@auxx/lib/resources/client'
+import { mapBaseTypeToFieldType } from '@auxx/lib/workflow-engine/client'
 import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
-import { type FieldReference, fieldRefToKey, toResourceFieldId } from '@auxx/types/field'
+import {
+  type FieldReference,
+  fieldRefToKey,
+  getFieldDefinitionId,
+  getFieldId,
+  isFieldPath,
+  keyToFieldRef,
+  type ResourceFieldId,
+  toFieldPath,
+  toResourceFieldId,
+} from '@auxx/types/field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { toastError } from '@auxx/ui/components/toast'
 import { SimpleTooltip } from '@auxx/ui/components/tooltip'
-import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { TreeRowButton } from '@auxx/ui/components/tree-row'
 import { generateId } from '@auxx/utils'
-import { ArrowRight, FunctionSquare, Loader2, Plus, Sparkles, Trash2 } from 'lucide-react'
+import { FunctionSquare, Loader2, Plus, Sparkles, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { ResourcePicker } from '~/components/pickers/resource-picker'
 import { useResourceFields, useResourceProperty } from '~/components/resources'
@@ -28,9 +41,18 @@ import type { FieldMapping, useStreamMutations } from '../hooks/use-stream-mutat
 import { BranchRow } from './branch-row'
 import { CappedNodeList } from './capped-node-list'
 import { FieldCalcDialog } from './field-calc-dialog'
-import { MAPPING_COLS } from './mapping-columns'
+import {
+  bareTokenSource,
+  bindingFor,
+  isBareToken,
+  removeBindingForSource,
+  retargetFormulaEntry,
+  setEntryIdentityRole,
+  upsertBinding,
+} from './field-mapping-edits'
+import { type IdentityRole, IdentityRoleControl } from './identity-role-control'
 import { MappingFieldPicker } from './mapping-field-picker'
-import { MergeStrategyToggle } from './merge-strategy-toggle'
+import { FieldRowActions, MappingRow } from './mapping-row'
 import { RelationshipLinkRow } from './relationship-link-row'
 import { SourceLeafRow } from './source-leaf-row'
 
@@ -42,6 +64,19 @@ type Mapping = RouterOutputs['dataConnector']['listStreams'][number]['mappings']
  */
 function refOf(field: ResourceField, entityDefinitionId: string | null | undefined): string {
   return field.resourceFieldId ?? toResourceFieldId(entityDefinitionId ?? '', field.id)
+}
+
+/**
+ * The field-type icon for an applied target field — mirrors {@link FieldItem}'s
+ * regular-field branch so the trigger chip matches the picker-list row. Falls back
+ * to the BaseType→FieldType mapping for system fields, then a generic `circle`.
+ */
+function fieldIconId(field: ResourceField | undefined): string | undefined {
+  if (!field) return undefined
+  const fieldType =
+    (field.fieldType as FieldType) ||
+    (field.type ? mapBaseTypeToFieldType(field.type as any) : undefined)
+  return (fieldType && fieldTypeOptions[fieldType]?.iconId) ?? 'circle'
 }
 
 /** The related def a relationship field points at, or null if it has none. */
@@ -66,20 +101,22 @@ function recordNoun(raw: string): string {
 
 /**
  * Plain-language description of where a mapping's records come from, derived from
- * the defined source schema. A named branch borrows its field name (`draft` →
- * "each draft"); the unnamed array ROOT (`[]`) has no schema name, so it falls
- * back to the stream's own noun (stream key `todos` → "each todo").
+ * the defined source schema. An ARRAY branch fans out one record per element, so it
+ * reads "each <noun>" (`drafts[]` → "each draft"); a SINGULAR object branch is one
+ * record, so it reads "one <noun>" (`customer` → "one customer"). The unnamed array
+ * ROOT (`[]`) has no schema name, so it falls back to the stream's own noun (stream
+ * key `todos` → "each todo"). Returns the parts split so the header can style the
+ * qualifier like a field's TYPE token and the noun like its LABEL (row-consistent).
  */
-function describeRootPath(rootPath: string, fallbackNoun?: string): string {
-  if (rootPath === '') return 'whole payload'
+function describeRootPath(
+  rootPath: string,
+  fallbackNoun?: string
+): { qualifier: string; noun: string } {
+  if (rootPath === '') return { qualifier: 'whole', noun: 'payload' }
+  const isArray = rootPath.endsWith('[]')
   const seg = rootPath.replace(/\[\]$/, '').split('.').pop()
-  if (seg) return `each ${recordNoun(seg)}`
-  return fallbackNoun ? `each ${recordNoun(fallbackNoun)}` : 'each item'
-}
-
-/** A degenerate single-token `{path}` expression (one-click row, not a calc). */
-function isBareToken(expression: string): boolean {
-  return /^\{[^{}]+\}$/.test(expression.trim())
+  const noun = seg ? recordNoun(seg) : fallbackNoun ? recordNoun(fallbackNoun) : 'item'
+  return { qualifier: isArray ? 'each' : 'one', noun }
 }
 
 /** The fan-out rootPath for a branch node — arrays keep their `[]` suffix. */
@@ -130,9 +167,10 @@ export function MappingNode({
   syncedDefIds,
 }: MappingNodeProps) {
   const [open, setOpen] = useState(true)
-  // The binding entry whose formula the dialog is editing (null = closed). Set to
-  // a draft entry's id when "Add formula" appends a fresh row.
-  const [calcEntryId, setCalcEntryId] = useState<string | null>(null)
+  // The formula entry the dialog is editing (null = closed). Carries the OWNING
+  // mapping id too, so the dialog can edit a drilled formula whose entry lives on a
+  // flat child — not just one on this parent mapping.
+  const [calcTarget, setCalcTarget] = useState<{ mappingId: string; entryId: string } | null>(null)
   const { setMappingTarget, removeMapping, setFieldMappings, fanOut } = mutations
 
   // Target def display + fields, read from the resource store (the same source
@@ -180,6 +218,18 @@ export function MappingNode({
   const patchEntry = (id: string, patch: Partial<FieldMapping>) =>
     writeEntries(fieldMappings.map((e) => (e.id === id ? { ...e, ...patch } : e)))
 
+  // Patch an entry on ANY mapping (this one or a flat child) — needed because a
+  // drilled formula's entry lives on a child. Reads the target mapping's entries
+  // from the shared index so the write is over its current array.
+  const patchEntryIn = (mappingId: string, entryId: string, patch: Partial<FieldMapping>) => {
+    const entries = (byMappingId.get(mappingId)?.fieldMappings ?? []) as FieldMapping[]
+    setFieldMappings(
+      streamId,
+      mappingId,
+      entries.map((e) => (e.id === entryId ? { ...e, ...patch } : e))
+    )
+  }
+
   // Every target field already bound by SOME entry — the pickers exclude these so
   // two entries can't fight over one field (an array allows it; the UI forbids it).
   const usedTargetKeys = new Set(
@@ -197,12 +247,19 @@ export function MappingNode({
   // branch node at `line_items` matches a child mapping with rootPath
   // `line_items[]`.
   const childMappings = childrenOf.get(mapping.id) ?? []
+  // FLAT drilled children (unified picker §2): a child that reads the SAME subtree as
+  // this mapping (`rootPath: ''`) to write a related def — created by drilling a leaf's
+  // target across a relationship (e.g. `email → Contact.Email`). They surface INLINE on
+  // their source leaf (via `drilledBindBySourcePath`), NOT as nested nodes — so they're
+  // partitioned out of the branch/ref indexing below.
+  const flatDrilledChildren = childMappings.filter((c) => c.rootPath === '')
+  const nonFlatChildren = childMappings.filter((c) => c.rootPath !== '')
   // Reference children (flat-FK links, Approach B) live on a SCALAR leaf, not a
   // branch — index them separately so a linked leaf renders in "linked" state
   // instead of being promoted to a nested MappingNode (the upsert fan-out path).
-  const upsertChildren = childMappings.filter((c) => c.linkMode !== 'reference')
+  const upsertChildren = nonFlatChildren.filter((c) => c.linkMode !== 'reference')
   const refChildByNodePath = new Map<string, Mapping>()
-  for (const c of childMappings) {
+  for (const c of nonFlatChildren) {
     if (c.linkMode === 'reference') refChildByNodePath.set(c.rootPath.replace(/\[\]$/, ''), c)
   }
   const childByNodePath = new Map<string, Mapping>()
@@ -211,6 +268,29 @@ export function MappingNode({
   // would otherwise vanish — render them appended so they stay editable/removable.
   const orphanChildren = upsertChildren.filter(
     (c) => !branchPaths.has(c.rootPath.replace(/\[\]$/, ''))
+  )
+
+  // A leaf bound ACROSS a relationship: its binding lives on a flat drilled child, but
+  // the leaf keeps its row (only the target chip reaches across). Index source path →
+  // { child, entry } so the leaf renders the drilled chip + routes its controls to the
+  // child mapping (unified picker §5).
+  const drilledBindBySourcePath = new Map<string, { child: Mapping; entry: FieldMapping }>()
+  for (const c of flatDrilledChildren) {
+    for (const e of (c.fieldMappings ?? []) as FieldMapping[]) {
+      if (e.targetFieldRef == null || !isBareToken(e.expression)) continue
+      drilledBindBySourcePath.set(bareTokenSource(e.expression), { child: c, entry: e })
+    }
+  }
+
+  // DRILLED FORMULAS (formula-drill-targets §2): a NON-bare entry on a flat child is a
+  // formula whose computed value writes a related def across the relationship — the
+  // formula analog of a drilled leaf bind. Bare entries on the same child are leaf
+  // binds (rendered inline via `drilledBindBySourcePath`); non-bare ones surface here
+  // as their own formula rows on this parent.
+  const drilledFormulaRows = flatDrilledChildren.flatMap((child) =>
+    ((child.fieldMappings ?? []) as FieldMapping[])
+      .filter((e) => !isBareToken(e.expression))
+      .map((entry) => ({ child, entry }))
   )
 
   // Reverse-index bare-token entries: source path → the binding entry on it.
@@ -307,10 +387,16 @@ export function MappingNode({
   const addFormula = () => {
     const id = generateId()
     writeEntries([...fieldMappings, { id, targetFieldRef: null, expression: '', sourceFields: {} }])
-    setCalcEntryId(id)
+    setCalcTarget({ mappingId: mapping.id, entryId: id })
   }
 
-  const calcEntry = calcEntryId ? fieldMappings.find((e) => e.id === calcEntryId) : undefined
+  // The formula being edited may live on this parent OR a flat child — resolve it
+  // from the shared index by the dialog's owning mapping id.
+  const calcEntry = calcTarget
+    ? ((byMappingId.get(calcTarget.mappingId)?.fieldMappings ?? []) as FieldMapping[]).find(
+        (e) => e.id === calcTarget.entryId
+      )
+    : undefined
 
   const toggleTargetMode = () =>
     setMappingTarget(streamId, {
@@ -372,10 +458,210 @@ export function MappingNode({
     })
   }
 
+  // Bind a leaf ACROSS a relationship (unified picker §2/§4): drill the target graph to
+  // a field on a related def — e.g. `email → Contact.Email`. Desugars to a FLAT
+  // contributing child mapping (`rootPath ''` reads THIS mapping's subtree,
+  // map-record.ts:285) carrying the binding, reusing one child per drilled
+  // relationship. v1 is single-hop (a 2-segment FieldPath).
+  const assignDrilled = (node: SourceTreeNode, _field: ResourceField, ref: FieldReference) => {
+    if (!isFieldPath(ref) || ref.length !== 2) {
+      toastError({
+        title: 'Multi-hop links not supported yet',
+        description: 'Pick a field one relationship away from this record.',
+      })
+      return
+    }
+    const rel = ref[0] // the drilled relationship, e.g. "order:contact"
+    const targetRef = ref[1] // the bound field on the related def, e.g. "contact:email"
+    const relatedDefId = getFieldDefinitionId(targetRef)
+    const relKey = fieldRefToKey(rel)
+    // Drop any prior DIRECT binding on this source — it now writes the related record.
+    if (sourceToEntry.has(node.path)) {
+      writeEntries(removeBindingForSource(fieldMappings, node.path))
+    }
+    const existing = flatDrilledChildren.find((c) => c.relationshipFieldKey === relKey)
+    if (existing) {
+      setFieldMappings(
+        streamId,
+        existing.id,
+        upsertBinding((existing.fieldMappings ?? []) as FieldMapping[], node.path, targetRef)
+      )
+      return
+    }
+    fanOut(streamId, {
+      parentMappingId: mapping.id,
+      rootPath: '', // flat: reads THIS mapping's subtree
+      linkMode: 'upsert', // server derives reference vs upsert from the bindings
+      targetMode: 'contributing',
+      entityDefinitionId: relatedDefId,
+      relationshipFieldKey: relKey,
+      fieldMappings: [bindingFor(node.path, targetRef)],
+    })
+  }
+
+  // Clear a drilled binding — drop it from the flat child, removing the child entirely
+  // once it carries no bindings (it existed only for drilled binds).
+  const clearDrilled = (node: SourceTreeNode) => {
+    const drilled = drilledBindBySourcePath.get(node.path)
+    if (!drilled) return
+    const remaining = removeBindingForSource(
+      (drilled.child.fieldMappings ?? []) as FieldMapping[],
+      node.path
+    )
+    if (remaining.length === 0) removeMapping(streamId, drilled.child.id)
+    else setFieldMappings(streamId, drilled.child.id, remaining)
+  }
+
+  // Identity role on a drilled leaf → patch the flat child's binding (External ID is a
+  // radio WITHIN that child — the related record's own key).
+  const setDrilledIdentityRole = (node: SourceTreeNode, role: 'externalId' | 'match' | null) => {
+    const drilled = drilledBindBySourcePath.get(node.path)
+    if (!drilled) return
+    setFieldMappings(
+      streamId,
+      drilled.child.id,
+      setEntryIdentityRole(
+        (drilled.child.fieldMappings ?? []) as FieldMapping[],
+        drilled.entry.id,
+        role,
+        deriveNormalize(drilled.entry.targetFieldRef ?? '')
+      )
+    )
+  }
+
+  // Merge strategy on a drilled leaf → patch the flat child's binding.
+  const setDrilledMerge = (node: SourceTreeNode, value: string) => {
+    const drilled = drilledBindBySourcePath.get(node.path)
+    if (!drilled) return
+    setFieldMappings(
+      streamId,
+      drilled.child.id,
+      ((drilled.child.fieldMappings ?? []) as FieldMapping[]).map((e) =>
+        e.id === drilled.entry.id
+          ? { ...e, mergeStrategy: value as FieldMapping['mergeStrategy'] }
+          : e
+      )
+    )
+  }
+
+  // ── Formula drill-across-relationship (formula-drill-targets §3) ──────────────
+  // A formula entry's "home" is either THIS parent mapping (a root-scalar target) or a
+  // flat child (a target a relationship away). Picking a target moves the entry to its
+  // desired home, preserving the expression. The flat child is REUSED per relationship
+  // (shared with drilled leaf binds) and GC'd when its last entry leaves.
+
+  // v1 drills are single-hop — a 2-segment FieldPath. Returns [rel, targetRef] or null
+  // (after toasting) for a root scalar / deeper path.
+  const asSingleHop = (ref: FieldReference): [ResourceFieldId, ResourceFieldId] | null => {
+    if (!isFieldPath(ref) || ref.length !== 2) {
+      toastError({
+        title: 'Multi-hop links not supported yet',
+        description: 'Pick a field one relationship away from this record.',
+      })
+      return null
+    }
+    return [ref[0], ref[1]]
+  }
+
+  // Upsert a (re-homed) formula entry into the flat child for `rel`, creating it if
+  // absent. The entry already carries its far-field target + expression.
+  const upsertFormulaIntoRelChild = (rel: ResourceFieldId, entry: FieldMapping) => {
+    const relKey = fieldRefToKey(rel)
+    const relatedDefId = getFieldDefinitionId(entry.targetFieldRef as ResourceFieldId)
+    const existing = flatDrilledChildren.find((c) => c.relationshipFieldKey === relKey)
+    if (existing) {
+      const next = [
+        ...((existing.fieldMappings ?? []) as FieldMapping[]).filter((e) => e.id !== entry.id),
+        entry,
+      ]
+      setFieldMappings(streamId, existing.id, next)
+      return
+    }
+    fanOut(streamId, {
+      parentMappingId: mapping.id,
+      rootPath: '', // flat: reads THIS mapping's subtree
+      linkMode: 'upsert', // server derives reference vs upsert from the bindings
+      targetMode: 'contributing',
+      entityDefinitionId: relatedDefId,
+      relationshipFieldKey: relKey,
+      fieldMappings: [entry],
+    })
+  }
+
+  // Drop a formula entry from a flat child, GC'ing the child when nothing remains.
+  const removeFormulaFromChild = (child: Mapping, entryId: string) => {
+    const remaining = ((child.fieldMappings ?? []) as FieldMapping[]).filter(
+      (e) => e.id !== entryId
+    )
+    if (remaining.length === 0) removeMapping(streamId, child.id)
+    else setFieldMappings(streamId, child.id, remaining)
+  }
+
+  // A HOME formula gains a drilled target → move it onto the relationship's flat child.
+  const drillHomeFormula = (entry: FieldMapping, ref: FieldReference) => {
+    const hop = asSingleHop(ref)
+    if (!hop) return
+    writeEntries(fieldMappings.filter((e) => e.id !== entry.id))
+    upsertFormulaIntoRelChild(hop[0], retargetFormulaEntry(entry, hop[1]))
+  }
+
+  // A DRILLED formula is retargeted to a ROOT scalar → move it back to this parent.
+  const undrillFormula = (child: Mapping, entry: FieldMapping, targetRef: string) => {
+    removeFormulaFromChild(child, entry.id)
+    writeEntries([...fieldMappings, retargetFormulaEntry(entry, targetRef)])
+  }
+
+  // A DRILLED formula gains another drilled target → retarget in place when the
+  // relationship is unchanged, else move it to the new relationship's child.
+  const redrillFormula = (child: Mapping, entry: FieldMapping, ref: FieldReference) => {
+    const hop = asSingleHop(ref)
+    if (!hop) return
+    if (child.relationshipFieldKey === fieldRefToKey(hop[0])) {
+      patchEntryIn(child.id, entry.id, { targetFieldRef: hop[1] })
+      return
+    }
+    removeFormulaFromChild(child, entry.id)
+    upsertFormulaIntoRelChild(hop[0], retargetFormulaEntry(entry, hop[1]))
+  }
+
+  // Identity role on a HOME formula (formula-drill-targets §5.1) — keyed by ENTRY ID,
+  // since a formula has no single source path. External ID stays a radio WITHIN this
+  // mapping (the record's own key); the runtime evaluates the expression as the key,
+  // so a composite/computed External ID works with no engine change.
+  const setFormulaIdentityRole = (entryId: string, role: IdentityRole) => {
+    const entry = fieldMappings.find((e) => e.id === entryId)
+    writeEntries(
+      setEntryIdentityRole(
+        fieldMappings,
+        entryId,
+        role,
+        deriveNormalize(entry?.targetFieldRef ?? '')
+      )
+    )
+  }
+
+  // Identity role on a DRILLED formula → patch the flat child's entry (External ID is a
+  // radio WITHIN that child — the related record's own key).
+  const setDrilledFormulaIdentityRole = (
+    child: Mapping,
+    entry: FieldMapping,
+    role: IdentityRole
+  ) => {
+    setFieldMappings(
+      streamId,
+      child.id,
+      setEntryIdentityRole(
+        (child.fieldMappings ?? []) as FieldMapping[],
+        entry.id,
+        role,
+        deriveNormalize(entry.targetFieldRef ?? '')
+      )
+    )
+  }
+
   return (
     <>
-      <GridTreeRow
-        columns={MAPPING_COLS}
+      <MappingRow
         depth={depth}
         expandable
         chevronOnHover
@@ -384,17 +670,21 @@ export function MappingNode({
         icon={<EntityIcon iconId={resource?.icon ?? 'table'} size='xs' />}
         title={
           // The rootPath is fixed by the source row this mapping was created from
-          // (`data` → "each data") — a static label, not a chooser.
-          <span className='text-xs text-muted-foreground'>
-            {describeRootPath(mapping.rootPath, streamKey)}
-          </span>
+          // (`data` → "each data") — a static label, not a chooser. Styled to match a
+          // source leaf: qualifier reads like the TYPE token, noun like the field LABEL.
+          (() => {
+            const { qualifier, noun } = describeRootPath(mapping.rootPath, streamKey)
+            return (
+              <span className='flex items-center gap-1.5'>
+                <span className='text-[10px] uppercase text-muted-foreground/60'>{qualifier}</span>
+                <span className='font-mono text-sm'>{noun}</span>
+              </span>
+            )
+          })()
         }
-        cells={[
-          <span key='arrow' className='flex w-full justify-center text-muted-foreground'>
-            <ArrowRight className='size-3.5' />
-          </span>,
+        arrow='filled'
+        target={
           <ResourcePicker
-            key='target'
             value={mapping.entityDefinitionId ? [mapping.entityDefinitionId] : []}
             onChange={() => {}}
             entityDefinedOnly
@@ -408,8 +698,10 @@ export function MappingNode({
               })
             }
             triggerProps={{ className: 'h-9 w-full justify-between rounded-none px-2 text-xs' }}
-          />,
-          <div key='actions' className='flex w-full items-center justify-end gap-1 pr-1'>
+          />
+        }
+        actions={
+          <>
             <SimpleTooltip
               side='left'
               delayDuration={500}
@@ -454,8 +746,8 @@ export function MappingNode({
               onClick={() => removeMapping(streamId, mapping.id)}>
               <Trash2 />
             </TreeRowButton>
-          </div>,
-        ]}>
+          </>
+        }>
         {sourceTree.length === 0 ? (
           <div
             style={{ paddingLeft: `${(depth + 1) * 1.5}rem` }}
@@ -467,7 +759,10 @@ export function MappingNode({
             nodes={sourceTree}
             childDepth={depth + 1}
             isCappable={(n) =>
-              !n.isBranch && !sourceToEntry.has(n.path) && !refChildByNodePath.has(n.path)
+              !n.isBranch &&
+              !sourceToEntry.has(n.path) &&
+              !refChildByNodePath.has(n.path) &&
+              !drilledBindBySourcePath.has(n.path)
             }
             renderNode={(node) => (
               <SourceNode
@@ -481,6 +776,7 @@ export function MappingNode({
                 usedTargetKeys={usedTargetKeys}
                 childByNodePath={childByNodePath}
                 refChildByNodePath={refChildByNodePath}
+                drilledBindBySourcePath={drilledBindBySourcePath}
                 onAssign={assignTarget}
                 onClear={clearEntry}
                 onMergeChange={(id, value) =>
@@ -490,6 +786,10 @@ export function MappingNode({
                 onFanOutRelationship={materializeRelatedChild}
                 onLinkRelationship={linkRelationship}
                 onClearLink={(refChildId) => removeMapping(streamId, refChildId)}
+                onAssignDrilled={assignDrilled}
+                onClearDrilled={clearDrilled}
+                onSetDrilledIdentityRole={setDrilledIdentityRole}
+                onDrilledMergeChange={setDrilledMerge}
                 // Child-mapping recursion context.
                 connectorId={connectorId}
                 streamId={streamId}
@@ -518,8 +818,11 @@ export function MappingNode({
                 label={
                   e.targetFieldRef ? (fieldByRef(e.targetFieldRef)?.label ?? e.targetFieldRef) : ''
                 }
+                iconId={e.targetFieldRef ? fieldIconId(fieldByRef(e.targetFieldRef)) : undefined}
                 expression={e.expression}
                 mergeStrategy={e.mergeStrategy ?? 'overwrite'}
+                // Drilling is offered once a target def is set (formula-drill-targets §4).
+                allowRelationships={mapping.entityDefinitionId != null}
                 // Exclude keys other entries already bind, so a formula can't be
                 // retargeted onto a field already in use.
                 excludeKeys={
@@ -527,30 +830,52 @@ export function MappingNode({
                     ? new Set([...usedTargetKeys].filter((k) => k !== e.targetFieldRef))
                     : usedTargetKeys
                 }
-                onEdit={() => setCalcEntryId(e.id)}
+                identityRole={e.identityRole?.kind ?? null}
+                canMatch={e.targetFieldRef != null}
+                onSetIdentityRole={(role) => setFormulaIdentityRole(e.id, role)}
+                onEdit={() => setCalcTarget({ mappingId: mapping.id, entryId: e.id })}
                 onRetarget={(newKey) => retargetEntry(e.id, newKey)}
+                onDrilledAssign={(ref) => drillHomeFormula(e, ref)}
                 onMergeChange={(value) =>
                   patchEntry(e.id, { mergeStrategy: value as FieldMapping['mergeStrategy'] })
                 }
                 onClear={() => clearEntry(e.id)}
               />
             ))}
+            {/* Drilled formulas — a computed value written across a relationship; its
+              entry lives on a flat child, but it renders here as a formula row whose
+              chip reaches across ("Contact › Full name"). */}
+            {drilledFormulaRows.map(({ child, entry }) => (
+              <DrilledFormulaRow
+                key={entry.id}
+                depth={depth + 1}
+                parentEntityDefinitionId={mapping.entityDefinitionId}
+                child={child}
+                entry={entry}
+                excludeKeys={usedTargetKeys}
+                onSetIdentityRole={(role) => setDrilledFormulaIdentityRole(child, entry, role)}
+                onEdit={() => setCalcTarget({ mappingId: child.id, entryId: entry.id })}
+                onRetargetRoot={(newKey) => undrillFormula(child, entry, newKey)}
+                onDrilledAssign={(ref) => redrillFormula(child, entry, ref)}
+                onMergeChange={(value) =>
+                  patchEntryIn(child.id, entry.id, {
+                    mergeStrategy: value as FieldMapping['mergeStrategy'],
+                  })
+                }
+                onClear={() => removeFormulaFromChild(child, entry.id)}
+              />
+            ))}
             {mapping.entityDefinitionId != null && (
-              <GridTreeRow
-                columns={MAPPING_COLS}
+              <MappingRow
                 depth={depth + 1}
                 icon={<Plus className='size-3.5 text-muted-foreground/50' />}
                 // "Add formula" persists a fresh draft row (no target yet) and opens
                 // the expression dialog on it — you author the formula first and pick
-                // the destination field after (or leave it unassigned for later).
-                title={
-                  <Button
-                    variant='transparent'
-                    onClick={addFormula}
-                    className='h-9 w-full justify-start rounded-none px-1 text-sm text-muted-foreground hover:bg-primary/5'>
-                    Add formula
-                  </Button>
-                }
+                // the destination field after (or leave it unassigned for later). The
+                // WHOLE row is the click target (onToggleOpen drives the row onClick),
+                // and the label reads like a field (font-mono text-sm, foreground).
+                onToggleOpen={addFormula}
+                title={<span className='font-mono text-sm'>Add formula</span>}
               />
             )}
           </>
@@ -574,14 +899,15 @@ export function MappingNode({
             syncedDefIds={syncedDefIds}
           />
         ))}
-      </GridTreeRow>
+      </MappingRow>
 
       {/* The formula editor — opened by a formula row's source button or the
           "Add formula" row. Source paths are scoped to this mapping's subtree
-          (matching the runtime). */}
+          (matching the runtime); a drilled formula's flat child reads the SAME
+          subtree (`rootPath ''`), so the same paths apply. */}
       <FieldCalcDialog
-        open={calcEntryId !== null}
-        onOpenChange={(o) => !o && setCalcEntryId(null)}
+        open={calcTarget !== null}
+        onOpenChange={(o) => !o && setCalcTarget(null)}
         targetLabel={
           calcEntry?.targetFieldRef
             ? (fieldByRef(calcEntry.targetFieldRef)?.label ?? calcEntry.targetFieldRef)
@@ -590,8 +916,8 @@ export function MappingNode({
         expression={calcEntry?.expression ?? ''}
         sourcePaths={leafPathsUnder(sourcePaths, prefix)}
         onSave={(expression, sourceFields) => {
-          if (!calcEntryId) return
-          patchEntry(calcEntryId, { expression, sourceFields })
+          if (!calcTarget) return
+          patchEntryIn(calcTarget.mappingId, calcTarget.entryId, { expression, sourceFields })
         }}
       />
     </>
@@ -614,6 +940,8 @@ interface SourceNodeProps {
   childByNodePath: Map<string, Mapping>
   /** Reference children (id-only links) keyed by FK source path. */
   refChildByNodePath: Map<string, Mapping>
+  /** Leaves bound ACROSS a relationship: source path → the flat child + its binding. */
+  drilledBindBySourcePath: Map<string, { child: Mapping; entry: FieldMapping }>
   onAssign: (sourcePath: string, targetKey: string) => void
   /** Per-entry mutations operate on the binding's stable id. */
   onClear: (entryId: string) => void
@@ -626,6 +954,14 @@ interface SourceNodeProps {
   onLinkRelationship: (node: SourceTreeNode, field: ResourceField, ref: FieldReference) => void
   /** Remove an id-only link (delete its reference child mapping). */
   onClearLink: (refChildId: string) => void
+  /** Bind a leaf ACROSS a relationship — a drilled `FieldPath` (unified picker §2). */
+  onAssignDrilled: (node: SourceTreeNode, field: ResourceField, ref: FieldReference) => void
+  /** Clear a leaf's drilled binding (and its flat child if now empty). */
+  onClearDrilled: (node: SourceTreeNode) => void
+  /** Set / clear a drilled leaf's identity role (routes to the flat child's binding). */
+  onSetDrilledIdentityRole: (node: SourceTreeNode, role: 'externalId' | 'match' | null) => void
+  /** Change a drilled leaf's merge strategy (routes to the flat child's binding). */
+  onDrilledMergeChange: (node: SourceTreeNode, value: string) => void
   // Child-mapping recursion context (forwarded to a nested MappingNode).
   connectorId: string
   streamId: string
@@ -662,6 +998,15 @@ function SourceNode(props: SourceNodeProps) {
   } = props
   const [open, setOpen] = useState(true)
 
+  // Drilled-binding context — a leaf bound ACROSS a relationship (its value writes a
+  // related record). Resolve the related def's label + the bound field's label for the
+  // chip ("Contact › Email"). Hooks run unconditionally (null def when not drilled) so
+  // order stays stable across the branch/leaf early returns below.
+  const drilled = !node.isBranch ? props.drilledBindBySourcePath.get(node.path) : undefined
+  const drilledDefId = drilled?.child.entityDefinitionId ?? null
+  const drilledDef = useResourceProperty(drilledDefId, ['label'])
+  const { fields: drilledDefFields } = useResourceFields(drilledDefId)
+
   // A child mapping at this branch → render it inline (promoted state).
   const childMapping = node.isBranch ? childByNodePath.get(node.path) : undefined
   if (childMapping) {
@@ -697,7 +1042,10 @@ function SourceNode(props: SourceNodeProps) {
           nodes={node.children}
           childDepth={depth + 1}
           isCappable={(n) =>
-            !n.isBranch && !props.sourceToEntry.has(n.path) && !props.refChildByNodePath.has(n.path)
+            !n.isBranch &&
+            !props.sourceToEntry.has(n.path) &&
+            !props.refChildByNodePath.has(n.path) &&
+            !props.drilledBindBySourcePath.has(n.path)
           }
           renderNode={(child) => (
             <SourceNode key={child.path} {...props} node={child} depth={depth + 1} />
@@ -707,15 +1055,36 @@ function SourceNode(props: SourceNodeProps) {
     )
   }
 
-  const entry = sourceToEntry.get(node.path)
-  const assignedTargetKey = entry?.targetFieldRef ?? undefined
-  const assignedLabel = assignedTargetKey
-    ? targetFields.find((f) => refOf(f, mapping.entityDefinitionId) === assignedTargetKey)?.label
+  const directEntry = sourceToEntry.get(node.path)
+  const assignedTargetKey = directEntry?.targetFieldRef ?? undefined
+  const assignedField = assignedTargetKey
+    ? targetFields.find((f) => refOf(f, mapping.entityDefinitionId) === assignedTargetKey)
     : undefined
+  const assignedLabel = assignedField?.label
+  const assignedIconId = fieldIconId(assignedField)
   // Exclude target keys bound elsewhere (keep this leaf's own key selectable).
   const excludeKeys = assignedTargetKey
     ? new Set([...usedTargetKeys].filter((k) => k !== assignedTargetKey))
     : usedTargetKeys
+
+  // A drilled binding (this leaf's value writes a related def, via a flat child) — the
+  // chip reaches across the relationship ("Contact › Email") and the controls route to
+  // the child. Direct and drilled are mutually exclusive on one leaf.
+  let drilledLabel: string | undefined
+  let drilledRef: FieldReference | undefined
+  let drilledIconId: string | undefined
+  if (drilled?.entry.targetFieldRef) {
+    const drilledField = drilledDefFields.find(
+      (f) => refOf(f, drilledDefId) === drilled.entry.targetFieldRef
+    )
+    const fieldLabel =
+      drilledField?.label ?? getFieldId(drilled.entry.targetFieldRef as ResourceFieldId)
+    drilledLabel = `${drilledDef?.label ?? 'Related'} › ${fieldLabel}`
+    drilledIconId = fieldIconId(drilledField)
+    const relRef = keyToFieldRef(drilled.child.relationshipFieldKey ?? '')
+    const relSegs = isFieldPath(relRef) ? relRef : [relRef as ResourceFieldId]
+    drilledRef = toFieldPath([...relSegs, drilled.entry.targetFieldRef as ResourceFieldId])
+  }
 
   // Id-only relationship link (§9.6a Case B): a `reference` child mapping on this
   // leaf path links the FK to a relationship. Independent of the scalar binding —
@@ -729,10 +1098,12 @@ function SourceNode(props: SourceNodeProps) {
     : undefined
   // `linkedField` was matched on refKey, so its canonical ref IS refKey.
   const linkedFieldRef = linkedField ? refKey : undefined
-  // The current identity role on this leaf (External ID anchor / secondary Match).
-  const identityRole = entry?.identityRole?.kind ?? null
-  // Relationships are linkable on a SCALAR FK leaf only (array fan-out is a branch
-  // drill, not a leaf link), once a target def is set.
+  // The active binding (drilled child's entry, else the direct entry) drives the
+  // identity-role + merge controls.
+  const activeEntry = drilled?.entry ?? directEntry
+  const identityRole = activeEntry?.identityRole?.kind ?? null
+  // Relationships are linkable/drillable on a SCALAR leaf only (array fan-out is a
+  // branch drill), once a target def is set.
   const allowRelationships = node.type !== 'array' && !!mapping.entityDefinitionId
 
   return (
@@ -742,6 +1113,7 @@ function SourceNode(props: SourceNodeProps) {
         node={node}
         entityDefinitionId={mapping.entityDefinitionId}
         assignedLabel={assignedLabel}
+        assignedIconId={drilledIconId ?? assignedIconId}
         assignedTargetKey={assignedTargetKey}
         excludeKeys={excludeKeys}
         // Quick-create is available whenever a target def is set — both owned
@@ -751,14 +1123,24 @@ function SourceNode(props: SourceNodeProps) {
         canCreate={!!mapping.entityDefinitionId}
         isOwned={targetMode === 'owned'}
         identityRole={identityRole}
-        mergeStrategy={entry?.mergeStrategy ?? 'overwrite'}
+        mergeStrategy={activeEntry?.mergeStrategy ?? 'overwrite'}
         allowRelationships={allowRelationships}
-        syncedDefIds={props.syncedDefIds}
         linkedFieldRef={linkedFieldRef}
+        drilledLabel={drilledLabel}
+        drilledRef={drilledRef}
         onAssign={(targetKey) => onAssign(node.path, targetKey)}
-        onClear={() => entry && onClear(entry.id)}
-        onMergeChange={(value) => entry && onMergeChange(entry.id, value)}
-        onSetIdentityRole={(role) => onSetIdentityRole(node.path, role)}
+        onDrilledAssign={(field, ref) => props.onAssignDrilled(node, field, ref)}
+        onClear={() =>
+          drilled ? props.onClearDrilled(node) : directEntry && onClear(directEntry.id)
+        }
+        onMergeChange={(value) =>
+          drilled
+            ? props.onDrilledMergeChange(node, value)
+            : directEntry && onMergeChange(directEntry.id, value)
+        }
+        onSetIdentityRole={(role) =>
+          drilled ? props.onSetDrilledIdentityRole(node, role) : onSetIdentityRole(node.path, role)
+        }
         onLinkRelationship={(field, ref) => props.onLinkRelationship(node, field, ref)}
       />
       {refChild && (
@@ -778,20 +1160,36 @@ function SourceNode(props: SourceNodeProps) {
 
 interface FormulaRowProps {
   depth: number
-  /** The def whose fields the formula can target. Null until a target def is picked. */
+  /** The def the picker drills/binds FROM. Null until a target def is picked. */
   entityDefinitionId: string | null
   /** Target field key this formula currently writes into (`''` if unassigned). */
   targetKey: string
   /** Resolved label for the target field. */
   label: string
+  /** Resolved icon id for the target field (for the picker chip). */
+  iconId?: string
   /** The calc expression (shown on the source button; click it to edit). */
   expression: string
   mergeStrategy: string
   /** Target keys bound by other entries — excluded from the retarget picker. */
   excludeKeys?: Set<string>
+  /** Show relationships in the picker so the formula can drill ACROSS one (§4). */
+  allowRelationships?: boolean
+  /** Chip text when bound across a relationship ("Contact › Full name"). */
+  drilledLabel?: string
+  /** The drilled `FieldPath`, for the picker's selected check on the far field. */
+  drilledRef?: FieldReference
+  /** This formula's identity role (External ID / Match), keyed by entry id (§5.1). */
+  identityRole?: IdentityRole
+  /** Offer the "Match existing" option — needs a bound target to compare against. */
+  canMatch?: boolean
   onEdit: () => void
-  /** Re-point the formula at a different target field key. */
+  /** Re-point the formula at a different ROOT target field key. */
   onRetarget: (newKey: string) => void
+  /** The picker drilled to a far field — bind the computed value across the relationship. */
+  onDrilledAssign?: (ref: FieldReference) => void
+  /** Set / clear this formula's identity role. Absent → no identifier control. */
+  onSetIdentityRole?: (role: IdentityRole) => void
   onMergeChange: (value: string) => void
   onClear: () => void
 }
@@ -802,44 +1200,61 @@ interface FormulaRowProps {
  * source leaf. Mirrors a leaf row: the source cell is a button (showing the calc
  * expression, or "Set formula…") that opens {@link FieldCalcDialog}; the target
  * column is a field picker (a formula produces a scalar — string-typed for the
- * compat filter). No Match toggle (no single source path to match identity on).
+ * compat filter). With {@link allowRelationships} the picker can drill ACROSS a
+ * relationship to write a related def (formula-drill-targets §4). The identity
+ * control (keyed by entry id) marks the computed value as the record's External ID
+ * or a Match key (§5.1) — the runtime evaluates the expression as the key.
  */
 function FormulaRow({
   depth,
   entityDefinitionId,
   targetKey,
   label,
+  iconId,
   expression,
   mergeStrategy,
   excludeKeys,
+  allowRelationships,
+  drilledLabel,
+  drilledRef,
+  identityRole,
+  canMatch,
   onEdit,
   onRetarget,
+  onDrilledAssign,
+  onSetIdentityRole,
   onMergeChange,
   onClear,
 }: FormulaRowProps) {
   return (
-    <GridTreeRow
-      columns={MAPPING_COLS}
+    <MappingRow
       depth={depth}
       icon={<FunctionSquare className='size-3.5' />}
       // Source cell = a button that opens the formula dialog (shows the expression
-      // when set); target column = the field it writes into.
+      // when set), trailed by the identity key icon; target column = the field it
+      // writes into.
       title={
-        <Button
-          variant='transparent'
-          onClick={onEdit}
-          className={`h-9 w-full justify-start rounded-none px-1 text-xs hover:bg-primary/5 ${
-            expression ? 'font-mono' : 'text-muted-foreground'
-          }`}>
-          <span className='truncate'>{expression || 'Set formula…'}</span>
-        </Button>
+        <span className='flex w-full items-center gap-1'>
+          <Button
+            variant='transparent'
+            onClick={onEdit}
+            className={`h-9 min-w-0 flex-1 justify-start rounded-none px-1 text-xs hover:bg-primary/5 ${
+              expression ? 'font-mono' : 'text-muted-foreground'
+            }`}>
+            <span className='truncate'>{expression || 'Set formula…'}</span>
+          </Button>
+          {onSetIdentityRole && (
+            <IdentityRoleControl
+              role={identityRole ?? null}
+              canMatch={!!canMatch}
+              onChange={onSetIdentityRole}
+            />
+          )}
+        </span>
       }
-      cells={[
-        <span key='arrow' className='flex w-full justify-center text-muted-foreground'>
-          <ArrowRight className='size-3.5' />
-        </span>,
+      arrow='filled'
+      target={
         <MappingFieldPicker
-          key='target'
           entityDefinitionId={entityDefinitionId}
           // A formula has no single source type — it yields a scalar; 'string'
           // drives the (TEXT-compatible) target filter. Quick-create is off; a
@@ -847,21 +1262,102 @@ function FormulaRow({
           sourceType='string'
           sourcePath=''
           assignedKey={targetKey || undefined}
-          assignedLabel={label}
+          // Drilled chip wins; else the field label, or undefined (not '') so the
+          // picker falls back to its "Apply field…" placeholder.
+          assignedLabel={drilledLabel ?? (label || undefined)}
+          assignedIconId={iconId}
+          drilledRef={drilledRef}
           excludeKeys={excludeKeys}
           canCreate={false}
+          allowRelationships={allowRelationships}
           onAssign={onRetarget}
+          // The picker hands back (field, ref); a formula only needs the path.
+          onDrilledAssign={onDrilledAssign ? (_field, ref) => onDrilledAssign(ref) : undefined}
           onClear={onClear}
-        />,
-        <div key='actions' className='flex w-full items-center justify-end gap-1 pr-1'>
-          {/* Right-aligned merge badge → trash, matching the leaf/header rows. No
-              Identifier — a formula has no single source path to match identity on. */}
-          <MergeStrategyToggle value={mergeStrategy} onValueChange={onMergeChange} />
-          <TreeRowButton variant='destructive' tooltipText='Remove formula' onClick={onClear}>
-            <Trash2 />
-          </TreeRowButton>
-        </div>,
-      ]}
+        />
+      }
+      // Right-aligned merge → trash, matching the leaf/header rows. No Identifier —
+      // a formula has no single source path to match identity on.
+      actions={
+        <FieldRowActions
+          mergeStrategy={mergeStrategy}
+          onMergeChange={onMergeChange}
+          onClear={onClear}
+          clearTooltip='Remove formula'
+        />
+      }
+    />
+  )
+}
+
+/**
+ * A formula bound ACROSS a relationship (formula-drill-targets §4): its entry lives
+ * on a flat child mapping, but it renders as a {@link FormulaRow} on the parent whose
+ * picker roots at the PARENT def (so it offers the same drill) and whose chip reaches
+ * across to "Def › Field". Resolves that chip + the far field's icon from the child's
+ * def. Controls route to the child's entry via the handlers from the parent.
+ */
+function DrilledFormulaRow({
+  depth,
+  parentEntityDefinitionId,
+  child,
+  entry,
+  excludeKeys,
+  onSetIdentityRole,
+  onEdit,
+  onRetargetRoot,
+  onDrilledAssign,
+  onMergeChange,
+  onClear,
+}: {
+  depth: number
+  parentEntityDefinitionId: string | null
+  child: Mapping
+  entry: FieldMapping
+  excludeKeys?: Set<string>
+  onSetIdentityRole: (role: IdentityRole) => void
+  onEdit: () => void
+  onRetargetRoot: (newKey: string) => void
+  onDrilledAssign: (ref: FieldReference) => void
+  onMergeChange: (value: string) => void
+  onClear: () => void
+}) {
+  const def = useResourceProperty(child.entityDefinitionId, ['label'])
+  const { fields } = useResourceFields(child.entityDefinitionId)
+  const targetRef = (entry.targetFieldRef ?? null) as ResourceFieldId | null
+  const farField = targetRef
+    ? fields.find((f) => refOf(f, child.entityDefinitionId) === targetRef)
+    : undefined
+  const fieldLabel = targetRef ? (farField?.label ?? getFieldId(targetRef)) : ''
+  const drilledLabel = `${def?.label ?? 'Related'} › ${fieldLabel}`
+  // Rebuild the drilled FieldPath ([rel…, targetRef]) for the picker's selected check.
+  const relRef = keyToFieldRef(child.relationshipFieldKey ?? '')
+  const relSegs = isFieldPath(relRef) ? relRef : [relRef as ResourceFieldId]
+  const drilledRef = targetRef ? toFieldPath([...relSegs, targetRef]) : undefined
+
+  return (
+    <FormulaRow
+      depth={depth}
+      // Root the picker at the PARENT def so it offers the same drill.
+      entityDefinitionId={parentEntityDefinitionId}
+      targetKey={targetRef ?? ''}
+      label={fieldLabel}
+      iconId={fieldIconId(farField)}
+      expression={entry.expression}
+      mergeStrategy={entry.mergeStrategy ?? 'overwrite'}
+      excludeKeys={excludeKeys}
+      allowRelationships={parentEntityDefinitionId != null}
+      drilledLabel={drilledLabel}
+      drilledRef={drilledRef}
+      // External ID here keys the RELATED record (a radio within the flat child).
+      identityRole={entry.identityRole?.kind ?? null}
+      canMatch={targetRef != null}
+      onSetIdentityRole={onSetIdentityRole}
+      onEdit={onEdit}
+      onRetarget={onRetargetRoot}
+      onDrilledAssign={onDrilledAssign}
+      onMergeChange={onMergeChange}
+      onClear={onClear}
     />
   )
 }

--- a/apps/web/src/components/data-connectors/ui/mapping-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-row.tsx
@@ -1,0 +1,119 @@
+// apps/web/src/components/data-connectors/ui/mapping-row.tsx
+'use client'
+
+import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { ArrowRight, Trash2 } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { MAPPING_COLS } from './mapping-columns'
+import { MergeStrategyToggle } from './merge-strategy-toggle'
+
+/**
+ * The `→` arrow state for a mapping row's second column:
+ *  - `filled` — an active edge (bound leaf, header, link)
+ *  - `dim` — the column is present but the row isn't bound yet (unmapped leaf)
+ *  - `none` — no arrow (a passive container with no target action)
+ */
+type ArrowState = 'filled' | 'dim' | 'none'
+
+interface MappingRowProps {
+  depth: number
+  icon?: ReactNode
+  title: ReactNode
+  expandable?: boolean
+  isOpen?: boolean
+  onToggleOpen?: () => void
+  chevronOnHover?: boolean
+  /** The `→` column state (default `none`). */
+  arrow?: ArrowState
+  /** The middle (target) cell — a picker, a def chip, or nothing. */
+  target?: ReactNode
+  /** Trailing action buttons — wrapped in the canonical right-aligned container. */
+  actions?: ReactNode
+  /** Nested rows. */
+  children?: ReactNode
+}
+
+/** The `→` cell, rendered from the {@link ArrowState} enum. */
+function ArrowCell({ state }: { state: ArrowState }) {
+  if (state === 'none') return <span className='flex w-full justify-center' />
+  return (
+    <span
+      className={`flex w-full justify-center ${
+        state === 'filled' ? 'text-muted-foreground' : 'text-muted-foreground/40'
+      }`}>
+      <ArrowRight className='size-3.5' />
+    </span>
+  )
+}
+
+/**
+ * The shared scaffold for every row in the mapping editor tree. Wraps
+ * {@link GridTreeRow} with {@link MAPPING_COLS} and owns the two cells every row
+ * was hand-rolling — the `→` arrow (driven by the {@link ArrowState} enum) and the
+ * right-aligned actions container — so a row only supplies its distinct `title`,
+ * `target`, and action buttons. Keeps the arrow/target columns aligned at every
+ * depth without each row re-declaring the boilerplate.
+ */
+export function MappingRow({
+  depth,
+  icon,
+  title,
+  expandable,
+  isOpen,
+  onToggleOpen,
+  chevronOnHover,
+  arrow = 'none',
+  target,
+  actions,
+  children,
+}: MappingRowProps) {
+  return (
+    <GridTreeRow
+      columns={MAPPING_COLS}
+      depth={depth}
+      icon={icon}
+      title={title}
+      expandable={expandable}
+      isOpen={isOpen}
+      onToggleOpen={onToggleOpen}
+      chevronOnHover={chevronOnHover}
+      cells={[
+        <ArrowCell key='arrow' state={arrow} />,
+        target ?? null,
+        <div key='actions' className='flex w-full items-center justify-end gap-1 pr-1'>
+          {actions}
+        </div>,
+      ]}>
+      {children}
+    </GridTreeRow>
+  )
+}
+
+/**
+ * The merge-strategy + clear cluster shared by every field-binding row (source
+ * leaf, formula, drilled formula). The merge toggle only matters on a SHARED def —
+ * an owned mapping is the sole writer, so it hides (an implicit overwrite). The
+ * caller decides WHEN to render it (e.g. a leaf only shows it once mapped).
+ */
+export function FieldRowActions({
+  isOwned = false,
+  mergeStrategy,
+  onMergeChange,
+  onClear,
+  clearTooltip = "Don't map this field",
+}: {
+  isOwned?: boolean
+  mergeStrategy: string
+  onMergeChange: (value: string) => void
+  onClear: () => void
+  clearTooltip?: string
+}) {
+  return (
+    <>
+      {!isOwned && <MergeStrategyToggle value={mergeStrategy} onValueChange={onMergeChange} />}
+      <TreeRowButton variant='destructive' tooltipText={clearTooltip} onClick={onClear}>
+        <Trash2 />
+      </TreeRowButton>
+    </>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/mapping-tree.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-tree.tsx
@@ -3,7 +3,7 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
-import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { TreeRowButton } from '@auxx/ui/components/tree-row'
 import { Braces, Brackets, Hash, Plus } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { ResourcePickerContent } from '~/components/pickers/resource-picker'
@@ -18,8 +18,8 @@ import {
 import { useStreamMutations } from '../hooks/use-stream-mutations'
 import { BranchRow } from './branch-row'
 import { CappedNodeList } from './capped-node-list'
-import { MAPPING_COLS } from './mapping-columns'
 import { MappingNode } from './mapping-node'
+import { MappingRow } from './mapping-row'
 
 type Mapping = RouterOutputs['dataConnector']['listStreams'][number]['mappings'][number]
 
@@ -157,8 +157,7 @@ export function MappingTree({
 
   return (
     <div className='flex flex-col py-1'>
-      <GridTreeRow
-        columns={MAPPING_COLS}
+      <MappingRow
         depth={0}
         expandable
         chevronOnHover
@@ -179,17 +178,13 @@ export function MappingTree({
             )}
           </span>
         }
-        cells={[
-          <span key='arrow' />,
-          <span key='target' />,
-          <div key='actions' className='flex w-full items-center justify-end pr-1'>
-            <CreateMappingAction
-              tooltip='Map whole payload → own record'
-              label={isEmpty ? 'Map record' : undefined}
-              onPick={(defId) => createMapping(rootBase, defId)}
-            />
-          </div>,
-        ]}>
+        actions={
+          <CreateMappingAction
+            tooltip='Map whole payload → own record'
+            label={isEmpty ? 'Map record' : undefined}
+            onPick={(defId) => createMapping(rootBase, defId)}
+          />
+        }>
         {topTree.length === 0 ? (
           <div className='px-3 py-2 text-[11px] text-muted-foreground'>
             No source schema yet — generate or edit the schema above to map fields.
@@ -212,7 +207,7 @@ export function MappingTree({
             )}
           />
         )}
-      </GridTreeRow>
+      </MappingRow>
     </div>
   )
 }
@@ -296,8 +291,7 @@ function TopSourceNode(props: TopSourceNodeProps) {
 function InertLeafRow({ depth, node }: { depth: number; node: SourcePath }) {
   const Icon = node.type === 'array' ? Brackets : Hash
   return (
-    <GridTreeRow
-      columns={MAPPING_COLS}
+    <MappingRow
       depth={depth}
       icon={<Icon className='size-3.5 text-muted-foreground/40' />}
       title={

--- a/apps/web/src/components/data-connectors/ui/relationship-link-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/relationship-link-row.tsx
@@ -2,10 +2,10 @@
 'use client'
 
 import { EntityIcon } from '@auxx/ui/components/icons'
-import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
-import { ArrowRight, Link2, Trash2 } from 'lucide-react'
+import { TreeRowButton } from '@auxx/ui/components/tree-row'
+import { Link2, Trash2 } from 'lucide-react'
 import { useResourceProperty } from '~/components/resources'
-import { MAPPING_COLS } from './mapping-columns'
+import { MappingRow } from './mapping-row'
 
 interface RelationshipLinkRowProps {
   depth: number
@@ -34,8 +34,7 @@ export function RelationshipLinkRow({
 }: RelationshipLinkRowProps) {
   const target = useResourceProperty(targetDefinitionId, ['label', 'icon'])
   return (
-    <GridTreeRow
-      columns={MAPPING_COLS}
+    <MappingRow
       depth={depth}
       icon={<Link2 className='size-3.5 text-muted-foreground' />}
       title={
@@ -44,21 +43,19 @@ export function RelationshipLinkRow({
           <span className='text-[10px] text-muted-foreground/60'>via {viaPath}</span>
         </span>
       }
-      cells={[
-        <span key='arrow' className='flex w-full justify-center text-muted-foreground'>
-          <ArrowRight className='size-3.5' />
-        </span>,
-        // Target column — the related def (implied by the relationship field).
-        <span key='target' className='flex h-9 w-full items-center gap-1.5 px-2 text-xs'>
+      arrow='filled'
+      // Target column — the related def (implied by the relationship field).
+      target={
+        <span className='flex h-9 w-full items-center gap-1.5 px-2 text-xs'>
           {target && <EntityIcon iconId={target.icon ?? 'table'} size='xs' />}
           <span className='truncate'>{target?.label ?? 'record'}</span>
-        </span>,
-        <div key='actions' className='flex w-full items-center justify-end gap-1 pr-1'>
-          <TreeRowButton variant='destructive' tooltipText='Remove link' onClick={onClear}>
-            <Trash2 />
-          </TreeRowButton>
-        </div>,
-      ]}
+        </span>
+      }
+      actions={
+        <TreeRowButton variant='destructive' tooltipText='Remove link' onClick={onClear}>
+          <Trash2 />
+        </TreeRowButton>
+      }
     />
   )
 }

--- a/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
@@ -3,18 +3,14 @@
 
 import type { ResourceField } from '@auxx/lib/resources/client'
 import type { FieldReference } from '@auxx/types/field'
-import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
-import { SimpleTooltip } from '@auxx/ui/components/tooltip'
-import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
-import { cn } from '@auxx/ui/lib/utils'
-import { ArrowRight, Brackets, Check, Hash, KeyRound, Trash2 } from 'lucide-react'
+import { Brackets, Hash } from 'lucide-react'
 import { lastSegment, type SourcePath } from '../hooks/use-source-paths'
-import { MAPPING_COLS } from './mapping-columns'
+import { type IdentityRole, IdentityRoleControl } from './identity-role-control'
 import { MappingFieldPicker } from './mapping-field-picker'
-import { MergeStrategyToggle } from './merge-strategy-toggle'
+import { FieldRowActions, MappingRow } from './mapping-row'
 
 /** The identity role a leaf currently plays (relationship-linking v3 §9.4). */
-export type LeafIdentityRole = 'externalId' | 'match' | null
+export type LeafIdentityRole = IdentityRole
 
 /**
  * Short type token for the leaf badge. Prefers a detected string `format`
@@ -51,6 +47,8 @@ interface SourceLeafRowProps {
   entityDefinitionId: string | null
   /** Resolved label for the bound key (for the chip). */
   assignedLabel: string | undefined
+  /** Resolved icon id for the applied field (direct or drilled) — shown on the chip. */
+  assignedIconId?: string | undefined
   assignedTargetKey: string | undefined
   /** Target keys bound by other entries — excluded from this leaf's picker. */
   excludeKeys?: Set<string>
@@ -63,10 +61,18 @@ interface SourceLeafRowProps {
   identityRole: LeafIdentityRole
   /** Relationship linking — the picker is the entry point; the link renders on a sub-row. */
   allowRelationships?: boolean
-  syncedDefIds?: Set<string>
   /** The currently-linked relationship field's ref, for the picker's selected check. */
   linkedFieldRef?: string
+  /**
+   * Set when this leaf is bound ACROSS a relationship (unified picker §2) — its value
+   * is written onto a related record. {@link drilledLabel} is the chip ("Contact ›
+   * Email"); {@link drilledRef} drives the in-picker selected check on the far field.
+   */
+  drilledLabel?: string
+  drilledRef?: FieldReference
   onAssign: (targetKey: string) => void
+  /** Bind this leaf ACROSS a relationship — a drilled `FieldPath`. */
+  onDrilledAssign?: (field: ResourceField, ref: FieldReference) => void
   onClear: () => void
   onMergeChange: (value: string) => void
   /** Set / clear this leaf's identity role (External ID anchor or secondary Match). */
@@ -86,6 +92,7 @@ export function SourceLeafRow({
   node,
   entityDefinitionId,
   assignedLabel,
+  assignedIconId,
   assignedTargetKey,
   excludeKeys,
   mergeStrategy,
@@ -93,20 +100,21 @@ export function SourceLeafRow({
   isOwned,
   identityRole,
   allowRelationships,
-  syncedDefIds,
   linkedFieldRef,
+  drilledLabel,
+  drilledRef,
   onAssign,
+  onDrilledAssign,
   onClear,
   onMergeChange,
   onSetIdentityRole,
   onLinkRelationship,
 }: SourceLeafRowProps) {
-  const isMapped = !!assignedTargetKey
+  const isMapped = !!assignedTargetKey || !!drilledRef
   const isArray = node.type === 'array'
   const Icon = isArray ? Brackets : Hash
   return (
-    <GridTreeRow
-      columns={MAPPING_COLS}
+    <MappingRow
       depth={depth}
       icon={<Icon className={isMapped ? 'size-3.5' : 'size-3.5 text-muted-foreground/50'} />}
       title={
@@ -128,140 +136,42 @@ export function SourceLeafRow({
           )}
         </span>
       }
-      cells={[
-        // The arrow always shows (the field picker is always present, even when
-        // unbound) — dimmed until a target field is bound.
-        <span
-          key='arrow'
-          className={`flex w-full justify-center ${
-            isMapped ? 'text-muted-foreground' : 'text-muted-foreground/40'
-          }`}>
-          <ArrowRight className='size-3.5' />
-        </span>,
-        // Target column — the field picker fills the cell and blends into the row.
+      // The arrow always shows (the field picker is always present, even when
+      // unbound) — dimmed until a target field is bound.
+      arrow={isMapped ? 'filled' : 'dim'}
+      // Target column — the field picker fills the cell and blends into the row.
+      target={
         <MappingFieldPicker
-          key='target'
+          kind='leaf'
           entityDefinitionId={entityDefinitionId}
           sourceType={node.type}
           sourcePath={node.path}
           sourceFormat={node.format}
           assignedKey={assignedTargetKey}
-          assignedLabel={assignedLabel}
+          assignedLabel={drilledLabel ?? assignedLabel}
+          assignedIconId={assignedIconId}
+          drilledRef={drilledRef}
           excludeKeys={excludeKeys}
           canCreate={canCreate}
           allowRelationships={allowRelationships}
-          syncedDefIds={syncedDefIds}
           linkedFieldRef={linkedFieldRef}
           onAssign={onAssign}
+          onDrilledAssign={onDrilledAssign}
           onClear={onClear}
-          onLinkRelationship={onLinkRelationship}
-        />,
-        // Actions — a right-aligned badge cluster (merge → clear). The identity role
-        // now lives in the title (§9.4), not here.
-        <div key='actions' className='flex w-full items-center justify-end gap-1 pr-1'>
-          {isMapped && (
-            <>
-              {/* Merge strategy only matters when the def is shared. An owned
-                  mapping is the sole writer, so every field is an implicit
-                  overwrite — no toggle. */}
-              {!isOwned && (
-                <MergeStrategyToggle value={mergeStrategy} onValueChange={onMergeChange} />
-              )}
-              <TreeRowButton
-                variant='destructive'
-                tooltipText="Don't map this field"
-                onClick={onClear}>
-                <Trash2 />
-              </TreeRowButton>
-            </>
-          )}
-        </div>,
-      ]}
-    />
-  )
-}
-
-/**
- * The unified identity-role control (relationship-linking v3 §9.4) — one `KeyRound`
- * icon that replaces both the old silent external-id guess and the separate "Match"
- * badge. State is conveyed by visibility + color (the glyph never changes):
- *   • none → hover-reveal, muted;  • External ID → always-on, primary/blue;
- *   • Match → always-on, amber. Click opens a tiny context-aware popover.
- */
-function IdentityRoleControl({
-  role,
-  canMatch,
-  onChange,
-}: {
-  role: LeafIdentityRole
-  canMatch: boolean
-  onChange: (role: LeafIdentityRole) => void
-}) {
-  const tooltip =
-    role === 'externalId'
-      ? 'External ID — the upstream key that dedups this record and anchors its links.'
-      : role === 'match'
-        ? 'Match — a secondary key used to adopt an existing record (external id stays primary).'
-        : 'Mark as an identifier (External ID or Match).'
-  return (
-    <Popover>
-      <SimpleTooltip side='top' delayDuration={500} content={tooltip}>
-        <PopoverTrigger asChild>
-          <button
-            type='button'
-            className={cn(
-              'inline-flex size-4 shrink-0 items-center justify-center rounded-sm transition-colors',
-              role === 'externalId' && 'text-primary',
-              role === 'match' && 'text-amber-500',
-              !role &&
-                'text-muted-foreground/0 group-hover/tree-row:text-muted-foreground/50 hover:text-muted-foreground'
-            )}>
-            <KeyRound className='size-3.5' />
-          </button>
-        </PopoverTrigger>
-      </SimpleTooltip>
-      <PopoverContent align='start' className='w-52 p-1'>
-        <RoleOption label='Not an identifier' active={!role} onClick={() => onChange(null)} />
-        <RoleOption
-          label='External ID'
-          hint='Primary upstream key'
-          active={role === 'externalId'}
-          onClick={() => onChange('externalId')}
+          onSelectRelationship={onLinkRelationship}
         />
-        {canMatch && (
-          <RoleOption
-            label='Match existing'
-            hint='Secondary adoption key'
-            active={role === 'match'}
-            onClick={() => onChange('match')}
+      }
+      // Actions — merge → clear. The identity role now lives in the title (§9.4).
+      actions={
+        isMapped && (
+          <FieldRowActions
+            isOwned={isOwned}
+            mergeStrategy={mergeStrategy}
+            onMergeChange={onMergeChange}
+            onClear={onClear}
           />
-        )}
-      </PopoverContent>
-    </Popover>
-  )
-}
-
-function RoleOption({
-  label,
-  hint,
-  active,
-  onClick,
-}: {
-  label: string
-  hint?: string
-  active: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      type='button'
-      onClick={onClick}
-      className='flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs hover:bg-muted'>
-      <Check className={cn('size-3.5 shrink-0', active ? 'opacity-100' : 'opacity-0')} />
-      <span className='flex flex-col'>
-        <span>{label}</span>
-        {hint && <span className='text-[10px] text-muted-foreground'>{hint}</span>}
-      </span>
-    </button>
+        )
+      }
+    />
   )
 }

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -500,7 +500,13 @@ export const dataConnectorRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      return deleteConnector(ctx.db, ctx.session.organizationId, input.id, input.syncedData)
+      return deleteConnector(
+        ctx.db,
+        ctx.session.organizationId,
+        ctx.session.userId,
+        input.id,
+        input.syncedData
+      )
     }),
 
   syncNow: adminProcedure

--- a/packages/lib/src/data-connectors/map-record.test.ts
+++ b/packages/lib/src/data-connectors/map-record.test.ts
@@ -104,6 +104,31 @@ describe('mapRecord', () => {
     ])
   })
 
+  it('evaluates a multi-source FORMULA as a `match` key (not just one raw field)', () => {
+    const m = mapping({
+      id: 'order',
+      rootPath: '',
+      targetMode: 'contributing',
+      fieldMappings: [
+        // A computed match key over two source fields — the candidate value must be the
+        // EVALUATED expression, not an arbitrary single `sourceFields` path.
+        {
+          id: 'e1',
+          targetFieldRef: 'def1:order_key',
+          expression: 'concat({store}, "-", {order_no})',
+          sourceFields: { store: 'store', order_no: 'order_no' },
+          identityRole: { kind: 'match', normalize: 'none' },
+        },
+      ],
+    })
+
+    const writes = mapRecord([m], source({ store: 'us', order_no: '1001' }))
+
+    expect(writes[0]?.projected?.identityCandidates).toEqual([
+      { targetFieldRef: 'def1:order_key', value: 'us-1001', normalize: 'none' },
+    ])
+  })
+
   it('fans a top-level array payload out via a `[]` root, deriving ids from each element', () => {
     // The generic-rest case: the raw response IS the array; the root mapping
     // selects records with rootPath `[]`, no connector-provided id hint.

--- a/packages/lib/src/data-connectors/map-record.ts
+++ b/packages/lib/src/data-connectors/map-record.ts
@@ -124,10 +124,12 @@ function evaluateFields(mapping: DecodedMapping, subtree: unknown): Record<strin
 /**
  * Resolve a mapping's secondary identity-match values from the source subtree.
  * Every bound field whose `identityRole.kind === 'match'` is a secondary identity
- * key (the external id is always the primary): read its subtree-relative source
- * path (the bare-token binding's single `sourceFields` value) and pair it with the
- * target field key it must equal; the sink normalizes + looks up. No flagged
- * fields → no candidates → the record creates / re-identifies by external id.
+ * key (the external id is always the primary): evaluate its binding's CALC value —
+ * the same `evaluateFieldValue` used for projection + the External ID, so a FORMULA
+ * match key (`concat({store},{order_no})`) works, and a bare token still resolves to
+ * its single source value — and pair it with the target field key it must equal; the
+ * sink normalizes + looks up. No flagged fields → no candidates → the record creates
+ * / re-identifies by external id.
  */
 function identityCandidates(
   mapping: DecodedMapping,
@@ -136,11 +138,9 @@ function identityCandidates(
   const candidates: ProjectedRecord['identityCandidates'] = []
   for (const fm of mapping.fieldMappings) {
     if (fm.identityRole?.kind !== 'match' || fm.targetFieldRef == null) continue
-    const sourcePath = Object.values(fm.sourceFields)[0]
-    if (!sourcePath) continue
     candidates.push({
       targetFieldRef: fm.targetFieldRef,
-      value: getByPath(subtree, sourcePath),
+      value: evaluateFieldValue(fm, subtree),
       normalize: fm.identityRole.normalize,
     })
   }

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -13,6 +13,7 @@ import { generateId } from '@auxx/utils'
 import { and, eq, inArray } from 'drizzle-orm'
 import { getCachedCustomFields, getCachedEntityDefId } from '../cache'
 import { BadRequestError, NotFoundError } from '../errors'
+import { toRecordId } from '../resources/resource-id'
 import { appCatalogStreamSchema, buildContributingMatchBindings } from './app-catalog'
 import { removeConnectorScheduler, syncConnectorScheduler } from './data-connector-scheduler'
 import {
@@ -670,17 +671,17 @@ export type DeleteSyncedDataBehavior = 'keep' | 'archive' | 'delete'
 
 /**
  * Delete a connector. The provisioned def/fields and synced entity records are the
- * user's CRM data — we never auto-delete them. `behavior` governs the bound
- * **owned** EntityInstances (via DataConnectorItem):
+ * user's CRM data — we never auto-delete them. `behavior` governs the entity records
+ * this connector CREATED, identified by the `integrationSource = connector.id` stamp
+ * the sink writes on every minted instance (owned and contributing alike):
  *   - 'keep'    → leave records untouched (default).
- *   - 'archive' → soft-delete the owned instances (set archivedAt).
- *   - 'delete'  → hard-delete the owned instances.
+ *   - 'archive' → soft-delete the created instances (set archivedAt).
+ *   - 'delete'  → hard-delete the created instances.
  *
- * `behavior` applies to OWNED records only. Contributing records belong to the
- * user (the connector only enriched pre-existing Contacts/Tickets), so they are
- * ALWAYS kept regardless of `behavior`; their per-cell
- * `FieldValue.managedByConnectorId` markers are nulled automatically by the FK
- * `set null` when the connector row cascades away.
+ * Records the connector merely ENRICHED — a pre-existing Contact/Ticket it matched
+ * and contributed fields to — carry a different/no `integrationSource`, so they are
+ * ALWAYS kept regardless of `behavior`; their per-cell `FieldValue.managedByConnectorId`
+ * markers are nulled automatically by the FK `set null` when the connector row cascades.
  *
  * The DataConnector row + its streams/mappings/items/runs cascade on delete; the
  * `dataConnectorId` FK on EntityDefinition/CustomField is `set null`, so provisioned
@@ -689,6 +690,7 @@ export type DeleteSyncedDataBehavior = 'keep' | 'archive' | 'delete'
 export async function deleteConnector(
   db: Database,
   organizationId: string,
+  userId: string,
   id: string,
   behavior: DeleteSyncedDataBehavior = 'keep'
 ): Promise<{ success: boolean }> {
@@ -697,49 +699,34 @@ export async function deleteConnector(
   await removeConnectorScheduler(id)
 
   if (behavior !== 'keep') {
-    // archive/delete applies ONLY to OWNED records — the connector created those
-    // (mirror rows). Contributing records belong to the user (the connector merely
-    // enriched existing Contacts/Tickets), so they are ALWAYS kept; their per-cell
+    // archive/delete applies to records THIS connector CREATED — owned mirror rows
+    // AND contributing instances it minted — identified by the instance-level
+    // `integrationSource = connector.id` stamp the sink writes on create. Records the
+    // connector merely enriched (a pre-existing Contact/Ticket it matched) carry a
+    // different/no `integrationSource` and are ALWAYS kept; their per-cell
     // `FieldValue.managedByConnectorId` markers null automatically via the FK.
-    const ownedMappings = await db
-      .select({ id: schema.DataConnectorMapping.id })
-      .from(schema.DataConnectorMapping)
-      .innerJoin(
-        schema.DataConnectorStream,
-        eq(schema.DataConnectorMapping.dataConnectorStreamId, schema.DataConnectorStream.id)
-      )
+    const created = await db
+      .select({ id: schema.EntityInstance.id, defId: schema.EntityInstance.entityDefinitionId })
+      .from(schema.EntityInstance)
       .where(
         and(
-          eq(schema.DataConnectorStream.dataConnectorId, id),
-          eq(schema.DataConnectorMapping.targetMode, 'owned')
+          eq(schema.EntityInstance.organizationId, organizationId),
+          eq(schema.EntityInstance.integrationSource, id)
         )
       )
-    const ownedMappingIds = ownedMappings.map((m) => m.id)
-
-    if (ownedMappingIds.length > 0) {
-      const items = await db.query.DataConnectorItem.findMany({
-        where: and(
-          eq(schema.DataConnectorItem.dataConnectorId, id),
-          inArray(schema.DataConnectorItem.mappingId, ownedMappingIds)
-        ),
-        columns: { entityInstanceId: true },
-      })
-      const instanceIds = items
-        .map((i) => i.entityInstanceId)
-        .filter((v): v is string => v !== null)
-      if (instanceIds.length > 0) {
-        if (behavior === 'archive') {
-          for (const instanceId of instanceIds) {
-            await db
-              .update(schema.EntityInstance)
-              .set({ archivedAt: new Date() })
-              .where(eq(schema.EntityInstance.id, instanceId))
-          }
-        } else {
-          for (const instanceId of instanceIds) {
-            await db.delete(schema.EntityInstance).where(eq(schema.EntityInstance.id, instanceId))
-          }
-        }
+    if (created.length > 0) {
+      // Route through the UnifiedCrudHandler (NOT a raw db.delete) so each record
+      // archive/delete fires the same side-effects as a UI delete: FieldValue cleanup,
+      // comment removal, pre-delete hooks, snapshot invalidation, and the domain +
+      // realtime (`record:archived` / `record:deleted`) events. Lazy-imported so the
+      // pure-helper exports of this module stay loadable without the crud chain.
+      const { UnifiedCrudHandler } = await import('../resources/crud/unified-handler')
+      const crud = new UnifiedCrudHandler(organizationId, userId, db)
+      const recordIds = created.map((r) => toRecordId(r.defId, r.id))
+      if (behavior === 'archive') {
+        await crud.bulkArchive(recordIds)
+      } else {
+        await crud.bulkDelete(recordIds)
       }
     }
   }
@@ -935,13 +922,14 @@ function deriveLinkMode(
   fallback: LinkMode
 ): LinkMode {
   if (!parentMappingId || !relationshipFieldKey) return fallback
-  const writesNonId = fieldMappings.some(
-    (fm) =>
-      fm.targetFieldRef != null &&
-      fm.identityRole?.kind !== 'externalId' &&
-      (fm.mergeStrategy ?? 'overwrite') !== 'ignore'
+  // A binding to a real target field means we WRITE/contribute the related record
+  // (upsert) — even when that field is ALSO the External ID (e.g. a drilled
+  // `email → Contact.Email` keyed by email). Only a TARGET-LESS External-ID anchor
+  // (point-at-someone-else's record by id, `targetFieldRef: null`) keeps it `reference`.
+  const writesField = fieldMappings.some(
+    (fm) => fm.targetFieldRef != null && (fm.mergeStrategy ?? 'overwrite') !== 'ignore'
   )
-  if (writesNonId) return 'upsert'
+  if (writesField) return 'upsert'
   // `reference` (point at someone else's record by id) is only meaningful once an
   // External ID anchor is designated. A freshly-drilled, still-unconfigured branch
   // has neither fields nor an anchor — treat it as `upsert` so it never trips the

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -481,10 +481,13 @@ export const entitySink: EntitySink = {
         const created = await handler.create(mapping.entityDefinitionId, writeSet, {
           skipSnapshotInvalidation: true,
           skipEvents: true,
-          provenance:
-            mapping.targetMode === 'owned'
-              ? { integrationSource: ctx.connector.id, externalId: record.externalId }
-              : undefined,
+          // Stamp instance-level provenance on every connector-CREATED record — owned
+          // AND contributing alike. This is the durable "this connector minted this
+          // instance" marker that lets connector deletion delete the records it created
+          // (a connector that provisions its own def, or contributing that mints a brand
+          // new instance) while leaving records it merely ENRICHED (a pre-existing
+          // Contact it matched by email — no/other integrationSource) untouched.
+          provenance: { integrationSource: ctx.connector.id, externalId: record.externalId },
         })
         instanceId = created.instance.id
         ctx.counters.created += 1

--- a/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.test.ts
+++ b/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.test.ts
@@ -15,6 +15,8 @@ vi.mock('@auxx/database', () => ({
       DataConnector: { findMany: (...a: unknown[]) => findManyConnectors(...a) },
       DataConnectorStream: { findMany: (...a: unknown[]) => findManyStreams(...a) },
     },
+    // `markWebhookEventReceived` stamps `lastWebhookEventAt` for every touched connector.
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
   },
   schema: new Proxy({}, { get: () => new Proxy({}, { get: () => ({}) }) }),
 }))

--- a/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.test.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.test.ts
@@ -8,11 +8,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const findManyConnectors = vi.fn()
 const findManyStreams = vi.fn()
+const updateSet = vi.fn()
 vi.mock('@auxx/database', () => ({
   database: {
     query: {
       DataConnector: { findMany: (...a: unknown[]) => findManyConnectors(...a) },
       DataConnectorStream: { findMany: (...a: unknown[]) => findManyStreams(...a) },
+    },
+    // `markWebhookEventReceived` stamps `lastWebhookEventAt` for every touched connector.
+    update: (...a: unknown[]) => {
+      updateSet(...a)
+      return { set: () => ({ where: async () => undefined }) }
     },
   },
   // Column refs are only fed to the (ignored) where-builder — any object works.
@@ -159,12 +165,33 @@ describe('dispatchWebhookEndpointToConnectors', () => {
     expect(queueAdd).not.toHaveBeenCalled()
   })
 
-  it('skips streams with no steering block and streams whose filter rejects the payload', async () => {
+  it('full-syncs a connector whose only stream has no steering block (signal-only binding)', async () => {
+    // The user's scenario: connector signal bound, stream is just `GET /orders` with no
+    // per-stream `webhookTrigger`. A delivery must still full-sync it (no `{path}` ⇒ not
+    // steerable) and yield a run-history row — the connector-level signal IS the binding.
     findManyConnectors.mockResolvedValue([
       { id: 'dc1', config: { webhookTrigger: { webhookEndpointId: 'ep1' } } },
     ])
     findManyStreams.mockResolvedValue([
-      { dataConnectorId: 'dc1', streamKey: 'a', requestConfig: {} }, // no webhookTrigger
+      { dataConnectorId: 'dc1', streamKey: 'orders', requestConfig: { path: '/orders' } },
+    ])
+    const result = await dispatchWebhookEndpointToConnectors(job(base))
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 1 })
+    expect(queueAdd).not.toHaveBeenCalled()
+    expect(enqueueConnectorSync).toHaveBeenCalledTimes(1)
+    expect(enqueueConnectorSync.mock.calls[0]?.[0]).toMatchObject({
+      connectorId: 'dc1',
+      organizationId: 'org1',
+      trigger: 'webhook',
+    })
+  })
+
+  it('full-syncs a no-steering stream but skips a sibling whose filter rejects the payload', async () => {
+    findManyConnectors.mockResolvedValue([
+      { id: 'dc1', config: { webhookTrigger: { webhookEndpointId: 'ep1' } } },
+    ])
+    findManyStreams.mockResolvedValue([
+      { dataConnectorId: 'dc1', streamKey: 'a', requestConfig: {} }, // no webhookTrigger → match-all
       {
         dataConnectorId: 'dc1',
         streamKey: 'b',
@@ -172,8 +199,9 @@ describe('dispatchWebhookEndpointToConnectors', () => {
       },
     ])
     const result = await dispatchWebhookEndpointToConnectors(job(base))
-    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 0 })
-    expect(enqueueConnectorSync).not.toHaveBeenCalled()
+    // Stream `a` full-syncs dc1 (one connector ⇒ count 1); `b`'s filter rejects orders/create.
+    expect(result).toEqual({ steerJobs: 0, connectorsFullSynced: 1 })
+    expect(enqueueConnectorSync).toHaveBeenCalledTimes(1)
     expect(queueAdd).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
@@ -2,8 +2,10 @@
 // The connector-sink leg of the generic WebhookEndpoint fan-out (unified-trigger-picker
 // §4.4). Sibling to `dispatchAppTriggerToConnectors` (the APP-trigger leg) and to the
 // workflow/agent `dispatchWebhookEndpoint*` jobs: one verified endpoint delivery → a sync of
-// every webhook-sync DataConnector bound to this `webhookEndpointId` with ≥1 stream whose
-// `filter` matches the payload. THIN — dedup + match + route by mode: steerable streams
+// every webhook-sync DataConnector bound to this `webhookEndpointId`. The connector-level signal
+// IS the binding; a stream reacts unless its OWN `webhookTrigger.filter` excludes the topic (a
+// stream with no steering block matches every topic). THIN — dedup + match + route by mode:
+// steerable streams
 // (`{path}` set) get a per-stream steer job (targeted PARTIAL run), non-steerable cursor
 // streams get the full `enqueueConnectorSync`. Either way the delivery yields a
 // `DataConnectorRun` history row + refreshed `lastSyncedAt`.
@@ -111,13 +113,17 @@ export async function dispatchWebhookEndpointToConnectors(
   // A connector with ANY non-steerable matched stream full-syncs (superset covers the rest).
   const matched: { connectorId: string; streamKey: string; steerable: boolean }[] = []
   for (const stream of streams) {
+    if (!stream.streamKey) continue
+    // The connector-level signal is the binding; per-stream `webhookTrigger` only REFINES it.
+    // A stream with no steering block still reacts: no `filter` ⇒ matches every topic
+    // (`matchesFilter` treats absent/empty as match-all), no `paths` ⇒ not steerable ⇒ a full
+    // run-based sync. Adding `{path}` paths upgrades it to a targeted partial (steered) run.
     const wt = stream.requestConfig?.webhookTrigger
-    if (!stream.streamKey || !wt) continue
-    if (!matchesFilter(wt.filter, matchData)) continue
+    if (!matchesFilter(wt?.filter, matchData)) continue
     matched.push({
       connectorId: stream.dataConnectorId,
       streamKey: stream.streamKey,
-      steerable: (wt.paths?.length ?? 0) > 0,
+      steerable: (wt?.paths?.length ?? 0) > 0,
     })
   }
 


### PR DESCRIPTION
## Problem

Deleting a data connector with **"delete synced records"** (or **archive**) left the synced records in place — they just lost their per-cell "synced" icon. Root cause: `deleteConnector` only touched records bound through `owned` mappings, but the relationship-linking redesign moved connector-created records onto `contributing` mappings. So the destructive choice silently did nothing for them; the icon vanished only because `FieldValue.managedByConnectorId` nulls via its `onDelete: set null` FK when the connector row cascades.

## Fix

- **`entity-sink.ts`** — stamp `integrationSource = connector.id` on **every instance the connector creates** (owned *and* contributing), not just owned. This is the durable "this connector minted this record" marker, distinguishing records the connector *created* from records it merely *enriched* (a pre-existing Contact it matched — left untouched).
- **`mutations.ts` `deleteConnector`** — collect instances by that stamp and route them through `UnifiedCrudHandler.bulkDelete` / `bulkArchive` (the same path as a UI delete) instead of a raw `db.delete`/`db.update`. Now FieldValue cleanup, comment removal, pre-delete hooks, snapshot invalidation, and domain + realtime (`record:deleted` / `record:archived`) events all fire. The acting `userId` is threaded through (`ctx.session.userId`) for event attribution. Records are processed before the `DataConnector` row is dropped.

## Also in this PR

Relationship-linking redesign UI follow-ups (mapping node/rows, field picker, new `identity-role-control` and `mapping-row`, `field-mapping-edits` helper + tests) and webhook-endpoint sync-dispatch-job tweaks.

## Testing

- `vitest run src/data-connectors` — 183/183 pass.
- Manually cleared the one stamped orphan left by a pre-fix delete via SQL (FieldValues + instance). Pre-fix leftover records have no `integrationSource` and can't be traced to a connector, so they remain (cleanable by def id if desired).

## Notes

`bulkDelete` loops per-record synchronously in the request — fine at current scale, but a connector that created thousands of records would warrant moving this to a worker job later.