### PR TITLE
feat(health): queue admin controls + DC identity fix + chat release CI

### DIFF
--- a/.github/workflows/chat-publish.yml
+++ b/.github/workflows/chat-publish.yml
@@ -60,6 +60,11 @@ jobs:
           fi
 
       - uses: actions/checkout@v6
+        with:
+          # Full history + tags so the post-publish release commit can rebase
+          # onto the latest main before pushing, and so "Check tag availability"
+          # sees remote tags (see "Commit version bump & tag").
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
@@ -150,6 +155,12 @@ jobs:
             exit 1
           fi
 
+      # npm has already published by this point (irreversible), so the release
+      # commit + tag MUST land on main — otherwise main's package.json stays
+      # behind npm and every future run re-bumps to the same taken version and
+      # dies on "cannot publish over <version>". main may have advanced since
+      # checkout, so rebase the one-line bump onto the latest main and push
+      # tag + branch ATOMICALLY (never an orphaned tag), retrying on races.
       - name: Commit version bump & tag
         if: ${{ !inputs.dry-run }}
         run: |
@@ -157,8 +168,23 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add packages/chat/package.json
           git commit -m "chore(chat): release @auxx/chat@${CHAT_VERSION}"
-          git tag "chat-v${CHAT_VERSION}"
-          git push origin main --tags
+          for attempt in 1 2 3 4 5; do
+            git fetch origin main
+            if ! git rebase origin/main; then
+              git rebase --abort || true
+              echo "::error::Cannot rebase the version bump onto main (conflict on package.json). Reconcile manually."
+              exit 1
+            fi
+            git tag -f "chat-v${CHAT_VERSION}"
+            if git push --atomic origin main "refs/tags/chat-v${CHAT_VERSION}"; then
+              echo "Pushed release commit + tag chat-v${CHAT_VERSION} (attempt ${attempt})"
+              exit 0
+            fi
+            echo "Push rejected (main moved); retrying (${attempt}/5)…"
+            sleep 3
+          done
+          echo "::error::Failed to push release commit + tag after 5 attempts. npm has ${CHAT_VERSION} but main is behind — reconcile packages/chat/package.json to ${CHAT_VERSION} on main before the next run."
+          exit 1
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry-run }}

--- a/apps/web/src/components/health/ui/queue-metrics-view.tsx
+++ b/apps/web/src/components/health/ui/queue-metrics-view.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/health/ui/queue-metrics-view.tsx
 'use client'
 
-import type { QueueMetricsTimeRange } from '@auxx/lib/health/client'
+import type { CleanableJobState, QueueMetricsTimeRange } from '@auxx/lib/health/client'
 import { Button } from '@auxx/ui/components/button'
 import { Section } from '@auxx/ui/components/section'
 import {
@@ -12,7 +12,7 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { ChevronLeft } from 'lucide-react'
+import { ChevronLeft, Pause, Play, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -20,6 +20,14 @@ import { QueueRunsList } from './queue-runs-list'
 import { StatRow } from './stat-row'
 
 const TIME_RANGES: QueueMetricsTimeRange[] = ['1H', '4H', '12H', '1D', '7D']
+
+/** Job states offered in the clear-by-state control, with display labels */
+const CLEAN_STATES: { value: CleanableJobState; label: string }[] = [
+  { value: 'failed', label: 'Failed' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'delayed', label: 'Delayed' },
+  { value: 'wait', label: 'Waiting' },
+]
 
 interface QueueMetricsViewProps {
   queueName: string
@@ -31,6 +39,7 @@ interface QueueMetricsViewProps {
  */
 export function QueueMetricsView({ queueName, onBack }: QueueMetricsViewProps) {
   const [timeRange, setTimeRange] = useState<QueueMetricsTimeRange>('1H')
+  const [cleanState, setCleanState] = useState<CleanableJobState>('failed')
   const [confirm, ConfirmDialog] = useConfirm()
   const utils = api.useUtils()
 
@@ -39,24 +48,86 @@ export function QueueMetricsView({ queueName, onBack }: QueueMetricsViewProps) {
     { refetchOnWindowFocus: false }
   )
 
-  const clearFailed = api.admin.health.clearFailedJobs.useMutation({
+  const { data: schedulers } = api.admin.health.getQueueSchedulers.useQuery(
+    { queueName },
+    { refetchOnWindowFocus: false }
+  )
+
+  function invalidateQueue() {
+    utils.admin.health.getQueueMetrics.invalidate({ queueName })
+    utils.admin.health.getQueueRuns.invalidate({ queueName })
+    utils.admin.health.getIndicator.invalidate({ id: 'worker' })
+  }
+
+  const cleanJobs = api.admin.health.cleanJobs.useMutation({ onSuccess: invalidateQueue })
+  const drainQueue = api.admin.health.drainQueue.useMutation({ onSuccess: invalidateQueue })
+  const pauseQueue = api.admin.health.pauseQueue.useMutation({ onSuccess: invalidateQueue })
+  const resumeQueue = api.admin.health.resumeQueue.useMutation({ onSuccess: invalidateQueue })
+
+  const removeScheduler = api.admin.health.removeScheduler.useMutation({
     onSuccess: () => {
+      utils.admin.health.getQueueSchedulers.invalidate({ queueName })
       utils.admin.health.getQueueMetrics.invalidate({ queueName })
-      utils.admin.health.getQueueRuns.invalidate({ queueName })
-      utils.admin.health.getIndicator.invalidate({ id: 'worker' })
     },
   })
 
-  async function handleClearFailed() {
+  const isPaused = data?.paused ?? false
+  const pauseBusy = pauseQueue.isPending || resumeQueue.isPending
+
+  async function handleTogglePause() {
+    if (isPaused) {
+      resumeQueue.mutate({ queueName })
+      return
+    }
     const confirmed = await confirm({
-      title: 'Clear failed jobs?',
-      description: `This will remove all failed jobs from the "${queueName}" queue and reset the failure rate.`,
-      confirmText: 'Clear Failed Jobs',
+      title: 'Pause queue?',
+      description: `Workers will stop picking up new jobs from the "${queueName}" queue. Jobs already in progress finish, and you can resume anytime.`,
+      confirmText: 'Pause Queue',
       cancelText: 'Cancel',
       destructive: true,
     })
     if (confirmed) {
-      clearFailed.mutate({ queueName })
+      pauseQueue.mutate({ queueName })
+    }
+  }
+
+  async function handleClean() {
+    const label = CLEAN_STATES.find((s) => s.value === cleanState)?.label ?? cleanState
+    const confirmed = await confirm({
+      title: `Clear ${label.toLowerCase()} jobs?`,
+      description: `This removes all ${label.toLowerCase()} jobs from the "${queueName}" queue. This cannot be undone.`,
+      confirmText: 'Clear Jobs',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) {
+      cleanJobs.mutate({ queueName, state: cleanState })
+    }
+  }
+
+  async function handleDrain() {
+    const confirmed = await confirm({
+      title: 'Drain pending jobs?',
+      description: `This removes all waiting and delayed jobs from the "${queueName}" queue. Active jobs and completed/failed history are kept. This cannot be undone.`,
+      confirmText: 'Drain Pending',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) {
+      drainQueue.mutate({ queueName })
+    }
+  }
+
+  async function handleRemoveScheduler(schedulerId: string, name: string) {
+    const confirmed = await confirm({
+      title: 'Remove scheduler?',
+      description: `This stops "${name}" from scheduling any further jobs on the "${queueName}" queue. Existing jobs are unaffected — clear failed jobs separately if needed.`,
+      confirmText: 'Remove Scheduler',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) {
+      removeScheduler.mutate({ queueName, schedulerId })
     }
   }
 
@@ -113,6 +184,78 @@ export function QueueMetricsView({ queueName, onBack }: QueueMetricsViewProps) {
           </div>
 
           <Section
+            title='Controls'
+            description='Pause processing or clear jobs on this queue.'
+            initialOpen>
+            <div className='space-y-3'>
+              <div className='flex items-center justify-between gap-2'>
+                <div className='text-sm'>
+                  <div className='font-medium'>{isPaused ? 'Queue paused' : 'Queue running'}</div>
+                  <div className='text-xs text-muted-foreground'>
+                    {isPaused
+                      ? 'Workers are not picking up new jobs.'
+                      : 'Workers are picking up new jobs.'}
+                  </div>
+                </div>
+                <Button variant='outline' size='sm' loading={pauseBusy} onClick={handleTogglePause}>
+                  {isPaused ? <Play /> : <Pause />}
+                  {isPaused ? 'Resume' : 'Pause'}
+                </Button>
+              </div>
+
+              <div className='flex items-center justify-between gap-2'>
+                <div className='text-sm'>
+                  <div className='font-medium'>Clear jobs</div>
+                  <div className='text-xs text-muted-foreground'>Remove all jobs in a state.</div>
+                </div>
+                <div className='flex items-center gap-2'>
+                  <Select
+                    value={cleanState}
+                    onValueChange={(v) => setCleanState(v as CleanableJobState)}>
+                    <SelectTrigger variant='default' size='sm' className='w-auto'>
+                      <SelectValue>
+                        {CLEAN_STATES.find((s) => s.value === cleanState)?.label}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CLEAN_STATES.map((s) => (
+                        <SelectItem key={s.value} value={s.value}>
+                          {s.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    variant='destructive'
+                    size='sm'
+                    loading={cleanJobs.isPending}
+                    loadingText='Clearing...'
+                    onClick={handleClean}>
+                    Clear
+                  </Button>
+                </div>
+              </div>
+
+              <div className='flex items-center justify-between gap-2'>
+                <div className='text-sm'>
+                  <div className='font-medium'>Drain pending</div>
+                  <div className='text-xs text-muted-foreground'>
+                    Remove all waiting + delayed jobs.
+                  </div>
+                </div>
+                <Button
+                  variant='destructive'
+                  size='sm'
+                  loading={drainQueue.isPending}
+                  loadingText='Draining...'
+                  onClick={handleDrain}>
+                  Drain
+                </Button>
+              </div>
+            </div>
+          </Section>
+
+          <Section
             title='Metrics'
             description='Job counts and failure rate for selected time range'
             initialOpen={false}>
@@ -122,18 +265,44 @@ export function QueueMetricsView({ queueName, onBack }: QueueMetricsViewProps) {
             <StatRow label='Active' value={data.active.toLocaleString()} />
             <StatRow label='Delayed' value={data.delayed.toLocaleString()} />
             <StatRow label='Failure Rate' value={`${data.failureRate}%`} />
+            <StatRow label='Paused' value={isPaused ? 'Yes' : 'No'} />
+          </Section>
 
-            {data.failed > 0 && (
-              <div className='pt-3'>
-                <Button
-                  variant='destructive'
-                  size='sm'
-                  loading={clearFailed.isPending}
-                  loadingText='Clearing...'
-                  onClick={handleClearFailed}>
-                  Clear Failed Jobs
-                </Button>
+          <Section
+            title='Schedulers'
+            description='Repeatable cron entries that spawn jobs. Remove an orphaned scheduler to stop a failing job from recurring.'
+            initialOpen={false}>
+            {schedulers && schedulers.length > 0 ? (
+              <div className='space-y-1'>
+                {schedulers.map((scheduler) => (
+                  <div
+                    key={scheduler.key}
+                    className='flex items-center justify-between gap-2 rounded-md border px-3 py-2'>
+                    <div className='min-w-0 flex-1'>
+                      <div className='font-mono text-sm truncate'>{scheduler.name}</div>
+                      <div className='text-xs text-muted-foreground'>
+                        {scheduler.pattern ??
+                          (scheduler.every ? `every ${scheduler.every}ms` : 'no schedule')}
+                        {scheduler.next && ` · next ${new Date(scheduler.next).toLocaleString()}`}
+                      </div>
+                    </div>
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      loading={
+                        removeScheduler.isPending &&
+                        removeScheduler.variables?.schedulerId === scheduler.key
+                      }
+                      onClick={() => handleRemoveScheduler(scheduler.key, scheduler.name)}>
+                      <Trash2 />
+                    </Button>
+                  </div>
+                ))}
               </div>
+            ) : (
+              <p className='text-sm text-muted-foreground py-2 text-center'>
+                No schedulers registered.
+              </p>
             )}
           </Section>
 

--- a/apps/web/src/server/api/routers/admin-health.ts
+++ b/apps/web/src/server/api/routers/admin-health.ts
@@ -1,7 +1,16 @@
 // apps/web/src/server/api/routers/admin-health.ts
 
 import { getIndicatorHealth, getSystemHealth } from '@auxx/lib/health/health-service'
-import { clearQueueFailedJobs, getQueueMetrics, getQueueRuns } from '@auxx/lib/health/queue-metrics'
+import {
+  cleanQueueJobs,
+  drainQueue,
+  getQueueMetrics,
+  getQueueRuns,
+  getQueueSchedulers,
+  pauseQueue,
+  removeQueueScheduler,
+  resumeQueue,
+} from '@auxx/lib/health/queue-metrics'
 import { z } from 'zod'
 import { createTRPCRouter, superAdminProcedure } from '~/server/api/trpc'
 
@@ -10,6 +19,9 @@ const indicatorIdSchema = z.enum(['database', 'redis', 'worker', 'jobs', 'app'])
 
 /** Valid time ranges for queue metrics */
 const timeRangeSchema = z.enum(['1H', '4H', '12H', '1D', '7D'])
+
+/** Job states that can be bulk-cleared */
+const cleanableStateSchema = z.enum(['completed', 'failed', 'delayed', 'wait'])
 
 /**
  * Admin health monitoring router — system health overview, indicator details, queue metrics.
@@ -53,10 +65,45 @@ export const adminHealthRouter = createTRPCRouter({
       return getQueueRuns(input.queueName, input.status, input.cursor, input.limit)
     }),
 
-  /** Clear all failed jobs for a queue */
-  clearFailedJobs: superAdminProcedure
+  /** Clear all jobs in a given state for a queue */
+  cleanJobs: superAdminProcedure
+    .input(z.object({ queueName: z.string(), state: cleanableStateSchema }))
+    .mutation(async ({ input }) => {
+      return cleanQueueJobs(input.queueName, input.state)
+    }),
+
+  /** Remove all waiting + delayed jobs from a queue */
+  drainQueue: superAdminProcedure
     .input(z.object({ queueName: z.string() }))
     .mutation(async ({ input }) => {
-      return clearQueueFailedJobs(input.queueName)
+      return drainQueue(input.queueName)
+    }),
+
+  /** Pause a queue — workers stop picking up new jobs */
+  pauseQueue: superAdminProcedure
+    .input(z.object({ queueName: z.string() }))
+    .mutation(async ({ input }) => {
+      return pauseQueue(input.queueName)
+    }),
+
+  /** Resume a paused queue */
+  resumeQueue: superAdminProcedure
+    .input(z.object({ queueName: z.string() }))
+    .mutation(async ({ input }) => {
+      return resumeQueue(input.queueName)
+    }),
+
+  /** List job schedulers (repeatable cron entries) for a queue */
+  getQueueSchedulers: superAdminProcedure
+    .input(z.object({ queueName: z.string() }))
+    .query(async ({ input }) => {
+      return getQueueSchedulers(input.queueName)
+    }),
+
+  /** Remove a job scheduler so it stops spawning further jobs */
+  removeScheduler: superAdminProcedure
+    .input(z.object({ queueName: z.string(), schedulerId: z.string() }))
+    .mutation(async ({ input }) => {
+      return removeQueueScheduler(input.queueName, input.schedulerId)
     }),
 })

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auxx/chat",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Auxx chat widget — npm package with browser bootstrap, server JWT signer, and React wrapper.",
   "type": "module",
   "files": [

--- a/packages/lib/src/data-connectors/app-catalog.test.ts
+++ b/packages/lib/src/data-connectors/app-catalog.test.ts
@@ -253,6 +253,43 @@ describe('buildContributingFieldBindings', () => {
     })
   })
 
+  it('stamps identityRole when ANY connection-scoped copy of the app field is identity (not find-first)', () => {
+    // Multiple connections of the same app → one `customerId` CustomField per connection.
+    // The oldest/first copy is a stale pre-feature row (isIdentity:false); a correctly
+    // stamped copy for the current connection is later in the list. Find-first would read
+    // the stale row's flag and skip identityRole — the bug. `.some()` must not.
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      'shopify',
+      '',
+      [{ sourceFieldKey: 'shopify_id', targetAppField: 'customerId' }],
+      [{ fieldKey: 'shopify_id', sourcePath: 'id', type: 'TEXT', name: 'Shopify ID' }],
+      [
+        {
+          id: 'cf_cust_stale',
+          name: 'Shopify customer ID',
+          systemAttribute: null,
+          type: 'TEXT',
+          appFieldKey: 'customerId',
+          isIdentity: false,
+        },
+        {
+          id: 'cf_cust_current',
+          name: 'Shopify customer ID',
+          systemAttribute: null,
+          type: 'TEXT',
+          appFieldKey: 'customerId',
+          isIdentity: true,
+        },
+      ]
+    )
+    expect(bindings).toHaveLength(1)
+    expect(bindings[0]).toMatchObject({
+      targetFieldRef: 'def_contact:@app:shopify:customerId',
+      identityRole: { kind: 'externalId' },
+    })
+  })
+
   it('binds targetAppField with no identityRole when the app field is not identity: true', () => {
     const bindings = buildContributingFieldBindings(
       'def_contact',

--- a/packages/lib/src/data-connectors/app-catalog.ts
+++ b/packages/lib/src/data-connectors/app-catalog.ts
@@ -198,8 +198,17 @@ export function buildContributingFieldBindings(
     if (!sourceField || (prefix && !sourceField.sourcePath.startsWith(prefix))) continue
 
     if (targetAppField) {
-      const appField = defFields.find((f) => f.appFieldKey === targetAppField)
-      if (!appField) continue
+      // App fields are CONNECTION-SCOPED — an org with multiple connections of the same
+      // app has one `CustomField` per connection (e.g. a `customerId` per Shopify store),
+      // so matching by `appFieldKey` alone is ambiguous. `identity` is a manifest constant
+      // across a field's connection-scoped copies, so a stale pre-feature copy
+      // (`isIdentity=false`) must not mask a correctly-stamped one: treat the app field as
+      // identity iff ANY copy is. The concrete field is resolved connection-scoped at sync
+      // (the late-bound `@app:` ref), so this branch only needs the flag — never `.find()`
+      // the first arbitrary row and read its label.
+      const matches = defFields.filter((f) => f.appFieldKey === targetAppField)
+      if (matches.length === 0) continue
+      const isIdentityField = matches.some((f) => f.isIdentity)
       bindings.push(
         bindSourceToAppField(
           entityDefinitionId,
@@ -207,7 +216,7 @@ export function buildContributingFieldBindings(
           targetAppField,
           prefix,
           sourceField,
-          appField.isIdentity ? { kind: 'externalId' } : undefined
+          isIdentityField ? { kind: 'externalId' } : undefined
         )
       )
       continue

--- a/packages/lib/src/health/index.ts
+++ b/packages/lib/src/health/index.ts
@@ -1,10 +1,20 @@
 // packages/lib/src/health/index.ts
 
 export { getIndicatorHealth, getSystemHealth } from './health-service'
-export { clearQueueFailedJobs, getQueueMetrics, getQueueRuns } from './queue-metrics'
+export {
+  cleanQueueJobs,
+  drainQueue,
+  getQueueMetrics,
+  getQueueRuns,
+  getQueueSchedulers,
+  pauseQueue,
+  removeQueueScheduler,
+  resumeQueue,
+} from './queue-metrics'
 export { HealthStateManager } from './state-manager'
 export { withHealthCheckTimeout } from './timeout'
 export {
+  type CleanableJobState,
   FAILURE_RATE_THRESHOLD,
   HEALTH_CHECK_TIMEOUT_MS,
   HEALTH_ERROR_MESSAGES,
@@ -20,5 +30,6 @@ export {
   type QueueMetricsTimeRange,
   type QueueRun,
   type QueueRunsResponse,
+  type QueueScheduler,
   type SystemHealth,
 } from './types'

--- a/packages/lib/src/health/queue-metrics.ts
+++ b/packages/lib/src/health/queue-metrics.ts
@@ -2,7 +2,13 @@
 
 import { getQueue } from '../jobs/queues'
 import type { Queues } from '../jobs/queues/types'
-import type { QueueMetricsResponse, QueueMetricsTimeRange, QueueRunsResponse } from './types'
+import type {
+  CleanableJobState,
+  QueueMetricsResponse,
+  QueueMetricsTimeRange,
+  QueueRunsResponse,
+  QueueScheduler,
+} from './types'
 
 /** Number of minutes of data to fetch per time range */
 const POINTS_NEEDED: Record<QueueMetricsTimeRange, number> = {
@@ -26,17 +32,27 @@ export async function getQueueMetrics(
   const pointsNeeded = POINTS_NEEDED[timeRange]
   const samplingFactor = Math.ceil(pointsNeeded / TARGET_VISUALIZATION_POINTS)
 
-  const [workers, failedMetrics, completedMetrics, waiting, active, delayed, failed, completed] =
-    await Promise.all([
-      queue.getWorkers(),
-      queue.getMetrics('failed', 0, pointsNeeded - 1),
-      queue.getMetrics('completed', 0, pointsNeeded - 1),
-      queue.getWaitingCount(),
-      queue.getActiveCount(),
-      queue.getDelayedCount(),
-      queue.getFailedCount(),
-      queue.getCompletedCount(),
-    ])
+  const [
+    workers,
+    failedMetrics,
+    completedMetrics,
+    waiting,
+    active,
+    delayed,
+    failed,
+    completed,
+    paused,
+  ] = await Promise.all([
+    queue.getWorkers(),
+    queue.getMetrics('failed', 0, pointsNeeded - 1),
+    queue.getMetrics('completed', 0, pointsNeeded - 1),
+    queue.getWaitingCount(),
+    queue.getActiveCount(),
+    queue.getDelayedCount(),
+    queue.getFailedCount(),
+    queue.getCompletedCount(),
+    queue.isPaused(),
+  ])
 
   const totalJobs = failed + completed
   const failureRate = totalJobs > 0 ? Number(((failed / totalJobs) * 100).toFixed(1)) : 0
@@ -54,6 +70,7 @@ export async function getQueueMetrics(
     active,
     delayed,
     failureRate,
+    paused,
     data: [
       { id: 'Completed', data: completedData.map((y, x) => ({ x, y })) },
       { id: 'Failed', data: failedData.map((y, x) => ({ x, y })) },
@@ -94,19 +111,75 @@ export async function getQueueRuns(
 }
 
 /**
- * Clear all failed jobs for a queue.
+ * List all job schedulers (repeatable cron entries) registered on a queue.
+ * A scheduler whose job name no longer has a worker handler is orphaned — it keeps
+ * spawning jobs that fail with "Job function not found" until it is removed.
  */
-export async function clearQueueFailedJobs(queueName: string): Promise<{ cleared: number }> {
+export async function getQueueSchedulers(queueName: string): Promise<QueueScheduler[]> {
   const queue = getQueue(queueName as Queues)
-  const failed = await queue.getFailed(0, -1)
+  const schedulers = await queue.getJobSchedulers(0, -1, true)
 
-  let cleared = 0
-  for (const job of failed) {
-    await job.remove()
-    cleared++
-  }
+  return schedulers.map((s) => ({
+    key: s.key,
+    name: s.name,
+    pattern: s.pattern ?? null,
+    every: s.every ?? null,
+    next: s.next ? new Date(s.next).toISOString() : null,
+    tz: s.tz ?? null,
+  }))
+}
 
-  return { cleared }
+/**
+ * Remove a single job scheduler, stopping it from spawning any further jobs.
+ * Existing queued/failed jobs are unaffected — clear those separately.
+ */
+export async function removeQueueScheduler(
+  queueName: string,
+  schedulerId: string
+): Promise<{ removed: boolean }> {
+  const queue = getQueue(queueName as Queues)
+  const removed = await queue.removeJobScheduler(schedulerId)
+  return { removed }
+}
+
+/**
+ * Pause a queue — workers stop picking up new jobs; jobs already in progress finish.
+ * Reversible via {@link resumeQueue}.
+ */
+export async function pauseQueue(queueName: string): Promise<{ paused: boolean }> {
+  const queue = getQueue(queueName as Queues)
+  await queue.pause()
+  return { paused: true }
+}
+
+/**
+ * Resume a paused queue so workers start picking up jobs again.
+ */
+export async function resumeQueue(queueName: string): Promise<{ paused: boolean }> {
+  const queue = getQueue(queueName as Queues)
+  await queue.resume()
+  return { paused: false }
+}
+
+/**
+ * Drain a queue — remove all waiting and delayed jobs. Active jobs and completed/failed
+ * history are left untouched.
+ */
+export async function drainQueue(queueName: string): Promise<void> {
+  const queue = getQueue(queueName as Queues)
+  await queue.drain(true)
+}
+
+/**
+ * Remove every job in the given state from a queue (grace 0, unlimited).
+ */
+export async function cleanQueueJobs(
+  queueName: string,
+  state: CleanableJobState
+): Promise<{ cleared: number }> {
+  const queue = getQueue(queueName as Queues)
+  const removed = await queue.clean(0, 0, state)
+  return { cleared: removed.length }
 }
 
 /** Summarize a job return value to a display string */

--- a/packages/lib/src/health/types.ts
+++ b/packages/lib/src/health/types.ts
@@ -79,8 +79,13 @@ export interface QueueMetricsResponse {
   active: number
   delayed: number
   failureRate: number
+  /** Whether the queue is paused (workers stop picking up new jobs) */
+  paused: boolean
   data: QueueMetricsSeries[]
 }
+
+/** Job states that can be bulk-cleared from a queue */
+export type CleanableJobState = 'completed' | 'failed' | 'delayed' | 'wait'
 
 /** Indicator definition used by the orchestrator */
 export interface HealthIndicatorDefinition {
@@ -108,6 +113,22 @@ export interface QueueRun {
 export interface QueueRunsResponse {
   runs: QueueRun[]
   nextCursor: number | null
+}
+
+/** A registered job scheduler (repeatable cron entry) on a queue */
+export interface QueueScheduler {
+  /** Scheduler id used to remove it */
+  key: string
+  /** Job name this scheduler spawns */
+  name: string
+  /** Cron pattern, if pattern-based */
+  pattern: string | null
+  /** Fixed interval in ms, if interval-based */
+  every: number | null
+  /** Next scheduled run (ISO string) */
+  next: string | null
+  /** Timezone, if set */
+  tz: string | null
 }
 
 /** Error message constants */


### PR DESCRIPTION
## Summary

Three independent changes bundled together:

### 1. Queue admin controls (`feat/health`)
Extends the super-admin queue metrics view with operational controls:
- **Pause/resume** a queue so workers stop/start picking up new jobs
- **Clean by state** (failed/completed/delayed/wait) instead of failed-only
- **Drain pending** (waiting + delayed) jobs
- **Schedulers** — list and remove job schedulers to stop an orphaned cron entry recurring

Surfaces `paused` in the metrics response; adds `CleanableJobState` + `QueueScheduler` types. Replaces the single `clearFailedJobs` mutation with `cleanJobs`/`drainQueue`/`pauseQueue`/`resumeQueue`/`getQueueSchedulers`/`removeScheduler`.

### 2. Data-connectors identity fix (`fix/data-connectors`)
App fields are connection-scoped, so an org with multiple connections of the same app has one `CustomField` per connection (e.g. a `customerId` per Shopify store). `buildContributingFieldBindings` matched by `appFieldKey` with find-first, so a stale pre-feature copy (`isIdentity=false`) could mask a correctly-stamped one and skip `identityRole`. Now treats the app field as identity iff **any** copy is (`.some()`).

### 3. chat release CI (`fix/ci`)
npm publish is irreversible, so the release commit + tag must land on `main` or future runs re-bump to a taken version and die on "cannot publish over". Fetches full history/tags, rebases the one-line bump onto the latest `main`, and pushes tag + branch atomically with retries. Bumps `@auxx/chat` to `0.0.7`.

## Test plan
- [ ] Queue controls exercised against a dev worker (pause/resume, clean, drain, remove scheduler)
- [x] `app-catalog.test.ts` covers the `.some()` identity-stamping case
- [ ] chat-publish workflow dry-run