### PR TITLE
feat(data-connectors): owned relationship provisioning + record source badge

### DIFF
--- a/apps/web/src/components/dynamic-table/cells/primary-cell.tsx
+++ b/apps/web/src/components/dynamic-table/cells/primary-cell.tsx
@@ -29,6 +29,9 @@ export interface PrimaryCellProps {
   /** Dropdown menu items passed as children for maximum flexibility */
   children: React.ReactNode
 
+  /** Optional inline node rendered right after the title (e.g. a source badge). */
+  suffix?: React.ReactNode
+
   /** Optional: Font weight for title (default: 'medium') */
   fontWeight?: 'normal' | 'medium' | 'semibold'
 
@@ -47,6 +50,7 @@ export function PrimaryCell({
   prefixIcon,
   onTitleClick,
   children,
+  suffix,
   fontWeight = 'medium',
   titleClassName = '',
 }: PrimaryCellProps) {
@@ -55,19 +59,22 @@ export function PrimaryCell({
 
   return (
     <div className='flex items-center justify-between w-full min-h-9 pl-3 pr-1 text-sm group/primary'>
-      <button
-        className={cn(
-          'flex items-center gap-2 text-left underline decoration-muted-foreground/50 hover:decoration-muted-foreground truncate max-w-[calc(100%-40px)]',
-          fontWeightClass,
-          titleClassName
-        )}
-        onClick={(e) => {
-          e.stopPropagation()
-          onTitleClick()
-        }}>
-        {prefixIcon}
-        <span className='truncate'>{displayValue}</span>
-      </button>
+      <div className='flex items-center gap-1.5 min-w-0 max-w-[calc(100%-40px)]'>
+        <button
+          className={cn(
+            'flex items-center gap-2 text-left underline decoration-muted-foreground/50 hover:decoration-muted-foreground truncate min-w-0',
+            fontWeightClass,
+            titleClassName
+          )}
+          onClick={(e) => {
+            e.stopPropagation()
+            onTitleClick()
+          }}>
+          {prefixIcon}
+          <span className='truncate'>{displayValue}</span>
+        </button>
+        {suffix}
+      </div>
 
       <div onClick={(e) => e.stopPropagation()} className='shrink-0'>
         <DropdownMenu>

--- a/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
+++ b/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
@@ -6,6 +6,7 @@ import { parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
 import { extractValue, type TypedFieldValue } from '@auxx/types/field-value'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { memo, type ReactNode, useMemo } from 'react'
+import { ConnectorSourceBadge } from '~/components/fields/connector-source-badge'
 import { toRecordId, useRecord, useResource } from '~/components/resources'
 import { useField } from '~/components/resources/hooks/use-field'
 import { useFieldValue } from '~/components/resources/hooks/use-field-values'
@@ -100,6 +101,13 @@ export const PrimaryFieldCell = memo(function PrimaryFieldCell({
           color={resource?.color || 'gray'}
           size='xs'
           inverse
+        />
+      }
+      suffix={
+        <ConnectorSourceBadge
+          integrationSource={record?.integrationSource}
+          variant='icon'
+          className='shrink-0'
         />
       }>
       {children}

--- a/apps/web/src/components/fields/connector-source-badge.tsx
+++ b/apps/web/src/components/fields/connector-source-badge.tsx
@@ -1,0 +1,93 @@
+// apps/web/src/components/fields/connector-source-badge.tsx
+
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
+import { useMemo } from 'react'
+import { useAppsContext } from '~/components/apps/providers/apps-context'
+import { AppIcon } from '~/components/apps/ui/app-icon'
+import { Tooltip } from '~/components/global/tooltip'
+import {
+  type ResolvedConnector,
+  useConnector,
+} from '~/components/resources/hooks/use-connector-name'
+
+interface ConnectorSourceBadgeProps {
+  /**
+   * `EntityInstance.integrationSource` — a DataConnector id for connector-synced
+   * records, null/undefined for hand-created records. Anything that doesn't
+   * resolve to a known connector renders nothing (handles legacy free-form
+   * sources).
+   */
+  integrationSource: string | null | undefined
+  /** `icon` → bare logo (grid primary cell); `chip` → logo + name (drawer header). */
+  variant: 'icon' | 'chip'
+  className?: string
+}
+
+/** `"app:shopify"` → `"shopify"`; null for non-app connector types. */
+function slugFromType(type: string): string | null {
+  return type.startsWith('app:') ? type.slice('app:'.length) : null
+}
+
+/**
+ * Entity-level "Synced from <connector>" indicator. Resolves the record's
+ * `integrationSource` (a DataConnector id) to its installed app's branding via
+ * the existing `useConnector` + `useAppsContext` hooks — the same pair the
+ * connector builder uses — so the badge shows the real app logo + title.
+ *
+ * Complements the per-cell `ConnectorLockBadge` (field-grain provenance) with a
+ * record-grain marker. Renders `null` until resolved / when the source isn't a
+ * known connector, so unmanaged rows pay nothing visually.
+ */
+export function ConnectorSourceBadge({
+  integrationSource,
+  variant,
+  className,
+}: ConnectorSourceBadgeProps) {
+  const connector = useConnector(integrationSource)
+  // Resolve nothing until the source maps to a known connector. Gating the
+  // inner component here means hand-created records (the common case) never read
+  // `useAppsContext` — so the badge is safe to render in tables that may live
+  // outside `AppsProvider` (e.g. KB articles), which carry no integrationSource.
+  if (!connector) return null
+  return <ResolvedSourceBadge connector={connector} variant={variant} className={className} />
+}
+
+function ResolvedSourceBadge({
+  connector,
+  variant,
+  className,
+}: { connector: ResolvedConnector } & Pick<ConnectorSourceBadgeProps, 'variant' | 'className'>) {
+  const { appInstallations } = useAppsContext()
+
+  const app = useMemo(() => {
+    const slug = slugFromType(connector.type)
+    return appInstallations.find(
+      (i) => i.installationId === connector.appInstallationId || (slug && i.app.slug === slug)
+    )?.app
+  }, [connector, appInstallations])
+
+  // Prefer the connector's own name (e.g. "Shopify Customers"); fall back to the
+  // app title. Logo = the app's uploaded avatar, else a generic plug.
+  const label = connector.name || app?.title || 'a data connector'
+  const iconId = app?.avatarUrl ?? 'plug'
+
+  if (variant === 'icon') {
+    return (
+      <Tooltip content={`Synced from ${label}`} side='top'>
+        <AppIcon iconId={iconId} fallbackIconId='plug' size='xs' className={className} />
+      </Tooltip>
+    )
+  }
+
+  return (
+    <Tooltip content={`Synced from ${label}`} side='top'>
+      <Badge variant='gray' size='sm' className={cn('gap-1', className)}>
+        <AppIcon iconId={iconId} fallbackIconId='plug' size='xs' />
+        {label}
+      </Badge>
+    </Tooltip>
+  )
+}

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -31,6 +31,7 @@ import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-insta
 import { BaseEntityDrawer } from '~/components/drawers/base-entity-drawer'
 import { getHeaderActions } from '~/components/drawers/drawer-action-registry'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
+import { ConnectorSourceBadge } from '~/components/fields/connector-source-badge'
 import { Tooltip } from '~/components/global/tooltip'
 import { CommandContext, RecordCommandActions } from '~/components/kbar/contextual'
 import { KopilotContext } from '~/components/kopilot/context'
@@ -423,14 +424,23 @@ export const RecordDrawer = React.memo(function RecordDrawer({
                 inverse
               />
             )}
-            <div className='flex flex-col align-start w-full'>
-              <div className='text-lg font-medium text-neutral-900 dark:text-neutral-400 truncate'>
-                {isRecordLoading ? (
-                  <div className='mb-1'>
-                    <Skeleton className='h-6 w-80' />
-                  </div>
-                ) : (
-                  displayName || 'Untitled'
+            <div className='flex flex-col align-start w-full min-w-0'>
+              <div className='flex items-center gap-2 min-w-0'>
+                <div className='text-lg font-medium text-neutral-900 dark:text-neutral-400 truncate min-w-0'>
+                  {isRecordLoading ? (
+                    <div className='mb-1'>
+                      <Skeleton className='h-6 w-80' />
+                    </div>
+                  ) : (
+                    displayName || 'Untitled'
+                  )}
+                </div>
+                {!isRecordLoading && (
+                  <ConnectorSourceBadge
+                    integrationSource={cachedRecord?.integrationSource}
+                    variant='chip'
+                    className='shrink-0'
+                  />
                 )}
               </div>
               <div className='text-xs text-neutral-500 truncate'>

--- a/apps/web/src/components/resources/hooks/use-connector-name.ts
+++ b/apps/web/src/components/resources/hooks/use-connector-name.ts
@@ -5,15 +5,27 @@
 import { useMemo } from 'react'
 import { api } from '~/trpc/react'
 
+/** The connector fields the source/lock badges need. */
+export interface ResolvedConnector {
+  id: string
+  name: string
+  /** Connector type, e.g. `"app:shopify"` | `"generic-rest"`. */
+  type: string
+  /** Installed-app id for app connectors; null for built-ins. Bridges to `useAppsContext`. */
+  appInstallationId: string | null
+}
+
 /**
- * Resolve a DataConnector's display name from its id for the field-lock badges.
+ * Resolve a DataConnector row from its id.
  *
  * Reads the org-scoped `dataConnector.list` query — React Query dedupes the
- * request so every owned/contributing cell shares one fetch. The query only
- * fires when a `connectorId` is present (the vast majority of fields have none),
- * so unmanaged grids pay nothing.
+ * request so every owned/contributing cell and source badge shares one fetch.
+ * The query only fires when a `connectorId` is present (the vast majority of
+ * fields have none), so unmanaged grids pay nothing.
  */
-export function useConnectorName(connectorId: string | null | undefined): string | undefined {
+export function useConnector(
+  connectorId: string | null | undefined
+): ResolvedConnector | undefined {
   const { data } = api.dataConnector.list.useQuery(undefined, {
     enabled: !!connectorId,
     staleTime: 5 * 60 * 1000,
@@ -21,6 +33,21 @@ export function useConnectorName(connectorId: string | null | undefined): string
 
   return useMemo(() => {
     if (!connectorId || !data) return undefined
-    return data.find((c) => c.id === connectorId)?.name
+    const row = data.find((c) => c.id === connectorId)
+    if (!row) return undefined
+    return {
+      id: row.id,
+      name: row.name,
+      type: row.type,
+      appInstallationId: row.appInstallationId ?? null,
+    }
   }, [connectorId, data])
+}
+
+/**
+ * Resolve a DataConnector's display name from its id for the field-lock badges.
+ * Thin wrapper over {@link useConnector}.
+ */
+export function useConnectorName(connectorId: string | null | undefined): string | undefined {
+  return useConnector(connectorId)?.name
 }

--- a/apps/web/src/components/resources/hooks/use-record-batch-fetcher.ts
+++ b/apps/web/src/components/resources/hooks/use-record-batch-fetcher.ts
@@ -82,6 +82,7 @@ export function useRecordBatchFetcher() {
         displayName: item.displayName,
         secondaryInfo: item.secondaryInfo,
         avatarUrl: item.avatarUrl,
+        integrationSource: item.integrationSource ?? null,
       }
 
       const entityDefinitionId = getDefinitionId(canonicalRecordId)

--- a/apps/web/src/components/resources/store/record-store.ts
+++ b/apps/web/src/components/resources/store/record-store.ts
@@ -26,6 +26,12 @@ export interface RecordMeta {
   avatarUrl?: string
   createdAt: string | Date
   updatedAt: string | Date
+  /**
+   * Data-connector / integration provenance (from `EntityInstance.integrationSource`).
+   * Holds the owning DataConnector id for synced records; null/undefined otherwise.
+   * Drives the "Synced from <connector>" source badge.
+   */
+  integrationSource?: string | null
   /** Additional database fields from the specific resource table */
   [key: string]: unknown
 }

--- a/docs/kopilot-architecture-guide.md
+++ b/docs/kopilot-architecture-guide.md
@@ -1,0 +1,282 @@
+# Kopilot Architecture Guide
+
+Kopilot is an AI-powered assistant embedded in the Auxx.ai web app. A single agent owns the full turn: it calls page-scoped tools in a loop, writes structured `auxx:*` reference fences, and ends the turn implicitly when it stops calling tools (or explicitly via an `endsTurn` tool).
+
+## System at a Glance
+
+```
+User Input (Composer)
+  |
+  v
+SSE POST /api/kopilot/stream ──── Auth + Feature Gate
+  |                                └─ resolveContinuationSurface (restore page/context
+  |                                   for approval-resume / task-notification turns)
+  v
+AgentEngine (in-process or BullMQ worker)
+  |
+  ├── Context Manager ── compress old messages if over token budget
+  ├── KopilotContextStore ── hydrate domainState.__context (vars, captured tool calls)
+  ├── Solo Agent (query loop, up to 30 iterations)
+  │     ├── buildMessages: system prompt + transformed history
+  │     ├── LLM call (streaming, tool-calling)
+  │     ├── applyContextDefaults: pre-fill binding args from session refs
+  │     ├── execute tool calls → onToolResult / transformToolResult hooks
+  │     ├── endsTurn tool succeeded → finalize turn without re-invoking LLM
+  │     └── stop when LLM returns no tool calls (final prose + fences)
+  ├── Snapshot Walker ── mines tool outputs for entity/thread/task/doc snapshots
+  └── postProcessFinalContent ── inject snapshots, extract auxx://-link snapshots
+  |
+  v
+SSE Events → Frontend Store → UI Render
+  |                └─ task-watch-store: poll async-task refs → inject
+  |                   <task-notification> message → new turn
+  v
+Persist: messages + domainState (incl. __context) + linkSnapshots → AiAgentSession (JSONB)
+```
+
+## Solo Agent, Not a Pipeline
+
+The previous design used a multi-agent pipeline (supervisor → planner → executor → responder) with a route table. That has been collapsed into a **single agent** (`agents/agent.ts`) registered against a single `default` route. There is no supervisor, no planner agent, and no separate responder.
+
+Multi-step planning is now a tool concern, not an agent concern: the agent calls `plan_create` to publish steps and `plan_update_step` to advance them. The plan lives on `KopilotDomainState.plan` and persists across turns until replaced.
+
+## Execution Context (chat v9)
+
+A shared `ContextManager` interface is threaded onto every `ToolContext` as `ctx.context`, so a tool reaches turn state the same way whether it runs in plain chat, internal Kopilot, or inside a workflow AI node. Two backing stores conform to it: `KopilotContextStore` (the full implementation) and the workflow `ExecutionContextManager` (via thin adapters).
+
+Values are addressed by a typed string grammar (`ContextRef`), parsed once into `(kind, root, path)` and navigated by one shared path walker:
+
+- `var:*` — scratch namespace, **persists across turns** (e.g. `var:cart.total`)
+- `tool:*` / `call:*` — captured tool invocations, **turn-scoped** (`tool:search_entities` latest, `tool:search_entities[]` all, `call:<toolCallId>` exact)
+- `sys:*` — read-only system values (`userId`, `orgId`, `now`, `agentName`)
+- `FieldReference` — v8 entity-field grammar, resolved off `Subject.anchors`, memoized per turn
+
+The store serializes onto `domainState.__context` (`CONTEXT_SLICE_KEY`): `vars` survives across turns; the optional `turn` sub-slice (captured tool outputs) survives an approval pause/resume but is wiped by `resetTurn()` on a new user message. A 256KB cap drops the turn slice on overflow.
+
+**Input bindings** (renamed from `restrictions`): tools declare `inputBindings?: ReadonlyArray<{ name; default: VarSource }>` on `AgentToolDefinition` to wire arguments to context sources.
+
+## Session Context Refs & Arg Pre-fill
+
+The composer's context chips (current page, `@`-mentions) flow in as `SessionContext.references`. Three layers agree on precedence (mention wins over surface):
+
+1. The agent prompt teaches the model about "Active references".
+2. `applyContextDefaults()` (`kopilot/context-refs.ts`) pre-fills empty binding args (`threadId`, `articleId`, `knowledgeBaseId`, `actorId`) from the matching ref before dispatch — even if the model ignored the prompt.
+3. `findRef()` / `findAllRefs()` give tools direct access to the same precedence rules.
+
+`record` is deliberately not auto-bound: pages often have several record-ish things live at once, and silently routing the wrong one is worse than asking.
+
+## Async Task Notifications
+
+Tools that fire background work (BullMQ jobs, minutes-long eval suites) opt into async continuation instead of blocking the loop: they return immediately with `taskNotification: { kind, ref }` in their success output. The client (`task-watch-store` + `use-task-watchers`) watches the ref; when the task reaches a terminal state, it injects a server-built `<task-notification>` message that triggers a new Kopilot turn automatically.
+
+Per-kind handlers (`task-notifications/kinds/`) know how to load the task, check terminal status, and summarize the outcome for the follow-up turn — `eval-suite` is the first kind (`run_eval_suite` tool). Convention doc: `plans/kopilot/task-notifications/convention.md`.
+
+## Continuation Surfaces
+
+Approval-resume and task-notification turns POST to `/api/kopilot/stream` without `page`/`context`, which used to drop the original page-scoped tools. `resolveContinuationSurface()` (`kopilot/continuation-surface.ts`) restores the persisted surface (`LAST_PAGE_KEY` / `LAST_CONTEXT_KEY` on `domainState`) **only for continuation turns** — fresh message turns deliberately stay page-less (global tools only), and live request values always win when present.
+
+## Terminal Tools & Tool Categories
+
+- **`endsTurn`** — a tool marked `endsTurn: true` is a turn-terminal UI directive. When all tool calls in an iteration are `endsTurn` tools and all succeed, the query loop finalizes the turn immediately without re-invoking the LLM; the prose emitted alongside the call becomes the final reply (e.g. `suggest_replies`).
+- **`category`** — tools self-classify for UI visibility: `control` (agent-loop plumbing like plan tools; hidden from user-facing lists, exempt from eval mock wrapping), `system` (platform built-ins like entity reads; collapsed by default in the eval mock editor), `capability` (default; ordinary user-meaningful tools).
+
+## Beyond Chat: Runners, Effective Runtime, Evals
+
+The Kopilot engine is reused outside the chat surface:
+
+- **Runners** (`kopilot/runners/`) — `run-workflow-ai-turn.ts` drives workflow AI nodes through the same agent loop; `run-structured-output-pass.ts` runs single-shot structured extraction.
+- **Effective runtime** (`agent-framework/effective-runtime.ts`) — unified execution abstraction covering capture mode, mock tools, and field overlays, so the same agent definition runs live, dry, or simulated. This is also the production path that wires MCP capabilities, applies per-agent toolset scoping, and sets `maxIterations` (30 for Kopilot).
+- **Live customer chat** (`packages/lib/src/chat/agent/`) — the visitor-facing chat agent runs on the same engine via `build-chat-engine-config.ts`, differentiated by surface/audience (below) rather than a separate pipeline.
+- **Evals** (`packages/lib/src/evals/`) — assertion-graded simulation suites run agents through the effective runtime with mocked tools, support draft-vs-pinned procedure binding and baseline diffing, and report back into chat via the `run_eval_suite` tool + task notification.
+
+## Surface & Audience
+
+The same agent engine serves several rendering targets. Two orthogonal axes select prompt formatting and semantics; both default for Kopilot but are set explicitly by the chat/email surfaces:
+
+- **`surface`** (`AgentSurface = 'internal' | 'chat' | 'email' | 'builder'`, `agents/client.ts`) — the rendering medium. `builder` emits rich `auxx:*` reference fences (internal Kopilot); `chat`/`email` emit plain text for customer channels.
+- **`audience`** (`'member' | 'customer'`) — who reads the output. `member` enables internal/debugging framing; `customer` switches the job-statement and house rules to a customer-facing voice.
+
+`effective-runtime.ts` derives both when not explicitly passed: a customer trigger ⇒ `audience: 'customer'`, and the surface is inferred from the trigger/channel (chat vs email). Kopilot defaults to `surface: 'builder', audience: 'member'`; the live chat agent sets `surface: 'chat', audience: 'customer'` in `build-chat-engine-config.ts`. Prompt sections (`prompts/sections/job-statement.ts`, `chat-formatting.ts`, `house-rules.ts`) branch on these. Tools may also declare `surfaces?: AgentSurface[]` to opt out of surfaces where they don't apply.
+
+## MCP Integration
+
+Client-side MCP servers contribute tools to the agent loop as a **global capability** (`ai/mcp/`, a ~20-file subsystem separate from `kopilot/`). `createMcpCapabilities({ organizationId, autonomous })` (`mcp/capabilities.ts`) is registered by the effective runtime and the chat-engine config, so MCP tools appear alongside native capabilities for both Kopilot and customer agents.
+
+- **Adaptation** — `buildMcpAgentTools()` (`mcp/tool-adapter.ts`) wraps each MCP tool as an `AgentToolDefinition`, names it `mcp__<server>__<tool>`, and sets `requiresApproval` from `readOnlyHint`/`trusted` so writes pause for HITL by default.
+- **Untrusted output** — results are marked with an output boundary (`outputBoundary: { server, tool }`) and fenced as untrusted before reaching the model.
+- **Autonomous runs** drop untrusted write tools entirely.
+- **Resilience** — `rate-limiter.ts` caps per-turn/org MCP calls; `call-with-auth-retry.ts` retries and flags 401s for reconnect. Server discovery/sync/auth live in `mcp/{discovery,sync,auth,client}.ts`.
+
+## Per-Agent Tool Scoping
+
+Agents don't get every registered tool. Toolsets are scoped per-agent (allow-list semantics), and the agent builder edits them via the `set_agent_toolsets` tool (`capabilities/agents-builder/`), which accepts `enabledTools?: string[]` per toolset — for MCP servers this restricts which of the server's tools the agent may call. Selections validate against the org toolset catalog for the surface (`agents/toolset-catalog.ts`) and are applied at session init before domain-config assembly.
+
+## Key Design Decisions
+
+- **Async generators everywhere** — the engine and query loop yield `AgentEvent` objects, enabling real-time SSE streaming without buffering.
+- **JSONB message storage** — full conversation history (messages + domainState) persisted as JSONB in `AiAgentSession`, not normalized rows.
+- **Page-scoped capabilities** — tools are registered per page (e.g., mail tools only on the mail page). Entity / actor / knowledge tools are global (`__global__`).
+- **Human-in-the-loop (HITL)** — tools marked `requiresApproval` pause the loop. The frontend renders an approval card; on approve/reject (with optional input amendment), the engine resumes. Captured tool outputs survive the pause via the `__context` turn slice.
+- **Reference fences, not blocks-as-content** — the agent writes prose with `auxx:<type>` fenced JSON references (entities, threads, tasks, plan-steps, docs, tables). The frontend resolves them against per-message snapshots into interactive cards.
+- **Snapshot mining** — every tool output is walked for entity / thread / task ids; knowledge tools also contribute doc snapshots. Captured into `state.turnSnapshots` and injected into the final assistant message before persistence.
+- **Inline `auxx://` links** — references inside prose (e.g. `[ACME](auxx://entity/companies/abc)`) get a per-message `linkSnapshots` lookup so hover cards work after reload without any tool replay.
+- **Plan as state** — plans live on `KopilotDomainState.plan` and survive across turns. `plan_update_step` validates the patch against the current plan and surfaces explicit errors back to the LLM via `transformToolResult`.
+- **Real-USD usage metering** — every LLM call records actual provider COGS (including prompt-cache costs) with provider type (`SYSTEM` vs BYOK) and credential source per iteration; credits are derived from list-price USD, not flat multipliers (`packages/lib/src/ai/quota/`, `ai/usage/`).
+- **Realtime refresh, not rail signals** — admin-side mutations (agent builder, procedures) emit `agent:updated` / `procedure:updated` realtime events on the org channel; clients use them as refresh signals instead of tool-output rail hacks.
+- **Handoff as pure intent** — the unified `handoff` tool (`chat/agent/tools/handoff.ts`) doesn't flip thread state itself; it writes a `{ kind: 'handoff' }` signal into the context store. A single post-turn applier (`flipHandoffState`, `chat/agent/handoff.ts`) performs the actual state flip, so chat and procedure agents share one tool and one flip site.
+
+## File Map
+
+```
+packages/lib/src/ai/
+├── agent-framework/             # Generic agent engine (domain-agnostic)
+│   ├── types.ts                 # AgentState, AgentEvent, AgentDefinition, ToolCategory,
+│   │                            # endsTurn, inputBindings, taskNotification, IterationUsage
+│   ├── engine.ts                # AgentEngine — turn orchestration, persistence, resume
+│   ├── query-loop.ts            # Single-agent tool loop (incl. endsTurn finalization)
+│   ├── context-manager.ts       # Token budget / message compression (NOT the ctx.context store)
+│   ├── context/                 # Chat-v9 execution context (ctx.context)
+│   │   ├── context-manager.ts   # ContextManager contract, ContextRef grammar
+│   │   ├── context-store.ts     # KopilotContextStore — vars, captured calls, __context slice
+│   │   ├── context-ref.ts       # parseContextRef()
+│   │   ├── path-walker.ts       # Shared path navigation
+│   │   └── sources/             # field-source (v8 FieldReference), sys-source
+│   ├── effective-runtime.ts     # Unified live/capture/mock execution (evals)
+│   ├── capture-mode.ts          # CapturedAction collection during dry runs
+│   ├── sessions/                # catchup-replay, find-or-create-thread-session
+│   ├── builder-model.ts
+│   ├── trigger-seed-message.ts
+│   ├── llm-adapter.ts           # LLM provider abstraction (callModel)
+│   ├── event-publisher.ts       # Redis pub/sub for SSE events
+│   ├── tool-bridge.ts           # AgentToolDefinition → LLM tool schema + executor
+│   ├── tool-context.ts          # ToolContext type passed to tool handlers
+│   ├── tool-inputs.ts           # Shared input schemas (pagination, etc.)
+│   ├── flatten-messages.ts      # Model-switch helpers (clean state, flatten history)
+│   ├── run-log.ts               # withAgentRunLog — per-run debug log wrapper
+│   ├── enqueue-agent-job.ts     # BullMQ job creation
+│   ├── process-agent-job.ts     # BullMQ job handler (worker mode)
+│   └── utils.ts
+│
+├── kopilot/                     # Kopilot domain layer
+│   ├── types.ts                 # KopilotDomainState, SessionContext, PlanState, PlanStep
+│   ├── domain-config.ts         # Solo-agent config: tools, onToolResult, postProcessFinalContent
+│   ├── context-refs.ts          # findRef / applyContextDefaults — session-ref arg pre-fill
+│   ├── continuation-surface.ts  # resolveContinuationSurface — restore page/context on resume
+│   ├── task-notifications/      # Async-task continuation
+│   │   ├── types.ts             # TaskNotificationRef, TaskSnapshot, kind handler contract
+│   │   ├── registry.ts          # Handler lookup by kind
+│   │   ├── body.ts              # buildTaskNotificationBody — the injected message
+│   │   └── kinds/eval-suite.ts  # Eval-suite kind handler
+│   ├── runners/                 # Engine reuse beyond chat
+│   │   ├── run-workflow-ai-turn.ts
+│   │   └── run-structured-output-pass.ts
+│   ├── session-title.ts         # Auto-generate session titles
+│   ├── digests.ts               # Tool digest definitions (pills, card payloads)
+│   ├── load-master-settings.ts
+│   ├── agents/
+│   │   └── agent.ts             # createKopilotAgent — buildMessages + tools
+│   ├── blocks/
+│   │   ├── block-types.ts       # auxx:* fence type definitions
+│   │   ├── snapshot-walker.ts   # Mine entity/thread/task ids out of tool outputs
+│   │   ├── extract-link-snapshots.ts  # Capture auxx:// hrefs from final prose
+│   │   ├── inject-snapshots.ts        # Embed turn snapshots into final assistant message
+│   │   └── transform-for-llm.ts # Render auxx:* fences as numbered text for the LLM view
+│   ├── capabilities/
+│   │   ├── types.ts             # PageCapability, CapabilityRegistry
+│   │   ├── registry.ts          # Capability registration
+│   │   ├── create-deps.ts       # Tool dependency injection
+│   │   ├── actors/              # list_members, list_groups (global)
+│   │   ├── agents-builder/      # Agent/procedure builder tools incl. run_eval_suite,
+│   │   │                        # suggest_replies (endsTurn)
+│   │   ├── apps/                # Installed-app tools
+│   │   ├── entities/            # CRUD + search + history + notes + transcripts (global)
+│   │   ├── kb/                  # Knowledge-base authoring tools
+│   │   ├── knowledge/           # search_docs, search_knowledge (global)
+│   │   ├── kopilot/             # plan_create, plan_update_step (global)
+│   │   ├── mail/                # find_threads, reply_to_thread, drafts, tags, … (mail page)
+│   │   ├── tasks/               # list_tasks, create_task (global)
+│   │   └── workflow/            # Workflow-builder tools
+│   └── prompts/
+│       ├── build-kopilot-prompt.ts   # Top-level prompt assembler
+│       ├── core-runtime-prompt.ts    # Shared runtime preamble
+│       ├── agent-persona-prompt.ts / kopilot-master-persona.ts
+│       ├── resolve-instruction-references.ts
+│       └── sections/                 # Composable prompt sections, branch on surface/audience:
+│                                     # job-statement, chat-formatting, house-rules, entity-catalog,
+│                                     # integration-catalog, block-catalog, active-refs, approval,
+│                                     # toolset-additions, trigger-*, agent-procedure-step, …
+│
+├── mcp/                         # Client-side MCP server subsystem (Kopilot + agents)
+│   ├── capabilities.ts          # createMcpCapabilities — global page capability
+│   ├── tool-adapter.ts          # buildMcpAgentTools — MCP tool → AgentToolDefinition
+│   ├── tool-schema.ts           # JSON-schema bridging
+│   ├── client.ts / auth.ts / call-with-auth-retry.ts  # Connection + 401 reconnect
+│   ├── discovery.ts / sync.ts / manage.ts             # Server lifecycle
+│   ├── rate-limiter.ts          # Per-turn/org MCP call caps
+│   ├── connections/ / templates/ / snippet/
+│   └── types.ts                 # CachedMcpServer, MCP types
+│
+└── ../chat/agent/               # Live customer chat agent (same engine, surface='chat')
+    ├── build-chat-engine-config.ts  # Wires surface/audience, MCP, toolsets for visitor chat
+    ├── tools/handoff.ts             # Unified handoff tool (pure intent)
+    └── handoff.ts                   # flipHandoffState — single post-turn applier
+
+packages/lib/src/agents/
+├── client.ts                    # AgentSurface type, ALL_SURFACES
+└── toolset-catalog.ts           # Per-surface org toolset catalog (tool scoping)
+
+packages/lib/src/evals/          # Eval framework (suites, grader, mock execution,
+                                 # draft/pinned binding, baseline diffing)
+
+apps/web/src/
+├── app/api/kopilot/stream/route.ts      # SSE endpoint (+ continuation-surface resolution)
+├── server/api/routers/kopilot.ts        # tRPC router (sessions, feedback, prompts)
+├── components/kopilot/
+│   ├── stores/
+│   │   ├── kopilot-store.ts             # Zustand (messages, thinking, streaming)
+│   │   ├── task-watch-store.ts          # Async-task watchers (poll + inject notification)
+│   │   ├── select-context.ts
+│   │   └── select-suggestions.ts
+│   ├── hooks/
+│   │   ├── use-kopilot-sse.ts           # SSE event consumer
+│   │   ├── use-task-watchers.tsx        # Wires task-watch-store into the session
+│   │   ├── use-smooth-stream.ts
+│   │   ├── use-tool-app-resolver.ts
+│   │   ├── use-kopilot-sessions.ts      # Session CRUD
+│   │   ├── kopilot-session-cache.ts
+│   │   ├── use-prompt-templates.ts
+│   │   └── use-prompt-template-mutations.ts
+│   ├── context/                         # KopilotContext provider + chip strip
+│   ├── suggestions/                     # Slash-command / quick-action suggestions
+│   ├── options/
+│   ├── styles/                          # kopilot-prose.css (markdown typography)
+│   └── ui/
+│       ├── kopilot-panel.tsx            # Main container (page mode)
+│       ├── kopilot-dock.tsx             # Floating dock mode
+│       ├── kopilot-runtime.tsx
+│       ├── kopilot-chat.tsx             # Chat surface
+│       ├── kopilot-page-shell.tsx
+│       ├── kopilot-message-list.tsx
+│       ├── kopilot-composer.tsx         # TipTap editor + slash commands
+│       ├── kopilot-reply-chip-strip.tsx
+│       ├── kopilot-session-list.tsx
+│       ├── kopilot-session-picker.tsx
+│       ├── kopilot-empty-state.tsx
+│       ├── messages/                    # user / assistant / tool message renderers,
+│       │                                # thinking-steps, tool-status pills, branch nav,
+│       │                                # task-notification-chip, eval-suite-progress
+│       ├── blocks/                      # auxx:* fence renderers + approval cards
+│       │                                # (incl. table-block, block-card wrapper)
+│       ├── pickers/                     # Prompt-template picker
+│       └── dialogs/                     # Prompt-template dialogs
+
+packages/database/src/db/schema/
+├── ai-agent-session.ts                  # Sessions + messages + domainState (JSONB)
+├── ai-message-feedback.ts               # Thumbs up/down per message
+├── ai-integration.ts                    # Provider API keys
+├── ai-usage.ts                          # Token usage tracking (incl. cache costs, provider type)
+├── ai-suggestion.ts                     # Cached suggestions
+├── eval-case.ts / eval-run.ts / eval-suite-run.ts  # Eval framework
+├── prompt-template.ts                   # Reusable prompt templates
+└── prompt-history.ts                    # Prompt audit log
+```

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -205,11 +205,31 @@ export interface CatalogConnectorField {
   capabilities?: { hidden?: boolean; filterable?: boolean }
 }
 
+/**
+ * Provisioning declaration for a parent↔child relationship edge (v5). Drives
+ * auto-creation of the relationship field (+ inverse) on the parent def at
+ * connector materialization. Mirrors the SDK `ConnectorRelationshipDecl`.
+ */
+export interface CatalogConnectorRelationshipDecl {
+  /** Stable field key of the edge created on the PARENT def (== `relationshipFieldKey`). */
+  fieldKey: string
+  /** Display name for the forward edge (e.g. `'Line Items'`). */
+  name: string
+  /** Forward cardinality from PARENT → this mapping's target. */
+  cardinality: 'has_many' | 'has_one' | 'belongs_to' | 'many_to_many'
+  /** Display name for the auto-created inverse edge on the child/target def. */
+  inverseName: string
+  /** Target def; omit for an owned child (resolves to the mapping's own provisioned def). */
+  targetRef?: { ownedApiSlug: string } | { entityKind: string }
+}
+
 /** A recommended fan-out mapping projected from a data connector's stream. */
 export interface CatalogConnectorDefaultMapping {
   rootPath: string
   linkMode?: 'upsert' | 'reference'
   relationshipFieldKey?: string
+  /** Provisioning decl for the parent↔child edge — auto-creates the field at materialization. */
+  relationship?: CatalogConnectorRelationshipDecl
   target:
     | {
         mode: 'owned'

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -5,7 +5,13 @@
 // re-registration is driven from create/update (pause/resume is a `status` patch
 // through update) so a cadence or lifecycle change is reflected in BullMQ immediately.
 
-import { type CatalogDataConnector, type Database, schema, type Transaction } from '@auxx/database'
+import {
+  type CatalogConnectorRelationshipDecl,
+  type CatalogDataConnector,
+  type Database,
+  schema,
+  type Transaction,
+} from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { getFieldDefinitionId, getFieldId, toResourceFieldId } from '@auxx/types/field'
@@ -27,7 +33,12 @@ import {
   classifyStreamRequestChange,
   type StructuralImpact,
 } from './edit-impact'
-import { type ProvisionFieldSpec, provisionTarget } from './provisioning'
+import {
+  type ProvisionFieldSpec,
+  provisionRelationshipField,
+  provisionTarget,
+  resolveRelationshipTargetDefId,
+} from './provisioning'
 import {
   countConnectorItems,
   countMappingItems,
@@ -418,33 +429,122 @@ export async function createConnectorFromAppCatalog(
     ...input,
     definitionKind: 'app',
   })
+
+  // Owned materialization is a CONNECTOR-LEVEL two-pass (owned-relationship-provisioning-plan §3.3):
+  // an edge references a target def by id, and a cross-stream `reference` targets ANOTHER stream's
+  // def — so ALL defs must exist before ANY edge is provisioned. Pass 1 creates defs + scalar fields
+  // + mappings (+ parentMappingId) across every stream, accumulating `apiSlug → defId`; pass 2 then
+  // provisions every declared relationship edge.
+  const defIdByApiSlug: Record<string, string> = {}
+  const pendingEdges: PendingOwnedEdge[] = []
   for (const stream of catalog.streams) {
     const streamRow = await addStream(db, organizationId, connector.id, {
       streamKey: stream.key,
       ...appCatalogStreamSchema(stream),
       syncMode: stream.syncMode ?? 'snapshot',
     })
-    await materializeAppOwnedMappings(db, organizationId, connector.id, streamRow.id, stream)
+    await provisionStreamOwnedDefs(
+      db,
+      organizationId,
+      connector.id,
+      streamRow.id,
+      stream,
+      defIdByApiSlug,
+      pendingEdges
+    )
     await materializeAppContributingMappings(db, organizationId, streamRow.id, stream)
   }
+
+  // Pass 2 — edges. Every def now exists, so each declared relationship resolves its target.
+  for (const edge of pendingEdges) {
+    const relatedResourceId = await resolveRelationshipTargetDefId(
+      db,
+      organizationId,
+      edge.relationship.targetRef,
+      edge.ownTargetDefId,
+      defIdByApiSlug
+    )
+    if (!relatedResourceId) {
+      logger.warn('Skipping connector relationship edge — target def unresolved', {
+        dataConnectorId: connector.id,
+        fieldKey: edge.relationship.fieldKey,
+        targetRef: edge.relationship.targetRef,
+      })
+      continue
+    }
+    await provisionRelationshipField(
+      db,
+      organizationId,
+      connector.id,
+      edge.parentDefId,
+      relatedResourceId,
+      {
+        appFieldKey: edge.relationship.fieldKey,
+        name: edge.relationship.name,
+        cardinality: edge.relationship.cardinality,
+        inverseName: edge.relationship.inverseName,
+      }
+    )
+  }
+
   return connector
 }
 
+/** A relationship edge collected in pass 1, provisioned in pass 2 once every def exists. */
+interface PendingOwnedEdge {
+  relationship: CatalogConnectorRelationshipDecl
+  /** Def the forward edge lives on (the parent mapping's def). */
+  parentDefId: string
+  /** Default target when the edge has no `targetRef` — the declaring mapping's own owned def. */
+  ownTargetDefId: string
+}
+
 /**
- * Materialize a catalog stream's `owned` default-mappings into provisioned defs +
- * `DataConnectorMapping` rows. The declared stream fields ARE the owned def's schema,
- * so we provision the def + a field per declaration, then bind concrete
- * `${defId}:${fieldId}` refs (no `@app:` late-binding — the connector owns the def).
- * `contributing` targets are skipped (left to the stepper).
+ * The parent of `rootPath` among `all` is the mapping whose rootPath is the longest
+ * proper boundary-prefix: `''` parents everything, `line_items[]` parents
+ * `line_items[].variants[]`. A bare prefix that doesn't end on a path boundary
+ * (`line_items` vs `line_items_extra[]`) is rejected. Returns null for a root mapping.
  */
-async function materializeAppOwnedMappings(
+export function ownedParentRootPath(rootPath: string, all: string[]): string | null {
+  const isBoundaryPrefix = (parent: string) => {
+    if (parent === rootPath) return false
+    if (parent === '') return true
+    if (!rootPath.startsWith(parent)) return false
+    const next = rootPath[parent.length]
+    return next === '.' || next === '['
+  }
+  const parents = all.filter(isBoundaryPrefix)
+  if (parents.length === 0) return null
+  return parents.reduce((longest, p) => (p.length > longest.length ? p : longest))
+}
+
+/**
+ * Pass 1 of connector-level owned materialization: provision each owned mapping's def +
+ * scalar fields + `DataConnectorMapping` row (with `parentMappingId` wired from rootPath
+ * nesting so the fan-out's `parentRelation` forms). Accumulates `apiSlug → defId` into
+ * `defIdByApiSlug` (shared across streams so a cross-stream `reference` resolves) and
+ * appends each declared relationship to `pendingEdges` for pass 2. Relationship *fields*
+ * are NOT created here — that's pass 2, after every def exists
+ * (owned-relationship-provisioning-plan §3.3/§3.4).
+ */
+async function provisionStreamOwnedDefs(
   db: Database,
   organizationId: string,
   dataConnectorId: string,
   streamId: string,
-  stream: CatalogDataConnector['streams'][number]
+  stream: CatalogDataConnector['streams'][number],
+  defIdByApiSlug: Record<string, string>,
+  pendingEdges: PendingOwnedEdge[]
 ): Promise<void> {
-  for (const mapping of stream.defaultMappings ?? []) {
+  const owned = (stream.defaultMappings ?? []).filter((m) => m.target.mode === 'owned')
+  const allRootPaths = owned.map((m) => m.rootPath)
+  // Parents before children so a child's `parentMappingId` always resolves.
+  const ordered = [...owned].sort((a, b) => a.rootPath.length - b.rootPath.length)
+
+  const mappingIdByRootPath: Record<string, string> = {}
+  const defIdByRootPath: Record<string, string> = {}
+
+  for (const mapping of ordered) {
     if (mapping.target.mode !== 'owned') continue
     const { entity } = mapping.target
 
@@ -466,12 +566,16 @@ async function materializeAppOwnedMappings(
       }
     )
 
-    await addMapping(db, organizationId, {
+    const parentRootPath = ownedParentRootPath(mapping.rootPath, allRootPaths)
+    const parentMappingId = parentRootPath != null ? mappingIdByRootPath[parentRootPath] : null
+
+    const row = await addMapping(db, organizationId, {
       dataConnectorStreamId: streamId,
       rootPath: mapping.rootPath,
       linkMode: mapping.linkMode ?? ('upsert' as LinkMode),
       targetMode: 'owned' as TargetMode,
       entityDefinitionId,
+      parentMappingId,
       relationshipFieldKey: mapping.relationshipFieldKey ?? null,
       fieldMappings: buildOwnedFieldMappings(entityDefinitionId, fieldIdByKey, stream.fields),
       // Incremental connectors only see the delta each run, so unseen ≠ deleted —
@@ -479,6 +583,20 @@ async function materializeAppOwnedMappings(
       // reconcile; v1 keeps it safe.
       orphanBehavior: 'ignore' as OrphanBehavior,
     })
+
+    mappingIdByRootPath[mapping.rootPath] = row.id
+    defIdByRootPath[mapping.rootPath] = entityDefinitionId
+    defIdByApiSlug[entity.apiSlug] = entityDefinitionId
+
+    // Collect the edge for pass 2. The forward field lives on the PARENT def; with no
+    // parent (a root mapping) there's nothing to attach to, so skip.
+    if (mapping.relationship && parentRootPath != null) {
+      pendingEdges.push({
+        relationship: mapping.relationship,
+        parentDefId: defIdByRootPath[parentRootPath]!,
+        ownTargetDefId: entityDefinitionId,
+      })
+    }
   }
 }
 
@@ -525,7 +643,7 @@ export function buildOwnedFieldMappings(
 /**
  * Materialize a catalog stream's `contributing` default-mappings into draft
  * `DataConnectorMapping` rows — the symmetric counterpart to
- * {@link materializeAppOwnedMappings}. Unlike an owned target (the connector
+ * {@link provisionStreamOwnedDefs}. Unlike an owned target (the connector
  * provisions the def + binds every field), a contributing target merges INTO an
  * existing system def (e.g. `contact`), so we only resolve the def and best-effort
  * pre-bind the declared identity-match keys (`matchFieldKeys`, e.g. `['email']`). Any

--- a/packages/lib/src/data-connectors/owned-mappings.test.ts
+++ b/packages/lib/src/data-connectors/owned-mappings.test.ts
@@ -5,7 +5,7 @@
 
 import { toResourceFieldId } from '@auxx/types/field'
 import { describe, expect, it } from 'vitest'
-import { buildOwnedFieldMappings, ownedProvisionSpecs } from './mutations'
+import { buildOwnedFieldMappings, ownedParentRootPath, ownedProvisionSpecs } from './mutations'
 
 type CatalogField = Parameters<typeof ownedProvisionSpecs>[0][number]
 
@@ -92,5 +92,32 @@ describe('buildOwnedFieldMappings', () => {
     for (const m of mappings) {
       expect(m.targetFieldRef?.startsWith(`${defId}:`)).toBe(true)
     }
+  })
+})
+
+describe('ownedParentRootPath', () => {
+  // The fan-out's `parentRelation` only forms when each child mapping carries a
+  // `parentMappingId` — derived from rootPath nesting at materialization.
+  const ALL = ['', 'line_items[]', 'line_items[].variants[]']
+
+  it('a root mapping has no parent', () => {
+    expect(ownedParentRootPath('', ALL)).toBeNull()
+  })
+
+  it('a one-level child parents to the root', () => {
+    expect(ownedParentRootPath('line_items[]', ALL)).toBe('')
+  })
+
+  it('a nested child parents to the LONGEST proper prefix, not the root', () => {
+    expect(ownedParentRootPath('line_items[].variants[]', ALL)).toBe('line_items[]')
+  })
+
+  it('rejects a bare prefix that does not end on a path boundary', () => {
+    // `line_items` is a textual prefix of `line_items_extra[]` but not a path parent.
+    expect(ownedParentRootPath('line_items_extra[]', ['', 'line_items[]'])).toBe('')
+  })
+
+  it('returns null when no candidate prefix exists (no root declared)', () => {
+    expect(ownedParentRootPath('orders[].lines[]', ['orders[].lines[]', 'customers[]'])).toBeNull()
   })
 })

--- a/packages/lib/src/data-connectors/provisioning.test.ts
+++ b/packages/lib/src/data-connectors/provisioning.test.ts
@@ -6,10 +6,11 @@
 // field's own id. The DB orchestration (`provisionConnectorMappings`/`provisionTarget`)
 // has no vitest harness — this locks the derivation it feeds.
 
+import type { Database } from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
 import { toResourceFieldId } from '@auxx/types/field'
 import { describe, expect, it } from 'vitest'
-import { provisionSpecsForMapping } from './provisioning'
+import { provisionSpecsForMapping, resolveRelationshipTargetDefId } from './provisioning'
 import type { DecodedMapping } from './service'
 import type { FieldMapping } from './types'
 
@@ -77,5 +78,68 @@ describe('provisionSpecsForMapping', () => {
         isCreatable: false,
       },
     ])
+  })
+})
+
+describe('resolveRelationshipTargetDefId', () => {
+  const ORG = 'org_1'
+  // A db that explodes if touched — proves the owned/apiSlug branches never query.
+  const noDb = new Proxy(
+    {},
+    {
+      get: () => () => {
+        throw new Error('db must not be touched')
+      },
+    }
+  ) as unknown as Database
+
+  it('an owned child (no targetRef) resolves to its OWN provisioned def', async () => {
+    const id = await resolveRelationshipTargetDefId(noDb, ORG, undefined, 'def_line_item', {})
+    expect(id).toBe('def_line_item')
+  })
+
+  it('a cross-stream ownedApiSlug resolves from the connector-wide pass-1 map', async () => {
+    const id = await resolveRelationshipTargetDefId(
+      noDb,
+      ORG,
+      { ownedApiSlug: 'product' },
+      'def_line_item',
+      { product: 'def_product', order: 'def_order' }
+    )
+    expect(id).toBe('def_product')
+  })
+
+  it('an unresolved ownedApiSlug (disabled stream) returns null — caller skips the edge', async () => {
+    const id = await resolveRelationshipTargetDefId(
+      noDb,
+      ORG,
+      { ownedApiSlug: 'product' },
+      'def_line_item',
+      {}
+    )
+    expect(id).toBeNull()
+  })
+
+  it('an entityKind targetRef resolves the system/contributing def by kind', async () => {
+    const calls: unknown[] = []
+    const fakeDb = {
+      query: {
+        EntityDefinition: {
+          findFirst: async (args: unknown) => {
+            calls.push(args)
+            return { id: 'def_contact' }
+          },
+        },
+      },
+    } as unknown as Database
+    const id = await resolveRelationshipTargetDefId(
+      fakeDb,
+      ORG,
+      { entityKind: 'contact' },
+      'def_line_item',
+      {}
+    )
+    expect(id).toBe('def_contact')
+    expect(calls).toHaveLength(1)
   })
 })

--- a/packages/lib/src/data-connectors/provisioning.ts
+++ b/packages/lib/src/data-connectors/provisioning.ts
@@ -14,8 +14,9 @@
 import { type Database, schema } from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
-import { createCustomField } from '@auxx/services/custom-fields'
+import { createCustomField, resolveEntityDefinitionIdByKind } from '@auxx/services/custom-fields'
 import { createEntityDefinition } from '@auxx/services/entity-definitions'
+import type { RelationshipType } from '@auxx/types/custom-field'
 import { toResourceFieldId } from '@auxx/types/field'
 import { and, eq } from 'drizzle-orm'
 import { getCachedCustomFields } from '../cache'
@@ -176,6 +177,102 @@ export async function provisionTarget(
   })
 
   return { entityDefinitionId: defId, provisionedFieldKeys, fieldIdByKey }
+}
+
+/** Where a relationship edge points. `undefined` ⇒ an owned child (the mapping's own def). */
+export type RelationshipTargetRef = { ownedApiSlug: string } | { entityKind: string }
+
+/** The parent↔child edge a mapping declares for provisioning (mirrors the catalog decl). */
+export interface ProvisionRelationshipSpec {
+  /** Stable key of the forward edge on the PARENT def (== `relationshipFieldKey`). */
+  appFieldKey: string
+  /** Display name for the forward edge. */
+  name: string
+  /** Forward cardinality from PARENT → target. */
+  cardinality: RelationshipType
+  /** Display name for the auto-created inverse edge on the target def. */
+  inverseName: string
+}
+
+/**
+ * Resolve a relationship edge's target `EntityDefinition.id`. For an owned child the
+ * target IS the mapping's own provisioned def (`ownTargetDefId`); a `targetRef` names a
+ * cross-stream owned def (by `apiSlug`, resolved from the connector-wide pass-1 map) or
+ * a contributing/system def (by `entityKind`). Returns null when the target can't be
+ * resolved (e.g. a disabled stream) so the caller skips the edge rather than pointing it
+ * at a non-existent def.
+ */
+export async function resolveRelationshipTargetDefId(
+  db: Database,
+  organizationId: string,
+  targetRef: RelationshipTargetRef | undefined,
+  ownTargetDefId: string,
+  defIdByApiSlug: Record<string, string>
+): Promise<string | null> {
+  if (!targetRef) return ownTargetDefId
+  if ('ownedApiSlug' in targetRef) return defIdByApiSlug[targetRef.ownedApiSlug] ?? null
+  return resolveEntityDefinitionIdByKind({ kind: targetRef.entityKind, organizationId }, db)
+}
+
+/**
+ * Provision the parent↔child relationship edge (+ auto-created inverse) on the PARENT
+ * def. Idempotent per `(dataConnectorId, appFieldKey)` exactly like a scalar field
+ * (mirrors {@link provisionField}): looks up an existing forward edge by `appFieldKey` on
+ * the parent def, re-stamping ownership if the FK was nulled on a prior delete; creates
+ * via `createCustomField({ type: 'RELATIONSHIP' })` otherwise — the relationship-capable
+ * service that also auto-wires the inverse (NOT the app-field provisioner that bans
+ * relationships). The forward field is the idempotency anchor, so a re-run short-circuits
+ * here before re-entering the creator and never duplicates the inverse.
+ *
+ * `relatedResourceId` is the resolved target def id (see {@link resolveRelationshipTargetDefId});
+ * pass a non-null value — a null target must be skipped by the caller.
+ */
+export async function provisionRelationshipField(
+  db: Database,
+  organizationId: string,
+  dataConnectorId: string,
+  parentDefId: string,
+  relatedResourceId: string,
+  spec: ProvisionRelationshipSpec
+): Promise<{ id: string; created: boolean } | null> {
+  // Idempotent adoption: match by appFieldKey WITHOUT a dataConnectorId filter so a
+  // delete+reconnect re-adopts the orphaned edge instead of colliding (see provisionField).
+  const existingFields = await getCachedCustomFields(organizationId, parentDefId)
+  const existing = existingFields.find((f) => f.appFieldKey === spec.appFieldKey)
+  if (existing) {
+    if (existing.dataConnectorId !== dataConnectorId) {
+      await db
+        .update(schema.CustomField)
+        .set({ dataConnectorId, updatedAt: new Date() })
+        .where(eq(schema.CustomField.id, existing.id))
+    }
+    return { id: existing.id, created: false }
+  }
+
+  const result = await createCustomField({
+    organizationId,
+    entityDefinitionId: parentDefId,
+    name: spec.name,
+    type: 'RELATIONSHIP' as FieldType,
+    appFieldKey: spec.appFieldKey,
+    dataConnectorId,
+    // Connector-owned edges are user-read-only, like every other provisioned field.
+    isUpdatable: false,
+    isCreatable: false,
+    relationship: {
+      relatedResourceId,
+      relationshipType: spec.cardinality,
+      inverseName: spec.inverseName,
+    },
+  })
+  if (result.isErr()) {
+    // A user/system field already owns this name → benign no-op (mirrors provisionField).
+    if (result.error.code === 'DUPLICATE_FIELD_NAME') return null
+    throw new Error(result.error.message)
+  }
+
+  await onCacheEvent('custom-field.created', { orgId: organizationId })
+  return { id: result.value.id, created: true }
 }
 
 /**

--- a/packages/lib/src/resources/picker/record-picker-service.ts
+++ b/packages/lib/src/resources/picker/record-picker-service.ts
@@ -608,6 +608,8 @@ export class RecordPickerService {
       avatarUrl: string | null
       createdAt: string
       updatedAt: string
+      integrationSource?: string | null
+      externalId?: string | null
     }
   ): RecordPickerItem {
     const { displayName, secondaryInfo } = resolveEntityDisplay(
@@ -621,6 +623,8 @@ export class RecordPickerService {
       displayName,
       secondaryInfo,
       avatarUrl: instance.avatarUrl || undefined,
+      integrationSource: instance.integrationSource ?? null,
+      externalId: instance.externalId ?? null,
       data: instance,
       createdAt: instance.createdAt,
       updatedAt: instance.updatedAt,

--- a/packages/lib/src/resources/picker/types.ts
+++ b/packages/lib/src/resources/picker/types.ts
@@ -55,6 +55,17 @@ export interface RecordPickerItem {
    */
   color?: string
 
+  /**
+   * Data-connector / integration provenance, denormalized from
+   * `EntityInstance.integrationSource`. For connector-synced records this holds
+   * the owning DataConnector id; null for hand-created records. Drives the
+   * "Synced from <connector>" source badge.
+   */
+  integrationSource?: string | null
+
+  /** Upstream id within the integration source (e.g. Shopify customer id). */
+  externalId?: string | null
+
   /** Full row data (for custom rendering) */
   data: Record<string, unknown>
 

--- a/packages/sdk/src/root/data-connectors/index.ts
+++ b/packages/sdk/src/root/data-connectors/index.ts
@@ -31,6 +31,8 @@ export type {
   ConnectorFieldCapabilities,
   ConnectorFieldDecl,
   ConnectorRecord,
+  ConnectorRelationshipDecl,
+  ConnectorRelationshipTargetRef,
   ConnectorStreamDecl,
   ConnectorStreamState,
   DataConnectorDefinition,

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -121,6 +121,33 @@ export interface ConnectorEntityDecl {
 }
 
 /**
+ * The edge's target def. For an owned child the target IS this mapping's own owned
+ * def — omit `targetRef` (provisioning resolves it from the mapping's provisioned
+ * def). For a `reference` to another stream's def, name that target by owned
+ * `apiSlug` or contributing `entityKind`.
+ */
+export type ConnectorRelationshipTargetRef = { ownedApiSlug: string } | { entityKind: string }
+
+/**
+ * Provisioning declaration for a parent↔child relationship edge (v5). Drives
+ * auto-creation of the relationship field (+ inverse) on the parent def at
+ * connector materialization. `fieldKey` must match the mapping's
+ * `relationshipFieldKey` so the fan-out resolves the provisioned field.
+ */
+export interface ConnectorRelationshipDecl {
+  /** Stable field key of the edge created on the PARENT def (== `relationshipFieldKey`). */
+  fieldKey: string
+  /** Display name for the forward edge (e.g. `'Line Items'`). */
+  name: string
+  /** Forward cardinality from PARENT → this mapping's target. */
+  cardinality: 'has_many' | 'has_one' | 'belongs_to' | 'many_to_many'
+  /** Display name for the auto-created inverse edge on the child/target def. */
+  inverseName: string
+  /** Target def of the edge; omit for an owned child (resolves to the mapping's own def). */
+  targetRef?: ConnectorRelationshipTargetRef
+}
+
+/**
  * A recommended fan-out mapping the connector suggests (05 §4). The user
  * confirms/overrides at setup; branches not declared here are inferred from the
  * schema tree.
@@ -130,8 +157,20 @@ export interface ConnectorDefaultMapping {
   rootPath: string
   /** Default: `upsert` for embedded data, `reference` for id-only branches. */
   linkMode?: 'upsert' | 'reference'
-  /** Edge on the PARENT def that holds this relationship. */
+  /**
+   * Runtime pointer the fan-out reads to find the edge field at write time. Keep it
+   * equal to `relationship.fieldKey` when `relationship` is declared. A bare key (no
+   * `relationship`) resolves against a PRE-EXISTING edge — e.g. a reference FK to a
+   * field the connector doesn't provision.
+   */
   relationshipFieldKey?: string
+  /**
+   * Provisioning declaration for the parent↔child edge this mapping links on. When
+   * present, connector materialization auto-creates the relationship field (+ its
+   * inverse) on the parent def so the link actually forms at sync time. Omit for
+   * bare-key references that resolve to a pre-existing edge.
+   */
+  relationship?: ConnectorRelationshipDecl
   target:
     | { mode: 'owned'; entity: ConnectorEntityDecl }
     | {

--- a/packages/sdk/src/root/index.ts
+++ b/packages/sdk/src/root/index.ts
@@ -29,6 +29,8 @@ export type {
   ConnectorFieldCapabilities,
   ConnectorFieldDecl,
   ConnectorRecord,
+  ConnectorRelationshipDecl,
+  ConnectorRelationshipTargetRef,
   ConnectorStreamDecl,
   ConnectorStreamState,
   DataConnectorDefinition,

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -195,11 +195,21 @@ export interface CatalogConnectorField {
   capabilities?: { hidden?: boolean; filterable?: boolean }
 }
 
+/** Provisioning decl for a parent↔child edge — mirrors SDK `ConnectorRelationshipDecl`. */
+export interface CatalogConnectorRelationshipDecl {
+  fieldKey: string
+  name: string
+  cardinality: 'has_many' | 'has_one' | 'belongs_to' | 'many_to_many'
+  inverseName: string
+  targetRef?: { ownedApiSlug: string } | { entityKind: string }
+}
+
 /** A recommended fan-out mapping projected from a data connector's stream. */
 export interface CatalogConnectorDefaultMapping {
   rootPath: string
   linkMode?: 'upsert' | 'reference'
   relationshipFieldKey?: string
+  relationship?: CatalogConnectorRelationshipDecl
   target:
     | {
         mode: 'owned'

--- a/packages/services/src/custom-fields/create-field.ts
+++ b/packages/services/src/custom-fields/create-field.ts
@@ -264,6 +264,16 @@ export async function createCustomField(input: CreateCustomFieldInput, tx?: Tran
         entityDefinitionId,
         relationship,
         systemAttribute,
+        // Connector/app ownership: the FORWARD field is the idempotency anchor, so
+        // it carries `appFieldKey` + the ownership FKs + read-only capability flags;
+        // the inverse rides along (stamped with the FKs only, never the app key).
+        appFieldKey,
+        appInstallationId,
+        connectionId,
+        dataConnectorId,
+        isCreatable,
+        isUpdatable,
+        isHidden,
       },
       db
     )
@@ -480,6 +490,15 @@ async function createRelationshipFieldWithInverse(
     entityDefinitionId?: string | null
     relationship?: RelationshipOptions
     systemAttribute?: string
+    /** App/connector ownership — stamped on the FORWARD field only (idempotency anchor). */
+    appFieldKey?: string
+    appInstallationId?: string
+    connectionId?: string
+    /** Stamped on BOTH forward + inverse so a `dataConnectorId`-keyed cleanup sweep removes both. */
+    dataConnectorId?: string
+    isCreatable?: boolean
+    isUpdatable?: boolean
+    isHidden?: boolean
   },
   db: Database | Transaction = database
 ) {
@@ -492,9 +511,14 @@ async function createRelationshipFieldWithInverse(
     entityDefinitionId,
     relationship,
     systemAttribute,
+    appFieldKey,
+    appInstallationId,
+    connectionId,
+    dataConnectorId,
+    isCreatable,
+    isUpdatable,
+    isHidden,
   } = input
-
-  console.log('Creating relationship field:', input)
 
   // Validate relationship options are provided
   if (!relationship) {
@@ -567,6 +591,14 @@ async function createRelationshipFieldWithInverse(
         organizationId,
         sortOrder: primarySortOrder,
         systemAttribute,
+        // App/connector ownership — FORWARD field is the idempotency anchor.
+        appInstallationId: appInstallationId ?? null,
+        connectionId: connectionId ?? null,
+        appFieldKey: appFieldKey ?? null,
+        dataConnectorId: dataConnectorId ?? null,
+        ...(isCreatable !== undefined && { isCreatable }),
+        ...(isUpdatable !== undefined && { isUpdatable }),
+        ...(isHidden !== undefined && { isHidden }),
         updatedAt: new Date(),
         options: {
           icon,
@@ -600,6 +632,12 @@ async function createRelationshipFieldWithInverse(
         organizationId,
         sortOrder: inverseSortOrder,
         systemAttribute: inverseSystemAttribute,
+        // Connector ownership FK only (NO appFieldKey — the inverse is never looked up
+        // for provisioning, only cascaded); lets the `dataConnectorId` sweep remove it.
+        dataConnectorId: dataConnectorId ?? null,
+        // The inverse mirrors the forward's user-read-only capability for connector edges.
+        ...(isCreatable !== undefined && { isCreatable }),
+        ...(isUpdatable !== undefined && { isUpdatable }),
         updatedAt: new Date(),
         options: {
           icon: inverseIcon,


### PR DESCRIPTION
## Summary

Two related data-connector changes:

### 1. Auto-provision owned parent↔child relationship edges
Connector materialization now creates the relationship fields that make the fan-out's `parentRelation` actually link at sync time.

- **Two-pass materialization** in `createConnectorFromAppCatalog`:
  - **Pass 1** (`provisionStreamOwnedDefs`) — provisions each owned stream's def + scalar fields + `DataConnectorMapping`, wiring `parentMappingId` from rootPath nesting (`ownedParentRootPath`) and accumulating a connector-wide `apiSlug → defId` map.
  - **Pass 2** — provisions each declared relationship edge once every def exists, so a cross-stream `reference` resolves its target.
- New `ConnectorRelationshipDecl` on the SDK / catalog / db catalog types.
- `provisionRelationshipField` + `resolveRelationshipTargetDefId` in `@auxx/lib` create the forward edge (+ auto-wired inverse) via `createCustomField({ type: 'RELATIONSHIP' })`, idempotent per `(dataConnectorId, appFieldKey)`.
- `createCustomField` now stamps app/connector ownership FKs + read-only capability flags onto relationship fields (forward = idempotency anchor with `appFieldKey`; inverse carries `dataConnectorId` only for cleanup sweeps). Also removed a stray `console.log`.

### 2. "Synced from <connector>" record source badge
- New `ConnectorSourceBadge` resolves a record's `integrationSource` (a DataConnector id) to its installed app's branding via `useConnector` + `useAppsContext` — icon in the grid primary cell, chip in the record drawer header. Renders `null` for hand-created records.
- Plumbs `integrationSource` / `externalId` through the record store, batch fetcher, and record-picker types.
- Generalizes `useConnectorName` into a `useConnector` hook returning the full resolved connector row.

### 3. Docs
- Adds `docs/kopilot-architecture-guide.md`.

## Test plan
- New unit tests: `ownedParentRootPath` (rootPath nesting / boundary-prefix rules) and `resolveRelationshipTargetDefId` (owned / cross-stream apiSlug / entityKind / unresolved branches).
- `pnpm test` for the data-connectors + provisioning suites.