### PR TITLE
feat(ui): bulk select + delete/archive for list-card grids

### DIFF
--- a/apps/web/src/app/(protected)/app/connectors/page.tsx
+++ b/apps/web/src/app/(protected)/app/connectors/page.tsx
@@ -4,9 +4,7 @@
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
-import { InputSearch } from '@auxx/ui/components/input-search'
 import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
-import { ListToolbar } from '@auxx/ui/components/list-toolbar'
 import {
   MainPage,
   MainPageBreadcrumb,
@@ -18,7 +16,10 @@ import { Lock, Plus } from 'lucide-react'
 import { useState } from 'react'
 import { ConnectSourceDialog } from '~/components/data-connectors/ui/connect-source-dialog'
 import { ConnectorList } from '~/components/data-connectors/ui/connector-list'
+import { ConnectorsBulkBar } from '~/components/data-connectors/ui/connectors-bulk-bar'
+import { ConnectorsToolbar } from '~/components/data-connectors/ui/connectors-toolbar'
 import { EmptyState } from '~/components/global/empty-state'
+import { ListSelectionProvider } from '~/components/list-selection'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 /**
@@ -48,19 +49,14 @@ export default function ConnectorsPage() {
       </MainPageHeader>
       <MainPageContent>
         {canConnect ? (
-          <ListPageScroll
-            toolbar={
-              <ListToolbar>
-                <InputSearch
-                  value={search}
-                  placeholder='Search connectors...'
-                  onChange={(e) => setSearch(e.target.value)}
-                />
-              </ListToolbar>
-            }
-            bodyClassName='flex-1 flex flex-col min-h-0'>
-            <ConnectorList onConnect={() => setPickerOpen(true)} search={search} />
-          </ListPageScroll>
+          <ListSelectionProvider>
+            <ListPageScroll
+              toolbar={<ConnectorsToolbar search={search} onSearchChange={setSearch} />}
+              bodyClassName='flex-1 flex flex-col min-h-0'>
+              <ConnectorList onConnect={() => setPickerOpen(true)} search={search} />
+            </ListPageScroll>
+            <ConnectorsBulkBar />
+          </ListSelectionProvider>
         ) : (
           <EmptyState
             icon={Lock}

--- a/apps/web/src/app/(protected)/app/datasets/page.tsx
+++ b/apps/web/src/app/(protected)/app/datasets/page.tsx
@@ -15,6 +15,7 @@ import {
 import { Lock } from 'lucide-react'
 import {
   CreateDatasetButton,
+  DatasetsBulkBar,
   DatasetsEmptyState,
   DatasetsFilterBar,
   DatasetsGridView,
@@ -24,6 +25,7 @@ import {
   useDatasets,
 } from '~/components/datasets'
 import { EmptyState } from '~/components/global/empty-state'
+import { ListSelectionProvider } from '~/components/list-selection'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 /**
@@ -45,21 +47,24 @@ function DatasetsPageContent() {
         <DatasetsStatsCards stats={stats} />
 
         {/* Filters + Datasets Content */}
-        <ListPageScroll toolbar={<DatasetsFilterBar />}>
-          {isLoading ? (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
-              {[...Array(8)].map((_, i) => (
-                <ListCard key={`skeleton-${i}`} loading descriptionLines={0} />
-              ))}
-            </div>
-          ) : items.length === 0 ? (
-            <DatasetsEmptyState searchQuery={searchQuery} selectedStatus={selectedStatus} />
-          ) : viewMode === 'grid' ? (
-            <DatasetsGridView />
-          ) : (
-            <DatasetsTableView />
-          )}
-        </ListPageScroll>
+        <ListSelectionProvider>
+          <ListPageScroll toolbar={<DatasetsFilterBar />}>
+            {isLoading ? (
+              <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
+                {[...Array(8)].map((_, i) => (
+                  <ListCard key={`skeleton-${i}`} loading descriptionLines={0} />
+                ))}
+              </div>
+            ) : items.length === 0 ? (
+              <DatasetsEmptyState searchQuery={searchQuery} selectedStatus={selectedStatus} />
+            ) : viewMode === 'grid' ? (
+              <DatasetsGridView />
+            ) : (
+              <DatasetsTableView />
+            )}
+          </ListPageScroll>
+          <DatasetsBulkBar />
+        </ListSelectionProvider>
       </MainPageContent>
     </MainPage>
   )

--- a/apps/web/src/app/(protected)/app/workflows/_components/filters/workflows-filter-bar.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/_components/filters/workflows-filter-bar.tsx
@@ -3,6 +3,7 @@
 
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { Label } from '@auxx/ui/components/label'
+import { ListBulkToggle } from '@auxx/ui/components/list-bulk-toggle'
 import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
 import {
   Select,
@@ -13,6 +14,7 @@ import {
 } from '@auxx/ui/components/select'
 import { Switch } from '@auxx/ui/components/switch'
 import { ViewModeToggle } from '@auxx/ui/components/view-mode-toggle'
+import { useBulkMode, useListSelection } from '~/components/list-selection'
 import { useWorkflows } from '../providers/workflows-provider'
 import { getAllTriggers } from '../utils/trigger-info'
 
@@ -27,6 +29,9 @@ export function WorkflowsFilterBar() {
     viewMode,
     setViewMode,
   } = useWorkflows()
+
+  const bulkMode = useBulkMode()
+  const setBulkMode = useListSelection((s) => s.setBulkMode)
 
   const triggerTypes = getAllTriggers().map((trigger) => ({
     value: trigger.id,
@@ -60,6 +65,7 @@ export function WorkflowsFilterBar() {
       />
 
       <ListToolbarGroup align='end'>
+        {viewMode === 'grid' && <ListBulkToggle active={bulkMode} onActiveChange={setBulkMode} />}
         <div className='flex items-center space-x-2 h-7'>
           <Switch
             id='show-disabled'

--- a/apps/web/src/app/(protected)/app/workflows/_components/lists/workflows-bulk-bar.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/_components/lists/workflows-bulk-bar.tsx
@@ -1,0 +1,61 @@
+// apps/web/src/app/(protected)/app/workflows/_components/lists/workflows-bulk-bar.tsx
+'use client'
+
+import { ActionBar, type ActionBarAction } from '@auxx/ui/components/action-bar'
+import { Trash } from 'lucide-react'
+import {
+  useBulkMode,
+  useBulkRunner,
+  useListSelection,
+  useSelectionCount,
+  useSelectionIds,
+} from '~/components/list-selection'
+import { api } from '~/trpc/react'
+import { useWorkflows } from '../providers/workflows-provider'
+
+/** Floating bulk-action bar for the workflows grid — currently just delete. */
+export function WorkflowsBulkBar() {
+  const ids = useSelectionIds()
+  const count = useSelectionCount()
+  const bulkMode = useBulkMode()
+  const exit = useListSelection((s) => s.exit)
+  const { refetchWorkflows } = useWorkflows()
+  const { ConfirmDialog, run, isRunning } = useBulkRunner()
+  const deleteWorkflow = api.workflow.delete.useMutation()
+
+  const actions: ActionBarAction[] = [
+    {
+      id: 'delete',
+      label: 'Delete',
+      icon: Trash,
+      variant: 'destructive',
+      tooltip: 'Delete selected',
+      disabled: isRunning || count === 0,
+      onClick: () =>
+        run(ids, (id) => deleteWorkflow.mutateAsync({ id }), {
+          title: `Delete ${count} workflow${count === 1 ? '' : 's'}?`,
+          description:
+            'This permanently deletes them and all their execution history. This cannot be undone.',
+          failureTitle: 'Some workflows could not be deleted',
+          onDone: () => {
+            refetchWorkflows()
+            exit()
+          },
+        }),
+    },
+  ]
+
+  return (
+    <>
+      <ConfirmDialog />
+      <ActionBar
+        open={bulkMode || count > 0}
+        onOpenChange={(open) => !open && exit()}
+        selectedCount={count}
+        selectedLabel='selected'
+        actions={actions}
+        showClose
+      />
+    </>
+  )
+}

--- a/apps/web/src/app/(protected)/app/workflows/_components/lists/workflows-grid-view.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/_components/lists/workflows-grid-view.tsx
@@ -9,8 +9,15 @@ import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { ListCard } from '@auxx/ui/components/list-card'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { Copy, Edit, Pause, Play, Trash } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
+import {
+  useBulkMode,
+  useIsPending,
+  useIsSelected,
+  useListSelection,
+  usePendingLabel,
+} from '~/components/list-selection'
 import { DuplicateWorkflowDialog } from '~/components/workflow/dialogs/duplicate-workflow-dialog'
 import { WorkflowFormDialog } from '~/components/workflow/dialogs/workflow-form-dialog'
 import { unifiedNodeRegistry } from '~/components/workflow/nodes/unified-registry'
@@ -27,6 +34,11 @@ function WorkflowCard({ workflow }: WorkflowCardProps) {
   const [confirm, ConfirmDialog] = useConfirm()
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false)
+  const bulkMode = useBulkMode()
+  const selected = useIsSelected(workflow.id)
+  const pending = useIsPending(workflow.id)
+  const pendingLabel = usePendingLabel()
+  const toggle = useListSelection((s) => s.toggle)
 
   const updateWorkflow = api.workflow.update.useMutation({
     onSuccess: () => {
@@ -72,6 +84,12 @@ function WorkflowCard({ workflow }: WorkflowCardProps) {
       <ListCard
         href={`/app/workflows/${workflow.id}`}
         ariaLabel={workflow.name}
+        selectable
+        selecting={bulkMode}
+        selected={selected}
+        onSelectChange={(_, e) => toggle(workflow.id, { shiftKey: e.shiftKey })}
+        pending={pending}
+        pendingLabel={pendingLabel}
         title={workflow.name}
         icon={
           workflow.icon ? (
@@ -147,6 +165,11 @@ function WorkflowCard({ workflow }: WorkflowCardProps) {
 
 export function WorkflowsGridView() {
   const { workflows } = useWorkflows()
+  const setItemIds = useListSelection((s) => s.setItemIds)
+
+  useEffect(() => {
+    setItemIds(workflows.map((w) => w.id))
+  }, [workflows, setItemIds])
 
   return (
     <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>

--- a/apps/web/src/app/(protected)/app/workflows/page.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/page.tsx
@@ -12,9 +12,11 @@ import {
 } from '@auxx/ui/components/main-page'
 import { Lock } from 'lucide-react'
 import { EmptyState } from '~/components/global/empty-state'
+import { ListSelectionProvider } from '~/components/list-selection'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { CreateWorkflowButton } from './_components/buttons/create-workflow-button'
 import { WorkflowsFilterBar } from './_components/filters/workflows-filter-bar'
+import { WorkflowsBulkBar } from './_components/lists/workflows-bulk-bar'
 import { WorkflowsList } from './_components/lists/workflows-list'
 import { WorkflowsProvider } from './_components/providers/workflows-provider'
 import { WorkflowsStatsCards } from './_components/stats/workflows-stats-cards'
@@ -34,11 +36,14 @@ function WorkflowsPageContent() {
         <WorkflowsStatsCards />
 
         {/* Filters + Workflows List */}
-        <ListPageScroll
-          toolbar={<WorkflowsFilterBar />}
-          bodyClassName='flex-1 flex flex-col min-h-0'>
-          <WorkflowsList />
-        </ListPageScroll>
+        <ListSelectionProvider>
+          <ListPageScroll
+            toolbar={<WorkflowsFilterBar />}
+            bodyClassName='flex-1 flex flex-col min-h-0'>
+            <WorkflowsList />
+          </ListPageScroll>
+          <WorkflowsBulkBar />
+        </ListSelectionProvider>
       </MainPageContent>
     </MainPage>
   )

--- a/apps/web/src/components/agents/ui/list/agent-card.tsx
+++ b/apps/web/src/components/agents/ui/list/agent-card.tsx
@@ -7,6 +7,13 @@ import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { ListCard } from '@auxx/ui/components/list-card'
 import { Archive, ArchiveRestore, MessageCircle, Pencil, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import {
+  useBulkMode,
+  useIsPending,
+  useIsSelected,
+  useListSelection,
+  usePendingLabel,
+} from '~/components/list-selection'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useAgentMutations } from '../../hooks/use-agent-mutations'
 import type { AgentListItem } from '../../store/agent-store'
@@ -20,6 +27,11 @@ export function AgentCard({ agent }: AgentCardProps) {
   const router = useRouter()
   const { archiveAgent, unarchiveAgent, deleteAgent, deleteSetupDraft } = useAgentMutations()
   const [confirm, ConfirmDialog] = useConfirm()
+  const bulkMode = useBulkMode()
+  const selected = useIsSelected(agent.id)
+  const pending = useIsPending(agent.id)
+  const pendingLabel = usePendingLabel()
+  const toggle = useListSelection((s) => s.toggle)
 
   const archived = agent.archivedAt != null
   const isDraft = agent.setupCompletedAt == null && !archived
@@ -72,6 +84,12 @@ export function AgentCard({ agent }: AgentCardProps) {
       <ListCard
         href={`/app/agents/${agent.slug}`}
         ariaLabel={displayName}
+        selectable
+        selecting={bulkMode}
+        selected={selected}
+        onSelectChange={(_, e) => toggle(agent.id, { shiftKey: e.shiftKey })}
+        pending={pending}
+        pendingLabel={pendingLabel}
         title={displayName}
         titleLines={1}
         classNames={agent.name ? undefined : { title: 'font-medium italic text-muted-foreground' }}

--- a/apps/web/src/components/agents/ui/list/agents-bulk-bar.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-bulk-bar.tsx
@@ -1,0 +1,83 @@
+// apps/web/src/components/agents/ui/list/agents-bulk-bar.tsx
+'use client'
+
+import { ActionBar, type ActionBarAction } from '@auxx/ui/components/action-bar'
+import { Archive, Trash2 } from 'lucide-react'
+import {
+  useBulkMode,
+  useBulkRunner,
+  useListSelection,
+  useSelectionCount,
+  useSelectionIds,
+} from '~/components/list-selection'
+import { api } from '~/trpc/react'
+
+/** Floating bulk-action bar for the agents grid — archive + permanent delete. */
+export function AgentsBulkBar() {
+  const ids = useSelectionIds()
+  const count = useSelectionCount()
+  const bulkMode = useBulkMode()
+  const exit = useListSelection((s) => s.exit)
+  const utils = api.useUtils()
+  const { ConfirmDialog, run, isRunning } = useBulkRunner()
+  const updateAgent = api.agent.update.useMutation()
+  const deleteAgent = api.agent.delete.useMutation()
+
+  const noun = (n: number) => `${n} agent${n === 1 ? '' : 's'}`
+  const refresh = () => {
+    void utils.agent.list.invalidate()
+    exit()
+  }
+
+  const actions: ActionBarAction[] = [
+    {
+      id: 'archive',
+      label: 'Archive',
+      icon: Archive,
+      tooltip: 'Archive selected',
+      disabled: isRunning || count === 0,
+      onClick: () =>
+        run(ids, (id) => updateAgent.mutateAsync({ agentId: id, archivedAt: new Date() }), {
+          title: `Archive ${noun(count)}?`,
+          description:
+            'They will stop responding to mentions and triggers. You can restore them later.',
+          confirmText: 'Archive',
+          destructive: false,
+          pendingLabel: 'Archiving…',
+          removesItem: false,
+          failureTitle: 'Some agents could not be archived',
+          onDone: refresh,
+        }),
+    },
+    {
+      id: 'delete',
+      label: 'Delete',
+      icon: Trash2,
+      variant: 'destructive',
+      tooltip: 'Delete selected permanently',
+      disabled: isRunning || count === 0,
+      onClick: () =>
+        run(ids, (id) => deleteAgent.mutateAsync({ agentId: id }), {
+          title: `Delete ${noun(count)} permanently?`,
+          description:
+            'The agents and their triggers will be permanently removed. This cannot be undone.',
+          failureTitle: 'Some agents could not be deleted',
+          onDone: refresh,
+        }),
+    },
+  ]
+
+  return (
+    <>
+      <ConfirmDialog />
+      <ActionBar
+        open={bulkMode || count > 0}
+        onOpenChange={(open) => !open && exit()}
+        selectedCount={count}
+        selectedLabel='selected'
+        actions={actions}
+        showClose
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/agents/ui/list/agents-grid-view.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-grid-view.tsx
@@ -2,7 +2,8 @@
 'use client'
 
 import { ListCard } from '@auxx/ui/components/list-card'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
+import { useListSelection } from '~/components/list-selection'
 import { useAgentSearch } from '../../hooks/use-agent-search'
 import { useAgents } from '../../hooks/use-agents'
 import type { AgentListItem } from '../../store/agent-store'
@@ -39,6 +40,7 @@ function AgentGrid({ agents }: { agents: AgentListItem[] }) {
 export function AgentsGridView() {
   const { agents, hasLoadedOnce } = useAgents()
   const { search } = useAgentSearch()
+  const setItemIds = useListSelection((s) => s.setItemIds)
 
   const { chat, internal } = useMemo(() => {
     const matched = filterAgents(agents, search)
@@ -47,6 +49,12 @@ export function AgentsGridView() {
       internal: sortDraftFirst(matched.filter((a) => a.kind !== 'chat')),
     }
   }, [agents, search])
+
+  // Keep the selection store's ordered ID list in sync (chat section, then
+  // internal) so shift+click range and Cmd/Ctrl+A act on what's on screen.
+  useEffect(() => {
+    setItemIds([...chat, ...internal].map((a) => a.id))
+  }, [chat, internal, setItemIds])
 
   if (!hasLoadedOnce) {
     return (

--- a/apps/web/src/components/agents/ui/list/agents-page-content.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-page-content.tsx
@@ -9,6 +9,8 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
+import { ListSelectionProvider } from '~/components/list-selection'
+import { AgentsBulkBar } from './agents-bulk-bar'
 import { AgentsGridView } from './agents-grid-view'
 import { AgentsSearchBar } from './agents-search-bar'
 import { CreateAgentButton } from './create-agent-button'
@@ -24,9 +26,14 @@ export function AgentsPageContent() {
       </MainPageHeader>
 
       <MainPageContent>
-        <ListPageScroll toolbar={<AgentsSearchBar />} bodyClassName='flex-1 flex flex-col min-h-0'>
-          <AgentsGridView />
-        </ListPageScroll>
+        <ListSelectionProvider>
+          <ListPageScroll
+            toolbar={<AgentsSearchBar />}
+            bodyClassName='flex-1 flex flex-col min-h-0'>
+            <AgentsGridView />
+          </ListPageScroll>
+          <AgentsBulkBar />
+        </ListSelectionProvider>
       </MainPageContent>
     </MainPage>
   )

--- a/apps/web/src/components/data-connectors/ui/connector-card.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-card.tsx
@@ -14,6 +14,13 @@ import { ListCard } from '@auxx/ui/components/list-card'
 import { Cable, FileText, FlaskConical, Pause, Play, RefreshCw, Trash } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { AppIcon } from '~/components/apps/ui/app-icon'
+import {
+  useBulkMode,
+  useIsPending,
+  useIsSelected,
+  useListSelection,
+  usePendingLabel,
+} from '~/components/list-selection'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useConnectorMutations } from '../hooks/use-connector-mutations'
 import { asConnectorStatus, CONNECTOR_STATUS_META } from './connector-status'
@@ -70,6 +77,11 @@ function iconIdForType(type: string): string {
 export function ConnectorCard({ connector, streamCount }: ConnectorCardProps) {
   const router = useRouter()
   const [confirm, ConfirmDialog] = useConfirm()
+  const bulkMode = useBulkMode()
+  const selected = useIsSelected(connector.id)
+  const pending = useIsPending(connector.id)
+  const pendingLabel = usePendingLabel()
+  const toggle = useListSelection((s) => s.toggle)
 
   const status = asConnectorStatus(connector.status)
   const meta = CONNECTOR_STATUS_META[status]
@@ -112,6 +124,12 @@ export function ConnectorCard({ connector, streamCount }: ConnectorCardProps) {
       <ListCard
         href={href}
         ariaLabel={connector.name}
+        selectable
+        selecting={bulkMode}
+        selected={selected}
+        onSelectChange={(_, e) => toggle(connector.id, { shiftKey: e.shiftKey })}
+        pending={pending}
+        pendingLabel={pendingLabel}
         title={connector.name}
         icon={
           <AppIcon

--- a/apps/web/src/components/data-connectors/ui/connector-list.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-list.tsx
@@ -4,7 +4,9 @@
 import { Button } from '@auxx/ui/components/button'
 import { ListCard } from '@auxx/ui/components/list-card'
 import { Plus } from 'lucide-react'
+import { useEffect, useMemo } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
+import { useListSelection } from '~/components/list-selection'
 import { api } from '~/trpc/react'
 import { ConnectorCard, ConnectorFallbackIcon } from './connector-card'
 
@@ -24,12 +26,20 @@ interface ConnectorListProps {
  */
 export function ConnectorList({ onConnect, search }: ConnectorListProps) {
   const connectors = api.dataConnector.list.useQuery()
+  const setItemIds = useListSelection((s) => s.setItemIds)
 
   const rows = connectors.data ?? []
   const query = search?.trim().toLowerCase() ?? ''
-  const filtered = query
-    ? rows.filter((connector) => connector.name.toLowerCase().includes(query))
-    : rows
+  const filtered = useMemo(
+    () => (query ? rows.filter((connector) => connector.name.toLowerCase().includes(query)) : rows),
+    [rows, query]
+  )
+
+  // Keep the selection store's ordered ID list in sync with the visible cards.
+  const itemIds = useMemo(() => filtered.map((c) => c.id), [filtered])
+  useEffect(() => {
+    setItemIds(itemIds)
+  }, [itemIds, setItemIds])
 
   return (
     <div className='flex flex-1 flex-col gap-4'>

--- a/apps/web/src/components/data-connectors/ui/connectors-bulk-bar.tsx
+++ b/apps/web/src/components/data-connectors/ui/connectors-bulk-bar.tsx
@@ -1,0 +1,111 @@
+// apps/web/src/components/data-connectors/ui/connectors-bulk-bar.tsx
+'use client'
+
+import { ActionBar, type ActionBarAction } from '@auxx/ui/components/action-bar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { Trash } from 'lucide-react'
+import type { ReactNode } from 'react'
+import {
+  useBulkMode,
+  useBulkRunner,
+  useListSelection,
+  useSelectionCount,
+  useSelectionIds,
+} from '~/components/list-selection'
+import { api } from '~/trpc/react'
+
+type Disposition = 'keep' | 'archive' | 'delete'
+
+/**
+ * Dropdown trigger used by the ActionBar `picker` slot — the Delete button opens
+ * a synced-records disposition menu (keep / archive / delete), mirroring the
+ * connector card's delete submenu. The single bulk action never overflows, so
+ * only the children-as-trigger path is needed.
+ */
+function ConnectorDeleteMenu({
+  children,
+  onSelect,
+}: {
+  children?: ReactNode
+  onSelect?: (disposition: Disposition) => void
+}) {
+  if (!children) return null
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+      <DropdownMenuContent align='end'>
+        <DropdownMenuItem onSelect={() => onSelect?.('keep')}>
+          Delete, keep synced records
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSelect?.('archive')}>
+          Delete, archive synced records
+        </DropdownMenuItem>
+        <DropdownMenuItem variant='destructive' onSelect={() => onSelect?.('delete')}>
+          Delete connectors and synced records
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+const DISPOSITION_COPY: Record<Disposition, string> = {
+  keep: 'The connectors are removed; their synced records are kept.',
+  archive: 'The connectors are removed and their synced records are archived.',
+  delete: 'The connectors and all their synced records are permanently deleted.',
+}
+
+/** Floating bulk-action bar for the connectors grid — delete with a disposition. */
+export function ConnectorsBulkBar() {
+  const ids = useSelectionIds()
+  const count = useSelectionCount()
+  const bulkMode = useBulkMode()
+  const exit = useListSelection((s) => s.exit)
+  const utils = api.useUtils()
+  const { ConfirmDialog, run, isRunning } = useBulkRunner()
+  const deleteConnector = api.dataConnector.delete.useMutation()
+
+  const handleDelete = (syncedData: Disposition) =>
+    run(ids, (id) => deleteConnector.mutateAsync({ id, syncedData }), {
+      title: `Delete ${count} connector${count === 1 ? '' : 's'}?`,
+      description: `${DISPOSITION_COPY[syncedData]} This cannot be undone.`,
+      failureTitle: 'Some connectors could not be deleted',
+      onDone: () => {
+        void utils.dataConnector.list.invalidate()
+        exit()
+      },
+    })
+
+  const actions: ActionBarAction[] = [
+    {
+      id: 'delete',
+      label: 'Delete',
+      icon: Trash,
+      variant: 'destructive',
+      tooltip: 'Delete selected',
+      disabled: isRunning || count === 0,
+      picker: {
+        component: ConnectorDeleteMenu,
+        props: { onSelect: handleDelete },
+      },
+    },
+  ]
+
+  return (
+    <>
+      <ConfirmDialog />
+      <ActionBar
+        open={bulkMode || count > 0}
+        onOpenChange={(open) => !open && exit()}
+        selectedCount={count}
+        selectedLabel='selected'
+        actions={actions}
+        showClose
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/connectors-toolbar.tsx
+++ b/apps/web/src/components/data-connectors/ui/connectors-toolbar.tsx
@@ -1,14 +1,18 @@
-// apps/web/src/components/agents/ui/list/agents-search-bar.tsx
+// apps/web/src/components/data-connectors/ui/connectors-toolbar.tsx
 'use client'
 
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { ListBulkToggle } from '@auxx/ui/components/list-bulk-toggle'
 import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
 import { useBulkMode, useListSelection } from '~/components/list-selection'
-import { useAgentSearch } from '../../hooks/use-agent-search'
 
-export function AgentsSearchBar() {
-  const { search, setSearch } = useAgentSearch()
+interface ConnectorsToolbarProps {
+  search: string
+  onSearchChange: (value: string) => void
+}
+
+/** Connectors list toolbar — name search + the bulk-select toggle. */
+export function ConnectorsToolbar({ search, onSearchChange }: ConnectorsToolbarProps) {
   const bulkMode = useBulkMode()
   const setBulkMode = useListSelection((s) => s.setBulkMode)
 
@@ -16,8 +20,8 @@ export function AgentsSearchBar() {
     <ListToolbar>
       <InputSearch
         value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        placeholder='Search agents…'
+        placeholder='Search connectors...'
+        onChange={(e) => onSearchChange(e.target.value)}
       />
       <ListToolbarGroup align='end'>
         <ListBulkToggle active={bulkMode} onActiveChange={setBulkMode} />

--- a/apps/web/src/components/datasets/dataset-card.tsx
+++ b/apps/web/src/components/datasets/dataset-card.tsx
@@ -12,6 +12,13 @@ import { Tooltip } from '@auxx/ui/components/tooltip'
 import { formatBytes } from '@auxx/utils'
 import { Archive, Database, Search, Settings, Trash } from 'lucide-react'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
+import {
+  useBulkMode,
+  useIsPending,
+  useIsSelected,
+  useListSelection,
+  usePendingLabel,
+} from '~/components/list-selection'
 import { useDatasetActions } from './hooks/use-dataset-actions'
 
 interface DatasetCardProps {
@@ -35,6 +42,12 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
       onSuccess: onActionComplete,
     })
 
+  const bulkMode = useBulkMode()
+  const selected = useIsSelected(dataset.id)
+  const pending = useIsPending(dataset.id)
+  const pendingLabel = usePendingLabel()
+  const toggle = useListSelection((s) => s.toggle)
+
   const status = STATUS_DOT[dataset.status] ?? STATUS_DOT.ARCHIVED
   const creatorName = dataset.createdBy.name ?? dataset.createdBy.email ?? '?'
   const creatorInitial = creatorName.charAt(0).toUpperCase()
@@ -50,6 +63,12 @@ export function DatasetCard({ dataset, onClick, onActionComplete }: DatasetCardP
       <ListCard
         onClick={onClick}
         ariaLabel={dataset.name}
+        selectable
+        selecting={bulkMode}
+        selected={selected}
+        onSelectChange={(_, e) => toggle(dataset.id, { shiftKey: e.shiftKey })}
+        pending={pending}
+        pendingLabel={pendingLabel}
         title={dataset.name}
         icon={<Database className='size-4' />}
         status={status}

--- a/apps/web/src/components/datasets/datasets-bulk-bar.tsx
+++ b/apps/web/src/components/datasets/datasets-bulk-bar.tsx
@@ -1,0 +1,85 @@
+// apps/web/src/components/datasets/datasets-bulk-bar.tsx
+'use client'
+
+import { ActionBar, type ActionBarAction } from '@auxx/ui/components/action-bar'
+import { Archive, Trash } from 'lucide-react'
+import {
+  useBulkMode,
+  useBulkRunner,
+  useListSelection,
+  useSelectionCount,
+  useSelectionIds,
+} from '~/components/list-selection'
+import { api } from '~/trpc/react'
+import { useDatasets } from './datasets-provider'
+
+/** Floating bulk-action bar for the datasets grid — archive + delete. */
+export function DatasetsBulkBar() {
+  const ids = useSelectionIds()
+  const count = useSelectionCount()
+  const bulkMode = useBulkMode()
+  const exit = useListSelection((s) => s.exit)
+  const { refetch } = useDatasets()
+  const { ConfirmDialog, run, isRunning } = useBulkRunner()
+  const deleteDataset = api.dataset.delete.useMutation()
+  const archiveDataset = api.dataset.archive.useMutation()
+
+  const noun = (n: number) => `${n} dataset${n === 1 ? '' : 's'}`
+
+  const actions: ActionBarAction[] = [
+    {
+      id: 'archive',
+      label: 'Archive',
+      icon: Archive,
+      tooltip: 'Archive selected',
+      disabled: isRunning || count === 0,
+      onClick: () =>
+        run(ids, (id) => archiveDataset.mutateAsync({ id }), {
+          title: `Archive ${noun(count)}?`,
+          description: 'They will be hidden from the main view but can be restored later.',
+          confirmText: 'Archive',
+          destructive: false,
+          pendingLabel: 'Archiving…',
+          removesItem: false,
+          failureTitle: 'Some datasets could not be archived',
+          onDone: () => {
+            refetch()
+            exit()
+          },
+        }),
+    },
+    {
+      id: 'delete',
+      label: 'Delete',
+      icon: Trash,
+      variant: 'destructive',
+      tooltip: 'Delete selected',
+      disabled: isRunning || count === 0,
+      onClick: () =>
+        run(ids, (id) => deleteDataset.mutateAsync({ id }), {
+          title: `Delete ${noun(count)}?`,
+          description:
+            'This permanently removes them and all associated documents and data. This cannot be undone.',
+          failureTitle: 'Some datasets could not be deleted',
+          onDone: () => {
+            refetch()
+            exit()
+          },
+        }),
+    },
+  ]
+
+  return (
+    <>
+      <ConfirmDialog />
+      <ActionBar
+        open={bulkMode || count > 0}
+        onOpenChange={(open) => !open && exit()}
+        selectedCount={count}
+        selectedLabel='selected'
+        actions={actions}
+        showClose
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/datasets/datasets-filter-bar.tsx
+++ b/apps/web/src/components/datasets/datasets-filter-bar.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { InputSearch } from '@auxx/ui/components/input-search'
+import { ListBulkToggle } from '@auxx/ui/components/list-bulk-toggle'
 import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
 import {
   Select,
@@ -12,6 +13,7 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { ViewModeToggle } from '@auxx/ui/components/view-mode-toggle'
+import { useBulkMode, useListSelection } from '~/components/list-selection'
 import { useDatasets } from './datasets-provider'
 
 /**
@@ -20,6 +22,8 @@ import { useDatasets } from './datasets-provider'
 export function DatasetsFilterBar() {
   const { searchQuery, setSearchQuery, selectedStatus, setSelectedStatus, viewMode, setViewMode } =
     useDatasets()
+  const bulkMode = useBulkMode()
+  const setBulkMode = useListSelection((s) => s.setBulkMode)
 
   return (
     <ListToolbar>
@@ -43,6 +47,7 @@ export function DatasetsFilterBar() {
       <InputSearch value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} />
 
       <ListToolbarGroup align='end'>
+        {viewMode === 'grid' && <ListBulkToggle active={bulkMode} onActiveChange={setBulkMode} />}
         <ViewModeToggle value={viewMode} onValueChange={setViewMode} />
       </ListToolbarGroup>
     </ListToolbar>

--- a/apps/web/src/components/datasets/datasets-grid-view.tsx
+++ b/apps/web/src/components/datasets/datasets-grid-view.tsx
@@ -3,6 +3,8 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import { useListSelection } from '~/components/list-selection'
 import { DatasetCard } from './dataset-card'
 import { useDatasets } from './datasets-provider'
 
@@ -12,6 +14,11 @@ import { useDatasets } from './datasets-provider'
 export function DatasetsGridView() {
   const { items, refetch } = useDatasets()
   const router = useRouter()
+  const setItemIds = useListSelection((s) => s.setItemIds)
+
+  useEffect(() => {
+    setItemIds(items.map((d) => d.id))
+  }, [items, setItemIds])
 
   /**
    * Navigate to dataset detail page

--- a/apps/web/src/components/datasets/index.ts
+++ b/apps/web/src/components/datasets/index.ts
@@ -3,6 +3,7 @@
 export { CreateDatasetButton } from './create-dataset-button'
 export { CreateDatasetDialog } from './create-dataset-dialog'
 export { DatasetCard } from './dataset-card'
+export { DatasetsBulkBar } from './datasets-bulk-bar'
 export { DatasetsEmptyState } from './datasets-empty-state'
 export { DatasetsFilterBar } from './datasets-filter-bar'
 export { DatasetsGridView } from './datasets-grid-view'

--- a/apps/web/src/components/list-selection/index.ts
+++ b/apps/web/src/components/list-selection/index.ts
@@ -1,0 +1,13 @@
+// apps/web/src/components/list-selection/index.ts
+export {
+  ListSelectionProvider,
+  type ListSelectionState,
+  useBulkMode,
+  useIsPending,
+  useIsSelected,
+  useListSelection,
+  usePendingLabel,
+  useSelectionCount,
+  useSelectionIds,
+} from './store'
+export { useBulkRunner } from './use-bulk-runner'

--- a/apps/web/src/components/list-selection/store.ts
+++ b/apps/web/src/components/list-selection/store.ts
@@ -1,0 +1,200 @@
+// apps/web/src/components/list-selection/store.ts
+'use client'
+
+import { createContext, createElement, type ReactNode, useContext, useEffect, useRef } from 'react'
+import { createStore, type StoreApi, useStore } from 'zustand'
+
+/**
+ * Generic, per-page bulk-selection state for `ListCard` grids — a framework-
+ * agnostic generalization of the mail thread-selection store. One store instance
+ * lives per `ListSelectionProvider`, so each list page is isolated and per-card
+ * selectors stay granular.
+ */
+export interface ListSelectionState {
+  /** Whether bulk-select mode is active (checkboxes shown, card click toggles). */
+  bulkMode: boolean
+  /**
+   * True only when bulk mode was entered deliberately via the Select toggle.
+   * Implicit mode (entered by checking a card) auto-exits once nothing is
+   * selected; sticky mode stays on with zero selection.
+   */
+  sticky: boolean
+  /** Selected item IDs, in selection order. */
+  selectedIds: string[]
+  /** Last toggled ID — the anchor for shift+click range selection. */
+  anchorId: string | null
+  /** Visible item IDs in display order (kept in sync by the grid). */
+  itemIds: string[]
+  /** IDs with a bulk action in flight — render a "Deleting…" overlay on these. */
+  pendingIds: string[]
+  /** Verb shown in the pending overlay, e.g. `Deleting…` / `Archiving…`. */
+  pendingLabel: string
+
+  setBulkMode: (on: boolean) => void
+  setItemIds: (ids: string[]) => void
+  /** Toggle one item. Pass `{ shiftKey }` to select the range from the anchor. */
+  toggle: (id: string, opts?: { shiftKey?: boolean }) => void
+  /** Select every visible item (Cmd/Ctrl+A). */
+  selectAll: () => void
+  /** Clear the selection but stay in bulk mode. */
+  clear: () => void
+  /** Clear the selection and leave bulk mode. */
+  exit: () => void
+  /** Mark an item as having a bulk action in flight. */
+  addPending: (id: string) => void
+  /** Clear the in-flight marker for an item (e.g. its action failed). */
+  removePending: (id: string) => void
+  /** Set the verb shown in the pending overlay. */
+  setPendingLabel: (label: string) => void
+}
+
+function createListSelectionStore() {
+  return createStore<ListSelectionState>((set, get) => ({
+    bulkMode: false,
+    sticky: false,
+    selectedIds: [],
+    anchorId: null,
+    itemIds: [],
+    pendingIds: [],
+    pendingLabel: 'Deleting…',
+
+    setBulkMode: (on) =>
+      set(
+        on
+          ? { bulkMode: true, sticky: true }
+          : { bulkMode: false, sticky: false, selectedIds: [], anchorId: null }
+      ),
+
+    setItemIds: (ids) => {
+      // Empty list (e.g. loading) → don't prune selection. Otherwise drop any
+      // selected/pending IDs no longer visible (filtered out, or removed by a
+      // completed delete), so bulk state only tracks what's on screen.
+      if (ids.length === 0) {
+        set({ itemIds: ids })
+        return
+      }
+      const allow = new Set(ids)
+      const { selectedIds, pendingIds } = get()
+      set({
+        itemIds: ids,
+        selectedIds: selectedIds.filter((id) => allow.has(id)),
+        pendingIds: pendingIds.filter((id) => allow.has(id)),
+      })
+    },
+
+    toggle: (id, opts) =>
+      set((state) => {
+        let selectedIds: string[]
+        // Shift+click → replace selection with the anchor→id range.
+        if (opts?.shiftKey && state.anchorId) {
+          const from = state.itemIds.indexOf(state.anchorId)
+          const to = state.itemIds.indexOf(id)
+          if (from !== -1 && to !== -1) {
+            const [start, end] = from < to ? [from, to] : [to, from]
+            selectedIds = state.itemIds.slice(start, end + 1)
+          } else {
+            selectedIds = state.selectedIds.includes(id)
+              ? state.selectedIds.filter((x) => x !== id)
+              : [...state.selectedIds, id]
+          }
+        } else {
+          selectedIds = state.selectedIds.includes(id)
+            ? state.selectedIds.filter((x) => x !== id)
+            : [...state.selectedIds, id]
+        }
+        // Implicit bulk mode (entered by checking a card) switches off once the
+        // selection empties; only the explicit Select toggle (`sticky`) persists.
+        return {
+          bulkMode: state.sticky || selectedIds.length > 0,
+          anchorId: selectedIds.length > 0 ? id : null,
+          selectedIds,
+        }
+      }),
+
+    selectAll: () => set((state) => ({ bulkMode: true, selectedIds: [...state.itemIds] })),
+
+    clear: () => set({ selectedIds: [], anchorId: null }),
+
+    // `pendingIds` is intentionally left intact on exit: a card whose delete has
+    // resolved keeps its overlay until the list refetch removes it (pruned by
+    // `setItemIds`), so it never flashes back to a normal row mid-teardown.
+    exit: () => set({ bulkMode: false, sticky: false, selectedIds: [], anchorId: null }),
+
+    addPending: (id) =>
+      set((state) =>
+        state.pendingIds.includes(id) ? state : { pendingIds: [...state.pendingIds, id] }
+      ),
+
+    removePending: (id) =>
+      set((state) => ({ pendingIds: state.pendingIds.filter((x) => x !== id) })),
+
+    setPendingLabel: (label) => set({ pendingLabel: label }),
+  }))
+}
+
+const ListSelectionContext = createContext<StoreApi<ListSelectionState> | null>(null)
+
+/**
+ * Provides a fresh selection store to a list page and wires the global keyboard
+ * shortcuts (Cmd/Ctrl+A select-all, Escape to exit) while bulk mode is active.
+ */
+export function ListSelectionProvider({ children }: { children: ReactNode }) {
+  const storeRef = useRef<StoreApi<ListSelectionState> | null>(null)
+  // Lazily create one store per provider; `??=` keeps `store` typed non-null.
+  const store = (storeRef.current ??= createListSelectionStore())
+
+  const bulkMode = useStore(store, (s) => s.bulkMode)
+  useEffect(() => {
+    if (!bulkMode) return
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null
+      const typing =
+        !!target &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+      if (e.key === 'Escape') {
+        store.getState().exit()
+        return
+      }
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'a' || e.key === 'A') && !typing) {
+        e.preventDefault()
+        store.getState().selectAll()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [bulkMode, store])
+
+  return createElement(ListSelectionContext.Provider, { value: store }, children)
+}
+
+function useListSelectionApi(): StoreApi<ListSelectionState> {
+  const store = useContext(ListSelectionContext)
+  if (!store) throw new Error('useListSelection* must be used within a ListSelectionProvider')
+  return store
+}
+
+/** Subscribe to a slice of the selection store with a selector. */
+export function useListSelection<T>(selector: (state: ListSelectionState) => T): T {
+  return useStore(useListSelectionApi(), selector)
+}
+
+const EMPTY_IDS: string[] = []
+
+/** True when bulk-select mode is active. */
+export const useBulkMode = () => useListSelection((s) => s.bulkMode)
+
+/** Whether a specific item is selected — re-renders only that card. */
+export const useIsSelected = (id: string) => useListSelection((s) => s.selectedIds.includes(id))
+
+/** Count of selected items. */
+export const useSelectionCount = () => useListSelection((s) => s.selectedIds.length)
+
+/** Selected IDs (stable empty-array ref when none). */
+export const useSelectionIds = () =>
+  useListSelection((s) => (s.selectedIds.length > 0 ? s.selectedIds : EMPTY_IDS))
+
+/** Whether a specific item has a bulk action in flight — re-renders only that card. */
+export const useIsPending = (id: string) => useListSelection((s) => s.pendingIds.includes(id))
+
+/** The verb shown in the pending overlay (e.g. `Deleting…`). */
+export const usePendingLabel = () => useListSelection((s) => s.pendingLabel)

--- a/apps/web/src/components/list-selection/use-bulk-runner.ts
+++ b/apps/web/src/components/list-selection/use-bulk-runner.ts
@@ -1,0 +1,89 @@
+// apps/web/src/components/list-selection/use-bulk-runner.ts
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useState } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useListSelection } from './store'
+
+interface RunOptions {
+  /** Confirm dialog title, e.g. `Delete 7 workflows?`. */
+  title: string
+  /** Confirm dialog body. */
+  description?: string
+  /** Confirm button label. Default `Delete`. */
+  confirmText?: string
+  /** Style the confirm as destructive (red). Default `true`. */
+  destructive?: boolean
+  /** Verb shown in each card's pending overlay. Default `Deleting…`. */
+  pendingLabel?: string
+  /**
+   * Whether `perItem` removes the row from the list (delete) vs keeps it (archive).
+   * Default `true` (delete): the overlay persists until the list refetch prunes the
+   * row, so it never flashes back to a normal row. Set `false` (archive) to clear
+   * the overlay as soon as the item settles, since the row stays on screen.
+   */
+  removesItem?: boolean
+  /** Toast title shown when one or more items fail. */
+  failureTitle?: string
+  /** Runs once after the loop settles (e.g. invalidate the list + exit bulk mode). */
+  onDone?: () => void
+}
+
+/**
+ * Shared driver for bulk actions on `ListCard` grids: one confirm up front, then
+ * a **sequential** loop over the per-item async mutation, collecting failures and
+ * surfacing a single summary toast. No new router endpoint — each surface passes
+ * the single-item mutation its card menu already uses.
+ */
+export function useBulkRunner() {
+  const [confirm, ConfirmDialog] = useConfirm()
+  const [isRunning, setIsRunning] = useState(false)
+  const addPending = useListSelection((s) => s.addPending)
+  const removePending = useListSelection((s) => s.removePending)
+  const setPendingLabel = useListSelection((s) => s.setPendingLabel)
+
+  const run = useCallback(
+    async (ids: string[], perItem: (id: string) => Promise<unknown>, opts: RunOptions) => {
+      if (ids.length === 0) return
+      const confirmed = await confirm({
+        title: opts.title,
+        description: opts.description,
+        confirmText: opts.confirmText ?? 'Delete',
+        cancelText: 'Cancel',
+        destructive: opts.destructive ?? true,
+      })
+      if (!confirmed) return
+
+      setPendingLabel(opts.pendingLabel ?? 'Deleting…')
+      setIsRunning(true)
+      let failures = 0
+      for (const id of ids) {
+        // Mark the card pending → it shows the blurred overlay. For a delete the
+        // marker stays until the list refetch removes the row (no flash back to a
+        // normal row); for an archive (item stays) we clear it on settle; on
+        // failure we always clear it so the card returns to normal.
+        addPending(id)
+        try {
+          await perItem(id)
+          if (opts.removesItem === false) removePending(id)
+        } catch {
+          failures++
+          removePending(id)
+        }
+      }
+      setIsRunning(false)
+
+      if (failures > 0) {
+        toastError({
+          title: opts.failureTitle ?? 'Some items could not be processed',
+          description: `${failures} of ${ids.length} failed.`,
+        })
+      }
+      opts.onDone?.()
+    },
+    [confirm, addPending, removePending, setPendingLabel]
+  )
+
+  return { ConfirmDialog, run, isRunning }
+}

--- a/packages/ui/src/components/list-bulk-toggle.tsx
+++ b/packages/ui/src/components/list-bulk-toggle.tsx
@@ -1,0 +1,32 @@
+// packages/ui/src/components/list-bulk-toggle.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import { CheckSquare } from 'lucide-react'
+
+interface ListBulkToggleProps {
+  /** Whether bulk-select mode is active. */
+  active: boolean
+  /** Called with the next active state when the button is pressed. */
+  onActiveChange: (active: boolean) => void
+  className?: string
+}
+
+/**
+ * The list-toolbar "Select" toggle — flips a list page into bulk-select mode.
+ * Drop into a `ListToolbarGroup align='end'`. Pairs with `ListCard`'s
+ * `selectable`/`selecting` props and a floating `ActionBar` for the actions.
+ */
+export function ListBulkToggle({ active, onActiveChange, className }: ListBulkToggleProps) {
+  return (
+    <Button
+      variant={active ? 'secondary' : 'ghost'}
+      size='xs'
+      className={cn('shrink-0', className)}
+      onClick={() => onActiveChange(!active)}>
+      <CheckSquare />
+      {active ? 'Done' : 'Select'}
+    </Button>
+  )
+}

--- a/packages/ui/src/components/list-card.tsx
+++ b/packages/ui/src/components/list-card.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
+import { Checkbox } from '@auxx/ui/components/checkbox'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,7 +12,7 @@ import {
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { SimpleTooltip as Tooltip } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
-import { BadgeCheck, MoreVertical } from 'lucide-react'
+import { BadgeCheck, Loader2, MoreVertical } from 'lucide-react'
 import { Slot as SlotPrimitive } from 'radix-ui'
 import type * as React from 'react'
 
@@ -93,6 +94,20 @@ export interface ListCardProps {
   menuItems?: ListCardMenuItem[]
   /** Raw `<DropdownMenuContent>` children — for submenus. Wins over `menuItems`. */
   menu?: React.ReactNode
+
+  // ---- selection (bulk mode) ----
+  /** Surface supports selection → reveal a checkbox on hover (top-right corner). */
+  selectable?: boolean
+  /** Bulk mode active → checkbox always shown; whole-card click toggles instead of navigating. */
+  selecting?: boolean
+  /** Controlled selected state → highlight + checked box. */
+  selected?: boolean
+  /** Toggle handler; receives the mouse event so callers can read `e.shiftKey` for range select. */
+  onSelectChange?: (next: boolean, e: React.MouseEvent) => void
+  /** Show a blurred, non-interactive "Deleting…" overlay (a bulk action is in flight). */
+  pending?: boolean
+  /** Centered label for the pending overlay. Default `Deleting…`. */
+  pendingLabel?: React.ReactNode
 
   // ---- interaction ----
   href?: string
@@ -181,6 +196,12 @@ export function ListCard({
   trailing,
   menuItems,
   menu,
+  selectable,
+  selecting,
+  selected,
+  onSelectChange,
+  pending,
+  pendingLabel,
   href,
   onClick,
   disabled,
@@ -191,16 +212,24 @@ export function ListCard({
   classNames,
 }: ListCardProps) {
   const isPlaceholder = variant === 'placeholder'
-  const interactive = !loading && !disabled && Boolean(href || onClick || link)
-  const hasMenu = !loading && Boolean(menu || menuItems?.length)
+  const interactive =
+    !loading && !disabled && !pending && (selecting || Boolean(href || onClick || link))
+  // While selecting, the per-card menu + header badge yield to the checkbox/bulk bar.
+  const hasMenu = !loading && !selecting && Boolean(menu || menuItems?.length)
   const hasFooter = !loading && Boolean(badges || trailing)
+  const showCheckbox = !loading && !pending && (selectable || selecting)
 
   const rootClass = cn(
     'group/list-card relative flex w-full flex-col gap-2 rounded-2xl border p-3 text-left',
     isPlaceholder
       ? 'border-dashed bg-primary-50 hover:bg-primary-50/50 hover:outline-5 hover:outline-primary-50'
       : 'bg-background dark:bg-primary-50 hover:bg-primary-50/50 hover:outline-5 hover:outline-primary-100 dark:hover:outline-primary-50/50',
-    interactive && 'cursor-pointer',
+    // Selected: a persistent info ring (even when not hovering), info tint that
+    // stays on hover (a touch darker), and an info hover ring.
+    selected &&
+      'border-info/90 outline-5 outline-info/20 bg-info/5 hover:bg-info/10 hover:outline-info/10 dark:bg-info/10 dark:hover:bg-info/10 dark:hover:outline-info/20',
+    // Pointer cursor only while bulk-selecting; normal cards keep the default cursor.
+    selecting && 'cursor-pointer',
     disabled && 'cursor-not-allowed opacity-60',
     className,
     classNames?.root
@@ -209,26 +238,50 @@ export function ListCard({
   const stop = (e: React.MouseEvent) => e.stopPropagation()
   const resolvedAriaLabel = ariaLabel ?? (typeof title === 'string' ? title : undefined)
 
-  const overlay = interactive ? (
-    link ? (
-      <SlotPrimitive.Slot className={OVERLAY_CLASS}>{link}</SlotPrimitive.Slot>
-    ) : href ? (
-      <a className={OVERLAY_CLASS} href={href} aria-label={resolvedAriaLabel} />
-    ) : (
-      <button
-        type='button'
-        className={OVERLAY_CLASS}
-        onClick={onClick}
-        aria-label={resolvedAriaLabel}
-      />
-    )
+  const overlay = !interactive ? null : selecting ? (
+    // Bulk mode: the stretched overlay toggles selection instead of navigating.
+    <button
+      type='button'
+      className={cn(OVERLAY_CLASS, 'cursor-pointer')}
+      aria-label={resolvedAriaLabel}
+      onClick={(e) => onSelectChange?.(!selected, e)}
+    />
+  ) : link ? (
+    <SlotPrimitive.Slot className={cn(OVERLAY_CLASS, 'cursor-default')}>{link}</SlotPrimitive.Slot>
+  ) : href ? (
+    <a className={cn(OVERLAY_CLASS, 'cursor-default')} href={href} aria-label={resolvedAriaLabel} />
+  ) : (
+    <button
+      type='button'
+      className={cn(OVERLAY_CLASS, 'cursor-default')}
+      onClick={onClick}
+      aria-label={resolvedAriaLabel}
+    />
+  )
+
+  // Top-right checkbox: always visible while selecting, hover-revealed otherwise.
+  // Wrapped in a div (not the Checkbox's own handler) so the click MouseEvent —
+  // and `e.shiftKey` for range select — reaches `onSelectChange`.
+  const checkbox = showCheckbox ? (
+    <div
+      data-slot='list-card-select'
+      className={cn(
+        'absolute right-3 top-2 z-20',
+        !selecting && 'opacity-0 transition-opacity group-hover/list-card:opacity-100'
+      )}
+      onClick={(e) => {
+        e.stopPropagation()
+        onSelectChange?.(!selected, e)
+      }}>
+      <Checkbox checked={selected} className='pointer-events-none size-4' />
+    </div>
   ) : null
 
   const menuNode = hasMenu ? (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          className='relative z-10 rounded-lg opacity-0 transition-opacity duration-300 group-hover/list-card:opacity-100 data-[state=open]:bg-muted! data-[state=open]:opacity-100!'
+          className='-mr-1 relative z-10 rounded-lg opacity-0 transition-opacity duration-300 group-hover/list-card:opacity-100 data-[state=open]:bg-muted! data-[state=open]:opacity-100!'
           variant='ghost'
           size='icon-xs'
           onClick={stop}>
@@ -257,6 +310,7 @@ export function ListCard({
   return (
     <div data-slot='list-card' className={rootClass}>
       {overlay}
+      {checkbox}
 
       {/* Header: media + title column */}
       <div data-slot='list-card-header' className='flex w-full flex-row items-start gap-2'>
@@ -305,7 +359,7 @@ export function ListCard({
                 )}
               </div>
             )}
-            {!loading && headerEnd && (
+            {!loading && !selecting && headerEnd && (
               <div data-slot='list-card-header-end' className='relative z-10 shrink-0'>
                 {headerEnd}
               </div>
@@ -361,13 +415,23 @@ export function ListCard({
       ) : hasFooter ? (
         <div
           data-slot='list-card-footer'
-          className={cn('mt-auto flex items-center justify-between gap-2', classNames?.footer)}>
+          // min-h-6 holds the footer at the menu-button height so the card doesn't
+          // shrink when the menu is hidden while selecting.
+          className={cn(
+            'mt-auto flex min-h-6 items-center justify-between gap-2',
+            classNames?.footer
+          )}>
           <div
             data-slot='list-card-badges'
             className={cn('flex min-w-0 items-center gap-1', classNames?.badges)}>
             {badges}
           </div>
-          <div className='relative z-10 flex items-center gap-1'>
+          {/* While selecting, let clicks fall through to the toggle overlay. */}
+          <div
+            className={cn(
+              'relative z-10 flex items-center gap-1',
+              selecting && 'pointer-events-none'
+            )}>
             {trailing}
             {menuNode}
           </div>
@@ -375,6 +439,17 @@ export function ListCard({
       ) : (
         // No footer content: float the menu bottom-right (preserves the app-card look).
         hasMenu && <div className='absolute bottom-2 right-2 z-10'>{menuNode}</div>
+      )}
+
+      {/* Pending overlay: blurs the card behind a centered "Deleting…" label and
+          blocks interaction while a bulk action is in flight. */}
+      {pending && (
+        <div
+          data-slot='list-card-pending'
+          className='absolute inset-0 z-30 flex items-center justify-center gap-2 rounded-2xl bg-background/50 text-sm font-medium text-muted-foreground backdrop-blur-sm'>
+          <Loader2 className='size-4 animate-spin' />
+          {pendingLabel ?? 'Deleting…'}
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## What

Adds mail-style **bulk selection** to the `ListCard` grids — **Workflows, Datasets, Agents, Connectors**. Enter bulk mode via a toolbar **Select** toggle *or* a hover-revealed per-card checkbox; act via a floating `ActionBar`.

## Shared pieces

- **`ListCard`** (`@auxx/ui`): new `selectable` / `selecting` / `selected` / `onSelectChange` props — top-right checkbox (hover when off, always when selecting), kanban-style highlight + persistent `info` ring, whole-card toggle overlay, suppressed header badge/menu while selecting. Plus a blurred, centered **"Deleting…" / "Archiving…"** `pending` overlay.
- **`ListBulkToggle`** (`@auxx/ui`): the toolbar Select/Done button.
- **`components/list-selection/`**: a per-page zustand store in React context — granular `useIsSelected(id)` selectors, shift+click range, Cmd/Ctrl+A, Escape, **sticky vs implicit** bulk mode (checking a single card auto-exits on deselect; only the Select button stays), and per-card pending tracking. `useBulkRunner` drives confirm → **sequential** loop → partial-failure toast → refetch.

## Per surface

Each surface owns its actions, looped over the **existing single-item mutation** (no new router endpoint):

| Surface | Actions |
| --- | --- |
| Workflows | Delete |
| Datasets | Archive · Delete |
| Agents | Archive · Delete (permanent) |
| Connectors | Delete with a keep/archive/delete disposition dropdown (ActionBar picker) |

The pending overlay persists until the list refetch removes a deleted row (no flash), and clears on settle for archive (the row stays).

## Scope

- App-family surfaces (Apps/MCP/Connections/Webhooks) intentionally out of scope.
- No router-level bulk endpoint — client loops the single-item mutations.
- Bulk toggle only shows in grid view for Workflows/Datasets (table-view selection out of scope).

## Verification

- `pnpm biome` clean across all touched files. `tsc` not run (project rule).
- Manually verified by the author across the four surfaces.