### PR TITLE
fix(data-connectors): pin sample review banner under tabs strip

### DIFF
--- a/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-tabs.tsx
@@ -45,6 +45,8 @@ interface ConnectorDetailTabsProps {
   connector: Connector
   /** On mobile (no dock) the Runs panel is appended as a tab/section. */
   mobileRunsPanel?: React.ReactNode
+  /** Parked-sample review banner — pinned under the tabs strip, above the resync banner. */
+  sampleReviewBanner?: React.ReactNode
   /** Pending mapping-edit re-sync banner — pinned directly under the tabs strip. */
   resyncBanner?: React.ReactNode
 }
@@ -61,6 +63,7 @@ interface ConnectorDetailTabsProps {
 export function ConnectorDetailTabs({
   connector,
   mobileRunsPanel,
+  sampleReviewBanner,
   resyncBanner,
 }: ConnectorDetailTabsProps) {
   const [tab, setTab] = useQueryState('tab', { defaultValue: 'connection' })
@@ -167,6 +170,7 @@ export function ConnectorDetailTabs({
               </Tabs>
             }>
             <div className='flex h-full flex-col'>
+              {sampleReviewBanner}
               {resyncBanner}
               <div className='relative min-h-0 flex-1'>
                 <ScrollArea

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -389,16 +389,6 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
         </MainPageBreadcrumb>
       </MainPageHeader>
 
-      {/* Parked-sample review (trial-sync §5.2): after a sample run pauses the
-          connector, offer to look at the records, then sync everything (resume). */}
-      <SampleReviewBanner
-        show={liveStatus === 'paused' && latestRun?.pausedReason === 'sample'}
-        recordCount={live?.itemCount ?? connector.itemCount}
-        onSyncEverything={() => syncNow(connector.id)}
-        onEditMappings={() => void setTab('streams')}
-        isSyncing={isSyncPending}
-      />
-
       <MainPageContent
         dockedPanels={
           isDesktop
@@ -417,6 +407,17 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
         <ConnectorDetailTabs
           connector={connector}
           mobileRunsPanel={!isDesktop ? runsPanel : null}
+          sampleReviewBanner={
+            // Parked-sample review (trial-sync §5.2): after a sample run pauses the
+            // connector, offer to look at the records, then sync everything (resume).
+            <SampleReviewBanner
+              show={liveStatus === 'paused' && latestRun?.pausedReason === 'sample'}
+              recordCount={live?.itemCount ?? connector.itemCount}
+              onSyncEverything={() => syncNow(connector.id)}
+              onEditMappings={() => void setTab('streams')}
+              isSyncing={isSyncPending}
+            />
+          }
           resyncBanner={
             <ConnectorResyncBanner
               pending={live?.resyncPending}

--- a/apps/web/src/components/data-connectors/ui/connector-resync-banner.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-resync-banner.tsx
@@ -46,7 +46,7 @@ export function ConnectorResyncBanner({
       action={
         <Button
           variant='outline'
-          size='sm'
+          size='xs'
           loading={isBackfilling}
           loadingText='Backfilling...'
           onClick={onBackfill}>

--- a/apps/web/src/components/data-connectors/ui/sample-review-banner.tsx
+++ b/apps/web/src/components/data-connectors/ui/sample-review-banner.tsx
@@ -46,11 +46,11 @@ export function SampleReviewBanner({
       onClose={() => setDismissed(true)}
       action={
         <div className='flex items-center gap-2'>
-          <Button variant='outline' size='sm' onClick={onEditMappings}>
+          <Button variant='outline' size='xs' onClick={onEditMappings}>
             <Waypoints />
             Edit mappings
           </Button>
-          <Button size='sm' loading={isSyncing} loadingText='Starting…' onClick={onSyncEverything}>
+          <Button size='xs' loading={isSyncing} loadingText='Starting…' onClick={onSyncEverything}>
             <RefreshCw />
             Sync everything
           </Button>


### PR DESCRIPTION
## Summary
- Move `SampleReviewBanner` out of `ConnectorDetailView` and into `ConnectorDetailTabs` (new `sampleReviewBanner` prop), pinning it directly under the tabs strip alongside the resync banner instead of floating above `MainPageContent`.
- Shrink the resync/sample-review banner action buttons from `size='sm'` to `size='xs'` to match the banner's compact footprint.

## Test plan
- [ ] Trigger a paused/`sample` connector run and confirm the sample review banner renders pinned under the tabs strip (desktop + mobile).
- [ ] Trigger a pending resync and confirm both banners stack correctly under the tabs strip.
- [ ] Visually confirm banner action buttons render at the smaller `xs` size.