### PR TITLE
feat(identity): retire single-source EntityInstance columns for RecordIdentity index (Phase 6)

### DIFF
--- a/apps/api/src/routes/entities/find-by-integration-id.ts
+++ b/apps/api/src/routes/entities/find-by-integration-id.ts
@@ -4,24 +4,15 @@
  * Lambda SDK callback for `ctx.entities.findByIntegrationId`.
  *
  * Authorized via the `entities` callback token scope minted by
- * `prepareLambdaContext` for AI tool invocations. Looks up a record by
- * `(orgId, kind, integrationSource, externalId)` and returns the auxx
- * recordId (`<defId>:<instId>`) plus the display name.
- *
- * Dual-read (plans/data-connectors/v7/option-3-multi-source-identity-store-plan.md
- * Phase 1): tries the `RecordIdentity` index first, then falls back to the
- * legacy `EntityInstance.integrationSource`/`externalId` columns. The index
- * has no writers yet (Phases 2-4), so today this always falls through — the
- * dual-read is what lets those later phases light this route up with zero
- * further changes here. Drop the fallback once the Phase-6 backfill lands.
+ * `prepareLambdaContext` for AI tool invocations. Resolves a record from the
+ * `RecordIdentity` index by `(orgId, kind, source, externalId)` and returns the
+ * auxx recordId (`<defId>:<instId>`) plus the display name.
  *
  * See plans/kopilot/apps/credentials.md §3.6 and refs.md §4.1.
  */
 
-import { database, schema } from '@auxx/database'
 import { getCachedEntityDefId } from '@auxx/lib/cache'
 import { findRecordByIdentity } from '@auxx/lib/identity'
-import { and, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import { verifyCallbackAuth } from '../../lib/callback-auth'
@@ -66,29 +57,7 @@ entities.post('/find-by-integration-id', async (c) => {
     source,
     externalId,
   })
-  if (indexed) {
-    return c.json({ entity: indexed })
-  }
-
-  const instance = await database.query.EntityInstance.findFirst({
-    where: and(
-      eq(schema.EntityInstance.organizationId, auth.organizationId),
-      eq(schema.EntityInstance.entityDefinitionId, defId),
-      eq(schema.EntityInstance.integrationSource, source),
-      eq(schema.EntityInstance.externalId, externalId)
-    ),
-    columns: { id: true, displayName: true },
-  })
-
-  if (!instance) {
-    return c.json({ entity: null })
-  }
-  return c.json({
-    entity: {
-      recordId: `${defId}:${instance.id}`,
-      displayName: instance.displayName,
-    },
-  })
+  return c.json({ entity: indexed })
 })
 
 export default entities

--- a/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
+++ b/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
@@ -131,11 +131,7 @@ export const PrimaryFieldCell = memo(function PrimaryFieldCell({
         />
       }
       suffix={
-        <ConnectorSourceBadge
-          integrationSource={record?.integrationSource}
-          variant='icon'
-          className='shrink-0'
-        />
+        <ConnectorSourceBadge sources={record?.sources} variant='icon' className='shrink-0' />
       }>
       {children}
     </PrimaryCell>

--- a/apps/web/src/components/fields/connector-source-badge.tsx
+++ b/apps/web/src/components/fields/connector-source-badge.tsx
@@ -2,77 +2,53 @@
 
 'use client'
 
+import type { RecordSourceChip } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { cn } from '@auxx/ui/lib/utils'
 import { useMemo } from 'react'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { Tooltip } from '~/components/global/tooltip'
-import {
-  type ResolvedConnector,
-  useConnector,
-} from '~/components/resources/hooks/use-connector-name'
 
 interface ConnectorSourceBadgeProps {
   /**
-   * `EntityInstance.integrationSource` — a DataConnector id for connector-synced
-   * records, null/undefined for hand-created records. Anything that doesn't
-   * resolve to a known connector renders nothing (handles legacy free-form
-   * sources).
+   * App-origin identity chips from the `RecordIdentity` index (replaces the
+   * retired `EntityInstance.integrationSource`). The badge renders the first
+   * chip that resolves to an installed app; empty/unresolved → nothing.
    */
-  integrationSource: string | null | undefined
+  sources: RecordSourceChip[] | null | undefined
   /** `icon` → bare logo (grid primary cell); `chip` → logo + name (drawer header). */
   variant: 'icon' | 'chip'
   className?: string
 }
 
-/** `"app:shopify"` → `"shopify"`; null for non-app connector types. */
-function slugFromType(type: string): string | null {
-  return type.startsWith('app:') ? type.slice('app:'.length) : null
-}
-
 /**
- * Entity-level "Synced from <connector>" indicator. Resolves the record's
- * `integrationSource` (a DataConnector id) to its installed app's branding via
- * the existing `useConnector` + `useAppsContext` hooks — the same pair the
- * connector builder uses — so the badge shows the real app logo + title.
+ * Entity-level "Synced from <app>" indicator. Resolves the record's app-origin
+ * identity chips (from the `RecordIdentity` index) to their installed app's
+ * branding via `useAppsContext` — so the badge shows the real app logo + title.
  *
  * Complements the per-cell `ConnectorLockBadge` (field-grain provenance) with a
- * record-grain marker. Renders `null` until resolved / when the source isn't a
- * known connector, so unmanaged rows pay nothing visually.
+ * record-grain marker. Renders `null` when the record has no app identity or
+ * the app isn't installed, so unmanaged rows pay nothing visually.
  */
-export function ConnectorSourceBadge({
-  integrationSource,
-  variant,
-  className,
-}: ConnectorSourceBadgeProps) {
-  const connector = useConnector(integrationSource)
-  // Resolve nothing until the source maps to a known connector. Gating the
-  // inner component here means hand-created records (the common case) never read
-  // `useAppsContext` — so the badge is safe to render in tables that may live
-  // outside `AppsProvider` (e.g. KB articles), which carry no integrationSource.
-  if (!connector) return null
-  return <ResolvedSourceBadge connector={connector} variant={variant} className={className} />
-}
-
-function ResolvedSourceBadge({
-  connector,
-  variant,
-  className,
-}: { connector: ResolvedConnector } & Pick<ConnectorSourceBadgeProps, 'variant' | 'className'>) {
+export function ConnectorSourceBadge({ sources, variant, className }: ConnectorSourceBadgeProps) {
   const { appInstallations } = useAppsContext()
 
   const app = useMemo(() => {
-    const slug = slugFromType(connector.type)
-    return appInstallations.find(
-      (i) => i.installationId === connector.appInstallationId || (slug && i.app.slug === slug)
-    )?.app
-  }, [connector, appInstallations])
+    if (!sources?.length) return null
+    for (const chip of sources) {
+      const match = appInstallations.find(
+        (i) => i.installationId === chip.appInstallationId || i.app.slug === chip.source
+      )?.app
+      if (match) return match
+    }
+    return null
+  }, [sources, appInstallations])
 
-  // Prefer the connector's own name (e.g. "Shopify Customers"); fall back to the
-  // app title. Logo = the app's uploaded avatar, else a generic plug.
-  const label = connector.name || app?.title || 'a data connector'
-  const iconId = app?.avatarUrl ?? 'plug'
+  if (!app) return null
+
+  const label = app.title || 'a connected app'
+  const iconId = app.avatarUrl ?? 'plug'
 
   if (variant === 'icon') {
     return (

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -437,7 +437,7 @@ export const RecordDrawer = React.memo(function RecordDrawer({
                 </div>
                 {!isRecordLoading && (
                   <ConnectorSourceBadge
-                    integrationSource={cachedRecord?.integrationSource}
+                    sources={cachedRecord?.sources}
                     variant='chip'
                     className='shrink-0'
                   />

--- a/apps/web/src/components/resources/hooks/use-record-batch-fetcher.ts
+++ b/apps/web/src/components/resources/hooks/use-record-batch-fetcher.ts
@@ -82,7 +82,7 @@ export function useRecordBatchFetcher() {
         displayName: item.displayName,
         secondaryInfo: item.secondaryInfo,
         avatarUrl: item.avatarUrl,
-        integrationSource: item.integrationSource ?? null,
+        sources: item.sources,
       }
 
       const entityDefinitionId = getDefinitionId(canonicalRecordId)

--- a/apps/web/src/components/resources/store/record-store.ts
+++ b/apps/web/src/components/resources/store/record-store.ts
@@ -2,7 +2,12 @@
 
 import '~/lib/immer-config' // Enables Map/Set support for immer
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
-import { parseRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import {
+  parseRecordId,
+  type RecordId,
+  type RecordSourceChip,
+  toRecordId,
+} from '@auxx/lib/resources/client'
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
@@ -27,11 +32,11 @@ export interface RecordMeta {
   createdAt: string | Date
   updatedAt: string | Date
   /**
-   * Data-connector / integration provenance (from `EntityInstance.integrationSource`).
-   * Holds the owning DataConnector id for synced records; null/undefined otherwise.
-   * Drives the "Synced from <connector>" source badge.
+   * App-origin identity chips derived from the `RecordIdentity` index. Drives
+   * the record-grain "Synced from <app>" source badge. Absent for records with
+   * no app identity.
    */
-  integrationSource?: string | null
+  sources?: RecordSourceChip[]
   /** Additional database fields from the specific resource table */
   [key: string]: unknown
 }

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -582,6 +582,23 @@ export async function setupSchedules() {
     }
   )
 
+  // Every day at 4:30 AM - Reconcile the RecordIdentity index against the
+  // identity FieldValue cells (drift backstop for any un-instrumented writer).
+  await maintenanceQueue.upsertJobScheduler(
+    'reconcileRecordIdentitiesJob',
+    { pattern: '30 4 * * *' },
+    {
+      data: {},
+      opts: {
+        attempts: 2,
+        backoff: { type: 'exponential', delay: 60000 },
+        priority: 10,
+        removeOnComplete: { count: 14 },
+        removeOnFail: { count: 30 },
+      },
+    }
+  )
+
   // Dataset maintenance schedules
 
   // Every day at 3 AM - Clean up orphaned dataset data

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -23,6 +23,7 @@ import {
   oauth2TokenRefreshScannerJob,
   orphanedAppBundleCleanupJob,
   quotaResetJob,
+  reconcileRecordIdentitiesJob,
   recordUsageEventJob,
   sendGettingStartedEmailsJob,
   sendMidTrialEmailsJob,
@@ -171,6 +172,10 @@ const jobMappings = {
 
   // Data migrations runner (enqueued at boot + from the superadmin panel)
   dataMigrationsJob,
+
+  // RecordIdentity drift backstop (daily; rebuilds the index from
+  // FieldValue ⋈ CustomField(isIdentity) for any un-instrumented writer)
+  reconcileRecordIdentitiesJob,
 
   // Global data-connector stale-run sweep (every 5 min; fails cold runs + releases
   // their connector claim so a crashed continuation chain can't strand a connector)

--- a/packages/database/drizzle/0252_drop_entity_instance_integration_columns.sql
+++ b/packages/database/drizzle/0252_drop_entity_instance_integration_columns.sql
@@ -1,0 +1,4 @@
+DROP INDEX "EntityInstance_integrationLookup_idx";--> statement-breakpoint
+ALTER TABLE "DataConnectorItem" ADD COLUMN "mintedInstance" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "EntityInstance" DROP COLUMN "integrationSource";--> statement-breakpoint
+ALTER TABLE "EntityInstance" DROP COLUMN "externalId";

--- a/packages/database/drizzle/meta/0252_snapshot.json
+++ b/packages/database/drizzle/meta/0252_snapshot.json
@@ -1,0 +1,34088 @@
+{
+  "id": "19afda5d-ed23-4fb5-8f43-a061f7681025",
+  "prevId": "bb9cdb4d-0de5-407c-9913-d8b63ce3009e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHistoryId": {
+          "name": "lastHistoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_providerId_accountId_key": {
+          "name": "account_providerId_accountId_key",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_User_id_fk": {
+          "name": "account_userId_User_id_fk",
+          "tableFrom": "account",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentProcedure": {
+      "name": "AgentProcedure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "procedureId": {
+          "name": "procedureId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "whenToUseOverride": {
+          "name": "whenToUseOverride",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerExamplesOverride": {
+          "name": "triggerExamplesOverride",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rulesetOverride": {
+          "name": "rulesetOverride",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentProcedure_agentId_idx": {
+          "name": "AgentProcedure_agentId_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentProcedure_agentId_procedureId_key": {
+          "name": "AgentProcedure_agentId_procedureId_key",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentProcedure_organizationId_Organization_id_fk": {
+          "name": "AgentProcedure_organizationId_Organization_id_fk",
+          "tableFrom": "AgentProcedure",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AgentProcedure_agentId_Agent_id_fk": {
+          "name": "AgentProcedure_agentId_Agent_id_fk",
+          "tableFrom": "AgentProcedure",
+          "tableTo": "Agent",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AgentProcedure_procedureId_Procedure_id_fk": {
+          "name": "AgentProcedure_procedureId_Procedure_id_fk",
+          "tableFrom": "AgentProcedure",
+          "tableTo": "Procedure",
+          "columnsFrom": ["procedureId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentTrigger": {
+      "name": "AgentTrigger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAppId": {
+          "name": "triggerAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAppTriggerId": {
+          "name": "triggerAppTriggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerInstallationId": {
+          "name": "triggerInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerConnectionId": {
+          "name": "triggerConnectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerWebhookEndpointId": {
+          "name": "triggerWebhookEndpointId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerTopic": {
+          "name": "triggerTopic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentTrigger_agentId_idx": {
+          "name": "AgentTrigger_agentId_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrigger_orgId_event_crud_idx": {
+          "name": "AgentTrigger_orgId_event_crud_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrigger_orgId_event_direct_idx": {
+          "name": "AgentTrigger_orgId_event_direct_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrigger_orgId_app_idx": {
+          "name": "AgentTrigger_orgId_app_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerAppTriggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrigger_orgId_kind_enabled_idx": {
+          "name": "AgentTrigger_orgId_kind_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrigger_orgId_webhook_idx": {
+          "name": "AgentTrigger_orgId_webhook_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerWebhookEndpointId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerTopic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentTrigger_agentId_Agent_id_fk": {
+          "name": "AgentTrigger_agentId_Agent_id_fk",
+          "tableFrom": "AgentTrigger",
+          "tableTo": "Agent",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AgentTrigger_organizationId_Organization_id_fk": {
+          "name": "AgentTrigger_organizationId_Organization_id_fk",
+          "tableFrom": "AgentTrigger",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AgentTrigger_triggerInstallationId_AppInstallation_id_fk": {
+          "name": "AgentTrigger_triggerInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AgentTrigger",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["triggerInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AgentTrigger_triggerWebhookEndpointId_WebhookEndpoint_id_fk": {
+          "name": "AgentTrigger_triggerWebhookEndpointId_WebhookEndpoint_id_fk",
+          "tableFrom": "AgentTrigger",
+          "tableTo": "WebhookEndpoint",
+          "columnsFrom": ["triggerWebhookEndpointId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "AgentTrigger_createdById_User_id_fk": {
+          "name": "AgentTrigger_createdById_User_id_fk",
+          "tableFrom": "AgentTrigger",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentVersion": {
+      "name": "AgentVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "toolsets": {
+          "name": "toolsets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "knowledge": {
+          "name": "knowledge",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "appAccounts": {
+          "name": "appAccounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "toolRestrictions": {
+          "name": "toolRestrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configHash": {
+          "name": "configHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editorId": {
+          "name": "editorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentVersion_agentId_idx": {
+          "name": "AgentVersion_agentId_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentVersion_agentId_versionNumber_key": {
+          "name": "AgentVersion_agentId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentVersion_organizationId_Organization_id_fk": {
+          "name": "AgentVersion_organizationId_Organization_id_fk",
+          "tableFrom": "AgentVersion",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AgentVersion_agentId_Agent_id_fk": {
+          "name": "AgentVersion_agentId_Agent_id_fk",
+          "tableFrom": "AgentVersion",
+          "tableTo": "Agent",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AgentVersion_editorId_User_id_fk": {
+          "name": "AgentVersion_editorId_User_id_fk",
+          "tableFrom": "AgentVersion",
+          "tableTo": "User",
+          "columnsFrom": ["editorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Agent": {
+      "name": "Agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "toolsets": {
+          "name": "toolsets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "knowledge": {
+          "name": "knowledge",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "appAccounts": {
+          "name": "appAccounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "toolRestrictions": {
+          "name": "toolRestrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "mentionable": {
+          "name": "mentionable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeVersionId": {
+          "name": "activeVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasUnpublishedChanges": {
+          "name": "hasUnpublishedChanges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setupCompletedAt": {
+          "name": "setupCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Agent_organizationId_slug_idx": {
+          "name": "Agent_organizationId_slug_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_organizationId_idx": {
+          "name": "Agent_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_createdById_idx": {
+          "name": "Agent_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_organizationId_archivedAt_idx": {
+          "name": "Agent_organizationId_archivedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_userId_idx": {
+          "name": "Agent_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Agent_organizationId_Organization_id_fk": {
+          "name": "Agent_organizationId_Organization_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Agent_userId_User_id_fk": {
+          "name": "Agent_userId_User_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Agent_createdById_User_id_fk": {
+          "name": "Agent_createdById_User_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Agent_userId_unique": {
+          "name": "Agent_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiAgentSession": {
+      "name": "AiAgentSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "domainState": {
+          "name": "domainState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentTriggerId": {
+          "name": "agentTriggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerContext": {
+          "name": "triggerContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "AiAgentSession_organizationId_userId_type_idx": {
+          "name": "AiAgentSession_organizationId_userId_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiAgentSession_userId_type_updatedAt_idx": {
+          "name": "AiAgentSession_userId_type_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiAgentSession_agentId_updatedAt_idx": {
+          "name": "AiAgentSession_agentId_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiAgentSession_agentTriggerId_updatedAt_idx": {
+          "name": "AiAgentSession_agentTriggerId_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "agentTriggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiAgentSession_organizationId_Organization_id_fk": {
+          "name": "AiAgentSession_organizationId_Organization_id_fk",
+          "tableFrom": "AiAgentSession",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiAgentSession_userId_User_id_fk": {
+          "name": "AiAgentSession_userId_User_id_fk",
+          "tableFrom": "AiAgentSession",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiAgentSession_agentId_Agent_id_fk": {
+          "name": "AiAgentSession_agentId_Agent_id_fk",
+          "tableFrom": "AiAgentSession",
+          "tableTo": "Agent",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "AiAgentSession_agentTriggerId_AgentTrigger_id_fk": {
+          "name": "AiAgentSession_agentTriggerId_AgentTrigger_id_fk",
+          "tableFrom": "AiAgentSession",
+          "tableTo": "AgentTrigger",
+          "columnsFrom": ["agentTriggerId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiIntegration": {
+      "name": "AiIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "AiIntegrationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedCredentials": {
+          "name": "encryptedCredentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loadBalancingEnabled": {
+          "name": "loadBalancingEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "AiIntegration_organizationId_idx": {
+          "name": "AiIntegration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_isDefault_idx": {
+          "name": "AiIntegration_organizationId_isDefault_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_modelType_idx": {
+          "name": "AiIntegration_organizationId_modelType_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_organizationId_providerType_idx": {
+          "name": "AiIntegration_organizationId_providerType_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiIntegration_provider_organizationId_key": {
+          "name": "AiIntegration_provider_organizationId_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiIntegration_organizationId_Organization_id_fk": {
+          "name": "AiIntegration_organizationId_Organization_id_fk",
+          "tableFrom": "AiIntegration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiIntegration_userId_User_id_fk": {
+          "name": "AiIntegration_userId_User_id_fk",
+          "tableFrom": "AiIntegration",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiMessageFeedback": {
+      "name": "AiMessageFeedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isPositive": {
+          "name": "isPositive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AiMessageFeedback_sessionId_messageId_userId_key": {
+          "name": "AiMessageFeedback_sessionId_messageId_userId_key",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiMessageFeedback_organizationId_idx": {
+          "name": "AiMessageFeedback_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiMessageFeedback_isPositive_idx": {
+          "name": "AiMessageFeedback_isPositive_idx",
+          "columns": [
+            {
+              "expression": "isPositive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiMessageFeedback_sessionId_AiAgentSession_id_fk": {
+          "name": "AiMessageFeedback_sessionId_AiAgentSession_id_fk",
+          "tableFrom": "AiMessageFeedback",
+          "tableTo": "AiAgentSession",
+          "columnsFrom": ["sessionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiMessageFeedback_organizationId_Organization_id_fk": {
+          "name": "AiMessageFeedback_organizationId_Organization_id_fk",
+          "tableFrom": "AiMessageFeedback",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiMessageFeedback_userId_User_id_fk": {
+          "name": "AiMessageFeedback_userId_User_id_fk",
+          "tableFrom": "AiMessageFeedback",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiSuggestion": {
+      "name": "AiSuggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerUserId": {
+          "name": "ownerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle": {
+          "name": "bundle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionCount": {
+          "name": "actionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computedForActivityAt": {
+          "name": "computedForActivityAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computedForLatestMessageId": {
+          "name": "computedForLatestMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerSource": {
+          "name": "triggerSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerEventType": {
+          "name": "triggerEventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FRESH'"
+        },
+        "outcomes": {
+          "name": "outcomes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decidedById": {
+          "name": "decidedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decidedAt": {
+          "name": "decidedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AiSuggestion_org_entity_active_key": {
+          "name": "AiSuggestion_org_entity_active_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'FRESH'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiSuggestion_org_status_idx": {
+          "name": "AiSuggestion_org_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiSuggestion_org_entity_createdAt_idx": {
+          "name": "AiSuggestion_org_entity_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiSuggestion_org_entityDef_status_idx": {
+          "name": "AiSuggestion_org_entityDef_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiSuggestion_organizationId_Organization_id_fk": {
+          "name": "AiSuggestion_organizationId_Organization_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_entityInstanceId_EntityInstance_id_fk": {
+          "name": "AiSuggestion_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "AiSuggestion_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_threadId_Thread_id_fk": {
+          "name": "AiSuggestion_threadId_Thread_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_ownerUserId_User_id_fk": {
+          "name": "AiSuggestion_ownerUserId_User_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "User",
+          "columnsFrom": ["ownerUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "AiSuggestion_decidedById_User_id_fk": {
+          "name": "AiSuggestion_decidedById_User_id_fk",
+          "tableFrom": "AiSuggestion",
+          "tableTo": "User",
+          "columnsFrom": ["decidedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AiUsage": {
+      "name": "AiUsage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cachedInputTokens": {
+          "name": "cachedInputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cacheWriteTokens": {
+          "name": "cacheWriteTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creditsUsed": {
+          "name": "creditsUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "ProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialSource": {
+          "name": "credentialSource",
+          "type": "CredentialSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "AiUsage_createdAt_idx": {
+          "name": "AiUsage_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_organizationId_createdAt_idx": {
+          "name": "AiUsage_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_provider_model_idx": {
+          "name": "AiUsage_provider_model_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AiUsage_source_idx": {
+          "name": "AiUsage_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AiUsage_organizationId_Organization_id_fk": {
+          "name": "AiUsage_organizationId_Organization_id_fk",
+          "tableFrom": "AiUsage",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AiUsage_userId_User_id_fk": {
+          "name": "AiUsage_userId_User_id_fk",
+          "tableFrom": "AiUsage",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApiKey": {
+      "name": "ApiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashedKey": {
+          "name": "hashedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryptedSecret": {
+          "name": "encryptedSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApiKey_hashedKey_key": {
+          "name": "ApiKey_hashedKey_key",
+          "columns": [
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_userId_isActive_idx": {
+          "name": "ApiKey_userId_isActive_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_type_referenceId_idx": {
+          "name": "ApiKey_type_referenceId_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referenceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApiKey_userId_User_id_fk": {
+          "name": "ApiKey_userId_User_id_fk",
+          "tableFrom": "ApiKey",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApiKey_organizationId_Organization_id_fk": {
+          "name": "ApiKey_organizationId_Organization_id_fk",
+          "tableFrom": "ApiKey",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppBundle": {
+      "name": "AppBundle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundleType": {
+          "name": "bundleType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploadedAt": {
+          "name": "uploadedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppBundle_content_idx": {
+          "name": "AppBundle_content_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bundleType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppBundle_appId_idx": {
+          "name": "AppBundle_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppBundle_appId_App_id_fk": {
+          "name": "AppBundle_appId_App_id_fk",
+          "tableFrom": "AppBundle",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppDeployment": {
+      "name": "AppDeployment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deploymentType": {
+          "name": "deploymentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientBundleId": {
+          "name": "clientBundleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverBundleId": {
+          "name": "serverBundleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settingsSchema": {
+          "name": "settingsSchema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetOrganizationId": {
+          "name": "targetOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environmentVariables": {
+          "name": "environmentVariables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "reviewedAt": {
+          "name": "reviewedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewedBy": {
+          "name": "reviewedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "releaseNotes": {
+          "name": "releaseNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppDeployment_appId_idx": {
+          "name": "AppDeployment_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppDeployment_type_idx": {
+          "name": "AppDeployment_type_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deploymentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppDeployment_targetOrganizationId_idx": {
+          "name": "AppDeployment_targetOrganizationId_idx",
+          "columns": [
+            {
+              "expression": "targetOrganizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppDeployment_appId_App_id_fk": {
+          "name": "AppDeployment_appId_App_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppDeployment_clientBundleId_AppBundle_id_fk": {
+          "name": "AppDeployment_clientBundleId_AppBundle_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "AppBundle",
+          "columnsFrom": ["clientBundleId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "AppDeployment_serverBundleId_AppBundle_id_fk": {
+          "name": "AppDeployment_serverBundleId_AppBundle_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "AppBundle",
+          "columnsFrom": ["serverBundleId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "AppDeployment_targetOrganizationId_Organization_id_fk": {
+          "name": "AppDeployment_targetOrganizationId_Organization_id_fk",
+          "tableFrom": "AppDeployment",
+          "tableTo": "Organization",
+          "columnsFrom": ["targetOrganizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppEventLog": {
+      "name": "AppEventLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appDeploymentId": {
+          "name": "appDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventData": {
+          "name": "eventData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestMethod": {
+          "name": "requestMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestPath": {
+          "name": "requestPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseStatus": {
+          "name": "responseStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppEventLog_appId_idx": {
+          "name": "AppEventLog_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_organizationId_idx": {
+          "name": "AppEventLog_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_appDeploymentId_idx": {
+          "name": "AppEventLog_appDeploymentId_idx",
+          "columns": [
+            {
+              "expression": "appDeploymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppEventLog_timestamp_idx": {
+          "name": "AppEventLog_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppEventLog_appId_App_id_fk": {
+          "name": "AppEventLog_appId_App_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppEventLog_organizationId_Organization_id_fk": {
+          "name": "AppEventLog_organizationId_Organization_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppEventLog_appDeploymentId_AppDeployment_id_fk": {
+          "name": "AppEventLog_appDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppEventLog",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["appDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppInstallation": {
+      "name": "AppInstallation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installationType": {
+          "name": "installationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentDeploymentId": {
+          "name": "currentDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installedAt": {
+          "name": "installedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uninstalledAt": {
+          "name": "uninstalledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppInstallation_unique_idx": {
+          "name": "AppInstallation_unique_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppInstallation_appId_idx": {
+          "name": "AppInstallation_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppInstallation_organizationId_idx": {
+          "name": "AppInstallation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppInstallation_appId_App_id_fk": {
+          "name": "AppInstallation_appId_App_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppInstallation_organizationId_Organization_id_fk": {
+          "name": "AppInstallation_organizationId_Organization_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppInstallation_currentDeploymentId_AppDeployment_id_fk": {
+          "name": "AppInstallation_currentDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppInstallation",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["currentDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppMarketplaceImage": {
+      "name": "AppMarketplaceImage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileExtension": {
+          "name": "fileExtension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "savedSortOrder": {
+          "name": "savedSortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploadCompletedAt": {
+          "name": "uploadCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSavedAt": {
+          "name": "lastSavedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppMarketplaceImage_appId_idx": {
+          "name": "AppMarketplaceImage_appId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppMarketplaceImage_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "AppMarketplaceImage_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "AppMarketplaceImage",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppMarketplaceImage_appId_App_id_fk": {
+          "name": "AppMarketplaceImage_appId_App_id_fk",
+          "tableFrom": "AppMarketplaceImage",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppSetting": {
+      "name": "AppSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appDeploymentId": {
+          "name": "appDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppSetting_appInstallationId_key_key": {
+          "name": "AppSetting_appInstallationId_key_key",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppSetting_appInstallationId_idx": {
+          "name": "AppSetting_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppSetting_appDeploymentId_idx": {
+          "name": "AppSetting_appDeploymentId_idx",
+          "columns": [
+            {
+              "expression": "appDeploymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppSetting_appInstallationId_AppInstallation_id_fk": {
+          "name": "AppSetting_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AppSetting",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppSetting_appDeploymentId_AppDeployment_id_fk": {
+          "name": "AppSetting_appDeploymentId_AppDeployment_id_fk",
+          "tableFrom": "AppSetting",
+          "tableTo": "AppDeployment",
+          "columnsFrom": ["appDeploymentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppStorage": {
+      "name": "AppStorage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppStorage_appInstallationId_idx": {
+          "name": "AppStorage_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppStorage_connectionId_idx": {
+          "name": "AppStorage_connectionId_idx",
+          "columns": [
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppStorage_expiresAt_idx": {
+          "name": "AppStorage_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppStorage_appInstallationId_AppInstallation_id_fk": {
+          "name": "AppStorage_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AppStorage",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "AppStorage_connectionId_Credential_id_fk": {
+          "name": "AppStorage_connectionId_Credential_id_fk",
+          "tableFrom": "AppStorage",
+          "tableTo": "Credential",
+          "columnsFrom": ["connectionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "AppStorage_install_connection_collection_key_key": {
+          "name": "AppStorage_install_connection_collection_key_key",
+          "nullsNotDistinct": true,
+          "columns": ["appInstallationId", "connectionId", "collection", "key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AppWebhookHandler": {
+      "name": "AppWebhookHandler",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataConnectorId": {
+          "name": "dataConnectorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handlerId": {
+          "name": "handlerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalWebhookId": {
+          "name": "externalWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerId": {
+          "name": "triggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AppWebhookHandler_unique_idx": {
+          "name": "AppWebhookHandler_unique_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handlerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppWebhookHandler_connector_unique_idx": {
+          "name": "AppWebhookHandler_connector_unique_idx",
+          "columns": [
+            {
+              "expression": "dataConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handlerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"AppWebhookHandler\".\"dataConnectorId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppWebhookHandler_connection_unique_idx": {
+          "name": "AppWebhookHandler_connection_unique_idx",
+          "columns": [
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handlerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"AppWebhookHandler\".\"appInstallationId\" IS NULL AND \"AppWebhookHandler\".\"dataConnectorId\" IS NULL AND \"AppWebhookHandler\".\"connectionId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppWebhookHandler_appInstallationId_idx": {
+          "name": "AppWebhookHandler_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AppWebhookHandler_dataConnectorId_idx": {
+          "name": "AppWebhookHandler_dataConnectorId_idx",
+          "columns": [
+            {
+              "expression": "dataConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AppWebhookHandler_appInstallationId_AppInstallation_id_fk": {
+          "name": "AppWebhookHandler_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "AppWebhookHandler",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "AppWebhookHandler_dataConnectorId_DataConnector_id_fk": {
+          "name": "AppWebhookHandler_dataConnectorId_DataConnector_id_fk",
+          "tableFrom": "AppWebhookHandler",
+          "tableTo": "DataConnector",
+          "columnsFrom": ["dataConnectorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "AppWebhookHandler_connectionId_Credential_id_fk": {
+          "name": "AppWebhookHandler_connectionId_Credential_id_fk",
+          "tableFrom": "AppWebhookHandler",
+          "tableTo": "Credential",
+          "columnsFrom": ["connectionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.App": {
+      "name": "App",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarId": {
+          "name": "avatarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "websiteUrl": {
+          "name": "websiteUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentationUrl": {
+          "name": "documentationUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contactUrl": {
+          "name": "contactUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supportSiteUrl": {
+          "name": "supportSiteUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termsOfServiceUrl": {
+          "name": "termsOfServiceUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentOverview": {
+          "name": "contentOverview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHowItWorks": {
+          "name": "contentHowItWorks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentConfigure": {
+          "name": "contentConfigure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "hasOauth": {
+          "name": "hasOauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "oauthApplicationId": {
+          "name": "oauthApplicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthExternalEntrypointUrl": {
+          "name": "oauthExternalEntrypointUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasBundle": {
+          "name": "hasBundle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "publicationStatus": {
+          "name": "publicationStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpublished'"
+        },
+        "reviewStatus": {
+          "name": "reviewStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autoApprove": {
+          "name": "autoApprove",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "autoUpdateInstallations": {
+          "name": "autoUpdateInstallations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "App_slug_idx": {
+          "name": "App_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_developerAccountId_idx": {
+          "name": "App_developerAccountId_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_reviewStatus_idx": {
+          "name": "App_reviewStatus_idx",
+          "columns": [
+            {
+              "expression": "reviewStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "App_autoApprove_idx": {
+          "name": "App_autoApprove_idx",
+          "columns": [
+            {
+              "expression": "autoApprove",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "App_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "App_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "App",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "App_oauthApplicationId_oauthApplication_id_fk": {
+          "name": "App_oauthApplicationId_oauthApplication_id_fk",
+          "tableFrom": "App",
+          "tableTo": "oauthApplication",
+          "columnsFrom": ["oauthApplicationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "App_slug_unique": {
+          "name": "App_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApprovalRequest": {
+      "name": "ApprovalRequest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowRunId": {
+          "name": "workflowRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeName": {
+          "name": "nodeName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ApprovalStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeUsers": {
+          "name": "assigneeUsers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeGroups": {
+          "name": "assigneeGroups",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflowName": {
+          "name": "workflowName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApprovalRequest_createdById_idx": {
+          "name": "ApprovalRequest_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_assigneeGroups_idx": {
+          "name": "ApprovalRequest_organizationId_assigneeGroups_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeGroups",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_assigneeUsers_idx": {
+          "name": "ApprovalRequest_organizationId_assigneeUsers_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeUsers",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_organizationId_idx": {
+          "name": "ApprovalRequest_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_status_expiresAt_idx": {
+          "name": "ApprovalRequest_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalRequest_workflowRunId_idx": {
+          "name": "ApprovalRequest_workflowRunId_idx",
+          "columns": [
+            {
+              "expression": "workflowRunId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApprovalRequest_organizationId_Organization_id_fk": {
+          "name": "ApprovalRequest_organizationId_Organization_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_workflowId_Workflow_id_fk": {
+          "name": "ApprovalRequest_workflowId_Workflow_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_workflowRunId_WorkflowRun_id_fk": {
+          "name": "ApprovalRequest_workflowRunId_WorkflowRun_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "WorkflowRun",
+          "columnsFrom": ["workflowRunId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "ApprovalRequest_createdById_User_id_fk": {
+          "name": "ApprovalRequest_createdById_User_id_fk",
+          "tableFrom": "ApprovalRequest",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApprovalResponse": {
+      "name": "ApprovalResponse",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approvalRequestId": {
+          "name": "approvalRequestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "ApprovalAction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responseMethod": {
+          "name": "responseMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ApprovalResponse_approvalRequestId_userId_key": {
+          "name": "ApprovalResponse_approvalRequestId_userId_key",
+          "columns": [
+            {
+              "expression": "approvalRequestId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApprovalResponse_userId_idx": {
+          "name": "ApprovalResponse_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApprovalResponse_approvalRequestId_ApprovalRequest_id_fk": {
+          "name": "ApprovalResponse_approvalRequestId_ApprovalRequest_id_fk",
+          "tableFrom": "ApprovalResponse",
+          "tableTo": "ApprovalRequest",
+          "columnsFrom": ["approvalRequestId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ApprovalResponse_userId_User_id_fk": {
+          "name": "ApprovalResponse_userId_User_id_fk",
+          "tableFrom": "ApprovalResponse",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ArticlePlacement": {
+      "name": "ArticlePlacement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "isPublished": {
+          "name": "isPublished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishedRevisionId": {
+          "name": "publishedRevisionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishedById": {
+          "name": "publishedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasUnpublishedChanges": {
+          "name": "hasUnpublishedChanges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linkedFromSourceId": {
+          "name": "linkedFromSourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ArticlePlacement_kb_slug_key": {
+          "name": "ArticlePlacement_kb_slug_key",
+          "columns": [
+            {
+              "expression": "knowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ArticlePlacement_kb_parent_sortOrder_idx": {
+          "name": "ArticlePlacement_kb_parent_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "knowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ArticlePlacement_articleId_idx": {
+          "name": "ArticlePlacement_articleId_idx",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ArticlePlacement_knowledgeBaseId_idx": {
+          "name": "ArticlePlacement_knowledgeBaseId_idx",
+          "columns": [
+            {
+              "expression": "knowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ArticlePlacement_parentId_idx": {
+          "name": "ArticlePlacement_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ArticlePlacement_organizationId_Organization_id_fk": {
+          "name": "ArticlePlacement_organizationId_Organization_id_fk",
+          "tableFrom": "ArticlePlacement",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticlePlacement_articleId_Article_id_fk": {
+          "name": "ArticlePlacement_articleId_Article_id_fk",
+          "tableFrom": "ArticlePlacement",
+          "tableTo": "Article",
+          "columnsFrom": ["articleId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticlePlacement_knowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "ArticlePlacement_knowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "ArticlePlacement",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["knowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticlePlacement_parentId_ArticlePlacement_id_fk": {
+          "name": "ArticlePlacement_parentId_ArticlePlacement_id_fk",
+          "tableFrom": "ArticlePlacement",
+          "tableTo": "ArticlePlacement",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticlePlacement_publishedRevisionId_ArticleRevision_id_fk": {
+          "name": "ArticlePlacement_publishedRevisionId_ArticleRevision_id_fk",
+          "tableFrom": "ArticlePlacement",
+          "tableTo": "ArticleRevision",
+          "columnsFrom": ["publishedRevisionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "ArticlePlacement_publishedById_User_id_fk": {
+          "name": "ArticlePlacement_publishedById_User_id_fk",
+          "tableFrom": "ArticlePlacement",
+          "tableTo": "User",
+          "columnsFrom": ["publishedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ArticlePlacement_linkedFromSourceId_KnowledgeSource_id_fk": {
+          "name": "ArticlePlacement_linkedFromSourceId_KnowledgeSource_id_fk",
+          "tableFrom": "ArticlePlacement",
+          "tableTo": "KnowledgeSource",
+          "columnsFrom": ["linkedFromSourceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ArticleRevision": {
+      "name": "ArticleRevision",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentJson": {
+          "name": "contentJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImage": {
+          "name": "coverImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImageId": {
+          "name": "coverImageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorId": {
+          "name": "editorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ArticleRevision_articleId_idx": {
+          "name": "ArticleRevision_articleId_idx",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ArticleRevision_articleId_versionNumber_key": {
+          "name": "ArticleRevision_articleId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "articleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"versionNumber\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ArticleRevision_articleId_Article_id_fk": {
+          "name": "ArticleRevision_articleId_Article_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "Article",
+          "columnsFrom": ["articleId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticleRevision_organizationId_Organization_id_fk": {
+          "name": "ArticleRevision_organizationId_Organization_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ArticleRevision_coverImageId_MediaAsset_id_fk": {
+          "name": "ArticleRevision_coverImageId_MediaAsset_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["coverImageId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "ArticleRevision_editorId_User_id_fk": {
+          "name": "ArticleRevision_editorId_User_id_fk",
+          "tableFrom": "ArticleRevision",
+          "tableTo": "User",
+          "columnsFrom": ["editorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Article": {
+      "name": "Article",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "articleKind": {
+          "name": "articleKind",
+          "type": "articleKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ArticleStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastReviewedAt": {
+          "name": "lastReviewedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewsCount": {
+          "name": "viewsCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homeKnowledgeBaseId": {
+          "name": "homeKnowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draftRevisionId": {
+          "name": "draftRevisionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiEnabled": {
+          "name": "aiEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceExternalId": {
+          "name": "sourceExternalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceContentHash": {
+          "name": "sourceContentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Article_articleKind_idx": {
+          "name": "Article_articleKind_idx",
+          "columns": [
+            {
+              "expression": "articleKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_homeKnowledgeBaseId_idx": {
+          "name": "Article_homeKnowledgeBaseId_idx",
+          "columns": [
+            {
+              "expression": "homeKnowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_title_idx": {
+          "name": "Article_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_archived_at_idx": {
+          "name": "Article_archived_at_idx",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Article_source_idx": {
+          "name": "Article_source_idx",
+          "columns": [
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceExternalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Article_authorId_User_id_fk": {
+          "name": "Article_authorId_User_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "User",
+          "columnsFrom": ["authorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Article_organizationId_Organization_id_fk": {
+          "name": "Article_organizationId_Organization_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Article_homeKnowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "Article_homeKnowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["homeKnowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Article_draftRevisionId_ArticleRevision_id_fk": {
+          "name": "Article_draftRevisionId_ArticleRevision_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "ArticleRevision",
+          "columnsFrom": ["draftRevisionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Article_sourceId_KnowledgeSource_id_fk": {
+          "name": "Article_sourceId_KnowledgeSource_id_fk",
+          "tableFrom": "Article",
+          "tableTo": "KnowledgeSource",
+          "columnsFrom": ["sourceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Attachment": {
+      "name": "Attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ATTACHMENT'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileVersionId": {
+          "name": "fileVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assetVersionId": {
+          "name": "assetVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Attachment_assetId_idx": {
+          "name": "Attachment_assetId_idx",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_createdAt_idx": {
+          "name": "Attachment_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_entityType_entityId_idx": {
+          "name": "Attachment_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_fileId_idx": {
+          "name": "Attachment_fileId_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_id_organizationId_key": {
+          "name": "Attachment_id_organizationId_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_organizationId_entityType_entityId_idx": {
+          "name": "Attachment_organizationId_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Attachment_organizationId_Organization_id_fk": {
+          "name": "Attachment_organizationId_Organization_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_fileId_FolderFile_id_fk": {
+          "name": "Attachment_fileId_FolderFile_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "FolderFile",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_fileVersionId_FileVersion_id_fk": {
+          "name": "Attachment_fileVersionId_FileVersion_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "FileVersion",
+          "columnsFrom": ["fileVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Attachment_assetId_MediaAsset_id_fk": {
+          "name": "Attachment_assetId_MediaAsset_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["assetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Attachment_assetVersionId_MediaAssetVersion_id_fk": {
+          "name": "Attachment_assetVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["assetVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Attachment_createdById_User_id_fk": {
+          "name": "Attachment_createdById_User_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorType": {
+          "name": "actorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousState": {
+          "name": "previousState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newState": {
+          "name": "newState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AuditLog_org_createdAt_idx": {
+          "name": "AuditLog_org_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_org_category_idx": {
+          "name": "AuditLog_org_category_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_org_visibility_createdAt_idx": {
+          "name": "AuditLog_org_visibility_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_actorId_idx": {
+          "name": "AuditLog_actorId_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_target_idx": {
+          "name": "AuditLog_target_idx",
+          "columns": [
+            {
+              "expression": "targetType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_createdAt_idx": {
+          "name": "AuditLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AuditLog_organizationId_Organization_id_fk": {
+          "name": "AuditLog_organizationId_Organization_id_fk",
+          "tableFrom": "AuditLog",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CalendarEvent": {
+      "name": "CalendarEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "CalendarProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingUrl": {
+          "name": "meetingUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetingPlatform": {
+          "name": "meetingPlatform",
+          "type": "MeetingPlatform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAllDay": {
+          "name": "isAllDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "CalendarEventStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirmed'"
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendees": {
+          "name": "attendees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "isExternal": {
+          "name": "isExternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedAt": {
+          "name": "syncedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "CalendarEvent_org_provider_externalId_key": {
+          "name": "CalendarEvent_org_provider_externalId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_organizationId_idx": {
+          "name": "CalendarEvent_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_userId_idx": {
+          "name": "CalendarEvent_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_startTime_endTime_idx": {
+          "name": "CalendarEvent_startTime_endTime_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CalendarEvent_entityInstanceId_idx": {
+          "name": "CalendarEvent_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CalendarEvent_organizationId_Organization_id_fk": {
+          "name": "CalendarEvent_organizationId_Organization_id_fk",
+          "tableFrom": "CalendarEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CalendarEvent_userId_User_id_fk": {
+          "name": "CalendarEvent_userId_User_id_fk",
+          "tableFrom": "CalendarEvent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CalendarEvent_entityInstanceId_EntityInstance_id_fk": {
+          "name": "CalendarEvent_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "CalendarEvent",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CallRecording": {
+      "name": "CallRecording",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingId": {
+          "name": "meetingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "RecordingProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingPlatform": {
+          "name": "meetingPlatform",
+          "type": "MeetingPlatform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalBotId": {
+          "name": "externalBotId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "RecordingStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "videoAssetId": {
+          "name": "videoAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audioAssetId": {
+          "name": "audioAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videoPreviewAssetId": {
+          "name": "videoPreviewAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videoStoryboardAssetId": {
+          "name": "videoStoryboardAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationSeconds": {
+          "name": "durationSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "botName": {
+          "name": "botName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentMessage": {
+          "name": "consentMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summaryText": {
+          "name": "summaryText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actionItems": {
+          "name": "actionItems",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProcessingStatus": {
+          "name": "aiProcessingStatus",
+          "type": "AiProcessingStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "aiProcessingError": {
+          "name": "aiProcessingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProcessedAt": {
+          "name": "aiProcessedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "CallRecording_organizationId_idx": {
+          "name": "CallRecording_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_meetingId_idx": {
+          "name": "CallRecording_meetingId_idx",
+          "columns": [
+            {
+              "expression": "meetingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_calendarEventId_idx": {
+          "name": "CallRecording_calendarEventId_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_status_idx": {
+          "name": "CallRecording_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_organizationId_status_idx": {
+          "name": "CallRecording_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_externalBotId_idx": {
+          "name": "CallRecording_externalBotId_idx",
+          "columns": [
+            {
+              "expression": "externalBotId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_createdById_idx": {
+          "name": "CallRecording_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CallRecording_organizationId_calendarEventId_key": {
+          "name": "CallRecording_organizationId_calendarEventId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"calendarEventId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CallRecording_organizationId_Organization_id_fk": {
+          "name": "CallRecording_organizationId_Organization_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_meetingId_EntityInstance_id_fk": {
+          "name": "CallRecording_meetingId_EntityInstance_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["meetingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_calendarEventId_CalendarEvent_id_fk": {
+          "name": "CallRecording_calendarEventId_CalendarEvent_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "CalendarEvent",
+          "columnsFrom": ["calendarEventId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_videoAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_videoAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["videoAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_audioAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_audioAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["audioAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_videoPreviewAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_videoPreviewAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["videoPreviewAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_videoStoryboardAssetId_MediaAsset_id_fk": {
+          "name": "CallRecording_videoStoryboardAssetId_MediaAsset_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["videoStoryboardAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "CallRecording_createdById_User_id_fk": {
+          "name": "CallRecording_createdById_User_id_fk",
+          "tableFrom": "CallRecording",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatWidget": {
+      "name": "ChatWidget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Chat Support'"
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryColor": {
+          "name": "primaryColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4F46E5'"
+        },
+        "headerColor": {
+          "name": "headerColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoLight": {
+          "name": "logoLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoDark": {
+          "name": "logoDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoLightId": {
+          "name": "logoLightId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoDarkId": {
+          "name": "logoDarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BOTTOM_RIGHT'"
+        },
+        "autoOpen": {
+          "name": "autoOpen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mobileFullScreen": {
+          "name": "mobileFullScreen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collectUserInfo": {
+          "name": "collectUserInfo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "offlineMessage": {
+          "name": "offlineMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'We''re currently offline. Please leave a message and we''ll get back to you as soon as possible.'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowedDomains": {
+          "name": "allowedDomains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homeGreetingTemplate": {
+          "name": "homeGreetingTemplate",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homeShowRecentMessage": {
+          "name": "homeShowRecentMessage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "homeShowSendMessageCta": {
+          "name": "homeShowSendMessageCta",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "brandingFooterEnabled": {
+          "name": "brandingFooterEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "welcomeMessageTemplate": {
+          "name": "welcomeMessageTemplate",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featuredArticleIds": {
+          "name": "featuredArticleIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowDownloadTranscript": {
+          "name": "allowDownloadTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "defaultTheme": {
+          "name": "defaultTheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'light'"
+        },
+        "primaryColorDark": {
+          "name": "primaryColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headerColorDark": {
+          "name": "headerColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggestedReplies": {
+          "name": "suggestedReplies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacyPolicyUrl": {
+          "name": "privacyPolicyUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identityVerification": {
+          "name": "identityVerification",
+          "type": "IdentityVerification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "chatAudience": {
+          "name": "chatAudience",
+          "type": "ChatAudience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'visitors'"
+        }
+      },
+      "indexes": {
+        "ChatWidget_integrationId_key": {
+          "name": "ChatWidget_integrationId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatWidget_logoLightId_key": {
+          "name": "ChatWidget_logoLightId_key",
+          "columns": [
+            {
+              "expression": "logoLightId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatWidget_logoDarkId_key": {
+          "name": "ChatWidget_logoDarkId_key",
+          "columns": [
+            {
+              "expression": "logoDarkId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatWidget_organizationId_idx": {
+          "name": "ChatWidget_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatWidget_organizationId_name_key": {
+          "name": "ChatWidget_organizationId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ChatWidget_integrationId_Integration_id_fk": {
+          "name": "ChatWidget_integrationId_Integration_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatWidget_logoLightId_MediaAsset_id_fk": {
+          "name": "ChatWidget_logoLightId_MediaAsset_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["logoLightId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "ChatWidget_logoDarkId_MediaAsset_id_fk": {
+          "name": "ChatWidget_logoDarkId_MediaAsset_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["logoDarkId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "ChatWidget_organizationId_Organization_id_fk": {
+          "name": "ChatWidget_organizationId_Organization_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ChatWidget_agentId_Agent_id_fk": {
+          "name": "ChatWidget_agentId_Agent_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "Agent",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ChatWidget_knowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "ChatWidget_knowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "ChatWidget",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["knowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CommentReaction": {
+      "name": "CommentReaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "CommentReaction_commentId_idx": {
+          "name": "CommentReaction_commentId_idx",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_commentId_userId_type_emoji_key": {
+          "name": "CommentReaction_commentId_userId_type_emoji_key",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_type_idx": {
+          "name": "CommentReaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReaction_userId_idx": {
+          "name": "CommentReaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CommentReaction_commentId_Comment_id_fk": {
+          "name": "CommentReaction_commentId_Comment_id_fk",
+          "tableFrom": "CommentReaction",
+          "tableTo": "Comment",
+          "columnsFrom": ["commentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CommentReaction_userId_User_id_fk": {
+          "name": "CommentReaction_userId_User_id_fk",
+          "tableFrom": "CommentReaction",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CommentReference": {
+      "name": "CommentReference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "CommentReference_commentId_idx": {
+          "name": "CommentReference_commentId_idx",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReference_commentId_def_inst_key": {
+          "name": "CommentReference_commentId_def_inst_key",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CommentReference_def_inst_idx": {
+          "name": "CommentReference_def_inst_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CommentReference_commentId_Comment_id_fk": {
+          "name": "CommentReference_commentId_Comment_id_fk",
+          "tableFrom": "CommentReference",
+          "tableTo": "Comment",
+          "columnsFrom": ["commentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Comment": {
+      "name": "Comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contentJson": {
+          "name": "contentJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinnedAt": {
+          "name": "pinnedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinnedById": {
+          "name": "pinnedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Comment_createdById_idx": {
+          "name": "Comment_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_deletedAt_idx": {
+          "name": "Comment_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_entityId_entityDefinitionId_idx": {
+          "name": "Comment_entityId_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_isPinned_idx": {
+          "name": "Comment_isPinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_organizationId_idx": {
+          "name": "Comment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_parentId_idx": {
+          "name": "Comment_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Comment_createdById_User_id_fk": {
+          "name": "Comment_createdById_User_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Comment_organizationId_Organization_id_fk": {
+          "name": "Comment_organizationId_Organization_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Comment_parentId_Comment_id_fk": {
+          "name": "Comment_parentId_Comment_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "Comment",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Comment_pinnedById_User_id_fk": {
+          "name": "Comment_pinnedById_User_id_fk",
+          "tableFrom": "Comment",
+          "tableTo": "User",
+          "columnsFrom": ["pinnedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ConnectionDefinition": {
+      "name": "ConnectionDefinition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcpServerId": {
+          "name": "mcpServerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerKey": {
+          "name": "providerKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "major": {
+          "name": "major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionType": {
+          "name": "connectionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global": {
+          "name": "global",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "oauth2AuthorizeUrl": {
+          "name": "oauth2AuthorizeUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2AccessTokenUrl": {
+          "name": "oauth2AccessTokenUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2RefreshUrl": {
+          "name": "oauth2RefreshUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2Scopes": {
+          "name": "oauth2Scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "oauth2ClientId": {
+          "name": "oauth2ClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2ClientSecret": {
+          "name": "oauth2ClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2TokenRequestAuthMethod": {
+          "name": "oauth2TokenRequestAuthMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'request-body'"
+        },
+        "oauth2RefreshTokenIntervalSeconds": {
+          "name": "oauth2RefreshTokenIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth2Features": {
+          "name": "oauth2Features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "platformClientApproved": {
+          "name": "platformClientApproved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "connectionVariables": {
+          "name": "connectionVariables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "authApply": {
+          "name": "authApply",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseUrlTemplate": {
+          "name": "baseUrlTemplate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ConnectionDefinition_app_version_idx": {
+          "name": "ConnectionDefinition_app_version_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "major",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ConnectionDefinition_mcpServerId_idx": {
+          "name": "ConnectionDefinition_mcpServerId_idx",
+          "columns": [
+            {
+              "expression": "mcpServerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ConnectionDefinition_providerKey_major_idx": {
+          "name": "ConnectionDefinition_providerKey_major_idx",
+          "columns": [
+            {
+              "expression": "providerKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "major",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ConnectionDefinition_app_key_major_idx": {
+          "name": "ConnectionDefinition_app_key_major_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "major",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"appId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ConnectionDefinition_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "ConnectionDefinition_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "ConnectionDefinition",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ConnectionDefinition_appId_App_id_fk": {
+          "name": "ConnectionDefinition_appId_App_id_fk",
+          "tableFrom": "ConnectionDefinition",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ConnectionDefinition_mcpServerId_McpServer_id_fk": {
+          "name": "ConnectionDefinition_mcpServerId_McpServer_id_fk",
+          "tableFrom": "ConnectionDefinition",
+          "tableTo": "McpServer",
+          "columnsFrom": ["mcpServerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ConnectionDefinition_owner_check": {
+          "name": "ConnectionDefinition_owner_check",
+          "value": "((\"appId\" IS NOT NULL)::int + (\"mcpServerId\" IS NOT NULL)::int + (\"providerKey\" IS NOT NULL)::int) = 1\n       AND (\"appId\" IS NULL OR \"key\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.Credential": {
+      "name": "Credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connection'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcpServerId": {
+          "name": "mcpServerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connectionDefinitionId": {
+          "name": "connectionDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryptedSecrets": {
+          "name": "encryptedSecrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRefreshAt": {
+          "name": "lastRefreshAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRefreshFailureAt": {
+          "name": "lastRefreshFailureAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutiveRefreshFailures": {
+          "name": "consecutiveRefreshFailures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAuthError": {
+          "name": "lastAuthError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAuthErrorAt": {
+          "name": "lastAuthErrorAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresReauth": {
+          "name": "requiresReauth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Credential_createdById_idx": {
+          "name": "Credential_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Credential_organizationId_idx": {
+          "name": "Credential_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Credential_organizationId_kind_idx": {
+          "name": "Credential_organizationId_kind_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Credential_appId_organizationId_idx": {
+          "name": "Credential_appId_organizationId_idx",
+          "columns": [
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Credential_userId_appId_idx": {
+          "name": "Credential_userId_appId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Credential_appInstallationId_idx": {
+          "name": "Credential_appInstallationId_idx",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Credential_mcpServerId_idx": {
+          "name": "Credential_mcpServerId_idx",
+          "columns": [
+            {
+              "expression": "mcpServerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Credential_connectionDefinitionId_idx": {
+          "name": "Credential_connectionDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "connectionDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Credential_app_org_default_idx": {
+          "name": "Credential_app_org_default_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"isDefault\" = true AND \"userId\" IS NULL AND \"kind\" = 'app'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Credential_expiresAt_idx": {
+          "name": "Credential_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Credential_lastRefreshAt_idx": {
+          "name": "Credential_lastRefreshAt_idx",
+          "columns": [
+            {
+              "expression": "lastRefreshAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Credential_organizationId_Organization_id_fk": {
+          "name": "Credential_organizationId_Organization_id_fk",
+          "tableFrom": "Credential",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Credential_createdById_User_id_fk": {
+          "name": "Credential_createdById_User_id_fk",
+          "tableFrom": "Credential",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Credential_userId_User_id_fk": {
+          "name": "Credential_userId_User_id_fk",
+          "tableFrom": "Credential",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Credential_appId_App_id_fk": {
+          "name": "Credential_appId_App_id_fk",
+          "tableFrom": "Credential",
+          "tableTo": "App",
+          "columnsFrom": ["appId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Credential_appInstallationId_AppInstallation_id_fk": {
+          "name": "Credential_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "Credential",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Credential_mcpServerId_McpServer_id_fk": {
+          "name": "Credential_mcpServerId_McpServer_id_fk",
+          "tableFrom": "Credential",
+          "tableTo": "McpServer",
+          "columnsFrom": ["mcpServerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Credential_connectionDefinitionId_ConnectionDefinition_id_fk": {
+          "name": "Credential_connectionDefinitionId_ConnectionDefinition_id_fk",
+          "tableFrom": "Credential",
+          "tableTo": "ConnectionDefinition",
+          "columnsFrom": ["connectionDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CustomField": {
+      "name": "CustomField",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "ContactFieldType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "displayOptions": {
+          "name": "displayOptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "defaultValue": {
+          "name": "defaultValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contact'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isCustom": {
+          "name": "isCustom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "systemAttribute": {
+          "name": "systemAttribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isUnique": {
+          "name": "isUnique",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isCreatable": {
+          "name": "isCreatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isUpdatable": {
+          "name": "isUpdatable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isComputed": {
+          "name": "isComputed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isSortable": {
+          "name": "isSortable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isFilterable": {
+          "name": "isFilterable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appFieldKey": {
+          "name": "appFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isHidden": {
+          "name": "isHidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dataConnectorId": {
+          "name": "dataConnectorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isIdentity": {
+          "name": "isIdentity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "appSlug": {
+          "name": "appSlug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "CustomField_modelType_idx": {
+          "name": "CustomField_modelType_idx",
+          "columns": [
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_name_org_model_entity_key": {
+          "name": "CustomField_name_org_model_entity_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"CustomField\".\"appInstallationId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_app_field_key": {
+          "name": "CustomField_app_field_key",
+          "columns": [
+            {
+              "expression": "appInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"connectionId\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appFieldKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"CustomField\".\"appInstallationId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_organizationId_idx": {
+          "name": "CustomField_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_entityDefinitionId_idx": {
+          "name": "CustomField_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "CustomField_organizationId_entityDefinitionId_sortOrder_idx": {
+          "name": "CustomField_organizationId_entityDefinitionId_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CustomField_organizationId_Organization_id_fk": {
+          "name": "CustomField_organizationId_Organization_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CustomField_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "CustomField_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CustomField_appInstallationId_AppInstallation_id_fk": {
+          "name": "CustomField_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CustomField_connectionId_Credential_id_fk": {
+          "name": "CustomField_connectionId_Credential_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "Credential",
+          "columnsFrom": ["connectionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "CustomField_dataConnectorId_DataConnector_id_fk": {
+          "name": "CustomField_dataConnectorId_DataConnector_id_fk",
+          "tableFrom": "CustomField",
+          "tableTo": "DataConnector",
+          "columnsFrom": ["dataConnectorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DataConnectorItem": {
+      "name": "DataConnectorItem",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataConnectorId": {
+          "name": "dataConnectorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mappingId": {
+          "name": "mappingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mintedInstance": {
+          "name": "mintedInstance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managedFields": {
+          "name": "managedFields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pendingRelations": {
+          "name": "pendingRelations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedRelations": {
+          "name": "linkedRelations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstreamUpdatedAt": {
+          "name": "upstreamUpdatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSeenRunId": {
+          "name": "lastSeenRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DataConnectorItem_dataConnectorId_mappingId_externalId_key": {
+          "name": "DataConnectorItem_dataConnectorId_mappingId_externalId_key",
+          "columns": [
+            {
+              "expression": "dataConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DataConnectorItem_entityInstanceId_idx": {
+          "name": "DataConnectorItem_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DataConnectorItem_dataConnectorId_entityDefinitionId_externalId_idx": {
+          "name": "DataConnectorItem_dataConnectorId_entityDefinitionId_externalId_idx",
+          "columns": [
+            {
+              "expression": "dataConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DataConnectorItem_dataConnectorId_mappingId_lastSeenRunId_idx": {
+          "name": "DataConnectorItem_dataConnectorId_mappingId_lastSeenRunId_idx",
+          "columns": [
+            {
+              "expression": "dataConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastSeenRunId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DataConnectorItem_dataConnectorId_DataConnector_id_fk": {
+          "name": "DataConnectorItem_dataConnectorId_DataConnector_id_fk",
+          "tableFrom": "DataConnectorItem",
+          "tableTo": "DataConnector",
+          "columnsFrom": ["dataConnectorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DataConnectorItem_organizationId_Organization_id_fk": {
+          "name": "DataConnectorItem_organizationId_Organization_id_fk",
+          "tableFrom": "DataConnectorItem",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DataConnectorItem_mappingId_DataConnectorMapping_id_fk": {
+          "name": "DataConnectorItem_mappingId_DataConnectorMapping_id_fk",
+          "tableFrom": "DataConnectorItem",
+          "tableTo": "DataConnectorMapping",
+          "columnsFrom": ["mappingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DataConnectorItem_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "DataConnectorItem_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "DataConnectorItem",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DataConnectorItem_entityInstanceId_EntityInstance_id_fk": {
+          "name": "DataConnectorItem_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "DataConnectorItem",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DataConnectorMapping": {
+      "name": "DataConnectorMapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataConnectorStreamId": {
+          "name": "dataConnectorStreamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rootPath": {
+          "name": "rootPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "linkMode": {
+          "name": "linkMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upsert'"
+        },
+        "parentMappingId": {
+          "name": "parentMappingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relationshipFieldKey": {
+          "name": "relationshipFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetMode": {
+          "name": "targetMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fieldMappings": {
+          "name": "fieldMappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "orphanBehavior": {
+          "name": "orphanBehavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ignore'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DataConnectorMapping_dataConnectorStreamId_idx": {
+          "name": "DataConnectorMapping_dataConnectorStreamId_idx",
+          "columns": [
+            {
+              "expression": "dataConnectorStreamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DataConnectorMapping_entityDefinitionId_idx": {
+          "name": "DataConnectorMapping_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DataConnectorMapping_parentMappingId_idx": {
+          "name": "DataConnectorMapping_parentMappingId_idx",
+          "columns": [
+            {
+              "expression": "parentMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DataConnectorMapping_dataConnectorStreamId_DataConnectorStream_id_fk": {
+          "name": "DataConnectorMapping_dataConnectorStreamId_DataConnectorStream_id_fk",
+          "tableFrom": "DataConnectorMapping",
+          "tableTo": "DataConnectorStream",
+          "columnsFrom": ["dataConnectorStreamId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DataConnectorMapping_organizationId_Organization_id_fk": {
+          "name": "DataConnectorMapping_organizationId_Organization_id_fk",
+          "tableFrom": "DataConnectorMapping",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DataConnectorMapping_parentMappingId_DataConnectorMapping_id_fk": {
+          "name": "DataConnectorMapping_parentMappingId_DataConnectorMapping_id_fk",
+          "tableFrom": "DataConnectorMapping",
+          "tableTo": "DataConnectorMapping",
+          "columnsFrom": ["parentMappingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DataConnectorMapping_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "DataConnectorMapping_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "DataConnectorMapping",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DataConnectorRun": {
+      "name": "DataConnectorRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataConnectorId": {
+          "name": "dataConnectorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sampleLimit": {
+          "name": "sampleLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched": {
+          "name": "fetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created": {
+          "name": "created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated": {
+          "name": "updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "relationshipWarnings": {
+          "name": "relationshipWarnings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pagesProcessed": {
+          "name": "pagesProcessed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rateLimitWaitMs": {
+          "name": "rateLimitWaitMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errorSample": {
+          "name": "errorSample",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainSnapshot": {
+          "name": "chainSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursorBefore": {
+          "name": "cursorBefore",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursorAfter": {
+          "name": "cursorAfter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "heartbeatAt": {
+          "name": "heartbeatAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DataConnectorRun_dataConnectorId_startedAt_idx": {
+          "name": "DataConnectorRun_dataConnectorId_startedAt_idx",
+          "columns": [
+            {
+              "expression": "dataConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DataConnectorRun_status_heartbeatAt_idx": {
+          "name": "DataConnectorRun_status_heartbeatAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeatAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DataConnectorRun_dataConnectorId_DataConnector_id_fk": {
+          "name": "DataConnectorRun_dataConnectorId_DataConnector_id_fk",
+          "tableFrom": "DataConnectorRun",
+          "tableTo": "DataConnector",
+          "columnsFrom": ["dataConnectorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DataConnectorRun_organizationId_Organization_id_fk": {
+          "name": "DataConnectorRun_organizationId_Organization_id_fk",
+          "tableFrom": "DataConnectorRun",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DataConnectorStream": {
+      "name": "DataConnectorStream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataConnectorId": {
+          "name": "dataConnectorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "streamKey": {
+          "name": "streamKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sourceSchema": {
+          "name": "sourceSchema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schemaSource": {
+          "name": "schemaSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'catalog'"
+        },
+        "syncMode": {
+          "name": "syncMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'snapshot'"
+        },
+        "requestConfig": {
+          "name": "requestConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sampleRunId": {
+          "name": "sampleRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DataConnectorStream_dataConnectorId_streamKey_key": {
+          "name": "DataConnectorStream_dataConnectorId_streamKey_key",
+          "columns": [
+            {
+              "expression": "dataConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "streamKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DataConnectorStream_dataConnectorId_DataConnector_id_fk": {
+          "name": "DataConnectorStream_dataConnectorId_DataConnector_id_fk",
+          "tableFrom": "DataConnectorStream",
+          "tableTo": "DataConnector",
+          "columnsFrom": ["dataConnectorId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DataConnectorStream_organizationId_Organization_id_fk": {
+          "name": "DataConnectorStream_organizationId_Organization_id_fk",
+          "tableFrom": "DataConnectorStream",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DataConnector": {
+      "name": "DataConnector",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definitionKind": {
+          "name": "definitionKind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'builtin'"
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "syncBehavior": {
+          "name": "syncBehavior",
+          "type": "DataConnectorSyncBehavior",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "scheduleConfig": {
+          "name": "scheduleConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "DataConnectorStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "resyncPending": {
+          "name": "resyncPending",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schemaHash": {
+          "name": "schemaHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastWebhookEventAt": {
+          "name": "lastWebhookEventAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastJobId": {
+          "name": "lastJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itemCount": {
+          "name": "itemCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DataConnector_organizationId_idx": {
+          "name": "DataConnector_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DataConnector_organizationId_Organization_id_fk": {
+          "name": "DataConnector_organizationId_Organization_id_fk",
+          "tableFrom": "DataConnector",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DataConnector_createdById_User_id_fk": {
+          "name": "DataConnector_createdById_User_id_fk",
+          "tableFrom": "DataConnector",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "DataConnector_credentialId_Credential_id_fk": {
+          "name": "DataConnector_credentialId_Credential_id_fk",
+          "tableFrom": "DataConnector",
+          "tableTo": "Credential",
+          "columnsFrom": ["credentialId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "DataConnector_appInstallationId_AppInstallation_id_fk": {
+          "name": "DataConnector_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "DataConnector",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DataMigration": {
+      "name": "DataMigration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appliedAt": {
+          "name": "appliedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetMetadata": {
+      "name": "DatasetMetadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetMetadata_datasetId_idx": {
+          "name": "DatasetMetadata_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetMetadata_datasetId_name_key": {
+          "name": "DatasetMetadata_datasetId_name_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetMetadata_type_idx": {
+          "name": "DatasetMetadata_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetMetadata_datasetId_Dataset_id_fk": {
+          "name": "DatasetMetadata_datasetId_Dataset_id_fk",
+          "tableFrom": "DatasetMetadata",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetSearchQuery": {
+      "name": "DatasetSearchQuery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queryType": {
+          "name": "queryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hybrid'"
+        },
+        "resultsCount": {
+          "name": "resultsCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vectorSimilarityThreshold": {
+          "name": "vectorSimilarityThreshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.7
+        },
+        "maxResults": {
+          "name": "maxResults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetSearchQuery_createdAt_idx": {
+          "name": "DatasetSearchQuery_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_datasetId_idx": {
+          "name": "DatasetSearchQuery_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_organizationId_idx": {
+          "name": "DatasetSearchQuery_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchQuery_userId_idx": {
+          "name": "DatasetSearchQuery_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetSearchQuery_datasetId_Dataset_id_fk": {
+          "name": "DatasetSearchQuery_datasetId_Dataset_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchQuery_organizationId_Organization_id_fk": {
+          "name": "DatasetSearchQuery_organizationId_Organization_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchQuery_userId_User_id_fk": {
+          "name": "DatasetSearchQuery_userId_User_id_fk",
+          "tableFrom": "DatasetSearchQuery",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DatasetSearchResult": {
+      "name": "DatasetSearchResult",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queryId": {
+          "name": "queryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segmentId": {
+          "name": "segmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "DatasetSearchResult_queryId_idx": {
+          "name": "DatasetSearchResult_queryId_idx",
+          "columns": [
+            {
+              "expression": "queryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_queryId_segmentId_key": {
+          "name": "DatasetSearchResult_queryId_segmentId_key",
+          "columns": [
+            {
+              "expression": "queryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_rank_idx": {
+          "name": "DatasetSearchResult_rank_idx",
+          "columns": [
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_score_idx": {
+          "name": "DatasetSearchResult_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DatasetSearchResult_segmentId_idx": {
+          "name": "DatasetSearchResult_segmentId_idx",
+          "columns": [
+            {
+              "expression": "segmentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DatasetSearchResult_queryId_DatasetSearchQuery_id_fk": {
+          "name": "DatasetSearchResult_queryId_DatasetSearchQuery_id_fk",
+          "tableFrom": "DatasetSearchResult",
+          "tableTo": "DatasetSearchQuery",
+          "columnsFrom": ["queryId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DatasetSearchResult_segmentId_DocumentSegment_id_fk": {
+          "name": "DatasetSearchResult_segmentId_DocumentSegment_id_fk",
+          "tableFrom": "DatasetSearchResult",
+          "tableTo": "DocumentSegment",
+          "columnsFrom": ["segmentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Dataset": {
+      "name": "Dataset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "DatasetStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "documentCount": {
+          "name": "documentCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalSize": {
+          "name": "totalSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastIndexedAt": {
+          "name": "lastIndexedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunkSettings": {
+          "name": "chunkSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"strategy\":\"FIXED_SIZE\",\"size\":1024,\"overlap\":50,\"delimiter\":\"\\n\\n\",\"preprocessing\":{\"normalizeWhitespace\":true,\"removeUrlsAndEmails\":false}}'::jsonb"
+        },
+        "vectorDbConfig": {
+          "name": "vectorDbConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vectorDimension": {
+          "name": "vectorDimension",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vectorDbType": {
+          "name": "vectorDbType",
+          "type": "VectorDbType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POSTGRESQL'"
+        },
+        "searchConfig": {
+          "name": "searchConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"searchType\":\"hybrid\"}'::jsonb"
+        },
+        "isManaged": {
+          "name": "isManaged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Dataset_createdById_idx": {
+          "name": "Dataset_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_organizationId_idx": {
+          "name": "Dataset_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_organizationId_name_key": {
+          "name": "Dataset_organizationId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Dataset_status_idx": {
+          "name": "Dataset_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dataset_org_status": {
+          "name": "idx_dataset_org_status",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dataset_org_managed": {
+          "name": "idx_dataset_org_managed",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isManaged",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Dataset_organizationId_Organization_id_fk": {
+          "name": "Dataset_organizationId_Organization_id_fk",
+          "tableFrom": "Dataset",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Dataset_createdById_User_id_fk": {
+          "name": "Dataset_createdById_User_id_fk",
+          "tableFrom": "Dataset",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccountInvite": {
+      "name": "DeveloperAccountInvite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailAddress": {
+          "name": "emailAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessLevel": {
+          "name": "accessLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "failedToSend": {
+          "name": "failedToSend",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccountInvite_account_idx": {
+          "name": "DeveloperAccountInvite_account_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeveloperAccountInvite_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "DeveloperAccountInvite_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "DeveloperAccountInvite",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccountMember": {
+      "name": "DeveloperAccountMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "developerAccountId": {
+          "name": "developerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailAddress": {
+          "name": "emailAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessLevel": {
+          "name": "accessLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccountMember_unique_idx": {
+          "name": "DeveloperAccountMember_unique_idx",
+          "columns": [
+            {
+              "expression": "developerAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DeveloperAccountMember_userId_idx": {
+          "name": "DeveloperAccountMember_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeveloperAccountMember_developerAccountId_DeveloperAccount_id_fk": {
+          "name": "DeveloperAccountMember_developerAccountId_DeveloperAccount_id_fk",
+          "tableFrom": "DeveloperAccountMember",
+          "tableTo": "DeveloperAccount",
+          "columnsFrom": ["developerAccountId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DeveloperAccountMember_userId_User_id_fk": {
+          "name": "DeveloperAccountMember_userId_User_id_fk",
+          "tableFrom": "DeveloperAccountMember",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeveloperAccount": {
+      "name": "DeveloperAccount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logoId": {
+          "name": "logoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoUrl": {
+          "name": "logoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featureFlags": {
+          "name": "featureFlags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"legacy-collection-scopes\":false,\"search-records-api\":false,\"find-create-meetings-api\":false,\"get-list-meetings-api\":true,\"write-call-recordings-api\":false,\"read-call-recordings-api\":true}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeveloperAccount_slug_idx": {
+          "name": "DeveloperAccount_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DeveloperAccount_slug_unique": {
+          "name": "DeveloperAccount_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DocumentSegment": {
+      "name": "DocumentSegment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startOffset": {
+          "name": "startOffset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endOffset": {
+          "name": "endOffset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenCount": {
+          "name": "tokenCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_512": {
+          "name": "embedding_512",
+          "type": "vector(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_768": {
+          "name": "embedding_768",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_1024": {
+          "name": "embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_1536": {
+          "name": "embedding_1536",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_3072": {
+          "name": "embedding_3072",
+          "type": "vector(3072)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingModel": {
+          "name": "embeddingModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingDimension": {
+          "name": "embeddingDimension",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "indexStatus": {
+          "name": "indexStatus",
+          "type": "IndexStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "searchMetadata": {
+          "name": "searchMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchVector": {
+          "name": "searchVector",
+          "type": "tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DocumentSegment_documentId_idx": {
+          "name": "DocumentSegment_documentId_idx",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DocumentSegment_organizationId_idx": {
+          "name": "DocumentSegment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DocumentSegment_position_idx": {
+          "name": "DocumentSegment_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_embedding_512_hnsw": {
+          "name": "idx_embedding_512_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_512",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_512 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_768_hnsw": {
+          "name": "idx_embedding_768_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_768",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_768 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_1024_hnsw": {
+          "name": "idx_embedding_1024_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_1024 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_embedding_1536_hnsw": {
+          "name": "idx_embedding_1536_hnsw",
+          "columns": [
+            {
+              "expression": "embedding_1536",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "(embedding_1536 IS NOT NULL AND enabled = true AND \"indexStatus\" = 'INDEXED'::\"IndexStatus\")",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": "16",
+            "ef_construction": "64"
+          }
+        },
+        "idx_document_segment_search_vector": {
+          "name": "idx_document_segment_search_vector",
+          "columns": [
+            {
+              "expression": "searchVector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_document_segment_dataset_filter": {
+          "name": "idx_document_segment_dataset_filter",
+          "columns": [
+            {
+              "expression": "documentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((enabled = true) AND (\"indexStatus\" = 'INDEXED'::\"IndexStatus\"))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DocumentSegment_documentId_Document_id_fk": {
+          "name": "DocumentSegment_documentId_Document_id_fk",
+          "tableFrom": "DocumentSegment",
+          "tableTo": "Document",
+          "columnsFrom": ["documentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "DocumentSegment_organizationId_Organization_id_fk": {
+          "name": "DocumentSegment_organizationId_Organization_id_fk",
+          "tableFrom": "DocumentSegment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalPath": {
+          "name": "originalPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "DocumentType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "DocumentStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UPLOADED'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingTime": {
+          "name": "processingTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalChunks": {
+          "name": "totalChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploadedById": {
+          "name": "uploadedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunkSettings": {
+          "name": "chunkSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mediaAssetId": {
+          "name": "mediaAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Document_checksum_idx": {
+          "name": "Document_checksum_idx",
+          "columns": [
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_datasetId_checksum_key": {
+          "name": "Document_datasetId_checksum_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_datasetId_idx": {
+          "name": "Document_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_enabled_idx": {
+          "name": "Document_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_mediaAssetId_idx": {
+          "name": "Document_mediaAssetId_idx",
+          "columns": [
+            {
+              "expression": "mediaAssetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_organizationId_idx": {
+          "name": "Document_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_status_idx": {
+          "name": "Document_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_type_idx": {
+          "name": "Document_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_uploadedById_idx": {
+          "name": "Document_uploadedById_idx",
+          "columns": [
+            {
+              "expression": "uploadedById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_document_dataset_enabled": {
+          "name": "idx_document_dataset_enabled",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Document_kb_articleId_idx": {
+          "name": "Document_kb_articleId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "((\"metadata\"->'kb'->>'articleId'))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metadata\"->'kb'->>'articleId' IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_datasetId_Dataset_id_fk": {
+          "name": "Document_datasetId_Dataset_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Document_organizationId_Organization_id_fk": {
+          "name": "Document_organizationId_Organization_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Document_uploadedById_User_id_fk": {
+          "name": "Document_uploadedById_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["uploadedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Document_mediaAssetId_MediaAsset_id_fk": {
+          "name": "Document_mediaAssetId_MediaAsset_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["mediaAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Draft": {
+      "name": "Draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inReplyToMessageId": {
+          "name": "inReplyToMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerThreadId": {
+          "name": "providerThreadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Draft_organizationId_idx": {
+          "name": "Draft_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_createdById_idx": {
+          "name": "Draft_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_threadId_idx": {
+          "name": "Draft_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_integrationId_idx": {
+          "name": "Draft_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_threadId_createdById_key": {
+          "name": "Draft_threadId_createdById_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"threadId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_organizationId_providerId_key": {
+          "name": "Draft_organizationId_providerId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"providerId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Draft_organizationId_createdById_idx": {
+          "name": "Draft_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Draft_organizationId_Organization_id_fk": {
+          "name": "Draft_organizationId_Organization_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_createdById_User_id_fk": {
+          "name": "Draft_createdById_User_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_threadId_Thread_id_fk": {
+          "name": "Draft_threadId_Thread_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Draft_inReplyToMessageId_Message_id_fk": {
+          "name": "Draft_inReplyToMessageId_Message_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Message",
+          "columnsFrom": ["inReplyToMessageId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Draft_integrationId_Integration_id_fk": {
+          "name": "Draft_integrationId_Integration_id_fk",
+          "tableFrom": "Draft",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailAddress": {
+      "name": "EmailAddress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationType": {
+          "name": "integrationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EmailAddress_integrationId_address_key": {
+          "name": "EmailAddress_integrationId_address_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailEmbedding": {
+      "name": "EmailEmbedding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text-embedding-3-small'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EmailEmbedding_messageId_idx": {
+          "name": "EmailEmbedding_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EmailEmbedding_messageId_Message_id_fk": {
+          "name": "EmailEmbedding_messageId_Message_id_fk",
+          "tableFrom": "EmailEmbedding",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailTemplate": {
+      "name": "EmailTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "EmailTemplateType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bodyHtml": {
+          "name": "bodyHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bodyPlain": {
+          "name": "bodyPlain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EmailTemplate_organizationId_type_idx": {
+          "name": "EmailTemplate_organizationId_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EmailTemplate_organizationId_type_isDefault_key": {
+          "name": "EmailTemplate_organizationId_type_isDefault_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EmailTemplate_organizationId_Organization_id_fk": {
+          "name": "EmailTemplate_organizationId_Organization_id_fk",
+          "tableFrom": "EmailTemplate",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EndUser": {
+      "name": "EndUser",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "totalRuns": {
+          "name": "totalRuns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EndUser_workflowAppId_idx": {
+          "name": "EndUser_workflowAppId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_sessionId_idx": {
+          "name": "EndUser_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_userId_idx": {
+          "name": "EndUser_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_workflowAppId_sessionId_idx": {
+          "name": "EndUser_workflowAppId_sessionId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EndUser_workflowAppId_userId_idx": {
+          "name": "EndUser_workflowAppId_userId_idx",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EndUser_workflowAppId_WorkflowApp_id_fk": {
+          "name": "EndUser_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "EndUser",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EndUser_userId_User_id_fk": {
+          "name": "EndUser_userId_User_id_fk",
+          "tableFrom": "EndUser",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityDefinition": {
+      "name": "EntityDefinition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiSlug": {
+          "name": "apiSlug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Box'"
+        },
+        "singular": {
+          "name": "singular",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plural": {
+          "name": "plural",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standardType": {
+          "name": "standardType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryDisplayFieldId": {
+          "name": "primaryDisplayFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondaryDisplayFieldId": {
+          "name": "secondaryDisplayFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarFieldId": {
+          "name": "avatarFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isVisible": {
+          "name": "isVisible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "dataConnectorId": {
+          "name": "dataConnectorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceKey": {
+          "name": "sourceKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "EntityDefinition_apiSlug_organizationId_key": {
+          "name": "EntityDefinition_apiSlug_organizationId_key",
+          "columns": [
+            {
+              "expression": "apiSlug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"EntityDefinition\".\"archivedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_source_key": {
+          "name": "EntityDefinition_source_key",
+          "columns": [
+            {
+              "expression": "COALESCE(\"appInstallationId\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"dataConnectorId\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"EntityDefinition\".\"sourceKey\" IS NOT NULL AND \"EntityDefinition\".\"archivedAt\" IS NULL AND (\"EntityDefinition\".\"appInstallationId\" IS NOT NULL OR \"EntityDefinition\".\"dataConnectorId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_organizationId_idx": {
+          "name": "EntityDefinition_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_entityType_idx": {
+          "name": "EntityDefinition_entityType_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityDefinition_archivedAt_idx": {
+          "name": "EntityDefinition_archivedAt_idx",
+          "columns": [
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityDefinition_organizationId_Organization_id_fk": {
+          "name": "EntityDefinition_organizationId_Organization_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_primaryDisplayFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_primaryDisplayFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["primaryDisplayFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_secondaryDisplayFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_secondaryDisplayFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["secondaryDisplayFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_avatarFieldId_CustomField_id_fk": {
+          "name": "EntityDefinition_avatarFieldId_CustomField_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "CustomField",
+          "columnsFrom": ["avatarFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_dataConnectorId_DataConnector_id_fk": {
+          "name": "EntityDefinition_dataConnectorId_DataConnector_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "DataConnector",
+          "columnsFrom": ["dataConnectorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EntityDefinition_appInstallationId_AppInstallation_id_fk": {
+          "name": "EntityDefinition_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "EntityDefinition",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityGroupMember": {
+      "name": "EntityGroupMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "groupInstanceId": {
+          "name": "groupInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memberType": {
+          "name": "memberType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memberRefId": {
+          "name": "memberRefId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedById": {
+          "name": "addedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortKey": {
+          "name": "sortKey",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a0'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EntityGroupMember_group_member_key": {
+          "name": "EntityGroupMember_group_member_key",
+          "columns": [
+            {
+              "expression": "groupInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberRefId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityGroupMember_group_idx": {
+          "name": "EntityGroupMember_group_idx",
+          "columns": [
+            {
+              "expression": "groupInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityGroupMember_member_idx": {
+          "name": "EntityGroupMember_member_idx",
+          "columns": [
+            {
+              "expression": "memberType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memberRefId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityGroupMember_groupInstanceId_EntityInstance_id_fk": {
+          "name": "EntityGroupMember_groupInstanceId_EntityInstance_id_fk",
+          "tableFrom": "EntityGroupMember",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["groupInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityGroupMember_addedById_User_id_fk": {
+          "name": "EntityGroupMember_addedById_User_id_fk",
+          "tableFrom": "EntityGroupMember",
+          "tableTo": "User",
+          "columnsFrom": ["addedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EntityInstance": {
+      "name": "EntityInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondaryDisplayValue": {
+          "name": "secondaryDisplayValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchText": {
+          "name": "searchText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActivityAt": {
+          "name": "lastActivityAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSuggestionScanAt": {
+          "name": "lastSuggestionScanAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "EntityInstance_entityDefinitionId_idx": {
+          "name": "EntityInstance_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_organizationId_idx": {
+          "name": "EntityInstance_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_archivedAt_idx": {
+          "name": "EntityInstance_archivedAt_idx",
+          "columns": [
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_orgId_defId_idx": {
+          "name": "EntityInstance_orgId_defId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_displayName_idx": {
+          "name": "EntityInstance_displayName_idx",
+          "columns": [
+            {
+              "expression": "displayName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_organizationId_entityDefinitionId_lastActivityAt_idx": {
+          "name": "EntityInstance_organizationId_entityDefinitionId_lastActivityAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastActivityAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EntityInstance_org_def_scan_idx": {
+          "name": "EntityInstance_org_def_scan_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastActivityAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastSuggestionScanAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"archivedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EntityInstance_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "EntityInstance_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityInstance_organizationId_Organization_id_fk": {
+          "name": "EntityInstance_organizationId_Organization_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EntityInstance_createdById_User_id_fk": {
+          "name": "EntityInstance_createdById_User_id_fk",
+          "tableFrom": "EntityInstance",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EvalCase": {
+      "name": "EvalCase",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "EvalKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assertions": {
+          "name": "assertions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedureId": {
+          "name": "procedureId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggestionId": {
+          "name": "suggestionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EvalCase_organizationId_idx": {
+          "name": "EvalCase_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EvalCase_kind_idx": {
+          "name": "EvalCase_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EvalCase_agentId_procedureId_idx": {
+          "name": "EvalCase_agentId_procedureId_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EvalCase_organizationId_Organization_id_fk": {
+          "name": "EvalCase_organizationId_Organization_id_fk",
+          "tableFrom": "EvalCase",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EvalCase_agentId_Agent_id_fk": {
+          "name": "EvalCase_agentId_Agent_id_fk",
+          "tableFrom": "EvalCase",
+          "tableTo": "Agent",
+          "columnsFrom": ["agentId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EvalCase_procedureId_Procedure_id_fk": {
+          "name": "EvalCase_procedureId_Procedure_id_fk",
+          "tableFrom": "EvalCase",
+          "tableTo": "Procedure",
+          "columnsFrom": ["procedureId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EvalCase_createdById_User_id_fk": {
+          "name": "EvalCase_createdById_User_id_fk",
+          "tableFrom": "EvalCase",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EvalRun": {
+      "name": "EvalRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caseId": {
+          "name": "caseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suiteRunId": {
+          "name": "suiteRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "EvalKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "EvalRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runMode": {
+          "name": "runMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pinned'"
+        },
+        "definitionSnapshot": {
+          "name": "definitionSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtimeSnapshot": {
+          "name": "runtimeSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshotHash": {
+          "name": "snapshotHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traceVersion": {
+          "name": "traceVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trace": {
+          "name": "trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "lastTraceSequence": {
+          "name": "lastTraceSequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "assertionResults": {
+          "name": "assertionResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeatAt": {
+          "name": "heartbeatAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorCode": {
+          "name": "errorCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EvalRun_caseId_createdAt_idx": {
+          "name": "EvalRun_caseId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "caseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EvalRun_suiteRunId_idx": {
+          "name": "EvalRun_suiteRunId_idx",
+          "columns": [
+            {
+              "expression": "suiteRunId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EvalRun_organizationId_createdAt_idx": {
+          "name": "EvalRun_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EvalRun_status_heartbeatAt_idx": {
+          "name": "EvalRun_status_heartbeatAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeatAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EvalRun_organizationId_Organization_id_fk": {
+          "name": "EvalRun_organizationId_Organization_id_fk",
+          "tableFrom": "EvalRun",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EvalRun_caseId_EvalCase_id_fk": {
+          "name": "EvalRun_caseId_EvalCase_id_fk",
+          "tableFrom": "EvalRun",
+          "tableTo": "EvalCase",
+          "columnsFrom": ["caseId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EvalRun_suiteRunId_EvalSuiteRun_id_fk": {
+          "name": "EvalRun_suiteRunId_EvalSuiteRun_id_fk",
+          "tableFrom": "EvalRun",
+          "tableTo": "EvalSuiteRun",
+          "columnsFrom": ["suiteRunId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EvalSuiteRun": {
+      "name": "EvalSuiteRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "EvalKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "EvalSuiteRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runMode": {
+          "name": "runMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pinned'"
+        },
+        "draftContentHash": {
+          "name": "draftContentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baselineSuiteRunId": {
+          "name": "baselineSuiteRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedureId": {
+          "name": "procedureId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedCount": {
+          "name": "requestedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completedCount": {
+          "name": "completedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "passedCount": {
+          "name": "passedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failedCount": {
+          "name": "failedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errorCount": {
+          "name": "errorCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cancelledCount": {
+          "name": "cancelledCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timedOutCount": {
+          "name": "timedOutCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "selectionSnapshot": {
+          "name": "selectionSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "EvalSuiteRun_organizationId_createdAt_idx": {
+          "name": "EvalSuiteRun_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EvalSuiteRun_status_idx": {
+          "name": "EvalSuiteRun_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EvalSuiteRun_agentId_createdAt_idx": {
+          "name": "EvalSuiteRun_agentId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EvalSuiteRun_organizationId_Organization_id_fk": {
+          "name": "EvalSuiteRun_organizationId_Organization_id_fk",
+          "tableFrom": "EvalSuiteRun",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EvalSuiteRun_baselineSuiteRunId_EvalSuiteRun_id_fk": {
+          "name": "EvalSuiteRun_baselineSuiteRunId_EvalSuiteRun_id_fk",
+          "tableFrom": "EvalSuiteRun",
+          "tableTo": "EvalSuiteRun",
+          "columnsFrom": ["baselineSuiteRunId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "EvalSuiteRun_createdById_User_id_fk": {
+          "name": "EvalSuiteRun_createdById_User_id_fk",
+          "tableFrom": "EvalSuiteRun",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Event": {
+      "name": "Event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "Event_organizationId_idx": {
+          "name": "Event_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Event_type_idx": {
+          "name": "Event_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Event_threadId_expr_idx": {
+          "name": "Event_threadId_expr_idx",
+          "columns": [
+            {
+              "expression": "((data->>'threadId'))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Event_organizationId_Organization_id_fk": {
+          "name": "Event_organizationId_Organization_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ExportJob": {
+      "name": "ExportJob",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tableId": {
+          "name": "tableId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewId": {
+          "name": "viewId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exportType": {
+          "name": "exportType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ExportJobStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sorting": {
+          "name": "sorting",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalRecords": {
+          "name": "totalRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processedRecords": {
+          "name": "processedRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "storageLocationId": {
+          "name": "storageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileSizeBytes": {
+          "name": "fileSizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ExportJob_organizationId_idx": {
+          "name": "ExportJob_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExportJob_status_idx": {
+          "name": "ExportJob_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExportJob_createdById_idx": {
+          "name": "ExportJob_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExportJob_entityDefinitionId_idx": {
+          "name": "ExportJob_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ExportJob_organizationId_Organization_id_fk": {
+          "name": "ExportJob_organizationId_Organization_id_fk",
+          "tableFrom": "ExportJob",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ExportJob_createdById_User_id_fk": {
+          "name": "ExportJob_createdById_User_id_fk",
+          "tableFrom": "ExportJob",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ExportJob_storageLocationId_StorageLocation_id_fk": {
+          "name": "ExportJob_storageLocationId_StorageLocation_id_fk",
+          "tableFrom": "ExportJob",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["storageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ExternalKnowledgeSource": {
+      "name": "ExternalKnowledgeSource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "syncEnabled": {
+          "name": "syncEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncInterval": {
+          "name": "syncInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextSyncAt": {
+          "name": "nextSyncAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ExternalKnowledgeSource_datasetId_idx": {
+          "name": "ExternalKnowledgeSource_datasetId_idx",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_datasetId_name_key": {
+          "name": "ExternalKnowledgeSource_datasetId_name_key",
+          "columns": [
+            {
+              "expression": "datasetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_nextSyncAt_idx": {
+          "name": "ExternalKnowledgeSource_nextSyncAt_idx",
+          "columns": [
+            {
+              "expression": "nextSyncAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_organizationId_idx": {
+          "name": "ExternalKnowledgeSource_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalKnowledgeSource_status_idx": {
+          "name": "ExternalKnowledgeSource_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ExternalKnowledgeSource_datasetId_Dataset_id_fk": {
+          "name": "ExternalKnowledgeSource_datasetId_Dataset_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ExternalKnowledgeSource_organizationId_Organization_id_fk": {
+          "name": "ExternalKnowledgeSource_organizationId_Organization_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ExternalKnowledgeSource_createdById_User_id_fk": {
+          "name": "ExternalKnowledgeSource_createdById_User_id_fk",
+          "tableFrom": "ExternalKnowledgeSource",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Favorite": {
+      "name": "Favorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationMemberId": {
+          "name": "organizationMemberId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "FavoriteNodeType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetIds": {
+          "name": "targetIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentFolderId": {
+          "name": "parentFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Favorite_member_idx": {
+          "name": "Favorite_member_idx",
+          "columns": [
+            {
+              "expression": "organizationMemberId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Favorite_organizationId_idx": {
+          "name": "Favorite_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Favorite_parentFolderId_idx": {
+          "name": "Favorite_parentFolderId_idx",
+          "columns": [
+            {
+              "expression": "parentFolderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Favorite_organizationId_Organization_id_fk": {
+          "name": "Favorite_organizationId_Organization_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Favorite_organizationMemberId_OrganizationMember_id_fk": {
+          "name": "Favorite_organizationMemberId_OrganizationMember_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "OrganizationMember",
+          "columnsFrom": ["organizationMemberId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Favorite_userId_User_id_fk": {
+          "name": "Favorite_userId_User_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Favorite_parentFolderId_Favorite_id_fk": {
+          "name": "Favorite_parentFolderId_Favorite_id_fk",
+          "tableFrom": "Favorite",
+          "tableTo": "Favorite",
+          "columnsFrom": ["parentFolderId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FieldValue": {
+      "name": "FieldValue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fieldId": {
+          "name": "fieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valueText": {
+          "name": "valueText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueNumber": {
+          "name": "valueNumber",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueBoolean": {
+          "name": "valueBoolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueDate": {
+          "name": "valueDate",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valueJson": {
+          "name": "valueJson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optionId": {
+          "name": "optionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityId": {
+          "name": "relatedEntityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityDefinitionId": {
+          "name": "relatedEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortKey": {
+          "name": "sortKey",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'a'"
+        },
+        "aiStatus": {
+          "name": "aiStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managedByConnectorId": {
+          "name": "managedByConnectorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FieldValue_organizationId_idx": {
+          "name": "FieldValue_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityId_idx": {
+          "name": "FieldValue_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityDefinitionId_idx": {
+          "name": "FieldValue_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_fieldId_idx": {
+          "name": "FieldValue_fieldId_idx",
+          "columns": [
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityId_fieldId_idx": {
+          "name": "FieldValue_entityId_fieldId_idx",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entityDefinitionId_entityId_idx": {
+          "name": "FieldValue_entityDefinitionId_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_orgId_fieldId_relatedEntityId_idx": {
+          "name": "FieldValue_orgId_fieldId_relatedEntityId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_optionId_idx": {
+          "name": "FieldValue_optionId_idx",
+          "columns": [
+            {
+              "expression": "optionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_relatedEntityId_idx": {
+          "name": "FieldValue_relatedEntityId_idx",
+          "columns": [
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_relatedEntityDefinitionId_idx": {
+          "name": "FieldValue_relatedEntityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "relatedEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_actorId_idx": {
+          "name": "FieldValue_actorId_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_entity_field_sortKey_key": {
+          "name": "FieldValue_entity_field_sortKey_key",
+          "columns": [
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_text_idx": {
+          "name": "FieldValue_lookup_text_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueText",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"valueText\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_number_idx": {
+          "name": "FieldValue_lookup_number_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"valueNumber\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_option_idx": {
+          "name": "FieldValue_lookup_option_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "optionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"optionId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_related_idx": {
+          "name": "FieldValue_lookup_related_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relatedEntityId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_actor_idx": {
+          "name": "FieldValue_lookup_actor_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"actorId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FieldValue_lookup_date_idx": {
+          "name": "FieldValue_lookup_date_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fieldId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"valueDate\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FieldValue_organizationId_Organization_id_fk": {
+          "name": "FieldValue_organizationId_Organization_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FieldValue_fieldId_CustomField_id_fk": {
+          "name": "FieldValue_fieldId_CustomField_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "CustomField",
+          "columnsFrom": ["fieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "FieldValue_actorId_User_id_fk": {
+          "name": "FieldValue_actorId_User_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "User",
+          "columnsFrom": ["actorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "FieldValue_managedByConnectorId_DataConnector_id_fk": {
+          "name": "FieldValue_managedByConnectorId_DataConnector_id_fk",
+          "tableFrom": "FieldValue",
+          "tableTo": "DataConnector",
+          "columnsFrom": ["managedByConnectorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FileAttachment": {
+      "name": "FileAttachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachableId": {
+          "name": "attachableId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachableType": {
+          "name": "attachableType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FileAttachment_attachableId_attachableType_idx": {
+          "name": "FileAttachment_attachableId_attachableType_idx",
+          "columns": [
+            {
+              "expression": "attachableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FileAttachment_fileId_attachableId_attachableType_key": {
+          "name": "FileAttachment_fileId_attachableId_attachableType_key",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachableType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FileAttachment_fileId_File_id_fk": {
+          "name": "FileAttachment_fileId_File_id_fk",
+          "tableFrom": "FileAttachment",
+          "tableTo": "File",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FileVersion": {
+      "name": "FileVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageLocationId": {
+          "name": "storageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "FileVersion_fileId_createdAt_idx": {
+          "name": "FileVersion_fileId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FileVersion_fileId_versionNumber_key": {
+          "name": "FileVersion_fileId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FileVersion_fileId_FolderFile_id_fk": {
+          "name": "FileVersion_fileId_FolderFile_id_fk",
+          "tableFrom": "FileVersion",
+          "tableTo": "FolderFile",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FileVersion_storageLocationId_StorageLocation_id_fk": {
+          "name": "FileVersion_storageLocationId_StorageLocation_id_fk",
+          "tableFrom": "FileVersion",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["storageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.File": {
+      "name": "File",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashedKey": {
+          "name": "hashedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedById": {
+          "name": "deletedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "articleId": {
+          "name": "articleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "knowledgeBaseId": {
+          "name": "knowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloadCount": {
+          "name": "downloadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "FileStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "FileVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        }
+      },
+      "indexes": {
+        "File_checksum_organizationId_idx": {
+          "name": "File_checksum_organizationId_idx",
+          "columns": [
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_hashedKey_key": {
+          "name": "File_hashedKey_key",
+          "columns": [
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_organizationId_status_idx": {
+          "name": "File_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_status_expiresAt_idx": {
+          "name": "File_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "File_visibility_hashedKey_idx": {
+          "name": "File_visibility_hashedKey_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hashedKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "File_createdById_User_id_fk": {
+          "name": "File_createdById_User_id_fk",
+          "tableFrom": "File",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "File_organizationId_Organization_id_fk": {
+          "name": "File_organizationId_Organization_id_fk",
+          "tableFrom": "File",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "File_deletedById_User_id_fk": {
+          "name": "File_deletedById_User_id_fk",
+          "tableFrom": "File",
+          "tableTo": "User",
+          "columnsFrom": ["deletedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "File_articleId_Article_id_fk": {
+          "name": "File_articleId_Article_id_fk",
+          "tableFrom": "File",
+          "tableTo": "Article",
+          "columnsFrom": ["articleId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "File_knowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "File_knowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "File",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["knowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FolderFile": {
+      "name": "FolderFile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentVersionId": {
+          "name": "currentVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FolderFile_currentVersionId_key": {
+          "name": "FolderFile_currentVersionId_key",
+          "columns": [
+            {
+              "expression": "currentVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_checksum_idx": {
+          "name": "FolderFile_organizationId_checksum_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_deletedAt_isArchived_idx": {
+          "name": "FolderFile_organizationId_deletedAt_isArchived_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_ext_createdAt_idx": {
+          "name": "FolderFile_organizationId_ext_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ext",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_folderId_idx": {
+          "name": "FolderFile_organizationId_folderId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_folderId_path_idx": {
+          "name": "FolderFile_organizationId_folderId_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_mimeType_updatedAt_idx": {
+          "name": "FolderFile_organizationId_mimeType_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mimeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_name_idx": {
+          "name": "FolderFile_organizationId_name_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_path_idx": {
+          "name": "FolderFile_organizationId_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_organizationId_updatedAt_idx": {
+          "name": "FolderFile_organizationId_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FolderFile_path_name_idx": {
+          "name": "FolderFile_path_name_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "FolderFile_organizationId_Organization_id_fk": {
+          "name": "FolderFile_organizationId_Organization_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_folderId_Folder_id_fk": {
+          "name": "FolderFile_folderId_Folder_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "Folder",
+          "columnsFrom": ["folderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_currentVersionId_FileVersion_id_fk": {
+          "name": "FolderFile_currentVersionId_FileVersion_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "FileVersion",
+          "columnsFrom": ["currentVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "FolderFile_createdById_User_id_fk": {
+          "name": "FolderFile_createdById_User_id_fk",
+          "tableFrom": "FolderFile",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Folder": {
+      "name": "Folder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Folder_organizationId_deletedAt_isArchived_idx": {
+          "name": "Folder_organizationId_deletedAt_isArchived_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_depth_path_idx": {
+          "name": "Folder_organizationId_depth_path_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_parentId_idx": {
+          "name": "Folder_organizationId_parentId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_organizationId_parentId_name_key": {
+          "name": "Folder_organizationId_parentId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Folder_parentId_name_idx": {
+          "name": "Folder_parentId_name_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Folder_organizationId_Organization_id_fk": {
+          "name": "Folder_organizationId_Organization_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Folder_parentId_Folder_id_fk": {
+          "name": "Folder_parentId_Folder_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "Folder",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Folder_createdById_User_id_fk": {
+          "name": "Folder_createdById_User_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FreeToolLead": {
+      "name": "FreeToolLead",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolSlug": {
+          "name": "toolSlug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utmSource": {
+          "name": "utmSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utmMedium": {
+          "name": "utmMedium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utmCampaign": {
+          "name": "utmCampaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FreeToolLead_toolSlug_idx": {
+          "name": "FreeToolLead_toolSlug_idx",
+          "columns": [
+            {
+              "expression": "toolSlug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FreeToolLead_email_idx": {
+          "name": "FreeToolLead_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FreeToolLead_createdAt_idx": {
+          "name": "FreeToolLead_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobMappableProperty": {
+      "name": "ImportJobMappableProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnIndex": {
+          "name": "columnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibleName": {
+          "name": "visibleName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ImportJobMappableProperty_importJobId_idx": {
+          "name": "ImportJobMappableProperty_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobMappableProperty_jobId_columnIndex_key": {
+          "name": "ImportJobMappableProperty_jobId_columnIndex_key",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobMappableProperty_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobMappableProperty_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobMappableProperty",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobProperty": {
+      "name": "ImportJobProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingPropertyId": {
+          "name": "importMappingPropertyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uniqueValueCount": {
+          "name": "uniqueValueCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolvedCount": {
+          "name": "resolvedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errorCount": {
+          "name": "errorCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ImportJobProperty_importJobId_idx": {
+          "name": "ImportJobProperty_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobProperty_jobId_mappingPropertyId_key": {
+          "name": "ImportJobProperty_jobId_mappingPropertyId_key",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "importMappingPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobProperty_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobProperty_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobProperty",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJobProperty_importMappingPropertyId_ImportMappingProperty_id_fk": {
+          "name": "ImportJobProperty_importMappingPropertyId_ImportMappingProperty_id_fk",
+          "tableFrom": "ImportJobProperty",
+          "tableTo": "ImportMappingProperty",
+          "columnsFrom": ["importMappingPropertyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJobRawData": {
+      "name": "ImportJobRawData",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnIndex": {
+          "name": "columnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "valueHash": {
+          "name": "valueHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ImportJobRawData_importJobId_idx": {
+          "name": "ImportJobRawData_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_importJobId_rowIndex_idx": {
+          "name": "ImportJobRawData_importJobId_rowIndex_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_importJobId_columnIndex_idx": {
+          "name": "ImportJobRawData_importJobId_columnIndex_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJobRawData_valueHash_idx": {
+          "name": "ImportJobRawData_valueHash_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "columnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valueHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJobRawData_importJobId_ImportJob_id_fk": {
+          "name": "ImportJobRawData_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportJobRawData",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportJob": {
+      "name": "ImportJob",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingId": {
+          "name": "importMappingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceFileName": {
+          "name": "sourceFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnCount": {
+          "name": "columnCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowCount": {
+          "name": "rowCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalChunks": {
+          "name": "totalChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedChunks": {
+          "name": "receivedChunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportJobStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "ingestionFailureReason": {
+          "name": "ingestionFailureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowPlanGeneration": {
+          "name": "allowPlanGeneration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedExecutionAt": {
+          "name": "startedExecutionAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportJob_organizationId_idx": {
+          "name": "ImportJob_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_importMappingId_idx": {
+          "name": "ImportJob_importMappingId_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_status_idx": {
+          "name": "ImportJob_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportJob_createdById_idx": {
+          "name": "ImportJob_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportJob_organizationId_Organization_id_fk": {
+          "name": "ImportJob_organizationId_Organization_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJob_importMappingId_ImportMapping_id_fk": {
+          "name": "ImportJob_importMappingId_ImportMapping_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "ImportMapping",
+          "columnsFrom": ["importMappingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportJob_createdById_User_id_fk": {
+          "name": "ImportJob_createdById_User_id_fk",
+          "tableFrom": "ImportJob",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportMappingProperty": {
+      "name": "ImportMappingProperty",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importMappingId": {
+          "name": "importMappingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceColumnIndex": {
+          "name": "sourceColumnIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceColumnName": {
+          "name": "sourceColumnName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "ImportMappingTargetType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip'"
+        },
+        "targetFieldKey": {
+          "name": "targetFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customFieldId": {
+          "name": "customFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionType": {
+          "name": "resolutionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text:value'"
+        },
+        "resolutionConfig": {
+          "name": "resolutionConfig",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportMappingProperty_importMappingId_idx": {
+          "name": "ImportMappingProperty_importMappingId_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportMappingProperty_sourceColumnIndex_idx": {
+          "name": "ImportMappingProperty_sourceColumnIndex_idx",
+          "columns": [
+            {
+              "expression": "importMappingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceColumnIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportMappingProperty_importMappingId_ImportMapping_id_fk": {
+          "name": "ImportMappingProperty_importMappingId_ImportMapping_id_fk",
+          "tableFrom": "ImportMappingProperty",
+          "tableTo": "ImportMapping",
+          "columnsFrom": ["importMappingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportMappingProperty_customFieldId_CustomField_id_fk": {
+          "name": "ImportMappingProperty_customFieldId_CustomField_id_fk",
+          "tableFrom": "ImportMappingProperty",
+          "tableTo": "CustomField",
+          "columnsFrom": ["customFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportMapping": {
+      "name": "ImportMapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv'"
+        },
+        "defaultStrategy": {
+          "name": "defaultStrategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'create'"
+        },
+        "identifierFieldKey": {
+          "name": "identifierFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportMapping_organizationId_idx": {
+          "name": "ImportMapping_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportMapping_entityDefinitionId_idx": {
+          "name": "ImportMapping_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportMapping_organizationId_Organization_id_fk": {
+          "name": "ImportMapping_organizationId_Organization_id_fk",
+          "tableFrom": "ImportMapping",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportMapping_createdById_User_id_fk": {
+          "name": "ImportMapping_createdById_User_id_fk",
+          "tableFrom": "ImportMapping",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlanRow": {
+      "name": "ImportPlanRow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importPlanStrategyId": {
+          "name": "importPlanStrategyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "existingRecordId": {
+          "name": "existingRecordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportPlanRowStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "resultRecordId": {
+          "name": "resultRecordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAt": {
+          "name": "executedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlanRow_importPlanStrategyId_idx": {
+          "name": "ImportPlanRow_importPlanStrategyId_idx",
+          "columns": [
+            {
+              "expression": "importPlanStrategyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanRow_status_idx": {
+          "name": "ImportPlanRow_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanRow_strategyId_rowIndex_key": {
+          "name": "ImportPlanRow_strategyId_rowIndex_key",
+          "columns": [
+            {
+              "expression": "importPlanStrategyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlanRow_importPlanStrategyId_ImportPlanStrategy_id_fk": {
+          "name": "ImportPlanRow_importPlanStrategyId_ImportPlanStrategy_id_fk",
+          "tableFrom": "ImportPlanRow",
+          "tableTo": "ImportPlanStrategy",
+          "columnsFrom": ["importPlanStrategyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlanStrategy": {
+      "name": "ImportPlanStrategy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importPlanId": {
+          "name": "importPlanId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "ImportStrategyType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matchingFieldKey": {
+          "name": "matchingFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matchingCustomFieldId": {
+          "name": "matchingCustomFieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportStrategyStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning_queued'"
+        },
+        "planningProgress": {
+          "name": "planningProgress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planningStartedAt": {
+          "name": "planningStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planningCompletedAt": {
+          "name": "planningCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionStartedAt": {
+          "name": "executionStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionCompletedAt": {
+          "name": "executionCompletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlanStrategy_importPlanId_idx": {
+          "name": "ImportPlanStrategy_importPlanId_idx",
+          "columns": [
+            {
+              "expression": "importPlanId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlanStrategy_strategy_idx": {
+          "name": "ImportPlanStrategy_strategy_idx",
+          "columns": [
+            {
+              "expression": "strategy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlanStrategy_importPlanId_ImportPlan_id_fk": {
+          "name": "ImportPlanStrategy_importPlanId_ImportPlan_id_fk",
+          "tableFrom": "ImportPlanStrategy",
+          "tableTo": "ImportPlan",
+          "columnsFrom": ["importPlanId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ImportPlanStrategy_matchingCustomFieldId_CustomField_id_fk": {
+          "name": "ImportPlanStrategy_matchingCustomFieldId_CustomField_id_fk",
+          "tableFrom": "ImportPlanStrategy",
+          "tableTo": "CustomField",
+          "columnsFrom": ["matchingCustomFieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportPlan": {
+      "name": "ImportPlan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobId": {
+          "name": "importJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportPlanStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning'"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportPlan_importJobId_idx": {
+          "name": "ImportPlan_importJobId_idx",
+          "columns": [
+            {
+              "expression": "importJobId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportPlan_status_idx": {
+          "name": "ImportPlan_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportPlan_importJobId_ImportJob_id_fk": {
+          "name": "ImportPlan_importJobId_ImportJob_id_fk",
+          "tableFrom": "ImportPlan",
+          "tableTo": "ImportJob",
+          "columnsFrom": ["importJobId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ImportValueResolution": {
+      "name": "ImportValueResolution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importJobPropertyId": {
+          "name": "importJobPropertyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashedValue": {
+          "name": "hashedValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rawValue": {
+          "name": "rawValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cellCount": {
+          "name": "cellCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "resolvedValues": {
+          "name": "resolvedValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ImportResolutionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "isValid": {
+          "name": "isValid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userOverride": {
+          "name": "userOverride",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overriddenAt": {
+          "name": "overriddenAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ImportValueResolution_importJobPropertyId_idx": {
+          "name": "ImportValueResolution_importJobPropertyId_idx",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportValueResolution_propertyId_hash_key": {
+          "name": "ImportValueResolution_propertyId_hash_key",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hashedValue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ImportValueResolution_status_idx": {
+          "name": "ImportValueResolution_status_idx",
+          "columns": [
+            {
+              "expression": "importJobPropertyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ImportValueResolution_importJobPropertyId_ImportJobProperty_id_fk": {
+          "name": "ImportValueResolution_importJobPropertyId_ImportJobProperty_id_fk",
+          "tableFrom": "ImportValueResolution",
+          "tableTo": "ImportJobProperty",
+          "columnsFrom": ["importJobPropertyId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.InboxIntegration": {
+      "name": "InboxIntegration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "InboxIntegration_inboxId_idx": {
+          "name": "InboxIntegration_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InboxIntegration_inboxId_integrationId_key": {
+          "name": "InboxIntegration_inboxId_integrationId_key",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InboxIntegration_integrationId_key": {
+          "name": "InboxIntegration_integrationId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "InboxIntegration_inboxId_EntityInstance_id_fk": {
+          "name": "InboxIntegration_inboxId_EntityInstance_id_fk",
+          "tableFrom": "InboxIntegration",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "InboxIntegration_integrationId_Integration_id_fk": {
+          "name": "InboxIntegration_integrationId_Integration_id_fk",
+          "tableFrom": "InboxIntegration",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.InsightTemplate": {
+      "name": "InsightTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiTitle": {
+          "name": "aiTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "InsightTemplateStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enabled'"
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "InsightTemplate_organizationId_idx": {
+          "name": "InsightTemplate_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "InsightTemplate_organizationId_status_idx": {
+          "name": "InsightTemplate_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "InsightTemplate_organizationId_Organization_id_fk": {
+          "name": "InsightTemplate_organizationId_Organization_id_fk",
+          "tableFrom": "InsightTemplate",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "InsightTemplate_createdById_User_id_fk": {
+          "name": "InsightTemplate_createdById_User_id_fk",
+          "tableFrom": "InsightTemplate",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Integration": {
+      "name": "Integration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "IntegrationProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSuccessfulSync": {
+          "name": "lastSuccessfulSync",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHistoryId": {
+          "name": "lastHistoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncStatus": {
+          "name": "syncStatus",
+          "type": "IntegrationSyncStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOT_SYNCED'"
+        },
+        "syncStage": {
+          "name": "syncStage",
+          "type": "IntegrationSyncStage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDLE'"
+        },
+        "syncStageStartedAt": {
+          "name": "syncStageStartedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "throttleFailureCount": {
+          "name": "throttleFailureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "throttleRetryAfter": {
+          "name": "throttleRetryAfter",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncMode": {
+          "name": "syncMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "pollingIntervalMs": {
+          "name": "pollingIntervalMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 300000
+        },
+        "is_example": {
+          "name": "is_example",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Integration_organizationId_provider_email_key": {
+          "name": "Integration_organizationId_provider_email_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"Integration\".\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_organizationId_idx": {
+          "name": "Integration_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_provider_organizationId_idx": {
+          "name": "Integration_provider_organizationId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_credentialId_idx": {
+          "name": "Integration_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Integration_syncStatus_idx": {
+          "name": "Integration_syncStatus_idx",
+          "columns": [
+            {
+              "expression": "syncStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Integration_organizationId_Organization_id_fk": {
+          "name": "Integration_organizationId_Organization_id_fk",
+          "tableFrom": "Integration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Integration_credentialId_Credential_id_fk": {
+          "name": "Integration_credentialId_Credential_id_fk",
+          "tableFrom": "Integration",
+          "tableTo": "Credential",
+          "columnsFrom": ["credentialId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.IntegrationTagLabel": {
+      "name": "IntegrationTagLabel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IntegrationTagLabel_integrationId_idx": {
+          "name": "IntegrationTagLabel_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_integrationId_labelId_key": {
+          "name": "IntegrationTagLabel_integrationId_labelId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "labelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_integrationId_tagId_key": {
+          "name": "IntegrationTagLabel_integrationId_tagId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IntegrationTagLabel_organizationId_idx": {
+          "name": "IntegrationTagLabel_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "IntegrationTagLabel_tagId_Tag_id_fk": {
+          "name": "IntegrationTagLabel_tagId_Tag_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Tag",
+          "columnsFrom": ["tagId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "IntegrationTagLabel_labelId_Label_id_fk": {
+          "name": "IntegrationTagLabel_labelId_Label_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Label",
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "IntegrationTagLabel_organizationId_Organization_id_fk": {
+          "name": "IntegrationTagLabel_organizationId_Organization_id_fk",
+          "tableFrom": "IntegrationTagLabel",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Invoice": {
+      "name": "Invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoiceNumber": {
+          "name": "invoiceNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InvoiceStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "invoiceDate": {
+          "name": "invoiceDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paidDate": {
+          "name": "paidDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billingReason": {
+          "name": "billingReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeInvoiceId": {
+          "name": "stripeInvoiceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdfUrl": {
+          "name": "pdfUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Invoice_organizationId_idx": {
+          "name": "Invoice_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Invoice_stripeInvoiceId_key": {
+          "name": "Invoice_stripeInvoiceId_key",
+          "columns": [
+            {
+              "expression": "stripeInvoiceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Invoice_subscriptionId_idx": {
+          "name": "Invoice_subscriptionId_idx",
+          "columns": [
+            {
+              "expression": "subscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Invoice_organizationId_Organization_id_fk": {
+          "name": "Invoice_organizationId_Organization_id_fk",
+          "tableFrom": "Invoice",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Invoice_subscriptionId_PlanSubscription_id_fk": {
+          "name": "Invoice_subscriptionId_PlanSubscription_id_fk",
+          "tableFrom": "Invoice",
+          "tableTo": "PlanSubscription",
+          "columnsFrom": ["subscriptionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KeyValuePair": {
+      "name": "KeyValuePair",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEncrypted": {
+          "name": "isEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedById": {
+          "name": "updatedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "KeyValuePair_key_userId_organizationId_key": {
+          "name": "KeyValuePair_key_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_organizationId_null_userId_key": {
+          "name": "KeyValuePair_key_organizationId_null_userId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"userId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_userId_null_organizationId_key": {
+          "name": "KeyValuePair_key_userId_null_organizationId_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organizationId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_key_system_unique": {
+          "name": "KeyValuePair_key_system_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"userId\" IS NULL AND \"organizationId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_type_idx": {
+          "name": "KeyValuePair_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_organizationId_idx": {
+          "name": "KeyValuePair_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KeyValuePair_userId_idx": {
+          "name": "KeyValuePair_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "KeyValuePair_organizationId_Organization_id_fk": {
+          "name": "KeyValuePair_organizationId_Organization_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KeyValuePair_userId_User_id_fk": {
+          "name": "KeyValuePair_userId_User_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KeyValuePair_updatedById_User_id_fk": {
+          "name": "KeyValuePair_updatedById_User_id_fk",
+          "tableFrom": "KeyValuePair",
+          "tableTo": "User",
+          "columnsFrom": ["updatedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KnowledgeBase": {
+      "name": "KnowledgeBase",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "KBKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "publishStatus": {
+          "name": "publishStatus",
+          "type": "KBPublishStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPublishedAt": {
+          "name": "lastPublishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "KBVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLIC'"
+        },
+        "customDomainVerifiedAt": {
+          "name": "customDomainVerifiedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customDomain": {
+          "name": "customDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoDark": {
+          "name": "logoDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoLight": {
+          "name": "logoLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'clean'"
+        },
+        "showMode": {
+          "name": "showMode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "defaultMode": {
+          "name": "defaultMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'light'"
+        },
+        "primaryColorLight": {
+          "name": "primaryColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryColorDark": {
+          "name": "primaryColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tintColorLight": {
+          "name": "tintColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tintColorDark": {
+          "name": "tintColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "infoColorLight": {
+          "name": "infoColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "infoColorDark": {
+          "name": "infoColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successColorLight": {
+          "name": "successColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successColorDark": {
+          "name": "successColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warningColorLight": {
+          "name": "warningColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warningColorDark": {
+          "name": "warningColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dangerColorLight": {
+          "name": "dangerColorLight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dangerColorDark": {
+          "name": "dangerColorDark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fontFamily": {
+          "name": "fontFamily",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iconsFamily": {
+          "name": "iconsFamily",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'regular'"
+        },
+        "cornerStyle": {
+          "name": "cornerStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'rounded'"
+        },
+        "sidebarListStyle": {
+          "name": "sidebarListStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "searchbarPosition": {
+          "name": "searchbarPosition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "headerEnabled": {
+          "name": "headerEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "footerEnabled": {
+          "name": "footerEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "headerNavigation": {
+          "name": "headerNavigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "footerNavigation": {
+          "name": "footerNavigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoDarkId": {
+          "name": "logoDarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logoLightId": {
+          "name": "logoLightId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draftSettings": {
+          "name": "draftSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datasetId": {
+          "name": "datasetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "KnowledgeBase_logoDarkId_key": {
+          "name": "KnowledgeBase_logoDarkId_key",
+          "columns": [
+            {
+              "expression": "logoDarkId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_logoLightId_key": {
+          "name": "KnowledgeBase_logoLightId_key",
+          "columns": [
+            {
+              "expression": "logoLightId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_organizationId_idx": {
+          "name": "KnowledgeBase_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeBase_organizationId_slug_key": {
+          "name": "KnowledgeBase_organizationId_slug_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "KnowledgeBase_organizationId_Organization_id_fk": {
+          "name": "KnowledgeBase_organizationId_Organization_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeBase_logoDarkId_MediaAsset_id_fk": {
+          "name": "KnowledgeBase_logoDarkId_MediaAsset_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["logoDarkId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeBase_logoLightId_MediaAsset_id_fk": {
+          "name": "KnowledgeBase_logoLightId_MediaAsset_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["logoLightId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeBase_datasetId_Dataset_id_fk": {
+          "name": "KnowledgeBase_datasetId_Dataset_id_fk",
+          "tableFrom": "KnowledgeBase",
+          "tableTo": "Dataset",
+          "columnsFrom": ["datasetId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.KnowledgeSource": {
+      "name": "KnowledgeSource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "KnowledgeSourceSurface",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'publishable'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ownedKnowledgeBaseId": {
+          "name": "ownedKnowledgeBaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rootFolderArticleId": {
+          "name": "rootFolderArticleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncBehavior": {
+          "name": "syncBehavior",
+          "type": "KnowledgeSourceSyncBehavior",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "scheduleConfig": {
+          "name": "scheduleConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "KnowledgeSourceStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastJobId": {
+          "name": "lastJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itemCount": {
+          "name": "itemCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "KnowledgeSource_organizationId_idx": {
+          "name": "KnowledgeSource_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "KnowledgeSource_ownedKnowledgeBaseId_idx": {
+          "name": "KnowledgeSource_ownedKnowledgeBaseId_idx",
+          "columns": [
+            {
+              "expression": "ownedKnowledgeBaseId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "KnowledgeSource_organizationId_Organization_id_fk": {
+          "name": "KnowledgeSource_organizationId_Organization_id_fk",
+          "tableFrom": "KnowledgeSource",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeSource_ownedKnowledgeBaseId_KnowledgeBase_id_fk": {
+          "name": "KnowledgeSource_ownedKnowledgeBaseId_KnowledgeBase_id_fk",
+          "tableFrom": "KnowledgeSource",
+          "tableTo": "KnowledgeBase",
+          "columnsFrom": ["ownedKnowledgeBaseId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeSource_rootFolderArticleId_Article_id_fk": {
+          "name": "KnowledgeSource_rootFolderArticleId_Article_id_fk",
+          "tableFrom": "KnowledgeSource",
+          "tableTo": "Article",
+          "columnsFrom": ["rootFolderArticleId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "KnowledgeSource_createdById_User_id_fk": {
+          "name": "KnowledgeSource_createdById_User_id_fk",
+          "tableFrom": "KnowledgeSource",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Label": {
+      "name": "Label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationType": {
+          "name": "integrationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isVisible": {
+          "name": "isVisible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "backgroundColor": {
+          "name": "backgroundColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textColor": {
+          "name": "textColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "LabelType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerCursor": {
+          "name": "providerCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pendingAction": {
+          "name": "pendingAction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSentBox": {
+          "name": "isSentBox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parentLabelId": {
+          "name": "parentLabelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCheckpoint": {
+          "name": "syncCheckpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Label_labelId_organizationId_integrationId_key": {
+          "name": "Label_labelId_organizationId_integrationId_key",
+          "columns": [
+            {
+              "expression": "labelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Label_name_organizationId_integrationId_idx": {
+          "name": "Label_name_organizationId_integrationId_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Label_integrationId_idx": {
+          "name": "Label_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Label_organizationId_Organization_id_fk": {
+          "name": "Label_organizationId_Organization_id_fk",
+          "tableFrom": "Label",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Label_parentLabelId_Label_id_fk": {
+          "name": "Label_parentLabelId_Label_id_fk",
+          "tableFrom": "Label",
+          "tableTo": "Label",
+          "columnsFrom": ["parentLabelId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LabelsOnThread": {
+      "name": "LabelsOnThread",
+      "schema": "",
+      "columns": {
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "LabelsOnThread_threadId_Thread_id_fk": {
+          "name": "LabelsOnThread_threadId_Thread_id_fk",
+          "tableFrom": "LabelsOnThread",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "LabelsOnThread_labelId_Label_id_fk": {
+          "name": "LabelsOnThread_labelId_Label_id_fk",
+          "tableFrom": "LabelsOnThread",
+          "tableTo": "Label",
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "LabelsOnThread_pkey": {
+          "name": "LabelsOnThread_pkey",
+          "columns": ["threadId", "labelId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LoadBalancingConfig": {
+      "name": "LoadBalancingConfig",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "LoadBalancingConfig_organizationId_provider_model_idx": {
+          "name": "LoadBalancingConfig_organizationId_provider_model_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LoadBalancingConfig_connectionId_idx": {
+          "name": "LoadBalancingConfig_connectionId_idx",
+          "columns": [
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LoadBalancingConfig_organizationId_provider_model_modelType_key": {
+          "name": "LoadBalancingConfig_organizationId_provider_model_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LoadBalancingConfig_organizationId_Organization_id_fk": {
+          "name": "LoadBalancingConfig_organizationId_Organization_id_fk",
+          "tableFrom": "LoadBalancingConfig",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "LoadBalancingConfig_connectionId_Credential_id_fk": {
+          "name": "LoadBalancingConfig_connectionId_Credential_id_fk",
+          "tableFrom": "LoadBalancingConfig",
+          "tableTo": "Credential",
+          "columnsFrom": ["connectionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MailDomain": {
+      "name": "MailDomain",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "DomainType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CUSTOM'"
+        },
+        "routingPrefix": {
+          "name": "routingPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "isVerified": {
+          "name": "isVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verificationToken": {
+          "name": "verificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookKey": {
+          "name": "webhookKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "MailDomain_organizationId_domain_key": {
+          "name": "MailDomain_organizationId_domain_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MailDomain_organizationId_Organization_id_fk": {
+          "name": "MailDomain_organizationId_Organization_id_fk",
+          "tableFrom": "MailDomain",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MailView": {
+      "name": "MailView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortField": {
+          "name": "sortField",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortDirection": {
+          "name": "sortDirection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'desc'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "MailView_isDefault_idx": {
+          "name": "MailView_isDefault_idx",
+          "columns": [
+            {
+              "expression": "isDefault",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_name_userId_organizationId_key": {
+          "name": "MailView_name_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_organizationId_idx": {
+          "name": "MailView_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MailView_userId_idx": {
+          "name": "MailView_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MailView_organizationId_Organization_id_fk": {
+          "name": "MailView_organizationId_Organization_id_fk",
+          "tableFrom": "MailView",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MailView_userId_User_id_fk": {
+          "name": "MailView_userId_User_id_fk",
+          "tableFrom": "MailView",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpInstallation": {
+      "name": "McpInstallation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcpServerId": {
+          "name": "mcpServerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "serverInfo": {
+          "name": "serverInfo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocolVersion": {
+          "name": "protocolVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncError": {
+          "name": "lastSyncError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpInstallation_org_server_idx": {
+          "name": "McpInstallation_org_server_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mcpServerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpInstallation_organizationId_Organization_id_fk": {
+          "name": "McpInstallation_organizationId_Organization_id_fk",
+          "tableFrom": "McpInstallation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "McpInstallation_mcpServerId_McpServer_id_fk": {
+          "name": "McpInstallation_mcpServerId_McpServer_id_fk",
+          "tableFrom": "McpInstallation",
+          "tableTo": "McpServer",
+          "columnsFrom": ["mcpServerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpServer": {
+      "name": "McpServer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authDiscovery": {
+          "name": "authDiscovery",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpServer_org_slug_idx": {
+          "name": "McpServer_org_slug_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpServer_org_idx": {
+          "name": "McpServer_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpServer_organizationId_Organization_id_fk": {
+          "name": "McpServer_organizationId_Organization_id_fk",
+          "tableFrom": "McpServer",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "McpServer_createdById_User_id_fk": {
+          "name": "McpServer_createdById_User_id_fk",
+          "tableFrom": "McpServer",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MediaAsset": {
+      "name": "MediaAsset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentVersionId": {
+          "name": "currentVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ORIGINAL'"
+        }
+      },
+      "indexes": {
+        "MediaAsset_currentVersionId_key": {
+          "name": "MediaAsset_currentVersionId_key",
+          "columns": [
+            {
+              "expression": "currentVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_expiresAt_idx": {
+          "name": "MediaAsset_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_id_organizationId_key": {
+          "name": "MediaAsset_id_organizationId_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_kind_isPrivate_idx": {
+          "name": "MediaAsset_kind_isPrivate_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPrivate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_expiresAt_idx": {
+          "name": "MediaAsset_organizationId_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_kind_idx": {
+          "name": "MediaAsset_organizationId_kind_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAsset_organizationId_purpose_kind_idx": {
+          "name": "MediaAsset_organizationId_purpose_kind_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_assets": {
+          "name": "idx_thumbnail_assets",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((kind = 'THUMBNAIL'::text) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MediaAsset_organizationId_Organization_id_fk": {
+          "name": "MediaAsset_organizationId_Organization_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAsset_currentVersionId_MediaAssetVersion_id_fk": {
+          "name": "MediaAsset_currentVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["currentVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "MediaAsset_createdById_User_id_fk": {
+          "name": "MediaAsset_createdById_User_id_fk",
+          "tableFrom": "MediaAsset",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MediaAssetVersion": {
+      "name": "MediaAssetVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assetId": {
+          "name": "assetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageLocationId": {
+          "name": "storageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivedFromVersionId": {
+          "name": "derivedFromVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preset": {
+          "name": "preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "AssetVersionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        }
+      },
+      "indexes": {
+        "MediaAssetVersion_assetId_createdAt_idx": {
+          "name": "MediaAssetVersion_assetId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_assetId_versionNumber_key": {
+          "name": "MediaAssetVersion_assetId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "assetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_derivedFromVersionId_preset_key": {
+          "name": "MediaAssetVersion_derivedFromVersionId_preset_key",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_derivedFromVersionId_preset_status_idx": {
+          "name": "MediaAssetVersion_derivedFromVersionId_preset_status_idx",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MediaAssetVersion_status_idx": {
+          "name": "MediaAssetVersion_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_cleanup": {
+          "name": "idx_thumbnail_cleanup",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_thumbnail_lookup_covering": {
+          "name": "idx_thumbnail_lookup_covering",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_unique_thumbnail": {
+          "name": "idx_unique_thumbnail",
+          "columns": [
+            {
+              "expression": "derivedFromVersionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "((\"derivedFromVersionId\" IS NOT NULL) AND (\"deletedAt\" IS NULL))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MediaAssetVersion_assetId_MediaAsset_id_fk": {
+          "name": "MediaAssetVersion_assetId_MediaAsset_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["assetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAssetVersion_storageLocationId_StorageLocation_id_fk": {
+          "name": "MediaAssetVersion_storageLocationId_StorageLocation_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["storageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MediaAssetVersion_derivedFromVersionId_MediaAssetVersion_id_fk": {
+          "name": "MediaAssetVersion_derivedFromVersionId_MediaAssetVersion_id_fk",
+          "tableFrom": "MediaAssetVersion",
+          "tableTo": "MediaAssetVersion",
+          "columnsFrom": ["derivedFromVersionId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MeetingParticipant": {
+      "name": "MeetingParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetingId": {
+          "name": "meetingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailDomain": {
+          "name": "emailDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contactEntityInstanceId": {
+          "name": "contactEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "companyEntityInstanceId": {
+          "name": "companyEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rsvpStatus": {
+          "name": "rsvpStatus",
+          "type": "RsvpStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'needs_action'"
+        },
+        "isBot": {
+          "name": "isBot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isExternal": {
+          "name": "isExternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "MeetingParticipant_organizationId_idx": {
+          "name": "MeetingParticipant_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_meetingId_idx": {
+          "name": "MeetingParticipant_meetingId_idx",
+          "columns": [
+            {
+              "expression": "meetingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_calendarEventId_idx": {
+          "name": "MeetingParticipant_calendarEventId_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_email_idx": {
+          "name": "MeetingParticipant_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_emailDomain_idx": {
+          "name": "MeetingParticipant_emailDomain_idx",
+          "columns": [
+            {
+              "expression": "emailDomain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_contactEntityInstanceId_idx": {
+          "name": "MeetingParticipant_contactEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "contactEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MeetingParticipant_companyEntityInstanceId_idx": {
+          "name": "MeetingParticipant_companyEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "companyEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MeetingParticipant_organizationId_Organization_id_fk": {
+          "name": "MeetingParticipant_organizationId_Organization_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_meetingId_EntityInstance_id_fk": {
+          "name": "MeetingParticipant_meetingId_EntityInstance_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["meetingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_calendarEventId_CalendarEvent_id_fk": {
+          "name": "MeetingParticipant_calendarEventId_CalendarEvent_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "CalendarEvent",
+          "columnsFrom": ["calendarEventId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_userId_User_id_fk": {
+          "name": "MeetingParticipant_userId_User_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_contactEntityInstanceId_EntityInstance_id_fk": {
+          "name": "MeetingParticipant_contactEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["contactEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "MeetingParticipant_companyEntityInstanceId_EntityInstance_id_fk": {
+          "name": "MeetingParticipant_companyEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "MeetingParticipant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["companyEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalThreadId": {
+          "name": "externalThreadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isInbound": {
+          "name": "isInbound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isFirstInThread": {
+          "name": "isFirstInThread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textHtml": {
+          "name": "textHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "textPlain": {
+          "name": "textPlain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internetMessageId": {
+          "name": "internetMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromId": {
+          "name": "fromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replyToId": {
+          "name": "replyToId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isReply": {
+          "name": "isReply",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "historyId": {
+          "name": "historyId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedAt": {
+          "name": "receivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureId": {
+          "name": "signatureId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "htmlBodyStorageLocationId": {
+          "name": "htmlBodyStorageLocationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasAttachments": {
+          "name": "hasAttachments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerError": {
+          "name": "providerError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sendStatus": {
+          "name": "sendStatus",
+          "type": "SendStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'SENT'"
+        },
+        "sendToken": {
+          "name": "sendToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Message_createdById_idx": {
+          "name": "Message_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_fromId_idx": {
+          "name": "Message_fromId_idx",
+          "columns": [
+            {
+              "expression": "fromId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_integrationId_externalId_key": {
+          "name": "Message_integrationId_externalId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_integrationId_idx": {
+          "name": "Message_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_organizationId_idx": {
+          "name": "Message_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_organizationId_internetMessageId_key": {
+          "name": "Message_organizationId_internetMessageId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internetMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"internetMessageId\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_replyToId_idx": {
+          "name": "Message_replyToId_idx",
+          "columns": [
+            {
+              "expression": "replyToId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_sendToken_key": {
+          "name": "Message_sendToken_key",
+          "columns": [
+            {
+              "expression": "sendToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"sendToken\" IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_sentAt_idx": {
+          "name": "Message_sentAt_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_threadId_createdById_idx": {
+          "name": "Message_threadId_createdById_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_threadId_idx": {
+          "name": "Message_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retry_queue_idx": {
+          "name": "retry_queue_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sendStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastAttemptAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_messages_idx": {
+          "name": "thread_messages_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Message_threadId_Thread_id_fk": {
+          "name": "Message_threadId_Thread_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_integrationId_Integration_id_fk": {
+          "name": "Message_integrationId_Integration_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_createdById_User_id_fk": {
+          "name": "Message_createdById_User_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Message_organizationId_Organization_id_fk": {
+          "name": "Message_organizationId_Organization_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Message_fromId_Participant_id_fk": {
+          "name": "Message_fromId_Participant_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Participant",
+          "columnsFrom": ["fromId"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Message_replyToId_Participant_id_fk": {
+          "name": "Message_replyToId_Participant_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Participant",
+          "columnsFrom": ["replyToId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Message_signatureId_EntityInstance_id_fk": {
+          "name": "Message_signatureId_EntityInstance_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["signatureId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Message_htmlBodyStorageLocationId_StorageLocation_id_fk": {
+          "name": "Message_htmlBodyStorageLocationId_StorageLocation_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "StorageLocation",
+          "columnsFrom": ["htmlBodyStorageLocationId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MessageParticipant": {
+      "name": "MessageParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "ParticipantRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participantId": {
+          "name": "participantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "MessageParticipant_messageId_idx": {
+          "name": "MessageParticipant_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_messageId_participantId_role_key": {
+          "name": "MessageParticipant_messageId_participantId_role_key",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "participantId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_participantId_idx": {
+          "name": "MessageParticipant_participantId_idx",
+          "columns": [
+            {
+              "expression": "participantId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageParticipant_role_idx": {
+          "name": "MessageParticipant_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_idx": {
+          "name": "contact_history_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "participant_lookup_idx": {
+          "name": "participant_lookup_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MessageParticipant_messageId_Message_id_fk": {
+          "name": "MessageParticipant_messageId_Message_id_fk",
+          "tableFrom": "MessageParticipant",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MessageParticipant_participantId_Participant_id_fk": {
+          "name": "MessageParticipant_participantId_Participant_id_fk",
+          "tableFrom": "MessageParticipant",
+          "tableTo": "Participant",
+          "columnsFrom": ["participantId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MessageReceipt": {
+      "name": "MessageReceipt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientParticipantId": {
+          "name": "recipientParticipantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "MessageReceipt_message_recipient_key": {
+          "name": "MessageReceipt_message_recipient_key",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipientParticipantId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MessageReceipt_messageId_idx": {
+          "name": "MessageReceipt_messageId_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MessageReceipt_messageId_Message_id_fk": {
+          "name": "MessageReceipt_messageId_Message_id_fk",
+          "tableFrom": "MessageReceipt",
+          "tableTo": "Message",
+          "columnsFrom": ["messageId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "MessageReceipt_recipientParticipantId_Participant_id_fk": {
+          "name": "MessageReceipt_recipientParticipantId_Participant_id_fk",
+          "tableFrom": "MessageReceipt",
+          "tableTo": "Participant",
+          "columnsFrom": ["recipientParticipantId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModelConfiguration": {
+      "name": "ModelConfiguration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'llm'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ModelConfiguration_organizationId_enabled_idx": {
+          "name": "ModelConfiguration_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModelConfiguration_organizationId_provider_idx": {
+          "name": "ModelConfiguration_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModelConfiguration_organizationId_provider_model_modelType_key": {
+          "name": "ModelConfiguration_organizationId_provider_model_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ModelConfiguration_organizationId_Organization_id_fk": {
+          "name": "ModelConfiguration_organizationId_Organization_id_fk",
+          "tableFrom": "ModelConfiguration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Notification": {
+      "name": "Notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryMethod": {
+          "name": "deliveryMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Notification_entityType_entityId_idx": {
+          "name": "Notification_entityType_entityId_idx",
+          "columns": [
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_organizationId_idx": {
+          "name": "Notification_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_createdAt_idx": {
+          "name": "Notification_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_isRead_idx": {
+          "name": "Notification_userId_isRead_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Notification_userId_User_id_fk": {
+          "name": "Notification_userId_User_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Notification_actorId_User_id_fk": {
+          "name": "Notification_actorId_User_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "User",
+          "columnsFrom": ["actorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Notification_organizationId_Organization_id_fk": {
+          "name": "Notification_organizationId_Organization_id_fk",
+          "tableFrom": "Notification",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthAccessToken_userId_User_id_fk": {
+          "name": "oauthAccessToken_userId_User_id_fk",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthAccessToken_accessToken_unique": {
+          "name": "oauthAccessToken_accessToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["accessToken"]
+        },
+        "oauthAccessToken_refreshToken_unique": {
+          "name": "oauthAccessToken_refreshToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refreshToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthApplication": {
+      "name": "oauthApplication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirectURLs": {
+          "name": "redirectURLs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthApplication_userId_User_id_fk": {
+          "name": "oauthApplication_userId_User_id_fk",
+          "tableFrom": "oauthApplication",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauthApplication_clientId_unique": {
+          "name": "oauthApplication_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["clientId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthConsent": {
+      "name": "oauthConsent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consentGiven": {
+          "name": "consentGiven",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauthConsent_userId_User_id_fk": {
+          "name": "oauthConsent_userId_User_id_fk",
+          "tableFrom": "oauthConsent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OperatingHours": {
+      "name": "OperatingHours",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "widgetId": {
+          "name": "widgetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dayOfWeek": {
+          "name": "dayOfWeek",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startHour": {
+          "name": "startHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startMinute": {
+          "name": "startMinute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endHour": {
+          "name": "endHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endMinute": {
+          "name": "endMinute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        }
+      },
+      "indexes": {
+        "OperatingHours_widgetId_dayOfWeek_key": {
+          "name": "OperatingHours_widgetId_dayOfWeek_key",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dayOfWeek",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OperatingHours_widgetId_idx": {
+          "name": "OperatingHours_widgetId_idx",
+          "columns": [
+            {
+              "expression": "widgetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OperatingHours_widgetId_ChatWidget_id_fk": {
+          "name": "OperatingHours_widgetId_ChatWidget_id_fk",
+          "tableFrom": "OperatingHours",
+          "tableTo": "ChatWidget",
+          "columnsFrom": ["widgetId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domains": {
+          "name": "domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "type": {
+          "name": "type",
+          "type": "OrganizationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'TEAM'"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "systemUserId": {
+          "name": "systemUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledReason": {
+          "name": "disabledReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabledBy": {
+          "name": "disabledBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedOnboarding": {
+          "name": "completedOnboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "demo_expires_at": {
+          "name": "demo_expires_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Organization_handle_idx": {
+          "name": "Organization_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_handle_key": {
+          "name": "Organization_handle_key",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_systemUserId_key": {
+          "name": "Organization_systemUserId_key",
+          "columns": [
+            {
+              "expression": "systemUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Organization_createdById_User_id_fk": {
+          "name": "Organization_createdById_User_id_fk",
+          "tableFrom": "Organization",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Organization_systemUserId_User_id_fk": {
+          "name": "Organization_systemUserId_User_id_fk",
+          "tableFrom": "Organization",
+          "tableTo": "User",
+          "columnsFrom": ["systemUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationAiQuota": {
+      "name": "OrganizationAiQuota",
+      "schema": "",
+      "columns": {
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "quotaPeriodStart": {
+          "name": "quotaPeriodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "quotaPeriodEnd": {
+          "name": "quotaPeriodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "OrganizationAiQuota_organizationId_Organization_id_fk": {
+          "name": "OrganizationAiQuota_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationAiQuota",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationInvitation": {
+      "name": "OrganizationInvitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "OrganizationRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InvitationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedById": {
+          "name": "invitedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptedById": {
+          "name": "acceptedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "OrganizationInvitation_email_idx": {
+          "name": "OrganizationInvitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_organizationId_idx": {
+          "name": "OrganizationInvitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_status_idx": {
+          "name": "OrganizationInvitation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationInvitation_token_key": {
+          "name": "OrganizationInvitation_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationInvitation_organizationId_Organization_id_fk": {
+          "name": "OrganizationInvitation_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationInvitation_invitedById_User_id_fk": {
+          "name": "OrganizationInvitation_invitedById_User_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "User",
+          "columnsFrom": ["invitedById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationInvitation_acceptedById_User_id_fk": {
+          "name": "OrganizationInvitation_acceptedById_User_id_fk",
+          "tableFrom": "OrganizationInvitation",
+          "tableTo": "User",
+          "columnsFrom": ["acceptedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMember": {
+      "name": "OrganizationMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "OrganizationMemberStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "role": {
+          "name": "role",
+          "type": "OrganizationRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "onChatDuty": {
+          "name": "onChatDuty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chatDutyUpdatedAt": {
+          "name": "chatDutyUpdatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chatDutyUpdatedById": {
+          "name": "chatDutyUpdatedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "OrganizationMember_organizationId_idx": {
+          "name": "OrganizationMember_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_userId_idx": {
+          "name": "OrganizationMember_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_userId_organizationId_key": {
+          "name": "OrganizationMember_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMember_userId_User_id_fk": {
+          "name": "OrganizationMember_userId_User_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationMember_organizationId_Organization_id_fk": {
+          "name": "OrganizationMember_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrganizationMember_chatDutyUpdatedById_User_id_fk": {
+          "name": "OrganizationMember_chatDutyUpdatedById_User_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "User",
+          "columnsFrom": ["chatDutyUpdatedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationSetting": {
+      "name": "OrganizationSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowUserOverride": {
+          "name": "allowUserOverride",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "SettingScope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GENERAL'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrganizationSetting_key_idx": {
+          "name": "OrganizationSetting_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_organizationId_idx": {
+          "name": "OrganizationSetting_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_organizationId_key_key": {
+          "name": "OrganizationSetting_organizationId_key_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationSetting_scope_idx": {
+          "name": "OrganizationSetting_scope_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationSetting_organizationId_Organization_id_fk": {
+          "name": "OrganizationSetting_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationSetting",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Participant": {
+      "name": "Participant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifierType": {
+          "name": "identifierType",
+          "type": "IdentifierType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSpammer": {
+          "name": "isSpammer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isInternal": {
+          "name": "isInternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstInteractionDate": {
+          "name": "firstInteractionDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstInteractionType": {
+          "name": "firstInteractionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasReceivedMessage": {
+          "name": "hasReceivedMessage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSentMessageAt": {
+          "name": "lastSentMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Participant_entityInstanceId_idx": {
+          "name": "Participant_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_identifierType_idx": {
+          "name": "Participant_identifierType_idx",
+          "columns": [
+            {
+              "expression": "identifierType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_identifier_idx": {
+          "name": "Participant_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_organizationId_identifier_identifierType_key": {
+          "name": "Participant_organizationId_identifier_identifierType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifierType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Participant_organizationId_idx": {
+          "name": "Participant_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Participant_entityInstanceId_EntityInstance_id_fk": {
+          "name": "Participant_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "Participant",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Participant_organizationId_Organization_id_fk": {
+          "name": "Participant_organizationId_Organization_id_fk",
+          "tableFrom": "Participant",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Passkey": {
+      "name": "Passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Passkey_userId_User_id_fk": {
+          "name": "Passkey_userId_User_id_fk",
+          "tableFrom": "Passkey",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PasswordResetToken": {
+      "name": "PasswordResetToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "PasswordResetToken_token_key": {
+          "name": "PasswordResetToken_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PasswordResetToken_userId_idx": {
+          "name": "PasswordResetToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PasswordResetToken_userId_User_id_fk": {
+          "name": "PasswordResetToken_userId_User_id_fk",
+          "tableFrom": "PasswordResetToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Plan": {
+      "name": "Plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "monthlyPrice": {
+          "name": "monthlyPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annualPrice": {
+          "name": "annualPrice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isCustomPricing": {
+          "name": "isCustomPricing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trialDays": {
+          "name": "trialDays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "hasTrial": {
+          "name": "hasTrial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "minSeats": {
+          "name": "minSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "maxSeats": {
+          "name": "maxSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "isLegacy": {
+          "name": "isLegacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selfServed": {
+          "name": "selfServed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isMostPopular": {
+          "name": "isMostPopular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isFree": {
+          "name": "isFree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featureLimits": {
+          "name": "featureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "trialFeatureLimits": {
+          "name": "trialFeatureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeProductId": {
+          "name": "stripeProductId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripePriceIdMonthly": {
+          "name": "stripePriceIdMonthly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripePriceIdAnnual": {
+          "name": "stripePriceIdAnnual",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchyLevel": {
+          "name": "hierarchyLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shopifyPlanHandle": {
+          "name": "shopifyPlanHandle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PlanSubscription": {
+      "name": "PlanSubscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planId": {
+          "name": "planId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billingProvider": {
+          "name": "billingProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incomplete'"
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "billingCycle": {
+          "name": "billingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MONTHLY'"
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shopifyShopDomain": {
+          "name": "shopifyShopDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shopifyShopGid": {
+          "name": "shopifyShopGid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "creditsBalance": {
+          "name": "creditsBalance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "trialStart": {
+          "name": "trialStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trialEnd": {
+          "name": "trialEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasTrialEnded": {
+          "name": "hasTrialEnded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trialConversionStatus": {
+          "name": "trialConversionStatus",
+          "type": "TrialConversionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEligibleForTrial": {
+          "name": "isEligibleForTrial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trialEligibilityReason": {
+          "name": "trialEligibilityReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPlanId": {
+          "name": "scheduledPlanId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPlan": {
+          "name": "scheduledPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledBillingCycle": {
+          "name": "scheduledBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledSeats": {
+          "name": "scheduledSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeAt": {
+          "name": "scheduledChangeAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeletionNotificationSent": {
+          "name": "lastDeletionNotificationSent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeletionNotificationDate": {
+          "name": "lastDeletionNotificationDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletionScheduledDate": {
+          "name": "deletionScheduledDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletionReason": {
+          "name": "deletionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customFeatureLimits": {
+          "name": "customFeatureLimits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingMonthly": {
+          "name": "customPricingMonthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingAnnual": {
+          "name": "customPricingAnnual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customPricingNotes": {
+          "name": "customPricingNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "PlanSubscription_organizationId_key": {
+          "name": "PlanSubscription_organizationId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PlanSubscription_organizationId_Organization_id_fk": {
+          "name": "PlanSubscription_organizationId_Organization_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PlanSubscription_planId_Plan_id_fk": {
+          "name": "PlanSubscription_planId_Plan_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Plan",
+          "columnsFrom": ["planId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PlanSubscription_scheduledPlanId_Plan_id_fk": {
+          "name": "PlanSubscription_scheduledPlanId_Plan_id_fk",
+          "tableFrom": "PlanSubscription",
+          "tableTo": "Plan",
+          "columnsFrom": ["scheduledPlanId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PlanSubscriptionHistory": {
+      "name": "PlanSubscriptionHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changeType": {
+          "name": "changeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromPlan": {
+          "name": "fromPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toPlan": {
+          "name": "toPlan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromBillingCycle": {
+          "name": "fromBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toBillingCycle": {
+          "name": "toBillingCycle",
+          "type": "BillingCycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromSeats": {
+          "name": "fromSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toSeats": {
+          "name": "toSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "immediate": {
+          "name": "immediate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledFor": {
+          "name": "scheduledFor",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appliedAt": {
+          "name": "appliedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prorationAmount": {
+          "name": "prorationAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PollingTriggerState": {
+      "name": "PollingTriggerState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerId": {
+          "name": "triggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "lastPollAt": {
+          "name": "lastPollAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPollStatus": {
+          "name": "lastPollStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPollError": {
+          "name": "lastPollError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutiveErrors": {
+          "name": "consecutiveErrors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "PollingTriggerState_workflowAppId_triggerId_key": {
+          "name": "PollingTriggerState_workflowAppId_triggerId_key",
+          "columns": [
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PollingTriggerState_organizationId_idx": {
+          "name": "PollingTriggerState_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PollingTriggerState_organizationId_Organization_id_fk": {
+          "name": "PollingTriggerState_organizationId_Organization_id_fk",
+          "tableFrom": "PollingTriggerState",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PollingTriggerState_workflowAppId_WorkflowApp_id_fk": {
+          "name": "PollingTriggerState_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "PollingTriggerState",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Procedure": {
+      "name": "Procedure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "whenToUse": {
+          "name": "whenToUse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "triggerExamples": {
+          "name": "triggerExamples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "draftVersionId": {
+          "name": "draftVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeVersionId": {
+          "name": "activeVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasUnpublishedChanges": {
+          "name": "hasUnpublishedChanges",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Procedure_organizationId_idx": {
+          "name": "Procedure_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Procedure_organizationId_Organization_id_fk": {
+          "name": "Procedure_organizationId_Organization_id_fk",
+          "tableFrom": "Procedure",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProcedureVersion": {
+      "name": "ProcedureVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "procedureId": {
+          "name": "procedureId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "versionNumber": {
+          "name": "versionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc": {
+          "name": "doc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "compiled": {
+          "name": "compiled",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whenToUse": {
+          "name": "whenToUse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "triggerExamples": {
+          "name": "triggerExamples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "editorId": {
+          "name": "editorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ProcedureVersion_procedureId_idx": {
+          "name": "ProcedureVersion_procedureId_idx",
+          "columns": [
+            {
+              "expression": "procedureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ProcedureVersion_procedureId_versionNumber_key": {
+          "name": "ProcedureVersion_procedureId_versionNumber_key",
+          "columns": [
+            {
+              "expression": "procedureId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "versionNumber",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"versionNumber\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProcedureVersion_organizationId_Organization_id_fk": {
+          "name": "ProcedureVersion_organizationId_Organization_id_fk",
+          "tableFrom": "ProcedureVersion",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ProcedureVersion_procedureId_Procedure_id_fk": {
+          "name": "ProcedureVersion_procedureId_Procedure_id_fk",
+          "tableFrom": "ProcedureVersion",
+          "tableTo": "Procedure",
+          "columnsFrom": ["procedureId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ProcedureVersion_editorId_User_id_fk": {
+          "name": "ProcedureVersion_editorId_User_id_fk",
+          "tableFrom": "ProcedureVersion",
+          "tableTo": "User",
+          "columnsFrom": ["editorId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PromptHistory": {
+      "name": "PromptHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "PromptHistory_userId_User_id_fk": {
+          "name": "PromptHistory_userId_User_id_fk",
+          "tableFrom": "PromptHistory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PromptTemplate": {
+      "name": "PromptTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "PromptTemplate_organizationId_idx": {
+          "name": "PromptTemplate_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PromptTemplate_categories_idx": {
+          "name": "PromptTemplate_categories_idx",
+          "columns": [
+            {
+              "expression": "categories",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PromptTemplate_organizationId_Organization_id_fk": {
+          "name": "PromptTemplate_organizationId_Organization_id_fk",
+          "tableFrom": "PromptTemplate",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "PromptTemplate_createdById_User_id_fk": {
+          "name": "PromptTemplate_createdById_User_id_fk",
+          "tableFrom": "PromptTemplate",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProviderConfiguration": {
+      "name": "ProviderConfiguration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionDefinitionId": {
+          "name": "connectionDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quotaType": {
+          "name": "quotaType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaLimit": {
+          "name": "quotaLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-1'"
+        },
+        "quotaPeriodEnd": {
+          "name": "quotaPeriodEnd",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaPeriodStart": {
+          "name": "quotaPeriodStart",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotaUsed": {
+          "name": "quotaUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ProviderConfiguration_organizationId_provider_idx": {
+          "name": "ProviderConfiguration_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ProviderConfiguration_org_provider_type_key": {
+          "name": "ProviderConfiguration_org_provider_type_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "providerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProviderConfiguration_organizationId_Organization_id_fk": {
+          "name": "ProviderConfiguration_organizationId_Organization_id_fk",
+          "tableFrom": "ProviderConfiguration",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ProviderConfiguration_connectionDefinitionId_ConnectionDefinition_id_fk": {
+          "name": "ProviderConfiguration_connectionDefinitionId_ConnectionDefinition_id_fk",
+          "tableFrom": "ProviderConfiguration",
+          "tableTo": "ConnectionDefinition",
+          "columnsFrom": ["connectionDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProviderPreference": {
+      "name": "ProviderPreference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferredType": {
+          "name": "preferredType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ProviderPreference_organizationId_provider_idx": {
+          "name": "ProviderPreference_organizationId_provider_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ProviderPreference_organizationId_provider_key": {
+          "name": "ProviderPreference_organizationId_provider_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ProviderPreference_organizationId_Organization_id_fk": {
+          "name": "ProviderPreference_organizationId_Organization_id_fk",
+          "tableFrom": "ProviderPreference",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecordIdentity": {
+      "name": "RecordIdentity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appInstallationId": {
+          "name": "appInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appFieldKey": {
+          "name": "appFieldKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fieldId": {
+          "name": "fieldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RecordIdentity_org_def_source_externalId_idx": {
+          "name": "RecordIdentity_org_def_source_externalId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordIdentity_org_source_conn_field_externalId_idx": {
+          "name": "RecordIdentity_org_source_conn_field_externalId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appFieldKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordIdentity_entityInstanceId_idx": {
+          "name": "RecordIdentity_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordIdentity_identity_key": {
+          "name": "RecordIdentity_identity_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"connectionId\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"appFieldKey\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordIdentity_record_kind_key": {
+          "name": "RecordIdentity_record_kind_key",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"connectionId\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"appFieldKey\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecordIdentity_organizationId_Organization_id_fk": {
+          "name": "RecordIdentity_organizationId_Organization_id_fk",
+          "tableFrom": "RecordIdentity",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordIdentity_entityInstanceId_EntityInstance_id_fk": {
+          "name": "RecordIdentity_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "RecordIdentity",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordIdentity_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "RecordIdentity_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "RecordIdentity",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordIdentity_appInstallationId_AppInstallation_id_fk": {
+          "name": "RecordIdentity_appInstallationId_AppInstallation_id_fk",
+          "tableFrom": "RecordIdentity",
+          "tableTo": "AppInstallation",
+          "columnsFrom": ["appInstallationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordIdentity_connectionId_Credential_id_fk": {
+          "name": "RecordIdentity_connectionId_Credential_id_fk",
+          "tableFrom": "RecordIdentity",
+          "tableTo": "Credential",
+          "columnsFrom": ["connectionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordIdentity_fieldId_CustomField_id_fk": {
+          "name": "RecordIdentity_fieldId_CustomField_id_fk",
+          "tableFrom": "RecordIdentity",
+          "tableTo": "CustomField",
+          "columnsFrom": ["fieldId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecordingChapter": {
+      "name": "RecordingChapter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startMs": {
+          "name": "startMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endMs": {
+          "name": "endMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "RecordingChapter_callRecordingId_sortOrder_idx": {
+          "name": "RecordingChapter_callRecordingId_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecordingChapter_organizationId_Organization_id_fk": {
+          "name": "RecordingChapter_organizationId_Organization_id_fk",
+          "tableFrom": "RecordingChapter",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingChapter_callRecordingId_CallRecording_id_fk": {
+          "name": "RecordingChapter_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "RecordingChapter",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecordingInsight": {
+      "name": "RecordingInsight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insightTemplateId": {
+          "name": "insightTemplateId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "InsightStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "RecordingInsight_callRecordingId_idx": {
+          "name": "RecordingInsight_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordingInsight_insightTemplateId_idx": {
+          "name": "RecordingInsight_insightTemplateId_idx",
+          "columns": [
+            {
+              "expression": "insightTemplateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordingInsight_organizationId_idx": {
+          "name": "RecordingInsight_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecordingInsight_organizationId_Organization_id_fk": {
+          "name": "RecordingInsight_organizationId_Organization_id_fk",
+          "tableFrom": "RecordingInsight",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingInsight_callRecordingId_CallRecording_id_fk": {
+          "name": "RecordingInsight_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "RecordingInsight",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingInsight_insightTemplateId_InsightTemplate_id_fk": {
+          "name": "RecordingInsight_insightTemplateId_InsightTemplate_id_fk",
+          "tableFrom": "RecordingInsight",
+          "tableTo": "InsightTemplate",
+          "columnsFrom": ["insightTemplateId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RecordingShareLink": {
+      "name": "RecordingShareLink",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeVideo": {
+          "name": "includeVideo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeTranscript": {
+          "name": "includeTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeInsights": {
+          "name": "includeInsights",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "RecordingShareLink_publicId_key": {
+          "name": "RecordingShareLink_publicId_key",
+          "columns": [
+            {
+              "expression": "publicId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RecordingShareLink_callRecordingId_idx": {
+          "name": "RecordingShareLink_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RecordingShareLink_organizationId_Organization_id_fk": {
+          "name": "RecordingShareLink_organizationId_Organization_id_fk",
+          "tableFrom": "RecordingShareLink",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingShareLink_callRecordingId_CallRecording_id_fk": {
+          "name": "RecordingShareLink_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "RecordingShareLink",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "RecordingShareLink_createdById_User_id_fk": {
+          "name": "RecordingShareLink_createdById_User_id_fk",
+          "tableFrom": "RecordingShareLink",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ResourceAccess": {
+      "name": "ResourceAccess",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granteeType": {
+          "name": "granteeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granteeId": {
+          "name": "granteeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantedById": {
+          "name": "grantedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ResourceAccess_entity_grantee_key": {
+          "name": "ResourceAccess_entity_grantee_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_entityDef_idx": {
+          "name": "ResourceAccess_entityDef_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_instance_idx": {
+          "name": "ResourceAccess_instance_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_grantee_idx": {
+          "name": "ResourceAccess_grantee_idx",
+          "columns": [
+            {
+              "expression": "granteeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granteeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ResourceAccess_org_idx": {
+          "name": "ResourceAccess_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ResourceAccess_organizationId_Organization_id_fk": {
+          "name": "ResourceAccess_organizationId_Organization_id_fk",
+          "tableFrom": "ResourceAccess",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ResourceAccess_grantedById_User_id_fk": {
+          "name": "ResourceAccess_grantedById_User_id_fk",
+          "tableFrom": "ResourceAccess",
+          "tableTo": "User",
+          "columnsFrom": ["grantedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ScheduledMessage": {
+      "name": "ScheduledMessage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draftId": {
+          "name": "draftId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledAt": {
+          "name": "scheduledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ScheduledMessageStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "jobId": {
+          "name": "jobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sendPayload": {
+          "name": "sendPayload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "ScheduledMessageSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER_SCHEDULED'"
+        },
+        "approvedById": {
+          "name": "approvedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledById": {
+          "name": "cancelledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiSuggestionId": {
+          "name": "aiSuggestionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ScheduledMessage_orgId_status_scheduledAt_idx": {
+          "name": "ScheduledMessage_orgId_status_scheduledAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduledAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ScheduledMessage_draftId_idx": {
+          "name": "ScheduledMessage_draftId_idx",
+          "columns": [
+            {
+              "expression": "draftId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ScheduledMessage_orgId_source_approvedById_status_idx": {
+          "name": "ScheduledMessage_orgId_source_approvedById_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "approvedById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ScheduledMessage_organizationId_Organization_id_fk": {
+          "name": "ScheduledMessage_organizationId_Organization_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_draftId_Draft_id_fk": {
+          "name": "ScheduledMessage_draftId_Draft_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Draft",
+          "columnsFrom": ["draftId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_integrationId_Integration_id_fk": {
+          "name": "ScheduledMessage_integrationId_Integration_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_threadId_Thread_id_fk": {
+          "name": "ScheduledMessage_threadId_Thread_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_createdById_User_id_fk": {
+          "name": "ScheduledMessage_createdById_User_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_approvedById_User_id_fk": {
+          "name": "ScheduledMessage_approvedById_User_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "User",
+          "columnsFrom": ["approvedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_cancelledById_User_id_fk": {
+          "name": "ScheduledMessage_cancelledById_User_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "User",
+          "columnsFrom": ["cancelledById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "ScheduledMessage_aiSuggestionId_AiSuggestion_id_fk": {
+          "name": "ScheduledMessage_aiSuggestionId_AiSuggestion_id_fk",
+          "tableFrom": "ScheduledMessage",
+          "tableTo": "AiSuggestion",
+          "columnsFrom": ["aiSuggestionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SearchHistory": {
+      "name": "SearchHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searchedAt": {
+          "name": "searchedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SearchHistory_userId_organizationId_searchedAt_idx": {
+          "name": "SearchHistory_userId_organizationId_searchedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "searchedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SearchHistory_userId_User_id_fk": {
+          "name": "SearchHistory_userId_User_id_fk",
+          "tableFrom": "SearchHistory",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SearchHistory_organizationId_Organization_id_fk": {
+          "name": "SearchHistory_organizationId_Organization_id_fk",
+          "tableFrom": "SearchHistory",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_User_id_fk": {
+          "name": "session_userId_User_id_fk",
+          "tableFrom": "session",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SignatureIntegrationShare": {
+      "name": "SignatureIntegrationShare",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SignatureIntegrationShare_integrationId_idx": {
+          "name": "SignatureIntegrationShare_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SignatureIntegrationShare_entityInstanceId_idx": {
+          "name": "SignatureIntegrationShare_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SignatureIntegrationShare_entityInstanceId_integrationId_key": {
+          "name": "SignatureIntegrationShare_entityInstanceId_integrationId_key",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SignatureIntegrationShare_entityInstanceId_EntityInstance_id_fk": {
+          "name": "SignatureIntegrationShare_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "SignatureIntegrationShare",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SignatureIntegrationShare_integrationId_Integration_id_fk": {
+          "name": "SignatureIntegrationShare_integrationId_Integration_id_fk",
+          "tableFrom": "SignatureIntegrationShare",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Snippet": {
+      "name": "Snippet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHtml": {
+          "name": "contentHtml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDeleted": {
+          "name": "isDeleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharingType": {
+          "name": "sharingType",
+          "type": "SnippetSharingType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIVATE'"
+        },
+        "isFavorite": {
+          "name": "isFavorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usageCount": {
+          "name": "usageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "Snippet_createdById_idx": {
+          "name": "Snippet_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_folderId_idx": {
+          "name": "Snippet_folderId_idx",
+          "columns": [
+            {
+              "expression": "folderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_organizationId_idx": {
+          "name": "Snippet_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Snippet_sharingType_idx": {
+          "name": "Snippet_sharingType_idx",
+          "columns": [
+            {
+              "expression": "sharingType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Snippet_folderId_SnippetFolder_id_fk": {
+          "name": "Snippet_folderId_SnippetFolder_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "SnippetFolder",
+          "columnsFrom": ["folderId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Snippet_organizationId_Organization_id_fk": {
+          "name": "Snippet_organizationId_Organization_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Snippet_createdById_User_id_fk": {
+          "name": "Snippet_createdById_User_id_fk",
+          "tableFrom": "Snippet",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SnippetFolder": {
+      "name": "SnippetFolder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "SnippetFolder_createdById_idx": {
+          "name": "SnippetFolder_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SnippetFolder_organizationId_idx": {
+          "name": "SnippetFolder_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SnippetFolder_organizationId_parentId_name_key": {
+          "name": "SnippetFolder_organizationId_parentId_name_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SnippetFolder_parentId_SnippetFolder_id_fk": {
+          "name": "SnippetFolder_parentId_SnippetFolder_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "SnippetFolder",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "SnippetFolder_organizationId_Organization_id_fk": {
+          "name": "SnippetFolder_organizationId_Organization_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SnippetFolder_createdById_User_id_fk": {
+          "name": "SnippetFolder_createdById_User_id_fk",
+          "tableFrom": "SnippetFolder",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.StorageLocation": {
+      "name": "StorageLocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalUrl": {
+          "name": "externalUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalRev": {
+          "name": "externalRev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "StorageLocation_credentialId_idx": {
+          "name": "StorageLocation_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credentialId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_provider_externalId_idx": {
+          "name": "StorageLocation_provider_externalId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_organizationId_idx": {
+          "name": "StorageLocation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StorageLocation_deletedAt_idx": {
+          "name": "StorageLocation_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"StorageLocation\".\"deletedAt\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "StorageLocation_organizationId_Organization_id_fk": {
+          "name": "StorageLocation_organizationId_Organization_id_fk",
+          "tableFrom": "StorageLocation",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "StorageLocation_credentialId_Credential_id_fk": {
+          "name": "StorageLocation_credentialId_Credential_id_fk",
+          "tableFrom": "StorageLocation",
+          "tableTo": "Credential",
+          "columnsFrom": ["credentialId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SuggestionDismissal": {
+      "name": "SuggestionDismissal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissedAtActivity": {
+          "name": "dismissedAtActivity",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snoozeUntil": {
+          "name": "snoozeUntil",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SuggestionDismissal_org_user_entity_key": {
+          "name": "SuggestionDismissal_org_user_entity_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SuggestionDismissal_org_user_idx": {
+          "name": "SuggestionDismissal_org_user_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SuggestionDismissal_organizationId_Organization_id_fk": {
+          "name": "SuggestionDismissal_organizationId_Organization_id_fk",
+          "tableFrom": "SuggestionDismissal",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SuggestionDismissal_userId_User_id_fk": {
+          "name": "SuggestionDismissal_userId_User_id_fk",
+          "tableFrom": "SuggestionDismissal",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "SuggestionDismissal_entityInstanceId_EntityInstance_id_fk": {
+          "name": "SuggestionDismissal_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "SuggestionDismissal",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SyncJob": {
+      "name": "SyncJob",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "SYNC_STATUS",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalRecords": {
+          "name": "totalRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processedRecords": {
+          "name": "processedRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failedRecords": {
+          "name": "failedRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "integrationCategory": {
+          "name": "integrationCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'message'"
+        },
+        "integrationSyncJobIds": {
+          "name": "integrationSyncJobIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"RAY\"}'"
+        }
+      },
+      "indexes": {
+        "SyncJob_organizationId_integrationCategory_integrationId_idx": {
+          "name": "SyncJob_organizationId_integrationCategory_integrationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationCategory",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SyncJob_organizationId_integrationCategory_status_idx": {
+          "name": "SyncJob_organizationId_integrationCategory_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integrationCategory",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SyncJob_organizationId_type_status_idx": {
+          "name": "SyncJob_organizationId_type_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SyncJob_organizationId_Organization_id_fk": {
+          "name": "SyncJob_organizationId_Organization_id_fk",
+          "tableFrom": "SyncJob",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SystemModelDefault": {
+      "name": "SystemModelDefault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelType": {
+          "name": "modelType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "SystemModelDefault_organizationId_modelType_key": {
+          "name": "SystemModelDefault_organizationId_modelType_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "modelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SystemModelDefault_organizationId_idx": {
+          "name": "SystemModelDefault_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SystemModelDefault_organizationId_Organization_id_fk": {
+          "name": "SystemModelDefault_organizationId_Organization_id_fk",
+          "tableFrom": "SystemModelDefault",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TableView": {
+      "name": "TableView",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tableId": {
+          "name": "tableId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextType": {
+          "name": "contextType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'table'"
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TableView_tableId_organizationId_idx": {
+          "name": "TableView_tableId_organizationId_idx",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_organizationId_contextType_isDefault_key": {
+          "name": "TableView_tableId_organizationId_contextType_isDefault_key",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"TableView\".\"isDefault\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_userId_idx": {
+          "name": "TableView_tableId_userId_idx",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TableView_tableId_userId_name_contextType_key": {
+          "name": "TableView_tableId_userId_name_contextType_key",
+          "columns": [
+            {
+              "expression": "tableId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TableView_userId_User_id_fk": {
+          "name": "TableView_userId_User_id_fk",
+          "tableFrom": "TableView",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TableView_organizationId_Organization_id_fk": {
+          "name": "TableView_organizationId_Organization_id_fk",
+          "tableFrom": "TableView",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Tag": {
+      "name": "Tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isSystemTag": {
+          "name": "isSystemTag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "Tag_organizationId_idx": {
+          "name": "Tag_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Tag_parentId_idx": {
+          "name": "Tag_parentId_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Tag_title_organizationId_parentId_key": {
+          "name": "Tag_title_organizationId_parentId_key",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Tag_parentId_Tag_id_fk": {
+          "name": "Tag_parentId_Tag_id_fk",
+          "tableFrom": "Tag",
+          "tableTo": "Tag",
+          "columnsFrom": ["parentId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "Tag_organizationId_Organization_id_fk": {
+          "name": "Tag_organizationId_Organization_id_fk",
+          "tableFrom": "Tag",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Task": {
+      "name": "Task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedById": {
+          "name": "completedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firedAt": {
+          "name": "firedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchText": {
+          "name": "searchText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedUserCount": {
+          "name": "assignedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "referenceCount": {
+          "name": "referenceCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Task_organizationId_idx": {
+          "name": "Task_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_archivedAt_deadline_idx": {
+          "name": "Task_organizationId_archivedAt_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_createdById_idx": {
+          "name": "Task_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_deadline_idx": {
+          "name": "Task_organizationId_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_createdAt_idx": {
+          "name": "Task_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_completedAt_idx": {
+          "name": "Task_organizationId_completedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Task_organizationId_firedAt_deadline_idx": {
+          "name": "Task_organizationId_firedAt_deadline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"completedAt\" IS NULL AND \"archivedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Task_organizationId_Organization_id_fk": {
+          "name": "Task_organizationId_Organization_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Task_createdById_User_id_fk": {
+          "name": "Task_createdById_User_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Task_completedById_User_id_fk": {
+          "name": "Task_completedById_User_id_fk",
+          "tableFrom": "Task",
+          "tableTo": "User",
+          "columnsFrom": ["completedById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TaskAssignment": {
+      "name": "TaskAssignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedToUserId": {
+          "name": "assignedToUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedAt": {
+          "name": "assignedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "assignedById": {
+          "name": "assignedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unassignedAt": {
+          "name": "unassignedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TaskAssignment_organizationId_idx": {
+          "name": "TaskAssignment_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_idx": {
+          "name": "TaskAssignment_taskId_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_assignedToUserId_idx": {
+          "name": "TaskAssignment_assignedToUserId_idx",
+          "columns": [
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_organizationId_assignedToUserId_unassignedAt_idx": {
+          "name": "TaskAssignment_organizationId_assignedToUserId_unassignedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "unassignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_assignedAt_idx": {
+          "name": "TaskAssignment_taskId_assignedAt_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_unassignedAt_idx": {
+          "name": "TaskAssignment_unassignedAt_idx",
+          "columns": [
+            {
+              "expression": "unassignedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskAssignment_taskId_assignedToUserId_key": {
+          "name": "TaskAssignment_taskId_assignedToUserId_key",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedToUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TaskAssignment_organizationId_Organization_id_fk": {
+          "name": "TaskAssignment_organizationId_Organization_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_taskId_Task_id_fk": {
+          "name": "TaskAssignment_taskId_Task_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "Task",
+          "columnsFrom": ["taskId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_assignedToUserId_User_id_fk": {
+          "name": "TaskAssignment_assignedToUserId_User_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "User",
+          "columnsFrom": ["assignedToUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskAssignment_assignedById_User_id_fk": {
+          "name": "TaskAssignment_assignedById_User_id_fk",
+          "tableFrom": "TaskAssignment",
+          "tableTo": "User",
+          "columnsFrom": ["assignedById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TaskReference": {
+      "name": "TaskReference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referencedEntityInstanceId": {
+          "name": "referencedEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referencedEntityDefinitionId": {
+          "name": "referencedEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TaskReference_organizationId_idx": {
+          "name": "TaskReference_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_taskId_idx": {
+          "name": "TaskReference_taskId_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_referencedEntityInstanceId_idx": {
+          "name": "TaskReference_referencedEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_referencedEntityDefinitionId_idx": {
+          "name": "TaskReference_referencedEntityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "referencedEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_organizationId_referencedEntityInstanceId_deletedAt_idx": {
+          "name": "TaskReference_organizationId_referencedEntityInstanceId_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_deletedAt_idx": {
+          "name": "TaskReference_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TaskReference_taskId_referencedEntityInstanceId_key": {
+          "name": "TaskReference_taskId_referencedEntityInstanceId_key",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referencedEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TaskReference_organizationId_Organization_id_fk": {
+          "name": "TaskReference_organizationId_Organization_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_taskId_Task_id_fk": {
+          "name": "TaskReference_taskId_Task_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "Task",
+          "columnsFrom": ["taskId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_referencedEntityInstanceId_EntityInstance_id_fk": {
+          "name": "TaskReference_referencedEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["referencedEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_referencedEntityDefinitionId_EntityDefinition_id_fk": {
+          "name": "TaskReference_referencedEntityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["referencedEntityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TaskReference_createdById_User_id_fk": {
+          "name": "TaskReference_createdById_User_id_fk",
+          "tableFrom": "TaskReference",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Thread": {
+      "name": "Thread",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrationId": {
+          "name": "integrationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ThreadStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "handoffState": {
+          "name": "handoffState",
+          "type": "ThreadHandoffState",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ai'"
+        },
+        "messageCount": {
+          "name": "messageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participantCount": {
+          "name": "participantCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "firstMessageAt": {
+          "name": "firstMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latestMessageId": {
+          "name": "latestMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latestCommentId": {
+          "name": "latestCommentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryEntityInstanceId": {
+          "name": "primaryEntityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryEntityDefinitionId": {
+          "name": "primaryEntityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repliedAt": {
+          "name": "repliedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitingSince": {
+          "name": "waitingSince",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mergedIntoThreadId": {
+          "name": "mergedIntoThreadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mergeData": {
+          "name": "mergeData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Thread_integrationId_externalId_key": {
+          "name": "Thread_integrationId_externalId_key",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_integrationId_idx": {
+          "name": "Thread_integrationId_idx",
+          "columns": [
+            {
+              "expression": "integrationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_lastMessageAt_idx": {
+          "name": "Thread_lastMessageAt_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_assigneeId_status_idx": {
+          "name": "Thread_organizationId_assigneeId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_createdAt_idx": {
+          "name": "Thread_organizationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_idx": {
+          "name": "Thread_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_status_idx": {
+          "name": "Thread_organizationId_status_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_status_idx": {
+          "name": "Thread_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_pagination_idx": {
+          "name": "thread_pagination_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_inboxId_idx": {
+          "name": "Thread_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_primaryEntityInstanceId_idx": {
+          "name": "Thread_organizationId_primaryEntityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "primaryEntityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_organizationId_primaryEntityDefinitionId_lastMessageAt_idx": {
+          "name": "Thread_organizationId_primaryEntityDefinitionId_lastMessageAt_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "primaryEntityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Thread_org_active_lastMessage_idx": {
+          "name": "Thread_org_active_lastMessage_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"mergedIntoThreadId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Thread_organizationId_Organization_id_fk": {
+          "name": "Thread_organizationId_Organization_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Thread_integrationId_Integration_id_fk": {
+          "name": "Thread_integrationId_Integration_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Integration",
+          "columnsFrom": ["integrationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Thread_assigneeId_User_id_fk": {
+          "name": "Thread_assigneeId_User_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "User",
+          "columnsFrom": ["assigneeId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_latestMessageId_Message_id_fk": {
+          "name": "Thread_latestMessageId_Message_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Message",
+          "columnsFrom": ["latestMessageId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_latestCommentId_Comment_id_fk": {
+          "name": "Thread_latestCommentId_Comment_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Comment",
+          "columnsFrom": ["latestCommentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_inboxId_EntityInstance_id_fk": {
+          "name": "Thread_inboxId_EntityInstance_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_primaryEntityInstanceId_EntityInstance_id_fk": {
+          "name": "Thread_primaryEntityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["primaryEntityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_primaryEntityDefinitionId_EntityDefinition_id_fk": {
+          "name": "Thread_primaryEntityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["primaryEntityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Thread_mergedIntoThreadId_Thread_id_fk": {
+          "name": "Thread_mergedIntoThreadId_Thread_id_fk",
+          "tableFrom": "Thread",
+          "tableTo": "Thread",
+          "columnsFrom": ["mergedIntoThreadId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadEntityLink": {
+      "name": "ThreadEntityLink",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityInstanceId": {
+          "name": "entityInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unlinkedAt": {
+          "name": "unlinkedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ThreadEntityLink_organizationId_idx": {
+          "name": "ThreadEntityLink_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_threadId_idx": {
+          "name": "ThreadEntityLink_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_entityInstanceId_idx": {
+          "name": "ThreadEntityLink_entityInstanceId_idx",
+          "columns": [
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_entityDefinitionId_idx": {
+          "name": "ThreadEntityLink_entityDefinitionId_idx",
+          "columns": [
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_unlinkedAt_idx": {
+          "name": "ThreadEntityLink_unlinkedAt_idx",
+          "columns": [
+            {
+              "expression": "unlinkedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadEntityLink_threadId_entityInstanceId_active_key": {
+          "name": "ThreadEntityLink_threadId_entityInstanceId_active_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"unlinkedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadEntityLink_organizationId_Organization_id_fk": {
+          "name": "ThreadEntityLink_organizationId_Organization_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_threadId_Thread_id_fk": {
+          "name": "ThreadEntityLink_threadId_Thread_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_entityInstanceId_EntityInstance_id_fk": {
+          "name": "ThreadEntityLink_entityInstanceId_EntityInstance_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["entityInstanceId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_entityDefinitionId_EntityDefinition_id_fk": {
+          "name": "ThreadEntityLink_entityDefinitionId_EntityDefinition_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "EntityDefinition",
+          "columnsFrom": ["entityDefinitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadEntityLink_createdById_User_id_fk": {
+          "name": "ThreadEntityLink_createdById_User_id_fk",
+          "tableFrom": "ThreadEntityLink",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadParticipant": {
+      "name": "ThreadParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isInternal": {
+          "name": "isInternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "messageCount": {
+          "name": "messageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "firstMessageAt": {
+          "name": "firstMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ThreadParticipant_threadId_email_key": {
+          "name": "ThreadParticipant_threadId_email_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadParticipant_threadId_Thread_id_fk": {
+          "name": "ThreadParticipant_threadId_Thread_id_fk",
+          "tableFrom": "ThreadParticipant",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ThreadReadStatus": {
+      "name": "ThreadReadStatus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSeenMessageId": {
+          "name": "lastSeenMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ThreadReadStatus_isRead_idx": {
+          "name": "ThreadReadStatus_isRead_idx",
+          "columns": [
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_organizationId_idx": {
+          "name": "ThreadReadStatus_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_organizationId_userId_idx": {
+          "name": "ThreadReadStatus_organizationId_userId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_threadId_idx": {
+          "name": "ThreadReadStatus_threadId_idx",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_threadId_userId_key": {
+          "name": "ThreadReadStatus_threadId_userId_key",
+          "columns": [
+            {
+              "expression": "threadId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_userId_idx": {
+          "name": "ThreadReadStatus_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ThreadReadStatus_userId_isRead_idx": {
+          "name": "ThreadReadStatus_userId_isRead_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ThreadReadStatus_threadId_Thread_id_fk": {
+          "name": "ThreadReadStatus_threadId_Thread_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "Thread",
+          "columnsFrom": ["threadId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadReadStatus_userId_User_id_fk": {
+          "name": "ThreadReadStatus_userId_User_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "ThreadReadStatus_organizationId_Organization_id_fk": {
+          "name": "ThreadReadStatus_organizationId_Organization_id_fk",
+          "tableFrom": "ThreadReadStatus",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TicketSequence": {
+      "name": "TicketSequence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentNumber": {
+          "name": "currentNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paddingLength": {
+          "name": "paddingLength",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        },
+        "usePrefix": {
+          "name": "usePrefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "useDateInPrefix": {
+          "name": "useDateInPrefix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dateFormat": {
+          "name": "dateFormat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'YYMM'"
+        },
+        "separator": {
+          "name": "separator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'-'"
+        },
+        "suffix": {
+          "name": "suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "useSuffix": {
+          "name": "useSuffix",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TicketSequence_organizationId_key": {
+          "name": "TicketSequence_organizationId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TicketSequence_organizationId_Organization_id_fk": {
+          "name": "TicketSequence_organizationId_Organization_id_fk",
+          "tableFrom": "TicketSequence",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TimelineEvent": {
+      "name": "TimelineEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relatedEntityType": {
+          "name": "relatedEntityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedEntityId": {
+          "name": "relatedEntityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorType": {
+          "name": "actorType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventData": {
+          "name": "eventData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isGrouped": {
+          "name": "isGrouped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "groupedEventIds": {
+          "name": "groupedEventIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TimelineEvent_entity_idx": {
+          "name": "TimelineEvent_entity_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_actor_idx": {
+          "name": "TimelineEvent_actor_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_type_idx": {
+          "name": "TimelineEvent_type_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_related_entity_idx": {
+          "name": "TimelineEvent_related_entity_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relatedEntityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEvent_org_timeline_idx": {
+          "name": "TimelineEvent_org_timeline_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TimelineEvent_organizationId_Organization_id_fk": {
+          "name": "TimelineEvent_organizationId_Organization_id_fk",
+          "tableFrom": "TimelineEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Transcript": {
+      "name": "Transcript",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcriptionProvider": {
+          "name": "transcriptionProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "TranscriptType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "TranscriptStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "externalJobId": {
+          "name": "externalJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fullText": {
+          "name": "fullText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wordCount": {
+          "name": "wordCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Transcript_organizationId_idx": {
+          "name": "Transcript_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transcript_callRecordingId_idx": {
+          "name": "Transcript_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Transcript_status_idx": {
+          "name": "Transcript_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Transcript_organizationId_Organization_id_fk": {
+          "name": "Transcript_organizationId_Organization_id_fk",
+          "tableFrom": "Transcript",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Transcript_callRecordingId_CallRecording_id_fk": {
+          "name": "Transcript_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "Transcript",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TranscriptSpeaker": {
+      "name": "TranscriptSpeaker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcriptId": {
+          "name": "transcriptId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callRecordingId": {
+          "name": "callRecordingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isHost": {
+          "name": "isHost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participantId": {
+          "name": "participantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manualParticipantId": {
+          "name": "manualParticipantId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "TranscriptSpeaker_transcriptId_idx": {
+          "name": "TranscriptSpeaker_transcriptId_idx",
+          "columns": [
+            {
+              "expression": "transcriptId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TranscriptSpeaker_callRecordingId_idx": {
+          "name": "TranscriptSpeaker_callRecordingId_idx",
+          "columns": [
+            {
+              "expression": "callRecordingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TranscriptSpeaker_organizationId_Organization_id_fk": {
+          "name": "TranscriptSpeaker_organizationId_Organization_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_transcriptId_Transcript_id_fk": {
+          "name": "TranscriptSpeaker_transcriptId_Transcript_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "Transcript",
+          "columnsFrom": ["transcriptId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_callRecordingId_CallRecording_id_fk": {
+          "name": "TranscriptSpeaker_callRecordingId_CallRecording_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "CallRecording",
+          "columnsFrom": ["callRecordingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_participantId_MeetingParticipant_id_fk": {
+          "name": "TranscriptSpeaker_participantId_MeetingParticipant_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "MeetingParticipant",
+          "columnsFrom": ["participantId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "TranscriptSpeaker_manualParticipantId_MeetingParticipant_id_fk": {
+          "name": "TranscriptSpeaker_manualParticipantId_MeetingParticipant_id_fk",
+          "tableFrom": "TranscriptSpeaker",
+          "tableTo": "MeetingParticipant",
+          "columnsFrom": ["manualParticipantId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TranscriptUtterance": {
+      "name": "TranscriptUtterance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcriptId": {
+          "name": "transcriptId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speakerId": {
+          "name": "speakerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startMs": {
+          "name": "startMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endMs": {
+          "name": "endMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "words": {
+          "name": "words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "TranscriptUtterance_transcriptId_sortOrder_idx": {
+          "name": "TranscriptUtterance_transcriptId_sortOrder_idx",
+          "columns": [
+            {
+              "expression": "transcriptId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sortOrder",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TranscriptUtterance_speakerId_idx": {
+          "name": "TranscriptUtterance_speakerId_idx",
+          "columns": [
+            {
+              "expression": "speakerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TranscriptUtterance_organizationId_Organization_id_fk": {
+          "name": "TranscriptUtterance_organizationId_Organization_id_fk",
+          "tableFrom": "TranscriptUtterance",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptUtterance_transcriptId_Transcript_id_fk": {
+          "name": "TranscriptUtterance_transcriptId_Transcript_id_fk",
+          "tableFrom": "TranscriptUtterance",
+          "tableTo": "Transcript",
+          "columnsFrom": ["transcriptId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TranscriptUtterance_speakerId_TranscriptSpeaker_id_fk": {
+          "name": "TranscriptUtterance_speakerId_TranscriptSpeaker_id_fk",
+          "tableFrom": "TranscriptUtterance",
+          "tableTo": "TranscriptSpeaker",
+          "columnsFrom": ["speakerId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TwoFactor": {
+      "name": "TwoFactor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backupCodes": {
+          "name": "backupCodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TwoFactor_userId_key": {
+          "name": "TwoFactor_userId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TwoFactor_userId_User_id_fk": {
+          "name": "TwoFactor_userId_User_id_fk",
+          "tableFrom": "TwoFactor",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UploadSession": {
+      "name": "UploadSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "StorageProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S3'"
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expectedSize": {
+          "name": "expectedSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UploadSession_organizationId_createdById_idx": {
+          "name": "UploadSession_organizationId_createdById_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UploadSession_provider_externalId_idx": {
+          "name": "UploadSession_provider_externalId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UploadSession_organizationId_Organization_id_fk": {
+          "name": "UploadSession_organizationId_Organization_id_fk",
+          "tableFrom": "UploadSession",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UsageEvent": {
+      "name": "UsageEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodKey": {
+          "name": "periodKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UsageEvent_org_metric_period_idx": {
+          "name": "UsageEvent_org_metric_period_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "periodKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UsageEvent_organizationId_Organization_id_fk": {
+          "name": "UsageEvent_organizationId_Organization_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "UsageEvent_userId_User_id_fk": {
+          "name": "UsageEvent_userId_User_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastLoginAt": {
+          "name": "lastLoginAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferredTimezone": {
+          "name": "preferredTimezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedOnboarding": {
+          "name": "completedOnboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "twoFactorEnabled": {
+          "name": "twoFactorEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "hashedPassword": {
+          "name": "hashedPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchEmailsExpirationDate": {
+          "name": "watchEmailsExpirationDate",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isSuperAdmin": {
+          "name": "isSuperAdmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "defaultOrganizationId": {
+          "name": "defaultOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "webhookSecret": {
+          "name": "webhookSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "phoneNumber": {
+          "name": "phoneNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phoneNumberVerified": {
+          "name": "phoneNumberVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatarAssetId": {
+          "name": "avatarAssetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userType": {
+          "name": "userType",
+          "type": "UserType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannedAt": {
+          "name": "bannedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forcePasswordChange": {
+          "name": "forcePasswordChange",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signupSource": {
+          "name": "signupSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        }
+      },
+      "indexes": {
+        "User_avatarAssetId_key": {
+          "name": "User_avatarAssetId_key",
+          "columns": [
+            {
+              "expression": "avatarAssetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_email_key": {
+          "name": "User_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "User_avatarAssetId_MediaAsset_id_fk": {
+          "name": "User_avatarAssetId_MediaAsset_id_fk",
+          "tableFrom": "User",
+          "tableTo": "MediaAsset",
+          "columnsFrom": ["avatarAssetId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserInboxUnreadCount": {
+      "name": "UserInboxUnreadCount",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inboxId": {
+          "name": "inboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreadCount": {
+          "name": "unreadCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastUpdatedAt": {
+          "name": "lastUpdatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserInboxUnreadCount_inboxId_idx": {
+          "name": "UserInboxUnreadCount_inboxId_idx",
+          "columns": [
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_idx": {
+          "name": "UserInboxUnreadCount_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_inboxId_userId_key": {
+          "name": "UserInboxUnreadCount_organizationId_inboxId_userId_key",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_organizationId_userId_idx": {
+          "name": "UserInboxUnreadCount_organizationId_userId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInboxUnreadCount_userId_idx": {
+          "name": "UserInboxUnreadCount_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserInboxUnreadCount_inboxId_EntityInstance_id_fk": {
+          "name": "UserInboxUnreadCount_inboxId_EntityInstance_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "EntityInstance",
+          "columnsFrom": ["inboxId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserInboxUnreadCount_userId_User_id_fk": {
+          "name": "UserInboxUnreadCount_userId_User_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserInboxUnreadCount_organizationId_Organization_id_fk": {
+          "name": "UserInboxUnreadCount_organizationId_Organization_id_fk",
+          "tableFrom": "UserInboxUnreadCount",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserSetting": {
+      "name": "UserSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationSettingId": {
+          "name": "organizationSettingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserSetting_organizationSettingId_idx": {
+          "name": "UserSetting_organizationSettingId_idx",
+          "columns": [
+            {
+              "expression": "organizationSettingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSetting_userId_idx": {
+          "name": "UserSetting_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSetting_userId_organizationSettingId_key": {
+          "name": "UserSetting_userId_organizationSettingId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationSettingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserSetting_userId_User_id_fk": {
+          "name": "UserSetting_userId_User_id_fk",
+          "tableFrom": "UserSetting",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "UserSetting_organizationSettingId_OrganizationSetting_id_fk": {
+          "name": "UserSetting_organizationSettingId_OrganizationSetting_id_fk",
+          "tableFrom": "UserSetting",
+          "tableTo": "OrganizationSetting",
+          "columnsFrom": ["organizationSettingId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.VerificationToken": {
+      "name": "VerificationToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "VerificationToken_token_key": {
+          "name": "VerificationToken_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "VerificationToken_userId_idx": {
+          "name": "VerificationToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "VerificationToken_userId_User_id_fk": {
+          "name": "VerificationToken_userId_User_id_fk",
+          "tableFrom": "VerificationToken",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Webhook": {
+      "name": "Webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "eventTypes": {
+          "name": "eventTypes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastTriggeredAt": {
+          "name": "lastTriggeredAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Webhook_organizationId_idx": {
+          "name": "Webhook_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Webhook_organizationId_Organization_id_fk": {
+          "name": "Webhook_organizationId_Organization_id_fk",
+          "tableFrom": "Webhook",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WebhookDelivery": {
+      "name": "WebhookDelivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookId": {
+          "name": "webhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responseStatus": {
+          "name": "responseStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responseBody": {
+          "name": "responseBody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attemptCount": {
+          "name": "attemptCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "nextRetryAt": {
+          "name": "nextRetryAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "WebhookDelivery_webhookId_idx": {
+          "name": "WebhookDelivery_webhookId_idx",
+          "columns": [
+            {
+              "expression": "webhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WebhookDelivery_webhookId_Webhook_id_fk": {
+          "name": "WebhookDelivery_webhookId_Webhook_id_fk",
+          "tableFrom": "WebhookDelivery",
+          "tableTo": "Webhook",
+          "columnsFrom": ["webhookId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WebhookEndpoint": {
+      "name": "WebhookEndpoint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification": {
+          "name": "verification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hmac'"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureHeader": {
+          "name": "signatureHeader",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signaturePrefix": {
+          "name": "signaturePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatureEncoding": {
+          "name": "signatureEncoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hex'"
+        },
+        "topicSource": {
+          "name": "topicSource",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "lastEventAt": {
+          "name": "lastEventAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "WebhookEndpoint_organizationId_idx": {
+          "name": "WebhookEndpoint_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WebhookEndpoint_organizationId_Organization_id_fk": {
+          "name": "WebhookEndpoint_organizationId_Organization_id_fk",
+          "tableFrom": "WebhookEndpoint",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WebhookEndpoint_createdById_User_id_fk": {
+          "name": "WebhookEndpoint_createdById_User_id_fk",
+          "tableFrom": "WebhookEndpoint",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Workflow": {
+      "name": "Workflow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityDefinitionId": {
+          "name": "entityDefinitionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAppId": {
+          "name": "triggerAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerTriggerId": {
+          "name": "triggerTriggerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerInstallationId": {
+          "name": "triggerInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerConnectionId": {
+          "name": "triggerConnectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerWebhookEndpointId": {
+          "name": "triggerWebhookEndpointId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerTopic": {
+          "name": "triggerTopic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Workflow_organizationId_enabled_idx": {
+          "name": "Workflow_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Workflow_orgId_triggerType_entityDefId_idx": {
+          "name": "Workflow_orgId_triggerType_entityDefId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entityDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Workflow_orgId_appTrigger_idx": {
+          "name": "Workflow_orgId_appTrigger_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerTriggerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerInstallationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Workflow_orgId_webhookTrigger_idx": {
+          "name": "Workflow_orgId_webhookTrigger_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerWebhookEndpointId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerTopic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Workflow_organizationId_Organization_id_fk": {
+          "name": "Workflow_organizationId_Organization_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Workflow_triggerWebhookEndpointId_WebhookEndpoint_id_fk": {
+          "name": "Workflow_triggerWebhookEndpointId_WebhookEndpoint_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "WebhookEndpoint",
+          "columnsFrom": ["triggerWebhookEndpointId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Workflow_createdById_User_id_fk": {
+          "name": "Workflow_createdById_User_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "Workflow_workflowAppId_WorkflowApp_id_fk": {
+          "name": "Workflow_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "Workflow",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowApp": {
+      "name": "WorkflowApp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isUniversal": {
+          "name": "isUniversal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draftWorkflowId": {
+          "name": "draftWorkflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shareToken": {
+          "name": "shareToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webEnabled": {
+          "name": "webEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "apiEnabled": {
+          "name": "apiEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessMode": {
+          "name": "accessMode",
+          "type": "WorkflowShareAccessMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'public'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rateLimit": {
+          "name": "rateLimit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalRuns": {
+          "name": "totalRuns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowApp_draftWorkflowId_key": {
+          "name": "WorkflowApp_draftWorkflowId_key",
+          "columns": [
+            {
+              "expression": "draftWorkflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_organizationId_enabled_idx": {
+          "name": "WorkflowApp_organizationId_enabled_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_organizationId_isPublic_idx": {
+          "name": "WorkflowApp_organizationId_isPublic_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_workflowId_key": {
+          "name": "WorkflowApp_workflowId_key",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_shareToken_key": {
+          "name": "WorkflowApp_shareToken_key",
+          "columns": [
+            {
+              "expression": "shareToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_webEnabled_idx": {
+          "name": "WorkflowApp_webEnabled_idx",
+          "columns": [
+            {
+              "expression": "webEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowApp_apiEnabled_idx": {
+          "name": "WorkflowApp_apiEnabled_idx",
+          "columns": [
+            {
+              "expression": "apiEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowApp_organizationId_Organization_id_fk": {
+          "name": "WorkflowApp_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_createdById_User_id_fk": {
+          "name": "WorkflowApp_createdById_User_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_workflowId_Workflow_id_fk": {
+          "name": "WorkflowApp_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "WorkflowApp_draftWorkflowId_Workflow_id_fk": {
+          "name": "WorkflowApp_draftWorkflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowApp",
+          "tableTo": "Workflow",
+          "columnsFrom": ["draftWorkflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "WorkflowApp_shareToken_unique": {
+          "name": "WorkflowApp_shareToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["shareToken"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowFile": {
+      "name": "WorkflowFile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploadedAt": {
+          "name": "uploadedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uploadSource": {
+          "name": "uploadSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "originalUrl": {
+          "name": "originalUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowFile_expiresAt_idx": {
+          "name": "WorkflowFile_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_nodeId_idx": {
+          "name": "WorkflowFile_nodeId_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_workflowId_fileId_key": {
+          "name": "WorkflowFile_workflowId_fileId_key",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowFile_workflowId_idx": {
+          "name": "WorkflowFile_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowFile_workflowId_Workflow_id_fk": {
+          "name": "WorkflowFile_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowFile",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowFile_fileId_File_id_fk": {
+          "name": "WorkflowFile_fileId_File_id_fk",
+          "tableFrom": "WorkflowFile",
+          "tableTo": "File",
+          "columnsFrom": ["fileId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowJoinState": {
+      "name": "WorkflowJoinState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joinNodeId": {
+          "name": "joinNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forkNodeId": {
+          "name": "forkNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expectedInputs": {
+          "name": "expectedInputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedInputs": {
+          "name": "completedInputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branchResults": {
+          "name": "branchResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "WorkflowJoinState_executionId_idx": {
+          "name": "WorkflowJoinState_executionId_idx",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowJoinState_executionId_joinNodeId_key": {
+          "name": "WorkflowJoinState_executionId_joinNodeId_key",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "joinNodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowJoinState_workflowId_idx": {
+          "name": "WorkflowJoinState_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowJoinState_workflowId_Workflow_id_fk": {
+          "name": "WorkflowJoinState_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowJoinState",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowNodeExecution": {
+      "name": "WorkflowNodeExecution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggeredFrom": {
+          "name": "triggeredFrom",
+          "type": "NodeTriggerSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowRunId": {
+          "name": "workflowRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "predecessorNodeId": {
+          "name": "predecessorNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processData": {
+          "name": "processData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "NodeExecutionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsedTime": {
+          "name": "elapsedTime",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionMetadata": {
+          "name": "executionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowNodeExecution_nodeId_idx": {
+          "name": "WorkflowNodeExecution_nodeId_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowNodeExecution_status_idx": {
+          "name": "WorkflowNodeExecution_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowNodeExecution_workflowRunId_idx": {
+          "name": "WorkflowNodeExecution_workflowRunId_idx",
+          "columns": [
+            {
+              "expression": "workflowRunId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowNodeExecution_organizationId_Organization_id_fk": {
+          "name": "WorkflowNodeExecution_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowAppId_WorkflowApp_id_fk": {
+          "name": "WorkflowNodeExecution_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowId_Workflow_id_fk": {
+          "name": "WorkflowNodeExecution_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_workflowRunId_WorkflowRun_id_fk": {
+          "name": "WorkflowNodeExecution_workflowRunId_WorkflowRun_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "WorkflowRun",
+          "columnsFrom": ["workflowRunId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowNodeExecution_createdById_User_id_fk": {
+          "name": "WorkflowNodeExecution_createdById_User_id_fk",
+          "tableFrom": "WorkflowNodeExecution",
+          "tableTo": "User",
+          "columnsFrom": ["createdById"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowRun": {
+      "name": "WorkflowRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowAppId": {
+          "name": "workflowAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequenceNumber": {
+          "name": "sequenceNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggeredFrom": {
+          "name": "triggeredFrom",
+          "type": "WorkflowTriggerSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elapsedTime": {
+          "name": "elapsedTime",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalSteps": {
+          "name": "totalSteps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pausedAt": {
+          "name": "pausedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pausedNodeId": {
+          "name": "pausedNodeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumeAt": {
+          "name": "resumeAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serializedState": {
+          "name": "serializedState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endUserId": {
+          "name": "endUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "WorkflowRun_createdAt_idx": {
+          "name": "WorkflowRun_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_organizationId_workflowAppId_idx": {
+          "name": "WorkflowRun_organizationId_workflowAppId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflowAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_resumeAt_idx": {
+          "name": "WorkflowRun_resumeAt_idx",
+          "columns": [
+            {
+              "expression": "resumeAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_status_idx": {
+          "name": "WorkflowRun_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowRun_workflowId_idx": {
+          "name": "WorkflowRun_workflowId_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "WorkflowRun_organizationId_Organization_id_fk": {
+          "name": "WorkflowRun_organizationId_Organization_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "Organization",
+          "columnsFrom": ["organizationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_workflowAppId_WorkflowApp_id_fk": {
+          "name": "WorkflowRun_workflowAppId_WorkflowApp_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "WorkflowApp",
+          "columnsFrom": ["workflowAppId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_workflowId_Workflow_id_fk": {
+          "name": "WorkflowRun_workflowId_Workflow_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "Workflow",
+          "columnsFrom": ["workflowId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_createdBy_User_id_fk": {
+          "name": "WorkflowRun_createdBy_User_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "User",
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "WorkflowRun_endUserId_EndUser_id_fk": {
+          "name": "WorkflowRun_endUserId_EndUser_id_fk",
+          "tableFrom": "WorkflowRun",
+          "tableTo": "EndUser",
+          "columnsFrom": ["endUserId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkflowTemplate": {
+      "name": "WorkflowTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "imgUrl": {
+          "name": "imgUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerConfig": {
+          "name": "triggerConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envVars": {
+          "name": "envVars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiredApps": {
+          "name": "requiredApps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "requiredEntities": {
+          "name": "requiredEntities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "WorkflowTemplate_status_idx": {
+          "name": "WorkflowTemplate_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_popularity_idx": {
+          "name": "WorkflowTemplate_popularity_idx",
+          "columns": [
+            {
+              "expression": "popularity",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_name_idx": {
+          "name": "WorkflowTemplate_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorkflowTemplate_categories_idx": {
+          "name": "WorkflowTemplate_categories_idx",
+          "columns": [
+            {
+              "expression": "categories",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ActionType": {
+      "name": "ActionType",
+      "schema": "public",
+      "values": [
+        "ARCHIVE",
+        "LABEL",
+        "REPLY",
+        "FORWARD",
+        "MARK_SPAM",
+        "DRAFT_EMAIL",
+        "SEND_MESSAGE",
+        "APPLY_TAG",
+        "REMOVE_TAG",
+        "APPLY_LABEL",
+        "REMOVE_LABEL",
+        "MARK_TRASH",
+        "ASSIGN_THREAD",
+        "ARCHIVE_THREAD",
+        "UNARCHIVE_THREAD",
+        "MOVE_TO_TRASH",
+        "REACT_TO_MESSAGE",
+        "SHARE_MESSAGE",
+        "SEND_SMS",
+        "MAKE_CALL",
+        "ESCALATE",
+        "ASSIGN",
+        "NOTIFY",
+        "CREATE_TICKET",
+        "SHOPIFY_ORDER_LOOKUP",
+        "SHOPIFY_GENERATE_RESPONSE"
+      ]
+    },
+    "public.AiIntegrationStatus": {
+      "name": "AiIntegrationStatus",
+      "schema": "public",
+      "values": ["PENDING", "VALID", "INVALID"]
+    },
+    "public.AiProcessingStatus": {
+      "name": "AiProcessingStatus",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed"]
+    },
+    "public.ApprovalAction": {
+      "name": "ApprovalAction",
+      "schema": "public",
+      "values": ["approve", "deny"]
+    },
+    "public.ApprovalStatus": {
+      "name": "ApprovalStatus",
+      "schema": "public",
+      "values": ["pending", "approved", "denied", "timeout"]
+    },
+    "public.articleKind": {
+      "name": "articleKind",
+      "schema": "public",
+      "values": ["page", "category", "header", "tab", "link"]
+    },
+    "public.ArticleStatus": {
+      "name": "ArticleStatus",
+      "schema": "public",
+      "values": ["DRAFT", "PUBLISHED", "ARCHIVED"]
+    },
+    "public.AssetVersionStatus": {
+      "name": "AssetVersionStatus",
+      "schema": "public",
+      "values": ["PENDING", "PROCESSING", "READY", "FAILED"]
+    },
+    "public.BillingCycle": {
+      "name": "BillingCycle",
+      "schema": "public",
+      "values": ["MONTHLY", "ANNUAL"]
+    },
+    "public.CalendarEventStatus": {
+      "name": "CalendarEventStatus",
+      "schema": "public",
+      "values": ["confirmed", "tentative", "cancelled"]
+    },
+    "public.CalendarProvider": {
+      "name": "CalendarProvider",
+      "schema": "public",
+      "values": ["google", "outlook"]
+    },
+    "public.ChatAudience": {
+      "name": "ChatAudience",
+      "schema": "public",
+      "values": ["visitors", "both", "users"]
+    },
+    "public.ChunkingStrategy": {
+      "name": "ChunkingStrategy",
+      "schema": "public",
+      "values": ["FIXED_SIZE", "SEMANTIC", "SENTENCE", "PARAGRAPH", "DOCUMENT"]
+    },
+    "public.ContactFieldType": {
+      "name": "ContactFieldType",
+      "schema": "public",
+      "values": [
+        "PHONE",
+        "EMAIL",
+        "ADDRESS",
+        "URL",
+        "TAGS",
+        "DATE",
+        "DATETIME",
+        "TIME",
+        "CHECKBOX",
+        "TEXT",
+        "NUMBER",
+        "CURRENCY",
+        "MULTI_SELECT",
+        "SINGLE_SELECT",
+        "RICH_TEXT",
+        "PHONE_INTL",
+        "ADDRESS_STRUCT",
+        "FILE",
+        "NAME",
+        "RELATIONSHIP",
+        "CALC",
+        "ACTOR",
+        "JSON"
+      ]
+    },
+    "public.CredentialSource": {
+      "name": "CredentialSource",
+      "schema": "public",
+      "values": ["SYSTEM", "CUSTOM", "MODEL_SPECIFIC", "LOAD_BALANCED"]
+    },
+    "public.CustomerSourceType": {
+      "name": "CustomerSourceType",
+      "schema": "public",
+      "values": ["EMAIL", "TICKET_SYSTEM", "SHOPIFY", "MANUAL", "OTHER", "FACEBOOK_PSID"]
+    },
+    "public.CustomerStatus": {
+      "name": "CustomerStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE", "SPAM", "MERGED"]
+    },
+    "public.DataConnectorStatus": {
+      "name": "DataConnectorStatus",
+      "schema": "public",
+      "values": ["pending", "ready", "provisioning", "syncing", "live", "error", "paused"]
+    },
+    "public.DataConnectorSyncBehavior": {
+      "name": "DataConnectorSyncBehavior",
+      "schema": "public",
+      "values": ["manual", "scheduled", "webhook"]
+    },
+    "public.DatasetStatus": {
+      "name": "DatasetStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE", "PROCESSING", "ERROR"]
+    },
+    "public.DeliveryStatus": {
+      "name": "DeliveryStatus",
+      "schema": "public",
+      "values": ["DELIVERED", "BOUNCED", "DELAYED", "DEFERRED", "REJECTED"]
+    },
+    "public.DocumentStatus": {
+      "name": "DocumentStatus",
+      "schema": "public",
+      "values": ["UPLOADED", "PROCESSING", "INDEXED", "FAILED", "ARCHIVED", "WAITING"]
+    },
+    "public.DocumentType": {
+      "name": "DocumentType",
+      "schema": "public",
+      "values": ["PDF", "DOCX", "TXT", "HTML", "MARKDOWN", "CSV", "JSON", "XML"]
+    },
+    "public.DomainType": {
+      "name": "DomainType",
+      "schema": "public",
+      "values": ["CUSTOM", "PROVIDER"]
+    },
+    "public.EmailLabel": {
+      "name": "EmailLabel",
+      "schema": "public",
+      "values": ["inbox", "sent", "draft"]
+    },
+    "public.EmailProvider": {
+      "name": "EmailProvider",
+      "schema": "public",
+      "values": ["GMAIL", "OUTLOOK", "IMAP"]
+    },
+    "public.EmailTemplateType": {
+      "name": "EmailTemplateType",
+      "schema": "public",
+      "values": [
+        "TICKET_CREATED",
+        "TICKET_REPLIED",
+        "TICKET_CLOSED",
+        "TICKET_REOPENED",
+        "TICKET_ASSIGNED",
+        "TICKET_STATUS_CHANGED",
+        "CUSTOM"
+      ]
+    },
+    "public.EvalKind": {
+      "name": "EvalKind",
+      "schema": "public",
+      "values": ["agent_simulation", "workflow", "recorded_ticket"]
+    },
+    "public.EvalRunStatus": {
+      "name": "EvalRunStatus",
+      "schema": "public",
+      "values": ["queued", "running", "passed", "failed", "error", "cancelled", "timed_out"]
+    },
+    "public.EvalSuiteRunStatus": {
+      "name": "EvalSuiteRunStatus",
+      "schema": "public",
+      "values": ["queued", "running", "completed", "cancelled", "error"]
+    },
+    "public.ExportJobStatus": {
+      "name": "ExportJobStatus",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "canceled"]
+    },
+    "public.ExtractionRuleType": {
+      "name": "ExtractionRuleType",
+      "schema": "public",
+      "values": ["REGEX", "MARKER", "POSITION", "AI_ASSISTED", "VISUAL_SELECTION"]
+    },
+    "public.FavoriteNodeType": {
+      "name": "FavoriteNodeType",
+      "schema": "public",
+      "values": ["ITEM", "FOLDER"]
+    },
+    "public.FileStatus": {
+      "name": "FileStatus",
+      "schema": "public",
+      "values": ["PENDING", "CONFIRMED", "ARCHIVED", "DELETED", "FAILED"]
+    },
+    "public.FileVisibility": {
+      "name": "FileVisibility",
+      "schema": "public",
+      "values": ["PUBLIC", "PRIVATE", "INTERNAL"]
+    },
+    "public.FULFILLMENT_STATUS": {
+      "name": "FULFILLMENT_STATUS",
+      "schema": "public",
+      "values": ["CANCELLED", "ERROR", "FAILURE", "SUCCESS", "OPEN", "PENDING"]
+    },
+    "public.IdentifierType": {
+      "name": "IdentifierType",
+      "schema": "public",
+      "values": ["EMAIL", "PHONE", "FACEBOOK_PSID", "INSTAGRAM_IGSID", "CHAT_VISITOR"]
+    },
+    "public.IdentityVerification": {
+      "name": "IdentityVerification",
+      "schema": "public",
+      "values": ["off", "in_progress", "enforced"]
+    },
+    "public.ImportJobStatus": {
+      "name": "ImportJobStatus",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "ingesting",
+        "waiting",
+        "planning",
+        "ready",
+        "executing",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.ImportMappingTargetType": {
+      "name": "ImportMappingTargetType",
+      "schema": "public",
+      "values": ["particle", "relation", "skip"]
+    },
+    "public.ImportPlanRowStatus": {
+      "name": "ImportPlanRowStatus",
+      "schema": "public",
+      "values": ["planned", "executing", "completed", "failed"]
+    },
+    "public.ImportPlanStatus": {
+      "name": "ImportPlanStatus",
+      "schema": "public",
+      "values": ["planning", "planned", "executing", "completed"]
+    },
+    "public.ImportResolutionStatus": {
+      "name": "ImportResolutionStatus",
+      "schema": "public",
+      "values": ["pending", "valid", "error", "warning", "create"]
+    },
+    "public.ImportStrategyStatus": {
+      "name": "ImportStrategyStatus",
+      "schema": "public",
+      "values": ["planning_queued", "planning", "planned", "executing", "completed"]
+    },
+    "public.ImportStrategyType": {
+      "name": "ImportStrategyType",
+      "schema": "public",
+      "values": ["create", "update", "skip"]
+    },
+    "public.InboxStatus": {
+      "name": "InboxStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "ARCHIVED", "PAUSED"]
+    },
+    "public.IndexStatus": {
+      "name": "IndexStatus",
+      "schema": "public",
+      "values": ["PENDING", "INDEXED", "ERROR"]
+    },
+    "public.InsightStatus": {
+      "name": "InsightStatus",
+      "schema": "public",
+      "values": ["processing", "completed", "failed"]
+    },
+    "public.InsightTemplateStatus": {
+      "name": "InsightTemplateStatus",
+      "schema": "public",
+      "values": ["enabled", "disabled", "archived"]
+    },
+    "public.IntegrationProviderType": {
+      "name": "IntegrationProviderType",
+      "schema": "public",
+      "values": [
+        "google",
+        "outlook",
+        "facebook",
+        "instagram",
+        "openphone",
+        "mailgun",
+        "sms",
+        "whatsapp",
+        "chat",
+        "email",
+        "shopify",
+        "imap"
+      ]
+    },
+    "public.IntegrationSyncStage": {
+      "name": "IntegrationSyncStage",
+      "schema": "public",
+      "values": [
+        "IDLE",
+        "MESSAGE_LIST_FETCH_PENDING",
+        "MESSAGE_LIST_FETCH",
+        "MESSAGES_IMPORT_PENDING",
+        "MESSAGES_IMPORT",
+        "FAILED"
+      ]
+    },
+    "public.IntegrationSyncStatus": {
+      "name": "IntegrationSyncStatus",
+      "schema": "public",
+      "values": ["NOT_SYNCED", "SYNCING", "ACTIVE", "FAILED"]
+    },
+    "public.INVENTORY_POLICY": {
+      "name": "INVENTORY_POLICY",
+      "schema": "public",
+      "values": ["CONTINUE", "DENY"]
+    },
+    "public.InvitationStatus": {
+      "name": "InvitationStatus",
+      "schema": "public",
+      "values": ["PENDING", "ACCEPTED", "EXPIRED", "CANCELLED"]
+    },
+    "public.InvoiceStatus": {
+      "name": "InvoiceStatus",
+      "schema": "public",
+      "values": ["PENDING", "PAID", "VOID", "UNCOLLECTIBLE", "DRAFT"]
+    },
+    "public.JobStatus": {
+      "name": "JobStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "PROCESSING",
+        "COMPLETED_SUCCESS",
+        "COMPLETED_PARTIAL",
+        "COMPLETED_FAILURE",
+        "FAILED",
+        "RETRYING"
+      ]
+    },
+    "public.KBKind": {
+      "name": "KBKind",
+      "schema": "public",
+      "values": ["standard", "source"]
+    },
+    "public.KBPublishStatus": {
+      "name": "KBPublishStatus",
+      "schema": "public",
+      "values": ["DRAFT", "PUBLISHED", "UNLISTED"]
+    },
+    "public.KBVisibility": {
+      "name": "KBVisibility",
+      "schema": "public",
+      "values": ["PUBLIC", "INTERNAL"]
+    },
+    "public.KnowledgeSourceStatus": {
+      "name": "KnowledgeSourceStatus",
+      "schema": "public",
+      "values": ["pending", "syncing", "live", "error", "paused"]
+    },
+    "public.KnowledgeSourceSurface": {
+      "name": "KnowledgeSourceSurface",
+      "schema": "public",
+      "values": ["publishable", "ai-only"]
+    },
+    "public.KnowledgeSourceSyncBehavior": {
+      "name": "KnowledgeSourceSyncBehavior",
+      "schema": "public",
+      "values": ["manual", "scheduled", "webhook"]
+    },
+    "public.LabelType": {
+      "name": "LabelType",
+      "schema": "public",
+      "values": ["system", "user"]
+    },
+    "public.MEDIA_CONTENT_TYPE": {
+      "name": "MEDIA_CONTENT_TYPE",
+      "schema": "public",
+      "values": ["EXTERNAL_VIDEO", "IMAGE", "MODEL_3D", "VIDEO"]
+    },
+    "public.MeetingMessageMethod": {
+      "name": "MeetingMessageMethod",
+      "schema": "public",
+      "values": ["request", "reply", "cancel", "counter", "other"]
+    },
+    "public.MeetingPlatform": {
+      "name": "MeetingPlatform",
+      "schema": "public",
+      "values": ["google_meet", "teams", "zoom", "unknown"]
+    },
+    "public.MessageType": {
+      "name": "MessageType",
+      "schema": "public",
+      "values": ["EMAIL", "FACEBOOK", "SMS", "WHATSAPP", "INSTAGRAM", "OPENPHONE", "CHAT"]
+    },
+    "public.ModelType": {
+      "name": "ModelType",
+      "schema": "public",
+      "values": ["LLM", "TEXT_EMBEDDING", "RERANK", "TTS", "SPEECH2TEXT", "MODERATION", "VISION"]
+    },
+    "public.NodeExecutionStatus": {
+      "name": "NodeExecutionStatus",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "exception",
+        "skipped",
+        "stopped",
+        "waiting"
+      ]
+    },
+    "public.NodeTriggerSource": {
+      "name": "NodeTriggerSource",
+      "schema": "public",
+      "values": ["SINGLE_STEP", "WORKFLOW_RUN"]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "COMMENT_MENTION",
+        "COMMENT_REPLY",
+        "COMMENT_REACTION",
+        "TICKET_ASSIGNED",
+        "TICKET_UPDATED",
+        "TICKET_MENTIONED",
+        "THREAD_ACTIVITY",
+        "SYSTEM_MESSAGE",
+        "WORKFLOW_APPROVAL_REQUIRED",
+        "WORKFLOW_APPROVAL_REMINDER",
+        "WORKFLOW_APPROVAL_COMPLETED",
+        "TASK_DEADLINE"
+      ]
+    },
+    "public.ORDER_ADDRESS_TYPE": {
+      "name": "ORDER_ADDRESS_TYPE",
+      "schema": "public",
+      "values": ["SHIPPING", "BILLING"]
+    },
+    "public.ORDER_CANCEL_REASON": {
+      "name": "ORDER_CANCEL_REASON",
+      "schema": "public",
+      "values": ["CUSTOMER", "DECLINED", "FRAUD", "INVENTORY", "OTHER", "STAFF"]
+    },
+    "public.ORDER_FINANCIAL_STATUS": {
+      "name": "ORDER_FINANCIAL_STATUS",
+      "schema": "public",
+      "values": [
+        "AUTHORIZED",
+        "EXPIRED",
+        "PAID",
+        "PARTIALLY_PAID",
+        "PARTIALLY_REFUNDED",
+        "PENDING",
+        "REFUNDED",
+        "VOIDED"
+      ]
+    },
+    "public.ORDER_FULFILLMENT_STATUS": {
+      "name": "ORDER_FULFILLMENT_STATUS",
+      "schema": "public",
+      "values": [
+        "FULFILLED",
+        "IN_PROGRESS",
+        "ON_HOLD",
+        "OPEN",
+        "PARTIALLY_FULFILLED",
+        "PENDING_FULFILLMENT",
+        "REQUEST_DECLINED",
+        "RESTOCKED",
+        "SCHEDULED",
+        "UNFULFILLED"
+      ]
+    },
+    "public.ORDER_RETURN_STATUS": {
+      "name": "ORDER_RETURN_STATUS",
+      "schema": "public",
+      "values": [
+        "INSPECTION_COMPLETED",
+        "IN_PROGRESS",
+        "NO_RETURN",
+        "RETURNED",
+        "RETURN_FAILED",
+        "RETURN_REQUESTED"
+      ]
+    },
+    "public.OrganizationMemberStatus": {
+      "name": "OrganizationMemberStatus",
+      "schema": "public",
+      "values": ["ACTIVE", "INACTIVE"]
+    },
+    "public.OrganizationRole": {
+      "name": "OrganizationRole",
+      "schema": "public",
+      "values": ["OWNER", "ADMIN", "USER"]
+    },
+    "public.OrganizationType": {
+      "name": "OrganizationType",
+      "schema": "public",
+      "values": ["INDIVIDUAL", "TEAM"]
+    },
+    "public.ParticipantRole": {
+      "name": "ParticipantRole",
+      "schema": "public",
+      "values": ["FROM", "TO", "CC", "BCC", "REPLY_TO"]
+    },
+    "public.PRODUDT_STATUS": {
+      "name": "PRODUDT_STATUS",
+      "schema": "public",
+      "values": ["ACTIVE", "ARCHIVED", "DRAFT"]
+    },
+    "public.ProposedActionStatus": {
+      "name": "ProposedActionStatus",
+      "schema": "public",
+      "values": ["PENDING", "APPROVED", "REJECTED", "EXECUTED", "FAILED"]
+    },
+    "public.ProviderQuotaType": {
+      "name": "ProviderQuotaType",
+      "schema": "public",
+      "values": ["PAID", "FREE", "TRIAL"]
+    },
+    "public.ProviderType": {
+      "name": "ProviderType",
+      "schema": "public",
+      "values": ["SYSTEM", "CUSTOM"]
+    },
+    "public.RecipientRole": {
+      "name": "RecipientRole",
+      "schema": "public",
+      "values": ["FROM", "TO", "CC", "BCC"]
+    },
+    "public.RecordingProvider": {
+      "name": "RecordingProvider",
+      "schema": "public",
+      "values": ["recall", "babl", "self_hosted"]
+    },
+    "public.RecordingStatus": {
+      "name": "RecordingStatus",
+      "schema": "public",
+      "values": [
+        "created",
+        "joining",
+        "waiting",
+        "admitted",
+        "recording",
+        "processing",
+        "completed",
+        "failed",
+        "kicked",
+        "denied",
+        "timeout",
+        "cancelled"
+      ]
+    },
+    "public.ResponseStatus": {
+      "name": "ResponseStatus",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PENDING_APPROVAL",
+        "APPROVED",
+        "SCHEDULED",
+        "SENDING",
+        "SENT",
+        "FAILED",
+        "CANCELLED"
+      ]
+    },
+    "public.ResponseType": {
+      "name": "ResponseType",
+      "schema": "public",
+      "values": ["MANUAL", "TEMPLATE", "AI_GENERATED", "RULE_BASED", "HYBRID"]
+    },
+    "public.RETURN_STATUS": {
+      "name": "RETURN_STATUS",
+      "schema": "public",
+      "values": ["CANCELLED", "CLOSED", "DECLINED", "OPEN", "REQUESTED"]
+    },
+    "public.RsvpStatus": {
+      "name": "RsvpStatus",
+      "schema": "public",
+      "values": ["accepted", "declined", "tentative", "needs_action"]
+    },
+    "public.RuleGroupOperator": {
+      "name": "RuleGroupOperator",
+      "schema": "public",
+      "values": ["AND", "OR", "NOT", "XOR", "THRESHOLD"]
+    },
+    "public.RuleType": {
+      "name": "RuleType",
+      "schema": "public",
+      "values": ["STATIC", "CATEGORY", "AI", "SPAM_HANDLER", "RULE_GROUP", "SHOPIFY_AUTOMATION"]
+    },
+    "public.ScheduledMessageSource": {
+      "name": "ScheduledMessageSource",
+      "schema": "public",
+      "values": ["USER_SCHEDULED", "AI_SUGGESTED", "AUTO_REPLY"]
+    },
+    "public.ScheduledMessageStatus": {
+      "name": "ScheduledMessageStatus",
+      "schema": "public",
+      "values": ["PENDING", "PROCESSING", "SENT", "FAILED", "CANCELLED"]
+    },
+    "public.SendStatus": {
+      "name": "SendStatus",
+      "schema": "public",
+      "values": ["PENDING", "SENT", "FAILED"]
+    },
+    "public.SenderType": {
+      "name": "SenderType",
+      "schema": "public",
+      "values": [
+        "INTERNAL_STAFF",
+        "INTERNAL_SYSTEM",
+        "PARTNER",
+        "CUSTOMER",
+        "VENDOR",
+        "UNKNOWN_EXTERNAL"
+      ]
+    },
+    "public.Sensitivity": {
+      "name": "Sensitivity",
+      "schema": "public",
+      "values": ["normal", "private", "personal", "confidential"]
+    },
+    "public.SettingScope": {
+      "name": "SettingScope",
+      "schema": "public",
+      "values": [
+        "APPEARANCE",
+        "NOTIFICATION",
+        "DASHBOARD",
+        "COMMUNICATION",
+        "SECURITY",
+        "INTEGRATION",
+        "GENERAL",
+        "SIDEBAR",
+        "RECORDING",
+        "KOPILOT",
+        "ONBOARDING"
+      ]
+    },
+    "public.SignatureSharingType": {
+      "name": "SignatureSharingType",
+      "schema": "public",
+      "values": ["PRIVATE", "ORGANIZATION_WIDE", "SPECIFIC_INTEGRATIONS"]
+    },
+    "public.SnippetPermission": {
+      "name": "SnippetPermission",
+      "schema": "public",
+      "values": ["VIEW", "EDIT"]
+    },
+    "public.SnippetSharingType": {
+      "name": "SnippetSharingType",
+      "schema": "public",
+      "values": ["PRIVATE", "ORGANIZATION", "GROUPS", "MEMBERS"]
+    },
+    "public.StaticRuleType": {
+      "name": "StaticRuleType",
+      "schema": "public",
+      "values": [
+        "SENDER_DOMAIN",
+        "SENDER_ADDRESS",
+        "RECIPIENT_PATTERN",
+        "SUBJECT_MATCH",
+        "BODY_KEYWORD",
+        "HEADER_CHECK",
+        "ATTACHMENT_TYPE",
+        "COMBINED",
+        "INTERNAL_EXTERNAL",
+        "THREAD_BASED"
+      ]
+    },
+    "public.StorageProvider": {
+      "name": "StorageProvider",
+      "schema": "public",
+      "values": ["S3", "GOOGLE_DRIVE", "DROPBOX", "ONEDRIVE", "BOX", "GENERIC_URL"]
+    },
+    "public.SYNC_STATUS": {
+      "name": "SYNC_STATUS",
+      "schema": "public",
+      "values": ["PENDING", "IN_PROGRESS", "COMPLETED", "FAILED"]
+    },
+    "public.ThreadHandoffState": {
+      "name": "ThreadHandoffState",
+      "schema": "public",
+      "values": ["ai", "human"]
+    },
+    "public.ThreadStatus": {
+      "name": "ThreadStatus",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "ARCHIVED",
+        "ACTIVE",
+        "RESOLVED",
+        "PENDING",
+        "CLOSED",
+        "SPAM",
+        "TRASH",
+        "IGNORED"
+      ]
+    },
+    "public.ThreadType": {
+      "name": "ThreadType",
+      "schema": "public",
+      "values": ["EMAIL", "CHAT"]
+    },
+    "public.TicketPriority": {
+      "name": "TicketPriority",
+      "schema": "public",
+      "values": ["LOW", "MEDIUM", "HIGH", "URGENT"]
+    },
+    "public.TicketStatus": {
+      "name": "TicketStatus",
+      "schema": "public",
+      "values": [
+        "OPEN",
+        "IN_PROGRESS",
+        "WAITING_FOR_CUSTOMER",
+        "WAITING_FOR_THIRD_PARTY",
+        "RESOLVED",
+        "CLOSED",
+        "CANCELLED",
+        "MERGED"
+      ]
+    },
+    "public.TicketType": {
+      "name": "TicketType",
+      "schema": "public",
+      "values": [
+        "GENERAL",
+        "MISSING_ITEM",
+        "RETURN",
+        "REFUND",
+        "PRODUCT_ISSUE",
+        "SHIPPING_ISSUE",
+        "BILLING",
+        "TECHNICAL",
+        "OTHER"
+      ]
+    },
+    "public.TranscriptStatus": {
+      "name": "TranscriptStatus",
+      "schema": "public",
+      "values": ["processing", "completed", "failed"]
+    },
+    "public.TranscriptType": {
+      "name": "TranscriptType",
+      "schema": "public",
+      "values": ["realtime", "async"]
+    },
+    "public.TrialConversionStatus": {
+      "name": "TrialConversionStatus",
+      "schema": "public",
+      "values": [
+        "TRIAL_ACTIVE",
+        "CONVERTED_TO_PAID",
+        "EXPIRED_WITHOUT_CONVERSION",
+        "CANCELED_DURING_TRIAL",
+        "MANUAL_CONVERSION"
+      ]
+    },
+    "public.UserType": {
+      "name": "UserType",
+      "schema": "public",
+      "values": ["USER", "SYSTEM", "AGENT"]
+    },
+    "public.VectorDbType": {
+      "name": "VectorDbType",
+      "schema": "public",
+      "values": ["POSTGRESQL", "CHROMA", "QDRANT", "WEAVIATE", "PINECONE", "MILVUS"]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": ["RUNNING", "SUCCEEDED", "FAILED", "STOPPED", "WAITING"]
+    },
+    "public.WorkflowShareAccessMode": {
+      "name": "WorkflowShareAccessMode",
+      "schema": "public",
+      "values": ["public", "organization"]
+    },
+    "public.WorkflowTriggerSource": {
+      "name": "WorkflowTriggerSource",
+      "schema": "public",
+      "values": ["DEBUGGING", "APP_RUN", "SINGLE_STEP", "PUBLIC_SHARE", "API_KEY", "WEBHOOK"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -1765,6 +1765,13 @@
       "when": 1782882979343,
       "tag": "0251_add_export_job",
       "breakpoints": true
+    },
+    {
+      "idx": 252,
+      "version": "7",
+      "when": 1782883528141,
+      "tag": "0252_drop_entity_instance_integration_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/db/schema/data-connector-item.ts
+++ b/packages/database/src/db/schema/data-connector-item.ts
@@ -5,7 +5,16 @@
 // See plans/data-connectors/.
 
 import { createId } from '@paralleldrive/cuid2'
-import { type AnyPgColumn, index, jsonb, pgTable, text, timestamp, uniqueIndex } from './_shared'
+import {
+  type AnyPgColumn,
+  boolean,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from './_shared'
 import { DataConnector } from './data-connector'
 import { DataConnectorMapping } from './data-connector-mapping'
 import { EntityDefinition } from './entity-definition'
@@ -47,6 +56,15 @@ export const DataConnectorItem = pgTable(
       onUpdate: 'cascade',
       onDelete: 'set null',
     }), // null until first bind
+
+    /**
+     * True when THIS connector CREATED (minted) the bound instance, false when it
+     * merely matched + enriched a pre-existing record. Sticky (once true, stays
+     * true across re-syncs). Replaces the retired `EntityInstance.integrationSource`
+     * marker — `deleteConnector`'s archive/delete only touches minted records so
+     * an enriched pre-existing Contact is never removed with the connector.
+     */
+    mintedInstance: boolean().default(false).notNull(),
 
     contentHash: text(), // sorted-key hash → skip-unchanged
     // Which target field keys this connector writes for this record (per-field

--- a/packages/database/src/db/schema/entity-instance.ts
+++ b/packages/database/src/db/schema/entity-instance.ts
@@ -96,21 +96,6 @@ export const EntityInstance = pgTable(
      * activity"). Replaces v2's NOOP-row mechanism.
      */
     lastSuggestionScanAt: timestamp({ precision: 3 }),
-
-    /**
-     * Denormalized integration source for fast lookup by external id.
-     * Powers `ctx.entities.findByIntegrationId` from AI-tool lambdas.
-     * Free-form string (e.g. 'shopify', 'hubspot'). Null when not imported
-     * from an external integration. See plans/kopilot/apps/credentials.md §3.7.
-     */
-    integrationSource: text(),
-
-    /**
-     * External id within the integration source (e.g. Shopify GID,
-     * HubSpot contact id). Lookup is keyed on
-     * (organizationId, entityDefinitionId, integrationSource, externalId).
-     */
-    externalId: text(),
   },
   (table) => [
     // Index for entity definition lookups
@@ -139,15 +124,6 @@ export const EntityInstance = pgTable(
       table.organizationId.asc().nullsLast(),
       table.entityDefinitionId.asc().nullsLast(),
       table.lastActivityAt.asc().nullsLast()
-    ),
-    // Integration-id lookup for AI tool refs.entity(...) resolution.
-    // Composite index on (organizationId, entityDefinitionId, integrationSource, externalId).
-    // See plans/kopilot/apps/credentials.md §3.7 (Q1).
-    index('EntityInstance_integrationLookup_idx').on(
-      table.organizationId,
-      table.entityDefinitionId,
-      table.integrationSource,
-      table.externalId
     ),
     // AI suggestion scanner candidate query (Phase 3c): non-archived rows
     // ordered by activity & last-scan, scoped per (org, entity definition).

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -1134,18 +1134,27 @@ export async function deleteConnector(
 
   if (behavior !== 'keep') {
     // archive/delete applies to records THIS connector CREATED — owned mirror rows
-    // AND contributing instances it minted — identified by the instance-level
-    // `integrationSource = connector.id` stamp the sink writes on create. Records the
-    // connector merely enriched (a pre-existing Contact/Ticket it matched) carry a
-    // different/no `integrationSource` and are ALWAYS kept; their per-cell
-    // `FieldValue.managedByConnectorId` markers null automatically via the FK.
+    // AND contributing instances it minted — identified by the sticky
+    // `DataConnectorItem.mintedInstance` flag the sink sets on create (replaces the
+    // retired `EntityInstance.integrationSource` stamp). Records the connector merely
+    // ENRICHED (a pre-existing Contact/Ticket it matched) carry `mintedInstance=false`
+    // and are ALWAYS kept; their per-cell `FieldValue.managedByConnectorId` markers
+    // null automatically via the FK.
     const created = await db
-      .select({ id: schema.EntityInstance.id, defId: schema.EntityInstance.entityDefinitionId })
-      .from(schema.EntityInstance)
+      .selectDistinct({
+        id: schema.EntityInstance.id,
+        defId: schema.EntityInstance.entityDefinitionId,
+      })
+      .from(schema.DataConnectorItem)
+      .innerJoin(
+        schema.EntityInstance,
+        eq(schema.EntityInstance.id, schema.DataConnectorItem.entityInstanceId)
+      )
       .where(
         and(
-          eq(schema.EntityInstance.organizationId, organizationId),
-          eq(schema.EntityInstance.integrationSource, id)
+          eq(schema.DataConnectorItem.organizationId, organizationId),
+          eq(schema.DataConnectorItem.dataConnectorId, id),
+          eq(schema.DataConnectorItem.mintedInstance, true)
         )
       )
     if (created.length > 0) {

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -700,6 +700,8 @@ export interface UpsertItemInput {
   pendingRelations?: PendingRelation[]
   upstreamUpdatedAt?: Date | null
   lastSeenRunId: string
+  /** True when the sink CREATED the bound instance this run (vs matched). Sticky. */
+  mintedInstance?: boolean
 }
 
 /**
@@ -726,6 +728,8 @@ export async function upsertItem(
         upstreamUpdatedAt: input.upstreamUpdatedAt ?? existing.upstreamUpdatedAt,
         lastSeenRunId: input.lastSeenRunId,
         lastSyncedAt: now,
+        // Sticky: once this connector minted the instance it stays minted.
+        mintedInstance: input.mintedInstance || existing.mintedInstance,
         archivedAt: null,
         error: null,
       })
@@ -749,6 +753,7 @@ export async function upsertItem(
       upstreamUpdatedAt: input.upstreamUpdatedAt ?? null,
       lastSeenRunId: input.lastSeenRunId,
       lastSyncedAt: now,
+      mintedInstance: input.mintedInstance ?? false,
     })
     .returning()
   return row!

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -577,9 +577,14 @@ export const entitySink: EntitySink = {
       refToConcrete
     )
 
-    // 4. Write — owned uses the bypass handler + provenance; contributing uses
-    //    the standard handler and leaves the row pair alone.
+    // 4. Write — owned uses the bypass handler; contributing uses the standard
+    //    handler and leaves the row pair alone. `justCreated` marks a minted
+    //    instance so the binding (below) records "this connector created this
+    //    record" — the durable marker that lets connector deletion touch only
+    //    records it created, leaving ENRICHED pre-existing records untouched
+    //    (replaces the retired `EntityInstance.integrationSource` stamp).
     const handler = mapping.targetMode === 'owned' ? ctx.ownedCrud : ctx.crud
+    let justCreated = false
     try {
       if (instanceId) {
         const recordId = toRecordId(mapping.entityDefinitionId, instanceId)
@@ -592,15 +597,9 @@ export const entitySink: EntitySink = {
         const created = await handler.create(mapping.entityDefinitionId, writeSet, {
           skipSnapshotInvalidation: true,
           skipEvents: true,
-          // Stamp instance-level provenance on every connector-CREATED record — owned
-          // AND contributing alike. This is the durable "this connector minted this
-          // instance" marker that lets connector deletion delete the records it created
-          // (a connector that provisions its own def, or contributing that mints a brand
-          // new instance) while leaving records it merely ENRICHED (a pre-existing
-          // Contact it matched by email — no/other integrationSource) untouched.
-          provenance: { integrationSource: ctx.connector.id, externalId: record.externalId },
         })
         instanceId = created.instance.id
+        justCreated = true
         ctx.counters.created += 1
       }
     } catch (error) {
@@ -657,6 +656,7 @@ export const entitySink: EntitySink = {
       ),
       upstreamUpdatedAt: record.upstreamUpdatedAt ?? null,
       lastSeenRunId: ctx.runId,
+      mintedInstance: justCreated,
     })
   },
 

--- a/packages/lib/src/data-migrations/migrations/029-seed-record-identity-index.ts
+++ b/packages/lib/src/data-migrations/migrations/029-seed-record-identity-index.ts
@@ -1,0 +1,42 @@
+// packages/lib/src/data-migrations/migrations/029-seed-record-identity-index.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { reconcileRecordIdentities } from '../../identity'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-029')
+
+/**
+ * One-shot seed of the `RecordIdentity` index from the existing identity
+ * `FieldValue` cells (`FieldValue ⋈ CustomField(isIdentity)`), org by org.
+ *
+ * This is NOT a legacy-store parse — the retired `EntityInstance.integrationSource`
+ * (connector provenance, not an identity) and the `external_id` array (disposable
+ * dev/test data) are simply dropped, not migrated. The only real identity worth
+ * preserving already lives in `FieldValue`, so this just invokes the same
+ * reconcile primitive the recurring cron uses, once, so the badge + reverse
+ * lookup have a populated index immediately after deploy. Idempotent.
+ */
+export const migration029SeedRecordIdentityIndex: DataMigrationDef = {
+  id: '029-seed-record-identity-index',
+  description: 'Seed RecordIdentity from identity FieldValue cells (reconcile one-shot)',
+  async run(db: Database): Promise<void> {
+    const orgs = await db.select({ id: schema.Organization.id }).from(schema.Organization)
+
+    let upserted = 0
+    let skipped = 0
+    for (const org of orgs) {
+      const result = await reconcileRecordIdentities(org.id, db)
+      upserted += result.upserted
+      skipped += result.skipped
+    }
+
+    logger.info('Seeded RecordIdentity index', {
+      organizations: orgs.length,
+      upserted,
+      skipped,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -6,6 +6,7 @@ import { migration025ReseedPlatformProviders } from './migrations/025-reseed-pla
 import { migration026NormalizeChannelCredentials } from './migrations/026-normalize-channel-credentials'
 import { migration027BackfillCredentialDefinitionFk } from './migrations/027-backfill-credential-definition-fk'
 import { migration028DataConnectorStreamSyncModeWebhook } from './migrations/028-data-connector-stream-syncmode-webhook'
+import { migration029SeedRecordIdentityIndex } from './migrations/029-seed-record-identity-index'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -28,6 +29,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration026NormalizeChannelCredentials,
     migration027BackfillCredentialDefinitionFk,
     migration028DataConnectorStreamSyncModeWebhook,
+    migration029SeedRecordIdentityIndex,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/import/fields/auto-map-columns.ts
+++ b/packages/lib/src/import/fields/auto-map-columns.ts
@@ -117,7 +117,11 @@ const FIELD_ALIASES: Record<string, string[]> = {
   notes: ['notes', 'note', 'comments', 'comment', 'description', 'memo', 'remarks'],
   createdAt: ['createdat', 'created', 'datecreated', 'creationdate', 'createdon'],
   updatedAt: ['updatedat', 'updated', 'datemodified', 'modifieddate', 'modifiedon'],
-  externalId: ['externalid', 'external_id', 'extid', 'customerid', 'clientid', 'refid'],
+  // NOTE: the `external_id` array attribute is retired (identities now live in
+  // the `RecordIdentity` index). Auto-mapping `externalid`/`customerid`/… into
+  // the index under a user-named source is a follow-up (needs import-mapping UI
+  // + writer work — see plan open-decision 9); until then these columns are
+  // left unmapped rather than pointed at a dropped field.
 }
 
 /** Match result with score for sorting */

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -154,6 +154,10 @@ export {
 } from './maintenance/org-seed-job'
 export { type QuotaResetStats, quotaResetJob } from './maintenance/quota-reset-job'
 export {
+  type ReconcileRecordIdentitiesStats,
+  reconcileRecordIdentitiesJob,
+} from './maintenance/reconcile-record-identities-job'
+export {
   type StalePendingMessageSweeperStats,
   stalePendingMessageSweeperJob,
 } from './maintenance/stale-pending-message-sweeper-job'

--- a/packages/lib/src/jobs/maintenance/index.ts
+++ b/packages/lib/src/jobs/maintenance/index.ts
@@ -15,6 +15,10 @@ export { type MidTrialStats, sendMidTrialEmailsJob } from './mid-trial-job'
 export { oauth2TokenRefreshScannerJob } from './oauth2-token-refresh-scanner-job'
 export { type QuotaResetStats, quotaResetJob } from './quota-reset-job'
 export {
+  type ReconcileRecordIdentitiesStats,
+  reconcileRecordIdentitiesJob,
+} from './reconcile-record-identities-job'
+export {
   type StalePendingMessageSweeperStats,
   stalePendingMessageSweeperJob,
 } from './stale-pending-message-sweeper-job'

--- a/packages/lib/src/jobs/maintenance/reconcile-record-identities-job.ts
+++ b/packages/lib/src/jobs/maintenance/reconcile-record-identities-job.ts
@@ -1,0 +1,65 @@
+// packages/lib/src/jobs/maintenance/reconcile-record-identities-job.ts
+
+import { database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { reconcileRecordIdentities } from '../../identity'
+import type { JobContext } from '../types'
+
+const logger = createScopedLogger('reconcile-record-identities')
+
+interface ReconcileRecordIdentitiesJobData {
+  /** Cap orgs processed per run (defence against runaway); defaults to all. */
+  batchSize?: number
+}
+
+export interface ReconcileRecordIdentitiesStats {
+  organizations: number
+  upserted: number
+  skipped: number
+  orphanedDeleted: number
+  errors: number
+}
+
+/**
+ * Drift backstop for the `RecordIdentity` index. Any writer outside the closed
+ * explicit set (connector sink, chat passport, chat JWT resolver) updates the
+ * identity `FieldValue` but not the mirror, silently. This sweeps every
+ * organization and rebuilds the index from `FieldValue ⋈ CustomField(isIdentity)`
+ * (see {@link reconcileRecordIdentities}). Idempotent; safe to run repeatedly.
+ */
+export async function reconcileRecordIdentitiesJob(
+  ctx: JobContext<ReconcileRecordIdentitiesJobData>
+): Promise<ReconcileRecordIdentitiesStats> {
+  const { batchSize } = ctx.job.data ?? {}
+
+  const orgs = await database
+    .select({ id: schema.Organization.id })
+    .from(schema.Organization)
+    .limit(batchSize ?? 100_000)
+
+  const stats: ReconcileRecordIdentitiesStats = {
+    organizations: orgs.length,
+    upserted: 0,
+    skipped: 0,
+    orphanedDeleted: 0,
+    errors: 0,
+  }
+
+  for (const org of orgs) {
+    try {
+      const result = await reconcileRecordIdentities(org.id)
+      stats.upserted += result.upserted
+      stats.skipped += result.skipped
+      stats.orphanedDeleted += result.orphanedDeleted
+    } catch (err) {
+      stats.errors++
+      logger.warn('Failed to reconcile record identities', {
+        organizationId: org.id,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  logger.info('Record identity reconcile finished', stats)
+  return stats
+}

--- a/packages/lib/src/resources/client.ts
+++ b/packages/lib/src/resources/client.ts
@@ -27,6 +27,7 @@ export type {
   GetResourcesInput,
   PaginatedResourcesResult,
   RecordPickerItem,
+  RecordSourceChip,
 } from './picker'
 // Detail view configuration (client-safe)
 export {

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -40,14 +40,6 @@ export interface CrudOptions {
   skipEvents?: boolean
   /** Skip snapshot invalidation (caller will invalidate once at end) */
   skipSnapshotInvalidation?: boolean
-  /**
-   * Trusted provenance stamp written onto the `EntityInstance` row at create
-   * time (`integrationSource` + `externalId`). Owned-mode data-connector /
-   * importer use only — links the synced record back to its upstream source
-   * and powers `findByIntegrationId`. Omit for user-driven creates; behavior
-   * is unchanged when absent. Ignored on update (provenance is set once).
-   */
-  provenance?: { integrationSource: string; externalId: string }
 }
 
 /** Inferred type for CustomField select */
@@ -332,14 +324,12 @@ export async function createEntity(
   // Check uniqueness constraints
   await ctx.validateUniqueFields(entityDef.id, processedValues)
 
-  // Create EntityInstance. Stamp upstream provenance when a trusted caller
-  // (owned-mode data connector / importer) supplies it — left null otherwise.
+  // Create EntityInstance. Connector-minted provenance now lives on
+  // `DataConnectorItem.mintedInstance`, not on the instance row.
   const instanceResult = await createEntityInstance({
     entityDefinitionId: entityDef.id,
     organizationId: ctx.organizationId,
     createdById: ctx.userId,
-    integrationSource: options.provenance?.integrationSource,
-    externalId: options.provenance?.externalId,
   })
 
   const instance = unwrapResult(instanceResult)

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -19,6 +19,7 @@ import { publisher } from '../../events/publisher'
 import { FieldValueService } from '../../field-values'
 import { normalizeForLookup } from '../../field-values/normalize-for-lookup'
 import { typedColumnMatch } from '../../field-values/typed-column-match'
+import { upsertRecordIdentity } from '../../identity'
 import { getOrCreateSnapshot, getSnapshotChunk, invalidateSnapshots } from '../../snapshot'
 import { getCommonHooks, getSystemHooks } from '../hooks'
 import { RecordPickerService } from '../picker'
@@ -62,6 +63,20 @@ type CustomFieldEntity = typeof schema.CustomField.$inferSelect
 type EntityInstanceEntity = typeof schema.EntityInstance.$inferSelect
 
 const lookupLogger = createScopedLogger('unified-handler-lookup')
+
+/**
+ * Parse an `external_id` value (`"<source>:<value>"`, e.g. `"gmail:jane@x.com"`,
+ * `"website:acme.com"`) into a `RecordIdentity` `(source, externalId)`. The
+ * `external_id` array attribute is retired; app-less external ids now live in
+ * the identity index, so both the extension dedupe lookup and its create-write
+ * route through this. Returns `null` for unprefixed / malformed values.
+ */
+function parseExternalIdentity(raw: unknown): { source: string; externalId: string } | null {
+  if (typeof raw !== 'string') return null
+  const idx = raw.indexOf(':')
+  if (idx <= 0 || idx >= raw.length - 1) return null
+  return { source: raw.slice(0, idx), externalId: raw.slice(idx + 1) }
+}
 
 /**
  * Candidate for `lookupByField` — one field reference + value to try. Two shapes,
@@ -221,9 +236,7 @@ export class UnifiedCrudHandler {
    *
    * @param entityDefinitionId - 'contact', 'ticket', or UUID for custom entities
    * @param values - Field values to set (map of fieldId -> value)
-   * @param options - Optional CRUD options (skipEvents, skipSnapshotInvalidation,
-   *   provenance — a trusted `{ integrationSource, externalId }` stamp for
-   *   owned-mode connector/importer writes)
+   * @param options - Optional CRUD options (skipEvents, skipSnapshotInvalidation)
    * @returns CreateEntityResult with instance, recordId, and all field values
    */
   async create(
@@ -232,7 +245,60 @@ export class UnifiedCrudHandler {
     options: CrudOptions = {}
   ): Promise<CreateEntityResult> {
     await this.warmCache(entityDefinitionId)
-    return createEntity(this.getMutationContext(), entityDefinitionId, values, options)
+    // The `external_id` ARRAY attribute is retired (contact/company). Its writers
+    // (browser extension) still send it under `values` as an array; peel it off
+    // and mirror each entry into the `RecordIdentity` index (app-less link)
+    // instead of a FieldValue. Gated on Array to leave `thread`'s scalar
+    // `external_id` dbColumn — a plain string — on the normal write path.
+    const isRetiredArray = Array.isArray(values.external_id)
+    const { external_id, ...rest } = values
+    const result = await createEntity(
+      this.getMutationContext(),
+      entityDefinitionId,
+      isRetiredArray ? rest : values,
+      options
+    )
+    if (isRetiredArray) {
+      await this.mirrorExternalIdentities(result.instance, external_id)
+    }
+    return result
+  }
+
+  /**
+   * Mirror one or more retired-`external_id` values into `RecordIdentity` as
+   * app-less links (`source=<prefix>`, no app/connection/field). Best-effort:
+   * a malformed value or unique-key clash is skipped, never fails the create.
+   */
+  private async mirrorExternalIdentities(
+    instance: EntityInstanceEntity,
+    external_id: unknown
+  ): Promise<void> {
+    const raws = Array.isArray(external_id) ? external_id : [external_id]
+    for (const raw of raws) {
+      const parsed = parseExternalIdentity(raw)
+      if (!parsed) continue
+      const result = await upsertRecordIdentity(
+        {
+          organizationId: this.organizationId,
+          entityInstanceId: instance.id,
+          entityDefinitionId: instance.entityDefinitionId,
+          source: parsed.source,
+          externalId: parsed.externalId,
+          appInstallationId: null,
+          connectionId: null,
+          appFieldKey: null,
+          fieldId: null,
+        },
+        this.db
+      )
+      if (!result.ok) {
+        lookupLogger.warn('Failed to mirror external_id into RecordIdentity', {
+          organizationId: this.organizationId,
+          entityInstanceId: instance.id,
+          source: parsed.source,
+        })
+      }
+    }
   }
 
   /**
@@ -362,6 +428,56 @@ export class UnifiedCrudHandler {
 
     for (const candidate of params.candidates) {
       if (items.length >= params.limit) break
+
+      // `external_id` is retired as a FieldValue attribute — resolve it against
+      // the `RecordIdentity` index instead (app-less link, source-scoped).
+      if ('systemAttribute' in candidate && candidate.systemAttribute === 'external_id') {
+        const parsed = parseExternalIdentity(candidate.value)
+        if (!parsed) {
+          skipped.push({ candidate, reason: 'unparseable external_id' })
+          continue
+        }
+        anyValid = true
+        const remaining = params.limit - items.length
+        const rows = await this.db
+          .select({
+            entityId: schema.RecordIdentity.entityInstanceId,
+            displayName: schema.EntityInstance.displayName,
+            secondaryDisplayValue: schema.EntityInstance.secondaryDisplayValue,
+            avatarUrl: schema.EntityInstance.avatarUrl,
+          })
+          .from(schema.RecordIdentity)
+          .innerJoin(
+            schema.EntityInstance,
+            eq(schema.EntityInstance.id, schema.RecordIdentity.entityInstanceId)
+          )
+          .where(
+            and(
+              eq(schema.RecordIdentity.organizationId, this.organizationId),
+              eq(schema.RecordIdentity.entityDefinitionId, entityDef.id),
+              eq(schema.RecordIdentity.source, parsed.source),
+              eq(schema.RecordIdentity.externalId, parsed.externalId)
+            )
+          )
+          .limit(remaining + 1)
+        for (const row of rows) {
+          const recordId = toRecordId(entityDef.id, row.entityId)
+          if (seen.has(recordId)) continue
+          if (items.length >= params.limit) {
+            hasMore = true
+            break
+          }
+          seen.add(recordId)
+          items.push({
+            recordId,
+            matchedBy: { systemAttribute: candidate.systemAttribute, value: candidate.value },
+            displayName: row.displayName,
+            secondaryDisplayValue: row.secondaryDisplayValue,
+            avatarUrl: row.avatarUrl,
+          })
+        }
+        continue
+      }
 
       const field =
         'fieldId' in candidate

--- a/packages/lib/src/resources/picker/index.ts
+++ b/packages/lib/src/resources/picker/index.ts
@@ -9,4 +9,5 @@ export type {
   GlobalSearchResult,
   PaginatedResourcesResult,
   RecordPickerItem,
+  RecordSourceChip,
 } from './types'

--- a/packages/lib/src/resources/picker/record-picker-service.ts
+++ b/packages/lib/src/resources/picker/record-picker-service.ts
@@ -5,6 +5,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { isEntityDefinitionType, type RecordId } from '@auxx/types/resource'
 import { and, asc, desc, eq, ilike, inArray, or, type SQL, sql } from 'drizzle-orm'
 import { getCachedEntityDefId, getCachedResource, getOrgCache } from '../../cache'
+import { getRecordIdentitiesForRecords } from '../../identity'
 import {
   type CustomResource,
   isCustomResource,
@@ -23,6 +24,7 @@ import type {
   GlobalSearchResult,
   PaginatedResourcesResult,
   RecordPickerItem,
+  RecordSourceChip,
 } from './types'
 
 const logger = createScopedLogger('record-picker-service')
@@ -608,8 +610,6 @@ export class RecordPickerService {
       avatarUrl: string | null
       createdAt: string
       updatedAt: string
-      integrationSource?: string | null
-      externalId?: string | null
     }
   ): RecordPickerItem {
     const { displayName, secondaryInfo } = resolveEntityDisplay(
@@ -623,8 +623,6 @@ export class RecordPickerService {
       displayName,
       secondaryInfo,
       avatarUrl: instance.avatarUrl || undefined,
-      integrationSource: instance.integrationSource ?? null,
-      externalId: instance.externalId ?? null,
       data: instance,
       createdAt: instance.createdAt,
       updatedAt: instance.updatedAt,
@@ -729,7 +727,40 @@ export class RecordPickerService {
       })
     )
 
+    await this.attachRecordSources(result)
     return result
+  }
+
+  /**
+   * Attach app-origin identity chips (`sources[]`) to a batch of picker items
+   * from the `RecordIdentity` index — the record-grain source badge, replacing
+   * the retired `EntityInstance.integrationSource`. App-less links (chat,
+   * social) carry no `appInstallationId` and are skipped here (they surface in
+   * the External identities card). Deduped by app + connection.
+   */
+  private async attachRecordSources(items: Record<RecordId, RecordPickerItem>): Promise<void> {
+    const recordKeys = Object.keys(items) as RecordId[]
+    if (recordKeys.length === 0) return
+
+    const identities = await getRecordIdentitiesForRecords(this.organizationId, recordKeys, this.db)
+    for (const [recordId, rows] of identities) {
+      const item = items[recordId]
+      if (!item) continue
+      const seen = new Set<string>()
+      const sources: RecordSourceChip[] = []
+      for (const row of rows) {
+        if (!row.appInstallationId) continue
+        const dedupeKey = `${row.appInstallationId}:${row.connectionId ?? ''}`
+        if (seen.has(dedupeKey)) continue
+        seen.add(dedupeKey)
+        sources.push({
+          source: row.source,
+          appInstallationId: row.appInstallationId,
+          connectionId: row.connectionId,
+        })
+      }
+      if (sources.length > 0) item.sources = sources
+    }
   }
 
   /**

--- a/packages/lib/src/resources/picker/types.ts
+++ b/packages/lib/src/resources/picker/types.ts
@@ -27,6 +27,22 @@ export interface GetResourcesInput {
 }
 
 /**
+ * Compact app-origin identity chip, derived from the `RecordIdentity` index.
+ * Drives the record-grain "Synced from <app>" source badge (replaces the
+ * retired `EntityInstance.integrationSource`). Only app-origin identities
+ * (`appInstallationId` set) become chips; app-less links (chat, social) surface
+ * in the External identities card, not the badge.
+ */
+export interface RecordSourceChip {
+  /** App slug of the identity's origin, e.g. `'shopify'`. */
+  source: string
+  /** Installed app id, for branding resolution. */
+  appInstallationId: string
+  /** Store/connection scope; null for installation-scoped identities. */
+  connectionId: string | null
+}
+
+/**
  * Record item formatted for picker display
  */
 export interface RecordPickerItem {
@@ -56,15 +72,11 @@ export interface RecordPickerItem {
   color?: string
 
   /**
-   * Data-connector / integration provenance, denormalized from
-   * `EntityInstance.integrationSource`. For connector-synced records this holds
-   * the owning DataConnector id; null for hand-created records. Drives the
-   * "Synced from <connector>" source badge.
+   * App-origin identity chips derived from the `RecordIdentity` index (deduped
+   * by app + connection). Drives the record-grain "Synced from <app>" source
+   * badge. Absent/empty for records with no app identity.
    */
-  integrationSource?: string | null
-
-  /** Upstream id within the integration source (e.g. Shopify customer id). */
-  externalId?: string | null
+  sources?: RecordSourceChip[]
 
   /** Full row data (for custom rendering) */
   data: Record<string, unknown>

--- a/packages/lib/src/resources/registry/resources/company-fields.ts
+++ b/packages/lib/src/resources/registry/resources/company-fields.ts
@@ -388,30 +388,6 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
     description: 'Meetings associated with this company',
   },
 
-  externalId: {
-    id: toFieldId('externalId'),
-    key: 'externalId',
-    label: 'External ID',
-    type: BaseType.STRING,
-    fieldType: FieldType.TEXT,
-    isSystem: true,
-    systemAttribute: 'external_id',
-    systemSortOrder: 'aX',
-    nullable: true,
-    isIdentifier: true,
-    options: { multi: true },
-    capabilities: {
-      filterable: true,
-      sortable: false,
-      creatable: true,
-      updatable: true,
-      configurable: false,
-      hidden: true,
-    },
-    description:
-      'Stable source identifiers (e.g. linkedin-company:slug) set when a company is captured via the Auxx extension. Multi-value — a company may be captured from several sources.',
-  },
-
   enrichedAt: {
     id: toFieldId('enrichedAt'),
     key: 'enrichedAt',

--- a/packages/lib/src/resources/registry/resources/contact-fields.ts
+++ b/packages/lib/src/resources/registry/resources/contact-fields.ts
@@ -361,30 +361,6 @@ export const CONTACT_FIELDS: Record<string, ResourceField> = {
     placeholder: 'Enter notes',
   },
 
-  externalId: {
-    id: toFieldId('externalId'),
-    key: 'externalId',
-    label: 'External ID',
-    type: BaseType.STRING,
-    fieldType: FieldType.TEXT,
-    isSystem: true,
-    systemAttribute: 'external_id',
-    systemSortOrder: 'b0',
-    nullable: true,
-    isIdentifier: true,
-    options: { multi: true },
-    capabilities: {
-      filterable: true,
-      sortable: false,
-      creatable: true,
-      updatable: true,
-      configurable: false,
-      hidden: true,
-    },
-    description:
-      'Stable source identifiers (e.g. linkedin:slug, gmail:email) set when a record is captured via the Auxx extension. Multi-value — a contact may be captured from several sources.',
-  },
-
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/services/src/entity-instances/create-entity-instance.ts
+++ b/packages/services/src/entity-instances/create-entity-instance.ts
@@ -17,14 +17,6 @@ export interface CreateEntityInstanceParams {
   avatarUrl?: string | null
   /** Generic metadata JSONB */
   metadata?: Record<string, unknown> | null
-  /**
-   * Denormalized integration source (e.g. 'shopify', a data-connector id).
-   * Powers `findByIntegrationId` lookups. Only set by trusted write paths
-   * (importers, data connectors) — left null for user-driven creates.
-   */
-  integrationSource?: string | null
-  /** External id within the integration source. Paired with `integrationSource`. */
-  externalId?: string | null
 }
 
 /**
@@ -42,8 +34,6 @@ export async function createEntityInstance(params: CreateEntityInstanceParams, t
     secondaryDisplayValue,
     avatarUrl,
     metadata,
-    integrationSource,
-    externalId,
   } = params
 
   const db = tx ?? database
@@ -60,8 +50,6 @@ export async function createEntityInstance(params: CreateEntityInstanceParams, t
         secondaryDisplayValue: secondaryDisplayValue ?? null,
         avatarUrl: avatarUrl ?? null,
         metadata: metadata ?? null,
-        integrationSource: integrationSource ?? null,
-        externalId: externalId ?? null,
         // Initialize activity at creation — keeps freshness scanners from
         // surfacing brand-new entities as stale on first scan.
         lastActivityAt: now,


### PR DESCRIPTION
## Summary

Phase 6 of the Option 3-B multi-source identity plan (`plans/data-connectors/v7/option-3-multi-source-identity-store-plan.md`). Retires the single-source `EntityInstance.integrationSource`/`externalId` columns, completing the cutover to the `RecordIdentity` write-through index as the sole home for cross-system record identity.

**No backfill** — the legacy stores held only disposable dev/test data (33 `integrationSource` rows incl. 10 junk, 18 `external_id` array rows).

## What changed

- **Migration `0252`** — drops `EntityInstance.integrationSource`/`externalId` + their `integrationLookup` index; adds `DataConnectorItem.mintedInstance`.
- **Connector delete-teardown** moved onto the sticky `mintedInstance` flag instead of `integrationSource = connector.id`.
- **Connector source badge** repointed to the `RecordIdentity` index (app-slug-rendered, redesigned off `useConnector`).
- **Reverse lookup** (`findByIntegrationId`) is now index-only; the legacy `EntityInstance` fallback is removed.
- **Extension `external_id`** write+dedupe intercepted server-side into the index (client unchanged).
- **Provenance stamp** plumbing removed; the `external_id` auto-map alias dropped so nothing points at a dropped field.
- **`reconcileRecordIdentities`** wired as a maintenance job + one-shot seed (`DataMigration 029`) — the drift backstop that rebuilds the index from `FieldValue ⋈ CustomField(isIdentity)`.

## Notes / follow-ups

- **Not live-verified.** Phase 7 (end-to-end `pnpm dev` against a live Shopify store) is the remaining work and requires a Shopify app redeploy in `auxxai-apps`.
- Reverse lookup now resolves **only** when an app's connector mirrors its id into `RecordIdentity` (Shopify does; QuickBooks/Stripe/gog-contacts do not — pre-existing gap, not a regression here).
- Deferred (deliberate): `findRecordByFieldValue` cross-store index resolution, CSV import → named-source mapping (UI-gated), orphaned `external_id` CustomField cleanup (disposable dev data).