### PR TITLE
feat(data-connectors): use declared requiresConnection for Connect + auto-link sole connection

### DIFF
--- a/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-setup-stepper.tsx
@@ -25,7 +25,6 @@ import {
 import { toastError } from '@auxx/ui/components/toast'
 import { Check, Clock, FlaskConical, Layers, Play, Plug, Waypoints } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { useAppsContext } from '~/components/apps/providers/apps-context'
 import { isMissing, readFieldNodes } from '~/components/global/schema-form'
 import { api, type RouterOutputs } from '~/trpc/react'
 import { useConnectorMutations } from '../hooks/use-connector-mutations'
@@ -172,23 +171,19 @@ export function ConnectorSetupStepper({ connector }: ConnectorSetupStepperProps)
   const stepOrder = useMemo(() => steps.map((s) => s.id), [steps])
 
   // Connect requirements for an app connector (generic-rest ignores these): a credential
-  // is required when the app exposes a connection definition, and the declared config
-  // schema decides whether there's a settings form to fill. Both come from sources a pure
-  // connector+streams read can't see, so we resolve them here and hand them to the hook.
-  const { appInstallations } = useAppsContext()
-  const requiresConnection = useMemo(() => {
-    if (connector.definitionKind !== 'app') return false
-    const slug = connector.type.startsWith('app:') ? connector.type.slice('app:'.length) : null
-    const inst = appInstallations.find(
-      (i) => i.installationId === connector.appInstallationId || i.app.slug === slug
-    )
-    return !!(inst?.connectionDefinitions?.user || inst?.connectionDefinitions?.organization)
-  }, [connector.definitionKind, connector.type, connector.appInstallationId, appInstallations])
-
+  // is required when the connector's OWN catalog declares `requiresConnection` (the same
+  // signal the runtime adapter gates on — NOT whether the app merely exposes a connection
+  // definition, which is app-level and over-counts client-credentials connectors), and the
+  // declared config schema decides whether there's a settings form to fill. Both ride the
+  // `connectorSchema` query — sources a pure connector+streams read can't see.
   const schemaQuery = api.dataConnector.connectorSchema.useQuery(
     { id: connector.id },
     { enabled: connector.definitionKind === 'app' }
   )
+  // Stay conservative (assume required) until the schema resolves, so the Connect step is
+  // never auto-skipped before we actually know the connector needs no connection.
+  const requiresConnection =
+    connector.definitionKind === 'app' ? (schemaQuery.data?.requiresConnection ?? true) : false
   const configFields = useMemo(
     () => readFieldNodes(schemaQuery.data?.configJsonSchema as Record<string, unknown> | null),
     [schemaQuery.data]

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -251,7 +251,12 @@ export const dataConnectorRouter = createTRPCRouter({
       }
       const connector = result.value
       if (!connector.type.startsWith('app:')) {
-        return { requestModel: 'builder' as const, configJsonSchema: null, configOptionHints: null }
+        return {
+          requestModel: 'builder' as const,
+          configJsonSchema: null,
+          configOptionHints: null,
+          requiresConnection: false,
+        }
       }
       const slug = connector.type.replace(/^app:/, '')
       const installedApps = await getCachedInstalledApps(ctx.session.organizationId)
@@ -263,6 +268,10 @@ export const dataConnectorRouter = createTRPCRouter({
         requestModel: dc?.requestModel ?? ('fixed' as const),
         configJsonSchema: dc?.configJsonSchema ?? null,
         configOptionHints: dc?.configOptionHints ?? null,
+        // The app-declared, connector-level connection requirement (the same signal
+        // the runtime adapter gates on). The setup wizard's Connect step keys off this
+        // — NOT off whether the installed app merely exposes a connection definition.
+        requiresConnection: dc?.requiresConnection ?? false,
       }
     }),
 
@@ -488,7 +497,10 @@ export const dataConnectorRouter = createTRPCRouter({
               name: input.name,
               type: input.type as DataConnectorType,
               credentialId: input.credentialId,
-              appInstallationId: input.appInstallationId,
+              // Stamp the resolved installation so the connector is pinned to the exact
+              // app install (keeps token refresh wired) AND the auto-link can count that
+              // install's connections. Falls back to a client-supplied id, then null.
+              appInstallationId: input.appInstallationId ?? app?.installationId ?? null,
               syncBehavior: input.syncBehavior,
               scheduleConfig: input.scheduleConfig,
               createdById: ctx.session.userId,

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -102,6 +102,7 @@ export {
   projectConnectorOwnedTargets,
   removeMapping,
   removeStream,
+  resolveSoleAppConnection,
   setStreamRequestConfig,
   setStreamSchema,
   updateConnector,

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -5,6 +5,7 @@
 // re-registration is driven from create/update (pause/resume is a `status` patch
 // through update) so a cadence or lifecycle change is reflected in BullMQ immediately.
 
+import { listCredentials } from '@auxx/credentials/store'
 import { type CatalogDataConnector, type Database, schema, type Transaction } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import {
@@ -396,6 +397,28 @@ async function buildTemplateFieldMappings(
 }
 
 /**
+ * Resolve the connection to auto-bind a fresh app connector to. Returns the id ONLY
+ * when the org has exactly one org-scoped connection for this app installation — the
+ * unambiguous case worth auto-linking. Zero (nothing to link) or two-plus (the user
+ * must disambiguate) → `null`, so the connector is created unbound. Personal
+ * (user-scoped) connections are excluded: a background sync must bind a shared org
+ * connection so it doesn't break for other members.
+ */
+export async function resolveSoleAppConnection(
+  organizationId: string,
+  appInstallationId: string
+): Promise<string | null> {
+  const result = await listCredentials({
+    organizationId,
+    kind: 'app',
+    appInstallationId,
+    userId: null,
+  })
+  if (result.isErr()) return null
+  return result.value.length === 1 ? result.value[0].id : null
+}
+
+/**
  * Create a connector from an installed app's catalog declaration (create-sync-flow
  * §3.1, Tier 1). Mirrors {@link createConnectorFromTemplate}: an `app:<slug>`
  * connector + one pre-filled stream per declared catalog stream, each with the
@@ -421,9 +444,21 @@ export async function createConnectorFromAppCatalog(
   input: Omit<CreateConnectorInput, 'definitionKind' | 'templateId' | 'config'>,
   catalog: CatalogDataConnector
 ): Promise<DataConnectorRow> {
+  // Auto-link the connection when the connector needs one and the org has EXACTLY one
+  // for this app installation — the unambiguous case (e.g. a single Shopify account
+  // already connected). Zero (nothing to link) or two-plus (ambiguous — the user must
+  // choose) leaves it unbound, so the Connect step prompts a pick. Only when the caller
+  // didn't already pass a credential.
+  const credentialId =
+    input.credentialId ??
+    (catalog.requiresConnection && input.appInstallationId
+      ? await resolveSoleAppConnection(organizationId, input.appInstallationId)
+      : null)
+
   const connector = await createConnector(db, organizationId, {
     ...input,
     definitionKind: 'app',
+    credentialId,
   })
 
   // The app slug namespaces the late-bound `@app:` field refs the owned mappings carry

--- a/packages/lib/src/data-connectors/resolve-sole-app-connection.test.ts
+++ b/packages/lib/src/data-connectors/resolve-sole-app-connection.test.ts
@@ -1,0 +1,45 @@
+// packages/lib/src/data-connectors/resolve-sole-app-connection.test.ts
+// Auto-link rule for a fresh app connector: bind ONLY when the org has exactly one
+// org-scoped connection for the app installation (unambiguous). Zero or two-plus → null.
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveSoleAppConnection } from './mutations'
+
+const listCredentials = vi.hoisted(() => vi.fn())
+vi.mock('@auxx/credentials/store', () => ({ listCredentials }))
+
+const ORG = 'org_1'
+const INSTALL = 'inst_1'
+const cred = (id: string) => ({ id })
+
+describe('resolveSoleAppConnection', () => {
+  beforeEach(() => listCredentials.mockReset())
+
+  it('binds the sole org-scoped connection', async () => {
+    listCredentials.mockResolvedValue(ok([cred('cred_a')]))
+    await expect(resolveSoleAppConnection(ORG, INSTALL)).resolves.toBe('cred_a')
+    // Org-scoped only (userId: null) + scoped to this app installation.
+    expect(listCredentials).toHaveBeenCalledWith({
+      organizationId: ORG,
+      kind: 'app',
+      appInstallationId: INSTALL,
+      userId: null,
+    })
+  })
+
+  it('leaves unbound when there is nothing to link', async () => {
+    listCredentials.mockResolvedValue(ok([]))
+    await expect(resolveSoleAppConnection(ORG, INSTALL)).resolves.toBeNull()
+  })
+
+  it('leaves unbound when the choice is ambiguous (two-plus)', async () => {
+    listCredentials.mockResolvedValue(ok([cred('cred_a'), cred('cred_b')]))
+    await expect(resolveSoleAppConnection(ORG, INSTALL)).resolves.toBeNull()
+  })
+
+  it('leaves unbound on a store error (never guesses)', async () => {
+    listCredentials.mockResolvedValue(err(new Error('boom')))
+    await expect(resolveSoleAppConnection(ORG, INSTALL)).resolves.toBeNull()
+  })
+})


### PR DESCRIPTION
## What

Two improvements to the app/template data-connector setup wizard's **Connect** step.

### 1. Connect step keys off the app-declared `requiresConnection`
The wizard derived "needs a connection" from a **proxy** — whether the installed app exposes *any* `connectionDefinition` (app-level) — instead of the connector's own declared `requiresConnection`. That over-counts a client-credentials connector whose app *also* defines a connection method for other purposes.

`requiresConnection` is already authoritative everywhere else: app author → SDK `DataConnectorDefinition.requiresConnection` → `CatalogDataConnector.requiresConnection` → honored at runtime by the app-connector adapter. The wizard just wasn't reading it.

- `dataConnector.connectorSchema` now returns `requiresConnection` (it already resolves the catalog entry).
- `connector-setup-stepper.tsx` reads `schemaQuery.data.requiresConnection` and drops the `useAppsContext` `connectionDefinitions` proxy. Stays conservative (`?? true`, assume required) until the query resolves so Connect is never auto-skipped prematurely.

### 2. Auto-link the sole existing connection
A fresh app connector was always created unbound, so the user hand-picked a connection even when the org already had exactly one.

- New `resolveSoleAppConnection(orgId, appInstallationId)`: returns the connection id **iff exactly one** org-scoped connection exists for that install; **zero** (nothing to link) or **2+** (ambiguous — the user must pick) → `null`.
- Wired into `createConnectorFromAppCatalog` behind `catalog.requiresConnection` + no caller-supplied credential. The `create` route now passes the resolved `app.installationId` (pins the install and lets the helper count that install's connections).

**Not a dup of the runtime resolver:** `findCredential`/`resolveConnectionForRuntime` is *primary-preferring* (picks the org default even among 2+) — the opposite of the "don't link when ambiguous" rule. The `readiness.canSample = !!credentialId` UI gate is what enforces "force a pick when 2+".

## Tests
- New `resolve-sole-app-connection.test.ts` — `1 → link`, `0 / 2+ / store-error → null`.
- Full data-connectors lib suite (237) + web `use-setup-progress` (9) green; biome clean.

## Not included / follow-up
- A `requiresConnection: false` connector with **zero** connections still can't reach Run (`canSample` demands a `credentialId`) — no such app exists today; backend-readiness fix is the natural follow-up if one ships.