### PR TITLE
feat(data-connectors): multi-stream app-connector setup

### DIFF
--- a/apps/web/src/components/data-connectors/hooks/use-connector-commit.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-connector-commit.ts
@@ -41,7 +41,13 @@ export function useConnectorCommit() {
         independent.push(update.mutateAsync({ id: connectorId, ...plan.connectorUpdate }))
       }
       for (const r of plan.streamRenames) {
-        independent.push(updateStream.mutateAsync({ streamId: r.streamId, streamKey: r.streamKey }))
+        independent.push(
+          updateStream.mutateAsync({
+            streamId: r.streamId,
+            ...(r.streamKey !== undefined ? { streamKey: r.streamKey } : {}),
+            ...(r.enabled !== undefined ? { enabled: r.enabled } : {}),
+          })
+        )
       }
       for (const rc of plan.streamRequestConfigs) {
         independent.push(

--- a/apps/web/src/components/data-connectors/hooks/use-setup-progress.test.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-setup-progress.test.ts
@@ -2,7 +2,13 @@
 
 import { describe, expect, it } from 'vitest'
 import type { RouterOutputs } from '~/trpc/react'
-import { deriveStreamReadiness } from './use-setup-progress'
+import {
+  type ConnectRequirements,
+  deriveSetupProgress,
+  deriveStreamReadiness,
+  type ProgressConnectorRow,
+  type ProgressStreamRow,
+} from './use-setup-progress'
 
 type Stream = RouterOutputs['dataConnector']['listStreams'][number]
 
@@ -34,5 +40,45 @@ describe('deriveStreamReadiness', () => {
         stream([{ targetFieldRefs: [null] }, { targetFieldRefs: [null, 'def:field'] }])
       )
     ).toBe('ready')
+  })
+})
+
+describe('deriveSetupProgress — map gate filters by enabled', () => {
+  // A generic-rest connector with an endpoint satisfies Connect, isolating the map gate.
+  const connector: ProgressConnectorRow = {
+    definitionKind: 'rest',
+    config: { endpoint: { baseUrl: 'https://api.example.com' } },
+    credentialId: null,
+  }
+  const reqs: ConnectRequirements = {
+    requiresConnection: false,
+    hasConfigForm: false,
+    requiredConfigSatisfied: true,
+  }
+  const ready = (enabled: boolean): ProgressStreamRow => ({
+    enabled,
+    sourceSchema: { type: 'object' },
+    mappings: [{ fieldMappings: [{ targetFieldRef: 'def:field' }] }],
+  })
+  const notReady = (enabled: boolean): ProgressStreamRow => ({
+    enabled,
+    sourceSchema: { type: 'object' },
+    mappings: [{ fieldMappings: [{ targetFieldRef: null }] }],
+  })
+
+  it('passes when an enabled stream is ready and a disabled one is not', () => {
+    expect(deriveSetupProgress(connector, [ready(true), notReady(false)], reqs).map).toBe(true)
+  })
+
+  it('passes when the only not-ready stream is disabled', () => {
+    expect(deriveSetupProgress(connector, [ready(true), notReady(false)], reqs).map).toBe(true)
+  })
+
+  it('blocks when a not-ready stream is enabled', () => {
+    expect(deriveSetupProgress(connector, [ready(true), notReady(true)], reqs).map).toBe(false)
+  })
+
+  it('blocks (map:false) when every stream is disabled', () => {
+    expect(deriveSetupProgress(connector, [ready(false), ready(false)], reqs).map).toBe(false)
   })
 })

--- a/apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-setup-progress.ts
@@ -50,7 +50,7 @@ export interface SetupProgress {
   connectTrivial: boolean
   /** At least one stream has a source schema (a successful sample → "use as schema"). */
   sample: boolean
-  /** EVERY stream is `ready` (≥1 mapping with a bound `targetFieldRef`). */
+  /** EVERY *enabled* stream is `ready` (≥1 mapping with a bound `targetFieldRef`). */
   map: boolean
   /** Map satisfied → the terminal "Run first sync" CTA is enabled
    *  (Sample is implied by Map; Schedule defaults to Manual). */
@@ -102,9 +102,11 @@ export function deriveSetupProgress(
   }
 
   const sample = streams.some((s) => s.sourceSchema != null)
-  // Every stream must be mapped — an app connector that fans out to N streams (or
-  // carries a draft contributing mapping) can't finish setup with a half-authored
-  // fan-out (multi-stream-setup-plan §4.2).
-  const map = streams.length > 0 && streams.every((s) => deriveStreamReadiness(s) === 'ready')
+  // Every *enabled* stream must be mapped — an app connector that fans out to N streams
+  // can't finish setup with a half-authored fan-out, but a stream the org toggled off
+  // is excluded (it won't sync). This realigns the gate with the backend readiness
+  // filter (`readiness.ts` does `streams.filter(s => s.enabled)`). (§3.2.)
+  const enabled = streams.filter((s) => s.enabled)
+  const map = enabled.length > 0 && enabled.every((s) => deriveStreamReadiness(s) === 'ready')
   return { connect, connectTrivial, sample, map, canRun: map }
 }

--- a/apps/web/src/components/data-connectors/lib/connector-commit-diff.test.ts
+++ b/apps/web/src/components/data-connectors/lib/connector-commit-diff.test.ts
@@ -281,6 +281,27 @@ describe('stream config', () => {
     const plan = diffConnectorDraft(snap, draft)
     expect(plan.streamRenames).toEqual([{ streamId: 'stream_1', streamKey: 'invoices' }])
   })
+
+  it('enabled-only toggle → one streamRenames entry with { enabled }, NOT structural', () => {
+    const [snap, draft] = withEdits(() => {
+      getConnectorDraftState().setStreamEnabled('stream_1', false)
+    })
+    const plan = diffConnectorDraft(snap, draft)
+    expect(plan.streamRenames).toEqual([{ streamId: 'stream_1', enabled: false }])
+    expect(plan.structural).toBe(false)
+  })
+
+  it('streamKey + enabled change merge into one entry', () => {
+    const [snap, draft] = withEdits(() => {
+      getConnectorDraftState().renameStream('stream_1', 'invoices')
+      getConnectorDraftState().setStreamEnabled('stream_1', false)
+    })
+    const plan = diffConnectorDraft(snap, draft)
+    expect(plan.streamRenames).toEqual([
+      { streamId: 'stream_1', streamKey: 'invoices', enabled: false },
+    ])
+    expect(plan.structural).toBe(false)
+  })
 })
 
 describe('mixed commit ordering', () => {

--- a/apps/web/src/components/data-connectors/lib/connector-commit-diff.ts
+++ b/apps/web/src/components/data-connectors/lib/connector-commit-diff.ts
@@ -53,7 +53,12 @@ export interface MappingUpdatePatch {
 
 export interface CommitPlan {
   connectorUpdate: ConnectorUpdatePatch | null
-  streamRenames: Array<{ streamId: string; streamKey: string }>
+  /**
+   * Per-stream `updateStream` calls — a `streamKey` rename and/or an `enabled`
+   * toggle. An enabled-only change is cosmetic (no resync), so it never sets
+   * `structural`.
+   */
+  streamRenames: Array<{ streamId: string; streamKey?: string; enabled?: boolean }>
   streamRequestConfigs: Array<{
     streamId: string
     requestConfig: UiRequestConfig
@@ -214,8 +219,15 @@ export function diffConnectorDraft(snapshot: ConnectorDraft, draft: ConnectorDra
     const prev = prevStreams.get(stream.id)
     if (!prev) continue
 
-    if (prev.streamKey !== stream.streamKey)
-      streamRenames.push({ streamId: stream.id, streamKey: stream.streamKey })
+    const streamKeyChanged = prev.streamKey !== stream.streamKey
+    const enabledChanged = prev.enabled !== stream.enabled
+    if (streamKeyChanged || enabledChanged)
+      // Enabled-only is cosmetic — deliberately does NOT set `structural`.
+      streamRenames.push({
+        streamId: stream.id,
+        ...(streamKeyChanged ? { streamKey: stream.streamKey } : {}),
+        ...(enabledChanged ? { enabled: stream.enabled } : {}),
+      })
 
     const requestChanged = !eq(prev.requestConfig, stream.requestConfig)
     const syncModeChanged = prev.syncMode !== stream.syncMode

--- a/apps/web/src/components/data-connectors/stores/connector-draft-store.ts
+++ b/apps/web/src/components/data-connectors/stores/connector-draft-store.ts
@@ -165,6 +165,7 @@ interface ConnectorDraftState {
 
   // ── stream setters (draft-only) ──
   renameStream: (streamId: string, streamKey: string) => void
+  setStreamEnabled: (streamId: string, enabled: boolean) => void
   setSyncMode: (streamId: string, syncMode: SyncMode) => void
   setRequestConfig: (streamId: string, requestConfig: UiRequestConfig) => void
   setStreamSchema: (
@@ -319,6 +320,9 @@ export const useConnectorDraftStore = create<ConnectorDraftState>()(
 
     renameStream: (streamId, streamKey) =>
       set((s) => ({ draft: patchStream(s.draft, streamId, (st) => ({ ...st, streamKey })) })),
+
+    setStreamEnabled: (streamId, enabled) =>
+      set((s) => ({ draft: patchStream(s.draft, streamId, (st) => ({ ...st, enabled })) })),
 
     setSyncMode: (streamId, syncMode) =>
       set((s) => ({ draft: patchStream(s.draft, streamId, (st) => ({ ...st, syncMode })) })),

--- a/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
@@ -5,7 +5,7 @@ import { Button } from '@auxx/ui/components/button'
 import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { EmptySection } from '@auxx/ui/components/section'
+import { EmptySection, Section } from '@auxx/ui/components/section'
 import {
   Select,
   SelectContent,
@@ -110,7 +110,6 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
   const utils = api.useUtils()
   const streamsQuery = api.dataConnector.listStreams.useQuery({ id: connector.id })
   const streams = useMemo(() => streamsQuery.data ?? [], [streamsQuery.data])
-  const primaryStream = streams[0] ?? null
 
   // Gate the stepper off the DRAFT — the client source of truth. The autosave commit
   // reconciles the draft in place and deliberately does NOT refetch getById/listStreams
@@ -139,14 +138,32 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
     return source
   }, [draftSeeded, draftStreams, streams])
 
+  // The enabled streams (draft-backed once seeded) are the ones setup must satisfy —
+  // a stream the org toggled off neither gates nor needs a sample. Step structure and
+  // the Connect/Sample bodies key off these, not `streams[0]` (§3.3).
+  const enabledStreams = useMemo(() => {
+    const enabledById = new Map(draftStreams.map((s) => [s.id, s.enabled]))
+    return streams.filter((s) => (draftSeeded ? (enabledById.get(s.id) ?? s.enabled) : s.enabled))
+  }, [streams, draftStreams, draftSeeded])
+
+  // The stream Connect previews / the Sample step configures. Prefer the first enabled
+  // stream still lacking a catalog schema (the one a sample is actually for); else the
+  // first enabled stream. Falls back to the whole list when nothing is enabled yet.
+  const sampleStream =
+    enabledStreams.find((s) => s.schemaSource !== 'catalog' || s.sourceSchema == null) ??
+    enabledStreams[0] ??
+    streams[0] ??
+    null
+
   // A catalog-supplied schema (app connectors always; templates that ship one)
   // means there's nothing to "pull a sample" for — the source shape arrived at
-  // create time. Drop that step; instead offer an optional live preview inside
-  // Connect so the user can still confirm the connection returns real data.
-  // `schemaSource === 'catalog'` is the stable signal — a user-pulled sample
-  // stamps 'inferred', so this never flips mid-setup.
+  // create time. Drop that step only when EVERY enabled stream already carries a
+  // catalog schema; a mix keeps Sample for the schema-less ones. `schemaSource ===
+  // 'catalog'` is the stable signal — a user-pulled sample stamps 'inferred', so this
+  // never flips mid-setup.
   const catalogSchema =
-    primaryStream?.schemaSource === 'catalog' && primaryStream.sourceSchema != null
+    enabledStreams.length > 0 &&
+    enabledStreams.every((s) => s.schemaSource === 'catalog' && s.sourceSchema != null)
 
   const steps = useMemo(
     () => (catalogSchema ? STEPS.filter((s) => s.id !== 'sample') : STEPS),
@@ -267,18 +284,18 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
         return (
           <>
             <ConnectionSection connector={connector} />
-            {catalogSchema && progress.connect && primaryStream && (
-              <ConnectPreview connector={connector} stream={primaryStream} />
+            {catalogSchema && progress.connect && sampleStream && (
+              <ConnectPreview connector={connector} stream={sampleStream} />
             )}
           </>
         )
       case 'sample':
-        if (!primaryStream)
+        if (!sampleStream)
           return <NoStreamPrompt addStream={addStream} connectorId={connector.id} />
         return (
           <StreamConfigPanel
             connector={connector}
-            stream={primaryStream}
+            stream={sampleStream}
             view='configure'
             scroll={false}
           />
@@ -463,14 +480,18 @@ function ConnectPreview({ connector, stream }: { connector: Connector; stream: S
   }
 
   return (
-    <div className='mt-2 flex flex-col gap-2 border-t px-1 pt-3'>
-      <div className='flex items-center justify-between gap-3'>
-        <div className='flex flex-col'>
-          <span className='text-sm font-medium'>Preview records</span>
-          <span className='text-xs text-muted-foreground'>
-            Optional — confirm the connection returns real data before the first sync.
-          </span>
-        </div>
+    // A real Section (not a bare div) so it matches Connection / Connector settings
+    // above it — same uppercase header + divider, no offset hand-rolled border.
+    <Section
+      title='Preview records'
+      icon={<FlaskConical className='size-4' />}
+      initialOpen
+      collapsible={false}
+      // Drop the body padding while there's no sample yet (the shared empty-body
+      // pattern — cf. stream-config-panel / pagination-section).
+      className={sample ? undefined : '[&_[data-slot=section]]:pb-0'}
+      description='Optional — confirm the connection returns real data before the first sync.'
+      actions={
         <Button
           size='sm'
           variant='outline'
@@ -480,9 +501,13 @@ function ConnectPreview({ connector, stream }: { connector: Connector; stream: S
           <FlaskConical />
           {sample ? 'Refresh' : 'Preview'}
         </Button>
-      </div>
-      {sample && <StreamSample sample={sample} />}
-    </div>
+      }>
+      {sample && (
+        <div className='px-1'>
+          <StreamSample sample={sample} />
+        </div>
+      )}
+    </Section>
   )
 }
 

--- a/apps/web/src/components/data-connectors/ui/setup-streams-overview.tsx
+++ b/apps/web/src/components/data-connectors/ui/setup-streams-overview.tsx
@@ -2,12 +2,15 @@
 'use client'
 
 import { Badge } from '@auxx/ui/components/badge'
+import { Switch } from '@auxx/ui/components/switch'
 import { cn } from '@auxx/ui/lib/utils'
 import { Check, ChevronRight, CircleAlert, Table2 } from 'lucide-react'
 import { useState } from 'react'
+import { Tooltip } from '~/components/global/tooltip'
 import { useResources } from '~/components/resources'
 import type { RouterOutputs } from '~/trpc/react'
 import type { StreamReadiness } from '../hooks/use-setup-progress'
+import { useConnectorDraftStore } from '../stores/connector-draft-store'
 import { StreamConfigPanel } from './stream-config-panel'
 
 type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
@@ -34,6 +37,11 @@ export function SetupStreamsOverview({
   readinessById,
 }: SetupStreamsOverviewProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null)
+  // The number of draft-enabled streams — drives the "keep ≥1 enabled" guard so the
+  // last remaining stream can't be toggled off (mirrors the backend nothing-to-sync guard).
+  const enabledCount = useConnectorDraftStore(
+    (s) => s.draft.streams.filter((st) => st.enabled).length
+  )
 
   return (
     <div className='flex flex-col gap-1.5 px-1 py-1'>
@@ -43,6 +51,7 @@ export function SetupStreamsOverview({
           connector={connector}
           stream={stream}
           readiness={readinessById[stream.id] ?? 'needs-mapping'}
+          enabledCount={enabledCount}
           expanded={expandedId === stream.id}
           onToggle={() => setExpandedId((id) => (id === stream.id ? null : stream.id))}
         />
@@ -55,42 +64,70 @@ function StreamOverviewRow({
   connector,
   stream,
   readiness,
+  enabledCount,
   expanded,
   onToggle,
 }: {
   connector: Connector
   stream: Stream
   readiness: StreamReadiness
+  enabledCount: number
   expanded: boolean
   onToggle: () => void
 }) {
   const { getResourceById } = useResources()
+  // Reflect the buffered draft so the toggle reacts live and the gate (which reads
+  // `enabled` off the draft) updates as the user flips streams (§3.1.E).
+  const setStreamEnabled = useConnectorDraftStore((s) => s.setStreamEnabled)
+  const draftEnabled = useConnectorDraftStore(
+    (s) => s.draft.streams.find((d) => d.id === stream.id)?.enabled ?? stream.enabled
+  )
+  // Keep ≥1 stream enabled — the off-toggle on the last enabled stream is locked.
+  const isLastEnabled = draftEnabled && enabledCount <= 1
+
   const defLabels = stream.mappings
     .map((m) => (m.entityDefinitionId ? getResourceById(m.entityDefinitionId)?.label : null))
     .filter(Boolean) as string[]
 
+  // The Switch renders its own <button>, so it can't nest inside the row's expand
+  // <button> (invalid DOM). Keep them siblings in a flex container instead.
+  const toggle = (
+    <Switch
+      size='xs'
+      checked={draftEnabled}
+      disabled={isLastEnabled}
+      onCheckedChange={(enabled) => setStreamEnabled(stream.id, enabled)}
+    />
+  )
+
   return (
-    <div className='rounded-lg border bg-background'>
-      <button
-        type='button'
-        onClick={onToggle}
-        className='flex w-full items-center gap-3 px-3 py-2.5 text-left'>
-        <ChevronRight
-          className={cn(
-            'size-4 shrink-0 text-muted-foreground transition-transform',
-            expanded && 'rotate-90'
-          )}
-        />
-        <Table2 className='size-4 shrink-0 text-muted-foreground' />
-        <div className='flex min-w-0 flex-1 flex-col'>
-          <span className='truncate text-sm font-medium'>
-            {stream.streamKey ?? 'Untitled stream'}
-          </span>
-          <span className='truncate text-xs text-muted-foreground'>
-            {defLabels.length > 0 ? `→ ${defLabels.join(' · ')}` : 'no targets yet'}
-          </span>
-        </div>
-        {readiness === 'ready' ? (
+    <div className={cn('rounded-lg border bg-background', !draftEnabled && 'opacity-60')}>
+      <div className='flex items-center gap-3 px-3 py-2.5'>
+        <button
+          type='button'
+          onClick={onToggle}
+          className='flex min-w-0 flex-1 items-center gap-3 text-left'>
+          <ChevronRight
+            className={cn(
+              'size-4 shrink-0 text-muted-foreground transition-transform',
+              expanded && 'rotate-90'
+            )}
+          />
+          <Table2 className='size-4 shrink-0 text-muted-foreground' />
+          <div className='flex min-w-0 flex-1 flex-col'>
+            <span className='truncate text-sm font-medium'>
+              {stream.streamKey ?? 'Untitled stream'}
+            </span>
+            <span className='truncate text-xs text-muted-foreground'>
+              {defLabels.length > 0 ? `→ ${defLabels.join(' · ')}` : 'no targets yet'}
+            </span>
+          </div>
+        </button>
+        {!draftEnabled ? (
+          <Badge variant='outline' size='sm' className='shrink-0 text-muted-foreground'>
+            Off
+          </Badge>
+        ) : readiness === 'ready' ? (
           <Badge variant='outline' size='sm' className='shrink-0'>
             <Check />
             Ready
@@ -101,9 +138,16 @@ function StreamOverviewRow({
             Needs mapping
           </Badge>
         )}
-      </button>
+        {isLastEnabled ? (
+          <Tooltip content='At least one stream must stay enabled.'>
+            <span className='shrink-0'>{toggle}</span>
+          </Tooltip>
+        ) : (
+          <span className='shrink-0'>{toggle}</span>
+        )}
+      </div>
 
-      {expanded && (
+      {expanded && draftEnabled && (
         <div className='border-t px-1 pb-1'>
           <StreamConfigPanel connector={connector} stream={stream} view='map' scroll={false} />
         </div>

--- a/apps/web/src/components/data-connectors/ui/streams-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/streams-section.tsx
@@ -3,6 +3,7 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { EmptySection, Section } from '@auxx/ui/components/section'
+import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
 import TreeRow, { TreeRowButton } from '@auxx/ui/components/tree-row'
 import { ArrowRight, Layers, Plus, Table2, Trash2 } from 'lucide-react'
@@ -24,10 +25,12 @@ function StreamRow({
   stream,
   onSelect,
   onDelete,
+  onToggleEnabled,
 }: {
   stream: Stream
   onSelect: () => void
   onDelete: () => void
+  onToggleEnabled: (enabled: boolean) => void
 }) {
   const { getResourceById } = useResources()
   const defLabels = stream.mappings
@@ -51,9 +54,16 @@ function StreamRow({
       onToggleOpen={onSelect}
       rowClassName='cursor-pointer'
       trailing={
-        <TreeRowButton variant='destructive' tooltipText='Delete stream' onClick={onDelete}>
-          <Trash2 />
-        </TreeRowButton>
+        <div className='flex items-center gap-1'>
+          <Switch
+            size='xs'
+            checked={stream.enabled}
+            onCheckedChange={(enabled) => onToggleEnabled(enabled)}
+          />
+          <TreeRowButton variant='destructive' tooltipText='Delete stream' onClick={onDelete}>
+            <Trash2 />
+          </TreeRowButton>
+        </div>
       }
     />
   )
@@ -83,6 +93,24 @@ export function StreamsSection({ connector, onSelect }: StreamsSectionProps) {
   const removeStream = api.dataConnector.removeStream.useMutation({
     onSuccess: () => void utils.dataConnector.listStreams.invalidate({ id: connector.id }),
     onError: (e) => toastError({ title: 'Could not delete stream', description: e.message }),
+  })
+
+  // Direct optimistic toggle (mirrors the procedure switch + the trash beside it).
+  // Enabling/disabling a stream is cosmetic — no resync, no archiving.
+  const toggleStream = api.dataConnector.updateStream.useMutation({
+    onMutate: async ({ streamId, enabled }) => {
+      await utils.dataConnector.listStreams.cancel({ id: connector.id })
+      const prev = utils.dataConnector.listStreams.getData({ id: connector.id })
+      utils.dataConnector.listStreams.setData({ id: connector.id }, (cached) =>
+        cached?.map((s) => (s.id === streamId ? { ...s, enabled: enabled ?? s.enabled } : s))
+      )
+      return { prev }
+    },
+    onError: (e, _v, ctx) => {
+      if (ctx?.prev) utils.dataConnector.listStreams.setData({ id: connector.id }, ctx.prev)
+      toastError({ title: 'Could not update stream', description: e.message })
+    },
+    onSettled: () => void utils.dataConnector.listStreams.invalidate({ id: connector.id }),
   })
 
   const handleDelete = async (stream: Stream) => {
@@ -133,6 +161,7 @@ export function StreamsSection({ connector, onSelect }: StreamsSectionProps) {
               stream={stream}
               onSelect={() => onSelect(stream.id)}
               onDelete={() => void handleDelete(stream)}
+              onToggleEnabled={(enabled) => toggleStream.mutate({ streamId: stream.id, enabled })}
             />
           ))}
         </div>

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -758,7 +758,13 @@ export const dataConnectorRouter = createTRPCRouter({
     }),
 
   updateStream: adminProcedure
-    .input(z.object({ streamId: z.string(), streamKey: z.string().min(1).optional() }))
+    .input(
+      z.object({
+        streamId: z.string(),
+        streamKey: z.string().min(1).optional(),
+        enabled: z.boolean().optional(),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       const { streamId, ...rest } = input
       return updateStream(ctx.db, ctx.session.organizationId, streamId, rest)

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -220,6 +220,14 @@ export interface CatalogConnectorDefaultMapping {
         entityKind: string
         /** Target field keys to flag as secondary identity-match keys (e.g. `['email']`). */
         matchFieldKeys?: string[]
+        /**
+         * Non-identity field bindings the app author pre-declares so a contributing
+         * stream is born closer to `ready` (e.g. `first_name` → contact's first-name
+         * attribute). Each binds a source field to a target `contact` field by key —
+         * the same resolver the match keys use, just without an `identityRole`.
+         * Unresolved bindings are dropped (the row stays a `needs-mapping` draft).
+         */
+        fieldBindings?: { sourceFieldKey: string; targetKey: string }[]
       }
 }
 

--- a/packages/lib/src/data-connectors/app-catalog.test.ts
+++ b/packages/lib/src/data-connectors/app-catalog.test.ts
@@ -3,7 +3,12 @@
 // Layer-A source schema from declared field paths, and preferring an exampleRecord.
 
 import { describe, expect, it } from 'vitest'
-import { appCatalogStreamSchema, buildSchemaFromFieldPaths } from './app-catalog'
+import {
+  appCatalogStreamSchema,
+  buildContributingFieldBindings,
+  buildSchemaFromFieldPaths,
+  type ContributingTargetField,
+} from './app-catalog'
 
 describe('buildSchemaFromFieldPaths', () => {
   it('nests dotted + array paths into an object/array schema with scalar leaf types', () => {
@@ -65,6 +70,87 @@ describe('appCatalogStreamSchema', () => {
     expect(result.sourceSchema).toEqual({
       type: 'object',
       properties: { name: { type: 'string' } },
+    })
+  })
+})
+
+describe('buildContributingFieldBindings', () => {
+  const defFields: ContributingTargetField[] = [
+    { id: 'f_first', name: 'First Name', systemAttribute: 'first_name', type: 'TEXT' },
+    { id: 'f_last', name: 'Last Name', systemAttribute: null, type: 'TEXT' },
+  ]
+  const sourceFields = [
+    { fieldKey: 'first_name', sourcePath: 'customer.first_name', type: 'TEXT', name: 'First' },
+    { fieldKey: 'last_name', sourcePath: 'customer.last_name', type: 'TEXT', name: 'Last' },
+    { fieldKey: 'unknown', sourcePath: 'customer.unknown', type: 'TEXT', name: 'Unknown' },
+  ]
+
+  it('binds by systemAttribute and by normalized name, subtree-relative, no identityRole', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      'customer',
+      [
+        { sourceFieldKey: 'first_name', targetKey: 'first_name' }, // → by systemAttribute
+        { sourceFieldKey: 'last_name', targetKey: 'Last Name' }, // → by name (no systemAttribute)
+      ],
+      sourceFields,
+      defFields
+    )
+    expect(bindings).toHaveLength(2)
+    expect(bindings[0]).toMatchObject({
+      targetFieldRef: 'def_contact:f_first',
+      expression: '{first_name}', // rootPath prefix stripped
+      sourceFields: { first_name: 'first_name' },
+    })
+    expect(bindings[0]!.identityRole).toBeUndefined()
+    expect(bindings[1]!.targetFieldRef).toBe('def_contact:f_last')
+  })
+
+  it('drops a binding whose target key does not resolve', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      'customer',
+      [{ sourceFieldKey: 'unknown', targetKey: 'no_such_field' }],
+      sourceFields,
+      defFields
+    )
+    expect(bindings).toHaveLength(0)
+  })
+
+  it('drops a binding whose source field key is unknown', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      'customer',
+      [{ sourceFieldKey: 'missing_source', targetKey: 'first_name' }],
+      sourceFields,
+      defFields
+    )
+    expect(bindings).toHaveLength(0)
+  })
+
+  it('drops everything for an array-rooted mapping', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      'line_items[]',
+      [{ sourceFieldKey: 'first_name', targetKey: 'first_name' }],
+      sourceFields,
+      defFields
+    )
+    expect(bindings).toHaveLength(0)
+  })
+
+  it('binds at root (no prefix) with the full source path', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      '',
+      [{ sourceFieldKey: 'email', targetKey: 'email' }],
+      [{ fieldKey: 'email', sourcePath: 'email', type: 'EMAIL', name: 'Email' }],
+      [{ id: 'f_email', name: 'Email', systemAttribute: 'email', type: 'EMAIL' }]
+    )
+    expect(bindings).toHaveLength(1)
+    expect(bindings[0]).toMatchObject({
+      targetFieldRef: 'def_contact:f_email',
+      expression: '{email}',
     })
   })
 })

--- a/packages/lib/src/data-connectors/app-catalog.ts
+++ b/packages/lib/src/data-connectors/app-catalog.ts
@@ -118,6 +118,69 @@ export function buildContributingMatchBindings(
   // single deterministic source path for a key, so skip auto-binding them.
   if (rootPath.includes('[]')) return []
 
+  const fieldByKey = buildTargetFieldIndex(defFields)
+  const prefix = rootPath ? `${rootPath}.` : ''
+  const bindings: FieldMapping[] = []
+  for (const key of matchFieldKeys) {
+    const target = fieldByKey.get(key) ?? fieldByKey.get(normalizeFieldKey(key))
+    if (!target) continue
+    const absolutePath = `${prefix}${key}`
+    const sourceField = sourceFields.find((f) => f.sourcePath === absolutePath)
+    if (!sourceField) continue
+    bindings.push(
+      bindSourceToTarget(entityDefinitionId, prefix, sourceField, target, {
+        kind: 'match',
+        normalize: deriveNormalizeFromType(target.type),
+      })
+    )
+  }
+  return bindings
+}
+
+/**
+ * Pre-bind a contributing mapping's author-declared NON-identity `fieldBindings`
+ * (e.g. `first_name` → contact's first-name attribute) into plain `FieldMapping`
+ * entries (no `identityRole`) — the symmetric counterpart to
+ * {@link buildContributingMatchBindings}. Lets an app author state how a stream's
+ * fields land in the contributing def so the stream is born closer to `ready` instead
+ * of a bare identity-only draft (multi-stream-setup-plan §3.4A). A binding resolves
+ * only when BOTH sides resolve unambiguously:
+ *   - source — a declared stream field by `fieldKey` (`binding.sourceFieldKey`);
+ *   - target — a field on the contributing def keyed by `binding.targetKey` (its
+ *     `systemAttribute`, name, or normalized name).
+ * Array-rooted mappings and unresolved bindings are dropped (the row keeps whatever
+ * draft state remains). The external id is never bound here.
+ */
+export function buildContributingFieldBindings(
+  entityDefinitionId: string,
+  rootPath: string,
+  fieldBindings: { sourceFieldKey: string; targetKey: string }[],
+  sourceFields: CatalogDataConnector['streams'][number]['fields'],
+  defFields: ContributingTargetField[]
+): FieldMapping[] {
+  if (fieldBindings.length === 0) return []
+  // An array root has no single deterministic subtree-relative path, same as match keys.
+  if (rootPath.includes('[]')) return []
+
+  const fieldByKey = buildTargetFieldIndex(defFields)
+  const prefix = rootPath ? `${rootPath}.` : ''
+  const bindings: FieldMapping[] = []
+  for (const { sourceFieldKey, targetKey } of fieldBindings) {
+    const target = fieldByKey.get(targetKey) ?? fieldByKey.get(normalizeFieldKey(targetKey))
+    if (!target) continue
+    const sourceField = sourceFields.find((f) => f.fieldKey === sourceFieldKey)
+    // The source field must live under this mapping's subtree (its sourcePath starts
+    // with the rootPath prefix), else its relative path is undefined for this root.
+    if (!sourceField || (prefix && !sourceField.sourcePath.startsWith(prefix))) continue
+    bindings.push(bindSourceToTarget(entityDefinitionId, prefix, sourceField, target))
+  }
+  return bindings
+}
+
+/** Build the target-field lookup keyed by systemAttribute / name (+ normalized). */
+function buildTargetFieldIndex(
+  defFields: ContributingTargetField[]
+): Map<string, ContributingTargetField> {
   const fieldByKey = new Map<string, ContributingTargetField>()
   for (const fld of defFields) {
     if (fld.systemAttribute) {
@@ -127,26 +190,30 @@ export function buildContributingMatchBindings(
     fieldByKey.set(fld.name, fld)
     fieldByKey.set(normalizeFieldKey(fld.name), fld)
   }
+  return fieldByKey
+}
 
-  const prefix = rootPath ? `${rootPath}.` : ''
-  const bindings: FieldMapping[] = []
-  for (const key of matchFieldKeys) {
-    const target = fieldByKey.get(key) ?? fieldByKey.get(normalizeFieldKey(key))
-    if (!target) continue
-    const absolutePath = `${prefix}${key}`
-    const sourceField = sourceFields.find((f) => f.sourcePath === absolutePath)
-    if (!sourceField) continue
-    // Subtree-relative path (strip the rootPath prefix the source field declares).
-    const relativePath = sourceField.sourcePath.slice(prefix.length)
-    bindings.push({
-      id: generateId(),
-      targetFieldRef: toResourceFieldId(entityDefinitionId, target.id),
-      expression: `{${relativePath}}`,
-      sourceFields: { [relativePath]: relativePath },
-      identityRole: { kind: 'match', normalize: deriveNormalizeFromType(target.type) },
-    })
+/**
+ * Construct one `FieldMapping` binding a resolved source field to a resolved target,
+ * computing the subtree-relative source path (strip the `rootPath` prefix — `mapRecord`
+ * evaluates a rooted mapping against subtree-relative paths). Pass `identityRole` to
+ * flag it a secondary-identity match; omit for a plain value binding.
+ */
+function bindSourceToTarget(
+  entityDefinitionId: string,
+  prefix: string,
+  sourceField: CatalogDataConnector['streams'][number]['fields'][number],
+  target: ContributingTargetField,
+  identityRole?: FieldMapping['identityRole']
+): FieldMapping {
+  const relativePath = prefix ? sourceField.sourcePath.slice(prefix.length) : sourceField.sourcePath
+  return {
+    id: generateId(),
+    targetFieldRef: toResourceFieldId(entityDefinitionId, target.id),
+    expression: `{${relativePath}}`,
+    sourceFields: { [relativePath]: relativePath },
+    ...(identityRole ? { identityRole } : {}),
   }
-  return bindings
 }
 
 /** The source schema for an app catalog stream — prefer its canonical sample. */

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -14,7 +14,11 @@ import { and, eq, inArray } from 'drizzle-orm'
 import { getCachedCustomFields, getCachedEntityDefId } from '../cache'
 import { BadRequestError, NotFoundError } from '../errors'
 import { toRecordId } from '../resources/resource-id'
-import { appCatalogStreamSchema, buildContributingMatchBindings } from './app-catalog'
+import {
+  appCatalogStreamSchema,
+  buildContributingFieldBindings,
+  buildContributingMatchBindings,
+} from './app-catalog'
 import { removeConnectorScheduler, syncConnectorScheduler } from './data-connector-scheduler'
 import {
   classifyConnectorChange,
@@ -537,7 +541,7 @@ async function materializeAppContributingMappings(
 ): Promise<void> {
   for (const mapping of stream.defaultMappings ?? []) {
     if (mapping.target.mode !== 'contributing') continue
-    const { entityKind, matchFieldKeys } = mapping.target
+    const { entityKind, matchFieldKeys, fieldBindings } = mapping.target
 
     const entityDefinitionId = await getCachedEntityDefId(organizationId, entityKind)
     if (!entityDefinitionId) {
@@ -550,13 +554,24 @@ async function materializeAppContributingMappings(
     }
 
     const defFields = await getCachedCustomFields(organizationId, entityDefinitionId)
-    const fieldMappings = buildContributingMatchBindings(
+    // Identity-match bindings first; then author-declared non-identity field bindings,
+    // skipping any target a match key already claimed (match's `identityRole` wins).
+    const matchBindings = buildContributingMatchBindings(
       entityDefinitionId,
       mapping.rootPath,
       matchFieldKeys ?? [],
       stream.fields,
       defFields
     )
+    const boundTargets = new Set(matchBindings.map((b) => b.targetFieldRef))
+    const valueBindings = buildContributingFieldBindings(
+      entityDefinitionId,
+      mapping.rootPath,
+      fieldBindings ?? [],
+      stream.fields,
+      defFields
+    ).filter((b) => !boundTargets.has(b.targetFieldRef))
+    const fieldMappings = [...matchBindings, ...valueBindings]
 
     await addMapping(db, organizationId, {
       dataConnectorStreamId: streamId,
@@ -799,18 +814,26 @@ export async function addStream(
   return row
 }
 
-/** Rename a stream (update its streamKey). */
+/**
+ * Update a stream's `streamKey` and/or `enabled` flag.
+ *
+ * Toggling `enabled` is non-structural (cosmetic per `edit-impact.ts`) — the next
+ * sync includes/excludes the stream naturally, so no cursor invalidation or
+ * record archiving happens here. Use `setStreamRequestConfig` for steering changes
+ * that carry cursor side effects.
+ */
 export async function updateStream(
   db: Database,
   organizationId: string,
   streamId: string,
-  input: { streamKey?: string }
+  input: { streamKey?: string; enabled?: boolean }
 ): Promise<DataConnectorStreamRow> {
   await loadStreamRow(db, organizationId, streamId)
   const [row] = await db
     .update(schema.DataConnectorStream)
     .set({
       ...(input.streamKey !== undefined ? { streamKey: input.streamKey } : {}),
+      ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
       updatedAt: new Date(),
     })
     .where(eq(schema.DataConnectorStream.id, streamId))

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -382,6 +382,9 @@ export interface ConnectorDefaultMapping {
         entityKind: string
         /** Target field keys to flag as secondary identity-match keys (e.g. `['email']`). */
         matchFieldKeys?: string[]
+        /** Non-identity field bindings pre-declared by the app author (e.g. `first_name`
+         *  → contact first-name). Bound by key like match keys, sans `identityRole`. */
+        fieldBindings?: { sourceFieldKey: string; targetKey: string }[]
       }
 }
 

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -143,6 +143,16 @@ export interface ConnectorDefaultMapping {
          * incoming record into an existing entity on first link.
          */
         matchFieldKeys?: string[]
+        /**
+         * Non-identity field bindings the author pre-declares so a contributing
+         * stream lands closer to `ready` — e.g. `{ sourceFieldKey: 'first_name',
+         * targetKey: 'first_name' }` binds the source field to the contact's
+         * first-name attribute. `targetKey` resolves against the target def's
+         * `systemAttribute` / field name; unresolved bindings are dropped (the
+         * mapping stays a setup draft). The external id is never bound here — it
+         * rides `ConnectorRecord.externalId`.
+         */
+        fieldBindings?: { sourceFieldKey: string; targetKey: string }[]
       }
 }
 

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -209,6 +209,7 @@ export interface CatalogConnectorDefaultMapping {
         mode: 'contributing'
         entityKind: string
         matchFieldKeys?: string[]
+        fieldBindings?: { sourceFieldKey: string; targetKey: string }[]
       }
 }
 


### PR DESCRIPTION
## Why

An app connector (e.g. Shopify) that declares `orders`/`products`/`customers` already lands three enabled `DataConnectorStream` rows, but the setup stepper behaved as if there were one — the gate required **every** stream ready (ignoring `enabled`), and Connect/Sample collapsed to `streams[0]`. A single stranded contributing stream (`customers → contact`, born `needs-mapping`) blocked finishing setup with no way to skip it. This fixes the **setup UX and gating**, not the data model.

## What

**Backend**
- `updateStream` route + lib accept `enabled` (non-structural — no cursor invalidation, no record archiving).

**Flat editor** (`streams-section.tsx`)
- Always-visible enable/disable `Switch` beside the trash, wired to a direct **optimistic** `updateStream({ enabled })` mutation (mirrors the procedure toggle).

**Draft store + commit**
- `setStreamEnabled` action; commit diff/flush carry `enabled`. An enabled-only change is **not** structural; streamKey+enabled merge into one `updateStream` call.

**Setup stepper**
- Map overview: draft-backed `Switch` per row — dims disabled rows, shows an "Off" badge, collapses the panel, and locks the last enabled stream's toggle ("at least one stream must stay enabled").
- Map gate filters to **enabled** streams (realigns with backend `readiness.ts`).
- De-`primaryStream`: Connect preview + Sample key off enabled streams; Sample step drops only when **every enabled** stream carries a catalog schema.

**Auto-bind contributing fields (§3.4A)**
- New `fieldBindings?: { sourceFieldKey; targetKey }[]` on contributing default-mappings (SDK + lib + database type mirrors; passes through the catalog projection verbatim).
- `app-catalog.ts` `buildContributingFieldBindings` (shares the target-index/binding helpers with the match binder, emits non-identity bindings); `materializeAppContributingMappings` merges match + value bindings, match wins on collision. Lets an app author pre-bind `first_name`/`last_name` so a contributing stream is born closer to `ready`. External id stays implicit (rides `ConnectorRecord.externalId`).

## Out of scope / follow-up
- The Shopify app in the sister repo `auxxai-apps` must `defineDataConnector` with `streams: [order, product, customer]` + per-stream `defaultMappings` (using the new `fieldBindings`). Without that the platform has nothing to fan out.
- **Open question:** disabling an already-synced stream currently **leaves** its imported records (non-destructive, matches `edit-impact` "cosmetic"). Flag if you'd prefer archiving.

## Testing
- `connector-commit-diff.test.ts` — enabled-only entry, streamKey+enabled merge, not structural.
- `use-setup-progress.test.ts` — map gate filters by `enabled` (ready+disabled passes, not-ready+disabled passes, not-ready+enabled blocks, all-disabled → `map:false`).
- `app-catalog.test.ts` — `buildContributingFieldBindings` resolves by systemAttribute/name, drops unresolved/array-rooted, root vs nested path.
- All 28 data-connectors lib test files + the two web test files pass. Biome clean. `tsc` not run (repo guidance).