### PR TITLE
fix(data-connectors): separate webhook steering from syncMode

### DIFF
--- a/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
@@ -176,15 +176,14 @@ export function StreamConfigPanel({
     isSavingRequest,
     request.commit
   )
-  const rawSyncMode = (stream.syncMode as 'snapshot' | 'incremental' | 'webhook') ?? 'snapshot'
-  // The picker only exposes snapshot/incremental; treat webhook as snapshot here.
   const syncMode: 'snapshot' | 'incremental' =
-    rawSyncMode === 'incremental' ? 'incremental' : 'snapshot'
+    stream.syncMode === 'incremental' ? 'incremental' : 'snapshot'
 
-  // Webhook streams steer the fetch with `{path}` placeholders declared in the
-  // Webhook steering section. Token-enable the request fields (URL + header/param
-  // values) so those paths are insertable via the `{` picker, not hand-typed.
-  const isWebhook = rawSyncMode === 'webhook'
+  // Webhook-driven connectors steer the fetch with `{path}` placeholders declared in the
+  // Webhook steering section. Token-enable the request fields (URL + header/param values)
+  // so those paths are insertable via the `{` picker, not hand-typed. Gated on the
+  // connector's trigger type — steering is orthogonal to syncMode (completeness).
+  const isSteered = connector.syncBehavior === 'webhook'
   const steeringPaths = useMemo<string[]>(() => {
     const wt = (stream.requestConfig as { webhookTrigger?: { paths?: string[] } } | null)
       ?.webhookTrigger
@@ -277,7 +276,7 @@ export function StreamConfigPanel({
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </InputGroupAddon>
-                {isWebhook ? (
+                {isSteered ? (
                   <div className='flex-1'>
                     <tokenFieldContext.FieldEditor
                       value={request.value.path}
@@ -323,7 +322,7 @@ export function StreamConfigPanel({
                   <RecordKeyValueEditor
                     record={request.value.headers}
                     onChange={(headers) => request.set({ ...request.value, headers })}
-                    fieldContext={isWebhook ? tokenFieldContext : undefined}
+                    fieldContext={isSteered ? tokenFieldContext : undefined}
                   />
                 </RequestEditorBlock>
               )}
@@ -332,7 +331,7 @@ export function StreamConfigPanel({
                   <RecordKeyValueEditor
                     record={request.value.params}
                     onChange={(params) => request.set({ ...request.value, params })}
-                    fieldContext={isWebhook ? tokenFieldContext : undefined}
+                    fieldContext={isSteered ? tokenFieldContext : undefined}
                   />
                 </RequestEditorBlock>
               )}

--- a/apps/web/src/components/data-connectors/ui/webhook-steering-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/webhook-steering-section.tsx
@@ -262,11 +262,12 @@ function WebhookSteeringEditor({ connector, stream }: { connector: Connector; st
         : {}),
     }
     const existing = (stream.requestConfig ?? {}) as Record<string, unknown>
+    // Steering lives in `requestConfig.webhookTrigger`; `syncMode` stays the completeness
+    // axis (snapshot/incremental) so a steered stream can still reconcile on its sweeps.
     return setStreamRequestConfig
       .mutateAsync({
         streamId: stream.id,
         requestConfig: { ...existing, webhookTrigger },
-        syncMode: 'webhook',
       })
       .then(() => utils.dataConnector.listStreams.invalidate({ id: connector.id }))
   }

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -693,7 +693,7 @@ export const dataConnectorRouter = createTRPCRouter({
         streamKey: z.string().min(1).nullish(),
         sourceSchema: z.record(z.string(), z.unknown()).nullish(),
         schemaSource: z.enum(['catalog', 'inferred', 'manual']).optional(),
-        syncMode: z.enum(['snapshot', 'incremental', 'webhook']).optional(),
+        syncMode: z.enum(['snapshot', 'incremental']).optional(),
         requestConfig: requestConfigSchema.nullish(),
         enabled: z.boolean().optional(),
       })
@@ -727,7 +727,7 @@ export const dataConnectorRouter = createTRPCRouter({
       z.object({
         streamId: z.string(),
         requestConfig: requestConfigSchema,
-        syncMode: z.enum(['snapshot', 'incremental', 'webhook']).optional(),
+        syncMode: z.enum(['snapshot', 'incremental']).optional(),
         enabled: z.boolean().optional(),
       })
     )

--- a/packages/database/src/db/schema/data-connector-stream.ts
+++ b/packages/database/src/db/schema/data-connector-stream.ts
@@ -41,7 +41,10 @@ export const DataConnectorStream = pgTable(
     // from the target (owned/contributing is per-mapping) — so no `existing` tag here.
     schemaSource: text().default('catalog').notNull(), // 'catalog' | 'inferred' | 'manual'
 
-    syncMode: text().default('snapshot').notNull(), // 'snapshot' | 'incremental' | 'webhook'
+    // Completeness strategy for full runs (gates orphan reconciliation). Webhook steering is
+    // an orthogonal trigger concern (syncBehavior='webhook' + requestConfig.webhookTrigger),
+    // NOT a sync mode — see SyncMode in @auxx/lib data-connectors/types.
+    syncMode: text().default('snapshot').notNull(), // 'snapshot' | 'incremental'
 
     // Per-stream request config (generic-rest only).
     requestConfig: jsonb().$type<StreamRequestConfig>(),

--- a/packages/lib/src/data-connectors/connectors/generic-rest.ts
+++ b/packages/lib/src/data-connectors/connectors/generic-rest.ts
@@ -23,6 +23,7 @@ import {
   type FetchResult,
   type PaginationSpec,
   PaginationStalledError,
+  PermanentSteerError,
   type StreamIncrementalConfig,
   type StreamRequestConfig,
 } from './types'
@@ -96,7 +97,9 @@ function assertResolved(parts: unknown[]): void {
   for (const part of parts) collectStringLeaves(part, leaves)
   const unresolved = leaves.flatMap(unresolvedPlaceholders)
   if (unresolved.length > 0) {
-    throw new Error(
+    // Deterministic: the same delivery fails identically on retry — flag it permanent so the
+    // steer job dead-letters immediately instead of burning bounded retries.
+    throw new PermanentSteerError(
       `generic-rest: unresolved webhook token(s) {${[...new Set(unresolved)].join('}, {')}} — ` +
         'the steering payload path returned no value'
     )

--- a/packages/lib/src/data-connectors/connectors/index.ts
+++ b/packages/lib/src/data-connectors/connectors/index.ts
@@ -23,4 +23,4 @@ export type {
   StreamIncrementalConfig,
   StreamRequestConfig,
 } from './types'
-export { ConnectorRateLimitError, isConnectorCheckpoint } from './types'
+export { ConnectorRateLimitError, isConnectorCheckpoint, PermanentSteerError } from './types'

--- a/packages/lib/src/data-connectors/connectors/types.ts
+++ b/packages/lib/src/data-connectors/connectors/types.ts
@@ -22,4 +22,9 @@ export type {
   StreamIncrementalConfig,
   StreamRequestConfig,
 } from '../types'
-export { ConnectorRateLimitError, isConnectorCheckpoint, PaginationStalledError } from '../types'
+export {
+  ConnectorRateLimitError,
+  isConnectorCheckpoint,
+  PaginationStalledError,
+  PermanentSteerError,
+} from '../types'

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -63,6 +63,7 @@ export {
   fixtureConnector,
   genericRestConnector,
   isConnectorCheckpoint,
+  PermanentSteerError,
 } from './connectors'
 export type { BackfillSliceJobData, DataConnectorSyncJobData } from './data-connector-queue'
 // Queue + scheduler

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -49,6 +49,7 @@ import type {
   SyncMode,
   TargetMode,
 } from './types'
+import { requiredSteerTokens } from './webhook-steer'
 
 const logger = createScopedLogger('data-connector-mutations')
 
@@ -739,6 +740,25 @@ export async function deleteConnector(
 
 // ── Streams ─────────────────────────────────────────────────────────────────
 
+/**
+ * Reject a steering config whose request template references a `{token}` not declared in
+ * the steering `paths`. At runtime such a token never resolves (the steer context is built
+ * only from the declared paths), so the fetch would fail `assertResolved` on EVERY delivery
+ * and dead-letter silently. Catching it at save turns that footgun into an edit-time error.
+ */
+function assertSteeringConfigValid(requestConfig: StreamRequestConfig | null | undefined): void {
+  const wt = requestConfig?.webhookTrigger
+  if (!wt || (wt.paths?.length ?? 0) === 0) return
+  const declared = new Set(wt.paths)
+  const missing = requiredSteerTokens(requestConfig).filter((t) => !declared.has(t))
+  if (missing.length > 0) {
+    throw new BadRequestError(
+      `Webhook steering references undeclared token(s) {${missing.join('}, {')}}. ` +
+        'Add them to the steering payload paths, or remove them from the request.'
+    )
+  }
+}
+
 export interface AddStreamInput {
   /** Omitted for a blank, not-yet-named stream — the user names it inline later. */
   streamKey?: string | null
@@ -757,6 +777,7 @@ export async function addStream(
   input: AddStreamInput
 ): Promise<DataConnectorStreamRow> {
   await loadConnectorRow(db, organizationId, dataConnectorId)
+  assertSteeringConfigValid(input.requestConfig)
   const [row] = await db
     .insert(schema.DataConnectorStream)
     .values({
@@ -847,6 +868,7 @@ export async function setStreamRequestConfig(
   streamId: string,
   input: { requestConfig: StreamRequestConfig; syncMode?: SyncMode; enabled?: boolean }
 ): Promise<DataConnectorStreamRow> {
+  assertSteeringConfigValid(input.requestConfig)
   return db.transaction(async (tx) => {
     const existing = await loadStreamRow(tx, organizationId, streamId)
     const impact = classifyStreamRequestChange(existing, input)

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -329,6 +329,19 @@ export class PaginationStalledError extends Error {
   }
 }
 
+/**
+ * A deterministic, non-retriable failure of a webhook-steered fetch — e.g. a payload path
+ * that returned no value, leaving an unresolved `{token}` in the request. Replaying the same
+ * delivery fails identically, so the steer job dead-letters it on the FIRST attempt instead
+ * of burning the bounded BullMQ retries (which are meant for transient 5xx/network errors).
+ */
+export class PermanentSteerError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PermanentSteerError'
+  }
+}
+
 /** A connector fetch result — a stream of records (+ resume checkpoints) plus the next cursor. */
 export interface FetchResult {
   records: AsyncIterable<ConnectorYield>
@@ -559,7 +572,14 @@ export interface ResyncPending {
 
 export type LinkMode = 'upsert' | 'reference'
 export type TargetMode = 'owned' | 'contributing'
-export type SyncMode = 'snapshot' | 'incremental' | 'webhook'
+/**
+ * A stream's completeness strategy for FULL (backfill/sweep/scheduled/manual) runs, which
+ * also gates orphan reconciliation: `snapshot` re-crawls everything every run (absence =
+ * deletion → reconcile), `incremental` fetches watermark deltas (absence ≠ deletion → no
+ * reconcile unless a sweep). Webhook-steered partial runs are an orthogonal, per-delivery
+ * trigger concern (`syncBehavior='webhook'` + per-stream steering config) — NOT a sync mode.
+ */
+export type SyncMode = 'snapshot' | 'incremental'
 export type OrphanBehavior = 'archive' | 'mark_deleted' | 'ignore'
 
 // ── Scheduled-trigger config (jsonb on DataConnector) ─────────────────────────

--- a/packages/lib/src/data-connectors/webhook-steer.ts
+++ b/packages/lib/src/data-connectors/webhook-steer.ts
@@ -4,11 +4,12 @@
 // whether this event is a DELETE (skip the fetch, archive by externalId) or a
 // FETCH (extract `{path}` values to steer the regular connector fetch at, then
 // sink the FETCH result). Kept free of DB/connector deps so it unit-tests on plain
-// payload fixtures. NOTE: not currently wired into the sync path — webhook deliveries now
-// steer a full run-based sync (see dispatchAppTriggerToConnectors); retained for a future
-// targeted point-write mode that fetches only the changed record via `{path}` steering.
+// payload fixtures. `resolveWebhookSteer` drives the steered partial run
+// (runWebhookSteeredRun); `isSteerableDelivery` drives the dispatch-time decision
+// of whether a delivery steers a partial run or falls through to a full sync.
 
-import type { StreamWebhookTrigger } from './connectors/types'
+import { unresolvedPlaceholders } from '@auxx/utils'
+import type { StreamRequestConfig, StreamWebhookTrigger } from './connectors/types'
 
 /** A resolved steering directive for one webhook delivery. */
 export type WebhookSteer =
@@ -73,4 +74,52 @@ export function resolveWebhookSteer(
     if (value !== undefined && value !== null) triggerContext[path] = scalar(value)
   }
   return { kind: 'fetch', triggerContext }
+}
+
+/** Collect every string leaf of a value (depth-first) for placeholder scanning. */
+function collectStringLeaves(value: unknown, acc: string[]): void {
+  if (typeof value === 'string') acc.push(value)
+  else if (Array.isArray(value)) for (const item of value) collectStringLeaves(item, acc)
+  else if (value && typeof value === 'object')
+    for (const v of Object.values(value)) collectStringLeaves(v, acc)
+}
+
+/**
+ * Every `{token}` the steered request template references across path/params/headers/body.
+ * These are exactly the placeholders the fetch's `assertResolved` would reject if a payload
+ * path returned nothing — lifted here so the dispatcher can decide steerability BEFORE
+ * opening a run, and the save path can validate the template against the declared paths.
+ */
+export function requiredSteerTokens(
+  requestConfig: StreamRequestConfig | null | undefined
+): string[] {
+  if (!requestConfig) return []
+  const leaves: string[] = []
+  collectStringLeaves(requestConfig.path, leaves)
+  collectStringLeaves(requestConfig.params, leaves)
+  collectStringLeaves(requestConfig.headers, leaves)
+  collectStringLeaves(requestConfig.body, leaves)
+  return [...new Set(leaves.flatMap(unresolvedPlaceholders))]
+}
+
+/**
+ * Can THIS delivery steer a targeted partial fetch on this stream? True iff the stream
+ * declares steering (`{path}` paths, or a delete predicate) AND the delivery resolves
+ * everything the request needs:
+ *   • delete → the externalId path resolved (else there's nothing to archive);
+ *   • fetch  → every `{token}` in the request template resolved from the payload.
+ * A stream with no steering, or a delivery missing a required token, is NOT steerable — the
+ * caller routes it to a full run-based sync instead of opening a doomed partial run (which
+ * would otherwise fail `assertResolved` and dead-letter).
+ */
+export function isSteerableDelivery(
+  requestConfig: StreamRequestConfig | null | undefined,
+  triggerData: Record<string, unknown>
+): boolean {
+  const wt = requestConfig?.webhookTrigger
+  if (!wt) return false
+  const steer = resolveWebhookSteer(wt, triggerData)
+  if (steer.kind === 'delete') return steer.externalId != null
+  if ((wt.paths?.length ?? 0) === 0) return false
+  return requiredSteerTokens(requestConfig).every((t) => t in steer.triggerContext)
 }

--- a/packages/lib/src/data-migrations/migrations/028-data-connector-stream-syncmode-webhook.ts
+++ b/packages/lib/src/data-migrations/migrations/028-data-connector-stream-syncmode-webhook.ts
@@ -1,0 +1,34 @@
+// packages/lib/src/data-migrations/migrations/028-data-connector-stream-syncmode-webhook.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-028')
+
+/**
+ * Retire the `'webhook'` value of `DataConnectorStream.syncMode`. Steering is now an
+ * orthogonal trigger concern (`syncBehavior='webhook'` + `requestConfig.webhookTrigger`),
+ * not a completeness mode — see SyncMode in @auxx/lib data-connectors/types and
+ * plans/data-connectors/v3/steered-vs-full-run-determination.md.
+ *
+ * The UI already treated `'webhook'` as snapshot ("treat webhook as snapshot here"), so
+ * folding these rows to `'snapshot'` preserves the intended completeness AND unlocks orphan
+ * reconciliation on their sweeps (the old `'webhook'` value silently skipped it). Idempotent:
+ * only touches rows still set to `'webhook'`.
+ */
+export const migration028DataConnectorStreamSyncModeWebhook: DataMigrationDef = {
+  id: '028-data-connector-stream-syncmode-webhook',
+  description: "Fold DataConnectorStream.syncMode='webhook' rows to 'snapshot'",
+  async run(db: Database): Promise<void> {
+    const result = await db.execute(sql`
+      UPDATE "DataConnectorStream"
+         SET "syncMode" = 'snapshot'
+       WHERE "syncMode" = 'webhook'
+    `)
+    logger.info('Folded webhook syncMode streams to snapshot', {
+      rowCount: (result as { rowCount?: number | null }).rowCount ?? 0,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -5,6 +5,7 @@ import { migration024VerifyCredentialV2Backfill } from './migrations/024-verify-
 import { migration025ReseedPlatformProviders } from './migrations/025-reseed-platform-providers'
 import { migration026NormalizeChannelCredentials } from './migrations/026-normalize-channel-credentials'
 import { migration027BackfillCredentialDefinitionFk } from './migrations/027-backfill-credential-definition-fk'
+import { migration028DataConnectorStreamSyncModeWebhook } from './migrations/028-data-connector-stream-syncmode-webhook'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -26,6 +27,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration025ReseedPlatformProviders,
     migration026NormalizeChannelCredentials,
     migration027BackfillCredentialDefinitionFk,
+    migration028DataConnectorStreamSyncModeWebhook,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.ts
+++ b/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.ts
@@ -15,6 +15,7 @@ import { and, eq, inArray, ne } from 'drizzle-orm'
 import { matchesFilter } from '../../agents/agent-trigger-queries'
 import { enqueueConnectorSync } from '../../data-connectors/data-connector-queue'
 import { markWebhookEventReceived } from '../../data-connectors/service'
+import { isSteerableDelivery } from '../../data-connectors/webhook-steer'
 import { createScopedLogger } from '../../logger'
 import { getQueue, Queues } from '../queues'
 import type { JobContext } from '../types'
@@ -104,9 +105,12 @@ export async function dispatchAppTriggerToConnectors(
   })
 
   // Match streams by `webhookTrigger.filter` (topic discrimination), then SPLIT by mode:
-  //  • steerable (`{path}` set) → a targeted PARTIAL run that fetches only the changed
-  //    record (the steer job, per-stream so retries stay isolated).
-  //  • non-steerable (cursor stream, no `{path}`) → the full run-based sync (enqueueConnectorSync).
+  //  • steerable → a targeted PARTIAL run that fetches only the changed record (the steer
+  //    job, per-stream so retries stay isolated). `isSteerableDelivery` checks not just that
+  //    the stream declares `{path}` steering but that THIS delivery resolves every token the
+  //    request needs — an unresolvable delivery falls through to a full sync instead of
+  //    opening a partial run doomed to fail `assertResolved`.
+  //  • non-steerable (cursor stream, or a delivery missing a token) → the full run-based sync.
   // A connector with ANY non-steerable matched stream full-syncs; the full crawl is a superset
   // that covers its steerable streams too, so we skip their steer jobs (no double-ingest).
   const matched: { connectorId: string; streamKey: string; steerable: boolean }[] = []
@@ -117,7 +121,7 @@ export async function dispatchAppTriggerToConnectors(
     matched.push({
       connectorId: stream.dataConnectorId,
       streamKey: stream.streamKey,
-      steerable: (wt.paths?.length ?? 0) > 0,
+      steerable: isSteerableDelivery(stream.requestConfig, triggerData),
     })
   }
 

--- a/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
@@ -20,6 +20,7 @@ import { and, eq, inArray, ne } from 'drizzle-orm'
 import { matchesFilter } from '../../agents/agent-trigger-queries'
 import { enqueueConnectorSync } from '../../data-connectors/data-connector-queue'
 import { markWebhookEventReceived } from '../../data-connectors/service'
+import { isSteerableDelivery } from '../../data-connectors/webhook-steer'
 import { createScopedLogger } from '../../logger'
 import { getQueue, Queues } from '../queues'
 import type { JobContext } from '../types'
@@ -117,13 +118,14 @@ export async function dispatchWebhookEndpointToConnectors(
     // The connector-level signal is the binding; per-stream `webhookTrigger` only REFINES it.
     // A stream with no steering block still reacts: no `filter` ⇒ matches every topic
     // (`matchesFilter` treats absent/empty as match-all), no `paths` ⇒ not steerable ⇒ a full
-    // run-based sync. Adding `{path}` paths upgrades it to a targeted partial (steered) run.
+    // run-based sync. Adding `{path}` paths upgrades it to a targeted partial (steered) run —
+    // but only when THIS delivery resolves every token the request needs (else full sync).
     const wt = stream.requestConfig?.webhookTrigger
     if (!matchesFilter(wt?.filter, matchData)) continue
     matched.push({
       connectorId: stream.dataConnectorId,
       streamKey: stream.streamKey,
-      steerable: (wt?.paths?.length ?? 0) > 0,
+      steerable: isSteerableDelivery(stream.requestConfig, matchData),
     })
   }
 

--- a/packages/lib/src/jobs/data-connector/webhook-steer-job.test.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-steer-job.test.ts
@@ -7,26 +7,38 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { runWebhookSteeredRun, ConnectorRateLimitError, queueAdd, redis } = vi.hoisted(() => {
-  class ConnectorRateLimitError extends Error {
-    retryAfterMs?: number
-    constructor(retryAfterMs?: number) {
-      super('throttled')
-      this.name = 'ConnectorRateLimitError'
-      this.retryAfterMs = retryAfterMs
+const { runWebhookSteeredRun, ConnectorRateLimitError, PermanentSteerError, queueAdd, redis } =
+  vi.hoisted(() => {
+    class ConnectorRateLimitError extends Error {
+      retryAfterMs?: number
+      constructor(retryAfterMs?: number) {
+        super('throttled')
+        this.name = 'ConnectorRateLimitError'
+        this.retryAfterMs = retryAfterMs
+      }
     }
-  }
-  return {
-    runWebhookSteeredRun: vi.fn(),
-    ConnectorRateLimitError,
-    queueAdd: vi.fn(),
-    redis: { lpush: vi.fn(), ltrim: vi.fn(), expire: vi.fn() },
-  }
-})
+    class PermanentSteerError extends Error {
+      constructor(message: string) {
+        super(message)
+        this.name = 'PermanentSteerError'
+      }
+    }
+    return {
+      runWebhookSteeredRun: vi.fn(),
+      ConnectorRateLimitError,
+      PermanentSteerError,
+      queueAdd: vi.fn(),
+      redis: { lpush: vi.fn(), ltrim: vi.fn(), expire: vi.fn() },
+    }
+  })
 
 vi.mock('@auxx/database', () => ({ database: {} }))
 vi.mock('@auxx/redis', () => ({ getRedisClient: async () => redis }))
-vi.mock('../../data-connectors', () => ({ runWebhookSteeredRun, ConnectorRateLimitError }))
+vi.mock('../../data-connectors', () => ({
+  runWebhookSteeredRun,
+  ConnectorRateLimitError,
+  PermanentSteerError,
+}))
 vi.mock('../queues', () => ({
   getQueue: () => ({ add: (...a: unknown[]) => queueAdd(...a) }),
   Queues: { appTriggerQueue: 'appTriggerQueue' },
@@ -96,6 +108,16 @@ describe('runConnectorWebhookSteer', () => {
     expect(redis.lpush).toHaveBeenCalledOnce()
     const [key] = redis.lpush.mock.calls[0] as [string, string]
     expect(key).toBe('app-trigger-test:inst1:shopify.shopify-trigger:dlq')
+  })
+
+  it('dead-letters a permanent error immediately without re-throwing or retrying', async () => {
+    // A PermanentSteerError (e.g. unresolved `{token}`) replays identically — fail-fast on
+    // attempt 0: dead-letter once, return (no throw ⇒ no BullMQ retry).
+    runWebhookSteeredRun.mockRejectedValue(new PermanentSteerError('unresolved webhook token {id}'))
+    const result = await runConnectorWebhookSteer(ctx({ attempts: 5, attemptsMade: 0 }))
+    expect(result).toMatchObject({ ok: false, permanent: true })
+    expect(redis.lpush).toHaveBeenCalledOnce()
+    expect(queueAdd).not.toHaveBeenCalled()
   })
 
   it('re-throws without dead-lettering when attempts remain', async () => {

--- a/packages/lib/src/jobs/data-connector/webhook-steer-job.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-steer-job.ts
@@ -56,7 +56,9 @@ export async function runConnectorWebhookSteer(
   // Lazy-import the heavy data-connectors barrel at call time (it pulls the sink / crud
   // spine) — keeps this job file light and side-effect-free for vitest.
   const { database: db } = await import('@auxx/database')
-  const { runWebhookSteeredRun, ConnectorRateLimitError } = await import('../../data-connectors')
+  const { runWebhookSteeredRun, ConnectorRateLimitError, PermanentSteerError } = await import(
+    '../../data-connectors'
+  )
 
   try {
     await runWebhookSteeredRun(db, {
@@ -71,8 +73,22 @@ export async function runConnectorWebhookSteer(
     if (err instanceof ConnectorRateLimitError) {
       return await deferForThrottle(job, err.retryAfterMs)
     }
-    // Last attempt → dead-letter before `removeOnFail` discards the job, then re-throw so
-    // BullMQ records the terminal failure.
+    // Permanent (deterministic) failure — e.g. an unresolved `{token}` because the payload
+    // path returned nothing. Retrying replays the identical delivery and fails the same way,
+    // so dead-letter NOW and return (don't re-throw → no BullMQ retry). The run row was
+    // already finalized `failed` by runWebhookSteeredRun.
+    if (err instanceof PermanentSteerError) {
+      await deadLetter(job, err)
+      logger.warn('Connector webhook steer permanent failure — dead-lettered without retry', {
+        connectorId,
+        streamKey,
+        eventId,
+        error: err.message,
+      })
+      return { ok: false, permanent: true }
+    }
+    // Transient → last attempt dead-letters before `removeOnFail` discards the job, then
+    // re-throws so BullMQ records the terminal failure (and retries earlier attempts).
     const maxAttempts = job.opts.attempts ?? 5
     if (job.attemptsMade >= maxAttempts - 1) {
       await deadLetter(job, err)


### PR DESCRIPTION
## Summary

Webhook steering was conflated with sync completeness via a `syncMode='webhook'` value. That value silently disabled orphan reconciliation on those streams' sweeps. This splits the two concerns:

- **Steering** (trigger): `connector.syncBehavior === 'webhook'` + per-stream `requestConfig.webhookTrigger`.
- **syncMode** (completeness): `'snapshot' | 'incremental'` — gates orphan reconciliation on full runs.

## Changes

- Drop `'webhook'` from `SyncMode`, the `DataConnectorStream.syncMode` column comment, and the `addStream` / `setStreamRequestConfig` tRPC enums.
- UI gates token-enabled request fields on `connector.syncBehavior === 'webhook'` (`isSteered`) instead of the retired `rawSyncMode === 'webhook'`; the steering save no longer forces `syncMode: 'webhook'`.
- **Migration 028** folds existing `syncMode='webhook'` rows to `'snapshot'` (idempotent), restoring orphan reconciliation on their sweeps. The UI already treated webhook as snapshot, so completeness is preserved.
- **Per-delivery steerability** — `isSteerableDelivery` / `requiredSteerTokens` check not just that a stream declares `{path}` steering but that THIS delivery resolves every token the request needs. An unresolvable delivery falls through to a full sync instead of opening a partial run doomed to fail `assertResolved`.
- **Save-time validation** — `assertSteeringConfigValid` rejects a request template referencing a `{token}` not declared in the steering paths (a runtime footgun that would dead-letter every delivery silently).
- **`PermanentSteerError`** — deterministic steer failures (unresolved `{token}`) dead-letter immediately instead of burning bounded BullMQ retries.

## Testing

- `webhook-steer-job.test.ts` updated for the permanent-vs-transient failure split.

## Migration

⚠️ Migration 028 runs through the DataMigration runner — folds `syncMode='webhook'` → `'snapshot'`.