### PR TITLE
feat(identity): connector + chat converge on RecordIdentity index (Phases 3-5)

### DIFF
--- a/apps/api/public/app-runtime/index.html
+++ b/apps/api/public/app-runtime/index.html
@@ -73,7 +73,7 @@
 
     <!-- Platform Runtime Bundle (same for ALL extensions) -->
     <!-- Hash is replaced during build: platform.{HASH}.js -->
-    <script src="/api/v1/app-runtime/platform.ca02977d.js"></script>
+    <script src="/api/v1/app-runtime/platform.930bd014.js"></script>
 
     <!-- Extension bundle will be loaded dynamically by platform runtime -->
   </body>

--- a/apps/api/src/routes/chat/passport.ts
+++ b/apps/api/src/routes/chat/passport.ts
@@ -313,12 +313,24 @@ passportRoute.post('/', async (c) => {
           : undefined,
         bootAttributes,
       })
+      // Shopify App-Proxy-signed identity claims (set in shopify-proxy.ts) —
+      // never a spoofable client attribute. Present → the resolver resolves
+      // tier-1 by the connection-scoped `customerId` index (converges with
+      // connector-synced contacts) and skips the app-less `chat` link.
+      const shopDomain = claims.attributes.shopify_shop_domain
+      const shopifyCustomerId = claims.attributes.shopify_customer_id
+      const shopifyIdentity =
+        typeof shopDomain === 'string' && typeof shopifyCustomerId === 'string'
+          ? { shopDomain, customerId: shopifyCustomerId }
+          : undefined
+
       try {
         const resolved = await findOrCreateContactFromJwt({
           organizationId: widget.organizationId,
           userId: claims.userId,
           email: claims.email,
           attributes: writes,
+          ...(shopifyIdentity ? { shopify: shopifyIdentity } : {}),
         })
         identityVerified = true
         contactId = resolved.contactId
@@ -370,15 +382,13 @@ passportRoute.post('/', async (c) => {
         // tools' scope arg to this visitor. Both values come from the
         // App-Proxy-SIGNED JWT claims (set in shopify-proxy.ts) — never from a
         // spoofable client attribute. Best-effort: a failure never blocks mint.
-        const shopDomain = claims.attributes.shopify_shop_domain
-        const shopifyCustomerId = claims.attributes.shopify_customer_id
-        if (typeof shopDomain === 'string' && typeof shopifyCustomerId === 'string') {
+        if (shopifyIdentity) {
           try {
             await writeShopifyCustomerIdField({
               organizationId: widget.organizationId,
               contactId: resolved.contactId,
-              shopDomain,
-              shopifyCustomerId,
+              shopDomain: shopifyIdentity.shopDomain,
+              shopifyCustomerId: shopifyIdentity.customerId,
             })
           } catch (error) {
             log.warn('Failed to write Shopify customerId identity field', {

--- a/apps/web/src/components/drawers/cards/contact-external-identities-card.tsx
+++ b/apps/web/src/components/drawers/cards/contact-external-identities-card.tsx
@@ -1,0 +1,89 @@
+// apps/web/src/components/drawers/cards/contact-external-identities-card.tsx
+'use client'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { Link2 } from 'lucide-react'
+import { api } from '~/trpc/react'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+
+/**
+ * ContactExternalIdentitiesCard — the multi-source answer: every external
+ * system this record is linked to, grouped app → connection. Backed by the
+ * `RecordIdentity` index (`record.getIdentities`). The identity *values* still
+ * render as normal cells in the field grid; this card surfaces the full link
+ * set (e.g. Shopify-US + Shopify-EU + chat at once) that plain per-connection
+ * cells can't show as one group.
+ *
+ * Renders nothing when the record has no external identities.
+ */
+export function ContactExternalIdentitiesCard({ recordId }: DrawerTabProps) {
+  const { data: identities, isLoading } = api.record.getIdentities.useQuery({ recordId })
+
+  if (isLoading) {
+    return (
+      <div className='bg-primary-100/50 rounded-2xl border py-2 px-3'>
+        <div className='flex items-center gap-3'>
+          <Skeleton className='size-8 rounded-lg' />
+          <div className='flex flex-col gap-1'>
+            <Skeleton className='h-4 w-28' />
+            <Skeleton className='h-3 w-40' />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!identities || identities.length === 0) return null
+
+  // Group by (source, connectionId) — one block per app/store.
+  const groups = new Map<string, typeof identities>()
+  for (const identity of identities) {
+    const key = `${identity.source}:${identity.connectionId ?? ''}`
+    const existing = groups.get(key)
+    if (existing) existing.push(identity)
+    else groups.set(key, [identity])
+  }
+
+  return (
+    <div className='flex flex-col gap-2'>
+      {[...groups.values()].map((group) => {
+        const head = group[0]
+        const label = head.appName ?? head.source
+        const connectionLabel = head.connectionLabel
+        return (
+          <div
+            key={`${head.source}:${head.connectionId ?? ''}`}
+            className='bg-primary-100/50 rounded-2xl border py-2 px-3'>
+            <div className='flex items-center gap-3'>
+              <Avatar className='size-8 rounded-lg border bg-muted'>
+                {head.appIconKey ? (
+                  <AvatarImage src={head.appIconKey} alt={label} className='rounded-lg' />
+                ) : null}
+                <AvatarFallback className='rounded-lg bg-transparent'>
+                  <Link2 className='size-4 text-muted-foreground' />
+                </AvatarFallback>
+              </Avatar>
+              <div className='flex flex-col min-w-0'>
+                <span className='text-sm font-medium capitalize'>{label}</span>
+                {connectionLabel ? (
+                  <span className='text-muted-foreground text-xs'>{connectionLabel}</span>
+                ) : null}
+              </div>
+            </div>
+            <div className='mt-1.5 flex flex-col gap-1'>
+              {group.map((identity) => (
+                <div key={identity.id} className='flex items-center justify-between gap-2 text-xs'>
+                  <span className='text-muted-foreground shrink-0'>
+                    {identity.fieldLabel ?? identity.appFieldKey ?? 'ID'}
+                  </span>
+                  <span className='font-mono truncate'>{identity.externalId}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -67,6 +67,14 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
   () => Promise<{ default: ComponentType<DrawerTabProps> }>
 > = {
   // ─────────────────────────────────────────────────────────────────
+  // CONTACT OVERVIEW CARDS
+  // ─────────────────────────────────────────────────────────────────
+  'contact:external-identities': () =>
+    import('./cards/contact-external-identities-card').then((m) => ({
+      default: m.ContactExternalIdentitiesCard,
+    })),
+
+  // ─────────────────────────────────────────────────────────────────
   // TICKET OVERVIEW CARDS
   // ─────────────────────────────────────────────────────────────────
   'ticket:metrics': () =>

--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -5,6 +5,7 @@ import { getCachedResource } from '@auxx/lib/cache'
 import { conditionGroupSchema } from '@auxx/lib/conditions'
 import { BadRequestError } from '@auxx/lib/errors'
 import { getDescendantIds } from '@auxx/lib/field-values'
+import { getRecordIdentityViews } from '@auxx/lib/identity'
 import {
   type LookupCandidate,
   RESOURCE_TABLE_REGISTRY,
@@ -180,6 +181,27 @@ export const recordRouter = createTRPCRouter({
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: `Failed to fetch record: ${error.message}`,
+        })
+      }
+    }),
+
+  /**
+   * External identities linked to a record — the "External identities" card
+   * data source (RecordIdentity index, decorated from org cache). One batch
+   * query, no N+1. Values themselves still render as normal FieldValues in the
+   * field grid; this surfaces the cross-system/cross-store link set.
+   */
+  getIdentities: protectedProcedure
+    .input(z.object({ recordId: recordIdSchema }))
+    .query(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      try {
+        return await getRecordIdentityViews(organizationId, input.recordId as RecordId)
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to fetch record identities: ${message}`,
         })
       }
     }),

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -262,10 +262,19 @@ export interface CatalogConnectorDefaultMapping {
          * Non-identity field bindings the app author pre-declares so a contributing
          * stream is born closer to `ready` (e.g. `first_name` → contact's first-name
          * attribute). Each binds a source field to a target `contact` field by key —
-         * the same resolver the match keys use, just without an `identityRole`.
-         * Unresolved bindings are dropped (the row stays a `needs-mapping` draft).
+         * the same resolver the match keys use, just without an `identityRole`, unless
+         * `targetAppField` names an `identity: true` app field (auto-stamps one — the
+         * `isExternalId` mechanism extended to contributing). Unresolved bindings are
+         * dropped (the row stays a `needs-mapping` draft).
          */
-        fieldBindings?: { sourceFieldKey: string; targetKey: string }[]
+        fieldBindings?: { sourceFieldKey: string; targetKey?: string; targetAppField?: string }[]
+        /**
+         * Fill a plain (non-identity) app field from the connector's CONNECTION
+         * METADATA (e.g. Shopify `shopDomain`) rather than the source record — the
+         * only synthetic write channel. `appFieldKey` must name a declared,
+         * non-identity app field; `from` is the connection metadata key.
+         */
+        connectionAppFields?: { appFieldKey: string; from: string }[]
       }
 }
 

--- a/packages/database/src/db/schema/data-connector-types.ts
+++ b/packages/database/src/db/schema/data-connector-types.ts
@@ -231,6 +231,12 @@ export interface FieldMapping {
   /** Per-field write behavior (folded in from the old parallel map). Absent ⇒ 'overwrite'. */
   mergeStrategy?: FieldMergeStrategy
   /**
+   * This binding writes a value read from the connector's CONNECTION METADATA
+   * (e.g. Shopify `shopDomain`), not the source record subtree. Mirror of the
+   * engine `FieldMapping.connectionMetaKey` (`@auxx/lib/data-connectors/types`).
+   */
+  connectionMetaKey?: string
+  /**
    * Provisioning hint for a connector-introduced target field (05d) — used to
    * create a missing target field with the declared type/name at sync time.
    * `appFieldKey` (05e) is the STABLE idempotency key the provisioner + ref

--- a/packages/lib/src/chat/index.ts
+++ b/packages/lib/src/chat/index.ts
@@ -23,7 +23,11 @@ export type {
   InitializeChatThreadResult,
 } from './session'
 export { initializeOrResumeChatThread } from './session'
-export { writeShopifyCustomerIdField } from './shopify-identity-field'
+export type { ShopifyStoreConnection } from './shopify-identity-field'
+export {
+  resolveShopifyStoreConnection,
+  writeShopifyCustomerIdField,
+} from './shopify-identity-field'
 export type { SignChannelUserJwtOptions, SignChannelUserJwtPayload } from './sign-jwt'
 export { signChannelUserJwt } from './sign-jwt'
 export type { ChatAttachment, ServiceContext, VisitInfo } from './types'

--- a/packages/lib/src/chat/shopify-identity-field.ts
+++ b/packages/lib/src/chat/shopify-identity-field.ts
@@ -27,6 +27,65 @@ interface WriteShopifyCustomerIdInput {
   db?: Database
 }
 
+/** The Shopify app installation + bound store connection for one shop domain. */
+export interface ShopifyStoreConnection {
+  appId: string
+  installationId: string
+  connectionId: string
+}
+
+/**
+ * Resolve the Shopify app installation + the store `Credential` bound to a
+ * trusted shop domain, org-scoped. This is the same app→installation→credential
+ * chain `writeShopifyCustomerIdField` walks and the same binding check
+ * `shopify-proxy.ts` performs at JWT mint — extracted so the chat JWT resolver
+ * can reuse it for connection-scoped identity lookup.
+ *
+ * `shopDomain` MUST come from an App-Proxy-signed JWT claim, never a spoofable
+ * client attribute. Returns `null` (never throws) when the app isn't installed,
+ * credentials can't be listed, or no connection matches the shop.
+ */
+export async function resolveShopifyStoreConnection(
+  organizationId: string,
+  shopDomain: string,
+  db: Database = database
+): Promise<ShopifyStoreConnection | null> {
+  const shopifyApp = await db.query.App.findFirst({
+    where: eq(schema.App.slug, 'shopify'),
+    columns: { id: true },
+  })
+  if (!shopifyApp) return null
+
+  const installation = await db.query.AppInstallation.findFirst({
+    where: and(
+      eq(schema.AppInstallation.appId, shopifyApp.id),
+      eq(schema.AppInstallation.organizationId, organizationId),
+      isNull(schema.AppInstallation.uninstalledAt)
+    ),
+    columns: { id: true },
+  })
+  if (!installation) return null
+
+  const credsResult = await listCredentials({
+    organizationId,
+    kind: 'app',
+    appId: shopifyApp.id,
+    userId: null,
+  })
+  if (credsResult.isErr()) {
+    log.warn('Failed to list Shopify credentials during connection resolution', {
+      organizationId,
+      error: credsResult.error.message,
+    })
+    return null
+  }
+
+  const connectionId = credsResult.value.find((cred) => cred.metadata.shopDomain === shopDomain)?.id
+  if (!connectionId) return null
+
+  return { appId: shopifyApp.id, installationId: installation.id, connectionId }
+}
+
 /**
  * Write the verified visitor's Shopify customer id onto their contact's
  * **connection-scoped** `customerId` app field, so the chat restriction engine
@@ -58,53 +117,22 @@ export async function writeShopifyCustomerIdField(
   const db = input.db ?? database
   const { organizationId, contactId, shopDomain, shopifyCustomerId } = input
 
-  // 1. Shopify app + its live installation for this org.
-  const shopifyApp = await db.query.App.findFirst({
-    where: eq(schema.App.slug, 'shopify'),
-    columns: { id: true },
-  })
-  if (!shopifyApp) return false
-
-  const installation = await db.query.AppInstallation.findFirst({
-    where: and(
-      eq(schema.AppInstallation.appId, shopifyApp.id),
-      eq(schema.AppInstallation.organizationId, organizationId),
-      isNull(schema.AppInstallation.uninstalledAt)
-    ),
-    columns: { id: true },
-  })
-  if (!installation) return false
-
-  // 2. Resolve the bound store connection by matching the trusted shop domain
-  //    against the plaintext credential metadata (mirrors shopify-proxy binding).
-  const credsResult = await listCredentials({
-    organizationId,
-    kind: 'app',
-    appId: shopifyApp.id,
-    userId: null,
-  })
-  if (credsResult.isErr()) {
-    log.warn('Failed to list Shopify credentials during identity-field write', {
-      organizationId,
-      error: credsResult.error.message,
-    })
-    return false
-  }
-
-  const connectionId = credsResult.value.find((cred) => cred.metadata.shopDomain === shopDomain)?.id
-  if (!connectionId) {
+  // 1+2. Shopify app installation + the store connection bound to this domain.
+  const store = await resolveShopifyStoreConnection(organizationId, shopDomain, db)
+  if (!store) {
     log.warn('No bound Shopify connection for shop domain — skipping customerId field write', {
       organizationId,
       shopDomain,
     })
     return false
   }
+  const { installationId, connectionId } = store
 
   // 3. The connection-scoped customerId field def for this store.
   const field = await db.query.CustomField.findFirst({
     where: and(
       eq(schema.CustomField.organizationId, organizationId),
-      eq(schema.CustomField.appInstallationId, installation.id),
+      eq(schema.CustomField.appInstallationId, installationId),
       eq(schema.CustomField.connectionId, connectionId),
       eq(schema.CustomField.appFieldKey, SHOPIFY_CUSTOMER_ID_FIELD_KEY)
     ),
@@ -145,7 +173,7 @@ export async function writeShopifyCustomerIdField(
       entityInstanceId: contactId,
       entityDefinitionId: contactDefId,
       source: SHOPIFY_SOURCE,
-      appInstallationId: installation.id,
+      appInstallationId: installationId,
       connectionId,
       appFieldKey: SHOPIFY_CUSTOMER_ID_FIELD_KEY,
       fieldId: field.id,

--- a/packages/lib/src/data-connectors/app-catalog.test.ts
+++ b/packages/lib/src/data-connectors/app-catalog.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 import {
   appCatalogStreamSchema,
   buildContributingAutoBindings,
+  buildContributingConnectionAppFields,
   buildContributingFieldBindings,
   buildSchemaFromFieldPaths,
   type ContributingTargetField,
@@ -155,6 +156,7 @@ describe('buildContributingFieldBindings', () => {
   it('binds by systemAttribute and by normalized name, subtree-relative, no identityRole', () => {
     const bindings = buildContributingFieldBindings(
       'def_contact',
+      'shopify',
       'customer',
       [
         { sourceFieldKey: 'first_name', targetKey: 'first_name' }, // → by systemAttribute
@@ -176,6 +178,7 @@ describe('buildContributingFieldBindings', () => {
   it('drops a binding whose target key does not resolve', () => {
     const bindings = buildContributingFieldBindings(
       'def_contact',
+      'shopify',
       'customer',
       [{ sourceFieldKey: 'unknown', targetKey: 'no_such_field' }],
       sourceFields,
@@ -187,6 +190,7 @@ describe('buildContributingFieldBindings', () => {
   it('drops a binding whose source field key is unknown', () => {
     const bindings = buildContributingFieldBindings(
       'def_contact',
+      'shopify',
       'customer',
       [{ sourceFieldKey: 'missing_source', targetKey: 'first_name' }],
       sourceFields,
@@ -198,6 +202,7 @@ describe('buildContributingFieldBindings', () => {
   it('drops everything for an array-rooted mapping', () => {
     const bindings = buildContributingFieldBindings(
       'def_contact',
+      'shopify',
       'line_items[]',
       [{ sourceFieldKey: 'first_name', targetKey: 'first_name' }],
       sourceFields,
@@ -209,6 +214,7 @@ describe('buildContributingFieldBindings', () => {
   it('binds at root (no prefix) with the full source path', () => {
     const bindings = buildContributingFieldBindings(
       'def_contact',
+      'shopify',
       '',
       [{ sourceFieldKey: 'email', targetKey: 'email' }],
       [{ fieldKey: 'email', sourcePath: 'email', type: 'EMAIL', name: 'Email' }],
@@ -219,6 +225,87 @@ describe('buildContributingFieldBindings', () => {
       targetFieldRef: 'def_contact:f_email',
       expression: '{email}',
     })
+  })
+
+  it('binds targetAppField to the late-bound @app: ref, stamping identityRole when the app field is identity: true', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      'shopify',
+      '',
+      [{ sourceFieldKey: 'shopify_id', targetAppField: 'customerId' }],
+      [{ fieldKey: 'shopify_id', sourcePath: 'id', type: 'TEXT', name: 'Shopify ID' }],
+      [
+        {
+          id: 'cf_cust_us',
+          name: 'Shopify customer ID',
+          systemAttribute: null,
+          type: 'TEXT',
+          appFieldKey: 'customerId',
+          isIdentity: true,
+        },
+      ]
+    )
+    expect(bindings).toHaveLength(1)
+    expect(bindings[0]).toMatchObject({
+      targetFieldRef: 'def_contact:@app:shopify:customerId',
+      expression: '{id}',
+      identityRole: { kind: 'externalId' },
+    })
+  })
+
+  it('binds targetAppField with no identityRole when the app field is not identity: true', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      'shopify',
+      '',
+      [{ sourceFieldKey: 'domain', targetAppField: 'storeDomain' }],
+      [{ fieldKey: 'domain', sourcePath: 'domain', type: 'TEXT', name: 'Domain' }],
+      [
+        {
+          id: 'cf_domain',
+          name: 'Shopify store',
+          systemAttribute: null,
+          type: 'TEXT',
+          appFieldKey: 'storeDomain',
+          isIdentity: false,
+        },
+      ]
+    )
+    expect(bindings).toHaveLength(1)
+    expect(bindings[0]!.targetFieldRef).toBe('def_contact:@app:shopify:storeDomain')
+    expect(bindings[0]!.identityRole).toBeUndefined()
+  })
+
+  it('drops a targetAppField binding whose appFieldKey is not declared', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      'shopify',
+      '',
+      [{ sourceFieldKey: 'shopify_id', targetAppField: 'noSuchField' }],
+      [{ fieldKey: 'shopify_id', sourcePath: 'id', type: 'TEXT', name: 'Shopify ID' }],
+      defFields
+    )
+    expect(bindings).toHaveLength(0)
+  })
+})
+
+describe('buildContributingConnectionAppFields', () => {
+  it('builds a connectionMetaKey-flagged FieldMapping per entry, never carrying identityRole', () => {
+    const bindings = buildContributingConnectionAppFields('def_contact', 'shopify', [
+      { appFieldKey: 'storeDomain', from: 'shopDomain' },
+    ])
+    expect(bindings).toHaveLength(1)
+    expect(bindings[0]).toMatchObject({
+      targetFieldRef: 'def_contact:@app:shopify:storeDomain',
+      connectionMetaKey: 'shopDomain',
+      expression: '',
+      sourceFields: {},
+    })
+    expect(bindings[0]!.identityRole).toBeUndefined()
+  })
+
+  it('returns an empty array for no entries', () => {
+    expect(buildContributingConnectionAppFields('def_contact', 'shopify', [])).toEqual([])
   })
 })
 

--- a/packages/lib/src/data-connectors/app-catalog.ts
+++ b/packages/lib/src/data-connectors/app-catalog.ts
@@ -5,7 +5,7 @@
 // with the DB write helpers in `createConnectorFromAppCatalog`.
 
 import type { CatalogDataConnector } from '@auxx/database'
-import { toResourceFieldId } from '@auxx/types/field'
+import { toAppFieldRef, toResourceFieldId } from '@auxx/types/field'
 import { generateId } from '@auxx/utils'
 import { inferJsonSchema, STRUCT_FIELD_TYPE_KEYWORD } from '../json-schema'
 import type { FieldMapping, IdentityNormalize } from './types'
@@ -99,6 +99,10 @@ export interface ContributingTargetField {
   isCreatable?: boolean
   isUpdatable?: boolean
   isComputed?: boolean
+  /** The app-declared `appFieldKey` this row provisioned from, if any (null for system attrs). */
+  appFieldKey?: string | null
+  /** Stamped by provisioning when the declaring `defineFields` entry is `identity: true`. */
+  isIdentity?: boolean
 }
 
 /** A target is a safe auto-bind sink unless it's computed or can be neither created nor updated. */
@@ -162,15 +166,21 @@ export function buildContributingMatchBindings(
  * of a bare identity-only draft (multi-stream-setup-plan §3.4A). A binding resolves
  * only when BOTH sides resolve unambiguously:
  *   - source — a declared stream field by `fieldKey` (`binding.sourceFieldKey`);
- *   - target — a field on the contributing def keyed by `binding.targetKey` (its
- *     `systemAttribute`, name, or normalized name).
+ *   - target — either `targetKey` against a field on the contributing def (its
+ *     `systemAttribute`, name, or normalized name), OR `targetAppField` (mutually
+ *     exclusive) against a declared app field's `appFieldKey` — resolved to the
+ *     connection-late-bound `@app:` ref (not a concrete id, since the field may be
+ *     connection-scoped) via `toAppFieldRef`. A `targetAppField` binding whose app
+ *     field is `identity: true` auto-stamps `identityRole: { kind: 'externalId' }`
+ *     (the `isExternalId` mechanism, extended to contributing).
  * Array-rooted mappings and unresolved bindings are dropped (the row keeps whatever
- * draft state remains). The external id is never bound here.
+ * draft state remains). The external id is never bound via `targetKey`.
  */
 export function buildContributingFieldBindings(
   entityDefinitionId: string,
+  appSlug: string,
   rootPath: string,
-  fieldBindings: { sourceFieldKey: string; targetKey: string }[],
+  fieldBindings: { sourceFieldKey: string; targetKey?: string; targetAppField?: string }[],
   sourceFields: CatalogDataConnector['streams'][number]['fields'],
   defFields: ContributingTargetField[]
 ): FieldMapping[] {
@@ -181,16 +191,56 @@ export function buildContributingFieldBindings(
   const fieldByKey = buildTargetFieldIndex(defFields)
   const prefix = rootPath ? `${rootPath}.` : ''
   const bindings: FieldMapping[] = []
-  for (const { sourceFieldKey, targetKey } of fieldBindings) {
-    const target = fieldByKey.get(targetKey) ?? fieldByKey.get(normalizeFieldKey(targetKey))
-    if (!target) continue
+  for (const { sourceFieldKey, targetKey, targetAppField } of fieldBindings) {
     const sourceField = sourceFields.find((f) => f.fieldKey === sourceFieldKey)
     // The source field must live under this mapping's subtree (its sourcePath starts
     // with the rootPath prefix), else its relative path is undefined for this root.
     if (!sourceField || (prefix && !sourceField.sourcePath.startsWith(prefix))) continue
+
+    if (targetAppField) {
+      const appField = defFields.find((f) => f.appFieldKey === targetAppField)
+      if (!appField) continue
+      bindings.push(
+        bindSourceToAppField(
+          entityDefinitionId,
+          appSlug,
+          targetAppField,
+          prefix,
+          sourceField,
+          appField.isIdentity ? { kind: 'externalId' } : undefined
+        )
+      )
+      continue
+    }
+    if (!targetKey) continue
+    const target = fieldByKey.get(targetKey) ?? fieldByKey.get(normalizeFieldKey(targetKey))
+    if (!target) continue
     bindings.push(bindSourceToTarget(entityDefinitionId, prefix, sourceField, target))
   }
   return bindings
+}
+
+/**
+ * Build the `FieldMapping[]` for a contributing mapping's `connectionAppFields` —
+ * plain (never identity) app fields filled from the connector's CONNECTION METADATA
+ * (e.g. Shopify `shopDomain`) rather than the source record. The only synthetic
+ * write channel: no source binding, so `expression`/`sourceFields` are unused and
+ * `connectionMetaKey` carries the metadata key the sink reads at write time
+ * (`ctx.connectionMeta`). Always the late-bound `@app:` ref — connection metadata is
+ * per-connection by nature, same reasoning as `targetAppField`.
+ */
+export function buildContributingConnectionAppFields(
+  entityDefinitionId: string,
+  appSlug: string,
+  connectionAppFields: { appFieldKey: string; from: string }[]
+): FieldMapping[] {
+  return connectionAppFields.map(({ appFieldKey, from }) => ({
+    id: generateId(),
+    targetFieldRef: toAppFieldRef(entityDefinitionId, appSlug, appFieldKey),
+    expression: '',
+    sourceFields: {},
+    connectionMetaKey: from,
+  }))
 }
 
 /**
@@ -285,6 +335,31 @@ function bindSourceToTarget(
   return {
     id: generateId(),
     targetFieldRef: toResourceFieldId(entityDefinitionId, target.id),
+    expression: `{${relativePath}}`,
+    sourceFields: { [relativePath]: relativePath },
+    ...(identityRole ? { identityRole } : {}),
+  }
+}
+
+/**
+ * Same as {@link bindSourceToTarget}, but for a `targetAppField` binding: the
+ * target is an app-declared field named by `appFieldKey`, resolved to the
+ * connection-late-bound `@app:` ref (never a concrete id — the field may be
+ * connection-scoped, so resolution defers to sync time against the connector's
+ * bound connection, same as owned `isExternalId` fields).
+ */
+function bindSourceToAppField(
+  entityDefinitionId: string,
+  appSlug: string,
+  appFieldKey: string,
+  prefix: string,
+  sourceField: CatalogDataConnector['streams'][number]['fields'][number],
+  identityRole?: FieldMapping['identityRole']
+): FieldMapping {
+  const relativePath = prefix ? sourceField.sourcePath.slice(prefix.length) : sourceField.sourcePath
+  return {
+    id: generateId(),
+    targetFieldRef: toAppFieldRef(entityDefinitionId, appSlug, appFieldKey),
     expression: `{${relativePath}}`,
     sourceFields: { [relativePath]: relativePath },
     ...(identityRole ? { identityRole } : {}),

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -18,6 +18,7 @@
 //   B2 — the chain decodes against a PINNED mapping snapshot (`mappings` captured
 //        at construction), not live config — a mid-backfill edit can't skew slices.
 
+import { getCredential } from '@auxx/credentials/store'
 import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { RuntimeConnectionData } from '../connections/resolve-connection-for-runtime'
@@ -141,6 +142,8 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
   private crud?: UnifiedCrudHandler
   private ownedCrud?: UnifiedCrudHandler
   private readonly warmedDefs = new Set<string>()
+  /** Bound connection's plaintext metadata (`connectionAppFields` source), loaded once. */
+  private connectionMeta?: Record<string, unknown> | null
 
   constructor(private readonly deps: ConnectorSyncSourceDeps) {
     this.id = `${deps.connector.id}:${deps.stream.streamId}`
@@ -359,6 +362,9 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
       await this.ownedCrud.warmCache(m.entityDefinitionId)
       this.warmedDefs.add(m.entityDefinitionId)
     }
+    if (this.connectionMeta === undefined) {
+      this.connectionMeta = await this.loadConnectionMeta()
+    }
     return {
       db: this.deps.db,
       orgId: this.deps.organizationId,
@@ -369,7 +375,24 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
       counters,
       touchedDefs: new Set<string>(),
       sweep: this.deps.sweep ?? false,
+      connectionMeta: this.connectionMeta,
     }
+  }
+
+  /** Load the bound connection's plaintext metadata once per instance (best-effort). */
+  private async loadConnectionMeta(): Promise<Record<string, unknown> | null> {
+    const credentialId = this.deps.connector.credentialId
+    if (!credentialId) return null
+    const result = await getCredential(credentialId, this.deps.organizationId)
+    if (result.isErr()) {
+      logger.warn('Failed to load connection metadata for connectionAppFields', {
+        connectorId: this.deps.connector.id,
+        credentialId,
+        error: result.error.message,
+      })
+      return null
+    }
+    return result.value.metadata
   }
 }
 

--- a/packages/lib/src/data-connectors/connector-webhook.ts
+++ b/packages/lib/src/data-connectors/connector-webhook.ts
@@ -10,6 +10,7 @@
 // dedupe + the receiver's event-id dedupe. The full-sync path (enqueueConnectorSync) still
 // handles cursor streams that have no `{path}` to steer — see the dispatch jobs.
 
+import { getCredential } from '@auxx/credentials/store'
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
@@ -201,6 +202,20 @@ async function buildWebhookCtx(
     await crud.warmCache(defId)
     await ownedCrud.warmCache(defId)
   }
+  // Best-effort — a webhook-steered partial run never fails on a metadata load miss.
+  let connectionMeta: Record<string, unknown> | null = null
+  if (connector.credentialId) {
+    const result = await getCredential(connector.credentialId, organizationId)
+    if (result.isOk()) {
+      connectionMeta = result.value.metadata
+    } else {
+      logger.warn('Failed to load connection metadata for connectionAppFields', {
+        connectorId: connector.id,
+        credentialId: connector.credentialId,
+        error: result.error.message,
+      })
+    }
+  }
   return {
     db,
     orgId: organizationId,
@@ -210,5 +225,6 @@ async function buildWebhookCtx(
     ownedCrud,
     counters,
     touchedDefs: new Set<string>(),
+    connectionMeta,
   }
 }

--- a/packages/lib/src/data-connectors/map-record.test.ts
+++ b/packages/lib/src/data-connectors/map-record.test.ts
@@ -365,4 +365,30 @@ describe('mapRecord', () => {
     const writes = mapRecord([m], source({ customer: null }))
     expect(writes).toHaveLength(0)
   })
+
+  // ── connectionAppFields (identity plan phase 3) ──────────────────────────────
+
+  it('skips a connectionMetaKey-flagged binding — the sink injects its value, not the source subtree', () => {
+    const m = mapping({
+      fieldMappings: [
+        {
+          id: 'e1',
+          targetFieldRef: 'def1:total',
+          expression: '{total_price}',
+          sourceFields: { total_price: 'total_price' },
+        },
+        {
+          id: 'conn',
+          targetFieldRef: 'def1:@app:shopify:storeDomain',
+          expression: '',
+          sourceFields: {},
+          connectionMetaKey: 'shopDomain',
+        },
+      ],
+    })
+    const writes = mapRecord([m], source({ total_price: '49.99' }))
+    // Only the normal binding is projected — the connection-meta ref is absent
+    // entirely, never evaluated against the (irrelevant) source subtree.
+    expect(writes[0]?.projected?.fields).toEqual({ 'def1:total': '49.99' })
+  })
 })

--- a/packages/lib/src/data-connectors/map-record.ts
+++ b/packages/lib/src/data-connectors/map-record.ts
@@ -116,6 +116,9 @@ function evaluateFields(mapping: DecodedMapping, subtree: unknown): Record<strin
   const out: Record<string, unknown> = {}
   for (const fm of mapping.fieldMappings) {
     if (fm.targetFieldRef == null) continue // unassigned draft — projected nowhere
+    // connectionMetaKey bindings read connection metadata, not the source subtree —
+    // the sink injects their value before the write set is built (entity-sink.ts).
+    if (fm.connectionMetaKey != null) continue
     out[fm.targetFieldRef] = evaluateFieldValue(fm, subtree)
   }
   return out

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -24,6 +24,7 @@ import { toRecordId } from '../resources/resource-id'
 import {
   appCatalogStreamSchema,
   buildContributingAutoBindings,
+  buildContributingConnectionAppFields,
   buildContributingFieldBindings,
   buildContributingMatchBindings,
 } from './app-catalog'
@@ -869,7 +870,7 @@ async function materializeAppContributingMappings(
   const ownedRootPaths = Object.keys(ownedMappingIdByRootPath)
   for (const mapping of stream.defaultMappings ?? []) {
     if (mapping.target.mode !== 'contributing') continue
-    const { entityKind, matchFieldKeys, fieldBindings } = mapping.target
+    const { entityKind, matchFieldKeys, fieldBindings, connectionAppFields } = mapping.target
 
     const entityDefinitionId = await getCachedEntityDefId(organizationId, entityKind)
     if (!entityDefinitionId) {
@@ -899,6 +900,7 @@ async function materializeAppContributingMappings(
       (fieldBindings?.length ?? 0) > 0
         ? buildContributingFieldBindings(
             entityDefinitionId,
+            appSlug,
             mapping.rootPath,
             fieldBindings ?? [],
             stream.fields,
@@ -911,12 +913,22 @@ async function materializeAppContributingMappings(
             defFields
           )
     ).filter((b) => !boundTargets.has(b.targetFieldRef))
+    // Connection-metadata fields (e.g. `storeDomain`) — no source binding, so no
+    // boundTargets filter applies; a declared connectionAppFields target never
+    // collides with a match/value binding in practice (different app fields).
+    const connMetaBindings = buildContributingConnectionAppFields(
+      entityDefinitionId,
+      appSlug,
+      connectionAppFields ?? []
+    )
     const linkMode = mapping.linkMode ?? ('upsert' as LinkMode)
     // A `reference` contributing edge owns no value columns — it carries only the
     // External-ID anchor (the FK resolves to the related record at sync), mirroring the
     // interactive `linkRelationship`. Otherwise bind match + author/auto value fields.
     const fieldMappings =
-      linkMode === 'reference' ? [buildReferenceAnchor()] : [...matchBindings, ...valueBindings]
+      linkMode === 'reference'
+        ? [buildReferenceAnchor()]
+        : [...matchBindings, ...valueBindings, ...connMetaBindings]
 
     // A nested contributing branch (e.g. the order stream's embedded `customer`)
     // hangs off the owned root it's drilled from. Wiring `parentMappingId` makes

--- a/packages/lib/src/data-connectors/sinks/entity-sink-connection-app-fields.test.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink-connection-app-fields.test.ts
@@ -1,0 +1,196 @@
+// packages/lib/src/data-connectors/sinks/entity-sink-connection-app-fields.test.ts
+// connectionAppFields (identity plan phase 3): a `connectionMetaKey`-flagged
+// FieldMapping reads its value from `ctx.connectionMeta`, not the source record —
+// injected before the normal write-set build so every existing merge-strategy /
+// provenance / ref-resolution path applies unchanged.
+// plans/data-connectors/v7/option-3-multi-source-identity-store-plan.md Phase 3.
+
+import { toResourceFieldId } from '@auxx/types/field'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DecodedMapping } from '../service'
+import type { ProjectedRecord, SyncCtx } from './types'
+
+const findItem = vi.fn()
+const findItemByDef = vi.fn()
+const touchItem = vi.fn()
+const upsertItem = vi.fn()
+vi.mock('../service', () => ({
+  findItem: (...a: unknown[]) => findItem(...a),
+  findItemByDef: (...a: unknown[]) => findItemByDef(...a),
+  touchItem: (...a: unknown[]) => touchItem(...a),
+  upsertItem: (...a: unknown[]) => upsertItem(...a),
+  listItemsForMapping: vi.fn(),
+  markItemArchived: vi.fn(),
+  setItemPendingRelations: vi.fn(),
+}))
+
+const resolveConnectorFieldRef = vi.fn()
+vi.mock('../../agents/bindings/resolve', () => ({
+  resolveConnectorFieldRef: (...a: unknown[]) => resolveConnectorFieldRef(...a),
+}))
+const buildWriteKeyToFieldId = vi.fn()
+vi.mock('../field-id-resolver', () => ({
+  buildWriteKeyToFieldId: (...a: unknown[]) => buildWriteKeyToFieldId(...a),
+}))
+
+const getCachedFieldMap = vi.fn()
+vi.mock('../../cache', () => ({ getCachedFieldMap: (...a: unknown[]) => getCachedFieldMap(...a) }))
+
+const upsertRecordIdentity = vi.fn()
+vi.mock('../../identity', () => ({
+  upsertRecordIdentity: (...a: unknown[]) => upsertRecordIdentity(...a),
+}))
+
+import { entitySink } from './entity-sink'
+
+const FIELD_ID = 'field_storeDomain'
+const RAW_REF = 'contact:@app:shopify:storeDomain'
+const DEF_ID = 'def_contact'
+
+function mapping(over: Partial<DecodedMapping> = {}): DecodedMapping {
+  return {
+    row: { id: 'm1' },
+    rootPath: '',
+    linkMode: 'upsert',
+    targetMode: 'contributing',
+    entityDefinitionId: DEF_ID,
+    parentMappingId: null,
+    relationshipFieldKey: null,
+    orphanBehavior: 'ignore',
+    fieldMappings: [
+      {
+        id: 'fm1',
+        targetFieldRef: RAW_REF,
+        expression: '',
+        sourceFields: {},
+        connectionMetaKey: 'shopDomain',
+      },
+    ],
+    ...over,
+  } as unknown as DecodedMapping
+}
+
+function record(over: Partial<ProjectedRecord> = {}): ProjectedRecord {
+  return {
+    externalId: 'c1',
+    displayName: 'Jane',
+    fields: {},
+    identityCandidates: [],
+    pendingRelations: [],
+    ...over,
+  }
+}
+
+const create = vi.fn()
+const update = vi.fn().mockResolvedValue(undefined)
+const getFieldValues = vi.fn()
+
+/** Chainable `db.update(...).set(...).where(...)` stub for stampContributingProvenance. */
+function makeDb() {
+  return {
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    })),
+  }
+}
+
+function makeCtx(over: Partial<SyncCtx> = {}): SyncCtx {
+  return {
+    db: makeDb() as never,
+    orgId: 'org1',
+    connector: { id: 'dc1', credentialId: 'cred1' } as SyncCtx['connector'],
+    runId: 'run1',
+    crud: { update, create, getFieldValues } as never,
+    ownedCrud: { update, create, getFieldValues } as never,
+    counters: {
+      fetched: 0,
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      archived: 0,
+      deleted: 0,
+      failed: 0,
+      relationshipWarnings: 0,
+      errorSample: [],
+    } as SyncCtx['counters'],
+    touchedDefs: new Set<string>(),
+    connectionMeta: { shopDomain: 'us.myshopify.com' },
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  findItem.mockReset()
+  findItem.mockResolvedValue(null)
+  findItemByDef.mockReset()
+  findItemByDef.mockResolvedValue(null)
+  touchItem.mockReset()
+  upsertItem.mockReset()
+  update.mockClear()
+  create.mockReset()
+  create.mockResolvedValue({ instance: { id: 'inst1' } })
+  getFieldValues.mockReset()
+  resolveConnectorFieldRef.mockReset()
+  resolveConnectorFieldRef.mockImplementation(async (ref: string) =>
+    ref === RAW_REF ? toResourceFieldId(DEF_ID, FIELD_ID) : null
+  )
+  buildWriteKeyToFieldId.mockReset()
+  buildWriteKeyToFieldId.mockResolvedValue(new Map([[FIELD_ID, FIELD_ID]]))
+  getCachedFieldMap.mockReset()
+  getCachedFieldMap.mockResolvedValue(new Map())
+  upsertRecordIdentity.mockReset()
+  upsertRecordIdentity.mockResolvedValue({ ok: true, value: { id: 'ri1' } })
+})
+
+describe('entitySink connectionAppFields injection', () => {
+  it('writes the connection-metadata value onto the resolved field, on create', async () => {
+    const ctx = makeCtx()
+
+    await entitySink.upsertRecord(ctx, mapping(), record())
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(create.mock.calls[0]?.[1]).toMatchObject({ [FIELD_ID]: 'us.myshopify.com' })
+  })
+
+  it('re-asserts the value on update (plain attribute — normal overwrite, not fill-blank)', async () => {
+    findItem.mockResolvedValue({
+      id: 'item1',
+      entityInstanceId: 'inst1',
+      contentHash: 'stale',
+      pendingRelations: [],
+    })
+    getFieldValues.mockResolvedValue(new Map())
+    const ctx = makeCtx()
+
+    await entitySink.upsertRecord(ctx, mapping(), record())
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update.mock.calls[0]?.[1]).toMatchObject({ [FIELD_ID]: 'us.myshopify.com' })
+  })
+
+  it('omits the key entirely when connectionMeta has no value for it (never writes null)', async () => {
+    const ctx = makeCtx({ connectionMeta: {} })
+
+    await entitySink.upsertRecord(ctx, mapping(), record())
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(create.mock.calls[0]?.[1]).not.toHaveProperty(FIELD_ID)
+  })
+
+  it('omits the key entirely when the connector has no bound connection (connectionMeta null)', async () => {
+    const ctx = makeCtx({ connectionMeta: null })
+
+    await entitySink.upsertRecord(ctx, mapping(), record())
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(create.mock.calls[0]?.[1]).not.toHaveProperty(FIELD_ID)
+  })
+
+  it('does not mirror a connectionMetaKey field into RecordIdentity (no identityRole)', async () => {
+    const ctx = makeCtx()
+
+    await entitySink.upsertRecord(ctx, mapping(), record())
+
+    expect(upsertRecordIdentity).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -62,6 +62,36 @@ function isBlank(value: unknown): boolean {
 }
 
 /**
+ * Merge this mapping's `connectionAppFields` values (connection metadata, e.g.
+ * Shopify `shopDomain`) into a COPY of the record's fields before the normal
+ * write-set pipeline runs — reusing every existing ref-resolution / merge-strategy /
+ * provenance / content-hash code path for free (map-record already skipped
+ * evaluating these `connectionMetaKey`-flagged entries against the source subtree,
+ * since they have nothing to evaluate). A key with no metadata value (no bound
+ * connection, credential load failed, or the metadata is missing that key) is left
+ * out entirely rather than writing `null` over a previously-synced value.
+ */
+function injectConnectionAppFields(
+  ctx: SyncCtx,
+  mapping: DecodedMapping,
+  record: ProjectedRecord
+): ProjectedRecord {
+  const connMetaFields = mapping.fieldMappings.filter(
+    (fm): fm is typeof fm & { connectionMetaKey: string; targetFieldRef: string } =>
+      fm.connectionMetaKey != null && fm.targetFieldRef != null
+  )
+  if (connMetaFields.length === 0) return record
+
+  const fields = { ...record.fields }
+  for (const fm of connMetaFields) {
+    const value = ctx.connectionMeta?.[fm.connectionMetaKey]
+    if (value === undefined) continue
+    fields[fm.targetFieldRef] = value
+  }
+  return { ...record, fields }
+}
+
+/**
  * Resolve every distinct `targetFieldRef` a record references (write fields +
  * identity candidates) to a concrete `ResourceFieldId`. Concrete refs pass
  * through; the late-bound `@app:` form resolves against the connector's bound
@@ -440,6 +470,11 @@ export const entitySink: EntitySink = {
   async upsertRecord(ctx, mapping, record) {
     ctx.counters.fetched += 1
     ctx.touchedDefs.add(mapping.entityDefinitionId)
+
+    // Fold in connection-metadata-sourced fields (e.g. Shopify `storeDomain`)
+    // before anything else reads `record.fields` — downstream logic treats them
+    // exactly like any other mapped field from here on.
+    record = injectConnectionAppFields(ctx, mapping, record)
 
     // Resolve every mapped `targetFieldRef` to a concrete field id once — both the
     // identity lookup and the write set key off this table (§3.3).

--- a/packages/lib/src/data-connectors/sinks/types.ts
+++ b/packages/lib/src/data-connectors/sinks/types.ts
@@ -50,6 +50,13 @@ export interface SyncCtx {
   /** Entity definition ids touched this run — invalidated once at the end. */
   touchedDefs: Set<string>
   /**
+   * The bound connection's plaintext `metadata` (e.g. Shopify `shopDomain`) — the
+   * source `connectionAppFields` bindings read from (`connectionMetaKey`). `null`
+   * when the connector has no bound connection or the credential failed to load;
+   * `undefined` is never persisted (always resolved once per ctx build).
+   */
+  connectionMeta?: Record<string, unknown> | null
+  /**
    * Reconciliation sweep run (Step 8C). A sweep is a full id-crawl whose purpose is
    * to catch deletes the watermark poll/webhooks missed. When set, `reconcileOrphans`
    * archives unseen orphans even for `incremental` streams (absence IS deletion,

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -389,8 +389,12 @@ export interface ConnectorDefaultMapping {
         /** Target field keys to flag as secondary identity-match keys (e.g. `['email']`). */
         matchFieldKeys?: string[]
         /** Non-identity field bindings pre-declared by the app author (e.g. `first_name`
-         *  → contact first-name). Bound by key like match keys, sans `identityRole`. */
-        fieldBindings?: { sourceFieldKey: string; targetKey: string }[]
+         *  → contact first-name). Bound by key like match keys, sans `identityRole` — unless
+         *  `targetAppField` names an `identity: true` app field, which auto-stamps one. */
+        fieldBindings?: { sourceFieldKey: string; targetKey?: string; targetAppField?: string }[]
+        /** Fill a plain (non-identity) app field from connection metadata (e.g. Shopify
+         *  `shopDomain`) — the only synthetic write channel. See SDK mirror for details. */
+        connectionAppFields?: { appFieldKey: string; from: string }[]
       }
 }
 
@@ -556,6 +560,15 @@ export interface FieldMapping {
     | { kind: 'match'; normalize?: IdentityNormalize }
   /** Per-field write behavior (folded in from the old parallel map). Absent ⇒ 'overwrite'. */
   mergeStrategy?: FieldMergeStrategy
+  /**
+   * This binding writes a value read from the connector's CONNECTION METADATA
+   * (e.g. Shopify `shopDomain`), not the source record subtree — the SDK
+   * `connectionAppFields` synthetic-write channel. The value is
+   * `ctx.connectionMeta?.[connectionMetaKey]`, injected by the sink before the
+   * normal write-set build; `expression`/`sourceFields` are unused (map-record
+   * skips evaluating these entries). Never carries an `identityRole`.
+   */
+  connectionMetaKey?: string
   /**
    * Provisioning hint for a connector-introduced target field (05d). Consumed by
    * `provisionConnectorMappings` to create the field with the declared type/name

--- a/packages/lib/src/identity/__tests__/view.test.ts
+++ b/packages/lib/src/identity/__tests__/view.test.ts
@@ -1,0 +1,104 @@
+// packages/lib/src/identity/__tests__/view.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getCachedInstalledApps = vi.fn()
+const getCachedCustomFields = vi.fn()
+vi.mock('../../cache', () => ({
+  getCachedInstalledApps: (...args: unknown[]) => getCachedInstalledApps(...args),
+  getCachedCustomFields: (...args: unknown[]) => getCachedCustomFields(...args),
+}))
+
+import { decorateRecordIdentities } from '../view'
+
+function row(overrides: Record<string, unknown>) {
+  return {
+    id: 'ri_1',
+    organizationId: 'org_1',
+    entityInstanceId: 'inst_1',
+    entityDefinitionId: 'def_contact',
+    source: 'shopify',
+    appInstallationId: null,
+    connectionId: null,
+    appFieldKey: null,
+    fieldId: null,
+    externalId: 'x',
+    createdAt: new Date('2026-06-30T00:00:00Z'),
+    updatedAt: new Date('2026-06-30T00:00:00Z'),
+    ...overrides,
+  } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getCachedInstalledApps.mockResolvedValue([
+    {
+      installationId: 'inst_shopify',
+      app: { title: 'Shopify', avatarUrl: 'https://icon/shopify' },
+    },
+  ])
+  getCachedCustomFields.mockResolvedValue([{ id: 'field_cust', name: 'Shopify customer ID' }])
+})
+
+describe('decorateRecordIdentities', () => {
+  it('decorates an app-backed identity from installed-apps + custom-fields cache', async () => {
+    const [view] = await decorateRecordIdentities('org_1', [
+      row({
+        id: 'ri_shopify',
+        source: 'shopify',
+        appInstallationId: 'inst_shopify',
+        connectionId: 'conn_us',
+        appFieldKey: 'customerId',
+        fieldId: 'field_cust',
+        externalId: '207119551',
+      }),
+    ])
+
+    expect(view).toEqual({
+      id: 'ri_shopify',
+      source: 'shopify',
+      appName: 'Shopify',
+      appIconKey: 'https://icon/shopify',
+      connectionId: 'conn_us',
+      connectionLabel: null,
+      appFieldKey: 'customerId',
+      fieldLabel: 'Shopify customer ID',
+      externalId: '207119551',
+      updatedAt: '2026-06-30T00:00:00.000Z',
+    })
+  })
+
+  it('labels the app-less chat link "Chat" with no icon or field label', async () => {
+    const [view] = await decorateRecordIdentities('org_1', [
+      row({ id: 'ri_chat', source: 'chat', externalId: 'visitor_1' }),
+    ])
+
+    expect(view.appName).toBe('Chat')
+    expect(view.appIconKey).toBeNull()
+    expect(view.fieldLabel).toBeNull()
+    expect(view.appFieldKey).toBeNull()
+  })
+
+  it('sorts by source then externalId for a stable card order', async () => {
+    const views = await decorateRecordIdentities('org_1', [
+      row({ id: 'b', source: 'shopify', externalId: '2' }),
+      row({ id: 'a', source: 'chat', externalId: 'z' }),
+      row({ id: 'c', source: 'shopify', externalId: '1' }),
+    ])
+    expect(views.map((v) => v.id)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('returns an empty array without hitting the cache when given no rows', async () => {
+    const views = await decorateRecordIdentities('org_1', [])
+    expect(views).toEqual([])
+    expect(getCachedInstalledApps).not.toHaveBeenCalled()
+  })
+
+  it('falls back to null app metadata when the installation is unknown (uninstalled)', async () => {
+    const [view] = await decorateRecordIdentities('org_1', [
+      row({ id: 'ri_gone', source: 'hubspot', appInstallationId: 'inst_missing' }),
+    ])
+    expect(view.appName).toBeNull()
+    expect(view.appIconKey).toBeNull()
+  })
+})

--- a/packages/lib/src/identity/index.ts
+++ b/packages/lib/src/identity/index.ts
@@ -14,3 +14,8 @@ export type {
   UpsertRecordIdentityInput,
 } from './types'
 export { upsertRecordIdentity } from './upsert'
+export {
+  decorateRecordIdentities,
+  getRecordIdentityViews,
+  type RecordIdentityView,
+} from './view'

--- a/packages/lib/src/identity/view.ts
+++ b/packages/lib/src/identity/view.ts
@@ -1,0 +1,92 @@
+// packages/lib/src/identity/view.ts
+
+import type { RecordIdentityEntity } from '@auxx/database/types'
+import type { RecordId } from '@auxx/types/resource'
+import { getCachedCustomFields, getCachedInstalledApps } from '../cache'
+import { getRecordIdentitiesForRecords } from './batch'
+
+/** `RecordIdentity.source` used for the app-less chat-visitor link. */
+const CHAT_SOURCE = 'chat'
+
+/**
+ * A display-ready external-identity link for the record detail's "External
+ * identities" card. Decorated from org cache only (installed apps + custom
+ * fields) — no extra DB round-trip on top of the batch identity load.
+ */
+export interface RecordIdentityView {
+  id: string
+  /** Universal namespace — `'shopify'`, `'chat'`, `'hubspot'`. */
+  source: string
+  /** Installed-app title (`'Shopify'`), a friendly label for `chat`, else null. */
+  appName: string | null
+  /** Installed-app avatar/icon url, when the source is an app. */
+  appIconKey: string | null
+  /** Which store/connection this identity belongs to (null for app-less links). */
+  connectionId: string | null
+  /** Human label for the connection — not available from org cache in v1. */
+  connectionLabel: string | null
+  /** The id kind, e.g. `customerId` (null for bare-source links like chat). */
+  appFieldKey: string | null
+  /** The backing `CustomField` name, e.g. `'Shopify customer ID'`. */
+  fieldLabel: string | null
+  /** The external value — numeric Shopify id, chat visitor id, … */
+  externalId: string
+  updatedAt: string
+}
+
+/**
+ * Decorate raw `RecordIdentity` rows into display-ready views using org cache
+ * only (installed apps for app name/icon, custom fields for the field label).
+ * Sorted by source then external id for a stable card order.
+ */
+export async function decorateRecordIdentities(
+  organizationId: string,
+  rows: RecordIdentityEntity[]
+): Promise<RecordIdentityView[]> {
+  if (rows.length === 0) return []
+
+  const installedApps = await getCachedInstalledApps(organizationId)
+  const appByInstallation = new Map(installedApps.map((a) => [a.installationId, a.app]))
+
+  // Field labels: load the custom-field set for each distinct entity def once.
+  const defIds = [...new Set(rows.map((r) => r.entityDefinitionId))]
+  const fieldNameById = new Map<string, string>()
+  await Promise.all(
+    defIds.map(async (defId) => {
+      const fields = await getCachedCustomFields(organizationId, defId)
+      for (const f of fields) fieldNameById.set(f.id, f.name)
+    })
+  )
+
+  return rows
+    .map((row) => {
+      const app = row.appInstallationId ? appByInstallation.get(row.appInstallationId) : undefined
+      return {
+        id: row.id,
+        source: row.source,
+        appName: app?.title ?? (row.source === CHAT_SOURCE ? 'Chat' : null),
+        appIconKey: app?.avatarUrl ?? null,
+        connectionId: row.connectionId,
+        connectionLabel: null,
+        appFieldKey: row.appFieldKey,
+        fieldLabel: row.fieldId ? (fieldNameById.get(row.fieldId) ?? null) : null,
+        externalId: row.externalId,
+        updatedAt: row.updatedAt.toISOString(),
+      }
+    })
+    .sort((a, b) => a.source.localeCompare(b.source) || a.externalId.localeCompare(b.externalId))
+}
+
+/**
+ * Batch-load + decorate the external identities for a single record — the
+ * "External identities" card's data source. One index query + org-cache
+ * decoration, no N+1.
+ */
+export async function getRecordIdentityViews(
+  organizationId: string,
+  recordId: RecordId
+): Promise<RecordIdentityView[]> {
+  const grouped = await getRecordIdentitiesForRecords(organizationId, [recordId])
+  const rows = grouped.get(recordId) ?? []
+  return decorateRecordIdentities(organizationId, rows)
+}

--- a/packages/lib/src/ingest/contacts/__tests__/find-or-create-from-jwt.test.ts
+++ b/packages/lib/src/ingest/contacts/__tests__/find-or-create-from-jwt.test.ts
@@ -1,0 +1,210 @@
+// packages/lib/src/ingest/contacts/__tests__/find-or-create-from-jwt.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// --- mocks -----------------------------------------------------------------
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }),
+}))
+
+vi.mock('@auxx/types/resource', () => ({
+  toRecordId: (defId: string, instId: string) => `${defId}:${instId}`,
+  getInstanceId: (recordId: string) => recordId.slice(recordId.indexOf(':') + 1),
+}))
+
+const getCachedEntityDefId = vi.fn()
+vi.mock('../../../cache', () => ({
+  getCachedEntityDefId: (...args: unknown[]) => getCachedEntityDefId(...args),
+}))
+
+const resolveShopifyStoreConnection = vi.fn()
+vi.mock('../../../chat/shopify-identity-field', () => ({
+  resolveShopifyStoreConnection: (...args: unknown[]) => resolveShopifyStoreConnection(...args),
+}))
+
+const findRecordByIdentity = vi.fn()
+const upsertRecordIdentity = vi.fn()
+vi.mock('../../../identity', () => ({
+  findRecordByIdentity: (...args: unknown[]) => findRecordByIdentity(...args),
+  upsertRecordIdentity: (...args: unknown[]) => upsertRecordIdentity(...args),
+}))
+
+const findByField = vi.fn()
+const update = vi.fn()
+const create = vi.fn()
+vi.mock('../../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    findByField = findByField
+    update = update
+    create = create
+  },
+}))
+
+vi.mock('../../../users/system-user-service', () => ({
+  SystemUserService: { getSystemUserForActions: vi.fn().mockResolvedValue('system_user') },
+}))
+
+import { findOrCreateContactFromJwt } from '../find-or-create-from-jwt'
+
+const CONTACT_DEF = 'def_contact'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getCachedEntityDefId.mockResolvedValue(CONTACT_DEF)
+  upsertRecordIdentity.mockResolvedValue({ ok: true, value: {} })
+  findByField.mockResolvedValue(null)
+  update.mockResolvedValue(undefined)
+  create.mockResolvedValue({ instance: { id: 'new_contact' } })
+  findRecordByIdentity.mockResolvedValue(null)
+})
+
+describe('findOrCreateContactFromJwt — chat (app-less) visitor', () => {
+  it('resolves an existing contact by the app-less chat link (tier-1, no email required)', async () => {
+    findRecordByIdentity.mockResolvedValueOnce({
+      recordId: `${CONTACT_DEF}:contact_1`,
+      displayName: 'Jane',
+    })
+
+    const result = await findOrCreateContactFromJwt({
+      organizationId: 'org_1',
+      userId: 'visitor_abc',
+    })
+
+    expect(findRecordByIdentity).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      entityDefinitionId: CONTACT_DEF,
+      source: 'chat',
+      externalId: 'visitor_abc',
+      connectionId: null,
+      appFieldKey: null,
+    })
+    expect(result).toEqual({ contactId: 'contact_1', resolution: 'matched_external_id' })
+    // Never touches the retired external_id array.
+    expect(update).not.toHaveBeenCalled()
+    // Re-asserts the chat link (idempotent).
+    expect(upsertRecordIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'chat', externalId: 'visitor_abc', fieldId: null })
+    )
+  })
+
+  it('creates a contact and mirrors the chat link when nothing matches', async () => {
+    const result = await findOrCreateContactFromJwt({
+      organizationId: 'org_1',
+      userId: 'visitor_new',
+      email: 'jane@example.com',
+    })
+
+    expect(create).toHaveBeenCalledWith('contact', {
+      primary_email: 'jane@example.com',
+      contact_status: 'ACTIVE',
+    })
+    // No external_id array in the create payload.
+    expect(create.mock.calls[0][1]).not.toHaveProperty('external_id')
+    expect(upsertRecordIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityInstanceId: 'new_contact',
+        source: 'chat',
+        externalId: 'visitor_new',
+        connectionId: null,
+        appFieldKey: null,
+        fieldId: null,
+      })
+    )
+    expect(result).toEqual({ contactId: 'new_contact', resolution: 'created' })
+  })
+
+  it('email-folds onto an existing contact and mirrors the chat link (no duplicate)', async () => {
+    findByField.mockResolvedValueOnce({ id: 'existing_contact' })
+
+    const result = await findOrCreateContactFromJwt({
+      organizationId: 'org_1',
+      userId: 'visitor_2',
+      email: 'jane@example.com',
+      attributes: { first_name: 'Jane' },
+    })
+
+    expect(create).not.toHaveBeenCalled()
+    expect(update).toHaveBeenCalledWith('contact:existing_contact', { first_name: 'Jane' })
+    expect(upsertRecordIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({ entityInstanceId: 'existing_contact', source: 'chat' })
+    )
+    expect(result).toEqual({ contactId: 'existing_contact', resolution: 'matched_email' })
+  })
+})
+
+describe('findOrCreateContactFromJwt — Shopify storefront visitor', () => {
+  const shopify = { shopDomain: 'us.myshopify.com', customerId: '207119551' }
+
+  it('resolves a connector-synced contact by connection-scoped customerId (converges, no email)', async () => {
+    resolveShopifyStoreConnection.mockResolvedValueOnce({
+      appId: 'app_shopify',
+      installationId: 'inst_1',
+      connectionId: 'conn_us',
+    })
+    findRecordByIdentity.mockResolvedValueOnce({
+      recordId: `${CONTACT_DEF}:synced_contact`,
+      displayName: 'Jane',
+    })
+
+    const result = await findOrCreateContactFromJwt({
+      organizationId: 'org_1',
+      userId: 'shopify:us.myshopify.com:207119551',
+      shopify,
+    })
+
+    expect(resolveShopifyStoreConnection).toHaveBeenCalledWith('org_1', 'us.myshopify.com')
+    expect(findRecordByIdentity).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      entityDefinitionId: CONTACT_DEF,
+      source: 'shopify',
+      connectionId: 'conn_us',
+      appFieldKey: 'customerId',
+      externalId: '207119551',
+    })
+    expect(result).toEqual({ contactId: 'synced_contact', resolution: 'matched_external_id' })
+    // Shopify identity is mirrored by writeShopifyCustomerIdField, NOT here.
+    expect(upsertRecordIdentity).not.toHaveBeenCalled()
+  })
+
+  it('keeps the same customer id under two stores separate via connection scoping', async () => {
+    resolveShopifyStoreConnection.mockResolvedValueOnce({
+      appId: 'app_shopify',
+      installationId: 'inst_1',
+      connectionId: 'conn_eu',
+    })
+    // EU store connection has no row for this id → miss, falls through to create.
+    findRecordByIdentity.mockResolvedValueOnce(null)
+
+    const result = await findOrCreateContactFromJwt({
+      organizationId: 'org_1',
+      userId: 'shopify:eu.myshopify.com:207119551',
+      shopify: { shopDomain: 'eu.myshopify.com', customerId: '207119551' },
+    })
+
+    expect(findRecordByIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'conn_eu', externalId: '207119551' })
+    )
+    expect(create).toHaveBeenCalled()
+    // No chat link mirrored for a Shopify visitor.
+    expect(upsertRecordIdentity).not.toHaveBeenCalled()
+    expect(result.resolution).toBe('created')
+  })
+
+  it('falls through to email-fold when the store connection cannot be resolved', async () => {
+    resolveShopifyStoreConnection.mockResolvedValueOnce(null)
+    findByField.mockResolvedValueOnce({ id: 'by_email' })
+
+    const result = await findOrCreateContactFromJwt({
+      organizationId: 'org_1',
+      userId: 'shopify:us.myshopify.com:207119551',
+      email: 'jane@example.com',
+      shopify,
+    })
+
+    expect(findRecordByIdentity).not.toHaveBeenCalled()
+    expect(result).toEqual({ contactId: 'by_email', resolution: 'matched_email' })
+    // Shopify visitor → no chat link even on email-fold.
+    expect(upsertRecordIdentity).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/ingest/contacts/external-id.ts
+++ b/packages/lib/src/ingest/contacts/external-id.ts
@@ -36,15 +36,3 @@ export function chatExternalId(userId: string): string {
 export function shopifyExternalId(shopDomain: string, customerId: string): string {
   return buildServerExternalId('shopify', `${shopDomain.trim()}:${customerId.trim()}`)
 }
-
-/**
- * If `userId` already starts with a known server-source prefix (`shopify:`),
- * return it verbatim; otherwise wrap with `chat:`. Used by the JWT contact
- * resolver so a JWT minted by our Shopify App Proxy (which encodes
- * `shopify:<shop>:<id>` directly into the `user_id` claim) doesn't get
- * double-namespaced to `chat:shopify:<shop>:<id>`.
- */
-export function resolveServerExternalId(userId: string): string {
-  if (userId.startsWith('shopify:')) return userId
-  return chatExternalId(userId)
-}

--- a/packages/lib/src/ingest/contacts/find-or-create-from-jwt.ts
+++ b/packages/lib/src/ingest/contacts/find-or-create-from-jwt.ts
@@ -1,29 +1,46 @@
 // packages/lib/src/ingest/contacts/find-or-create-from-jwt.ts
 
 import { createScopedLogger } from '@auxx/logger'
-import { toRecordId } from '@auxx/types/resource'
+import { getInstanceId, toRecordId } from '@auxx/types/resource'
+import { getCachedEntityDefId } from '../../cache'
+import { resolveShopifyStoreConnection } from '../../chat/shopify-identity-field'
+import { findRecordByIdentity, upsertRecordIdentity } from '../../identity'
 import { UnifiedCrudHandler } from '../../resources/crud'
 import { SystemUserService } from '../../users/system-user-service'
-import { resolveServerExternalId } from './external-id'
 
 const log = createScopedLogger('chat-find-or-create-from-jwt')
+
+/** `RecordIdentity.source` for the app-less chat-visitor link. */
+const CHAT_SOURCE = 'chat'
+/** `RecordIdentity.source` + app field key for a Shopify storefront identity. */
+const SHOPIFY_SOURCE = 'shopify'
+const SHOPIFY_CUSTOMER_ID_FIELD_KEY = 'customerId'
 
 export interface FindOrCreateContactFromJwtInput {
   organizationId: string
   /**
-   * Customer-chosen stable identifier. Wrapped with `chat:` to form the
-   * external id, unless it already carries a recognized source prefix
-   * (currently `shopify:`), in which case it's used verbatim. This lets the
-   * Shopify App Proxy mint encode `shopify:<shop>:<customerId>` directly in
-   * the `user_id` JWT claim without producing `chat:shopify:…` duplicates.
+   * Customer-chosen stable identifier from the verified JWT's `user_id` claim.
+   * For a plain chat visitor this is the raw id; for a Shopify App-Proxy mint
+   * it's `shopify:<shop>:<customerId>` — but Shopify identity is resolved via
+   * the connection-scoped `customerId` index using `shopify` below, not by
+   * parsing this string. Used verbatim as the app-less `chat` index externalId
+   * for non-Shopify visitors.
    */
   userId: string
   /** Signed email from the customer's JWT, when present. Used for email-fold. */
   email?: string
-  /** Caller-resolved attributes to write on create (phase 4 resolves these). */
+  /** Caller-resolved attributes to write on create/match. */
   attributes?: Record<string, unknown>
   /** Optional userId for audit attribution on writes; defaults to 'system'. */
   actingUserId?: string
+  /**
+   * Present when the JWT was minted by our Shopify App Proxy. Tier-1 then
+   * resolves the contact by the connection-scoped `customerId` identity in
+   * `RecordIdentity` (converging with connector-synced contacts, id-based, no
+   * email required); absent → tier-1 resolves the app-less `chat:<userId>`
+   * link. Both values come from App-Proxy-signed claims, never client input.
+   */
+  shopify?: { shopDomain: string; customerId: string }
 }
 
 export interface FindOrCreateContactFromJwtResult {
@@ -35,16 +52,22 @@ export interface FindOrCreateContactFromJwtResult {
 
 /**
  * Three-tier resolution for a chat-widget visitor identified by a verified
- * customer JWT. The external id is `chat:<userId>` by default, or `<userId>`
- * verbatim when it carries a recognized source prefix (`shopify:` —
- * minted by our Shopify App Proxy):
+ * customer JWT, backed by the `RecordIdentity` index (Phase 4 of the
+ * multi-source identity plan — replaces the retired `external_id` array):
  *
- *   1. Exact match on `external_id` containing the resolved id.
- *   2. If miss and `jwt.email` is present, match on `primary_email`. On hit,
- *      append the resolved id to the existing `external_id` array — no
+ *   1. Identity index. Shopify visitor → resolve the store connection from the
+ *      signed `shopDomain`, then look up
+ *      `(source='shopify', connectionId, appFieldKey='customerId', externalId)`
+ *      — this also matches connector-synced contacts. Otherwise look up the
+ *      app-less `(source='chat', externalId=userId)` link.
+ *   2. If miss and `jwt.email` is present, match on `primary_email` — no
  *      duplicate Contact created.
- *   3. Otherwise create a new Contact with `external_id: [resolved id]`,
- *      `primary_email` (when present), and the resolved attribute map.
+ *   3. Otherwise create a new Contact.
+ *
+ * For non-Shopify visitors the resolved contact's app-less `chat:<userId>`
+ * link is mirrored into `RecordIdentity` (idempotent). Shopify identity is
+ * written separately by `writeShopifyCustomerIdField` (the `customerId` cell +
+ * its mirror), so no `chat` row is written for Shopify visitors.
  *
  * Caller is responsible for verifying the JWT first; this function trusts
  * every claim it receives.
@@ -52,7 +75,7 @@ export interface FindOrCreateContactFromJwtResult {
 export async function findOrCreateContactFromJwt(
   input: FindOrCreateContactFromJwtInput
 ): Promise<FindOrCreateContactFromJwtResult> {
-  const { organizationId, userId, email, attributes = {}, actingUserId } = input
+  const { organizationId, userId, email, attributes = {}, actingUserId, shopify } = input
 
   // The default audit user must be a real `User.id` — passing the literal
   // 'system' fails the `EntityInstance.createdById → User.id` FK. The
@@ -62,34 +85,46 @@ export async function findOrCreateContactFromJwt(
     actingUserId ?? (await SystemUserService.getSystemUserForActions(organizationId))
 
   const handler = new UnifiedCrudHandler(organizationId, resolvedActingUserId)
-  const externalId = resolveServerExternalId(userId)
 
-  // Tier 1 — exact external-id match (multi-value containment via lookupByField).
-  const byExternalId = await handler.findByField('contact', 'external_id', externalId)
-  if (byExternalId) {
-    return { contactId: byExternalId.id, resolution: 'matched_external_id' }
+  // The index is entity-scoped, so every read/write needs the contact def id.
+  const contactDefId = await getCachedEntityDefId(organizationId, 'contact')
+  if (!contactDefId) {
+    // Without a def id we can't touch the index, but the value-path
+    // resolution below (email-fold + create) still works.
+    log.warn('No contact entity definition — skipping identity-index resolution', {
+      organizationId,
+    })
   }
 
-  // Tier 2 — email-fold. Append our external_id to the existing Contact.
-  // `findByField` returns the raw EntityInstance row with `values` as an array
-  // of FieldValue rows — not a Record<systemAttribute, value>. Rather than
-  // parse that to read the current external_id list and re-set it (which would
-  // silently overwrite any other external_ids the Contact already carries),
-  // use `mode: 'add'` so the handler appends with server-side dedup.
+  // Tier 1 — identity index.
+  if (contactDefId) {
+    const match = await resolveByIdentity({ organizationId, contactDefId, userId, shopify })
+    if (match) {
+      // Re-assert the app-less chat link (idempotent) so a contact first
+      // resolved by email/Shopify still becomes reverse-resolvable by userId.
+      if (!shopify) {
+        await mirrorChatLink({ organizationId, contactDefId, contactId: match, userId })
+      }
+      return { contactId: match, resolution: 'matched_external_id' }
+    }
+  }
+
+  // Tier 2 — email-fold. Attach our identity to the existing Contact.
   if (email) {
     const byEmail = await handler.findByField('contact', 'primary_email', email)
     if (byEmail) {
-      try {
-        await handler.update(
-          toRecordId('contact', byEmail.id),
-          { external_id: [externalId], ...attributes },
-          { external_id: 'add' }
-        )
-      } catch (error) {
-        log.warn('Email-fold update failed, returning matched contact unchanged', {
-          contactId: byEmail.id,
-          error: (error as Error).message,
-        })
+      if (Object.keys(attributes).length > 0) {
+        try {
+          await handler.update(toRecordId('contact', byEmail.id), attributes)
+        } catch (error) {
+          log.warn('Email-fold attribute update failed, returning matched contact unchanged', {
+            contactId: byEmail.id,
+            error: (error as Error).message,
+          })
+        }
+      }
+      if (!shopify && contactDefId) {
+        await mirrorChatLink({ organizationId, contactDefId, contactId: byEmail.id, userId })
       }
       return { contactId: byEmail.id, resolution: 'matched_email' }
     }
@@ -97,10 +132,83 @@ export async function findOrCreateContactFromJwt(
 
   // Tier 3 — create on first sight.
   const { instance } = await handler.create('contact', {
-    external_id: [externalId],
     ...(email ? { primary_email: email } : {}),
     contact_status: 'ACTIVE',
     ...attributes,
   })
+  if (!shopify && contactDefId) {
+    await mirrorChatLink({ organizationId, contactDefId, contactId: instance.id, userId })
+  }
   return { contactId: instance.id, resolution: 'created' }
+}
+
+/**
+ * Reverse-resolve the contact for this JWT via `RecordIdentity`. Shopify
+ * visitors resolve the store connection first (connection-scoped so a customer
+ * id colliding across two stores never cross-links); everyone else resolves
+ * the app-less `chat` link.
+ */
+async function resolveByIdentity(opts: {
+  organizationId: string
+  contactDefId: string
+  userId: string
+  shopify?: { shopDomain: string; customerId: string }
+}): Promise<string | null> {
+  const { organizationId, contactDefId, userId, shopify } = opts
+
+  if (shopify) {
+    const store = await resolveShopifyStoreConnection(organizationId, shopify.shopDomain)
+    if (!store) return null
+    const match = await findRecordByIdentity({
+      organizationId,
+      entityDefinitionId: contactDefId,
+      source: SHOPIFY_SOURCE,
+      connectionId: store.connectionId,
+      appFieldKey: SHOPIFY_CUSTOMER_ID_FIELD_KEY,
+      externalId: shopify.customerId,
+    })
+    return match ? getInstanceId(match.recordId) : null
+  }
+
+  const match = await findRecordByIdentity({
+    organizationId,
+    entityDefinitionId: contactDefId,
+    source: CHAT_SOURCE,
+    externalId: userId,
+    connectionId: null,
+    appFieldKey: null,
+  })
+  return match ? getInstanceId(match.recordId) : null
+}
+
+/**
+ * Mirror the app-less `chat:<userId>` link into `RecordIdentity`. This is the
+ * chat visitor id's only home — no `CustomField`/`FieldValue` exists for it
+ * (chat isn't an app). Best-effort: a missed mirror never fails contact
+ * resolution; `reconcileRecordIdentities` cannot repair app-less links, so the
+ * merge re-point + this explicit write are the guarantees.
+ */
+async function mirrorChatLink(opts: {
+  organizationId: string
+  contactDefId: string
+  contactId: string
+  userId: string
+}): Promise<void> {
+  const result = await upsertRecordIdentity({
+    organizationId: opts.organizationId,
+    entityInstanceId: opts.contactId,
+    entityDefinitionId: opts.contactDefId,
+    source: CHAT_SOURCE,
+    appInstallationId: null,
+    connectionId: null,
+    appFieldKey: null,
+    fieldId: null,
+    externalId: opts.userId,
+  })
+  if (!result.ok) {
+    log.warn('Failed to mirror chat visitor link into RecordIdentity', {
+      contactId: opts.contactId,
+      error: result.error.message,
+    })
+  }
 }

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -39,6 +39,9 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     },
     defaultTab: 'tickets',
     defaultSidebarTab: 'overview',
+    // Renders nothing when the contact has no external identities (card
+    // returns null), so it's inert until an app/store/chat links the record.
+    sidebarCards: [{ value: 'external-identities', label: 'External identities' }],
   },
 
   ticket: {

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -220,11 +220,22 @@ export interface ConnectorDefaultMapping {
          * stream lands closer to `ready` — e.g. `{ sourceFieldKey: 'first_name',
          * targetKey: 'first_name' }` binds the source field to the contact's
          * first-name attribute. `targetKey` resolves against the target def's
-         * `systemAttribute` / field name; unresolved bindings are dropped (the
-         * mapping stays a setup draft). The external id is never bound here — it
-         * rides `ConnectorRecord.externalId`.
+         * `systemAttribute` / field name. `targetAppField` (mutually exclusive
+         * with `targetKey`) instead names an app-declared field by its
+         * `appFieldKey` (`defineFields`) — when that field is `identity: true`,
+         * the binding auto-stamps `identityRole: { kind: 'externalId' }`, the
+         * mechanism `isExternalId` uses for owned defs, extended to contributing.
+         * Unresolved bindings are dropped (the mapping stays a setup draft).
          */
-        fieldBindings?: { sourceFieldKey: string; targetKey: string }[]
+        fieldBindings?: { sourceFieldKey: string; targetKey?: string; targetAppField?: string }[]
+        /**
+         * Fill a plain (non-identity) app field from the connector's CONNECTION
+         * METADATA (e.g. Shopify `shopDomain`) rather than the source record —
+         * the only synthetic write channel. `appFieldKey` must name a declared,
+         * non-identity app field; `from` is the connection metadata key
+         * (`ConnectorConnection.metadata`).
+         */
+        connectionAppFields?: { appFieldKey: string; from: string }[]
       }
 }
 

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -237,7 +237,8 @@ export interface CatalogConnectorDefaultMapping {
         mode: 'contributing'
         entityKind: string
         matchFieldKeys?: string[]
-        fieldBindings?: { sourceFieldKey: string; targetKey: string }[]
+        fieldBindings?: { sourceFieldKey: string; targetKey?: string; targetAppField?: string }[]
+        connectionAppFields?: { appFieldKey: string; from: string }[]
       }
 }
 
@@ -710,6 +711,47 @@ export async function compileAndExtractCatalog(): Promise<
           code: 'CATALOG_VALIDATION_FAILED',
           message: `Connector "${connector.id}" config "${fieldKey}": dynamic-select requires valuePath and labelTemplate`,
         })
+      }
+    }
+
+    // Cross-validate app-field-targeting contributing bindings against this app's
+    // declared `fields[]` (identity plan, phase 3): `targetAppField` must name a
+    // field the app declares for the SAME contributing entityKind;
+    // `connectionAppFields` must name a declared NON-identity field there too
+    // (connection metadata can't fill an identity cell).
+    for (const stream of connector.streams ?? []) {
+      for (const mapping of stream.defaultMappings ?? []) {
+        if (mapping.target.mode !== 'contributing') continue
+        const { entityKind, fieldBindings, connectionAppFields } = mapping.target
+        const fieldByKey = new Map(
+          cataloguedFields
+            .filter((f) => f.targetEntity === entityKind)
+            .map((f) => [f.appFieldKey, f])
+        )
+        for (const binding of fieldBindings ?? []) {
+          if (!binding.targetAppField) continue
+          if (!fieldByKey.has(binding.targetAppField)) {
+            return errored({
+              code: 'CATALOG_VALIDATION_FAILED',
+              message: `Connector "${connector.id}" stream "${stream.key}": targetAppField "${binding.targetAppField}" is not a declared field on "${entityKind}"`,
+            })
+          }
+        }
+        for (const conn of connectionAppFields ?? []) {
+          const field = fieldByKey.get(conn.appFieldKey)
+          if (!field) {
+            return errored({
+              code: 'CATALOG_VALIDATION_FAILED',
+              message: `Connector "${connector.id}" stream "${stream.key}": connectionAppFields "${conn.appFieldKey}" is not a declared field on "${entityKind}"`,
+            })
+          }
+          if (field.identity) {
+            return errored({
+              code: 'CATALOG_VALIDATION_FAILED',
+              message: `Connector "${connector.id}" stream "${stream.key}": connectionAppFields "${conn.appFieldKey}" targets an identity field — connection metadata cannot fill an identity field`,
+            })
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Continues the multi-source identity work from #1025 (Phases 1-2). Implements Phases 3-5 of `plans/data-connectors/v7/option-3-multi-source-identity-store-plan.md`.

## Phase 3 — connector writes identity (+ `storeDomain`)
- Extend `isExternalId` to **contributing** bindings: SDK `fieldBindings[].targetAppField` + `connectionAppFields` on the contributing target (mirrored across SDK types, SDK catalog extractor, DB catalog schema, lib engine types).
- `app-catalog.ts`: `buildContributingFieldBindings` binds `targetAppField` → late-bound `@app:` ref and auto-stamps `identityRole` when the target app field is `isIdentity`; new `buildContributingConnectionAppFields` for connection-metadata fields via a new `FieldMapping.connectionMetaKey`.
- `entity-sink.ts` `injectConnectionAppFields` merges `SyncCtx.connectionMeta` into the write set **before** the existing merge/provenance/hash pipeline (no new write path). `connectionMeta` loaded once per sync-source / per webhook delivery via `getCredential` (best-effort).
- Catalog-extraction cross-validation for `targetAppField`/`connectionAppFields`.

## Phase 4 — chat + passport converge on the same cell + index
- `find-or-create-from-jwt.ts` tier-1 rewritten off the `external_id` array onto `findRecordByIdentity`:
  - chat visitor → app-less `(source='chat', externalId=userId)`
  - Shopify visitor → resolve store connection from the signed `shopDomain`, then `(source='shopify', connectionId, appFieldKey='customerId', externalId)` — **now also matches connector-synced contacts** (id-based convergence, no email required).
- Stops writing `external_id`; mirrors the app-less chat link via `upsertRecordIdentity`. New shared `resolveShopifyStoreConnection` extracted from `shopify-identity-field.ts`; removed dead `resolveServerExternalId`.

## Phase 5 (partial) — linked-systems display
- `identity/view.ts`: `RecordIdentityView` + `decorateRecordIdentities` / `getRecordIdentityViews` (decorated from org cache only — installed apps + custom fields; `connectionLabel` null in v1).
- New `record.getIdentities` tRPC query + **External identities** card on the contact detail view (grouped app→connection, hidden when empty).
- **Deferred to Phase 6 (deliberate):** the connector **badge** repoint + compact `sources[]`. The badge resolves a *DataConnector id* via `useConnector`, but the index only carries an *app slug*; dual-reading buys nothing until the column is dropped in Phase 6, and the repoint only has to land before that drop.

## Tests
`find-or-create-from-jwt` (6), `identity/view` (5), `entity-sink-connection-app-fields`; data-connectors + identity + chat suites green. Biome clean.

## Notes
- Not live-verified against a real Shopify store yet (Phase 7 does the end-to-end `pnpm dev` pass).
- `apps/api/public/app-runtime/index.html` is a platform-runtime bundle-hash bump from the Phase 3 SDK rebuild.