### PR TITLE
fix(records): primary cell shows loading skeleton instead of "Untitled"

### DIFF
--- a/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
+++ b/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
@@ -2,7 +2,12 @@
 'use client'
 
 import { formatToDisplayValue } from '@auxx/lib/field-values/client'
-import { parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
+import {
+  buildFieldValueKey,
+  type FieldId,
+  parseResourceFieldId,
+  type ResourceFieldId,
+} from '@auxx/types/field'
 import { extractValue, type TypedFieldValue } from '@auxx/types/field-value'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { memo, type ReactNode, useMemo } from 'react'
@@ -10,6 +15,8 @@ import { ConnectorSourceBadge } from '~/components/fields/connector-source-badge
 import { toRecordId, useRecord, useResource } from '~/components/resources'
 import { useField } from '~/components/resources/hooks/use-field'
 import { useFieldValue } from '~/components/resources/hooks/use-field-values'
+import { computedFieldRegistry } from '~/components/resources/store/computed-field-registry'
+import { useFieldValueStore } from '~/components/resources/store/field-value-store'
 import { RecordIcon } from '~/components/resources/ui/record-icon'
 import { PrimaryCell } from './primary-cell'
 
@@ -54,6 +61,23 @@ export const PrimaryFieldCell = memo(function PrimaryFieldCell({
   // autoFetch ensures isLoading=true on first render (queues synchronously)
   const { value, isLoading } = useFieldValue(recordId, fieldId, { autoFetch: true })
 
+  // Computed primary fields (e.g. NAME = firstName + lastName) never mark their own key as
+  // fetching — the fetch queue decomposes them into source fields, so this cell's
+  // `isLoading` is permanently false and it would flash "Untitled" instead of a skeleton.
+  // Derive a real loading signal from the source fields' fetching state, which `setValues`
+  // clears on both success and failure (so the skeleton can't hang); fall back to
+  // `isLoading` for plain fields. This gate and the fetch queue branch on the same
+  // registry, so they stay consistent whether or not the registry has synced yet.
+  const computedConfig = computedFieldRegistry.getConfig(resourceFieldId)
+  const sourcesFetching = useFieldValueStore((s) => {
+    if (!computedConfig) return false
+    for (const sourceFieldId of Object.values(computedConfig.sourceFields)) {
+      if (buildFieldValueKey(recordId, sourceFieldId as FieldId) in s.fetchingKeys) return true
+    }
+    return false
+  })
+  const isResolving = computedConfig ? sourcesFetching : isLoading
+
   // Get record (already in store from batch fetch) for avatarUrl
   const { record } = useRecord({ recordId })
   const { resource } = useResource(entityDefinitionId)
@@ -81,11 +105,14 @@ export const PrimaryFieldCell = memo(function PrimaryFieldCell({
     return String(value)
   }, [value, fieldType])
 
-  // Show skeleton while loading and no value yet
-  if (isLoading && value === undefined) {
+  // Show skeleton while loading and no value yet — mirror the loaded layout: a
+  // record-icon-sized square (RecordIcon size='xs' → size-4 rounded-md) plus the
+  // display-name bar, with the same gap/padding/min-height so there's no layout shift.
+  if (isResolving && value === undefined) {
     return (
-      <div className='flex items-center pl-3 pr-2'>
-        <Skeleton className='h-5 w-32' />
+      <div className='flex items-center gap-2 min-h-9 pl-3 pr-2'>
+        <Skeleton className='size-4 shrink-0 rounded-md' />
+        <Skeleton className='h-4 w-32' />
       </div>
     )
   }


### PR DESCRIPTION
## Problem

In the records table, every non-primary cell shows a skeleton while its value loads, but the **primary cell flashes `Untitled`** during that same window before resolving to the real title.

## Root cause

The primary display field is (almost always) a computed `NAME` field (`firstName` + `lastName`). The field-value fetch queue special-cases computed fields: a fetch for a `NAME`/`CALC` field is **decomposed into its source fields**, and only the *source* keys get `markFetching`. The computed field's own key is never put into `fetchingKeys`.

`PrimaryFieldCell` subscribes via `useFieldValue(recordId, nameFieldId)`, whose `isLoading` reads `nameKey in fetchingKeys` — permanently `false`. So the skeleton gate `isLoading && value === undefined` never fired; the cell fell through to `PrimaryCell`, where `value` is `undefined` → `displayValue` is `null` → renders the `Untitled` fallback. The computed value only materializes later, once the sources arrive and `computeDependentCalcValues` writes it.

Plain (non-computed) cells don't hit this — their own key *is* marked fetching, so they skeleton correctly.

## Fix

Derive a real loading signal for computed primary fields from their **source fields' fetching state**, falling back to `isLoading` for plain fields:

```ts
const computedConfig = computedFieldRegistry.getConfig(resourceFieldId)
const sourcesFetching = useFieldValueStore((s) => {
  if (!computedConfig) return false
  for (const sourceFieldId of Object.values(computedConfig.sourceFields)) {
    if (buildFieldValueKey(recordId, sourceFieldId as FieldId) in s.fetchingKeys) return true
  }
  return false
})
const isResolving = computedConfig ? sourcesFetching : isLoading
```

Why this is the right signal (and can't hang): `setValues` clears `fetchingKeys` **and** writes the computed value in the same store update — on both the success path and the `allSettled` failure path. So the skeleton has a guaranteed terminal state. (Gating naively on `value === undefined` alone would spin forever if a fetch never wrote the value, e.g. an early-return before the tRPC `fetchFn` registers.) Both this gate and the fetch queue branch on the same `computedFieldRegistry`, so they stay consistent regardless of registry sync timing.

## Also

The loading skeleton now mirrors the loaded layout — an icon-sized square (`size-4 rounded-md`, matching `RecordIcon size='xs'`) plus the display-name bar, reusing `PrimaryCell`'s `gap-2`/`pl-3`/`min-h-9` so there's no layout shift when it resolves.

## Notes

- Props interface unchanged → kanban (`kanban-card.tsx`) and articles (`articles-view.tsx`), which also use `PrimaryFieldCell`, are unaffected.
- The loading window is sub-second; to observe the skeleton, throttle the network on a records page.

## Test plan

- [ ] Hard-refresh a contacts records table → first column shows the two skeletons (icon + name), not `Untitled`, then resolves to the real name
- [ ] A record with empty first+last name still resolves to `Untitled` (not a stuck skeleton)
- [ ] Throttle/fail the value fetch → skeleton terminates (falls to `Untitled`) rather than spinning forever
- [ ] A custom entity whose primary field is plain `TEXT` still skeletons via the `isLoading` fallback