### PR TITLE
feat(data-connectors): connector-declared External ID on owned defs

### DIFF
--- a/apps/web/src/components/data-connectors/ui/formula-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/formula-row.tsx
@@ -45,6 +45,8 @@ interface FormulaRowProps {
   identityRole?: IdentityRole
   /** Offer the "Match existing" option — needs a bound target to compare against. */
   canMatch?: boolean
+  /** This formula is under an app OWNED mapping — lock the declared External ID, suppress others. */
+  appManaged?: boolean
   /** The mapping is OWNED — relaxes the picker's writable filter to owned columns. */
   ownedWrite?: boolean
   onEdit: () => void
@@ -83,6 +85,7 @@ export function FormulaRow({
   drilledRef,
   identityRole,
   canMatch,
+  appManaged,
   ownedWrite,
   onEdit,
   onRetarget,
@@ -112,6 +115,7 @@ export function FormulaRow({
             <IdentityRoleControl
               role={identityRole ?? null}
               canMatch={!!canMatch}
+              appManaged={appManaged}
               onChange={onSetIdentityRole}
             />
           )}

--- a/apps/web/src/components/data-connectors/ui/identity-role-control.tsx
+++ b/apps/web/src/components/data-connectors/ui/identity-role-control.tsx
@@ -5,6 +5,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/pop
 import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
 import { Check, KeyRound } from 'lucide-react'
+import { useMappingConnector } from './mapping-connector-context'
 
 /** The identity role a binding plays (relationship-linking v3 §9.4). */
 export type IdentityRole = 'externalId' | 'match' | null
@@ -22,13 +23,39 @@ export type IdentityRole = 'externalId' | 'match' | null
 export function IdentityRoleControl({
   role,
   canMatch,
+  appManaged,
   onChange,
 }: {
   role: IdentityRole
   /** Show the "Match existing" option (needs a bound target to compare against). */
   canMatch: boolean
+  /**
+   * This leaf belongs to an app OWNED mapping, where the connector declares the record's
+   * External ID (a real column stamped by the seeder). When true: the leaf that IS the
+   * External ID renders as a non-interactive blue key ("managed"), and every OTHER leaf
+   * drops the "External ID" option so the user can't designate a competing one that would
+   * silently override the app's record identity (see connector-declared-external-id-plan).
+   */
+  appManaged?: boolean
   onChange: (role: IdentityRole) => void
 }) {
+  // The app's display title for the managed tooltip is a tree-wide constant — read it from
+  // context rather than prop-drilling it through every SourceNode/leaf/formula.
+  const { appLabel } = useMappingConnector()
+  // The connector-declared External ID leaf: read-only, blue, no popover. It's stamped by
+  // the seeder and equals the app's `ConnectorRecord.externalId` — the user never edits it.
+  if (appManaged && role === 'externalId') {
+    return (
+      <SimpleTooltip
+        side='top'
+        delayDuration={500}
+        content={`External ID · managed by ${appLabel ?? 'the connector'} — the upstream key that dedups this record.`}>
+        <span className='inline-flex size-4 shrink-0 items-center justify-center text-primary'>
+          <KeyRound className='size-3.5' />
+        </span>
+      </SimpleTooltip>
+    )
+  }
   const tooltip =
     role === 'externalId'
       ? 'External ID — the upstream key that dedups this record and anchors its links.'
@@ -54,12 +81,14 @@ export function IdentityRoleControl({
       </SimpleTooltip>
       <PopoverContent align='start' className='w-52 p-1'>
         <RoleOption label='Not an identifier' active={!role} onClick={() => onChange(null)} />
-        <RoleOption
-          label='External ID'
-          hint='Primary upstream key'
-          active={role === 'externalId'}
-          onClick={() => onChange('externalId')}
-        />
+        {!appManaged && (
+          <RoleOption
+            label='External ID'
+            hint='Primary upstream key'
+            active={role === 'externalId'}
+            onClick={() => onChange('externalId')}
+          />
+        )}
         {canMatch && (
           <RoleOption
             label='Match existing'

--- a/apps/web/src/components/data-connectors/ui/mapping-connector-context.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-connector-context.tsx
@@ -1,0 +1,56 @@
+// apps/web/src/components/data-connectors/ui/mapping-connector-context.tsx
+'use client'
+
+import { createContext, type ReactNode, useContext } from 'react'
+import type { DraftMapping } from '../stores/connector-draft-store'
+
+/**
+ * Cross-cutting, read-only display facts the mapping tree needs but shouldn't drill
+ * through every recursive `SourceNode`: whether the connector is app-backed and the
+ * app's display label. Consumed by `MappingNode` (the app-managed External ID
+ * indicator) and, transitively, the per-leaf/per-formula identity controls.
+ */
+export interface MappingConnectorContextValue {
+  /** The connector is app-backed (`definitionKind === 'app'`). */
+  isAppConnector: boolean
+  /** The app's display title (e.g. "Shopify"); null when unresolved. */
+  appLabel: string | null
+}
+
+const MappingConnectorContext = createContext<MappingConnectorContextValue>({
+  isAppConnector: false,
+  appLabel: null,
+})
+
+export function MappingConnectorProvider({
+  value,
+  children,
+}: {
+  value: MappingConnectorContextValue
+  children: ReactNode
+}) {
+  return (
+    <MappingConnectorContext.Provider value={value}>{children}</MappingConnectorContext.Provider>
+  )
+}
+
+export function useMappingConnector(): MappingConnectorContextValue {
+  return useContext(MappingConnectorContext)
+}
+
+/**
+ * Every OWNED mapping of an app connector carries a connector-declared External ID: the
+ * app supplies each owned record's stable id as a real column (e.g. Shopify's `id` →
+ * "Shopify Order ID"), and the seeder stamps `identityRole: externalId` on that field's
+ * mapping. So — at ANY depth (order root, line-item child) — the editor marks that leaf's
+ * External ID as connector-managed (blue, locked) and suppresses the "External ID" option
+ * on every other owned leaf, so the user can't designate a competing one that would
+ * silently override the app's record identity. Contributing branches (customer → contact,
+ * whose id is multi-source) are NOT managed here — Phase 2 (v7) handles those.
+ */
+export function isAppOwnedManaged(
+  isAppConnector: boolean,
+  mapping: Pick<DraftMapping, 'targetMode'>
+): boolean {
+  return isAppConnector && mapping.targetMode === 'owned'
+}

--- a/apps/web/src/components/data-connectors/ui/mapping-connector.test.ts
+++ b/apps/web/src/components/data-connectors/ui/mapping-connector.test.ts
@@ -1,0 +1,31 @@
+// apps/web/src/components/data-connectors/ui/mapping-connector.test.ts
+import { describe, expect, it } from 'vitest'
+import type { DraftMapping } from '../stores/connector-draft-store'
+import { isAppOwnedManaged } from './mapping-connector-context'
+
+/** Minimal mapping shape the predicate reads. */
+const mapping = (
+  over: Partial<Pick<DraftMapping, 'targetMode'>>
+): Pick<DraftMapping, 'targetMode'> => ({
+  targetMode: 'owned',
+  ...over,
+})
+
+describe('isAppOwnedManaged', () => {
+  it('is true for an app connector OWNED mapping (record id is connector-declared)', () => {
+    expect(isAppOwnedManaged(true, mapping({ targetMode: 'owned' }))).toBe(true)
+  })
+
+  it('is true for a nested owned mapping (line items own their own id too)', () => {
+    // No longer root-gated — any owned app mapping, at any depth, is managed.
+    expect(isAppOwnedManaged(true, mapping({ targetMode: 'owned' }))).toBe(true)
+  })
+
+  it('is false for a contributing app mapping (customer → contact — Phase 2/v7)', () => {
+    expect(isAppOwnedManaged(true, mapping({ targetMode: 'contributing' }))).toBe(false)
+  })
+
+  it('is false for a manual/generic-REST connector', () => {
+    expect(isAppOwnedManaged(false, mapping({ targetMode: 'owned' }))).toBe(false)
+  })
+})

--- a/apps/web/src/components/data-connectors/ui/mapping-node.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-node.tsx
@@ -30,6 +30,7 @@ import { CappedNodeList } from './capped-node-list'
 import { FieldCalcDialog } from './field-calc-dialog'
 import { isBareToken } from './field-mapping-edits'
 import { DrilledFormulaRow, FormulaRow } from './formula-row'
+import { isAppOwnedManaged, useMappingConnector } from './mapping-connector-context'
 import { describeRootPath, fieldIconId } from './mapping-node-helpers'
 import { MappingRow } from './mapping-row'
 import { computeMappingView } from './mapping-view'
@@ -97,6 +98,15 @@ export function MappingNode({
   const linkMode = mapping.linkMode as 'upsert' | 'reference'
   const targetMode = mapping.targetMode as 'owned' | 'contributing'
   const fieldMappings = (mapping.fieldMappings ?? []) as FieldMapping[]
+
+  // Every OWNED mapping of an app connector declares its record's External ID as a real
+  // field (the seeder stamps `identityRole: externalId` on it). So the editor marks that
+  // leaf's key blue + locked and suppresses the "External ID" option on every other owned
+  // leaf — a user-set one would silently override the app's record identity (see
+  // connector-declared-external-id-plan). The app label for the tooltip is read from
+  // context inside `IdentityRoleControl` (tree-wide constant, not drilled).
+  const { isAppConnector } = useMappingConnector()
+  const appManaged = isAppOwnedManaged(isAppConnector, mapping)
 
   // Find the target field a stored ref points at (label/normalize resolution).
   const fieldByRef = (ref: string | null | undefined): ResourceField | undefined =>
@@ -285,6 +295,7 @@ export function MappingNode({
                 depth={depth + 1}
                 mapping={mapping}
                 targetMode={targetMode}
+                appManaged={appManaged}
                 targetFields={targetFields}
                 sourceToEntry={view.sourceToEntry}
                 usedTargetKeys={usedTargetKeys}
@@ -346,6 +357,7 @@ export function MappingNode({
                 }
                 identityRole={e.identityRole?.kind ?? null}
                 canMatch={e.targetFieldRef != null}
+                appManaged={appManaged}
                 ownedWrite={targetMode === 'owned'}
                 onSetIdentityRole={(role) => actions.setFormulaIdentityRole(e.id, role)}
                 onEdit={() => setCalcTarget({ mappingId: mapping.id, entryId: e.id })}
@@ -454,6 +466,8 @@ interface SourceNodeProps {
   /** The enclosing mapping (binding target for leaves under it). */
   mapping: Mapping
   targetMode: 'owned' | 'contributing'
+  /** App OWNED mapping — mark the declared External ID + suppress it on other direct leaves. */
+  appManaged: boolean
   targetFields: ResourceField[]
   /** Reverse index: source path → the bare-token binding entry on it. */
   sourceToEntry: Map<string, FieldMapping>
@@ -650,6 +664,9 @@ function SourceNode(props: SourceNodeProps) {
         canCreate={!!mapping.entityDefinitionId}
         isOwned={targetMode === 'owned'}
         identityRole={identityRole}
+        // A drilled leaf sets a RELATED def's identity (via its flat child), so only a
+        // direct binding on this app owned mapping is managed.
+        appManaged={props.appManaged && !drilled}
         mergeStrategy={activeEntry?.mergeStrategy ?? 'overwrite'}
         allowRelationships={allowRelationships}
         linkedFieldRef={linkedFieldRef}

--- a/apps/web/src/components/data-connectors/ui/mapping-tree.tsx
+++ b/apps/web/src/components/data-connectors/ui/mapping-tree.tsx
@@ -23,6 +23,7 @@ import {
 } from '../stores/connector-draft-store'
 import { BranchRow } from './branch-row'
 import { CappedNodeList } from './capped-node-list'
+import { MappingConnectorProvider } from './mapping-connector-context'
 import { MappingNode } from './mapping-node'
 import { MappingRow } from './mapping-row'
 
@@ -38,6 +39,10 @@ interface MappingTreeProps {
   sourcePaths: SourcePath[]
   /** The stream's raw source schema (Layer A) — fed to the Tier 2 suggester. */
   sourceSchema?: Record<string, unknown> | null
+  /** The connector is app-backed — drives the app-managed External ID indicator. */
+  isAppConnector: boolean
+  /** The app's display title (for the managed-id note); null when unresolved. */
+  appLabel: string | null
 }
 
 /** The fan-out rootPath for a branch node — arrays keep their `[]` suffix. */
@@ -61,6 +66,8 @@ export function MappingTree({
   streamKey,
   sourcePaths,
   sourceSchema,
+  isAppConnector,
+  appLabel,
 }: MappingTreeProps) {
   // Render the stream's mappings from the DRAFT (optimistic, never the network): a
   // fan-out/remove shows instantly and only commits via the save bar (the live-safety
@@ -176,66 +183,70 @@ export function MappingTree({
   // an envelope the user chose to treat as one record) — render just that node.
   if (rootMapping) {
     return (
-      <div className='flex flex-col py-1'>
-        <MappingNode mapping={rootMapping} depth={0} {...recursionCtx} />
-      </div>
+      <MappingConnectorProvider value={{ isAppConnector, appLabel }}>
+        <div className='flex flex-col py-1'>
+          <MappingNode mapping={rootMapping} depth={0} {...recursionCtx} />
+        </div>
+      </MappingConnectorProvider>
     )
   }
 
   return (
-    <div className='flex flex-col py-1'>
-      <MappingRow
-        depth={0}
-        expandable
-        chevronOnHover
-        isOpen={rootOpen}
-        onToggleOpen={() => setRootOpen((o) => !o)}
-        icon={
-          rootIsArray ? (
-            <Brackets className='size-3.5 text-muted-foreground/60' />
+    <MappingConnectorProvider value={{ isAppConnector, appLabel }}>
+      <div className='flex flex-col py-1'>
+        <MappingRow
+          depth={0}
+          expandable
+          chevronOnHover
+          isOpen={rootOpen}
+          onToggleOpen={() => setRootOpen((o) => !o)}
+          icon={
+            rootIsArray ? (
+              <Brackets className='size-3.5 text-muted-foreground/60' />
+            ) : (
+              <Braces className='size-3.5 text-muted-foreground/60' />
+            )
+          }
+          title={
+            <span className='text-xs text-muted-foreground'>
+              {rootIsArray ? `each ${streamKey || 'item'}` : 'whole payload'}
+              {isEmpty && (
+                <span className='ml-2 text-muted-foreground/50'>· map to a record to begin</span>
+              )}
+            </span>
+          }
+          actions={
+            <CreateMappingAction
+              tooltip='Map whole payload → own record'
+              label={isEmpty ? 'Map record' : undefined}
+              onPick={(defId) => createMapping(rootBase, defId)}
+            />
+          }>
+          {topTree.length === 0 ? (
+            <div className='px-3 py-2 text-[11px] text-muted-foreground'>
+              No source schema yet — generate or edit the schema above to map fields.
+            </div>
           ) : (
-            <Braces className='size-3.5 text-muted-foreground/60' />
-          )
-        }
-        title={
-          <span className='text-xs text-muted-foreground'>
-            {rootIsArray ? `each ${streamKey || 'item'}` : 'whole payload'}
-            {isEmpty && (
-              <span className='ml-2 text-muted-foreground/50'>· map to a record to begin</span>
-            )}
-          </span>
-        }
-        actions={
-          <CreateMappingAction
-            tooltip='Map whole payload → own record'
-            label={isEmpty ? 'Map record' : undefined}
-            onPick={(defId) => createMapping(rootBase, defId)}
-          />
-        }>
-        {topTree.length === 0 ? (
-          <div className='px-3 py-2 text-[11px] text-muted-foreground'>
-            No source schema yet — generate or edit the schema above to map fields.
-          </div>
-        ) : (
-          <CappedNodeList
-            nodes={topTree}
-            childDepth={1}
-            isCappable={(n) => !n.isBranch}
-            renderNode={(node) => (
-              <TopSourceNode
-                key={node.path}
-                node={node}
-                depth={1}
-                isEmpty={isEmpty}
-                branchMappingByPath={branchMappingByPath}
-                onCreate={createMapping}
-                {...recursionCtx}
-              />
-            )}
-          />
-        )}
-      </MappingRow>
-    </div>
+            <CappedNodeList
+              nodes={topTree}
+              childDepth={1}
+              isCappable={(n) => !n.isBranch}
+              renderNode={(node) => (
+                <TopSourceNode
+                  key={node.path}
+                  node={node}
+                  depth={1}
+                  isEmpty={isEmpty}
+                  branchMappingByPath={branchMappingByPath}
+                  onCreate={createMapping}
+                  {...recursionCtx}
+                />
+              )}
+            />
+          )}
+        </MappingRow>
+      </div>
+    </MappingConnectorProvider>
   )
 }
 

--- a/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-leaf-row.tsx
@@ -66,6 +66,8 @@ interface SourceLeafRowProps {
   isOwned: boolean
   /** The identity role this leaf plays (external-id anchor / secondary match / none). */
   identityRole: LeafIdentityRole
+  /** This leaf is under an app OWNED mapping — lock the declared External ID, suppress others. */
+  appManaged?: boolean
   /** Relationship linking — the picker is the entry point; the link renders on a sub-row. */
   allowRelationships?: boolean
   /** The currently-linked relationship field's ref, for the picker's selected check. */
@@ -106,6 +108,7 @@ export function SourceLeafRow({
   canCreate,
   isOwned,
   identityRole,
+  appManaged,
   allowRelationships,
   linkedFieldRef,
   drilledLabel,
@@ -144,6 +147,7 @@ export function SourceLeafRow({
             <IdentityRoleControl
               role={identityRole}
               canMatch={isMapped}
+              appManaged={appManaged}
               onChange={onSetIdentityRole}
             />
           )}

--- a/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/stream-config-panel.tsx
@@ -29,6 +29,7 @@ import {
   Waypoints,
 } from 'lucide-react'
 import { type ReactNode, useMemo, useState } from 'react'
+import { useAppsContext } from '~/components/apps/providers/apps-context'
 import type { HttpRequestFieldContextValue } from '~/components/global/http-request'
 import { makeTokenFieldEditor } from '~/components/global/token-field'
 import { Tooltip } from '~/components/global/tooltip'
@@ -117,6 +118,15 @@ export function StreamConfigPanel({
   const showMappings = view !== 'configure'
   // Branch on the persisted definitionKind (05c §7), not a `type` prefix sniff.
   const isGenericRest = connector.definitionKind !== 'app'
+
+  // Resolve the app's display title for the app-managed External ID indicator (an app
+  // connector's `type` is `app:<slug>`). Falls back to the slug, then null.
+  const { appInstallations } = useAppsContext()
+  const appLabel = useMemo(() => {
+    if (isGenericRest || !connector.type.startsWith('app:')) return null
+    const slug = connector.type.slice('app:'.length)
+    return appInstallations.find((i) => i.app.slug === slug)?.app.title ?? slug
+  }, [isGenericRest, connector.type, appInstallations])
 
   const [helpOpen, setHelpOpen] = useState(false)
   const [seed, setSeed] = useState<{
@@ -486,6 +496,8 @@ export function StreamConfigPanel({
               streamKey={stream.streamKey ?? ''}
               sourcePaths={sourcePaths}
               sourceSchema={liveSourceSchema}
+              isAppConnector={!isGenericRest}
+              appLabel={appLabel}
             />
           </Section>
         )}

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -207,6 +207,8 @@ export interface CatalogConnectorField {
   options?: Array<{ value: string; label?: string; color?: string }>
   /** Sub-field set for an ADDRESS_STRUCT field (e.g. `['street', 'city', 'state', 'country']`). */
   addressComponents?: string[]
+  /** This field's value is the owned record's stable external id — the seeder stamps `identityRole: externalId` on its mapping. */
+  isExternalId?: boolean
 }
 
 /**

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -682,12 +682,36 @@ export function buildAppOwnedFieldMappings(
   appSlug: string,
   ownedApiSlug: string
 ): FieldMapping[] {
-  return entries.map(({ field, relativeSourcePath: relPath }) => ({
-    id: generateId(),
-    targetFieldRef: toAppFieldRef(ownedApiSlug, appSlug, field.fieldKey),
-    expression: `{${relPath}}`,
-    sourceFields: { [relPath]: relPath },
-  }))
+  // The manifest may flag one field as the owned record's External ID (`isExternalId`).
+  // v1 allows at most one per owned def — first-wins, warn on extras — so the stamped
+  // `identityRole` is unambiguous.
+  let externalIdClaimed = false
+  return entries.map(({ field, relativeSourcePath: relPath }) => {
+    // Stamp the External-ID anchor onto the flagged field's mapping WITHOUT dropping its
+    // column write: it keeps its `targetFieldRef` (writes the "Shopify ID" column) and
+    // gains `identityRole: externalId` (drives record identity). `resolveExternalId` then
+    // reads this same value — which equals the app's `ConnectorRecord.externalId` — so the
+    // visible column and the record's identity agree by construction. `deriveLinkMode`
+    // stays `upsert` (a real target write always wins), so this never flips an owned def
+    // to `reference`.
+    let isExternalId = field.isExternalId === true
+    if (isExternalId && externalIdClaimed) {
+      logger.warn('Multiple isExternalId fields on one owned def — ignoring extra', {
+        appSlug,
+        ownedApiSlug,
+        fieldKey: field.fieldKey,
+      })
+      isExternalId = false
+    }
+    if (isExternalId) externalIdClaimed = true
+    return {
+      id: generateId(),
+      targetFieldRef: toAppFieldRef(ownedApiSlug, appSlug, field.fieldKey),
+      expression: `{${relPath}}`,
+      sourceFields: { [relPath]: relPath },
+      ...(isExternalId ? { identityRole: { kind: 'externalId' as const } } : {}),
+    }
+  })
 }
 
 /**

--- a/packages/lib/src/data-connectors/owned-mappings.test.ts
+++ b/packages/lib/src/data-connectors/owned-mappings.test.ts
@@ -55,6 +55,52 @@ describe('buildAppOwnedFieldMappings', () => {
     expect(author?.id).toBeTruthy()
   })
 
+  it('stamps identityRole.externalId on the isExternalId field, keeping its column write', () => {
+    const flagged: CatalogField[] = [
+      {
+        fieldKey: 'shopify_id',
+        sourcePath: 'id',
+        type: 'TEXT',
+        name: 'Shopify Order ID',
+        isExternalId: true,
+      },
+      { fieldKey: 'name', sourcePath: 'name', type: 'TEXT', name: 'Order Name' },
+    ]
+    const mappings = buildAppOwnedFieldMappings(
+      flagged.map((field) => ({ field, relativeSourcePath: field.sourcePath })),
+      'shopify',
+      'shopify_orders'
+    )
+    const idEntry = mappings.find((m) => m.targetFieldRef?.endsWith(':shopify_id'))
+    // The flagged field is the External ID anchor AND still writes its own column.
+    expect(idEntry?.identityRole).toEqual({ kind: 'externalId' })
+    expect(idEntry?.targetFieldRef).toBe('shopify_orders:@app:shopify:shopify_id')
+    expect(idEntry?.expression).toBe('{id}')
+    // Unflagged fields carry no identity role.
+    const nameEntry = mappings.find((m) => m.targetFieldRef?.endsWith(':name'))
+    expect(nameEntry?.identityRole).toBeUndefined()
+  })
+
+  it('is inert when no field is flagged (unchanged behavior)', () => {
+    const mappings = buildAppOwnedFieldMappings(entries, 'github', 'github_issues')
+    expect(mappings.every((m) => m.identityRole === undefined)).toBe(true)
+  })
+
+  it('first-wins when two fields are flagged on one owned def', () => {
+    const twoFlagged: CatalogField[] = [
+      { fieldKey: 'a', sourcePath: 'a', type: 'TEXT', name: 'A', isExternalId: true },
+      { fieldKey: 'b', sourcePath: 'b', type: 'TEXT', name: 'B', isExternalId: true },
+    ]
+    const mappings = buildAppOwnedFieldMappings(
+      twoFlagged.map((field) => ({ field, relativeSourcePath: field.sourcePath })),
+      'shopify',
+      'shopify_orders'
+    )
+    const stamped = mappings.filter((m) => m.identityRole?.kind === 'externalId')
+    expect(stamped).toHaveLength(1)
+    expect(stamped[0]?.targetFieldRef).toBe('shopify_orders:@app:shopify:a')
+  })
+
   it('keys a child mapping expression on the SUBTREE-relative path, not the full sourcePath', () => {
     // A `line_items[]` child: the ref keys on the stable fieldKey, but the expression
     // must read `{sku}` (the subtree is one line item), not `{line_items[].sku}`.

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -370,6 +370,8 @@ export interface ConnectorFieldDecl {
   options?: Array<{ value: string; label?: string; color?: string }>
   /** Sub-field set for an ADDRESS_STRUCT field. */
   addressComponents?: string[]
+  /** This field's value is the owned record's stable external id (dedupe/link key). */
+  isExternalId?: boolean
 }
 
 /** A recommended fan-out mapping the connector suggests (05 §4). User confirms at setup. */

--- a/packages/sdk/__fixtures__/connector-app/src/shopify-core.connector.ts
+++ b/packages/sdk/__fixtures__/connector-app/src/shopify-core.connector.ts
@@ -44,7 +44,12 @@ export const shopifyCoreDataConnector = defineDataConnector({
       // embedded customer + line_items. PII flags on customer fields are
       // surfaced + default-excluded in the mapping UI.
       fields: {
-        id: { type: 'TEXT', name: 'Order ID', sourcePath: 'id' },
+        shopify_id: {
+          type: 'TEXT',
+          name: 'Shopify Order ID',
+          sourcePath: 'id',
+          isExternalId: true,
+        },
         name: { type: 'TEXT', name: 'Order Name', sourcePath: 'name' },
         totalPrice: { type: 'CURRENCY', name: 'Total', sourcePath: 'total_price' },
         financialStatus: {

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -125,6 +125,15 @@ export interface ConnectorFieldDecl {
    * country }`. Ignored for non-address types.
    */
   addressComponents?: string[]
+  /**
+   * This field's value is the owned record's stable external id; the platform marks it
+   * the record's External ID (the dedupe/link key) — a visible, read-only blue-key
+   * column, not a synthetic managed row. Owned streams only, one per owned def; must be
+   * a coercible scalar (TEXT/NUMBER). The seeder stamps `identityRole: externalId` on the
+   * field's mapping (keeping its column write), so `resolveExternalId`'s
+   * `designatedExternalId` reads the same value the app sets on `ConnectorRecord.externalId`.
+   */
+  isExternalId?: boolean
 }
 
 /** Minimal entity declaration for an owned-mode default mapping. */

--- a/packages/sdk/src/util/__tests__/compile-and-extract-catalog-connectors.test.ts
+++ b/packages/sdk/src/util/__tests__/compile-and-extract-catalog-connectors.test.ts
@@ -67,7 +67,15 @@ describe('compileAndExtractCatalog — data connectors', () => {
     expect(stream).toMatchObject({ key: 'order', displayFieldKey: 'name' })
 
     const byKey = new Map((stream?.fields ?? []).map((f) => [f.fieldKey, f]))
-    expect(byKey.get('id')).toMatchObject({ sourcePath: 'id', type: 'TEXT' })
+    // The declared external-id flag survives extraction onto the catalog field (the id
+    // field is keyed `shopify_id` — a real owned column, not the bare `id` a def reserves).
+    expect(byKey.get('shopify_id')).toMatchObject({
+      sourcePath: 'id',
+      type: 'TEXT',
+      isExternalId: true,
+    })
+    // Unflagged fields don't carry it.
+    expect(byKey.get('name')?.isExternalId).toBeUndefined()
     expect(byKey.get('totalPrice')).toMatchObject({ sourcePath: 'total_price', type: 'CURRENCY' })
     // PII flag survives serialization.
     expect(byKey.get('customer.email')).toMatchObject({

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -197,6 +197,8 @@ export interface CatalogConnectorField {
   options?: Array<{ value: string; label?: string; color?: string }>
   /** Sub-field set for an ADDRESS_STRUCT field. */
   addressComponents?: string[]
+  /** This field's value is the owned record's stable external id (dedupe/link key). */
+  isExternalId?: boolean
 }
 
 /** Provisioning decl for a parent↔child edge — mirrors SDK `ConnectorRelationshipDecl`. */
@@ -721,6 +723,7 @@ export async function compileAndExtractCatalog(): Promise<
         capabilities: decl.capabilities,
         options: decl.options,
         addressComponents: decl.addressComponents,
+        isExternalId: decl.isExternalId,
       })),
       defaultMappings: stream.defaultMappings,
       exampleRecord: stream.exampleRecord,
@@ -881,6 +884,7 @@ interface RawConnectorFieldDecl {
   capabilities?: { hidden?: boolean; filterable?: boolean }
   options?: Array<{ value: string; label?: string; color?: string }>
   addressComponents?: string[]
+  isExternalId?: boolean
 }
 
 interface RawConnectorStream {


### PR DESCRIPTION
## What

An app connector supplies each record's external id, and for **owned** defs that id is a **real declared field** (Shopify's `id` → "Shopify Order ID" column). Instead of a synthetic "managed" indicator row (v6 Option A), we **mark that actual field as the External ID** — visible + blue like a manual mapping, but read-only — driven by a manifest flag.

This means the sync's `designatedExternalId` and the visible column agree by construction, and it gives line items a real `shopify_id` (killing their positional `{orderId}:{index}` identity fallback).

Supersedes v6 Option A (`show-app-managed-external-id-plan.md`); reworks + keeps its context/provider plumbing.

## Changes

**SDK / catalog**
- `ConnectorFieldDecl.isExternalId` flag (`packages/sdk/.../types.ts`).
- Propagated through the extractor (`compile-and-extract-catalog.ts`) + the DB (`app-deployment.ts`) and lib (`data-connectors/types.ts`) catalog field types.

**Seeder** (`mutations.ts`)
- `buildAppOwnedFieldMappings` stamps `identityRole: externalId` on the flagged field **while keeping its column write** — so `resolveExternalId`'s `designatedExternalId` reads the same value the app sets on `ConnectorRecord.externalId`, and `deriveLinkMode` stays `upsert` (a real target write always wins → never flips an owned def to `reference`). First-wins + warn on multiple flags per owned def.

**Editor**
- Predicate `isAppManagedExternalId` (root-only) → `isAppOwnedManaged` (owned, **any depth** — line items lock too).
- `hideExternalId` prop → `appManaged`: locks the marked id leaf (non-interactive blue key, "External ID · managed by {App}") and suppresses the "External ID" option on every other owned leaf. Removes the v6 synthetic indicator row. `appLabel` read from context (not prop-drilled).

## Scope

Phase 1 = **owned** defs (order, line item, product), any depth. Contributing customer→contact id is multi-source and stays **Phase 2 (v7)**. Manual / generic-REST connectors: zero change.

## Tests
- lib `owned-mappings.test.ts`: seeder stamping (flagged → `identityRole` + column write; unflagged unchanged; first-wins on duplicates).
- SDK `compile-and-extract-catalog-connectors.test.ts`: `isExternalId` survives extraction.
- web `mapping-connector.test.ts`: the owned-based predicate (app+owned true; contributing/manual false).
- Green: full lib DC suite (240), web DC suite (117), SDK catalog (2). Biome clean.

## Companion / deploy
- Shopify manifest changes (rename order/product `id` → `shopify_id` + `isExternalId`; add `lineItems.shopifyId` + emit it server-side) ship in the **`auxxai-apps`** sister repo — separate PR.
- Before deploy: rebuild `@auxx/sdk` (done) + `pnpm --filter @auxx/api build:platform-runtime`, redeploy the Shopify app (catalog re-extract), refresh `installedApps`.

## Verified live
Dev catalog + reinstalled connector confirmed via DB: order/line-item/product owned mappings each carry the stamped `identityRole: externalId`; the id leaf renders as the locked blue External-ID key in the Map step.