### PR TITLE
refactor(forms): extract FieldPanel/FieldPanelRow out of workflow var-editor

### DIFF
--- a/apps/web/src/components/global/forms/field-panel.tsx
+++ b/apps/web/src/components/global/forms/field-panel.tsx
@@ -1,0 +1,158 @@
+// apps/web/src/components/global/forms/field-panel.tsx
+
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { X } from 'lucide-react'
+import type React from 'react'
+import { Tooltip, TooltipExplanation } from '~/components/global/tooltip'
+import type { BaseType } from '~/components/workflow/types/unified-types'
+import { VarTypeIcon } from '~/components/workflow/utils/icon-helper'
+import { ValidationErrorBadge } from './validation-error-badge'
+
+/**
+ * Variants for FieldPanel orientation
+ * Controls how FieldPanelRow children lay out their label and content
+ */
+const fieldPanelVariants = cva(
+  [
+    'relative grow rounded-2xl px-1.5 py-0.5',
+    'bg-primary-200/30 dark:bg-[#23272e]/30 border flex flex-col focus-within:border-primary-300',
+    '[&>[data-slot=field-row]:not(:has(~[data-slot=field-row]))]:border-b-0',
+  ],
+  {
+    variants: {
+      orientation: {
+        horizontal: [
+          // field-row: horizontal layout (default behavior)
+          '[&_[data-slot=field-row]]:flex-row [&_[data-slot=field-row]]:items-start',
+          // field-row-label: fixed width and height
+          '[&_[data-slot=field-row-label]]:w-40 [&_[data-slot=field-row-label]]:shrink-0 [&_[data-slot=field-row-label]]:min-h-8',
+        ],
+        vertical: [
+          // field-row: vertical layout (stacked)
+          '[&_[data-slot=field-row]]:flex-col [&_[data-slot=field-row]]:items-stretch',
+          // field-row-label: full width
+          '[&_[data-slot=field-row-label]]:w-full [&_[data-slot=field-row-label]]:shrink [&_[data-slot=field-row-label]]:pt-1.5 [&_[data-slot=field-row-label]]:pb-1 [&_[data-slot=field-row-content]]:ps-2',
+          '[&_[data-slot=field-row]]:pb-1',
+        ],
+        responsive: [
+          '@container',
+          // Base (mobile): vertical layout
+          '[&_[data-slot=field-row]]:flex-col [&_[data-slot=field-row]]:items-stretch',
+          '[&_[data-slot=field-row-label]]:w-full [&_[data-slot=field-row-label]]:shrink [&_[data-slot=field-row-label]]:pt-1.5 [&_[data-slot=field-row-label]]:pb-1 [&_[data-slot=field-row-content]]:ps-2',
+          '[&_[data-slot=field-row]]:pb-1',
+          // @sm+ : horizontal layout
+          '@sm:[&_[data-slot=field-row]]:flex-row @sm:[&_[data-slot=field-row]]:items-start',
+          '@sm:[&_[data-slot=field-row-label]]:w-40 @sm:[&_[data-slot=field-row-label]]:shrink-0 @sm:[&_[data-slot=field-row-label]]:min-h-8',
+          '@sm:[&_[data-slot=field-row-label]]:pt-0 @sm:[&_[data-slot=field-row-label]]:pb-0 @sm:[&_[data-slot=field-row-content]]:ps-0',
+          '@sm:[&_[data-slot=field-row]]:pb-0',
+        ],
+      },
+    },
+    defaultVariants: {
+      orientation: 'responsive',
+    },
+  }
+)
+
+/**
+ * Bordered, rounded panel that groups labeled form rows (FieldPanelRow).
+ * Formerly VarEditorField — generic form-layout primitive, not workflow-specific.
+ */
+interface FieldPanelProps extends VariantProps<typeof fieldPanelVariants> {
+  children: React.ReactNode
+  validationError?: string
+  validationType?: 'error' | 'warning'
+  className?: string
+}
+
+const FieldPanel: React.FC<FieldPanelProps> = ({
+  children,
+  validationError,
+  validationType = 'error',
+  orientation = 'responsive',
+  className,
+}) => {
+  return (
+    <div
+      data-slot='field'
+      data-orientation={orientation}
+      className={cn(fieldPanelVariants({ orientation }), className)}>
+      {children}
+      <ValidationErrorBadge error={validationError} type={validationType} />
+    </div>
+  )
+}
+
+interface FieldPanelRowProps {
+  children: React.ReactNode
+  title: string
+  description?: string
+  isRequired?: boolean
+  validationError?: string
+  validationType?: 'error' | 'warning'
+  type?: BaseType
+  showIcon?: boolean
+  icon?: React.ReactNode
+  className?: string
+  /** When provided, renders a clear button on row hover (positioned on the right edge) */
+  onClear?: () => void
+}
+
+/**
+ * Labeled row inside a FieldPanel: label (with optional icon/description) + content.
+ * Formerly VarEditorFieldRow.
+ */
+const FieldPanelRow: React.FC<FieldPanelRowProps> = ({
+  children,
+  title,
+  description,
+  isRequired = false,
+  validationError,
+  validationType = 'error',
+  type,
+  icon,
+  showIcon = false,
+  className,
+  onClear,
+}) => {
+  return (
+    <div
+      data-slot='field-row'
+      className={cn(
+        'group/field-row relative flex border-b dark:border-b-[#404754]/20',
+        className
+      )}>
+      <div
+        data-slot='field-row-label'
+        className='flex flex-row gap-1 ps-2 items-center [&_svg]:size-4'>
+        {showIcon && (icon ? icon : <VarTypeIcon type={type!} />)}
+        <div className='text-sm'>
+          <span className='text-primary-600'>{title}</span>
+          {isRequired && <span className='text-red-500'>*</span>}
+        </div>
+        {description && <TooltipExplanation text={description} />}
+      </div>
+      <div data-slot='field-row-content' className='w-full flex-1 relative'>
+        {children}
+      </div>
+      {onClear && (
+        <div className='absolute -right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover/field-row:opacity-100 transition-opacity z-10'>
+          <Tooltip content='Clear content'>
+            <Button
+              variant='ghost'
+              size='icon-xs'
+              className='size-4 bg-primary-500/30 text-primary-100 transition-colors hover:bg-bad-100 hover:text-bad-500'
+              onClick={onClear}>
+              <X className='size-3!' />
+            </Button>
+          </Tooltip>
+        </div>
+      )}
+      <ValidationErrorBadge error={validationError} type={validationType} />
+    </div>
+  )
+}
+
+export { FieldPanel, FieldPanelRow }

--- a/apps/web/src/components/global/forms/validation-error-badge.tsx
+++ b/apps/web/src/components/global/forms/validation-error-badge.tsx
@@ -1,4 +1,4 @@
-// apps/web/src/components/workflow/ui/input-editor/validation-error-badge.tsx
+// apps/web/src/components/global/forms/validation-error-badge.tsx
 
 import { cn } from '@auxx/ui/lib/utils'
 import { AlertTriangle } from 'lucide-react'

--- a/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
@@ -15,12 +15,12 @@ import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { BaseType } from '~/components/workflow/types'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 import {
   defaultVendorPartValues,
@@ -241,11 +241,11 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
           </DialogDescription>
         </DialogHeader>
 
-        <VarEditorField
+        <FieldPanel
           orientation='responsive'
           className='p-0 sm:[&_[data-slot=field-row-label]]:w-50'>
           {/* Title */}
-          <VarEditorFieldRow
+          <FieldPanelRow
             title='Title'
             type={BaseType.STRING}
             showIcon
@@ -259,10 +259,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
               placeholder='Part name'
               disabled={isPending}
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
 
           {/* SKU */}
-          <VarEditorFieldRow
+          <FieldPanelRow
             title='SKU'
             description='This must be unique across all parts'
             type={BaseType.STRING}
@@ -278,14 +278,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
               placeholder='Unique part number'
               disabled={isPending}
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
 
           {/* Category */}
-          <VarEditorFieldRow
-            title='Category'
-            type={BaseType.STRING}
-            showIcon
-            orientation='responsive'>
+          <FieldPanelRow title='Category' type={BaseType.STRING} showIcon orientation='responsive'>
             <ConstantInputAdapter
               value={values.category}
               onChange={(_, val) => handleChange('category', val)}
@@ -293,10 +289,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
               placeholder='Category'
               disabled={isPending}
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
 
           {/* HS Code */}
-          <VarEditorFieldRow
+          <FieldPanelRow
             title='HS Code'
             description='Harmonized System Code for customs'
             type={BaseType.STRING}
@@ -309,10 +305,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
               placeholder='Harmonized System Code'
               disabled={isPending}
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
 
           {/* Shopify Product Link ID */}
-          <VarEditorFieldRow
+          <FieldPanelRow
             title='Shopify Product ID'
             description='Link to a Shopify product'
             orientation='responsive'
@@ -325,10 +321,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
               placeholder='Shopify Product ID (optional)'
               disabled={isPending}
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
 
           {/* Description */}
-          <VarEditorFieldRow
+          <FieldPanelRow
             title='Description'
             type={BaseType.STRING}
             orientation='responsive'
@@ -341,8 +337,8 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
               disabled={isPending}
               fieldOptions={{ string: { multiline: true } }}
             />
-          </VarEditorFieldRow>
-        </VarEditorField>
+          </FieldPanelRow>
+        </FieldPanel>
 
         {/* Collapsible Supplier Section - Only shown in create mode */}
         {!isEditMode && (
@@ -360,14 +356,14 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
             </button>
 
             {showSupplier && (
-              <VarEditorField className='p-0 mt-4 ' orientation='responsive'>
+              <FieldPanel className='p-0 mt-4 ' orientation='responsive'>
                 <VendorPartFields
                   values={vendorPartValues}
                   onChange={handleVendorPartChange}
                   errors={vendorPartErrors}
                   disabled={isPending}
                 />
-              </VarEditorField>
+              </FieldPanel>
             )}
           </div>
         )}

--- a/apps/web/src/components/workflow/ui/input-editor/var-editor.tsx
+++ b/apps/web/src/components/workflow/ui/input-editor/var-editor.tsx
@@ -5,165 +5,22 @@ import { Button } from '@auxx/ui/components/button'
 import { cn } from '@auxx/ui/lib/utils'
 
 import { EditorContent } from '@tiptap/react'
-import { cva, type VariantProps } from 'class-variance-authority'
 import { ChevronsLeftRightEllipsis, X } from 'lucide-react'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { InlinePickerPopover } from '~/components/editor/inline-picker'
-import { Tooltip, TooltipExplanation } from '~/components/global/tooltip'
-import { type BaseType, type UnifiedVariable, VAR_MODE } from '~/components/workflow/types'
+import { Tooltip } from '~/components/global/tooltip'
+import { type UnifiedVariable, VAR_MODE } from '~/components/workflow/types'
 import { VariablePicker } from '~/components/workflow/ui/variables/variable-picker'
 import {
   VariableTagContextMenu,
   VariableTagDropdown,
 } from '~/components/workflow/ui/variables/variable-tag-context-menu'
 import { containsVariableReference } from '~/components/workflow/utils/variable-utils'
-import { VarTypeIcon } from '../../utils'
 import { VariableExplorerEnhanced } from '../variables/variable-explorer-enhanced'
 import VariableTag from '../variables/variable-tag'
 import { ConstantInputAdapter as ConstantInput } from './constant-input-adapter'
 import { useWorkflowVariableEditor } from './hooks/use-workflow-variable-editor'
 import type { VarEditorProps } from './types'
-import { ValidationErrorBadge } from './validation-error-badge'
-
-/**
- * Variants for VarEditorField orientation
- * Controls how VarEditorFieldRow children lay out their label and content
- */
-const varEditorFieldVariants = cva(
-  [
-    'relative grow rounded-2xl px-1.5 py-0.5',
-    'bg-primary-200/30 dark:bg-[#23272e]/30 border flex flex-col focus-within:border-primary-300',
-    '[&>[data-slot=field-row]:not(:has(~[data-slot=field-row]))]:border-b-0',
-  ],
-  {
-    variants: {
-      orientation: {
-        horizontal: [
-          // field-row: horizontal layout (default behavior)
-          '[&_[data-slot=field-row]]:flex-row [&_[data-slot=field-row]]:items-start',
-          // field-row-label: fixed width and height
-          '[&_[data-slot=field-row-label]]:w-40 [&_[data-slot=field-row-label]]:shrink-0 [&_[data-slot=field-row-label]]:min-h-8',
-        ],
-        vertical: [
-          // field-row: vertical layout (stacked)
-          '[&_[data-slot=field-row]]:flex-col [&_[data-slot=field-row]]:items-stretch',
-          // field-row-label: full width
-          '[&_[data-slot=field-row-label]]:w-full [&_[data-slot=field-row-label]]:shrink [&_[data-slot=field-row-label]]:pt-1.5 [&_[data-slot=field-row-label]]:pb-1 [&_[data-slot=field-row-content]]:ps-2',
-          '[&_[data-slot=field-row]]:pb-1',
-        ],
-        responsive: [
-          '@container',
-          // Base (mobile): vertical layout
-          '[&_[data-slot=field-row]]:flex-col [&_[data-slot=field-row]]:items-stretch',
-          '[&_[data-slot=field-row-label]]:w-full [&_[data-slot=field-row-label]]:shrink [&_[data-slot=field-row-label]]:pt-1.5 [&_[data-slot=field-row-label]]:pb-1 [&_[data-slot=field-row-content]]:ps-2',
-          '[&_[data-slot=field-row]]:pb-1',
-          // @sm+ : horizontal layout
-          '@sm:[&_[data-slot=field-row]]:flex-row @sm:[&_[data-slot=field-row]]:items-start',
-          '@sm:[&_[data-slot=field-row-label]]:w-40 @sm:[&_[data-slot=field-row-label]]:shrink-0 @sm:[&_[data-slot=field-row-label]]:min-h-8',
-          '@sm:[&_[data-slot=field-row-label]]:pt-0 @sm:[&_[data-slot=field-row-label]]:pb-0 @sm:[&_[data-slot=field-row-content]]:ps-0',
-          '@sm:[&_[data-slot=field-row]]:pb-0',
-        ],
-      },
-    },
-    defaultVariants: {
-      orientation: 'responsive',
-    },
-  }
-)
-
-/**
- * Wrapper component for VarEditor field styling
- */
-interface VarEditorFieldProps extends VariantProps<typeof varEditorFieldVariants> {
-  children: React.ReactNode
-  validationError?: string
-  validationType?: 'error' | 'warning'
-  className?: string
-}
-
-const VarEditorField: React.FC<VarEditorFieldProps> = ({
-  children,
-  validationError,
-  validationType = 'error',
-  orientation = 'responsive',
-  className,
-}) => {
-  return (
-    <div
-      data-slot='field'
-      data-orientation={orientation}
-      className={cn(varEditorFieldVariants({ orientation }), className)}>
-      {children}
-      <ValidationErrorBadge error={validationError} type={validationType} />
-    </div>
-  )
-}
-
-interface VarEditorFieldRowProps {
-  children: React.ReactNode
-  title: string
-  description?: string
-  isRequired?: boolean
-  validationError?: string
-  validationType?: 'error' | 'warning'
-  type?: BaseType
-  showIcon?: boolean
-  icon?: React.ReactNode
-  className?: string
-  /** When provided, renders a clear button on row hover (positioned on the right edge) */
-  onClear?: () => void
-}
-
-const VarEditorFieldRow: React.FC<VarEditorFieldRowProps> = ({
-  children,
-  title,
-  description,
-  isRequired = false,
-  validationError,
-  validationType = 'error',
-  type,
-  icon,
-  showIcon = false,
-  className,
-  onClear,
-}) => {
-  return (
-    <div
-      data-slot='field-row'
-      className={cn(
-        'group/field-row relative flex border-b dark:border-b-[#404754]/20',
-        className
-      )}>
-      <div
-        data-slot='field-row-label'
-        className='flex flex-row gap-1 ps-2 items-center [&_svg]:size-4'>
-        {showIcon && (icon ? icon : <VarTypeIcon type={type!} />)}
-        <div className='text-sm'>
-          <span className='text-primary-600'>{title}</span>
-          {isRequired && <span className='text-red-500'>*</span>}
-        </div>
-        {description && <TooltipExplanation text={description} />}
-      </div>
-      <div data-slot='field-row-content' className='w-full flex-1 relative'>
-        {children}
-      </div>
-      {onClear && (
-        <div className='absolute -right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover/field-row:opacity-100 transition-opacity z-10'>
-          <Tooltip content='Clear content'>
-            <Button
-              variant='ghost'
-              size='icon-xs'
-              className='size-4 bg-primary-500/30 text-primary-100 transition-colors hover:bg-bad-100 hover:text-bad-500'
-              onClick={onClear}>
-              <X className='size-3!' />
-            </Button>
-          </Tooltip>
-        </div>
-      )}
-      <ValidationErrorBadge error={validationError} type={validationType} />
-    </div>
-  )
-}
 
 const VarEditor: React.FC<VarEditorProps> = React.memo(
   ({
@@ -468,4 +325,13 @@ const VarEditor: React.FC<VarEditorProps> = React.memo(
   }
 )
 
-export { VarEditor, VarEditorField, VarEditorFieldRow }
+export { VarEditor }
+
+/**
+ * @deprecated Moved to `~/components/global/forms/field-panel` as FieldPanel / FieldPanelRow.
+ * Import from there in new code; these aliases exist so existing imports keep working.
+ */
+export {
+  FieldPanel as VarEditorField,
+  FieldPanelRow as VarEditorFieldRow,
+} from '~/components/global/forms/field-panel'


### PR DESCRIPTION
## Summary
- Move `VarEditorField`/`VarEditorFieldRow` out of `workflow/ui/input-editor/var-editor.tsx` into `~/components/global/forms/field-panel.tsx` as `FieldPanel`/`FieldPanelRow` — these are generic form-layout primitives, not workflow-specific.
- `var-editor.tsx` keeps deprecated re-exports (`VarEditorField`/`VarEditorFieldRow` aliasing the new components) so the ~50 existing call sites across the app keep working unchanged.
- `part-form-dialog.tsx` switched to the new import directly.
- `validation-error-badge.tsx` moved alongside into `global/forms`.

Split out of a larger data-connectors/inventory-bridge branch as pure refactor with no behavior change, so it can be reviewed independently.

## Test plan
- [x] Visual no-op: `FieldPanel`/`FieldPanelRow` render identical markup/classes to the old `VarEditorField`/`VarEditorFieldRow`
- [ ] Spot-check part-form-dialog and a workflow node panel in the browser to confirm no visual regression