### PR TITLE
fix(data-connectors): full-wipe schema teardown + surface setup-phase errors

### DIFF
--- a/packages/lib/src/ai/providers/deepseek/deepseek-llm-client.ts
+++ b/packages/lib/src/ai/providers/deepseek/deepseek-llm-client.ts
@@ -17,6 +17,18 @@ import { OpenAILLMClient } from '../openai/openai-llm-client'
  */
 export class DeepSeekLLMClient extends OpenAILLMClient {
   /**
+   * DeepSeek's OpenAI-compatible endpoint only supports legacy JSON mode
+   * (`response_format: { type: 'json_object' }`), not strict Structured Outputs
+   * (`{ type: 'json_schema' }`) — sending the latter returns
+   * `400 This response_format type is unavailable now`. Returning false routes
+   * json_schema requests through the base client's downgrade path, which emits
+   * json_object and injects the schema into the system prompt.
+   */
+  protected override modelSupportsStrictJsonSchema(): boolean {
+    return false
+  }
+
+  /**
    * Strip reasoning_content from all assistant messages except the last one.
    * DeepSeek requires that reasoning_content from prior turns is NOT sent back,
    * but the most recent assistant message's reasoning must be preserved within

--- a/packages/lib/src/ai/providers/openai/openai-llm-client.ts
+++ b/packages/lib/src/ai/providers/openai/openai-llm-client.ts
@@ -596,7 +596,7 @@ export class OpenAILLMClient extends LLMClient {
    * Pre-gpt-4o models (gpt-4-turbo, gpt-4, gpt-3.5-turbo) and the original gpt-4o-2024-05-13
    * only support legacy JSON mode (`json_object`), not strict schema enforcement.
    */
-  private modelSupportsStrictJsonSchema(model: string): boolean {
+  protected modelSupportsStrictJsonSchema(model: string): boolean {
     const base = this.getBaseModel(model)
     if (base === 'gpt-4o-2024-05-13') return false
     if (base.startsWith('gpt-4-turbo')) return false

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -855,9 +855,13 @@ export type DeleteSyncedDataBehavior = 'keep' | 'archive' | 'delete'
  * ALWAYS kept regardless of `behavior`; their per-cell `FieldValue.managedByConnectorId`
  * markers are nulled automatically by the FK `set null` when the connector row cascades.
  *
- * The DataConnector row + its streams/mappings/items/runs cascade on delete; the
- * `dataConnectorId` FK on EntityDefinition/CustomField is `set null`, so provisioned
- * schema survives (now an ordinary user-owned def/field).
+ * The DataConnector row + its streams/mappings/items/runs cascade on delete. For
+ * `keep`/`archive` the `dataConnectorId` FK on EntityDefinition/CustomField is `set null`,
+ * so provisioned schema survives as an ordinary user-owned def/field. For `delete` (a full
+ * wipe) the provisioned SCHEMA is torn down too — owned defs (+ their columns/records and
+ * the inverse relationship fields they planted on shared defs like Contacts) and any
+ * contributing columns added to shared defs — so nothing is left stranded to collide when
+ * the connector is set up again.
  */
 export async function deleteConnector(
   db: Database,
@@ -899,6 +903,64 @@ export async function deleteConnector(
         await crud.bulkArchive(recordIds)
       } else {
         await crud.bulkDelete(recordIds)
+      }
+    }
+  }
+
+  // Full wipe (behavior='delete'): tear down the provisioned SCHEMA too, so a re-setup
+  // starts clean instead of tripping over a stranded def/relationship. 'keep'/'archive'
+  // deliberately leave the schema in place (the FK just nulls), keeping the synced data as
+  // ordinary user-owned entities.
+  if (behavior === 'delete') {
+    // Route every teardown through the sanctioned service entry points (NOT raw db.delete)
+    // so each one busts the org cache (resources / customFields / entityDefs) and fires the
+    // same events a UI delete would. Connector fields aren't protected (no
+    // appInstallationId / systemAttribute), so the services delete them cleanly. Lazy-import
+    // to keep this module's pure-helper exports loadable without the teardown chains.
+    const { EntityDefinitionService } = await import('../entity-definitions')
+    const { CustomFieldService } = await import('../custom-fields')
+
+    // Owned defs first: `delete()` runs the deep teardown (columns, records, items,
+    // mappings, AND the inverse relationship fields planted on shared defs) and busts the
+    // entity-def + custom-field projections. Still tagged with this connector's id here —
+    // the FK set-null fires only on the connector-row delete below.
+    const ownedDefs = await db
+      .select({ id: schema.EntityDefinition.id })
+      .from(schema.EntityDefinition)
+      .where(
+        and(
+          eq(schema.EntityDefinition.organizationId, organizationId),
+          eq(schema.EntityDefinition.dataConnectorId, id)
+        )
+      )
+    if (ownedDefs.length > 0) {
+      const defService = new EntityDefinitionService(organizationId, userId)
+      for (const ownedDef of ownedDefs) {
+        await defService.delete(ownedDef.id)
+      }
+    }
+
+    // Then any contributing columns the connector added to SHARED defs (e.g. fields on the
+    // system Contact def) — tagged by `dataConnectorId` but not owned by a torn-down def.
+    // `deleteField` handles values + relationship inverses + display-field cleanup and busts
+    // the custom-field cache.
+    const strayFields = await db
+      .select({
+        id: schema.CustomField.id,
+        entityDefinitionId: schema.CustomField.entityDefinitionId,
+      })
+      .from(schema.CustomField)
+      .where(
+        and(
+          eq(schema.CustomField.organizationId, organizationId),
+          eq(schema.CustomField.dataConnectorId, id)
+        )
+      )
+    if (strayFields.length > 0) {
+      const fieldService = new CustomFieldService(organizationId, userId, db)
+      for (const stray of strayFields) {
+        if (!stray.entityDefinitionId) continue
+        await fieldService.deleteField(toResourceFieldId(stray.entityDefinitionId, stray.id))
       }
     }
   }

--- a/packages/lib/src/data-connectors/provisioning.ts
+++ b/packages/lib/src/data-connectors/provisioning.ts
@@ -293,9 +293,20 @@ export async function provisionRelationshipField(
     },
   })
   if (result.isErr()) {
-    // A user/system field already owns this name → benign no-op (mirrors provisionField).
+    // A user/system field already owns the FORWARD name → benign no-op (mirrors provisionField).
     if (result.error.code === 'DUPLICATE_FIELD_NAME') return null
-    throw new Error(result.error.message)
+    // Surface the underlying DB cause — `fromDatabase` hides it behind a generic
+    // "Database operation ... failed", so without this the connector error reads as an
+    // opaque wrapper. The common case is the auto-created INVERSE edge colliding with a
+    // field of the same name already on the target def (e.g. an orphaned inverse left by
+    // a previously deleted connector → unique violation on CustomField_name_org_model_entity_key).
+    const cause = (result.error as { cause?: unknown }).cause
+    throw new Error(
+      `Failed to provision relationship "${spec.name}" (inverse "${spec.inverseName}"): ${
+        cause instanceof Error ? cause.message : result.error.message
+      }`,
+      cause instanceof Error ? { cause } : undefined
+    )
   }
 
   await onCacheEvent('custom-field.created', { orgId: organizationId })

--- a/packages/lib/src/data-connectors/slice-orchestrator.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator.ts
@@ -131,27 +131,35 @@ function computeBackfillFloor(
 
 // ── Start a connector sync (backfill or steady) ──────────────────────────────────
 
+export interface StartConnectorSyncOptions {
+  trigger?: 'manual' | 'scheduled' | 'webhook' | 'backfill' | 'sweep'
+  /**
+   * Per-stream sample cap (trial-sync §4). Set ⇒ a SAMPLE run: each stream backfills
+   * only this many records, then the run parks for review. Always forces the backfill
+   * phase (you can't "sample" a steady delta) and is persisted per-run, never on the
+   * connector — the "Sync everything" resume passes no cap and runs to completion.
+   */
+  sampleLimit?: number | null
+}
+
 /**
  * Begin a connector backfill as a continuation chain. Sweeps a stale prior run,
  * claims the connector, provisions the target schema, decides the phase (backfill vs
  * steady — see below), opens ONE run pinned to the decoded mapping snapshot (B2),
  * seeds the completion latch (B1), and enqueues the first slice per stream. Returns
  * false when the connector is missing/unmapped or already syncing.
+ *
+ * Setup runs BEFORE `openRun` (sweep, provision, claim) — a throw there (e.g. a
+ * relationship-edge provisioning collision) would otherwise leave NO run row and the
+ * connector stuck reading `live`, so the failure never surfaces and BullMQ just retries
+ * silently. The public {@link startConnectorSync} wraps this to stamp `connector.error`
+ * on any such pre-run throw; once a run is open, `runBackfillSlice` owns the bookkeeping.
  */
-export async function startConnectorSync(
+async function startConnectorSyncInner(
   db: Database,
   organizationId: string,
   dataConnectorId: string,
-  options: {
-    trigger?: 'manual' | 'scheduled' | 'webhook' | 'backfill' | 'sweep'
-    /**
-     * Per-stream sample cap (trial-sync §4). Set ⇒ a SAMPLE run: each stream backfills
-     * only this many records, then the run parks for review. Always forces the backfill
-     * phase (you can't "sample" a steady delta) and is persisted per-run, never on the
-     * connector — the "Sync everything" resume passes no cap and runs to completion.
-     */
-    sampleLimit?: number | null
-  } = {}
+  options: StartConnectorSyncOptions = {}
 ): Promise<boolean> {
   // A sweep is a full reconciling re-crawl (Step 8C): force the backfill phase even
   // for an incremental connector that's been running steady deltas, so it lists every
@@ -280,6 +288,36 @@ export async function startConnectorSync(
   // run the 4s poll never armed for (it only polls when status already reads syncing).
   await publishConnectorSync(db, organizationId, dataConnectorId, 'run-started')
   return true
+}
+
+/**
+ * Public entry. Runs the orchestration and, on any throw during setup (before a run
+ * exists to record its own failure), stamps `connector.status = 'error'` with the
+ * message + logs the underlying `cause` (which the neverthrow `fromDatabase` wrapper
+ * otherwise hides) so the connector page shows "failed + why" instead of silently
+ * reading `live` while the job loops through BullMQ retries. Re-throws so the job is
+ * still recorded as failed.
+ */
+export async function startConnectorSync(
+  db: Database,
+  organizationId: string,
+  dataConnectorId: string,
+  options: StartConnectorSyncOptions = {}
+): Promise<boolean> {
+  try {
+    return await startConnectorSyncInner(db, organizationId, dataConnectorId, options)
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error))
+    logger.error('startConnectorSync failed during setup — marking connector errored', {
+      dataConnectorId,
+      organizationId,
+      error: err.message,
+      cause: err.cause instanceof Error ? err.cause.message : err.cause,
+    })
+    await finalizeConnector(db, dataConnectorId, { ok: false, error: err.message })
+    await publishConnectorSync(db, organizationId, dataConnectorId, 'run-finished')
+    throw err
+  }
 }
 
 // ── Backfill a pending mapping-edit change (Layer 2 — "Backfill now") ─────────────

--- a/packages/lib/src/resources/registry/resource-registry-service.ts
+++ b/packages/lib/src/resources/registry/resource-registry-service.ts
@@ -110,6 +110,7 @@ type EntityDefinitionWithFields = {
   organizationId: string
   entityType: string | null
   isVisible: boolean
+  dataConnectorId: string | null
   primaryDisplayField: { id: string; name: string; type: string } | null
   secondaryDisplayField: { id: string; name: string; type: string } | null
   avatarField: { id: string; name: string; type: string } | null
@@ -146,6 +147,7 @@ function toCustomResourceBase(
     entityDefinitionId: def.id,
     organizationId: def.organizationId,
     isVisible: def.isVisible,
+    dataConnectorId: def.dataConnectorId ?? undefined,
     display: {
       primaryDisplayField: toDisplayFieldConfig(def.primaryDisplayField),
       secondaryDisplayField: toDisplayFieldConfig(def.secondaryDisplayField),

--- a/packages/lib/src/resources/registry/types.ts
+++ b/packages/lib/src/resources/registry/types.ts
@@ -66,6 +66,13 @@ export interface CustomResource extends BaseResource {
   apiSlug: string
   entityDefinitionId: string
   organizationId: string
+  /**
+   * Data-connector ownership — set when this entity def was provisioned as an
+   * `owned` target by a connector (mirrors `ResourceField.dataConnectorId` at the
+   * field level). Lets cached read paths identify a connector's owned resources
+   * without a fresh DB query. Undefined for user-authored / adopted defs.
+   */
+  dataConnectorId?: string
   display: {
     /** Primary display field with full metadata */
     primaryDisplayField: DisplayFieldConfig | null


### PR DESCRIPTION
## Summary

Hardens the data-connector lifecycle around delete and sync setup, plus a small DeepSeek JSON-mode fix.

- **`deleteConnector(behavior='delete')` full-wipe schema teardown** — owned defs (their columns/records/items/mappings + inverse relationship fields planted on shared defs like Contacts) and contributing columns on shared defs are now torn down too, routed through `EntityDefinitionService`/`CustomFieldService` so org caches bust and the same events as a UI delete fire. `keep`/`archive` are unchanged (FK `set null`, schema survives as ordinary user-owned entities).
- **`provisionRelationshipField`** — surfaces the underlying DB cause instead of the generic `fromDatabase` wrapper. The common case is an auto-created inverse edge colliding with an orphaned inverse left by a previously deleted connector (unique violation) — now readable.
- **`startConnectorSync`** — split into `startConnectorSyncInner` + a public wrapper that stamps `connector.status='error'` on any throw during setup (before a run row exists). Previously such a throw left no run, the connector stuck reading `live`, and BullMQ retried silently.
- **`DeepSeekLLMClient`** — overrides `modelSupportsStrictJsonSchema()` → `false`; DeepSeek's OpenAI-compatible endpoint only supports legacy `json_object` mode, so `json_schema` requests now route through the base client's downgrade path.
- **resource registry** — threads `dataConnectorId` onto `CustomResource` so cached read paths can identify a connector's owned resources without a fresh DB query.

## Test plan

- [ ] Delete a connector with `delete` behavior → owned defs/fields and contributing columns are gone, no stranded inverse edges.
- [ ] Re-setup the same connector → no unique-collision on relationship provisioning.
- [ ] Force a setup-phase throw → connector page shows errored state instead of `live`.
- [ ] DeepSeek structured-output request → succeeds via json_object downgrade.