### PR TITLE
feat(data-connectors): share one entity definition across connectors + delete-safety

### DIFF
--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -86,6 +86,11 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
     () => customResources.filter((r) => r.dataConnectorId === connector.id),
     [customResources, connector.id]
   )
+  // Owned defs ANOTHER connector still maps to — a `delete` keeps these (reassigns
+  // ownership) rather than tears them down. Split them out of the delete-blast-radius
+  // copy so "delete definitions" doesn't imply a shared record type gets wiped.
+  const sharedOwnedDefs = api.dataConnector.sharedOwnedDefs.useQuery({ id: connector.id })
+  const sharedDefIds = useMemo(() => new Set(sharedOwnedDefs.data ?? []), [sharedOwnedDefs.data])
 
   const status = asConnectorStatus(connector.status)
   const isSyncing = status === 'syncing' || status === 'provisioning'
@@ -191,15 +196,26 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
         : null
 
   const handleDelete = async (syncedData: 'keep' | 'archive' | 'delete') => {
-    const ownedDefsClause = ownedDefs.length
-      ? `, including ${ownedDefs.length} entity ${
-          ownedDefs.length === 1 ? 'definition' : 'definitions'
-        } (${ownedDefs.map((d) => d.label).join(', ')}) and all their records`
+    // Owned defs split into those THIS delete tears down (sole owner) vs those it keeps
+    // (another connector still maps to them — reassigned, not deleted).
+    const toDelete = ownedDefs.filter((d) => !sharedDefIds.has(d.id))
+    const keptShared = ownedDefs.filter((d) => sharedDefIds.has(d.id))
+    const deleteClause = toDelete.length
+      ? `, including ${toDelete.length} entity ${
+          toDelete.length === 1 ? 'definition' : 'definitions'
+        } (${toDelete.map((d) => d.label).join(', ')}) and all their records`
+      : ''
+    const sharedClause = keptShared.length
+      ? ` ${keptShared.length} record ${keptShared.length === 1 ? 'type' : 'types'} (${keptShared
+          .map((d) => d.label)
+          .join(', ')}) ${
+          keptShared.length === 1 ? 'is' : 'are'
+        } shared with another connector and will be kept.`
       : ''
     const copy = {
       keep: 'Synced records are kept; only the connector is removed.',
       archive: 'Synced records are archived and the connector is removed.',
-      delete: `Synced records and the connector are permanently deleted${ownedDefsClause}.`,
+      delete: `Synced records and the connector are permanently deleted${deleteClause}.${sharedClause}`,
     }[syncedData]
     const ok = await confirm({
       title: 'Delete connector?',

--- a/apps/web/src/components/data-connectors/ui/install-owned-defs.tsx
+++ b/apps/web/src/components/data-connectors/ui/install-owned-defs.tsx
@@ -2,12 +2,13 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
-import { Boxes } from 'lucide-react'
+import { Boxes, Link2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import {
   EntityTemplateDialog,
   type EntityTemplateInstallResult,
 } from '~/components/custom-fields/ui/entity-template-dialog'
+import { useResources } from '~/components/resources/hooks/use-resources'
 import type { RouterOutputs } from '~/trpc/react'
 import { api } from '~/trpc/react'
 import { bindInstalledOwnedDefs } from '../lib/bind-installed-owned-defs'
@@ -16,13 +17,19 @@ import { getConnectorDraftState, useConnectorDraftStore } from '../stores/connec
 type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
 
 /**
- * The Map-step affordance for an app connector whose OWNED record types don't exist yet
- * (v6 — install-target-defs-via-templates). The connector seeds its owned mappings
- * UNBOUND; this banner installs the app's record-type definitions through the reused
- * `EntityTemplateDialog` (stamping connector/app ownership via `installContext`), then
- * binds each owned mapping to its freshly-installed def + concrete field refs in the
- * draft (committed with the connector save). Hidden once every owned mapping is bound,
- * or for a connector that declares no owned targets.
+ * The Map-step affordance for an app connector's OWNED record types (v6 —
+ * install-target-defs-via-templates). Renders up to two banners:
+ *
+ * - **Install** — for owned mappings still UNBOUND (`entityDefinitionId == null`):
+ *   installs the app's record-type definitions through the reused `EntityTemplateDialog`
+ *   (stamping connector/app ownership via `installContext`), then binds each owned mapping
+ *   to its freshly-installed def + concrete field refs in the draft.
+ * - **Reusing existing** — for owned mappings that were ADOPTED at setup (bound to a def
+ *   another connector already owns, e.g. GitHub Issues repo 1 + repo 2 sharing one def).
+ *   Read-only note so the user knows records join an existing table, not that a step was
+ *   skipped. See plans/data-connectors/v6/shared-definitions-across-connectors-plan.md.
+ *
+ * Hidden when neither applies.
  */
 export function InstallOwnedDefs({ connector }: { connector: Connector }) {
   const [open, setOpen] = useState(false)
@@ -31,15 +38,51 @@ export function InstallOwnedDefs({ connector }: { connector: Connector }) {
     { enabled: connector.type.startsWith('app:') }
   )
 
-  // Any owned mapping still unbound? Read off the DRAFT so the banner vanishes the
-  // moment the install's binding lands (no refetch). Tombstoned rows don't count.
-  const hasUnboundOwned = useConnectorDraftStore((s) =>
-    s.draft.streams.some((st) =>
-      st.mappings.some(
-        (m) => !m._deleted && m.targetMode === 'owned' && m.entityDefinitionId == null
-      )
-    )
+  // Owned mappings read off the DRAFT so both banners react the moment a binding lands
+  // (no refetch). Tombstoned rows don't count.
+  const draftStreams = useConnectorDraftStore((s) => s.draft.streams)
+  const hasUnboundOwned = useMemo(
+    () =>
+      draftStreams.some((st) =>
+        st.mappings.some(
+          (m) => !m._deleted && m.targetMode === 'owned' && m.entityDefinitionId == null
+        )
+      ),
+    [draftStreams]
   )
+  const boundOwnedDefIds = useMemo(
+    () =>
+      new Set(
+        draftStreams.flatMap((st) =>
+          st.mappings
+            .filter((m) => !m._deleted && m.targetMode === 'owned' && m.entityDefinitionId != null)
+            .map((m) => m.entityDefinitionId as string)
+        )
+      ),
+    [draftStreams]
+  )
+
+  // Adopted = an owned mapping bound to a def ANOTHER connector owns (shared, not forked).
+  // A null-owner def (user/template pick) is deliberately excluded — that's a different flow.
+  const { customResources } = useResources()
+  const connectors = api.dataConnector.list.useQuery()
+  const connectorNameById = useMemo(
+    () => new Map((connectors.data ?? []).map((c) => [c.id, c.name])),
+    [connectors.data]
+  )
+  const adoptedDefs = useMemo(() => {
+    const out: Array<{ id: string; label: string; ownerName: string | null }> = []
+    for (const r of customResources) {
+      if (!boundOwnedDefIds.has(r.id)) continue
+      if (r.dataConnectorId == null || r.dataConnectorId === connector.id) continue
+      out.push({
+        id: r.id,
+        label: r.label,
+        ownerName: connectorNameById.get(r.dataConnectorId) ?? null,
+      })
+    }
+    return out
+  }, [customResources, boundOwnedDefIds, connector.id, connectorNameById])
 
   // One template per owned key (a key shared by a def + a reference mapping installs once).
   const templateIds = useMemo(
@@ -47,17 +90,23 @@ export function InstallOwnedDefs({ connector }: { connector: Connector }) {
     [data]
   )
 
-  if (!data || !data.appSlug || templateIds.length === 0 || !hasUnboundOwned) return null
+  const showInstall = !!data?.appSlug && templateIds.length > 0 && hasUnboundOwned
+  if (!showInstall && adoptedDefs.length === 0) return null
 
-  const appTitle = data.appTitle ?? data.appSlug
+  const appTitle = data?.appTitle ?? data?.appSlug ?? 'This app'
   const count = templateIds.length
+
+  const adoptedList = adoptedDefs
+    .map((d) => (d.ownerName ? `${d.label} (from ${d.ownerName})` : d.label))
+    .join(', ')
 
   // Bind every owned mapping to its installed def + repointed refs in ONE store
   // mutation (one re-render / dirty tick), then close.
   const applyBindings = (result: EntityTemplateInstallResult) => {
+    if (!data?.appSlug) return
     const { draft, updateMappings } = getConnectorDraftState()
     const bindings = bindInstalledOwnedDefs({
-      appSlug: data.appSlug!,
+      appSlug: data.appSlug,
       result,
       ownedTargets: data.targets,
       draftStreams: draft.streams,
@@ -73,33 +122,54 @@ export function InstallOwnedDefs({ connector }: { connector: Connector }) {
   }
 
   return (
-    <>
-      <div className='flex items-center gap-3 rounded-lg border border-violet-200 bg-violet-50/50 px-3 py-2.5 dark:border-violet-300/30 dark:bg-violet-300/10'>
-        <Boxes className='size-4 shrink-0 text-violet-600 dark:text-violet-300' />
-        <div className='flex min-w-0 flex-1 flex-col'>
-          <span className='text-sm font-medium'>
-            {appTitle}{' '}
-            {count === 1 ? 'creates a new record type' : `creates ${count} new record types`}
-          </span>
-          <span className='text-xs text-muted-foreground'>
-            Install {count === 1 ? 'it' : 'them'} to map this connector — or pick an existing
-            definition per stream below.
-          </span>
+    <div className='flex flex-col gap-2'>
+      {adoptedDefs.length > 0 && (
+        <div className='flex items-center gap-3 rounded-lg border border-sky-200 bg-sky-50/50 px-3 py-2.5 dark:border-sky-300/30 dark:bg-sky-300/10'>
+          <Link2 className='size-4 shrink-0 text-sky-600 dark:text-sky-300' />
+          <div className='flex min-w-0 flex-1 flex-col'>
+            <span className='text-sm font-medium'>
+              Reusing{' '}
+              {adoptedDefs.length === 1 ? 'an existing record type' : 'existing record types'}
+            </span>
+            <span className='text-xs text-muted-foreground'>
+              {adoptedList} already {adoptedDefs.length === 1 ? 'exists' : 'exist'} — new records
+              will be added to {adoptedDefs.length === 1 ? 'it' : 'them'}, not duplicated.
+            </span>
+          </div>
         </div>
-        <Button variant='outline' size='xs' className='shrink-0' onClick={() => setOpen(true)}>
-          Install definitions
-        </Button>
-      </div>
-      <EntityTemplateDialog
-        open={open}
-        onOpenChange={setOpen}
-        preSelectedTemplateIds={templateIds}
-        installContext={{
-          dataConnectorId: connector.id,
-          appInstallationId: connector.appInstallationId ?? undefined,
-        }}
-        onComplete={applyBindings}
-      />
-    </>
+      )}
+
+      {showInstall && (
+        <div className='flex items-center gap-3 rounded-lg border border-violet-200 bg-violet-50/50 px-3 py-2.5 dark:border-violet-300/30 dark:bg-violet-300/10'>
+          <Boxes className='size-4 shrink-0 text-violet-600 dark:text-violet-300' />
+          <div className='flex min-w-0 flex-1 flex-col'>
+            <span className='text-sm font-medium'>
+              {appTitle}{' '}
+              {count === 1 ? 'creates a new record type' : `creates ${count} new record types`}
+            </span>
+            <span className='text-xs text-muted-foreground'>
+              Install {count === 1 ? 'it' : 'them'} to map this connector — or pick an existing
+              definition per stream below.
+            </span>
+          </div>
+          <Button variant='outline' size='xs' className='shrink-0' onClick={() => setOpen(true)}>
+            Install definitions
+          </Button>
+        </div>
+      )}
+
+      {showInstall && (
+        <EntityTemplateDialog
+          open={open}
+          onOpenChange={setOpen}
+          preSelectedTemplateIds={templateIds}
+          installContext={{
+            dataConnectorId: connector.id,
+            appInstallationId: connector.appInstallationId ?? undefined,
+          }}
+          onComplete={applyBindings}
+        />
+      )}
+    </div>
   )
 }

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -24,6 +24,7 @@ import {
   getConnectorTemplateById,
   listConnectors,
   listRuns,
+  listSharedOwnedDefIds,
   listStreams,
   projectConnectorOwnedTargets,
   READINESS_REASON,
@@ -538,6 +539,17 @@ export const dataConnectorRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { id, ...patch } = input
       return updateConnector(ctx.db, ctx.session.organizationId, id, patch)
+    }),
+
+  /**
+   * Owned-def ids of this connector that another connector ALSO maps to — a `delete`
+   * KEEPS them (reassigns ownership) instead of tearing them down. The detail view joins
+   * these against the cached resource labels to spell out "shared → kept" in the confirm.
+   */
+  sharedOwnedDefs: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      return listSharedOwnedDefIds(ctx.db, ctx.session.organizationId, input.id)
     }),
 
   delete: adminProcedure

--- a/packages/lib/src/data-connectors/adopt-shared-owned-def.test.ts
+++ b/packages/lib/src/data-connectors/adopt-shared-owned-def.test.ts
@@ -1,0 +1,45 @@
+// packages/lib/src/data-connectors/adopt-shared-owned-def.test.ts
+// Adoption decision for a second connector's owned mapping: share an existing app-owned
+// def by (appInstallationId, sourceKey) instead of forking. Requires the SAME app install
+// (owned field values resolve through @app: refs keyed on appFieldKey + install); no
+// install → never adopt (fork). See shared-definitions-across-connectors-plan.md.
+
+import type { Database } from '@auxx/database'
+import { describe, expect, it, vi } from 'vitest'
+import { adoptSharedOwnedDefId } from './mutations'
+
+/** Minimal drizzle chain whose terminal `.limit()` resolves to `rows`. */
+function mockDb(rows: Array<{ id: string }>) {
+  const limit = vi.fn(() => Promise.resolve(rows))
+  const chain = {
+    select: vi.fn(() => chain),
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    limit,
+  }
+  return { db: chain as unknown as Database, select: chain.select, limit }
+}
+
+const ORG = 'org_1'
+const INSTALL = 'inst_1'
+const KEY = 'issues'
+
+describe('adoptSharedOwnedDefId', () => {
+  it('adopts the existing app-owned def for the record type', async () => {
+    const { db, limit } = mockDb([{ id: 'def_shared' }])
+    await expect(adoptSharedOwnedDefId(db, ORG, INSTALL, KEY)).resolves.toBe('def_shared')
+    expect(limit).toHaveBeenCalledWith(1)
+  })
+
+  it('forks (returns null) when no matching def exists', async () => {
+    const { db } = mockDb([])
+    await expect(adoptSharedOwnedDefId(db, ORG, INSTALL, KEY)).resolves.toBeNull()
+  })
+
+  it('never adopts across installs — no appInstallationId means fork, and no query runs', async () => {
+    const { db, select } = mockDb([{ id: 'def_shared' }])
+    await expect(adoptSharedOwnedDefId(db, ORG, null, KEY)).resolves.toBeNull()
+    await expect(adoptSharedOwnedDefId(db, ORG, undefined, KEY)).resolves.toBeNull()
+    expect(select).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -99,6 +99,7 @@ export {
   createConnectorFromTemplate,
   deleteConnector,
   finishConnectorSetup,
+  listSharedOwnedDefIds,
   projectConnectorOwnedTargets,
   removeMapping,
   removeStream,

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -15,8 +15,10 @@ import {
   toResourceFieldId,
 } from '@auxx/types/field'
 import { generateId } from '@auxx/utils'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull, ne } from 'drizzle-orm'
 import { getCachedCustomFields, getCachedEntityDefId } from '../cache'
+import { onCacheEvent } from '../cache/invalidate'
+import { notifyEntityDefChanged } from '../entity-definitions/notify'
 import { BadRequestError, NotFoundError } from '../errors'
 import { toRecordId } from '../resources/resource-id'
 import {
@@ -479,7 +481,8 @@ export async function createConnectorFromAppCatalog(
       organizationId,
       streamRow.id,
       stream,
-      appSlug
+      appSlug,
+      input.appInstallationId
     )
     await materializeAppContributingMappings(
       db,
@@ -576,13 +579,50 @@ export function partitionOwnedFields(
 }
 
 /**
- * Seed the UNBOUND owned mappings for a catalog stream (v6 — install-target-defs-via
- * -templates, "Option A"). One `DataConnectorMapping` per owned default-mapping, with
- * `entityDefinitionId: null` and `fieldMappings` carrying the connection-late-bound
- * `@app:` ref per declared field. NO `EntityDefinition`s, columns,
- * or relationship edges are created here — they are created when the user installs the
- * app's record-type templates from the Map step (the reused `EntityTemplateDialog`), and
- * the install `onComplete` then binds each mapping's def + concrete field refs.
+ * The id of an existing, non-archived app-owned def for `sourceKey` under this app
+ * install, or `null` to fork a new one. Adoption REQUIRES the same `appInstallationId`:
+ * owned field values sync through `@app:` refs resolved by `appFieldKey` + install (R1),
+ * so a different install's columns wouldn't resolve — a different install forks instead.
+ * `sourceKey === entity.key` (Phase 2). Ownership (`dataConnectorId`) is deliberately NOT
+ * re-stamped — it stays with the def's first owner; the second connector just adds a
+ * mapping. See `plans/data-connectors/v6/shared-definitions-across-connectors-plan.md`.
+ */
+export async function adoptSharedOwnedDefId(
+  db: Database,
+  organizationId: string,
+  appInstallationId: string | null | undefined,
+  sourceKey: string
+): Promise<string | null> {
+  if (!appInstallationId) return null
+  const [existing] = await db
+    .select({ id: schema.EntityDefinition.id })
+    .from(schema.EntityDefinition)
+    .where(
+      and(
+        eq(schema.EntityDefinition.organizationId, organizationId),
+        eq(schema.EntityDefinition.appInstallationId, appInstallationId),
+        eq(schema.EntityDefinition.sourceKey, sourceKey),
+        isNull(schema.EntityDefinition.archivedAt)
+      )
+    )
+    .limit(1)
+  return existing?.id ?? null
+}
+
+/**
+ * Seed the owned mappings for a catalog stream (v6 — install-target-defs-via-templates,
+ * "Option A"). One `DataConnectorMapping` per owned default-mapping, with `fieldMappings`
+ * carrying the connection-late-bound `@app:` ref per declared field.
+ *
+ * A mapping is seeded **bound** when an app-owned def for its record type already exists
+ * for this app install — see `adoptSharedOwnedDefId`: a second connector for the SAME app
+ * install (e.g. GitHub Issues repo 1 + repo 2) shares ONE def instead of forking, with
+ * records kept attributable per-connector via `integrationSource`. Otherwise it is seeded
+ * UNBOUND (`entityDefinitionId: null`) — no `EntityDefinition`s, columns, or relationship
+ * edges are created here; they are created when the user installs the app's record-type
+ * templates from the Map step (the reused `EntityTemplateDialog`), and the install
+ * `onComplete` binds each mapping's def + concrete field refs.
+ *
  * `parentMappingId` is wired from rootPath nesting (parents first) so the fan-out tree —
  * and the install-created relationship edge it anchors — forms before any def exists.
  */
@@ -591,7 +631,8 @@ async function seedAppOwnedMappings(
   organizationId: string,
   streamId: string,
   stream: CatalogDataConnector['streams'][number],
-  appSlug: string
+  appSlug: string,
+  appInstallationId: string | null | undefined
 ): Promise<Record<string, string>> {
   const allMappings = stream.defaultMappings ?? []
   const owned = allMappings.filter((m) => m.target.mode === 'owned')
@@ -610,6 +651,15 @@ async function seedAppOwnedMappings(
     // its entry list is empty; it only carries the structural link (parent + edge key).
     const entries = partition[mapping.rootPath] ?? []
     const linkMode = mapping.linkMode ?? ('upsert' as LinkMode)
+
+    // Share an existing app-owned def for this record type instead of forking a new
+    // one (null → the install banner creates it). The def's `sourceKey === entity.key`.
+    const entityDefinitionId = await adoptSharedOwnedDefId(
+      db,
+      organizationId,
+      appInstallationId,
+      entity.key
+    )
 
     const parentRootPath = ownedParentRootPath(mapping.rootPath, allRootPaths)
     const parentMappingId = parentRootPath != null ? mappingIdByRootPath[parentRootPath] : null
@@ -638,7 +688,7 @@ async function seedAppOwnedMappings(
           : mapping.rootPath,
       linkMode,
       targetMode: 'owned' as TargetMode,
-      entityDefinitionId: null,
+      entityDefinitionId,
       parentMappingId,
       relationshipFieldKey: appRelationshipFieldKey(
         mapping.relationshipFieldKey,
@@ -1129,17 +1179,61 @@ export async function deleteConnector(
           eq(schema.EntityDefinition.dataConnectorId, id)
         )
       )
-    if (ownedDefs.length > 0) {
-      const defService = new EntityDefinitionService(organizationId, userId)
-      for (const ownedDef of ownedDefs) {
+    // A def SHARED with another connector (that connector still maps to it — e.g. GitHub
+    // Issues repo 1 + repo 2 into one def) must NOT be torn down: `delete()` cascades the
+    // other connector's mappings AND every record in the def, blowing past the per-record
+    // `integrationSource` scoping. For a shared def we keep it, reassign ownership to a
+    // surviving connector (stays `'connector'`-locked + survives this row's delete), and
+    // let the record wipe above (scoped to `integrationSource = id`) remove only THIS
+    // connector's rows. See shared-definitions-across-connectors-plan.md.
+    const defService = new EntityDefinitionService(organizationId, userId)
+    const keptSharedDefIds = new Set<string>()
+    for (const ownedDef of ownedDefs) {
+      const otherOwners = await db
+        .selectDistinct({ connectorId: schema.DataConnectorStream.dataConnectorId })
+        .from(schema.DataConnectorMapping)
+        .innerJoin(
+          schema.DataConnectorStream,
+          eq(schema.DataConnectorStream.id, schema.DataConnectorMapping.dataConnectorStreamId)
+        )
+        .where(
+          and(
+            eq(schema.DataConnectorMapping.entityDefinitionId, ownedDef.id),
+            eq(schema.DataConnectorMapping.organizationId, organizationId),
+            ne(schema.DataConnectorStream.dataConnectorId, id)
+          )
+        )
+      if (otherOwners.length === 0) {
         await defService.delete(ownedDef.id)
+        continue
       }
+      // Reassign to a deterministic survivor. Move the def AND its columns owned by THIS
+      // connector (so the stray-field sweep below skips them and they stay locked under
+      // the survivor). Do this BEFORE the connector-row delete so its FK set-null can't
+      // fire on the reassigned rows.
+      const survivorId = [...otherOwners.map((o) => o.connectorId)].sort()[0]
+      await db
+        .update(schema.EntityDefinition)
+        .set({ dataConnectorId: survivorId, updatedAt: new Date() })
+        .where(eq(schema.EntityDefinition.id, ownedDef.id))
+      await db
+        .update(schema.CustomField)
+        .set({ dataConnectorId: survivorId, updatedAt: new Date() })
+        .where(
+          and(
+            eq(schema.CustomField.entityDefinitionId, ownedDef.id),
+            eq(schema.CustomField.dataConnectorId, id)
+          )
+        )
+      keptSharedDefIds.add(ownedDef.id)
+      await notifyEntityDefChanged(organizationId, ownedDef.id, 'updated')
+      await onCacheEvent('custom-field.updated', { orgId: organizationId })
     }
 
     // Then any contributing columns the connector added to SHARED defs (e.g. fields on the
     // system Contact def) — tagged by `dataConnectorId` but not owned by a torn-down def.
     // `deleteField` handles values + relationship inverses + display-field cleanup and busts
-    // the custom-field cache.
+    // the custom-field cache. Skip columns on a kept shared def — they were reassigned above.
     const strayFields = await db
       .select({
         id: schema.CustomField.id,
@@ -1156,6 +1250,7 @@ export async function deleteConnector(
       const fieldService = new CustomFieldService(organizationId, userId, db)
       for (const stray of strayFields) {
         if (!stray.entityDefinitionId) continue
+        if (keptSharedDefIds.has(stray.entityDefinitionId)) continue
         await fieldService.deleteField(toResourceFieldId(stray.entityDefinitionId, stray.id))
       }
     }
@@ -1165,6 +1260,45 @@ export async function deleteConnector(
 
   logger.info('Deleted data connector', { id, behavior })
   return { success: true }
+}
+
+/**
+ * Owned-def ids of `connectorId` that ANOTHER connector also maps to — the defs a
+ * `delete` KEEPS (reassigning ownership) instead of tearing down (see `deleteConnector`'s
+ * shared-def guard). Powers the "shared → kept" delete-confirm copy. Empty when the
+ * connector owns no defs or none are shared.
+ */
+export async function listSharedOwnedDefIds(
+  db: Database,
+  organizationId: string,
+  connectorId: string
+): Promise<string[]> {
+  const ownedDefs = await db
+    .select({ id: schema.EntityDefinition.id })
+    .from(schema.EntityDefinition)
+    .where(
+      and(
+        eq(schema.EntityDefinition.organizationId, organizationId),
+        eq(schema.EntityDefinition.dataConnectorId, connectorId)
+      )
+    )
+  if (ownedDefs.length === 0) return []
+  const ownedIds = ownedDefs.map((d) => d.id)
+  const shared = await db
+    .selectDistinct({ defId: schema.DataConnectorMapping.entityDefinitionId })
+    .from(schema.DataConnectorMapping)
+    .innerJoin(
+      schema.DataConnectorStream,
+      eq(schema.DataConnectorStream.id, schema.DataConnectorMapping.dataConnectorStreamId)
+    )
+    .where(
+      and(
+        inArray(schema.DataConnectorMapping.entityDefinitionId, ownedIds),
+        eq(schema.DataConnectorMapping.organizationId, organizationId),
+        ne(schema.DataConnectorStream.dataConnectorId, connectorId)
+      )
+    )
+  return shared.map((s) => s.defId).filter((defId): defId is string => defId != null)
 }
 
 // ── Streams ─────────────────────────────────────────────────────────────────

--- a/packages/lib/src/entity-definitions/delete-entity-definition.ts
+++ b/packages/lib/src/entity-definitions/delete-entity-definition.ts
@@ -162,7 +162,11 @@ export async function deleteEntityDefinitionDeep(params: {
     .limit(1)
 
   if (!def) throw new NotFoundError('Entity definition not found')
-  if (def.entityType !== null) {
+  // System entities carry a real, non-empty entityType (contact, ticket, …). Custom
+  // and connector-owned defs have `null` — but a legacy owned-def create path wrote an
+  // empty string, so treat '' the same as null (a truthy check), else those defs are
+  // wrongly refused as "system" and can never be deleted (e.g. on connector teardown).
+  if (def.entityType) {
     throw new ForbiddenError('System entities cannot be deleted')
   }
 

--- a/packages/lib/src/entity-definitions/entity-definition-service.ts
+++ b/packages/lib/src/entity-definitions/entity-definition-service.ts
@@ -170,11 +170,13 @@ export class EntityDefinitionService {
   /**
    * Archive an entity definition (soft delete)
    * Convenience method that calls update with archivedAt set.
-   * System entities (any non-null entityType) are not archivable.
+   * System entities (any real, non-empty entityType) are not archivable.
    */
   async archive(id: string) {
     const existing = await this.getById(id)
-    if (existing && existing.entityType !== null) {
+    // Truthy check (not `!== null`): a legacy owned-def path wrote an empty-string
+    // entityType, which must NOT count as a system entity (see deleteEntityDefinitionDeep).
+    if (existing?.entityType) {
       throw new ForbiddenError('System entities cannot be archived')
     }
     return this.update(id, { archivedAt: new Date() })


### PR DESCRIPTION
## What

Multiple connectors for the same app install (e.g. **GitHub Issues repo 1 + repo 2**) can now write into **one shared entity definition** instead of forking a near-duplicate def per connector — and deleting a connector never destroys a def another connector still uses.

## Why

A connector and a def are linked at three layers that didn't agree: ownership (`EntityDefinition.dataConnectorId`, 1:1), usage (`DataConnectorMapping.entityDefinitionId`, M:N — already worked), and record provenance (`EntityInstance.integrationSource`, per-connector). Setup **forked** a def per connector, and `deleteConnector('delete')` hard-deleted owned defs by owner FK with **no cross-connector check** — cascading another connector's mappings + all records in the def, past the per-record `integrationSource` scoping.

## Changes

- **Adopt on setup** — `seedAppOwnedMappings` binds an owned mapping to an existing app-owned def via new `adoptSharedOwnedDefId((appInstallationId, sourceKey))`. Same app install only (owned values sync through `@app:` refs keyed on `appFieldKey` + install); a different install forks. Ownership is **not** re-stamped on adopt — it stays with the def's first owner; the second connector just adds a mapping.
- **Delete-safety guard** — `deleteConnector('delete')` detects other-connector mappings per owned def. Sole owner → full teardown as before. Shared → **keep**: reassign the def + its columns to a deterministic survivor, skip them in the stray-field sweep, bust caches. Records stay scoped to `integrationSource = id`.
- **Bug fix** — the `deleteEntityDefinitionDeep` / `archive` system-entity guard used `entityType !== null`, which misclassified a legacy owned def with `entityType = ''` as a system entity and blocked deletion. Now a truthy check.
- **UX** — install-owned-defs shows a *"Reusing existing record type(s) (from {owner})"* banner when a mapping adopts another connector's def; the detail-view delete copy splits torn-down defs vs *"N record type(s) … are shared with another connector and will be kept,"* backed by a new `dataConnector.sharedOwnedDefs` query (`listSharedOwnedDefIds`).

## Tests

- New `adopt-shared-owned-def.test.ts` (3 cases: adopt / fork-on-miss / never-adopt-without-install).
- Full data-connectors lib suite (31 files / 243) green; biome + IDE diagnostics clean.

## Not in this PR / follow-ups

- **Live verification** still pending (two GitHub connectors, same install → share → delete one → confirm the other survives).
- The DB-level FK/cache effects of the guard are exercised by the live run (no vitest DB harness).
- Deferred: a "create a separate type instead" fork escape hatch; the card / bulk-bar delete entry points still use the old copy (only the detail view got the "shared → kept" line).
- Composes with the still-unbuilt two-axis delete UX (`unbind-definitions-on-delete-plan.md`).

Plan: `plans/data-connectors/v6/shared-definitions-across-connectors-plan.md` (local; `plans/` is gitignored).