### PR TITLE
feat(data-connectors): reachability probe + Connecting status for fresh syncs

### DIFF
--- a/apps/web/src/components/data-connectors/lib/resolve-sync-status.test.ts
+++ b/apps/web/src/components/data-connectors/lib/resolve-sync-status.test.ts
@@ -113,6 +113,15 @@ describe('resolveSyncStatus', () => {
     expect(r.detail).toBe('Importing orders — 3,250 records so far')
   })
 
+  it('reads as Connecting while a fresh backfill has seen no records yet', () => {
+    const r = resolveSyncStatus(
+      { status: 'syncing', latestRun: { status: 'running', phase: 'backfill', recordsSeen: 0 } },
+      NOW
+    )
+    expect(r).toMatchObject({ state: 'syncing', label: 'Connecting', primaryAction: 'pause' })
+    expect(r.detail).toBe('Reaching the source…')
+  })
+
   it('does not show "records so far" for a steady run', () => {
     const r = resolveSyncStatus(
       { status: 'syncing', latestRun: { status: 'running', phase: 'steady', recordsSeen: 9999 } },

--- a/apps/web/src/components/data-connectors/lib/resolve-sync-status.ts
+++ b/apps/web/src/components/data-connectors/lib/resolve-sync-status.ts
@@ -171,13 +171,20 @@ export function resolveSyncStatus(
     // "records so far" is a backfill concept; steady deltas use the run +n/+n line.
     const isBackfill = !latestRun || latestRun.phase !== 'steady'
     const noun = latestRun?.primaryStreamLabel?.trim() || 'records'
+    // No page has landed yet on a fresh backfill — we're still establishing the
+    // connection / awaiting the first response. Reading this as "Connecting…" keeps an
+    // unreachable host from looking like a healthy in-progress import (it'll flip to
+    // Error once the reachability probe times out).
+    const connecting = isBackfill && records === 0
     const detail =
       isBackfill && records > 0
         ? `Importing ${noun} — ${records.toLocaleString()} records so far`
-        : 'Syncing…'
+        : connecting
+          ? 'Reaching the source…'
+          : 'Syncing…'
     return {
       state: 'syncing',
-      label: status === 'provisioning' ? 'Provisioning' : 'Syncing',
+      label: status === 'provisioning' ? 'Provisioning' : connecting ? 'Connecting' : 'Syncing',
       detail,
       primaryAction: 'pause',
     }

--- a/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
@@ -116,7 +116,9 @@ function RunRow({ run, sourceLabel }: { run: ConnectorRun; sourceLabel: string }
       isOpen={hasErrors ? open : undefined}
       onToggleOpen={hasErrors ? () => setOpen((v) => !v) : undefined}>
       {hasErrors && (
-        <Alert variant='destructive' className='mt-1 me-2 ms-8 flex flex-col gap-1 text-xs'>
+        <Alert
+          variant='destructive'
+          className='mt-1 me-2 ms-8 flex w-auto flex-col items-start gap-1 text-xs'>
           {errors.slice(0, 3).map((e, i) => (
             <div key={i} className='break-words'>
               {e.error}

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -199,6 +199,7 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
           requestConfig: this.deps.stream.requestConfig ?? undefined,
           // H1 — never sleep on a throttle inside a slice.
           rateLimitOverride: { maxRetries: 0 },
+          signal: ctx.signal,
         }),
       sink: (record) =>
         sinkSourceRecord(syncCtx, this.deps.stream.mappings, record, this.updatedAtPath),

--- a/packages/lib/src/data-connectors/connectors/generic-rest.ts
+++ b/packages/lib/src/data-connectors/connectors/generic-rest.ts
@@ -30,6 +30,13 @@ import {
 
 const logger = createScopedLogger('data-connector-generic-rest')
 
+// Reachability-probe timeout for the FIRST request of a fresh fetch chain. Short
+// enough that an unreachable host (offline dev server, wrong base URL) surfaces an
+// error in seconds rather than spinning on the transport's 30s default. Subsequent
+// pages fall back to the default — a reachable-but-slow paginated API keeps the
+// full budget once the first page proves the host is up.
+const PROBE_TIMEOUT_MS = 10_000
+
 // ── Webhook fetch steering (sync bridge §4) ──────────────────────────────────
 // A webhook-steered fetch interpolates `{token}` placeholders (resolved from the
 // delivery payload) into the request's path/params/headers/body using the SAME
@@ -457,12 +464,19 @@ async function* fetchRecords(args: ConnectorFetchArgs): AsyncIterable<ConnectorY
     // The HTTP transport applies the resolved connection's declarative auth
     // (header/basic/query), sends the request, handles rate limits (429 +
     // Retry-After / Shopify-GraphQL throttle / backoff), and normalizes the response.
+    // Reachability probe: the FIRST request of a fresh chain (no resume cursor, page
+    // 0) gets a short timeout so an unreachable host fails in seconds instead of
+    // sitting on the full 30s budget. Resumed/subsequent pages keep the default so a
+    // slow-but-alive paginated API isn't penalized.
+    const isProbe = fetched === 0 && !cursor && pageIndex === 0
     const response = await httpTransport.request(applyCredential, {
       method,
       url,
       headers: baseHeaders,
       body: method === 'POST' ? steeredBody : undefined,
       rateLimit,
+      timeoutMs: isProbe ? PROBE_TIMEOUT_MS : undefined,
+      signal: args.signal,
     })
 
     // H1: a throttle the transport did NOT sleep through (the sliced source sets

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -441,6 +441,13 @@ export interface ConnectorFetchArgs {
    */
   rateLimitOverride?: Partial<RateLimitPolicy>
   /**
+   * The slice's cancellation signal (worker lock budget / graceful shutdown).
+   * Threaded into the HTTP transport so an in-flight request aborts when the
+   * slice does — without it the connector relies solely on the transport's own
+   * per-request timeout.
+   */
+  signal?: AbortSignal
+  /**
    * Sample/test-fetch only: invoked once per fetched page with the transport's
    * normalized response headers (lowercased keys). Lets the builder's test-fetch
    * surface `link-header` pagination without putting transport metadata on


### PR DESCRIPTION
## What

Fresh data-connector syncs against an unreachable host (offline dev server, wrong base URL) used to sit on the transport's 30s default timeout and read as a healthy in-progress import. This makes that failure mode fast and legible.

## Changes

- **Reachability probe** (`generic-rest.ts`): the *first* request of a fresh fetch chain (no resume cursor, page 0) gets a short 10s timeout so an unreachable host fails in seconds. Subsequent/resumed pages keep the full default budget so a slow-but-alive paginated API isn't penalized.
- **"Connecting" sync status** (`resolve-sync-status.ts`): a backfill that has seen no records yet now reads as `Connecting / Reaching the source…` instead of a generic `Syncing`, so an unreachable host doesn't look healthy mid-import. It flips to `Error` once the probe times out.
- **AbortSignal threading** (`types.ts`, `connector-sync-source.ts`, `generic-rest.ts`): the slice's cancellation signal is threaded through `ConnectorFetchArgs` into the HTTP transport so an in-flight request aborts when the slice does (worker lock budget / graceful shutdown).
- **Runs panel** (`connector-runs-panel.tsx`): minor error-alert layout fix (`w-auto`, `items-start`).

## Tests

Added a `resolveSyncStatus` case asserting the `Connecting` state for a fresh backfill with `recordsSeen: 0`.