### PR TITLE
fix(data-connectors): lazy owned-def field picker projection-aware

### DIFF
--- a/apps/web/src/components/data-connectors/lib/connector-target-projection.ts
+++ b/apps/web/src/components/data-connectors/lib/connector-target-projection.ts
@@ -77,6 +77,10 @@ export function projectProvisionFields(
       label: fm.provision.name,
       name: fm.provision.name,
       fieldType: fm.provision.type as FieldType,
+      active: true,
+      // A provisioned column the connector will create — fully writable by the sync,
+      // so it passes the target picker's `isWritableTarget` capability gate.
+      capabilities: { creatable: true, updatable: true, computed: false },
     } as unknown as ResourceField)
   }
   return fields

--- a/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
@@ -62,6 +62,19 @@ interface MappingFieldPickerProps {
   kind?: 'leaf' | 'branch'
   /** The def the picker drills/binds FROM (the enclosing mapping's def). Null = no def yet. */
   entityDefinitionId: string | null
+  /**
+   * The enclosing mapping targets a not-yet-created (lazily-provisioned) owned def
+   * (05e). There's no real `entityDefinitionId` to resolve against, so the picker
+   * operates on {@link projectedFields} (the columns the def will create) and binds /
+   * quick-creates as `provision` specs instead of concrete `ResourceFieldId`s.
+   */
+  willCreate?: boolean
+  /** Projected provision fields for a {@link willCreate} target — the picker's root list. */
+  projectedFields?: ResourceField[]
+  /** Bind a source node to one of the potential def's projected provision columns. */
+  onProvisionSelect?: (provision: { name: string; type: string; appFieldKey?: string }) => void
+  /** Quick-create a new column on the potential def (writes a `provision` spec). */
+  onProvisionCreate?: (provision: { name: string; type: FieldTypeType }) => void
   /** The source node being bound — drives the type filter + quick-create seed ('leaf'). */
   sourceType?: string
   sourcePath?: string
@@ -119,6 +132,10 @@ interface MappingFieldPickerProps {
 export function MappingFieldPicker({
   kind = 'leaf',
   entityDefinitionId,
+  willCreate = false,
+  projectedFields,
+  onProvisionSelect,
+  onProvisionCreate,
   sourceType = 'string',
   sourcePath = '',
   sourceFormat,
@@ -145,9 +162,15 @@ export function MappingFieldPicker({
   const chipLabel =
     assignedLabel ?? (isAssigned ? (assignedKey ?? 'Linked') : (placeholder ?? 'Apply field…'))
 
-  // No target def yet — nothing to resolve against. Show a disabled trigger;
-  // binding unlocks once a target def is picked (plan 08 §3.4).
-  if (!entityDefinitionId) {
+  // A lazily-provisioned owned target has no `entityDefinitionId` yet, but its columns
+  // are known from the projected provision specs — so the picker stays live, resolving
+  // and binding against those instead of a real def (05e).
+  const isLazy = !entityDefinitionId && willCreate
+  const hasTarget = !!entityDefinitionId || isLazy
+
+  // No target at all — neither a real def nor a potential owned one. Show a disabled
+  // trigger; binding unlocks once a target def is picked (plan 08 §3.4).
+  if (!hasTarget) {
     return (
       <Button
         variant='transparent'
@@ -190,7 +213,10 @@ export function MappingFieldPicker({
       <PopoverContent className='w-72 p-0' align='start'>
         {view === 'pick' ? (
           <FieldPickerContent
-            entityDefinitionId={entityDefinitionId}
+            entityDefinitionId={entityDefinitionId ?? ''}
+            // A lazy owned target has no def to resolve — render its projected provision
+            // columns directly (05e).
+            fields={isLazy ? projectedFields : undefined}
             // Check the bound DIRECT scalar, the drilled FieldPath, and any id-only
             // link — a leaf can carry both a value bind and a link.
             fieldReferences={
@@ -208,9 +234,14 @@ export function MappingFieldPicker({
             filterField={(f) => {
               if (f.relationship) return showRelationships
               if (isBranch) return false
-              const rfid = f.resourceFieldId ?? toResourceFieldId(entityDefinitionId, f.id)
-              const notExcluded =
-                getFieldDefinitionId(rfid) === entityDefinitionId ? !excludeKeys?.has(rfid) : true
+              const rfid = f.resourceFieldId ?? toResourceFieldId(entityDefinitionId ?? '', f.id)
+              // Lazy projected fields are keyed by a `@potential:` ref (no def segment),
+              // so just honor the uniqueness exclusion; a real def also checks ownership.
+              const notExcluded = isLazy
+                ? !excludeKeys?.has(rfid)
+                : getFieldDefinitionId(rfid) === entityDefinitionId
+                  ? !excludeKeys?.has(rfid)
+                  : true
               return (
                 notExcluded &&
                 isWritableTarget(f) &&
@@ -227,13 +258,25 @@ export function MappingFieldPicker({
                 onSelectRelationship?.(field, ref)
                 return
               }
+              // Lazy owned target → bind to a projected provision column (no concrete
+              // ref exists yet; the binding carries the provision spec instead).
+              if (isLazy) {
+                onProvisionSelect?.({
+                  name: field.label,
+                  type: field.fieldType as string,
+                  appFieldKey: field.id,
+                })
+                return
+              }
               // Scalar reached by drilling → bind across the relationship.
               if (isFieldPath(ref)) {
                 onDrilledAssign?.(field, ref)
                 return
               }
               // Scalar at root → bind directly on the current def.
-              onAssign?.(field.resourceFieldId ?? toResourceFieldId(entityDefinitionId, field.id))
+              onAssign?.(
+                field.resourceFieldId ?? toResourceFieldId(entityDefinitionId ?? '', field.id)
+              )
             }}
             // Skip = unbind whatever is currently bound on this leaf (direct or drilled).
             onSkip={!isBranch && isAssigned ? onClear : undefined}
@@ -241,9 +284,21 @@ export function MappingFieldPicker({
             createLabel='Quick create'
             onCreateField={!isBranch && canCreate ? () => setView('create') : undefined}
           />
+        ) : isLazy ? (
+          // The def doesn't exist yet, so we can't mint a real field — author a
+          // provision spec instead; materialize creates the column at first sync (05e).
+          <ProvisionCreateForm
+            seedName={humanizeFieldPath(sourcePath)}
+            seedType={inferFieldType(sourcePath, sourceType, sourceFormat)}
+            onBack={() => setView('pick')}
+            onCreated={(provision) => {
+              onProvisionCreate?.(provision)
+              onOpenChange(false)
+            }}
+          />
         ) : (
           <QuickCreateFieldForm
-            entityDefinitionId={entityDefinitionId}
+            entityDefinitionId={entityDefinitionId ?? ''}
             sourceType={sourceType}
             excludeKeys={excludeKeys}
             seedName={humanizeFieldPath(sourcePath)}
@@ -257,6 +312,97 @@ export function MappingFieldPicker({
         )}
       </PopoverContent>
     </Popover>
+  )
+}
+
+/**
+ * Inline name + type authoring for a NEW column on a not-yet-created (lazily-provisioned)
+ * owned def (05e). Unlike {@link QuickCreateFieldForm}, it runs no mutation — the def has
+ * no id yet — and hands back a `provision` spec the caller stores on the binding; the
+ * column is created at materialize (finish / first sync). The type picker is the full
+ * {@link FIELD_TYPE_GROUPS} catalog (minus RELATIONSHIP), pre-seeded from the source node.
+ */
+function ProvisionCreateForm({
+  seedName,
+  seedType,
+  onBack,
+  onCreated,
+}: {
+  seedName: string
+  seedType: FieldTypeType
+  onBack: () => void
+  onCreated: (provision: { name: string; type: FieldTypeType }) => void
+}) {
+  const [name, setName] = useState(seedName)
+  const [type, setType] = useState<FieldTypeType>(seedType)
+  const [typePickerOpen, setTypePickerOpen] = useState(false)
+  const groups = useFieldTypeGroups()
+
+  const trimmed = name.trim()
+  const canSubmit = !!trimmed
+  const submit = () => {
+    if (!canSubmit) return
+    onCreated({ name: trimmed, type })
+  }
+
+  const selectedTypeOption = fieldTypeOptions[type]
+  const selectedAsOption: Option | null = selectedTypeOption
+    ? { value: type, label: selectedTypeOption.label, iconId: selectedTypeOption.iconId }
+    : null
+
+  return (
+    <div className='flex flex-col gap-2 p-3'>
+      <button
+        type='button'
+        onClick={onBack}
+        className='-ml-1 flex w-fit items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground'>
+        <ChevronLeft className='size-3.5' />
+        New field
+      </button>
+
+      <input
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') submit()
+          if (e.key === 'Escape') onBack()
+        }}
+        placeholder='Field name'
+        className='w-full rounded-md border bg-background px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-ring'
+      />
+
+      <ComboPicker
+        groups={groups}
+        selected={selectedAsOption}
+        multi={false}
+        className='w-[var(--radix-popover-trigger-width)]!'
+        open={typePickerOpen}
+        onOpen={() => setTypePickerOpen(true)}
+        onClose={() => setTypePickerOpen(false)}
+        onChange={(opt) => {
+          if (opt && !Array.isArray(opt)) setType(opt.value as FieldTypeType)
+          setTypePickerOpen(false)
+        }}
+        showSearch
+        searchPlaceholder='Search field types…'>
+        <Button variant='outline' size='sm' className='h-7 w-full justify-between text-xs'>
+          <span className='flex items-center gap-2'>
+            {selectedTypeOption && (
+              <EntityIcon iconId={selectedTypeOption.iconId} variant='default' size='xs' />
+            )}
+            {selectedTypeOption?.label ?? 'Select type'}
+          </span>
+          <ChevronsUpDown className='size-3.5 opacity-50' />
+        </Button>
+      </ComboPicker>
+
+      <div className='flex justify-end gap-1.5'>
+        <Button variant='outline' size='xs' disabled={!canSubmit} onClick={submit}>
+          Add field
+        </Button>
+      </div>
+    </div>
   )
 }
 

--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -349,6 +349,27 @@ export function MappingNode({
   }
   const clearEntry = (id: string) => writeEntries(fieldMappings.filter((e) => e.id !== id))
 
+  // Bind a source leaf onto a LAZY owned def's column (05e): the def doesn't exist yet,
+  // so there's no concrete `targetFieldRef` — the entry carries the `provision` spec and
+  // materialize creates the column (then backfills the ref) at finish / first sync. Drops
+  // any prior bare-token entry on this source (1 source → 1 target), same as assignTarget.
+  const assignProvision = (
+    sourcePath: string,
+    provision: { name: string; type: string; appFieldKey?: string }
+  ) => {
+    const next = fieldMappings.filter(
+      (e) => !(isBareToken(e.expression) && bareTokenSource(e.expression) === sourcePath)
+    )
+    next.push({
+      id: generateId(),
+      targetFieldRef: null,
+      provision,
+      expression: `{${sourcePath}}`,
+      sourceFields: { [sourcePath]: sourcePath },
+    })
+    writeEntries(next)
+  }
+
   // Re-point a formula at a different target field. Identity is the entry id, so
   // this is a single field set — merge/match ride along, no re-key.
   const retargetEntry = (id: string, newRef: string) => patchEntry(id, { targetFieldRef: newRef })
@@ -841,6 +862,8 @@ export function MappingNode({
                 mapping={mapping}
                 targetMode={targetMode}
                 targetFields={targetFields}
+                willCreate={!!potential}
+                onAssignProvision={assignProvision}
                 sourceToEntry={sourceToEntry}
                 usedTargetKeys={usedTargetKeys}
                 childByNodePath={childByNodePath}
@@ -1002,6 +1025,13 @@ interface SourceNodeProps {
   mapping: Mapping
   targetMode: 'owned' | 'contributing'
   targetFields: ResourceField[]
+  /** The target is a not-yet-created (lazily-provisioned) owned def (05e). */
+  willCreate: boolean
+  /** Bind / quick-create a leaf onto a lazy owned def's projected provision column. */
+  onAssignProvision: (
+    sourcePath: string,
+    provision: { name: string; type: string; appFieldKey?: string }
+  ) => void
   /** Reverse index: source path → the bare-token binding entry on it. */
   sourceToEntry: Map<string, FieldMapping>
   /** Every target key bound by some entry — leaf pickers exclude the rest. */
@@ -1191,15 +1221,18 @@ function SourceNode(props: SourceNodeProps) {
         depth={depth}
         node={node}
         entityDefinitionId={mapping.entityDefinitionId}
+        willCreate={props.willCreate}
+        projectedFields={props.willCreate ? targetFields : undefined}
+        onAssignProvision={(provision) => props.onAssignProvision(node.path, provision)}
         assignedLabel={assignedLabel}
         assignedIconId={drilledIconId ?? assignedIconId}
         assignedTargetKey={assignedTargetKey}
         excludeKeys={excludeKeys}
-        // Quick-create is available whenever a target def is set — both owned
-        // (the connector provisions the def) and contributing (adding a field to
-        // an existing def). The `customField.create` mutation is the backstop for
-        // a def that rejects new fields.
-        canCreate={!!mapping.entityDefinitionId}
+        // Quick-create is available whenever there's a target — a real def (owned or
+        // contributing; the `customField.create` mutation mints the field) OR a lazy
+        // owned def not yet created (05e), where it authors a `provision` spec the
+        // connector materializes at first sync.
+        canCreate={!!mapping.entityDefinitionId || props.willCreate}
         isOwned={targetMode === 'owned'}
         identityRole={identityRole}
         mergeStrategy={activeEntry?.mergeStrategy ?? 'overwrite'}

--- a/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
@@ -45,6 +45,10 @@ interface SourceLeafRowProps {
   node: SourcePath
   /** The enclosing mapping's def — the binding target. Null until a def is picked. */
   entityDefinitionId: string | null
+  /** The target is a not-yet-created (lazily-provisioned) owned def — bind via provisions (05e). */
+  willCreate?: boolean
+  /** Projected provision columns for a {@link willCreate} target — the picker's field list. */
+  projectedFields?: ResourceField[]
   /** Resolved label for the bound key (for the chip). */
   assignedLabel: string | undefined
   /** Resolved icon id for the applied field (direct or drilled) — shown on the chip. */
@@ -78,6 +82,8 @@ interface SourceLeafRowProps {
   /** Set / clear this leaf's identity role (External ID anchor or secondary Match). */
   onSetIdentityRole: (role: LeafIdentityRole) => void
   onLinkRelationship?: (field: ResourceField, ref: FieldReference) => void
+  /** Bind / quick-create this leaf onto a projected provision column of a lazy owned def. */
+  onAssignProvision?: (provision: { name: string; type: string; appFieldKey?: string }) => void
 }
 
 /**
@@ -91,6 +97,8 @@ export function SourceLeafRow({
   depth,
   node,
   entityDefinitionId,
+  willCreate,
+  projectedFields,
   assignedLabel,
   assignedIconId,
   assignedTargetKey,
@@ -109,6 +117,7 @@ export function SourceLeafRow({
   onMergeChange,
   onSetIdentityRole,
   onLinkRelationship,
+  onAssignProvision,
 }: SourceLeafRowProps) {
   const isMapped = !!assignedTargetKey || !!drilledRef
   const isArray = node.type === 'array'
@@ -144,6 +153,10 @@ export function SourceLeafRow({
         <MappingFieldPicker
           kind='leaf'
           entityDefinitionId={entityDefinitionId}
+          willCreate={willCreate}
+          projectedFields={projectedFields}
+          onProvisionSelect={onAssignProvision}
+          onProvisionCreate={onAssignProvision}
           sourceType={node.type}
           sourcePath={node.path}
           sourceFormat={node.format}

--- a/apps/web/src/components/pickers/field-picker/field-picker-content.tsx
+++ b/apps/web/src/components/pickers/field-picker/field-picker-content.tsx
@@ -70,6 +70,7 @@ function shouldExcludeField(field: ResourceField, excludeFields?: ExcludeFilter[
  */
 export function FieldPickerInnerContent({
   entityDefinitionId,
+  fields: rootFieldsOverride,
   fieldReferences = [],
   excludeFields,
   filterField,
@@ -98,8 +99,11 @@ export function FieldPickerInnerContent({
   // Determine which entity to show fields for
   const currentEntityDefinitionId = current?.targetEntityDefinitionId ?? entityDefinitionId
 
-  // Get fields for current entity
-  const { fields } = useResourceFields(currentEntityDefinitionId)
+  // Get fields for current entity. A root-level override (projected provision fields
+  // for a not-yet-created def) wins only at the root; once drilled into a real related
+  // def, resolve that def's fields from the store as usual.
+  const { fields: storeFields } = useResourceFields(currentEntityDefinitionId)
+  const fields = isAtRoot && rootFieldsOverride ? rootFieldsOverride : storeFields
 
   // Get current entity's label and icon (for drilled-down view)
   const entityProps = useResourceProperty(currentEntityDefinitionId, ['label', 'icon', 'color'])

--- a/apps/web/src/components/pickers/field-picker/types.ts
+++ b/apps/web/src/components/pickers/field-picker/types.ts
@@ -22,6 +22,16 @@ export interface FieldPickerContentProps {
   /** Entity definition ID to show fields for */
   entityDefinitionId: string
 
+  /**
+   * Optional explicit field list to render at the ROOT instead of resolving them
+   * from {@link entityDefinitionId} via the resource store. Used for a not-yet-created
+   * (lazily-provisioned) def whose columns live only as projected provision specs — the
+   * def has no id to resolve against yet. Drill-down still resolves a related def's
+   * fields from the store; projected provision fields carry no relationships, so they
+   * never drill.
+   */
+  fields?: ResourceField[]
+
   /** Already selected field references */
   fieldReferences?: FieldReference[]
 


### PR DESCRIPTION
## Problem

In the 05e lazy owned-def mapping editor, the def header correctly showed the potential entity (e.g. **Shopify Order (New)**), but every subfield rendered a disabled **"Pick a target def…"** — including fields already provision-bound from the catalog.

**Root cause:** `MappingFieldPicker` hard-gated on the raw `entityDefinitionId`:

```ts
if (!entityDefinitionId) return <disabled "Pick a target def…">
```

For a lazily-provisioned owned def that id is `null`, so the picker short-circuited and ignored the projection (`targetSpec` + per-entry `provision` specs) that the rest of `MappingNode` already resolves from. The 05e plan's frontend swap covered the display hooks but missed this guard, and §3.4's "quick-create writes a provision spec" path was never wired.

## Fix

Made the leaf picker projection-aware, mirroring the def header:

- **projection** — projected provision fields now carry `active` + `capabilities` so they pass the picker's `isWritableTarget`/active filters.
- **field-picker** — optional root `fields` override so a def with no id can render its projected provision columns (drill-down still resolves real related defs from the store).
- **mapping-field-picker** — new `willCreate` / `projectedFields` / `onProvisionSelect` / `onProvisionCreate`; replaced the `!entityDefinitionId` guard with `!hasTarget` (real def **or** potential owned). Binding a column or quick-creating now writes a `provision` spec (materialized at finish/first sync) instead of a concrete ref. Added a mutation-free `ProvisionCreateForm`.
- **source-leaf-row / mapping-node** — threaded the props, added an `assignProvision` handler, and enabled quick-create on lazy owned defs.

Result: provision-bound catalog fields show their chips ("Order ID", "Order Name"); unbound source leaves let you link a projected column or quick-create a new one; contributing/real-def mappings are unchanged.

## Out of scope

Formula rows on a lazy owned def remain unsupported (the "Add formula" row is still gated on a real def id) — not reachable in the current setup flow.

## Testing

- Biome clean on all touched files.
- All 100 `data-connectors` web tests pass (incl. the projection unit). Broader-run failures are pre-existing in agents/knowledge/entity-definitions, untouched here.
- Not yet verified end-to-end in a browser.