### PR TITLE
refactor(snippets): thin snippet router → @auxx/lib/snippets

### DIFF
--- a/apps/web/src/server/api/routers/snippet.ts
+++ b/apps/web/src/server/api/routers/snippet.ts
@@ -1,47 +1,29 @@
 // server/api/routers/snippets.ts
 
-import { schema } from '@auxx/database'
+import { SnippetSharingType } from '@auxx/database/enums'
 import {
-  BuiltInEntityType,
-  ResourceGranteeType,
-  ResourcePermission,
-  SnippetSharingType,
-} from '@auxx/database/enums'
-import {
-  getInstanceAccess,
-  getUserAccessibleInstances,
-  setInstanceAccess,
-} from '@auxx/lib/resource-access'
-import { createScopedLogger } from '@auxx/logger'
-import { parseRecordId, toRecordId } from '@auxx/types/resource'
-import { TRPCError } from '@trpc/server'
-import {
-  and,
-  asc,
-  count,
-  desc,
-  eq,
-  ilike,
-  inArray,
-  isNull,
-  not,
-  or,
-  type SQL,
-  sql,
-} from 'drizzle-orm'
+  createSnippet,
+  createSnippetFolder,
+  deleteSnippet,
+  deleteSnippetFolderWithCascade,
+  getSnippetWithAccess,
+  incrementSnippetUsage,
+  listSnippetFoldersWithCounts,
+  listSnippetsForUser,
+  setSnippetSharing,
+  updateSnippet,
+  updateSnippetFolder,
+} from '@auxx/lib/snippets'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
-
-const logger = createScopedLogger('snippets-router')
 
 /**
  * TRPC router for snippets management operations.
  *
- * This router provides endpoints for:
- * - Retrieving snippets (all, by ID, by folder)
- * - Creating, updating, and deleting snippets
- * - Managing snippet sharing settings
- * - Creating and managing snippet folders
+ * Thin glue: validate input (zod) → call a `@auxx/lib/snippets` helper → return.
+ * All business logic, queries, and transactions live in `@auxx/lib/snippets`.
+ * Helpers return neverthrow `Result<T, AuxxError>`; thrown `AuxxError`s are
+ * mapped to the right tRPC code by `auxxErrorMiddleware`.
  */
 export const snippetsRouter = createTRPCRouter({
   // Get all snippets for the organization
@@ -55,209 +37,17 @@ export const snippetsRouter = createTRPCRouter({
     )
     .query(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
-      const { folderId, searchQuery, includeShared } = input
-      try {
-        // Build where clause using AND to combine filters
-        const filters: SQL[] = [
-          eq(schema.Snippet.organizationId, organizationId),
-          eq(schema.Snippet.isDeleted, false),
-        ]
-
-        // Filter by folder if specified
-        if (folderId) {
-          filters.push(eq(schema.Snippet.folderId, folderId))
-        }
-
-        // Add search filter if specified (matches title OR content)
-        if (searchQuery) {
-          filters.push(
-            or(
-              ilike(schema.Snippet.title, `%${searchQuery}%`),
-              ilike(schema.Snippet.content, `%${searchQuery}%`)
-            )!
-          )
-        }
-
-        // Handle shared snippets visibility
-        if (includeShared) {
-          // Get snippets user has access to via ResourceAccess
-          const accessResult = await getUserAccessibleInstances(
-            { db: ctx.db, organizationId, userId },
-            userId,
-            BuiltInEntityType.snippet
-          )
-
-          if (accessResult.hasTypeAccess) {
-            // User has access to ALL snippets (org admin), no additional filter needed
-            // but still filter to own + org-shared + CUSTOM shared
-            filters.push(
-              or(
-                eq(schema.Snippet.createdById, userId),
-                eq(schema.Snippet.sharingType, SnippetSharingType.ORGANIZATION),
-                eq(schema.Snippet.sharingType, SnippetSharingType.GROUPS)
-              )!
-            )
-          } else {
-            // Get snippet IDs from ResourceAccess instances
-            const sharedSnippetIds = accessResult.instances.map(
-              (a) => parseRecordId(a.recordId).entityInstanceId
-            )
-
-            // Include user's own OR org shared OR specifically shared via ResourceAccess
-            filters.push(
-              or(
-                eq(schema.Snippet.createdById, userId),
-                eq(schema.Snippet.sharingType, SnippetSharingType.ORGANIZATION),
-                sharedSnippetIds.length > 0
-                  ? inArray(schema.Snippet.id, sharedSnippetIds)
-                  : sql`false`
-              )!
-            )
-          }
-        } else {
-          // Only include user's own snippets
-          filters.push(eq(schema.Snippet.createdById, userId))
-        }
-
-        // Fetch snippets
-        const snippets = await ctx.db.query.Snippet.findMany({
-          where: and(...filters),
-          with: {
-            folder: true,
-            createdBy: {
-              columns: { id: true, name: true, email: true, image: true },
-            },
-          },
-          orderBy: [desc(schema.Snippet.updatedAt)],
-        })
-
-        // Get shares count for each snippet from ResourceAccess
-        const snippetIds = snippets.map((s) => s.id)
-        const sharesCounts =
-          snippetIds.length > 0
-            ? await ctx.db
-                .select({
-                  snippetId: schema.ResourceAccess.entityInstanceId,
-                  count: count(schema.ResourceAccess.id),
-                })
-                .from(schema.ResourceAccess)
-                .where(
-                  and(
-                    eq(schema.ResourceAccess.entityDefinitionId, BuiltInEntityType.snippet),
-                    inArray(schema.ResourceAccess.entityInstanceId, snippetIds)
-                  )
-                )
-                .groupBy(schema.ResourceAccess.entityInstanceId)
-            : []
-
-        // Merge the counts back into snippets
-        const snippetsWithCounts = snippets.map((snippet) => ({
-          ...snippet,
-          _count: {
-            shares: sharesCounts.find((c) => c.snippetId === snippet.id)?.count ?? 0,
-          },
-        }))
-
-        return { snippets: snippetsWithCounts }
-      } catch (error) {
-        logger.error('Error getting snippets:', { error })
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to get snippets' })
-      }
+      const result = await listSnippetsForUser(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return { snippets: result.value }
     }),
 
   // Get a snippet by ID
   byId: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
     const { organizationId, userId } = ctx.session
-    const { id } = input
-    try {
-      // Check if user has access via ResourceAccess
-      const accessResult = await getUserAccessibleInstances(
-        { db: ctx.db, organizationId, userId },
-        userId,
-        BuiltInEntityType.snippet
-      )
-      const sharedSnippetIds = accessResult.instances.map(
-        (a) => parseRecordId(a.recordId).entityInstanceId
-      )
-
-      const snippet = await ctx.db.query.Snippet.findFirst({
-        where: and(
-          eq(schema.Snippet.id, id),
-          eq(schema.Snippet.organizationId, organizationId),
-          eq(schema.Snippet.isDeleted, false),
-          or(
-            eq(schema.Snippet.createdById, userId), // User's own snippets
-            eq(schema.Snippet.sharingType, SnippetSharingType.ORGANIZATION), // Org-wide shared snippets
-            accessResult.hasTypeAccess
-              ? sql`true`
-              : sharedSnippetIds.includes(id)
-                ? sql`true`
-                : sql`false` // Shared via ResourceAccess
-          )!
-        ),
-        with: {
-          folder: true,
-          createdBy: {
-            columns: { id: true, name: true, email: true, image: true },
-          },
-        },
-      })
-
-      if (!snippet) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Snippet not found' })
-      }
-
-      // Get shares from ResourceAccess for display
-      const shares = await getInstanceAccess(
-        { db: ctx.db, organizationId },
-        toRecordId(BuiltInEntityType.snippet, id)
-      )
-
-      // Check if user can edit the snippet
-      let canEdit = snippet.createdById === userId
-
-      if (!canEdit && shares.length > 0) {
-        // Check if user has EDIT permission directly
-        const userShare = shares.find(
-          (s) => s.granteeType === ResourceGranteeType.user && s.granteeId === userId
-        )
-        if (userShare && userShare.permission === ResourcePermission.edit) {
-          canEdit = true
-        }
-
-        // Check if user has EDIT permission via group membership
-        if (!canEdit) {
-          const groupShares = shares.filter(
-            (s) =>
-              s.granteeType === ResourceGranteeType.group &&
-              s.permission === ResourcePermission.edit
-          )
-          if (groupShares.length > 0) {
-            const userGroupMembership = await ctx.db.query.EntityGroupMember.findFirst({
-              where: and(
-                eq(schema.EntityGroupMember.memberType, 'user'),
-                eq(schema.EntityGroupMember.memberRefId, userId),
-                inArray(
-                  schema.EntityGroupMember.groupInstanceId,
-                  groupShares.map((s) => s.granteeId)
-                )
-              ),
-            })
-            if (userGroupMembership) {
-              canEdit = true
-            }
-          }
-        }
-      }
-
-      return { snippet: { ...snippet, shares }, canEdit }
-    } catch (error) {
-      logger.error('Error getting snippet:', { error, snippetId: id })
-      if (error instanceof TRPCError) {
-        throw error
-      }
-      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to get snippet' })
-    }
+    const result = await getSnippetWithAccess(ctx.db, organizationId, userId, input.id)
+    if (result.isErr()) throw result.error
+    return result.value
   }),
 
   // Create a new snippet
@@ -274,57 +64,9 @@ export const snippetsRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
-      const { title, content, contentHtml, description, folderId, sharingType } = input
-      // try {
-      // Verify folder exists and belongs to this organization if provided
-      if (folderId) {
-        const folder = await ctx.db.query.SnippetFolder.findFirst({
-          where: and(
-            eq(schema.SnippetFolder.id, folderId),
-            eq(schema.SnippetFolder.organizationId, organizationId)
-          ),
-        })
-
-        if (!folder) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: 'Selected folder not found' })
-        }
-      }
-
-      // Create the snippet
-      const [snippet] = await ctx.db
-        .insert(schema.Snippet)
-        .values({
-          title,
-          content,
-          contentHtml,
-          description,
-          folderId,
-          sharingType,
-          organizationId,
-          createdById: userId,
-          updatedAt: new Date(),
-        })
-        .returning()
-
-      // Fetch with relations
-      const snippetWithRelations = await ctx.db.query.Snippet.findFirst({
-        where: eq(schema.Snippet.id, snippet.id),
-        with: {
-          folder: true,
-          createdBy: {
-            columns: { id: true, name: true, email: true, image: true },
-          },
-        },
-      })
-
-      return { success: true, snippet: snippetWithRelations }
-      // } catch (error) {
-      //   logger.error('Error creating snippet:', { error, input })
-      //   if (error instanceof TRPCError) {
-      //     throw error
-      //   }
-      //   throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to create snippet' })
-      // }
+      const result = await createSnippet(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return { success: true, snippet: result.value }
     }),
 
   // Update an existing snippet
@@ -343,186 +85,20 @@ export const snippetsRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
-      const { id, title, content, contentHtml, description, folderId, sharingType, isFavorite } =
-        input
-
-      try {
-        // Check if snippet exists
-        const existingSnippet = await ctx.db.query.Snippet.findFirst({
-          where: and(
-            eq(schema.Snippet.id, id),
-            eq(schema.Snippet.organizationId, organizationId),
-            eq(schema.Snippet.isDeleted, false)
-          ),
-        })
-
-        if (!existingSnippet) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: 'Snippet not found',
-          })
-        }
-
-        // Check if user has edit access
-        let canEdit = existingSnippet.createdById === userId
-
-        if (!canEdit) {
-          // Check ResourceAccess for edit permissions
-          const shares = await getInstanceAccess(
-            { db: ctx.db, organizationId },
-            toRecordId(BuiltInEntityType.snippet, id)
-          )
-
-          // Check direct user permission
-          const userShare = shares.find(
-            (s) => s.granteeType === ResourceGranteeType.user && s.granteeId === userId
-          )
-          if (userShare && userShare.permission === ResourcePermission.edit) {
-            canEdit = true
-          }
-
-          // Check group-based permission
-          if (!canEdit) {
-            const groupShares = shares.filter(
-              (s) =>
-                s.granteeType === ResourceGranteeType.group &&
-                s.permission === ResourcePermission.edit
-            )
-            if (groupShares.length > 0) {
-              const userGroupMembership = await ctx.db.query.EntityGroupMember.findFirst({
-                where: and(
-                  eq(schema.EntityGroupMember.memberType, 'user'),
-                  eq(schema.EntityGroupMember.memberRefId, userId),
-                  inArray(
-                    schema.EntityGroupMember.groupInstanceId,
-                    groupShares.map((s) => s.granteeId)
-                  )
-                ),
-              })
-              if (userGroupMembership) {
-                canEdit = true
-              }
-            }
-          }
-        }
-
-        if (!canEdit) {
-          throw new TRPCError({
-            code: 'FORBIDDEN',
-            message: 'You do not have permission to edit this snippet',
-          })
-        }
-
-        // Only the creator can change sharing settings
-        if (sharingType && existingSnippet.createdById !== userId) {
-          throw new TRPCError({
-            code: 'FORBIDDEN',
-            message: 'Only the creator can change sharing settings',
-          })
-        }
-
-        // Verify folder exists and belongs to this organization if provided
-        if (folderId) {
-          const folder = await ctx.db.query.SnippetFolder.findFirst({
-            where: and(
-              eq(schema.SnippetFolder.id, folderId),
-              eq(schema.SnippetFolder.organizationId, organizationId)
-            ),
-          })
-
-          if (!folder) {
-            throw new TRPCError({ code: 'BAD_REQUEST', message: 'Selected folder not found' })
-          }
-        }
-
-        // Update the snippet
-        const updateData: any = {
-          updatedAt: new Date(),
-        }
-        if (title !== undefined) updateData.title = title
-        if (content !== undefined) updateData.content = content
-        if (contentHtml !== undefined) updateData.contentHtml = contentHtml
-        if (description !== undefined) updateData.description = description
-        if (folderId !== undefined) updateData.folderId = folderId === null ? null : folderId
-        if (sharingType !== undefined) updateData.sharingType = sharingType
-        if (isFavorite !== undefined) updateData.isFavorite = isFavorite
-
-        await ctx.db.update(schema.Snippet).set(updateData).where(eq(schema.Snippet.id, id))
-
-        // Fetch updated snippet with relations
-        const updatedSnippet = await ctx.db.query.Snippet.findFirst({
-          where: eq(schema.Snippet.id, id),
-          with: {
-            folder: true,
-            createdBy: {
-              columns: { id: true, name: true, email: true, image: true },
-            },
-          },
-        })
-
-        return { success: true, snippet: updatedSnippet }
-      } catch (error) {
-        logger.error('Error updating snippet:', { error, snippetId: id })
-        if (error instanceof TRPCError) {
-          throw error
-        }
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to update snippet' })
-      }
+      const { id, ...updates } = input
+      const result = await updateSnippet(ctx.db, organizationId, userId, id, updates)
+      if (result.isErr()) throw result.error
+      return { success: true, snippet: result.value }
     }),
 
   // Delete a snippet (soft delete)
   delete: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const { id } = input
       const { organizationId, userId } = ctx.session
-      try {
-        // Check if snippet exists and user has access
-        const existingSnippet = await ctx.db.query.Snippet.findFirst({
-          where: and(
-            eq(schema.Snippet.id, id),
-            eq(schema.Snippet.organizationId, organizationId),
-            eq(schema.Snippet.isDeleted, false)
-          ),
-        })
-
-        if (!existingSnippet) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: 'Snippet not found' })
-        }
-
-        // Only the creator or admin can delete
-        const membership = await ctx.db.query.OrganizationMember.findFirst({
-          where: and(
-            eq(schema.OrganizationMember.userId, userId),
-            eq(schema.OrganizationMember.organizationId, organizationId)
-          ),
-        })
-
-        if (
-          existingSnippet.createdById !== userId &&
-          membership?.role !== 'ADMIN' &&
-          membership?.role !== 'OWNER'
-        ) {
-          throw new TRPCError({
-            code: 'FORBIDDEN',
-            message: 'You do not have permission to delete this snippet',
-          })
-        }
-
-        // Soft delete the snippet
-        await ctx.db
-          .update(schema.Snippet)
-          .set({ isDeleted: true, updatedAt: new Date() })
-          .where(eq(schema.Snippet.id, id))
-
-        return { success: true }
-      } catch (error) {
-        logger.error('Error deleting snippet:', { error, snippetId: id })
-        if (error instanceof TRPCError) {
-          throw error
-        }
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to delete snippet' })
-      }
+      const result = await deleteSnippet(ctx.db, organizationId, userId, input.id)
+      if (result.isErr()) throw result.error
+      return { success: true }
     }),
 
   // Share a snippet with groups or members via ResourceAccess
@@ -545,83 +121,16 @@ export const snippetsRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
-      const { snippetId, sharingType, shares } = input
-      try {
-        // Check if snippet exists and user is the creator
-        const snippet = await ctx.db.query.Snippet.findFirst({
-          where: and(
-            eq(schema.Snippet.id, snippetId),
-            eq(schema.Snippet.organizationId, organizationId),
-            eq(schema.Snippet.createdById, userId), // Only creator can change sharing settings
-            eq(schema.Snippet.isDeleted, false)
-          ),
-        })
-
-        if (!snippet) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: 'Snippet not found or you do not have permission to share it',
-          })
-        }
-
-        // Start a transaction to update sharing settings
-        await ctx.db.transaction(async (tx) => {
-          // Update the snippet's sharing type
-          await tx
-            .update(schema.Snippet)
-            .set({ sharingType, updatedAt: new Date() })
-            .where(eq(schema.Snippet.id, snippetId))
-
-          if (sharingType === SnippetSharingType.GROUPS) {
-            // Replace both grantee types (empty array clears that type's grants)
-            const groupShares = (shares ?? []).filter((s) => s.granteeType === 'group')
-            const userShares = (shares ?? []).filter((s) => s.granteeType === 'user')
-
-            await setInstanceAccess(
-              { db: tx, organizationId, userId },
-              toRecordId(BuiltInEntityType.snippet, snippetId),
-              ResourceGranteeType.group,
-              groupShares.map((s) => ({
-                granteeId: s.granteeId,
-                permission:
-                  s.permission === 'EDIT' ? ResourcePermission.edit : ResourcePermission.view,
-              }))
-            )
-
-            await setInstanceAccess(
-              { db: tx, organizationId, userId },
-              toRecordId(BuiltInEntityType.snippet, snippetId),
-              ResourceGranteeType.user,
-              userShares.map((s) => ({
-                granteeId: s.granteeId,
-                permission:
-                  s.permission === 'EDIT' ? ResourcePermission.edit : ResourcePermission.view,
-              }))
-            )
-          } else {
-            // Clear all ResourceAccess for this snippet when not using GROUPS sharing
-            await tx
-              .delete(schema.ResourceAccess)
-              .where(
-                and(
-                  eq(schema.ResourceAccess.entityDefinitionId, BuiltInEntityType.snippet),
-                  eq(schema.ResourceAccess.entityInstanceId, snippetId)
-                )
-              )
-          }
-        })
-
-        return { success: true }
-      } catch (error) {
-        logger.error('Error sharing snippet:', { error, snippetId })
-        if (error instanceof TRPCError) {
-          throw error
-        }
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to update sharing settings',
-        })
-      }
+      const result = await setSnippetSharing(
+        ctx.db,
+        organizationId,
+        userId,
+        input.snippetId,
+        input.sharingType,
+        input.shares
+      )
+      if (result.isErr()) throw result.error
+      return { success: true }
     }),
 
   // Increment usage count
@@ -629,75 +138,16 @@ export const snippetsRouter = createTRPCRouter({
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
-      const { id } = input
-      try {
-        await ctx.db
-          .update(schema.Snippet)
-          .set({ usageCount: sql`${schema.Snippet.usageCount} + 1` })
-          .where(
-            and(
-              eq(schema.Snippet.id, id),
-              eq(schema.Snippet.organizationId, organizationId),
-              eq(schema.Snippet.isDeleted, false)
-            )
-          )
-
-        return { success: true }
-      } catch (error) {
-        logger.error('Error incrementing snippet usage:', { error, snippetId: id })
-        // Don't throw an error for usage tracking failures
-        return { success: false }
-      }
+      // Best-effort: never fail the caller on usage-tracking errors
+      const result = await incrementSnippetUsage(ctx.db, organizationId, input.id)
+      return { success: result.isOk() }
     }),
 
   // Get all snippet folders
   getFolders: protectedProcedure.query(async ({ ctx }) => {
-    const { organizationId } = ctx.session
-    try {
-      // Get folders with subfolders relation
-      const folders = await ctx.db.query.SnippetFolder.findMany({
-        where: eq(schema.SnippetFolder.organizationId, organizationId),
-        with: {
-          subfolders: true,
-        },
-        orderBy: [asc(schema.SnippetFolder.name)],
-      })
-
-      // Get snippet counts for each folder
-      const folderIds = folders.map((f) => f.id)
-      const snippetCounts =
-        folderIds.length > 0
-          ? await ctx.db
-              .select({
-                folderId: schema.Snippet.folderId,
-                count: count(schema.Snippet.id),
-              })
-              .from(schema.Snippet)
-              .where(
-                and(
-                  inArray(schema.Snippet.folderId, folderIds),
-                  eq(schema.Snippet.isDeleted, false)
-                )
-              )
-              .groupBy(schema.Snippet.folderId)
-          : []
-
-      // Merge the counts back into folders
-      const foldersWithCounts = folders.map((folder) => ({
-        ...folder,
-        _count: {
-          snippets: snippetCounts.find((c) => c.folderId === folder.id)?.count ?? 0,
-        },
-      }))
-
-      return { folders: foldersWithCounts }
-    } catch (error) {
-      logger.error('Error getting snippet folders:', { error })
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Failed to get snippet folders',
-      })
-    }
+    const result = await listSnippetFoldersWithCounts(ctx.db, ctx.session.organizationId)
+    if (result.isErr()) throw result.error
+    return { folders: result.value }
   }),
 
   // Create a new folder
@@ -711,61 +161,9 @@ export const snippetsRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { organizationId, userId } = ctx.session
-      const { name, description, parentId } = input
-      try {
-        // Verify parent folder exists if provided
-        if (parentId) {
-          const parentFolder = await ctx.db.query.SnippetFolder.findFirst({
-            where: and(
-              eq(schema.SnippetFolder.id, parentId),
-              eq(schema.SnippetFolder.organizationId, organizationId)
-            ),
-          })
-
-          if (!parentFolder) {
-            throw new TRPCError({ code: 'BAD_REQUEST', message: 'Parent folder not found' })
-          }
-        }
-
-        // Check for name uniqueness within the parent folder
-        const existingFolder = await ctx.db.query.SnippetFolder.findFirst({
-          where: and(
-            eq(schema.SnippetFolder.name, name),
-            eq(schema.SnippetFolder.organizationId, organizationId),
-            parentId
-              ? eq(schema.SnippetFolder.parentId, parentId)
-              : isNull(schema.SnippetFolder.parentId)
-          ),
-        })
-
-        if (existingFolder) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: 'A folder with this name already exists at this location',
-          })
-        }
-
-        // Create the folder
-        const [folder] = await ctx.db
-          .insert(schema.SnippetFolder)
-          .values({
-            name,
-            description,
-            parentId,
-            organizationId,
-            createdById: userId,
-            updatedAt: new Date(),
-          })
-          .returning()
-
-        return { success: true, folder }
-      } catch (error) {
-        logger.error('Error creating snippet folder:', { error, input })
-        if (error instanceof TRPCError) {
-          throw error
-        }
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to create folder' })
-      }
+      const result = await createSnippetFolder(ctx.db, organizationId, userId, input)
+      if (result.isErr()) throw result.error
+      return { success: true, folder: result.value }
     }),
 
   // Update a folder
@@ -779,101 +177,10 @@ export const snippetsRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const { organizationId } = ctx.session
-      const { id, name, description, parentId } = input
-      try {
-        // Check if folder exists
-        const existingFolder = await ctx.db.query.SnippetFolder.findFirst({
-          where: and(
-            eq(schema.SnippetFolder.id, id),
-            eq(schema.SnippetFolder.organizationId, organizationId)
-          ),
-        })
-
-        if (!existingFolder) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: 'Folder not found' })
-        }
-
-        // Prevent circular references (folder can't be its own parent)
-        if (parentId === id) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: 'A folder cannot be its own parent' })
-        }
-
-        // Check for name uniqueness if changing name or parent
-        if (
-          (name && name !== existingFolder.name) ||
-          (parentId !== undefined && parentId !== existingFolder.parentId)
-        ) {
-          const duplicateFolder = await ctx.db.query.SnippetFolder.findFirst({
-            where: and(
-              eq(schema.SnippetFolder.name, name || existingFolder.name),
-              eq(schema.SnippetFolder.organizationId, organizationId),
-              parentId !== undefined
-                ? parentId
-                  ? eq(schema.SnippetFolder.parentId, parentId)
-                  : isNull(schema.SnippetFolder.parentId)
-                : existingFolder.parentId
-                  ? eq(schema.SnippetFolder.parentId, existingFolder.parentId)
-                  : isNull(schema.SnippetFolder.parentId),
-              not(eq(schema.SnippetFolder.id, id))
-            ),
-          })
-
-          if (duplicateFolder) {
-            throw new TRPCError({
-              code: 'BAD_REQUEST',
-              message: 'A folder with this name already exists at this location',
-            })
-          }
-        }
-
-        // Check for circular references in the folder hierarchy
-        if (parentId) {
-          let currentParentId = input.parentId
-          const visited = new Set([input.id])
-
-          while (currentParentId) {
-            if (visited.has(currentParentId)) {
-              throw new TRPCError({
-                code: 'BAD_REQUEST',
-                message: 'Circular reference detected in folder hierarchy',
-              })
-            }
-
-            visited.add(currentParentId)
-            const parentFolder = await ctx.db.query.SnippetFolder.findFirst({
-              where: eq(schema.SnippetFolder.id, currentParentId),
-              columns: { parentId: true },
-            })
-
-            if (!parentFolder) break
-            currentParentId = parentFolder.parentId
-          }
-        }
-
-        // Update the folder
-        const updateData: any = {
-          updatedAt: new Date(),
-        }
-        if (name !== undefined) updateData.name = name
-        if (description !== undefined) updateData.description = description
-        if (parentId !== undefined)
-          updateData.parentId = input.parentId === null ? null : input.parentId
-
-        const [updatedFolder] = await ctx.db
-          .update(schema.SnippetFolder)
-          .set(updateData)
-          .where(eq(schema.SnippetFolder.id, id))
-          .returning()
-
-        return { success: true, folder: updatedFolder }
-      } catch (error) {
-        logger.error('Error updating snippet folder:', { error, folderId: id })
-        if (error instanceof TRPCError) {
-          throw error
-        }
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to update folder' })
-      }
+      const { id, ...updates } = input
+      const result = await updateSnippetFolder(ctx.db, ctx.session.organizationId, id, updates)
+      if (result.isErr()) throw result.error
+      return { success: true, folder: result.value }
     }),
 
   // Delete a folder
@@ -885,83 +192,13 @@ export const snippetsRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const { organizationId } = ctx.session
-      const { id, moveSnippetsTo } = input
-      try {
-        // Check if folder exists
-        const existingFolder = await ctx.db.query.SnippetFolder.findFirst({
-          where: and(
-            eq(schema.SnippetFolder.id, id),
-            eq(schema.SnippetFolder.organizationId, organizationId)
-          ),
-        })
-
-        if (!existingFolder) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: 'Folder not found' })
-        }
-
-        // Verify target folder if provided
-        if (moveSnippetsTo) {
-          if (moveSnippetsTo === id) {
-            throw new TRPCError({
-              code: 'BAD_REQUEST',
-              message: 'Cannot move snippets to the folder being deleted',
-            })
-          }
-
-          const targetFolder = await ctx.db.query.SnippetFolder.findFirst({
-            where: and(
-              eq(schema.SnippetFolder.id, moveSnippetsTo),
-              eq(schema.SnippetFolder.organizationId, organizationId)
-            ),
-          })
-
-          if (!targetFolder) {
-            throw new TRPCError({ code: 'BAD_REQUEST', message: 'Target folder not found' })
-          }
-        }
-
-        // Start a transaction to handle deletion
-        await ctx.db.transaction(async (tx) => {
-          // Check for subfolders
-          const subfolders = await tx.query.SnippetFolder.findMany({
-            where: eq(schema.SnippetFolder.parentId, id),
-          })
-
-          if (subfolders.length > 0) {
-            // Update subfolders to have the same parent as the deleted folder
-            await tx
-              .update(schema.SnippetFolder)
-              .set({ parentId: existingFolder.parentId })
-              .where(eq(schema.SnippetFolder.parentId, id))
-          }
-
-          // Handle snippets in the folder
-          if (moveSnippetsTo) {
-            // Move snippets to target folder
-            await tx
-              .update(schema.Snippet)
-              .set({ folderId: moveSnippetsTo })
-              .where(eq(schema.Snippet.folderId, id))
-          } else {
-            // Remove folder association from snippets
-            await tx
-              .update(schema.Snippet)
-              .set({ folderId: null })
-              .where(eq(schema.Snippet.folderId, id))
-          }
-
-          // Delete the folder
-          await tx.delete(schema.SnippetFolder).where(eq(schema.SnippetFolder.id, id))
-        })
-
-        return { success: true }
-      } catch (error) {
-        logger.error('Error deleting snippet folder:', { error, folderId: id })
-        if (error instanceof TRPCError) {
-          throw error
-        }
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to delete folder' })
-      }
+      const result = await deleteSnippetFolderWithCascade(
+        ctx.db,
+        ctx.session.organizationId,
+        input.id,
+        input.moveSnippetsTo
+      )
+      if (result.isErr()) throw result.error
+      return { success: true }
     }),
 })

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -844,6 +844,12 @@
       "import": "./dist/signatures/index.mjs",
       "default": "./src/signatures/index.ts"
     },
+    "./snippets": {
+      "types": "./src/snippets/index.ts",
+      "source": "./src/snippets/index.ts",
+      "import": "./dist/snippets/index.mjs",
+      "default": "./src/snippets/index.ts"
+    },
     "./tags": {
       "types": "./src/tags/index.ts",
       "source": "./src/tags/index.ts",

--- a/packages/lib/src/snippets/__tests__/snippet-folder-mutations.test.ts
+++ b/packages/lib/src/snippets/__tests__/snippet-folder-mutations.test.ts
@@ -1,0 +1,154 @@
+// packages/lib/src/snippets/__tests__/snippet-folder-mutations.test.ts
+
+import type { Database } from '@auxx/database'
+import { describe, expect, it, vi } from 'vitest'
+import { deleteSnippetFolderWithCascade, updateSnippetFolder } from '../snippet-folder-mutations'
+
+/** Build a `db` stub whose `query.SnippetFolder.findFirst` returns queued values. */
+function makeDb(opts: {
+  folderFindFirst?: unknown[]
+  updateCalls?: Array<Record<string, unknown>>
+  deletedTables?: string[]
+  txUpdateCalls?: Array<{ table: string; payload: Record<string, unknown> }>
+}) {
+  const folderQueue = [...(opts.folderFindFirst ?? [])]
+
+  const tx = {
+    query: {
+      SnippetFolder: { findMany: vi.fn(async () => [{ id: 'sub1' }]) },
+    },
+    update: (table: { _: { name?: string } } | unknown) => ({
+      set: (payload: Record<string, unknown>) => ({
+        where: async () => {
+          opts.txUpdateCalls?.push({ table: tableName(table), payload })
+        },
+      }),
+    }),
+    delete: (table: unknown) => ({
+      where: async () => {
+        opts.deletedTables?.push(tableName(table))
+      },
+    }),
+  }
+
+  const db = {
+    query: {
+      SnippetFolder: {
+        findFirst: vi.fn(async () => folderQueue.shift()),
+      },
+    },
+    update: () => ({
+      set: (payload: Record<string, unknown>) => ({
+        where: () => ({
+          returning: async () => {
+            opts.updateCalls?.push(payload)
+            return [{ id: 'f1', ...payload }]
+          },
+        }),
+      }),
+    }),
+    transaction: async (cb: (t: typeof tx) => Promise<void>) => cb(tx),
+  }
+
+  return db as unknown as Database
+}
+
+function tableName(table: unknown): string {
+  // Drizzle columns/tables are undefined under vitest; fall back to a marker.
+  const sym = table as { [k: symbol]: unknown } | undefined
+  return sym ? 'table' : 'unknown'
+}
+
+describe('updateSnippetFolder', () => {
+  it('rejects a folder that is its own parent', async () => {
+    const db = makeDb({ folderFindFirst: [{ id: 'f1', name: 'A', parentId: null }] })
+    const result = await updateSnippetFolder(db, 'org1', 'f1', { parentId: 'f1' })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.statusCode).toBe(400)
+      expect(result.error.message).toBe('A folder cannot be its own parent')
+    }
+  })
+
+  it('detects a circular reference while walking the parent chain', async () => {
+    // f1 → reparent under f2; f2's parent is f1 → cycle.
+    const db = makeDb({
+      folderFindFirst: [
+        { id: 'f1', name: 'A', parentId: null }, // existing folder lookup
+        undefined, // duplicate-name check: none
+        { parentId: 'f1' }, // walk: parent of f2 is f1 (already visited)
+      ],
+    })
+    const result = await updateSnippetFolder(db, 'org1', 'f1', { parentId: 'f2' })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.message).toBe('Circular reference detected in folder hierarchy')
+    }
+  })
+
+  it('updates a folder when the new parent chain is acyclic', async () => {
+    const updateCalls: Array<Record<string, unknown>> = []
+    const db = makeDb({
+      folderFindFirst: [
+        { id: 'f1', name: 'A', parentId: null }, // existing
+        undefined, // duplicate-name check
+        { parentId: null }, // walk: f2's parent is root → stop
+      ],
+      updateCalls,
+    })
+    const result = await updateSnippetFolder(db, 'org1', 'f1', { parentId: 'f2', name: 'B' })
+    expect(result.isOk()).toBe(true)
+    expect(updateCalls[0]).toMatchObject({ parentId: 'f2', name: 'B' })
+  })
+})
+
+describe('deleteSnippetFolderWithCascade', () => {
+  it('rejects moving snippets into the folder being deleted', async () => {
+    const db = makeDb({ folderFindFirst: [{ id: 'f1', parentId: null }] })
+    const result = await deleteSnippetFolderWithCascade(db, 'org1', 'f1', 'f1')
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.message).toBe('Cannot move snippets to the folder being deleted')
+    }
+  })
+
+  it('re-parents subfolders and detaches snippets when no target given', async () => {
+    const txUpdateCalls: Array<{ table: string; payload: Record<string, unknown> }> = []
+    const deletedTables: string[] = []
+    const db = makeDb({
+      folderFindFirst: [{ id: 'f1', parentId: 'parent1' }], // existing folder
+      txUpdateCalls,
+      deletedTables,
+    })
+    const result = await deleteSnippetFolderWithCascade(db, 'org1', 'f1', undefined)
+    expect(result.isOk()).toBe(true)
+    // Subfolders re-parented to the deleted folder's parent, snippets detached (null).
+    expect(txUpdateCalls.map((c) => c.payload)).toEqual([
+      { parentId: 'parent1' },
+      { folderId: null },
+    ])
+    expect(deletedTables).toHaveLength(1)
+  })
+
+  it('moves snippets to the target folder when provided', async () => {
+    const txUpdateCalls: Array<{ table: string; payload: Record<string, unknown> }> = []
+    const db = makeDb({
+      folderFindFirst: [
+        { id: 'f1', parentId: null }, // existing folder
+        { id: 'target1', parentId: null }, // target folder exists
+      ],
+      txUpdateCalls,
+      deletedTables: [],
+    })
+    const result = await deleteSnippetFolderWithCascade(db, 'org1', 'f1', 'target1')
+    expect(result.isOk()).toBe(true)
+    expect(txUpdateCalls.some((c) => c.payload.folderId === 'target1')).toBe(true)
+  })
+
+  it('returns NotFound when the folder does not exist', async () => {
+    const db = makeDb({ folderFindFirst: [undefined] })
+    const result = await deleteSnippetFolderWithCascade(db, 'org1', 'missing', undefined)
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.statusCode).toBe(404)
+  })
+})

--- a/packages/lib/src/snippets/__tests__/snippet-sharing.test.ts
+++ b/packages/lib/src/snippets/__tests__/snippet-sharing.test.ts
@@ -1,0 +1,81 @@
+// packages/lib/src/snippets/__tests__/snippet-sharing.test.ts
+
+import type { Database } from '@auxx/database'
+import { ResourceGranteeType, ResourcePermission, SnippetSharingType } from '@auxx/database/enums'
+import { describe, expect, it, vi } from 'vitest'
+
+const setInstanceAccess = vi.fn(async () => {})
+vi.mock('../../resource-access', () => ({
+  setInstanceAccess: (...a: unknown[]) => setInstanceAccess(...a),
+  getInstanceAccess: vi.fn(async () => []),
+}))
+
+import { setSnippetSharing } from '../snippet-mutations'
+
+function makeDb(snippet: unknown, sink: { deleted: number; sharingTypeSet: unknown[] }) {
+  const tx = {
+    update: () => ({
+      set: (payload: Record<string, unknown>) => ({
+        where: async () => {
+          if ('sharingType' in payload) sink.sharingTypeSet.push(payload.sharingType)
+        },
+      }),
+    }),
+    delete: () => ({
+      where: async () => {
+        sink.deleted += 1
+      },
+    }),
+  }
+  return {
+    query: { Snippet: { findFirst: vi.fn(async () => snippet) } },
+    transaction: async (cb: (t: typeof tx) => Promise<void>) => cb(tx),
+  } as unknown as Database
+}
+
+describe('setSnippetSharing', () => {
+  it('rejects when the snippet is missing or not owned by the user', async () => {
+    const db = makeDb(undefined, { deleted: 0, sharingTypeSet: [] })
+    const result = await setSnippetSharing(db, 'org1', 'u1', 's1', SnippetSharingType.PRIVATE, [])
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.statusCode).toBe(404)
+    expect(setInstanceAccess).not.toHaveBeenCalled()
+  })
+
+  it('replaces group and user grants for GROUPS sharing', async () => {
+    setInstanceAccess.mockClear()
+    const sink = { deleted: 0, sharingTypeSet: [] as unknown[] }
+    const db = makeDb({ id: 's1', createdById: 'u1' }, sink)
+    const result = await setSnippetSharing(db, 'org1', 'u1', 's1', SnippetSharingType.GROUPS, [
+      { granteeType: 'group', granteeId: 'g1', permission: 'EDIT' },
+      { granteeType: 'user', granteeId: 'u2', permission: 'VIEW' },
+    ])
+    expect(result.isOk()).toBe(true)
+    expect(sink.sharingTypeSet).toEqual([SnippetSharingType.GROUPS])
+    expect(setInstanceAccess).toHaveBeenCalledTimes(2)
+
+    const [groupCall, userCall] = setInstanceAccess.mock.calls
+    expect(groupCall[2]).toBe(ResourceGranteeType.group)
+    expect(groupCall[3]).toEqual([{ granteeId: 'g1', permission: ResourcePermission.edit }])
+    expect(userCall[2]).toBe(ResourceGranteeType.user)
+    expect(userCall[3]).toEqual([{ granteeId: 'u2', permission: ResourcePermission.view }])
+    expect(sink.deleted).toBe(0)
+  })
+
+  it('clears all grants when switching away from GROUPS sharing', async () => {
+    setInstanceAccess.mockClear()
+    const sink = { deleted: 0, sharingTypeSet: [] as unknown[] }
+    const db = makeDb({ id: 's1', createdById: 'u1' }, sink)
+    const result = await setSnippetSharing(
+      db,
+      'org1',
+      'u1',
+      's1',
+      SnippetSharingType.ORGANIZATION,
+      undefined
+    )
+    expect(result.isOk()).toBe(true)
+    expect(setInstanceAccess).not.toHaveBeenCalled()
+    expect(sink.deleted).toBe(1)
+  })
+})

--- a/packages/lib/src/snippets/guard.ts
+++ b/packages/lib/src/snippets/guard.ts
@@ -1,0 +1,31 @@
+// packages/lib/src/snippets/guard.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError } from '../errors'
+
+const logger = createScopedLogger('snippets')
+
+/**
+ * Run an imperative helper body that may `throw` an {@link AuxxError} for known
+ * business-rule failures, and convert the outcome into a neverthrow `Result`.
+ *
+ * - Thrown `AuxxError`s are returned as `err(error)` and mapped to the right
+ *   HTTP/tRPC code by the router's `auxxErrorMiddleware`.
+ * - Any other (unexpected) error is logged and surfaced as a generic 500.
+ */
+export async function guard<T>(
+  fn: () => Promise<T>,
+  logMessage: string,
+  meta: Record<string, unknown> = {}
+): Promise<Result<T, AuxxError>> {
+  try {
+    return ok(await fn())
+  } catch (error) {
+    if (error instanceof AuxxError) {
+      return err(error)
+    }
+    logger.error(logMessage, { error, ...meta })
+    return err(new AuxxError('Internal error'))
+  }
+}

--- a/packages/lib/src/snippets/index.ts
+++ b/packages/lib/src/snippets/index.ts
@@ -1,0 +1,25 @@
+// packages/lib/src/snippets/index.ts
+
+export {
+  type CreateSnippetFolderInput,
+  createSnippetFolder,
+  deleteSnippetFolderWithCascade,
+  type UpdateSnippetFolderInput,
+  updateSnippetFolder,
+} from './snippet-folder-mutations'
+export {
+  type CreateSnippetInput,
+  createSnippet,
+  deleteSnippet,
+  incrementSnippetUsage,
+  type SnippetShareInput,
+  setSnippetSharing,
+  type UpdateSnippetInput,
+  updateSnippet,
+} from './snippet-mutations'
+export {
+  getSnippetWithAccess,
+  type ListSnippetsFilters,
+  listSnippetFoldersWithCounts,
+  listSnippetsForUser,
+} from './snippet-queries'

--- a/packages/lib/src/snippets/snippet-folder-mutations.ts
+++ b/packages/lib/src/snippets/snippet-folder-mutations.ts
@@ -1,0 +1,229 @@
+// packages/lib/src/snippets/snippet-folder-mutations.ts
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq, isNull, not } from 'drizzle-orm'
+import { BadRequestError, NotFoundError } from '../errors'
+import { guard } from './guard'
+
+export interface CreateSnippetFolderInput {
+  name: string
+  description?: string
+  parentId?: string
+}
+
+/** Create a snippet folder, verifying the parent and name uniqueness in-location. */
+export async function createSnippetFolder(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: CreateSnippetFolderInput
+) {
+  return guard(async () => {
+    const { name, description, parentId } = input
+
+    if (parentId) {
+      const parentFolder = await db.query.SnippetFolder.findFirst({
+        where: and(
+          eq(schema.SnippetFolder.id, parentId),
+          eq(schema.SnippetFolder.organizationId, organizationId)
+        ),
+      })
+      if (!parentFolder) {
+        throw new BadRequestError('Parent folder not found')
+      }
+    }
+
+    const existingFolder = await db.query.SnippetFolder.findFirst({
+      where: and(
+        eq(schema.SnippetFolder.name, name),
+        eq(schema.SnippetFolder.organizationId, organizationId),
+        parentId
+          ? eq(schema.SnippetFolder.parentId, parentId)
+          : isNull(schema.SnippetFolder.parentId)
+      ),
+    })
+    if (existingFolder) {
+      throw new BadRequestError('A folder with this name already exists at this location')
+    }
+
+    const [folder] = await db
+      .insert(schema.SnippetFolder)
+      .values({
+        name,
+        description,
+        parentId,
+        organizationId,
+        createdById: userId,
+        updatedAt: new Date(),
+      })
+      .returning()
+
+    return folder
+  }, 'Error creating snippet folder')
+}
+
+export interface UpdateSnippetFolderInput {
+  name?: string
+  description?: string
+  parentId?: string | null
+}
+
+/**
+ * Update a snippet folder, guarding against name collisions and circular
+ * parent references in the hierarchy.
+ */
+export async function updateSnippetFolder(
+  db: Database,
+  organizationId: string,
+  folderId: string,
+  input: UpdateSnippetFolderInput
+) {
+  return guard(
+    async () => {
+      const { name, description, parentId } = input
+
+      const existingFolder = await db.query.SnippetFolder.findFirst({
+        where: and(
+          eq(schema.SnippetFolder.id, folderId),
+          eq(schema.SnippetFolder.organizationId, organizationId)
+        ),
+      })
+      if (!existingFolder) {
+        throw new NotFoundError('Folder not found')
+      }
+
+      // A folder can't be its own parent
+      if (parentId === folderId) {
+        throw new BadRequestError('A folder cannot be its own parent')
+      }
+
+      // Name uniqueness when changing name or parent
+      if (
+        (name && name !== existingFolder.name) ||
+        (parentId !== undefined && parentId !== existingFolder.parentId)
+      ) {
+        const duplicateFolder = await db.query.SnippetFolder.findFirst({
+          where: and(
+            eq(schema.SnippetFolder.name, name || existingFolder.name),
+            eq(schema.SnippetFolder.organizationId, organizationId),
+            parentId !== undefined
+              ? parentId
+                ? eq(schema.SnippetFolder.parentId, parentId)
+                : isNull(schema.SnippetFolder.parentId)
+              : existingFolder.parentId
+                ? eq(schema.SnippetFolder.parentId, existingFolder.parentId)
+                : isNull(schema.SnippetFolder.parentId),
+            not(eq(schema.SnippetFolder.id, folderId))
+          ),
+        })
+        if (duplicateFolder) {
+          throw new BadRequestError('A folder with this name already exists at this location')
+        }
+      }
+
+      // Walk the parent chain to detect circular references
+      if (parentId) {
+        let currentParentId: string | null = parentId
+        const visited = new Set([folderId])
+
+        while (currentParentId) {
+          if (visited.has(currentParentId)) {
+            throw new BadRequestError('Circular reference detected in folder hierarchy')
+          }
+          visited.add(currentParentId)
+          const parentFolder = await db.query.SnippetFolder.findFirst({
+            where: eq(schema.SnippetFolder.id, currentParentId),
+            columns: { parentId: true },
+          })
+          if (!parentFolder) break
+          currentParentId = parentFolder.parentId
+        }
+      }
+
+      const updateData: Record<string, unknown> = { updatedAt: new Date() }
+      if (name !== undefined) updateData.name = name
+      if (description !== undefined) updateData.description = description
+      if (parentId !== undefined) updateData.parentId = parentId === null ? null : parentId
+
+      const [updatedFolder] = await db
+        .update(schema.SnippetFolder)
+        .set(updateData)
+        .where(eq(schema.SnippetFolder.id, folderId))
+        .returning()
+
+      return updatedFolder
+    },
+    'Error updating snippet folder',
+    { folderId }
+  )
+}
+
+/**
+ * Delete a snippet folder. Re-parents any subfolders to the deleted folder's
+ * parent and either moves contained snippets to `moveSnippetsTo` or detaches
+ * them. Wrapped in a transaction.
+ */
+export async function deleteSnippetFolderWithCascade(
+  db: Database,
+  organizationId: string,
+  folderId: string,
+  moveSnippetsTo: string | undefined
+) {
+  return guard(
+    async () => {
+      const existingFolder = await db.query.SnippetFolder.findFirst({
+        where: and(
+          eq(schema.SnippetFolder.id, folderId),
+          eq(schema.SnippetFolder.organizationId, organizationId)
+        ),
+      })
+      if (!existingFolder) {
+        throw new NotFoundError('Folder not found')
+      }
+
+      if (moveSnippetsTo) {
+        if (moveSnippetsTo === folderId) {
+          throw new BadRequestError('Cannot move snippets to the folder being deleted')
+        }
+        const targetFolder = await db.query.SnippetFolder.findFirst({
+          where: and(
+            eq(schema.SnippetFolder.id, moveSnippetsTo),
+            eq(schema.SnippetFolder.organizationId, organizationId)
+          ),
+        })
+        if (!targetFolder) {
+          throw new BadRequestError('Target folder not found')
+        }
+      }
+
+      await db.transaction(async (tx) => {
+        const subfolders = await tx.query.SnippetFolder.findMany({
+          where: eq(schema.SnippetFolder.parentId, folderId),
+        })
+
+        if (subfolders.length > 0) {
+          await tx
+            .update(schema.SnippetFolder)
+            .set({ parentId: existingFolder.parentId })
+            .where(eq(schema.SnippetFolder.parentId, folderId))
+        }
+
+        if (moveSnippetsTo) {
+          await tx
+            .update(schema.Snippet)
+            .set({ folderId: moveSnippetsTo })
+            .where(eq(schema.Snippet.folderId, folderId))
+        } else {
+          await tx
+            .update(schema.Snippet)
+            .set({ folderId: null })
+            .where(eq(schema.Snippet.folderId, folderId))
+        }
+
+        await tx.delete(schema.SnippetFolder).where(eq(schema.SnippetFolder.id, folderId))
+      })
+    },
+    'Error deleting snippet folder',
+    { folderId }
+  )
+}

--- a/packages/lib/src/snippets/snippet-mutations.ts
+++ b/packages/lib/src/snippets/snippet-mutations.ts
@@ -1,0 +1,302 @@
+// packages/lib/src/snippets/snippet-mutations.ts
+
+import { type Database, schema } from '@auxx/database'
+import {
+  BuiltInEntityType,
+  ResourceGranteeType,
+  ResourcePermission,
+  SnippetSharingType,
+} from '@auxx/database/enums'
+import { toRecordId } from '@auxx/types/resource'
+import { and, eq, sql } from 'drizzle-orm'
+import { BadRequestError, ForbiddenError, NotFoundError } from '../errors'
+import { getInstanceAccess, setInstanceAccess } from '../resource-access'
+import { guard } from './guard'
+import { resolveCanEdit } from './snippet-permissions'
+
+const snippetWith = {
+  folder: true,
+  createdBy: { columns: { id: true, name: true, email: true, image: true } },
+} as const
+
+async function assertFolderInOrg(db: Database, organizationId: string, folderId: string) {
+  const folder = await db.query.SnippetFolder.findFirst({
+    where: and(
+      eq(schema.SnippetFolder.id, folderId),
+      eq(schema.SnippetFolder.organizationId, organizationId)
+    ),
+  })
+  if (!folder) {
+    throw new BadRequestError('Selected folder not found')
+  }
+}
+
+export interface CreateSnippetInput {
+  title: string
+  content: string
+  contentHtml?: string
+  description?: string
+  folderId?: string | null
+  sharingType: SnippetSharingType
+}
+
+/** Create a snippet (verifying the target folder belongs to the org). */
+export async function createSnippet(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  input: CreateSnippetInput
+) {
+  return guard(async () => {
+    if (input.folderId) {
+      await assertFolderInOrg(db, organizationId, input.folderId)
+    }
+
+    const [snippet] = await db
+      .insert(schema.Snippet)
+      .values({
+        title: input.title,
+        content: input.content,
+        contentHtml: input.contentHtml,
+        description: input.description,
+        folderId: input.folderId,
+        sharingType: input.sharingType,
+        organizationId,
+        createdById: userId,
+        updatedAt: new Date(),
+      })
+      .returning()
+
+    return db.query.Snippet.findFirst({
+      where: eq(schema.Snippet.id, snippet.id),
+      with: snippetWith,
+    })
+  }, 'Error creating snippet')
+}
+
+export interface UpdateSnippetInput {
+  title?: string
+  content?: string
+  contentHtml?: string
+  description?: string
+  folderId?: string | null
+  sharingType?: SnippetSharingType
+  isFavorite?: boolean
+}
+
+/** Update a snippet, enforcing edit access and creator-only sharing changes. */
+export async function updateSnippet(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  snippetId: string,
+  input: UpdateSnippetInput
+) {
+  return guard(
+    async () => {
+      const existing = await db.query.Snippet.findFirst({
+        where: and(
+          eq(schema.Snippet.id, snippetId),
+          eq(schema.Snippet.organizationId, organizationId),
+          eq(schema.Snippet.isDeleted, false)
+        ),
+      })
+
+      if (!existing) {
+        throw new NotFoundError('Snippet not found')
+      }
+
+      let canEdit = existing.createdById === userId
+      if (!canEdit) {
+        const shares = await getInstanceAccess(
+          { db, organizationId },
+          toRecordId(BuiltInEntityType.snippet, snippetId)
+        )
+        canEdit = await resolveCanEdit(db, userId, existing.createdById, shares)
+      }
+
+      if (!canEdit) {
+        throw new ForbiddenError('You do not have permission to edit this snippet')
+      }
+
+      // Only the creator can change sharing settings
+      if (input.sharingType && existing.createdById !== userId) {
+        throw new ForbiddenError('Only the creator can change sharing settings')
+      }
+
+      if (input.folderId) {
+        await assertFolderInOrg(db, organizationId, input.folderId)
+      }
+
+      const updateData: Record<string, unknown> = { updatedAt: new Date() }
+      if (input.title !== undefined) updateData.title = input.title
+      if (input.content !== undefined) updateData.content = input.content
+      if (input.contentHtml !== undefined) updateData.contentHtml = input.contentHtml
+      if (input.description !== undefined) updateData.description = input.description
+      if (input.folderId !== undefined) updateData.folderId = input.folderId
+      if (input.sharingType !== undefined) updateData.sharingType = input.sharingType
+      if (input.isFavorite !== undefined) updateData.isFavorite = input.isFavorite
+
+      await db.update(schema.Snippet).set(updateData).where(eq(schema.Snippet.id, snippetId))
+
+      return db.query.Snippet.findFirst({
+        where: eq(schema.Snippet.id, snippetId),
+        with: snippetWith,
+      })
+    },
+    'Error updating snippet',
+    { snippetId }
+  )
+}
+
+/** Soft-delete a snippet (creator or org admin/owner only). */
+export async function deleteSnippet(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  snippetId: string
+) {
+  return guard(
+    async () => {
+      const existing = await db.query.Snippet.findFirst({
+        where: and(
+          eq(schema.Snippet.id, snippetId),
+          eq(schema.Snippet.organizationId, organizationId),
+          eq(schema.Snippet.isDeleted, false)
+        ),
+      })
+
+      if (!existing) {
+        throw new NotFoundError('Snippet not found')
+      }
+
+      const membership = await db.query.OrganizationMember.findFirst({
+        where: and(
+          eq(schema.OrganizationMember.userId, userId),
+          eq(schema.OrganizationMember.organizationId, organizationId)
+        ),
+      })
+
+      if (
+        existing.createdById !== userId &&
+        membership?.role !== 'ADMIN' &&
+        membership?.role !== 'OWNER'
+      ) {
+        throw new ForbiddenError('You do not have permission to delete this snippet')
+      }
+
+      await db
+        .update(schema.Snippet)
+        .set({ isDeleted: true, updatedAt: new Date() })
+        .where(eq(schema.Snippet.id, snippetId))
+    },
+    'Error deleting snippet',
+    { snippetId }
+  )
+}
+
+export interface SnippetShareInput {
+  granteeType: 'group' | 'user'
+  granteeId: string
+  permission: 'VIEW' | 'EDIT'
+}
+
+/**
+ * Replace a snippet's sharing settings (creator only). For GROUPS sharing the
+ * provided grants replace existing group + user grants; any other sharing type
+ * clears all ResourceAccess for the snippet. Wrapped in a transaction.
+ */
+export async function setSnippetSharing(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  snippetId: string,
+  sharingType: SnippetSharingType,
+  shares: SnippetShareInput[] | undefined
+) {
+  return guard(
+    async () => {
+      const snippet = await db.query.Snippet.findFirst({
+        where: and(
+          eq(schema.Snippet.id, snippetId),
+          eq(schema.Snippet.organizationId, organizationId),
+          eq(schema.Snippet.createdById, userId),
+          eq(schema.Snippet.isDeleted, false)
+        ),
+      })
+
+      if (!snippet) {
+        throw new NotFoundError('Snippet not found or you do not have permission to share it')
+      }
+
+      await db.transaction(async (tx) => {
+        await tx
+          .update(schema.Snippet)
+          .set({ sharingType, updatedAt: new Date() })
+          .where(eq(schema.Snippet.id, snippetId))
+
+        if (sharingType === SnippetSharingType.GROUPS) {
+          const groupShares = (shares ?? []).filter((s) => s.granteeType === 'group')
+          const userShares = (shares ?? []).filter((s) => s.granteeType === 'user')
+
+          await setInstanceAccess(
+            { db: tx, organizationId, userId },
+            toRecordId(BuiltInEntityType.snippet, snippetId),
+            ResourceGranteeType.group,
+            groupShares.map((s) => ({
+              granteeId: s.granteeId,
+              permission:
+                s.permission === 'EDIT' ? ResourcePermission.edit : ResourcePermission.view,
+            }))
+          )
+
+          await setInstanceAccess(
+            { db: tx, organizationId, userId },
+            toRecordId(BuiltInEntityType.snippet, snippetId),
+            ResourceGranteeType.user,
+            userShares.map((s) => ({
+              granteeId: s.granteeId,
+              permission:
+                s.permission === 'EDIT' ? ResourcePermission.edit : ResourcePermission.view,
+            }))
+          )
+        } else {
+          await tx
+            .delete(schema.ResourceAccess)
+            .where(
+              and(
+                eq(schema.ResourceAccess.entityDefinitionId, BuiltInEntityType.snippet),
+                eq(schema.ResourceAccess.entityInstanceId, snippetId)
+              )
+            )
+        }
+      })
+    },
+    'Error sharing snippet',
+    { snippetId }
+  )
+}
+
+/** Increment a snippet's usage counter (best-effort, org-scoped). */
+export async function incrementSnippetUsage(
+  db: Database,
+  organizationId: string,
+  snippetId: string
+) {
+  return guard(
+    async () => {
+      await db
+        .update(schema.Snippet)
+        .set({ usageCount: sql`${schema.Snippet.usageCount} + 1` })
+        .where(
+          and(
+            eq(schema.Snippet.id, snippetId),
+            eq(schema.Snippet.organizationId, organizationId),
+            eq(schema.Snippet.isDeleted, false)
+          )
+        )
+    },
+    'Error incrementing snippet usage',
+    { snippetId }
+  )
+}

--- a/packages/lib/src/snippets/snippet-permissions.ts
+++ b/packages/lib/src/snippets/snippet-permissions.ts
@@ -1,0 +1,49 @@
+// packages/lib/src/snippets/snippet-permissions.ts
+
+import { type Database, schema } from '@auxx/database'
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { and, eq, inArray } from 'drizzle-orm'
+import type { ResourceAccessInfo } from '../resource-access'
+
+/**
+ * Resolve whether `userId` may edit a snippet, given its creator and the
+ * already-fetched ResourceAccess grants. Mirrors the duplicated checks that
+ * lived in the `byId` and `update` router procedures: creator → direct user
+ * EDIT grant → group-membership EDIT grant.
+ */
+export async function resolveCanEdit(
+  db: Database,
+  userId: string,
+  createdById: string,
+  shares: ResourceAccessInfo[]
+): Promise<boolean> {
+  if (createdById === userId) return true
+  if (shares.length === 0) return false
+
+  // Direct user EDIT permission
+  const userShare = shares.find(
+    (s) => s.granteeType === ResourceGranteeType.user && s.granteeId === userId
+  )
+  if (userShare && userShare.permission === ResourcePermission.edit) {
+    return true
+  }
+
+  // EDIT permission via group membership
+  const groupShares = shares.filter(
+    (s) => s.granteeType === ResourceGranteeType.group && s.permission === ResourcePermission.edit
+  )
+  if (groupShares.length === 0) return false
+
+  const userGroupMembership = await db.query.EntityGroupMember.findFirst({
+    where: and(
+      eq(schema.EntityGroupMember.memberType, 'user'),
+      eq(schema.EntityGroupMember.memberRefId, userId),
+      inArray(
+        schema.EntityGroupMember.groupInstanceId,
+        groupShares.map((s) => s.granteeId)
+      )
+    ),
+  })
+
+  return !!userGroupMembership
+}

--- a/packages/lib/src/snippets/snippet-queries.ts
+++ b/packages/lib/src/snippets/snippet-queries.ts
@@ -1,0 +1,211 @@
+// packages/lib/src/snippets/snippet-queries.ts
+
+import { type Database, schema } from '@auxx/database'
+import { BuiltInEntityType, SnippetSharingType } from '@auxx/database/enums'
+import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import { and, asc, count, desc, eq, ilike, inArray, or, type SQL, sql } from 'drizzle-orm'
+import { NotFoundError } from '../errors'
+import { getInstanceAccess, getUserAccessibleInstances } from '../resource-access'
+import { guard } from './guard'
+import { resolveCanEdit } from './snippet-permissions'
+
+export interface ListSnippetsFilters {
+  folderId?: string
+  searchQuery?: string
+  includeShared: boolean
+}
+
+/**
+ * List the snippets visible to a user (own + org-shared + group/instance-shared),
+ * with a per-snippet share count merged in. Replaces the `all` router query.
+ */
+export async function listSnippetsForUser(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  filters: ListSnippetsFilters
+) {
+  return guard(async () => {
+    const { folderId, searchQuery, includeShared } = filters
+
+    const where: SQL[] = [
+      eq(schema.Snippet.organizationId, organizationId),
+      eq(schema.Snippet.isDeleted, false),
+    ]
+
+    if (folderId) {
+      where.push(eq(schema.Snippet.folderId, folderId))
+    }
+
+    if (searchQuery) {
+      where.push(
+        or(
+          ilike(schema.Snippet.title, `%${searchQuery}%`),
+          ilike(schema.Snippet.content, `%${searchQuery}%`)
+        )!
+      )
+    }
+
+    if (includeShared) {
+      const accessResult = await getUserAccessibleInstances(
+        { db, organizationId, userId },
+        userId,
+        BuiltInEntityType.snippet
+      )
+
+      if (accessResult.hasTypeAccess) {
+        // Org admin: own + org-shared + group-shared
+        where.push(
+          or(
+            eq(schema.Snippet.createdById, userId),
+            eq(schema.Snippet.sharingType, SnippetSharingType.ORGANIZATION),
+            eq(schema.Snippet.sharingType, SnippetSharingType.GROUPS)
+          )!
+        )
+      } else {
+        const sharedSnippetIds = accessResult.instances.map(
+          (a) => parseRecordId(a.recordId).entityInstanceId
+        )
+        where.push(
+          or(
+            eq(schema.Snippet.createdById, userId),
+            eq(schema.Snippet.sharingType, SnippetSharingType.ORGANIZATION),
+            sharedSnippetIds.length > 0 ? inArray(schema.Snippet.id, sharedSnippetIds) : sql`false`
+          )!
+        )
+      }
+    } else {
+      where.push(eq(schema.Snippet.createdById, userId))
+    }
+
+    const snippets = await db.query.Snippet.findMany({
+      where: and(...where),
+      with: {
+        folder: true,
+        createdBy: { columns: { id: true, name: true, email: true, image: true } },
+      },
+      orderBy: [desc(schema.Snippet.updatedAt)],
+    })
+
+    const snippetIds = snippets.map((s) => s.id)
+    const sharesCounts =
+      snippetIds.length > 0
+        ? await db
+            .select({
+              snippetId: schema.ResourceAccess.entityInstanceId,
+              count: count(schema.ResourceAccess.id),
+            })
+            .from(schema.ResourceAccess)
+            .where(
+              and(
+                eq(schema.ResourceAccess.entityDefinitionId, BuiltInEntityType.snippet),
+                inArray(schema.ResourceAccess.entityInstanceId, snippetIds)
+              )
+            )
+            .groupBy(schema.ResourceAccess.entityInstanceId)
+        : []
+
+    return snippets.map((snippet) => ({
+      ...snippet,
+      _count: {
+        shares: sharesCounts.find((c) => c.snippetId === snippet.id)?.count ?? 0,
+      },
+    }))
+  }, 'Error getting snippets')
+}
+
+/**
+ * Fetch a single snippet the user is allowed to see, plus its share grants and
+ * whether the user may edit it. Replaces the `byId` router query.
+ */
+export async function getSnippetWithAccess(
+  db: Database,
+  organizationId: string,
+  userId: string,
+  snippetId: string
+) {
+  return guard(
+    async () => {
+      const accessResult = await getUserAccessibleInstances(
+        { db, organizationId, userId },
+        userId,
+        BuiltInEntityType.snippet
+      )
+      const sharedSnippetIds = accessResult.instances.map(
+        (a) => parseRecordId(a.recordId).entityInstanceId
+      )
+
+      const snippet = await db.query.Snippet.findFirst({
+        where: and(
+          eq(schema.Snippet.id, snippetId),
+          eq(schema.Snippet.organizationId, organizationId),
+          eq(schema.Snippet.isDeleted, false),
+          or(
+            eq(schema.Snippet.createdById, userId),
+            eq(schema.Snippet.sharingType, SnippetSharingType.ORGANIZATION),
+            accessResult.hasTypeAccess
+              ? sql`true`
+              : sharedSnippetIds.includes(snippetId)
+                ? sql`true`
+                : sql`false`
+          )!
+        ),
+        with: {
+          folder: true,
+          createdBy: { columns: { id: true, name: true, email: true, image: true } },
+        },
+      })
+
+      if (!snippet) {
+        throw new NotFoundError('Snippet not found')
+      }
+
+      const shares = await getInstanceAccess(
+        { db, organizationId },
+        toRecordId(BuiltInEntityType.snippet, snippetId)
+      )
+
+      const canEdit = await resolveCanEdit(db, userId, snippet.createdById, shares)
+
+      return { snippet: { ...snippet, shares }, canEdit }
+    },
+    'Error getting snippet',
+    { snippetId }
+  )
+}
+
+/**
+ * List all snippet folders for an organization with a per-folder snippet count.
+ * Replaces the `getFolders` router query.
+ */
+export async function listSnippetFoldersWithCounts(db: Database, organizationId: string) {
+  return guard(async () => {
+    const folders = await db.query.SnippetFolder.findMany({
+      where: eq(schema.SnippetFolder.organizationId, organizationId),
+      with: { subfolders: true },
+      orderBy: [asc(schema.SnippetFolder.name)],
+    })
+
+    const folderIds = folders.map((f) => f.id)
+    const snippetCounts =
+      folderIds.length > 0
+        ? await db
+            .select({
+              folderId: schema.Snippet.folderId,
+              count: count(schema.Snippet.id),
+            })
+            .from(schema.Snippet)
+            .where(
+              and(inArray(schema.Snippet.folderId, folderIds), eq(schema.Snippet.isDeleted, false))
+            )
+            .groupBy(schema.Snippet.folderId)
+        : []
+
+    return folders.map((folder) => ({
+      ...folder,
+      _count: {
+        snippets: snippetCounts.find((c) => c.folderId === folder.id)?.count ?? 0,
+      },
+    }))
+  }, 'Error getting snippet folders')
+}


### PR DESCRIPTION
## What

Phase 2 of the thin-routers refactor (`plans/routers/thin-routers-refactor-plan.md`), scoped to **snippets only**. Moves all inline business logic out of the `snippet` tRPC router and into a new functional `@auxx/lib/snippets` module.

The router (968 → ~215 lines) is now thin glue: **validate (zod) → call helper → map `Result`**.

## How

- **New `packages/lib/src/snippets/`** (functional, `db`-first, no `BaseModel`):
  - `snippet-queries.ts` — `listSnippetsForUser`, `getSnippetWithAccess`, `listSnippetFoldersWithCounts`
  - `snippet-mutations.ts` — `createSnippet`, `updateSnippet`, `deleteSnippet`, `setSnippetSharing` (txn), `incrementSnippetUsage`
  - `snippet-folder-mutations.ts` — `createSnippetFolder`, `updateSnippetFolder`, `deleteSnippetFolderWithCascade` (txn)
  - `snippet-permissions.ts` — shared `resolveCanEdit` (was duplicated between `byId`/`update`)
  - `guard.ts` — wraps each body: thrown `AuxxError` → `err`, unexpected → logged 500
- Helpers return neverthrow `Result<T, AuxxError>`. The router throws `result.error`; the existing `auxxErrorMiddleware` on `protectedProcedure` maps it to the correct tRPC code.
- Added `./snippets` export to `@auxx/lib/package.json`.

## Behavior

Pure relocation — no behavior change. The two visibility filters in `all` vs `byId` were **kept separate** (their admin branches genuinely differ); only `resolveCanEdit` was shared. `incrementUsage` keeps its swallow-errors semantics.

## Tests

10 passing unit tests (`__tests__/`) covering the sharing transaction, folder circular-ref guard, folder-delete re-parenting, and NotFound paths.

> Note: adds a brand-new `@auxx/lib/snippets` subpath — lib may need a build before the web dev server resolves it (stale-dist behavior).