### PR TITLE
feat(records-sidebar): org-wide folders for entity definitions

### DIFF
--- a/apps/web/src/components/global/sidebar/editable-sidebar-item.tsx
+++ b/apps/web/src/components/global/sidebar/editable-sidebar-item.tsx
@@ -3,6 +3,7 @@
 
 import { Badge } from '@auxx/ui/components/badge'
 import { Checkbox } from '@auxx/ui/components/checkbox'
+import { cn } from '@auxx/ui/lib/utils'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { GripVertical } from 'lucide-react'
@@ -19,6 +20,10 @@ interface EditableSidebarItemProps {
   className?: string
   // Props for dnd-kit integration (optional, only passed when draggable)
   isDraggable?: boolean
+  /** Arbitrary data attached to the sortable, read in the DndContext's onDragEnd. */
+  dndData?: Record<string, unknown>
+  /** Show a blue drop-target outline while another row is dragged over this one. */
+  showDropIndicator?: boolean
 }
 
 export function EditableSidebarItem({
@@ -31,12 +36,18 @@ export function EditableSidebarItem({
   onToggleVisibility,
   className = '',
   isDraggable = true, // Default to not draggable
+  dndData,
+  showDropIndicator = false,
 }: EditableSidebarItemProps) {
   // DnD logic
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: id,
-    disabled: isLocked || !isDraggable,
-  }) // Disable sorting if locked or not explicitly draggable
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging, isOver } =
+    useSortable({
+      id: id,
+      disabled: isLocked || !isDraggable,
+      data: dndData,
+    }) // Disable sorting if locked or not explicitly draggable
+
+  const isDropOver = showDropIndicator && isOver && !isDragging
 
   const style: HTMLAttributes<HTMLDivElement>['style'] = isDraggable
     ? {
@@ -51,9 +62,12 @@ export function EditableSidebarItem({
     <div
       ref={isDraggable ? setNodeRef : undefined} // Only set ref if draggable
       style={style}
-      className={`flex h-7 w-full items-center justify-between px-2 text-sm ${
-        isDragging ? 'shadow-lg' : ''
-      } ${className}`}>
+      className={cn(
+        'flex h-7 w-full items-center justify-between rounded-md px-2 text-sm',
+        isDragging && 'shadow-lg',
+        isDropOver && 'bg-blue-500/10 ring-2 ring-inset ring-blue-500/50',
+        className
+      )}>
       <div className='flex items-center'>
         {isDraggable && !isLocked ? (
           // Draggable handle (only if draggable and not locked)

--- a/apps/web/src/components/global/sidebar/entity-folder.tsx
+++ b/apps/web/src/components/global/sidebar/entity-folder.tsx
@@ -1,0 +1,259 @@
+// apps/web/src/components/global/sidebar/entity-folder.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { CollapsibleChevron } from '@auxx/ui/components/collapsible'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import {
+  SidebarGroupCollapse,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+} from '@auxx/ui/components/sidebar'
+import { cn } from '@auxx/ui/lib/utils'
+import { useDroppable } from '@dnd-kit/core'
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Folder, MoreVertical, Pencil, Trash2 } from 'lucide-react'
+import { type ReactNode, useCallback, useState } from 'react'
+import { useDndState } from '~/app/context/dnd-state-context'
+import type { EntityFolder as EntityFolderType, ProcessedEntity } from '~/hooks/use-entity-sidebar'
+import { useSidebarStateContext } from './sidebar-state-context'
+
+/** Stable dnd id for an entity row (root or folder child). */
+export const entityDndId = (id: string) => `entity:${id}`
+/** Stable dnd id for a folder row (sortable among root nodes). */
+export const folderDndId = (id: string) => `folder:${id}`
+/** Stable dnd id for a folder's drop target. */
+export const folderDropId = (id: string) => `folder-drop:${id}`
+
+interface EntityFolderProps {
+  folder: EntityFolderType
+  items: ProcessedEntity[]
+  isEditMode: boolean
+  canEdit: boolean
+  onRename: (folderId: string, title: string) => void
+  onDelete: (folderId: string) => void
+  /** Renders one entity row; nav decides normal (link) vs edit (sortable) row. */
+  renderChild: (entity: ProcessedEntity, folderId: string) => ReactNode
+}
+
+/**
+ * Collapsible Records folder. In edit mode the row is sortable (reorders among
+ * root nodes) and a drop target (an entity dragged onto it moves into the
+ * folder), mirroring the favorites folder. Read-only otherwise.
+ */
+export function EntityFolder({
+  folder,
+  items,
+  isEditMode,
+  canEdit,
+  onRename,
+  onDelete,
+  renderChild,
+}: EntityFolderProps) {
+  const sectionId = `records.folder.${folder.id}`
+  const { getSectionOpen, toggleSection } = useSidebarStateContext()
+  const isOpen = getSectionOpen(sectionId, false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [draftTitle, setDraftTitle] = useState(folder.title)
+
+  const commitRename = useCallback(() => {
+    const title = draftTitle.trim()
+    if (!title || title === folder.title) {
+      setEditing(false)
+      setDraftTitle(folder.title)
+      return
+    }
+    onRename(folder.id, title)
+    setEditing(false)
+  }, [draftTitle, folder.id, folder.title, onRename])
+
+  const cancelRename = useCallback(() => {
+    setEditing(false)
+    setDraftTitle(folder.title)
+  }, [folder.title])
+
+  // ── DnD bindings (edit mode only) ──────────────────────────────────────────
+  const sortable = useSortable({
+    id: folderDndId(folder.id),
+    data: { kind: 'folder', folderId: folder.id, container: 'root' },
+    disabled: !isEditMode || editing,
+  })
+
+  const { activeDndItem } = useDndState()
+  const activeData = activeDndItem?.data.current as { kind?: string } | undefined
+  const isDraggingEntity = activeData?.kind === 'entity'
+
+  const dropTarget = useDroppable({
+    id: folderDropId(folder.id),
+    data: { kind: 'folderDrop', folderId: folder.id },
+    disabled: !isEditMode || !isDraggingEntity,
+  })
+
+  const isFolderDropOver = isDraggingEntity && (dropTarget.isOver || sortable.isOver)
+
+  const setRefs = useCallback(
+    (el: HTMLLIElement | null) => {
+      sortable.setNodeRef(el)
+      dropTarget.setNodeRef(el)
+    },
+    [sortable.setNodeRef, dropTarget.setNodeRef]
+  )
+
+  const style = {
+    transform: CSS.Transform.toString(sortable.transform),
+    transition: sortable.transition,
+  }
+
+  const childIds = items.map((e) => entityDndId(e.id))
+  const showMenu = isEditMode && canEdit
+
+  return (
+    <SidebarMenuItem
+      ref={setRefs}
+      style={style}
+      className={cn(
+        'rounded-md transition-colors duration-150',
+        sortable.isDragging && 'opacity-40',
+        isDraggingEntity && 'outline-dashed outline-1 outline-blue-500/30 [outline-offset:-1px]',
+        isFolderDropOver && 'bg-blue-500/10 ring-2 ring-inset ring-blue-500/50'
+      )}>
+      <SidebarMenuButton
+        asChild
+        className='h-7 py-0 pe-[3px]'
+        tooltip={folder.title}
+        {...(isEditMode && !editing ? sortable.attributes : {})}
+        {...(isEditMode && !editing ? sortable.listeners : {})}>
+        <div
+          className='group/item relative flex h-7 w-full cursor-pointer items-center justify-between'
+          onClick={(e) => {
+            if ((e.target as HTMLElement).closest('[data-no-toggle]')) return
+            if (editing) return
+            toggleSection(sectionId)
+          }}>
+          <div className='flex min-w-0 items-center grow'>
+            <Folder className='size-4 mr-2 shrink-0' />
+            {editing ? (
+              <input
+                data-no-toggle
+                autoFocus
+                value={draftTitle}
+                onChange={(e) => setDraftTitle(e.target.value)}
+                onClick={(e) => e.stopPropagation()}
+                onPointerDown={(e) => e.stopPropagation()}
+                onBlur={commitRename}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    commitRename()
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault()
+                    cancelRename()
+                  }
+                }}
+                className='h-5 min-w-0 grow rounded bg-background px-1 text-sm outline-none ring-1 ring-border'
+              />
+            ) : (
+              <>
+                <span className='truncate group-data-[collapsible=icon]:hidden'>
+                  {folder.title}
+                </span>
+                <button
+                  type='button'
+                  data-no-toggle
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    toggleSection(sectionId)
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  className='ml-1 inline-flex shrink-0 items-center text-muted-foreground group-data-[collapsible=icon]:hidden'>
+                  <CollapsibleChevron open={isOpen} />
+                </button>
+              </>
+            )}
+          </div>
+
+          {showMenu && !editing && (
+            <div
+              className='flex items-center group-data-[collapsible=icon]:hidden'
+              data-no-toggle
+              onClick={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+              }}
+              onPointerDown={(e) => e.stopPropagation()}>
+              <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    className={cn(
+                      'size-6 rounded-md opacity-100 sm:opacity-0 hover:bg-primary/10 focus-visible:ring-primary/10 hover:bg-primary-200/50',
+                      {
+                        'bg-primary-200 opacity-100': menuOpen,
+                        'sm:group-hover/item:opacity-100': !menuOpen,
+                      }
+                    )}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      e.preventDefault()
+                      setMenuOpen(!menuOpen)
+                    }}>
+                    <MoreVertical className='size-3.5' />
+                    <span className='sr-only'>Folder options</span>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className='w-50' align='start'>
+                  <DropdownMenuGroup>
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setDraftTitle(folder.title)
+                        setEditing(true)
+                      }}>
+                      <Pencil />
+                      Rename
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      variant='destructive'
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onDelete(folder.id)
+                      }}>
+                      <Trash2 />
+                      Delete folder
+                    </DropdownMenuItem>
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
+        </div>
+      </SidebarMenuButton>
+
+      <SidebarGroupCollapse open={isOpen || isEditMode}>
+        <SidebarMenuSub className='me-0 pe-0'>
+          {isEditMode ? (
+            <SortableContext items={childIds} strategy={verticalListSortingStrategy}>
+              {items.length > 0 ? (
+                items.map((entity) => renderChild(entity, folder.id))
+              ) : (
+                <li className='px-3 py-1 text-xs text-muted-foreground italic'>Empty folder</li>
+              )}
+            </SortableContext>
+          ) : items.length > 0 ? (
+            items.map((entity) => renderChild(entity, folder.id))
+          ) : null}
+        </SidebarMenuSub>
+      </SidebarGroupCollapse>
+    </SidebarMenuItem>
+  )
+}

--- a/apps/web/src/components/global/sidebar/entity-sidebar-nav.tsx
+++ b/apps/web/src/components/global/sidebar/entity-sidebar-nav.tsx
@@ -17,9 +17,11 @@ import {
 } from '@auxx/ui/components/sidebar'
 import { toastError } from '@auxx/ui/components/toast'
 import {
+  type Active,
   closestCenter,
   DndContext,
   type DragEndEvent,
+  type DragStartEvent,
   KeyboardSensor,
   PointerSensor,
   useSensor,
@@ -32,9 +34,19 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Archive, LayoutTemplate, Pencil, Plus, Settings, Settings2, Trash2 } from 'lucide-react'
+import {
+  Archive,
+  FolderPlus,
+  LayoutTemplate,
+  Pencil,
+  Plus,
+  Settings,
+  Settings2,
+  Trash2,
+} from 'lucide-react'
 import { usePathname, useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
+import { DndStateProvider } from '~/app/context/dnd-state-context'
 import { EntityDefinitionDialog } from '~/components/custom-fields/ui/entity-definition-dialog'
 import { EntityTemplateDialog } from '~/components/custom-fields/ui/entity-template-dialog'
 import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
@@ -46,16 +58,31 @@ import { type ProcessedEntity, useEntitySidebar } from '~/hooks/use-entity-sideb
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { EditableSidebarItem } from './editable-sidebar-item'
+import { EntityFolder, entityDndId, folderDndId } from './entity-folder'
 import { SidebarItem } from './sidebar-item'
 import { useSidebarStateContext } from './sidebar-state-context'
 
-/** Entity ID type for sidebar state */
-type EntityDefinitionId = string
+/** dnd-kit drag payload for Records nodes. */
+interface DragData {
+  kind: 'entity' | 'folder' | 'folderDrop'
+  entityId?: string
+  folderId?: string
+  /** 'root' or a folder id — which container the dragged entity lives in. */
+  container?: string
+}
+
+const ROOT = 'root'
+
+/** The raw (unprefixed) id a drop target points at. */
+function rawIdOf(d?: DragData): string | undefined {
+  if (!d) return undefined
+  return d.kind === 'entity' ? d.entityId : d.folderId
+}
 
 /**
- * Sidebar navigation component for dynamic entity definitions.
- * Displays entity definitions under "Records" section with icons.
- * Supports edit mode with drag-and-drop reordering and visibility toggles.
+ * Sidebar navigation for entity definitions ("Records").
+ * Org-wide layout with folders, drag-and-drop reordering, and visibility
+ * toggles — all editable by admins/owners inside Edit mode.
  */
 export function EntitySidebarNav() {
   const pathname = usePathname()
@@ -63,7 +90,10 @@ export function EntitySidebarNav() {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [templateDialogOpen, setTemplateDialogOpen] = useState(false)
   const [limitDialogOpen, setLimitDialogOpen] = useState(false)
-  const [editingEntityId, setEditingEntityId] = useState<EntityDefinitionId | null>(null)
+  const [editingEntityId, setEditingEntityId] = useState<string | null>(null)
+  const [activeDndItem, setActiveDndItem] = useState<Active | null>(null)
+  const [creatingFolder, setCreatingFolder] = useState(false)
+  const [draftFolderTitle, setDraftFolderTitle] = useState('')
   const [confirm, ConfirmDialog] = useConfirm()
   const { archiveEntity, deleteEntity } = useEntityDefinitionMutations()
   const { isAdminOrOwner } = useUser()
@@ -75,77 +105,104 @@ export function EntitySidebarNav() {
   const atEntityLimit = isAtLimit(FeatureKey.entities, userCreatedEntityCount)
   const entityLimit = getLimit(FeatureKey.entities)
 
-  // Use the entity sidebar hook for edit mode, visibility, and ordering
   const {
     isEditMode,
-    entities,
+    tree,
     isLoading,
+    canEdit,
     toggleEditMode,
     updateEntityVisibility,
-    updateEntityOrder,
     isGroupVisible,
     toggleGroupVisibility,
+    reorderRoot,
+    reorderWithinFolder,
+    createFolder,
+    renameFolder,
+    deleteFolder,
+    moveEntityToFolder,
   } = useEntitySidebar()
 
-  // DnD sensors setup
   const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 5 },
-    }),
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 
   // Close edit mode when unmounting
   useEffect(() => {
     return () => {
-      if (isEditMode) {
-        toggleEditMode()
-      }
+      if (isEditMode) toggleEditMode()
     }
   }, [isEditMode, toggleEditMode])
 
-  /** Toggle the Records group open/closed state */
   function handleToggleOpen() {
     toggleGroup('records')
   }
 
-  /** Toggle entity visibility in edit mode */
-  const handleToggleVisibility = useCallback(
-    (entityId: string) => {
-      const entity = entities.find((e) => e.id === entityId)
-      if (entity && !entity.isLocked) {
-        updateEntityVisibility(entityId, !entity.isVisible)
-      }
-    },
-    [entities, updateEntityVisibility]
+  // ── DnD ──────────────────────────────────────────────────────────────────
+  const rootRawIds = tree.rootSequence.map((n) =>
+    n.nodeType === 'FOLDER' ? n.folder.id : n.entity.id
   )
 
-  /** Handle drag end event for reordering */
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveDndItem(event.active)
+  }, [])
+
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event
+      setActiveDndItem(null)
+      if (!over) return
+      const a = active.data.current as DragData | undefined
+      const o = over.data.current as DragData | undefined
+      if (!a) return
 
-      if (over && active.id !== over.id) {
-        const oldIndex = entities.findIndex((item) => item.id === active.id)
-        const newIndex = entities.findIndex((item) => item.id === over.id)
+      // Entity dropped onto a folder (its drop target or the folder row itself).
+      if (a.kind === 'entity' && (o?.kind === 'folderDrop' || o?.kind === 'folder')) {
+        if (a.container !== o.folderId) moveEntityToFolder(a.entityId!, o.folderId!)
+        return
+      }
 
-        if (oldIndex !== -1 && newIndex !== -1) {
-          const newOrderedEntities = arrayMove(entities, oldIndex, newIndex)
-          const newOrderIds = newOrderedEntities.map((entity) => entity.id)
-          updateEntityOrder(newOrderIds)
+      if (active.id === over.id) return
+
+      // Folder reordered among root nodes.
+      if (a.kind === 'folder') {
+        const from = rootRawIds.indexOf(a.folderId!)
+        const to = rootRawIds.indexOf(rawIdOf(o)!)
+        if (from !== -1 && to !== -1 && from !== to) reorderRoot(arrayMove(rootRawIds, from, to))
+        return
+      }
+
+      // Entity reorder / cross-container move.
+      const overContainer = o?.container ?? ROOT
+      if (overContainer === a.container) {
+        if (a.container === ROOT) {
+          const from = rootRawIds.indexOf(a.entityId!)
+          const to = rootRawIds.indexOf(rawIdOf(o)!)
+          if (from !== -1 && to !== -1 && from !== to) reorderRoot(arrayMove(rootRawIds, from, to))
+        } else {
+          const ids = (tree.folderItems[a.container!] ?? []).map((e) => e.id)
+          const from = ids.indexOf(a.entityId!)
+          const to = ids.indexOf(o?.entityId ?? '')
+          if (from !== -1 && to !== -1 && from !== to)
+            reorderWithinFolder(a.container!, arrayMove(ids, from, to))
         }
+      } else if (overContainer === ROOT) {
+        const idx = rootRawIds.indexOf(rawIdOf(o)!)
+        moveEntityToFolder(a.entityId!, null, idx === -1 ? undefined : idx)
+      } else {
+        const idx = (tree.folderItems[overContainer] ?? []).findIndex((e) => e.id === o?.entityId)
+        moveEntityToFolder(a.entityId!, overContainer, idx === -1 ? undefined : idx)
       }
     },
-    [entities, updateEntityOrder]
+    [rootRawIds, tree.folderItems, moveEntityToFolder, reorderRoot, reorderWithinFolder]
   )
 
-  /** Open dialog in edit mode */
+  // ── Entity actions ─────────────────────────────────────────────────────────
   function handleEditEntity(entity: CustomResource) {
     setEditingEntityId(entity.id)
     setDialogOpen(true)
   }
 
-  /** Archive an entity definition */
   async function handleArchiveEntity(entity: CustomResource) {
     const confirmed = await confirm({
       title: `Archive "${entity.label}"?`,
@@ -155,7 +212,6 @@ export function EntitySidebarNav() {
       cancelText: 'Cancel',
       destructive: true,
     })
-
     if (confirmed) {
       archiveEntity.mutate(
         { id: entity.id },
@@ -168,7 +224,6 @@ export function EntitySidebarNav() {
     }
   }
 
-  /** Permanently delete an entity definition (records, fields, relationships). */
   async function handleDeleteEntity(entity: CustomResource) {
     const confirmed = await confirm({
       title: `Delete "${entity.label}" permanently?`,
@@ -180,7 +235,6 @@ export function EntitySidebarNav() {
       cancelText: 'Cancel',
       destructive: true,
     })
-
     if (confirmed) {
       deleteEntity.mutate(
         { id: entity.id },
@@ -193,13 +247,11 @@ export function EntitySidebarNav() {
     }
   }
 
-  /** Check if an entity route is active */
   function isActive(entity: ProcessedEntity) {
     const url = entity.href
     return pathname === url || pathname.startsWith(`${url}/`)
   }
 
-  /** Render icon component for entity definition */
   function renderIcon(iconId: string, color: string) {
     return (
       <EntityIcon
@@ -212,20 +264,12 @@ export function EntitySidebarNav() {
     )
   }
 
-  // Filtered entities for normal mode (only visible ones)
-  const visibleEntities = entities.filter((e) => e.isVisible)
-  const allEntityIds = entities.map((e) => e.id)
-  const allItemsHidden = visibleEntities.length === 0
-
-  /** Get edit items for an entity */
+  /** Per-entity dropdown items (normal mode). */
   function getEditItems(entity: ProcessedEntity) {
-    // Find the corresponding custom resource for edit/archive actions
     const resource = customResources?.find((r) => r.id === entity.id)
     if (!resource) return null
 
     const isSystemEntity = !!resource.entityType
-    // Archive + permanent delete are admin/owner only (org-wide destructive ops);
-    // the server enforces this too via `adminProcedure`.
     const canRemove = !isSystemEntity && isAdminOrOwner
 
     return (
@@ -260,42 +304,80 @@ export function EntitySidebarNav() {
     )
   }
 
-  /** Render entity list in edit mode with DnD */
-  function renderEditModeList() {
-    if (entities.length === 0) {
-      return (
-        <SidebarMenuItem>
-          <div className='px-2 py-1.5 text-sm text-muted-foreground'>No entities to edit</div>
-        </SidebarMenuItem>
-      )
-    }
-
+  // ── Row renderers ──────────────────────────────────────────────────────────
+  function renderEntityRowNormal(entity: ProcessedEntity, parentFolderId: string | null) {
     return (
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-        modifiers={[restrictToVerticalAxis]}>
-        <SortableContext items={allEntityIds} strategy={verticalListSortingStrategy}>
-          {entities.map((entity) => (
-            <SidebarMenuItem key={entity.id} className='p-0'>
-              <EditableSidebarItem
-                id={entity.id}
-                name={entity.plural}
-                icon={renderIcon(entity.icon, entity.color)}
-                isVisible={entity.isVisible}
-                isLocked={entity.isLocked}
-                onToggleVisibility={handleToggleVisibility}
-                isDraggable={true}
-              />
-            </SidebarMenuItem>
-          ))}
-        </SortableContext>
-      </DndContext>
+      <SidebarMenuItem key={entity.id}>
+        <SidebarItem
+          id={entity.id}
+          name={entity.plural}
+          href={entity.href}
+          icon={renderIcon(entity.icon, entity.color)}
+          isActive={isActive(entity)}
+          isSubmenu={parentFolderId !== null}
+          editItems={getEditItems(entity)}
+        />
+      </SidebarMenuItem>
     )
   }
 
-  /** Render entity list in normal mode */
+  function renderEntityRowEdit(entity: ProcessedEntity, parentFolderId: string | null) {
+    return (
+      <SidebarMenuItem key={entity.id} className='p-0'>
+        <EditableSidebarItem
+          id={entityDndId(entity.id)}
+          name={entity.plural}
+          icon={renderIcon(entity.icon, entity.color)}
+          isVisible={entity.isVisible}
+          isLocked={entity.isLocked}
+          onToggleVisibility={() => updateEntityVisibility(entity.id, !entity.isVisible)}
+          isDraggable={canEdit}
+          showDropIndicator
+          dndData={{ kind: 'entity', entityId: entity.id, container: parentFolderId ?? ROOT }}
+        />
+      </SidebarMenuItem>
+    )
+  }
+
+  // ── Folder create ──────────────────────────────────────────────────────────
+  function startCreateFolder() {
+    setDraftFolderTitle('')
+    setCreatingFolder(true)
+  }
+
+  function commitCreateFolder() {
+    const title = draftFolderTitle.trim()
+    if (title) createFolder(title)
+    setCreatingFolder(false)
+    setDraftFolderTitle('')
+  }
+
+  function cancelCreateFolder() {
+    setCreatingFolder(false)
+    setDraftFolderTitle('')
+  }
+
+  const folderDraftRow = creatingFolder ? (
+    <SidebarItem
+      id='__new_entity_folder__'
+      name=''
+      href='#'
+      icon={<FolderPlus />}
+      isEditing
+      editValue={draftFolderTitle}
+      onEditChange={setDraftFolderTitle}
+      onEditCommit={commitCreateFolder}
+      onEditCancel={cancelCreateFolder}
+    />
+  ) : null
+
+  // ── Empty / content state ──────────────────────────────────────────────────
+  const hasVisibleContent = tree.rootSequence.some((n) =>
+    n.nodeType === 'FOLDER'
+      ? (tree.folderItems[n.folder.id] ?? []).some((e) => e.isVisible)
+      : n.entity.isVisible
+  )
+
   function renderNormalModeList() {
     if (isLoading) {
       return (
@@ -306,25 +388,72 @@ export function EntitySidebarNav() {
       )
     }
 
-    return visibleEntities.map((entity) => {
-      const entityActive = isActive(entity)
-
-      return (
-        <SidebarMenuItem key={entity.id}>
-          <SidebarItem
-            id={entity.id}
-            name={entity.plural}
-            href={entity.href}
-            icon={renderIcon(entity.icon, entity.color)}
-            isActive={entityActive}
-            editItems={getEditItems(entity)}
+    return tree.rootSequence.map((node) => {
+      if (node.nodeType === 'FOLDER') {
+        const items = (tree.folderItems[node.folder.id] ?? []).filter((e) => e.isVisible)
+        return (
+          <EntityFolder
+            key={node.folder.id}
+            folder={node.folder}
+            items={items}
+            isEditMode={false}
+            canEdit={canEdit}
+            onRename={renameFolder}
+            onDelete={deleteFolder}
+            renderChild={(entity) => renderEntityRowNormal(entity, node.folder.id)}
           />
-        </SidebarMenuItem>
-      )
+        )
+      }
+      if (!node.entity.isVisible) return null
+      return renderEntityRowNormal(node.entity, null)
     })
   }
 
-  /** Handle create entity click — show limit dialog or open entity dialog */
+  function renderEditModeList() {
+    if (tree.rootSequence.length === 0) {
+      return (
+        <SidebarMenuItem>
+          <div className='px-2 py-1.5 text-sm text-muted-foreground'>No entities to edit</div>
+        </SidebarMenuItem>
+      )
+    }
+
+    const rootIds = tree.rootSequence.map((n) =>
+      n.nodeType === 'FOLDER' ? folderDndId(n.folder.id) : entityDndId(n.entity.id)
+    )
+
+    return (
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        modifiers={[restrictToVerticalAxis]}>
+        <DndStateProvider activeDndItem={activeDndItem}>
+          <SortableContext items={rootIds} strategy={verticalListSortingStrategy}>
+            {tree.rootSequence.map((node) => {
+              if (node.nodeType === 'FOLDER') {
+                return (
+                  <EntityFolder
+                    key={node.folder.id}
+                    folder={node.folder}
+                    items={tree.folderItems[node.folder.id] ?? []}
+                    isEditMode
+                    canEdit={canEdit}
+                    onRename={renameFolder}
+                    onDelete={deleteFolder}
+                    renderChild={(entity) => renderEntityRowEdit(entity, node.folder.id)}
+                  />
+                )
+              }
+              return renderEntityRowEdit(node.entity, null)
+            })}
+          </SortableContext>
+        </DndStateProvider>
+      </DndContext>
+    )
+  }
+
   function handleCreateFromBlank(e: React.MouseEvent) {
     e.stopPropagation()
     if (atEntityLimit) {
@@ -335,7 +464,6 @@ export function EntitySidebarNav() {
     }
   }
 
-  /** Handle create from template click — show limit dialog or open template dialog */
   function handleCreateFromTemplate(e: React.MouseEvent) {
     e.stopPropagation()
     if (atEntityLimit) {
@@ -356,6 +484,7 @@ export function EntitySidebarNav() {
           toggleOpen={handleToggleOpen}
           isGroupVisible={isGroupVisible}
           onToggleGroupVisibility={toggleGroupVisibility}
+          hideEditOption={!canEdit}
           additionalOptions={
             <>
               <DropdownMenuItem
@@ -365,8 +494,16 @@ export function EntitySidebarNav() {
                 }}>
                 <Settings /> Manage Entities
               </DropdownMenuItem>
+              {canEdit && (
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    startCreateFolder()
+                  }}>
+                  <FolderPlus /> New folder
+                </DropdownMenuItem>
+              )}
               <DropdownMenuSeparator />
-              {/* <DropdownMenuLabel>Create Entity</DropdownMenuLabel> */}
               <DropdownMenuItem onClick={handleCreateFromBlank}>
                 <Plus /> Create entity
               </DropdownMenuItem>
@@ -381,8 +518,9 @@ export function EntitySidebarNav() {
           }
         />
 
-        {/* Empty state when all items hidden (but group is visible) */}
-        <SidebarGroupCollapse open={allItemsHidden && !isEditMode && isOpen && isGroupVisible}>
+        {/* Empty state when nothing is visible (group still visible). */}
+        <SidebarGroupCollapse
+          open={!hasVisibleContent && !isEditMode && isOpen && isGroupVisible && canEdit}>
           <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton onClick={toggleEditMode}>
@@ -393,21 +531,23 @@ export function EntitySidebarNav() {
           </SidebarMenu>
         </SidebarGroupCollapse>
 
-        {/* Entity list - only show when group is visible or in edit mode */}
-        <SidebarGroupCollapse open={(isEditMode || (isOpen && isGroupVisible)) && !allItemsHidden}>
-          <SidebarMenu>{isEditMode ? renderEditModeList() : renderNormalModeList()}</SidebarMenu>
-        </SidebarGroupCollapse>
-
-        {/* Edit mode list when all items are hidden */}
-        <SidebarGroupCollapse open={isEditMode && allItemsHidden}>
-          <SidebarMenu>{renderEditModeList()}</SidebarMenu>
+        {/* Entity list. */}
+        <SidebarGroupCollapse
+          open={(isEditMode || (isOpen && isGroupVisible)) && (hasVisibleContent || isEditMode)}>
+          <SidebarMenu className='gap-0'>
+            {folderDraftRow}
+            {isEditMode ? renderEditModeList() : renderNormalModeList()}
+          </SidebarMenu>
         </SidebarGroupCollapse>
       </SidebarGroup>
 
-      {/* Done button footer for edit mode */}
+      {/* Edit-mode footer. */}
       {isEditMode && (
-        <div className='flex shrink-0 items-center justify-end gap-2 border-t p-2'>
-          <Button className='w-full rounded-md' size='sm' onClick={toggleEditMode}>
+        <div className='flex shrink-0 items-center justify-between gap-2 border-t p-2'>
+          <Button variant='outline' size='sm' onClick={startCreateFolder}>
+            <FolderPlus /> New folder
+          </Button>
+          <Button className='rounded-md' size='sm' onClick={toggleEditMode}>
             Done
           </Button>
         </div>

--- a/apps/web/src/hooks/use-entity-sidebar.tsx
+++ b/apps/web/src/hooks/use-entity-sidebar.tsx
@@ -1,15 +1,19 @@
 // apps/web/src/hooks/use-entity-sidebar.tsx
 
+import { generateId } from '@auxx/utils'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useResources } from '~/components/resources/hooks'
 import { useSettings } from '~/hooks/use-settings'
+import { useUser } from '~/hooks/use-user'
 
-/** Setting keys for entity sidebar */
+/** Setting keys for the Records sidebar (all org-wide / admin-editable). */
 const ENTITY_ORDER_SETTING_KEY = 'sidebar.entities.order'
 const ENTITY_VISIBILITY_SETTING_KEY = 'sidebar.entities.visibility'
 const ENTITY_GROUP_VISIBILITY_SETTING_KEY = 'sidebar.entities.groupVisible'
+const ENTITY_FOLDERS_SETTING_KEY = 'sidebar.entities.folders'
+const ENTITY_FOLDER_ITEMS_SETTING_KEY = 'sidebar.entities.folderItems'
 
-/** Processed entity with visibility and ordering metadata */
+/** Processed entity with visibility metadata */
 export interface ProcessedEntity {
   id: string
   apiSlug: string
@@ -23,30 +27,80 @@ export interface ProcessedEntity {
   href: string
 }
 
+/** A folder definition in the Records sidebar. */
+export interface EntityFolder {
+  id: string
+  title: string
+}
+
+/** A node in the root sequence: either a folder or a top-level entity. */
+export type EntityRootNode =
+  | { nodeType: 'FOLDER'; folder: EntityFolder }
+  | { nodeType: 'ENTITY'; entity: ProcessedEntity }
+
+/** Tree shape consumed by the sidebar: root nodes + per-folder children. */
+export interface EntityTree {
+  rootSequence: EntityRootNode[]
+  folderItems: Record<string, ProcessedEntity[]>
+  folders: EntityFolder[]
+}
+
 interface UseEntitySidebarOptions {
   scope?: string
 }
 
 /**
- * Hook for managing entity sidebar state including edit mode, visibility, and ordering.
- * Follows the same patterns as useMailSidebar.
+ * Hook for the Records sidebar: org-wide folders, ordering, and visibility.
+ *
+ * Layout is stored entirely in org settings (no DB table) and is editable by
+ * admins/owners only. Reordering/visibility/folder ops write through
+ * `updateOrganizationSetting` (which enforces admin server-side and broadcasts
+ * `org.settings.changed` to every member).
  */
 export function useEntitySidebar({ scope = 'SIDEBAR' }: UseEntitySidebarOptions = {}) {
   const [isEditMode, setIsEditMode] = useState(false)
   const lastToggleTime = useRef<number>(0)
 
-  const { getSetting, updateUserSetting, isLoading: settingsLoading } = useSettings({ scope })
+  const {
+    getSetting,
+    updateOrganizationSetting,
+    isLoading: settingsLoading,
+  } = useSettings({ scope })
   const { customResources, isLoading: resourcesLoading } = useResources()
+  const { isAdminOrOwner } = useUser()
 
-  /** Process entities: apply saved order and visibility */
-  const entities = useMemo((): ProcessedEntity[] => {
-    // Get saved order and visibility settings
-    const entityOrder = (getSetting(ENTITY_ORDER_SETTING_KEY) as string[]) || []
-    const visibilitySettings =
-      (getSetting(ENTITY_VISIBILITY_SETTING_KEY) as Record<string, boolean>) || {}
+  // ── Typed reads ────────────────────────────────────────────────────────────
+  const readOrder = useCallback(
+    () => (getSetting(ENTITY_ORDER_SETTING_KEY) as string[]) || [],
+    [getSetting]
+  )
+  const readVisibility = useCallback(
+    () => (getSetting(ENTITY_VISIBILITY_SETTING_KEY) as Record<string, boolean>) || {},
+    [getSetting]
+  )
+  const readFolders = useCallback(
+    () => (getSetting(ENTITY_FOLDERS_SETTING_KEY) as EntityFolder[]) || [],
+    [getSetting]
+  )
+  const readFolderItems = useCallback(
+    () => (getSetting(ENTITY_FOLDER_ITEMS_SETTING_KEY) as Record<string, string[]>) || {},
+    [getSetting]
+  )
 
-    // Convert custom resources to processed entities, filtering out hidden entities
-    const allEntities: ProcessedEntity[] = (customResources || [])
+  /** Persist an org-scoped layout setting (admin only, enforced server-side). */
+  const setOrg = useCallback(
+    (key: string, value: unknown) => updateOrganizationSetting(key, value as never, false),
+    [updateOrganizationSetting]
+  )
+
+  // ── Tree ─────────────────────────────────────────────────────────────────
+  const tree = useMemo((): EntityTree => {
+    const order = readOrder()
+    const visibility = readVisibility()
+    const folders = readFolders()
+    const folderItemsRaw = readFolderItems()
+
+    const baseEntities: ProcessedEntity[] = (customResources || [])
       .filter((resource) => resource.isVisible !== false)
       .map((resource) => ({
         id: resource.id,
@@ -57,91 +111,191 @@ export function useEntitySidebar({ scope = 'SIDEBAR' }: UseEntitySidebarOptions 
         color: resource.color,
         entityType: resource.entityType,
         isLocked: false,
-        isVisible: visibilitySettings[resource.id] !== false,
+        isVisible: visibility[resource.id] !== false,
         href: resource.entityType ? `/app/${resource.apiSlug}` : `/app/custom/${resource.apiSlug}`,
       }))
 
-    // Create a map for quick lookup
-    const entityMap = new Map(allEntities.map((entity) => [entity.id, entity]))
+    const entityMap = new Map(baseEntities.map((e) => [e.id, e]))
+    const folderIds = new Set(folders.map((f) => f.id))
 
-    // Build sorted list based on saved order
-    const sortedEntities: ProcessedEntity[] = []
-    const processedIds = new Set<string>()
-
-    // First, add entities in saved order
-    entityOrder.forEach((id) => {
-      const entity = entityMap.get(id)
-      if (entity) {
-        sortedEntities.push({
-          ...entity,
-          isVisible: entity.isLocked ? true : visibilitySettings[id] !== false,
-        })
-        processedIds.add(id)
+    // Resolve folder children, tracking which entities are claimed by a folder.
+    const assigned = new Set<string>()
+    const folderItems: Record<string, ProcessedEntity[]> = {}
+    for (const folder of folders) {
+      const ids = folderItemsRaw[folder.id] ?? []
+      const resolved: ProcessedEntity[] = []
+      for (const eid of ids) {
+        const entity = entityMap.get(eid)
+        if (entity && !assigned.has(eid)) {
+          resolved.push(entity)
+          assigned.add(eid)
+        }
       }
-    })
+      folderItems[folder.id] = resolved
+    }
 
-    // Then, append any entities not in saved order (new entities)
-    allEntities.forEach((entity) => {
-      if (!processedIds.has(entity.id)) {
-        sortedEntities.push({
-          ...entity,
-          isVisible: entity.isLocked ? true : visibilitySettings[entity.id] !== false,
-        })
+    // Build the root sequence from `order` (folders + root entities interleaved).
+    const rootSequence: EntityRootNode[] = []
+    const seenFolders = new Set<string>()
+    const seenRootEntities = new Set<string>()
+    for (const id of order) {
+      if (folderIds.has(id)) {
+        if (seenFolders.has(id)) continue
+        const folder = folders.find((f) => f.id === id)
+        if (folder) {
+          rootSequence.push({ nodeType: 'FOLDER', folder })
+          seenFolders.add(id)
+        }
+      } else {
+        const entity = entityMap.get(id)
+        if (entity && !assigned.has(id) && !seenRootEntities.has(id)) {
+          rootSequence.push({ nodeType: 'ENTITY', entity })
+          seenRootEntities.add(id)
+        }
       }
-    })
+    }
+    // Append folders/entities not present in `order` (newly created).
+    for (const folder of folders) {
+      if (!seenFolders.has(folder.id)) {
+        rootSequence.push({ nodeType: 'FOLDER', folder })
+        seenFolders.add(folder.id)
+      }
+    }
+    for (const entity of baseEntities) {
+      if (!assigned.has(entity.id) && !seenRootEntities.has(entity.id)) {
+        rootSequence.push({ nodeType: 'ENTITY', entity })
+        seenRootEntities.add(entity.id)
+      }
+    }
 
-    return sortedEntities
-  }, [customResources, getSetting])
+    return { rootSequence, folderItems, folders }
+  }, [customResources, readOrder, readVisibility, readFolders, readFolderItems])
 
-  /** Get group visibility setting */
+  /** Group visibility setting */
   const isGroupVisible = useMemo((): boolean => {
-    const setting = getSetting(ENTITY_GROUP_VISIBILITY_SETTING_KEY)
-    return setting !== false
+    return getSetting(ENTITY_GROUP_VISIBILITY_SETTING_KEY) !== false
   }, [getSetting])
 
-  /** Toggle edit mode with debounce */
+  // ── Edit mode ──────────────────────────────────────────────────────────────
   const toggleEditMode = useCallback(() => {
     const now = Date.now()
-    if (now - lastToggleTime.current < 300) {
-      return
-    }
+    if (now - lastToggleTime.current < 300) return
     lastToggleTime.current = now
     setIsEditMode((prev) => !prev)
   }, [])
 
-  /** Update entity visibility */
+  // ── Visibility ─────────────────────────────────────────────────────────────
   const updateEntityVisibility = useCallback(
     (entityId: string, isVisible: boolean) => {
-      const currentSettings =
-        (getSetting(ENTITY_VISIBILITY_SETTING_KEY) as Record<string, boolean>) || {}
-      const updatedSettings = { ...currentSettings, [entityId]: isVisible }
-      updateUserSetting(ENTITY_VISIBILITY_SETTING_KEY, updatedSettings)
+      setOrg(ENTITY_VISIBILITY_SETTING_KEY, { ...readVisibility(), [entityId]: isVisible })
     },
-    [getSetting, updateUserSetting]
+    [readVisibility, setOrg]
   )
 
-  /** Update entity order */
-  const updateEntityOrder = useCallback(
-    (orderedEntityIds: string[]) => {
-      updateUserSetting(ENTITY_ORDER_SETTING_KEY, orderedEntityIds)
-    },
-    [updateUserSetting]
-  )
-
-  /** Toggle group visibility */
   const toggleGroupVisibility = useCallback(() => {
-    const currentValue = getSetting(ENTITY_GROUP_VISIBILITY_SETTING_KEY) !== false
-    updateUserSetting(ENTITY_GROUP_VISIBILITY_SETTING_KEY, !currentValue)
-  }, [getSetting, updateUserSetting])
+    const current = getSetting(ENTITY_GROUP_VISIBILITY_SETTING_KEY) !== false
+    setOrg(ENTITY_GROUP_VISIBILITY_SETTING_KEY, !current)
+  }, [getSetting, setOrg])
+
+  // ── Ordering ───────────────────────────────────────────────────────────────
+  /** Reorder the root sequence (array of folder/entity IDs). */
+  const reorderRoot = useCallback(
+    (orderedIds: string[]) => setOrg(ENTITY_ORDER_SETTING_KEY, orderedIds),
+    [setOrg]
+  )
+
+  /** Reorder entities within a folder. */
+  const reorderWithinFolder = useCallback(
+    (folderId: string, orderedEntityIds: string[]) => {
+      setOrg(ENTITY_FOLDER_ITEMS_SETTING_KEY, {
+        ...readFolderItems(),
+        [folderId]: orderedEntityIds,
+      })
+    },
+    [readFolderItems, setOrg]
+  )
+
+  // ── Folder CRUD ────────────────────────────────────────────────────────────
+  const createFolder = useCallback(
+    (title: string) => {
+      const id = generateId()
+      setOrg(ENTITY_FOLDERS_SETTING_KEY, [...readFolders(), { id, title }])
+      setOrg(ENTITY_ORDER_SETTING_KEY, [...readOrder(), id])
+      return id
+    },
+    [readFolders, readOrder, setOrg]
+  )
+
+  const renameFolder = useCallback(
+    (folderId: string, title: string) => {
+      setOrg(
+        ENTITY_FOLDERS_SETTING_KEY,
+        readFolders().map((f) => (f.id === folderId ? { ...f, title } : f))
+      )
+    },
+    [readFolders, setOrg]
+  )
+
+  /** Delete a folder; its entities fall back to the root (appended). */
+  const deleteFolder = useCallback(
+    (folderId: string) => {
+      const items = readFolderItems()
+      const children = items[folderId] ?? []
+      const { [folderId]: _removed, ...restItems } = items
+      setOrg(
+        ENTITY_FOLDERS_SETTING_KEY,
+        readFolders().filter((f) => f.id !== folderId)
+      )
+      setOrg(ENTITY_FOLDER_ITEMS_SETTING_KEY, restItems)
+      setOrg(ENTITY_ORDER_SETTING_KEY, [
+        ...readOrder().filter((id) => id !== folderId),
+        ...children,
+      ])
+    },
+    [readFolderItems, readFolders, readOrder, setOrg]
+  )
+
+  /**
+   * Move an entity into a folder (or to the root when `folderId` is null).
+   * Removes it from wherever it currently lives first.
+   */
+  const moveEntityToFolder = useCallback(
+    (entityId: string, folderId: string | null, index?: number) => {
+      const order = readOrder().filter((id) => id !== entityId)
+      const items = readFolderItems()
+      const nextItems: Record<string, string[]> = {}
+      for (const [fid, arr] of Object.entries(items)) {
+        nextItems[fid] = arr.filter((id) => id !== entityId)
+      }
+
+      if (folderId) {
+        const arr = nextItems[folderId] ?? []
+        arr.splice(index ?? arr.length, 0, entityId)
+        nextItems[folderId] = arr
+      } else {
+        order.splice(index ?? order.length, 0, entityId)
+      }
+
+      setOrg(ENTITY_ORDER_SETTING_KEY, order)
+      setOrg(ENTITY_FOLDER_ITEMS_SETTING_KEY, nextItems)
+    },
+    [readOrder, readFolderItems, setOrg]
+  )
 
   return {
     isEditMode,
-    entities,
     isLoading: resourcesLoading || settingsLoading,
+    canEdit: isAdminOrOwner,
+    tree,
+    isGroupVisible,
     toggleEditMode,
     updateEntityVisibility,
-    updateEntityOrder,
-    isGroupVisible,
     toggleGroupVisibility,
+    reorderRoot,
+    reorderWithinFolder,
+    createFolder,
+    renameFolder,
+    deleteFolder,
+    moveEntityToFolder,
   }
 }

--- a/packages/lib/src/settings/settings-service.ts
+++ b/packages/lib/src/settings/settings-service.ts
@@ -54,18 +54,21 @@ export const sidebarSettings = {
     type: 'object',
     description: 'Visibility settings for sidebar groups (Me, Views, Shared)',
   },
+  // Records sidebar layout is org-wide (shared by everyone, admin-editable).
   'sidebar.entities.order': {
     key: 'sidebar.entities.order',
     scope: 'SIDEBAR',
     defaultValue: [],
     type: 'object',
-    description: 'Order of entity definitions in the Records sidebar',
+    organizationOnly: true,
+    description: 'Order of root-level Records sidebar nodes (interleaved folder + entity IDs)',
   },
   'sidebar.entities.visibility': {
     key: 'sidebar.entities.visibility',
     scope: 'SIDEBAR',
     defaultValue: {},
     type: 'object',
+    organizationOnly: true,
     description: 'Visibility settings for entity definitions in the Records sidebar',
   },
   'sidebar.entities.groupVisible': {
@@ -73,7 +76,24 @@ export const sidebarSettings = {
     scope: 'SIDEBAR',
     defaultValue: true,
     type: 'boolean',
+    organizationOnly: true,
     description: 'Visibility of the Records group in sidebar',
+  },
+  'sidebar.entities.folders': {
+    key: 'sidebar.entities.folders',
+    scope: 'SIDEBAR',
+    defaultValue: [], // Array<{ id: string; title: string }>
+    type: 'object',
+    organizationOnly: true,
+    description: 'Folder definitions for the Records sidebar',
+  },
+  'sidebar.entities.folderItems': {
+    key: 'sidebar.entities.folderItems',
+    scope: 'SIDEBAR',
+    defaultValue: {}, // Record<folderId, entityId[]>
+    type: 'object',
+    organizationOnly: true,
+    description: 'Ordered entity IDs within each Records sidebar folder (membership + order)',
   },
 }
 


### PR DESCRIPTION
## Summary

Adds **folders** to the Records (entity definitions) sidebar — the same folder UX as the Favorites sidebar — so entity definitions can be grouped under collapsible, named folders.

Design decisions (per discussion):
- **Persistence:** org settings JSON, **no DB table** (extends the `sidebar.entities.*` keys).
- **Scope:** **org-wide** — folders, membership, order, and visibility are shared by everyone in the org.
- **Editing:** the existing **"Edit Sidebar"** mode, gated to **admins/owners only**.
- **Structure:** one level, **mixed root** — entities live at root *or* in a folder; folders don't nest.

## How it works

The settings system already supports org-scoped keys via `organizationOnly: true`:
- **Reads** — `getAllUserSettings` returns the org value to *every* user (flows through dehydrated state → `useSettings`).
- **Writes** — `updateOrganizationSetting` already enforces admin/owner, runs `notDemo`, fires `org.settings.changed` realtime (`broadcastUserKeys`), and audit-logs.

So no migration and no new tRPC router — edit-mode mutations just switch to `updateOrganizationSetting`.

## Changes

- **`packages/lib/.../settings-service.ts`** — `organizationOnly: true` on `sidebar.entities.{order,visibility,groupVisible}`; new `sidebar.entities.{folders,folderItems}` keys.
- **`use-entity-sidebar.tsx`** (rewrite) — builds an `EntityTree` (interleaved folders + root entities) with stale-id guards; adds `canEdit` + folder CRUD / move / reorder ops.
- **`entity-folder.tsx`** (new) — collapsible folder row: sortable among root, drop target for entities, rename/delete. Mirrors `favorite-folder.tsx`.
- **`entity-sidebar-nav.tsx`** (rewrite) — renders the tree (normal + edit), local `DndContext` + `DndStateProvider`, drag handler (reorder / cross-container move / drop-into-folder), inline "New folder", admin gating.
- **`editable-sidebar-item.tsx`** — opt-in **blue drop-over indicator** (`showDropIndicator`); blue ring matched on the folder over-state for a cohesive drag interaction.

## Notes / scope

- **No backfill.** Existing per-user order/visibility become legacy/ignored now that the keys are org-scoped; the org layout starts empty (all entities at root, visible). Safe given few production users.
- Uses multiple `updateOrganizationSetting` calls (not `batchUpdate*`, which fires a success toast on every drag).
- Out of scope (v1): nested folders, per-user overrides on top of the org layout.

## Verification

- Biome clean on all changed files; `@auxx/lib` rebuilt so the server recognizes the new keys.
- ⚠️ Not yet manually exercised in-browser — recommend testing drag/drop, folder create/rename/delete, and realtime propagation to a second user session before merge.