### PR TITLE
fix(identity): stamp appSlug/isIdentity durably so RecordIdentity mirrors + reconcile work

### DIFF
--- a/packages/lib/src/data-connectors/connection-meta.test.ts
+++ b/packages/lib/src/data-connectors/connection-meta.test.ts
@@ -1,0 +1,48 @@
+// packages/lib/src/data-connectors/connection-meta.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { flattenConnectionMeta } from './connection-meta'
+
+describe('flattenConnectionMeta', () => {
+  it('hoists connectionVariables to the top level so `from: <var>` resolves', () => {
+    const flat = flattenConnectionMeta({
+      label: 'auxxai.myshopify.com',
+      metadata: { scope: 'read_customers', connectionVariables: { shop: 'auxxai' } },
+    })
+    expect(flat.shop).toBe('auxxai')
+  })
+
+  it('exposes the connection label so `from: "label"` resolves (shop domain / email)', () => {
+    const flat = flattenConnectionMeta({
+      label: 'auxxai.myshopify.com',
+      metadata: { connectionVariables: { shop: 'auxxai' } },
+    })
+    expect(flat.label).toBe('auxxai.myshopify.com')
+  })
+
+  it('keeps raw top-level metadata keys', () => {
+    const flat = flattenConnectionMeta({
+      label: null,
+      metadata: { scope: 'read_customers', connectionVariables: {} },
+    })
+    expect(flat.scope).toBe('read_customers')
+  })
+
+  it('omits label when null (never writes a null label key)', () => {
+    const flat = flattenConnectionMeta({ label: null, metadata: {} })
+    expect('label' in flat).toBe(false)
+  })
+
+  it('lets a connection variable win over a same-named metadata key', () => {
+    const flat = flattenConnectionMeta({
+      label: null,
+      metadata: { region: 'meta', connectionVariables: { region: 'var' } },
+    })
+    expect(flat.region).toBe('var')
+  })
+
+  it('tolerates missing connectionVariables', () => {
+    const flat = flattenConnectionMeta({ label: 'x', metadata: { scope: 'a' } })
+    expect(flat).toEqual({ scope: 'a', label: 'x' })
+  })
+})

--- a/packages/lib/src/data-connectors/connection-meta.ts
+++ b/packages/lib/src/data-connectors/connection-meta.ts
@@ -1,0 +1,26 @@
+// packages/lib/src/data-connectors/connection-meta.ts
+
+/** A connection's plaintext companion data as `connectionAppFields` sees it. */
+export interface ConnectionMetaSource {
+  label: string | null
+  metadata: Record<string, unknown>
+}
+
+/**
+ * Flatten a connection's plaintext metadata into the lookup map a
+ * `connectionAppFields` binding's `from` key reads. Exposes, in precedence
+ * order (later wins on a key clash):
+ *  1. the raw `metadata` keys (scopes, …);
+ *  2. the captured `connectionVariables` hoisted to the top level, so
+ *     `from: 'shop'` resolves to what the user entered at connect;
+ *  3. the connection `label`, so `from: 'label'` resolves to the meaningful
+ *     name the app's connection-added handler set (shop domain / account email).
+ *
+ * Without this, `from` could only see raw top-level metadata keys — never the
+ * connection variables or the label — which is where the useful values live.
+ */
+export function flattenConnectionMeta(cred: ConnectionMetaSource): Record<string, unknown> {
+  const metadata = cred.metadata ?? {}
+  const vars = (metadata.connectionVariables ?? {}) as Record<string, unknown>
+  return { ...metadata, ...vars, ...(cred.label != null ? { label: cred.label } : {}) }
+}

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -26,6 +26,7 @@ import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { invalidateSnapshots } from '../snapshot'
 import type { SliceResult, SyncRunCounters, SyncSliceCtx, SyncSource } from '../sync-core/contracts'
 import { runAsyncExportSlice } from './async-export'
+import { flattenConnectionMeta } from './connection-meta'
 import { runConnectorSlice } from './connector-slice-loop'
 import { reconcileManagedMarkers, reconcileOrphans } from './reconciliation'
 import { resolveRelationships } from './relationship-pass'
@@ -392,7 +393,7 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
       })
       return null
     }
-    return result.value.metadata
+    return flattenConnectionMeta(result.value)
   }
 }
 

--- a/packages/lib/src/data-connectors/connector-webhook.ts
+++ b/packages/lib/src/data-connectors/connector-webhook.ts
@@ -16,6 +16,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
 import { invalidateSnapshots } from '../snapshot'
+import { flattenConnectionMeta } from './connection-meta'
 import { prepareConnectorFetch } from './connector-runtime'
 import { ConnectorRateLimitError } from './connectors'
 import { isConnectorCheckpoint } from './connectors/types'
@@ -207,7 +208,7 @@ async function buildWebhookCtx(
   if (connector.credentialId) {
     const result = await getCredential(connector.credentialId, organizationId)
     if (result.isOk()) {
-      connectionMeta = result.value.metadata
+      connectionMeta = flattenConnectionMeta(result.value)
     } else {
       logger.warn('Failed to load connection metadata for connectionAppFields', {
         connectorId: connector.id,

--- a/packages/lib/src/data-connectors/provisioning.test.ts
+++ b/packages/lib/src/data-connectors/provisioning.test.ts
@@ -66,16 +66,30 @@ describe('provisionSpecsForMapping', () => {
         provision: { name: 'total_price', type: 'NUMBER' as FieldType, isHidden: true },
       }),
     ])
-    expect(provisionSpecsForMapping(m)).toEqual([
+    expect(provisionSpecsForMapping(m)).toMatchObject([
       {
         appFieldKey: 'total_price',
         name: 'total_price',
         type: 'NUMBER',
         icon: undefined,
         isHidden: true,
+        isIdentity: false,
         isUpdatable: false,
         isCreatable: false,
       },
+    ])
+  })
+
+  it('marks a provisioned owned external-id field as identity (from identityRole)', () => {
+    const m = mapping('owned', [
+      fm({
+        targetFieldRef: null,
+        identityRole: { kind: 'externalId' },
+        provision: { name: 'shopify_id', type: 'TEXT' as FieldType, appFieldKey: 'shopify_id' },
+      }),
+    ])
+    expect(provisionSpecsForMapping(m)).toMatchObject([
+      { appFieldKey: 'shopify_id', isIdentity: true },
     ])
   })
 })

--- a/packages/lib/src/data-connectors/provisioning.ts
+++ b/packages/lib/src/data-connectors/provisioning.ts
@@ -39,6 +39,14 @@ export interface ProvisionFieldSpec {
   isCreatable?: boolean
   /** External-id / raw-payload bookkeeping fields are hidden from the grid. */
   isHidden?: boolean
+  /**
+   * Marks an owned external-id field as an identity cell (from the mapping's
+   * `identityRole: externalId`). Stamped onto `CustomField.isIdentity` so the
+   * `reconcileRecordIdentities` backstop rebuilds its `RecordIdentity` mirror —
+   * without it, an owned identity relies solely on the sink, which never re-runs
+   * for a content-hash-unchanged record (see the reconcile design note).
+   */
+  isIdentity?: boolean
   /** Predefined select options (SINGLE_SELECT / MULTI_SELECT / TAGS). */
   options?: Array<{ value: string; label?: string; color?: string }>
   /** Sub-field set for an ADDRESS_STRUCT field. */
@@ -51,6 +59,13 @@ export interface ProvisionTarget {
   targetMode: 'owned' | 'contributing'
   /** The existing def to provision onto — required (this never creates a def). */
   entityDefinitionId: string | null
+  /**
+   * The connector's app slug (`app:<slug>` → `<slug>`), stamped onto every
+   * provisioned `CustomField.appSlug`. The identity sink-mirror reads it as the
+   * `RecordIdentity.source`, so an owned external-id field can't mirror without
+   * it. Null for builtin/generic-rest connectors (no app origin).
+   */
+  appSlug?: string | null
   fields: ProvisionFieldSpec[]
 }
 
@@ -89,7 +104,14 @@ export async function provisionTarget(
   const provisionedFieldKeys: string[] = []
   const fieldIdByKey: Record<string, string> = {}
   for (const field of target.fields) {
-    const result = await provisionField(db, organizationId, dataConnectorId, defId, field)
+    const result = await provisionField(
+      db,
+      organizationId,
+      dataConnectorId,
+      defId,
+      field,
+      target.appSlug ?? null
+    )
     if (!result) continue
     fieldIdByKey[field.appFieldKey] = result.id
     if (result.created) provisionedFieldKeys.push(field.appFieldKey)
@@ -127,7 +149,8 @@ async function provisionField(
   organizationId: string,
   dataConnectorId: string,
   entityDefinitionId: string,
-  field: ProvisionFieldSpec
+  field: ProvisionFieldSpec,
+  appSlug: string | null
 ): Promise<{ id: string; created: boolean } | null> {
   // Already provisioned on this def? Look up by `appFieldKey` in the org cache —
   // matched WITHOUT a dataConnectorId filter so a delete+reconnect ADOPTS the
@@ -138,13 +161,19 @@ async function provisionField(
   const existingFields = await getCachedCustomFields(organizationId, entityDefinitionId)
   const existing = existingFields.find((f) => f.appFieldKey === field.appFieldKey)
   if (existing) {
-    // Re-stamp ownership if a prior connector's delete nulled (or never set) the FK.
-    // The cached value may be stale here (the FK-null cascade doesn't invalidate),
-    // so the write is idempotent and harmless when already ours.
-    if (existing.dataConnectorId !== dataConnectorId) {
+    // Re-stamp ownership if a prior connector's delete nulled (or never set) the FK,
+    // and back-fill `appSlug` on a field provisioned before this column was written
+    // (owned identity fields can't mirror into RecordIdentity without it). The cached
+    // value may be stale here (the FK-null cascade doesn't invalidate), so the write
+    // is idempotent and harmless when already ours.
+    const patch: Partial<typeof schema.CustomField.$inferInsert> = {}
+    if (existing.dataConnectorId !== dataConnectorId) patch.dataConnectorId = dataConnectorId
+    if (appSlug && existing.appSlug !== appSlug) patch.appSlug = appSlug
+    if (field.isIdentity && !existing.isIdentity) patch.isIdentity = true
+    if (Object.keys(patch).length > 0) {
       await db
         .update(schema.CustomField)
-        .set({ dataConnectorId, updatedAt: new Date() })
+        .set({ ...patch, updatedAt: new Date() })
         .where(eq(schema.CustomField.id, existing.id))
     }
     return { id: existing.id, created: false }
@@ -161,6 +190,11 @@ async function provisionField(
     icon: field.icon,
     appFieldKey: field.appFieldKey,
     dataConnectorId,
+    // App origin — lets the identity sink-mirror resolve RecordIdentity.source for
+    // owned external-id fields. Null/undefined for builtin/generic-rest connectors.
+    appSlug: appSlug ?? undefined,
+    // Owned external-id → identity cell, so reconcile backstops its mirror.
+    isIdentity: field.isIdentity ?? false,
     // Predefined enum options / address sub-fields, when the connector declared
     // them. Options are normalized to `SelectOption` (label defaults to value, color
     // is the constrained palette) the same way the app-field provisioner does.
@@ -206,6 +240,8 @@ export function provisionSpecsForMapping(mapping: {
       type: fm.provision.type,
       icon: fm.provision.icon,
       isHidden: fm.provision.isHidden,
+      // Owned external-id field → identity cell, so reconcile backstops its mirror.
+      isIdentity: fm.identityRole?.kind === 'externalId',
       options: fm.provision.options,
       addressComponents: fm.provision.addressComponents,
       isUpdatable: false,
@@ -234,6 +270,7 @@ export async function provisionConnectorMappings(
   dataConnectorId: string,
   mappings: DecodedMapping[]
 ): Promise<ProvisionResult[]> {
+  const appSlug = await getConnectorAppSlug(db, dataConnectorId)
   const results: ProvisionResult[] = []
   for (const mapping of mappings) {
     if (mapping.linkMode === 'reference') continue
@@ -247,11 +284,27 @@ export async function provisionConnectorMappings(
     const result = await provisionTarget(db, organizationId, dataConnectorId, {
       targetMode: mapping.targetMode,
       entityDefinitionId: mapping.entityDefinitionId,
+      appSlug,
       fields,
     })
     results.push(result)
   }
   return results
+}
+
+/**
+ * Derive the connector's app slug from `DataConnector.type` (`app:<slug>` →
+ * `<slug>`). Null for builtin/generic-rest connectors. Stamped onto every
+ * provisioned field's `appSlug` so the identity sink-mirror can resolve a
+ * `RecordIdentity.source`. One query per provisioning pass (not per field).
+ */
+async function getConnectorAppSlug(db: Database, dataConnectorId: string): Promise<string | null> {
+  const row = await db.query.DataConnector.findFirst({
+    where: eq(schema.DataConnector.id, dataConnectorId),
+    columns: { type: true },
+  })
+  if (!row?.type) return null
+  return row.type.startsWith('app:') ? row.type.slice('app:'.length) : null
 }
 
 /**
@@ -324,6 +377,8 @@ export async function materializeConnectorTargets(
   const mappingRows = streams.flatMap((s) => s.mappings)
   if (mappingRows.length === 0) return
 
+  const appSlug = await getConnectorAppSlug(db, dataConnectorId)
+
   // ── Provision `provision`-hint fields onto each mapping's existing def ─────────
   for (const row of mappingRows) {
     if (row.linkMode === 'reference') continue
@@ -339,6 +394,7 @@ export async function materializeConnectorTargets(
     await provisionTarget(db, organizationId, dataConnectorId, {
       targetMode: row.targetMode as 'owned' | 'contributing',
       entityDefinitionId: row.entityDefinitionId,
+      appSlug,
       fields,
     })
   }

--- a/packages/services/src/custom-fields/app-field-provisioning.ts
+++ b/packages/services/src/custom-fields/app-field-provisioning.ts
@@ -10,7 +10,7 @@ import {
 } from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
-import { eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { type CreateCustomFieldInput, createCustomField } from './create-field'
 import type { SelectOption } from './types'
 
@@ -136,9 +136,33 @@ export async function provisionAppField(
     tx
   )
 
-  if (result.isErr() && result.error.code !== 'DUPLICATE_FIELD_NAME') {
-    // Don't silently lose a declared field — surface real failures.
-    throw new Error(`Failed to provision app field "${field.appFieldKey}": ${result.error.message}`)
+  if (result.isErr()) {
+    if (result.error.code !== 'DUPLICATE_FIELD_NAME') {
+      // Don't silently lose a declared field — surface real failures.
+      throw new Error(
+        `Failed to provision app field "${field.appFieldKey}": ${result.error.message}`
+      )
+    }
+    // The field already exists — `createCustomField` no-ops on a duplicate and never
+    // updates it. Re-stamp the identity metadata so a catalog change (adding
+    // `identity: true`, or a field provisioned before these columns existed) propagates
+    // to the existing row on redeploy/reconnect. Keyed by the app-field identity
+    // `(installation, connection, appFieldKey)` — never touches a user field of the same
+    // name (no `appFieldKey`). Idempotent.
+    const db = tx ?? database
+    await db
+      .update(schema.CustomField)
+      .set({ isIdentity: field.identity ?? false, appSlug: ctx.appSlug, updatedAt: new Date() })
+      .where(
+        and(
+          eq(schema.CustomField.organizationId, ctx.organizationId),
+          eq(schema.CustomField.appInstallationId, ctx.appInstallationId),
+          eq(schema.CustomField.appFieldKey, field.appFieldKey),
+          ctx.connectionId
+            ? eq(schema.CustomField.connectionId, ctx.connectionId)
+            : isNull(schema.CustomField.connectionId)
+        )
+      )
   }
 }
 


### PR DESCRIPTION
## Summary

Phase 7 live-verify of the Option 3-B multi-source identity plan surfaced that the `RecordIdentity` index stayed **empty after a real Shopify sync** (0 rows for 24 synced items), so reverse-lookup was fully dark. Root cause: the sink's identity mirror gate (`mirrorIdentityWrites` skips when `!field.appSlug`) skipped every field because **provisioning never landed the `appSlug`/`isIdentity` stamps** — contributing fields predating the feature were never re-stamped on redeploy, and owned-def fields were never stamped at all.

This PR makes the stamps land durably so the mirror + `reconcileRecordIdentities` backstop work for real, going forward — no manual backfill needed again.

## Fixes

1. **Contributing re-stamp on redeploy** (`app-field-provisioning.ts`) — `provisionAppField` now `UPDATE`s `isIdentity`+`appSlug` on an existing field instead of no-op'ing on `DUPLICATE_FIELD_NAME`. So a redeploy that adds `identity: true` (or a field provisioned before these columns existed) propagates. **The root-cause fix.**
2. **Owned-def stamps** (`provisioning.ts`) — thread the connector app slug (derived from `DataConnector.type`, e.g. `app:shopify` → `shopify`) into `provisionTarget`/`provisionField`; stamp `appSlug` on create + back-fill existing. Derive `isIdentity` from the mapping's `identityRole: externalId` so **owned external-id fields are reconcile-backstopped** — necessary because the sink mirror sits *after* the content-hash skip (`entity-sink.ts:540`), so it never re-runs for an unchanged record, and owned had no backstop otherwise.
3. **`connectionAppFields` reachability** (`connection-meta.ts`, new) — `flattenConnectionMeta` hoists `connectionVariables` to the top level and exposes the connection `label`, so a `from` key can reach them. Previously `connectionMeta` was the raw `Credential.metadata`, so only top-level keys were reachable — `from: 'shop'` (nested under `connectionVariables`) and `from: 'label'` both failed. Wired into both the sync-source and webhook ctx builders.

## Tests

- +6 `connection-meta` unit tests (flatten precedence, label exposure, null handling).
- +1 provisioning spec test (owned external-id field → `isIdentity: true`).
- Full `data-connectors` + `identity` suites green (291 tests). Biome clean.

## Notes / not in this PR

- **Not live-verified end-to-end** against the running worker (the long-running dev worker loaded `@auxx/lib` before these edits). Verified via unit tests + a manual reconcile against the live dev connector (contact reverse-lookup `9350251544713` → the right contact; 23 index rows after backfilling the pre-existing connector's stamps).
- **storeDomain** needs a paired `auxxai-apps` manifest change (`connectionAppFields` `from: 'shopDomain'` → `from: 'shop'`) + redeploy for new connectors; this PR makes the platform side (`from` reachability) ready.
- No schema/migration changes.