### PR TITLE
feat(getting-started): action + Learn more buttons in checklist hovercard

### DIFF
--- a/apps/docs/content/docs/help/getting-started/install-extension.mdx
+++ b/apps/docs/content/docs/help/getting-started/install-extension.mdx
@@ -1,0 +1,73 @@
+---
+title: Install the browser extension
+description: Install the Auxx.ai browser extension to see the matching customer record alongside Gmail, LinkedIn, X, Facebook, and Instagram.
+---
+
+The Auxx.ai browser extension brings your customer context into the tools you already work in. It injects a side panel on top of supported sites that shows the Auxx record matching whoever you're looking at — with an **Open in Auxx** shortcut to jump to the full record — so you don't have to switch tabs to see who you're talking to.
+
+## Supported sites
+
+The panel appears on these sites today:
+
+- **Gmail** (`mail.google.com`)
+- **LinkedIn**
+- **X / Twitter**
+- **Facebook**
+- **Instagram**
+
+On any other site the extension stays out of the way.
+
+## Install
+
+<Steps>
+<Step>
+### Add it from the Chrome Web Store
+
+Open the [Auxx.ai extension listing](https://chromewebstore.google.com/detail/hlhbgglcglfmicfaafdecfnenpocbffl) and click **Add to Chrome**, then confirm **Add extension**. It works in any Chromium-based browser (Chrome, Edge, Arc, Brave).
+</Step>
+<Step>
+### Pin it to your toolbar
+
+Click the puzzle-piece extensions icon in your browser toolbar and pin **Auxx.ai** so the panel toggle is always one click away.
+</Step>
+<Step>
+### Sign in to Auxx.ai
+
+Make sure you're signed in to Auxx.ai in the same browser. The extension authenticates against your active session, so the panel can only load your records once you're logged in.
+</Step>
+</Steps>
+
+<Callout type="info" title="Same account, same browser">
+  The panel uses your signed-in Auxx.ai session. If you use multiple accounts, sign in to the one whose data you want to see before opening the panel.
+</Callout>
+
+## Using the panel
+
+1. Open a supported site (for example, an email thread in Gmail).
+2. The Auxx.ai panel shows the contact or company record that matches the person on the page.
+3. Click **Open in Auxx** to open the full record in the app, where you can edit fields, view tickets, and see the complete history.
+
+## Troubleshooting
+
+<Accordions type="single">
+  <Accordion title="The panel isn't showing up">
+    Confirm the extension is installed and pinned, that you're on one of the [supported sites](#supported-sites), and that you're signed in to Auxx.ai in the same browser. Reload the page after installing.
+  </Accordion>
+  <Accordion title="No matching record is found">
+    The panel matches on the contact's details (such as email). If there's no record yet, the person hasn't been added to Auxx.ai — they'll appear once a matching contact or ticket exists.
+  </Accordion>
+  <Accordion title="The panel asks me to sign in again">
+    Your Auxx.ai session expired. Open Auxx.ai, sign back in, and the panel will reconnect automatically.
+  </Accordion>
+</Accordions>
+
+## Next steps
+
+<Cards>
+  <Card title="Connect your first inbox" href="/help/getting-started/connect-inbox">
+    Sync Gmail or Outlook so records have email context.
+  </Card>
+  <Card title="Navigate the dashboard" href="/help/getting-started/navigate-dashboard">
+    Learn your way around the Auxx.ai interface.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/getting-started/meta.json
+++ b/apps/docs/content/docs/help/getting-started/meta.json
@@ -6,6 +6,7 @@
     "connect-inbox",
     "connect-shopify",
     "navigate-dashboard",
-    "invite-team"
+    "invite-team",
+    "install-extension"
   ]
 }

--- a/apps/web/src/components/getting-started/client.ts
+++ b/apps/web/src/components/getting-started/client.ts
@@ -20,6 +20,10 @@ export type GettingStartedGoal = {
   ctaText: string
   /** Where the CTA goes — internal app route or external URL. */
   href: string
+  /** Relative docs path for the "Learn more" link, joined onto useEnv().docsUrl. */
+  docsPath: string
+  /** Optional preview image shown in the hovercard; falls back to the icon. */
+  previewImage?: string
   /** External links open in a new tab. */
   external?: boolean
   /** Goals with no server signal are marked complete when the CTA is clicked. */
@@ -34,6 +38,7 @@ const GOALS: Record<GoalKey, Omit<GettingStartedGoal, 'key'>> = {
     color: 'blue',
     ctaText: 'Connect inbox',
     href: '/app/settings/channels',
+    docsPath: '/help/getting-started/connect-inbox',
   },
   'setup-agent': {
     label: 'Set up an AI agent',
@@ -42,6 +47,7 @@ const GOALS: Record<GoalKey, Omit<GettingStartedGoal, 'key'>> = {
     color: 'purple',
     ctaText: 'Set up agent',
     href: '/app/agents',
+    docsPath: '/help/agents/creating-an-agent',
   },
   'create-workflow': {
     label: 'Create a workflow',
@@ -50,6 +56,7 @@ const GOALS: Record<GoalKey, Omit<GettingStartedGoal, 'key'>> = {
     color: 'amber',
     ctaText: 'New workflow',
     href: '/app/workflows',
+    docsPath: '/help/ai/creating-workflows',
   },
   'create-field': {
     label: 'Create a custom field',
@@ -58,6 +65,7 @@ const GOALS: Record<GoalKey, Omit<GettingStartedGoal, 'key'>> = {
     color: 'teal',
     ctaText: 'Add field',
     href: '/app/settings/custom-fields',
+    docsPath: '/help/workspace/custom-fields',
   },
   'invite-team': {
     label: 'Invite your team',
@@ -66,6 +74,7 @@ const GOALS: Record<GoalKey, Omit<GettingStartedGoal, 'key'>> = {
     color: 'green',
     ctaText: 'Invite teammates',
     href: '/app/settings/members',
+    docsPath: '/help/getting-started/invite-team',
   },
   'install-extension': {
     label: 'Install the extension',
@@ -74,6 +83,7 @@ const GOALS: Record<GoalKey, Omit<GettingStartedGoal, 'key'>> = {
     color: 'indigo',
     ctaText: 'Get the extension',
     href: EXTENSION_STORE_URL,
+    docsPath: '/help/getting-started/install-extension',
     external: true,
     markOnClick: true,
   },

--- a/apps/web/src/components/getting-started/ui/getting-started-group.tsx
+++ b/apps/web/src/components/getting-started/ui/getting-started-group.tsx
@@ -19,10 +19,11 @@ import {
   SidebarMenuItem,
   SidebarMenuSub,
 } from '@auxx/ui/components/sidebar'
-import { CheckCheck, MoreHorizontal, Rocket, X } from 'lucide-react'
+import { CheckCheck, ExternalLink, MoreHorizontal, Rocket, X } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { type MouseEvent, useCallback, useRef, useState } from 'react'
 import { useSidebarState } from '~/hooks/use-sidebar-state'
+import { useEnv } from '~/providers/dehydrated-state-provider'
 import type { GettingStartedGoal } from '../client'
 import { useGettingStarted } from '../hooks/use-getting-started'
 import { GettingStartedStep } from './getting-started-step'
@@ -44,6 +45,7 @@ function stop(e: MouseEvent) {
  */
 export function GettingStartedGroup() {
   const router = useRouter()
+  const { docsUrl } = useEnv()
   const { getSectionOpen, toggleSection } = useSidebarState()
   const {
     isLoading,
@@ -63,8 +65,9 @@ export function GettingStartedGroup() {
   const [hoveredKey, setHoveredKey] = useState<string | null>(null)
 
   // Callback ref: measure the whole group (header + progress + items) whenever
-  // it actually mounts, and track its height as the accordion animates. Used to
-  // make the side panel exactly as tall as the group.
+  // it actually mounts, and track its height as the accordion animates. Used as
+  // the side panel's min-height so it aligns with the group but can grow taller
+  // when its own content needs more room.
   const measureRef = useCallback((node: HTMLDivElement | null) => {
     observerRef.current?.disconnect()
     if (!node) return
@@ -83,7 +86,6 @@ export function GettingStartedGroup() {
   // Default the panel to the first incomplete step until the user hovers one.
   const activeGoal =
     goals.find((g) => g.key === hoveredKey) ?? goals.find((g) => !completed.has(g.key)) ?? goals[0]
-  const activeCompleted = !!activeGoal && completed.has(activeGoal.key)
 
   const handleCTA = (goal: GettingStartedGoal) => {
     if (goal.markOnClick) markGoalComplete(goal.key)
@@ -97,7 +99,7 @@ export function GettingStartedGroup() {
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <HoverCard openDelay={60} closeDelay={80}>
+        <HoverCard openDelay={250} closeDelay={200}>
           <HoverCardTrigger asChild>
             <div ref={measureRef}>
               <SidebarMenuButton asChild tooltip='Getting started'>
@@ -161,20 +163,40 @@ export function GettingStartedGroup() {
               side='right'
               align='start'
               sideOffset={12}
-              style={{ height: panelHeight }}
-              className='flex w-64 flex-col p-3'>
-              <div className='flex items-center gap-2'>
+              style={{ minHeight: panelHeight }}
+              // Invisible bridge (`before`) spans the `sideOffset` gap so a
+              // diagonal cursor path from the list to the card stays over a
+              // hoverable region and the card doesn't close mid-traversal.
+              className="relative flex w-64 flex-col p-3 before:absolute before:right-full before:top-0 before:h-full before:w-3 before:content-['']">
+              {/* Step preview; grows to push the title + description block to the
+                  bottom of the panel. Shows the goal's image when set, otherwise
+                  its icon as a placeholder visual. */}
+              <div className='flex min-h-24 flex-1 items-center justify-center overflow-hidden rounded-lg bg-primary-200'>
+                {activeGoal.previewImage ? (
+                  <img src={activeGoal.previewImage} alt='' className='size-full object-cover' />
+                ) : (
+                  <EntityIcon iconId={activeGoal.iconId} color={activeGoal.color} size='xl' />
+                )}
+              </div>
+              <div className='mt-3 flex items-center gap-2'>
                 <EntityIcon iconId={activeGoal.iconId} color={activeGoal.color} size='default' />
                 <span className='text-sm font-medium'>{activeGoal.label}</span>
               </div>
-              <p className='mt-2 text-sm text-muted-foreground'>{activeGoal.description}</p>
-              <Button
-                size='sm'
-                variant={activeCompleted ? 'outline' : 'default'}
-                className='mt-auto w-full'
-                onClick={() => handleCTA(activeGoal)}>
-                {activeCompleted ? 'Done' : activeGoal.ctaText}
-              </Button>
+              <p className='mt-1 text-sm text-muted-foreground'>{activeGoal.description}</p>
+              <div className='mt-3 flex items-center gap-2'>
+                <Button size='sm' onClick={() => handleCTA(activeGoal)}>
+                  {activeGoal.ctaText}
+                </Button>
+                <Button size='sm' variant='outline' asChild>
+                  <a
+                    href={`${docsUrl}${activeGoal.docsPath}`}
+                    target='_blank'
+                    rel='noopener noreferrer'>
+                    Learn more
+                    <ExternalLink />
+                  </a>
+                </Button>
+              </div>
             </HoverCardContent>
           )}
         </HoverCard>


### PR DESCRIPTION
## What

Improves the getting-started checklist hovercard in the sidebar footer.

- **Two buttons instead of one.** Replaces the single full-width CTA (which flipped to "Done") with two auto-width buttons: the **action button** always shows the goal's action, and a **Learn more** outline button (with an external-link icon) that opens the relevant docs page.
- **Docs link via dehydrated env.** The docs base comes from `useEnv().docsUrl` (same source as the app footer); each goal gains a `docsPath`.
- **Step preview area.** Adds a `bg-primary-200` rounded preview box that shows the goal's `previewImage` when set, otherwise its icon. Title + description align to the bottom.
- **Panel sizing.** Switched from a fixed height to `min-height` so the card aligns with the group but grows when content needs more room (no more buttons spilling below).
- **Smarter hover.** Slight open delay + longer close delay, plus an invisible bridge across the `sideOffset` gap so diagonal cursor paths from the list to the card don't dismiss it (no new dependency).
- **Docs.** New `install-extension` help article (Chrome Web Store install, supported sites, usage, troubleshooting), registered in `getting-started/meta.json`.

## Notes

- `previewImage` is optional and currently unset on all goals — the icon fallback renders until real images are added.
- No new dependencies.

## Test plan

- Hover each checklist step in the sidebar footer: two buttons appear, the action label never reads "Done", and **Learn more** opens the docs page in a new tab.
- Move the cursor diagonally from a step toward the card — it stays open.
- Long content no longer overflows below the card.