### PR TITLE
fix(data-connectors): namespace app relationshipFieldKey + struct source-field mapping

### DIFF
--- a/apps/web/src/components/data-connectors/hooks/use-source-paths.test.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-source-paths.test.ts
@@ -34,6 +34,26 @@ describe('flattenSourceSchema', () => {
     expect(paths).toContain('line_items[].sku')
     expect(paths).toContain('line_items[].price')
   })
+
+  it('flattens an `x-auxx-fieldType` struct node as a single typed value leaf', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        shipping_address: {
+          type: 'object',
+          'x-auxx-fieldType': 'ADDRESS_STRUCT',
+          properties: { street1: { type: 'string' }, city: { type: 'string' } },
+        },
+      },
+    }
+    const paths = flattenSourceSchema(schema)
+    const addr = paths.find((p) => p.path === 'shipping_address')
+    expect(addr).toMatchObject({ isBranch: false, fieldType: 'ADDRESS_STRUCT', type: 'object' })
+    // It does NOT explode into its components.
+    expect(paths.map((p) => p.path)).not.toContain('shipping_address.street1')
+    // And it IS a mappable leaf (passes leafPathsUnder's `!isBranch` filter).
+    expect(leafPathsUnder(paths, '').map((p) => p.path)).toContain('shipping_address')
+  })
 })
 
 describe('leafPathsUnder', () => {

--- a/apps/web/src/components/data-connectors/hooks/use-source-paths.ts
+++ b/apps/web/src/components/data-connectors/hooks/use-source-paths.ts
@@ -1,6 +1,8 @@
 // apps/web/src/components/data-connectors/hooks/use-source-paths.ts
 'use client'
 
+import type { FieldType } from '@auxx/database/types'
+import { STRUCT_FIELD_TYPE_KEYWORD } from '@auxx/lib/json-schema/client'
 import { useMemo } from 'react'
 
 /** A leaf/branch path in the source (Layer A) schema, for the inline pickers. */
@@ -11,6 +13,12 @@ export interface SourcePath {
   type: string
   /** Detected JSON-schema string `format` (`email` / `uri` / `date` / `time` / `date-time`). */
   format?: string
+  /**
+   * Declared STRUCT field type when the node maps as ONE value (`ADDRESS_STRUCT`). Set by
+   * the catalog schema overlay; turns an object node into a typed value leaf rather than a
+   * branch to explode. Drives the badge, the picker's type filter, and quick-create seed.
+   */
+  fieldType?: FieldType
   /** Depth (for indenting the picker list). */
   depth: number
   /** True for object/array branches (not directly mappable as a value). */
@@ -22,6 +30,7 @@ interface JsonSchemaNode {
   format?: string
   properties?: Record<string, JsonSchemaNode>
   items?: JsonSchemaNode
+  [STRUCT_FIELD_TYPE_KEYWORD]?: string
 }
 
 function typeOf(node: JsonSchemaNode): string {
@@ -54,6 +63,20 @@ export function flattenSourceSchema(
       for (const [key, child] of Object.entries(node.properties)) {
         const childPath = prefix ? `${prefix}.${key}` : key
         const childType = typeOf(child)
+        // A declared struct field (e.g. ADDRESS_STRUCT) maps as ONE value — emit a typed
+        // value leaf and DON'T descend into its components.
+        const structType = child[STRUCT_FIELD_TYPE_KEYWORD]
+        if (structType) {
+          out.push({
+            path: childPath,
+            type: childType,
+            format: child.format,
+            fieldType: structType as FieldType,
+            depth,
+            isBranch: false,
+          })
+          continue
+        }
         const isBranch =
           childType === 'object' || (childType === 'array' && !!child.items?.properties)
         out.push({ path: childPath, type: childType, format: child.format, depth, isBranch })

--- a/apps/web/src/components/data-connectors/ui/field-type-compat.test.ts
+++ b/apps/web/src/components/data-connectors/ui/field-type-compat.test.ts
@@ -2,7 +2,7 @@
 
 import type { ResourceField } from '@auxx/lib/resources/client'
 import { describe, expect, it } from 'vitest'
-import { isWritableTarget } from './field-type-compat'
+import { isSourceTargetCompatible, isWritableTarget } from './field-type-compat'
 
 /** Minimal ResourceField with just the bits isWritableTarget reads. */
 function field(
@@ -44,5 +44,26 @@ describe('isWritableTarget', () => {
     // e.g. Created By on an owned def — not connector/app-managed, so it stays out.
     const sysCol = field({ creatable: false, updatable: false })
     expect(isWritableTarget(sysCol, { ownedWrite: true })).toBe(false)
+  })
+})
+
+describe('isSourceTargetCompatible', () => {
+  it('null target is always compatible', () => {
+    expect(isSourceTargetCompatible(null, 'object')).toBe(true)
+  })
+
+  it('reduces an object source to JSON when no declared field type', () => {
+    // object → JSON; ADDRESS_STRUCT accepts JSON, TEXT does not.
+    expect(isSourceTargetCompatible('ADDRESS_STRUCT', 'object')).toBe(true)
+    expect(isSourceTargetCompatible('TEXT', 'object')).toBe(false)
+  })
+
+  it('uses the declared struct type directly, constraining to its accepting sinks', () => {
+    // An ADDRESS_STRUCT source binds to ADDRESS_STRUCT (self), ADDRESS, and JSON only.
+    expect(isSourceTargetCompatible('ADDRESS_STRUCT', 'object', 'ADDRESS_STRUCT')).toBe(true)
+    expect(isSourceTargetCompatible('ADDRESS', 'object', 'ADDRESS_STRUCT')).toBe(true)
+    expect(isSourceTargetCompatible('JSON', 'object', 'ADDRESS_STRUCT')).toBe(true)
+    expect(isSourceTargetCompatible('TEXT', 'object', 'ADDRESS_STRUCT')).toBe(false)
+    expect(isSourceTargetCompatible('NUMBER', 'object', 'ADDRESS_STRUCT')).toBe(false)
   })
 })

--- a/apps/web/src/components/data-connectors/ui/field-type-compat.ts
+++ b/apps/web/src/components/data-connectors/ui/field-type-compat.ts
@@ -53,11 +53,18 @@ function jsonSourceFieldType(jsonType: string): FieldTypeType {
  * `jsonType` is a source leaf's JSON-schema type. A computed formula has no
  * single source type — it produces a scalar string/number, so pass `'string'`
  * (→ TEXT) for formula targets.
+ *
+ * `sourceFieldType` is the leaf's DECLARED field type when it carries one (a struct
+ * source like `ADDRESS_STRUCT`). When set it's checked directly, so the target list is
+ * exactly that type's accepting sinks (`ADDRESS_STRUCT` → ADDRESS_STRUCT / ADDRESS / JSON)
+ * rather than the lossy `object → JSON` widening.
  */
 export function isSourceTargetCompatible(
   target: FieldTypeType | null | undefined,
-  jsonType: string
+  jsonType: string,
+  sourceFieldType?: FieldTypeType
 ): boolean {
   if (!target) return true
+  if (sourceFieldType) return isFieldTypeCompatible(target, sourceFieldType)
   return isFieldTypeCompatible(target, jsonSourceFieldType(jsonType))
 }

--- a/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-field-picker.tsx
@@ -64,6 +64,12 @@ interface MappingFieldPickerProps {
   entityDefinitionId: string | null
   /** The source node being bound — drives the type filter + quick-create seed ('leaf'). */
   sourceType?: string
+  /**
+   * The source leaf's DECLARED struct field type (`ADDRESS_STRUCT`), when it carries one.
+   * Constrains the target filter to that type's accepting sinks and seeds quick-create to
+   * it — bypassing the lossy `object → JSON` reduction the bare `sourceType` would apply.
+   */
+  sourceFieldType?: FieldTypeType
   sourcePath?: string
   /** Detected source string `format` — seeds the quick-create field type (§2.2). */
   sourceFormat?: string
@@ -126,6 +132,7 @@ export function MappingFieldPicker({
   kind = 'leaf',
   entityDefinitionId,
   sourceType = 'string',
+  sourceFieldType,
   sourcePath = '',
   sourceFormat,
   assignedKey,
@@ -228,7 +235,7 @@ export function MappingFieldPicker({
               return (
                 notExcluded &&
                 isWritableTarget(f, { ownedWrite }) &&
-                isSourceTargetCompatible(f.fieldType, sourceType)
+                isSourceTargetCompatible(f.fieldType, sourceType, sourceFieldType)
               )
             }}
             mode='single'
@@ -259,10 +266,11 @@ export function MappingFieldPicker({
           <QuickCreateFieldForm
             entityDefinitionId={entityDefinitionId}
             sourceType={sourceType}
+            sourceFieldType={sourceFieldType}
             ownedWrite={ownedWrite}
             excludeKeys={excludeKeys}
             seedName={humanizeFieldPath(sourcePath)}
-            seedType={inferFieldType(sourcePath, sourceType, sourceFormat)}
+            seedType={sourceFieldType ?? inferFieldType(sourcePath, sourceType, sourceFormat)}
             onBack={() => setView('pick')}
             onCreated={(fieldRef) => {
               onAssign(fieldRef)
@@ -308,6 +316,7 @@ function useFieldTypeGroups(): OptionGroup[] {
 function QuickCreateFieldForm({
   entityDefinitionId,
   sourceType,
+  sourceFieldType,
   ownedWrite,
   excludeKeys,
   seedName,
@@ -317,6 +326,7 @@ function QuickCreateFieldForm({
 }: {
   entityDefinitionId: string
   sourceType: string
+  sourceFieldType?: FieldTypeType
   ownedWrite?: boolean
   excludeKeys?: Set<string>
   seedName: string
@@ -347,9 +357,9 @@ function QuickCreateFieldForm({
     const bindable =
       !alreadyMapped &&
       isWritableTarget(existing, { ownedWrite }) &&
-      isSourceTargetCompatible(existing.fieldType, sourceType)
+      isSourceTargetCompatible(existing.fieldType, sourceType, sourceFieldType)
     return { existing, ref, bindable, alreadyMapped }
-  }, [trimmed, fields, entityDefinitionId, excludeKeys, sourceType, ownedWrite])
+  }, [trimmed, fields, entityDefinitionId, excludeKeys, sourceType, sourceFieldType, ownedWrite])
 
   const canSubmit = !!trimmed && !conflict && !create.isPending
 

--- a/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
@@ -3,7 +3,7 @@
 
 import type { ResourceField } from '@auxx/lib/resources/client'
 import type { FieldReference } from '@auxx/types/field'
-import { Brackets, Hash } from 'lucide-react'
+import { Braces, Brackets, Hash } from 'lucide-react'
 import { lastSegment, type SourcePath } from '../hooks/use-source-paths'
 import { type IdentityRole, IdentityRoleControl } from './identity-role-control'
 import { MappingFieldPicker } from './mapping-field-picker'
@@ -13,12 +13,19 @@ import { FieldRowActions, MappingRow } from './mapping-row'
 export type LeafIdentityRole = IdentityRole
 
 /**
- * Short type token for the leaf badge. Prefers a detected string `format`
+ * Short type token for the leaf badge. A declared struct field type wins (an
+ * `ADDRESS_STRUCT` leaf reads `ADDRESS`), then a detected string `format`
  * (`uri`/`email`/`date`/…) over the bare JSON type, so the badge matches what
  * quick-create seeds — a `url`-valued string reads `URL`, not `STRING`. The
  * badge's `uppercase` class handles casing.
  */
 function sourceTypeLabel(node: SourcePath): string {
+  // `ADDRESS_STRUCT` → `address`, `NAME` → `name` (CSS uppercases for display).
+  if (node.fieldType)
+    return node.fieldType
+      .replace(/_STRUCT$/, '')
+      .replace(/_/g, ' ')
+      .toLowerCase()
   switch (node.format) {
     case 'uri':
       return 'url'
@@ -117,7 +124,8 @@ export function SourceLeafRow({
   const isLinked = !!linkedFieldRef
   const isActive = isMapped || isLinked
   const isArray = node.type === 'array'
-  const Icon = isArray ? Brackets : Hash
+  // A struct leaf (object value, e.g. ADDRESS_STRUCT) reads as `{}`; arrays `[]`; scalars `#`.
+  const Icon = isArray ? Brackets : node.fieldType ? Braces : Hash
   return (
     <MappingRow
       depth={depth}
@@ -150,6 +158,7 @@ export function SourceLeafRow({
           kind='leaf'
           entityDefinitionId={entityDefinitionId}
           sourceType={node.type}
+          sourceFieldType={node.fieldType}
           sourcePath={node.path}
           sourceFormat={node.format}
           assignedKey={assignedTargetKey}

--- a/packages/lib/src/data-connectors/app-catalog.test.ts
+++ b/packages/lib/src/data-connectors/app-catalog.test.ts
@@ -9,6 +9,7 @@ import {
   buildContributingFieldBindings,
   buildSchemaFromFieldPaths,
   type ContributingTargetField,
+  overlayDeclaredFieldTypes,
 } from './app-catalog'
 
 describe('buildSchemaFromFieldPaths', () => {
@@ -72,6 +73,71 @@ describe('appCatalogStreamSchema', () => {
       type: 'object',
       properties: { name: { type: 'string' } },
     })
+  })
+
+  it('stamps x-auxx-fieldType on an ADDRESS_STRUCT field node (keeping its components)', () => {
+    const result = appCatalogStreamSchema({
+      key: 'order',
+      displayFieldKey: 'name',
+      fields: [
+        { fieldKey: 'id', sourcePath: 'id', type: 'TEXT', name: 'ID' },
+        {
+          fieldKey: 'shippingAddress',
+          sourcePath: 'shipping_address',
+          type: 'ADDRESS_STRUCT',
+          name: 'Shipping Address',
+        },
+      ],
+      exampleRecord: {
+        id: 'o1',
+        shipping_address: { street1: '123 Main St', city: 'Austin', country: 'US' },
+      },
+    })
+    const props = (result.sourceSchema as { properties: Record<string, Record<string, unknown>> })
+      .properties
+    expect(props.shipping_address['x-auxx-fieldType']).toBe('ADDRESS_STRUCT')
+    // Components survive in the schema — only the CLIENT flatten stops descending.
+    expect(props.shipping_address.properties).toHaveProperty('city')
+  })
+})
+
+describe('overlayDeclaredFieldTypes', () => {
+  it('stamps a nested + array-element struct path', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        customer: {
+          type: 'object',
+          properties: { address: { type: 'object', properties: { city: { type: 'string' } } } },
+        },
+        line_items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: { ship: { type: 'object', properties: { zip: { type: 'string' } } } },
+          },
+        },
+      },
+    }
+    overlayDeclaredFieldTypes(schema, [
+      { fieldKey: 'a', sourcePath: 'customer.address', type: 'ADDRESS_STRUCT', name: 'A' },
+      { fieldKey: 'b', sourcePath: 'line_items[].ship', type: 'ADDRESS_STRUCT', name: 'B' },
+    ])
+    const props = schema.properties as Record<string, Record<string, Record<string, unknown>>>
+    expect(props.customer.properties.address['x-auxx-fieldType']).toBe('ADDRESS_STRUCT')
+    const itemProps = (
+      props.line_items.items as { properties: Record<string, Record<string, unknown>> }
+    ).properties
+    expect(itemProps.ship['x-auxx-fieldType']).toBe('ADDRESS_STRUCT')
+  })
+
+  it('ignores non-struct fields and absent paths', () => {
+    const schema = { type: 'object', properties: { name: { type: 'string' } } }
+    overlayDeclaredFieldTypes(schema, [
+      { fieldKey: 'name', sourcePath: 'name', type: 'TEXT', name: 'Name' },
+      { fieldKey: 'gone', sourcePath: 'missing', type: 'ADDRESS_STRUCT', name: 'Gone' },
+    ])
+    expect(schema).toEqual({ type: 'object', properties: { name: { type: 'string' } } })
   })
 })
 

--- a/packages/lib/src/data-connectors/app-catalog.ts
+++ b/packages/lib/src/data-connectors/app-catalog.ts
@@ -7,7 +7,7 @@
 import type { CatalogDataConnector } from '@auxx/database'
 import { toResourceFieldId } from '@auxx/types/field'
 import { generateId } from '@auxx/utils'
-import { inferJsonSchema } from '../json-schema'
+import { inferJsonSchema, STRUCT_FIELD_TYPE_KEYWORD } from '../json-schema'
 import type { FieldMapping, IdentityNormalize } from './types'
 
 /** A catalog source field's declared type → the JSON-schema scalar type it carries. */
@@ -291,6 +291,57 @@ function bindSourceToTarget(
   }
 }
 
+/**
+ * Source field types that carry a STRUCT value (one nested object that maps as a
+ * single value, not a branch to explode). The schema overlay stamps these so the
+ * mapping editor renders the node as a typed value leaf bound to a matching target
+ * field — see plans/data-connectors/v6/address-struct-mapping-plan.md. `NAME` is a
+ * candidate but lacks a JSON/object compat entry today, so it stays out for now.
+ */
+export const STRUCT_SOURCE_FIELD_TYPES = new Set(['ADDRESS_STRUCT'])
+
+interface MutableSchemaNode {
+  type?: string | string[]
+  properties?: Record<string, MutableSchemaNode>
+  items?: MutableSchemaNode
+  [key: string]: unknown
+}
+
+/** Descend a dotted, `[]`-aware `sourcePath` into the inferred schema. Null if absent. */
+function findSchemaNode(root: MutableSchemaNode, sourcePath: string): MutableSchemaNode | null {
+  let node: MutableSchemaNode | undefined = root
+  for (const rawSeg of sourcePath.split('.').filter(Boolean)) {
+    const isArray = rawSeg.endsWith('[]')
+    const seg = isArray ? rawSeg.slice(0, -2) : rawSeg
+    const child = node?.properties?.[seg]
+    if (!child) return null
+    // An array property carries its element shape under `items` — descend into it so a
+    // path segment like `line_items[]` lands on the element, not the array container.
+    node = isArray && child.type === 'array' && child.items ? child.items : child
+  }
+  return node ?? null
+}
+
+/**
+ * Stamp each STRUCT-typed declared field's {@link STRUCT_FIELD_TYPE_KEYWORD} onto the
+ * schema node at its `sourcePath`, so the client flatten/suggester treat that node as a
+ * single typed value leaf instead of an object branch. Mutates `schema` in place (it's
+ * freshly built by the caller). Fields without a struct type, or whose node is absent
+ * from the example record, are skipped.
+ */
+export function overlayDeclaredFieldTypes(
+  schema: Record<string, unknown>,
+  fields: CatalogDataConnector['streams'][number]['fields']
+): Record<string, unknown> {
+  const root = schema as MutableSchemaNode
+  for (const f of fields) {
+    if (!STRUCT_SOURCE_FIELD_TYPES.has(f.type)) continue
+    const node = findSchemaNode(root, f.sourcePath)
+    if (node) node[STRUCT_FIELD_TYPE_KEYWORD] = f.type
+  }
+  return schema
+}
+
 /** The source schema for an app catalog stream — prefer its canonical sample. */
 export function appCatalogStreamSchema(stream: CatalogDataConnector['streams'][number]): {
   sourceSchema: Record<string, unknown>
@@ -299,5 +350,6 @@ export function appCatalogStreamSchema(stream: CatalogDataConnector['streams'][n
   const sourceSchema = stream.exampleRecord
     ? (inferJsonSchema(stream.exampleRecord) as Record<string, unknown>)
     : buildSchemaFromFieldPaths(stream.fields)
+  overlayDeclaredFieldTypes(sourceSchema, stream.fields)
   return { sourceSchema, schemaSource: 'catalog' }
 }

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -451,6 +451,7 @@ export async function createConnectorFromAppCatalog(
       organizationId,
       streamRow.id,
       stream,
+      appSlug,
       ownedMappingIdByRootPath
     )
   }
@@ -577,6 +578,15 @@ async function seedAppOwnedMappings(
 
     const parentRootPath = ownedParentRootPath(mapping.rootPath, allRootPaths)
     const parentMappingId = parentRootPath != null ? mappingIdByRootPath[parentRootPath] : null
+    // The edge field lives on the PARENT def — namespace the relationship key with the
+    // parent's apiSlug (cosmetic), falling back to this mapping's own slug for a
+    // top-level reference (no parent in scope).
+    const parentManifest =
+      parentRootPath != null ? owned.find((m) => m.rootPath === parentRootPath) : undefined
+    const parentSlug =
+      parentManifest?.target.mode === 'owned'
+        ? parentManifest.target.entity.apiSlug
+        : entity.apiSlug
 
     const row = await addMapping(db, organizationId, {
       dataConnectorStreamId: streamId,
@@ -595,7 +605,11 @@ async function seedAppOwnedMappings(
       targetMode: 'owned' as TargetMode,
       entityDefinitionId: null,
       parentMappingId,
-      relationshipFieldKey: mapping.relationshipFieldKey ?? null,
+      relationshipFieldKey: appRelationshipFieldKey(
+        mapping.relationshipFieldKey,
+        appSlug,
+        parentSlug
+      ),
       // A `reference` edge carries only its External-ID anchor (the FK value IS the
       // related record's external id). An upsert mapping owns its subtree's columns:
       // late-bound refs key on the manifest apiSlug; the install rewrites them to
@@ -639,6 +653,25 @@ export function buildAppOwnedFieldMappings(
     expression: `{${relPath}}`,
     sourceFields: { [relPath]: relPath },
   }))
+}
+
+/**
+ * Wrap a manifest's BARE `relationshipFieldKey` (e.g. `product`) into the same
+ * connection-late-bound `@app:` envelope the owned field refs use —
+ * `${parentSlug}:@app:${appSlug}:${key}`. A bare token in a ref slot is ambiguous (it
+ * could read as an apiSlug or a concrete field id); the envelope is self-describing and
+ * carries the app slug so two apps sharing a key can't collide. The edge field lives on
+ * the PARENT def, so the (cosmetic) leading segment is the parent's slug — the sink +
+ * editor resolve def-keyed on `@app:${appSlug}:${key}` and never read the leading segment.
+ * The manual editor already stores a concrete `defId:fieldId`, so after this no ref slot
+ * ever holds a bare key. `null`/absent passes through.
+ */
+export function appRelationshipFieldKey(
+  bareKey: string | null | undefined,
+  appSlug: string,
+  parentSlug: string
+): string | null {
+  return bareKey ? toAppFieldRef(parentSlug, appSlug, bareKey) : null
 }
 
 /**
@@ -719,6 +752,8 @@ async function materializeAppContributingMappings(
   organizationId: string,
   streamId: string,
   stream: CatalogDataConnector['streams'][number],
+  /** Namespaces the late-bound `@app:` relationship-field refs (`app:<slug>`). */
+  appSlug: string,
   /** rootPath → owned-mapping id, so a nested contributing branch can find its parent. */
   ownedMappingIdByRootPath: Record<string, string> = {}
 ): Promise<void> {
@@ -782,6 +817,19 @@ async function materializeAppContributingMappings(
     const parentRootPath = ownedParentRootPath(mapping.rootPath, ownedRootPaths)
     const parentMappingId =
       parentRootPath != null ? (ownedMappingIdByRootPath[parentRootPath] ?? null) : null
+    // The edge field lives on the PARENT def — namespace the relationship key with the
+    // parent's slug (cosmetic), falling back to this mapping's own entity for a top-level
+    // contributing reference.
+    const parentManifest =
+      parentRootPath != null
+        ? (stream.defaultMappings ?? []).find((m) => m.rootPath === parentRootPath)
+        : undefined
+    const parentSlug =
+      parentManifest?.target.mode === 'owned'
+        ? parentManifest.target.entity.apiSlug
+        : parentManifest?.target.mode === 'contributing'
+          ? parentManifest.target.entityKind
+          : entityKind
 
     await addMapping(db, organizationId, {
       dataConnectorStreamId: streamId,
@@ -796,7 +844,11 @@ async function materializeAppContributingMappings(
       targetMode: 'contributing' as TargetMode,
       entityDefinitionId,
       parentMappingId,
-      relationshipFieldKey: mapping.relationshipFieldKey ?? null,
+      relationshipFieldKey: appRelationshipFieldKey(
+        mapping.relationshipFieldKey,
+        appSlug,
+        parentSlug
+      ),
       fieldMappings,
       orphanBehavior: 'ignore' as OrphanBehavior,
     })

--- a/packages/lib/src/data-connectors/owned-mappings.test.ts
+++ b/packages/lib/src/data-connectors/owned-mappings.test.ts
@@ -6,6 +6,7 @@
 import type { CatalogDataConnector } from '@auxx/database'
 import { describe, expect, it } from 'vitest'
 import {
+  appRelationshipFieldKey,
   buildAppOwnedFieldMappings,
   buildReferenceAnchor,
   type OwnedFieldEntry,
@@ -233,6 +234,26 @@ describe('relativeSourcePath (nested-child rootPath relativization)', () => {
     // before the fix, which is why only depth-≥2 children regressed).
     expect(relativeSourcePath('line_items[]', '')).toBe('line_items[]')
     expect(relativeSourcePath('customer', '')).toBe('customer')
+  })
+})
+
+describe('appRelationshipFieldKey', () => {
+  it('wraps a bare manifest key in the parent-scoped @app: envelope', () => {
+    // The edge field lives on the parent (line_item) def, so the leading segment is the
+    // parent slug; resolution keys on `@app:<appSlug>:<key>` (the leading slug is cosmetic).
+    expect(appRelationshipFieldKey('product', 'shopify', 'shopify_line_items')).toBe(
+      'shopify_line_items:@app:shopify:product'
+    )
+  })
+
+  it('passes null/undefined through (no edge to namespace)', () => {
+    expect(appRelationshipFieldKey(null, 'shopify', 'shopify_line_items')).toBeNull()
+    expect(appRelationshipFieldKey(undefined, 'shopify', 'shopify_line_items')).toBeNull()
+  })
+
+  it('never emits a bare token a ref slot could mistake for an apiSlug/field id', () => {
+    const ref = appRelationshipFieldKey('lineItems', 'shopify', 'shopify_orders')!
+    expect(ref).toContain(':@app:')
   })
 })
 

--- a/packages/lib/src/data-connectors/sink-source-record.test.ts
+++ b/packages/lib/src/data-connectors/sink-source-record.test.ts
@@ -17,7 +17,8 @@ vi.mock('./reconciliation', () => ({ archiveExternalId: vi.fn() }))
 
 // Field cache: the order def carries a connector-provisioned `Line Items` has_many
 // field whose REAL id differs from its `appFieldKey` ('lineItems') — the exact shape
-// that broke `resolveEdge` (it matched on id/resourceFieldId, never appFieldKey).
+// `resolveEdge` must resolve via the late-bound `@app:` ref (it matches by appFieldKey,
+// never the provisioned id).
 const fieldsByDef: Record<string, ResourceField[]> = {}
 vi.mock('../cache', () => ({
   getCachedResourceFields: (_org: string, defId: string) =>
@@ -82,9 +83,10 @@ describe('sinkSourceRecord — relationship edge resolution', () => {
       rootPath: 'line_items[]',
       entityDefinitionId: 'lineDef',
       parentMappingId: 'orderMap',
-      // The authored key is the app's relationship.fieldKey — equals appFieldKey,
-      // NOT the provisioned field id.
-      relationshipFieldKey: 'lineItems',
+      // The seeded key is the late-bound `@app:` envelope — its `appFieldKey` segment
+      // ('lineItems') matches the provisioned field's appFieldKey, NOT its id. The
+      // leading slug is cosmetic; resolveEdge resolves on the parent def.
+      relationshipFieldKey: 'shopify_orders:@app:shopify:lineItems',
     })
 
     const source: ConnectorRecord = {

--- a/packages/lib/src/data-connectors/sink-source-record.ts
+++ b/packages/lib/src/data-connectors/sink-source-record.ts
@@ -11,13 +11,15 @@ import type { RelationshipConfig } from '@auxx/types/custom-field'
 import {
   getFieldDefinitionId,
   getFieldId,
+  isAppFieldRef,
   isFieldPath,
   keyToFieldRef,
+  parseAppFieldRef,
   type ResourceFieldId,
   toResourceFieldId,
 } from '@auxx/types/field'
 import { getCachedResourceFields } from '../cache'
-import type { ResourceField } from '../resources'
+import { type ResourceField, resolveFieldRef } from '../resources'
 import type { ConnectorRecord } from './connectors/types'
 import type { MappedWrite } from './map-record'
 import { mapRecord } from './map-record'
@@ -61,25 +63,28 @@ async function resolveEdge(
   // The drilled relationship lives on the parent def; a deeper FieldPath nests via
   // child mappings (each a single drill), so the last segment is the edge field.
   const lastSeg = isFieldPath(ref) ? ref[ref.length - 1]! : ref
-  // A bare authored key (template/app connectors store just the field id, e.g.
-  // `customer`) carries no def prefix — qualify it against the parent mapping's def.
-  // A def-qualified ref (UI `order:customer`) or a deeper path segment is used as-is.
-  const forwardRef = (
-    lastSeg.includes(':') ? lastSeg : toResourceFieldId(parentDef, lastSeg)
-  ) as ResourceFieldId
-  const ownerDef = getFieldDefinitionId(forwardRef)
-  const derivedFieldId = getFieldId(forwardRef)
-
-  // Resolve the forward field up front (needed for cardinality AND its real id). A
-  // connector-provisioned RELATIONSHIP field has an AUTO-GENERATED id distinct from
-  // its `appFieldKey` — so the authored `relationshipFieldKey` ('lineItems') matches
-  // the field's `appFieldKey`, NOT its id. Match on all three, then use the resolved
-  // field's REAL id for the forward edge (the derived id is just the authored key).
+  // The edge field lives on the PARENT def. Two ref forms reach here: a concrete
+  // `defId:fieldId` segment (UI `order:customer` or a deeper drilled hop) names its OWN
+  // def; a late-bound `<slug>:@app:<app>:<key>` ref (app/template connectors) resolves on
+  // the parent — its leading slug is the manifest apiSlug, NOT a real def id. Resolve
+  // through the SAME resolver the editor uses (`resolveFieldRef` → concrete OR `@app:`,
+  // which matches a connector-provisioned RELATIONSHIP field's AUTO-GENERATED id by its
+  // `appFieldKey`), so display + sync never diverge. Then use the field's REAL id.
+  const ownerDef =
+    !isAppFieldRef(lastSeg) && lastSeg.includes(':') ? getFieldDefinitionId(lastSeg) : parentDef
   const fields = await getFields(ownerDef)
-  const field = fields.find(
-    (f) => f.id === derivedFieldId || f.resourceFieldId === forwardRef || f.appFieldKey === lastSeg
-  )
-  const forwardFieldId = field?.id ?? derivedFieldId
+  const field = resolveFieldRef(fields, ownerDef, lastSeg)?.field
+  // Fall back to the authored id when nothing resolves (shouldn't happen post-install):
+  // the bare app key for an `@app:` ref, else the def-qualified concrete id.
+  const forwardFieldId =
+    field?.id ??
+    (isAppFieldRef(lastSeg)
+      ? (parseAppFieldRef(lastSeg)?.appFieldKey ?? lastSeg)
+      : getFieldId(
+          (lastSeg.includes(':')
+            ? lastSeg
+            : toResourceFieldId(parentDef, lastSeg)) as ResourceFieldId
+        ))
 
   // CLEAR — belongs_to only (a reference FK that went empty). Null the parent field.
   if (rel.childExternalId === null) {

--- a/packages/lib/src/data-connectors/suggest-mappings.test.ts
+++ b/packages/lib/src/data-connectors/suggest-mappings.test.ts
@@ -62,6 +62,22 @@ describe('collectSchemaLeaves', () => {
       { path: 'ids', jsonType: 'number' },
     ])
   })
+
+  it('emits an `x-auxx-fieldType` struct node as one leaf (carrying the type, not its components)', () => {
+    const leaves = collectSchemaLeaves({
+      type: 'object',
+      properties: {
+        shipping_address: {
+          type: 'object',
+          'x-auxx-fieldType': 'ADDRESS_STRUCT',
+          properties: { city: { type: 'string' } },
+        },
+      },
+    })
+    expect(leaves).toEqual([
+      { path: 'shipping_address', jsonType: 'object', fieldType: 'ADDRESS_STRUCT' },
+    ])
+  })
 })
 
 describe('suggestFieldMappings', () => {
@@ -121,6 +137,40 @@ describe('suggestFieldMappings', () => {
       targets
     )
     expect(proposals).toEqual([])
+  })
+
+  it('binds a struct leaf to a same-named ADDRESS_STRUCT target (and not to a TEXT one)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        shipping_address: {
+          type: 'object',
+          'x-auxx-fieldType': 'ADDRESS_STRUCT',
+          properties: { city: { type: 'string' } },
+        },
+      },
+    }
+    // TEXT target → struct source incompatible, no proposal.
+    expect(
+      suggestFieldMappings(DEF, schema, [
+        field({ id: 'addr', key: 'shippingAddress', label: 'Shipping Address', fieldType: 'TEXT' }),
+      ])
+    ).toEqual([])
+    // ADDRESS_STRUCT target → binds the whole-object leaf.
+    const proposals = suggestFieldMappings(DEF, schema, [
+      field({
+        id: 'addr',
+        key: 'shippingAddress',
+        label: 'Shipping Address',
+        fieldType: 'ADDRESS_STRUCT',
+      }),
+    ])
+    expect(proposals).toHaveLength(1)
+    expect(proposals[0]).toMatchObject({
+      targetFieldRef: `${DEF}:addr`,
+      expression: '{shipping_address}',
+      sourceFields: { shipping_address: 'shipping_address' },
+    })
   })
 
   it('binds at most one source per target field', () => {

--- a/packages/lib/src/data-connectors/suggest-mappings.ts
+++ b/packages/lib/src/data-connectors/suggest-mappings.ts
@@ -66,12 +66,14 @@ export function suggestFieldMappings(
   for (const leaf of leaves) {
     const leafName = normalizeName(lastSegment(leaf.path))
     if (!leafName) continue
+    // A struct leaf (e.g. ADDRESS_STRUCT) carries its declared field type — match against
+    // it directly so it binds to a same-named struct target; else reduce the JSON type.
+    const sourceFieldType =
+      (leaf.fieldType as FieldTypeValue | undefined) ?? jsonToFieldType(leaf.jsonType)
     const match = writable.find((f) => {
       if (used.has(f.id)) return false
       if (![normalizeName(f.key), normalizeName(f.label)].includes(leafName)) return false
-      if (f.fieldType && !isFieldTypeCompatible(f.fieldType, jsonToFieldType(leaf.jsonType))) {
-        return false
-      }
+      if (f.fieldType && !isFieldTypeCompatible(f.fieldType, sourceFieldType)) return false
       return true
     })
     if (!match) continue

--- a/packages/lib/src/json-schema/client.ts
+++ b/packages/lib/src/json-schema/client.ts
@@ -13,6 +13,7 @@ export {
   collectSchemaLeaves,
   lastSegment,
   type SourceLeaf,
+  STRUCT_FIELD_TYPE_KEYWORD,
 } from './flatten'
 export { inferJsonSchema, type JsonSchema } from './infer'
 export { sanitizeFormatsForOpenAiStrict, stripVendorKeywords, VENDOR_KEYWORD } from './vendor'

--- a/packages/lib/src/json-schema/flatten.ts
+++ b/packages/lib/src/json-schema/flatten.ts
@@ -3,12 +3,23 @@
 // server-side mapping suggester (`data-connectors/suggest-mappings`) and client UIs
 // (webhook token-path pickers) share one walker. Extracted from suggest-mappings (v7).
 
+/**
+ * JSON-Schema extension keyword carrying a node's declared STRUCT field type
+ * (e.g. `ADDRESS_STRUCT`). Stamped by the data-connector catalog overlay so a struct
+ * source value flattens as a single typed leaf instead of an object branch — see
+ * plans/data-connectors/v6/address-struct-mapping-plan.md. Unknown keywords are ignored
+ * by JSON-Schema and survive the `sourceSchema` jsonb round-trip.
+ */
+export const STRUCT_FIELD_TYPE_KEYWORD = 'x-auxx-fieldType'
+
 /** A scalar source leaf extracted from a JSON schema, with its record-relative path. */
 export interface SourceLeaf {
   /** Record-relative dotted path, e.g. `email` / `customer.email`. */
   path: string
   /** JSON-schema scalar type at this path (`string` / `number` / `boolean` / …). */
   jsonType: string
+  /** Declared STRUCT field type when the node is a typed struct leaf (`ADDRESS_STRUCT`). */
+  fieldType?: string
 }
 
 interface JsonSchemaNode {
@@ -16,6 +27,7 @@ interface JsonSchemaNode {
   format?: string
   properties?: Record<string, JsonSchemaNode>
   items?: JsonSchemaNode
+  [STRUCT_FIELD_TYPE_KEYWORD]?: string
 }
 
 function nodeType(node: JsonSchemaNode): string {
@@ -54,7 +66,11 @@ export function collectSchemaLeaves(
     for (const [key, child] of Object.entries(node.properties)) {
       const path = prefix ? `${prefix}.${key}` : key
       const t = nodeType(child)
-      if (t === 'object') walk(child, path)
+      // A struct-typed node maps as ONE value — emit it as a leaf and don't descend into
+      // its components (mirrors the client flatten in `use-source-paths`).
+      const structType = child[STRUCT_FIELD_TYPE_KEYWORD]
+      if (structType) out.push({ path, jsonType: t, fieldType: structType })
+      else if (t === 'object') walk(child, path)
       else if (t === 'array') {
         // A collection of objects → its own mapping, not a field. A collection of
         // scalars can steer a comma-joined token when the caller opts in.

--- a/packages/lib/src/json-schema/index.ts
+++ b/packages/lib/src/json-schema/index.ts
@@ -10,6 +10,7 @@ export {
   collectSchemaLeaves,
   lastSegment,
   type SourceLeaf,
+  STRUCT_FIELD_TYPE_KEYWORD,
 } from './flatten'
 export { inferJsonSchema, type JsonSchema } from './infer'
 export { sanitizeFormatsForOpenAiStrict, stripVendorKeywords, VENDOR_KEYWORD } from './vendor'

--- a/packages/lib/src/resources/index.ts
+++ b/packages/lib/src/resources/index.ts
@@ -70,6 +70,7 @@ export type {
 // Resource types (system + custom)
 export {
   ENTITY_DEFINITION_TYPES,
+  fieldMatchesRef,
   getAllFields,
   getCreatableFields,
   getField,
@@ -96,6 +97,7 @@ export {
   RESOURCE_FIELD_REGISTRY,
   RESOURCE_TABLE_MAP,
   RESOURCE_TABLE_REGISTRY,
+  resolveFieldRef,
   setEntityVariables,
   setResourceVariables,
 } from './registry'

--- a/packages/lib/src/resources/registry/index.ts
+++ b/packages/lib/src/resources/registry/index.ts
@@ -223,6 +223,7 @@ export { resolveEntityDefTypeId } from './entity-def-resolver'
 export { ENTITY_INSTANCE_FIELDS, getEntityInstanceFields } from './entity-instance-fields'
 // Re-export field utility functions
 export {
+  fieldMatchesRef,
   getDefaultIdentifierField,
   getDisplayFields,
   getFieldOperators,
@@ -230,6 +231,7 @@ export {
   isComputedField,
   isSystemField,
   isValidOperatorForField,
+  resolveFieldRef,
   setEntityVariables,
   setResourceVariables,
   sortFieldsForDisplay,


### PR DESCRIPTION
Two related data-connectors mapping changes, in separate commits.

## 1. Namespace the app `relationshipFieldKey` (the bug you hit)

**Symptom:** on an app-installed connector, the `line_item.product_id` FK leaf showed the unlinked "Apply field…" placeholder even though the relationship link existed (its sub-row rendered). A *manually*-linked connector showed "Linked". Same data, two different displays.

**Root cause:** the app-install seeders stored `relationshipFieldKey` as a **bare** manifest key (e.g. `product`). A bare token in a ref slot is ambiguous — indistinguishable from an apiSlug or a concrete field id — so the editor's display resolver (`fieldMatchesRef`, which only understands `defId:fieldId` and `@app:`) couldn't resolve it. The sync resolver (`resolveEdge`) *did* match it by `appFieldKey`, so display and sync diverged.

**Fix:** wrap the bare key into the same connection-late-bound `@app:` envelope the owned field refs already use — `${parentSlug}:@app:${appSlug}:${key}` — via a new `appRelationshipFieldKey` helper, in both the owned and contributing seeders. `resolveEdge` drops its bare-`appFieldKey` arm and resolves through the **same** shared `resolveFieldRef` the editor uses, so both paths converge on one grammar + one resolver. The manual editor already stores a concrete `defId:fieldId`, so no ref slot ever holds a bare key again.

- `text()` column value shape changes (`product` → `shopify_line_items:@app:shopify:product`); **no schema/migration**.
- Existing connectors with bare keys must be **recreated** (delete/recreate norm) to reseed the namespaced form — after that the row reads "Linked" in both paths and the edge writes.

## 2. Map struct source fields as typed value leaves (`ADDRESS_STRUCT`)

A declared STRUCT source field is one nested object that should map as a **single** value, not explode into a branch. Adds the `x-auxx-fieldType` JSON-Schema extension keyword, stamped onto the schema node via the catalog overlay; both flatten walkers (server suggester + client source-tree) then emit it as a typed value leaf. The declared `fieldType` drives the leaf badge/icon, the picker's target filter + quick-create seed (via a new optional `sourceFieldType` on `isSourceTargetCompatible`, bypassing the lossy `object → JSON` widening), and the name-match suggester. See `plans/data-connectors/v6/address-struct-mapping-plan.md`.

## Tests
Green: data-connectors + resources lib (251), json-schema (24), web data-connectors (113). Lint clean; `@auxx/lib` rebuilt. Do NOT run tsc (per repo rules).