### PR TITLE
feat(custom-fields): render URL fields as image thumbnails + connector avatar field wiring

### DIFF
--- a/apps/web/src/components/custom-fields/ui/custom-field-form.tsx
+++ b/apps/web/src/components/custom-fields/ui/custom-field-form.tsx
@@ -85,6 +85,7 @@ import {
   PhoneFormattingEditor,
   parseDisplayOptions,
   TimeFormattingEditor,
+  UrlFormattingEditor,
 } from './formatting-editors'
 import { OptionsEditor, parseSelectOptions, type SelectOption } from './options-editor'
 import { RelationshipFieldEditor, type RelationshipOptions } from './relationship-field-editor'
@@ -686,6 +687,7 @@ export function CustomFieldForm({
       FieldType.TIME,
       FieldType.CHECKBOX,
       FieldType.PHONE_INTL,
+      FieldType.URL,
     ].includes(type)
   }
 
@@ -711,6 +713,13 @@ export function CustomFieldForm({
         return <BooleanFormattingEditor options={displayOptions} onChange={setDisplayOptions} />
       case FieldType.PHONE_INTL:
         return <PhoneFormattingEditor options={displayOptions} onChange={setDisplayOptions} />
+      case FieldType.URL:
+        return (
+          <UrlFormattingEditor
+            options={displayOptions}
+            onChange={(opts) => setDisplayOptions((prev) => ({ ...prev, ...opts }))}
+          />
+        )
       default:
         return null
     }

--- a/apps/web/src/components/custom-fields/ui/formatting-editors/index.ts
+++ b/apps/web/src/components/custom-fields/ui/formatting-editors/index.ts
@@ -9,6 +9,7 @@ export { DateTimeFormattingEditor } from './datetime-formatting-editor'
 export { NumberFormattingEditor } from './number-formatting-editor'
 export { PhoneFormattingEditor } from './phone-formatting-editor'
 export { TimeFormattingEditor } from './time-formatting-editor'
+export { UrlFormattingEditor } from './url-formatting-editor'
 
 /**
  * Display options type for internal state.
@@ -32,6 +33,8 @@ export interface DisplayOptions {
   falseLabel?: string
   // PHONE options
   phoneFormat?: 'raw' | 'national' | 'international'
+  // URL options
+  urlDisplay?: 'link' | 'image'
 }
 
 /** Keys that are display options (flat on field.options) */
@@ -48,6 +51,7 @@ const DISPLAY_OPTION_KEYS: (keyof DisplayOptions)[] = [
   'trueLabel',
   'falseLabel',
   'phoneFormat',
+  'urlDisplay',
 ]
 
 /**

--- a/apps/web/src/components/custom-fields/ui/formatting-editors/url-formatting-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/formatting-editors/url-formatting-editor.tsx
@@ -1,0 +1,46 @@
+// apps/web/src/components/custom-fields/ui/formatting-editors/url-formatting-editor.tsx
+'use client'
+
+import type { FieldOptions } from '@auxx/lib/field-values/client'
+import { Field, FieldGroup, FieldLabel } from '@auxx/ui/components/field'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+
+/** Props for UrlFormattingEditor */
+interface UrlFormattingEditorProps {
+  options: Pick<FieldOptions, 'urlDisplay'>
+  onChange: (options: { urlDisplay: 'link' | 'image' }) => void
+}
+
+/**
+ * Editor for URL field display options.
+ * Controls whether the value renders as a clickable link or an image thumbnail
+ * (e.g. for product images or avatar URLs).
+ */
+export function UrlFormattingEditor({ options, onChange }: UrlFormattingEditorProps) {
+  const urlDisplay = options.urlDisplay ?? 'link'
+
+  return (
+    <FieldGroup className='gap-3'>
+      <Field>
+        <FieldLabel>Display As</FieldLabel>
+        <Select
+          value={urlDisplay}
+          onValueChange={(v) => onChange({ urlDisplay: v as 'link' | 'image' })}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value='link'>Link</SelectItem>
+            <SelectItem value='image'>Image</SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
+    </FieldGroup>
+  )
+}

--- a/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
+++ b/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
@@ -18,6 +18,7 @@ import { format, formatDistanceToNow } from 'date-fns'
 import { CheckSquare } from 'lucide-react'
 import { useMemo } from 'react'
 import { FileIcon } from '~/components/files/utils/file-icon'
+import { VisualIcon } from '~/components/icons/ui/visual-icon'
 import { ActorBadge, RecordBadge } from '~/components/resources/ui'
 import { ItemsCellView } from '~/components/ui/items-list-view'
 import { TagsCellView } from '~/components/ui/tags-view'
@@ -380,13 +381,23 @@ export function renderPhoneValue(
 }
 
 /**
- * Render URL value as copyable link
+ * Render URL value as a copyable link, or — when the field opts into
+ * `urlDisplay: 'image'` — as an image thumbnail (e.g. product images / avatar URLs).
  */
-export function renderUrlValue(value: unknown): React.ReactNode {
+export function renderUrlValue(value: unknown, config?: CellConfig): React.ReactNode {
   if (value == null || value === '') return <EmptyCell />
 
   const url = String(value)
   const href = url.startsWith('http') ? url : `https://${url}`
+
+  if (config?.options?.urlDisplay === 'image') {
+    return (
+      <ExpandableCell mode='horizontal'>
+        <VisualIcon value={href} fit='cover' imageFallback fallbackIconId='image' />
+      </ExpandableCell>
+    )
+  }
+
   return (
     <ExpandableCell mode='horizontal'>
       <div>
@@ -588,7 +599,7 @@ const cellRenderers: Record<string, CellRenderer> = {
   EMAIL: (value) => renderEmailValue(value),
   PHONE_INTL: (value, formatting, config) =>
     renderPhoneValue(value, formatting as PhoneColumnFormatting, config),
-  URL: (value) => renderUrlValue(value),
+  URL: (value, _formatting, config) => renderUrlValue(value, config),
 
   // Boolean - pass config for displayOptions
   CHECKBOX: (value, _, config) => renderCheckboxValue(value, config),

--- a/apps/web/src/components/fields/displays/display-url.tsx
+++ b/apps/web/src/components/fields/displays/display-url.tsx
@@ -2,20 +2,24 @@
 
 // apps/web/src/components/fields/displays/display-url.tsx
 
+import type { FieldOptions } from '@auxx/lib/field-values/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { formatUrlForDisplay, normalizeUrl } from '@auxx/utils'
 import { ExternalLink } from 'lucide-react'
 import { useMemo } from 'react'
+import { VisualIcon } from '~/components/icons/ui/visual-icon'
 import { useFieldContext } from './display-field'
 import DisplayWrapper from './display-wrapper'
 import { FieldOptionButton } from './field-option-button'
 
 /**
  * DisplayUrl component
- * Renders a URL value with action buttons to open and copy the link
+ * Renders a URL value with action buttons to open and copy the link, or — when the
+ * field opts into `urlDisplay: 'image'` — as an image thumbnail (product images, avatars).
  */
 export function DisplayUrl() {
-  const { value } = useFieldContext()
+  const { value, field } = useFieldContext()
+  const asImage = (field.options as FieldOptions | undefined)?.urlDisplay === 'image'
 
   const normalizedValue = useMemo(() => {
     if (typeof value !== 'string') return null
@@ -40,6 +44,20 @@ export function DisplayUrl() {
       <ExternalLink />
     </FieldOptionButton>,
   ]
+
+  if (asImage) {
+    return (
+      <DisplayWrapper copyValue={normalizedValue} buttons={buttons}>
+        <VisualIcon
+          value={normalizedValue}
+          fit='cover'
+          imageFallback
+          fallbackIconId='image'
+          size='lg'
+        />
+      </DisplayWrapper>
+    )
+  }
 
   return (
     <DisplayWrapper copyValue={normalizedValue} buttons={buttons}>

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -237,7 +237,14 @@ export interface CatalogConnectorDefaultMapping {
   target:
     | {
         mode: 'owned'
-        entity: { apiSlug: string; singular: string; plural: string; primaryDisplayField?: string }
+        entity: {
+          apiSlug: string
+          singular: string
+          plural: string
+          primaryDisplayField?: string
+          /** `fieldKey` of a URL/FILE field to wire as the def's avatar/display image. */
+          avatarField?: string
+        }
       }
     | {
         mode: 'contributing'

--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -264,6 +264,8 @@ export interface ConnectorMappingTargetSpec {
     icon?: string
     /** `appFieldKey` of the field to wire as the def's primary display field. */
     primaryDisplayFieldKey?: string
+    /** `appFieldKey` of the field to wire as the def's avatar/display image. */
+    avatarFieldKey?: string
   }
   /** Parent↔child relationship edge to provision once every def exists. */
   relationship?: {

--- a/packages/lib/src/custom-fields/field-options.ts
+++ b/packages/lib/src/custom-fields/field-options.ts
@@ -53,6 +53,12 @@ export interface FieldOptions {
   phoneFormat?: 'raw' | 'national' | 'international'
 
   // ─────────────────────────────────────────────────────────────
+  // URL (flat)
+  // ─────────────────────────────────────────────────────────────
+  /** Render the URL as a clickable link (default) or as an image thumbnail. */
+  urlDisplay?: 'link' | 'image'
+
+  // ─────────────────────────────────────────────────────────────
   // SELECT (flat)
   // ─────────────────────────────────────────────────────────────
   maxItemsShown?: number

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -564,6 +564,7 @@ async function createLazyStreamOwnedMappings(
         singular: entity.singular,
         plural: entity.plural,
         primaryDisplayFieldKey: entity.primaryDisplayField,
+        avatarFieldKey: entity.avatarField,
       },
     }
     // The forward edge lives on the PARENT def; with no parent (a root mapping) there's

--- a/packages/lib/src/data-connectors/provisioning.ts
+++ b/packages/lib/src/data-connectors/provisioning.ts
@@ -66,6 +66,8 @@ export interface ProvisionTarget {
     color?: string
     /** `appFieldKey` of the field to wire as the def's primary display field. */
     primaryDisplayFieldKey?: string
+    /** `appFieldKey` of the field to wire as the def's avatar/display image. */
+    avatarFieldKey?: string
   }
   fields: ProvisionFieldSpec[]
 }
@@ -175,6 +177,21 @@ export async function provisionTarget(
     await db
       .update(schema.EntityDefinition)
       .set({ primaryDisplayFieldId, updatedAt: new Date() })
+      .where(eq(schema.EntityDefinition.id, defId))
+    await onCacheEvent('entity-def.updated', { orgId: organizationId })
+  }
+
+  // Wire the declared avatar/display-image field — same direct-pointer write as the
+  // primary display field above. Rendering the URL field as an image is the field's
+  // own `urlDisplay` option (set by the connector's field provision), not forced here.
+  const avatarFieldId =
+    target.targetMode === 'owned' && target.ownedDef?.avatarFieldKey
+      ? fieldIdByKey[target.ownedDef.avatarFieldKey]
+      : undefined
+  if (avatarFieldId) {
+    await db
+      .update(schema.EntityDefinition)
+      .set({ avatarFieldId, updatedAt: new Date() })
       .where(eq(schema.EntityDefinition.id, defId))
     await onCacheEvent('entity-def.updated', { orgId: organizationId })
   }

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -398,6 +398,8 @@ export interface ConnectorEntityDecl {
   singular: string
   plural: string
   primaryDisplayField?: string
+  /** `fieldKey` of a URL/FILE field to wire as the def's avatar/display image. */
+  avatarField?: string
 }
 
 /** One stream (fetch) declaration. */
@@ -597,6 +599,8 @@ export interface ConnectorMappingTargetSpec {
     icon?: string
     /** `appFieldKey` of the field to wire as the def's primary display field. */
     primaryDisplayFieldKey?: string
+    /** `appFieldKey` of the field to wire as the def's avatar/display image. */
+    avatarFieldKey?: string
   }
   /** Parent↔child relationship edge to provision once every def exists. */
   relationship?: {

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -133,6 +133,8 @@ export interface ConnectorEntityDecl {
   singular: string
   plural: string
   primaryDisplayField?: string
+  /** `fieldKey` of a URL/FILE field to wire as the def's avatar/display image. */
+  avatarField?: string
 }
 
 /**

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -217,7 +217,14 @@ export interface CatalogConnectorDefaultMapping {
   target:
     | {
         mode: 'owned'
-        entity: { apiSlug: string; singular: string; plural: string; primaryDisplayField?: string }
+        entity: {
+          apiSlug: string
+          singular: string
+          plural: string
+          primaryDisplayField?: string
+          /** `fieldKey` of a URL/FILE field to wire as the def's avatar/display image. */
+          avatarField?: string
+        }
       }
     | {
         mode: 'contributing'

--- a/packages/types/custom-field/index.ts
+++ b/packages/types/custom-field/index.ts
@@ -270,6 +270,8 @@ export const displayOptionsSchema = z.object({
   falseLabel: z.string().optional(),
   // PHONE display options
   phoneFormat: z.enum(['raw', 'national', 'international']).optional(),
+  // URL display options — render the value as a clickable link (default) or as an image thumbnail
+  urlDisplay: z.enum(['link', 'image']).optional(),
   // CURRENCY display options (decimals + useGrouping shared with NUMBER)
   currencyCode: z.string().length(3).optional(),
   currencyDisplay: z.enum(['symbol', 'code', 'name', 'compact']).optional(),
@@ -303,6 +305,7 @@ export const FIELD_TYPE_DISPLAY_OPTIONS: Partial<Record<string, (keyof DisplayOp
   [FieldTypeEnum.TIME]: ['format', 'timeFormat'],
   [FieldTypeEnum.CHECKBOX]: ['checkboxStyle', 'trueLabel', 'falseLabel'],
   [FieldTypeEnum.PHONE_INTL]: ['phoneFormat'],
+  [FieldTypeEnum.URL]: ['urlDisplay'],
 }
 
 /**


### PR DESCRIPTION
## What

Two related additions for displaying URL-valued fields as images.

### URL field image display
- New `urlDisplay: 'link' | 'image'` display option on URL fields. URL values (product images, avatar URLs) can now render as image thumbnails instead of clickable links.
- New `UrlFormattingEditor` wired into the custom-field form, plus schema/option plumbing in `@auxx/types`, `@auxx/lib/custom-fields`, and the formatting-editors index.
- `renderUrlValue` (dynamic table) and `DisplayUrl` (record display) render a `VisualIcon` image thumbnail when the field opts into `image`.

### Connector avatar field wiring
- Connector entity declarations can declare an `avatarField` (`fieldKey` of a URL/FILE field).
- Threaded through the catalog → mapping target spec (`avatarFieldKey`) → `provisionTarget`, which sets the owned def's `avatarFieldId` at provision time using the same direct-pointer write as the primary display field.

## Notes
- Rendering the avatar URL as an image is the field's own `urlDisplay` option (set by the connector's field provision), not forced by provisioning.