### PR TITLE
feat(sidebar): make connector-sync badge link to its connector

### DIFF
--- a/apps/web/src/components/data-connectors/ui/entity-icon-with-connector.tsx
+++ b/apps/web/src/components/data-connectors/ui/entity-icon-with-connector.tsx
@@ -4,6 +4,7 @@
 import { EntityIcon, type EntityIconProps } from '@auxx/ui/components/icons'
 import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { RefreshCw } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 
 interface EntityIconWithConnectorProps extends EntityIconProps {
   /**
@@ -16,26 +17,55 @@ interface EntityIconWithConnectorProps extends EntityIconProps {
   dataConnectorId?: string
   /** Tooltip copy for the badge. Defaults to a generic sync message. */
   tooltip?: string
+  /**
+   * When set, the badge becomes a clickable target that routes to the connector
+   * (e.g. `/app/connectors/{id}`). Rendered as a `<button>` — not a `<Link>` —
+   * because the badge sits inside the sidebar row's `<Link>`, and nesting an
+   * anchor inside an anchor is invalid HTML. The handler stops propagation so
+   * the row's own navigation doesn't also fire. Omit to keep the badge a plain
+   * indicator (e.g. in sidebar edit mode).
+   */
+  connectorHref?: string
 }
 
 /**
  * `EntityIcon` with an optional connector-sync badge — the entity-level analog
  * of `AppWithStatusIcon`. Renders a bare `EntityIcon` when not connector-owned.
+ * When `connectorHref` is provided the badge is clickable and routes there.
  */
 export function EntityIconWithConnector({
   dataConnectorId,
   tooltip,
+  connectorHref,
   ...iconProps
 }: EntityIconWithConnectorProps) {
+  const router = useRouter()
   if (!dataConnectorId) return <EntityIcon {...iconProps} />
+
+  const badgeClassName =
+    'absolute -right-0.5 -bottom-0.5 inline-flex size-2.5 items-center justify-center rounded-full bg-background ring-1 ring-background'
 
   return (
     <SimpleTooltip content={tooltip ?? 'Synced by a data connector'} side='right'>
       <span className='relative inline-flex shrink-0'>
         <EntityIcon {...iconProps} />
-        <span className='absolute -right-0.5 -bottom-0.5 inline-flex size-2.5 items-center justify-center rounded-full bg-background ring-1 ring-background'>
-          <RefreshCw className='size-2! text-muted-foreground' />
-        </span>
+        {connectorHref ? (
+          <button
+            type='button'
+            aria-label='Open data connector'
+            onClick={(e) => {
+              e.stopPropagation()
+              e.preventDefault()
+              router.push(connectorHref)
+            }}
+            className={`${badgeClassName} hover:text-foreground`}>
+            <RefreshCw className='size-2! text-muted-foreground' />
+          </button>
+        ) : (
+          <span className={badgeClassName}>
+            <RefreshCw className='size-2! text-muted-foreground' />
+          </span>
+        )}
       </span>
     </SimpleTooltip>
   )

--- a/apps/web/src/components/global/sidebar/entity-sidebar-nav.tsx
+++ b/apps/web/src/components/global/sidebar/entity-sidebar-nav.tsx
@@ -252,7 +252,11 @@ export function EntitySidebarNav() {
     return pathname === url || pathname.startsWith(`${url}/`)
   }
 
-  function renderIcon(entity: ProcessedEntity) {
+  /**
+   * `interactive` makes the connector badge route to its connector. Enabled in
+   * normal mode; left off in edit mode so the badge doesn't hijack drag/reorder.
+   */
+  function renderIcon(entity: ProcessedEntity, interactive = false) {
     return (
       <EntityIconWithConnector
         iconId={entity.icon}
@@ -261,6 +265,11 @@ export function EntitySidebarNav() {
         inverse
         className='-ms-0.5 inset-shadow-xs inset-shadow-black/20'
         dataConnectorId={entity.dataConnectorId}
+        connectorHref={
+          interactive && entity.dataConnectorId
+            ? `/app/connectors/${entity.dataConnectorId}`
+            : undefined
+        }
         tooltip={`${entity.plural} are synced by a data connector`}
       />
     )
@@ -314,7 +323,7 @@ export function EntitySidebarNav() {
           id={entity.id}
           name={entity.plural}
           href={entity.href}
-          icon={renderIcon(entity)}
+          icon={renderIcon(entity, true)}
           isActive={isActive(entity)}
           isSubmenu={parentFolderId !== null}
           editItems={getEditItems(entity)}


### PR DESCRIPTION
## Summary

Makes the connector-sync badge on connector-owned record types in the sidebar clickable — it now routes to `/app/connectors/{id}` so you can jump straight to the connector that owns a record type.

## Details

- `EntityIconWithConnector` gains an optional `connectorHref` prop. When set, the badge renders as a `<button>` (not a `<Link>`) — it sits inside the sidebar row's own anchor, and nesting an anchor inside an anchor is invalid HTML. The click handler stops propagation/prevents default so the row's own navigation doesn't also fire.
- `entity-sidebar-nav` passes `connectorHref` only in normal mode (`renderIcon(entity, true)`); edit mode leaves the badge a plain indicator so it doesn't hijack drag/reorder.

## Test plan

- [ ] Connector-owned record type in the sidebar: clicking the sync badge navigates to the connector page.
- [ ] Clicking the row (not the badge) still navigates to the record type.
- [ ] In sidebar edit mode, the badge is a plain indicator and drag/reorder still works.