### PR TITLE
feat(data-connectors): select/address field provisioning + nested rel parenting + sync UI polish

### DIFF
--- a/apps/web/src/components/data-connectors/ui/connector-backfill-progress.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-backfill-progress.tsx
@@ -1,9 +1,10 @@
 // apps/web/src/components/data-connectors/ui/connector-backfill-progress.tsx
 'use client'
 
+import { Badge } from '@auxx/ui/components/badge'
 import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { cn } from '@auxx/ui/lib/utils'
-import { ArrowRight } from 'lucide-react'
+import { CheckCircle2 } from 'lucide-react'
 
 /** One stream's live import progress, projected from `getStatus.perStream`. */
 export interface BackfillStreamProgress {
@@ -25,6 +26,15 @@ interface ConnectorBackfillProgressProps {
    * since a sample HAS a known denominator (unlike a full backfill).
    */
   sampleLimit?: number | null
+  /**
+   * Render the settled, post-sync state: no more candy-stripe motion, a "Synced"
+   * header with a check, and the freshness time in the footer instead of "Started".
+   * Lets the per-stream breakdown LINGER after a run finishes rather than vanishing
+   * the instant the connector flips `syncing → live`.
+   */
+  completed?: boolean
+  /** Freshness time shown in the completed footer (lastSyncedAt). */
+  syncedAt?: Date | string | null
 }
 
 /**
@@ -39,34 +49,60 @@ export function ConnectorBackfillProgress({
   startedAt,
   perStream,
   sampleLimit,
+  completed = false,
+  syncedAt,
 }: ConnectorBackfillProgressProps) {
   const total = perStream.reduce((n, s) => n + s.recordsSeen, 0)
   const isSample = sampleLimit != null
 
+  const header = completed
+    ? `Synced from ${sourceLabel}`
+    : isSample
+      ? `Sampling from ${sourceLabel}`
+      : `Importing from ${sourceLabel}`
+
   return (
     <div className='flex flex-col gap-3 border-b bg-muted/30 px-4 py-3'>
-      <div className='text-xs font-semibold text-muted-foreground'>
-        {isSample ? `Sampling from ${sourceLabel}` : `Importing from ${sourceLabel}`}
+      <div className='flex items-center gap-1.5 text-xs font-semibold text-muted-foreground'>
+        {completed && <CheckCircle2 className='size-3.5 text-info' />}
+        {header}
       </div>
 
       <div className='flex flex-col gap-2'>
         {perStream.map((s) => (
-          <StreamRow key={s.streamKey || '∅'} stream={s} sampleLimit={sampleLimit} />
+          <StreamRow
+            key={s.streamKey || '∅'}
+            stream={s}
+            sampleLimit={sampleLimit}
+            done={completed}
+          />
         ))}
       </div>
 
-      <PipelineFlow />
-
       <div className='text-[11px] text-muted-foreground'>
-        {startedAt && (
+        {completed ? (
           <>
-            <LastUpdated timestamp={startedAt} prefix='Started' className='text-[11px]' />
-            {' · '}
+            {`${total.toLocaleString()} records synced`}
+            {syncedAt && (
+              <>
+                {' · '}
+                <LastUpdated timestamp={syncedAt} className='text-[11px]' />
+              </>
+            )}
+          </>
+        ) : (
+          <>
+            {startedAt && (
+              <>
+                <LastUpdated timestamp={startedAt} prefix='Started' className='text-[11px]' />
+                {' · '}
+              </>
+            )}
+            {isSample
+              ? `Sampling up to ${sampleLimit?.toLocaleString()} per stream`
+              : `${total.toLocaleString()} records so far`}
           </>
         )}
-        {isSample
-          ? `Sampling up to ${sampleLimit?.toLocaleString()} per stream`
-          : `${total.toLocaleString()} records so far`}
       </div>
     </div>
   )
@@ -76,14 +112,17 @@ export function ConnectorBackfillProgress({
 function StreamRow({
   stream,
   sampleLimit,
+  done: forceDone = false,
 }: {
   stream: BackfillStreamProgress
   sampleLimit?: number | null
+  /** Force the settled (solid, "done") look — the card-level completed state. */
+  done?: boolean
 }) {
   // A sample HAS a denominator (the cap), so show "N of limit" + a real fill ratio —
   // the one place a backfill bar isn't faking a percent (full backfills never know total).
   const capped = sampleLimit != null && stream.recordsSeen >= sampleLimit
-  const done = stream.done || capped
+  const done = forceDone || stream.done || capped
   const fillPct =
     sampleLimit != null ? Math.min(100, Math.round((stream.recordsSeen / sampleLimit) * 100)) : null
   return (
@@ -91,11 +130,11 @@ function StreamRow({
       <span className='w-24 shrink-0 truncate capitalize' title={stream.streamKey}>
         {stream.streamKey || 'Records'}
       </span>
-      <div className='h-1.5 flex-1 overflow-hidden rounded-full bg-foreground/10'>
+      <div className='h-1.5 flex-1 overflow-hidden rounded-full bg-primary-500'>
         <div
           className={cn(
-            'h-full rounded-full',
-            done ? 'bg-green-500/70' : 'animate-pulse bg-amber-500/70',
+            'h-full rounded-full bg-info',
+            !done && 'candy-stripes',
             fillPct == null && 'w-full'
           )}
           style={fillPct != null ? { width: `${fillPct}%` } : undefined}
@@ -106,30 +145,11 @@ function StreamRow({
           ? `${stream.recordsSeen.toLocaleString()} / ${sampleLimit.toLocaleString()}`
           : stream.recordsSeen.toLocaleString()}
       </span>
-      <span className={cn('w-16 shrink-0 text-right', done ? 'text-green-600' : 'text-amber-600')}>
-        {done ? 'done' : 'fetching…'}
-      </span>
-    </div>
-  )
-}
-
-/**
- * The Fetch → Map → Save flow metaphor (Stitch). Our engine streams records through
- * all three continuously, so during a backfill all three read as active — it conveys
- * "data is flowing", not staged percentages.
- */
-function PipelineFlow() {
-  return (
-    <div className='flex items-center gap-1.5 text-[11px] text-muted-foreground'>
-      {['Fetch', 'Map', 'Save'].map((label, i) => (
-        <span key={label} className='inline-flex items-center gap-1.5'>
-          {i > 0 && <ArrowRight className='size-3 opacity-50' />}
-          <span className='inline-flex items-center gap-1'>
-            <span className='size-1.5 animate-pulse rounded-full bg-amber-500' />
-            {label}
-          </span>
-        </span>
-      ))}
+      <div className='flex w-16 shrink-0 justify-end'>
+        <Badge size='xs' variant={done ? 'green' : 'amber'}>
+          {done ? 'done' : 'fetching…'}
+        </Badge>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
@@ -131,6 +131,269 @@ function RunRow({ run, sourceLabel }: { run: ConnectorRun; sourceLabel: string }
   )
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// DEV-ONLY UI mock. Flip `MOCK_SCENARIO` away from 'off' to render the Runs drawer
+// against canned synced data without standing up a real connector + sync. Lets
+// us iterate on the freshness / backfill / run-history layout. DELETE before
+// shipping — nothing here is reachable when the scenario is 'off'.
+//   • 'live'     → steady state: freshness panel + a rich run history
+//   • 'backfill' → first import in flight (unknown total)
+//   • 'sampling' → trial sample run in flight (known denominator)
+// ──────────────────────────────────────────────────────────────────────────
+const MOCK_SCENARIO: 'off' | 'live' | 'backfill' | 'sampling' = 'off'
+
+type StatusData = RouterOutputs['dataConnector']['getStatus']
+
+/** Build one fake run row, filling every required column so the fixture stays terse. */
+function mockRun(partial: Partial<ConnectorRun> & { id: string }): ConnectorRun {
+  return {
+    dataConnectorId: 'mock-connector',
+    organizationId: 'mock-org',
+    trigger: 'manual',
+    mode: 'incremental',
+    status: 'completed',
+    phase: 'steady',
+    sampleLimit: null,
+    fetched: 0,
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    archived: 0,
+    deleted: 0,
+    failed: 0,
+    relationshipWarnings: 0,
+    pagesProcessed: 1,
+    rateLimitWaitMs: 0,
+    errorSample: null,
+    progress: null,
+    chainSnapshot: null,
+    cursorBefore: null,
+    cursorAfter: null,
+    startedAt: new Date(),
+    heartbeatAt: new Date(),
+    finishedAt: new Date(),
+    durationMs: 1200,
+    ...partial,
+  } as ConnectorRun
+}
+
+/** Relative timestamp helper for the fixtures (N ms ago). */
+const ago = (ms: number) => new Date(Date.now() - ms)
+
+/** Canned `getStatus` + `listRuns` data per scenario, shaped exactly like the queries. */
+function buildMockData(scenario: Exclude<typeof MOCK_SCENARIO, 'off'>): {
+  status: StatusData
+  runs: ConnectorRun[]
+} {
+  if (scenario === 'backfill' || scenario === 'sampling') {
+    const sampleLimit = scenario === 'sampling' ? 500 : null
+    const perStream = [
+      {
+        streamKey: 'customers',
+        recordsSeen: scenario === 'sampling' ? 500 : 1840,
+        phase: 'steady' as const,
+        done: true,
+      },
+      {
+        streamKey: 'orders',
+        recordsSeen: scenario === 'sampling' ? 312 : 6204,
+        phase: 'backfill' as const,
+        done: false,
+      },
+      {
+        streamKey: 'products',
+        recordsSeen: scenario === 'sampling' ? 88 : 742,
+        phase: 'backfill' as const,
+        done: false,
+      },
+    ]
+    const recordsSeen = perStream.reduce((n, s) => n + s.recordsSeen, 0)
+    return {
+      status: {
+        status: 'syncing',
+        syncBehavior: 'scheduled',
+        lastSyncedAt: null,
+        lastWebhookEventAt: null,
+        itemCount: recordsSeen,
+        error: null,
+        resyncPending: null,
+        nextSyncAt: null,
+        cadenceLabel: 'every 15 minutes',
+        latestRun: {
+          id: 'mock-run-live',
+          status: 'running',
+          phase: 'backfill',
+          trigger: 'manual',
+          mode: 'snapshot',
+          recordsSeen,
+          created: 0,
+          updated: 0,
+          startedAt: ago(42_000),
+          finishedAt: null,
+          rateLimitedUntil: null,
+          pausedReason: null,
+          sampleLimit,
+          primaryStreamLabel: 'orders',
+        },
+        perStream,
+      } as StatusData,
+      runs: [
+        mockRun({
+          id: 'mock-run-live',
+          status: 'running',
+          phase: 'backfill',
+          mode: 'snapshot',
+          sampleLimit,
+          startedAt: ago(42_000),
+          finishedAt: null,
+          durationMs: null,
+        }),
+      ],
+    }
+  }
+
+  // 'live' — steady state with a rich history.
+  return {
+    status: {
+      status: 'live',
+      syncBehavior: 'scheduled',
+      lastSyncedAt: ago(8 * 60_000),
+      lastWebhookEventAt: null,
+      itemCount: 8786,
+      error: null,
+      resyncPending: null,
+      nextSyncAt: new Date(Date.now() + 7 * 60_000).toISOString(),
+      cadenceLabel: 'every 15 minutes',
+      latestRun: {
+        id: 'mock-run-1',
+        status: 'completed',
+        phase: 'steady',
+        trigger: 'scheduled',
+        mode: 'incremental',
+        recordsSeen: 124,
+        created: 12,
+        updated: 38,
+        startedAt: ago(8 * 60_000),
+        finishedAt: ago(8 * 60_000 - 4200),
+        rateLimitedUntil: null,
+        pausedReason: null,
+        sampleLimit: null,
+        primaryStreamLabel: 'orders',
+      },
+      perStream: [
+        { streamKey: 'customers', recordsSeen: 1840, phase: 'steady', done: true },
+        { streamKey: 'orders', recordsSeen: 6204, phase: 'steady', done: true },
+        { streamKey: 'products', recordsSeen: 742, phase: 'steady', done: true },
+      ],
+    } as StatusData,
+    runs: [
+      mockRun({
+        id: 'mock-run-1',
+        trigger: 'scheduled',
+        created: 12,
+        updated: 38,
+        skipped: 70,
+        fetched: 124,
+        startedAt: ago(8 * 60_000),
+        finishedAt: ago(8 * 60_000 - 4200),
+        durationMs: 4200,
+      }),
+      mockRun({
+        id: 'mock-run-2',
+        trigger: 'scheduled',
+        updated: 5,
+        skipped: 119,
+        fetched: 124,
+        relationshipWarnings: 2,
+        startedAt: ago(23 * 60_000),
+        durationMs: 3100,
+      }),
+      mockRun({
+        id: 'mock-run-3',
+        trigger: 'manual',
+        status: 'partial',
+        phase: 'backfill',
+        mode: 'snapshot',
+        sampleLimit: 500,
+        created: 488,
+        skipped: 0,
+        failed: 12,
+        fetched: 500,
+        startedAt: ago(2 * 3600_000),
+        durationMs: 18400,
+        errorSample: [
+          { externalId: 'cust_8812', error: 'Missing required field: email', tier: 'invalid' },
+          { externalId: 'cust_9043', error: 'Address line exceeds 255 chars', tier: 'rejected' },
+          {
+            externalId: 'cust_9101',
+            error: 'Phone number failed E.164 validation',
+            tier: 'invalid',
+          },
+        ],
+      }),
+      mockRun({
+        id: 'mock-run-4',
+        trigger: 'scheduled',
+        status: 'failed',
+        updated: 0,
+        fetched: 0,
+        failed: 1,
+        startedAt: ago(5 * 3600_000),
+        durationMs: 900,
+        errorSample: [{ externalId: '', error: 'Upstream returned 503 Service Unavailable' }],
+      }),
+      mockRun({
+        id: 'mock-run-5',
+        trigger: 'manual',
+        mode: 'snapshot',
+        phase: 'backfill',
+        created: 8786,
+        fetched: 8786,
+        startedAt: ago(26 * 3600_000),
+        durationMs: 142000,
+      }),
+      mockRun({
+        id: 'mock-run-6',
+        trigger: 'scheduled',
+        updated: 3,
+        skipped: 121,
+        fetched: 124,
+        startedAt: ago(27 * 3600_000),
+        durationMs: 2800,
+      }),
+      mockRun({
+        id: 'mock-run-7',
+        trigger: 'scheduled',
+        updated: 1,
+        skipped: 123,
+        fetched: 124,
+        startedAt: ago(28 * 3600_000),
+        durationMs: 2600,
+      }),
+      mockRun({
+        id: 'mock-run-8',
+        trigger: 'scheduled',
+        archived: 4,
+        updated: 2,
+        skipped: 118,
+        fetched: 124,
+        startedAt: ago(29 * 3600_000),
+        durationMs: 2900,
+      }),
+      mockRun({
+        id: 'mock-run-9',
+        trigger: 'scheduled',
+        deleted: 1,
+        updated: 6,
+        skipped: 117,
+        fetched: 124,
+        startedAt: ago(30 * 3600_000),
+        durationMs: 3050,
+      }),
+    ],
+  }
+}
+
 /** How many runs render before the "Show more" row collapses the rest. */
 const VISIBLE_RUN_LIMIT = 7
 
@@ -197,7 +460,12 @@ export function ConnectorRunsPanel({
       },
     }
   )
-  const status = statusQuery.data?.status ?? initialStatus
+  // DEV-ONLY: when `MOCK_SCENARIO` is on, override the live query data so the panel
+  // renders against canned synced data. No-op (and tree-shakeable) when it's 'off'.
+  const mock = MOCK_SCENARIO === 'off' ? null : buildMockData(MOCK_SCENARIO)
+  const statusData = mock?.status ?? statusQuery.data
+
+  const status = statusData?.status ?? initialStatus
   const isSyncing = status === 'syncing' || status === 'provisioning'
 
   const runs = api.dataConnector.listRuns.useQuery(
@@ -205,21 +473,26 @@ export function ConnectorRunsPanel({
     { refetchInterval: isSyncing ? 15000 : false }
   )
 
-  const rows = runs.data ?? []
+  const rows = mock?.runs ?? runs.data ?? []
 
   // Live initial-backfill card (Step 9 §10.2): only while a backfill chain is in
   // flight. Steady runs use the per-run counts below; this is the "first import" view.
-  const latestRun = statusQuery.data?.latestRun
-  const perStream = statusQuery.data?.perStream ?? []
+  const latestRun = statusData?.latestRun
+  const perStream = statusData?.perStream ?? []
   const showBackfill = isSyncing && latestRun?.phase === 'backfill' && perStream.length > 0
 
   // Steady freshness summary (Step 9 §10.3): once the source has synced and isn't
   // mid-backfill, show last/next synced + the latest run's delta instead of the card.
-  const lastSyncedAt = statusQuery.data?.lastSyncedAt ?? null
+  const lastSyncedAt = statusData?.lastSyncedAt ?? null
   // Webhook syncs never stamp `lastSyncedAt`, so a webhook delivery counts as freshness
   // too — else a live webhook-sync connector would show no freshness panel at all (§9).
-  const lastWebhookEventAt = statusQuery.data?.lastWebhookEventAt ?? null
+  const lastWebhookEventAt = statusData?.lastWebhookEventAt ?? null
   const showFreshness = !showBackfill && (!!lastSyncedAt || !!lastWebhookEventAt)
+
+  // Persist the per-stream breakdown after a run finishes (not mid-backfill) so the
+  // sync result lingers instead of vanishing the instant the connector goes `live`.
+  // Settled, solid state — sits above the freshness grid.
+  const showCompletedSummary = !isSyncing && perStream.length > 0 && !!lastSyncedAt
 
   return (
     <div className='flex flex-1 min-h-0 flex-col bg-background'>
@@ -234,7 +507,7 @@ export function ConnectorRunsPanel({
             </Badge>
           ) : (
             <Badge variant='outline' size='sm'>
-              {statusQuery.data?.itemCount ?? 0} records
+              {statusData?.itemCount ?? 0} records
             </Badge>
           )
         }
@@ -249,13 +522,22 @@ export function ConnectorRunsPanel({
         />
       )}
 
+      {showCompletedSummary && (
+        <ConnectorBackfillProgress
+          sourceLabel={sourceLabel}
+          perStream={perStream}
+          completed
+          syncedAt={lastSyncedAt}
+        />
+      )}
+
       {showFreshness && (
         <ConnectorFreshnessPanel
           lastSyncedAt={lastSyncedAt}
           lastWebhookEventAt={lastWebhookEventAt}
-          nextSyncAt={statusQuery.data?.nextSyncAt ?? null}
-          cadenceLabel={statusQuery.data?.cadenceLabel ?? null}
-          syncBehavior={statusQuery.data?.syncBehavior ?? 'manual'}
+          nextSyncAt={statusData?.nextSyncAt ?? null}
+          cadenceLabel={statusData?.cadenceLabel ?? null}
+          syncBehavior={statusData?.syncBehavior ?? 'manual'}
           latestRun={latestRun}
         />
       )}

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -203,6 +203,10 @@ export interface CatalogConnectorField {
   name: string
   pii?: boolean
   capabilities?: { hidden?: boolean; filterable?: boolean }
+  /** Predefined select option set (SINGLE_SELECT / MULTI_SELECT / TAGS) provisioned onto the owned column. */
+  options?: Array<{ value: string; label?: string; color?: string }>
+  /** Sub-field set for an ADDRESS_STRUCT field (e.g. `['street', 'city', 'state', 'country']`). */
+  addressComponents?: string[]
 }
 
 /**

--- a/packages/lib/src/apps/lambda/invoke-lambda-executor.ts
+++ b/packages/lib/src/apps/lambda/invoke-lambda-executor.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/apps/lambda/invoke-lambda-executor.ts
 
-import { INTERNAL_LAMBDA_URL, LAMBDA_URL } from '@auxx/config/server'
+import { INTERNAL_LAMBDA_URL } from '@auxx/config/server'
 import { signInboundRequest } from '@auxx/credentials/lambda-auth'
 import type { Result } from 'neverthrow'
 import { err, ok } from 'neverthrow'
@@ -80,15 +80,6 @@ export async function invokeLambdaExecutor(params: {
   lambdaUrl?: string
 }): Promise<Result<LambdaExecutionResult, LambdaExecutionError>> {
   const { payload, caller, lambdaUrl = INTERNAL_LAMBDA_URL } = params
-
-  console.log('[invoke-lambda] URL resolution debug:', {
-    resolvedUrl: lambdaUrl,
-    envInternalLambdaUrl: process.env.LAMBDA_INTERNAL_URL,
-    envLambdaUrl: process.env.LAMBDA_URL,
-    configInternalLambdaUrl: INTERNAL_LAMBDA_URL,
-    configLambdaUrl: LAMBDA_URL,
-    caller,
-  })
 
   try {
     const body = JSON.stringify(payload)

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -428,8 +428,22 @@ export async function createConnectorFromAppCatalog(
       ...appCatalogStreamSchema(stream),
       syncMode: stream.syncMode ?? 'snapshot',
     })
-    await createLazyStreamOwnedMappings(db, organizationId, streamRow.id, stream)
-    await materializeAppContributingMappings(db, organizationId, streamRow.id, stream)
+    // Owned mappings first so a nested contributing mapping (e.g. order → customer)
+    // can parent to the owned root it hangs off — the parentMappingId both forms the
+    // fan-out tree at sync AND lets pass-2 provision the relationship edge.
+    const ownedMappingIdByRootPath = await createLazyStreamOwnedMappings(
+      db,
+      organizationId,
+      streamRow.id,
+      stream
+    )
+    await materializeAppContributingMappings(
+      db,
+      organizationId,
+      streamRow.id,
+      stream,
+      ownedMappingIdByRootPath
+    )
   }
 
   return connector
@@ -523,7 +537,7 @@ async function createLazyStreamOwnedMappings(
   organizationId: string,
   streamId: string,
   stream: CatalogDataConnector['streams'][number]
-): Promise<void> {
+): Promise<Record<string, string>> {
   const allMappings = stream.defaultMappings ?? []
   const owned = allMappings.filter((m) => m.target.mode === 'owned')
   const allRootPaths = owned.map((m) => m.rootPath)
@@ -582,6 +596,8 @@ async function createLazyStreamOwnedMappings(
 
     mappingIdByRootPath[mapping.rootPath] = row.id
   }
+
+  return mappingIdByRootPath
 }
 
 /**
@@ -604,6 +620,8 @@ export function buildLazyOwnedFieldMappings(entries: OwnedFieldEntry[]): FieldMa
       appFieldKey: field.fieldKey,
       type: field.type as FieldType,
       isHidden: field.capabilities?.hidden ?? false,
+      options: field.options,
+      addressComponents: field.addressComponents,
     },
   }))
 }
@@ -624,8 +642,11 @@ async function materializeAppContributingMappings(
   db: Database,
   organizationId: string,
   streamId: string,
-  stream: CatalogDataConnector['streams'][number]
+  stream: CatalogDataConnector['streams'][number],
+  /** rootPath → owned-mapping id, so a nested contributing branch can find its parent. */
+  ownedMappingIdByRootPath: Record<string, string> = {}
 ): Promise<void> {
+  const ownedRootPaths = Object.keys(ownedMappingIdByRootPath)
   for (const mapping of stream.defaultMappings ?? []) {
     if (mapping.target.mode !== 'contributing') continue
     const { entityKind, matchFieldKeys, fieldBindings } = mapping.target
@@ -672,14 +693,38 @@ async function materializeAppContributingMappings(
     ).filter((b) => !boundTargets.has(b.targetFieldRef))
     const fieldMappings = [...matchBindings, ...valueBindings]
 
+    // A nested contributing branch (e.g. the order stream's embedded `customer`)
+    // hangs off the owned root it's drilled from. Wiring `parentMappingId` makes
+    // mapRecord emit the parent→child relation at sync; persisting the relationship
+    // into `targetSpec` makes pass-2 provision the edge field on the PARENT (owned)
+    // def. The forward edge lives on the parent, so both require a resolved parent.
+    const parentRootPath = ownedParentRootPath(mapping.rootPath, ownedRootPaths)
+    const parentMappingId =
+      parentRootPath != null ? (ownedMappingIdByRootPath[parentRootPath] ?? null) : null
+
+    const targetSpec: ConnectorMappingTargetSpec | null =
+      mapping.relationship && parentMappingId != null
+        ? {
+            relationship: {
+              fieldKey: mapping.relationship.fieldKey,
+              name: mapping.relationship.name,
+              cardinality: mapping.relationship.cardinality,
+              inverseName: mapping.relationship.inverseName,
+              targetRef: mapping.relationship.targetRef,
+            },
+          }
+        : null
+
     await addMapping(db, organizationId, {
       dataConnectorStreamId: streamId,
       rootPath: mapping.rootPath,
       linkMode: mapping.linkMode ?? ('upsert' as LinkMode),
       targetMode: 'contributing' as TargetMode,
       entityDefinitionId,
+      parentMappingId,
       relationshipFieldKey: mapping.relationshipFieldKey ?? null,
       fieldMappings,
+      targetSpec,
       orphanBehavior: 'ignore' as OrphanBehavior,
     })
   }

--- a/packages/lib/src/data-connectors/provisioning.ts
+++ b/packages/lib/src/data-connectors/provisioning.ts
@@ -16,7 +16,7 @@ import type { FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { createCustomField, resolveEntityDefinitionIdByKind } from '@auxx/services/custom-fields'
 import { createEntityDefinition } from '@auxx/services/entity-definitions'
-import type { RelationshipType } from '@auxx/types/custom-field'
+import type { RelationshipType, SelectOption } from '@auxx/types/custom-field'
 import { toResourceFieldId } from '@auxx/types/field'
 import { and, eq } from 'drizzle-orm'
 import { getCachedCustomFields } from '../cache'
@@ -45,6 +45,10 @@ export interface ProvisionFieldSpec {
   isCreatable?: boolean
   /** External-id / raw-payload bookkeeping fields are hidden from the grid. */
   isHidden?: boolean
+  /** Predefined select options (SINGLE_SELECT / MULTI_SELECT / TAGS). */
+  options?: Array<{ value: string; label?: string; color?: string }>
+  /** Sub-field set for an ADDRESS_STRUCT field. */
+  addressComponents?: string[]
 }
 
 /** One owned/contributing target the connector provisions schema for. */
@@ -327,6 +331,17 @@ async function provisionField(
     icon: field.icon,
     appFieldKey: field.appFieldKey,
     dataConnectorId,
+    // Predefined enum options / address sub-fields, when the connector declared
+    // them. Options are normalized to `SelectOption` (label defaults to value, color
+    // is the constrained palette) the same way the app-field provisioner does.
+    options: field.options?.length
+      ? field.options.map((o) => ({
+          value: o.value,
+          label: o.label ?? o.value,
+          color: o.color as SelectOption['color'],
+        }))
+      : undefined,
+    addressComponents: field.addressComponents,
     isUpdatable: field.isUpdatable ?? false,
     isCreatable: field.isCreatable ?? false,
     isHidden: field.isHidden ?? false,
@@ -361,6 +376,8 @@ export function provisionSpecsForMapping(mapping: {
       type: fm.provision.type,
       icon: fm.provision.icon,
       isHidden: fm.provision.isHidden,
+      options: fm.provision.options,
+      addressComponents: fm.provision.addressComponents,
       isUpdatable: false,
       isCreatable: false,
     })

--- a/packages/lib/src/data-connectors/sink-source-record.test.ts
+++ b/packages/lib/src/data-connectors/sink-source-record.test.ts
@@ -1,0 +1,114 @@
+// packages/lib/src/data-connectors/sink-source-record.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ResourceField } from '../resources'
+import type { ConnectorRecord } from './connectors/types'
+import type { DecodedMapping } from './service'
+import type { ProjectedRecord, SyncCtx } from './sinks/types'
+
+// Capture each projected record the sink would write so we can assert the
+// relationship edges that `sinkSourceRecord` stamped onto them. `vi.hoisted` so the
+// fn exists before the hoisted `vi.mock` factory references it.
+const { upsertRecord } = vi.hoisted(() => ({
+  upsertRecord: vi.fn<(ctx: unknown, m: DecodedMapping, r: ProjectedRecord) => Promise<void>>(),
+}))
+vi.mock('./sinks/entity-sink', () => ({ entitySink: { upsertRecord } }))
+vi.mock('./reconciliation', () => ({ archiveExternalId: vi.fn() }))
+
+// Field cache: the order def carries a connector-provisioned `Line Items` has_many
+// field whose REAL id differs from its `appFieldKey` ('lineItems') — the exact shape
+// that broke `resolveEdge` (it matched on id/resourceFieldId, never appFieldKey).
+const fieldsByDef: Record<string, ResourceField[]> = {}
+vi.mock('../cache', () => ({
+  getCachedResourceFields: (_org: string, defId: string) =>
+    Promise.resolve(fieldsByDef[defId] ?? []),
+}))
+
+import { sinkSourceRecord } from './sink-source-record'
+
+function mapping(over: Partial<DecodedMapping> & { id?: string }): DecodedMapping {
+  const { id = 'm1', ...rest } = over
+  return {
+    row: { id } as DecodedMapping['row'],
+    rootPath: '',
+    linkMode: 'upsert',
+    targetMode: 'owned',
+    entityDefinitionId: 'def1',
+    parentMappingId: null,
+    relationshipFieldKey: null,
+    orphanBehavior: 'ignore',
+    fieldMappings: [],
+    ...rest,
+  }
+}
+
+function relField(over: Partial<ResourceField> & { id: string }): ResourceField {
+  return {
+    key: over.id,
+    label: over.id,
+    type: 'object',
+    fieldType: 'RELATIONSHIP',
+    capabilities: {} as ResourceField['capabilities'],
+    ...over,
+  } as ResourceField
+}
+
+const ctx = { orgId: 'org1', connector: { id: 'conn1' } } as unknown as SyncCtx
+
+describe('sinkSourceRecord — relationship edge resolution', () => {
+  beforeEach(() => {
+    upsertRecord.mockReset().mockResolvedValue(undefined)
+    for (const k of Object.keys(fieldsByDef)) delete fieldsByDef[k]
+  })
+
+  it('resolves a has_many edge by appFieldKey and side-flips the inverse onto each child', async () => {
+    // Order def: `Line Items` has_many, real id `cf_lineItems`, appFieldKey `lineItems`,
+    // inverse `Order` (id `cf_order`) on the line-item def.
+    fieldsByDef.orderDef = [
+      relField({
+        id: 'cf_lineItems',
+        resourceFieldId: 'orderDef:cf_lineItems',
+        appFieldKey: 'lineItems',
+        relationship: {
+          relationshipType: 'has_many',
+          inverseResourceFieldId: 'lineDef:cf_order',
+        } as ResourceField['relationship'],
+      }),
+    ]
+
+    const order = mapping({ id: 'orderMap', rootPath: '', entityDefinitionId: 'orderDef' })
+    const lineItems = mapping({
+      id: 'lineMap',
+      rootPath: 'line_items[]',
+      entityDefinitionId: 'lineDef',
+      parentMappingId: 'orderMap',
+      // The authored key is the app's relationship.fieldKey — equals appFieldKey,
+      // NOT the provisioned field id.
+      relationshipFieldKey: 'lineItems',
+    })
+
+    const source: ConnectorRecord = {
+      streamKey: 'order',
+      externalId: 'o1',
+      displayName: 'Order',
+      fields: { id: 'o1', line_items: [{ sku: 'A' }, { sku: 'B' }] },
+    }
+
+    await sinkSourceRecord(ctx, [order, lineItems], source)
+
+    // Two line items written, each carrying the inverse `Order` (cf_order) belongs_to
+    // edge pointing back at the order — NOT a bogus `lineItems` edge on the order.
+    const writes = upsertRecord.mock.calls.map(([, , r]) => r)
+    const children = writes.filter((r) => r.externalId.startsWith('o1:'))
+    expect(children).toHaveLength(2)
+    for (const child of children) {
+      expect(child.pendingRelations).toEqual([
+        { fieldKey: 'cf_order', targetDef: 'orderDef', targetExternalId: 'o1' },
+      ])
+    }
+    // The order instance itself gets NO relationship edge stamped (the has_many side
+    // flips to the children; the inverse collection syncs from the child writes).
+    const parent = writes.find((r) => r.externalId === 'o1')
+    expect(parent?.pendingRelations).toEqual([])
+  })
+})

--- a/packages/lib/src/data-connectors/sink-source-record.ts
+++ b/packages/lib/src/data-connectors/sink-source-record.ts
@@ -68,7 +68,18 @@ async function resolveEdge(
     lastSeg.includes(':') ? lastSeg : toResourceFieldId(parentDef, lastSeg)
   ) as ResourceFieldId
   const ownerDef = getFieldDefinitionId(forwardRef)
-  const forwardFieldId = getFieldId(forwardRef)
+  const derivedFieldId = getFieldId(forwardRef)
+
+  // Resolve the forward field up front (needed for cardinality AND its real id). A
+  // connector-provisioned RELATIONSHIP field has an AUTO-GENERATED id distinct from
+  // its `appFieldKey` — so the authored `relationshipFieldKey` ('lineItems') matches
+  // the field's `appFieldKey`, NOT its id. Match on all three, then use the resolved
+  // field's REAL id for the forward edge (the derived id is just the authored key).
+  const fields = await getFields(ownerDef)
+  const field = fields.find(
+    (f) => f.id === derivedFieldId || f.resourceFieldId === forwardRef || f.appFieldKey === lastSeg
+  )
+  const forwardFieldId = field?.id ?? derivedFieldId
 
   // CLEAR — belongs_to only (a reference FK that went empty). Null the parent field.
   if (rel.childExternalId === null) {
@@ -78,8 +89,6 @@ async function resolveEdge(
     }
   }
 
-  const fields = await getFields(ownerDef)
-  const field = fields.find((f) => f.id === forwardFieldId || f.resourceFieldId === forwardRef)
   const config = field?.relationship as RelationshipConfig | undefined
   const cardinality = config?.relationshipType
 

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -366,6 +366,10 @@ export interface ConnectorFieldDecl {
   /** Flag PII — surfaced + default-excluded in the mapping UI. */
   pii?: boolean
   capabilities?: ConnectorFieldCapabilities
+  /** Predefined select option set (SINGLE_SELECT / MULTI_SELECT / TAGS). */
+  options?: Array<{ value: string; label?: string; color?: string }>
+  /** Sub-field set for an ADDRESS_STRUCT field. */
+  addressComponents?: string[]
 }
 
 /** A recommended fan-out mapping the connector suggests (05 §4). User confirms at setup. */
@@ -566,6 +570,10 @@ export interface FieldMapping {
     icon?: string
     isHidden?: boolean
     appFieldKey?: string
+    /** Predefined select options to provision (SINGLE_SELECT / MULTI_SELECT / TAGS). */
+    options?: Array<{ value: string; label?: string; color?: string }>
+    /** Sub-field set to provision for an ADDRESS_STRUCT field. */
+    addressComponents?: string[]
   }
 }
 

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -20,7 +20,7 @@
  */
 
 import type { z } from 'zod/v4'
-import type { FieldType } from '../fields/field-types.js'
+import type { FieldSelectOption, FieldType } from '../fields/field-types.js'
 import type { ActionInputHint } from '../tools/types.js'
 
 /**
@@ -110,6 +110,21 @@ export interface ConnectorFieldDecl {
   /** Flag PII — surfaced + default-excluded in the mapping UI. */
   pii?: boolean
   capabilities?: ConnectorFieldCapabilities
+  /**
+   * Predefined option set for `SINGLE_SELECT` / `MULTI_SELECT` / `TAGS` fields.
+   * When present, the platform provisions the owned column with these options so a
+   * synced value renders as a real (colored, filterable) enum chip. Declare the
+   * provider's FULL value set — an incoming value outside the list is rejected at
+   * sink. Ignored for non-select types.
+   */
+  options?: FieldSelectOption[]
+  /**
+   * Sub-field set for an `ADDRESS_STRUCT` field, e.g. `['street', 'city', 'state',
+   * 'country']`. Controls which address components the provisioned field surfaces.
+   * The synced value must be shaped `{ street1, street2, city, state, zipCode,
+   * country }`. Ignored for non-address types.
+   */
+  addressComponents?: string[]
 }
 
 /** Minimal entity declaration for an owned-mode default mapping. */

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -193,6 +193,10 @@ export interface CatalogConnectorField {
   name: string
   pii?: boolean
   capabilities?: { hidden?: boolean; filterable?: boolean }
+  /** Predefined select option set (SINGLE_SELECT / MULTI_SELECT / TAGS). */
+  options?: Array<{ value: string; label?: string; color?: string }>
+  /** Sub-field set for an ADDRESS_STRUCT field. */
+  addressComponents?: string[]
 }
 
 /** Provisioning decl for a parent↔child edge — mirrors SDK `ConnectorRelationshipDecl`. */
@@ -706,6 +710,8 @@ export async function compileAndExtractCatalog(): Promise<
         name: decl.name,
         pii: decl.pii,
         capabilities: decl.capabilities,
+        options: decl.options,
+        addressComponents: decl.addressComponents,
       })),
       defaultMappings: stream.defaultMappings,
       exampleRecord: stream.exampleRecord,
@@ -864,6 +870,8 @@ interface RawConnectorFieldDecl {
   name: string
   pii?: boolean
   capabilities?: { hidden?: boolean; filterable?: boolean }
+  options?: Array<{ value: string; label?: string; color?: string }>
+  addressComponents?: string[]
 }
 
 interface RawConnectorStream {

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -873,6 +873,44 @@
   }
 }
 
+@theme inline {
+  --animate-candy-stripes: candy-stripes 1s linear infinite;
+
+  @keyframes candy-stripes {
+    from {
+      background-position: 1rem 0;
+    }
+    to {
+      background-position: 0 0;
+    }
+  }
+}
+
+/* Indeterminate "candy cane" progress fill — diagonal stripes sliding over the
+   element's own background color. Pair with a `bg-*` color (the stripes are a
+   translucent white overlay). Used for unknown-total backfills where there's no
+   real percentage to show. */
+.candy-stripes {
+  background-image: linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.25) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.25) 50%,
+    rgba(255, 255, 255, 0.25) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 1rem 1rem;
+  animation: var(--animate-candy-stripes);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .candy-stripes {
+    animation: none;
+  }
+}
+
 .glass {
   /* Blur effect */
   backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- Provision `SINGLE_SELECT` / `MULTI_SELECT` / `TAGS` options and `ADDRESS_STRUCT` components on owned and contributing columns, threaded end-to-end through the SDK catalog → `@auxx/lib` provisioning → DB schema types.
- Parent nested contributing branches (e.g. an order stream's embedded `customer`) to their owned root via `parentMappingId`, and persist the relationship into `targetSpec` so pass-2 provisions the edge field on the parent def.
- Fix sink edge resolution: a connector-provisioned RELATIONSHIP field has an auto-generated id distinct from its `appFieldKey`, so resolve the forward field by matching id / resourceFieldId / appFieldKey and use its real id.
- Backfill progress UI: settled "Synced" completed state with a check + record count; candy-stripe indeterminate fill for unknown-total backfills; persist the per-stream breakdown after a run finishes so it lingers instead of vanishing when the connector flips to `live`.
- Runs panel dev-only mock scenarios (`MOCK_SCENARIO`, off by default) for iterating on the freshness / backfill / history layout.
- Drop the noisy `invoke-lambda` URL-resolution debug log.

## Test plan
- Added `packages/lib/src/data-connectors/sink-source-record.test.ts`.
- `pnpm test` for the data-connectors module.