### PR TITLE
feat(data-connectors): fix @app: owned-def field resolution + surface dropped fields

### DIFF
--- a/apps/web/src/components/data-connectors/hooks/use-mapping-actions.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-mapping-actions.ts
@@ -1,0 +1,458 @@
+// apps/web/src/components/data-connectors/hooks/use-mapping-actions.ts
+// The mutation orchestration for ONE mapping node — every leaf-bind / relationship-link /
+// drilled-bind / formula-relocation handler, lifted out of `MappingNode` so the component
+// is just resolve → view → actions → render. Each handler closes over the connector draft
+// `mutations` (fanOut / setFieldMappings / removeMapping) and the precomputed `view`; the
+// pure entry transforms live in `field-mapping-edits`. UI-only handlers (opening the calc
+// dialog, the target-mode toggle, the suggester) stay in the component — these are the
+// data edits.
+
+import { fieldMatchesRef, type ResourceField } from '@auxx/lib/resources/client'
+import {
+  type FieldReference,
+  fieldRefToKey,
+  getFieldDefinitionId,
+  isFieldPath,
+  type ResourceFieldId,
+} from '@auxx/types/field'
+import { toastError } from '@auxx/ui/components/toast'
+import { generateId } from '@auxx/utils'
+import type { DraftMapping, MappingDraftMutations } from '../stores/connector-draft-store'
+import {
+  bindingFor,
+  isBareToken,
+  removeBindingForSource,
+  retargetFormulaEntry,
+  setEntryIdentityRole,
+  upsertBinding,
+} from '../ui/field-mapping-edits'
+import type { IdentityRole } from '../ui/identity-role-control'
+import { branchRootPath, relatedDefOf } from '../ui/mapping-node-helpers'
+import type { MappingView } from '../ui/mapping-view'
+import type { SourceTreeNode } from './use-source-paths'
+import type { FieldMapping } from './use-stream-mutations'
+
+type Normalize = 'email' | 'phone' | 'domain' | 'none'
+
+interface UseMappingActionsArgs {
+  streamId: string
+  mapping: DraftMapping
+  /** This mapping's current entries (`mapping.fieldMappings`). */
+  fieldMappings: FieldMapping[]
+  /** The precomputed render model — child/drilled indices the handlers read. */
+  view: MappingView
+  /** All mappings by id — to read another mapping's entries (drilled formulas). */
+  byMappingId: Map<string, DraftMapping>
+  /** The target def's fields — for the match normalizer. */
+  targetFields: ResourceField[]
+  mutations: MappingDraftMutations
+}
+
+/** Every data-mutation handler a mapping node binds to its rows. */
+export interface MappingActions {
+  patchEntry: (id: string, patch: Partial<FieldMapping>) => void
+  patchEntryIn: (mappingId: string, entryId: string, patch: Partial<FieldMapping>) => void
+  assignTarget: (sourcePath: string, targetRef: string) => void
+  clearEntry: (id: string) => void
+  retargetEntry: (id: string, newRef: string) => void
+  setIdentityRole: (sourcePath: string, role: 'externalId' | 'match' | null) => void
+  materializeRelatedChild: (node: SourceTreeNode, field: ResourceField, ref: FieldReference) => void
+  linkRelationship: (node: SourceTreeNode, field: ResourceField, ref: FieldReference) => void
+  assignDrilled: (node: SourceTreeNode, field: ResourceField, ref: FieldReference) => void
+  clearDrilled: (node: SourceTreeNode) => void
+  setDrilledIdentityRole: (node: SourceTreeNode, role: 'externalId' | 'match' | null) => void
+  setDrilledMerge: (node: SourceTreeNode, value: string) => void
+  setFormulaIdentityRole: (entryId: string, role: IdentityRole) => void
+  setDrilledFormulaIdentityRole: (
+    child: DraftMapping,
+    entry: FieldMapping,
+    role: IdentityRole
+  ) => void
+  drillHomeFormula: (entry: FieldMapping, ref: FieldReference) => void
+  undrillFormula: (child: DraftMapping, entry: FieldMapping, targetRef: string) => void
+  redrillFormula: (child: DraftMapping, entry: FieldMapping, ref: FieldReference) => void
+  removeFormulaFromChild: (child: DraftMapping, entryId: string) => void
+}
+
+/**
+ * Build the {@link MappingActions} for a mapping node. Not memoized (the handlers close
+ * over freshly-derived `fieldMappings`/`view` each render, matching the inline closures
+ * they replace); the connector draft store is the source of truth, so re-creating cheap
+ * closures per render is fine.
+ */
+export function useMappingActions({
+  streamId,
+  mapping,
+  fieldMappings,
+  view,
+  byMappingId,
+  targetFields,
+  mutations,
+}: UseMappingActionsArgs): MappingActions {
+  const { setFieldMappings, fanOut, removeMapping } = mutations
+  const { flatDrilledChildren, refChildByNodePath, drilledBindBySourcePath, sourceToEntry } = view
+
+  // Persist a new entry array (the single mapping field-write surface).
+  const writeEntries = (next: FieldMapping[]) => setFieldMappings(streamId, mapping.id, next)
+
+  const fieldByRef = (ref: string | null | undefined): ResourceField | undefined =>
+    ref ? targetFields.find((f) => fieldMatchesRef(f, mapping.entityDefinitionId, ref)) : undefined
+
+  // Normalizer for a match key, derived from the target field's storage type so the role
+  // stays one-click (no normalize selector).
+  const deriveNormalize = (targetRef: string): Normalize => {
+    const ft = fieldByRef(targetRef)?.fieldType
+    if (ft === 'EMAIL') return 'email'
+    if (ft === 'PHONE_INTL') return 'phone'
+    if (ft === 'URL') return 'domain'
+    return 'none'
+  }
+
+  // Patch one entry in place by its stable id (used by every per-entry mutation).
+  const patchEntry = (id: string, patch: Partial<FieldMapping>) =>
+    writeEntries(fieldMappings.map((e) => (e.id === id ? { ...e, ...patch } : e)))
+
+  // Patch an entry on ANY mapping (this one or a flat child) — a drilled formula's entry
+  // lives on a child. Reads the target mapping's entries from the shared index.
+  const patchEntryIn = (mappingId: string, entryId: string, patch: Partial<FieldMapping>) => {
+    const entries = (byMappingId.get(mappingId)?.fieldMappings ?? []) as FieldMapping[]
+    setFieldMappings(
+      streamId,
+      mappingId,
+      entries.map((e) => (e.id === entryId ? { ...e, ...patch } : e))
+    )
+  }
+
+  const assignTarget = (sourcePath: string, targetRef: string) => {
+    // Drop any prior bare-token entry bound to this source (1 source → 1 target), then
+    // append a fresh entry with a stable id.
+    const next = fieldMappings.filter(
+      (e) => !(isBareToken(e.expression) && e.expression.replace(/^\{|\}$/g, '') === sourcePath)
+    )
+    next.push({
+      id: generateId(),
+      targetFieldRef: targetRef,
+      expression: `{${sourcePath}}`,
+      sourceFields: { [sourcePath]: sourcePath },
+    })
+    writeEntries(next)
+  }
+
+  const clearEntry = (id: string) => writeEntries(fieldMappings.filter((e) => e.id !== id))
+
+  // Re-point a formula at a different target field. Identity is the entry id, so this is a
+  // single field set — merge/match ride along, no re-key.
+  const retargetEntry = (id: string, newRef: string) => patchEntry(id, { targetFieldRef: newRef })
+
+  // Set / clear a leaf's identity role (relationship-linking v3 §9.4). External ID is the
+  // primary upstream key (radio — picking it elsewhere moves it) and can live on an
+  // UNMAPPED leaf. Match is secondary and needs a bound target. Clearing a role on an
+  // External-ID-only entry drops the entry entirely (it only existed to carry the role).
+  const setIdentityRole = (sourcePath: string, role: 'externalId' | 'match' | null) => {
+    let next = fieldMappings
+    if (role === 'externalId') {
+      next = next.map((e) =>
+        e.identityRole?.kind === 'externalId' ? { ...e, identityRole: undefined } : e
+      )
+    }
+    const idx = next.findIndex(
+      (e) => isBareToken(e.expression) && e.expression.replace(/^\{|\}$/g, '') === sourcePath
+    )
+    if (idx === -1) {
+      if (role == null) return
+      next = [
+        ...next,
+        {
+          id: generateId(),
+          targetFieldRef: null,
+          expression: `{${sourcePath}}`,
+          sourceFields: { [sourcePath]: sourcePath },
+          identityRole:
+            role === 'externalId' ? { kind: 'externalId' } : { kind: 'match', normalize: 'none' },
+        },
+      ]
+    } else {
+      const e = next[idx]!
+      if (role == null && e.targetFieldRef == null) {
+        next = next.filter((_, i) => i !== idx)
+      } else {
+        const identityRole =
+          role == null
+            ? undefined
+            : role === 'externalId'
+              ? ({ kind: 'externalId' } as const)
+              : ({ kind: 'match', normalize: deriveNormalize(e.targetFieldRef ?? '') } as const)
+        next = next.map((x, i) => (i === idx ? { ...x, identityRole } : x))
+      }
+    }
+    writeEntries(next)
+  }
+
+  // Materialize a child mapping at a branch by DRILLING a relationship off this mapping's
+  // def (relationship-linking v3 §11.1 — the core inversion). The related def is DERIVED
+  // from the drilled relationship, the edge is the drilled `FieldReference`, the mode is
+  // forced `contributing` — so a null `relationshipFieldKey` and an owned-on-system-def
+  // footgun are both unrepresentable.
+  const materializeRelatedChild = (
+    node: SourceTreeNode,
+    field: ResourceField,
+    ref: FieldReference
+  ) => {
+    const relatedDefId = relatedDefOf(field)
+    if (!relatedDefId) return
+    fanOut(streamId, {
+      parentMappingId: mapping.id,
+      rootPath: branchRootPath(node),
+      linkMode: 'upsert', // server derives reference vs upsert from the field bindings
+      targetMode: 'contributing',
+      entityDefinitionId: relatedDefId,
+      relationshipFieldKey: fieldRefToKey(ref),
+    })
+  }
+
+  // Link a flat-FK SCALAR leaf to an existing relationship by drilling it (the id-only
+  // reference case, §9.6a Case B). Desugars to a child mapping rooted at the FK path whose
+  // ONLY binding is the FK marked External ID — so the runtime derives `reference` and
+  // anchors the lazy link on that id (no frozen target pointer). A prior link on the same
+  // leaf is replaced.
+  const linkRelationship = (node: SourceTreeNode, field: ResourceField, ref: FieldReference) => {
+    const relatedDefId = relatedDefOf(field)
+    if (!relatedDefId) return
+    const prior = refChildByNodePath.get(node.path)
+    if (prior) removeMapping(streamId, prior.id)
+    fanOut(streamId, {
+      parentMappingId: mapping.id,
+      rootPath: node.path,
+      linkMode: 'reference',
+      targetMode: 'contributing',
+      entityDefinitionId: relatedDefId,
+      relationshipFieldKey: fieldRefToKey(ref),
+      // Ship the anchor atomically: the FK value IS the related record's external id.
+      fieldMappings: [
+        {
+          id: generateId(),
+          targetFieldRef: null,
+          expression: '{source}',
+          sourceFields: {},
+          identityRole: { kind: 'externalId' },
+        },
+      ],
+    })
+  }
+
+  // Bind a leaf ACROSS a relationship (unified picker §2/§4): drill the target graph to a
+  // field on a related def — e.g. `email → Contact.Email`. Desugars to a FLAT contributing
+  // child mapping (`rootPath ''` reads THIS mapping's subtree), reusing one child per
+  // drilled relationship. v1 is single-hop (a 2-segment FieldPath).
+  const assignDrilled = (node: SourceTreeNode, _field: ResourceField, ref: FieldReference) => {
+    if (!isFieldPath(ref) || ref.length !== 2) {
+      toastError({
+        title: 'Multi-hop links not supported yet',
+        description: 'Pick a field one relationship away from this record.',
+      })
+      return
+    }
+    const rel = ref[0]
+    const targetRef = ref[1]
+    const relatedDefId = getFieldDefinitionId(targetRef)
+    const relKey = fieldRefToKey(rel)
+    if (sourceToEntry.has(node.path)) {
+      writeEntries(removeBindingForSource(fieldMappings, node.path))
+    }
+    const existing = flatDrilledChildren.find((c) => c.relationshipFieldKey === relKey)
+    if (existing) {
+      setFieldMappings(
+        streamId,
+        existing.id,
+        upsertBinding((existing.fieldMappings ?? []) as FieldMapping[], node.path, targetRef)
+      )
+      return
+    }
+    fanOut(streamId, {
+      parentMappingId: mapping.id,
+      rootPath: '', // flat: reads THIS mapping's subtree
+      linkMode: 'upsert', // server derives reference vs upsert from the bindings
+      targetMode: 'contributing',
+      entityDefinitionId: relatedDefId,
+      relationshipFieldKey: relKey,
+      fieldMappings: [bindingFor(node.path, targetRef)],
+    })
+  }
+
+  // Clear a drilled binding — drop it from the flat child, removing the child entirely once
+  // it carries no bindings (it existed only for drilled binds).
+  const clearDrilled = (node: SourceTreeNode) => {
+    const drilled = drilledBindBySourcePath.get(node.path)
+    if (!drilled) return
+    const remaining = removeBindingForSource(
+      (drilled.child.fieldMappings ?? []) as FieldMapping[],
+      node.path
+    )
+    if (remaining.length === 0) removeMapping(streamId, drilled.child.id)
+    else setFieldMappings(streamId, drilled.child.id, remaining)
+  }
+
+  // Identity role on a drilled leaf → patch the flat child's binding (External ID is a
+  // radio WITHIN that child — the related record's own key).
+  const setDrilledIdentityRole = (node: SourceTreeNode, role: 'externalId' | 'match' | null) => {
+    const drilled = drilledBindBySourcePath.get(node.path)
+    if (!drilled) return
+    setFieldMappings(
+      streamId,
+      drilled.child.id,
+      setEntryIdentityRole(
+        (drilled.child.fieldMappings ?? []) as FieldMapping[],
+        drilled.entry.id,
+        role,
+        deriveNormalize(drilled.entry.targetFieldRef ?? '')
+      )
+    )
+  }
+
+  // Merge strategy on a drilled leaf → patch the flat child's binding.
+  const setDrilledMerge = (node: SourceTreeNode, value: string) => {
+    const drilled = drilledBindBySourcePath.get(node.path)
+    if (!drilled) return
+    setFieldMappings(
+      streamId,
+      drilled.child.id,
+      ((drilled.child.fieldMappings ?? []) as FieldMapping[]).map((e) =>
+        e.id === drilled.entry.id
+          ? { ...e, mergeStrategy: value as FieldMapping['mergeStrategy'] }
+          : e
+      )
+    )
+  }
+
+  // ── Formula drill-across-relationship (formula-drill-targets §3) ──────────────
+  // A formula entry's "home" is either THIS parent mapping (a root-scalar target) or a flat
+  // child (a target a relationship away). Picking a target moves the entry to its desired
+  // home, preserving the expression. The flat child is REUSED per relationship (shared with
+  // drilled leaf binds) and GC'd when its last entry leaves.
+
+  const asSingleHop = (ref: FieldReference): [ResourceFieldId, ResourceFieldId] | null => {
+    if (!isFieldPath(ref) || ref.length !== 2) {
+      toastError({
+        title: 'Multi-hop links not supported yet',
+        description: 'Pick a field one relationship away from this record.',
+      })
+      return null
+    }
+    return [ref[0], ref[1]]
+  }
+
+  // Upsert a (re-homed) formula entry into the flat child for `rel`, creating it if absent.
+  const upsertFormulaIntoRelChild = (rel: ResourceFieldId, entry: FieldMapping) => {
+    const relKey = fieldRefToKey(rel)
+    const relatedDefId = getFieldDefinitionId(entry.targetFieldRef as ResourceFieldId)
+    const existing = flatDrilledChildren.find((c) => c.relationshipFieldKey === relKey)
+    if (existing) {
+      const next = [
+        ...((existing.fieldMappings ?? []) as FieldMapping[]).filter((e) => e.id !== entry.id),
+        entry,
+      ]
+      setFieldMappings(streamId, existing.id, next)
+      return
+    }
+    fanOut(streamId, {
+      parentMappingId: mapping.id,
+      rootPath: '', // flat: reads THIS mapping's subtree
+      linkMode: 'upsert',
+      targetMode: 'contributing',
+      entityDefinitionId: relatedDefId,
+      relationshipFieldKey: relKey,
+      fieldMappings: [entry],
+    })
+  }
+
+  // Drop a formula entry from a flat child, GC'ing the child when nothing remains.
+  const removeFormulaFromChild = (child: DraftMapping, entryId: string) => {
+    const remaining = ((child.fieldMappings ?? []) as FieldMapping[]).filter(
+      (e) => e.id !== entryId
+    )
+    if (remaining.length === 0) removeMapping(streamId, child.id)
+    else setFieldMappings(streamId, child.id, remaining)
+  }
+
+  // A HOME formula gains a drilled target → move it onto the relationship's flat child.
+  const drillHomeFormula = (entry: FieldMapping, ref: FieldReference) => {
+    const hop = asSingleHop(ref)
+    if (!hop) return
+    writeEntries(fieldMappings.filter((e) => e.id !== entry.id))
+    upsertFormulaIntoRelChild(hop[0], retargetFormulaEntry(entry, hop[1]))
+  }
+
+  // A DRILLED formula is retargeted to a ROOT scalar → move it back to this parent.
+  const undrillFormula = (child: DraftMapping, entry: FieldMapping, targetRef: string) => {
+    removeFormulaFromChild(child, entry.id)
+    writeEntries([...fieldMappings, retargetFormulaEntry(entry, targetRef)])
+  }
+
+  // A DRILLED formula gains another drilled target → retarget in place when the
+  // relationship is unchanged, else move it to the new relationship's child.
+  const redrillFormula = (child: DraftMapping, entry: FieldMapping, ref: FieldReference) => {
+    const hop = asSingleHop(ref)
+    if (!hop) return
+    if (child.relationshipFieldKey === fieldRefToKey(hop[0])) {
+      patchEntryIn(child.id, entry.id, { targetFieldRef: hop[1] })
+      return
+    }
+    removeFormulaFromChild(child, entry.id)
+    upsertFormulaIntoRelChild(hop[0], retargetFormulaEntry(entry, hop[1]))
+  }
+
+  // Identity role on a HOME formula (formula-drill-targets §5.1) — keyed by ENTRY ID, since
+  // a formula has no single source path. External ID stays a radio WITHIN this mapping (the
+  // record's own key); the runtime evaluates the expression as the key, so a
+  // composite/computed External ID works with no engine change.
+  const setFormulaIdentityRole = (entryId: string, role: IdentityRole) => {
+    const entry = fieldMappings.find((e) => e.id === entryId)
+    writeEntries(
+      setEntryIdentityRole(
+        fieldMappings,
+        entryId,
+        role,
+        deriveNormalize(entry?.targetFieldRef ?? '')
+      )
+    )
+  }
+
+  // Identity role on a DRILLED formula → patch the flat child's entry.
+  const setDrilledFormulaIdentityRole = (
+    child: DraftMapping,
+    entry: FieldMapping,
+    role: IdentityRole
+  ) => {
+    setFieldMappings(
+      streamId,
+      child.id,
+      setEntryIdentityRole(
+        (child.fieldMappings ?? []) as FieldMapping[],
+        entry.id,
+        role,
+        deriveNormalize(entry.targetFieldRef ?? '')
+      )
+    )
+  }
+
+  return {
+    patchEntry,
+    patchEntryIn,
+    assignTarget,
+    clearEntry,
+    retargetEntry,
+    setIdentityRole,
+    materializeRelatedChild,
+    linkRelationship,
+    assignDrilled,
+    clearDrilled,
+    setDrilledIdentityRole,
+    setDrilledMerge,
+    setFormulaIdentityRole,
+    setDrilledFormulaIdentityRole,
+    drillHomeFormula,
+    undrillFormula,
+    redrillFormula,
+    removeFormulaFromChild,
+  }
+}

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -28,6 +28,7 @@ import { useQueryState } from 'nuqs'
 import { useMemo } from 'react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { Tooltip } from '~/components/global/tooltip'
+import { useResources } from '~/components/resources/hooks/use-resources'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useMedia } from '~/hooks/use-media'
 import { useDockStore } from '~/stores/dock-store'
@@ -75,6 +76,16 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
 
   const [confirm, ConfirmDialog] = useConfirm()
   const [, setTab] = useQueryState('tab')
+
+  // Owned entity defs this connector provisioned — already on the cached resource
+  // shape (`CustomResource.dataConnectorId`), so no extra query. Used to spell out
+  // the blast radius in the `delete` confirm copy. Contributing columns on shared
+  // defs aren't counted (they survive a `delete` as user-owned).
+  const { customResources } = useResources()
+  const ownedDefs = useMemo(
+    () => customResources.filter((r) => r.dataConnectorId === connector.id),
+    [customResources, connector.id]
+  )
 
   const status = asConnectorStatus(connector.status)
   const isSyncing = status === 'syncing' || status === 'provisioning'
@@ -180,10 +191,15 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
         : null
 
   const handleDelete = async (syncedData: 'keep' | 'archive' | 'delete') => {
+    const ownedDefsClause = ownedDefs.length
+      ? `, including ${ownedDefs.length} entity ${
+          ownedDefs.length === 1 ? 'definition' : 'definitions'
+        } (${ownedDefs.map((d) => d.label).join(', ')}) and all their records`
+      : ''
     const copy = {
       keep: 'Synced records are kept; only the connector is removed.',
       archive: 'Synced records are archived and the connector is removed.',
-      delete: 'Synced records and the connector are permanently deleted.',
+      delete: `Synced records and the connector are permanently deleted${ownedDefsClause}.`,
     }[syncedData]
     const ok = await confirm({
       title: 'Delete connector?',

--- a/apps/web/src/components/data-connectors/ui/field-type-compat.test.ts
+++ b/apps/web/src/components/data-connectors/ui/field-type-compat.test.ts
@@ -1,0 +1,48 @@
+// apps/web/src/components/data-connectors/ui/field-type-compat.test.ts
+
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { describe, expect, it } from 'vitest'
+import { isWritableTarget } from './field-type-compat'
+
+/** Minimal ResourceField with just the bits isWritableTarget reads. */
+function field(
+  caps: Partial<ResourceField['capabilities']>,
+  ownership: Partial<Pick<ResourceField, 'dataConnectorId' | 'isAppOwned'>> = {}
+): ResourceField {
+  return {
+    capabilities: { creatable: true, updatable: true, computed: false, ...caps },
+    ...ownership,
+  } as ResourceField
+}
+
+describe('isWritableTarget', () => {
+  it('accepts a normal creatable + updatable field', () => {
+    expect(isWritableTarget(field({}))).toBe(true)
+  })
+
+  it('rejects a computed field even with ownedWrite', () => {
+    expect(isWritableTarget(field({ computed: true }), { ownedWrite: true })).toBe(false)
+  })
+
+  it('rejects a read-only field in contributing mode (no ownedWrite)', () => {
+    const ro = field({ creatable: false, updatable: false }, { dataConnectorId: 'dc1' })
+    expect(isWritableTarget(ro)).toBe(false)
+  })
+
+  it('accepts a connector-managed read-only field when ownedWrite', () => {
+    // The v6 owned-def column: user-read-only, but the owned sink populates it.
+    const ownedCol = field({ creatable: false, updatable: false }, { dataConnectorId: 'dc1' })
+    expect(isWritableTarget(ownedCol, { ownedWrite: true })).toBe(true)
+  })
+
+  it('accepts an app-owned read-only field when ownedWrite', () => {
+    const appCol = field({ creatable: false, updatable: false }, { isAppOwned: true })
+    expect(isWritableTarget(appCol, { ownedWrite: true })).toBe(true)
+  })
+
+  it('still hides a pure system read-only field under ownedWrite (no ownership signal)', () => {
+    // e.g. Created By on an owned def — not connector/app-managed, so it stays out.
+    const sysCol = field({ creatable: false, updatable: false })
+    expect(isWritableTarget(sysCol, { ownedWrite: true })).toBe(false)
+  })
+})

--- a/apps/web/src/components/data-connectors/ui/field-type-compat.ts
+++ b/apps/web/src/components/data-connectors/ui/field-type-compat.ts
@@ -6,17 +6,23 @@ import { isFieldTypeCompatible } from '@auxx/lib/custom-fields/client'
 import type { ResourceField } from '@auxx/lib/resources/client'
 
 /**
- * Can the connector sink keep this target field in sync? The sink upserts via
- * `UnifiedCrudHandler`, which silently drops non-creatable values on create and
- * non-updatable values on update — so a field that isn't BOTH creatable and
- * updatable (or is computed/derived) can never be reliably written by an ongoing
- * sync. Such fields (record id, createdAt, ticket number, formula/rollup fields,
- * …) are filtered out of the mapping target pickers. Normal custom fields are
- * creatable + updatable, so the common owned/contributing case is unaffected.
+ * Can the connector sink keep this target field in sync? Computed/derived fields
+ * (formula/rollup) are never writable. Otherwise a field needs to be both creatable
+ * and updatable so an ongoing sync can write it on create AND update — that filters
+ * out record id, createdAt, ticket number, etc. from the mapping target pickers.
+ *
+ * `ownedWrite` (the mapping is OWNED) flips this for connector-managed columns: an
+ * owned def's own columns are stamped user-read-only (`isCreatable`/`isUpdatable`
+ * false) by the v6 template projector, but the owned-mode sink populates them via
+ * its bypass crud handler — so they ARE valid targets. Gated to connector/app-owned
+ * fields (`dataConnectorId`/`isAppOwned`) so a pure system field (e.g. Created By)
+ * on an owned def stays hidden. Contributing mappings keep the strict check.
  */
-export function isWritableTarget(field: ResourceField): boolean {
+export function isWritableTarget(field: ResourceField, opts?: { ownedWrite?: boolean }): boolean {
   const c = field.capabilities
-  return c.creatable && c.updatable && !c.computed
+  if (c.computed) return false
+  if (c.creatable && c.updatable) return true
+  return !!opts?.ownedWrite && (field.dataConnectorId != null || !!field.isAppOwned)
 }
 
 /**

--- a/apps/web/src/components/data-connectors/ui/formula-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/formula-row.tsx
@@ -1,0 +1,232 @@
+// apps/web/src/components/data-connectors/ui/formula-row.tsx
+'use client'
+
+import { fieldMatchesRef } from '@auxx/lib/resources/client'
+import {
+  type FieldReference,
+  getFieldId,
+  isFieldPath,
+  keyToFieldRef,
+  type ResourceFieldId,
+  toFieldPath,
+} from '@auxx/types/field'
+import { Button } from '@auxx/ui/components/button'
+import { FunctionSquare } from 'lucide-react'
+import { useResourceFields, useResourceProperty } from '~/components/resources'
+import type { FieldMapping } from '../hooks/use-stream-mutations'
+import type { DraftMapping } from '../stores/connector-draft-store'
+import { type IdentityRole, IdentityRoleControl } from './identity-role-control'
+import { MappingFieldPicker } from './mapping-field-picker'
+import { fieldIconId } from './mapping-node-helpers'
+import { FieldRowActions, MappingRow } from './mapping-row'
+
+interface FormulaRowProps {
+  depth: number
+  /** The def the picker drills/binds FROM. Null until a target def is picked. */
+  entityDefinitionId: string | null
+  /** Target field key this formula currently writes into (`''` if unassigned). */
+  targetKey: string
+  /** Resolved label for the target field. */
+  label: string
+  /** Resolved icon id for the target field (for the picker chip). */
+  iconId?: string
+  /** The calc expression (shown on the source button; click it to edit). */
+  expression: string
+  mergeStrategy: string
+  /** Target keys bound by other entries — excluded from the retarget picker. */
+  excludeKeys?: Set<string>
+  /** Show relationships in the picker so the formula can drill ACROSS one (§4). */
+  allowRelationships?: boolean
+  /** Chip text when bound across a relationship ("Contact › Full name"). */
+  drilledLabel?: string
+  /** The drilled `FieldPath`, for the picker's selected check on the far field. */
+  drilledRef?: FieldReference
+  /** This formula's identity role (External ID / Match), keyed by entry id (§5.1). */
+  identityRole?: IdentityRole
+  /** Offer the "Match existing" option — needs a bound target to compare against. */
+  canMatch?: boolean
+  /** The mapping is OWNED — relaxes the picker's writable filter to owned columns. */
+  ownedWrite?: boolean
+  onEdit: () => void
+  /** Re-point the formula at a different ROOT target field key. */
+  onRetarget: (newKey: string) => void
+  /** The picker drilled to a far field — bind the computed value across the relationship. */
+  onDrilledAssign?: (ref: FieldReference) => void
+  /** Set / clear this formula's identity role. Absent → no identifier control. */
+  onSetIdentityRole?: (role: IdentityRole) => void
+  onMergeChange: (value: string) => void
+  onClear: () => void
+}
+
+/**
+ * A computed target field (plan 10 §3.2) — a non-bare `fieldMappings` entry that can
+ * reference many source fields, so it lives on its own row rather than on a source leaf.
+ * Mirrors a leaf row: the source cell is a button (showing the calc expression, or "Set
+ * formula…") that opens {@link FieldCalcDialog}; the target column is a field picker (a
+ * formula produces a scalar — string-typed for the compat filter). With
+ * {@link allowRelationships} the picker can drill ACROSS a relationship to write a related
+ * def (formula-drill-targets §4). The identity control (keyed by entry id) marks the
+ * computed value as the record's External ID or a Match key (§5.1) — the runtime
+ * evaluates the expression as the key.
+ */
+export function FormulaRow({
+  depth,
+  entityDefinitionId,
+  targetKey,
+  label,
+  iconId,
+  expression,
+  mergeStrategy,
+  excludeKeys,
+  allowRelationships,
+  drilledLabel,
+  drilledRef,
+  identityRole,
+  canMatch,
+  ownedWrite,
+  onEdit,
+  onRetarget,
+  onDrilledAssign,
+  onSetIdentityRole,
+  onMergeChange,
+  onClear,
+}: FormulaRowProps) {
+  return (
+    <MappingRow
+      depth={depth}
+      icon={<FunctionSquare className='size-3.5' />}
+      // Source cell = a button that opens the formula dialog (shows the expression
+      // when set), trailed by the identity key icon; target column = the field it
+      // writes into.
+      title={
+        <span className='flex w-full items-center gap-1'>
+          <Button
+            variant='transparent'
+            onClick={onEdit}
+            className={`h-9 min-w-0 flex-1 justify-start rounded-none px-1 text-xs hover:bg-primary/5 ${
+              expression ? 'font-mono' : 'text-muted-foreground'
+            }`}>
+            <span className='truncate'>{expression || 'Set formula…'}</span>
+          </Button>
+          {onSetIdentityRole && (
+            <IdentityRoleControl
+              role={identityRole ?? null}
+              canMatch={!!canMatch}
+              onChange={onSetIdentityRole}
+            />
+          )}
+        </span>
+      }
+      arrow='filled'
+      target={
+        <MappingFieldPicker
+          entityDefinitionId={entityDefinitionId}
+          // A formula has no single source type — it yields a scalar; 'string'
+          // drives the (TEXT-compatible) target filter. Quick-create is off; a
+          // formula targets an existing field.
+          sourceType='string'
+          sourcePath=''
+          assignedKey={targetKey || undefined}
+          // Drilled chip wins; else the field label, or undefined (not '') so the
+          // picker falls back to its "Apply field…" placeholder.
+          assignedLabel={drilledLabel ?? (label || undefined)}
+          assignedIconId={iconId}
+          drilledRef={drilledRef}
+          excludeKeys={excludeKeys}
+          canCreate={false}
+          ownedWrite={ownedWrite}
+          allowRelationships={allowRelationships}
+          onAssign={onRetarget}
+          // The picker hands back (field, ref); a formula only needs the path.
+          onDrilledAssign={onDrilledAssign ? (_field, ref) => onDrilledAssign(ref) : undefined}
+          onClear={onClear}
+        />
+      }
+      // Right-aligned merge → trash, matching the leaf/header rows. No Identifier —
+      // a formula has no single source path to match identity on.
+      actions={
+        <FieldRowActions
+          mergeStrategy={mergeStrategy}
+          onMergeChange={onMergeChange}
+          onClear={onClear}
+          clearTooltip='Remove formula'
+        />
+      }
+    />
+  )
+}
+
+/**
+ * A formula bound ACROSS a relationship (formula-drill-targets §4): its entry lives on a
+ * flat child mapping, but it renders as a {@link FormulaRow} on the parent whose picker
+ * roots at the PARENT def (so it offers the same drill) and whose chip reaches across to
+ * "Def › Field". Resolves that chip + the far field's icon from the child's def. Controls
+ * route to the child's entry via the handlers from the parent.
+ */
+export function DrilledFormulaRow({
+  depth,
+  parentEntityDefinitionId,
+  child,
+  entry,
+  excludeKeys,
+  ownedWrite,
+  onSetIdentityRole,
+  onEdit,
+  onRetargetRoot,
+  onDrilledAssign,
+  onMergeChange,
+  onClear,
+}: {
+  depth: number
+  parentEntityDefinitionId: string | null
+  child: DraftMapping
+  entry: FieldMapping
+  excludeKeys?: Set<string>
+  ownedWrite?: boolean
+  onSetIdentityRole: (role: IdentityRole) => void
+  onEdit: () => void
+  onRetargetRoot: (newKey: string) => void
+  onDrilledAssign: (ref: FieldReference) => void
+  onMergeChange: (value: string) => void
+  onClear: () => void
+}) {
+  const def = useResourceProperty(child.entityDefinitionId, ['label'])
+  const { fields } = useResourceFields(child.entityDefinitionId)
+  const targetRef = (entry.targetFieldRef ?? null) as ResourceFieldId | null
+  const farField = targetRef
+    ? fields.find((f) => fieldMatchesRef(f, child.entityDefinitionId, targetRef))
+    : undefined
+  const fieldLabel = targetRef ? (farField?.label ?? getFieldId(targetRef)) : ''
+  const drilledLabel = `${def?.label ?? 'Related'} › ${fieldLabel}`
+  // Rebuild the drilled FieldPath ([rel…, targetRef]) for the picker's selected check.
+  const relRef = keyToFieldRef(child.relationshipFieldKey ?? '')
+  const relSegs = isFieldPath(relRef) ? relRef : [relRef as ResourceFieldId]
+  const drilledRef = targetRef ? toFieldPath([...relSegs, targetRef]) : undefined
+
+  return (
+    <FormulaRow
+      depth={depth}
+      // Root the picker at the PARENT def so it offers the same drill.
+      entityDefinitionId={parentEntityDefinitionId}
+      targetKey={targetRef ?? ''}
+      label={fieldLabel}
+      iconId={fieldIconId(farField)}
+      expression={entry.expression}
+      mergeStrategy={entry.mergeStrategy ?? 'overwrite'}
+      excludeKeys={excludeKeys}
+      allowRelationships={parentEntityDefinitionId != null}
+      drilledLabel={drilledLabel}
+      drilledRef={drilledRef}
+      // External ID here keys the RELATED record (a radio within the flat child).
+      identityRole={entry.identityRole?.kind ?? null}
+      canMatch={targetRef != null}
+      ownedWrite={ownedWrite}
+      onSetIdentityRole={onSetIdentityRole}
+      onEdit={onEdit}
+      onRetarget={onRetargetRoot}
+      onDrilledAssign={onDrilledAssign}
+      onMergeChange={onMergeChange}
+      onClear={onClear}
+    />
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
@@ -86,6 +86,12 @@ interface MappingFieldPickerProps {
   excludeKeys?: Set<string>
   /** Quick-create is wired only for owned defs (plan decision 3). */
   canCreate?: boolean
+  /**
+   * The enclosing mapping is OWNED — the owned-mode sink writes via its bypass crud
+   * handler, so the def's connector-managed (user-read-only) columns are valid
+   * targets. Relaxes {@link isWritableTarget} for those fields.
+   */
+  ownedWrite?: boolean
   /** Trigger placeholder when nothing is assigned (default "Apply field…"). */
   placeholder?: string
   /** Bind this source node to a DIRECT field on the current def (canonical `ResourceFieldId`). */
@@ -128,6 +134,7 @@ export function MappingFieldPicker({
   drilledRef,
   excludeKeys,
   canCreate = false,
+  ownedWrite = false,
   placeholder,
   onAssign,
   onDrilledAssign,
@@ -141,9 +148,16 @@ export function MappingFieldPicker({
 
   const isBranch = kind === 'branch'
   const showRelationships = isBranch || allowRelationships
+  // A VALUE binding (direct scalar or drilled-across) vs a link-only leaf (an id-only
+  // relationship whose FK anchors an edge but writes no column). Both make the trigger
+  // read "active"; only a value binding drives the icon + the in-picker "Don't map".
   const isAssigned = !!assignedKey || !!drilledRef
+  const isLinked = !!linkedFieldRef
+  const isActive = isAssigned || isLinked
+  // Chip prefers a value/drill label, then the bound key, then a bare "Linked" for a
+  // link-only leaf (the relationship renders its own sub-row), else the placeholder.
   const chipLabel =
-    assignedLabel ?? (isAssigned ? (assignedKey ?? 'Linked') : (placeholder ?? 'Apply field…'))
+    assignedLabel ?? assignedKey ?? (isLinked ? 'Linked' : (placeholder ?? 'Apply field…'))
 
   // No target def yet — show a disabled trigger; binding unlocks once a target def is
   // picked (plan 08 §3.4).
@@ -172,7 +186,7 @@ export function MappingFieldPicker({
         <Button
           variant='transparent'
           className={`h-9 w-full justify-between rounded-none px-2 text-xs hover:bg-primary-200/20 ${
-            isAssigned ? '' : 'text-primary-400'
+            isActive ? '' : 'text-primary-400'
           }`}>
           <span className='flex min-w-0 items-center gap-1.5'>
             {isAssigned && assignedIconId && (
@@ -213,7 +227,7 @@ export function MappingFieldPicker({
                 getFieldDefinitionId(rfid) === entityDefinitionId ? !excludeKeys?.has(rfid) : true
               return (
                 notExcluded &&
-                isWritableTarget(f) &&
+                isWritableTarget(f, { ownedWrite }) &&
                 isSourceTargetCompatible(f.fieldType, sourceType)
               )
             }}
@@ -245,6 +259,7 @@ export function MappingFieldPicker({
           <QuickCreateFieldForm
             entityDefinitionId={entityDefinitionId}
             sourceType={sourceType}
+            ownedWrite={ownedWrite}
             excludeKeys={excludeKeys}
             seedName={humanizeFieldPath(sourcePath)}
             seedType={inferFieldType(sourcePath, sourceType, sourceFormat)}
@@ -293,6 +308,7 @@ function useFieldTypeGroups(): OptionGroup[] {
 function QuickCreateFieldForm({
   entityDefinitionId,
   sourceType,
+  ownedWrite,
   excludeKeys,
   seedName,
   seedType,
@@ -301,6 +317,7 @@ function QuickCreateFieldForm({
 }: {
   entityDefinitionId: string
   sourceType: string
+  ownedWrite?: boolean
   excludeKeys?: Set<string>
   seedName: string
   seedType: FieldTypeType
@@ -329,10 +346,10 @@ function QuickCreateFieldForm({
     const alreadyMapped = excludeKeys?.has(ref) ?? false
     const bindable =
       !alreadyMapped &&
-      isWritableTarget(existing) &&
+      isWritableTarget(existing, { ownedWrite }) &&
       isSourceTargetCompatible(existing.fieldType, sourceType)
     return { existing, ref, bindable, alreadyMapped }
-  }, [trimmed, fields, entityDefinitionId, excludeKeys, sourceType])
+  }, [trimmed, fields, entityDefinitionId, excludeKeys, sourceType, ownedWrite])
 
   const canSubmit = !!trimmed && !conflict && !create.isPending
 

--- a/apps/web/src/components/data-connectors/ui/mapping-node-helpers.ts
+++ b/apps/web/src/components/data-connectors/ui/mapping-node-helpers.ts
@@ -1,0 +1,69 @@
+// apps/web/src/components/data-connectors/ui/mapping-node-helpers.ts
+// Pure presentation helpers shared by the mapping editor's node/row components —
+// field-icon resolution, related-def lookup, and the source-rootPath → record-noun
+// phrasing for a mapping header. No React / no state.
+
+import type { FieldType } from '@auxx/database/types'
+import { fieldTypeOptions } from '@auxx/lib/custom-fields/types'
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { mapBaseTypeToFieldType } from '@auxx/lib/workflow-engine/client'
+import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
+import type { SourceTreeNode } from '../hooks/use-source-paths'
+
+/**
+ * The field-type icon for an applied target field — mirrors the picker-list row so the
+ * trigger chip matches what you picked. Falls back to the BaseType→FieldType mapping for
+ * system fields, then a generic `circle`.
+ */
+export function fieldIconId(field: ResourceField | undefined): string | undefined {
+  if (!field) return undefined
+  const fieldType =
+    (field.fieldType as FieldType) ||
+    (field.type ? mapBaseTypeToFieldType(field.type as any) : undefined)
+  return (fieldType && fieldTypeOptions[fieldType]?.iconId) ?? 'circle'
+}
+
+/** The related def a relationship field points at, or null if it has none. */
+export function relatedDefOf(field: ResourceField): string | null {
+  return field.relationship
+    ? getRelatedEntityDefinitionId(field.relationship as RelationshipConfig)
+    : null
+}
+
+/** Naive singularizer for record nouns (`todos → todo`, `line_items → line item`). */
+function singularize(word: string): string {
+  if (/ies$/.test(word)) return word.replace(/ies$/, 'y')
+  if (/(ss|sis|us)$/.test(word)) return word // address, analysis, status
+  if (/s$/.test(word)) return word.replace(/s$/, '')
+  return word
+}
+
+/** A source segment → a lowercase singular noun (`line_items[]` → `line item`). */
+function recordNoun(raw: string): string {
+  return singularize(raw.replace(/\[\]$/, '')).replace(/[_-]+/g, ' ').toLowerCase().trim()
+}
+
+/**
+ * Plain-language description of where a mapping's records come from, derived from the
+ * defined source schema. An ARRAY branch fans out one record per element, so it reads
+ * "each <noun>" (`drafts[]` → "each draft"); a SINGULAR object branch is one record, so
+ * it reads "one <noun>" (`customer` → "one customer"). The unnamed array ROOT (`[]`) has
+ * no schema name, so it falls back to the stream's own noun (stream key `todos` → "each
+ * todo"). Returns the parts split so the header can style the qualifier like a field's
+ * TYPE token and the noun like its LABEL (row-consistent).
+ */
+export function describeRootPath(
+  rootPath: string,
+  fallbackNoun?: string
+): { qualifier: string; noun: string } {
+  if (rootPath === '') return { qualifier: 'whole', noun: 'payload' }
+  const isArray = rootPath.endsWith('[]')
+  const seg = rootPath.replace(/\[\]$/, '').split('.').pop()
+  const noun = seg ? recordNoun(seg) : fallbackNoun ? recordNoun(fallbackNoun) : 'item'
+  return { qualifier: isArray ? 'each' : 'one', noun }
+}
+
+/** The fan-out rootPath for a branch node — arrays keep their `[]` suffix. */
+export function branchRootPath(node: SourceTreeNode): string {
+  return node.type === 'array' ? `${node.path}[]` : node.path
+}

--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -1,15 +1,9 @@
 // apps/web/src/components/data-connectors/ui/mapping-node.tsx
 'use client'
 
-import type { FieldType } from '@auxx/database/types'
-import { fieldTypeOptions } from '@auxx/lib/custom-fields/types'
 import { fieldMatchesRef, type ResourceField } from '@auxx/lib/resources/client'
-import { mapBaseTypeToFieldType } from '@auxx/lib/workflow-engine/client'
-import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
 import {
   type FieldReference,
-  fieldRefToKey,
-  getFieldDefinitionId,
   getFieldId,
   isFieldPath,
   keyToFieldRef,
@@ -17,108 +11,36 @@ import {
   toFieldPath,
 } from '@auxx/types/field'
 import { Badge } from '@auxx/ui/components/badge'
-import { Button } from '@auxx/ui/components/button'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { toastError } from '@auxx/ui/components/toast'
 import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { TreeRowButton } from '@auxx/ui/components/tree-row'
 import { generateId } from '@auxx/utils'
-import { FunctionSquare, Loader2, Plus, Sparkles, Trash2 } from 'lucide-react'
+import { Loader2, Plus, Sparkles, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { ResourcePicker } from '~/components/pickers/resource-picker'
 import { useResourceFields, useResourceProperty } from '~/components/resources'
 import { api } from '~/trpc/react'
-import {
-  absolutePrefix,
-  buildSourceTree,
-  leafPathsUnder,
-  type SourcePath,
-  type SourceTreeNode,
-  subtreeUnder,
-} from '../hooks/use-source-paths'
+import { useMappingActions } from '../hooks/use-mapping-actions'
+import { leafPathsUnder, type SourcePath, type SourceTreeNode } from '../hooks/use-source-paths'
 import type { FieldMapping } from '../hooks/use-stream-mutations'
 import type { DraftMapping, MappingDraftMutations } from '../stores/connector-draft-store'
 import { BranchRow } from './branch-row'
 import { CappedNodeList } from './capped-node-list'
 import { FieldCalcDialog } from './field-calc-dialog'
-import {
-  bareTokenSource,
-  bindingFor,
-  isBareToken,
-  removeBindingForSource,
-  retargetFormulaEntry,
-  setEntryIdentityRole,
-  upsertBinding,
-} from './field-mapping-edits'
-import { type IdentityRole, IdentityRoleControl } from './identity-role-control'
-import { MappingFieldPicker } from './mapping-field-picker'
-import { FieldRowActions, MappingRow } from './mapping-row'
+import { isBareToken } from './field-mapping-edits'
+import { DrilledFormulaRow, FormulaRow } from './formula-row'
+import { describeRootPath, fieldIconId } from './mapping-node-helpers'
+import { MappingRow } from './mapping-row'
+import { computeMappingView } from './mapping-view'
 import { RelationshipLinkRow } from './relationship-link-row'
 import { SourceLeafRow } from './source-leaf-row'
 
-// The mapping tree now renders from the connector DRAFT store (plans/data-connectors/v4),
+// The mapping tree renders from the connector DRAFT store (plans/data-connectors/v4),
 // so a row is a `DraftMapping` (fan-out/remove are temp-id/tombstone draft edits). The UI
 // reads only the common subset (id, def, link/target mode, fieldMappings, rootPath, parent,
 // relationshipFieldKey), all present on `DraftMapping`.
 type Mapping = DraftMapping
-
-/**
- * The field-type icon for an applied target field — mirrors {@link FieldItem}'s
- * regular-field branch so the trigger chip matches the picker-list row. Falls back
- * to the BaseType→FieldType mapping for system fields, then a generic `circle`.
- */
-function fieldIconId(field: ResourceField | undefined): string | undefined {
-  if (!field) return undefined
-  const fieldType =
-    (field.fieldType as FieldType) ||
-    (field.type ? mapBaseTypeToFieldType(field.type as any) : undefined)
-  return (fieldType && fieldTypeOptions[fieldType]?.iconId) ?? 'circle'
-}
-
-/** The related def a relationship field points at, or null if it has none. */
-function relatedDefOf(field: ResourceField): string | null {
-  return field.relationship
-    ? getRelatedEntityDefinitionId(field.relationship as RelationshipConfig)
-    : null
-}
-
-/** Naive singularizer for record nouns (`todos → todo`, `line_items → line item`). */
-function singularize(word: string): string {
-  if (/ies$/.test(word)) return word.replace(/ies$/, 'y')
-  if (/(ss|sis|us)$/.test(word)) return word // address, analysis, status
-  if (/s$/.test(word)) return word.replace(/s$/, '')
-  return word
-}
-
-/** A source segment → a lowercase singular noun (`line_items[]` → `line item`). */
-function recordNoun(raw: string): string {
-  return singularize(raw.replace(/\[\]$/, '')).replace(/[_-]+/g, ' ').toLowerCase().trim()
-}
-
-/**
- * Plain-language description of where a mapping's records come from, derived from
- * the defined source schema. An ARRAY branch fans out one record per element, so it
- * reads "each <noun>" (`drafts[]` → "each draft"); a SINGULAR object branch is one
- * record, so it reads "one <noun>" (`customer` → "one customer"). The unnamed array
- * ROOT (`[]`) has no schema name, so it falls back to the stream's own noun (stream
- * key `todos` → "each todo"). Returns the parts split so the header can style the
- * qualifier like a field's TYPE token and the noun like its LABEL (row-consistent).
- */
-function describeRootPath(
-  rootPath: string,
-  fallbackNoun?: string
-): { qualifier: string; noun: string } {
-  if (rootPath === '') return { qualifier: 'whole', noun: 'payload' }
-  const isArray = rootPath.endsWith('[]')
-  const seg = rootPath.replace(/\[\]$/, '').split('.').pop()
-  const noun = seg ? recordNoun(seg) : fallbackNoun ? recordNoun(fallbackNoun) : 'item'
-  return { qualifier: isArray ? 'each' : 'one', noun }
-}
-
-/** The fan-out rootPath for a branch node — arrays keep their `[]` suffix. */
-function branchRootPath(node: SourceTreeNode): string {
-  return node.type === 'array' ? `${node.path}[]` : node.path
-}
 
 export interface MappingNodeProps {
   mapping: Mapping
@@ -141,13 +63,13 @@ export interface MappingNodeProps {
 }
 
 /**
- * One `DataConnectorMapping` rendered as the source-schema subtree it owns (plan
- * §3.3). The header carries the target def + target mode toggle; identity
- * is configured per-leaf (the "Match" toggle), not in the header. The body
- * walks the mapping's subtree (sliced by {@link absolutePrefix} — the nesting-bug
- * fix) and, at each node, either binds a leaf, offers a branch action menu, or —
- * when a child mapping exists at that branch — recurses inline as the child
- * `MappingNode`. No separate appended child block.
+ * One `DataConnectorMapping` rendered as the source-schema subtree it owns (plan §3.3).
+ * The header carries the target def + target mode toggle; identity is configured per-leaf
+ * (the "Match" toggle), not in the header. The render model (which leaves bind, which
+ * branches promote to child mappings, which entries are formulas) is derived by
+ * {@link computeMappingView}; every data edit routes through {@link useMappingActions}. The
+ * body walks the mapping's subtree and, at each node, binds a leaf, offers a branch action,
+ * or recurses inline as the child `MappingNode`.
  */
 export function MappingNode({
   mapping,
@@ -163,14 +85,13 @@ export function MappingNode({
   syncedDefIds,
 }: MappingNodeProps) {
   const [open, setOpen] = useState(true)
-  // The formula entry the dialog is editing (null = closed). Carries the OWNING
-  // mapping id too, so the dialog can edit a drilled formula whose entry lives on a
-  // flat child — not just one on this parent mapping.
+  // The formula entry the dialog is editing (null = closed). Carries the OWNING mapping id
+  // too, so the dialog can edit a drilled formula whose entry lives on a flat child.
   const [calcTarget, setCalcTarget] = useState<{ mappingId: string; entryId: string } | null>(null)
-  const { setMappingTarget, removeMapping, setFieldMappings, fanOut } = mutations
+  const { setMappingTarget, removeMapping, setFieldMappings } = mutations
 
-  // Target def display + fields — resolved from the global resource store. App-owned
-  // defs are installed (real) before mapping (v6), so there's no projection layer.
+  // Target def display + fields — resolved from the global resource store. App-owned defs
+  // are installed (real) before mapping (v6), so there's no projection layer.
   const resource = useResourceProperty(mapping.entityDefinitionId, ['icon', 'label'])
   const { fields: targetFields } = useResourceFields(mapping.entityDefinitionId)
   const linkMode = mapping.linkMode as 'upsert' | 'reference'
@@ -181,13 +102,31 @@ export function MappingNode({
   const fieldByRef = (ref: string | null | undefined): ResourceField | undefined =>
     ref ? targetFields.find((f) => fieldMatchesRef(f, mapping.entityDefinitionId, ref)) : undefined
 
-  // Persist a new entry array (the single mapping field-write surface).
+  // The derived render model + every data-mutation handler.
+  const view = computeMappingView(mapping, sourcePaths, byMappingId, childrenOf)
+  const actions = useMappingActions({
+    streamId,
+    mapping,
+    fieldMappings,
+    view,
+    byMappingId,
+    targetFields,
+    mutations,
+  })
+
+  // Persist a new entry array (used by the suggester merge + add-formula draft).
   const writeEntries = (next: FieldMapping[]) => setFieldMappings(streamId, mapping.id, next)
 
-  // Tier 2 suggester (create-sync-flow §3.2) — only offered on a root-record
-  // mapping (whole payload / each item), where the suggester's record-relative
-  // leaves match this mapping's subtree. Merges proposals in as editable rows,
-  // skipping any source path or target field that's already bound.
+  // Every target field already bound by SOME entry — the pickers exclude these so two
+  // entries can't fight over one field (an array allows it; the UI forbids it).
+  const usedTargetKeys = new Set(
+    fieldMappings.map((e) => e.targetFieldRef).filter((k): k is string => k != null)
+  )
+
+  // Tier 2 suggester (create-sync-flow §3.2) — only offered on a root-record mapping (whole
+  // payload / each item), where the suggester's record-relative leaves match this mapping's
+  // subtree. Merges proposals in as editable rows, skipping any source path or target field
+  // that's already bound.
   const canSuggest =
     mapping.parentMappingId == null &&
     (mapping.rootPath === '' || mapping.rootPath === '[]') &&
@@ -210,183 +149,6 @@ export function MappingNode({
     },
     onError: (e) => toastError({ title: 'Could not suggest mappings', description: e.message }),
   })
-  // Patch one entry in place by its stable id (used by every per-entry mutation).
-  const patchEntry = (id: string, patch: Partial<FieldMapping>) =>
-    writeEntries(fieldMappings.map((e) => (e.id === id ? { ...e, ...patch } : e)))
-
-  // Patch an entry on ANY mapping (this one or a flat child) — needed because a
-  // drilled formula's entry lives on a child. Reads the target mapping's entries
-  // from the shared index so the write is over its current array.
-  const patchEntryIn = (mappingId: string, entryId: string, patch: Partial<FieldMapping>) => {
-    const entries = (byMappingId.get(mappingId)?.fieldMappings ?? []) as FieldMapping[]
-    setFieldMappings(
-      streamId,
-      mappingId,
-      entries.map((e) => (e.id === entryId ? { ...e, ...patch } : e))
-    )
-  }
-
-  // Every target field already bound by SOME entry — the pickers exclude these so
-  // two entries can't fight over one field (an array allows it; the UI forbids it).
-  const usedTargetKeys = new Set(
-    fieldMappings.map((e) => e.targetFieldRef).filter((k): k is string => k != null)
-  )
-
-  // Slice this mapping's subtree by its FULL absolute prefix (not the bare,
-  // parent-relative rootPath) so nested mappings render the correct subtree.
-  const prefix = absolutePrefix(mapping, byMappingId)
-  const relativeSubtree = subtreeUnder(sourcePaths, prefix)
-  const sourceTree = buildSourceTree(relativeSubtree)
-  const branchPaths = new Set(relativeSubtree.filter((p) => p.isBranch).map((p) => p.path))
-
-  // Child mappings indexed by their (array-normalized) rootPath segment, so a
-  // branch node at `line_items` matches a child mapping with rootPath
-  // `line_items[]`.
-  const childMappings = childrenOf.get(mapping.id) ?? []
-  // FLAT drilled children (unified picker §2): a child that reads the SAME subtree as
-  // this mapping (`rootPath: ''`) to write a related def — created by drilling a leaf's
-  // target across a relationship (e.g. `email → Contact.Email`). They surface INLINE on
-  // their source leaf (via `drilledBindBySourcePath`), NOT as nested nodes — so they're
-  // partitioned out of the branch/ref indexing below.
-  const flatDrilledChildren = childMappings.filter((c) => c.rootPath === '')
-  const nonFlatChildren = childMappings.filter((c) => c.rootPath !== '')
-  // Reference children (flat-FK links, Approach B) live on a SCALAR leaf, not a
-  // branch — index them separately so a linked leaf renders in "linked" state
-  // instead of being promoted to a nested MappingNode (the upsert fan-out path).
-  const upsertChildren = nonFlatChildren.filter((c) => c.linkMode !== 'reference')
-  const refChildByNodePath = new Map<string, Mapping>()
-  for (const c of nonFlatChildren) {
-    if (c.linkMode === 'reference') refChildByNodePath.set(c.rootPath.replace(/\[\]$/, ''), c)
-  }
-  const childByNodePath = new Map<string, Mapping>()
-  for (const c of upsertChildren) childByNodePath.set(c.rootPath.replace(/\[\]$/, ''), c)
-  // Children whose branch isn't in the current schema (e.g. schema regenerated)
-  // would otherwise vanish — render them appended so they stay editable/removable.
-  const orphanChildren = upsertChildren.filter(
-    (c) => !branchPaths.has(c.rootPath.replace(/\[\]$/, ''))
-  )
-
-  // A leaf bound ACROSS a relationship: its binding lives on a flat drilled child, but
-  // the leaf keeps its row (only the target chip reaches across). Index source path →
-  // { child, entry } so the leaf renders the drilled chip + routes its controls to the
-  // child mapping (unified picker §5).
-  const drilledBindBySourcePath = new Map<string, { child: Mapping; entry: FieldMapping }>()
-  for (const c of flatDrilledChildren) {
-    for (const e of (c.fieldMappings ?? []) as FieldMapping[]) {
-      if (e.targetFieldRef == null || !isBareToken(e.expression)) continue
-      drilledBindBySourcePath.set(bareTokenSource(e.expression), { child: c, entry: e })
-    }
-  }
-
-  // DRILLED FORMULAS (formula-drill-targets §2): a NON-bare entry on a flat child is a
-  // formula whose computed value writes a related def across the relationship — the
-  // formula analog of a drilled leaf bind. Bare entries on the same child are leaf
-  // binds (rendered inline via `drilledBindBySourcePath`); non-bare ones surface here
-  // as their own formula rows on this parent.
-  const drilledFormulaRows = flatDrilledChildren.flatMap((child) =>
-    ((child.fieldMappings ?? []) as FieldMapping[])
-      .filter((e) => !isBareToken(e.expression))
-      .map((entry) => ({ child, entry }))
-  )
-
-  // Reverse-index bare-token entries: source path → the binding entry on it.
-  const sourceToEntry = new Map<string, FieldMapping>()
-  for (const e of fieldMappings) {
-    if (isBareToken(e.expression)) sourceToEntry.set(e.expression.replace(/^\{|\}$/g, ''), e)
-  }
-
-  // Visible leaf paths under THIS mapping's subtree — a bare-token entry on one of
-  // these renders on its leaf (External-ID anchor included), so it must NOT also
-  // surface as a formula row.
-  const visibleLeafPaths = new Set(relativeSubtree.filter((p) => !p.isBranch).map((p) => p.path))
-
-  // Formula rows = computed entries (a multi-source formula has no single leaf to
-  // anchor on) PLUS target-less entries with nowhere to live on the source tree: a
-  // half-authored formula draft, or an orphaned bare token whose source path vanished
-  // (schema regenerated) — kept here so it stays editable/removable. A bare-token
-  // External-ID anchor on a VISIBLE leaf renders on that leaf, never here.
-  const formulaEntries = fieldMappings.filter(
-    (e) =>
-      !isBareToken(e.expression) ||
-      (e.targetFieldRef == null && !visibleLeafPaths.has(bareTokenSource(e.expression)))
-  )
-
-  const assignTarget = (sourcePath: string, targetRef: string) => {
-    // Drop any prior bare-token entry bound to this source (1 source → 1 target),
-    // then append a fresh entry with a stable id.
-    const next = fieldMappings.filter(
-      (e) => !(isBareToken(e.expression) && e.expression.replace(/^\{|\}$/g, '') === sourcePath)
-    )
-    next.push({
-      id: generateId(),
-      targetFieldRef: targetRef,
-      expression: `{${sourcePath}}`,
-      sourceFields: { [sourcePath]: sourcePath },
-    })
-    writeEntries(next)
-  }
-  const clearEntry = (id: string) => writeEntries(fieldMappings.filter((e) => e.id !== id))
-
-  // Re-point a formula at a different target field. Identity is the entry id, so
-  // this is a single field set — merge/match ride along, no re-key.
-  const retargetEntry = (id: string, newRef: string) => patchEntry(id, { targetFieldRef: newRef })
-
-  // Normalizer for a match key, derived from the target field's storage type so
-  // the role stays one-click (no normalize selector).
-  const deriveNormalize = (targetRef: string): 'email' | 'phone' | 'domain' | 'none' => {
-    const ft = fieldByRef(targetRef)?.fieldType
-    if (ft === 'EMAIL') return 'email'
-    if (ft === 'PHONE_INTL') return 'phone'
-    if (ft === 'URL') return 'domain'
-    return 'none'
-  }
-
-  // Set / clear a leaf's identity role (relationship-linking v3 §9.4). External ID
-  // is the primary upstream key (radio — picking it elsewhere moves it) and can live
-  // on an UNMAPPED leaf (an entry with no target). Match is a secondary key and
-  // needs a bound target. Clearing a role on an External-ID-only entry drops the
-  // entry entirely (it only existed to carry the role).
-  const setIdentityRole = (sourcePath: string, role: 'externalId' | 'match' | null) => {
-    let next = fieldMappings
-    // Radio: a single primary External ID per mapping — clear it elsewhere first.
-    if (role === 'externalId') {
-      next = next.map((e) =>
-        e.identityRole?.kind === 'externalId' ? { ...e, identityRole: undefined } : e
-      )
-    }
-    const idx = next.findIndex(
-      (e) => isBareToken(e.expression) && e.expression.replace(/^\{|\}$/g, '') === sourcePath
-    )
-    if (idx === -1) {
-      // No entry on this leaf yet — External ID creates an unmapped (target-less) one.
-      if (role == null) return
-      next = [
-        ...next,
-        {
-          id: generateId(),
-          targetFieldRef: null,
-          expression: `{${sourcePath}}`,
-          sourceFields: { [sourcePath]: sourcePath },
-          identityRole:
-            role === 'externalId' ? { kind: 'externalId' } : { kind: 'match', normalize: 'none' },
-        },
-      ]
-    } else {
-      const e = next[idx]!
-      if (role == null && e.targetFieldRef == null) {
-        next = next.filter((_, i) => i !== idx)
-      } else {
-        const identityRole =
-          role == null
-            ? undefined
-            : role === 'externalId'
-              ? ({ kind: 'externalId' } as const)
-              : ({ kind: 'match', normalize: deriveNormalize(e.targetFieldRef ?? '') } as const)
-        next = next.map((x, i) => (i === idx ? { ...x, identityRole } : x))
-      }
-    }
-    writeEntries(next)
-  }
 
   // Append a persisted draft formula (no target yet) and open the dialog on it.
   const addFormula = () => {
@@ -395,8 +157,8 @@ export function MappingNode({
     setCalcTarget({ mappingId: mapping.id, entryId: id })
   }
 
-  // The formula being edited may live on this parent OR a flat child — resolve it
-  // from the shared index by the dialog's owning mapping id.
+  // The formula being edited may live on this parent OR a flat child — resolve it from the
+  // shared index by the dialog's owning mapping id.
   const calcEntry = calcTarget
     ? ((byMappingId.get(calcTarget.mappingId)?.fieldMappings ?? []) as FieldMapping[]).find(
         (e) => e.id === calcTarget.entryId
@@ -410,259 +172,6 @@ export function MappingNode({
       targetMode: targetMode === 'owned' ? 'contributing' : 'owned',
       linkMode,
     })
-
-  // Materialize a child mapping at a branch by DRILLING a relationship off this
-  // mapping's def (relationship-linking v3 §11.1 — the core inversion). The related
-  // def is DERIVED from the drilled relationship (never freely picked), the edge is
-  // the drilled `FieldReference`, and the mode is forced `contributing` — so a null
-  // `relationshipFieldKey` and an owned-on-system-def footgun are both unrepresentable.
-  const materializeRelatedChild = (
-    node: SourceTreeNode,
-    field: ResourceField,
-    ref: FieldReference
-  ) => {
-    const relatedDefId = relatedDefOf(field)
-    if (!relatedDefId) return
-    fanOut(streamId, {
-      parentMappingId: mapping.id,
-      rootPath: branchRootPath(node),
-      linkMode: 'upsert', // server derives reference vs upsert from the field bindings
-      targetMode: 'contributing',
-      entityDefinitionId: relatedDefId,
-      relationshipFieldKey: fieldRefToKey(ref),
-    })
-  }
-
-  // Link a flat-FK SCALAR leaf to an existing relationship by drilling it (the
-  // id-only reference case, §9.6a Case B). Desugars to a child mapping rooted at the
-  // FK path whose ONLY binding is the FK marked External ID — so the runtime derives
-  // `reference` and anchors the lazy link on that id (no frozen target pointer). A
-  // prior link on the same leaf is replaced.
-  const linkRelationship = (node: SourceTreeNode, field: ResourceField, ref: FieldReference) => {
-    const relatedDefId = relatedDefOf(field)
-    if (!relatedDefId) return
-    const prior = refChildByNodePath.get(node.path)
-    if (prior) removeMapping(streamId, prior.id)
-    fanOut(streamId, {
-      parentMappingId: mapping.id,
-      rootPath: node.path,
-      linkMode: 'reference',
-      targetMode: 'contributing',
-      entityDefinitionId: relatedDefId,
-      relationshipFieldKey: fieldRefToKey(ref),
-      // Ship the anchor atomically: the FK value IS the related record's external id.
-      fieldMappings: [
-        {
-          id: generateId(),
-          targetFieldRef: null,
-          expression: '{source}',
-          sourceFields: {},
-          identityRole: { kind: 'externalId' },
-        },
-      ],
-    })
-  }
-
-  // Bind a leaf ACROSS a relationship (unified picker §2/§4): drill the target graph to
-  // a field on a related def — e.g. `email → Contact.Email`. Desugars to a FLAT
-  // contributing child mapping (`rootPath ''` reads THIS mapping's subtree,
-  // map-record.ts:285) carrying the binding, reusing one child per drilled
-  // relationship. v1 is single-hop (a 2-segment FieldPath).
-  const assignDrilled = (node: SourceTreeNode, _field: ResourceField, ref: FieldReference) => {
-    if (!isFieldPath(ref) || ref.length !== 2) {
-      toastError({
-        title: 'Multi-hop links not supported yet',
-        description: 'Pick a field one relationship away from this record.',
-      })
-      return
-    }
-    const rel = ref[0] // the drilled relationship, e.g. "order:contact"
-    const targetRef = ref[1] // the bound field on the related def, e.g. "contact:email"
-    const relatedDefId = getFieldDefinitionId(targetRef)
-    const relKey = fieldRefToKey(rel)
-    // Drop any prior DIRECT binding on this source — it now writes the related record.
-    if (sourceToEntry.has(node.path)) {
-      writeEntries(removeBindingForSource(fieldMappings, node.path))
-    }
-    const existing = flatDrilledChildren.find((c) => c.relationshipFieldKey === relKey)
-    if (existing) {
-      setFieldMappings(
-        streamId,
-        existing.id,
-        upsertBinding((existing.fieldMappings ?? []) as FieldMapping[], node.path, targetRef)
-      )
-      return
-    }
-    fanOut(streamId, {
-      parentMappingId: mapping.id,
-      rootPath: '', // flat: reads THIS mapping's subtree
-      linkMode: 'upsert', // server derives reference vs upsert from the bindings
-      targetMode: 'contributing',
-      entityDefinitionId: relatedDefId,
-      relationshipFieldKey: relKey,
-      fieldMappings: [bindingFor(node.path, targetRef)],
-    })
-  }
-
-  // Clear a drilled binding — drop it from the flat child, removing the child entirely
-  // once it carries no bindings (it existed only for drilled binds).
-  const clearDrilled = (node: SourceTreeNode) => {
-    const drilled = drilledBindBySourcePath.get(node.path)
-    if (!drilled) return
-    const remaining = removeBindingForSource(
-      (drilled.child.fieldMappings ?? []) as FieldMapping[],
-      node.path
-    )
-    if (remaining.length === 0) removeMapping(streamId, drilled.child.id)
-    else setFieldMappings(streamId, drilled.child.id, remaining)
-  }
-
-  // Identity role on a drilled leaf → patch the flat child's binding (External ID is a
-  // radio WITHIN that child — the related record's own key).
-  const setDrilledIdentityRole = (node: SourceTreeNode, role: 'externalId' | 'match' | null) => {
-    const drilled = drilledBindBySourcePath.get(node.path)
-    if (!drilled) return
-    setFieldMappings(
-      streamId,
-      drilled.child.id,
-      setEntryIdentityRole(
-        (drilled.child.fieldMappings ?? []) as FieldMapping[],
-        drilled.entry.id,
-        role,
-        deriveNormalize(drilled.entry.targetFieldRef ?? '')
-      )
-    )
-  }
-
-  // Merge strategy on a drilled leaf → patch the flat child's binding.
-  const setDrilledMerge = (node: SourceTreeNode, value: string) => {
-    const drilled = drilledBindBySourcePath.get(node.path)
-    if (!drilled) return
-    setFieldMappings(
-      streamId,
-      drilled.child.id,
-      ((drilled.child.fieldMappings ?? []) as FieldMapping[]).map((e) =>
-        e.id === drilled.entry.id
-          ? { ...e, mergeStrategy: value as FieldMapping['mergeStrategy'] }
-          : e
-      )
-    )
-  }
-
-  // ── Formula drill-across-relationship (formula-drill-targets §3) ──────────────
-  // A formula entry's "home" is either THIS parent mapping (a root-scalar target) or a
-  // flat child (a target a relationship away). Picking a target moves the entry to its
-  // desired home, preserving the expression. The flat child is REUSED per relationship
-  // (shared with drilled leaf binds) and GC'd when its last entry leaves.
-
-  // v1 drills are single-hop — a 2-segment FieldPath. Returns [rel, targetRef] or null
-  // (after toasting) for a root scalar / deeper path.
-  const asSingleHop = (ref: FieldReference): [ResourceFieldId, ResourceFieldId] | null => {
-    if (!isFieldPath(ref) || ref.length !== 2) {
-      toastError({
-        title: 'Multi-hop links not supported yet',
-        description: 'Pick a field one relationship away from this record.',
-      })
-      return null
-    }
-    return [ref[0], ref[1]]
-  }
-
-  // Upsert a (re-homed) formula entry into the flat child for `rel`, creating it if
-  // absent. The entry already carries its far-field target + expression.
-  const upsertFormulaIntoRelChild = (rel: ResourceFieldId, entry: FieldMapping) => {
-    const relKey = fieldRefToKey(rel)
-    const relatedDefId = getFieldDefinitionId(entry.targetFieldRef as ResourceFieldId)
-    const existing = flatDrilledChildren.find((c) => c.relationshipFieldKey === relKey)
-    if (existing) {
-      const next = [
-        ...((existing.fieldMappings ?? []) as FieldMapping[]).filter((e) => e.id !== entry.id),
-        entry,
-      ]
-      setFieldMappings(streamId, existing.id, next)
-      return
-    }
-    fanOut(streamId, {
-      parentMappingId: mapping.id,
-      rootPath: '', // flat: reads THIS mapping's subtree
-      linkMode: 'upsert', // server derives reference vs upsert from the bindings
-      targetMode: 'contributing',
-      entityDefinitionId: relatedDefId,
-      relationshipFieldKey: relKey,
-      fieldMappings: [entry],
-    })
-  }
-
-  // Drop a formula entry from a flat child, GC'ing the child when nothing remains.
-  const removeFormulaFromChild = (child: Mapping, entryId: string) => {
-    const remaining = ((child.fieldMappings ?? []) as FieldMapping[]).filter(
-      (e) => e.id !== entryId
-    )
-    if (remaining.length === 0) removeMapping(streamId, child.id)
-    else setFieldMappings(streamId, child.id, remaining)
-  }
-
-  // A HOME formula gains a drilled target → move it onto the relationship's flat child.
-  const drillHomeFormula = (entry: FieldMapping, ref: FieldReference) => {
-    const hop = asSingleHop(ref)
-    if (!hop) return
-    writeEntries(fieldMappings.filter((e) => e.id !== entry.id))
-    upsertFormulaIntoRelChild(hop[0], retargetFormulaEntry(entry, hop[1]))
-  }
-
-  // A DRILLED formula is retargeted to a ROOT scalar → move it back to this parent.
-  const undrillFormula = (child: Mapping, entry: FieldMapping, targetRef: string) => {
-    removeFormulaFromChild(child, entry.id)
-    writeEntries([...fieldMappings, retargetFormulaEntry(entry, targetRef)])
-  }
-
-  // A DRILLED formula gains another drilled target → retarget in place when the
-  // relationship is unchanged, else move it to the new relationship's child.
-  const redrillFormula = (child: Mapping, entry: FieldMapping, ref: FieldReference) => {
-    const hop = asSingleHop(ref)
-    if (!hop) return
-    if (child.relationshipFieldKey === fieldRefToKey(hop[0])) {
-      patchEntryIn(child.id, entry.id, { targetFieldRef: hop[1] })
-      return
-    }
-    removeFormulaFromChild(child, entry.id)
-    upsertFormulaIntoRelChild(hop[0], retargetFormulaEntry(entry, hop[1]))
-  }
-
-  // Identity role on a HOME formula (formula-drill-targets §5.1) — keyed by ENTRY ID,
-  // since a formula has no single source path. External ID stays a radio WITHIN this
-  // mapping (the record's own key); the runtime evaluates the expression as the key,
-  // so a composite/computed External ID works with no engine change.
-  const setFormulaIdentityRole = (entryId: string, role: IdentityRole) => {
-    const entry = fieldMappings.find((e) => e.id === entryId)
-    writeEntries(
-      setEntryIdentityRole(
-        fieldMappings,
-        entryId,
-        role,
-        deriveNormalize(entry?.targetFieldRef ?? '')
-      )
-    )
-  }
-
-  // Identity role on a DRILLED formula → patch the flat child's entry (External ID is a
-  // radio WITHIN that child — the related record's own key).
-  const setDrilledFormulaIdentityRole = (
-    child: Mapping,
-    entry: FieldMapping,
-    role: IdentityRole
-  ) => {
-    setFieldMappings(
-      streamId,
-      child.id,
-      setEntryIdentityRole(
-        (child.fieldMappings ?? []) as FieldMapping[],
-        entry.id,
-        role,
-        deriveNormalize(entry.targetFieldRef ?? '')
-      )
-    )
-  }
 
   return (
     <>
@@ -753,7 +262,7 @@ export function MappingNode({
             </TreeRowButton>
           </>
         }>
-        {sourceTree.length === 0 ? (
+        {view.sourceTree.length === 0 ? (
           <div
             style={{ paddingLeft: `${(depth + 1) * 1.5}rem` }}
             className='px-1 py-1 text-[11px] text-muted-foreground'>
@@ -761,13 +270,13 @@ export function MappingNode({
           </div>
         ) : (
           <CappedNodeList
-            nodes={sourceTree}
+            nodes={view.sourceTree}
             childDepth={depth + 1}
             isCappable={(n) =>
               !n.isBranch &&
-              !sourceToEntry.has(n.path) &&
-              !refChildByNodePath.has(n.path) &&
-              !drilledBindBySourcePath.has(n.path)
+              !view.sourceToEntry.has(n.path) &&
+              !view.refChildByNodePath.has(n.path) &&
+              !view.drilledBindBySourcePath.has(n.path)
             }
             renderNode={(node) => (
               <SourceNode
@@ -777,24 +286,24 @@ export function MappingNode({
                 mapping={mapping}
                 targetMode={targetMode}
                 targetFields={targetFields}
-                sourceToEntry={sourceToEntry}
+                sourceToEntry={view.sourceToEntry}
                 usedTargetKeys={usedTargetKeys}
-                childByNodePath={childByNodePath}
-                refChildByNodePath={refChildByNodePath}
-                drilledBindBySourcePath={drilledBindBySourcePath}
-                onAssign={assignTarget}
-                onClear={clearEntry}
+                childByNodePath={view.childByNodePath}
+                refChildByNodePath={view.refChildByNodePath}
+                drilledBindBySourcePath={view.drilledBindBySourcePath}
+                onAssign={actions.assignTarget}
+                onClear={actions.clearEntry}
                 onMergeChange={(id, value) =>
-                  patchEntry(id, { mergeStrategy: value as FieldMapping['mergeStrategy'] })
+                  actions.patchEntry(id, { mergeStrategy: value as FieldMapping['mergeStrategy'] })
                 }
-                onSetIdentityRole={setIdentityRole}
-                onFanOutRelationship={materializeRelatedChild}
-                onLinkRelationship={linkRelationship}
+                onSetIdentityRole={actions.setIdentityRole}
+                onFanOutRelationship={actions.materializeRelatedChild}
+                onLinkRelationship={actions.linkRelationship}
                 onClearLink={(refChildId) => removeMapping(streamId, refChildId)}
-                onAssignDrilled={assignDrilled}
-                onClearDrilled={clearDrilled}
-                onSetDrilledIdentityRole={setDrilledIdentityRole}
-                onDrilledMergeChange={setDrilledMerge}
+                onAssignDrilled={actions.assignDrilled}
+                onClearDrilled={actions.clearDrilled}
+                onSetDrilledIdentityRole={actions.setDrilledIdentityRole}
+                onDrilledMergeChange={actions.setDrilledMerge}
                 // Child-mapping recursion context.
                 connectorId={connectorId}
                 streamId={streamId}
@@ -810,11 +319,11 @@ export function MappingNode({
           />
         )}
 
-        {/* Formula rows — one per non-bare field mapping (a computed target field),
-          plus an add row. Reference-mode mappings only link, so no formulas. */}
+        {/* Formula rows — one per non-bare field mapping (a computed target field), plus an
+          add row. Reference-mode mappings only link, so no formulas. */}
         {linkMode !== 'reference' && (
           <>
-            {formulaEntries.map((e) => (
+            {view.formulaEntries.map((e) => (
               <FormulaRow
                 key={e.id}
                 depth={depth + 1}
@@ -828,8 +337,8 @@ export function MappingNode({
                 mergeStrategy={e.mergeStrategy ?? 'overwrite'}
                 // Drilling is offered once a target def is set (formula-drill-targets §4).
                 allowRelationships={mapping.entityDefinitionId != null}
-                // Exclude keys other entries already bind, so a formula can't be
-                // retargeted onto a field already in use.
+                // Exclude keys other entries already bind, so a formula can't be retargeted
+                // onto a field already in use.
                 excludeKeys={
                   e.targetFieldRef
                     ? new Set([...usedTargetKeys].filter((k) => k !== e.targetFieldRef))
@@ -837,20 +346,23 @@ export function MappingNode({
                 }
                 identityRole={e.identityRole?.kind ?? null}
                 canMatch={e.targetFieldRef != null}
-                onSetIdentityRole={(role) => setFormulaIdentityRole(e.id, role)}
+                ownedWrite={targetMode === 'owned'}
+                onSetIdentityRole={(role) => actions.setFormulaIdentityRole(e.id, role)}
                 onEdit={() => setCalcTarget({ mappingId: mapping.id, entryId: e.id })}
-                onRetarget={(newKey) => retargetEntry(e.id, newKey)}
-                onDrilledAssign={(ref) => drillHomeFormula(e, ref)}
+                onRetarget={(newKey) => actions.retargetEntry(e.id, newKey)}
+                onDrilledAssign={(ref) => actions.drillHomeFormula(e, ref)}
                 onMergeChange={(value) =>
-                  patchEntry(e.id, { mergeStrategy: value as FieldMapping['mergeStrategy'] })
+                  actions.patchEntry(e.id, {
+                    mergeStrategy: value as FieldMapping['mergeStrategy'],
+                  })
                 }
-                onClear={() => clearEntry(e.id)}
+                onClear={() => actions.clearEntry(e.id)}
               />
             ))}
-            {/* Drilled formulas — a computed value written across a relationship; its
-              entry lives on a flat child, but it renders here as a formula row whose
-              chip reaches across ("Contact › Full name"). */}
-            {drilledFormulaRows.map(({ child, entry }) => (
+            {/* Drilled formulas — a computed value written across a relationship; its entry
+              lives on a flat child, but it renders here as a formula row whose chip reaches
+              across ("Contact › Full name"). */}
+            {view.drilledFormulaRows.map(({ child, entry }) => (
               <DrilledFormulaRow
                 key={entry.id}
                 depth={depth + 1}
@@ -858,27 +370,29 @@ export function MappingNode({
                 child={child}
                 entry={entry}
                 excludeKeys={usedTargetKeys}
-                onSetIdentityRole={(role) => setDrilledFormulaIdentityRole(child, entry, role)}
+                ownedWrite={targetMode === 'owned'}
+                onSetIdentityRole={(role) =>
+                  actions.setDrilledFormulaIdentityRole(child, entry, role)
+                }
                 onEdit={() => setCalcTarget({ mappingId: child.id, entryId: entry.id })}
-                onRetargetRoot={(newKey) => undrillFormula(child, entry, newKey)}
-                onDrilledAssign={(ref) => redrillFormula(child, entry, ref)}
+                onRetargetRoot={(newKey) => actions.undrillFormula(child, entry, newKey)}
+                onDrilledAssign={(ref) => actions.redrillFormula(child, entry, ref)}
                 onMergeChange={(value) =>
-                  patchEntryIn(child.id, entry.id, {
+                  actions.patchEntryIn(child.id, entry.id, {
                     mergeStrategy: value as FieldMapping['mergeStrategy'],
                   })
                 }
-                onClear={() => removeFormulaFromChild(child, entry.id)}
+                onClear={() => actions.removeFormulaFromChild(child, entry.id)}
               />
             ))}
             {mapping.entityDefinitionId != null && (
               <MappingRow
                 depth={depth + 1}
                 icon={<Plus className='size-3.5 text-muted-foreground/50' />}
-                // "Add formula" persists a fresh draft row (no target yet) and opens
-                // the expression dialog on it — you author the formula first and pick
-                // the destination field after (or leave it unassigned for later). The
-                // WHOLE row is the click target (onToggleOpen drives the row onClick),
-                // and the label reads like a field (font-mono text-sm, foreground).
+                // "Add formula" persists a fresh draft row (no target yet) and opens the
+                // expression dialog on it — you author the formula first and pick the
+                // destination field after (or leave it unassigned for later). The WHOLE row
+                // is the click target, and the label reads like a field.
                 onToggleOpen={addFormula}
                 title={<span className='font-mono text-sm'>Add formula</span>}
               />
@@ -886,9 +400,9 @@ export function MappingNode({
           </>
         )}
 
-        {/* Child mappings whose branch isn't in the current schema — appended so
-          they don't silently disappear (and stay removable). */}
-        {orphanChildren.map((child) => (
+        {/* Child mappings whose branch isn't in the current schema — appended so they don't
+          silently disappear (and stay removable). */}
+        {view.orphanChildren.map((child) => (
           <MappingNode
             key={child.id}
             mapping={child}
@@ -906,10 +420,10 @@ export function MappingNode({
         ))}
       </MappingRow>
 
-      {/* The formula editor — opened by a formula row's source button or the
-          "Add formula" row. Source paths are scoped to this mapping's subtree
-          (matching the runtime); a drilled formula's flat child reads the SAME
-          subtree (`rootPath ''`), so the same paths apply. */}
+      {/* The formula editor — opened by a formula row's source button or the "Add formula"
+          row. Source paths are scoped to this mapping's subtree (matching the runtime); a
+          drilled formula's flat child reads the SAME subtree (`rootPath ''`), so the same
+          paths apply. */}
       <FieldCalcDialog
         open={calcTarget !== null}
         onOpenChange={(o) => !o && setCalcTarget(null)}
@@ -919,10 +433,13 @@ export function MappingNode({
             : ''
         }
         expression={calcEntry?.expression ?? ''}
-        sourcePaths={leafPathsUnder(sourcePaths, prefix)}
+        sourcePaths={leafPathsUnder(sourcePaths, view.prefix)}
         onSave={(expression, sourceFields) => {
           if (!calcTarget) return
-          patchEntryIn(calcTarget.mappingId, calcTarget.entryId, { expression, sourceFields })
+          actions.patchEntryIn(calcTarget.mappingId, calcTarget.entryId, {
+            expression,
+            sourceFields,
+          })
         }}
       />
     </>
@@ -980,10 +497,10 @@ interface SourceNodeProps {
 }
 
 /**
- * One node of a mapping's source subtree (plan §3.3). Resolves to one of three
- * renders: a promoted child `MappingNode` (a child mapping exists at this
- * branch), an un-promoted {@link BranchRow} (object/array container + action
- * menu), or a {@link SourceLeafRow} (scalar / array-of-scalars binding).
+ * One node of a mapping's source subtree (plan §3.3). Resolves to one of three renders: a
+ * promoted child `MappingNode` (a child mapping exists at this branch), an un-promoted
+ * {@link BranchRow} (object/array container + action menu), or a {@link SourceLeafRow}
+ * (scalar / array-of-scalars binding).
  */
 function SourceNode(props: SourceNodeProps) {
   const {
@@ -1003,10 +520,10 @@ function SourceNode(props: SourceNodeProps) {
   } = props
   const [open, setOpen] = useState(true)
 
-  // Drilled-binding context — a leaf bound ACROSS a relationship (its value writes a
-  // related record). Resolve the related def's label + the bound field's label for the
-  // chip ("Contact › Email"). Hooks run unconditionally (null def when not drilled) so
-  // order stays stable across the branch/leaf early returns below.
+  // Drilled-binding context — a leaf bound ACROSS a relationship (its value writes a related
+  // record). Resolve the related def's label + the bound field's label for the chip
+  // ("Contact › Email"). Hooks run unconditionally (null def when not drilled) so order
+  // stays stable across the branch/leaf early returns below.
   const drilled = !node.isBranch ? props.drilledBindBySourcePath.get(node.path) : undefined
   const drilledDefId = drilled?.child.entityDefinitionId ?? null
   const drilledDef = useResourceProperty(drilledDefId, ['label'])
@@ -1046,8 +563,8 @@ function SourceNode(props: SourceNodeProps) {
         node={node}
         isOpen={open}
         onToggleOpen={() => setOpen((o) => !o)}
-        // A branch INSIDE a mapping fans out by drilling a relationship off the
-        // parent def (§11.1) — the related def is derived, never freely picked.
+        // A branch INSIDE a mapping fans out by drilling a relationship off the parent def
+        // (§11.1) — the related def is derived, never freely picked.
         parentEntityDefinitionId={mapping.entityDefinitionId}
         onFanOutRelationship={(field, ref) => onFanOutRelationship(node, field, ref)}>
         <CappedNodeList
@@ -1079,9 +596,9 @@ function SourceNode(props: SourceNodeProps) {
     ? new Set([...usedTargetKeys].filter((k) => k !== assignedTargetKey))
     : usedTargetKeys
 
-  // A drilled binding (this leaf's value writes a related def, via a flat child) — the
-  // chip reaches across the relationship ("Contact › Email") and the controls route to
-  // the child. Direct and drilled are mutually exclusive on one leaf.
+  // A drilled binding (this leaf's value writes a related def, via a flat child) — the chip
+  // reaches across the relationship ("Contact › Email") and the controls route to the child.
+  // Direct and drilled are mutually exclusive on one leaf.
   let drilledLabel: string | undefined
   let drilledRef: FieldReference | undefined
   let drilledIconId: string | undefined
@@ -1099,12 +616,11 @@ function SourceNode(props: SourceNodeProps) {
     drilledRef = toFieldPath([...relSegs, drilled.entry.targetFieldRef as ResourceFieldId])
   }
 
-  // Id-only relationship link (§9.6a Case B): a `reference` child mapping on this
-  // leaf path links the FK to a relationship. Independent of the scalar binding —
-  // the leaf keeps its scalar cell; the link renders on its own sub-row. The stored
-  // `relationshipFieldKey` is a serialized FieldReference (single-drill = the
-  // relationship's `ResourceFieldId`), so resolve the field by that ref. (`refChild` +
-  // its resolved def are hoisted above for rules-of-hooks.)
+  // Id-only relationship link (§9.6a Case B): a `reference` child mapping on this leaf path
+  // links the FK to a relationship. Independent of the scalar binding — the leaf keeps its
+  // scalar cell; the link renders on its own sub-row. The stored `relationshipFieldKey` is a
+  // serialized FieldReference (single-drill = the relationship's `ResourceFieldId`), so
+  // resolve the field by that ref.
   const refKey = refChild?.relationshipFieldKey ?? undefined
   const linkedField = refKey
     ? targetFields.find((f) => fieldMatchesRef(f, mapping.entityDefinitionId, refKey))
@@ -1115,8 +631,8 @@ function SourceNode(props: SourceNodeProps) {
   // identity-role + merge controls.
   const activeEntry = drilled?.entry ?? directEntry
   const identityRole = activeEntry?.identityRole?.kind ?? null
-  // Relationships are linkable/drillable on a SCALAR leaf only (array fan-out is a
-  // branch drill), once a target def is set.
+  // Relationships are linkable/drillable on a SCALAR leaf only (array fan-out is a branch
+  // drill), once a target def is set.
   const allowRelationships = node.type !== 'array' && !!mapping.entityDefinitionId
 
   return (
@@ -1165,211 +681,5 @@ function SourceNode(props: SourceNodeProps) {
         />
       )}
     </>
-  )
-}
-
-// ── Formula row (a computed target field) ──────────────────────────────────────
-
-interface FormulaRowProps {
-  depth: number
-  /** The def the picker drills/binds FROM. Null until a target def is picked. */
-  entityDefinitionId: string | null
-  /** Target field key this formula currently writes into (`''` if unassigned). */
-  targetKey: string
-  /** Resolved label for the target field. */
-  label: string
-  /** Resolved icon id for the target field (for the picker chip). */
-  iconId?: string
-  /** The calc expression (shown on the source button; click it to edit). */
-  expression: string
-  mergeStrategy: string
-  /** Target keys bound by other entries — excluded from the retarget picker. */
-  excludeKeys?: Set<string>
-  /** Show relationships in the picker so the formula can drill ACROSS one (§4). */
-  allowRelationships?: boolean
-  /** Chip text when bound across a relationship ("Contact › Full name"). */
-  drilledLabel?: string
-  /** The drilled `FieldPath`, for the picker's selected check on the far field. */
-  drilledRef?: FieldReference
-  /** This formula's identity role (External ID / Match), keyed by entry id (§5.1). */
-  identityRole?: IdentityRole
-  /** Offer the "Match existing" option — needs a bound target to compare against. */
-  canMatch?: boolean
-  onEdit: () => void
-  /** Re-point the formula at a different ROOT target field key. */
-  onRetarget: (newKey: string) => void
-  /** The picker drilled to a far field — bind the computed value across the relationship. */
-  onDrilledAssign?: (ref: FieldReference) => void
-  /** Set / clear this formula's identity role. Absent → no identifier control. */
-  onSetIdentityRole?: (role: IdentityRole) => void
-  onMergeChange: (value: string) => void
-  onClear: () => void
-}
-
-/**
- * A computed target field (plan 10 §3.2) — a non-bare `fieldMappings` entry that
- * can reference many source fields, so it lives on its own row rather than on a
- * source leaf. Mirrors a leaf row: the source cell is a button (showing the calc
- * expression, or "Set formula…") that opens {@link FieldCalcDialog}; the target
- * column is a field picker (a formula produces a scalar — string-typed for the
- * compat filter). With {@link allowRelationships} the picker can drill ACROSS a
- * relationship to write a related def (formula-drill-targets §4). The identity
- * control (keyed by entry id) marks the computed value as the record's External ID
- * or a Match key (§5.1) — the runtime evaluates the expression as the key.
- */
-function FormulaRow({
-  depth,
-  entityDefinitionId,
-  targetKey,
-  label,
-  iconId,
-  expression,
-  mergeStrategy,
-  excludeKeys,
-  allowRelationships,
-  drilledLabel,
-  drilledRef,
-  identityRole,
-  canMatch,
-  onEdit,
-  onRetarget,
-  onDrilledAssign,
-  onSetIdentityRole,
-  onMergeChange,
-  onClear,
-}: FormulaRowProps) {
-  return (
-    <MappingRow
-      depth={depth}
-      icon={<FunctionSquare className='size-3.5' />}
-      // Source cell = a button that opens the formula dialog (shows the expression
-      // when set), trailed by the identity key icon; target column = the field it
-      // writes into.
-      title={
-        <span className='flex w-full items-center gap-1'>
-          <Button
-            variant='transparent'
-            onClick={onEdit}
-            className={`h-9 min-w-0 flex-1 justify-start rounded-none px-1 text-xs hover:bg-primary/5 ${
-              expression ? 'font-mono' : 'text-muted-foreground'
-            }`}>
-            <span className='truncate'>{expression || 'Set formula…'}</span>
-          </Button>
-          {onSetIdentityRole && (
-            <IdentityRoleControl
-              role={identityRole ?? null}
-              canMatch={!!canMatch}
-              onChange={onSetIdentityRole}
-            />
-          )}
-        </span>
-      }
-      arrow='filled'
-      target={
-        <MappingFieldPicker
-          entityDefinitionId={entityDefinitionId}
-          // A formula has no single source type — it yields a scalar; 'string'
-          // drives the (TEXT-compatible) target filter. Quick-create is off; a
-          // formula targets an existing field.
-          sourceType='string'
-          sourcePath=''
-          assignedKey={targetKey || undefined}
-          // Drilled chip wins; else the field label, or undefined (not '') so the
-          // picker falls back to its "Apply field…" placeholder.
-          assignedLabel={drilledLabel ?? (label || undefined)}
-          assignedIconId={iconId}
-          drilledRef={drilledRef}
-          excludeKeys={excludeKeys}
-          canCreate={false}
-          allowRelationships={allowRelationships}
-          onAssign={onRetarget}
-          // The picker hands back (field, ref); a formula only needs the path.
-          onDrilledAssign={onDrilledAssign ? (_field, ref) => onDrilledAssign(ref) : undefined}
-          onClear={onClear}
-        />
-      }
-      // Right-aligned merge → trash, matching the leaf/header rows. No Identifier —
-      // a formula has no single source path to match identity on.
-      actions={
-        <FieldRowActions
-          mergeStrategy={mergeStrategy}
-          onMergeChange={onMergeChange}
-          onClear={onClear}
-          clearTooltip='Remove formula'
-        />
-      }
-    />
-  )
-}
-
-/**
- * A formula bound ACROSS a relationship (formula-drill-targets §4): its entry lives
- * on a flat child mapping, but it renders as a {@link FormulaRow} on the parent whose
- * picker roots at the PARENT def (so it offers the same drill) and whose chip reaches
- * across to "Def › Field". Resolves that chip + the far field's icon from the child's
- * def. Controls route to the child's entry via the handlers from the parent.
- */
-function DrilledFormulaRow({
-  depth,
-  parentEntityDefinitionId,
-  child,
-  entry,
-  excludeKeys,
-  onSetIdentityRole,
-  onEdit,
-  onRetargetRoot,
-  onDrilledAssign,
-  onMergeChange,
-  onClear,
-}: {
-  depth: number
-  parentEntityDefinitionId: string | null
-  child: Mapping
-  entry: FieldMapping
-  excludeKeys?: Set<string>
-  onSetIdentityRole: (role: IdentityRole) => void
-  onEdit: () => void
-  onRetargetRoot: (newKey: string) => void
-  onDrilledAssign: (ref: FieldReference) => void
-  onMergeChange: (value: string) => void
-  onClear: () => void
-}) {
-  const def = useResourceProperty(child.entityDefinitionId, ['label'])
-  const { fields } = useResourceFields(child.entityDefinitionId)
-  const targetRef = (entry.targetFieldRef ?? null) as ResourceFieldId | null
-  const farField = targetRef
-    ? fields.find((f) => fieldMatchesRef(f, child.entityDefinitionId, targetRef))
-    : undefined
-  const fieldLabel = targetRef ? (farField?.label ?? getFieldId(targetRef)) : ''
-  const drilledLabel = `${def?.label ?? 'Related'} › ${fieldLabel}`
-  // Rebuild the drilled FieldPath ([rel…, targetRef]) for the picker's selected check.
-  const relRef = keyToFieldRef(child.relationshipFieldKey ?? '')
-  const relSegs = isFieldPath(relRef) ? relRef : [relRef as ResourceFieldId]
-  const drilledRef = targetRef ? toFieldPath([...relSegs, targetRef]) : undefined
-
-  return (
-    <FormulaRow
-      depth={depth}
-      // Root the picker at the PARENT def so it offers the same drill.
-      entityDefinitionId={parentEntityDefinitionId}
-      targetKey={targetRef ?? ''}
-      label={fieldLabel}
-      iconId={fieldIconId(farField)}
-      expression={entry.expression}
-      mergeStrategy={entry.mergeStrategy ?? 'overwrite'}
-      excludeKeys={excludeKeys}
-      allowRelationships={parentEntityDefinitionId != null}
-      drilledLabel={drilledLabel}
-      drilledRef={drilledRef}
-      // External ID here keys the RELATED record (a radio within the flat child).
-      identityRole={entry.identityRole?.kind ?? null}
-      canMatch={targetRef != null}
-      onSetIdentityRole={onSetIdentityRole}
-      onEdit={onEdit}
-      onRetarget={onRetargetRoot}
-      onDrilledAssign={onDrilledAssign}
-      onMergeChange={onMergeChange}
-      onClear={onClear}
-    />
   )
 }

--- a/apps/web/src/components/data-connectors/ui/mapping-view.test.ts
+++ b/apps/web/src/components/data-connectors/ui/mapping-view.test.ts
@@ -1,0 +1,102 @@
+// apps/web/src/components/data-connectors/ui/mapping-view.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { SourcePath } from '../hooks/use-source-paths'
+import type { DraftMapping } from '../stores/connector-draft-store'
+import { computeMappingView } from './mapping-view'
+
+/** Minimal DraftMapping with just the fields computeMappingView reads. */
+function mapping(m: Partial<DraftMapping> & Pick<DraftMapping, 'id' | 'rootPath'>): DraftMapping {
+  return {
+    parentMappingId: null,
+    linkMode: 'upsert',
+    targetMode: 'contributing',
+    entityDefinitionId: null,
+    relationshipFieldKey: null,
+    fieldMappings: [],
+    ...m,
+  } as DraftMapping
+}
+
+function indices(rows: DraftMapping[]) {
+  const byMappingId = new Map<string, DraftMapping>()
+  const childrenOf = new Map<string | null, DraftMapping[]>()
+  for (const m of rows) {
+    byMappingId.set(m.id, m)
+    const key = m.parentMappingId ?? null
+    const list = childrenOf.get(key) ?? []
+    list.push(m)
+    childrenOf.set(key, list)
+  }
+  return { byMappingId, childrenOf }
+}
+
+// The Shopify order shape: order root → line_items[] (owned child) → product_id (the FK).
+const SOURCE_PATHS: SourcePath[] = [
+  { path: 'line_items', type: 'array', depth: 0, isBranch: true },
+  { path: 'line_items[].sku', type: 'string', depth: 0, isBranch: false },
+  { path: 'line_items[].product_id', type: 'integer', depth: 0, isBranch: false },
+]
+
+describe('computeMappingView — nested reference child keying', () => {
+  const root = mapping({ id: 'root', rootPath: '' })
+  const line = mapping({ id: 'line', rootPath: 'line_items[]', parentMappingId: 'root' })
+
+  it('keys a RELATIVE-rootPath reference child to its leaf node (the seeding-fix contract)', () => {
+    // Correctly-seeded: the product reference under line_items[] stores rootPath
+    // `product_id` (parent-relative), matching the relative leaf node in this subtree.
+    const product = mapping({
+      id: 'prod',
+      rootPath: 'product_id',
+      parentMappingId: 'line',
+      linkMode: 'reference',
+    })
+    const { byMappingId, childrenOf } = indices([root, line, product])
+
+    const view = computeMappingView(line, SOURCE_PATHS, byMappingId, childrenOf)
+
+    // The line subtree exposes `sku` + `product_id` as relative leaves.
+    expect(view.sourceTree.map((n) => n.path).sort()).toEqual(['product_id', 'sku'])
+    // The reference child renders INLINE on the product_id leaf.
+    expect(view.refChildByNodePath.get('product_id')).toBe(product)
+    expect(view.orphanChildren).toEqual([])
+  })
+
+  it('does NOT match an ABSOLUTE-rootPath reference child (the bug this guards against)', () => {
+    // The mis-seeded shape (payload-absolute rootPath) keys on the wrong path, so it
+    // never matches the relative `product_id` leaf — the inline link silently vanishes.
+    const product = mapping({
+      id: 'prod',
+      rootPath: 'line_items[].product_id',
+      parentMappingId: 'line',
+      linkMode: 'reference',
+    })
+    const { byMappingId, childrenOf } = indices([root, line, product])
+
+    const view = computeMappingView(line, SOURCE_PATHS, byMappingId, childrenOf)
+
+    expect(view.refChildByNodePath.has('product_id')).toBe(false)
+    expect(view.refChildByNodePath.get('line_items[].product_id')).toBe(product)
+  })
+})
+
+describe('computeMappingView — entry partitioning', () => {
+  const root = mapping({
+    id: 'root',
+    rootPath: '',
+    fieldMappings: [
+      // A bare-token bind on a visible leaf → renders on the leaf, not as a formula.
+      { id: 'e1', targetFieldRef: 'def:name', expression: '{line_items[].sku}', sourceFields: {} },
+      // A computed (non-bare) entry → a formula row.
+      { id: 'e2', targetFieldRef: 'def:total', expression: '{a} + {b}', sourceFields: {} },
+    ],
+  })
+
+  it('splits leaf binds from formula rows', () => {
+    const { byMappingId, childrenOf } = indices([root])
+    const view = computeMappingView(root, SOURCE_PATHS, byMappingId, childrenOf)
+
+    expect([...view.sourceToEntry.keys()]).toContain('line_items[].sku')
+    expect(view.formulaEntries.map((e) => e.id)).toEqual(['e2'])
+  })
+})

--- a/apps/web/src/components/data-connectors/ui/mapping-view.ts
+++ b/apps/web/src/components/data-connectors/ui/mapping-view.ts
@@ -1,0 +1,152 @@
+// apps/web/src/components/data-connectors/ui/mapping-view.ts
+// Pure derivation of everything `MappingNode` needs to RENDER a mapping's source
+// subtree — the index-building that used to live inline in the component body. Given
+// a mapping plus the shared path schema + mapping indices, it computes the relative
+// source tree and partitions the mapping's children/entries into the buckets the
+// renderer keys on (inline ref-link leaves, promoted branch children, drilled binds,
+// formula rows, orphans). No React / no I/O, so it's unit-testable in isolation — and
+// it's where the nested-child rootPath contract is enforced (a `reference` child's
+// stored rootPath must be parent-RELATIVE to match its leaf node here).
+
+import {
+  absolutePrefix,
+  buildSourceTree,
+  type SourcePath,
+  type SourceTreeNode,
+  subtreeUnder,
+} from '../hooks/use-source-paths'
+import type { FieldMapping } from '../hooks/use-stream-mutations'
+import type { DraftMapping } from '../stores/connector-draft-store'
+import { bareTokenSource, isBareToken } from './field-mapping-edits'
+
+/** A drilled binding/formula: the flat child that owns it + the entry itself. */
+export interface DrilledEntry {
+  child: DraftMapping
+  entry: FieldMapping
+}
+
+/** The fully-derived render model for one {@link DraftMapping}. */
+export interface MappingView {
+  /** This mapping's payload-absolute prefix (root → … → self), for the calc dialog. */
+  prefix: string
+  /** The source subtree under {@link prefix}, nested for rendering. */
+  sourceTree: SourceTreeNode[]
+  /** FLAT drilled children (`rootPath: ''`) — binds across a relationship, rendered inline. */
+  flatDrilledChildren: DraftMapping[]
+  /** Reference children (id-only FK links) keyed by their array-normalized FK source path. */
+  refChildByNodePath: Map<string, DraftMapping>
+  /** Upsert children promoted as a nested branch, keyed by array-normalized branch path. */
+  childByNodePath: Map<string, DraftMapping>
+  /** Upsert children whose branch isn't in the current schema — appended so they stay editable. */
+  orphanChildren: DraftMapping[]
+  /** A leaf bound ACROSS a relationship: source path → the flat child + its binding. */
+  drilledBindBySourcePath: Map<string, DrilledEntry>
+  /** Computed values written across a relationship — rendered as formula rows on this mapping. */
+  drilledFormulaRows: DrilledEntry[]
+  /** Reverse index: source path → the bare-token binding entry on it. */
+  sourceToEntry: Map<string, FieldMapping>
+  /** Entries that render as their own formula row (computed, or an orphaned/half-authored entry). */
+  formulaEntries: FieldMapping[]
+}
+
+/** Array-normalize a child's rootPath to the branch/leaf node path it keys on. */
+function nodePathOf(rootPath: string): string {
+  return rootPath.replace(/\[\]$/, '')
+}
+
+/**
+ * Build the {@link MappingView} for `mapping`. Pure over the shared `sourcePaths`
+ * (payload-absolute Layer-A schema) and the tree indices (`byMappingId` for the
+ * parent chain, `childrenOf` for this mapping's children). Mirrors the inline logic
+ * `MappingNode` used to carry, so behavior is identical — just hoisted + testable.
+ */
+export function computeMappingView(
+  mapping: DraftMapping,
+  sourcePaths: SourcePath[],
+  byMappingId: Map<string, DraftMapping>,
+  childrenOf: Map<string | null, DraftMapping[]>
+): MappingView {
+  const fieldMappings = (mapping.fieldMappings ?? []) as FieldMapping[]
+
+  // Slice this mapping's subtree by its FULL absolute prefix (not the bare,
+  // parent-relative rootPath) so nested mappings render the correct subtree.
+  const prefix = absolutePrefix(mapping, byMappingId)
+  const relativeSubtree = subtreeUnder(sourcePaths, prefix)
+  const sourceTree = buildSourceTree(relativeSubtree)
+  const branchPaths = new Set(relativeSubtree.filter((p) => p.isBranch).map((p) => p.path))
+
+  // FLAT drilled children (unified picker §2): a child reading the SAME subtree
+  // (`rootPath: ''`) to write a related def via a drilled relationship. They surface
+  // INLINE on their source leaf, NOT as nested nodes — partition them out.
+  const childMappings = childrenOf.get(mapping.id) ?? []
+  const flatDrilledChildren = childMappings.filter((c) => c.rootPath === '')
+  const nonFlatChildren = childMappings.filter((c) => c.rootPath !== '')
+
+  // Reference children (flat-FK links) live on a SCALAR leaf, not a branch — index them
+  // separately so a linked leaf renders in "linked" state instead of being promoted to a
+  // nested MappingNode (the upsert fan-out path). NB: a child's stored rootPath is
+  // parent-RELATIVE (`product_id`, not `line_items[].product_id`), so it matches the leaf
+  // node path under this mapping's subtree.
+  const upsertChildren = nonFlatChildren.filter((c) => c.linkMode !== 'reference')
+  const refChildByNodePath = new Map<string, DraftMapping>()
+  for (const c of nonFlatChildren) {
+    if (c.linkMode === 'reference') refChildByNodePath.set(nodePathOf(c.rootPath), c)
+  }
+  const childByNodePath = new Map<string, DraftMapping>()
+  for (const c of upsertChildren) childByNodePath.set(nodePathOf(c.rootPath), c)
+  // Children whose branch isn't in the current schema (e.g. schema regenerated) would
+  // otherwise vanish — render them appended so they stay editable/removable.
+  const orphanChildren = upsertChildren.filter((c) => !branchPaths.has(nodePathOf(c.rootPath)))
+
+  // A leaf bound ACROSS a relationship: its binding lives on a flat drilled child, but
+  // the leaf keeps its row (only the target chip reaches across).
+  const drilledBindBySourcePath = new Map<string, DrilledEntry>()
+  for (const c of flatDrilledChildren) {
+    for (const e of (c.fieldMappings ?? []) as FieldMapping[]) {
+      if (e.targetFieldRef == null || !isBareToken(e.expression)) continue
+      drilledBindBySourcePath.set(bareTokenSource(e.expression), { child: c, entry: e })
+    }
+  }
+
+  // DRILLED FORMULAS: a NON-bare entry on a flat child is a formula whose computed value
+  // writes a related def across the relationship. Bare entries are leaf binds (inline via
+  // `drilledBindBySourcePath`); non-bare ones surface as formula rows on this parent.
+  const drilledFormulaRows = flatDrilledChildren.flatMap((child) =>
+    ((child.fieldMappings ?? []) as FieldMapping[])
+      .filter((e) => !isBareToken(e.expression))
+      .map((entry) => ({ child, entry }))
+  )
+
+  // Reverse-index bare-token entries: source path → the binding entry on it.
+  const sourceToEntry = new Map<string, FieldMapping>()
+  for (const e of fieldMappings) {
+    if (isBareToken(e.expression)) sourceToEntry.set(bareTokenSource(e.expression), e)
+  }
+
+  // Visible leaf paths under THIS subtree — a bare-token entry on one renders on its leaf,
+  // so it must NOT also surface as a formula row.
+  const visibleLeafPaths = new Set(relativeSubtree.filter((p) => !p.isBranch).map((p) => p.path))
+
+  // Formula rows = computed entries (no single leaf to anchor on) PLUS target-less entries
+  // with nowhere to live on the source tree (a half-authored draft, or an orphaned bare
+  // token whose source path vanished). A bare-token anchor on a VISIBLE leaf renders on
+  // that leaf, never here.
+  const formulaEntries = fieldMappings.filter(
+    (e) =>
+      !isBareToken(e.expression) ||
+      (e.targetFieldRef == null && !visibleLeafPaths.has(bareTokenSource(e.expression)))
+  )
+
+  return {
+    prefix,
+    sourceTree,
+    flatDrilledChildren,
+    refChildByNodePath,
+    childByNodePath,
+    orphanChildren,
+    drilledBindBySourcePath,
+    drilledFormulaRows,
+    sourceToEntry,
+    formulaEntries,
+  }
+}

--- a/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
@@ -110,16 +110,21 @@ export function SourceLeafRow({
   onSetIdentityRole,
   onLinkRelationship,
 }: SourceLeafRowProps) {
+  // A VALUE binding (direct or drilled) vs a link-only leaf (an id-only relationship
+  // FK that anchors an edge but writes no column). Both read "active" (lit icon/arrow);
+  // only a value binding shows the merge/clear actions + can serve as a Match key.
   const isMapped = !!assignedTargetKey || !!drilledRef
+  const isLinked = !!linkedFieldRef
+  const isActive = isMapped || isLinked
   const isArray = node.type === 'array'
   const Icon = isArray ? Brackets : Hash
   return (
     <MappingRow
       depth={depth}
-      icon={<Icon className={isMapped ? 'size-3.5' : 'size-3.5 text-muted-foreground/50'} />}
+      icon={<Icon className={isActive ? 'size-3.5' : 'size-3.5 text-muted-foreground/50'} />}
       title={
         <span className='flex items-center gap-1.5'>
-          <span className={`font-mono text-sm ${isMapped ? '' : 'text-muted-foreground'}`}>
+          <span className={`font-mono text-sm ${isActive ? '' : 'text-muted-foreground'}`}>
             {lastSegment(node.path)}
           </span>
           <span className='text-[10px] uppercase text-muted-foreground/60'>
@@ -137,8 +142,8 @@ export function SourceLeafRow({
         </span>
       }
       // The arrow always shows (the field picker is always present, even when
-      // unbound) — dimmed until a target field is bound.
-      arrow={isMapped ? 'filled' : 'dim'}
+      // unbound) — dimmed until the leaf is value-bound OR linked.
+      arrow={isActive ? 'filled' : 'dim'}
       // Target column — the field picker fills the cell and blends into the row.
       target={
         <MappingFieldPicker
@@ -153,6 +158,7 @@ export function SourceLeafRow({
           drilledRef={drilledRef}
           excludeKeys={excludeKeys}
           canCreate={canCreate}
+          ownedWrite={isOwned}
           allowRelationships={allowRelationships}
           linkedFieldRef={linkedFieldRef}
           onAssign={onAssign}

--- a/packages/lib/src/agents/bindings/__tests__/resolve.test.ts
+++ b/packages/lib/src/agents/bindings/__tests__/resolve.test.ts
@@ -13,16 +13,16 @@ vi.mock('../../../field-values/field-value-service', () => ({
 }))
 
 // Stub the org-cache helpers the @app: pre-pass drives.
-const getCachedEntityDefId = vi.fn()
+const findCachedResource = vi.fn()
 const getCachedFieldMap = vi.fn()
 const getCachedInstalledApps = vi.fn()
 vi.mock('../../../cache/org-cache-helpers', () => ({
-  getCachedEntityDefId: (...args: unknown[]) => getCachedEntityDefId(...args),
+  findCachedResource: (...args: unknown[]) => findCachedResource(...args),
   getCachedFieldMap: (...args: unknown[]) => getCachedFieldMap(...args),
   getCachedInstalledApps: (...args: unknown[]) => getCachedInstalledApps(...args),
 }))
 
-import { buildResolveVarSource } from '../resolve'
+import { buildResolveVarSource, resolveConnectorFieldRef } from '../resolve'
 
 /** Subject with the given anchors (slug → RecordId). */
 function subjectWith(anchors: Record<string, string>): Subject {
@@ -43,7 +43,7 @@ const ANON = subjectWith({ thread: 'thread:t1', participant: 'participant:p1' })
 describe('buildResolveVarSource', () => {
   beforeEach(() => {
     batchGetValues.mockReset()
-    getCachedEntityDefId.mockReset()
+    findCachedResource.mockReset()
     getCachedFieldMap.mockReset()
     getCachedInstalledApps.mockReset()
   })
@@ -121,7 +121,13 @@ describe('buildResolveVarSource', () => {
 
   describe('@app: segment (turn-time connection resolution)', () => {
     beforeEach(() => {
-      getCachedEntityDefId.mockResolvedValue('contact')
+      // Agent-binding ref keys the leading segment by entityType ('contact').
+      findCachedResource.mockResolvedValue({
+        id: 'contact',
+        entityDefinitionId: 'contact',
+        entityType: 'contact',
+        apiSlug: 'contacts',
+      })
       getCachedInstalledApps.mockResolvedValue([
         { installationId: 'inst-1', app: { slug: 'shopify' } },
       ])
@@ -176,5 +182,110 @@ describe('buildResolveVarSource', () => {
       expect(result).toBeUndefined()
       expect(batchGetValues).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('resolveConnectorFieldRef', () => {
+  beforeEach(() => {
+    findCachedResource.mockReset()
+    getCachedFieldMap.mockReset()
+    getCachedInstalledApps.mockReset()
+    getCachedInstalledApps.mockResolvedValue([
+      { installationId: 'inst-1', app: { slug: 'shopify' } },
+    ])
+  })
+
+  it('resolves an owned-def @app: ref by apiSlug (entityType null) — the bug fix', async () => {
+    // Connector-owned def: apiSlug set, entityType null. The old entityType-only
+    // lookup missed this and dropped the field; findCachedResource matches apiSlug.
+    findCachedResource.mockResolvedValue({
+      id: 'p2r4bk3q',
+      entityDefinitionId: 'p2r4bk3q',
+      entityType: null,
+      apiSlug: 'shopify_products',
+    })
+    getCachedFieldMap.mockResolvedValue(
+      new Map([
+        [
+          'fg1hf3go',
+          {
+            id: 'fg1hf3go',
+            appFieldKey: 'title',
+            connectionId: 'ou13',
+            appInstallationId: 'inst-1',
+          },
+        ],
+      ])
+    )
+
+    const resolved = await resolveConnectorFieldRef(
+      'shopify_products:@app:shopify:title' as ResourceFieldId,
+      'org-1',
+      'ou13'
+    )
+
+    expect(resolved).toBe('p2r4bk3q:fg1hf3go')
+    expect(findCachedResource).toHaveBeenCalledWith('org-1', 'shopify_products')
+  })
+
+  it('resolves an agent-binding @app: ref by entityType (no regression)', async () => {
+    findCachedResource.mockResolvedValue({
+      id: 'mzxt3cxy',
+      entityDefinitionId: 'mzxt3cxy',
+      entityType: 'contact',
+      apiSlug: 'contacts',
+    })
+    getCachedFieldMap.mockResolvedValue(
+      new Map([
+        [
+          'cf-order-total',
+          {
+            id: 'cf-order-total',
+            appFieldKey: 'orderTotal',
+            connectionId: 'ou13',
+            appInstallationId: 'inst-1',
+          },
+        ],
+      ])
+    )
+
+    const resolved = await resolveConnectorFieldRef(
+      'contact:@app:shopify:orderTotal' as ResourceFieldId,
+      'org-1',
+      'ou13'
+    )
+
+    expect(resolved).toBe('mzxt3cxy:cf-order-total')
+    expect(findCachedResource).toHaveBeenCalledWith('org-1', 'contact')
+  })
+
+  it('passes a concrete defId:fieldId ref through unchanged (no @app:, no cache read)', async () => {
+    const resolved = await resolveConnectorFieldRef(
+      'mzxt3cxy:l34o9dzv' as ResourceFieldId,
+      'org-1',
+      'ou13'
+    )
+    expect(resolved).toBe('mzxt3cxy:l34o9dzv')
+    expect(findCachedResource).not.toHaveBeenCalled()
+  })
+
+  it('→ null when the owned def is missing from the resources cache', async () => {
+    findCachedResource.mockResolvedValue(null)
+    const resolved = await resolveConnectorFieldRef(
+      'shopify_products:@app:shopify:title' as ResourceFieldId,
+      'org-1',
+      'ou13'
+    )
+    expect(resolved).toBeNull()
+  })
+
+  it('→ null when no connection is bound (connect-a-store gate)', async () => {
+    const resolved = await resolveConnectorFieldRef(
+      'shopify_products:@app:shopify:title' as ResourceFieldId,
+      'org-1',
+      undefined
+    )
+    expect(resolved).toBeNull()
+    expect(findCachedResource).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/agents/bindings/resolve.ts
+++ b/packages/lib/src/agents/bindings/resolve.ts
@@ -19,7 +19,7 @@ import {
 import { parseRecordId, type RecordId } from '@auxx/types/resource'
 import type { Subject, ToolContext } from '../../ai/agent-framework/tool-context'
 import {
-  getCachedEntityDefId,
+  findCachedResource,
   getCachedFieldMap,
   getCachedInstalledApps,
 } from '../../cache/org-cache-helpers'
@@ -160,8 +160,12 @@ async function resolveAppSegmentsWith(
     }
     const credId = credIdForSlug(app.slug)
     if (!credId) return null // no bound store → "connect a store"
-    const entityDefId = await getCachedEntityDefId(orgId, slug)
-    if (!entityDefId) return null
+    // Resolve the leading segment the way the rest of the app does — by id OR
+    // entityType OR apiSlug. Connector-owned defs key by apiSlug (entityType is
+    // null); agent bindings key by entityType. Both live in the `resources` cache.
+    const resource = await findCachedResource(orgId, slug)
+    if (!resource) return null
+    const entityDefId = resource.entityDefinitionId
     const cfId = await resolveAppFieldId(orgId, entityDefId, app.slug, app.key, credId)
     if (!cfId) return null
     rewritten.push(toResourceFieldId(entityDefId, cfId))

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -175,7 +175,7 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
           sinkSourceRecord(syncCtx, this.deps.stream.mappings, record, this.updatedAtPath),
       })
       await this.emitRecordsInvalidated(syncCtx.touchedDefs)
-      return { ...result, counters: toSyncCounters(counters) }
+      return { ...result, counters: toSyncCounters(counters), errorSample: counters.errorSample }
     }
 
     // Backfill paginates from the top/cursor (snapshot); steady incremental injects
@@ -206,7 +206,7 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
     })
 
     await this.emitRecordsInvalidated(syncCtx.touchedDefs)
-    return { ...result, counters: toSyncCounters(counters) }
+    return { ...result, counters: toSyncCounters(counters), errorSample: counters.errorSample }
   }
 
   /**
@@ -317,7 +317,10 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
     // Fold finalize-only counters (archived/deleted/relationshipWarnings). No
     // checkpoint key ⇒ always folds (runs exactly once, last stream only).
     const ledger = createConnectorRunLedger(this.deps.db, this.deps.run, this.deps.stream.streamId)
-    await ledger.recordSlice({ counters: toSyncCounters(counters) })
+    await ledger.recordSlice({
+      counters: toSyncCounters(counters),
+      errorSample: counters.errorSample,
+    })
 
     // Close the run for backfill (delegated by the runner); steady already finalized
     // in the runner. Then release the connector claim + stamp the item count.

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -471,8 +471,15 @@ function isBoundaryPrefix(path: string, prefix: string): boolean {
   return next === '.' || next === '['
 }
 
-/** Strip a mapping's rootPath off a field's sourcePath, leaving a subtree-relative path. */
-function relativeSourcePath(sourcePath: string, rootPath: string): string {
+/**
+ * Strip a `rootPath` prefix off a `path`, leaving it relative to that subtree —
+ * `('line_items[].sku', 'line_items[]') → 'sku'`. Used both to relativize a field's
+ * sourcePath against its owning mapping AND to relativize a nested child mapping's
+ * own (payload-absolute, manifest) rootPath against its parent's rootPath before it
+ * is stored (`absolutePrefix`/`subtreeUnder`/`mapRecord` all expect parent-relative).
+ * `rootPath` must be a boundary-prefix of `path` (the caller resolves it that way).
+ */
+export function relativeSourcePath(sourcePath: string, rootPath: string): string {
   if (rootPath === '') return sourcePath
   return sourcePath.slice(rootPath.length).replace(/^\./, '')
 }
@@ -566,23 +573,39 @@ async function seedAppOwnedMappings(
     // A `reference` owned mapping (id-only edge, e.g. line→product) owns no columns —
     // its entry list is empty; it only carries the structural link (parent + edge key).
     const entries = partition[mapping.rootPath] ?? []
+    const linkMode = mapping.linkMode ?? ('upsert' as LinkMode)
 
     const parentRootPath = ownedParentRootPath(mapping.rootPath, allRootPaths)
     const parentMappingId = parentRootPath != null ? mappingIdByRootPath[parentRootPath] : null
 
     const row = await addMapping(db, organizationId, {
       dataConnectorStreamId: streamId,
-      rootPath: mapping.rootPath,
-      linkMode: mapping.linkMode ?? ('upsert' as LinkMode),
+      // STORE parent-relative. The manifest rootPath is payload-absolute (so
+      // `ownedParentRootPath` can nest it: `'' ⊂ line_items[] ⊂ line_items[].product_id`),
+      // but every consumer — `absolutePrefix`, `subtreeUnder`, and the sync `mapRecord`
+      // subtree descent — treats a child's stored rootPath as relative to its parent.
+      // Relativize against the parent we just resolved; top-level children (parent `''`)
+      // are unchanged. NB: `mappingIdByRootPath` below stays keyed by the ABSOLUTE path,
+      // because parent detection nests on absolute paths.
+      rootPath:
+        parentRootPath != null
+          ? relativeSourcePath(mapping.rootPath, parentRootPath)
+          : mapping.rootPath,
+      linkMode,
       targetMode: 'owned' as TargetMode,
       entityDefinitionId: null,
       parentMappingId,
       relationshipFieldKey: mapping.relationshipFieldKey ?? null,
-      // Late-bound refs key on the manifest apiSlug; the install rewrites them to
+      // A `reference` edge carries only its External-ID anchor (the FK value IS the
+      // related record's external id). An upsert mapping owns its subtree's columns:
+      // late-bound refs key on the manifest apiSlug; the install rewrites them to
       // concrete `${defId}:${fieldId}` once the def exists (or fixes the slug segment
       // to the actual installed slug). Until then they resolve at sync via the `@app:`
       // path — so even an uninstalled-but-slug-matching def would still bind.
-      fieldMappings: buildAppOwnedFieldMappings(entries, appSlug, entity.apiSlug),
+      fieldMappings:
+        linkMode === 'reference'
+          ? [buildReferenceAnchor()]
+          : buildAppOwnedFieldMappings(entries, appSlug, entity.apiSlug),
       // Incremental connectors only see the delta each run, so unseen ≠ deleted —
       // never archive owned orphans automatically. Full-snapshot sweeps can still
       // reconcile; v1 keeps it safe.
@@ -616,6 +639,26 @@ export function buildAppOwnedFieldMappings(
     expression: `{${relPath}}`,
     sourceFields: { [relPath]: relPath },
   }))
+}
+
+/**
+ * The External-ID anchor a `reference` (id-only edge) mapping carries so the FK value
+ * resolves to the related record's external id at sync. A bare scalar-rooted reference
+ * (e.g. `line_items[].product_id → product`) declares no `fieldMappings` in the manifest
+ * — but with an empty entry list the edge has nothing to anchor on and stays inert. This
+ * synthesizes the same anchor the interactive `linkRelationship` ships (`{source}` over
+ * the reference's own scalar, marked External ID), so a manifest-seeded reference resolves
+ * identically with no manifest change. The seeder owns this default; the manifest stays
+ * declarative.
+ */
+export function buildReferenceAnchor(): FieldMapping {
+  return {
+    id: generateId(),
+    targetFieldRef: null,
+    expression: '{source}',
+    sourceFields: {},
+    identityRole: { kind: 'externalId' },
+  }
 }
 
 /**
@@ -724,7 +767,12 @@ async function materializeAppContributingMappings(
             defFields
           )
     ).filter((b) => !boundTargets.has(b.targetFieldRef))
-    const fieldMappings = [...matchBindings, ...valueBindings]
+    const linkMode = mapping.linkMode ?? ('upsert' as LinkMode)
+    // A `reference` contributing edge owns no value columns — it carries only the
+    // External-ID anchor (the FK resolves to the related record at sync), mirroring the
+    // interactive `linkRelationship`. Otherwise bind match + author/auto value fields.
+    const fieldMappings =
+      linkMode === 'reference' ? [buildReferenceAnchor()] : [...matchBindings, ...valueBindings]
 
     // A nested contributing branch (e.g. the order stream's embedded `customer`)
     // hangs off the owned root it's drilled from. Wiring `parentMappingId` makes
@@ -737,8 +785,14 @@ async function materializeAppContributingMappings(
 
     await addMapping(db, organizationId, {
       dataConnectorStreamId: streamId,
-      rootPath: mapping.rootPath,
-      linkMode: mapping.linkMode ?? ('upsert' as LinkMode),
+      // STORE parent-relative (see `seedAppOwnedMappings`): only when a parent was
+      // resolved — top-level contributing branches keep their absolute (== relative)
+      // path. `ownedMappingIdByRootPath` lookups stay keyed ABSOLUTE.
+      rootPath:
+        parentRootPath != null
+          ? relativeSourcePath(mapping.rootPath, parentRootPath)
+          : mapping.rootPath,
+      linkMode,
       targetMode: 'contributing' as TargetMode,
       entityDefinitionId,
       parentMappingId,

--- a/packages/lib/src/data-connectors/owned-mappings.test.ts
+++ b/packages/lib/src/data-connectors/owned-mappings.test.ts
@@ -7,10 +7,12 @@ import type { CatalogDataConnector } from '@auxx/database'
 import { describe, expect, it } from 'vitest'
 import {
   buildAppOwnedFieldMappings,
+  buildReferenceAnchor,
   type OwnedFieldEntry,
   ownedParentRootPath,
   partitionOwnedFields,
   projectConnectorOwnedTargets,
+  relativeSourcePath,
 } from './mutations'
 
 type CatalogField = OwnedFieldEntry['field']
@@ -209,6 +211,41 @@ describe('partitionOwnedFields', () => {
     expect(line.some((e) => e.field.fieldKey === 'lineItems.productId')).toBe(false)
     // The reference mapping (shopify_products) owns no columns at all.
     expect(result['line_items[].product_id']).toBeUndefined()
+  })
+})
+
+describe('relativeSourcePath (nested-child rootPath relativization)', () => {
+  // The seeders relativize a child mapping's payload-absolute manifest rootPath
+  // against its parent's rootPath before storing it — the shape the editor + sync
+  // runtime expect. Same helper that strips a field's sourcePath against its owner.
+  it('strips a grandchild rootPath against its array parent', () => {
+    // The product reference under line_items[]: `line_items[].product_id` must store
+    // as `product_id` so it matches the relative leaf node + resolves at sync.
+    expect(relativeSourcePath('line_items[].product_id', 'line_items[]')).toBe('product_id')
+  })
+
+  it('strips an object-branch child rootPath', () => {
+    expect(relativeSourcePath('customer.address', 'customer')).toBe('address')
+  })
+
+  it('leaves a top-level child unchanged (parent is the root)', () => {
+    // A one-level child parents to `''` → absolute == relative (accidentally correct
+    // before the fix, which is why only depth-≥2 children regressed).
+    expect(relativeSourcePath('line_items[]', '')).toBe('line_items[]')
+    expect(relativeSourcePath('customer', '')).toBe('customer')
+  })
+})
+
+describe('buildReferenceAnchor', () => {
+  it('synthesizes the {source} External-ID anchor a reference edge needs', () => {
+    const anchor = buildReferenceAnchor()
+    // Matches the interactive linkRelationship shape exactly: target-less, the FK value
+    // ({source}) IS the related record's external id.
+    expect(anchor.targetFieldRef).toBeNull()
+    expect(anchor.expression).toBe('{source}')
+    expect(anchor.sourceFields).toEqual({})
+    expect(anchor.identityRole).toEqual({ kind: 'externalId' })
+    expect(anchor.id).toBeTruthy()
   })
 })
 

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -8,6 +8,7 @@ import { type Database, database as defaultDb, schema, type Transaction } from '
 import { createScopedLogger } from '@auxx/logger'
 import { and, asc, count, desc, eq, inArray, ne, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
+import type { SyncRunErrorSample } from '../sync-core/contracts'
 import { maxLevel } from './edit-impact'
 import type {
   FieldMapping,
@@ -234,8 +235,9 @@ export interface RunCounters {
   // `tier` classifies the failure for the two-tier error UI (Step 9 §1.1):
   // 'invalid' = bad shape / missing identity, dropped before the write;
   // 'rejected' = the entity write itself threw. Omitted ⇒ engine-level error
-  // (stale sweep / ledger fail), rendered under a neutral "Error" bucket.
-  errorSample: Array<{ externalId: string; error: string; tier?: 'invalid' | 'rejected' }>
+  // (stale sweep / ledger fail), rendered under a neutral "Error" bucket. Shared
+  // with the sliced sync-core ledger fold (`SliceLedgerEntry.errorSample`).
+  errorSample: SyncRunErrorSample[]
 }
 
 export function newRunCounters(): RunCounters {

--- a/packages/lib/src/data-connectors/sync-core-adapters.ts
+++ b/packages/lib/src/data-connectors/sync-core-adapters.ts
@@ -123,6 +123,15 @@ class ConnectorRunLedger implements RunLedger {
       failed: sql`${T.failed} + ${c.failed ?? 0}`,
       pagesProcessed: sql`${T.pagesProcessed} + ${entry.pagesProcessed ?? 0}`,
       rateLimitWaitMs: sql`${T.rateLimitWaitMs} + ${entry.rateLimitWaitMs ?? 0}`,
+      // Append this slice's dropped/failed sample onto the run row so a run that
+      // silently drops every field value can't present as clean (Step 9 §8). Soft-
+      // capped at ~50 entries (stop appending past 50) — it's a sample, not a log.
+      // No sample this slice ⇒ self-assign so a NULL stays NULL (the clean-run shape).
+      errorSample: entry.errorSample?.length
+        ? sql`CASE WHEN jsonb_array_length(coalesce(${T.errorSample}, '[]'::jsonb)) < 50
+            THEN coalesce(${T.errorSample}, '[]'::jsonb) || ${JSON.stringify(entry.errorSample)}::jsonb
+            ELSE ${T.errorSample} END`
+        : sql`${T.errorSample}`,
       heartbeatAt: new Date(),
     }
 
@@ -159,9 +168,14 @@ class ConnectorRunLedger implements RunLedger {
     const T = schema.DataConnectorRun
     const row = await this.db.query.DataConnectorRun.findFirst({
       where: eq(T.id, this.runId),
-      columns: { failed: true },
+      columns: { failed: true, errorSample: true },
     })
-    const status = (row?.failed ?? 0) > 0 ? 'partial' : 'completed'
+    // A run is 'partial' if the entity write threw (`failed`) OR any record/field was
+    // dropped before the write (an `errorSample` entry — e.g. an unresolved field ref).
+    // Pre-write drops don't bump `failed`, so without this an all-dropped run reported
+    // `completed / failed: 0` while writing no data (Step 9 §8).
+    const status =
+      (row?.failed ?? 0) > 0 || (row?.errorSample?.length ?? 0) > 0 ? 'partial' : 'completed'
     await this.db
       .update(T)
       .set({ status, finishedAt: new Date(), durationMs: Date.now() - this.startedAt.getTime() })

--- a/packages/lib/src/sync-core/contracts.ts
+++ b/packages/lib/src/sync-core/contracts.ts
@@ -71,6 +71,22 @@ export interface SyncRunCounters {
 }
 
 /**
+ * One dropped/failed record sampled for the run's error UI. `tier` classifies the
+ * failure: 'invalid' = bad shape / missing identity, dropped BEFORE the write;
+ * 'rejected' = the entity write itself threw. Omitted ⇒ engine-level error.
+ *
+ * This rides ALONGSIDE the numeric `SyncRunCounters` (which can't carry an array)
+ * so a slice that silently drops every field value can no longer present as a clean
+ * run — the sample is folded onto the run row. Mirrors `DataConnectorRun.errorSample`
+ * (the only `RunLedger` sink today).
+ */
+export interface SyncRunErrorSample {
+  externalId: string
+  error: string
+  tier?: 'invalid' | 'rejected'
+}
+
+/**
  * Durable per-stream sync state. The `SyncStateStore` maps this onto whatever the
  * sink uses for persistence (data-connectors: `DataConnectorStream.state` jsonb;
  * channels: `Integration` columns). The core reads/writes it as an opaque blob.
@@ -134,6 +150,8 @@ export interface SliceResult {
   commit: SliceCommit
   /** Counter deltas for this slice, folded into the run ledger. */
   counters?: Partial<SyncRunCounters>
+  /** Dropped/failed records sampled this slice, appended onto the run's error sample. */
+  errorSample?: SyncRunErrorSample[]
 }
 
 /**
@@ -143,6 +161,8 @@ export interface SliceResult {
 export interface SliceLedgerEntry {
   /** Entity counter deltas (created/updated/skipped/…). */
   counters?: Partial<SyncRunCounters>
+  /** Dropped/failed records sampled this slice, jsonb-appended onto the run row. */
+  errorSample?: SyncRunErrorSample[]
   /** Pages fetched this slice. */
   pagesProcessed?: number
   /** Rate-limit wait this slice. */

--- a/packages/lib/src/sync-core/index.ts
+++ b/packages/lib/src/sync-core/index.ts
@@ -13,6 +13,7 @@ export type {
   SyncCursor,
   SyncPhase,
   SyncRunCounters,
+  SyncRunErrorSample,
   SyncSliceCtx,
   SyncSource,
   SyncState,

--- a/packages/lib/src/sync-core/slice-runner.test.ts
+++ b/packages/lib/src/sync-core/slice-runner.test.ts
@@ -99,6 +99,35 @@ describe('runSyncSlice', () => {
     expect(ledger.slices[0]?.counters).toEqual({ created: 50 })
   })
 
+  it('forwards the slice error sample into the ledger entry (Step 9 §8)', async () => {
+    const state = fakeStateStore({ phase: 'backfill' })
+    const ledger = fakeLedger()
+    await runSyncSlice({
+      source: source({
+        slice: {
+          recordsProcessed: 1,
+          pagesProcessed: 1,
+          nextCursor: { kind: 'token', value: 'pg_1' },
+          hasMore: true,
+          commit: 'all',
+          counters: { created: 1 },
+          // A pre-write drop (unresolved field ref) — does NOT bump `failed`, so the
+          // sample is the only signal the run wrote nothing for this record.
+          errorSample: [{ externalId: 'p1', error: 'unresolved targetFieldRef', tier: 'invalid' }],
+        },
+      }),
+      stateStore: state.store,
+      ledger: ledger.ledger,
+      throttle: THROTTLE,
+      budget: BUDGET,
+      signal: new AbortController().signal,
+    })
+
+    expect(ledger.slices[0]?.errorSample).toEqual([
+      { externalId: 'p1', error: 'unresolved targetFieldRef', tier: 'invalid' },
+    ])
+  })
+
   it('HOLDS the cursor and passes no idempotency key on a transient failure', async () => {
     const state = fakeStateStore({ phase: 'backfill', cursor: { kind: 'token', value: 'pg_3' } })
     const ledger = fakeLedger()

--- a/packages/lib/src/sync-core/slice-runner.ts
+++ b/packages/lib/src/sync-core/slice-runner.ts
@@ -147,6 +147,7 @@ export async function runSyncSlice(args: RunSliceArgs): Promise<SliceOutcome> {
   const checkpointKey = advance ? (exhausted ? `done:${phase}` : cursorKey(nextCursor)) : undefined
   await ledger.recordSlice({
     counters: result.counters,
+    errorSample: result.errorSample,
     pagesProcessed: result.pagesProcessed,
     rateLimitWaitMs: result.rateLimitWaitMs,
     checkpointKey,


### PR DESCRIPTION
## Summary

A test Shopify owned-def sync created the records (Products/Orders/Line Items) but wrote **zero field values** — every cell blank, display name "Untitled". This PR fixes the root cause, makes such a regression loud, and folds in the in-flight mapping-editor refactor + nested-child seeding fix.

### R1 — `@app:` owned-def field resolution (the bug)
The sink resolves each mapped `targetFieldRef` through `resolveAppSegmentsWith`, which looked up the ref's leading def-segment with the **entityType-only** `getCachedEntityDefId`. Connector-owned defs have `entityType = null` (only `apiSlug`), so every `@app:<app>:<key>` ref failed to resolve → the field was dropped → records were created empty. (Contacts synced fine — concrete `defId:fieldId` refs skip `@app:` resolution.)

**Fix:** converge that one resolver onto the unified `findCachedResource` (matches `id` OR `entityType` OR `apiSlug`) — the same path Read/Display/`getEntityDefIdResolver` already use. One chokepoint, so it heals the sink write path, drift check, reconcile, agent bindings, and quick-actions at once. No schema/migration/backfill.

### §8 — surface dropped fields on the run (make it loud)
The run reported `completed / failed: 0 / errorSample: null` despite ~187 dropped fields, which is why the bug went unnoticed. Root cause: the sink fills `ctx.counters.errorSample` (an **array**), but `toSyncCounters` maps to the **numeric-only** `SyncRunCounters`, dropping it; `recordSlice` folded only numbers and `finalize()` never wrote it.

**Fix:** new shared `SyncRunErrorSample` type + optional `errorSample` on `SliceResult`/`SliceLedgerEntry`; the runner forwards it; `recordSlice` jsonb-appends it onto `DataConnectorRun.errorSample` (soft-capped ~50); `finalize()` now marks the run **`partial`** when anything was dropped (pre-write drops don't bump `failed`). Channels don't use the slice-runner yet, so the optional field is non-breaking.

### Mapping editor refactor + nested-child seeding fix (in-flight v6 work)
- Split `mapping-node.tsx` (1384 → 685) into `mapping-view.ts`, `hooks/use-mapping-actions.ts`, `formula-row.tsx`, `mapping-node-helpers.ts`.
- Seeders now relativize the stored `rootPath` and unconditionally seed the `{source}` external-id anchor for `reference` mappings (`mutations.ts`).

## Test plan
- `pnpm --filter @auxx/lib` — resolve / sync-core / data-connectors suites green (incl. new `resolveConnectorFieldRef` + slice-runner `errorSample` cases).
- `pnpm --filter @auxx/web exec vitest run src/components/data-connectors` — 109 green (incl. new `mapping-view` + `field-type-compat` tests).
- ⚠️ **Live verify still pending:** delete + recreate the Shopify connector, re-install owned defs, sync — confirm Title/Vendor/etc. populated, display name non-null, **zero** `targetFieldRef did not resolve` logs, and that a drop now surfaces as `errorSample` + `partial`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)