### PR TITLE
feat(ui): records-view guide + shared guide shortcut primitives

### DIFF
--- a/apps/web/src/components/agents/procedures/ui/procedure-blocks-popover.tsx
+++ b/apps/web/src/components/agents/procedures/ui/procedure-blocks-popover.tsx
@@ -72,7 +72,7 @@ export function ProcedureBlocksPopover() {
           </Button>
         </PopoverTrigger>
         <PopoverContent align='end' className='w-72 p-0'>
-          <Command shouldFilter={false} className='rounded-lg'>
+          <Command shouldFilter={false} className='rounded-2xl'>
             <CommandList>
               {isEmpty && <CommandPlaceholder>No building blocks yet</CommandPlaceholder>}
 

--- a/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-tabs.tsx
@@ -15,6 +15,7 @@ import { Section } from '@auxx/ui/components/section'
 import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
 import {
   BookOpen,
+  CircleHelp,
   Clock,
   FileText,
   ListChecks,
@@ -38,6 +39,7 @@ import { ProcedureEditor } from '../../procedures/ui/procedure-editor'
 import { ProceduresSection } from '../../procedures/ui/procedures-section'
 import type { AgentDetail } from '../../store/agent-store'
 import type { AutosaveState } from '../shared/autosave-indicator'
+import { AgentGuideDialog } from './agent-guide-dialog'
 import { AgentHero } from './agent-hero'
 import { BindingsSection } from './bindings/bindings-section'
 import { KnowledgeSectionContent } from './knowledge/knowledge-section-content'
@@ -89,6 +91,7 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
   const [selectedProcedureId, setSelectedProcedureId] = useQueryState('procedure')
   const [drill, setDrill] = useQueryState('drill')
   const [addingKind, setAddingKind] = useState<'scheduled' | 'event' | 'source' | null>(null)
+  const [guideOpen, setGuideOpen] = useState(false)
   // Lifted from the pushed ProcedureEditor so the detail bar (rendered by
   // <NavStackBar>, a separate subtree) can show live Saving…/Saved next to Publish.
   const [procedureAutosave, setProcedureAutosave] = useState<AutosaveState>({ kind: 'idle' })
@@ -208,6 +211,14 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
                         </TabsTrigger>
                       )
                     })}
+                    <Button
+                      variant='ghost'
+                      size='xs'
+                      className='ml-auto'
+                      onClick={() => setGuideOpen(true)}>
+                      <CircleHelp />
+                      Guide
+                    </Button>
                   </TabsList>
                 </Tabs>
               }>
@@ -324,6 +335,14 @@ export function AgentDetailTabs({ agent, onAutosaveChange }: AgentDetailTabsProp
           </NavStackPanels>
         </NavStack>
       </ProcedureDraftProvider>
+      {guideOpen && (
+        <AgentGuideDialog
+          open={guideOpen}
+          onOpenChange={setGuideOpen}
+          canProcedures={canProcedures}
+          isChat={agent.kind === 'chat'}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/agents/ui/detail/agent-guide-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-guide-dialog.tsx
@@ -1,0 +1,554 @@
+// apps/web/src/components/agents/ui/detail/agent-guide-dialog.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  GuideCode,
+  GuideColumn,
+  GuideColumns,
+  GuideConcept,
+  GuideConcepts,
+  GuideDialog,
+  GuidePage,
+  GuideSection,
+  GuideStep,
+  GuideSteps,
+} from '@auxx/ui/components/guide'
+import {
+  Ban,
+  BookOpen,
+  Bot,
+  Check,
+  ChevronRight,
+  Clock,
+  Code2,
+  CornerDownRight,
+  FileText,
+  Filter,
+  Flag,
+  FlaskConical,
+  GitBranch,
+  Hand,
+  History,
+  MessageCircle,
+  MessageSquareText,
+  Pencil,
+  Pin,
+  Play,
+  Plug,
+  Plus,
+  ShieldCheck,
+  Sparkles,
+  Square,
+  Tags,
+  User,
+  Variable,
+  Workflow,
+  Wrench,
+  X,
+  Zap,
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+type AgentGuidePage = 'overview' | 'capabilities' | 'procedures' | 'triggers' | 'simulations'
+
+const PAGE_LABELS: Record<AgentGuidePage, string> = {
+  overview: 'Overview',
+  capabilities: 'Capabilities',
+  procedures: 'Procedures',
+  triggers: 'Triggers',
+  simulations: 'Simulations',
+}
+
+/**
+ * The agent help guide: a paged `GuideDialog` mirroring the detail page's own
+ * sections, with the SAME glyphs the page uses. "Overview" frames the build flow
+ * and the draft: publish model; "Capabilities" covers tools, bindings, and
+ * knowledge; "Procedures" details selection and the special steps; "Triggers"
+ * covers autonomous invocation; "Simulations" covers testing the agent. An
+ * active-crumb header switches between the pages and the body crossfades +
+ * height-springs.
+ *
+ * `canProcedures` (procedures is plan-gated) drops the Procedures page entirely;
+ * `isChat` (chat agents fire from their widget, not from triggers) reshapes the
+ * Triggers copy so the guide never explains controls the reader can't see.
+ */
+export function AgentGuideDialog({
+  open,
+  onOpenChange,
+  canProcedures = false,
+  isChat = false,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Procedures is a beta entitlement: drop its page when the org lacks it. */
+  canProcedures?: boolean
+  /** Chat agents have no triggers: swap the Triggers copy for the widget note. */
+  isChat?: boolean
+}) {
+  // Re-seed to the overview each time the dialog opens, regardless of where it
+  // was last closed.
+  const [page, setPage] = useState<AgentGuidePage>('overview')
+  useEffect(() => {
+    if (open) setPage('overview')
+  }, [open])
+
+  // The ordered set of visible pages drives both the crumb header and the
+  // per-page "Continue to…" forward link.
+  const order: AgentGuidePage[] = [
+    'overview',
+    'capabilities',
+    ...(canProcedures ? (['procedures'] as const) : []),
+    'triggers',
+    'simulations',
+  ]
+  const nextOf = (p: AgentGuidePage) => order[order.indexOf(p) + 1]
+
+  /** Footer for a page: Esc hint plus a forward link to the next page (if any). */
+  const footerFor = (p: AgentGuidePage) => {
+    const next = nextOf(p)
+    if (!next) return undefined // GuidePage default: "Press Esc to close"
+    return (
+      <div className='flex items-center justify-between'>
+        <p className='text-muted-foreground text-xs'>Press Esc to close</p>
+        <Button variant='ghost' size='xs' onClick={() => setPage(next)}>
+          Continue to {PAGE_LABELS[next].toLowerCase()}
+          <ChevronRight />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <GuideDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title='Agent guide'
+      page={page}
+      crumbs={order.map((p) => ({
+        label: PAGE_LABELS[p],
+        active: page === p,
+        onClick: () => setPage(p),
+      }))}>
+      <GuidePage value='overview' size='3xl' footer={footerFor('overview')}>
+        <OverviewGuideBody canProcedures={canProcedures} isChat={isChat} />
+      </GuidePage>
+
+      <GuidePage value='capabilities' size='3xl' footer={footerFor('capabilities')}>
+        <CapabilitiesGuideBody />
+      </GuidePage>
+
+      {canProcedures && (
+        <GuidePage value='procedures' size='3xl' footer={footerFor('procedures')}>
+          <ProceduresGuideBody />
+        </GuidePage>
+      )}
+
+      <GuidePage value='triggers' size='3xl' footer={footerFor('triggers')}>
+        <TriggersGuideBody isChat={isChat} />
+      </GuidePage>
+
+      <GuidePage value='simulations' size='3xl' footer={footerFor('simulations')}>
+        <SimulationsGuideBody canProcedures={canProcedures} />
+      </GuidePage>
+    </GuideDialog>
+  )
+}
+
+// ── Page 1: overview ──────────────────────────────────────────────────────────
+
+/**
+ * The build flow as a numbered happy path mirroring the page's section order, plus
+ * the identity basics and the draft: publish model that governs every change.
+ */
+function OverviewGuideBody({ canProcedures, isChat }: { canProcedures: boolean; isChat: boolean }) {
+  // The automation step only exists if there's something to automate.
+  const hasAutomation = canProcedures || !isChat
+  return (
+    <GuideColumns>
+      {/* 1: the happy path, ordered like the page itself */}
+      <GuideColumn title='How an agent is built'>
+        <GuideSteps>
+          <GuideStep n={1} title='Write the prompt'>
+            Give the agent its persona and standing instructions: who it is and how it should behave
+            every run.
+          </GuideStep>
+          <GuideStep n={2} title='Give it tools'>
+            Enable the actions it can take, from app integrations to built-ins.
+          </GuideStep>
+          <GuideStep n={3} title='Add knowledge'>
+            Attach reference docs it can search while it works.
+          </GuideStep>
+          {hasAutomation && (
+            <GuideStep n={4} title='Automate'>
+              Optional: add procedures it follows and triggers that fire it on their own.
+            </GuideStep>
+          )}
+          <GuideStep n={hasAutomation ? 5 : 4} title='Test'>
+            Run simulations to check the agent behaves before it goes live.
+          </GuideStep>
+          <GuideStep n={hasAutomation ? 6 : 5} title='Publish'>
+            Snapshot the draft so production starts running it.
+          </GuideStep>
+        </GuideSteps>
+      </GuideColumn>
+
+      {/* 2: identity */}
+      <GuideColumn title='The basics'>
+        <GuideConcepts>
+          <GuideConcept
+            glyph={<FileText className='size-3.5 text-muted-foreground' />}
+            term='Prompt'>
+            The agent's persona and standing instructions. It frames how the agent behaves on every
+            run.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<BookOpen className='size-3.5 text-muted-foreground' />}
+            term='Knowledge'>
+            Reference docs the agent can pull from while it works, so its answers stay grounded in
+            your material.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+
+      {/* 3: draft -> publish */}
+      <GuideColumn title='Going live'>
+        <GuideConcepts>
+          <GuideConcept glyph={<Pencil className='size-3.5 text-muted-foreground' />} term='Draft'>
+            Where your edits live. Unsaved changes only affect the builder Chat tab and draft
+            simulations: production is untouched until you publish.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<History className='size-3.5 text-muted-foreground' />}
+            term='Published version'
+            example='Production always runs the published version, never your in-progress draft.'>
+            Publishing snapshots the current draft. Version history lets you compare and roll back.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+    </GuideColumns>
+  )
+}
+
+// ── Page 2: capabilities ──────────────────────────────────────────────────────
+
+/**
+ * What the agent can do and how it's scoped: tools, the per-tool binding overrides
+ * (with the same vocabulary the override editor uses), and knowledge.
+ */
+function CapabilitiesGuideBody() {
+  return (
+    <GuideColumns>
+      {/* 1: tools */}
+      <GuideColumn title='Tools'>
+        <GuideConcepts>
+          <GuideConcept glyph={<Wrench className='size-3.5 text-muted-foreground' />} term='Tools'>
+            The actions the agent can take: app integrations and built-ins. Enable the ones the task
+            needs; the model decides when to call them.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+
+      {/* 2: bindings — the override layer */}
+      <GuideColumn title='Bindings'>
+        <GuideConcepts>
+          <GuideConcept
+            glyph={<ShieldCheck className='size-3.5 text-muted-foreground' />}
+            term='Overrides'>
+            Tools run on their built-in defaults. Add an override to take control of a single input.
+            Most agents need none.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<Pin className='size-3.5 text-muted-foreground' />}
+            term='Pin a value'>
+            Lock an input to a constant so the model can't change it.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<Variable className='size-3.5 text-muted-foreground' />}
+            term='Rebind'>
+            Feed an input from another source instead of the default.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<Bot className='size-3.5 text-muted-foreground' />}
+            term='Model decides'>
+            Leave the input to the model: the standard behavior with no override.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+
+      {/* 3: knowledge */}
+      <GuideColumn title='Knowledge'>
+        <GuideConcepts>
+          <GuideConcept
+            glyph={<BookOpen className='size-3.5 text-muted-foreground' />}
+            term='Knowledge'
+            example='Product docs or policies the agent cites instead of guessing.'>
+            Docs the agent can search at runtime to ground its answers in your own material.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+    </GuideColumns>
+  )
+}
+
+// ── Page 3: procedures ────────────────────────────────────────────────────────
+
+/**
+ * The procedures deep-dive: how a procedure gets selected (when-to-run + use/avoid
+ * examples + rules) and the special steps you drop in from the `/` menu, each shown
+ * with the editor's own glyph.
+ */
+function ProceduresGuideBody() {
+  return (
+    <>
+      <GuideColumns cols={2}>
+        {/* 1: selection inputs, ordered like the trigger header */}
+        <GuideColumn title='When it runs'>
+          <GuideConcepts>
+            <GuideConcept
+              glyph={<Clock className='size-3.5 text-muted-foreground' />}
+              term='When to run'
+              example="Customer asks to cancel or change an order that hasn't shipped yet.">
+              A plain-language description of the situation this procedure handles. The agent reads
+              it to decide whether to pick this procedure.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<Filter className='size-3.5 text-muted-foreground' />}
+              term='Rules'>
+              Optional structured conditions that must hold before the procedure can run, like order
+              status is unfulfilled.
+            </GuideConcept>
+          </GuideConcepts>
+        </GuideColumn>
+
+        {/* 2: the use/avoid examples that sharpen selection */}
+        <GuideColumn title='Trigger examples'>
+          <GuideConcepts>
+            <GuideConcept
+              glyph={<Tags className='size-3.5 text-muted-foreground' />}
+              term='Why they matter'>
+              Short example phrases that sharpen which procedure the agent picks. Aim for 10 or
+              more.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<Check className='size-3.5 text-emerald-500' />}
+              term='Use when'
+              example='“I want to cancel my order.”'>
+              Situations that should pick this procedure.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<X className='size-3.5 text-muted-foreground' />}
+              term='Avoid when'
+              example='“Where is my order right now?”'>
+              Look-alike situations that should NOT, so the agent doesn't over-trigger.
+            </GuideConcept>
+          </GuideConcepts>
+        </GuideColumn>
+      </GuideColumns>
+
+      {/* Special steps — the structured insertions from the editor's `/` menu. */}
+      <GuideSection title='Special steps' cols={3}>
+        <GuideConcept
+          glyph={<Plus className='size-3.5 text-muted-foreground' />}
+          term='Insert with /'>
+          Most steps are plain instructions. Type <GuideCode>/</GuideCode> in the editor to drop in
+          one of these structured steps.
+        </GuideConcept>
+        <GuideConcept
+          glyph={<Square className='size-3.5 text-muted-foreground' />}
+          term='End procedure'>
+          Finish the run cleanly. The agent stops here and reports back.
+        </GuideConcept>
+        <GuideConcept glyph={<Hand className='size-3.5 text-amber-500' />} term='Hand off to human'>
+          Escalate to a teammate and hand over the conversation.
+        </GuideConcept>
+        <GuideConcept
+          glyph={<CornerDownRight className='size-3.5 text-muted-foreground' />}
+          term='Switch to procedure'>
+          Jump to a different procedure and continue the run there.
+        </GuideConcept>
+        <GuideConcept
+          glyph={<Workflow className='size-3.5 text-muted-foreground' />}
+          term='Sub-procedure'>
+          Call a reusable procedure inline, then return to this one.
+        </GuideConcept>
+        <GuideConcept
+          glyph={<GitBranch className='size-3.5 text-muted-foreground' />}
+          term='Condition (IF / ELSE)'>
+          Branch the following steps on a condition.
+        </GuideConcept>
+        <GuideConcept
+          glyph={<Code2 className='size-3.5 text-muted-foreground' />}
+          term='Code block'>
+          Run a JavaScript snippet and feed its output into later steps.
+        </GuideConcept>
+      </GuideSection>
+    </>
+  )
+}
+
+// ── Page 4: triggers ──────────────────────────────────────────────────────────
+
+/**
+ * How the agent fires on its own: the three trigger kinds, or the chat-widget note
+ * for chat agents (which have no scheduled / event / app triggers).
+ */
+function TriggersGuideBody({ isChat }: { isChat: boolean }) {
+  return (
+    <GuideColumns cols={2}>
+      <GuideColumn title='Triggers'>
+        <GuideConcepts>
+          {isChat ? (
+            <GuideConcept
+              glyph={<MessageCircle className='size-3.5 text-muted-foreground' />}
+              term='Chat widget'>
+              Chat agents run when a visitor messages the widget they're bound to. They have no
+              scheduled, event, or app triggers.
+            </GuideConcept>
+          ) : (
+            <>
+              <GuideConcept
+                glyph={<Clock className='size-3.5 text-muted-foreground' />}
+                term='Scheduled'>
+                Fire the agent on a recurring schedule.
+              </GuideConcept>
+              <GuideConcept glyph={<Zap className='size-3.5 text-muted-foreground' />} term='Event'>
+                Fire when a record changes, like a contact created or a ticket updated.
+              </GuideConcept>
+              <GuideConcept
+                glyph={<Plug className='size-3.5 text-muted-foreground' />}
+                term='App or webhook'>
+                Fire on an external app event or an inbound webhook.
+              </GuideConcept>
+            </>
+          )}
+        </GuideConcepts>
+      </GuideColumn>
+
+      <GuideColumn title='Good to know'>
+        <GuideConcepts>
+          <GuideConcept
+            glyph={<History className='size-3.5 text-muted-foreground' />}
+            term='Runs the published version'>
+            Triggers only fire the published version. Editing your draft never disrupts a live run.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+    </GuideColumns>
+  )
+}
+
+// ── Page 5: simulations ───────────────────────────────────────────────────────
+
+/**
+ * Testing the agent: how a simulation runs (a scripted customer talks to the agent
+ * and assertions grade it), the case setup, the four assertion types with the
+ * editor's own glyphs, and a "Going further" block on verdicts, the draft loop, and
+ * AI-suggested cases.
+ */
+function SimulationsGuideBody({ canProcedures }: { canProcedures: boolean }) {
+  return (
+    <>
+      <GuideColumns>
+        {/* 1: the happy path, ordered like the case editor */}
+        <GuideColumn title='How a simulation works'>
+          <GuideSteps>
+            <GuideStep n={1} title='Set the scene'>
+              Write the customer's opening message and any context they know. Optionally simulate as
+              a real contact.
+            </GuideStep>
+            <GuideStep n={2} title='Mock the tools'>
+              Give tools canned responses so a run is deterministic and offline. Writes are always
+              mocked.
+            </GuideStep>
+            <GuideStep n={3} title='Add assertions'>
+              State what must be true for the run to pass.
+            </GuideStep>
+            <GuideStep n={4} title='Run'>
+              A scripted customer holds the conversation with the agent.
+            </GuideStep>
+            <GuideStep n={5} title='Read the verdict'>
+              See pass or fail, the full conversation trace, and each assertion's result.
+            </GuideStep>
+          </GuideSteps>
+        </GuideColumn>
+
+        {/* 2: the case setup */}
+        <GuideColumn title='The setup'>
+          <GuideConcepts>
+            <GuideConcept
+              glyph={<User className='size-3.5 text-muted-foreground' />}
+              term='Customer'>
+              The scripted persona: opening message, context, channel, and how many turns it may
+              take. Point it at a contact to simulate a real customer.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<Wrench className='size-3.5 text-muted-foreground' />}
+              term='Tool responses'>
+              Mock what each tool returns. Read-only tools can optionally run live; writes never do.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<FlaskConical className='size-3.5 text-muted-foreground' />}
+              term='Scope'>
+              Test the whole agent, or{' '}
+              {canProcedures ? 'one procedure pinned to a version' : 'a single procedure'}.
+            </GuideConcept>
+          </GuideConcepts>
+        </GuideColumn>
+
+        {/* 3: the assertion types, with the editor's real glyphs */}
+        <GuideColumn title='Assertions'>
+          <GuideConcepts>
+            <GuideConcept
+              glyph={<Flag className='size-3.5 text-muted-foreground' />}
+              term='Terminal outcome'>
+              How the conversation must end: finished, handed off to a human, or switched to another
+              procedure.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<MessageSquareText className='size-3.5 text-muted-foreground' />}
+              term='Response criteria'>
+              Natural-language criteria the replies must satisfy, graded by an LLM.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<Wrench className='size-3.5 text-muted-foreground' />}
+              term='Tool called'>
+              The agent must call this tool at least once.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<Ban className='size-3.5 text-muted-foreground' />}
+              term='Tool not called'>
+              The agent must never call this tool.
+            </GuideConcept>
+          </GuideConcepts>
+        </GuideColumn>
+      </GuideColumns>
+
+      {/* Advanced: verdict nuance, the draft loop, and AI suggestions. */}
+      <GuideSection title='Going further' cols={3}>
+        <GuideConcept
+          glyph={<Check className='size-3.5 text-emerald-500' />}
+          term='Pass, fail, or error'>
+          Pass means every assertion held. Fail means one didn't. Error is different: the run or its
+          grading couldn't complete.
+        </GuideConcept>
+        <GuideConcept glyph={<Play className='size-3.5 text-muted-foreground' />} term='Run all'>
+          Run a whole suite at once and watch its live progress. A failing run can be handed to
+          Kopilot to fix.
+        </GuideConcept>
+        <GuideConcept
+          glyph={<History className='size-3.5 text-muted-foreground' />}
+          term='Draft loop'>
+          Run on the draft until it passes, then publish. The guide nudges a confirmation run on the
+          published version.
+        </GuideConcept>
+        <GuideConcept
+          glyph={<Sparkles className='size-3.5 text-muted-foreground' />}
+          term='Suggested simulations'>
+          For a procedure, the system reads your draft and proposes ready-to-run cases. Add the ones
+          you want.
+        </GuideConcept>
+      </GuideSection>
+    </>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
@@ -1,12 +1,13 @@
 // apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
 'use client'
 
+import { Button } from '@auxx/ui/components/button'
 import { NavStack, NavStackBar, NavStackPanel, NavStackPanels } from '@auxx/ui/components/nav-stack'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
-import { Clock, Layers, Plug } from 'lucide-react'
+import { CircleHelp, Clock, Layers, Plug } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useScrollSpy } from '~/hooks/use-scroll-spy'
 import { api } from '~/trpc/react'
 import { useConnectorCommit } from '../hooks/use-connector-commit'
@@ -18,6 +19,7 @@ import { asConnectorStatus } from './connector-status'
 import { ScheduleSection } from './schedule-section'
 import { StreamConfigPanel } from './stream-config-panel'
 import { StreamDetailBar } from './stream-detail-bar'
+import { StreamGuideDialog } from './stream-guide-dialog'
 import { StreamsSection } from './streams-section'
 
 type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
@@ -63,6 +65,11 @@ export function ConnectorDetailTabs({
 }: ConnectorDetailTabsProps) {
   const [tab, setTab] = useQueryState('tab', { defaultValue: 'connection' })
   const [selectedStreamId, setSelectedStreamId] = useQueryState('stream')
+  const [guideOpen, setGuideOpen] = useState(false)
+
+  // Branch the guide copy on connector kind (05c §7), matching `StreamConfigPanel`:
+  // app-kind connectors don't expose the request/pagination controls the guide explains.
+  const isGenericRest = connector.definitionKind !== 'app'
 
   const streams = api.dataConnector.listStreams.useQuery({ id: connector.id })
   const selectedStream = useMemo(
@@ -114,6 +121,7 @@ export function ConnectorDetailTabs({
       connectorId={connector.id}
       streamId={selectedStream.id}
       streamKey={selectedStream.streamKey}
+      isGenericRest={isGenericRest}
     />
   ) : null
 
@@ -147,6 +155,14 @@ export function ConnectorDetailTabs({
                       </TabsTrigger>
                     )
                   })}
+                  <Button
+                    variant='ghost'
+                    size='xs'
+                    className='ml-auto'
+                    onClick={() => setGuideOpen(true)}>
+                    <CircleHelp />
+                    Guide
+                  </Button>
                 </TabsList>
               </Tabs>
             }>
@@ -195,6 +211,13 @@ export function ConnectorDetailTabs({
           </NavStackPanel>
         </NavStackPanels>
       </NavStack>
+      {guideOpen && (
+        <StreamGuideDialog
+          open={guideOpen}
+          onOpenChange={setGuideOpen}
+          isGenericRest={isGenericRest}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -135,7 +135,6 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
     if (!draftSeeded || !draftMeta) return null
     const streams: ReadinessStream[] = draftStreams.map((s) => ({
       enabled: s.enabled,
-      streamKey: s.streamKey || null,
       sourceSchema: s.sourceSchema,
       requestConfig: s.requestConfig ?? null,
       mappings: visibleMappings(s).map((m) => ({

--- a/apps/web/src/components/data-connectors/ui/pagination-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/pagination-section.tsx
@@ -89,7 +89,10 @@ export function PaginationSection({ connector, stream, sample }: PaginationSecti
     getConnectorDraftState().setRequestConfig(stream.id, { ...cur, pagination: detected.spec })
   }
 
-  const hasDetected = !!(detectedPagination && detected)
+  // Once the configured pagination already matches the detection, there's nothing
+  // to apply — hide the whole proposal (otherwise "Use this" lingers after a click).
+  const alreadyUsingDetected = !!(detected && samePaginationSpec(pagination, detected.spec))
+  const hasDetected = !!(detectedPagination && detected && !alreadyUsingDetected)
 
   return (
     <Section
@@ -102,7 +105,7 @@ export function PaginationSection({ connector, stream, sample }: PaginationSecti
       className={hasDetected ? undefined : '[&_[data-slot=section]]:pb-0'}
       description='How this fetch reads through multiple pages.'
       actions={<PaginationBadge description={configuredPagination} />}>
-      {detectedPagination && detected && (
+      {hasDetected && detectedPagination && detected && (
         <div className='flex items-center gap-2 px-1'>
           <span className='text-xs text-muted-foreground'>Detected from test fetch</span>
           <PaginationBadge description={detectedPagination} note={detected.note} />
@@ -159,6 +162,17 @@ function PaginationTooltip({
       )}
       {note && <p className='text-amber-600 dark:text-amber-500'>{note}</p>}
     </div>
+  )
+}
+
+/** Shallow spec equality — pagination specs are flat records of scalars. */
+function samePaginationSpec(a?: PaginationSpec, b?: PaginationSpec): boolean {
+  if (!a || !b) return false
+  const ka = Object.keys(a).sort()
+  const kb = Object.keys(b).sort()
+  if (ka.length !== kb.length) return false
+  return ka.every(
+    (k, i) => k === kb[i] && (a as Record<string, unknown>)[k] === (b as Record<string, unknown>)[k]
   )
 }
 

--- a/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
@@ -19,7 +19,15 @@ import {
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { EmptySection, Section } from '@auxx/ui/components/section'
-import { ChevronDown, Database, FlaskConical, Pencil, RefreshCw, Waypoints } from 'lucide-react'
+import {
+  ChevronDown,
+  CircleHelp,
+  Database,
+  FlaskConical,
+  Pencil,
+  RefreshCw,
+  Waypoints,
+} from 'lucide-react'
 import { type ReactNode, useMemo, useState } from 'react'
 import type { HttpRequestFieldContextValue } from '~/components/global/http-request'
 import { makeTokenFieldEditor } from '~/components/global/token-field'
@@ -41,6 +49,7 @@ import {
   RevealChip,
 } from './request-editors'
 import { makeSteeringTokenSource } from './steering-token-source'
+import { StreamGuideDialog } from './stream-guide-dialog'
 import { StreamSample } from './stream-sample'
 
 type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
@@ -109,6 +118,7 @@ export function StreamConfigPanel({
   // Branch on the persisted definitionKind (05c §7), not a `type` prefix sniff.
   const isGenericRest = connector.definitionKind !== 'app'
 
+  const [helpOpen, setHelpOpen] = useState(false)
   const [seed, setSeed] = useState<{
     schema: Record<string, unknown>
     seededFrom: SeededFrom
@@ -459,7 +469,17 @@ export function StreamConfigPanel({
             icon={<Database className='size-4' />}
             initialOpen
             collapsible={false}
-            description='Project subtrees of the source onto target definitions.'>
+            description='Project subtrees of the source onto target definitions.'
+            actions={
+              <Button
+                variant='ghost'
+                size='xs'
+                onClick={() => setHelpOpen(true)}
+                aria-label='Mapping help'>
+                <CircleHelp />
+                Help
+              </Button>
+            }>
             <MappingTree
               connectorId={connector.id}
               streamId={stream.id}
@@ -479,6 +499,14 @@ export function StreamConfigPanel({
         policy={{ emitRequired: false, root: 'any', rootLabel: 'record', freeformNames: true }}
         onSave={handleSaveSchema}
       />
+      {helpOpen && (
+        <StreamGuideDialog
+          open={helpOpen}
+          onOpenChange={setHelpOpen}
+          initialPage='mapping'
+          isGenericRest={isGenericRest}
+        />
+      )}
     </>
   )
 

--- a/apps/web/src/components/data-connectors/ui/stream-detail-bar.tsx
+++ b/apps/web/src/components/data-connectors/ui/stream-detail-bar.tsx
@@ -4,15 +4,18 @@
 import { AutosizeInput, type AutosizeInputRef } from '@auxx/ui/components/autosize-input'
 import { Button } from '@auxx/ui/components/button'
 import { useNavStack } from '@auxx/ui/components/nav-stack'
-import { ChevronLeft } from 'lucide-react'
+import { ChevronLeft, CircleHelp } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { getConnectorDraftState, useConnectorDraftStore } from '../stores/connector-draft-store'
+import { StreamGuideDialog } from './stream-guide-dialog'
 
 interface StreamDetailBarProps {
   connectorId: string
   streamId: string
   /** Null until the user names the stream — the input shows its placeholder. */
   streamKey: string | null
+  /** Hides request/pagination copy in the guide for app-kind connectors. */
+  isGenericRest: boolean
 }
 
 /**
@@ -21,8 +24,14 @@ interface StreamDetailBarProps {
  * blank from the section and named here (mirrors the agent `ProcedureDetailBar`).
  * Rename writes the connector DRAFT (plans/data-connectors/v4); the save bar commits it.
  */
-export function StreamDetailBar({ connectorId, streamId, streamKey }: StreamDetailBarProps) {
+export function StreamDetailBar({
+  connectorId,
+  streamId,
+  streamKey,
+  isGenericRest,
+}: StreamDetailBarProps) {
   const { pop } = useNavStack()
+  const [guideOpen, setGuideOpen] = useState(false)
   // Prefer the draft's stream name so an unsaved rename shows live; fall back to the prop.
   const draftKey = useConnectorDraftStore(
     (s) => s.draft.streams.find((st) => st.id === streamId)?.streamKey
@@ -81,6 +90,17 @@ export function StreamDetailBar({ connectorId, streamId, streamKey }: StreamDeta
         minWidth={40}
         maxWidth={240}
       />
+      <Button variant='ghost' size='xs' className='ml-auto' onClick={() => setGuideOpen(true)}>
+        <CircleHelp />
+        Guide
+      </Button>
+      {guideOpen && (
+        <StreamGuideDialog
+          open={guideOpen}
+          onOpenChange={setGuideOpen}
+          isGenericRest={isGenericRest}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/data-connectors/ui/stream-guide-dialog.tsx
+++ b/apps/web/src/components/data-connectors/ui/stream-guide-dialog.tsx
@@ -1,0 +1,334 @@
+// apps/web/src/components/data-connectors/ui/stream-guide-dialog.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import {
+  GuideCode,
+  GuideColumn,
+  GuideColumns,
+  GuideConcept,
+  GuideConcepts,
+  GuideDialog,
+  GuidePage,
+  GuideSection,
+  GuideStep,
+  GuideSteps,
+} from '@auxx/ui/components/guide'
+import {
+  Braces,
+  Brackets,
+  ChevronRight,
+  Database,
+  FlaskConical,
+  FunctionSquare,
+  KeyRound,
+  Link2,
+  Pencil,
+  RefreshCw,
+  Waypoints,
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+type StreamGuidePage = 'setup' | 'mapping'
+
+/**
+ * The stream help guide: a two-page `GuideDialog` covering everything needed to
+ * wire up a stream. The "Setup" page walks the request: sample: schema: sync-mode
+ * flow; the "Mapping" page explains the mapping editor. A `Setup › Mapping` header
+ * (both always shown, the active one highlighted) switches between them, and the
+ * body crossfades + height-springs.
+ *
+ * Both entry points open the SAME dialog: the stream bar / connector tabs open at
+ * `setup`; the Mappings-section Help button deep-links at `mapping`. `isGenericRest`
+ * hides the request/pagination copy for app-kind connectors, which don't expose
+ * those controls.
+ */
+export function StreamGuideDialog({
+  open,
+  onOpenChange,
+  initialPage = 'setup',
+  isGenericRest = true,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Which page to land on when opened. Defaults to the setup walkthrough. */
+  initialPage?: StreamGuidePage
+  /** Hide request/pagination copy for app-kind connectors (no such controls). */
+  isGenericRest?: boolean
+}) {
+  // Re-seed the page each time the dialog opens so a deep-linked entry point
+  // always lands where it asked, regardless of where it was last closed.
+  const [page, setPage] = useState<StreamGuidePage>(initialPage)
+  useEffect(() => {
+    if (open) setPage(initialPage)
+  }, [open, initialPage])
+
+  return (
+    <GuideDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title='Stream guide'
+      heading='Help'
+      page={page}
+      crumbs={[
+        { label: 'Setup', active: page === 'setup', onClick: () => setPage('setup') },
+        { label: 'Mapping', active: page === 'mapping', onClick: () => setPage('mapping') },
+      ]}>
+      <GuidePage
+        value='setup'
+        size='3xl'
+        footer={
+          <div className='flex items-center justify-between'>
+            <p className='text-muted-foreground text-xs'>Press Esc to close</p>
+            <Button variant='ghost' size='xs' onClick={() => setPage('mapping')}>
+              Continue to mapping
+              <ChevronRight />
+            </Button>
+          </div>
+        }>
+        <SetupGuideBody isGenericRest={isGenericRest} />
+      </GuidePage>
+      <GuidePage value='mapping' size='3xl'>
+        <MappingGuideBody />
+      </GuidePage>
+    </GuideDialog>
+  )
+}
+
+// ── Page 1: stream setup ──────────────────────────────────────────────────────
+
+/**
+ * The setup walkthrough: a numbered happy path mirroring the panel's real
+ * section order, plus concept columns for the trickier vocabulary. The request
+ * and pagination rows drop out for app-kind connectors.
+ */
+function SetupGuideBody({ isGenericRest }: { isGenericRest: boolean }) {
+  return (
+    <GuideColumns>
+      {/* 1: the happy path, ordered like the panel itself */}
+      <GuideColumn title='How a stream is set up'>
+        <GuideSteps>
+          {isGenericRest && (
+            <GuideStep n={1} title='Request'>
+              Point the stream at an endpoint: method and path, plus any headers, query params, or
+              body.
+            </GuideStep>
+          )}
+          <GuideStep n={isGenericRest ? 2 : 1} title='Sample'>
+            Run a test fetch to pull a few real records and see exactly what the source returns.
+          </GuideStep>
+          <GuideStep n={isGenericRest ? 3 : 2} title='Source schema'>
+            Lock in the shape of one record: derived from your sample, or edited by hand.
+          </GuideStep>
+          <GuideStep n={isGenericRest ? 4 : 3} title='Sync mode'>
+            Choose whether each run re-reads everything or only what changed.
+          </GuideStep>
+          <GuideStep n={isGenericRest ? 5 : 4} title='Map the data'>
+            Project that shape onto your definitions: that's the last step, on the{' '}
+            <em className='not-italic text-foreground'>Mapping</em> page.
+          </GuideStep>
+        </GuideSteps>
+      </GuideColumn>
+
+      {/* 2: fetching the data */}
+      <GuideColumn title='Fetching'>
+        <GuideConcepts>
+          <GuideConcept
+            glyph={<FlaskConical className='size-3.5 text-muted-foreground' />}
+            term='Sample'>
+            A single live request against the source. It powers schema detection and the pagination
+            hint: nothing is written to your data.
+          </GuideConcept>
+          {isGenericRest && (
+            <GuideConcept
+              glyph={
+                <Badge variant='blue' size='xs'>
+                  pagination
+                </Badge>
+              }
+              term='Pagination'
+              inlineGlyph>
+              How the fetch walks through multiple pages of results. Detected from your test fetch;
+              the badge shows what's configured.
+            </GuideConcept>
+          )}
+        </GuideConcepts>
+      </GuideColumn>
+
+      {/* 3: shape & sync */}
+      <GuideColumn title='Shape & sync'>
+        <GuideConcepts>
+          <GuideConcept
+            glyph={<Database className='size-3.5 text-muted-foreground' />}
+            term='Source schema'>
+            The fields one record contains. Predefined for some connectors, auto-detected from a
+            sample, or hand-edited{' '}
+            <Pencil className='inline size-3 translate-y-px text-muted-foreground' />.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<RefreshCw className='size-3.5 text-muted-foreground' />}
+            term='Snapshot'>
+            Re-fetches the entire dataset each run. Records that vanish upstream are treated as
+            deleted.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<Waypoints className='size-3.5 text-muted-foreground' />}
+            term='Incremental'>
+            Uses a saved cursor to fetch only what changed since the last run. Nothing is archived.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+    </GuideColumns>
+  )
+}
+
+// ── Page 2: mapping ───────────────────────────────────────────────────────────
+
+/**
+ * The mapping explainer (formerly `MappingHelpDialog`): the editor's vocabulary
+ * with the SAME glyphs/badges the editor uses. Sync mode now lives on the setup
+ * page, so it's dropped from "Going further" here to avoid saying it twice.
+ */
+function MappingGuideBody() {
+  return (
+    <>
+      <GuideColumns>
+        {/* 1: the happy path */}
+        <GuideColumn title='How mapping works'>
+          <GuideSteps>
+            <GuideStep n={1} title='Pick a record source'>
+              Choose the part of the payload that becomes one record. An array like{' '}
+              <GuideCode>orders[]</GuideCode>{' '}
+              <Brackets className='inline size-3 text-muted-foreground' /> fans out to one record
+              per item; a single object maps once ("whole payload"{' '}
+              <Braces className='inline size-3 text-muted-foreground' />
+              ).
+            </GuideStep>
+            <GuideStep n={2} title='Send it to a definition'>
+              Map that source onto a target: Contact, Ticket, or your own definition. One source can
+              fan out to several.
+            </GuideStep>
+            <GuideStep n={3} title='Bind fields'>
+              Connect source values to fields on that definition. Fields you don't map are left
+              untouched.
+            </GuideStep>
+            <GuideStep n={4} title='Mark an External ID'>
+              <span className='inline-flex items-baseline gap-1'>
+                <KeyRound className='size-3 translate-y-0.5 text-primary' />
+                Set at least one field as the key
+              </span>{' '}
+              so re-syncs update the same record instead of creating duplicates.
+            </GuideStep>
+          </GuideSteps>
+        </GuideColumn>
+
+        {/* 2: identity */}
+        <GuideColumn title='Keys'>
+          <GuideConcepts>
+            <GuideConcept
+              glyph={<KeyRound className='size-3.5 text-primary' />}
+              term='External ID'
+              example={
+                <>
+                  A Shopify order's <GuideCode>id</GuideCode>: on the next sync the same order
+                  updates in place instead of creating a duplicate.
+                </>
+              }>
+              The upstream's primary key. Dedupes the record across every sync and anchors links
+              that point at it. Set one per record.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<KeyRound className='size-3.5 text-amber-500' />}
+              term='Match existing'
+              example={
+                <>
+                  Match a customer on <GuideCode>email</GuideCode>: the order attaches to the
+                  Contact you already have instead of creating a second one.
+                </>
+              }>
+              A secondary key (e.g. email). If a record with this value already exists, attach to it
+              instead of creating a new one: the External ID stays primary.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<KeyRound className='size-3.5 text-muted-foreground/40' />}
+              term='Not an identifier'>
+              A normal field: no effect on identity.
+            </GuideConcept>
+          </GuideConcepts>
+        </GuideColumn>
+
+        {/* 3: how records get written */}
+        <GuideColumn title='How records are written'>
+          <GuideConcepts>
+            <GuideConcept
+              glyph={
+                <Badge variant='amber' size='xs'>
+                  contributing
+                </Badge>
+              }
+              term='Contributing'
+              inlineGlyph>
+              Default. Writes into an existing, shared definition; updates only the fields you
+              mapped and never removes records.
+            </GuideConcept>
+            <GuideConcept
+              glyph={
+                <Badge variant='violet' size='xs'>
+                  owned
+                </Badge>
+              }
+              term='Owned'
+              inlineGlyph>
+              The connector owns these records in their own definition: it can even clean up ones
+              that disappear upstream.
+            </GuideConcept>
+            <GuideConcept
+              glyph={
+                <span className='flex flex-wrap gap-1'>
+                  <Badge variant='default' size='xs'>
+                    Always update
+                  </Badge>
+                  <Badge variant='sky' size='xs'>
+                    Only if empty
+                  </Badge>
+                  <Badge variant='emerald' size='xs'>
+                    Keep manual edits
+                  </Badge>
+                </span>
+              }
+              term='Per-field update rule'
+              inlineGlyph>
+              On each bound field, choose whether a synced value overwrites what's already there.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<Link2 className='size-3.5 text-muted-foreground' />}
+              term='Relationship link'>
+              Point a relationship field at a related definition via a foreign-key value. Resolved
+              by identity, so sync order doesn't matter.
+            </GuideConcept>
+          </GuideConcepts>
+        </GuideColumn>
+      </GuideColumns>
+
+      {/* Advanced: sync mode is intentionally absent (it lives on the setup page). */}
+      <GuideSection title='Going further'>
+        <GuideConcept
+          glyph={<Brackets className='size-3.5 text-muted-foreground' />}
+          term='Fan-out into nested records'>
+          Drill into a nested array like <GuideCode>line_items[]</GuideCode> to project it onto its
+          own definition: one child record per element, linked back to the parent.
+        </GuideConcept>
+        <GuideConcept term='Records deleted upstream'>
+          For owned records, anything that vanishes from the source is archived automatically on the
+          next full (snapshot) sync. Contributing records are never removed.
+        </GuideConcept>
+        <GuideConcept
+          glyph={<FunctionSquare className='size-3.5 text-muted-foreground' />}
+          term='Formula fields'>
+          Compute a value from one or more source fields instead of binding a single value.
+        </GuideConcept>
+      </GuideSection>
+    </>
+  )
+}

--- a/apps/web/src/components/dynamic-table/components/table-toolbar/index.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/index.tsx
@@ -16,6 +16,7 @@ import {
   ArrowDownUp,
   ArrowLeft,
   ChevronLeft,
+  CircleHelp,
   Download,
   RefreshCw,
   Save,
@@ -37,6 +38,7 @@ import { useActiveView, useTableFilters, useTableViews } from '../../stores/stor
 import type { ViewConfig, ViewType } from '../../types'
 import { ColumnManager } from './column-manager'
 import { KanbanViewSettings } from './kanban-view-settings'
+import { RecordsGuideDialog } from './records-guide-dialog'
 import { TableFilterBuilder } from './table-filter-builder'
 import { ViewSelector } from './view-selector'
 
@@ -112,6 +114,9 @@ export function TableToolbar<TData = any>({
 
   // Mobile search toggle
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false)
+
+  // Records help guide
+  const [guideOpen, setGuideOpen] = useState(false)
 
   // Local search state for immediate UI feedback
   const [localSearchQuery, setLocalSearchQuery] = useState(searchQuery)
@@ -283,6 +288,18 @@ export function TableToolbar<TData = any>({
 
       {/* Custom children */}
       {children && <div className='group-data-[search-expanded]/toolbar:hidden'>{children}</div>}
+
+      {/* Help guide — always last */}
+      <Tooltip content='Records guide'>
+        <Button
+          variant='ghost'
+          size='sm'
+          className='ml-auto group-data-[search-expanded]/toolbar:hidden'
+          onClick={() => setGuideOpen(true)}>
+          <CircleHelp />
+        </Button>
+      </Tooltip>
+      {guideOpen && <RecordsGuideDialog open={guideOpen} onOpenChange={setGuideOpen} />}
     </div>
   )
 }

--- a/apps/web/src/components/dynamic-table/components/table-toolbar/records-guide-dialog.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/records-guide-dialog.tsx
@@ -1,0 +1,310 @@
+// apps/web/src/components/dynamic-table/components/table-toolbar/records-guide-dialog.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  GuideColumn,
+  GuideColumns,
+  GuideConcept,
+  GuideConcepts,
+  GuideDialog,
+  GuideKbd,
+  GuidePage,
+  GuideSection,
+  GuideShortcut,
+  GuideShortcuts,
+  GuideStep,
+  GuideSteps,
+} from '@auxx/ui/components/guide'
+import { isMac } from '@auxx/utils'
+import {
+  ArrowDownUp,
+  ChevronRight,
+  Columns3,
+  Filter,
+  LayoutGrid,
+  ListChecks,
+  Lock,
+  MousePointerClick,
+  Pin,
+  Search,
+  Sparkles,
+  Star,
+  Table2,
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+type RecordsGuidePage = 'views' | 'display' | 'shortcuts'
+
+/** cmd on Mac, ctrl elsewhere — matches the cell-navigation key handling. */
+const mod = isMac() ? 'cmd' : 'ctrl'
+
+/**
+ * The records-view help guide: a three-page `GuideDialog` shared by every dynamic
+ * view (records, contacts, tickets, connectors, …) via the table toolbar's `?`
+ * button. "Views" explains the view lifecycle, "Display" covers view types and how
+ * you shape the grid, and "Shortcuts" lists the cell keyboard map. A
+ * `Views › Display › Shortcuts` header switches between them; the body crossfades.
+ */
+export function RecordsGuideDialog({
+  open,
+  onOpenChange,
+  initialPage = 'views',
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Which page to land on when opened. Defaults to the views overview. */
+  initialPage?: RecordsGuidePage
+}) {
+  // Re-seed the page each time the dialog opens so it never reopens on a stale page.
+  const [page, setPage] = useState<RecordsGuidePage>(initialPage)
+  useEffect(() => {
+    if (open) setPage(initialPage)
+  }, [open, initialPage])
+
+  return (
+    <GuideDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title='Records guide'
+      heading='Help'
+      page={page}
+      crumbs={[
+        { label: 'Views', active: page === 'views', onClick: () => setPage('views') },
+        { label: 'Display', active: page === 'display', onClick: () => setPage('display') },
+        { label: 'Shortcuts', active: page === 'shortcuts', onClick: () => setPage('shortcuts') },
+      ]}>
+      <GuidePage
+        value='views'
+        size='3xl'
+        footer={
+          <div className='flex items-center justify-between'>
+            <p className='text-muted-foreground text-xs'>Press Esc to close</p>
+            <Button variant='ghost' size='xs' onClick={() => setPage('display')}>
+              Display options
+              <ChevronRight />
+            </Button>
+          </div>
+        }>
+        <ViewsGuideBody />
+      </GuidePage>
+      <GuidePage
+        value='display'
+        size='3xl'
+        footer={
+          <div className='flex items-center justify-between'>
+            <p className='text-muted-foreground text-xs'>Press Esc to close</p>
+            <Button variant='ghost' size='xs' onClick={() => setPage('shortcuts')}>
+              Keyboard shortcuts
+              <ChevronRight />
+            </Button>
+          </div>
+        }>
+        <DisplayGuideBody />
+      </GuidePage>
+      <GuidePage value='shortcuts' size='3xl'>
+        <ShortcutsGuideBody />
+      </GuidePage>
+    </GuideDialog>
+  )
+}
+
+// ── Page 1: views ─────────────────────────────────────────────────────────────
+
+/**
+ * The view lifecycle: how a saved view captures your layout, plus the vocabulary
+ * around the view selector (All rows, default, shared, manage).
+ */
+function ViewsGuideBody() {
+  return (
+    <GuideColumns>
+      {/* 1: the happy path */}
+      <GuideColumn title='Saving a view'>
+        <GuideSteps>
+          <GuideStep n={1} title='Start from All rows'>
+            The base view every table opens with. Shape it freely: it just can't be saved over.
+          </GuideStep>
+          <GuideStep n={2} title='Shape the layout'>
+            Show or hide columns, reorder, resize, sort, and add filters until the table looks the
+            way you want.
+          </GuideStep>
+          <GuideStep n={3} title='Save as a view'>
+            One view captures columns, their order, widths, pinning, sort, and filters together.
+          </GuideStep>
+          <GuideStep n={4} title='Switch anytime'>
+            Pick any saved view from the selector; your unsaved tweaks stay until you save or reset
+            them.
+          </GuideStep>
+        </GuideSteps>
+      </GuideColumn>
+
+      {/* 2: the vocabulary */}
+      <GuideColumn title='Kinds of view'>
+        <GuideConcepts>
+          <GuideConcept glyph={<Lock className='size-3.5 text-muted-foreground' />} term='All rows'>
+            The unsaved starting point. Always shows every record with the default layout.
+          </GuideConcept>
+          <GuideConcept glyph={<Pin className='size-3.5 text-muted-foreground' />} term='Default'>
+            The view this table opens to. Set any saved view as the default from its menu.
+          </GuideConcept>
+          <GuideConcept glyph={<Star className='size-3.5 text-muted-foreground' />} term='Favorite'>
+            Pin a view to your sidebar for one-click access from anywhere.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+
+      {/* 3: managing */}
+      <GuideColumn title='Managing views'>
+        <GuideConcepts>
+          <GuideConcept term='Unsaved changes'>
+            A dot on the view menu means the layout drifted from what's saved. Save to keep it, or
+            reset to snap back.
+          </GuideConcept>
+          <GuideConcept term='Duplicate & rename'>
+            Branch a new view off an existing one, or rename it, from the view menu.
+          </GuideConcept>
+          <GuideConcept term='Save as new view'>
+            Changed the filters? A shortcut button offers to bank them as a fresh view without
+            touching the current one.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+    </GuideColumns>
+  )
+}
+
+// ── Page 2: display ───────────────────────────────────────────────────────────
+
+/**
+ * How you shape what you see: the two view types and the column / filter / sort
+ * controls, with formatting and import/export under "Going further".
+ */
+function DisplayGuideBody() {
+  return (
+    <>
+      <GuideColumns>
+        {/* 1: view types */}
+        <GuideColumn title='View types'>
+          <GuideConcepts>
+            <GuideConcept
+              glyph={<Table2 className='size-3.5 text-muted-foreground' />}
+              term='Table'>
+              The dense grid: sort, resize, pin columns, and edit cells inline. The default for any
+              records view.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<LayoutGrid className='size-3.5 text-muted-foreground' />}
+              term='Kanban'>
+              Group records by a single-select field into pipeline columns. Drag cards between
+              stages, choose which fields show on each card, and track time-in-status.
+            </GuideConcept>
+          </GuideConcepts>
+        </GuideColumn>
+
+        {/* 2: shaping the grid */}
+        <GuideColumn title='Shaping the grid'>
+          <GuideConcepts>
+            <GuideConcept
+              glyph={<Columns3 className='size-3.5 text-muted-foreground' />}
+              term='Columns'>
+              Show, hide, reorder, and resize fields. Pin the primary column so it stays put as you
+              scroll sideways.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<ArrowDownUp className='size-3.5 text-muted-foreground' />}
+              term='Sort'>
+              Order rows by any column. Saved into the view so it sticks.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<Filter className='size-3.5 text-muted-foreground' />}
+              term='Filter'>
+              Build conditions to narrow the rows down. Filters are part of the view.
+            </GuideConcept>
+          </GuideConcepts>
+        </GuideColumn>
+
+        {/* 3: finding records */}
+        <GuideColumn title='Finding records'>
+          <GuideConcepts>
+            <GuideConcept
+              glyph={<Search className='size-3.5 text-muted-foreground' />}
+              term='Search'>
+              Quick text search across the table, on top of whatever filters the view applies.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<ListChecks className='size-3.5 text-muted-foreground' />}
+              term='Select rows'>
+              Tick rows to act on several at once. Bulk actions appear when a selection is active.
+            </GuideConcept>
+          </GuideConcepts>
+        </GuideColumn>
+      </GuideColumns>
+
+      <GuideSection title='Going further'>
+        <GuideConcept term='Column formatting'>
+          Tune how values display per column: currency, dates and times, number precision, phone
+          format, and checkboxes.
+        </GuideConcept>
+        <GuideConcept
+          glyph={<ArrowDownUp className='size-3.5 text-muted-foreground' />}
+          term='Import & export'>
+          Bring records in from a CSV, or export the current view. Find both under the Import /
+          Export menu.
+        </GuideConcept>
+      </GuideSection>
+    </>
+  )
+}
+
+// ── Page 3: shortcuts ─────────────────────────────────────────────────────────
+
+/**
+ * The cell keyboard map (from `use-cell-navigation` + `use-cell-clipboard`), plus
+ * a couple of mouse-driven tips for the fill handle and range select.
+ */
+function ShortcutsGuideBody() {
+  return (
+    <GuideColumns>
+      <GuideColumn title='Move & select'>
+        <GuideShortcuts>
+          <GuideShortcut keys={['↑', '↓', '←', '→']} label='Move cell' />
+          <GuideShortcut keys={[mod, '→']} label='Jump to edge' />
+          <GuideShortcut keys={['shift', '→']} label='Extend selection' />
+          <GuideShortcut keys={['Tab']} label='Next cell' />
+          <GuideShortcut keys={['shift', 'Tab']} label='Previous cell' />
+          <GuideShortcut keys={[mod, 'A']} label='Select all cells' />
+        </GuideShortcuts>
+      </GuideColumn>
+
+      <GuideColumn title='Edit & clipboard'>
+        <GuideShortcuts>
+          <GuideShortcut keys={['enter']} label='Edit cell' />
+          <GuideShortcut keys={['esc']} label='Collapse, then clear' />
+          <GuideShortcut keys={[mod, 'C']} label='Copy' />
+          <GuideShortcut keys={[mod, 'V']} label='Paste' />
+          <GuideShortcut keys={['Del']} label='Clear cells' />
+        </GuideShortcuts>
+      </GuideColumn>
+
+      <GuideColumn title='Tips'>
+        <GuideConcepts>
+          <GuideConcept
+            glyph={<MousePointerClick className='size-3.5 text-muted-foreground' />}
+            term='Fill handle'>
+            Drag the corner of a selection to copy the value down a column.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<Sparkles className='size-3.5 text-muted-foreground' />}
+            term='AI autofill'>
+            Drag the fill handle over an AI column to generate a value for each row instead of
+            copying.
+          </GuideConcept>
+          <GuideConcept term='Copy & paste anywhere'>
+            Cells round-trip losslessly between auxx tables, and paste cleanly to and from Excel,
+            Sheets, and Notion. Press <GuideKbd k='cmd' /> <GuideKbd>C</GuideKbd> to copy a range.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+    </GuideColumns>
+  )
+}

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -154,8 +154,9 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
   async fetchSlice(ctx: SyncSliceCtx): Promise<SliceResult> {
     const counters = newRunCounters()
     const syncCtx = await this.buildCtx(counters, this.deps.stream.mappings)
-    const streamKey = this.deps.stream.streamKey
-    if (!streamKey) throw new Error(`SyncSource ${this.id}: stream has no streamKey`)
+    // A stream needs no user-facing name to sync — fall back to the stable streamId
+    // as the functional fetch/record key when it's unnamed.
+    const streamKey = this.deps.stream.streamKey || this.deps.stream.streamId
 
     // Async bulk export (Step 7): a large BACKFILL runs the initiate→poll→download
     // lifecycle instead of synchronous paging. Steady deltas still page/webhook, so

--- a/packages/lib/src/data-connectors/connector-webhook.ts
+++ b/packages/lib/src/data-connectors/connector-webhook.ts
@@ -69,7 +69,10 @@ export async function runWebhookSteeredRun(
     return
   }
   const { connector, streams } = loaded
-  const stream = streams.find((s) => s.stream.streamKey === streamKey)
+  // Match by the functional key — a named stream uses its streamKey, an unnamed one its
+  // stable streamId (the dispatch enqueues the same fallback). Keeps webhook deletes +
+  // steered fetches routable for streams the user never named.
+  const stream = streams.find((s) => (s.stream.streamKey ?? s.stream.id) === streamKey)
   const webhookTrigger = stream?.stream.requestConfig?.webhookTrigger
   if (!stream || !webhookTrigger) {
     logger.info('runWebhookSteeredRun: stream unmapped or not webhook-bound, dropping', {

--- a/packages/lib/src/data-connectors/readiness.test.ts
+++ b/packages/lib/src/data-connectors/readiness.test.ts
@@ -23,7 +23,6 @@ const withBaseUrl = genericRest({ endpoint: { baseUrl: 'https://api.example.com'
 /** A fully-configured generic-rest stream. Override fields to break it. */
 const completeStream = (over: Partial<ReadinessStream> = {}): ReadinessStream => ({
   enabled: true,
-  streamKey: 'orders',
   sourceSchema: { id: { type: 'string' } },
   requestConfig: { path: '/orders' },
   mappings: [{ entityDefinitionId: 'def_1', fieldMappings: [{ id: 'fm_1' }] }],
@@ -77,9 +76,11 @@ describe('getConnectorReadiness — canSync (streams)', () => {
     expect(r.problems[0]).toBe('stream-no-path')
   })
 
-  it('stream missing a streamKey → stream-no-path', () => {
-    const r = getConnectorReadiness(withBaseUrl, [completeStream({ streamKey: null })])
-    expect(r.problems[0]).toBe('stream-no-path')
+  it('a user-facing name is not required to sync → an unnamed but complete stream syncs', () => {
+    // The stable streamId is the functional key; a blank name never blocks sync.
+    const r = getConnectorReadiness(withBaseUrl, [completeStream()])
+    expect(r.canSync).toBe(true)
+    expect(r.problems).toEqual([])
   })
 
   it('stream with path but no schema → stream-no-schema', () => {
@@ -132,7 +133,7 @@ describe('getConnectorReadiness — canSync (streams)', () => {
 
   it('multi-stream none complete: reports the closest-to-complete stream reason', () => {
     const r = getConnectorReadiness(withBaseUrl, [
-      completeStream({ streamKey: null }), // fails earliest (path)
+      completeStream({ requestConfig: null }), // fails earliest (path)
       completeStream({ mappings: [{ entityDefinitionId: null, fieldMappings: null }] }), // fails latest (mapping)
     ])
     expect(r.canSync).toBe(false)

--- a/packages/lib/src/data-connectors/readiness.ts
+++ b/packages/lib/src/data-connectors/readiness.ts
@@ -12,7 +12,7 @@ import type { DataConnectorConfig } from './types'
 export type ReadinessProblem =
   | 'no-endpoint' // no base URL (generic-rest) / no bound connection (app)
   | 'no-stream' // no enabled stream at all
-  | 'stream-no-path' // best stream missing streamKey / requestConfig.path
+  | 'stream-no-path' // best stream missing requestConfig.path
   | 'stream-no-schema' // best stream missing sourceSchema
   | 'no-mapping' // best stream has no targeted mapping with a field mapping
 
@@ -33,7 +33,6 @@ export interface ConnectorReadiness {
  */
 export interface ReadinessStream {
   enabled: boolean
-  streamKey: string | null
   sourceSchema: Record<string, unknown> | null
   requestConfig: { path?: string } | null
   mappings: { entityDefinitionId: string | null; fieldMappings: unknown[] | null }[]
@@ -65,15 +64,14 @@ const STREAM_STEPS = ['stream-no-path', 'stream-no-schema', 'no-mapping'] as con
 /**
  * First failing step of an enabled stream, in order path → schema → mapping, or
  * `null` when fully configured. `requirePath` is false for app connectors (their
- * fetch is fixed — no request path to author).
+ * fetch is fixed — no request path to author). A stream needs no user-facing name
+ * to sync — its stable `streamId` is the functional key (see slice-orchestrator).
  */
 function firstStreamFailure(
   stream: ReadinessStream,
   requirePath: boolean
 ): (typeof STREAM_STEPS)[number] | null {
-  const hasKey = !!stream.streamKey && stream.streamKey.length > 0
-  const hasPath = !requirePath || !!stream.requestConfig?.path
-  if (!hasKey || !hasPath) return 'stream-no-path'
+  if (requirePath && !stream.requestConfig?.path) return 'stream-no-path'
   if (!hasSchema(stream.sourceSchema)) return 'stream-no-schema'
   if (!hasTargetedMapping(stream.mappings)) return 'no-mapping'
   return null
@@ -84,10 +82,10 @@ function firstStreamFailure(
  *
  * - `canSample` = endpoint present (generic-rest: `config.endpoint.baseUrl`;
  *   app connector: a bound `credentialId`). Enough for a Test fetch.
- * - `canSync` = `canSample` AND ≥1 ENABLED, fully-configured stream (streamKey,
- *   a request path for generic-rest, a non-empty `sourceSchema`, and a targeted
- *   mapping with ≥1 field mapping). At least one — never every — stream, so a
- *   connector mid-build of a second stream still syncs the first.
+ * - `canSync` = `canSample` AND ≥1 ENABLED, fully-configured stream (a request
+ *   path for generic-rest, a non-empty `sourceSchema`, and a targeted mapping
+ *   with ≥1 field mapping — no user-facing name required). At least one — never
+ *   every — stream, so a connector mid-build of a second stream still syncs the first.
  *
  * Pure: reads only the named fields, no DB. `problems[0]` is the actionable hint.
  */

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -142,9 +142,9 @@ export async function loadConnector(
         .filter((m) => m.entityDefinitionId !== null)
         .map(decodeMapping),
     }))
-    // Skip unconfigured streams: no targeted mappings, or not yet named (a blank
-    // stream has no streamKey, so there's nothing to fetch).
-    .filter((s) => s.mappings.length > 0 && !!s.stream.streamKey)
+    // Skip unconfigured streams: no targeted mappings means nowhere for a fetch to
+    // land. A missing streamKey is fine — the stable streamId is the functional key.
+    .filter((s) => s.mappings.length > 0)
 
   return { connector, streams }
 }

--- a/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.ts
+++ b/packages/lib/src/jobs/data-connector/app-trigger-sync-dispatch-job.ts
@@ -101,7 +101,7 @@ export async function dispatchAppTriggerToConnectors(
       ),
       eq(schema.DataConnectorStream.enabled, true)
     ),
-    columns: { dataConnectorId: true, streamKey: true, requestConfig: true },
+    columns: { id: true, dataConnectorId: true, streamKey: true, requestConfig: true },
   })
 
   // Match streams by `webhookTrigger.filter` (topic discrimination), then SPLIT by mode:
@@ -116,11 +116,13 @@ export async function dispatchAppTriggerToConnectors(
   const matched: { connectorId: string; streamKey: string; steerable: boolean }[] = []
   for (const stream of streams) {
     const wt = stream.requestConfig?.webhookTrigger
-    if (!stream.streamKey || !wt) continue
+    if (!wt) continue
     if (!matchesFilter(wt.filter, triggerData)) continue
     matched.push({
       connectorId: stream.dataConnectorId,
-      streamKey: stream.streamKey,
+      // An unnamed stream routes by its stable streamId (the functional key) — same
+      // fallback the sync/steer paths use, so a nameless stream is still webhook-routable.
+      streamKey: stream.streamKey ?? stream.id,
       steerable: isSteerableDelivery(stream.requestConfig, triggerData),
     })
   }

--- a/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
+++ b/packages/lib/src/jobs/data-connector/webhook-endpoint-sync-dispatch-job.ts
@@ -104,7 +104,7 @@ export async function dispatchWebhookEndpointToConnectors(
       ),
       eq(schema.DataConnectorStream.enabled, true)
     ),
-    columns: { dataConnectorId: true, streamKey: true, requestConfig: true },
+    columns: { id: true, dataConnectorId: true, streamKey: true, requestConfig: true },
   })
 
   // Match streams by `webhookTrigger.filter` (topic discrimination), then SPLIT by mode —
@@ -114,7 +114,6 @@ export async function dispatchWebhookEndpointToConnectors(
   // A connector with ANY non-steerable matched stream full-syncs (superset covers the rest).
   const matched: { connectorId: string; streamKey: string; steerable: boolean }[] = []
   for (const stream of streams) {
-    if (!stream.streamKey) continue
     // The connector-level signal is the binding; per-stream `webhookTrigger` only REFINES it.
     // A stream with no steering block still reacts: no `filter` ⇒ matches every topic
     // (`matchesFilter` treats absent/empty as match-all), no `paths` ⇒ not steerable ⇒ a full
@@ -124,7 +123,9 @@ export async function dispatchWebhookEndpointToConnectors(
     if (!matchesFilter(wt?.filter, matchData)) continue
     matched.push({
       connectorId: stream.dataConnectorId,
-      streamKey: stream.streamKey,
+      // An unnamed stream routes by its stable streamId (the functional key) — same
+      // fallback the sync/steer paths use, so a nameless stream is still webhook-routable.
+      streamKey: stream.streamKey ?? stream.id,
       steerable: isSteerableDelivery(stream.requestConfig, matchData),
     })
   }

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -318,7 +318,14 @@ function CommandBreadcrumb({
 function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
   return (
     <CommandPrimitive
-      className={cn('flex h-full w-full flex-col  rounded-2xl text-popover-foreground', className)}
+      className={cn(
+        'flex h-full w-full flex-col  rounded-2xl text-popover-foreground',
+        // When there's no CommandInput above the list, the list sits flush at the
+        // top — round its top corners to the container radius so its overflow-clip
+        // trims the first group's sticky label to match (no square corner poke).
+        '[&:not(:has([cmdk-input-wrapper]))>[data-slot=command-list]]:rounded-t-[inherit]',
+        className
+      )}
       {...props}
     />
   )
@@ -580,6 +587,7 @@ function CommandGroup({
 function CommandGroupLabel({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
+      data-slot='command-group-label'
       className={cn(
         'sticky top-0 z-10 -mt-1 -mx-1 bg-background/90 backdrop-blur-lg px-2 py-1.5 text-xs font-medium text-muted-foreground mask-b-from-80%',
         className

--- a/packages/ui/src/components/dialog-nav.tsx
+++ b/packages/ui/src/components/dialog-nav.tsx
@@ -32,8 +32,15 @@ const SPRING = { type: 'spring', stiffness: 300, damping: 30 } as const
 
 export interface DialogNavCrumb {
   label: ReactNode
-  /** Omit on the last/current crumb; set to make it a clickable jump-back. */
+  /** Set to make the crumb a clickable jump (back or forward). */
   onClick?: () => void
+  /**
+   * Mark this crumb as the current page (highlighted, non-interactive). When no
+   * crumb sets `active`, the **last** crumb is treated as current. Set it to show
+   * every destination at once and let the active one be any of them — e.g. a
+   * bidirectional `Setup › Mapping` header where either side can be current.
+   */
+  active?: boolean
   icon?: ReactNode
 }
 
@@ -42,6 +49,12 @@ export interface DialogNavProps {
   title: string
   /** sr-only DialogDescription. */
   description?: string
+  /**
+   * A visible leading label before the crumbs (e.g. "Help"), separated from them
+   * by a divider. Use when the crumbs act as tabs and you still want a fixed
+   * dialog title in front of them.
+   */
+  heading?: ReactNode
   crumbs: DialogNavCrumb[]
   /** Renders the leading "‹ Back" button when provided. */
   onBack?: () => void
@@ -60,12 +73,15 @@ export interface DialogNavProps {
 export function DialogNav({
   title,
   description,
+  heading,
   crumbs,
   onBack,
   backDisabled,
   actions,
   className,
 }: DialogNavProps) {
+  // When no crumb marks itself active, fall back to "last crumb is current".
+  const hasExplicitActive = crumbs.some((c) => c.active)
   return (
     <DialogHeader
       className={cn(
@@ -85,8 +101,14 @@ export function DialogNav({
             <Separator orientation='vertical' className='h-5' />
           </>
         )}
+        {heading && (
+          <>
+            <span className='px-2 font-medium text-foreground text-sm'>{heading}</span>
+            {crumbs.length > 0 && <Separator orientation='vertical' className='h-5' />}
+          </>
+        )}
         {crumbs.map((crumb, i) => {
-          const isLast = i === crumbs.length - 1
+          const isCurrent = hasExplicitActive ? !!crumb.active : i === crumbs.length - 1
           return (
             <Fragment key={i}>
               {i > 0 && <Separator orientation='vertical' className='h-5' />}
@@ -94,8 +116,8 @@ export function DialogNav({
                 variant='ghost'
                 size='sm'
                 onClick={crumb.onClick}
-                disabled={isLast || !crumb.onClick}
-                className={isLast ? 'pointer-events-none' : undefined}>
+                disabled={isCurrent || !crumb.onClick}
+                className={isCurrent ? 'pointer-events-none' : undefined}>
                 {crumb.icon}
                 {crumb.label}
               </Button>

--- a/packages/ui/src/components/guide.tsx
+++ b/packages/ui/src/components/guide.tsx
@@ -101,7 +101,7 @@ export function GuideDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* Paged guides shrink-wrap to the animating body (`content`); static ones
           use the fixed width preset. */}
-      <DialogContent size={paged ? 'content' : size} innerClassName='p-0'>
+      <DialogContent size={paged ? 'content' : size} position='tc' innerClassName='p-0'>
         <div className='flex flex-col'>
           <DialogNav
             title={title}

--- a/packages/ui/src/components/guide.tsx
+++ b/packages/ui/src/components/guide.tsx
@@ -1,0 +1,392 @@
+// packages/ui/src/components/guide.tsx
+'use client'
+
+import { Dialog, DialogContent, type DialogSize } from '@auxx/ui/components/dialog'
+import {
+  DialogNav,
+  type DialogNavCrumb,
+  DialogNavPage,
+  DialogNavPages,
+} from '@auxx/ui/components/dialog-nav'
+import { Kbd, KbdGroup, type ShortcutKey } from '@auxx/ui/components/kbd'
+import { cn } from '@auxx/ui/lib/utils'
+import type { ReactNode } from 'react'
+
+/**
+ * Guide — the shared look for read-only "quick start" / help-sheet dialogs. A titled
+ * surface of explanatory columns: numbered steps, glyph+term concepts, and example
+ * callouts. The CONTENT primitives (`GuideColumns`, `GuideColumn`, `GuideSteps`,
+ * `GuideStep`, `GuideConcept`, `GuideSection`, `GuideCode`) are container-agnostic —
+ * drop them into `GuideDialog` here, or into any overlay/sheet that wants the same
+ * vocabulary. Modeled on `apps/web/.../getting-started-overlay`'s `p-6` grid.
+ *
+ * @example
+ * <GuideDialog open={open} onOpenChange={setOpen} title='Mapping quick start'>
+ *   <GuideColumns>
+ *     <GuideColumn title='Keys'>
+ *       <GuideConcept glyph={<KeyRound />} term='External ID' example='An order id…'>
+ *         The upstream's primary key…
+ *       </GuideConcept>
+ *     </GuideColumn>
+ *   </GuideColumns>
+ *   <GuideSection title='Going further'>…</GuideSection>
+ * </GuideDialog>
+ */
+
+// ── Dialog shell ──────────────────────────────────────────────────────────────
+
+export interface GuideDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The title shown in the nav bar (also the accessible dialog title). */
+  title: string
+  /** Screen-reader-only summary; falls back to the title when omitted. */
+  description?: string
+  /**
+   * A visible leading label before the crumbs (e.g. "Help"), separated by a
+   * divider. Use with a custom `crumbs` trail acting as tabs, so a fixed dialog
+   * title sits in front of the page switches. (Single-crumb guides don't need it:
+   * their `title` already renders as the lone crumb.)
+   */
+  heading?: ReactNode
+  /**
+   * Override the nav breadcrumb trail. Defaults to a single current crumb from
+   * `title`. Pass a trail when several guides share one dialog (e.g. tabbed help
+   * sheets or a drill-in), so the bar reflects where the reader is.
+   */
+  crumbs?: DialogNavCrumb[]
+  /**
+   * Active page key. When set, the body animates between `GuidePage` children
+   * (crossfade + height/width spring) via `DialogNavPages`, and the shell becomes
+   * content-sized. Leave unset for a single static body. Pair with `crumbs` (mark
+   * the active one) for a multi-page header.
+   */
+  page?: string
+  /** Renders the leading "‹ Back" button in the nav bar when provided. */
+  onBack?: () => void
+  /** Right-aligned slot in the nav bar — e.g. tabs or a step indicator. */
+  navActions?: ReactNode
+  /** Dialog width preset. Defaults to a roomy `3xl` for multi-column guides. */
+  size?: DialogSize
+  /**
+   * Footer hint on the right (static-body mode only). Defaults to "Press Esc to
+   * close"; pass `null` to hide. In paged mode each `GuidePage` owns its footer.
+   */
+  footer?: ReactNode
+  children: ReactNode
+}
+
+/**
+ * A help/quick-start dialog: a `DialogNav` header carrying the title (so multiple
+ * guides can share one dialog via `crumbs`/`navActions`/`onBack`) above the
+ * standard `p-6` body and Esc footer. Set `page` (+ `GuidePage` children) for an
+ * animated multi-page body, with `crumbs` marking the active page in the header.
+ */
+export function GuideDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  heading,
+  crumbs,
+  page,
+  onBack,
+  navActions,
+  size = '3xl',
+  footer = 'Press Esc to close',
+  children,
+}: GuideDialogProps) {
+  const paged = page !== undefined
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* Paged guides shrink-wrap to the animating body (`content`); static ones
+          use the fixed width preset. */}
+      <DialogContent size={paged ? 'content' : size} innerClassName='p-0'>
+        <div className='flex flex-col'>
+          <DialogNav
+            title={title}
+            description={description ?? title}
+            heading={heading}
+            crumbs={crumbs ?? [{ label: title }]}
+            onBack={onBack}
+            actions={navActions}
+          />
+          {paged ? (
+            <DialogNavPages value={page}>{children}</DialogNavPages>
+          ) : (
+            <div className='p-6'>
+              {children}
+              {footer && (
+                <div className='mt-4 flex justify-end'>
+                  <p className='text-muted-foreground text-xs'>{footer}</p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/**
+ * One page of a paged `GuideDialog` (rendered only when active). Wraps the body in
+ * the standard `p-6` padding and an optional footer row; the dialog crossfades and
+ * height-springs between pages.
+ *
+ * - `value` is matched against the dialog's `page`.
+ * - `size` is the width the body springs to. Keep it equal across a guide's pages
+ *   for a pure height/crossfade switch. **Pass it explicitly** — a default-param
+ *   value wouldn't surface on the element's props, which is where the underlying
+ *   `DialogNavPages` reads the width.
+ * - `footer` renders below the body: a string shows as the right-aligned Esc hint;
+ *   a node renders as-is; `null` hides it.
+ */
+export function GuidePage({
+  value,
+  size = '3xl',
+  footer = 'Press Esc to close',
+  children,
+}: {
+  value: string
+  size?: DialogSize
+  footer?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <DialogNavPage value={value} size={size}>
+      <div className='p-6'>
+        {children}
+        {footer != null &&
+          (typeof footer === 'string' ? (
+            <div className='mt-4 flex justify-end'>
+              <p className='text-muted-foreground text-xs'>{footer}</p>
+            </div>
+          ) : (
+            <div className='mt-4'>{footer}</div>
+          ))}
+      </div>
+    </DialogNavPage>
+  )
+}
+
+// ── Content primitives (container-agnostic) ───────────────────────────────────
+
+/** Responsive grid of `GuideColumn`s. Defaults to 3 columns on `md+`. */
+export function GuideColumns({
+  cols = 3,
+  className,
+  children,
+}: {
+  cols?: 2 | 3 | 4
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-1 gap-6',
+        cols === 2 && 'md:grid-cols-2',
+        cols === 3 && 'md:grid-cols-3',
+        cols === 4 && 'md:grid-cols-4',
+        className
+      )}>
+      {children}
+    </div>
+  )
+}
+
+/** A titled column with the uppercase-muted section heading. */
+export function GuideColumn({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className='space-y-3'>
+      <h3 className='font-medium text-muted-foreground text-xs uppercase tracking-wide'>{title}</h3>
+      {children}
+    </div>
+  )
+}
+
+/** Ordered list wrapper for `GuideStep`s. */
+export function GuideSteps({ children }: { children: ReactNode }) {
+  return <ol className='space-y-2.5 text-sm'>{children}</ol>
+}
+
+/**
+ * Description-list wrapper for a column of `GuideConcept`s (gives the `dt`/`dd` a
+ * valid `dl` ancestor). Not needed inside `GuideSection`, which renders its own `dl`.
+ */
+export function GuideConcepts({ children }: { children: ReactNode }) {
+  return <dl className='space-y-2.5 text-sm'>{children}</dl>
+}
+
+/** A numbered step: number gutter + bold title + muted detail. */
+export function GuideStep({
+  n,
+  title,
+  children,
+}: {
+  n: number
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <li className='flex gap-2'>
+      <span className='shrink-0 font-medium text-muted-foreground'>{n}.</span>
+      <div>
+        <span className='font-medium'>{title}</span>
+        <p className='mt-0.5 text-muted-foreground text-xs'>{children}</p>
+      </div>
+    </li>
+  )
+}
+
+/**
+ * A glyph + term + description entry, with an optional left-ruled example callout.
+ *
+ * - `glyph` is rendered before the term (an icon or a badge cluster). When present
+ *   on the default layout, the description aligns under the term.
+ * - `inlineGlyph` keeps the description flush-left — use it for wide glyphs (badge
+ *   clusters) where a hanging indent would look off.
+ */
+export function GuideConcept({
+  glyph,
+  term,
+  example,
+  inlineGlyph = false,
+  children,
+}: {
+  glyph?: ReactNode
+  term: string
+  example?: ReactNode
+  inlineGlyph?: boolean
+  children: ReactNode
+}) {
+  return (
+    <div>
+      <dt className={cn('flex', inlineGlyph ? 'items-center gap-2' : 'items-center gap-1.5')}>
+        {glyph &&
+          (inlineGlyph ? (
+            glyph
+          ) : (
+            <span className='inline-flex w-4 shrink-0 justify-center'>{glyph}</span>
+          ))}
+        <span className='font-medium text-foreground text-sm'>{term}</span>
+      </dt>
+      <dd
+        className={cn(
+          'mt-0.5 text-muted-foreground text-xs',
+          glyph && !inlineGlyph && 'pl-[1.375rem]'
+        )}>
+        {children}
+        {example && <GuideExample>{example}</GuideExample>}
+      </dd>
+    </div>
+  )
+}
+
+/** A muted, left-ruled "Example:" line shown beneath a concept's description. */
+export function GuideExample({ children }: { children: ReactNode }) {
+  return (
+    <span className='mt-1 block border-muted-foreground/20 border-l-2 pl-2 text-muted-foreground/80'>
+      <span className='font-medium'>Example: </span>
+      {children}
+    </span>
+  )
+}
+
+/**
+ * A secondary block below the main columns ("Going further") — a top rule, an
+ * uppercase heading, and a responsive grid of `GuideConcept`s. Defaults to 2 columns.
+ */
+export function GuideSection({
+  title,
+  cols = 2,
+  children,
+}: {
+  title: string
+  cols?: 1 | 2 | 3
+  children: ReactNode
+}) {
+  return (
+    <div className='mt-6 border-t pt-4'>
+      <h3 className='mb-3 font-medium text-muted-foreground text-xs uppercase tracking-wide'>
+        {title}
+      </h3>
+      <dl
+        className={cn(
+          'grid grid-cols-1 gap-x-6 gap-y-3 text-sm',
+          cols === 2 && 'sm:grid-cols-2',
+          cols === 3 && 'sm:grid-cols-3'
+        )}>
+        {children}
+      </dl>
+    </div>
+  )
+}
+
+/** Inline monospace token for paths / field names inside guide copy. */
+export function GuideCode({ children }: { children: ReactNode }) {
+  return (
+    <code className='rounded bg-muted px-1 font-mono text-foreground text-[11px]'>{children}</code>
+  )
+}
+
+/** Keys that render as a glyph/label via `Kbd`'s `shortcut` prop; everything else is literal text. */
+const SHORTCUT_KEYS = new Set<ShortcutKey>([
+  'cmd',
+  'command',
+  'ctrl',
+  'esc',
+  'enter',
+  'alt',
+  'option',
+])
+
+/**
+ * Inline keyboard key for use inside guide copy (the keyboard sibling of
+ * `GuideCode`): renders a single `Kbd` with the guide's outline/sm styling. Pass a
+ * shortcut token (cmd/ctrl/enter/esc/alt) as `k` to get its glyph, or `children`
+ * for a literal key like `N`.
+ *
+ * @example Press <GuideKbd>N</GuideKbd> or <GuideKbd k='cmd' /><GuideKbd>C</GuideKbd>.
+ */
+export function GuideKbd({ k, children }: { k?: ShortcutKey; children?: ReactNode }) {
+  return (
+    <Kbd
+      variant='outline'
+      size='sm'
+      {...(k && SHORTCUT_KEYS.has(k) ? { shortcut: k } : { children })}
+    />
+  )
+}
+
+/**
+ * Column of keyboard shortcuts: a label-left, keys-right list. Wrap a set of
+ * `GuideShortcut`s. Pairs with `GuideColumn title='Shortcuts'`.
+ */
+export function GuideShortcuts({ children }: { children: ReactNode }) {
+  return <div className='space-y-1.5'>{children}</div>
+}
+
+/**
+ * One shortcut row: a `KbdGroup` of keys on the left, a muted label on the right.
+ * Keys matching a `Kbd` `shortcut` token (cmd/ctrl/enter/esc/alt) render as their
+ * glyph; any other key renders as literal text.
+ */
+export function GuideShortcut({ keys, label }: { keys: readonly string[]; label: string }) {
+  return (
+    <div className='flex items-center justify-between gap-3'>
+      <KbdGroup variant='outline' size='sm'>
+        {keys.map((key) => (
+          <Kbd
+            key={key}
+            {...(SHORTCUT_KEYS.has(key as ShortcutKey)
+              ? { shortcut: key as ShortcutKey }
+              : { children: key })}
+          />
+        ))}
+      </KbdGroup>
+      <span className='text-muted-foreground text-xs'>{label}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a shared **records-view help guide** opened from a `?` button in the dynamic-table toolbar, so every dynamic view (records, contacts, tickets, connectors, …) gets it automatically. Also extends the guide system with reusable keyboard-shortcut primitives.

### Guide primitives (`packages/ui/src/components/guide.tsx`)
- `GuideShortcuts` / `GuideShortcut` — label-left / keys-right shortcut rows, lifting the workflow overlay's `Kbd` pattern (cmd/ctrl/enter/esc glyph mapping) into the guide vocabulary.
- `GuideKbd` — inline keyboard-key token (sibling of `GuideCode`) for use inside prose.

### The guide (`dynamic-table/.../table-toolbar/records-guide-dialog.tsx`)
A 3-page `GuideDialog` with a `Views › Display › Shortcuts` header:
1. **Views** — the save lifecycle + All rows / Default / Favorite / managing.
2. **Display** — Table vs Kanban, columns/sort/filter/search, plus formatting & import-export.
3. **Shortcuts** — the real cell keyboard map (from `use-cell-navigation` + `use-cell-clipboard`) plus fill-handle / AI-autofill / cross-app copy tips.

### Wiring
- `CircleHelp` ghost icon button as the last toolbar item, opening the dialog.
- All guide dialogs (records, stream, agent) now mount only while `open` (conditional render).

### Also bundled
In-progress data-connector readiness and `dialog-nav` / `command` tweaks from the same working set.

## Notes
- Conditional mount skips the Radix exit animation by design.
- Kanban concept is always shown (the shared toolbar can't know per-table); no `?` hotkey (button-only) to avoid clashing with search/cell typing.