### PR TITLE
feat(sidebar): connector-sync badge on connector-owned record types

### DIFF
--- a/apps/web/src/components/data-connectors/ui/entity-icon-with-connector.tsx
+++ b/apps/web/src/components/data-connectors/ui/entity-icon-with-connector.tsx
@@ -1,0 +1,42 @@
+// apps/web/src/components/data-connectors/ui/entity-icon-with-connector.tsx
+'use client'
+
+import { EntityIcon, type EntityIconProps } from '@auxx/ui/components/icons'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
+import { RefreshCw } from 'lucide-react'
+
+interface EntityIconWithConnectorProps extends EntityIconProps {
+  /**
+   * Set when the entity definition is *owned* by a data connector (mirrors
+   * `CustomResource.dataConnectorId`). When present, a small sync badge is
+   * overlaid on the icon to signal the record type is connector-managed.
+   * Contributing-only connectors tag individual fields, not the def, so they
+   * intentionally don't surface here.
+   */
+  dataConnectorId?: string
+  /** Tooltip copy for the badge. Defaults to a generic sync message. */
+  tooltip?: string
+}
+
+/**
+ * `EntityIcon` with an optional connector-sync badge — the entity-level analog
+ * of `AppWithStatusIcon`. Renders a bare `EntityIcon` when not connector-owned.
+ */
+export function EntityIconWithConnector({
+  dataConnectorId,
+  tooltip,
+  ...iconProps
+}: EntityIconWithConnectorProps) {
+  if (!dataConnectorId) return <EntityIcon {...iconProps} />
+
+  return (
+    <SimpleTooltip content={tooltip ?? 'Synced by a data connector'} side='right'>
+      <span className='relative inline-flex shrink-0'>
+        <EntityIcon {...iconProps} />
+        <span className='absolute -right-0.5 -bottom-0.5 inline-flex size-2.5 items-center justify-center rounded-full bg-background ring-1 ring-background'>
+          <RefreshCw className='size-2! text-muted-foreground' />
+        </span>
+      </span>
+    </SimpleTooltip>
+  )
+}

--- a/apps/web/src/components/global/sidebar/entity-sidebar-nav.tsx
+++ b/apps/web/src/components/global/sidebar/entity-sidebar-nav.tsx
@@ -6,7 +6,6 @@ import type { CustomResource } from '@auxx/lib/resources/client'
 import { AnimatedGradientText } from '@auxx/ui/components/animated-gradient-text'
 import { Button } from '@auxx/ui/components/button'
 import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
-import { EntityIcon } from '@auxx/ui/components/icons'
 import {
   SidebarGroup,
   SidebarGroupCollapse,
@@ -49,6 +48,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { DndStateProvider } from '~/app/context/dnd-state-context'
 import { EntityDefinitionDialog } from '~/components/custom-fields/ui/entity-definition-dialog'
 import { EntityTemplateDialog } from '~/components/custom-fields/ui/entity-template-dialog'
+import { EntityIconWithConnector } from '~/components/data-connectors/ui/entity-icon-with-connector'
 import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
 import { useCreateEntityStore } from '~/components/global-create/create-entity-store'
 import { useEntityDefinitionMutations, useResources } from '~/components/resources/hooks'
@@ -252,14 +252,16 @@ export function EntitySidebarNav() {
     return pathname === url || pathname.startsWith(`${url}/`)
   }
 
-  function renderIcon(iconId: string, color: string) {
+  function renderIcon(entity: ProcessedEntity) {
     return (
-      <EntityIcon
-        iconId={iconId}
-        color={color ?? 'gray'}
+      <EntityIconWithConnector
+        iconId={entity.icon}
+        color={entity.color ?? 'gray'}
         size='sm'
         inverse
         className='-ms-0.5 inset-shadow-xs inset-shadow-black/20'
+        dataConnectorId={entity.dataConnectorId}
+        tooltip={`${entity.plural} are synced by a data connector`}
       />
     )
   }
@@ -312,7 +314,7 @@ export function EntitySidebarNav() {
           id={entity.id}
           name={entity.plural}
           href={entity.href}
-          icon={renderIcon(entity.icon, entity.color)}
+          icon={renderIcon(entity)}
           isActive={isActive(entity)}
           isSubmenu={parentFolderId !== null}
           editItems={getEditItems(entity)}
@@ -327,7 +329,7 @@ export function EntitySidebarNav() {
         <EditableSidebarItem
           id={entityDndId(entity.id)}
           name={entity.plural}
-          icon={renderIcon(entity.icon, entity.color)}
+          icon={renderIcon(entity)}
           isVisible={entity.isVisible}
           isLocked={entity.isLocked}
           onToggleVisibility={() => updateEntityVisibility(entity.id, !entity.isVisible)}

--- a/apps/web/src/hooks/use-entity-sidebar.tsx
+++ b/apps/web/src/hooks/use-entity-sidebar.tsx
@@ -25,6 +25,8 @@ export interface ProcessedEntity {
   isLocked: boolean
   isVisible: boolean
   href: string
+  /** Set when this entity def is owned by a data connector (sync badge). */
+  dataConnectorId?: string
 }
 
 /** A folder definition in the Records sidebar. */
@@ -113,6 +115,7 @@ export function useEntitySidebar({ scope = 'SIDEBAR' }: UseEntitySidebarOptions 
         isLocked: false,
         isVisible: visibility[resource.id] !== false,
         href: resource.entityType ? `/app/${resource.apiSlug}` : `/app/custom/${resource.apiSlug}`,
+        dataConnectorId: resource.dataConnectorId,
       }))
 
     const entityMap = new Map(baseEntities.map((e) => [e.id, e]))

--- a/packages/ui/src/components/list-card.tsx
+++ b/packages/ui/src/components/list-card.tsx
@@ -221,13 +221,16 @@ export function ListCard({
 
   const rootClass = cn(
     'group/list-card relative flex w-full flex-col gap-2 rounded-2xl border p-3 text-left',
-    isPlaceholder
-      ? 'border-dashed bg-primary-50 hover:bg-primary-50/50 hover:outline-5 hover:outline-primary-50'
-      : 'bg-background dark:bg-primary-50 hover:bg-primary-50/50 hover:outline-5 hover:outline-primary-100 dark:hover:outline-primary-50/50',
+    isPlaceholder ? 'border-dashed bg-primary-50' : 'bg-background dark:bg-primary-50',
+    !pending &&
+      (isPlaceholder
+        ? 'hover:bg-primary-50/50 hover:outline-5 hover:outline-primary-50'
+        : 'hover:bg-primary-50/50 hover:outline-5 hover:outline-primary-100 dark:hover:outline-primary-50/50'),
     // Selected: a persistent info ring (even when not hovering), info tint that
     // stays on hover (a touch darker), and an info hover ring.
-    selected &&
-      'border-info/90 outline-5 outline-info/20 bg-info/5 hover:bg-info/10 hover:outline-info/10 dark:bg-info/10 dark:hover:bg-info/10 dark:hover:outline-info/20',
+    !pending &&
+      selected &&
+      'border-info/90 outline-5 outline-info/20 bg-info/5 hover:bg-info/8 hover:outline-info/10 dark:bg-info/10 dark:hover:bg-info/10 dark:hover:outline-info/20',
     // Pointer cursor only while bulk-selecting; normal cards keep the default cursor.
     selecting && 'cursor-pointer',
     disabled && 'cursor-not-allowed opacity-60',
@@ -446,7 +449,7 @@ export function ListCard({
       {pending && (
         <div
           data-slot='list-card-pending'
-          className='absolute inset-0 z-30 flex items-center justify-center gap-2 rounded-2xl bg-background/50 text-sm font-medium text-muted-foreground backdrop-blur-sm'>
+          className='absolute inset-0 z-30 flex items-center justify-center gap-2 rounded-2xl bg-background/50 text-sm font-medium text-foreground/50 backdrop-blur-sm'>
           <Loader2 className='size-4 animate-spin' />
           {pendingLabel ?? 'Deleting…'}
         </div>


### PR DESCRIPTION
## What

Indicate in the **Records** sidebar that an entity definition is owned by a data connector, via a small sync badge on the entity icon — mirroring the `AppWithStatusIcon` corner-overlay pattern.

## How

- **New `EntityIconWithConnector`** (`apps/web/src/components/data-connectors/ui/entity-icon-with-connector.tsx`) — wraps `EntityIcon`, overlaying a muted `RefreshCw` badge inside a `SimpleTooltip` (bottom-right, `ring-background`). Renders a bare `EntityIcon` when not connector-owned, so non-connector entities are unaffected.
- **Threaded the signal** — added `dataConnectorId` to `ProcessedEntity` (`use-entity-sidebar.tsx`) off the cached `CustomResource.dataConnectorId`. No new query; same field `connector-detail-view.tsx` already consumes.
- **Wired the sidebar** — `entity-sidebar-nav.tsx` `renderIcon` now takes the full entity and passes `dataConnectorId` + tooltip copy.
- **`list-card.tsx`** (bundled per request, from the separate bulk-actions WIP) — gate hover/selected styling behind `!pending` and soften the pending overlay text color.

## Notes / scope

- The badge surfaces **only on connector-_owned_ defs** (e.g. Shopify Orders/Products). Contributing connectors tag individual fields, not the def, so they correctly don't get an entity-level badge.
- **Edit mode**: `EditableSidebarItem` only renders an icon for *locked* rows (drag handle otherwise) — existing behavior, unchanged here.
- Tooltip is generic ("synced by a data connector"), not the connector's name — naming it would need an id→title lookup; easy follow-up.

## Testing

- Biome clean (pre-commit hook). No `tsc` per project rules; change is type-safe against the existing `CustomResource` shape.