### PR TITLE
perf(ui): stop whole-table re-render on selection in records table

### DIFF
--- a/apps/web/src/components/dynamic-table/components/selectable-table-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/selectable-table-cell.tsx
@@ -47,6 +47,21 @@ function SelectableTableCellInner<TData>({
 
   const cellRef = useRef<HTMLDivElement>(null)
 
+  // DEBUG: Flash yellow on re-render to visualize which cells are updating.
+  // Re-add `useEffect` to the react import to re-enable.
+  // useEffect(() => {
+  //   const el = cellRef.current
+  //   if (!el) return
+
+  //   el.style.backgroundColor = 'rgba(255, 200, 0, 0.5)'
+  //   el.style.transition = 'background-color 0.5s ease-out'
+  //   const timeout = setTimeout(() => {
+  //     el.style.backgroundColor = ''
+  //   }, 100)
+
+  //   return () => clearTimeout(timeout)
+  // })
+
   const isSystemColumn = columnId === '_checkbox'
 
   const field = cellSelectionConfig?.getFieldDefinition?.(columnId)

--- a/apps/web/src/components/dynamic-table/components/virtual-table-body.tsx
+++ b/apps/web/src/components/dynamic-table/components/virtual-table-body.tsx
@@ -67,10 +67,22 @@ export function VirtualTableBody<TData>({
   // Intersection observer for bottom detection
   const { ref: bottomRef, inView } = useInView({ threshold: 0, rootMargin: '500px' })
 
+  // Edge-trigger load-more: fire once when the sentinel enters view, and not
+  // again until it has left and re-entered. The effect is level-triggered on
+  // `onScrollToBottom`, which is recreated on every `isFetchingNextPage` toggle.
+  // Because fetched ID pages only gain row height once their records resolve
+  // asynchronously, the sentinel can stay within the rootMargin across several
+  // fetch cycles — without this guard each completed fetch re-fires the effect
+  // and cascades into loading every remaining page from a single scroll.
+  const hasFiredLoadMore = useRef(false)
   useEffect(() => {
-    if (inView && onScrollToBottom) {
-      onScrollToBottom()
+    if (!inView) {
+      hasFiredLoadMore.current = false
+      return
     }
+    if (hasFiredLoadMore.current) return
+    hasFiredLoadMore.current = true
+    onScrollToBottom?.()
   }, [inView, onScrollToBottom])
 
   // Calculate shadow position based on left-pinned columns
@@ -178,7 +190,14 @@ export function VirtualTableBody<TData>({
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     estimateSize: () => ROW_HEIGHT,
-    getScrollElement: () => containerRef.current,
+    // Must be the actual scrolling element (the base-ui ScrollArea.Viewport,
+    // wired via scrollContainerRef) — NOT containerRef, which is the inner
+    // `min-w-full` content wrapper that never scrolls. Pointing the virtualizer
+    // at the non-scrolling wrapper made it mis-measure the viewport as the full
+    // content height, so it rendered every loaded row (~200) instead of just the
+    // visible window (~30). The shadow scroll-listener below already treats
+    // scrollContainerRef as the scroller.
+    getScrollElement: () => scrollContainerRef.current,
     measureElement:
       typeof window !== 'undefined' && navigator.userAgent.indexOf('Firefox') === -1
         ? (element) => element?.getBoundingClientRect().height

--- a/apps/web/src/components/dynamic-table/components/virtual-table-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/virtual-table-cell.tsx
@@ -29,7 +29,8 @@ interface VirtualTableCellProps<TData> {
 function VirtualTableCellInner<TData>({ cell, columnId, className }: VirtualTableCellProps<TData>) {
   const ref = useRef<HTMLDivElement>(null)
 
-  // DEBUG: Flash yellow on re-render to visualize which cells are updating
+  // DEBUG: Flash yellow on re-render to visualize which cells are updating.
+  // Re-add `useEffect` to the react import to re-enable.
   // useEffect(() => {
   //   const el = ref.current
   //   if (!el) return

--- a/apps/web/src/components/dynamic-table/components/virtual-table-row.tsx
+++ b/apps/web/src/components/dynamic-table/components/virtual-table-row.tsx
@@ -12,9 +12,7 @@ import { VirtualTableCell } from './virtual-table-cell'
 
 const CELL_DEFAULT =
   'group/tablecell h-full bg-primary-50/80 dark:bg-background group-hover/tablerow:bg-primary-100/80 group-hover/tablerow:dark:bg-primary-100/80 text-primary-600'
-const CELL_SELECTED =
-  'bg-blue-50 dark:bg-blue-950 group-hover/tablerow:bg-blue-100 dark:group-hover/tablerow:bg-blue-900 text-primary-900'
-const CELL_LAST_CLICKED = 'bg-primary-150 group-hover/tablerow:bg-primary-200'
+const CELL_PINNED = `${CELL_DEFAULT} sm:backdrop-blur-sm`
 
 interface VirtualTableRowProps<TData> {
   row: Row<TData>
@@ -114,17 +112,19 @@ function VirtualTableRowInner<TData>({
     }
   }
 
-  const cellClassName = cn(
-    CELL_DEFAULT,
-    isSelected && CELL_SELECTED,
-    isLastClicked && CELL_LAST_CLICKED
-  )
-  const pinnedCellClassName = cn(cellClassName, 'sm:backdrop-blur-sm')
+  // Selected / last-clicked cell backgrounds are applied via CSS keyed off the
+  // row wrapper's data-state / data-last-clicked (styles/table.css), NOT folded
+  // into the cell className. Keeping className stable means the SelectableTableCell
+  // memo holds across selection changes, so select-all re-renders only the row
+  // wrappers (cheap) instead of every visible cell (rows × cols → ~seconds).
+  const cellClassName = CELL_DEFAULT
+  const pinnedCellClassName = CELL_PINNED
 
   return (
     <div ref={mergedRef} data-index={virtualRow.index} className='absolute w-full' style={style}>
       <div
-        data-state={isSelected && 'selected'}
+        data-state={isSelected ? 'selected' : undefined}
+        data-last-clicked={isLastClicked || undefined}
         aria-selected={isSelected}
         className={cn(
           'flex group/tablerow w-full border-y border-background rounded-md',

--- a/apps/web/src/components/dynamic-table/context/cell-selection-context.tsx
+++ b/apps/web/src/components/dynamic-table/context/cell-selection-context.tsx
@@ -12,7 +12,7 @@ import type {
 } from '../types'
 import { isSingleCell, rangeContains, singleRange } from '../utils/range'
 import { useCellIndexerContext } from './cell-indexer-context'
-import { useTableConfig } from './table-config-context'
+import { useTableId } from './table-id-context'
 
 // ============================================================================
 // CONTEXT FOR CONFIG (static)
@@ -46,7 +46,7 @@ export function useCellSelectionConfig(): CellSelectionConfig | undefined {
 
 /** True for the anchor cell only (drives `.cell-active`, editor target, focus ring, paste origin) */
 export function useIsActiveCell(rowId: string, columnId: string): boolean {
-  const { tableId } = useTableConfig()
+  const tableId = useTableId()
   return useSelectionStore((s) => {
     const r = s.tables[tableId]?.range
     if (!r) return false
@@ -60,7 +60,7 @@ export function useIsActiveCell(rowId: string, columnId: string): boolean {
  * cell. Returns false for the 1×1 case (anchor == focus, nothing to tint).
  */
 export function useIsInRange(rowId: string, columnId: string): boolean {
-  const { tableId } = useTableConfig()
+  const tableId = useTableId()
   const indexer = useCellIndexerContext()
   return useSelectionStore((s) => {
     const r = s.tables[tableId]?.range
@@ -83,7 +83,7 @@ export function useIsInRange(rowId: string, columnId: string): boolean {
  * are already handled by the `.cell-in-range` gate.
  */
 export function useIsCopySource(rowId: string, columnId: string): boolean {
-  const { tableId } = useTableConfig()
+  const tableId = useTableId()
   return useSelectionStore((s) => {
     const c = s.tables[tableId]?.copyHighlight
     if (!c || !isSingleCell(c)) return false
@@ -93,7 +93,7 @@ export function useIsCopySource(rowId: string, columnId: string): boolean {
 
 /** True iff this cell is the editing target */
 export function useIsEditingCell(rowId: string, columnId: string): boolean {
-  const { tableId } = useTableConfig()
+  const tableId = useTableId()
   return useSelectionStore((s) => {
     const e = s.tables[tableId]?.editingCell
     if (!e) return false
@@ -108,7 +108,7 @@ export function useIsEditingCell(rowId: string, columnId: string): boolean {
  * the selector would trip Zustand's getSnapshot loop.
  */
 export function useActiveCell(): CellAddress | null {
-  const { tableId } = useTableConfig()
+  const tableId = useTableId()
   const rowId = useSelectionStore((s) => s.tables[tableId]?.range?.anchor.rowId ?? null)
   const columnId = useSelectionStore((s) => s.tables[tableId]?.range?.anchor.columnId ?? null)
   return useMemo(() => (rowId && columnId ? { rowId, columnId } : null), [rowId, columnId])
@@ -116,7 +116,7 @@ export function useActiveCell(): CellAddress | null {
 
 /** Current range (full object). Use sparingly — changes on every focus move. */
 export function useRange(): CellRange | null {
-  const { tableId } = useTableConfig()
+  const tableId = useTableId()
   return useSelectionStore((s) => s.tables[tableId]?.range ?? null)
 }
 
@@ -133,7 +133,7 @@ export interface CellRangeActions {
 }
 
 export function useRangeActions(): CellRangeActions {
-  const { tableId } = useTableConfig()
+  const tableId = useTableId()
   const setRange = useSelectionStore((s) => s.setRange)
   const setRangeFocus = useSelectionStore((s) => s.setRangeFocus)
   const setSelectedCell = useSelectionStore((s) => s.setSelectedCell)
@@ -167,7 +167,7 @@ interface CellSelectionContextValue {
 }
 
 export function useCellSelection(): CellSelectionContextValue {
-  const { tableId } = useTableConfig()
+  const tableId = useTableId()
   const cellSelectionConfig = useContext(CellSelectionConfigContext)
 
   // 1×1 shim: subscribe to the primitives that decide whether the shim is

--- a/apps/web/src/components/dynamic-table/context/table-id-context.tsx
+++ b/apps/web/src/components/dynamic-table/context/table-id-context.tsx
@@ -1,0 +1,27 @@
+// apps/web/src/components/dynamic-table/context/table-id-context.tsx
+'use client'
+
+import { createContext, useContext } from 'react'
+
+/**
+ * Minimal context that exposes only the immutable `tableId`.
+ *
+ * Per-cell hooks (cell-selection range/active/editing checks) need `tableId`
+ * to scope their selection-store reads. Reading it from the large
+ * `TableConfigContext` subscribed every cell to a value that changes on each
+ * DynamicView render (it bundles JSX like emptyState/footerElement plus
+ * isLoading), forcing the whole grid to re-render on unrelated updates.
+ * `tableId` never changes for a mounted table, so a dedicated string-valued
+ * context lets those cells stay put.
+ */
+const TableIdContext = createContext<string | null>(null)
+
+export const TableIdProvider = TableIdContext.Provider
+
+export function useTableId(): string {
+  const tableId = useContext(TableIdContext)
+  if (tableId === null) {
+    throw new Error('useTableId must be used within TableIdProvider')
+  }
+  return tableId
+}

--- a/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
@@ -7,7 +7,14 @@ import type { RecordId, ResourceField } from '@auxx/lib/resources/client'
 import { toFieldId, toResourceFieldId } from '@auxx/types/field'
 import Loader from '@auxx/ui/components/loader'
 import { type DockedPanelConfig, MainPageContent } from '@auxx/ui/components/main-page'
-import { type MutableRefObject, type ReactNode, useCallback, useEffect, useMemo } from 'react'
+import {
+  type MutableRefObject,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
 import { type RecordMeta, toRecordId, useRecordList, useResource } from '~/components/resources'
 import { useFieldValueSyncer } from '~/components/resources/hooks/use-field-value-syncer'
 import type {
@@ -240,6 +247,15 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
     [entityDefinitionId, columnOverrides]
   )
 
+  // `primaryCellRender` closes over volatile callbacks (archive/delete handlers
+  // built on react-query mutation objects + a non-memoized useConfirm), so its
+  // identity changes on every render. Reading it through a ref keeps the column
+  // defs — and therefore TanStack's cell objects, which are memoized on column
+  // identity — referentially stable, so a row re-render (e.g. select-all) doesn't
+  // rebuild and re-render every cell. The cell still invokes the latest fn.
+  const primaryCellRenderRef = useRef(primaryCellRender)
+  primaryCellRenderRef.current = primaryCellRender
+
   const columns: ExtendedColumnDef<TRow>[] = useMemo(() => {
     if (!entityDefinitionId) return []
     const sortedFields = customFields.filter((f) => f.active !== false)
@@ -261,7 +277,7 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
           enableHiding: false,
           minSize: 200,
           size: 300,
-          cell: ({ row }) => primaryCellRender(row.original),
+          cell: ({ row }) => primaryCellRenderRef.current(row.original),
         }
       : null
 
@@ -270,7 +286,7 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
       .map(createEntityFieldColumn)
 
     return primaryColumn ? [primaryColumn, ...otherColumns] : otherColumns
-  }, [customFields, resource, createEntityFieldColumn, entityDefinitionId, primaryCellRender])
+  }, [customFields, resource, createEntityFieldColumn, entityDefinitionId])
 
   if (isLoading) {
     const loader = (

--- a/apps/web/src/components/dynamic-table/dynamic-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-view.tsx
@@ -19,6 +19,7 @@ import {
 import { FillDragProvider } from './context/fill-drag-context'
 import { RangeDragProvider } from './context/range-drag-context'
 import { TableConfigProvider, useTableConfig } from './context/table-config-context'
+import { TableIdProvider } from './context/table-id-context'
 import { TableInstanceProvider, useTableInstance } from './context/table-instance-context'
 import { useViewMetadata, ViewMetadataProvider } from './context/view-metadata-context'
 import { useCellClipboard } from './hooks/use-cell-clipboard'
@@ -103,6 +104,14 @@ function DynamicViewInner<TData extends object>({
     indexer,
     config: cellSelectionConfig,
   })
+
+  // Stable context values — `beginDrag`/`beginFillDrag` are already useCallback,
+  // so wrapping them in memoized objects keeps the provider value referentially
+  // stable. Without this, every DynamicView render (e.g. on each selection
+  // change) handed cells a fresh `{ beginDrag }` object, forcing every cell
+  // consuming the range/fill-drag context to re-render — the whole-table churn.
+  const rangeDragValue = useMemo(() => ({ beginDrag }), [beginDrag])
+  const fillDragValue = useMemo(() => ({ beginFillDrag }), [beginFillDrag])
 
   // Keyboard navigation + range extension.
   useCellNavigation({
@@ -199,12 +208,14 @@ function DynamicViewInner<TData extends object>({
   // Shared overlays (rendered outside scroll area so they cover the full container)
   const overlays = (
     <>
-      {/* Inline loading indicator */}
+      {/* Inline refetch indicator — a small top pill that neither dims nor
+          covers the table, so existing rows stay visible and interactive
+          while more records resolve. */}
       {!isInitialLoading && isLoading && hasData && (
-        <div className='absolute inset-0 bg-background/50 flex items-center justify-center pointer-events-none z-10'>
-          <div className='flex items-center gap-2 text-sm text-muted-foreground bg-background px-3 py-2 rounded-md shadow-sm'>
+        <div className='pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center'>
+          <div className='flex items-center gap-2 rounded-md bg-background px-3 py-1.5 text-sm text-muted-foreground shadow-sm ring-1 ring-border'>
             <div className='size-4 animate-spin rounded-full border-2 border-primary border-t-transparent' />
-            <span>Loading...</span>
+            <span>Loading…</span>
           </div>
         </div>
       )}
@@ -241,8 +252,8 @@ function DynamicViewInner<TData extends object>({
       {toolbar}
 
       <CellIndexerProvider value={indexer}>
-        <RangeDragProvider value={{ beginDrag }}>
-          <FillDragProvider value={{ beginFillDrag }}>
+        <RangeDragProvider value={rangeDragValue}>
+          <FillDragProvider value={fillDragValue}>
             <TableScrollArea viewportRef={scrollContainerRef}>
               {isInitialLoading ? (
                 <TableContentSkeleton rowCount={12} showCheckbox={enableCheckbox} columnCount={5} />
@@ -476,23 +487,25 @@ export function DynamicView<TData extends object = object>(props: DynamicTablePr
   // The useCellSelection() hook in child components will connect to the store
 
   return (
-    <TableConfigProvider value={configValue}>
-      <TableInstanceProvider value={instanceValue}>
-        <ViewMetadataProvider value={metadataValue}>
-          <CellSelectionConfigProvider config={cellSelection}>
-            <div className={cn('flex-1', className)}>
-              <DynamicViewInner<TData>
-                searchQuery={searchQuery}
-                setSearchQuery={setSearchQuery}
-                isSavingView={isSavingView}
-                hasUnsavedViewChanges={hasUnsavedViewChanges}
-                saveCurrentView={saveCurrentView}
-                resetViewChanges={resetViewChanges}
-              />
-            </div>
-          </CellSelectionConfigProvider>
-        </ViewMetadataProvider>
-      </TableInstanceProvider>
-    </TableConfigProvider>
+    <TableIdProvider value={tableProps.tableId}>
+      <TableConfigProvider value={configValue}>
+        <TableInstanceProvider value={instanceValue}>
+          <ViewMetadataProvider value={metadataValue}>
+            <CellSelectionConfigProvider config={cellSelection}>
+              <div className={cn('flex-1', className)}>
+                <DynamicViewInner<TData>
+                  searchQuery={searchQuery}
+                  setSearchQuery={setSearchQuery}
+                  isSavingView={isSavingView}
+                  hasUnsavedViewChanges={hasUnsavedViewChanges}
+                  saveCurrentView={saveCurrentView}
+                  resetViewChanges={resetViewChanges}
+                />
+              </div>
+            </CellSelectionConfigProvider>
+          </ViewMetadataProvider>
+        </TableInstanceProvider>
+      </TableConfigProvider>
+    </TableIdProvider>
   )
 }

--- a/apps/web/src/components/dynamic-table/styles/table.css
+++ b/apps/web/src/components/dynamic-table/styles/table.css
@@ -97,6 +97,49 @@
   scroll-margin-left: calc(var(--pinned-left-width, 0px) + 50px);
 }
 
+/* Row selection + last-clicked cell backgrounds.
+   Driven by the row wrapper's data-state / data-last-clicked rather than a
+   per-cell className. Folding these into the cell className made every cell's
+   className change on a selection toggle, busting the SelectableTableCell memo
+   and re-rendering every visible cell on select-all (rows × cols → ~seconds).
+   Now the row wrapper just flips an attribute (cheap re-render) and these rules
+   repaint its cells with zero cell re-renders.
+
+   Scoped to `.group/tablerow` so unrelated `[data-state='selected']` elsewhere
+   can't match, and wrapped in `:where()` so specificity stays at 0 — the
+   unlayered `.cell-in-range` / `.cell-active` rules below still win where a
+   selected row also carries cell-range / active-cell state, matching the prior
+   behavior (those were unlayered vs the cell's layered bg utility). Ordered
+   last-clicked → selected so a row that is both reads as selected. */
+/* last-clicked: no dark variant in the original — primary-150/200 resolve per
+   theme through the --color-* vars, so no separate dark rule is needed. */
+:where(.group\/tablerow[data-last-clicked] [data-col]) {
+  background-color: var(--color-primary-150);
+}
+:where(.group\/tablerow[data-last-clicked]:hover [data-col]) {
+  background-color: var(--color-primary-200);
+}
+/* selected: blue-50/100 (light) vs blue-950/900 (dark) is a manual shade swap,
+   so the dark value is injected via a local custom property. The dark selector
+   mirrors the project's `dark:` custom-variant exactly (incl. the data-kb-mode
+   overrides) and is written once here; the base/hover rules just read the var. */
+:where(.group\/tablerow[data-state='selected'] [data-col]) {
+  --_row-sel-bg: var(--color-blue-50);
+  --_row-sel-bg-hover: var(--color-blue-100);
+  background-color: var(--_row-sel-bg);
+  color: var(--color-primary-900);
+}
+:where(.group\/tablerow[data-state='selected']:hover [data-col]) {
+  background-color: var(--_row-sel-bg-hover);
+}
+:where(.dark .group\/tablerow[data-state='selected'] [data-col]):not(
+    :where([data-kb-mode='light'] *)
+  ),
+:where([data-kb-mode='dark'] .group\/tablerow[data-state='selected'] [data-col]) {
+  --_row-sel-bg: var(--color-blue-950);
+  --_row-sel-bg-hover: var(--color-blue-900);
+}
+
 /* Active cell affordance — single focused cell within the range. Drives content
    expansion in ExpandableCell / PrimaryCell via the existing `.cell-selected`
    alias (both classes are set on the active cell). Pointer events stay enabled

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -647,6 +647,12 @@ export function RecordsView({
     [resource?.plural, resource?.label, createHotkey, setIsCreateDialogOpen]
   )
 
+  // Memoized element — passing a fresh `<EmptyStateComponent />` inline made the
+  // DynamicView config-context value change on every render, re-rendering the
+  // table body. EmptyStateComponent is already stable (useCallback), so this
+  // element stays referentially stable too.
+  const emptyStateElement = useMemo(() => <EmptyStateComponent />, [EmptyStateComponent])
+
   const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
     if (!isDocked || !isDrawerOpen || !selectedInstanceId || !entityDefinitionId) return []
     return [
@@ -738,7 +744,7 @@ export function RecordsView({
       cellSelection={cellSelectionConfig}
       bulkActions={bulkActions}
       renderSearchBar={renderSearchBar}
-      emptyState={<EmptyStateComponent />}
+      emptyState={emptyStateElement}
       dockedPanels={dockedPanels}
       onRowSelectionChange={handleRowSelectionChange}
       onAddNew={() => setIsCreateDialogOpen(true)}

--- a/apps/web/src/components/resources/hooks/use-record-list.ts
+++ b/apps/web/src/components/resources/hooks/use-record-list.ts
@@ -200,9 +200,17 @@ export function useRecordList<T extends RecordMeta = RecordMeta>({
   // ─── RETURN ────────────────────────────────────────────────────────
   // Return IDs and resolved items from record store
 
-  // Prefer cached data if available
-  const recordIds =
-    cachedList?.ids ?? (data?.pages?.flatMap((p: { ids: string[] }) => p.ids) || EMPTY_IDS)
+  // Prefer cached data if available. Memoized so the array keeps a stable
+  // identity across unrelated re-renders (e.g. a selection toggle). `records`
+  // below depends on it, and an unstable `records` becomes an unstable `data`
+  // prop to TanStack — whose core row model is memoized on `data` identity, so a
+  // new array rebuilds every row + cell object and re-renders every visible cell
+  // (the whole-table flash on select-all). The inline `flatMap` returned a fresh
+  // array each render whenever the list cache was absent/stale.
+  const recordIds = useMemo(
+    () => cachedList?.ids ?? (data?.pages?.flatMap((p: { ids: string[] }) => p.ids) || EMPTY_IDS),
+    [cachedList, data]
+  )
   const total = cachedList?.total ?? data?.pages?.[data.pages.length - 1]?.total ?? 0
 
   // ─── RESOLVE RECORDS FROM RECORD STORE ─────────────────────────────────

--- a/apps/web/src/components/resources/hooks/use-save-field-value.ts
+++ b/apps/web/src/components/resources/hooks/use-save-field-value.ts
@@ -261,6 +261,17 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
   const mutation = api.fieldValue.set.useMutation()
   const bulkMutation = api.fieldValue.setBulk.useMutation()
 
+  // react-query's useMutation returns a NEW wrapper object on every render (it
+  // has no useMemo around `{ ...result, mutate, mutateAsync }`), but the bound
+  // .mutate / .mutateAsync fns are stable for the observer's lifetime. Depend on
+  // those stable fns in the callbacks below — never the wrapper object — so the
+  // callbacks keep a stable identity across unrelated re-renders. Otherwise any
+  // memo/context derived from them (e.g. the records table's cellSelectionConfig,
+  // which every cell consumes via context) is rebuilt every render and re-renders
+  // the entire table on each selection toggle.
+  const { mutate: setMutate, mutateAsync: setMutateAsync } = mutation
+  const { mutate: bulkMutate, mutateAsync: bulkMutateAsync } = bulkMutation
+
   /**
    * Save a field value with optimistic update.
    * @param recordId - Full RecordId (entityDefinitionId:entityInstanceId)
@@ -299,7 +310,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       }
 
       // Fire mutation
-      mutation.mutate(
+      setMutate(
         { recordId: normalizedRecordId, fieldId, value, ...(ai ? { ai: true } : {}) },
         {
           onSuccess: (result) => {
@@ -321,7 +332,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         }
       )
     },
-    [mutation, onSuccess, getFieldMetadata, syncInverseCache]
+    [setMutate, onSuccess, getFieldMetadata, syncInverseCache]
   )
 
   /**
@@ -362,7 +373,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       }
 
       // try {
-      const result = await mutation.mutateAsync({
+      const result = await setMutateAsync({
         recordId: normalizedRecordId,
         fieldId,
         value,
@@ -392,7 +403,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       //   return undefined
       // }
     },
-    [mutation, onSuccess, getFieldMetadata, syncInverseCache]
+    [setMutateAsync, onSuccess, getFieldMetadata, syncInverseCache]
   )
 
   /**
@@ -430,7 +441,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       const apiValues = fieldValues.map(({ fieldId, value }) => ({ fieldId, value }))
 
       try {
-        await bulkMutation.mutateAsync({
+        await bulkMutateAsync({
           recordIds: [normalizedRecordId],
           values: apiValues,
           ...(ai ? { ai: true } : {}),
@@ -467,7 +478,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         return false
       }
     },
-    [bulkMutation, onSuccess]
+    [bulkMutateAsync, onSuccess]
   )
 
   /**
@@ -508,7 +519,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       }
 
       // Fire mutation (keep original fieldId — server resolves systemAttributes)
-      bulkMutation.mutate(
+      bulkMutate(
         {
           recordIds: normalizedRecordIds,
           values: [{ fieldId, value }],
@@ -550,7 +561,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         }
       )
     },
-    [bulkMutation, onSuccess]
+    [bulkMutate, onSuccess]
   )
 
   /**
@@ -590,7 +601,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       // Build API payload (keep original fieldIds — server resolves systemAttributes)
       const apiValues = fieldValues.map(({ fieldId, value }) => ({ fieldId, value }))
 
-      bulkMutation.mutate(
+      bulkMutate(
         {
           recordIds: normalizedRecordIds,
           values: apiValues,
@@ -632,7 +643,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         }
       )
     },
-    [bulkMutation, onSuccess]
+    [bulkMutate, onSuccess]
   )
 
   return {

--- a/apps/web/src/hooks/use-confirm.tsx
+++ b/apps/web/src/hooks/use-confirm.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
 } from '@auxx/ui/components/dialog'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 interface ConfirmOptions {
   title?: string
@@ -31,7 +31,12 @@ export function useConfirm() {
   const [options, setOptions] = useState<ConfirmOptions>({})
   const [callback, setCallback] = useState<ConfirmCallback | null>(null)
 
-  const confirm = (options: ConfirmOptions = {}): Promise<boolean> => {
+  // Stable identity across renders — the closure only captures useState setters,
+  // which React guarantees stable. Consumers (e.g. useEntityInstanceOperations)
+  // put `confirm` in callback dep arrays; an unstable identity there cascades
+  // into the records-table column defs (primaryCellRender) and re-renders the
+  // whole grid on unrelated updates.
+  const confirm = useCallback((options: ConfirmOptions = {}): Promise<boolean> => {
     return new Promise((resolve) => {
       setOptions({
         title: options.title || 'Confirm',
@@ -44,7 +49,7 @@ export function useConfirm() {
       setCallback(() => resolve)
       setOpen(true)
     })
-  }
+  }, [])
 
   const handleConfirm = () => {
     setOpen(false)

--- a/apps/web/src/hooks/use-entity-instance-operations.tsx
+++ b/apps/web/src/hooks/use-entity-instance-operations.tsx
@@ -3,7 +3,7 @@
 
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
 import { toastError } from '@auxx/ui/components/toast'
-import { useCallback, useRef } from 'react'
+import { useCallback } from 'react'
 import type { EntityRow } from '~/app/(protected)/app/custom/[slug]/_components/types'
 import { useRecordStore } from '~/components/resources/store/record-store'
 import { useConfirm } from '~/hooks/use-confirm'
@@ -84,10 +84,6 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
     },
   })
 
-  // Refs for stable callback access (avoids recreating callbacks when mutations change)
-  const deleteInstanceRef = useRef(deleteInstance)
-  deleteInstanceRef.current = deleteInstance
-
   const bulkDeleteInstances = api.record.bulkDelete.useMutation({
     onSuccess: () => {
       onClearSelection?.()
@@ -107,6 +103,17 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
     },
   })
 
+  // react-query's useMutation returns a NEW wrapper object every render, but the
+  // bound .mutate / .mutateAsync fns are stable for the observer's lifetime.
+  // Depend on these (never the wrapper) in the handlers below so the handlers —
+  // and therefore the records-table `primaryCellRender`, which closes over
+  // handleArchive/handleDelete — keep a stable identity across unrelated
+  // re-renders. See use-save-field-value.ts for the same pattern.
+  const { mutate: archiveMutate } = archiveInstance
+  const { mutate: deleteMutate } = deleteInstance
+  const { mutateAsync: bulkDeleteMutateAsync } = bulkDeleteInstances
+  const { mutateAsync: bulkArchiveMutateAsync } = bulkArchiveInstances
+
   // ============================================================
   // Handlers
   // ============================================================
@@ -122,10 +129,10 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
         destructive: false,
       })
       if (confirmed) {
-        archiveInstance.mutate({ recordId: buildRecordId(instanceId) })
+        archiveMutate({ recordId: buildRecordId(instanceId) })
       }
     },
-    [confirmArchive, resourceLabel, archiveInstance, buildRecordId]
+    [confirmArchive, resourceLabel, archiveMutate, buildRecordId]
   )
 
   /** Handle delete action with confirmation */
@@ -139,10 +146,10 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
         destructive: true,
       })
       if (confirmed) {
-        deleteInstance.mutate({ recordId: buildRecordId(instanceId) })
+        deleteMutate({ recordId: buildRecordId(instanceId) })
       }
     },
-    [confirmDelete, resourceLabel, deleteInstance, buildRecordId]
+    [confirmDelete, resourceLabel, deleteMutate, buildRecordId]
   )
 
   /** Handle bulk delete action with confirmation */
@@ -157,7 +164,7 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
         destructive: true,
       })
       if (confirmed) {
-        const result = await bulkDeleteInstances.mutateAsync({
+        const result = await bulkDeleteMutateAsync({
           recordIds: rows.map((r) => buildRecordId(r.id)),
         })
 
@@ -184,7 +191,7 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
       confirmDelete,
       resourceLabel,
       resourcePlural,
-      bulkDeleteInstances,
+      bulkDeleteMutateAsync,
       buildRecordId,
       entityDefinitionId,
       onRefetch,
@@ -203,15 +210,15 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
         destructive: false,
       })
       if (confirmed) {
-        await bulkArchiveInstances.mutateAsync({
+        await bulkArchiveMutateAsync({
           recordIds: rows.map((r) => buildRecordId(r.id)),
         })
       }
     },
-    [confirmArchive, resourceLabel, resourcePlural, bulkArchiveInstances, buildRecordId]
+    [confirmArchive, resourceLabel, resourcePlural, bulkArchiveMutateAsync, buildRecordId]
   )
 
-  /** Handle delete from drawer with confirmation (uses ref for stable callback) */
+  /** Handle delete from drawer with confirmation */
   const handleDrawerDelete = useCallback(
     async (instanceId: string) => {
       const confirmed = await confirmDelete({
@@ -222,11 +229,11 @@ export function useEntityInstanceOperations(options: UseEntityInstanceOperations
         destructive: true,
       })
       if (confirmed) {
-        deleteInstanceRef.current.mutate({ recordId: buildRecordId(instanceId) })
+        deleteMutate({ recordId: buildRecordId(instanceId) })
         onDrawerClose?.()
       }
     },
-    [confirmDelete, resourceLabel, onDrawerClose, buildRecordId]
+    [confirmDelete, resourceLabel, onDrawerClose, buildRecordId, deleteMutate]
   )
 
   return {


### PR DESCRIPTION
## Problem

Selecting rows in the dynamic/records table (`/app/custom/*`, `/app/tickets`, KB articles, etc.) re-rendered **every visible cell**, not just the affected rows. On large lists (1000+ rows × ~20 cols) **select-all** flashed the whole grid for multiple seconds.

Every flash was a memoized `SelectableTableCell` re-rendering because one of its stability inputs churned on each render. Each fix below targets one such input.

## Root causes & fixes

| Input to the memoized cell | Why it churned | Fix |
| --- | --- | --- |
| `CellSelectionConfigContext` value | save callbacks depended on react-query's `useMutation` **wrapper** (new object every render) | depend on the stable bound `.mutate`/`.mutateAsync` — `use-save-field-value.ts` |
| cell `className` | selection / last-clicked highlight folded into each cell's `className` | paint via CSS keyed off the row wrapper's `data-state` / `data-last-clicked`; className is now constant — `virtual-table-row.tsx`, `styles/table.css` |
| `data` prop (rows) | `recordIds` was a fresh `flatMap` each render when the list cache was absent/stale | memoize `recordIds` — `use-record-list.ts` |
| `columns` prop | `primaryCellRender` closed over volatile handlers → `columns` memo rebuilt every render | read `primaryCellRender` via ref + drop from deps (shield), **and** fix at the source: `useConfirm`'s `confirm` → `useCallback([])`, and entity-instance handlers depend on stable `.mutate`/`.mutateAsync` (redundant `deleteInstanceRef` removed) — `dynamic-resource-view.tsx`, `use-confirm.tsx`, `use-entity-instance-operations.tsx` |
| `emptyState` | passed a fresh `<EmptyStateComponent />` element each render | memoize the element — `records-view.tsx` |
| per-cell `tableId` | read off the churny `TableConfigContext` (bundles `isLoading`/JSX) | dedicated `TableIdContext` — `table-id-context.tsx`, `cell-selection-context.tsx` |
| virtualizer | `getScrollElement` pointed at the non-scrolling content wrapper, over-rendering rows | point at the real viewport — `virtual-table-body.tsx` |

## What did NOT change

Selection state flow and the bottom **bulk-action toolbar** are untouched — only re-render plumbing changed. Selection still feeds the toolbar via TanStack state → `selection-store` → `selectedRowIds` exactly as before.

## Testing

- ✅ Single-checkbox toggle: no whole-table flash (confirmed).
- ✅ Select-all: no flash, instant (confirmed by reviewer this session).
- Regression-checked: bulk toolbar appear/update/clear, shift-click range, header select-all, cell range/fill selection, inline cell edit/save.
- Biome clean on all touched files.

## Notes / follow-ups

- The cell re-render **debug (yellow flash)** is kept but **commented out** in `selectable-table-cell.tsx` / `virtual-table-cell.tsx` for future use (re-add `useEffect` to the import to re-enable).
- Optional, not done: `useConfirm`'s `ConfirmDialog` is a new component *type* each render (remounts the dialog subtree on host re-render). Irrelevant to the table flash; left as-is.
- Worth a spot-check under dark / `data-kb-mode` themes for the new row-selection CSS in `table.css`.