### PR TITLE
feat(ui): unify list-page layout (toolbar + view-mode + scroll primitives)

### DIFF
--- a/apps/web/src/app/(protected)/app/connectors/page.tsx
+++ b/apps/web/src/app/(protected)/app/connectors/page.tsx
@@ -4,6 +4,9 @@
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
+import { ListToolbar } from '@auxx/ui/components/list-toolbar'
 import {
   MainPage,
   MainPageBreadcrumb,
@@ -25,6 +28,7 @@ import { useFeatureFlags } from '~/providers/feature-flag-provider'
 export default function ConnectorsPage() {
   const { hasAccess } = useFeatureFlags()
   const [pickerOpen, setPickerOpen] = useState(false)
+  const [search, setSearch] = useState('')
   const canConnect = hasAccess(FeatureKey.dataConnectors)
 
   return (
@@ -44,7 +48,19 @@ export default function ConnectorsPage() {
       </MainPageHeader>
       <MainPageContent>
         {canConnect ? (
-          <ConnectorList onConnect={() => setPickerOpen(true)} />
+          <ListPageScroll
+            toolbar={
+              <ListToolbar>
+                <InputSearch
+                  value={search}
+                  placeholder='Search connectors...'
+                  onChange={(e) => setSearch(e.target.value)}
+                />
+              </ListToolbar>
+            }
+            bodyClassName='flex-1 flex flex-col min-h-0'>
+            <ConnectorList onConnect={() => setPickerOpen(true)} search={search} />
+          </ListPageScroll>
         ) : (
           <EmptyState
             icon={Lock}

--- a/apps/web/src/app/(protected)/app/datasets/page.tsx
+++ b/apps/web/src/app/(protected)/app/datasets/page.tsx
@@ -4,6 +4,7 @@
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { ListCard } from '@auxx/ui/components/list-card'
+import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
 import {
   MainPage,
   MainPageBreadcrumb,
@@ -11,7 +12,6 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Lock } from 'lucide-react'
 import {
   CreateDatasetButton,
@@ -45,12 +45,9 @@ function DatasetsPageContent() {
         <DatasetsStatsCards stats={stats} />
 
         {/* Filters + Datasets Content */}
-        <ScrollArea className='flex-1 min-h-0 bg-muted @container'>
-          <div className='sticky top-0 z-10 backdrop-blur-sm'>
-            <DatasetsFilterBar />
-          </div>
+        <ListPageScroll toolbar={<DatasetsFilterBar />}>
           {isLoading ? (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 p-3'>
+            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
               {[...Array(8)].map((_, i) => (
                 <ListCard key={`skeleton-${i}`} loading descriptionLines={0} />
               ))}
@@ -62,7 +59,7 @@ function DatasetsPageContent() {
           ) : (
             <DatasetsTableView />
           )}
-        </ScrollArea>
+        </ListPageScroll>
       </MainPageContent>
     </MainPage>
   )

--- a/apps/web/src/app/(protected)/app/workflows/_components/filters/workflows-filter-bar.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/_components/filters/workflows-filter-bar.tsx
@@ -3,6 +3,7 @@
 
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { Label } from '@auxx/ui/components/label'
+import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
 import {
   Select,
   SelectContent,
@@ -11,12 +12,9 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { Switch } from '@auxx/ui/components/switch'
-import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
-import { LayoutGrid, List } from 'lucide-react'
+import { ViewModeToggle } from '@auxx/ui/components/view-mode-toggle'
 import { useWorkflows } from '../providers/workflows-provider'
 import { getAllTriggers } from '../utils/trigger-info'
-
-type ViewMode = 'grid' | 'table'
 
 export function WorkflowsFilterBar() {
   const {
@@ -36,34 +34,33 @@ export function WorkflowsFilterBar() {
   }))
 
   return (
-    <div className='px-3 py-2 border-b bg-background/80'>
-      <div className='flex flex-wrap sm:flex-nowrap gap-1.5'>
-        <div className='hidden sm:block'>
-          <Select
-            value={selectedTriggerType || 'ALL'}
-            onValueChange={(value) => setSelectedTriggerType(value === 'ALL' ? null : value)}>
-            <SelectTrigger className='w-[180px]' size='sm' variant='outline'>
-              <SelectValue placeholder='Filter by trigger' />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value='ALL'>All Triggers</SelectItem>
-              {triggerTypes.map((type) => (
-                <SelectItem key={type.value} value={type.value}>
-                  {type.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+    <ListToolbar>
+      <ListToolbarGroup className='hidden sm:flex'>
+        <Select
+          value={selectedTriggerType || 'ALL'}
+          onValueChange={(value) => setSelectedTriggerType(value === 'ALL' ? null : value)}>
+          <SelectTrigger className='w-[180px]' size='sm' variant='outline'>
+            <SelectValue placeholder='Filter by trigger' />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value='ALL'>All Triggers</SelectItem>
+            {triggerTypes.map((type) => (
+              <SelectItem key={type.value} value={type.value}>
+                {type.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </ListToolbarGroup>
 
-        <InputSearch
-          className='basis-full sm:basis-auto'
-          value={searchQuery}
-          placeholder='Search workflows...'
-          onChange={(e) => setSearchQuery(e.target.value)}
-        />
+      <InputSearch
+        value={searchQuery}
+        placeholder='Search workflows...'
+        onChange={(e) => setSearchQuery(e.target.value)}
+      />
 
-        <div className='order-3 flex items-center space-x-2 h-7'>
+      <ListToolbarGroup align='end'>
+        <div className='flex items-center space-x-2 h-7'>
           <Switch
             id='show-disabled'
             size='sm'
@@ -74,20 +71,8 @@ export function WorkflowsFilterBar() {
             Show disabled
           </Label>
         </div>
-
-        <div className='order-4 items-center gap-2 md:flex hidden'>
-          <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as ViewMode)}>
-            <TabsList className='h-7'>
-              <TabsTrigger value='grid' className='h-5 px-1.5'>
-                <LayoutGrid className='size-4' />
-              </TabsTrigger>
-              <TabsTrigger value='table' className='h-5 px-1.5'>
-                <List className='size-4' />
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-        </div>
-      </div>
-    </div>
+        <ViewModeToggle value={viewMode} onValueChange={setViewMode} className='hidden md:block' />
+      </ListToolbarGroup>
+    </ListToolbar>
   )
 }

--- a/apps/web/src/app/(protected)/app/workflows/page.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/page.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
+import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
 import {
   MainPage,
   MainPageBreadcrumb,
@@ -9,7 +10,6 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Lock } from 'lucide-react'
 import { EmptyState } from '~/components/global/empty-state'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
@@ -34,14 +34,11 @@ function WorkflowsPageContent() {
         <WorkflowsStatsCards />
 
         {/* Filters + Workflows List */}
-        <ScrollArea className='flex-1 min-h-0 flex flex-col'>
-          <div className='sticky top-0 z-10 backdrop-blur-sm shrink-0'>
-            <WorkflowsFilterBar />
-          </div>
-          <div className='p-3 sm:p-6 flex-1 flex flex-col min-h-0'>
-            <WorkflowsList />
-          </div>
-        </ScrollArea>
+        <ListPageScroll
+          toolbar={<WorkflowsFilterBar />}
+          bodyClassName='flex-1 flex flex-col min-h-0'>
+          <WorkflowsList />
+        </ListPageScroll>
       </MainPageContent>
     </MainPage>
   )

--- a/apps/web/src/components/agents/ui/list/agents-page-content.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-page-content.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/agents/ui/list/agents-page-content.tsx
 'use client'
 
+import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
 import {
   MainPage,
   MainPageBreadcrumb,
@@ -8,7 +9,6 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { AgentsGridView } from './agents-grid-view'
 import { AgentsSearchBar } from './agents-search-bar'
 import { CreateAgentButton } from './create-agent-button'
@@ -24,14 +24,9 @@ export function AgentsPageContent() {
       </MainPageHeader>
 
       <MainPageContent>
-        <ScrollArea className='flex-1 min-h-0 flex flex-col'>
-          <div className='sticky top-0 z-10 backdrop-blur-sm shrink-0 px-3 sm:px-6 pt-3 pb-2'>
-            <AgentsSearchBar />
-          </div>
-          <div className='p-3 sm:p-6 flex-1 flex flex-col min-h-0'>
-            <AgentsGridView />
-          </div>
-        </ScrollArea>
+        <ListPageScroll toolbar={<AgentsSearchBar />} bodyClassName='flex-1 flex flex-col min-h-0'>
+          <AgentsGridView />
+        </ListPageScroll>
       </MainPageContent>
     </MainPage>
   )

--- a/apps/web/src/components/agents/ui/list/agents-search-bar.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-search-bar.tsx
@@ -1,21 +1,19 @@
 // apps/web/src/components/agents/ui/list/agents-search-bar.tsx
 'use client'
 
-import { Input } from '@auxx/ui/components/input'
-import { Search } from 'lucide-react'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { ListToolbar } from '@auxx/ui/components/list-toolbar'
 import { useAgentSearch } from '../../hooks/use-agent-search'
 
 export function AgentsSearchBar() {
   const { search, setSearch } = useAgentSearch()
   return (
-    <div className='relative max-w-md'>
-      <Search className='absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground' />
-      <Input
+    <ListToolbar>
+      <InputSearch
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         placeholder='Search agents…'
-        className='pl-8'
       />
-    </div>
+    </ListToolbar>
   )
 }

--- a/apps/web/src/components/data-connectors/ui/connector-list.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-list.tsx
@@ -11,6 +11,8 @@ import { ConnectorCard, ConnectorFallbackIcon } from './connector-card'
 interface ConnectorListProps {
   /** Opens the "Connect a source" picker (owned by the page; also in the header). */
   onConnect: () => void
+  /** Client-side filter on connector name (from the toolbar search). */
+  search?: string
 }
 
 /**
@@ -20,13 +22,17 @@ interface ConnectorListProps {
  * action lives in the page header; `onConnect` opens its picker.
  * See plans/data-connectors/claude/05-frontend.md §1.
  */
-export function ConnectorList({ onConnect }: ConnectorListProps) {
+export function ConnectorList({ onConnect, search }: ConnectorListProps) {
   const connectors = api.dataConnector.list.useQuery()
 
   const rows = connectors.data ?? []
+  const query = search?.trim().toLowerCase() ?? ''
+  const filtered = query
+    ? rows.filter((connector) => connector.name.toLowerCase().includes(query))
+    : rows
 
   return (
-    <div className='flex flex-1 flex-col gap-4 p-4'>
+    <div className='flex flex-1 flex-col gap-4'>
       {connectors.isLoading ? (
         <div className='grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3'>
           {[0, 1, 2].map((i) => (
@@ -45,9 +51,15 @@ export function ConnectorList({ onConnect }: ConnectorListProps) {
             </Button>
           }
         />
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          icon={ConnectorFallbackIcon}
+          title='No matching connectors'
+          description={`No connectors match “${search?.trim()}”.`}
+        />
       ) : (
         <div className='grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3'>
-          {rows.map((connector) => (
+          {filtered.map((connector) => (
             <ConnectorCard key={connector.id} connector={connector} />
           ))}
         </div>

--- a/apps/web/src/components/datasets/datasets-filter-bar.tsx
+++ b/apps/web/src/components/datasets/datasets-filter-bar.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { InputSearch } from '@auxx/ui/components/input-search'
+import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
 import {
   Select,
   SelectContent,
@@ -10,8 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@auxx/ui/components/select'
-import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
-import { LayoutGrid, List } from 'lucide-react'
+import { ViewModeToggle } from '@auxx/ui/components/view-mode-toggle'
 import { useDatasets } from './datasets-provider'
 
 /**
@@ -22,36 +22,29 @@ export function DatasetsFilterBar() {
     useDatasets()
 
   return (
-    <div className='flex items-center border-b gap-1.5 py-2 px-3 bg-background/80 overflow-x-auto no-scrollbar w-full'>
+    <ListToolbar>
       {/* Status Filter */}
-      <Select value={selectedStatus} onValueChange={(value: any) => setSelectedStatus(value)}>
-        <SelectTrigger className='w-[140px]' size='sm' variant='outline'>
-          <SelectValue placeholder='Status' />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value='all'>All Status</SelectItem>
-          <SelectItem value='ACTIVE'>Active</SelectItem>
-          <SelectItem value='PROCESSING'>Processing</SelectItem>
-          <SelectItem value='ERROR'>Error</SelectItem>
-          <SelectItem value='INACTIVE'>Archived</SelectItem>
-        </SelectContent>
-      </Select>
+      <ListToolbarGroup>
+        <Select value={selectedStatus} onValueChange={(value: any) => setSelectedStatus(value)}>
+          <SelectTrigger className='w-[140px]' size='sm' variant='outline'>
+            <SelectValue placeholder='Status' />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value='all'>All Status</SelectItem>
+            <SelectItem value='ACTIVE'>Active</SelectItem>
+            <SelectItem value='PROCESSING'>Processing</SelectItem>
+            <SelectItem value='ERROR'>Error</SelectItem>
+            <SelectItem value='INACTIVE'>Archived</SelectItem>
+          </SelectContent>
+        </Select>
+      </ListToolbarGroup>
 
       {/* Search */}
       <InputSearch value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} />
 
-      <div className='items-center gap-2'>
-        <Tabs value={viewMode} onValueChange={(v) => setViewMode(v)}>
-          <TabsList className='h-7'>
-            <TabsTrigger value='grid' className='h-5 px-1.5'>
-              <LayoutGrid className='size-4' />
-            </TabsTrigger>
-            <TabsTrigger value='table' className='h-5 px-1.5'>
-              <List className='size-4' />
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
-      </div>
-    </div>
+      <ListToolbarGroup align='end'>
+        <ViewModeToggle value={viewMode} onValueChange={setViewMode} />
+      </ListToolbarGroup>
+    </ListToolbar>
   )
 }

--- a/apps/web/src/components/datasets/datasets-grid-view.tsx
+++ b/apps/web/src/components/datasets/datasets-grid-view.tsx
@@ -21,7 +21,7 @@ export function DatasetsGridView() {
   }
 
   return (
-    <div className='grid gap-4 @md:grid-cols-2 @lg:grid-cols-3 @xl:grid-cols-4 p-3'>
+    <div className='grid gap-4 @md:grid-cols-2 @lg:grid-cols-3 @xl:grid-cols-4'>
       {items.map((dataset) => (
         <DatasetCard
           key={dataset.id}

--- a/apps/web/src/components/datasets/datasets-table-view.tsx
+++ b/apps/web/src/components/datasets/datasets-table-view.tsx
@@ -130,7 +130,7 @@ export function DatasetsTableView() {
   const { items, refetch } = useDatasets()
 
   return (
-    <div className='border rounded-lg my-2 mx-3'>
+    <div className='border rounded-lg'>
       <Table>
         <TableHeader>
           <TableRow>

--- a/apps/web/src/components/tasks/ui/task-filter-bar.tsx
+++ b/apps/web/src/components/tasks/ui/task-filter-bar.tsx
@@ -6,6 +6,7 @@ import type { TaskSortConfig } from '@auxx/lib/tasks/client'
 import { TASK_FILTER_FIELDS } from '@auxx/lib/tasks/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button, buttonVariants } from '@auxx/ui/components/button'
+import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { Switch } from '@auxx/ui/components/switch'
 import { Filter, X } from 'lucide-react'
@@ -131,77 +132,78 @@ export function TaskFilterBar({
   const hasFilters = filterCount > 0
 
   return (
-    <div className='flex items-center border-b gap-1.5 py-2 px-3 bg-background/80 overflow-x-auto no-scrollbar w-full'>
-      {/* Filter Popover */}
-      <Popover open={isFilterOpen} onOpenChange={handleFilterOpenChange}>
-        <PopoverTrigger asChild>
-          <Button variant='ghost' size='sm' disabled={disabled}>
-            <Filter />
-            <span className='hidden sm:inline'>Filter</span>
-            {hasFilters && (
-              <Badge variant='secondary' className='ml-1 h-4 px-1'>
-                {filterCount}
-              </Badge>
-            )}
-          </Button>
-        </PopoverTrigger>
-
-        <PopoverContent className='w-[400px] max-h-[400px] overflow-auto p-2' align='start'>
-          <div className='space-y-2'>
-            <div className='flex items-center justify-between'>
-              <span className='text-sm font-medium'>Filters</span>
+    <ListToolbar>
+      <ListToolbarGroup>
+        {/* Filter Popover */}
+        <Popover open={isFilterOpen} onOpenChange={handleFilterOpenChange}>
+          <PopoverTrigger asChild>
+            <Button variant='ghost' size='sm' disabled={disabled}>
+              <Filter />
+              <span className='hidden sm:inline'>Filter</span>
               {hasFilters && (
-                <Button
-                  variant='ghost'
-                  size='sm'
-                  onClick={handleClearAll}
-                  className='h-6 px-2 text-xs'>
-                  <X className='mr-1 size-3' />
-                  Clear all
-                </Button>
+                <Badge variant='secondary' className='ml-1 h-4 px-1'>
+                  {filterCount}
+                </Badge>
               )}
+            </Button>
+          </PopoverTrigger>
+
+          <PopoverContent className='w-[400px] max-h-[400px] overflow-auto p-2' align='start'>
+            <div className='space-y-2'>
+              <div className='flex items-center justify-between'>
+                <span className='text-sm font-medium'>Filters</span>
+                {hasFilters && (
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    onClick={handleClearAll}
+                    className='h-6 px-2 text-xs'>
+                    <X className='mr-1 size-3' />
+                    Clear all
+                  </Button>
+                )}
+              </div>
+
+              <ConditionProvider
+                conditions={draftFilters}
+                groups={[{ id: 'main', conditions: draftFilters, logicalOperator: 'AND' }]}
+                config={config}
+                readOnly={disabled}
+                onConditionsChange={handleDraftChange}
+                onGroupsChange={() => {}}
+                getAvailableFields={() => fieldDefinitions}
+                getFieldDefinition={(id) => fieldDefinitions.find((f) => f.id === id)}>
+                <ConditionContainer
+                  emptyStateText='Add a filter to start'
+                  showAddButton
+                  showGrouping={false}
+                />
+              </ConditionProvider>
             </div>
+          </PopoverContent>
+        </Popover>
 
-            <ConditionProvider
-              conditions={draftFilters}
-              groups={[{ id: 'main', conditions: draftFilters, logicalOperator: 'AND' }]}
-              config={config}
-              readOnly={disabled}
-              onConditionsChange={handleDraftChange}
-              onGroupsChange={() => {}}
-              getAvailableFields={() => fieldDefinitions}
-              getFieldDefinition={(id) => fieldDefinitions.find((f) => f.id === id)}>
-              <ConditionContainer
-                emptyStateText='Add a filter to start'
-                showAddButton
-                showGrouping={false}
-              />
-            </ConditionProvider>
-          </div>
-        </PopoverContent>
-      </Popover>
-
-      {/* Sort Select */}
-      <TaskSortSelect value={sort} onChange={onSortChange} disabled={disabled} />
-
-      {/* Spacer */}
-      <div className='flex-1' />
+        {/* Sort Select */}
+        <TaskSortSelect value={sort} onChange={onSortChange} disabled={disabled} />
+      </ListToolbarGroup>
 
       {/* Show Completed Toggle */}
-      <label
-        className={buttonVariants({
-          variant: 'ghost',
-          size: 'sm',
-          className: `gap-2 ${disabled ? 'pointer-events-none opacity-50' : 'cursor-pointer'}`,
-        })}>
-        <span className='text-muted-foreground text-xs'>Show completed</span>
-        <Switch
-          size='sm'
-          checked={includeCompleted}
-          onCheckedChange={onIncludeCompletedChange}
-          disabled={disabled}
-        />
-      </label>
-    </div>
+      <ListToolbarGroup align='end'>
+        <label
+          className={buttonVariants({
+            variant: 'ghost',
+            size: 'sm',
+            className: `gap-2 ${disabled ? 'pointer-events-none opacity-50' : 'cursor-pointer'}`,
+          })}>
+          <span className='text-muted-foreground text-xs'>Show completed</span>
+          <Switch
+            size='sm'
+            checked={includeCompleted}
+            onCheckedChange={onIncludeCompletedChange}
+            disabled={disabled}
+          />
+        </label>
+      </ListToolbarGroup>
+    </ListToolbar>
   )
 }

--- a/apps/web/src/components/tasks/ui/tasks-page.tsx
+++ b/apps/web/src/components/tasks/ui/tasks-page.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import type { TaskSortConfig } from '@auxx/lib/tasks/client'
+import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
 import {
   MainPage,
   MainPageBreadcrumb,
@@ -10,7 +11,6 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { useState } from 'react'
 import type { Condition } from '~/components/conditions'
 import { api } from '~/trpc/react'
@@ -48,8 +48,8 @@ export function TasksPage() {
         <TasksStatsCards stats={stats ?? null} />
 
         {/* Filter Bar + Task List */}
-        <ScrollArea className='flex-1 min-h-0 bg-muted dark:bg-[#1e2227] @container'>
-          <div className='sticky top-0 z-10 backdrop-blur-sm'>
+        <ListPageScroll
+          toolbar={
             <TaskFilterBar
               filters={filters}
               onFiltersChange={setFilters}
@@ -58,16 +58,15 @@ export function TasksPage() {
               includeCompleted={includeCompleted}
               onIncludeCompletedChange={setIncludeCompleted}
             />
-          </div>
+          }>
           <TasksList
             viewMode='global'
             filters={filters}
             sort={sort}
             includeCompleted={includeCompleted}
             showEntityReferences
-            className='p-3'
           />
-        </ScrollArea>
+        </ListPageScroll>
       </MainPageContent>
     </MainPage>
   )

--- a/packages/ui/src/components/list-page-scroll.tsx
+++ b/packages/ui/src/components/list-page-scroll.tsx
@@ -1,0 +1,35 @@
+// packages/ui/src/components/list-page-scroll.tsx
+'use client'
+
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { cn } from '@auxx/ui/lib/utils'
+
+interface ListPageScrollProps {
+  /** A `<ListToolbar/>` (already sticky); rendered as the first scroll child. */
+  toolbar?: React.ReactNode
+  children: React.ReactNode
+  /** Extra ScrollArea root classes. */
+  className?: string
+  /** Body wrapper classes around `children`. Default `p-3 sm:p-6`. */
+  bodyClassName?: string
+}
+
+/**
+ * Scrollable body for list pages: a `ScrollArea` with the canonical `bg-muted`
+ * backdrop, a sticky toolbar slot, and a padded body wrapper. Lists that branch
+ * on loading/empty/grid render those branches as `children` and should not
+ * self-pad — the body wrapper owns padding.
+ */
+export function ListPageScroll({
+  toolbar,
+  children,
+  className,
+  bodyClassName,
+}: ListPageScrollProps) {
+  return (
+    <ScrollArea className={cn('flex-1 min-h-0 bg-muted @container', className)}>
+      {toolbar}
+      <div className={cn('p-3 sm:p-6', bodyClassName)}>{children}</div>
+    </ScrollArea>
+  )
+}

--- a/packages/ui/src/components/list-toolbar.tsx
+++ b/packages/ui/src/components/list-toolbar.tsx
@@ -1,0 +1,56 @@
+// packages/ui/src/components/list-toolbar.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+
+interface ListToolbarProps extends React.ComponentProps<'div'> {
+  /** Stick to the top of the scroll container with backdrop blur. Default true. */
+  sticky?: boolean
+}
+
+/**
+ * Canonical view-settings row for list pages. Folds the sticky `backdrop-blur`
+ * wrapper and the bordered bar into one component. Compose its content with
+ * `ListToolbarGroup` (left/right clusters) and a raw `InputSearch` (center,
+ * already `flex-1`) in source order:
+ *
+ * ```tsx
+ * <ListToolbar>
+ *   <ListToolbarGroup>{filters}</ListToolbarGroup>
+ *   <InputSearch … />
+ *   <ListToolbarGroup align='end'>{toggles}</ListToolbarGroup>
+ * </ListToolbar>
+ * ```
+ */
+export function ListToolbar({ sticky = true, className, children, ...props }: ListToolbarProps) {
+  return (
+    <div
+      data-slot='list-toolbar'
+      className={cn(sticky && 'sticky top-0 z-10 shrink-0 backdrop-blur-sm', className)}
+      {...props}>
+      <div className='flex w-full items-center gap-1.5 overflow-x-auto border-b bg-background/80 px-3 py-2 no-scrollbar'>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * A cluster of controls inside a `ListToolbar`. `align='end'` self-pins the group
+ * (and everything after it) to the right via `ml-auto` — works with or without a
+ * center search field.
+ */
+export function ListToolbarGroup({
+  align = 'start',
+  className,
+  ...props
+}: React.ComponentProps<'div'> & { align?: 'start' | 'end' }) {
+  return (
+    <div
+      data-slot='list-toolbar-group'
+      data-align={align}
+      className={cn('flex items-center gap-1.5 data-[align=end]:ml-auto', className)}
+      {...props}
+    />
+  )
+}

--- a/packages/ui/src/components/view-mode-toggle.tsx
+++ b/packages/ui/src/components/view-mode-toggle.tsx
@@ -1,0 +1,36 @@
+// packages/ui/src/components/view-mode-toggle.tsx
+'use client'
+
+import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
+import { LayoutGrid, List } from 'lucide-react'
+
+/** Grid vs table list rendering. */
+export type ListViewMode = 'grid' | 'table'
+
+interface ViewModeToggleProps {
+  value: ListViewMode
+  onValueChange: (value: ListViewMode) => void
+  className?: string
+}
+
+/**
+ * Grid/table view switch shared by list pages (Workflows, Datasets). Drop it into
+ * a `ListToolbarGroup align='end'`.
+ */
+export function ViewModeToggle({ value, onValueChange, className }: ViewModeToggleProps) {
+  return (
+    <Tabs
+      value={value}
+      onValueChange={(v) => onValueChange(v as ListViewMode)}
+      className={className}>
+      <TabsList className='h-7'>
+        <TabsTrigger value='grid' className='h-5 px-1.5'>
+          <LayoutGrid className='size-4' />
+        </TabsTrigger>
+        <TabsTrigger value='table' className='h-5 px-1.5'>
+          <List className='size-4' />
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  )
+}


### PR DESCRIPTION
## Context

Follows the unified `ListCard` work (`plans/ui/unified-list-card.md`). That unified the **cards**; this unifies the **page shell** that renders them. The list index pages (Workflows, Datasets, Tasks, Agents, Connectors) all want the same `Stats → Toolbar → ScrollBody` shape, but the view-settings row and scroll container were copy-pasted with small inconsistencies, and Agents/Connectors didn't follow the shape at all.

## New `@auxx/ui` primitives

Framework-free, auto-exported via the existing `./components/*` wildcard (no `package.json` edit).

- **`ListToolbar` + `ListToolbarGroup`** — the canonical view-settings row (sticky `backdrop-blur` wrapper + bordered `bg-background/80` bar). Compound API à la `field.tsx`: groups tag themselves with `data-slot` and self-align via `data-[align=end]:ml-auto` — pins right with or without a center search field.
- **`ViewModeToggle`** — the grid/table tabs, previously copy-pasted byte-for-byte in Workflows + Datasets.
- **`ListPageScroll`** — `ScrollArea` + sticky toolbar slot + `p-3 sm:p-6` body, standardized on the `bg-muted @container` backdrop.

## Migrations

| Page | Change |
| --- | --- |
| Workflows | filter bar → compound toolbar; page → `ListPageScroll`. Mobile now horizontal-scrolls instead of wrap-and-reorder. |
| Datasets | filter bar → toolbar; page → `ListPageScroll`; removed self-padding from grid + table views. |
| Tasks | filter bar → toolbar (dropped manual `flex-1` spacer); page → `ListPageScroll`; dropped the `dark:bg-[#1e2227]` magic hex. |
| Agents | search → shared `InputSearch` in a `ListToolbar` (now a bordered bar); page → `ListPageScroll`. |
| Connectors | wrapped in `ListPageScroll` + a search toolbar; added client-side name filter with a "No matching connectors" state. |

## Out of scope (v2)
- Table views for Connectors/Agents.
- Stats rows for Connectors/Agents (no stats queries exist yet).

## Test plan
- [ ] Biome clean (pre-commit hook passed).
- [ ] Stats rows unchanged; toolbar is one consistent sticky bar on every page.
- [ ] Grid/table toggle still switches Workflows + Datasets.
- [ ] Search filters Workflows/Datasets/Agents/Connectors; Tasks filter popover + sort + show-completed still work.
- [ ] End-aligned clusters pin right with and without a search field.
- [ ] No double padding on cards; loading skeletons still render.
- [ ] Visual focus: Workflows mobile (wrap→scroll) and Agents search (now in a bar).