### PR TITLE
perf(mail): hoist per-row thread-mutation toolkit to one app-wide provider

### DIFF
--- a/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
+++ b/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
@@ -17,7 +17,7 @@ import { SignatureDialogRoot } from '~/components/signatures/ui/signature-dialog
 import { SnippetDialogRoot } from '~/components/snippets/snippet-dialog-root'
 import { SubscriptionEnded } from '~/components/subscriptions/subscription-ended'
 import { FloatingTaskRoot } from '~/components/tasks/ui/floating-task-root'
-import { ThreadDataProvider } from '~/components/threads'
+import { ThreadActionsProvider, ThreadDataProvider } from '~/components/threads'
 import { useIsSelfHosted } from '~/hooks/use-deployment-mode'
 import { useDehydratedOrganizations } from '~/providers/dehydrated-state-provider'
 import { useOrganizationIdContext } from '~/providers/feature-flag-provider'
@@ -83,13 +83,15 @@ export function AppLayoutWrapper({ children, user }: AppLayoutWrapperProps) {
       <AuxxAppProviders>
         <ChannelProvider>
           <ThreadDataProvider>
-            <Dashboard user={user}>{children}</Dashboard>
-            <FloatingComposeRoot />
-            <FloatingTaskRoot />
-            <GlobalCreateRoot />
-            <SignatureDialogRoot />
-            <SnippetDialogRoot />
-            <CommandPalette />
+            <ThreadActionsProvider>
+              <Dashboard user={user}>{children}</Dashboard>
+              <FloatingComposeRoot />
+              <FloatingTaskRoot />
+              <GlobalCreateRoot />
+              <SignatureDialogRoot />
+              <SnippetDialogRoot />
+              <CommandPalette />
+            </ThreadActionsProvider>
           </ThreadDataProvider>
         </ChannelProvider>
       </AuxxAppProviders>

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -23,9 +23,9 @@ import {
   useMessage,
   useMessageParticipants,
   useThread,
-  useThreadMutation,
   useThreadReadStatus,
 } from '~/components/threads/hooks'
+import { useThreadActions } from '~/components/threads/providers'
 import {
   useHasSelection,
   useIsThreadSelected,
@@ -76,7 +76,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
   const selectRange = useThreadSelectionStore((s) => s.selectRange)
   const setFocusedThread = useThreadSelectionStore((s) => s.setFocusedThread)
   const selectionAnchorId = useSelectionAnchorId()
-  const { update, isUpdating } = useThreadMutation()
+  const { update } = useThreadActions()
   const { data: session } = useSession()
   const currentUserId = session?.user?.id
 
@@ -362,8 +362,6 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                       ? senderParticipant.identifier
                       : undefined
                   }
-                  update={update}
-                  isUpdating={isUpdating}
                   onOpenChange={setIsMenuOpen}
                 />
               </div>

--- a/apps/web/src/components/mail/hooks/use-count-updates.ts
+++ b/apps/web/src/components/mail/hooks/use-count-updates.ts
@@ -49,7 +49,15 @@ export interface ViewDefinition {
  * // In mutation onError:
  * rollback()
  */
-export function useCountUpdates(views: ViewDefinition[] = []) {
+/**
+ * Stable empty default so a no-arg `useCountUpdates()` call doesn't allocate a
+ * fresh `views` array each render — that would bust every memoized callback
+ * below and, transitively, the hoisted thread-action callbacks that depend on
+ * them (see ThreadActionsProvider).
+ */
+const EMPTY_VIEWS: ViewDefinition[] = []
+
+export function useCountUpdates(views: ViewDefinition[] = EMPTY_VIEWS) {
   const { data: session } = useSession()
   const currentUserId = session?.user?.id
   const conditionContext = useMemo(() => ({ currentUserId }), [currentUserId])

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -37,9 +37,9 @@ import {
   useMessage,
   useMessageParticipants,
   useThread,
-  useThreadMutation,
   useThreadReadStatus,
 } from '~/components/threads/hooks'
+import { useThreadActions } from '~/components/threads/providers'
 import {
   useIsThreadActive,
   useIsThreadSelected,
@@ -61,25 +61,19 @@ export function ProcessingMenu({
   threadId,
   integrationId,
   senderEmail,
-  update,
-  isUpdating,
   onOpenChange,
 }: {
   threadId: string
   integrationId?: string
   senderEmail?: string
-  update: (
-    threadId: string,
-    updates: { status?: 'OPEN' | 'ARCHIVED' | 'SPAM' | 'TRASH' | 'IGNORED' }
-  ) => void
-  isUpdating: boolean
   onOpenChange?: (open: boolean) => void
 }) {
   const onSuccess = useCallback(() => {
     console.log('Workflow triggered successfully')
   }, [])
 
-  const { merge } = useThreadMutation()
+  // Shared, hoisted thread actions (one instance app-wide) — see ThreadActionsProvider.
+  const { update, merge } = useThreadActions()
 
   const handleMergeInto = useCallback(
     (ids: RecordId[]) => {
@@ -95,7 +89,10 @@ export function ProcessingMenu({
 
   const addExcludedSender = api.channel.addExcludedSender.useMutation({
     onSuccess: () => {
-      update(threadId, { status: 'IGNORED' })
+      // `IGNORED` is a valid backend status that the client `ThreadStatus`
+      // union omits; the store + mutation accept it at runtime (previously
+      // bridged by a widened `update` prop type on this menu).
+      update(threadId, { status: 'IGNORED' } as unknown as Parameters<typeof update>[1])
     },
   })
 
@@ -154,24 +151,19 @@ export function ProcessingMenu({
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         <DropdownMenuSeparator />
-        <DropdownMenuItem
-          onClick={() => update(threadId, { status: 'ARCHIVED' })}
-          disabled={isUpdating}>
+        <DropdownMenuItem onClick={() => update(threadId, { status: 'ARCHIVED' })}>
           <Archive />
           Archive
           <DropdownMenuShortcut>D</DropdownMenuShortcut>
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => update(threadId, { status: 'TRASH' })}
-          disabled={isUpdating}
           variant='destructive'>
           <Trash2 />
           Trash Thread
           <DropdownMenuShortcut>#</DropdownMenuShortcut>
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => update(threadId, { status: 'SPAM' })}
-          disabled={isUpdating}>
+        <DropdownMenuItem onClick={() => update(threadId, { status: 'SPAM' })}>
           <MailWarning />
           Mark as spam
           <DropdownMenuShortcut>!</DropdownMenuShortcut>
@@ -229,9 +221,6 @@ export const MailThreadItem = memo(function MailThreadItem({
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setSelectionAnchor)
   const selectRange = useThreadSelectionStore((s) => s.selectRange)
   const selectionAnchorId = useSelectionAnchorId()
-
-  // --- Thread mutations using new unified hook ---
-  const { update, isUpdating } = useThreadMutation()
 
   const { data: session } = useSession()
   const currentUserId = session?.user?.id
@@ -471,8 +460,6 @@ export const MailThreadItem = memo(function MailThreadItem({
                           ? senderParticipant.identifier
                           : undefined
                       }
-                      update={update}
-                      isUpdating={isUpdating}
                     />
                   </div>
                 </div>
@@ -523,8 +510,6 @@ export const MailThreadItem = memo(function MailThreadItem({
                   ? senderParticipant.identifier
                   : undefined
               }
-              update={update}
-              isUpdating={isUpdating}
             />
           </div>
         </motion.div>

--- a/apps/web/src/components/threads/hooks/use-thread-mutation.ts
+++ b/apps/web/src/components/threads/hooks/use-thread-mutation.ts
@@ -226,7 +226,7 @@ export function useThreadMutation() {
       updateThreadOptimistic,
       confirmOptimistic,
       rollbackOptimistic,
-      updateMutation,
+      updateMutation.mutate,
       applyCountUpdates,
       restoreSnapshot,
     ]
@@ -269,7 +269,7 @@ export function useThreadMutation() {
       updateThreadOptimistic,
       confirmOptimistic,
       rollbackOptimistic,
-      updateBulkMutation,
+      updateBulkMutation.mutate,
       applyCountUpdates,
       restoreSnapshot,
     ]
@@ -321,7 +321,7 @@ export function useThreadMutation() {
       removeThread,
       undeleteThread,
       getThread,
-      removeMutation,
+      removeMutation.mutate,
       currentUserId,
       buildThreadContext,
       restoreSnapshot,
@@ -387,7 +387,7 @@ export function useThreadMutation() {
       removeThread,
       undeleteThread,
       getThread,
-      removeBulkMutation,
+      removeBulkMutation.mutate,
       currentUserId,
       buildThreadContext,
       restoreSnapshot,
@@ -471,7 +471,7 @@ export function useThreadMutation() {
       getThread,
       removeThread,
       undeleteThread,
-      updateBulkMutation,
+      updateBulkMutation.mutate,
       closeIfActive,
       currentUserId,
       updateThreadOptimistic,
@@ -496,7 +496,7 @@ export function useThreadMutation() {
         }
       )
     },
-    [updateMutation]
+    [updateMutation.mutate]
   )
 
   return {

--- a/apps/web/src/components/threads/index.ts
+++ b/apps/web/src/components/threads/index.ts
@@ -22,7 +22,7 @@ export {
   useThreadSelection,
 } from './hooks'
 // Providers
-export { ThreadDataProvider } from './providers'
+export { ThreadActionsProvider, ThreadDataProvider, useThreadActions } from './providers'
 // Stores
 export {
   type ActorId,

--- a/apps/web/src/components/threads/providers/index.ts
+++ b/apps/web/src/components/threads/providers/index.ts
@@ -1,3 +1,4 @@
 // apps/web/src/components/threads/providers/index.ts
 
+export { ThreadActionsProvider, useThreadActions } from './thread-actions-provider'
 export { ThreadDataProvider } from './thread-data-provider'

--- a/apps/web/src/components/threads/providers/thread-actions-provider.tsx
+++ b/apps/web/src/components/threads/providers/thread-actions-provider.tsx
@@ -1,0 +1,50 @@
+// apps/web/src/components/threads/providers/thread-actions-provider.tsx
+'use client'
+
+import { createContext, type ReactNode, useContext, useMemo } from 'react'
+import { useThreadMutation } from '../hooks'
+
+/**
+ * Stable thread-action callbacks shared by every thread list row.
+ *
+ * Without this, each `MailThreadItem` / `CompactThreadItem` (and each nested
+ * `ProcessingMenu`) called `useThreadMutation()` itself — 4 `useMutation()` +
+ * count-store subscriptions per row, multiplied across hundreds of rows. The
+ * toolkit is identical for every row (its `update(threadId, …)` is already
+ * id-parameterized), so we create it once here and share it.
+ *
+ * Deliberately exposes only the action callbacks, not the `isPending` flags:
+ * those are volatile (flip on every in-flight mutation) and would re-render
+ * every consumer. Rows already reflect changes via the optimistic thread-store
+ * update. The callbacks are referentially stable (see the `.mutate` deps in
+ * `useThreadMutation` + the stable default in `useCountUpdates`), so this
+ * context value never churns.
+ */
+type ThreadActions = Pick<
+  ReturnType<typeof useThreadMutation>,
+  'update' | 'updateBulk' | 'remove' | 'removeBulk' | 'merge' | 'unmerge'
+>
+
+const ThreadActionsContext = createContext<ThreadActions | null>(null)
+
+export function ThreadActionsProvider({ children }: { children: ReactNode }) {
+  const { update, updateBulk, remove, removeBulk, merge, unmerge } = useThreadMutation()
+  const value = useMemo<ThreadActions>(
+    () => ({ update, updateBulk, remove, removeBulk, merge, unmerge }),
+    [update, updateBulk, remove, removeBulk, merge, unmerge]
+  )
+  return <ThreadActionsContext.Provider value={value}>{children}</ThreadActionsContext.Provider>
+}
+
+/**
+ * Read the shared thread-action callbacks. Throws if no ThreadActionsProvider
+ * is mounted above — every thread-item render site lives under the app layout's
+ * provider, so a missing provider is a wiring bug, not a runtime branch.
+ */
+export function useThreadActions(): ThreadActions {
+  const ctx = useContext(ThreadActionsContext)
+  if (!ctx) {
+    throw new Error('useThreadActions must be used within a ThreadActionsProvider')
+  }
+  return ctx
+}


### PR DESCRIPTION
## What & why

Phase 2 of the mail thread-list performance work (follow-up to #983). The per-row cost was larger than expected: each `MailThreadItem` / `CompactThreadItem` called `useThreadMutation()`, **and** each nested `ProcessingMenu` (2 per default row, 1 per compact row) called it again — **~3× per row**, every call spinning up 4 `api.*.useMutation()` + count-store subscriptions + `useUser()`. Across hundreds of rows that's a lot of mount/render overhead.

## The fix

Hoist the toolkit to **one app-wide `ThreadActionsProvider`** (new `threads/providers/thread-actions-provider.tsx`), mounted in `app-layout-wrapper.tsx` inside `ThreadDataProvider`. Rows read `update` / `merge` from `useThreadActions()`.

App-level rather than per-`ThreadList` because `MailThreadItem` renders in **three** trees that all sit under the `(protected)/app` layout: the mailbox, the ticket **Conversation tab** (`ticket-conversation-tab.tsx`), and the **contact drawer** (`contact-conversations-tab.tsx`). One provider covers all of them; `useThreadActions()` throws if mounted outside, so a missing provider is a loud wiring bug rather than a silent branch.

### Stability prerequisites (why the diff touches the mutation/count hooks)

For a shared context value to not re-broadcast on every mutation's `isPending` flip, the action callbacks must be referentially stable. Two latent instabilities had to be fixed first:

- **Fix A on `useThreadMutation`** — the 6 callbacks now depend on the stable `.mutate` method instead of React Query's re-created wrapper object. (Same pattern as the records-table re-render fix; behavior-preserving, and benefits every `useThreadMutation` consumer.)
- **Stable `EMPTY_VIEWS` default in `useCountUpdates`** — its `views: ViewDefinition[] = []` default allocated a fresh array each render, which cascaded into unstable `onMarkAsRead`/`onArchiveOrTrash`/… callbacks and, transitively, `update`/`updateBulk`/`remove`/`removeBulk`.

With both, all six action callbacks are stable → the memoized context value never changes identity, so consumers don't re-render when a mutation runs.

### Two judgment calls

- **Dropped `isUpdating`** from the `ProcessingMenu` items. It was effectively dead — Radix closes the dropdown on select, so `disabled={isUpdating}` never actually disabled anything — and broadcasting a shared pending bool would re-render every row. The optimistic store update already drives the row's visible state.
- **One `IGNORED`-status cast.** The ignore-sender path sets `status: 'IGNORED'`, which the **client** `ThreadStatus` union omits (it's present in `@auxx/lib`'s `ThreadStatus` and the DB enum). The old code masked this by widening `ProcessingMenu`'s `update` *prop* type; with the shared `update` I added a localized, commented cast. (Biome doesn't typecheck, so this wasn't a lint finding — calling it out explicitly.)

## Files

`threads/providers/thread-actions-provider.tsx` (new), `app-layout-wrapper.tsx`, `threads/hooks/use-thread-mutation.ts`, `mail/hooks/use-count-updates.ts`, `mail/mail-thread-item.tsx`, `mail/compact-thread-item.tsx`, `threads/{index,providers/index}.ts`.

Net: ~`(1–3)×N` `useMutation` instantiations per render collapse to **4 total, app-wide**.

## Testing

Biome clean. Smoke-tested `/app/mail` in the browser: thread rows render (each mounting `ProcessingMenu`s that call `useThreadActions`), so the provider resolves — no provider-throw, no React errors. (Only console noise is a pre-existing base-ui/Radix `useId` hydration mismatch on the toolbar `ScrollArea`/`Select`, untouched here, plus a Stripe-over-HTTP dev warning.)

Still wants an interactive pass (these mutate real data, so not driven here):

- [ ] Archive / Trash / Spam / Merge / Assign from a row (default + compact), and the **sidebar count deltas** update + roll back on error.
- [ ] Ignore-sender (`IGNORED`) path from the row menu.
- [ ] Rows in the ticket **Conversation tab** and the **contact drawer** still act correctly.

## Scope

Phase 2 of 4. Next: Issue 3 (drop `useThreadList`'s whole-`threads`-Map subscription), then virtualization.
