### PR TITLE
fix(data-connectors): stop double-rendering visible-leaf bare tokens as formula rows

### DIFF
--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -304,11 +304,20 @@ export function MappingNode({
     if (isBareToken(e.expression)) sourceToEntry.set(e.expression.replace(/^\{|\}$/g, ''), e)
   }
 
+  // Visible leaf paths under THIS mapping's subtree — a bare-token entry on one of
+  // these renders on its leaf (External-ID anchor included), so it must NOT also
+  // surface as a formula row.
+  const visibleLeafPaths = new Set(relativeSubtree.filter((p) => !p.isBranch).map((p) => p.path))
+
   // Formula rows = computed entries (a multi-source formula has no single leaf to
-  // anchor on) PLUS unassigned drafts (`targetFieldRef: null`), which are persisted
-  // half-authored formulas with nowhere to live on the source tree yet.
+  // anchor on) PLUS target-less entries with nowhere to live on the source tree: a
+  // half-authored formula draft, or an orphaned bare token whose source path vanished
+  // (schema regenerated) — kept here so it stays editable/removable. A bare-token
+  // External-ID anchor on a VISIBLE leaf renders on that leaf, never here.
   const formulaEntries = fieldMappings.filter(
-    (e) => !isBareToken(e.expression) || e.targetFieldRef == null
+    (e) =>
+      !isBareToken(e.expression) ||
+      (e.targetFieldRef == null && !visibleLeafPaths.has(bareTokenSource(e.expression)))
   )
 
   const assignTarget = (sourcePath: string, targetRef: string) => {


### PR DESCRIPTION
## Why
In the mapping editor, a bare-token field mapping (`{some.path}`) that anchors on a leaf still present in the mapping's subtree — e.g. an External-ID anchor — rendered on its leaf **and** again as a formula row, showing the same binding twice.

## What
`mapping-node.tsx` now computes the set of visible leaf paths under the current subtree and excludes bare tokens on those leaves from the formula list. A target-less (`targetFieldRef == null`) bare token only falls to the formula rows when its source path has **vanished** (schema regenerated) — kept there so an orphaned binding stays editable/removable. Multi-source formulas and genuine half-authored drafts are unaffected.