### PR TITLE
feat(apps): reconcile app fields at connector sync (create/drift/orphan)

### DIFF
--- a/packages/lib/src/apps/connections/__tests__/save-app-connection.test.ts
+++ b/packages/lib/src/apps/connections/__tests__/save-app-connection.test.ts
@@ -39,7 +39,7 @@ vi.mock('@auxx/services/app-connections', () => ({
 
 vi.mock('@auxx/services/custom-fields', () => ({
   getInstallationCatalog: async () => ({}),
-  provisionAppFields: async () => undefined,
+  reconcileAppFields: async () => ({ created: 0, updated: 0, orphaned: 0, errors: [] }),
 }))
 
 vi.mock('../../events', () => ({

--- a/packages/lib/src/apps/connections/save-app-connection.ts
+++ b/packages/lib/src/apps/connections/save-app-connection.ts
@@ -14,7 +14,7 @@ import {
   renameAppConnection,
   safeSerializeMetadata,
 } from '@auxx/services/app-connections'
-import { getInstallationCatalog, provisionAppFields } from '@auxx/services/custom-fields'
+import { getInstallationCatalog, reconcileAppFields } from '@auxx/services/custom-fields'
 import { eq } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
 import { onCacheEvent } from '../../cache/invalidate'
@@ -237,6 +237,9 @@ export async function saveAppConnection(
       return err(breakerReset.error)
     }
 
+    // No app-field provisioning here — connector sync setup runs the authoritative
+    // reconcile (create/drift/orphan) and parks visibly on any error, so a field the
+    // catalog gained since this connection was created self-heals on the next sync.
     logger.info('Successfully reconnected app connection:', { credentialId: options.connectionId })
     return ok(options.connectionId)
   }
@@ -303,10 +306,13 @@ export async function saveAppConnection(
         where: eq(schema.App.id, appId),
         columns: { slug: true },
       })
-      await provisionAppFields(catalog, 'connection', {
+      // Reconcile the whole installation against the catalog now that a new
+      // org-scoped connection exists — creates this connection's connection-scoped
+      // fields (and heals any drift). The authoritative reconcile still runs at sync
+      // setup; this warm-up just makes the fields resolvable before the first sync.
+      await reconcileAppFields(catalog, {
         appInstallationId,
         organizationId,
-        connectionId: created.id,
         appSlug: appRow?.slug ?? appId,
       })
       // Bust the customFields org cache immediately — otherwise a freshly
@@ -314,7 +320,7 @@ export async function saveAppConnection(
       // 24h TTL, silently dropping the connector's/chat's first write.
       await onCacheEvent('custom-field.created', { orgId: organizationId })
     } catch (error) {
-      logger.error('Failed to provision connection-scoped app fields', {
+      logger.error('Failed to reconcile app fields for new connection', {
         error: error instanceof Error ? error.message : String(error),
         credentialId: created.id,
         appInstallationId,

--- a/packages/lib/src/data-connectors/app-catalog.test.ts
+++ b/packages/lib/src/data-connectors/app-catalog.test.ts
@@ -241,6 +241,7 @@ describe('buildContributingFieldBindings', () => {
           systemAttribute: null,
           type: 'TEXT',
           appFieldKey: 'customerId',
+          appSlug: 'shopify',
           isIdentity: true,
         },
       ]
@@ -271,6 +272,7 @@ describe('buildContributingFieldBindings', () => {
           systemAttribute: null,
           type: 'TEXT',
           appFieldKey: 'customerId',
+          appSlug: 'shopify',
           isIdentity: false,
         },
         {
@@ -279,6 +281,7 @@ describe('buildContributingFieldBindings', () => {
           systemAttribute: null,
           type: 'TEXT',
           appFieldKey: 'customerId',
+          appSlug: 'shopify',
           isIdentity: true,
         },
       ]
@@ -304,6 +307,7 @@ describe('buildContributingFieldBindings', () => {
           systemAttribute: null,
           type: 'TEXT',
           appFieldKey: 'storeDomain',
+          appSlug: 'shopify',
           isIdentity: false,
         },
       ]
@@ -311,6 +315,52 @@ describe('buildContributingFieldBindings', () => {
     expect(bindings).toHaveLength(1)
     expect(bindings[0]!.targetFieldRef).toBe('def_contact:@app:shopify:storeDomain')
     expect(bindings[0]!.identityRole).toBeUndefined()
+  })
+
+  it('does NOT match a targetAppField whose row belongs to a DIFFERENT app (slug scope)', () => {
+    // The org also runs Stripe, which provisioned its own `customerId` on contact.
+    // Shopify's binder (appSlug 'shopify') must never bind to the Stripe row.
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      'shopify',
+      '',
+      [{ sourceFieldKey: 'shopify_id', targetAppField: 'customerId' }],
+      [{ fieldKey: 'shopify_id', sourcePath: 'id', type: 'TEXT', name: 'Shopify ID' }],
+      [
+        {
+          id: 'cf_cust_stripe',
+          name: 'Stripe customer ID',
+          systemAttribute: null,
+          type: 'TEXT',
+          appFieldKey: 'customerId',
+          appSlug: 'stripe',
+          isIdentity: true,
+        },
+      ]
+    )
+    expect(bindings).toHaveLength(0)
+  })
+
+  it('does NOT match a targetAppField whose row has a null appSlug (fails closed)', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_contact',
+      'shopify',
+      '',
+      [{ sourceFieldKey: 'shopify_id', targetAppField: 'customerId' }],
+      [{ fieldKey: 'shopify_id', sourcePath: 'id', type: 'TEXT', name: 'Shopify ID' }],
+      [
+        {
+          id: 'cf_cust_legacy',
+          name: 'Shopify customer ID',
+          systemAttribute: null,
+          type: 'TEXT',
+          appFieldKey: 'customerId',
+          appSlug: null,
+          isIdentity: true,
+        },
+      ]
+    )
+    expect(bindings).toHaveLength(0)
   })
 
   it('drops a targetAppField binding whose appFieldKey is not declared', () => {

--- a/packages/lib/src/data-connectors/app-catalog.ts
+++ b/packages/lib/src/data-connectors/app-catalog.ts
@@ -103,6 +103,11 @@ export interface ContributingTargetField {
   appFieldKey?: string | null
   /** Stamped by provisioning when the declaring `defineFields` entry is `identity: true`. */
   isIdentity?: boolean
+  /** Owning app's slug, stamped by provisioning — scopes `targetAppField` matches to the
+   *  connector's OWN app so a sibling app's identically-keyed field (Stripe `customerId` vs
+   *  Shopify `customerId`) can't satisfy the match. Rows provisioned before slug-stamping
+   *  have `null` and fail closed (the reconciler re-stamps `appSlug` on every sync). */
+  appSlug?: string | null
 }
 
 /** A target is a safe auto-bind sink unless it's computed or can be neither created nor updated. */
@@ -206,7 +211,13 @@ export function buildContributingFieldBindings(
       // identity iff ANY copy is. The concrete field is resolved connection-scoped at sync
       // (the late-bound `@app:` ref), so this branch only needs the flag — never `.find()`
       // the first arbitrary row and read its label.
-      const matches = defFields.filter((f) => f.appFieldKey === targetAppField)
+      // Scope the match to this connector's OWN app (`appSlug`) — matching by
+      // `appFieldKey` alone let a sibling app's identically-keyed field satisfy the
+      // check (Stripe `customerId` for Shopify's binder). A `null`-slug row (provisioned
+      // before slug-stamping) fails closed; the reconciler re-stamps it on the next sync.
+      const matches = defFields.filter(
+        (f) => f.appFieldKey === targetAppField && f.appSlug === appSlug
+      )
       if (matches.length === 0) continue
       const isIdentityField = matches.some((f) => f.isIdentity)
       bindings.push(

--- a/packages/lib/src/data-connectors/slice-orchestrator.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator.ts
@@ -13,7 +13,11 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { getInstallationCatalog, reconcileAppFields } from '@auxx/services/custom-fields'
+import type { ResourceFieldId } from '@auxx/types/field'
 import { and, eq, inArray, lt } from 'drizzle-orm'
+import { resolveConnectorFieldRef } from '../agents/bindings/resolve'
+import { onCacheEvent } from '../cache/invalidate'
 import type { ThrottleHandle } from '../sync-core/contracts'
 import { runSyncSlice } from '../sync-core/slice-runner'
 import { prepareConnectorFetch } from './connector-runtime'
@@ -176,6 +180,41 @@ async function startConnectorSyncInner(
   // unbound owned row is simply skipped until its def is installed.
   await materializeConnectorTargets(db, organizationId, dataConnectorId)
 
+  // App-field reconcile — the AUTHORITATIVE provisioning call site. An app-backed
+  // connector's late-bound `@app:` refs resolve at sink time against connection-scoped
+  // `CustomField` rows; those must exist and be current (create/drift/orphan) BEFORE the
+  // sink writes. Reconcile now; PARK on any error — the throw here (before `openRun`) is
+  // stamped onto `connector.error` by the public {@link startConnectorSync} wrapper, so
+  // the connector page shows "failed + why" instead of dropping every record silently.
+  const appConnector = await db.query.DataConnector.findFirst({
+    where: eq(schema.DataConnector.id, dataConnectorId),
+    columns: { appInstallationId: true },
+  })
+  if (appConnector?.appInstallationId) {
+    const installation = await db.query.AppInstallation.findFirst({
+      where: eq(schema.AppInstallation.id, appConnector.appInstallationId),
+      with: { app: { columns: { slug: true } } },
+    })
+    const catalog = await getInstallationCatalog(appConnector.appInstallationId)
+    const result = await reconcileAppFields(catalog, {
+      appInstallationId: appConnector.appInstallationId,
+      organizationId,
+      appSlug: installation?.app?.slug ?? '',
+    })
+    if (result.created + result.updated + result.orphaned > 0) {
+      // Bust the customFields org cache so the @app: rail resolves the reconciled
+      // fields on this very sync instead of after the TTL (services can't invalidate).
+      await onCacheEvent('custom-field.created', { orgId: organizationId })
+    }
+    if (result.errors.length > 0) {
+      throw new Error(
+        `app-field reconcile failed: ${result.errors
+          .map((e) => `${e.appFieldKey}: ${e.reason}`)
+          .join('; ')}`
+      )
+    }
+  }
+
   const loaded = await loadConnector(db, organizationId, dataConnectorId)
   if (!loaded) {
     logger.warn('startConnectorSync: connector not found or has no mappings', { dataConnectorId })
@@ -192,6 +231,34 @@ async function startConnectorSyncInner(
       { dataConnectorId }
     )
     return false
+  }
+
+  // Pre-flight ref resolution — resolve every distinct mapped `targetFieldRef` ONCE
+  // against the connector's bound connection and PARK if any is unresolvable (a
+  // late-bound `@app:` ref whose CustomField the reconcile above couldn't provision).
+  // Concrete refs resolve trivially; this turns thousands of silent per-record drops
+  // in the sink into one visible setup error. The sink's own `resolveFieldRefs` stays
+  // as the per-record resolver — post-pre-flight, an unresolved ref there is a genuine
+  // mid-run anomaly, not the primary failure surface.
+  const distinctRefs = new Set<string>()
+  for (const s of streams) {
+    for (const m of s.mappings) {
+      for (const fm of m.fieldMappings) {
+        if (fm.targetFieldRef != null) distinctRefs.add(fm.targetFieldRef)
+      }
+    }
+  }
+  const unresolvedRefs: string[] = []
+  for (const ref of distinctRefs) {
+    const resolved = await resolveConnectorFieldRef(
+      ref as ResourceFieldId,
+      organizationId,
+      connector.credentialId ?? undefined
+    )
+    if (!resolved) unresolvedRefs.push(ref)
+  }
+  if (unresolvedRefs.length > 0) {
+    throw new Error(`unresolved target field refs: ${unresolvedRefs.join(', ')}`)
   }
 
   const claimed = await claimForSync(db, dataConnectorId)

--- a/packages/services/src/app-installations/roll-forward-installations.ts
+++ b/packages/services/src/app-installations/roll-forward-installations.ts
@@ -3,7 +3,7 @@
 import { type CatalogPayload, database, schema, type Transaction } from '@auxx/database'
 import { and, eq, isNull } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
-import { provisionAppFields } from '../custom-fields/app-field-provisioning'
+import { applyInstallationCatalog } from '../custom-fields/app-field-provisioning'
 import { fromDatabase } from '../shared/utils'
 
 /**
@@ -49,13 +49,16 @@ export async function rollForwardInstallations(params: { appId: string; deployme
         })
 
       for (const installation of updated) {
-        await provisionAppFields(
-          deployment.catalog as CatalogPayload | null,
-          'installation',
+        // Reconcile the new catalog's custom fields per installation (installation-
+        // AND connection-scoped, for any existing org-scoped connections). Best-effort
+        // warm-up — the authoritative reconcile runs at connector sync setup and parks
+        // visibly on any error, so a bad field must not abort the roll-forward txn.
+        await applyInstallationCatalog(
           {
             appInstallationId: installation.id,
             organizationId: installation.organizationId,
             appSlug: deployment.app.slug,
+            catalog: deployment.catalog as CatalogPayload | null,
           },
           tx
         )

--- a/packages/services/src/apps/install-app.ts
+++ b/packages/services/src/apps/install-app.ts
@@ -3,7 +3,7 @@
 import { type CatalogPayload, database, schema, type Transaction } from '@auxx/database'
 import { and, eq, isNotNull } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
-import { provisionAppFields } from '../custom-fields/app-field-provisioning'
+import { applyInstallationCatalog } from '../custom-fields/app-field-provisioning'
 import { fromDatabase } from '../shared/utils'
 import type { InstallAppInput } from './schemas'
 
@@ -246,14 +246,17 @@ export async function installApp(input: InstallAppInput) {
         installation = created
       }
 
-      // Provision the app's installation-scoped custom fields (app-registered
-      // custom fields §5). Connection-scoped fields are provisioned later, per
-      // connected account, off connection-added. Idempotent, so reinstall
-      // re-creating the same definitions is a no-op.
-      await provisionAppFields(
-        selectedDeployment!.catalog as CatalogPayload | null,
-        'installation',
-        { appInstallationId: installation.id, organizationId, appSlug: app.slug },
+      // Reconcile the app's custom fields against the catalog (installation- AND
+      // connection-scoped, for any existing org-scoped connections a reactivated
+      // installation kept). Best-effort warm-up — the authoritative reconcile runs
+      // at connector sync setup, which parks visibly on any error.
+      await applyInstallationCatalog(
+        {
+          appInstallationId: installation.id,
+          organizationId,
+          appSlug: app.slug,
+          catalog: selectedDeployment!.catalog as CatalogPayload | null,
+        },
         tx
       )
 

--- a/packages/services/src/custom-fields/__tests__/app-field-provisioning.test.ts
+++ b/packages/services/src/custom-fields/__tests__/app-field-provisioning.test.ts
@@ -1,0 +1,238 @@
+// packages/services/src/custom-fields/__tests__/app-field-provisioning.test.ts
+// Pure-diff coverage for the app-field reconciler (create / drift / orphan). No DB
+// harness — `computeAppFieldReconcileActions` is DB-free by construction.
+
+import type { CatalogAppField } from '@auxx/database'
+import { describe, expect, it, vi } from 'vitest'
+
+// The pure diff under test touches no DB — but importing the module pulls
+// `@auxx/database` (DATABASE_URL at load). Stub it; the diff never reads it.
+vi.mock('@auxx/database', () => ({ database: {}, schema: {} }))
+
+import {
+  computeAppFieldReconcileActions,
+  type ExistingAppFieldRow,
+} from '../app-field-provisioning'
+
+const APP_SLUG = 'shopify'
+
+function field(overrides: Partial<CatalogAppField> = {}): CatalogAppField {
+  return {
+    appFieldKey: 'customerId',
+    scope: 'installation',
+    targetEntity: 'contact',
+    type: 'TEXT',
+    name: 'Customer ID',
+    ...overrides,
+  }
+}
+
+function row(overrides: Partial<ExistingAppFieldRow> = {}): ExistingAppFieldRow {
+  return {
+    id: 'cf_1',
+    appFieldKey: 'customerId',
+    connectionId: null,
+    type: 'TEXT',
+    name: 'Customer ID',
+    description: null,
+    isIdentity: false,
+    appSlug: APP_SLUG,
+    options: null,
+    required: false,
+    isUnique: false,
+    isCreatable: true,
+    isUpdatable: true,
+    isComputed: false,
+    isSortable: true,
+    isFilterable: true,
+    isHidden: false,
+    ...overrides,
+  }
+}
+
+const NO_VALUES = () => false
+const HAS_VALUES = () => true
+
+function run(params: {
+  catalogFields: CatalogAppField[]
+  existingRows?: ExistingAppFieldRow[]
+  connectionIds?: string[]
+  hasValues?: (id: string) => boolean
+}) {
+  return computeAppFieldReconcileActions({
+    catalogFields: params.catalogFields,
+    existingRows: params.existingRows ?? [],
+    connectionIds: params.connectionIds ?? [],
+    hasValues: params.hasValues ?? NO_VALUES,
+    appSlug: APP_SLUG,
+  })
+}
+
+describe('computeAppFieldReconcileActions', () => {
+  it('creates a missing installation-scope cell with connectionId null', () => {
+    const { actions, errors } = run({ catalogFields: [field()] })
+    expect(errors).toEqual([])
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      kind: 'create',
+      appFieldKey: 'customerId',
+      connectionId: null,
+    })
+  })
+
+  it('creates one cell per connection for missing connection-scope fields (the incident shape)', () => {
+    // Catalog declares 2 connection-scoped fields, 1 org-scoped connection, 0 rows → 2 creates.
+    const { actions, errors } = run({
+      catalogFields: [
+        field({ appFieldKey: 'customerId', scope: 'connection' }),
+        field({ appFieldKey: 'storeDomain', scope: 'connection', name: 'Store Domain' }),
+      ],
+      connectionIds: ['conn_1'],
+    })
+    expect(errors).toEqual([])
+    expect(actions).toHaveLength(2)
+    expect(actions.every((a) => a.kind === 'create' && a.connectionId === 'conn_1')).toBe(true)
+    expect(actions.map((a) => a.appFieldKey).sort()).toEqual(['customerId', 'storeDomain'])
+  })
+
+  it('creates a connection-scope field once per connection', () => {
+    const { actions } = run({
+      catalogFields: [field({ scope: 'connection' })],
+      connectionIds: ['conn_1', 'conn_2'],
+    })
+    expect(actions).toHaveLength(2)
+    expect(actions.map((a) => a.connectionId).sort()).toEqual(['conn_1', 'conn_2'])
+  })
+
+  it('emits no action when an existing row matches the catalog exactly', () => {
+    const { actions, errors } = run({ catalogFields: [field()], existingRows: [row()] })
+    expect(errors).toEqual([])
+    expect(actions).toEqual([])
+  })
+
+  it('updates only the drifted name column', () => {
+    const { actions } = run({
+      catalogFields: [field({ name: 'Renamed Customer ID' })],
+      existingRows: [row({ name: 'Customer ID' })],
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ kind: 'update', existingFieldId: 'cf_1' })
+    expect(actions[0]!.changes).toEqual({ name: 'Renamed Customer ID' })
+  })
+
+  it('updates a drifted capability column only', () => {
+    const { actions } = run({
+      catalogFields: [field({ capabilities: { hidden: true } })],
+      existingRows: [row({ isHidden: false })],
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]!.changes).toEqual({ isHidden: true })
+  })
+
+  it('adds isIdentity when the catalog flags identity: true', () => {
+    const { actions } = run({
+      catalogFields: [field({ identity: true })],
+      existingRows: [row({ isIdentity: false })],
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]!.changes).toEqual({ isIdentity: true })
+  })
+
+  it('re-stamps a null appSlug on drift', () => {
+    const { actions } = run({
+      catalogFields: [field()],
+      existingRows: [row({ appSlug: null })],
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]!.changes).toEqual({ appSlug: APP_SLUG })
+  })
+
+  it('does NOT update when select options only differ by key order (jsonb reorder)', () => {
+    const selectField = field({
+      type: 'SINGLE_SELECT',
+      options: [
+        { value: 'a', label: 'A', color: 'red' },
+        { value: 'b', label: 'B', color: 'blue' },
+      ],
+    })
+    // Stored options: wrapped, keys reordered, same content.
+    const stored = {
+      isCustom: true,
+      options: [
+        { color: 'red', label: 'A', value: 'a' },
+        { label: 'B', value: 'b', color: 'blue' },
+      ],
+    }
+    const { actions } = run({
+      catalogFields: [selectField],
+      existingRows: [row({ type: 'SINGLE_SELECT', options: stored })],
+    })
+    expect(actions).toEqual([])
+  })
+
+  it('updates options when the select set actually changes, preserving the wrapper', () => {
+    const selectField = field({
+      type: 'SINGLE_SELECT',
+      options: [{ value: 'a', label: 'A' }],
+    })
+    const { actions } = run({
+      catalogFields: [selectField],
+      existingRows: [
+        row({ type: 'SINGLE_SELECT', options: { isCustom: true, options: [{ value: 'z' }] } }),
+      ],
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]!.changes?.options).toMatchObject({
+      isCustom: true,
+      options: [{ value: 'a', label: 'A' }],
+    })
+  })
+
+  it('errors (no action) on a type change — parks the sync', () => {
+    const { actions, errors } = run({
+      catalogFields: [field({ type: 'NUMBER' })],
+      existingRows: [row({ type: 'TEXT' })],
+    })
+    expect(actions).toEqual([])
+    expect(errors).toHaveLength(1)
+    expect(errors[0]!.appFieldKey).toBe('customerId')
+    expect(errors[0]!.reason).toContain('type changed')
+  })
+
+  it('hides an orphaned row that holds values', () => {
+    const { actions } = run({
+      catalogFields: [],
+      existingRows: [row({ id: 'cf_old', appFieldKey: 'removedField' })],
+      hasValues: HAS_VALUES,
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ kind: 'orphan-hide', existingFieldId: 'cf_old' })
+  })
+
+  it('deletes an orphaned row with no values', () => {
+    const { actions } = run({
+      catalogFields: [],
+      existingRows: [row({ id: 'cf_old', appFieldKey: 'removedField' })],
+      hasValues: NO_VALUES,
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ kind: 'orphan-delete', existingFieldId: 'cf_old' })
+  })
+
+  it('does not re-hide an already-hidden orphan with values', () => {
+    const { actions } = run({
+      catalogFields: [],
+      existingRows: [row({ id: 'cf_old', appFieldKey: 'removedField', isHidden: true })],
+      hasValues: HAS_VALUES,
+    })
+    expect(actions).toEqual([])
+  })
+
+  it('takes no action and raises no error for a RELATIONSHIP field', () => {
+    const { actions, errors } = run({
+      catalogFields: [field({ type: 'RELATIONSHIP', appFieldKey: 'orders' })],
+    })
+    expect(actions).toEqual([])
+    expect(errors).toEqual([])
+  })
+})

--- a/packages/services/src/custom-fields/app-field-provisioning.ts
+++ b/packages/services/src/custom-fields/app-field-provisioning.ts
@@ -8,9 +8,9 @@ import {
   schema,
   type Transaction,
 } from '@auxx/database'
-import type { FieldType } from '@auxx/database/types'
+import type { CustomFieldEntity, FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, isNull } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { type CreateCustomFieldInput, createCustomField } from './create-field'
 import type { SelectOption } from './types'
 
@@ -21,8 +21,8 @@ const logger = createScopedLogger('app-fields')
  * the `entityType` (there is one def per entityType per org). Returns null when
  * no def matches (caller logs + skips).
  *
- * Stays a DB query: this runs at install/connection time on the tier-2 services
- * layer, which can't import the tier-3 org cache. The hot read path
+ * Stays a DB query: this runs at install/connection/sync time on the tier-2
+ * services layer, which can't import the tier-3 org cache. The hot read path
  * (`apps/api` value-I/O routes) uses `getCachedEntityDefId` instead.
  */
 export async function resolveEntityDefinitionIdByKind(
@@ -84,25 +84,33 @@ export interface ProvisionContext {
   appSlug: string
 }
 
+/** Outcome of a single `provisionAppField` call — lets the reconciler tally creates
+ *  without treating an idempotent no-op (a field that already exists) or an
+ *  unsupported/unresolvable field as a failure. */
+export type ProvisionOutcome = 'created' | 'duplicate' | 'skipped'
+
 /**
  * Provision one declared app field. Idempotent: `createCustomField` returns
  * DUPLICATE_FIELD_NAME when a field already exists for this
- * `(appInstallationId, connectionId?, appFieldKey)` — treated as a no-op.
+ * `(appInstallationId, connectionId?, appFieldKey)` — reported as `'duplicate'`.
+ * A genuine (non-duplicate) create failure THROWS — the reconciler wraps the call
+ * and records it as a field-level error (which parks the sync).
  *
  * RELATIONSHIP fields are not supported in v1 (their inverse-field wiring isn't
- * covered) — logged and skipped.
+ * covered) — logged and skipped. Drift on an existing field is NOT handled here;
+ * the reconciler's `update` action owns that (single source of truth).
  */
 export async function provisionAppField(
   field: CatalogAppField,
   ctx: ProvisionContext,
   tx?: Transaction
-): Promise<void> {
+): Promise<ProvisionOutcome> {
   if (field.type === 'RELATIONSHIP') {
     logger.warn('skipping RELATIONSHIP field — not supported in v1', {
       appFieldKey: field.appFieldKey,
       appInstallationId: ctx.appInstallationId,
     })
-    return
+    return 'skipped'
   }
 
   const entityDefinitionId = await resolveEntityDefinitionIdByKind(
@@ -115,7 +123,7 @@ export async function provisionAppField(
       targetEntity: field.targetEntity,
       appInstallationId: ctx.appInstallationId,
     })
-    return
+    return 'skipped'
   }
 
   const result = await createCustomField(
@@ -138,38 +146,21 @@ export async function provisionAppField(
 
   if (result.isErr()) {
     if (result.error.code !== 'DUPLICATE_FIELD_NAME') {
-      // Don't silently lose a declared field — surface real failures.
+      // Don't silently lose a declared field — surface real failures to the reconciler.
       throw new Error(
         `Failed to provision app field "${field.appFieldKey}": ${result.error.message}`
       )
     }
-    // The field already exists — `createCustomField` no-ops on a duplicate and never
-    // updates it. Re-stamp the identity metadata so a catalog change (adding
-    // `identity: true`, or a field provisioned before these columns existed) propagates
-    // to the existing row on redeploy/reconnect. Keyed by the app-field identity
-    // `(installation, connection, appFieldKey)` — never touches a user field of the same
-    // name (no `appFieldKey`). Idempotent.
-    const db = tx ?? database
-    await db
-      .update(schema.CustomField)
-      .set({ isIdentity: field.identity ?? false, appSlug: ctx.appSlug, updatedAt: new Date() })
-      .where(
-        and(
-          eq(schema.CustomField.organizationId, ctx.organizationId),
-          eq(schema.CustomField.appInstallationId, ctx.appInstallationId),
-          eq(schema.CustomField.appFieldKey, field.appFieldKey),
-          ctx.connectionId
-            ? eq(schema.CustomField.connectionId, ctx.connectionId)
-            : isNull(schema.CustomField.connectionId)
-        )
-      )
+    return 'duplicate'
   }
+  return 'created'
 }
 
 /**
  * Provision every declared field of a given scope from a deployment catalog.
- * For `connection` scope the caller must assert the connection is org-scoped
- * (`Credential.userId IS NULL`) first — see decision 8.
+ * Thin helper over {@link provisionAppField}; the full reconciler
+ * ({@link reconcileAppFields}) is the authoritative path — this stays for callers
+ * that only want the plain create pass for a single scope.
  */
 export async function provisionAppFields(
   catalog: CatalogPayload | null | undefined,
@@ -183,9 +174,436 @@ export async function provisionAppFields(
   }
 }
 
+// ── Reconciler (create / drift / orphan) ─────────────────────────────────────────
+
+/** The existing-row projection the pure diff reads — a subset of `CustomFieldEntity`. */
+export type ExistingAppFieldRow = Pick<
+  CustomFieldEntity,
+  | 'id'
+  | 'appFieldKey'
+  | 'connectionId'
+  | 'type'
+  | 'name'
+  | 'description'
+  | 'isIdentity'
+  | 'appSlug'
+  | 'options'
+  | 'required'
+  | 'isUnique'
+  | 'isCreatable'
+  | 'isUpdatable'
+  | 'isComputed'
+  | 'isSortable'
+  | 'isFilterable'
+  | 'isHidden'
+>
+
+/** The columns a drift `update` may write — only the ones the reconciler diffs. */
+export type AppFieldUpdateChanges = Partial<
+  Pick<
+    CustomFieldEntity,
+    | 'name'
+    | 'description'
+    | 'isIdentity'
+    | 'appSlug'
+    | 'options'
+    | 'required'
+    | 'isUnique'
+    | 'isCreatable'
+    | 'isUpdatable'
+    | 'isComputed'
+    | 'isSortable'
+    | 'isFilterable'
+    | 'isHidden'
+  >
+>
+
+export interface AppFieldReconcileAction {
+  kind: 'create' | 'update' | 'orphan-delete' | 'orphan-hide'
+  appFieldKey: string
+  /** null for installation-scope; the owning connection for connection-scope. */
+  connectionId: string | null
+  /** create/update source field. */
+  field?: CatalogAppField
+  /** update/orphan target row. */
+  existingFieldId?: string
+  /** update: only the drifted columns. */
+  changes?: AppFieldUpdateChanges
+}
+
+export interface AppFieldReconcileError {
+  appFieldKey: string
+  reason: string
+}
+
+/**
+ * Deterministic key-sorted JSON serialization. jsonb round-trips reorder object
+ * keys, so a naive `JSON.stringify` equality check false-positives on drift — a
+ * known repo trap. Skips `undefined`-valued keys to match jsonb semantics (a
+ * `{ color: undefined }` in-memory value is stored as an absent key).
+ */
+function stableStringify(value: unknown): string {
+  if (value === undefined || value === null) return 'null'
+  if (typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  const obj = value as Record<string, unknown>
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .sort()
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`
+}
+
+/** Pull the select-option list out of a stored `options` blob (array or `{ options }`). */
+function extractSelectOptions(stored: unknown): unknown[] | undefined {
+  if (Array.isArray(stored)) return stored
+  if (stored && typeof stored === 'object') {
+    const inner = (stored as { options?: unknown }).options
+    if (Array.isArray(inner)) return inner
+  }
+  return undefined
+}
+
+/**
+ * Compute the drifted `options` value for a field, or null when unchanged. Only
+ * option-bearing types (SELECT/MULTI_SELECT/TAGS + CALC) can drift; anything else
+ * never touches `options`. Preserves the existing options wrapper (`icon`,
+ * `isCustom`, …) — only the select list / calc block is replaced.
+ */
+function computeOptionsChange(field: CatalogAppField, existingOptions: unknown): unknown | null {
+  const desired = buildFieldOptions(field)
+  const base =
+    existingOptions && typeof existingOptions === 'object' && !Array.isArray(existingOptions)
+      ? (existingOptions as Record<string, unknown>)
+      : {}
+
+  if (Array.isArray(desired)) {
+    const existingList = extractSelectOptions(existingOptions) ?? []
+    if (stableStringify(desired) === stableStringify(existingList)) return null
+    return { ...base, options: desired }
+  }
+  if (desired && typeof desired === 'object' && 'calc' in desired) {
+    const desiredCalc = (desired as { calc: unknown }).calc
+    const existingCalc = (base as { calc?: unknown }).calc
+    if (stableStringify(desiredCalc) === stableStringify(existingCalc)) return null
+    return { ...base, calc: desiredCalc }
+  }
+  return null
+}
+
+const CAPABILITY_KEYS = [
+  'required',
+  'isUnique',
+  'isCreatable',
+  'isUpdatable',
+  'isComputed',
+  'isSortable',
+  'isFilterable',
+  'isHidden',
+] as const
+
+/** Diff a catalog field against its existing row → only the drifted columns. */
+function diffFieldColumns(
+  field: CatalogAppField,
+  existing: ExistingAppFieldRow,
+  appSlug: string
+): AppFieldUpdateChanges {
+  const changes: AppFieldUpdateChanges = {}
+  if (existing.name !== field.name) changes.name = field.name
+  const desiredDescription = field.description ?? null
+  if ((existing.description ?? null) !== desiredDescription)
+    changes.description = desiredDescription
+  const desiredIdentity = field.identity ?? false
+  if (existing.isIdentity !== desiredIdentity) changes.isIdentity = desiredIdentity
+  if ((existing.appSlug ?? null) !== appSlug) changes.appSlug = appSlug
+  const optionsChange = computeOptionsChange(field, existing.options)
+  if (optionsChange !== null) changes.options = optionsChange
+  const caps = capabilitiesToColumns(field.capabilities)
+  for (const key of CAPABILITY_KEYS) {
+    if (existing[key] !== caps[key]) changes[key] = caps[key]
+  }
+  return changes
+}
+
+const cellKey = (appFieldKey: string, connectionId: string | null): string =>
+  `${appFieldKey} ${connectionId ?? ''}`
+
+/**
+ * Pure diff (DB-free, unit-testable) — the desired cells (each declared field ×
+ * its scope's slots) vs the existing rows. Emits create/update actions and drift
+ * `errors` (a type change parks the sync), plus orphan-handling for rows whose
+ * `appFieldKey` no longer appears in the catalog.
+ *
+ * A *cell* is one `(appFieldKey, connectionId)` slot: installation-scope fields
+ * take `connectionId: null`; connection-scope fields take one slot per entry in
+ * `connectionIds`.
+ */
+export function computeAppFieldReconcileActions(params: {
+  catalogFields: CatalogAppField[]
+  existingRows: ExistingAppFieldRow[]
+  connectionIds: string[]
+  /** Pre-computed by the executor — does a candidate-orphan field id have any values? */
+  hasValues: (fieldId: string) => boolean
+  appSlug: string
+}): { actions: AppFieldReconcileAction[]; errors: AppFieldReconcileError[] } {
+  const { catalogFields, existingRows, connectionIds, hasValues, appSlug } = params
+  const actions: AppFieldReconcileAction[] = []
+  const errors: AppFieldReconcileError[] = []
+
+  const catalogKeys = new Set(catalogFields.map((f) => f.appFieldKey))
+  const rowByCell = new Map<string, ExistingAppFieldRow>()
+  for (const row of existingRows) {
+    if (!row.appFieldKey) continue
+    rowByCell.set(cellKey(row.appFieldKey, row.connectionId ?? null), row)
+  }
+
+  for (const field of catalogFields) {
+    // RELATIONSHIP fields aren't provisioned in v1 (their inverse wiring isn't
+    // covered) — skip create/update; their key stays in the catalog so their rows
+    // are never orphaned either.
+    if (field.type === 'RELATIONSHIP') continue
+
+    const cellConnectionIds: (string | null)[] =
+      field.scope === 'connection' ? connectionIds : [null]
+
+    for (const connectionId of cellConnectionIds) {
+      const existing = rowByCell.get(cellKey(field.appFieldKey, connectionId))
+      if (!existing) {
+        actions.push({ kind: 'create', appFieldKey: field.appFieldKey, connectionId, field })
+        continue
+      }
+      if (existing.type !== field.type) {
+        errors.push({
+          appFieldKey: field.appFieldKey,
+          reason: `type changed ${existing.type} → ${field.type} — not auto-converted`,
+        })
+        continue
+      }
+      const changes = diffFieldColumns(field, existing, appSlug)
+      if (Object.keys(changes).length > 0) {
+        actions.push({
+          kind: 'update',
+          appFieldKey: field.appFieldKey,
+          connectionId,
+          existingFieldId: existing.id,
+          changes,
+        })
+      }
+    }
+  }
+
+  // Orphans — rows whose `appFieldKey` no longer appears in the catalog. v1 rule
+  // (see plan §1a.5): only orphan by missing key; leave connectionId-mismatch rows
+  // alone (connection deletion already cascades them). Hide rows that hold values
+  // (reversible, no name-collision), delete empty ones.
+  for (const row of existingRows) {
+    if (!row.appFieldKey || catalogKeys.has(row.appFieldKey)) continue
+    if (hasValues(row.id)) {
+      if (row.isHidden) continue // already at rest
+      actions.push({
+        kind: 'orphan-hide',
+        appFieldKey: row.appFieldKey,
+        connectionId: row.connectionId ?? null,
+        existingFieldId: row.id,
+      })
+    } else {
+      actions.push({
+        kind: 'orphan-delete',
+        appFieldKey: row.appFieldKey,
+        connectionId: row.connectionId ?? null,
+        existingFieldId: row.id,
+      })
+    }
+  }
+
+  return { actions, errors }
+}
+
+export interface ReconcileResult {
+  created: number
+  updated: number
+  orphaned: number
+  errors: AppFieldReconcileError[]
+}
+
+/**
+ * Full app-field reconciler — the authoritative provisioning path (called at sync
+ * setup and, best-effort, from lifecycle warm-ups). Loads the installation's app
+ * fields + its org-scoped connections, computes the create/update/orphan diff,
+ * and executes it. Returns counts + per-field errors; does NOT invalidate the org
+ * cache (tier-2 services can't import the tier-3 cache) — lib-side callers do that
+ * when any action executed.
+ */
+export async function reconcileAppFields(
+  catalog: CatalogPayload | null | undefined,
+  ctx: { appInstallationId: string; organizationId: string; appSlug: string },
+  tx?: Transaction
+): Promise<ReconcileResult> {
+  const db = tx ?? database
+  const catalogFields = catalog?.fields ?? []
+
+  const existingRows: ExistingAppFieldRow[] = await db.query.CustomField.findMany({
+    where: eq(schema.CustomField.appInstallationId, ctx.appInstallationId),
+    columns: {
+      id: true,
+      appFieldKey: true,
+      connectionId: true,
+      type: true,
+      name: true,
+      description: true,
+      isIdentity: true,
+      appSlug: true,
+      options: true,
+      required: true,
+      isUnique: true,
+      isCreatable: true,
+      isUpdatable: true,
+      isComputed: true,
+      isSortable: true,
+      isFilterable: true,
+      isHidden: true,
+    },
+  })
+
+  // Nothing declared and nothing provisioned — cheapest exit.
+  if (catalogFields.length === 0 && existingRows.length === 0) {
+    return { created: 0, updated: 0, orphaned: 0, errors: [] }
+  }
+
+  // Only org-scoped (`userId IS NULL`) connections get connection-scoped fields — a
+  // visitor's identity must be one truth for the org, not vary by teammate.
+  const connections = await db.query.Credential.findMany({
+    where: and(
+      eq(schema.Credential.appInstallationId, ctx.appInstallationId),
+      eq(schema.Credential.kind, 'app'),
+      isNull(schema.Credential.userId)
+    ),
+    columns: { id: true },
+  })
+  const connectionIds = connections.map((c) => c.id)
+
+  // Pre-compute `hasValues` for candidate-orphan fields (missing from the catalog)
+  // so the pure diff can decide hide-vs-delete without a DB call.
+  const catalogKeys = new Set(catalogFields.map((f) => f.appFieldKey))
+  const candidateOrphanIds = existingRows
+    .filter((r) => r.appFieldKey && !catalogKeys.has(r.appFieldKey))
+    .map((r) => r.id)
+  const fieldsWithValues = new Set<string>()
+  if (candidateOrphanIds.length > 0) {
+    const valueRows = await db
+      .selectDistinct({ fieldId: schema.FieldValue.fieldId })
+      .from(schema.FieldValue)
+      .where(inArray(schema.FieldValue.fieldId, candidateOrphanIds))
+    for (const v of valueRows) fieldsWithValues.add(v.fieldId)
+  }
+
+  const { actions, errors } = computeAppFieldReconcileActions({
+    catalogFields,
+    existingRows,
+    connectionIds,
+    hasValues: (id) => fieldsWithValues.has(id),
+    appSlug: ctx.appSlug,
+  })
+
+  let created = 0
+  let updated = 0
+  let orphaned = 0
+  const execErrors: AppFieldReconcileError[] = [...errors]
+
+  for (const action of actions) {
+    try {
+      if (action.kind === 'create' && action.field) {
+        const outcome = await provisionAppField(
+          action.field,
+          {
+            appInstallationId: ctx.appInstallationId,
+            organizationId: ctx.organizationId,
+            connectionId: action.connectionId ?? undefined,
+            appSlug: ctx.appSlug,
+          },
+          tx
+        )
+        if (outcome === 'created') created++
+      } else if (action.kind === 'update' && action.existingFieldId) {
+        await db
+          .update(schema.CustomField)
+          .set({ ...action.changes, updatedAt: new Date() })
+          .where(eq(schema.CustomField.id, action.existingFieldId))
+        updated++
+      } else if (action.kind === 'orphan-hide' && action.existingFieldId) {
+        await db
+          .update(schema.CustomField)
+          .set({ isHidden: true, updatedAt: new Date() })
+          .where(eq(schema.CustomField.id, action.existingFieldId))
+        orphaned++
+        logger.info('reconcileAppFields: hid orphaned app field (has values)', {
+          appFieldKey: action.appFieldKey,
+          fieldId: action.existingFieldId,
+          appInstallationId: ctx.appInstallationId,
+        })
+      } else if (action.kind === 'orphan-delete' && action.existingFieldId) {
+        await db.delete(schema.CustomField).where(eq(schema.CustomField.id, action.existingFieldId))
+        orphaned++
+        logger.info('reconcileAppFields: deleted orphaned app field (no values)', {
+          appFieldKey: action.appFieldKey,
+          fieldId: action.existingFieldId,
+          appInstallationId: ctx.appInstallationId,
+        })
+      }
+    } catch (error) {
+      execErrors.push({
+        appFieldKey: action.appFieldKey,
+        reason: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  return { created, updated, orphaned, errors: execErrors }
+}
+
+/**
+ * Warm-up event: "a catalog version became active" (install / reactivate / deploy
+ * roll-forward). Runs the full reconcile best-effort — a bad catalog field must
+ * never abort an install or block a deploy, because the authoritative sync-setup
+ * reconcile will park the connector visibly anyway. Never throws.
+ */
+export async function applyInstallationCatalog(
+  params: {
+    appInstallationId: string
+    organizationId: string
+    appSlug: string
+    catalog: CatalogPayload | null
+  },
+  tx?: Transaction
+): Promise<void> {
+  try {
+    const result = await reconcileAppFields(
+      params.catalog,
+      {
+        appInstallationId: params.appInstallationId,
+        organizationId: params.organizationId,
+        appSlug: params.appSlug,
+      },
+      tx
+    )
+    if (result.errors.length > 0) {
+      logger.warn('applyInstallationCatalog: reconcile completed with field errors', {
+        appInstallationId: params.appInstallationId,
+        appSlug: params.appSlug,
+        errors: result.errors,
+      })
+    }
+  } catch (error) {
+    logger.error('applyInstallationCatalog: reconcile threw — continuing (sync will re-check)', {
+      appInstallationId: params.appInstallationId,
+      appSlug: params.appSlug,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
 /**
  * Load the active deployment's catalog for an installation (used by the
- * connection lifecycle, which doesn't already have the catalog in hand).
+ * connection lifecycle + sync setup, which don't already have the catalog in hand).
  */
 export async function getInstallationCatalog(
   appInstallationId: string,

--- a/packages/services/src/custom-fields/index.ts
+++ b/packages/services/src/custom-fields/index.ts
@@ -2,10 +2,19 @@
 
 // App-registered custom field provisioning
 export {
+  type AppFieldReconcileAction,
+  type AppFieldReconcileError,
+  type AppFieldUpdateChanges,
+  applyInstallationCatalog,
+  computeAppFieldReconcileActions,
+  type ExistingAppFieldRow,
   getInstallationCatalog,
   type ProvisionContext,
+  type ProvisionOutcome,
   provisionAppField,
   provisionAppFields,
+  type ReconcileResult,
+  reconcileAppFields,
   resolveEntityDefinitionIdByKind,
 } from './app-field-provisioning'
 // Uniqueness checks

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -1,0 +1,20 @@
+// packages/services/vitest.config.ts
+
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    name: 'services',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts', 'src/**/__tests__/**/*.ts'],
+    exclude: ['node_modules/**', 'dist/**', '**/*.config.*'],
+  },
+  resolve: {
+    alias: {
+      '@auxx/services': path.resolve(__dirname, './src'),
+    },
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       './apps/web/vitest.config.ts',
       './packages/billing/vitest.config.ts',
       './packages/lib/vitest.config.ts',
+      './packages/services/vitest.config.ts',
       './packages/workflow-nodes/vitest.config.ts',
       './packages/database/vitest.config.ts',
       './packages/credentials/vitest.config.ts',


### PR DESCRIPTION
## Why

The 2026-07-01 Shopify incident — unresolved `@app:shopify:customerId` → every record dropped `tier: invalid` — was a **forgotten-call-site bug**: connection-scoped app fields were provisioned in exactly one lifecycle path (first connect) and every other path skipped them. The model was push-based provisioning fanned out across lifecycle events, so the bug class stayed open: any new path creating/reviving a connection had to *remember* to call the helper.

This replaces that with **one reconciler run at connector sync setup** — the authoritative call site — plus best-effort lifecycle warm-ups. Implements `plans/data-connectors/app-field-provisioning-overhaul-plan.md`.

## What

- **Reconciler** (`packages/services/src/custom-fields/app-field-provisioning.ts`): pure `computeAppFieldReconcileActions` (DB-free, unit-tested) + `reconcileAppFields` executor. Creates missing cells, propagates drift, orphan-handles removals (**hide** if the field holds values, **delete** if empty). A **type change parks** the sync rather than auto-converting. `provisionAppField` now returns `'created' | 'duplicate' | 'skipped'`; the re-stamp-on-duplicate block is gone. Options compared via sorted-key serialization (jsonb reorders keys).
- **Warm-ups**: `applyInstallationCatalog` (best-effort, never throws) replaces the two provision calls in `install-app.ts` and `roll-forward-installations.ts`; `save-app-connection` create branch → `reconcileAppFields`; reconnect interim block + one-off backfill script deleted.
- **Authoritative site** (`slice-orchestrator.ts`): reconcile after `materializeConnectorTargets` (throw = loud park via `connector.error`), then pre-flight-resolve every mapped `targetFieldRef` (same resolver/connection the sink uses) and park on any unresolved ref — turning thousands of silent per-record drops into one visible setup error.
- **Binder hardening**: scope `buildContributingFieldBindings`' `targetAppField` match by `appSlug` so a sibling app's identically-keyed field (Stripe vs Shopify `customerId`) can't satisfy the match; a `null` slug fails closed.
- **CI**: wire `@auxx/services` into the vitest `projects` list so its tests actually run (they weren't before).

## Test

- 15 pure-diff cases (create / drift / options-reorder-no-op / type-change-parks / orphan hide+delete / RELATIONSHIP skip) + `app-catalog` appSlug-scope cases.
- `vitest run --project services` and `--project lib` (data-connectors + connections) green: 17 + 285 tests.
- **Not** live-verified yet. Manual replay (needs a dev org with Shopify, after rebuilding `@auxx/services` + `@auxx/lib`): delete the `Shopify customer ID` field → sync self-heals; rename its `type` in the DB → connector parks with `connector.error` naming the field.

## Notes

- Connection scope is deliberately **kept** — `CustomField.connectionId`'s `ON DELETE CASCADE` is load-bearing for disconnect cleanup and identity reads.
- Behavioral change: pre-flight parks the *whole* connector if any mapped ref is unresolvable (vs. the old per-record silent drop). Intended — after the reconcile all catalog-declared fields exist, so only genuinely broken config stays unresolved.