### PR TITLE
perf(mail): stop selection changes re-rendering the whole thread list

### DIFF
--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -64,7 +64,6 @@ import { RecordDrawer } from '~/components/records/record-drawer'
 import {
   useActiveThreadId,
   useActiveThreadVersion,
-  useSelectedThreadIds,
   useThreadSelectionStore,
   useViewMode,
 } from '~/components/threads'
@@ -210,9 +209,6 @@ function MailboxInner({
   const { hasAccess } = useFeatureFlags()
   const kopilotEnabled = hasAccess('kopilot')
 
-  // Use new selection store directly
-  const selectedThreads = useSelectedThreadIds()
-
   // Fetch pending actions count
   // const { data: pendingActionsCount } = api.proposedAction.getPendingCount.useQuery(undefined, {
   //   refetchInterval: 5 * 60 * 1000, // Refetch 2 min
@@ -333,7 +329,6 @@ function MailboxInner({
       contextId,
       statusSlug: activeStatusSlug, // Use the active slug derived from URL/state
       searchQuery: deferredSearchQuery || undefined, // Use deferred query for consistency
-      selectedThreadIds: selectedThreads, // Pass selected IDs down
       viewMode, // Add view mode state
       sortBy, // Add sort option state
       sortDirection, // Add sort direction state
@@ -347,7 +342,6 @@ function MailboxInner({
       contextId,
       activeStatusSlug,
       deferredSearchQuery,
-      selectedThreads,
       viewMode,
       sortBy,
       sortDirection,

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -26,7 +26,12 @@ import {
   useThreadMutation,
   useThreadReadStatus,
 } from '~/components/threads/hooks'
-import { useSelectionAnchorId, useThreadSelectionStore } from '~/components/threads/store'
+import {
+  useHasSelection,
+  useIsThreadSelected,
+  useSelectionAnchorId,
+  useThreadSelectionStore,
+} from '~/components/threads/store'
 import { threadFieldResolver } from '~/components/threads/utils/thread-field-resolver'
 import { useIsRecordProcessing } from '~/components/workflow/use-is-record-processing'
 import { AssigneeChip } from './assignee-chip'
@@ -56,7 +61,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
   onTagClick,
   onAssignClick,
 }: CompactThreadItemProps) {
-  const { selectedThreadIds, viewMode, filterConditions } = useMailFilter()
+  const { viewMode, filterConditions } = useMailFilter()
   const { thread, isLoading: isThreadLoading, isDeleted } = useThread({ threadId })
   const { message: latestMessage } = useMessage({
     messageId: thread?.latestMessageId,
@@ -90,17 +95,14 @@ export const CompactThreadItem = memo(function CompactThreadItem({
   const hasDraft = (thread?.draftIds?.length ?? 0) > 0
   const hasScheduledMessage = (thread?.scheduledMessageCount ?? 0) > 0
 
-  const isMultiSelected = useMemo(
-    () => selectedThreadIds.includes(threadId),
-    [selectedThreadIds, threadId]
-  )
+  const isMultiSelected = useIsThreadSelected(threadId)
 
   const isFocused = useThreadSelectionStore((s) => s.focusedThreadId === threadId)
   const isProcessing = useIsRecordProcessing(toRecordId('thread', threadId))
 
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
-  const hasAnySelected = selectedThreadIds.length > 0
+  const hasAnySelected = useHasSelection()
   const showCheckbox = viewMode === 'edit' || isFocused || hasAnySelected
 
   const handleClick = useCallback(

--- a/apps/web/src/components/mail/mail-filter-context.tsx
+++ b/apps/web/src/components/mail/mail-filter-context.tsx
@@ -22,7 +22,15 @@ interface MailFilterState {
   /** The search query currently applied to the list (use the deferred value for consistency). */
   searchQuery?: string // Use the deferred value from Mailbox here
 
-  selectedThreadIds: string[]
+  /**
+   * Explicit scoped selection for embedded mini-lists (e.g. the ticket /
+   * contact conversation tabs) that render their own short thread list outside
+   * the global mailbox. The main mailbox deliberately omits this — its items
+   * read per-thread selection from the thread-selection store
+   * (`useIsThreadSelected`) so a selection change re-renders only the affected
+   * row instead of every context consumer.
+   */
+  selectedThreadIds?: string[]
 
   /** Current view mode - determines whether checkboxes are shown and selection behavior */
   viewMode: ViewMode

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -42,6 +42,7 @@ import {
 } from '~/components/threads/hooks'
 import {
   useIsThreadActive,
+  useIsThreadSelected,
   useSelectionAnchorId,
   useThreadSelectionStore,
 } from '~/components/threads/store'
@@ -209,7 +210,10 @@ export const MailThreadItem = memo(function MailThreadItem({
   threadIds,
 }: MailThreadItemProps) {
   // --- Get filter context ---
-  const { selectedThreadIds, viewMode, filterConditions } = useMailFilter()
+  // `selectedThreadIds` is only provided by embedded mini-lists (ticket/contact
+  // tabs). In the main mailbox it's undefined and we fall back to the granular
+  // thread-selection store so toggling one checkbox re-renders only that row.
+  const { viewMode, filterConditions, selectedThreadIds: scopedSelectedIds } = useMailFilter()
 
   // --- NEW: Use ID-based hooks ---
   const { thread, isLoading: isThreadLoading, isDeleted } = useThread({ threadId })
@@ -255,10 +259,10 @@ export const MailThreadItem = memo(function MailThreadItem({
   // isMultiSelected = user-driven checkbox selection (drives checkbox + drag payload).
   // isActive = the thread currently open in the detail pane.
   // isHighlighted = visual blue highlight: either currently open OR checkbox-selected.
-  const isMultiSelected = useMemo(
-    () => selectedThreadIds.includes(threadId),
-    [selectedThreadIds, threadId]
-  )
+  const globalIsSelected = useIsThreadSelected(threadId)
+  const isMultiSelected = scopedSelectedIds
+    ? scopedSelectedIds.includes(threadId)
+    : globalIsSelected
   const isActive = useIsThreadActive(threadId)
   const isHighlighted = isActive || isMultiSelected
   const isProcessing = useIsRecordProcessing(toRecordId('thread', threadId))
@@ -270,7 +274,8 @@ export const MailThreadItem = memo(function MailThreadItem({
       type: 'thread',
       threadId,
       get draggedThreadIds() {
-        return selectedThreadIds.includes(threadId) ? selectedThreadIds : [threadId]
+        const selected = useThreadSelectionStore.getState().selectedThreadIds
+        return selected.includes(threadId) ? selected : [threadId]
       },
     },
     disabled: !threadId,


### PR DESCRIPTION
## What & why

Selecting threads in `/app/mail` janked because **selection state was carried on the `MailFilterContext` value**, which every `MailThreadItem` / `CompactThreadItem` consumes via `useMailFilter()`. Since context changes defeat `React.memo`, toggling one checkbox re-rendered **every mounted row**, and **select-all was O(n²)** (each row also ran `.includes()` over the full selected array). `MailboxInner` itself also re-rendered on every selection change.

This is the same root-cause pattern as the records-table re-render work (the `cellSelectionConfig` context churn).

## The fix

Pull volatile selection out of the context and let rows read it granularly from the `thread-selection-store`:

- **`mail-box.tsx`** — dropped the `useSelectedThreadIds()` subscription and the `selectedThreadIds` context field. `MailboxInner` no longer re-renders on selection.
- **`mail-thread-item.tsx`** / **`compact-thread-item.tsx`** — `isMultiSelected` now comes from the granular `useIsThreadSelected(threadId)` selector (`useHasSelection()` for the compact "any selected" check), so only the toggled row re-renders. The drag payload reads selection from `getState()` at drag time.
- **`mail-filter-context.tsx`** — `selectedThreadIds` kept as an **optional** field (see below).

Net: toggling a checkbox re-renders only the affected row; select-all is O(n) single-pass with no context fan-out and no `MailboxInner` re-render.

## One nuance — embedded mini-lists

`selectedThreadIds` was a **required** context field that two *embedded* surfaces — the **ticket Conversation tab** (`detail-view/tabs/ticket-conversation-tab.tsx`) and the **contact drawer's conversations list** (`drawers/tabs/contact-conversations-tab.tsx`) — pass to highlight their own locally-selected thread. Rather than break them, the field is now **optional**: the mailbox omits it (rows use the store), while those mini-lists keep passing their scoped selection and `MailThreadItem` uses it when present (`scopedSelectedIds ? scopedSelectedIds.includes(id) : useIsThreadSelected(id)`). So those surfaces are behavior-unchanged.

`bulk-action-toolbar.tsx` already read `useSelectedThreadIds()` from the store directly — untouched.

## Testing

Lint-clean. Best verified interactively (the real win shows up in the React DevTools Profiler, which needs a human driving clicks):

- [ ] Edit mode: toggle one checkbox → only that row re-renders; **select-all** on a long list is instant.
- [ ] Bulk toolbar appears/updates/clears; shift-click range + cmd-click multi-select; **drag a multi-selection** carries the full set.
- [ ] Embedded highlight still works: ticket detail → **Conversation tab**, and the **contact drawer** conversations list.
- [ ] Both `split` (default cards) and `list` (compact) layouts.

## Scope

Phase 1 of a larger plan (Issue 1 of 6). Follow-ups (not in this PR): hoisting the per-row `useThreadMutation()`, the `useThreadList` whole-`threads`-Map subscription, and list virtualization.
