### PR TITLE
fix(data-connectors): collapse delete menu when no records synced

### DIFF
--- a/apps/web/src/components/data-connectors/ui/connector-card.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-card.tsx
@@ -172,25 +172,32 @@ export function ConnectorCard({ connector, streamCount }: ConnectorCardProps) {
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger variant='destructive'>
+            {connector.itemCount > 0 ? (
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger variant='destructive'>
+                  <Trash />
+                  Delete
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  <DropdownMenuItem onClick={wrap(() => handleDelete('keep'))}>
+                    Delete, keep synced records
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={wrap(() => handleDelete('archive'))}>
+                    Delete, archive synced records
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    variant='destructive'
+                    onClick={wrap(() => handleDelete('delete'))}>
+                    Delete connector and synced records
+                  </DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            ) : (
+              <DropdownMenuItem variant='destructive' onClick={wrap(() => handleDelete('delete'))}>
                 <Trash />
                 Delete
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                <DropdownMenuItem onClick={wrap(() => handleDelete('keep'))}>
-                  Delete, keep synced records
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={wrap(() => handleDelete('archive'))}>
-                  Delete, archive synced records
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  variant='destructive'
-                  onClick={wrap(() => handleDelete('delete'))}>
-                  Delete connector and synced records
-                </DropdownMenuItem>
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
+              </DropdownMenuItem>
+            )}
           </>
         }
       />

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -312,17 +312,27 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align='end'>
-                  <DropdownMenuItem onClick={() => void handleDelete('keep')}>
-                    Delete, keep synced records
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => void handleDelete('archive')}>
-                    Delete, archive synced records
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    variant='destructive'
-                    onClick={() => void handleDelete('delete')}>
-                    Delete connector and synced records
-                  </DropdownMenuItem>
+                  {(live?.itemCount ?? connector.itemCount) > 0 ? (
+                    <>
+                      <DropdownMenuItem onClick={() => void handleDelete('keep')}>
+                        Delete, keep synced records
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => void handleDelete('archive')}>
+                        Delete, archive synced records
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        variant='destructive'
+                        onClick={() => void handleDelete('delete')}>
+                        Delete connector and synced records
+                      </DropdownMenuItem>
+                    </>
+                  ) : (
+                    <DropdownMenuItem
+                      variant='destructive'
+                      onClick={() => void handleDelete('delete')}>
+                      Delete connector
+                    </DropdownMenuItem>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             </ButtonGroup>


### PR DESCRIPTION
## Why
The connector delete dropdown always offered the record-disposition choice (keep / archive / delete synced records), even when the connector had synced **zero** records — where the choice is meaningless and just adds a click.

## What
When `itemCount === 0`, render a single plain **Delete** action instead:
- **`connector-card.tsx`** — replace the `DropdownMenuSub` (keep/archive/delete) with one destructive `Delete` item.
- **`connector-detail-view.tsx`** — replace the three-way list with one destructive `Delete connector` item. Uses the live `getStatus` count when available (`live?.itemCount ?? connector.itemCount`).

Connectors with synced records are unchanged — they keep the full keep/archive/delete submenu.