### PR TITLE
feat(getting-started): onboarding checklist in the sidebar footer

### DIFF
--- a/apps/web/src/components/getting-started/client.ts
+++ b/apps/web/src/components/getting-started/client.ts
@@ -1,0 +1,86 @@
+// apps/web/src/components/getting-started/client.ts
+// Client-safe display catalog for the getting-started checklist. Labels,
+// descriptions, icons and CTAs live here (web concerns); the canonical key set
+// + persisted state shapes come from @auxx/lib/getting-started/client.
+
+import { GOAL_KEYS, type GoalKey } from '@auxx/lib/getting-started/client'
+
+/** Chrome Web Store listing for the browser extension (published unlisted). */
+export const EXTENSION_STORE_URL =
+  'https://chromewebstore.google.com/detail/hlhbgglcglfmicfaafdecfnenpocbffl'
+
+export type GettingStartedGoal = {
+  key: GoalKey
+  label: string
+  description: string
+  /** EntityIcon icon id (from ICON_DATA). */
+  iconId: string
+  /** EntityIcon color id (from ICON_COLORS). */
+  color: string
+  ctaText: string
+  /** Where the CTA goes — internal app route or external URL. */
+  href: string
+  /** External links open in a new tab. */
+  external?: boolean
+  /** Goals with no server signal are marked complete when the CTA is clicked. */
+  markOnClick?: boolean
+}
+
+const GOALS: Record<GoalKey, Omit<GettingStartedGoal, 'key'>> = {
+  'connect-email': {
+    label: 'Connect your inbox',
+    description: 'Link a Gmail or Outlook mailbox so Auxx can read and reply to support email.',
+    iconId: 'mail',
+    color: 'blue',
+    ctaText: 'Connect inbox',
+    href: '/app/settings/channels',
+  },
+  'setup-agent': {
+    label: 'Set up an AI agent',
+    description: 'Create and configure an AI agent to draft and send replies for you.',
+    iconId: 'sparkles',
+    color: 'purple',
+    ctaText: 'Set up agent',
+    href: '/app/agents',
+  },
+  'create-workflow': {
+    label: 'Create a workflow',
+    description: 'Automate triage, routing and follow-ups with a custom workflow.',
+    iconId: 'git-branch',
+    color: 'amber',
+    ctaText: 'New workflow',
+    href: '/app/workflows',
+  },
+  'create-field': {
+    label: 'Create a custom field',
+    description: 'Capture the data your team cares about with a custom field on any record.',
+    iconId: 'text-cursor-input',
+    color: 'teal',
+    ctaText: 'Add field',
+    href: '/app/settings/custom-fields',
+  },
+  'invite-team': {
+    label: 'Invite your team',
+    description: 'Bring teammates in to collaborate on tickets and share the workload.',
+    iconId: 'user-plus',
+    color: 'green',
+    ctaText: 'Invite teammates',
+    href: '/app/settings/members',
+  },
+  'install-extension': {
+    label: 'Install the extension',
+    description: 'Get Auxx alongside your other tools with the browser extension.',
+    iconId: 'plug',
+    color: 'indigo',
+    ctaText: 'Get the extension',
+    href: EXTENSION_STORE_URL,
+    external: true,
+    markOnClick: true,
+  },
+}
+
+/** Ordered display catalog (display order = GOAL_KEYS order). */
+export const GETTING_STARTED_GOALS: GettingStartedGoal[] = GOAL_KEYS.map((key) => ({
+  key,
+  ...GOALS[key],
+}))

--- a/apps/web/src/components/getting-started/hooks/use-getting-started.ts
+++ b/apps/web/src/components/getting-started/hooks/use-getting-started.ts
@@ -1,0 +1,47 @@
+// apps/web/src/components/getting-started/hooks/use-getting-started.ts
+'use client'
+
+import type { GoalKey } from '@auxx/lib/getting-started/client'
+import { useMemo } from 'react'
+import { api } from '~/trpc/react'
+import { GETTING_STARTED_GOALS } from '../client'
+
+/**
+ * Wraps the getting-started tRPC query and folds the server status into the
+ * display catalog. Returns the displayed goals, a completed-key set, the
+ * done/total ratio, and the mutation handlers (each invalidates the query).
+ */
+export function useGettingStarted() {
+  const utils = api.useUtils()
+  const { data, isLoading } = api.gettingStarted.getStatus.useQuery(undefined, {
+    staleTime: 60_000,
+  })
+
+  const invalidate = () => utils.gettingStarted.getStatus.invalidate()
+
+  const markGoalComplete = api.gettingStarted.markGoalComplete.useMutation({
+    onSuccess: invalidate,
+  })
+  const completeAll = api.gettingStarted.completeAll.useMutation({ onSuccess: invalidate })
+  const setDismissed = api.gettingStarted.setDismissed.useMutation({ onSuccess: invalidate })
+
+  // The displayed list is the whole catalog for v1 (no role/feature gating yet).
+  const goals = GETTING_STARTED_GOALS
+  const completed = useMemo(() => new Set<GoalKey>(data?.completedGoals ?? []), [data])
+
+  const done = goals.filter((g) => completed.has(g.key)).length
+  const total = goals.length
+
+  return {
+    isLoading,
+    goals,
+    completed,
+    done,
+    total,
+    allComplete: total > 0 && done === total,
+    dismissed: data?.dismissed ?? false,
+    markGoalComplete: (key: GoalKey) => markGoalComplete.mutate({ key }),
+    completeAll: () => completeAll.mutate({ keys: goals.map((g) => g.key) }),
+    dismiss: () => setDismissed.mutate({ dismissed: true }),
+  }
+}

--- a/apps/web/src/components/getting-started/ui/getting-started-group.tsx
+++ b/apps/web/src/components/getting-started/ui/getting-started-group.tsx
@@ -1,0 +1,186 @@
+// apps/web/src/components/getting-started/ui/getting-started-group.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { CollapsibleChevron } from '@auxx/ui/components/collapsible'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@auxx/ui/components/hover-card'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { Progress } from '@auxx/ui/components/progress'
+import {
+  SidebarGroupCollapse,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+} from '@auxx/ui/components/sidebar'
+import { CheckCheck, MoreHorizontal, Rocket, X } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { type MouseEvent, useCallback, useRef, useState } from 'react'
+import { useSidebarState } from '~/hooks/use-sidebar-state'
+import type { GettingStartedGoal } from '../client'
+import { useGettingStarted } from '../hooks/use-getting-started'
+import { GettingStartedStep } from './getting-started-step'
+
+const SECTION_ID = 'getting-started'
+
+/** Stop a nested control's click from toggling the accordion header. */
+function stop(e: MouseEvent) {
+  e.stopPropagation()
+  e.preventDefault()
+}
+
+/**
+ * Inline, animated getting-started checklist pinned in the sidebar footer. The
+ * header accordions the step list open/closed (height spring via
+ * `SidebarGroupCollapse`). Hovering the list reveals a fixed side panel —
+ * anchored to the list, matching its height — that shows the hovered step's
+ * description + CTA. Auto-hides once every goal is complete or dismissed.
+ */
+export function GettingStartedGroup() {
+  const router = useRouter()
+  const { getSectionOpen, toggleSection } = useSidebarState()
+  const {
+    isLoading,
+    goals,
+    completed,
+    done,
+    total,
+    allComplete,
+    dismissed,
+    markGoalComplete,
+    completeAll,
+    dismiss,
+  } = useGettingStarted()
+
+  const observerRef = useRef<ResizeObserver | null>(null)
+  const [panelHeight, setPanelHeight] = useState<number>()
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null)
+
+  // Callback ref: measure the whole group (header + progress + items) whenever
+  // it actually mounts, and track its height as the accordion animates. Used to
+  // make the side panel exactly as tall as the group.
+  const measureRef = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect()
+    if (!node) return
+    const update = () => setPanelHeight(node.offsetHeight)
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(node)
+    observerRef.current = ro
+  }, [])
+
+  // Hidden while loading, once dismissed, or all done. (Footer = post-onboarding.)
+  if (isLoading || dismissed || allComplete || total === 0) return null
+
+  const isOpen = getSectionOpen(SECTION_ID, true)
+
+  // Default the panel to the first incomplete step until the user hovers one.
+  const activeGoal =
+    goals.find((g) => g.key === hoveredKey) ?? goals.find((g) => !completed.has(g.key)) ?? goals[0]
+  const activeCompleted = !!activeGoal && completed.has(activeGoal.key)
+
+  const handleCTA = (goal: GettingStartedGoal) => {
+    if (goal.markOnClick) markGoalComplete(goal.key)
+    if (goal.external) {
+      window.open(goal.href, '_blank', 'noopener,noreferrer')
+      return
+    }
+    router.push(goal.href)
+  }
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <HoverCard openDelay={60} closeDelay={80}>
+          <HoverCardTrigger asChild>
+            <div ref={measureRef}>
+              <SidebarMenuButton asChild tooltip='Getting started'>
+                <div
+                  onClick={() => toggleSection(SECTION_ID)}
+                  className='group/gs relative h-7 cursor-pointer'>
+                  <Rocket className='size-4' />
+                  <span className='group-data-[collapsible=icon]:hidden'>Getting started</span>
+                  <CollapsibleChevron open={isOpen} className='ms-1 text-muted-foreground' />
+
+                  <div className='ms-auto flex items-center gap-1 group-data-[collapsible=icon]:hidden'>
+                    <span className='text-xs text-muted-foreground'>
+                      {done}/{total}
+                    </span>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant='ghost'
+                          size='icon'
+                          className='size-6 opacity-0 sm:group-hover/gs:opacity-100'
+                          onClick={stop}>
+                          <MoreHorizontal className='size-3.5' />
+                          <span className='sr-only'>Getting started options</span>
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align='start' onClick={stop}>
+                        <DropdownMenuItem onClick={() => completeAll()}>
+                          <CheckCheck className='size-4' />
+                          Mark all as complete
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => dismiss()}>
+                          <X className='size-4' />
+                          Dismiss
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                </div>
+              </SidebarMenuButton>
+
+              <SidebarGroupCollapse open={isOpen} className='group-data-[collapsible=icon]:hidden'>
+                <div className='px-2 pb-1.5 pt-1'>
+                  <Progress value={(done / total) * 100} indicatorClassName='bg-info' />
+                </div>
+                <SidebarMenuSub className='mx-0 translate-x-0 border-l-0 px-0'>
+                  {goals.map((goal) => (
+                    <GettingStartedStep
+                      key={goal.key}
+                      goal={goal}
+                      completed={completed.has(goal.key)}
+                      onCTA={handleCTA}
+                      onHover={(g) => setHoveredKey(g.key)}
+                    />
+                  ))}
+                </SidebarMenuSub>
+              </SidebarGroupCollapse>
+            </div>
+          </HoverCardTrigger>
+          {isOpen && activeGoal && (
+            <HoverCardContent
+              side='right'
+              align='start'
+              sideOffset={12}
+              style={{ height: panelHeight }}
+              className='flex w-64 flex-col p-3'>
+              <div className='flex items-center gap-2'>
+                <EntityIcon iconId={activeGoal.iconId} color={activeGoal.color} size='default' />
+                <span className='text-sm font-medium'>{activeGoal.label}</span>
+              </div>
+              <p className='mt-2 text-sm text-muted-foreground'>{activeGoal.description}</p>
+              <Button
+                size='sm'
+                variant={activeCompleted ? 'outline' : 'default'}
+                className='mt-auto w-full'
+                onClick={() => handleCTA(activeGoal)}>
+                {activeCompleted ? 'Done' : activeGoal.ctaText}
+              </Button>
+            </HoverCardContent>
+          )}
+        </HoverCard>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}
+
+export default GettingStartedGroup

--- a/apps/web/src/components/getting-started/ui/getting-started-step.tsx
+++ b/apps/web/src/components/getting-started/ui/getting-started-step.tsx
@@ -1,0 +1,42 @@
+// apps/web/src/components/getting-started/ui/getting-started-step.tsx
+'use client'
+
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { SidebarMenuSubButton, SidebarMenuSubItem } from '@auxx/ui/components/sidebar'
+import { cn } from '@auxx/ui/lib/utils'
+import { Check } from 'lucide-react'
+import type { GettingStartedGoal } from '../client'
+
+type Props = {
+  goal: GettingStartedGoal
+  completed: boolean
+  onCTA: (goal: GettingStartedGoal) => void
+  onHover: (goal: GettingStartedGoal) => void
+}
+
+/** One checklist row inside the collapsible group — a compact full-width nav row. */
+export function GettingStartedStep({ goal, completed, onCTA, onHover }: Props) {
+  return (
+    <SidebarMenuSubItem>
+      <SidebarMenuSubButton asChild>
+        <button
+          type='button'
+          onClick={() => onCTA(goal)}
+          onMouseEnter={() => onHover(goal)}
+          onFocus={() => onHover(goal)}
+          className='w-full cursor-pointer'>
+          <EntityIcon iconId={goal.iconId} color={goal.color} size='sm' />
+          <span
+            className={cn('flex-1 text-left', completed && 'text-muted-foreground line-through')}>
+            {goal.label}
+          </span>
+          {completed && (
+            <div className='ms-auto flex size-4 items-center justify-center rounded-full border border-blue-800 bg-info'>
+              <Check className='size-2.5! text-white' strokeWidth={4} />
+            </div>
+          )}
+        </button>
+      </SidebarMenuSubButton>
+    </SidebarMenuSubItem>
+  )
+}

--- a/apps/web/src/components/global/sidebar/index.tsx
+++ b/apps/web/src/components/global/sidebar/index.tsx
@@ -10,6 +10,7 @@ import {
   SidebarRail,
 } from '@auxx/ui/components/sidebar'
 import type * as React from 'react'
+import { GettingStartedGroup } from '~/components/getting-started/ui/getting-started-group'
 import { MailSidebar } from '~/components/global/sidebar/mail-sidebar'
 import { SIDEBAR_MENU } from '~/constants/menu'
 import AppFooter from './app-footer'
@@ -54,6 +55,7 @@ export default function AppSidebar({ user, ...props }: Prop) {
           <EntitySidebarNav />
         </SidebarContent>
         <SidebarFooter>
+          <GettingStartedGroup />
           <AppFooter />
         </SidebarFooter>
         <SidebarRail />

--- a/apps/web/src/server/api/root.ts
+++ b/apps/web/src/server/api/root.ts
@@ -43,6 +43,7 @@ import { featurePermissionsRouter } from './routers/featurePermissions'
 import { fieldValueRouter } from './routers/fieldValue'
 import { fileRouter } from './routers/file'
 import { folderRouter } from './routers/folder'
+import { gettingStartedRouter } from './routers/getting-started'
 import { inboxRouter } from './routers/inbox'
 import { knowledgeBaseRouter } from './routers/kb'
 import { knowledgeSourceRouter } from './routers/knowledge-sources'
@@ -135,6 +136,7 @@ export const appRouter = createTRPCRouter({
   extension: extensionRouter,
   favorite: favoriteRouter,
   featurePermission: featurePermissionsRouter,
+  gettingStarted: gettingStartedRouter,
   inbox: inboxRouter,
   channel: channelRouter,
   channelReauth: channelReauthRouter,

--- a/apps/web/src/server/api/routers/getting-started.ts
+++ b/apps/web/src/server/api/routers/getting-started.ts
@@ -1,0 +1,43 @@
+// apps/web/src/server/api/routers/getting-started.ts
+// Slim router for the getting-started checklist — all logic lives in
+// @auxx/lib/getting-started. Each procedure just builds the lib ctx and delegates.
+
+import {
+  completeAllGoals,
+  GOAL_KEYS,
+  getGettingStartedStatus,
+  markGoalComplete,
+  setDismissed,
+} from '@auxx/lib/getting-started'
+import { z } from 'zod'
+import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+
+const goalKeySchema = z.enum(GOAL_KEYS)
+
+export const gettingStartedRouter = createTRPCRouter({
+  /** Resolved checklist status: completed goal keys + dismissal flag. */
+  getStatus: protectedProcedure.query(({ ctx }) =>
+    getGettingStartedStatus({ db: ctx.db, organizationId: ctx.session.organizationId })
+  ),
+
+  /** Mark a single goal complete (e.g. the extension step). */
+  markGoalComplete: protectedProcedure
+    .input(z.object({ key: goalKeySchema }))
+    .mutation(({ ctx, input }) =>
+      markGoalComplete({ db: ctx.db, organizationId: ctx.session.organizationId }, input.key)
+    ),
+
+  /** "Mark all" — union the displayed goal keys into manual completions. */
+  completeAll: protectedProcedure
+    .input(z.object({ keys: z.array(goalKeySchema) }))
+    .mutation(({ ctx, input }) =>
+      completeAllGoals({ db: ctx.db, organizationId: ctx.session.organizationId }, input.keys)
+    ),
+
+  /** Dismiss or un-dismiss the widget. */
+  setDismissed: protectedProcedure
+    .input(z.object({ dismissed: z.boolean() }))
+    .mutation(({ ctx, input }) =>
+      setDismissed({ db: ctx.db, organizationId: ctx.session.organizationId }, input.dismissed)
+    ),
+})

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -466,6 +466,18 @@
       "import": "./dist/geo/index.mjs",
       "default": "./src/geo/index.ts"
     },
+    "./getting-started": {
+      "types": "./src/getting-started/index.ts",
+      "source": "./src/getting-started/index.ts",
+      "import": "./dist/getting-started/index.mjs",
+      "default": "./src/getting-started/index.ts"
+    },
+    "./getting-started/client": {
+      "types": "./src/getting-started/client.ts",
+      "source": "./src/getting-started/client.ts",
+      "import": "./dist/getting-started/client.mjs",
+      "default": "./src/getting-started/client.ts"
+    },
     "./groups": {
       "types": "./src/groups/index.ts",
       "source": "./src/groups/index.ts",

--- a/packages/lib/src/getting-started/client.ts
+++ b/packages/lib/src/getting-started/client.ts
@@ -1,0 +1,51 @@
+// packages/lib/src/getting-started/client.ts
+// CLIENT-SAFE: goal-key catalog shared by the server signal layer and the web
+// widget. No server-only deps — display metadata (labels, icons, CTA routes)
+// lives in the web component, this only owns the canonical key set.
+
+/** The setting key under which getting-started state is persisted (per-org). */
+export const GETTING_STARTED_SETTING_KEY = 'onboarding.gettingStarted'
+
+/** Canonical, ordered list of onboarding goal keys. Order is display order. */
+export const GOAL_KEYS = [
+  'connect-email',
+  'setup-agent',
+  'create-workflow',
+  'create-field',
+  'invite-team',
+  'install-extension',
+] as const
+
+export type GoalKey = (typeof GOAL_KEYS)[number]
+
+/**
+ * Goals with no server-derivable signal — completion is only ever recorded
+ * explicitly in `manualCompletions` (see §6 of the plan). Everything else is
+ * auto-inferred from live org state.
+ */
+export const MANUAL_GOAL_KEYS: readonly GoalKey[] = ['install-extension']
+
+/** Persisted per-org getting-started state (jsonb value of the setting). */
+export type GettingStartedState = {
+  /** ISO timestamp the widget was dismissed via the ⋯ menu; `null` = visible. */
+  dismissedAt: string | null
+  /** Goal keys completed explicitly (extension step, "mark all"). */
+  manualCompletions: string[]
+}
+
+/** Default state for an org that has never touched the checklist. */
+export const DEFAULT_GETTING_STARTED_STATE: GettingStartedState = {
+  dismissedAt: null,
+  manualCompletions: [],
+}
+
+/** Status returned to the client: the resolved completed set + dismissal flag. */
+export type GettingStartedStatus = {
+  completedGoals: GoalKey[]
+  dismissed: boolean
+}
+
+/** Narrow an arbitrary string to a known GoalKey. */
+export function isGoalKey(value: string): value is GoalKey {
+  return (GOAL_KEYS as readonly string[]).includes(value)
+}

--- a/packages/lib/src/getting-started/get-status.ts
+++ b/packages/lib/src/getting-started/get-status.ts
@@ -1,0 +1,47 @@
+// packages/lib/src/getting-started/get-status.ts
+import { getOrgCache } from '../cache'
+import {
+  DEFAULT_GETTING_STARTED_STATE,
+  GETTING_STARTED_SETTING_KEY,
+  type GettingStartedState,
+  type GettingStartedStatus,
+  type GoalKey,
+  isGoalKey,
+} from './client'
+import { getAutoInferredGoals } from './signals'
+import type { GettingStartedContext } from './types'
+
+/** Read persisted state from the `orgSettings` cache (defaults merged in). */
+export async function getGettingStartedState(
+  ctx: GettingStartedContext
+): Promise<GettingStartedState> {
+  const settings = await getOrgCache().get(ctx.organizationId, 'orgSettings')
+  return (
+    (settings[GETTING_STARTED_SETTING_KEY] as GettingStartedState | undefined) ??
+    DEFAULT_GETTING_STARTED_STATE
+  )
+}
+
+/**
+ * Resolve the full checklist status for an org: the union of auto-inferred
+ * goals and explicitly-recorded manual completions, plus the dismissal flag.
+ * Every read is cache-backed (one DB hit for the pending-invite check).
+ */
+export async function getGettingStartedStatus(
+  ctx: GettingStartedContext
+): Promise<GettingStartedStatus> {
+  const [state, autoGoals] = await Promise.all([
+    getGettingStartedState(ctx),
+    getAutoInferredGoals(ctx),
+  ])
+
+  const completed = new Set<GoalKey>(autoGoals)
+  for (const key of state.manualCompletions) {
+    if (isGoalKey(key)) completed.add(key)
+  }
+
+  return {
+    completedGoals: [...completed],
+    dismissed: state.dismissedAt !== null,
+  }
+}

--- a/packages/lib/src/getting-started/getting-started-service.ts
+++ b/packages/lib/src/getting-started/getting-started-service.ts
@@ -1,0 +1,35 @@
+// packages/lib/src/getting-started/getting-started-service.ts
+
+import type { GoalKey } from './client'
+import { getGettingStartedState, getGettingStartedStatus } from './get-status'
+import { completeAllGoals, markGoalComplete, setDismissed } from './mutations'
+import type { GettingStartedContext } from './types'
+
+/**
+ * Thin object wrapper over the functional getting-started API, holding a fixed
+ * {@link GettingStartedContext}. Parity with `KBService` — callers that prefer
+ * the object form use this; new code can call the functions directly.
+ */
+export class GettingStartedService {
+  constructor(private readonly ctx: GettingStartedContext) {}
+
+  getStatus() {
+    return getGettingStartedStatus(this.ctx)
+  }
+
+  getState() {
+    return getGettingStartedState(this.ctx)
+  }
+
+  markGoalComplete(key: GoalKey) {
+    return markGoalComplete(this.ctx, key)
+  }
+
+  completeAllGoals(keys: readonly string[]) {
+    return completeAllGoals(this.ctx, keys)
+  }
+
+  setDismissed(dismissed: boolean) {
+    return setDismissed(this.ctx, dismissed)
+  }
+}

--- a/packages/lib/src/getting-started/index.ts
+++ b/packages/lib/src/getting-started/index.ts
@@ -1,0 +1,19 @@
+// packages/lib/src/getting-started/index.ts
+// Server entrypoint for the getting-started checklist. Client-safe catalog/types
+// live in ./client (import those from the web widget).
+
+export {
+  DEFAULT_GETTING_STARTED_STATE,
+  GETTING_STARTED_SETTING_KEY,
+  type GettingStartedState,
+  type GettingStartedStatus,
+  GOAL_KEYS,
+  type GoalKey,
+  isGoalKey,
+  MANUAL_GOAL_KEYS,
+} from './client'
+export { getGettingStartedState, getGettingStartedStatus } from './get-status'
+export { GettingStartedService } from './getting-started-service'
+export { completeAllGoals, markGoalComplete, setDismissed } from './mutations'
+export { getAutoInferredGoals } from './signals'
+export type { GettingStartedContext } from './types'

--- a/packages/lib/src/getting-started/mutations.ts
+++ b/packages/lib/src/getting-started/mutations.ts
@@ -1,0 +1,79 @@
+// packages/lib/src/getting-started/mutations.ts
+import { onCacheEvent } from '../cache'
+import { SettingsService } from '../settings'
+import {
+  DEFAULT_GETTING_STARTED_STATE,
+  GETTING_STARTED_SETTING_KEY,
+  type GettingStartedState,
+  type GoalKey,
+  isGoalKey,
+} from './client'
+import type { GettingStartedContext } from './types'
+
+/** Read the current persisted state directly (not via cache — write path). */
+async function readState(service: SettingsService, organizationId: string) {
+  const value = await service.getOrganizationSetting({
+    organizationId,
+    key: GETTING_STARTED_SETTING_KEY,
+  })
+  return (value as GettingStartedState | null) ?? DEFAULT_GETTING_STARTED_STATE
+}
+
+/** Persist new state + invalidate the org-settings cache. */
+async function writeState(
+  service: SettingsService,
+  organizationId: string,
+  state: GettingStartedState
+) {
+  await service.updateOrganizationSetting({
+    organizationId,
+    key: GETTING_STARTED_SETTING_KEY,
+    value: state,
+    allowUserOverride: false,
+  })
+  await onCacheEvent('org.settings.changed', { orgId: organizationId })
+}
+
+/**
+ * Record a single goal as manually complete (e.g. the extension step). Unions
+ * into `manualCompletions` — never clobbers, so concurrent writers are safe.
+ */
+export async function markGoalComplete(ctx: GettingStartedContext, key: GoalKey): Promise<void> {
+  const service = new SettingsService(ctx.db)
+  const state = await readState(service, ctx.organizationId)
+  if (state.manualCompletions.includes(key)) return
+  await writeState(service, ctx.organizationId, {
+    ...state,
+    manualCompletions: [...state.manualCompletions, key],
+  })
+}
+
+/**
+ * Mark every currently-displayed goal complete ("Mark all"). Unions the passed
+ * keys into `manualCompletions` so auto-inferred goals also stick.
+ */
+export async function completeAllGoals(
+  ctx: GettingStartedContext,
+  keys: readonly string[]
+): Promise<void> {
+  const service = new SettingsService(ctx.db)
+  const state = await readState(service, ctx.organizationId)
+  const union = new Set(state.manualCompletions)
+  for (const key of keys) {
+    if (isGoalKey(key)) union.add(key)
+  }
+  await writeState(service, ctx.organizationId, {
+    ...state,
+    manualCompletions: [...union],
+  })
+}
+
+/** Dismiss (stamp `dismissedAt`) or un-dismiss (clear it) the widget. */
+export async function setDismissed(ctx: GettingStartedContext, dismissed: boolean): Promise<void> {
+  const service = new SettingsService(ctx.db)
+  const state = await readState(service, ctx.organizationId)
+  await writeState(service, ctx.organizationId, {
+    ...state,
+    dismissedAt: dismissed ? new Date().toISOString() : null,
+  })
+}

--- a/packages/lib/src/getting-started/signals.ts
+++ b/packages/lib/src/getting-started/signals.ts
@@ -1,0 +1,86 @@
+// packages/lib/src/getting-started/signals.ts
+// Per-goal completion signals, auto-inferred from live org state. Every signal
+// subtracts seeded defaults so a fresh org reads as "nothing done yet":
+//   - email:    seeded mailboxes are `enabled: false` (example also isExample)
+//   - workflow: the example scenario seeds `[Example] …`-named workflows
+//   - members:  AI agents are synthetic users (userType !== 'USER')
+//   - agents:   no agent is seeded; a real one has name + setupCompletedAt set
+// Reads come from the per-org cache; only the pending-invite check touches the DB.
+
+import { database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { getAllCachedCustomFields, getCachedAgents, getCachedMembers, getOrgCache } from '../cache'
+import type { GoalKey } from './client'
+import type { GettingStartedContext } from './types'
+
+/** A real, enabled inbound mailbox (Gmail/Outlook) that isn't seeded demo data. */
+async function isEmailConnected(ctx: GettingStartedContext): Promise<boolean> {
+  const channels = await getOrgCache().get(ctx.organizationId, 'channels')
+  return channels.some(
+    (c) => (c.provider === 'google' || c.provider === 'outlook') && c.enabled && !c.isExample
+  )
+}
+
+/** At least one set-up (non-draft) agent. Drafts lack `setupCompletedAt`. */
+async function hasConfiguredAgent(ctx: GettingStartedContext): Promise<boolean> {
+  const agents = await getCachedAgents(ctx.organizationId)
+  return agents.some((a) => a.name !== null && a.setupCompletedAt !== null)
+}
+
+/** A user-authored workflow — i.e. not a seeded `[Example] …` one. */
+async function hasUserWorkflow(ctx: GettingStartedContext): Promise<boolean> {
+  const workflows = await getOrgCache().get(ctx.organizationId, 'workflowApps')
+  return workflows.some((w) => !w.name.startsWith('[Example]'))
+}
+
+/** A genuinely custom field — not a system attribute, not app-provisioned. */
+async function hasCustomField(ctx: GettingStartedContext): Promise<boolean> {
+  const fields = await getAllCachedCustomFields(ctx.organizationId)
+  return fields.some(
+    (f) => f.isCustom && f.systemAttribute === null && f.appInstallationId === null
+  )
+}
+
+/** More than one human member, or a pending human invitation. */
+async function hasHumanTeammate(ctx: GettingStartedContext): Promise<boolean> {
+  const members = await getCachedMembers(ctx.organizationId)
+  const humans = members.filter((m) => m.user?.userType === 'USER')
+  if (humans.length > 1) return true
+
+  // A teammate who was invited but hasn't accepted yet still counts — that's
+  // exactly the action this goal asks for. Agents are never email-invited, so
+  // any pending invitation is human.
+  const db = ctx.db ?? database
+  const pending = await db
+    .select({ id: schema.OrganizationInvitation.id })
+    .from(schema.OrganizationInvitation)
+    .where(
+      and(
+        eq(schema.OrganizationInvitation.organizationId, ctx.organizationId),
+        eq(schema.OrganizationInvitation.status, 'PENDING')
+      )
+    )
+    .limit(1)
+  return pending.length > 0
+}
+
+/** Map of auto-inferred goal → signal. `install-extension` has no signal. */
+const AUTO_SIGNALS: Partial<Record<GoalKey, (ctx: GettingStartedContext) => Promise<boolean>>> = {
+  'connect-email': isEmailConnected,
+  'setup-agent': hasConfiguredAgent,
+  'create-workflow': hasUserWorkflow,
+  'create-field': hasCustomField,
+  'invite-team': hasHumanTeammate,
+}
+
+/**
+ * Compute the set of auto-inferred completed goal keys for an org. Runs all
+ * signals concurrently against the per-org cache.
+ */
+export async function getAutoInferredGoals(ctx: GettingStartedContext): Promise<GoalKey[]> {
+  const entries = Object.entries(AUTO_SIGNALS) as Array<
+    [GoalKey, (ctx: GettingStartedContext) => Promise<boolean>]
+  >
+  const results = await Promise.all(entries.map(([, signal]) => signal(ctx)))
+  return entries.filter((_, i) => results[i]).map(([key]) => key)
+}

--- a/packages/lib/src/getting-started/types.ts
+++ b/packages/lib/src/getting-started/types.ts
@@ -1,0 +1,13 @@
+// packages/lib/src/getting-started/types.ts
+import type { Database, Transaction } from '@auxx/database'
+
+/**
+ * Shared context passed into every getting-started function. `db` is optional —
+ * when omitted, functions fall back to the singleton `database` export (the
+ * settings read/write path and the few cache-omitted DB lookups). Pass a
+ * `Transaction` to participate in an existing tx.
+ */
+export interface GettingStartedContext {
+  db?: Database | Transaction
+  organizationId: string
+}

--- a/packages/lib/src/settings/settings-service.ts
+++ b/packages/lib/src/settings/settings-service.ts
@@ -79,6 +79,15 @@ export const sidebarSettings = {
 
 // Define a catalog of available settings with their metadata
 export const SETTINGS_CATALOG: Record<string, SettingConfig> = {
+  'onboarding.gettingStarted': {
+    key: 'onboarding.gettingStarted',
+    scope: 'ONBOARDING',
+    // GettingStartedState — { dismissedAt: string | null; manualCompletions: string[] }
+    defaultValue: { dismissedAt: null, manualCompletions: [] },
+    type: 'object',
+    organizationOnly: true,
+    description: 'Getting-started checklist state (dismissal + manual completions)',
+  },
   'appearance.logo': {
     key: 'appearance.logo',
     scope: 'APPEARANCE',


### PR DESCRIPTION
## What

Adds an Attio-style **Getting started** onboarding checklist as an inline, animated group pinned in the sidebar footer (above `AppFooter`).

Builds on #990 (which added the `ONBOARDING` `SettingScope` enum value + migration `0242`).

## How it works

- **Auto-inferred completion** — the 5 derivable goals are computed from the per-org cache (no client "I did it" calls), each subtracting seeded defaults:
  - `connect-email` → an enabled, non-example Gmail/Outlook channel
  - `setup-agent` → an agent with `name` + `setupCompletedAt`
  - `create-workflow` → a workflow not named `[Example] …`
  - `create-field` → a genuinely custom field (not system/app-provisioned)
  - `invite-team` → >1 human member or a pending invite
- **`install-extension`** has no server signal → marked complete on click (opens the published listing).
- **Storage** — one `OrganizationSetting` row (`onboarding.gettingStarted`, jsonb `{ dismissedAt, manualCompletions }`), riding the existing `orgSettings` org-cache. Reads are cache-backed; writes invalidate via `org.settings.changed`.
- **UI** — collapsible `SidebarMenu` group (height-spring via `SidebarGroupCollapse`); the header accordions the step list and hovering reveals one fixed side panel (height matched to the group) that swaps to the hovered step's description + CTA. Auto-hides once dismissed or all goals complete.

## Structure

- `packages/lib/src/getting-started/` — client-safe catalog/state types, signals, get-status, mutations, thin service (mirrors `kb`). New `@auxx/lib/getting-started` + `/client` exports.
- `apps/web/src/server/api/routers/getting-started.ts` — slim router (`getStatus`/`markGoalComplete`/`completeAll`/`setDismissed`), registered in `root.ts`.
- `apps/web/src/components/getting-started/` — `getting-started-group.tsx`, `getting-started-step.tsx`, `use-getting-started.ts`, display catalog `client.ts`.

## Notes / follow-ups

- CTA routes point at existing settings/app pages; confirm if any move.
- Extension step links the real (unlisted) Web Store listing `hlhbgglcglfmicfaafdecfnenpocbffl`.
- v1 shows all goals to everyone (no role/feature gating yet).