### PR TITLE
feat(data-connectors): draft-in-place commit reconcile + header action cluster

### DIFF
--- a/apps/web/src/components/data-connectors/hooks/use-connector-commit.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-connector-commit.ts
@@ -6,15 +6,16 @@ import { useCallback } from 'react'
 import { api } from '~/trpc/react'
 import { type CommitPlan, diffConnectorDraft, isEmptyPlan } from '../lib/connector-commit-diff'
 import { getConnectorDraftState, useConnectorDraftStore } from '../stores/connector-draft-store'
-import { toConnectorDraft, toConnectorMeta } from './use-connector-draft-sync'
 
 /**
  * The commit/flush engine (plan §5) — the ONLY place connector configuration is
  * written. Reads the draft store imperatively, diffs it against the committed
  * snapshot, issues the minimal ordered set of tRPC mutations (resolving temp ids to
- * server ids), then re-seeds the store from the authoritative refetch so the draft
- * adopts real ids + server-derived fields (`linkMode`, §5.4). Nothing here fires on
- * keystroke — only on `commit()` (invariant P3).
+ * server ids), then reconciles the draft IN PLACE (`applyCommit`): it adopts the new
+ * server ids for created mappings and re-baselines the snapshot — no getById/listStreams
+ * refetch, because re-seeding would erase keystrokes typed during the round-trip. The
+ * client draft is authoritative. Nothing here fires on keystroke — only on `commit()`
+ * (invariant P3).
  *
  * Lives in a hook (not the store) so the store stays free of `api`/network imports.
  */
@@ -97,6 +98,9 @@ export function useConnectorCommit() {
       for (const d of plan.mappingDeletes) {
         await removeMapping.mutateAsync({ mappingId: d.mappingId })
       }
+
+      // The temp→real id map the caller uses to reconcile the draft in place (no refetch).
+      return tempToReal
     },
     [
       update,
@@ -111,8 +115,9 @@ export function useConnectorCommit() {
 
   /**
    * Flush the draft. Diffs against the snapshot, runs the ordered mutations, then
-   * re-seeds from the authoritative refetch. All-or-nothing: any failure rolls the
-   * draft back to the snapshot and surfaces one toast (plan §R2).
+   * reconciles the draft in place (adopt created-mapping ids + re-baseline the
+   * snapshot) — no refetch. All-or-nothing: any failure rolls the draft back to the
+   * snapshot and surfaces one toast (plan §R2).
    */
   const commit = useCallback(async () => {
     const state = getConnectorDraftState()
@@ -121,30 +126,25 @@ export function useConnectorCommit() {
     const plan = diffConnectorDraft(snapshot, draft)
     if (isEmptyPlan(plan)) return
 
+    // The baseline we're about to persist — captured BEFORE the round-trip so edits
+    // typed during it stay in the live draft (they're not in `committed`).
+    const committed = JSON.parse(JSON.stringify(draft)) as typeof draft
+
     setSaving(true)
     try {
-      await runPlan(connectorId, plan)
+      const tempToReal = await runPlan(connectorId, plan)
 
-      // Re-seed from the authoritative shape — real ids, server-derived `linkMode`.
-      // The single intentional post-commit refetch (replaces the per-edit storm, §5.4).
-      await Promise.all([
-        utils.dataConnector.getById.invalidate({ id: connectorId }),
-        utils.dataConnector.listStreams.invalidate({ id: connectorId }),
-      ])
-      const [connector, streams] = await Promise.all([
-        utils.dataConnector.getById.fetch({ id: connectorId }),
-        utils.dataConnector.listStreams.fetch({ id: connectorId }),
-      ])
-      if (connector) {
-        getConnectorDraftState().seed(
-          connectorId,
-          toConnectorMeta(connector),
-          toConnectorDraft(connector, streams)
-        )
-      }
+      // Reconcile the draft IN PLACE — adopt the freshly-minted server ids for created
+      // mappings and re-baseline the snapshot to `committed`. Deliberately NO
+      // getById/listStreams refetch + re-seed: a re-seed replaces the live draft and
+      // erases keystrokes made during the round-trip (the page-query-invalidate
+      // anti-pattern the agents editor calls out). The client draft is authoritative;
+      // anything edited since this commit stays dirty and flushes on the next autosave.
+      getConnectorDraftState().applyCommit(committed, tempToReal)
 
-      // One status nudge per commit, only for a resync-affecting change (§5.3) — kills
-      // the per-keystroke `getStatus` storm.
+      // One status nudge per commit, only for a resync-affecting change (§5.3). This is
+      // `getStatus` only (the status pill / resync banner) — it never feeds a controlled
+      // input, so it can't clobber typing. Kills the per-keystroke `getStatus` storm.
       if (plan.structural) {
         void utils.dataConnector.getStatus.invalidate({ id: connectorId })
       }

--- a/apps/web/src/components/data-connectors/hooks/use-connector-draft-sync.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-connector-draft-sync.ts
@@ -92,17 +92,22 @@ export function useConnectorDraftSync(input: {
   const meta = useMemo(() => toConnectorMeta(connector), [connector])
 
   const lastSeededKey = useRef<string | null>(null)
-  const lastConnectorId = useRef<string | null>(null)
 
-  // Seed / re-seed. On a connector-id change, always seed (page-scoped lifecycle).
-  // Otherwise re-seed only when the server shape changed AND the draft is clean.
+  // Seed / re-seed. Seed whenever the store isn't already holding THIS connector —
+  // a fresh mount, a connector-id change (page-scoped lifecycle), or a store that was
+  // wiped by the unmount `reset()` cleanup. The last case is what React StrictMode
+  // exercises in dev: it runs every effect setup → cleanup → setup, so the cleanup
+  // resets the store while this effect's refs survive — guarding on the live store
+  // `connectorId` (not a ref) is what lets the second setup re-seed. Otherwise re-seed
+  // only when the server shape changed AND the draft is clean (a background refresh
+  // must never clobber an uncommitted edit, invariant I1).
   useEffect(() => {
-    const connectorChanged = lastConnectorId.current !== connector.id
-    const dirty = selectIsDirty(useConnectorDraftStore.getState())
-    if (connectorChanged || (serverKey !== lastSeededKey.current && !dirty)) {
+    const state = useConnectorDraftStore.getState()
+    const notSeeded = state.connectorId !== connector.id
+    const dirty = selectIsDirty(state)
+    if (notSeeded || (serverKey !== lastSeededKey.current && !dirty)) {
       seed(connector.id, meta, serverDraft)
       lastSeededKey.current = serverKey
-      lastConnectorId.current = connector.id
     }
   }, [connector.id, serverKey, serverDraft, meta, seed])
 

--- a/apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
@@ -1,11 +1,6 @@
 // apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
 'use client'
 
-import type { RouterOutputs } from '~/trpc/react'
-
-type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
-type Stream = RouterOutputs['dataConnector']['listStreams'][number]
-
 /** The setup stepper's ordered steps (create-sync-flow-plan §2.1). */
 export type SetupStepId = 'connect' | 'sample' | 'map' | 'schedule' | 'run'
 
@@ -13,13 +8,33 @@ export type SetupStepId = 'connect' | 'sample' | 'map' | 'schedule' | 'run'
 export type StreamReadiness = 'ready' | 'needs-mapping'
 
 /**
+ * Minimal shapes the setup predicates read. The server `getById`/`listStreams` rows
+ * AND the editor draft (`ConnectorDraft`/`DraftStream`) both satisfy these — so the
+ * stepper can gate off the DRAFT (the client source of truth, never a commit behind)
+ * while keeping the same predicates the server-row tests exercise.
+ */
+export interface ProgressMappingRow {
+  fieldMappings?: ({ targetFieldRef: string | null } | null)[] | null
+}
+export interface ProgressStreamRow {
+  enabled: boolean
+  sourceSchema: Record<string, unknown> | null
+  mappings: ProgressMappingRow[]
+}
+export interface ProgressConnectorRow {
+  definitionKind: string
+  config: { endpoint?: { baseUrl?: string } } | Record<string, unknown> | null
+  credentialId: string | null
+}
+
+/**
  * A stream is ready once it has ≥1 mapping with a bound `targetFieldRef`. A row with
  * zero bound bindings (a freshly materialized draft — owned never is, a contributing
  * default-mapping is until authored) needs attention (multi-stream-setup-plan §4.1).
  */
-export function deriveStreamReadiness(stream: Stream): StreamReadiness {
+export function deriveStreamReadiness(stream: ProgressStreamRow): StreamReadiness {
   const bound = stream.mappings.some((m) =>
-    m.fieldMappings?.some((fm) => fm.targetFieldRef != null)
+    m.fieldMappings?.some((fm) => fm?.targetFieldRef != null)
   )
   return bound ? 'ready' : 'needs-mapping'
 }
@@ -60,8 +75,8 @@ export interface ConnectRequirements {
  * detail view already queries (`getById` + `listStreams`). See plan §2.2.
  */
 export function deriveSetupProgress(
-  connector: Connector,
-  streams: Stream[],
+  connector: ProgressConnectorRow,
+  streams: ProgressStreamRow[],
   connectReqs: ConnectRequirements
 ): SetupProgress {
   const isGenericRest = connector.definitionKind !== 'app'

--- a/apps/web/src/components/data-connectors/stores/connector-draft-store.ts
+++ b/apps/web/src/components/data-connectors/stores/connector-draft-store.ts
@@ -142,6 +142,15 @@ interface ConnectorDraftState {
 
   // ── lifecycle ──
   seed: (connectorId: string, meta: ConnectorMeta, server: ConnectorDraft) => void
+  /**
+   * Post-commit reconcile WITHOUT a server refetch (the commit no longer invalidates
+   * getById/listStreams — a re-seed would clobber keystrokes typed during the
+   * round-trip). Adopts the freshly-minted server ids for any created mappings
+   * (`tempToReal`) in the live draft, and re-baselines the snapshot to `committed`
+   * (the draft as it was when the commit began) so `isDirty` reflects only edits made
+   * SINCE the commit — those stay in the draft and flush on the next autosave.
+   */
+  applyCommit: (committed: ConnectorDraft, tempToReal: Map<string, string>) => void
   reset: () => void
   setSaving: (isSaving: boolean) => void
   setAutoSave: (autoSave: boolean) => void
@@ -182,6 +191,29 @@ const EMPTY_DRAFT: ConnectorDraft = {
 /** A temp id the server has never seen — minted for fan-out/add until commit. */
 export function isTempId(id: string): boolean {
   return id.startsWith('temp_')
+}
+
+/**
+ * Replace temp mapping ids (and any child `parentMappingId` that points at one) with
+ * their committed server ids. A no-op when nothing was created — returns the same draft
+ * reference so a config/field-only commit doesn't churn the mapping tree.
+ */
+function remapMappingIds(draft: ConnectorDraft, map: Map<string, string>): ConnectorDraft {
+  if (map.size === 0) return draft
+  return {
+    ...draft,
+    streams: draft.streams.map((s) => ({
+      ...s,
+      mappings: s.mappings.map((m) => ({
+        ...m,
+        id: map.get(m.id) ?? m.id,
+        parentMappingId:
+          m.parentMappingId && map.has(m.parentMappingId)
+            ? (map.get(m.parentMappingId) as string)
+            : m.parentMappingId,
+      })),
+    })),
+  }
 }
 
 /** Map a draft stream's mappings, replacing the one with `mappingId`. */
@@ -253,6 +285,12 @@ export const useConnectorDraftStore = create<ConnectorDraftState>()(
         streamValidity: {},
       })
     },
+
+    applyCommit: (committed, tempToReal) =>
+      set((s) => ({
+        draft: remapMappingIds(s.draft, tempToReal),
+        snapshot: remapMappingIds(committed, tempToReal),
+      })),
 
     reset: () =>
       set({

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -7,6 +7,7 @@ import {
   type ReadinessStream,
 } from '@auxx/lib/data-connectors/client'
 import { Button } from '@auxx/ui/components/button'
+import { ButtonGroup, ButtonGroupSeparator } from '@auxx/ui/components/button-group'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -20,7 +21,8 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { ChevronDown, FlaskConical, Pause, Play, Plug, RefreshCw, Trash } from 'lucide-react'
+import { cn } from '@auxx/ui/lib/utils'
+import { ChevronDown, Plug, RefreshCw, Trash } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useQueryState } from 'nuqs'
 import { useMemo } from 'react'
@@ -107,6 +109,22 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
     latestRun,
   })
 
+  // Pause/resume cluster pill: a colored dot + short label.
+  // green=live/ready · amber=syncing/provisioning · red=paused or action-needed.
+  // Drive paused/syncing off the OPTIMISTIC getById `status` (same source the toggle
+  // uses) so a click flips the dot instantly — the `getStatus` poll lags and only
+  // refetches mid-sync. `action-needed` is the one state that comes from the resolver.
+  const actionNeeded = resolved.state === 'action-needed'
+  const pillDotClass =
+    isPaused || actionNeeded ? 'bg-red-500' : isSyncing ? 'bg-amber-500' : 'bg-emerald-500'
+  const pillLabel = isPaused
+    ? 'Paused'
+    : actionNeeded
+      ? 'Action needed'
+      : isSyncing
+        ? 'Syncing'
+        : 'Live'
+
   const {
     syncNow,
     sampleSync,
@@ -191,103 +209,123 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
       <MainPageHeader
         action={
           <div className='flex items-center gap-2'>
-            {/* Soft-disable (not native `disabled`) when the config is incomplete OR unsaved
-                so a tooltip can explain why; native `disabled` stays for the in-flight state. */}
-            {(() => {
-              const syncButton = (
-                <Button
-                  variant='outline'
-                  size='sm'
-                  loading={isSyncPending}
-                  loadingText='Syncing...'
-                  disabled={isSyncing}
-                  aria-disabled={!!syncBlockReason}
-                  className={syncBlockReason ? 'cursor-not-allowed opacity-50' : undefined}
-                  onClick={() => {
-                    if (syncBlockReason) return
-                    syncNow(connector.id)
-                  }}>
-                  <RefreshCw />
-                  Sync now
-                </Button>
-              )
-              return syncBlockReason ? (
-                <Tooltip content={syncBlockReason}>{syncButton}</Tooltip>
-              ) : (
-                syncButton
-              )
-            })()}
-            {/* Sample sync (trial-sync §5.3): a bounded first look, available after setup
-                too — pick a per-stream size; the run parks for review when it's done. */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  disabled={isSyncing}
-                  aria-disabled={!!syncBlockReason}
-                  className={syncBlockReason ? 'cursor-not-allowed opacity-50' : undefined}
-                  onClick={(e) => {
-                    if (syncBlockReason) e.preventDefault()
-                  }}>
-                  <FlaskConical />
-                  Sample
-                  <ChevronDown />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align='end'>
-                {[50, 100, 500].map((n) => (
-                  <DropdownMenuItem key={n} onClick={() => sampleSync(connector.id, n)}>
-                    Sample {n} per stream
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-            {resolved.state === 'action-needed' && (
-              <Button variant='outline' size='sm' onClick={() => void setTab('connection')}>
+            {/* Reconnect stays a standalone CTA to the left of the cluster, shown only
+                when the connection needs attention (the resolver's action-needed state). */}
+            {actionNeeded && (
+              <Button variant='outline' size='xs' onClick={() => void setTab('connection')}>
                 <Plug />
                 Reconnect
               </Button>
             )}
-            {isPaused ? (
-              <Button
-                variant='outline'
-                size='sm'
-                loading={isResuming}
-                onClick={() => resume(connector.id)}>
-                <Play />
-                Resume
-              </Button>
-            ) : (
-              <Button
-                variant='outline'
-                size='sm'
-                loading={isPausing}
-                onClick={() => pause(connector.id)}>
-                <Pause />
-                Pause
-              </Button>
-            )}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant='destructive' size='sm' loading={isDeleting}>
-                  <Trash />
-                  Delete
-                  <ChevronDown />
+            <ButtonGroup className='shrink-0'>
+              {/* Pause/resume toggle: the colored dot conveys live status, clicking it
+                  flips paused ⇄ live. Decision uses the authoritative `isPaused`; the
+                  dot/label follow the live polled status. */}
+              <Tooltip content={isPaused ? 'Click to resume' : 'Click to pause'}>
+                <Button
+                  variant='outline'
+                  size='xs'
+                  className='gap-2 border-r-0'
+                  loading={isPausing || isResuming}
+                  loadingText=''
+                  onClick={() => (isPaused ? resume(connector.id) : pause(connector.id))}>
+                  <span className={cn('inline-block size-2 rounded-full', pillDotClass)} />
+                  {pillLabel}
                 </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align='end'>
-                <DropdownMenuItem onClick={() => void handleDelete('keep')}>
-                  Delete, keep synced records
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => void handleDelete('archive')}>
-                  Delete, archive synced records
-                </DropdownMenuItem>
-                <DropdownMenuItem variant='destructive' onClick={() => void handleDelete('delete')}>
-                  Delete connector and synced records
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+              </Tooltip>
+
+              <ButtonGroupSeparator />
+
+              {/* Sync now is the split button's primary action; soft-disable (not native
+                  `disabled`) when the config is incomplete OR unsaved so a tooltip can
+                  explain why; native `disabled` stays for the in-flight state. */}
+              {(() => {
+                const syncButton = (
+                  <Button
+                    variant='outline'
+                    size='xs'
+                    className={cn('border-r-0', syncBlockReason && 'cursor-not-allowed opacity-50')}
+                    loading={isSyncPending}
+                    loadingText='Syncing...'
+                    disabled={isSyncing}
+                    aria-disabled={!!syncBlockReason}
+                    onClick={() => {
+                      if (syncBlockReason) return
+                      syncNow(connector.id)
+                    }}>
+                    <RefreshCw />
+                    Sync now
+                  </Button>
+                )
+                return syncBlockReason ? (
+                  <Tooltip content={syncBlockReason}>{syncButton}</Tooltip>
+                ) : (
+                  syncButton
+                )
+              })()}
+
+              <ButtonGroupSeparator />
+
+              {/* Sample sync (trial-sync §5.3): the attached chevron opens per-stream
+                  sizes; same readiness gate as Sync now. The run parks for review. */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='outline'
+                    size='xs'
+                    className={cn(
+                      'border-r-0 px-1.5',
+                      syncBlockReason && 'cursor-not-allowed opacity-50'
+                    )}
+                    disabled={isSyncing}
+                    aria-disabled={!!syncBlockReason}
+                    aria-label='Sample sync'
+                    onClick={(e) => {
+                      if (syncBlockReason) e.preventDefault()
+                    }}>
+                    <ChevronDown />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end'>
+                  {[50, 100, 500].map((n) => (
+                    <DropdownMenuItem key={n} onClick={() => sampleSync(connector.id, n)}>
+                      Sample {n} per stream
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <ButtonGroupSeparator />
+
+              {/* Delete overflow menu — keep / archive / delete synced records. */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='outline'
+                    size='xs'
+                    className='px-1.5'
+                    loading={isDeleting}
+                    loadingText=''
+                    aria-label='Delete connector'>
+                    <Trash />
+                    <ChevronDown />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end'>
+                  <DropdownMenuItem onClick={() => void handleDelete('keep')}>
+                    Delete, keep synced records
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => void handleDelete('archive')}>
+                    Delete, archive synced records
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    variant='destructive'
+                    onClick={() => void handleDelete('delete')}>
+                    Delete connector and synced records
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </ButtonGroup>
           </div>
         }>
         <MainPageBreadcrumb>

--- a/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
@@ -32,10 +32,13 @@ import { useConnectorMutations } from '../hooks/use-connector-mutations'
 import {
   deriveSetupProgress,
   deriveStreamReadiness,
+  type ProgressConnectorRow,
+  type ProgressStreamRow,
   type SetupStepId,
   type StreamReadiness,
 } from '../hooks/use-setup-progress'
 import { useStreamMutations } from '../hooks/use-stream-mutations'
+import { useConnectorDraftStore, visibleMappings } from '../stores/connector-draft-store'
 import { ConnectionSection } from './connection-section'
 import { ConnectorSaveBar } from './connector-save-bar'
 import { ScheduleSection } from './schedule-section'
@@ -109,6 +112,33 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
   const streams = useMemo(() => streamsQuery.data ?? [], [streamsQuery.data])
   const primaryStream = streams[0] ?? null
 
+  // Gate the stepper off the DRAFT — the client source of truth. The autosave commit
+  // reconciles the draft in place and deliberately does NOT refetch getById/listStreams
+  // (it would re-seed the draft mid-keystroke and erase what's being typed — the same
+  // page-query-invalidate anti-pattern the agents editor avoids), so the server
+  // `connector`/`streams` props now lag a commit behind. The draft never does, so a step
+  // unlocks the instant its edit lands. Fall back to the server props until the store is
+  // seeded (one render on mount) so nothing flashes locked.
+  const draftSeeded = useConnectorDraftStore((s) => s.connectorId === connector.id)
+  const draftConfig = useConnectorDraftStore((s) => s.draft.config)
+  const draftStreams = useConnectorDraftStore((s) => s.draft.streams)
+  const gatingStreams = useMemo<Array<ProgressStreamRow & { id: string }>>(() => {
+    const source = draftSeeded
+      ? draftStreams.map((s) => ({
+          id: s.id,
+          enabled: s.enabled,
+          sourceSchema: s.sourceSchema,
+          mappings: visibleMappings(s),
+        }))
+      : streams.map((s) => ({
+          id: s.id,
+          enabled: s.enabled,
+          sourceSchema: s.sourceSchema as Record<string, unknown> | null,
+          mappings: s.mappings as ProgressStreamRow['mappings'],
+        }))
+    return source
+  }, [draftSeeded, draftStreams, streams])
+
   // A catalog-supplied schema (app connectors always; templates that ship one)
   // means there's nothing to "pull a sample" for — the source shape arrived at
   // create time. Drop that step; instead offer an optional live preview inside
@@ -147,11 +177,16 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
     [schemaQuery.data]
   )
   const requiredConfigSatisfied = useMemo(() => {
-    const cfg = (connector.config ?? {}) as Record<string, unknown>
+    const cfg = ((draftSeeded ? draftConfig : connector.config) ?? {}) as Record<string, unknown>
     return configFields.filter((f) => f.required).every((f) => !isMissing(cfg[f.key]))
-  }, [configFields, connector.config])
+  }, [configFields, draftSeeded, draftConfig, connector.config])
 
-  const progress = deriveSetupProgress(connector, streams, {
+  const progressConnector: ProgressConnectorRow = {
+    definitionKind: connector.definitionKind,
+    config: (draftSeeded ? draftConfig : connector.config) as ProgressConnectorRow['config'],
+    credentialId: connector.credentialId,
+  }
+  const progress = deriveSetupProgress(progressConnector, gatingStreams, {
     requiresConnection,
     hasConfigForm: configFields.length > 0,
     requiredConfigSatisfied,
@@ -159,8 +194,8 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
 
   // Per-stream readiness drives the Map step's overview badges + its `every`-stream gate.
   const readinessById = useMemo<Record<string, StreamReadiness>>(
-    () => Object.fromEntries(streams.map((s) => [s.id, deriveStreamReadiness(s)])),
-    [streams]
+    () => Object.fromEntries(gatingStreams.map((s) => [s.id, deriveStreamReadiness(s)])),
+    [gatingStreams]
   )
 
   // Gating: can the user advance past this step? Schedule is always satisfiable

--- a/apps/web/src/components/data-connectors/ui/webhook-signal-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/webhook-signal-section.tsx
@@ -164,7 +164,16 @@ export function WebhookSignalInspector({ connector }: { connector: Connector }) 
     appConnections.find((c) => c.id === connector.credentialId)?.appInstallationId ??
     null
 
-  const saved = (connector.config as { webhookTrigger?: WebhookSignal } | null)?.webhookTrigger
+  // Follow the DRAFT signal so the inspector swaps the instant the picker binds an
+  // endpoint/trigger — the commit no longer refetches getById, so `connector.config`
+  // lags until a reload (plans/data-connectors/v4). Fall back to the server prop until
+  // the store is seeded for this connector so a committed signal never flashes empty.
+  const draftSeeded = useConnectorDraftStore((s) => s.connectorId === connector.id)
+  const draftConfig = useConnectorDraftStore((s) => s.draft.config)
+  const cfg = (draftSeeded ? draftConfig : connector.config) as {
+    webhookTrigger?: WebhookSignal
+  } | null
+  const saved = cfg?.webhookTrigger
   const source = savedSource(saved)
 
   // These inspectors render their own `Section`; inside the connector's scroll column the

--- a/apps/web/src/components/data-connectors/ui/webhook-steering-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/webhook-steering-section.tsx
@@ -13,7 +13,11 @@ import { useTriggerSources } from '~/components/pickers/trigger-source'
 import { type Tag, TagInput } from '~/components/tag-input/tag-input'
 import { WebhookTopicPicker } from '~/components/webhooks/ui/webhook-topic-picker'
 import type { RouterOutputs } from '~/trpc/react'
-import { getConnectorDraftState, selectIsDirty } from '../stores/connector-draft-store'
+import {
+  getConnectorDraftState,
+  selectIsDirty,
+  useConnectorDraftStore,
+} from '../stores/connector-draft-store'
 
 type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
 type Stream = RouterOutputs['dataConnector']['listStreams'][number]
@@ -142,7 +146,15 @@ function WebhookSteeringEditor({ connector, stream }: { connector: Connector; st
     appIdFilter: appId,
   })
 
-  const signal = (connector.config as { webhookTrigger?: WebhookSignal } | null)?.webhookTrigger
+  // Read the SIGNAL from the DRAFT so the topics picker + payload-field checklist resolve
+  // the instant the connector-level picker binds an endpoint/trigger — the commit no longer
+  // refetches getById, so `connector.config` lags until a reload (plans/data-connectors/v4).
+  // Server prop fallback until the store seeds, so a committed signal never flashes empty.
+  const draftSeeded = useConnectorDraftStore((s) => s.connectorId === connector.id)
+  const draftConfig = useConnectorDraftStore((s) => s.draft.config)
+  const signal = (
+    (draftSeeded ? draftConfig : connector.config) as { webhookTrigger?: WebhookSignal } | null
+  )?.webhookTrigger
   const selectedAppTrigger = signal?.triggerId
     ? (appSources.find((s) => s.trigger.triggerId === signal.triggerId)?.trigger ?? null)
     : null


### PR DESCRIPTION
## Summary

Two related data-connectors UI changes.

### 1. Reconcile the draft in place after commit; gate UI off the draft
The autosave commit no longer refetches `getById`/`listStreams` and re-seeds the draft — a re-seed clobbers keystrokes typed during the round-trip. Instead it reconciles in place via a new `applyCommit`:
- adopts the freshly-minted server ids for created mappings (`temp→real`, including child `parentMappingId`),
- re-baselines the snapshot to the committed draft, so only edits made **since** the commit stay dirty (and flush on the next autosave).

The client draft is now the source of truth, so the **setup stepper**, **webhook signal inspector**, and **webhook steering editor** read config/streams from the draft (server props lag a commit behind), falling back to server props until the store seeds. Draft-sync seeding now guards on the live store `connectorId` rather than a ref, so React StrictMode's setup → cleanup → setup re-seeds correctly. `use-setup-progress` predicates now take minimal row shapes that both the server rows and the draft satisfy.

### 2. Regroup the connector header actions into a button cluster
Collapse the separate Sync / Sample / Pause / Resume / Delete buttons into one `ButtonGroup` modeled on `publish-cluster-shell`:
- a colored-dot pill that **toggles pause/resume** (🟢 live/ready, 🟡 syncing, 🔴 paused/action-needed),
- a split **Sync now** button whose attached chevron opens the sample sizes (50/100/500 per stream),
- a trailing **delete** overflow menu (keep / archive / delete).

Reconnect stays a separate CTA shown only when action-needed. All buttons are `size=xs`. The pill dot/label derive from the optimistic `getById` status (same source the toggle uses) so a pause click flips it instantly — the `getStatus` poll lags and only refetches mid-sync.

## Test plan
- [ ] Edit a connector field, keep typing through an autosave — no keystroke loss, no mid-edit re-seed.
- [ ] Setup stepper steps unlock immediately as their edits land (not a commit behind).
- [ ] Bind a webhook signal — steering/inspector resolve without a reload.
- [ ] Header: Sync now / sample sizes / pause↔resume (dot flips instantly) / delete variants all work; Reconnect appears only when action-needed.