### PR TITLE
fix(dynamic-table): bulk-mode row click toggles instead of collapsing selection

### DIFF
--- a/apps/web/src/components/dynamic-table/stores/selection-store.ts
+++ b/apps/web/src/components/dynamic-table/stores/selection-store.ts
@@ -188,7 +188,17 @@ export const useSelectionStore = create<SelectionStore>()(
             newSelection = { ...rowSelection, [rowId]: !rowSelection[rowId] }
             newLastIndex = allRowIds.indexOf(rowId)
           } else {
-            newSelection = { [rowId]: true }
+            // Bulk mode: a plain row-body click toggles this row in/out, matching
+            // the checkbox. The previous `{ [rowId]: true }` collapsed the whole
+            // multi-selection to a single row — so a stray click on the row body
+            // (easy to hit when rapidly clicking the narrow checkbox column) wiped
+            // every other checked row.
+            newSelection = { ...rowSelection }
+            if (newSelection[rowId]) {
+              delete newSelection[rowId]
+            } else {
+              newSelection[rowId] = true
+            }
             newLastIndex = allRowIds.indexOf(rowId)
           }
 


### PR DESCRIPTION
## Why
In bulk-selection mode, a plain click on the row body reset the entire selection to that one row (`{ [rowId]: true }`). A stray row-body click — easy to hit when rapidly clicking the narrow checkbox column — wiped every other checked row.

## What
`selection-store.ts`: in bulk mode a row-body click now **toggles** that row in/out of the existing selection, matching the checkbox behavior, instead of collapsing to a single row. Range-select (shift-click) is unchanged.