### PR TITLE
fix(apps): mark app About page as client to fix Tooltip crash

### DIFF
--- a/apps/web/src/components/apps/ui/app-about.tsx
+++ b/apps/web/src/components/apps/ui/app-about.tsx
@@ -1,5 +1,7 @@
 // apps/web/src/components/apps/ui/app-about.tsx
 
+'use client'
+
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Item, ItemContent, ItemGroup, ItemHeader } from '@auxx/ui/components/item'


### PR DESCRIPTION
## Problem

`/app/settings/apps/<slug>` (the app **About** page) crashed with a React
#130 — *"Element type is invalid… but got: undefined… Check the render method
of `Primitive.button.SlotClone`"* — for any **non-installed, capability-rich**
app. In production this was **Shopify** (uninstalled, 75 tools + a data
connector). Installed apps redirect away from this route, and apps with zero
capabilities don't render the offending badge, so Shopify was the only app
that hit both conditions — which is why it looked Shopify-specific and
prod-only.

## Root cause — an RSC / `'use client'` boundary bug

`app-about.tsx` had **no `'use client'`**, so `AppAbout` / `CapabilityBadge`
rendered as **Server Components**. `CapabilityBadge` renders the client
`<Tooltip>` (`SimpleTooltip`) and passes a `<Badge>` as its `children`. On the
client, `SimpleTooltip` does `React.cloneElement(child, …)` and Radix's
`asChild` `Slot` clones it **again** to attach a `ref` (`Primitive.button.SlotClone`).
Cloning / attaching a ref to an element that was produced on the **server**,
across the RSC boundary, resolves the element type to `undefined` → #130.

Every other working tooltip (e.g. `model-cost-badge.tsx`) lives in a file that
already has `'use client'`, so its trigger is created client-side. This one was
the exception.

## Fix

Add `'use client'` to `app-about.tsx`. The page is purely presentational and
receives serializable `app` data from the server `page.tsx`, so promoting it to
a Client Component is safe and keeps the tooltip trigger client-side.

## Verification

Reproduced on localhost (Shopify uninstalled) → same #130 crash. After the fix,
reloaded the page: it renders fully (Overview / How it works / Configuration,
Install button, capability badges) and the console is clean. Also confirmed the
exact `AppAbout` tree renders without error in a client-only test harness,
which is what pointed at the server/client boundary.

## Follow-up (not in this PR)

Any other **Server Component** that renders a Radix `asChild` client component
(Tooltip / Dropdown / etc.) with an element trigger can hit the same thing —
worth a grep sweep to catch siblings.
