### PR TITLE
feat(data-connectors): zero-config name-match auto-binder for contributing mappings

### DIFF
--- a/packages/lib/src/data-connectors/app-catalog.test.ts
+++ b/packages/lib/src/data-connectors/app-catalog.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   appCatalogStreamSchema,
+  buildContributingAutoBindings,
   buildContributingFieldBindings,
   buildSchemaFromFieldPaths,
   type ContributingTargetField,
@@ -152,5 +153,118 @@ describe('buildContributingFieldBindings', () => {
       targetFieldRef: 'def_contact:f_email',
       expression: '{email}',
     })
+  })
+})
+
+describe('buildContributingAutoBindings (zero-config heuristic)', () => {
+  // Mirrors the system `contact` def: writable first/last/phone, non-writable `id` +
+  // `created_at`, computed `fullName`.
+  const contactFields: ContributingTargetField[] = [
+    {
+      id: 'f_id',
+      name: 'ID',
+      systemAttribute: 'id',
+      type: 'TEXT',
+      isCreatable: false,
+      isUpdatable: false,
+    },
+    { id: 'f_first', name: 'First Name', systemAttribute: 'first_name', type: 'TEXT' },
+    { id: 'f_last', name: 'Last Name', systemAttribute: 'last_name', type: 'TEXT' },
+    { id: 'f_phone', name: 'Phone', systemAttribute: 'phone', type: 'PHONE_INTL' },
+    { id: 'f_full', name: 'Name', systemAttribute: 'full_name', type: 'TEXT', isComputed: true },
+    {
+      id: 'f_created',
+      name: 'Created',
+      systemAttribute: 'created_at',
+      type: 'DATETIME',
+      isCreatable: false,
+      isUpdatable: false,
+    },
+  ]
+
+  it('name-matches leaf source fields to writable targets at root, no identityRole', () => {
+    const bindings = buildContributingAutoBindings(
+      'def_contact',
+      '',
+      [
+        { fieldKey: 'firstName', sourcePath: 'first_name', type: 'TEXT', name: 'First Name' },
+        { fieldKey: 'lastName', sourcePath: 'last_name', type: 'TEXT', name: 'Last Name' },
+        { fieldKey: 'phone', sourcePath: 'phone', type: 'TEXT', name: 'Phone' },
+      ],
+      contactFields
+    )
+    expect(bindings.map((b) => b.targetFieldRef).sort()).toEqual([
+      'def_contact:f_first',
+      'def_contact:f_last',
+      'def_contact:f_phone',
+    ])
+    expect(bindings.every((b) => b.identityRole === undefined)).toBe(true)
+  })
+
+  it('skips non-writable (id, created_at) and computed (fullName) targets', () => {
+    const bindings = buildContributingAutoBindings(
+      'def_contact',
+      '',
+      [
+        { fieldKey: 'id', sourcePath: 'id', type: 'TEXT', name: 'Shopify ID' },
+        { fieldKey: 'createdAt', sourcePath: 'created_at', type: 'DATETIME', name: 'Created' },
+        { fieldKey: 'fullName', sourcePath: 'full_name', type: 'TEXT', name: 'Name' },
+      ],
+      contactFields
+    )
+    expect(bindings).toHaveLength(0)
+  })
+
+  it('skips a target two source fields both resolve to (ambiguous)', () => {
+    const bindings = buildContributingAutoBindings(
+      'def_contact',
+      '',
+      [
+        { fieldKey: 'firstName', sourcePath: 'first_name', type: 'TEXT', name: 'First Name' },
+        { fieldKey: 'givenName', sourcePath: 'First Name', type: 'TEXT', name: 'Given' },
+      ],
+      contactFields
+    )
+    expect(bindings).toHaveLength(0)
+  })
+
+  it('skips nested + array-element source paths, keeps only direct leaves', () => {
+    const bindings = buildContributingAutoBindings(
+      'def_contact',
+      'customer',
+      [
+        {
+          fieldKey: 'firstName',
+          sourcePath: 'customer.first_name',
+          type: 'TEXT',
+          name: 'First Name',
+        },
+        { fieldKey: 'city', sourcePath: 'customer.address.phone', type: 'TEXT', name: 'Nested' },
+        { fieldKey: 'tag', sourcePath: 'customer.tags[].phone', type: 'TEXT', name: 'Array' },
+      ],
+      contactFields
+    )
+    expect(bindings).toHaveLength(1)
+    expect(bindings[0]).toMatchObject({
+      targetFieldRef: 'def_contact:f_first',
+      expression: '{first_name}',
+    })
+  })
+
+  it('drops everything for an array-rooted mapping', () => {
+    const bindings = buildContributingAutoBindings(
+      'def_contact',
+      'line_items[]',
+      [
+        {
+          fieldKey: 'firstName',
+          sourcePath: 'line_items[].first_name',
+          type: 'TEXT',
+          name: 'First Name',
+        },
+      ],
+      contactFields
+    )
+    expect(bindings).toHaveLength(0)
   })
 })

--- a/packages/lib/src/data-connectors/app-catalog.ts
+++ b/packages/lib/src/data-connectors/app-catalog.ts
@@ -90,6 +90,22 @@ export interface ContributingTargetField {
   systemAttribute: string | null
   /** Storage field type (EMAIL / PHONE_INTL / URL / …) → the match `normalize` strategy. */
   type: string
+  /**
+   * Capability flags — present on the cached `CustomFieldEntity`, undefined on the
+   * test/literal shape. Only the zero-config auto-binder ({@link buildContributingAutoBindings})
+   * reads them, to skip non-writable / computed targets (`id`, `created_at`, the computed
+   * `fullName`). The explicit binders ignore them — an author who names a target owns the choice.
+   */
+  isCreatable?: boolean
+  isUpdatable?: boolean
+  isComputed?: boolean
+}
+
+/** A target is a safe auto-bind sink unless it's computed or can be neither created nor updated. */
+function isWritableTarget(field: ContributingTargetField): boolean {
+  if (field.isComputed) return false
+  if (field.isCreatable === false && field.isUpdatable === false) return false
+  return true
 }
 
 /**
@@ -173,6 +189,65 @@ export function buildContributingFieldBindings(
     // with the rootPath prefix), else its relative path is undefined for this root.
     if (!sourceField || (prefix && !sourceField.sourcePath.startsWith(prefix))) continue
     bindings.push(bindSourceToTarget(entityDefinitionId, prefix, sourceField, target))
+  }
+  return bindings
+}
+
+/**
+ * Zero-config fallback for a contributing mapping that declared NO explicit
+ * `fieldBindings` (approach B, automap-plan §5): name-match every LEAF source field
+ * sitting directly under `rootPath` to a target field, binding only UNAMBIGUOUS,
+ * writable hits. Lets a contributing stream land first/last/phone pre-mapped even when
+ * the app author writes no `fieldBindings` boilerplate — explicit `fieldBindings`
+ * always take precedence (the caller runs this only when none were declared).
+ *
+ * Conservative by construction:
+ *   - only LEAF fields directly on the root object (relative path has no `.`/`[]`) —
+ *     nested + array-element fields are skipped, same spirit as the match binder;
+ *   - a target two source fields both resolve to is AMBIGUOUS and dropped (never guess);
+ *   - non-writable / computed targets (`id`, `created_at`, the computed `fullName`) are
+ *     skipped via {@link isWritableTarget}, so a Shopify `id` never lands on contact `id`;
+ *   - emits plain (no `identityRole`) `FieldMapping`s; the external id is never bound.
+ * Match-key targets are de-duped by the caller (match's `identityRole` wins). Every
+ * binding stays overridable in the Map step.
+ */
+export function buildContributingAutoBindings(
+  entityDefinitionId: string,
+  rootPath: string,
+  sourceFields: CatalogDataConnector['streams'][number]['fields'],
+  defFields: ContributingTargetField[]
+): FieldMapping[] {
+  if (rootPath.includes('[]')) return []
+
+  const fieldByKey = buildTargetFieldIndex(defFields)
+  const prefix = rootPath ? `${rootPath}.` : ''
+
+  // Group candidates by resolved target id so a target claimed by 2+ sources is ambiguous.
+  const byTarget = new Map<
+    string,
+    {
+      source: CatalogDataConnector['streams'][number]['fields'][number]
+      target: ContributingTargetField
+    }[]
+  >()
+  for (const sourceField of sourceFields) {
+    const path = sourceField.sourcePath
+    if (prefix && !path.startsWith(prefix)) continue
+    const relative = prefix ? path.slice(prefix.length) : path
+    // Only leaf fields directly on the root object — skip nested + array-element paths.
+    if (relative.includes('.') || relative.includes('[]')) continue
+    const target = fieldByKey.get(relative) ?? fieldByKey.get(normalizeFieldKey(relative))
+    if (!target || !isWritableTarget(target)) continue
+    const list = byTarget.get(target.id) ?? []
+    list.push({ source: sourceField, target })
+    byTarget.set(target.id, list)
+  }
+
+  const bindings: FieldMapping[] = []
+  for (const candidates of byTarget.values()) {
+    if (candidates.length !== 1) continue // ambiguous → skip
+    const { source, target } = candidates[0]!
+    bindings.push(bindSourceToTarget(entityDefinitionId, prefix, source, target))
   }
   return bindings
 }

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -16,6 +16,7 @@ import { BadRequestError, NotFoundError } from '../errors'
 import { toRecordId } from '../resources/resource-id'
 import {
   appCatalogStreamSchema,
+  buildContributingAutoBindings,
   buildContributingFieldBindings,
   buildContributingMatchBindings,
 } from './app-catalog'
@@ -564,12 +565,24 @@ async function materializeAppContributingMappings(
       defFields
     )
     const boundTargets = new Set(matchBindings.map((b) => b.targetFieldRef))
-    const valueBindings = buildContributingFieldBindings(
-      entityDefinitionId,
-      mapping.rootPath,
-      fieldBindings ?? [],
-      stream.fields,
-      defFields
+    // Author-declared `fieldBindings` win; if none were declared, fall back to the
+    // zero-config name-match heuristic (automap-plan §5). Either way, drop any target a
+    // match key already claimed (match's `identityRole` wins).
+    const valueBindings = (
+      (fieldBindings?.length ?? 0) > 0
+        ? buildContributingFieldBindings(
+            entityDefinitionId,
+            mapping.rootPath,
+            fieldBindings ?? [],
+            stream.fields,
+            defFields
+          )
+        : buildContributingAutoBindings(
+            entityDefinitionId,
+            mapping.rootPath,
+            stream.fields,
+            defFields
+          )
     ).filter((b) => !boundTargets.has(b.targetFieldRef))
     const fieldMappings = [...matchBindings, ...valueBindings]
 


### PR DESCRIPTION
## What

Adds a conservative zero-config fallback so a **contributing** data-connector mapping that declares no explicit `fieldBindings` still lands its leaf fields pre-mapped (automap-plan §5) — no author boilerplate required.

`buildContributingAutoBindings()` name-matches leaf source fields under `rootPath` to target fields, binding only unambiguous, writable hits:

- **Leaves only** — fields directly on the root object; nested + array-element paths are skipped (same spirit as the match binder).
- **No guessing** — a target that two source fields both resolve to is ambiguous and dropped.
- **Writable only** — non-writable (`id`, `created_at`) and computed (`fullName`) targets are skipped, via new `isCreatable` / `isUpdatable` / `isComputed` capability flags on `ContributingTargetField` (read from the cached `CustomFieldEntity`; undefined on the literal/test shape, which the explicit binders ignore).
- **Plain mappings** — emits `FieldMapping`s with no `identityRole`; the external id is never bound.

`materializeAppContributingMappings` calls it only when no `fieldBindings` were declared — explicit bindings always win — and de-dupes against match-key targets (match's `identityRole` wins).

## Test plan

- `pnpm vitest run src/data-connectors/app-catalog.test.ts` (in `packages/lib`) — 14 passing, including 5 new cases covering name-match, non-writable/computed skips, ambiguity, nested/array skips, and array-rooted drop.