### PR TITLE
refactor(forms): migrate non-workflow FieldPanel call sites off VarEditorField

### DIFF
--- a/apps/web/src/app/(protected)/app/tickets/_components/ticket-number-form.tsx
+++ b/apps/web/src/app/(protected)/app/tickets/_components/ticket-number-form.tsx
@@ -11,9 +11,9 @@ import { Hash } from 'lucide-react'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 const formSchema = z.object({
@@ -178,9 +178,9 @@ export default function TicketNumberingSettings() {
         description='Configure how ticket numbers are generated.'>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)}>
-            <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-60'>
+            <FieldPanel className='p-0 [&_[data-slot=field-row-label]]:w-60'>
               {/* Prefix Settings */}
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Use Prefix'
                 description='Enable to use a prefix for ticket numbers (e.g., SUP-0001)'
                 type={BaseType.BOOLEAN}
@@ -191,11 +191,11 @@ export default function TicketNumberingSettings() {
                   varType={BaseType.BOOLEAN}
                   fieldOptions={{ variant: 'switch' }}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
 
               {form.watch('usePrefix') && (
                 <>
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Prefix Text'
                     description='Short text to prefix the ticket number (e.g., SUP)'
                     type={BaseType.STRING}
@@ -206,9 +206,9 @@ export default function TicketNumberingSettings() {
                       varType={BaseType.STRING}
                       placeholder='SUP'
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
 
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Include Date'
                     description='Add date component to prefix (e.g., SUP2403-0001)'
                     type={BaseType.BOOLEAN}
@@ -219,10 +219,10 @@ export default function TicketNumberingSettings() {
                       varType={BaseType.BOOLEAN}
                       fieldOptions={{ variant: 'switch' }}
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
 
                   {form.watch('useDateInPrefix') && (
-                    <VarEditorFieldRow
+                    <FieldPanelRow
                       title='Date Format'
                       description='Format of the date component in the prefix'
                       type={BaseType.ENUM}
@@ -233,13 +233,13 @@ export default function TicketNumberingSettings() {
                         varType={BaseType.ENUM}
                         fieldOptions={{ enum: DATE_FORMAT_OPTIONS }}
                       />
-                    </VarEditorFieldRow>
+                    </FieldPanelRow>
                   )}
                 </>
               )}
 
               {/* Suffix Settings */}
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Use Suffix'
                 description='Enable to use a suffix for ticket numbers (e.g., 0001-SUP)'
                 type={BaseType.BOOLEAN}
@@ -250,10 +250,10 @@ export default function TicketNumberingSettings() {
                   varType={BaseType.BOOLEAN}
                   fieldOptions={{ variant: 'switch' }}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
 
               {form.watch('useSuffix') && (
-                <VarEditorFieldRow
+                <FieldPanelRow
                   title='Suffix Text'
                   description='Text to append after the ticket number'
                   type={BaseType.STRING}
@@ -264,11 +264,11 @@ export default function TicketNumberingSettings() {
                     varType={BaseType.STRING}
                     placeholder='SUP'
                   />
-                </VarEditorFieldRow>
+                </FieldPanelRow>
               )}
 
               {/* Number Format */}
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Padding Length'
                 description='Number of digits to pad the numeric part (e.g., 4 for 0001)'
                 type={BaseType.NUMBER}
@@ -279,9 +279,9 @@ export default function TicketNumberingSettings() {
                   varType={BaseType.NUMBER}
                   placeholder='4'
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
 
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Separator'
                 description='Character(s) to separate parts (e.g., -, ., _)'
                 type={BaseType.STRING}
@@ -292,8 +292,8 @@ export default function TicketNumberingSettings() {
                   varType={BaseType.STRING}
                   placeholder='-'
                 />
-              </VarEditorFieldRow>
-            </VarEditorField>
+              </FieldPanelRow>
+            </FieldPanel>
 
             {/* Preview Section */}
             <div className='mt-6 rounded-xl border bg-primary-100/30 p-4'>

--- a/apps/web/src/components/agents/ui/detail/bindings/add-binding-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/bindings/add-binding-dialog.tsx
@@ -10,8 +10,8 @@ import { EntityIcon } from '@auxx/ui/components/icons'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { type ReactNode, useEffect, useMemo, useState } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { ToolReferenceList } from '~/components/pickers/tool-picker/tool-reference-list'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { argToFieldType } from '~/lib/agents/bindings/arg-to-field-type'
 import type { AgentDetail } from '../../../store/agent-store'
 import { BindingValueEditor } from './binding-value-editor'
@@ -63,7 +63,7 @@ function isIncomplete(source: VarSource): boolean {
 /**
  * Add/edit a tool's input **overrides**. Two steps:
  *   1. Tool select — reuses `ToolReferenceList`, scoped to enabled tools.
- *   2. All-inputs panel — every top-level input as a `VarEditorField` row with
+ *   2. All-inputs panel — every top-level input as a `FieldPanelRow` with
  *      an inline constant⇄dynamic value editor. Empty rows mean "model decides"
  *      (no override) and are pruned on save, leaving the tool on its author
  *      defaults. See plans/chat/v8 phase-5.
@@ -172,13 +172,13 @@ export function AddBindingDialog({
                       This tool has no top-level inputs.
                     </p>
                   ) : (
-                    <VarEditorField className='p-0'>
+                    <FieldPanel className='p-0' resizeId='agent-binding' breakpoint='md'>
                       {args.map((arg) => {
                         const mapped = argToFieldType(arg.schema)
                         const source = draft[arg.name] ?? MODEL_DECIDES
 
                         return (
-                          <VarEditorFieldRow
+                          <FieldPanelRow
                             key={arg.name}
                             title={arg.name}
                             description={arg.schema.description}
@@ -201,10 +201,10 @@ export function AddBindingDialog({
                                 {mapped.reason}
                               </p>
                             )}
-                          </VarEditorFieldRow>
+                          </FieldPanelRow>
                         )
                       })}
-                    </VarEditorField>
+                    </FieldPanel>
                   )}
                 </div>
               </ScrollArea>

--- a/apps/web/src/components/agents/ui/detail/bindings/binding-value-editor.tsx
+++ b/apps/web/src/components/agents/ui/detail/bindings/binding-value-editor.tsx
@@ -25,7 +25,7 @@ type Mode = 'constant' | 'var'
 
 /**
  * The inline value control for one tool input, placed inside a
- * `VarEditorFieldRow`. A left mode-toggle (constant ⇄ dynamic field) plus the
+ * `FieldPanelRow`. A left mode-toggle (constant ⇄ dynamic field) plus the
  * active input. The empty state means **"model decides"** (`{ kind:'model' }`)
  * — the row's hover `X` returns a bound input to it. See plans/chat/v8 phase-5.
  */

--- a/apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
+++ b/apps/web/src/components/agents/ui/detail/triggers/agent-trigger-dialog.tsx
@@ -32,6 +32,7 @@ import { AppIcon } from '~/components/apps/ui/app-icon'
 import { DEFAULT_TABS } from '~/components/editor/inline-picker'
 import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
 import { PromptEditor } from '~/components/editor/prompt-editor'
+import { FieldPanel } from '~/components/global/forms/field-panel'
 import {
   DEFAULT_SCHEDULED_STATE,
   type ScheduledState,
@@ -50,7 +51,6 @@ import { TriggerSourceRow } from '~/components/pickers/trigger-source'
 import { useResources } from '~/components/resources/hooks/use-resources'
 import { WebhookEndpointInspector } from '~/components/webhooks/ui/webhook-endpoint-inspector'
 import { WebhookTopicPicker } from '~/components/webhooks/ui/webhook-topic-picker'
-import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api, type RouterOutputs } from '~/trpc/react'
 
@@ -459,7 +459,7 @@ export function AgentTriggerDialog({
               <ResourceField
                 title='Resource'
                 description='Select the operation and type of resource for this trigger'>
-                <VarEditorField className='px-0.5'>
+                <FieldPanel className='px-0.5'>
                   <div className='flex flex-row'>
                     <div>
                       <Select
@@ -488,7 +488,7 @@ export function AgentTriggerDialog({
                       />
                     </div>
                   </div>
-                </VarEditorField>
+                </FieldPanel>
               </ResourceField>
             ) : effectiveKind === 'app' && appContext ? (
               <>

--- a/apps/web/src/components/ai/ui/credential-configuration-dialog.tsx
+++ b/apps/web/src/components/ai/ui/credential-configuration-dialog.tsx
@@ -23,8 +23,8 @@ import type React from 'react'
 import { type FormEvent, useEffect, useMemo, useState } from 'react'
 import { useCredentialForm } from '~/components/connections/hooks/use-credential-form'
 import { ConnectionVariableFields } from '~/components/connections/ui/connection-variable-fields'
+import { FieldPanel } from '~/components/global/forms/field-panel'
 import { AiProviderPicker } from '~/components/pickers/ai-provider-picker'
-import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import type { ProviderConfiguration } from './utils'
@@ -374,9 +374,12 @@ export function CredentialConfigurationDialog({
                     <h3 className='text-sm font-semibold uppercase text-primary-500'>
                       {isProviderMode ? 'Provider Credentials' : 'Model Credentials'}
                     </h3>
-                    <VarEditorField
+                    <FieldPanel
                       orientation='responsive'
-                      className='p-0 sm:[&_[data-slot=field-row-label]]:w-70!'>
+                      breakpoint='md'
+                      className='p-0'
+                      resizeId='ai-credential'
+                      defaultLabelWidth={280}>
                       <ConnectionVariableFields
                         variables={visibleFields}
                         values={values}
@@ -384,7 +387,7 @@ export function CredentialConfigurationDialog({
                         errors={errors}
                         savedSecrets={savedSecrets}
                       />
-                    </VarEditorField>
+                    </FieldPanel>
                   </div>
                 </>
               )}

--- a/apps/web/src/components/ai/ui/system-model-settings-dialog.tsx
+++ b/apps/web/src/components/ai/ui/system-model-settings-dialog.tsx
@@ -17,8 +17,8 @@ import { toastError } from '@auxx/ui/components/toast'
 import { Settings2 } from 'lucide-react'
 import type React from 'react'
 import { useState } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { AiModelPicker, type ModelPickerItem } from '~/components/pickers/ai-model-picker'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 /**
@@ -73,7 +73,7 @@ interface SystemModelSettingsDialogProps {
 
 /**
  * Dialog for configuring system-wide default models per ModelType
- * Uses VarEditorField pattern similar to entity-instance-dialog.tsx
+ * Uses FieldPanel pattern similar to entity-instance-dialog.tsx
  */
 export function SystemModelSettingsDialog({
   trigger,
@@ -154,9 +154,9 @@ export function SystemModelSettingsDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <VarEditorField orientation='responsive'>
+        <FieldPanel orientation='responsive' breakpoint='md' resizeId='ai-system-model'>
           {MODEL_TYPE_CONFIG.map(({ type, label, description }) => (
-            <VarEditorFieldRow key={type} title={label} description={description}>
+            <FieldPanelRow key={type} title={label} description={description}>
               {unifiedModelData ? (
                 <AiModelPicker
                   data={unifiedModelData}
@@ -172,9 +172,9 @@ export function SystemModelSettingsDialog({
               ) : (
                 <Skeleton className='mt-2 h-5 w-25' />
               )}
-            </VarEditorFieldRow>
+            </FieldPanelRow>
           ))}
-        </VarEditorField>
+        </FieldPanel>
 
         <DialogFooter>
           <Button variant='ghost' size='sm' onClick={() => setOpen(false)} disabled={isPending}>

--- a/apps/web/src/components/calls/ui/meeting-form.tsx
+++ b/apps/web/src/components/calls/ui/meeting-form.tsx
@@ -7,9 +7,9 @@ import { DialogFooter } from '@auxx/ui/components/dialog'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { type ReactNode, useCallback, useEffect, useState } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 const PLATFORM_OPTIONS = [
@@ -160,11 +160,14 @@ export function MeetingForm({ open, onSuccess, onClose, onCancel, header }: Meet
     <>
       {header?.({ title })}
 
-      <VarEditorField
+      <FieldPanel
         orientation='responsive'
-        className='p-0 sm:[&_[data-slot=field-row-label]]:w-50'>
+        breakpoint='md'
+        resizeId='meeting-form'
+        defaultLabelWidth={200}
+        className='p-0'>
         {/* Title */}
-        <VarEditorFieldRow
+        <FieldPanelRow
           title='Title'
           type={BaseType.STRING}
           showIcon
@@ -178,10 +181,10 @@ export function MeetingForm({ open, onSuccess, onClose, onCancel, header }: Meet
             placeholder='Meeting title'
             disabled={isPending}
           />
-        </VarEditorFieldRow>
+        </FieldPanelRow>
 
         {/* Platform */}
-        <VarEditorFieldRow title='Platform' type={BaseType.ENUM} showIcon>
+        <FieldPanelRow title='Platform' type={BaseType.ENUM} showIcon>
           <ConstantInputAdapter
             value={values.platform}
             onChange={(_, val) => handleChange('platform', val)}
@@ -189,10 +192,10 @@ export function MeetingForm({ open, onSuccess, onClose, onCancel, header }: Meet
             disabled={isPending}
             fieldOptions={{ enum: PLATFORM_OPTIONS }}
           />
-        </VarEditorFieldRow>
+        </FieldPanelRow>
 
         {/* Date & Time */}
-        <VarEditorFieldRow
+        <FieldPanelRow
           title='Date & Time'
           type={BaseType.DATETIME}
           showIcon
@@ -205,10 +208,10 @@ export function MeetingForm({ open, onSuccess, onClose, onCancel, header }: Meet
             varType={BaseType.DATETIME}
             disabled={isPending}
           />
-        </VarEditorFieldRow>
+        </FieldPanelRow>
 
         {/* Duration */}
-        <VarEditorFieldRow
+        <FieldPanelRow
           title='Duration'
           type={BaseType.ENUM}
           showIcon
@@ -222,11 +225,11 @@ export function MeetingForm({ open, onSuccess, onClose, onCancel, header }: Meet
             disabled={isPending}
             fieldOptions={{ enum: DURATION_OPTIONS }}
           />
-        </VarEditorFieldRow>
+        </FieldPanelRow>
 
         {/* Meeting URL — only for non-Google Meet */}
         {isManualUrl && (
-          <VarEditorFieldRow
+          <FieldPanelRow
             title='Meeting URL'
             type={BaseType.URL}
             showIcon
@@ -240,11 +243,11 @@ export function MeetingForm({ open, onSuccess, onClose, onCancel, header }: Meet
               placeholder='https://zoom.us/j/...'
               disabled={isPending}
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
         )}
 
         {/* Participants */}
-        <VarEditorFieldRow title='Participants' type={BaseType.RELATION} showIcon>
+        <FieldPanelRow title='Participants' type={BaseType.RELATION} showIcon>
           <ConstantInputAdapter
             value={values.participants}
             onChange={(_, val) => handleChange('participants', val)}
@@ -256,10 +259,10 @@ export function MeetingForm({ open, onSuccess, onClose, onCancel, header }: Meet
               relationshipType: 'has_many',
             }}
           />
-        </VarEditorFieldRow>
+        </FieldPanelRow>
 
         {/* Description */}
-        <VarEditorFieldRow title='Description' type={BaseType.STRING} showIcon>
+        <FieldPanelRow title='Description' type={BaseType.STRING} showIcon>
           <ConstantInputAdapter
             value={values.description}
             onChange={(_, val) => handleChange('description', val)}
@@ -268,8 +271,8 @@ export function MeetingForm({ open, onSuccess, onClose, onCancel, header }: Meet
             disabled={isPending}
             fieldOptions={{ string: { multiline: true } }}
           />
-        </VarEditorFieldRow>
-      </VarEditorField>
+        </FieldPanelRow>
+      </FieldPanel>
 
       <DialogFooter>
         <Button type='button' variant='ghost' size='sm' onClick={cancel} disabled={isPending}>

--- a/apps/web/src/components/chat-widget/ui/settings/sections/ai-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/ai-section.tsx
@@ -18,11 +18,11 @@ import { BookOpen, Bot, Sparkles } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { ActorPicker } from '~/components/pickers/actor-picker'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 import { FeaturedArticlesField } from '../featured-articles-field'
 
@@ -118,8 +118,8 @@ export function AiSection({ widget, channelId }: AiSectionProps) {
             icon={Bot}
             title='Agent'
             description='The AI agent that replies to incoming chat messages.'>
-            <VarEditorField orientation='responsive' className='p-0'>
-              <VarEditorFieldRow
+            <FieldPanel orientation='responsive' resizeId='chat-widget-settings' className='p-0'>
+              <FieldPanelRow
                 title='AI Auto-Reply'
                 description='Pick an Agent that responds automatically to new chat messages. Leave unset to require a human reply.'
                 type={BaseType.ACTOR}
@@ -135,8 +135,8 @@ export function AiSection({ widget, channelId }: AiSectionProps) {
                   disabled={update.isPending}
                   triggerProps={{ className: 'w-full ps-0 pe-1' }}
                 />
-              </VarEditorFieldRow>
-            </VarEditorField>
+              </FieldPanelRow>
+            </FieldPanel>
           </SettingsSection>
         </div>
 
@@ -145,14 +145,14 @@ export function AiSection({ widget, channelId }: AiSectionProps) {
             icon={BookOpen}
             title='Knowledge base'
             description="Source articles for the widget's Home and Browse screens.">
-            <VarEditorField orientation='responsive' className='p-0'>
+            <FieldPanel orientation='responsive' resizeId='chat-widget-settings' className='p-0'>
               <FormField
                 control={form.control}
                 name='knowledgeBaseId'
                 render={({ field, fieldState }) => {
                   const recordId = field.value ? (`kb:${field.value}` as RecordId) : null
                   return (
-                    <VarEditorFieldRow
+                    <FieldPanelRow
                       title='Knowledge base'
                       description="Articles from this KB power the widget's featured cards and Browse all view."
                       type={BaseType.RELATION}
@@ -178,11 +178,11 @@ export function AiSection({ widget, channelId }: AiSectionProps) {
                         }}
                       />
                       <KbVisibilityWarning knowledgeBaseId={field.value} />
-                    </VarEditorFieldRow>
+                    </FieldPanelRow>
                   )
                 }}
               />
-            </VarEditorField>
+            </FieldPanel>
           </SettingsSection>
 
           <div>

--- a/apps/web/src/components/chat-widget/ui/settings/sections/appearance-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/appearance-section.tsx
@@ -11,10 +11,10 @@ import { LayoutGrid, MessageSquare, Moon, Palette, Smartphone, Sun, SunMoon } fr
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { ColorField } from '~/components/ui/color-field'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 import { GreetingEditor } from '../greeting-editor'
 import { SuggestedRepliesEditor } from '../suggested-replies-editor'
@@ -137,14 +137,16 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
               icon={Palette}
               title='Branding'
               description='The color and logo shown on the widget header.'>
-              <VarEditorField
+              <FieldPanel
                 orientation='responsive'
-                className='p-0 **:data-[slot=field-row-label]:w-[12rem]! @sm:**:data-[slot=field-row-label]:w-[12rem]!'>
+                resizeId='chat-widget-settings'
+                defaultLabelWidth={192}
+                className='p-0'>
                 <FormField
                   control={form.control}
                   name='defaultTheme'
                   render={({ field, fieldState }) => (
-                    <VarEditorFieldRow
+                    <FieldPanelRow
                       title='Theme'
                       description='Default color scheme. The embed script can override this per-page via data-theme.'
                       type={BaseType.ENUM}
@@ -164,7 +166,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                         placeholder='Choose theme'
                         triggerProps={{ className: 'w-full ps-0 pe-1' }}
                       />
-                    </VarEditorFieldRow>
+                    </FieldPanelRow>
                   )}
                 />
 
@@ -172,7 +174,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                   control={form.control}
                   name='primaryColor'
                   render={({ field, fieldState }) => (
-                    <VarEditorFieldRow
+                    <FieldPanelRow
                       title='Primary Color'
                       description='Used for the launcher button, send buttons, and accent UI.'
                       type={BaseType.STRING}
@@ -185,7 +187,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                         onChange={field.onChange}
                         placeholder='Pick a color'
                       />
-                    </VarEditorFieldRow>
+                    </FieldPanelRow>
                   )}
                 />
 
@@ -194,7 +196,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                     control={form.control}
                     name='primaryColorDark'
                     render={({ field, fieldState }) => (
-                      <VarEditorFieldRow
+                      <FieldPanelRow
                         title='Primary Color (dark)'
                         description='Primary color in dark mode. Optional — falls back to the light primary color.'
                         type={BaseType.STRING}
@@ -206,7 +208,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                           onChange={field.onChange}
                           placeholder='Same as light'
                         />
-                      </VarEditorFieldRow>
+                      </FieldPanelRow>
                     )}
                   />
                 ) : null}
@@ -215,7 +217,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                   control={form.control}
                   name='headerColor'
                   render={({ field, fieldState }) => (
-                    <VarEditorFieldRow
+                    <FieldPanelRow
                       title='Header Color'
                       description='Background of the Home greeting band. Leave empty to derive from the brand color. Text color is auto-picked for contrast.'
                       type={BaseType.STRING}
@@ -228,7 +230,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                         placeholder='Auto (brand)'
                         clearable
                       />
-                    </VarEditorFieldRow>
+                    </FieldPanelRow>
                   )}
                 />
 
@@ -237,7 +239,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                     control={form.control}
                     name='headerColorDark'
                     render={({ field, fieldState }) => (
-                      <VarEditorFieldRow
+                      <FieldPanelRow
                         title='Header Color (dark)'
                         description='Home greeting band color in dark mode. Optional — falls back to the light header color.'
                         type={BaseType.STRING}
@@ -249,7 +251,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                           onChange={field.onChange}
                           placeholder='Same as light'
                         />
-                      </VarEditorFieldRow>
+                      </FieldPanelRow>
                     )}
                   />
                 ) : null}
@@ -258,7 +260,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                   control={form.control}
                   name='logoLight'
                   render={({ field, fieldState }) => (
-                    <VarEditorFieldRow
+                    <FieldPanelRow
                       title='Light mode logo'
                       description='Shown on the dark primary-colored header band.'
                       icon={<Sun className='size-3.5' />}
@@ -270,7 +272,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                         onChange={(v) => field.onChange(v)}
                         chatWidgetId={chatWidgetId}
                       />
-                    </VarEditorFieldRow>
+                    </FieldPanelRow>
                   )}
                 />
 
@@ -278,7 +280,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                   control={form.control}
                   name='logoDark'
                   render={({ field, fieldState }) => (
-                    <VarEditorFieldRow
+                    <FieldPanelRow
                       title='Dark mode logo'
                       description='Used when the resolved theme is dark. Falls back to the light logo if unset.'
                       icon={<Moon className='size-3.5' />}
@@ -290,10 +292,10 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                         onChange={(v) => field.onChange(v)}
                         chatWidgetId={chatWidgetId}
                       />
-                    </VarEditorFieldRow>
+                    </FieldPanelRow>
                   )}
                 />
-              </VarEditorField>
+              </FieldPanel>
             </SettingsSection>
 
             <SettingsSection
@@ -301,12 +303,12 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
               icon={LayoutGrid}
               title='Layout'
               description='Where and how the widget appears on the page.'>
-              <VarEditorField orientation='responsive' className='p-0'>
+              <FieldPanel orientation='responsive' resizeId='chat-widget-settings' className='p-0'>
                 <FormField
                   control={form.control}
                   name='position'
                   render={({ field, fieldState }) => (
-                    <VarEditorFieldRow
+                    <FieldPanelRow
                       title='Position'
                       description='Corner of the page where the widget anchors.'
                       type={BaseType.ENUM}
@@ -326,7 +328,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                         placeholder='Choose position'
                         triggerProps={{ className: 'w-full' }}
                       />
-                    </VarEditorFieldRow>
+                    </FieldPanelRow>
                   )}
                 />
 
@@ -334,7 +336,7 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                   control={form.control}
                   name='mobileFullScreen'
                   render={({ field, fieldState }) => (
-                    <VarEditorFieldRow
+                    <FieldPanelRow
                       title='Mobile Full Screen'
                       description='Expand the widget to fill the screen on small devices.'
                       type={BaseType.BOOLEAN}
@@ -349,10 +351,10 @@ export function AppearanceSection({ widget, channelId }: AppearanceSectionProps)
                           onChange={(v) => field.onChange(Boolean(v))}
                         />
                       </div>
-                    </VarEditorFieldRow>
+                    </FieldPanelRow>
                   )}
                 />
-              </VarEditorField>
+              </FieldPanel>
             </SettingsSection>
           </div>
 

--- a/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/behavior-section.tsx
@@ -28,9 +28,9 @@ import {
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 interface BehaviorSectionProps {
@@ -96,14 +96,14 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
             icon={SlidersHorizontal}
             title='Engagement'
             description='How and when the widget engages visitors.'>
-            <VarEditorField
+            <FieldPanel
               orientation='horizontal'
               className='p-0 **:data-[slot=field-row-label]:w-auto! @sm:**:data-[slot=field-row-label]:w-auto! **:data-[slot=field-row-content]:flex **:data-[slot=field-row-content]:justify-end **:data-[slot=field-row-content]:pe-3'>
               <FormField
                 control={form.control}
                 name='autoOpen'
                 render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Auto-open'
                     description='Automatically open the widget when a visitor lands on the page.'
                     type={BaseType.BOOLEAN}
@@ -118,7 +118,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                         onChange={(v) => field.onChange(Boolean(v))}
                       />
                     </div>
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 )}
               />
 
@@ -126,7 +126,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                 control={form.control}
                 name='collectUserInfo'
                 render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Collect Visitor Info'
                     description='Prompt visitors for name and email before the chat starts.'
                     type={BaseType.BOOLEAN}
@@ -139,7 +139,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                       value={field.value}
                       onChange={(v) => field.onChange(Boolean(v))}
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 )}
               />
 
@@ -147,7 +147,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                 control={form.control}
                 name='homeShowRecentMessage'
                 render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Show recent message card'
                     description="Show a card linking to the visitor's most recent conversation."
                     type={BaseType.BOOLEAN}
@@ -160,7 +160,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                       value={field.value}
                       onChange={(v) => field.onChange(Boolean(v))}
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 )}
               />
 
@@ -168,7 +168,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                 control={form.control}
                 name='homeShowSendMessageCta'
                 render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Show "Send us a message" card'
                     description='Always-visible CTA that starts a new conversation.'
                     type={BaseType.BOOLEAN}
@@ -181,7 +181,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                       value={field.value}
                       onChange={(v) => field.onChange(Boolean(v))}
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 )}
               />
 
@@ -189,7 +189,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                 control={form.control}
                 name='allowDownloadTranscript'
                 render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Allow transcript download'
                     description='Let visitors download a conversation as text.'
                     type={BaseType.BOOLEAN}
@@ -202,7 +202,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                       value={field.value}
                       onChange={(v) => field.onChange(Boolean(v))}
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 )}
               />
 
@@ -210,7 +210,7 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                 control={form.control}
                 name='brandingFooterEnabled'
                 render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Show "Powered by" footer'
                     description='Display Auxx branding at the bottom of the widget.'
                     type={BaseType.BOOLEAN}
@@ -223,10 +223,10 @@ export function BehaviorSection({ widget, channelId }: BehaviorSectionProps) {
                       value={field.value}
                       onChange={(v) => field.onChange(Boolean(v))}
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 )}
               />
-            </VarEditorField>
+            </FieldPanel>
           </SettingsSection>
 
           <SettingsSection

--- a/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/general-section.tsx
@@ -27,12 +27,12 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { InboxDialog } from '~/components/inbox/inbox-dialog'
 import { useResource } from '~/components/resources/hooks/use-resource'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 interface GeneralSectionProps {
@@ -132,12 +132,12 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
             icon={Settings}
             title='General'
             description='Internal name, header text, and active status.'>
-            <VarEditorField orientation='responsive' className='p-0'>
+            <FieldPanel orientation='responsive' resizeId='chat-widget-settings' className='p-0'>
               <FormField
                 control={form.control}
                 name='name'
                 render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Widget Name'
                     description='Shown only to your team.'
                     type={BaseType.STRING}
@@ -151,7 +151,7 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
                       onChange={(v) => field.onChange((v as string) ?? '')}
                       placeholder='Internal name'
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 )}
               />
 
@@ -159,7 +159,7 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
                 control={form.control}
                 name='title'
                 render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Header Title'
                     description='Appears at the top of the widget.'
                     type={BaseType.STRING}
@@ -173,7 +173,7 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
                       onChange={(v) => field.onChange((v as string) ?? '')}
                       placeholder='Chat'
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 )}
               />
 
@@ -181,7 +181,7 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
                 control={form.control}
                 name='subtitle'
                 render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Subtitle'
                     description='Shown under the header title.'
                     type={BaseType.STRING}
@@ -194,7 +194,7 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
                       onChange={(v) => field.onChange((v as string) ?? '')}
                       placeholder='We typically reply in minutes'
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 )}
               />
 
@@ -202,7 +202,7 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
                 control={form.control}
                 name='isActive'
                 render={({ field, fieldState }) => (
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Active'
                     description='When off, the widget will not render or accept new chats.'
                     type={BaseType.BOOLEAN}
@@ -215,11 +215,11 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
                       value={field.value}
                       onChange={(v) => field.onChange(Boolean(v))}
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 )}
               />
 
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Inbox'
                 description='Where new chat conversations land.'
                 type={BaseType.RELATION}
@@ -236,9 +236,9 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
                   onCreate={() => setInboxDialogOpen(true)}
                   createLabel='Create inbox'
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
 
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Privacy URL'
                 description='When set, the widget shows a consent banner under the composer linking to this URL. Leave blank to hide.'
                 type={BaseType.STRING}
@@ -263,8 +263,8 @@ export function GeneralSection({ widget, channelId, onDelete }: GeneralSectionPr
                     disabled={update.isPending}
                   />
                 </div>
-              </VarEditorFieldRow>
-            </VarEditorField>
+              </FieldPanelRow>
+            </FieldPanel>
           </SettingsSection>
         </div>
 

--- a/apps/web/src/components/connections/ui/connection-detail-page.tsx
+++ b/apps/web/src/components/connections/ui/connection-detail-page.tsx
@@ -9,7 +9,7 @@ import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { cn } from '@auxx/ui/lib/utils'
 import { KeyRound, Plug } from 'lucide-react'
 import { ConnectionVariableFields } from '~/components/connections/ui/connection-variable-fields'
-import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
+import { FieldPanel } from '~/components/global/forms/field-panel'
 
 /** One connect method an item exposes (the detail page renders + collects input for it). */
 export interface DetailMethod {
@@ -153,9 +153,12 @@ export function ConnectionDetailPage({
       {chosen && methodNeedsFields(chosen) && (
         <div className='flex flex-col gap-2'>
           <div className='text-xs font-medium text-muted-foreground'>Credentials</div>
-          <VarEditorField
+          <FieldPanel
             orientation='responsive'
-            className='p-0 sm:[&_[data-slot=field-row-label]]:w-70!'>
+            breakpoint='md'
+            resizeId='connection-detail'
+            defaultLabelWidth={280}
+            className='p-0'>
             <ConnectionVariableFields
               variables={chosen.connectionVariables ?? []}
               values={values}
@@ -168,7 +171,7 @@ export function ConnectionDetailPage({
               savedSecrets={savedSecrets}
               tokenSaved={tokenSaved}
             />
-          </VarEditorField>
+          </FieldPanel>
         </div>
       )}
     </div>

--- a/apps/web/src/components/connections/ui/connection-variable-fields.tsx
+++ b/apps/web/src/components/connections/ui/connection-variable-fields.tsx
@@ -7,8 +7,8 @@ import { FieldType } from '@auxx/database/enums'
 import type { FieldOptions } from '@auxx/lib/field-values/client'
 import { mapFieldTypeToBaseType } from '@auxx/lib/workflow-engine/client'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { isFieldVisible } from './connection-variable-validation'
 
 interface ConnectionVariableFieldsProps {
@@ -73,7 +73,7 @@ function triggerPropsFor(v: ConnectionVariable) {
  * Connection-variable rows + optional bearer-token row, shared by the curated connect dialog
  * and the template dialog's fields step. Each row renders the control matching its platform
  * `FieldType` (text/number/checkbox/select), masks `secret` fields, and respects
- * `displayOptions.show` visibility. Render inside a `VarEditorField`.
+ * `displayOptions.show` visibility. Render inside a `FieldPanel`.
  */
 export function ConnectionVariableFields({
   variables,
@@ -92,7 +92,7 @@ export function ConnectionVariableFields({
       {variables
         .filter((variable) => isFieldVisible(variable, values))
         .map((variable) => (
-          <VarEditorFieldRow
+          <FieldPanelRow
             key={variable.key}
             title={variable.label}
             description={variable.description}
@@ -114,11 +114,11 @@ export function ConnectionVariableFields({
                 variable.secret && savedSecrets?.has(variable.key) ? HIDDEN_VALUE : undefined
               }
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
         ))}
 
       {showToken && (
-        <VarEditorFieldRow
+        <FieldPanelRow
           title='Token'
           type={BaseType.STRING}
           showIcon
@@ -134,7 +134,7 @@ export function ConnectionVariableFields({
             disabled={disabled}
             revertValue={tokenSaved ? HIDDEN_VALUE : undefined}
           />
-        </VarEditorFieldRow>
+        </FieldPanelRow>
       )}
     </>
   )

--- a/apps/web/src/components/custom-fields/ui/bulk-update-entity-instance-dialog.tsx
+++ b/apps/web/src/components/custom-fields/ui/bulk-update-entity-instance-dialog.tsx
@@ -15,10 +15,10 @@ import {
 } from '@auxx/ui/components/dialog'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { FieldPanel } from '~/components/global/forms/field-panel'
 import { useResource } from '~/components/resources'
 import { useFieldValueSyncer } from '~/components/resources/hooks/use-field-value-syncer'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
-import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDirtyCheck } from '~/hooks/use-dirty-state'
 import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
 import { FieldInputRow } from './field-input-row'
@@ -218,7 +218,7 @@ export function BulkUpdateEntityInstanceDialog({
             </DialogDescription>
           </DialogHeader>
 
-          <VarEditorField className='p-0'>
+          <FieldPanel className='p-0' breakpoint='md' resizeId='bulk-update-entity-instance'>
             {editableFields.map((field) => {
               // Disable unique fields when editing multiple instances (would violate uniqueness)
               const isUniqueDisabled = field.isUnique && instanceCount > 1
@@ -237,7 +237,7 @@ export function BulkUpdateEntityInstanceDialog({
                 />
               )
             })}
-          </VarEditorField>
+          </FieldPanel>
 
           {editableFields.length === 0 && (
             <div className='text-sm text-muted-foreground text-center py-8'>

--- a/apps/web/src/components/custom-fields/ui/dialog-field-config-row.tsx
+++ b/apps/web/src/components/custom-fields/ui/dialog-field-config-row.tsx
@@ -22,7 +22,7 @@ interface DialogFieldConfigRowProps {
 
 /**
  * Sortable row for dialog config mode.
- * Mirrors VarEditorFieldRow DOM structure (data-slot="field-row") so there is
+ * Mirrors FieldPanelRow DOM structure (data-slot="field-row") so there is
  * zero layout shift when toggling between normal and config mode.
  * GripVertical replaces the type icon; Switch replaces the input content.
  */
@@ -57,7 +57,7 @@ export const DialogFieldConfigRow = memo(function DialogFieldConfigRow({
         isDragging && 'bg-accent rounded',
         !isVisible && 'opacity-50'
       )}>
-      {/* Label area — matches VarEditorFieldRow [data-slot="field-row-label"] */}
+      {/* Label area — matches FieldPanelRow [data-slot="field-row-label"] */}
       <div
         data-slot='field-row-label'
         className='flex flex-row gap-1 ps-2 items-center cursor-grab active:cursor-grabbing'
@@ -69,7 +69,7 @@ export const DialogFieldConfigRow = memo(function DialogFieldConfigRow({
         </div>
       </div>
 
-      {/* Content area — matches VarEditorFieldRow [data-slot="field-row-content"] */}
+      {/* Content area — matches FieldPanelRow [data-slot="field-row-content"] */}
       <div
         data-slot='field-row-content'
         className='w-full flex-1 flex items-center justify-end pe-2 py-1.5'>

--- a/apps/web/src/components/custom-fields/ui/entity-appearance-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-appearance-editor.tsx
@@ -13,9 +13,9 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { AlertTriangle, Check, Palette } from 'lucide-react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { useEntityDefinitionMutations } from '~/components/resources/hooks'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 
 /** Props for EntityAppearanceEditor */
 interface EntityAppearanceEditorProps {
@@ -102,10 +102,8 @@ export function EntityAppearanceEditor({
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
           {/* Left column: Select fields */}
           <div>
-            <VarEditorField className='p-0 dark:bg-primary-50'>
-              <VarEditorFieldRow
-                title='Display Field'
-                description='Shown as the main name in pickers'>
+            <FieldPanel className='p-0 dark:bg-primary-50'>
+              <FieldPanelRow title='Display Field' description='Shown as the main name in pickers'>
                 {disabled ? (
                   <span className='text-sm text-muted-foreground h-7.5 flex items-center'>
                     {primaryField?.name ?? 'None'}
@@ -135,10 +133,8 @@ export function EntityAppearanceEditor({
                     </SelectContent>
                   </Select>
                 )}
-              </VarEditorFieldRow>
-              <VarEditorFieldRow
-                title='Subtitle Field'
-                description='Optional subtitle below the name'>
+              </FieldPanelRow>
+              <FieldPanelRow title='Subtitle Field' description='Optional subtitle below the name'>
                 {disabled ? (
                   <span className='text-sm text-muted-foreground h-7.5 flex items-center'>
                     {secondaryField?.name ?? secondaryField?.label ?? 'None'}
@@ -162,8 +158,8 @@ export function EntityAppearanceEditor({
                     </SelectContent>
                   </Select>
                 )}
-              </VarEditorFieldRow>
-              <VarEditorFieldRow title='Avatar Field' description='Image field for avatar'>
+              </FieldPanelRow>
+              <FieldPanelRow title='Avatar Field' description='Image field for avatar'>
                 {disabled ? (
                   <span className='text-sm text-muted-foreground h-7.5 flex items-center'>
                     {avatarField?.name ?? avatarField?.label ?? 'None'}
@@ -187,7 +183,7 @@ export function EntityAppearanceEditor({
                     </SelectContent>
                   </Select>
                 )}
-              </VarEditorFieldRow>
+              </FieldPanelRow>
               {avatarWarnings.length > 0 && (
                 <div className='flex gap-2 px-3 py-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 rounded-md mx-2 mb-2'>
                   <AlertTriangle className='size-3.5 shrink-0 mt-0.5' />
@@ -198,7 +194,7 @@ export function EntityAppearanceEditor({
                   </div>
                 </div>
               )}
-            </VarEditorField>
+            </FieldPanel>
           </div>
 
           {/* Right column: Preview */}

--- a/apps/web/src/components/custom-fields/ui/entity-definition-dialog.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-definition-dialog.tsx
@@ -40,13 +40,13 @@ import { Spinner } from '@auxx/ui/components/spinner'
 import { toastError } from '@auxx/ui/components/toast'
 import { Check, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import {
   useEntityDefinitionMutations,
   useResource,
   useResourceFields,
   useResources,
 } from '~/components/resources/hooks'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
 import { useDirtyCheck } from '~/hooks/use-dirty-state'
 import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
@@ -528,8 +528,8 @@ export function EntityDefinitionDialog({
                   </div>
 
                   <Field>
-                    <VarEditorField className='p-0'>
-                      <VarEditorFieldRow
+                    <FieldPanel className='p-0'>
+                      <FieldPanelRow
                         title='Display Field'
                         description='This field will be shown as the main name in pickers'>
                         <Select
@@ -551,8 +551,8 @@ export function EntityDefinitionDialog({
                               ))}
                           </SelectContent>
                         </Select>
-                      </VarEditorFieldRow>
-                      <VarEditorFieldRow
+                      </FieldPanelRow>
+                      <FieldPanelRow
                         title='Subtitle Field'
                         description='Optional subtitle shown below the primary name'>
                         <Select
@@ -572,8 +572,8 @@ export function EntityDefinitionDialog({
                             ))}
                           </SelectContent>
                         </Select>
-                      </VarEditorFieldRow>
-                      <VarEditorFieldRow
+                      </FieldPanelRow>
+                      <FieldPanelRow
                         title='Avatar Field'
                         description='Image field to use as avatar in pickers'>
                         <Select
@@ -593,8 +593,8 @@ export function EntityDefinitionDialog({
                               ))}
                           </SelectContent>
                         </Select>
-                      </VarEditorFieldRow>
-                    </VarEditorField>
+                      </FieldPanelRow>
+                    </FieldPanel>
                   </Field>
                 </>
               )}

--- a/apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
@@ -35,10 +35,10 @@ import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useDynamicTableStore } from '~/components/dynamic-table/stores/dynamic-table-store'
 import { useOrgFieldView } from '~/components/dynamic-table/stores/store-selectors'
 import { useFieldView } from '~/components/fields/hooks/use-field-view'
+import { FieldPanel } from '~/components/global/forms/field-panel'
 import { useResource } from '~/components/resources'
 import { useFieldValueSyncer } from '~/components/resources/hooks/use-field-value-syncer'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
-import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDirtyCheck } from '~/hooks/use-dirty-state'
 import { api } from '~/trpc/react'
 import { DialogFieldConfigRow } from '../dialog-field-config-row'
@@ -655,8 +655,10 @@ export function EntityInstanceForm({
         </div>
 
         {isConfigMode ? (
-          /* Config mode: sortable field list with visibility switches */
-          <VarEditorField className='p-0'>
+          /* Config mode: sortable field list with visibility switches.
+             No resizeId here — the resize strip would steal pointer-downs from
+             the row drag-and-drop. */
+          <FieldPanel className='p-0'>
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}
@@ -677,12 +679,15 @@ export function EntityInstanceForm({
                 })}
               </SortableContext>
             </DndContext>
-          </VarEditorField>
+          </FieldPanel>
         ) : (
           /* Normal mode: form inputs */
           <>
             <div ref={formRef}>
-              <VarEditorField className='p-0'>
+              <FieldPanel
+                className='p-0'
+                breakpoint='md'
+                resizeId={`entity-instance:${entityDefinitionId}`}>
                 {editableFields.map((field) => (
                   <FieldInputRow
                     key={field.id}
@@ -698,7 +703,7 @@ export function EntityInstanceForm({
                     disabled={isPending}
                   />
                 ))}
-              </VarEditorField>
+              </FieldPanel>
             </div>
 
             {editableFields.length === 0 && (

--- a/apps/web/src/components/custom-fields/ui/field-input-row.tsx
+++ b/apps/web/src/components/custom-fields/ui/field-input-row.tsx
@@ -10,7 +10,7 @@ import type { ResourceField } from '@auxx/lib/resources/client'
 import { type ActorId, isActorId, toActorId } from '@auxx/types/actor'
 import type { ActorOptions, RelationshipConfig } from '@auxx/types/custom-field'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
-import { VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+import { FieldPanelRow } from '~/components/global/forms/field-panel'
 
 /**
  * Extract ActorIds from various value formats.
@@ -85,7 +85,7 @@ interface FieldInputRowProps {
 }
 
 /**
- * Renders a single field input row with VarEditorFieldRow layout.
+ * Renders a single field input row with FieldPanelRow layout.
  * Uses FieldInputAdapter which handles all field types including relationships.
  */
 export function FieldInputRow({
@@ -145,7 +145,7 @@ export function FieldInputRow({
   }
 
   return (
-    <VarEditorFieldRow
+    <FieldPanelRow
       title={field.label}
       description={field.description}
       type={field.type}
@@ -162,6 +162,6 @@ export function FieldInputRow({
         disabled={disabled}
         triggerProps={{ className: 'ps-0 pe-1 w-full' }}
       />
-    </VarEditorFieldRow>
+    </FieldPanelRow>
   )
 }

--- a/apps/web/src/components/custom-fields/ui/text-options-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/text-options-editor.tsx
@@ -2,9 +2,9 @@
 
 'use client'
 
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types/unified-types'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 
 /**
  * String options for text field configuration
@@ -27,7 +27,7 @@ interface TextOptionsEditorProps {
 /**
  * TextOptionsEditor component
  * Configures string field options: multiline, min/max length
- * Uses VarEditorField/VarEditorFieldRow pattern for consistency with panel design
+ * Uses FieldPanel/FieldPanelRow pattern for consistency with panel design
  */
 export function TextOptionsEditor({ options, onChange, disabled }: TextOptionsEditorProps) {
   /**
@@ -38,9 +38,9 @@ export function TextOptionsEditor({ options, onChange, disabled }: TextOptionsEd
   }
 
   return (
-    <VarEditorField orientation='horizontal' className='p-0'>
+    <FieldPanel orientation='horizontal' className='p-0'>
       {/* Multiline Toggle */}
-      <VarEditorFieldRow
+      <FieldPanelRow
         title='Multiline'
         description='Allow multiple lines of text (textarea)'
         type={BaseType.BOOLEAN}>
@@ -51,10 +51,10 @@ export function TextOptionsEditor({ options, onChange, disabled }: TextOptionsEd
           varType={BaseType.BOOLEAN}
           disabled={disabled}
         />
-      </VarEditorFieldRow>
+      </FieldPanelRow>
 
       {/* Min Length */}
-      <VarEditorFieldRow
+      <FieldPanelRow
         title='Min Length'
         description='Minimum number of characters required'
         type={BaseType.NUMBER}>
@@ -65,10 +65,10 @@ export function TextOptionsEditor({ options, onChange, disabled }: TextOptionsEd
           placeholder='No minimum'
           disabled={disabled}
         />
-      </VarEditorFieldRow>
+      </FieldPanelRow>
 
       {/* Max Length */}
-      <VarEditorFieldRow
+      <FieldPanelRow
         title='Max Length'
         description='Maximum number of characters allowed'
         type={BaseType.NUMBER}>
@@ -79,7 +79,7 @@ export function TextOptionsEditor({ options, onChange, disabled }: TextOptionsEd
           placeholder='No maximum'
           disabled={disabled}
         />
-      </VarEditorFieldRow>
-    </VarEditorField>
+      </FieldPanelRow>
+    </FieldPanel>
   )
 }

--- a/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-config-panel.tsx
@@ -10,9 +10,9 @@ import { Section } from '@auxx/ui/components/section'
 import { Globe, Settings2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { type FieldEntry, readFieldNodes, seedDefaults } from '~/components/global/schema-form'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 import { getConnectorDraftState, useConnectorDraftStore } from '../stores/connector-draft-store'
 import { RecordKeyValueEditor, RequestEditorBlock, RevealChip } from './request-editors'
@@ -149,7 +149,7 @@ function AppConfigSource({ connector }: { connector: Connector }) {
         initialOpen
         collapsible={false}
         description='Options declared by this connector.'>
-        <VarEditorField
+        <FieldPanel
           orientation='responsive'
           className='p-0 sm:[&_[data-slot=field-row-label]]:w-70!'>
           {fields.map((entry) => {
@@ -173,7 +173,7 @@ function AppConfigSource({ connector }: { connector: Connector }) {
               />
             )
           })}
-        </VarEditorField>
+        </FieldPanel>
       </Section>
     </div>
   )
@@ -202,7 +202,7 @@ function baseTypeFor(fieldType: FieldType): BaseType {
 const ROW_TRIGGER_PROPS = { className: 'w-full ps-0 pe-1' }
 
 /**
- * A plain connector-config field rendered as a `VarEditorFieldRow` + matching
+ * A plain connector-config field rendered as a `FieldPanelRow` + matching
  * `FieldInputAdapter` control (mirrors `ConnectionVariableFields`). Text / number /
  * checkbox by the field's JSON-Schema type.
  */
@@ -217,7 +217,7 @@ function ConfigFieldRow({
 }) {
   const fieldType = fieldTypeFor(entry)
   return (
-    <VarEditorFieldRow
+    <FieldPanelRow
       title={entry.meta.label ?? entry.key}
       description={entry.meta.description}
       type={baseTypeFor(fieldType)}
@@ -230,7 +230,7 @@ function ConfigFieldRow({
         placeholder={entry.meta.placeholder}
         triggerProps={ROW_TRIGGER_PROPS}
       />
-    </VarEditorFieldRow>
+    </FieldPanelRow>
   )
 }
 
@@ -279,7 +279,7 @@ function ToolBackedSelectRow({
   const fieldOptions: FieldOptions = { options }
 
   return (
-    <VarEditorFieldRow
+    <FieldPanelRow
       title={entry.meta.label ?? entry.key}
       description={entry.meta.description}
       type={BaseType.STRING}
@@ -304,6 +304,6 @@ function ToolBackedSelectRow({
         useValueAsLabel={allowCustom}
         triggerProps={ROW_TRIGGER_PROPS}
       />
-    </VarEditorFieldRow>
+    </FieldPanelRow>
   )
 }

--- a/apps/web/src/components/datasets/dataset-form.tsx
+++ b/apps/web/src/components/datasets/dataset-form.tsx
@@ -29,8 +29,8 @@ import type { ReactNode } from 'react'
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { AiModelPicker, type ModelPickerItem } from '~/components/pickers/ai-model-picker'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 const createDatasetSchema = z.object({
@@ -192,8 +192,12 @@ export function DatasetForm({ onSuccess, onClose, onCancel, header }: DatasetFor
             )}
           />
 
-          <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-30'>
-            <VarEditorFieldRow
+          <FieldPanel
+            className='p-0'
+            resizeId='dataset-form'
+            defaultLabelWidth={120}
+            breakpoint='md'>
+            <FieldPanelRow
               title='Model'
               description='Select a text embedding model from your configured providers'>
               <FormField
@@ -216,11 +220,11 @@ export function DatasetForm({ onSuccess, onClose, onCancel, header }: DatasetFor
                   </FormItem>
                 )}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
             {/* Dimension selector - only show if model supports configurable dimensions */}
             {hasConfigurableDimensions && (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Dimensions'
                 description={
                   dimensionRule?.help ||
@@ -249,9 +253,9 @@ export function DatasetForm({ onSuccess, onClose, onCancel, header }: DatasetFor
                     </FormItem>
                   )}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
-          </VarEditorField>
+          </FieldPanel>
 
           <DialogFooter>
             <Button

--- a/apps/web/src/components/datasets/settings/sections/chunking-settings-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/chunking-settings-section.tsx
@@ -11,9 +11,9 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { Book, Brain, FileText, Layers, Scissors } from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 interface ChunkingSettingsSectionProps {
@@ -198,8 +198,8 @@ export function ChunkingSettingsSection({
               icon={StrategyIcon}
               title={`${strategyInfo?.label} Parameters`}
               description='Configure chunk size and overlap settings.'>
-              <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-60'>
-                <VarEditorFieldRow
+              <FieldPanel className='p-0' resizeId='dataset-settings' defaultLabelWidth={240}>
+                <FieldPanelRow
                   title='Chunk Size'
                   description='Target size for each chunk in characters (100-5000)'
                   type={BaseType.NUMBER}
@@ -211,9 +211,9 @@ export function ChunkingSettingsSection({
                     placeholder='1000'
                     disabled={readOnly}
                   />
-                </VarEditorFieldRow>
+                </FieldPanelRow>
 
-                <VarEditorFieldRow
+                <FieldPanelRow
                   title='Chunk Overlap'
                   description='Overlapping characters between adjacent chunks (0-1000)'
                   type={BaseType.NUMBER}
@@ -225,9 +225,9 @@ export function ChunkingSettingsSection({
                     placeholder='200'
                     disabled={readOnly}
                   />
-                </VarEditorFieldRow>
+                </FieldPanelRow>
 
-                <VarEditorFieldRow
+                <FieldPanelRow
                   title='Custom Delimiter'
                   description='Split text at this delimiter. Default is double newline (paragraph breaks).'
                   type={BaseType.STRING}
@@ -239,9 +239,9 @@ export function ChunkingSettingsSection({
                     placeholder='\n\n'
                     disabled={readOnly}
                   />
-                </VarEditorFieldRow>
+                </FieldPanelRow>
 
-                <VarEditorFieldRow
+                <FieldPanelRow
                   title='Normalize Whitespace'
                   description='Replace consecutive spaces, newlines, and tabs with single characters'
                   type={BaseType.BOOLEAN}
@@ -253,9 +253,9 @@ export function ChunkingSettingsSection({
                     fieldOptions={{ variant: 'switch' }}
                     disabled={readOnly}
                   />
-                </VarEditorFieldRow>
+                </FieldPanelRow>
 
-                <VarEditorFieldRow
+                <FieldPanelRow
                   title='Remove URLs & Emails'
                   description='Delete all URLs and email addresses from content before chunking'
                   type={BaseType.BOOLEAN}
@@ -267,8 +267,8 @@ export function ChunkingSettingsSection({
                     fieldOptions={{ variant: 'switch' }}
                     disabled={readOnly}
                   />
-                </VarEditorFieldRow>
-              </VarEditorField>
+                </FieldPanelRow>
+              </FieldPanel>
 
               <div className='space-y-4 mt-4'>
                 {/* Overlap validation warning */}

--- a/apps/web/src/components/datasets/settings/sections/embedding-settings-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/embedding-settings-section.tsx
@@ -21,9 +21,9 @@ import { AlertTriangle, Brain, CheckCircle, Info, Lightbulb } from 'lucide-react
 import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { AiModelPicker, type ModelPickerItem } from '~/components/pickers/ai-model-picker'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 /**
@@ -195,8 +195,8 @@ export function EmbeddingSettingsSection({
             }
             description='Select an embedding model for vector search.'>
             {/* Model Selection */}
-            <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-60'>
-              <VarEditorFieldRow
+            <FieldPanel className='p-0' resizeId='dataset-settings' defaultLabelWidth={240}>
+              <FieldPanelRow
                 title='Embedding Model'
                 description='Select a text embedding model from your configured providers'>
                 <FormField
@@ -219,11 +219,11 @@ export function EmbeddingSettingsSection({
                     </FormItem>
                   )}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
 
               {/* Dimension selector - only show if model supports configurable dimensions */}
               {hasConfigurableDimensions && (
-                <VarEditorFieldRow
+                <FieldPanelRow
                   title='Embedding Dimensions'
                   description={
                     dimensionRule?.help ||
@@ -253,9 +253,9 @@ export function EmbeddingSettingsSection({
                       </FormItem>
                     )}
                   />
-                </VarEditorFieldRow>
+                </FieldPanelRow>
               )}
-            </VarEditorField>
+            </FieldPanel>
 
             {/* Warning for dimension changes on existing datasets */}
             {dimensionChanged && (

--- a/apps/web/src/components/datasets/settings/sections/search-configuration-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/search-configuration-section.tsx
@@ -12,9 +12,9 @@ import { FileText, Lightbulb, Search, Sparkles, Zap } from 'lucide-react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 interface SearchConfigurationSectionProps {
@@ -186,13 +186,13 @@ export function SearchConfigurationSection({
       })
     }
   }
-  /** Renders search type specific options using VarEditorField layout */
+  /** Renders search type specific options using FieldPanel layout */
   const renderSearchTypeOptions = () => {
     switch (selectedSearchType) {
       case 'vector':
         return (
-          <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-50'>
-            <VarEditorFieldRow
+          <FieldPanel className='p-0' resizeId='dataset-settings' defaultLabelWidth={200}>
+            <FieldPanelRow
               title='Similarity Threshold'
               description='Minimum similarity score (0.0 - 1.0)'
               type={BaseType.NUMBER}
@@ -204,9 +204,9 @@ export function SearchConfigurationSection({
                 placeholder='0.7'
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Maximum Results'
               description='Maximum number of results to return'
               type={BaseType.NUMBER}
@@ -218,9 +218,9 @@ export function SearchConfigurationSection({
                 placeholder='20'
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Include Metadata'
               description='Include document metadata in results'
               type={BaseType.BOOLEAN}
@@ -232,9 +232,9 @@ export function SearchConfigurationSection({
                 fieldOptions={{ variant: 'switch' }}
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Search Mode'
               description='Algorithm for selecting and ranking results'
               type={BaseType.ENUM}
@@ -253,13 +253,13 @@ export function SearchConfigurationSection({
                 placeholder='Select search mode'
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
-          </VarEditorField>
+            </FieldPanelRow>
+          </FieldPanel>
         )
       case 'text':
         return (
-          <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-50'>
-            <VarEditorFieldRow
+          <FieldPanel className='p-0' resizeId='dataset-settings' defaultLabelWidth={200}>
+            <FieldPanelRow
               title='Fuzzy Search'
               description='Enable fuzzy matching for typos and variations'
               type={BaseType.BOOLEAN}
@@ -271,9 +271,9 @@ export function SearchConfigurationSection({
                 fieldOptions={{ variant: 'switch' }}
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Phrase Search'
               description='Enable exact phrase matching with quotes'
               type={BaseType.BOOLEAN}
@@ -285,9 +285,9 @@ export function SearchConfigurationSection({
                 fieldOptions={{ variant: 'switch' }}
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Boolean Mode'
               description='Support AND, OR, NOT operators in queries'
               type={BaseType.BOOLEAN}
@@ -299,9 +299,9 @@ export function SearchConfigurationSection({
                 fieldOptions={{ variant: 'switch' }}
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Ranking Algorithm'
               description='Algorithm for scoring and ranking text matches'
               type={BaseType.ENUM}
@@ -319,9 +319,9 @@ export function SearchConfigurationSection({
                 placeholder='Select ranking algorithm'
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Minimum Score'
               description='Minimum relevance score to include results'
               type={BaseType.NUMBER}
@@ -333,13 +333,13 @@ export function SearchConfigurationSection({
                 placeholder='0.1'
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
-          </VarEditorField>
+            </FieldPanelRow>
+          </FieldPanel>
         )
       case 'hybrid':
         return (
-          <VarEditorField className='p-0 [&_[data-slot=field-row-label]]:w-50'>
-            <VarEditorFieldRow
+          <FieldPanel className='p-0' resizeId='dataset-settings' defaultLabelWidth={200}>
+            <FieldPanelRow
               title='Vector Weight'
               description='Weight for vector search results (0.0 - 1.0)'
               type={BaseType.NUMBER}
@@ -351,9 +351,9 @@ export function SearchConfigurationSection({
                 placeholder='0.6'
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Text Weight'
               description='Weight for text search results (0.0 - 1.0)'
               type={BaseType.NUMBER}
@@ -365,9 +365,9 @@ export function SearchConfigurationSection({
                 placeholder='0.4'
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Combination Method'
               description='Method for combining vector and text results'
               type={BaseType.ENUM}
@@ -386,8 +386,8 @@ export function SearchConfigurationSection({
                 placeholder='Select combination method'
                 disabled={readOnly}
               />
-            </VarEditorFieldRow>
-          </VarEditorField>
+            </FieldPanelRow>
+          </FieldPanel>
         )
       default:
         return null

--- a/apps/web/src/components/editor/placeholders/placeholder-popover.tsx
+++ b/apps/web/src/components/editor/placeholders/placeholder-popover.tsx
@@ -9,7 +9,7 @@ import { Separator } from '@auxx/ui/components/separator'
 import { ArrowRightLeft, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { FieldInputRow } from '~/components/custom-fields/ui/field-input-row'
-import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
+import { FieldPanel } from '~/components/global/forms/field-panel'
 import { PlaceholderPickerContent } from './placeholder-picker-content'
 
 interface PlaceholderPopoverProps {
@@ -76,7 +76,7 @@ export function PlaceholderPopover({
       <div className='text-xs text-muted-foreground px-1'>{breadcrumb}</div>
 
       {fallbackSupported && field && fieldType ? (
-        <VarEditorField orientation='vertical'>
+        <FieldPanel orientation='vertical'>
           <FieldInputRow
             field={field}
             value={currentValue}
@@ -86,7 +86,7 @@ export function PlaceholderPopover({
             }}
             placeholder='Fallback value...'
           />
-        </VarEditorField>
+        </FieldPanel>
       ) : (
         <div className='text-xs text-muted-foreground px-1 py-2'>
           Fallback not available for this field type.

--- a/apps/web/src/components/evals/ui/assertions-section.tsx
+++ b/apps/web/src/components/evals/ui/assertions-section.tsx
@@ -16,7 +16,7 @@ import { Ban, Flag, ListChecks, MessageSquareText, Plus, Wrench } from 'lucide-r
 import type { ReactNode } from 'react'
 import { useMemo } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useToolGroups } from '../hooks/use-tool-groups'
 import { ToolSelect } from './tool-select'
 
@@ -113,11 +113,11 @@ export function AssertionsSection({ agentId, assertions, onChange }: AssertionsS
             description='A case must assert at least one outcome before it can pass.'
           />
         ) : (
-          <VarEditorField className='p-0'>
+          <FieldPanel className='p-0'>
             {assertions.map((a) => {
               const meta = ASSERTION_META[a.type]
               return (
-                <VarEditorFieldRow
+                <FieldPanelRow
                   key={a.id}
                   title={meta?.label ?? a.type}
                   description={meta?.description}
@@ -129,10 +129,10 @@ export function AssertionsSection({ agentId, assertions, onChange }: AssertionsS
                     toolOptions={toolOptions}
                     onChange={(next) => patch(a.id, next)}
                   />
-                </VarEditorFieldRow>
+                </FieldPanelRow>
               )
             })}
-          </VarEditorField>
+          </FieldPanel>
         )}
       </div>
     </Section>

--- a/apps/web/src/components/evals/ui/eval-case-drawer.tsx
+++ b/apps/web/src/components/evals/ui/eval-case-drawer.tsx
@@ -14,11 +14,11 @@ import { generateId } from '@auxx/utils'
 import { FlaskConical, Play, User, Wrench } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
 import { AutoResolveBadge } from '~/components/workflow/nodes/core/answer/components/auto-resolve-badge'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 import { AutosaveIndicator, type AutosaveState } from '../../agents/ui/shared/autosave-indicator'
 import { AssertionsSection } from './assertions-section'
@@ -390,26 +390,24 @@ function EvalCaseForm({
           icon={<User className='size-4' />}
           className='[&>[data-slot=section]>[data-slot=section-content]]:-mx-3'>
           <div className='flex flex-col ps-2 pe-4'>
-            <VarEditorField className='p-0'>
-              <VarEditorFieldRow title='Opening message' isRequired>
+            <FieldPanel className='p-0'>
+              <FieldPanelRow title='Opening message' isRequired>
                 <FieldInputAdapter
                   fieldType={FieldType.RICH_TEXT}
                   value={config.openingMessage}
                   onChange={(v) => setConfigField('openingMessage', (v as string) ?? '')}
                   placeholder='I want to cancel my order'
                 />
-              </VarEditorFieldRow>
-              <VarEditorFieldRow
-                title='Customer context'
-                description='Background the persona knows.'>
+              </FieldPanelRow>
+              <FieldPanelRow title='Customer context' description='Background the persona knows.'>
                 <FieldInputAdapter
                   fieldType={FieldType.RICH_TEXT}
                   value={config.customerContext ?? ''}
                   onChange={(v) => setConfigField('customerContext', (v as string) || null)}
                   placeholder='Has not received an order confirmation.'
                 />
-              </VarEditorFieldRow>
-              <VarEditorFieldRow
+              </FieldPanelRow>
+              <FieldPanelRow
                 title='Customer record'
                 description='Simulate as this contact — the agent resolves its data.'>
                 <MultiRelationInput
@@ -420,10 +418,8 @@ function EvalCaseForm({
                   placeholder='Select a contact'
                   triggerProps={{ className: 'w-full ps-0' }}
                 />
-              </VarEditorFieldRow>
-              <VarEditorFieldRow
-                title='Email'
-                description='The email the customer gives when asked.'>
+              </FieldPanelRow>
+              <FieldPanelRow title='Email' description='The email the customer gives when asked.'>
                 <div className='relative flex items-center'>
                   {hasContact && (
                     <div className='z-10 me-0.5 shrink-0 @sm:absolute @sm:right-full @sm:top-1/2 @sm:-translate-y-1/2'>
@@ -453,8 +449,8 @@ function EvalCaseForm({
                     />
                   )}
                 </div>
-              </VarEditorFieldRow>
-              <VarEditorFieldRow title='Name'>
+              </FieldPanelRow>
+              <FieldPanelRow title='Name'>
                 <div className='relative flex items-center'>
                   {hasContact && (
                     <div className='z-10 me-0.5 shrink-0 @sm:absolute @sm:right-full @sm:top-1/2 @sm:-translate-y-1/2'>
@@ -484,8 +480,8 @@ function EvalCaseForm({
                     />
                   )}
                 </div>
-              </VarEditorFieldRow>
-              <VarEditorFieldRow title='Channel'>
+              </FieldPanelRow>
+              <FieldPanelRow title='Channel'>
                 <FieldInputAdapter
                   fieldType={FieldType.SINGLE_SELECT}
                   fieldOptions={{ options: CHANNEL_OPTIONS }}
@@ -495,22 +491,22 @@ function EvalCaseForm({
                     setConfigField('channel', ((v as string[])[0] as 'chat' | 'email') ?? 'chat')
                   }
                 />
-              </VarEditorFieldRow>
-              <VarEditorFieldRow title='Max customer turns'>
+              </FieldPanelRow>
+              <FieldPanelRow title='Max customer turns'>
                 <FieldInputAdapter
                   fieldType={FieldType.NUMBER}
                   value={config.maxCustomerTurns}
                   onChange={(v) => setConfigField('maxCustomerTurns', Number(v) || 1)}
                 />
-              </VarEditorFieldRow>
-            </VarEditorField>
+              </FieldPanelRow>
+            </FieldPanel>
           </div>
         </Section>
 
         {/* Execution policy */}
         <Section title='Execution' icon={<Wrench className='size-4' />}>
-          <VarEditorField className='p-0 **:data-[slot=field-row-label]:w-auto! @sm:**:data-[slot=field-row-label]:w-auto! **:data-[slot=field-row-content]:flex **:data-[slot=field-row-content]:justify-end **:data-[slot=field-row-content]:pe-3'>
-            <VarEditorFieldRow
+          <FieldPanel className='p-0 **:data-[slot=field-row-label]:w-auto! @sm:**:data-[slot=field-row-label]:w-auto! **:data-[slot=field-row-content]:flex **:data-[slot=field-row-content]:justify-end **:data-[slot=field-row-content]:pe-3'>
+            <FieldPanelRow
               title='Execute read-only tools live'
               description='Passthrough lets idempotent tools execute; writes are always mocked. Off = fully offline (unmatched calls fail closed).'>
               <div className='flex h-8 items-center'>
@@ -525,8 +521,8 @@ function EvalCaseForm({
                   }
                 />
               </div>
-            </VarEditorFieldRow>
-          </VarEditorField>
+            </FieldPanelRow>
+          </FieldPanel>
         </Section>
 
         {/* Tool responses */}

--- a/apps/web/src/components/global/forms/field-panel.tsx
+++ b/apps/web/src/components/global/forms/field-panel.tsx
@@ -1,18 +1,44 @@
 // apps/web/src/components/global/forms/field-panel.tsx
+'use client'
 
 import { Button } from '@auxx/ui/components/button'
 import { cn } from '@auxx/ui/lib/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { X } from 'lucide-react'
 import type React from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Tooltip, TooltipExplanation } from '~/components/global/tooltip'
 import type { BaseType } from '~/components/workflow/types/unified-types'
 import { VarTypeIcon } from '~/components/workflow/utils/icon-helper'
+import { safeLocalStorage } from '~/lib/safe-localstorage'
 import { ValidationErrorBadge } from './validation-error-badge'
+
+/** Default label column width in px — matches the previous hardcoded `w-40` (10rem). */
+const DEFAULT_LABEL_WIDTH = 160
+const MIN_LABEL_WIDTH = 96
+/** Max label width as a fraction of the panel width, so content never collapses. */
+const MAX_LABEL_FRACTION = 0.7
+
+const RESIZE_EVENT = 'auxx:field-panel-resize'
+const storageKey = (resizeId: string) => `auxx:field-panel:label-w:${resizeId}`
+
+interface FieldPanelResizeDetail {
+  resizeId: string
+  width: number
+  /** false while dragging (DOM-only updates), true on release/reset (state + storage) */
+  commit: boolean
+  /** Emitting panel element, so it can ignore its own events */
+  source: HTMLElement | null
+}
+
+const dispatchResize = (detail: FieldPanelResizeDetail) => {
+  window.dispatchEvent(new CustomEvent<FieldPanelResizeDetail>(RESIZE_EVENT, { detail }))
+}
 
 /**
  * Variants for FieldPanel orientation
- * Controls how FieldPanelRow children lay out their label and content
+ * Controls how FieldPanelRow children lay out their label and content.
+ * The label column width comes from --field-panel-label-w, set inline on the panel root.
  */
 const fieldPanelVariants = cva(
   [
@@ -27,7 +53,9 @@ const fieldPanelVariants = cva(
           // field-row: horizontal layout (default behavior)
           '[&_[data-slot=field-row]]:flex-row [&_[data-slot=field-row]]:items-start',
           // field-row-label: fixed width and height
-          '[&_[data-slot=field-row-label]]:w-40 [&_[data-slot=field-row-label]]:shrink-0 [&_[data-slot=field-row-label]]:min-h-8',
+          '[&_[data-slot=field-row-label]]:w-(--field-panel-label-w) [&_[data-slot=field-row-label]]:shrink-0 [&_[data-slot=field-row-label]]:min-h-8',
+          // gutter between the label/content boundary (where the resize line sits) and the content
+          '[&_[data-slot=field-row-content]]:ps-2',
         ],
         vertical: [
           // field-row: vertical layout (stacked)
@@ -42,16 +70,41 @@ const fieldPanelVariants = cva(
           '[&_[data-slot=field-row]]:flex-col [&_[data-slot=field-row]]:items-stretch',
           '[&_[data-slot=field-row-label]]:w-full [&_[data-slot=field-row-label]]:shrink [&_[data-slot=field-row-label]]:pt-1.5 [&_[data-slot=field-row-label]]:pb-1 [&_[data-slot=field-row-content]]:ps-2',
           '[&_[data-slot=field-row]]:pb-1',
-          // @sm+ : horizontal layout
+        ],
+      },
+      /** Container width at which a responsive panel flips to horizontal (sm=24rem, md=28rem) */
+      breakpoint: {
+        sm: [],
+        md: [],
+      },
+    },
+    compoundVariants: [
+      // Horizontal layout above the container breakpoint
+      // (field-row-content keeps its ps-2 as the boundary gutter)
+      {
+        orientation: 'responsive',
+        breakpoint: 'sm',
+        className: [
           '@sm:[&_[data-slot=field-row]]:flex-row @sm:[&_[data-slot=field-row]]:items-start',
-          '@sm:[&_[data-slot=field-row-label]]:w-40 @sm:[&_[data-slot=field-row-label]]:shrink-0 @sm:[&_[data-slot=field-row-label]]:min-h-8',
-          '@sm:[&_[data-slot=field-row-label]]:pt-0 @sm:[&_[data-slot=field-row-label]]:pb-0 @sm:[&_[data-slot=field-row-content]]:ps-0',
+          '@sm:[&_[data-slot=field-row-label]]:w-(--field-panel-label-w) @sm:[&_[data-slot=field-row-label]]:shrink-0 @sm:[&_[data-slot=field-row-label]]:min-h-8',
+          '@sm:[&_[data-slot=field-row-label]]:pt-0 @sm:[&_[data-slot=field-row-label]]:pb-0',
           '@sm:[&_[data-slot=field-row]]:pb-0',
         ],
       },
-    },
+      {
+        orientation: 'responsive',
+        breakpoint: 'md',
+        className: [
+          '@md:[&_[data-slot=field-row]]:flex-row @md:[&_[data-slot=field-row]]:items-start',
+          '@md:[&_[data-slot=field-row-label]]:w-(--field-panel-label-w) @md:[&_[data-slot=field-row-label]]:shrink-0 @md:[&_[data-slot=field-row-label]]:min-h-8',
+          '@md:[&_[data-slot=field-row-label]]:pt-0 @md:[&_[data-slot=field-row-label]]:pb-0',
+          '@md:[&_[data-slot=field-row]]:pb-0',
+        ],
+      },
+    ],
     defaultVariants: {
       orientation: 'responsive',
+      breakpoint: 'sm',
     },
   }
 )
@@ -65,21 +118,143 @@ interface FieldPanelProps extends VariantProps<typeof fieldPanelVariants> {
   validationError?: string
   validationType?: 'error' | 'warning'
   className?: string
+  /**
+   * Opt-in drag-resizing of the label column (horizontal / responsive-at-@sm only).
+   * The width persists in localStorage under this id; mounted panels sharing the
+   * same id resize together in real time. Double-click the divider to reset.
+   */
+  resizeId?: string
+  /** Label column width in px. Also the reset target when resizing. Default 160 (the old w-40). */
+  defaultLabelWidth?: number
 }
 
-const FieldPanel: React.FC<FieldPanelProps> = ({
+function FieldPanel({
   children,
   validationError,
   validationType = 'error',
   orientation = 'responsive',
+  breakpoint = 'sm',
   className,
-}) => {
+  resizeId,
+  defaultLabelWidth = DEFAULT_LABEL_WIDTH,
+}: FieldPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const dragState = useRef<{ startX: number; startWidth: number; maxWidth: number } | null>(null)
+  const [labelWidth, setLabelWidth] = useState(defaultLabelWidth)
+  const [isResizing, setIsResizing] = useState(false)
+  // The label column starts after the panel's left padding, which callers can
+  // override via className (e.g. p-0) — measure it instead of assuming px-1.5
+  const [padLeft, setPadLeft] = useState('0.375rem')
+
+  // Hydrate the stored width before paint (avoids a visible width jump)
+  useLayoutEffect(() => {
+    if (!resizeId) return
+    const stored = Number(safeLocalStorage.get(storageKey(resizeId)))
+    if (Number.isFinite(stored) && stored >= MIN_LABEL_WIDTH) setLabelWidth(stored)
+    if (panelRef.current) setPadLeft(getComputedStyle(panelRef.current).paddingLeft)
+  }, [resizeId])
+
+  // Follow resizes from other mounted panels sharing this resizeId
+  useEffect(() => {
+    if (!resizeId) return
+    const onResize = (e: Event) => {
+      const detail = (e as CustomEvent<FieldPanelResizeDetail>).detail
+      if (detail.resizeId !== resizeId || detail.source === panelRef.current) return
+      if (detail.commit) {
+        setLabelWidth(detail.width)
+      } else {
+        // Mid-drag: mutate the CSS var directly, no re-render
+        panelRef.current?.style.setProperty('--field-panel-label-w', `${detail.width}px`)
+      }
+    }
+    window.addEventListener(RESIZE_EVENT, onResize)
+    return () => window.removeEventListener(RESIZE_EVENT, onResize)
+  }, [resizeId])
+
+  const widthFromDrag = (clientX: number) => {
+    const drag = dragState.current!
+    return Math.min(
+      drag.maxWidth,
+      Math.max(MIN_LABEL_WIDTH, drag.startWidth + clientX - drag.startX)
+    )
+  }
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.currentTarget.setPointerCapture(e.pointerId)
+    const panelWidth = panelRef.current?.offsetWidth ?? 0
+    dragState.current = {
+      startX: e.clientX,
+      startWidth: labelWidth,
+      maxWidth: Math.max(MIN_LABEL_WIDTH, panelWidth * MAX_LABEL_FRACTION),
+    }
+    setIsResizing(true)
+  }
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragState.current) return
+    const width = widthFromDrag(e.clientX)
+    panelRef.current?.style.setProperty('--field-panel-label-w', `${width}px`)
+    dispatchResize({ resizeId: resizeId!, width, commit: false, source: panelRef.current })
+  }
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragState.current) return
+    const width = widthFromDrag(e.clientX)
+    dragState.current = null
+    setIsResizing(false)
+    setLabelWidth(width)
+    safeLocalStorage.set(storageKey(resizeId!), String(width))
+    dispatchResize({ resizeId: resizeId!, width, commit: true, source: panelRef.current })
+  }
+
+  const handleDoubleClick = () => {
+    setLabelWidth(defaultLabelWidth)
+    safeLocalStorage.remove(storageKey(resizeId!))
+    dispatchResize({
+      resizeId: resizeId!,
+      width: defaultLabelWidth,
+      commit: true,
+      source: panelRef.current,
+    })
+  }
+
+  const showResizer = !!resizeId && orientation !== 'vertical'
+
   return (
     <div
+      ref={panelRef}
       data-slot='field'
       data-orientation={orientation}
-      className={cn(fieldPanelVariants({ orientation }), className)}>
+      style={{ '--field-panel-label-w': `${labelWidth}px` } as React.CSSProperties}
+      className={cn(fieldPanelVariants({ orientation, breakpoint }), className)}>
       {children}
+      {showResizer && (
+        <div
+          aria-hidden
+          className={cn(
+            // Only rendered for fine pointers (mouse/trackpad) — no drag affordance on touch devices
+            'group/resizer absolute inset-y-0 z-10 hidden w-2.5 -translate-x-1/2 cursor-col-resize touch-none',
+            // In responsive mode the handle also requires the container to lay out horizontally
+            orientation !== 'responsive'
+              ? 'pointer-fine:block'
+              : breakpoint === 'md'
+                ? 'pointer-fine:@md:block'
+                : 'pointer-fine:@sm:block'
+          )}
+          style={{ left: `calc(var(--field-panel-label-w) + ${padLeft})` }}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onDoubleClick={handleDoubleClick}>
+          <div
+            className={cn(
+              'mx-auto h-full w-px bg-primary-200 opacity-0 transition-opacity group-hover/resizer:opacity-100',
+              isResizing && 'opacity-100 bg-info'
+            )}
+          />
+        </div>
+      )}
       <ValidationErrorBadge error={validationError} type={validationType} />
     </div>
   )
@@ -104,7 +279,7 @@ interface FieldPanelRowProps {
  * Labeled row inside a FieldPanel: label (with optional icon/description) + content.
  * Formerly VarEditorFieldRow.
  */
-const FieldPanelRow: React.FC<FieldPanelRowProps> = ({
+function FieldPanelRow({
   children,
   title,
   description,
@@ -116,7 +291,7 @@ const FieldPanelRow: React.FC<FieldPanelRowProps> = ({
   showIcon = false,
   className,
   onClear,
-}) => {
+}: FieldPanelRowProps) {
   return (
     <div
       data-slot='field-row'

--- a/apps/web/src/components/global/schedule/interval-selector.tsx
+++ b/apps/web/src/components/global/schedule/interval-selector.tsx
@@ -14,7 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@auxx/ui/components/select'
-import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
+import { FieldPanel } from '~/components/global/forms/field-panel'
 
 export type Interval = 'minutes' | 'hours' | 'days' | 'weeks'
 
@@ -40,7 +40,7 @@ interface IntervalSelectorProps {
 
 /**
  * Inline [Unit] [Number] selector matching the workflow scheduled trigger
- * look. Uses VarEditorField for the container styling and NumberInput +
+ * look. Uses FieldPanel for the container styling and NumberInput +
  * NumberInputArrows for the value input — no ReactFlow context required.
  */
 export function IntervalSelector({
@@ -52,7 +52,7 @@ export function IntervalSelector({
 }: IntervalSelectorProps) {
   const minValue = minIntervalValue(interval, minMinutes)
   return (
-    <VarEditorField className='py-0 pe-0 ps-0.5'>
+    <FieldPanel className='py-0 pe-0 ps-0.5'>
       <div className='flex flex-row items-center gap-2'>
         <Select value={interval} onValueChange={(v) => onIntervalChange(v as Interval)}>
           <SelectTrigger size='sm' className='w-24'>
@@ -77,6 +77,6 @@ export function IntervalSelector({
           </NumberInput>
         </div>
       </div>
-    </VarEditorField>
+    </FieldPanel>
   )
 }

--- a/apps/web/src/components/kb/ui/settings/general/branding-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/branding-section.tsx
@@ -10,8 +10,8 @@ import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDraftSettingsAutosave } from '../../../hooks/use-draft-settings-autosave'
 import { type KnowledgeBase, selectDraftedSections } from '../../../store/knowledge-base-store'
 import { SectionStatusBadge } from '../section-header'
@@ -59,12 +59,12 @@ export function BrandingSection({ knowledgeBaseId, knowledgeBase }: BrandingSect
       description='Title and short description shown on your knowledge base.'
       actions={<SectionStatusBadge drafted={drafted} saving={isSaving} savedAt={lastSavedAt} />}>
       <Form {...form}>
-        <VarEditorField orientation='vertical' className='p-0'>
+        <FieldPanel orientation='vertical' className='p-0' resizeId='kb-settings'>
           <FormField
             control={form.control}
             name='name'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Title'
                 description='Overwrite the title and icon of your content when published.'
                 type={BaseType.STRING}
@@ -77,7 +77,7 @@ export function BrandingSection({ knowledgeBaseId, knowledgeBase }: BrandingSect
                   onChange={(v) => field.onChange(v ?? '')}
                   placeholder='My Knowledge Base'
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
 
@@ -85,7 +85,7 @@ export function BrandingSection({ knowledgeBaseId, knowledgeBase }: BrandingSect
             control={form.control}
             name='description'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Description'
                 description='A brief description of your knowledge base.'
                 type={BaseType.STRING}
@@ -97,10 +97,10 @@ export function BrandingSection({ knowledgeBaseId, knowledgeBase }: BrandingSect
                   onChange={(v) => field.onChange(v ?? '')}
                   placeholder='Enter a description...'
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
-        </VarEditorField>
+        </FieldPanel>
       </Form>
     </Section>
   )

--- a/apps/web/src/components/kb/ui/settings/general/colors-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/colors-section.tsx
@@ -9,9 +9,9 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { useEffect, useState } from 'react'
 import { type UseFormReturn, useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { ColorField } from '~/components/ui/color-field'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDraftSettingsAutosave } from '../../../hooks/use-draft-settings-autosave'
 import { type KnowledgeBase, selectDraftedSections } from '../../../store/knowledge-base-store'
 import { SectionStatusBadge } from '../section-header'
@@ -75,7 +75,7 @@ function ColorPaletteFields({ form, mode }: ColorPaletteFieldsProps) {
   const suffix = mode === 'light' ? 'Light' : 'Dark'
 
   return (
-    <VarEditorField orientation='responsive' className='p-0'>
+    <FieldPanel orientation='responsive' className='p-0' resizeId='kb-settings'>
       {colorRows.map((row) => {
         const fieldName = `${row.key}Color${suffix}` as keyof ColorsFormValues
         return (
@@ -84,7 +84,7 @@ function ColorPaletteFields({ form, mode }: ColorPaletteFieldsProps) {
             control={form.control}
             name={fieldName}
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title={row.label}
                 description={row.description}
                 type={BaseType.STRING}
@@ -95,12 +95,12 @@ function ColorPaletteFields({ form, mode }: ColorPaletteFieldsProps) {
                   onChange={field.onChange}
                   placeholder='Pick a color'
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
         )
       })}
-    </VarEditorField>
+    </FieldPanel>
   )
 }
 

--- a/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
@@ -9,8 +9,8 @@ import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { useKnowledgeBaseMutations } from '../../../hooks/use-knowledge-base-mutations'
 import type { KnowledgeBase } from '../../../store/knowledge-base-store'
 import { registerSettingsSubmit } from '../settings-submit-registry'
@@ -78,12 +78,12 @@ export function IdentitySection({ knowledgeBaseId, knowledgeBase }: IdentitySect
     <Section title='Identity' description='URL and access for this knowledge base.'>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
-          <VarEditorField orientation='vertical' className='p-0'>
+          <FieldPanel orientation='vertical' className='p-0' resizeId='kb-settings'>
             <FormField
               control={form.control}
               name='slug'
               render={({ field, fieldState }) => (
-                <VarEditorFieldRow
+                <FieldPanelRow
                   title='URL slug'
                   description='Used in the URL of your knowledge base.'
                   type={BaseType.STRING}
@@ -97,7 +97,7 @@ export function IdentitySection({ knowledgeBaseId, knowledgeBase }: IdentitySect
                     placeholder='my-knowledge-base'
                     disabled={isUpdating}
                   />
-                </VarEditorFieldRow>
+                </FieldPanelRow>
               )}
             />
 
@@ -105,7 +105,7 @@ export function IdentitySection({ knowledgeBaseId, knowledgeBase }: IdentitySect
               control={form.control}
               name='visibility'
               render={({ field, fieldState }) => (
-                <VarEditorFieldRow
+                <FieldPanelRow
                   title='Visibility'
                   description='Public knowledge bases are accessible to anyone with the link. Internal knowledge bases require visitors to sign in and be a member of your organization.'
                   type={BaseType.ENUM}
@@ -120,10 +120,10 @@ export function IdentitySection({ knowledgeBaseId, knowledgeBase }: IdentitySect
                     disabled={isUpdating}
                     triggerProps={{ className: 'w-full' }}
                   />
-                </VarEditorFieldRow>
+                </FieldPanelRow>
               )}
             />
-          </VarEditorField>
+          </FieldPanel>
         </form>
       </Form>
     </Section>

--- a/apps/web/src/components/kb/ui/settings/general/logos-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/logos-section.tsx
@@ -12,8 +12,8 @@ import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { useFileSelect } from '~/components/file-select'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { FileSelectPicker } from '~/components/pickers/file-select-picker'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDraftSettingsAutosave } from '../../../hooks/use-draft-settings-autosave'
 import { type KnowledgeBase, selectDraftedSections } from '../../../store/knowledge-base-store'
 import { SectionStatusBadge } from '../section-header'
@@ -121,12 +121,12 @@ export function LogosSection({ knowledgeBaseId, knowledgeBase }: LogosSectionPro
       description="Replace the content's title with a custom logo. Recommended width: 600px or wider."
       actions={<SectionStatusBadge drafted={drafted} saving={isSaving} savedAt={lastSavedAt} />}>
       <Form {...form}>
-        <VarEditorField orientation='vertical' className='p-0'>
+        <FieldPanel orientation='vertical' className='p-0' resizeId='kb-settings'>
           <FormField
             control={form.control}
             name='logoLight'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Light mode logo'
                 showIcon
                 icon={<Sun className='size-3.5' />}
@@ -137,7 +137,7 @@ export function LogosSection({ knowledgeBaseId, knowledgeBase }: LogosSectionPro
                   onChange={(v) => field.onChange(v)}
                   knowledgeBaseId={knowledgeBaseId}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
 
@@ -145,7 +145,7 @@ export function LogosSection({ knowledgeBaseId, knowledgeBase }: LogosSectionPro
             control={form.control}
             name='logoDark'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Dark mode logo'
                 showIcon
                 icon={<Moon className='size-3.5' />}
@@ -156,10 +156,10 @@ export function LogosSection({ knowledgeBaseId, knowledgeBase }: LogosSectionPro
                   onChange={(v) => field.onChange(v)}
                   knowledgeBaseId={knowledgeBaseId}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
-        </VarEditorField>
+        </FieldPanel>
       </Form>
     </Section>
   )

--- a/apps/web/src/components/kb/ui/settings/general/modes-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/modes-section.tsx
@@ -10,8 +10,8 @@ import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDraftSettingsAutosave } from '../../../hooks/use-draft-settings-autosave'
 import { type KnowledgeBase, selectDraftedSections } from '../../../store/knowledge-base-store'
 import { SectionStatusBadge } from '../section-header'
@@ -66,12 +66,12 @@ export function ModesSection({ knowledgeBaseId, knowledgeBase }: ModesSectionPro
       description='Light/dark mode behaviour for visitors.'
       actions={<SectionStatusBadge drafted={drafted} saving={isSaving} savedAt={lastSavedAt} />}>
       <Form {...form}>
-        <VarEditorField orientation='responsive' className='p-0'>
+        <FieldPanel orientation='responsive' className='p-0' resizeId='kb-settings'>
           <FormField
             control={form.control}
             name='showMode'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Show switcher'
                 description='Allow users to switch between light and dark mode.'
                 type={BaseType.BOOLEAN}
@@ -83,7 +83,7 @@ export function ModesSection({ knowledgeBaseId, knowledgeBase }: ModesSectionPro
                   value={field.value}
                   onChange={(v) => field.onChange(v)}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
 
@@ -91,7 +91,7 @@ export function ModesSection({ knowledgeBaseId, knowledgeBase }: ModesSectionPro
             control={form.control}
             name='defaultMode'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Default mode'
                 description='All your viewers will see this mode by default.'
                 type={BaseType.ENUM}
@@ -105,10 +105,10 @@ export function ModesSection({ knowledgeBaseId, knowledgeBase }: ModesSectionPro
                   placeholder='Pick…'
                   triggerProps={{ className: 'w-full' }}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
-        </VarEditorField>
+        </FieldPanel>
       </Form>
     </Section>
   )

--- a/apps/web/src/components/kb/ui/settings/general/styling-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/styling-section.tsx
@@ -12,8 +12,8 @@ import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDraftSettingsAutosave } from '../../../hooks/use-draft-settings-autosave'
 import { type KnowledgeBase, selectDraftedSections } from '../../../store/knowledge-base-store'
 import { SectionStatusBadge } from '../section-header'
@@ -108,12 +108,12 @@ export function StylingSection({ knowledgeBaseId, knowledgeBase }: StylingSectio
         title='Site styles'
         description='Typography, icons and shapes.'
         actions={<SectionStatusBadge drafted={drafted} saving={isSaving} savedAt={lastSavedAt} />}>
-        <VarEditorField orientation='responsive' className='p-0'>
+        <FieldPanel orientation='responsive' className='p-0' resizeId='kb-settings'>
           <FormField
             control={form.control}
             name='fontFamily'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Font family'
                 type={BaseType.ENUM}
                 showIcon
@@ -126,14 +126,14 @@ export function StylingSection({ knowledgeBaseId, knowledgeBase }: StylingSectio
                   placeholder='System default'
                   triggerProps={{ className: 'w-full' }}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
           <FormField
             control={form.control}
             name='cornerStyle'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Corner style'
                 type={BaseType.ENUM}
                 showIcon
@@ -146,14 +146,14 @@ export function StylingSection({ knowledgeBaseId, knowledgeBase }: StylingSectio
                   placeholder='Pick…'
                   triggerProps={{ className: 'w-full' }}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
           <FormField
             control={form.control}
             name='searchbarPosition'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Search bar'
                 description="Pick the style of the search bar. On small screens it's displayed as an icon button."
                 type={BaseType.ENUM}
@@ -167,10 +167,10 @@ export function StylingSection({ knowledgeBaseId, knowledgeBase }: StylingSectio
                   placeholder='Pick…'
                   triggerProps={{ className: 'w-full' }}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
-        </VarEditorField>
+        </FieldPanel>
       </Section>
 
       <Section title='Sidebar style' description='How active items render in the sidebar.'>

--- a/apps/web/src/components/kb/ui/settings/layout/footer-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/layout/footer-section.tsx
@@ -8,8 +8,8 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDraftSettingsAutosave } from '../../../hooks/use-draft-settings-autosave'
 import { type KnowledgeBase, selectDraftedSections } from '../../../store/knowledge-base-store'
 import { SectionStatusBadge } from '../section-header'
@@ -68,12 +68,12 @@ export function FooterSection({ knowledgeBaseId, knowledgeBase }: FooterSectionP
       onEnableChange={(checked) => form.setValue('footerEnabled', checked, { shouldDirty: true })}
       actions={<SectionStatusBadge drafted={drafted} saving={isSaving} savedAt={lastSavedAt} />}>
       <Form {...form}>
-        <VarEditorField orientation='vertical' className='p-0'>
+        <FieldPanel orientation='vertical' className='p-0' resizeId='kb-settings'>
           <FormField
             control={form.control}
             name='footerNavigation'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Navigation'
                 description='Configure the navigation menu items for the footer. Drag to rearrange.'
                 type={BaseType.ARRAY}
@@ -85,10 +85,10 @@ export function FooterSection({ knowledgeBaseId, knowledgeBase }: FooterSectionP
                   onChange={field.onChange}
                   disabled={!footerEnabled}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
-        </VarEditorField>
+        </FieldPanel>
       </Form>
     </Section>
   )

--- a/apps/web/src/components/kb/ui/settings/layout/header-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/layout/header-section.tsx
@@ -8,8 +8,8 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { useDraftSettingsAutosave } from '../../../hooks/use-draft-settings-autosave'
 import { type KnowledgeBase, selectDraftedSections } from '../../../store/knowledge-base-store'
 import { SectionStatusBadge } from '../section-header'
@@ -68,12 +68,12 @@ export function HeaderSection({ knowledgeBaseId, knowledgeBase }: HeaderSectionP
       onEnableChange={(checked) => form.setValue('headerEnabled', checked, { shouldDirty: true })}
       actions={<SectionStatusBadge drafted={drafted} saving={isSaving} savedAt={lastSavedAt} />}>
       <Form {...form}>
-        <VarEditorField orientation='vertical' className='p-0'>
+        <FieldPanel orientation='vertical' className='p-0' resizeId='kb-settings'>
           <FormField
             control={form.control}
             name='headerNavigation'
             render={({ field, fieldState }) => (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Navigation'
                 description='Configure the navigation menu items for the header. Drag to rearrange.'
                 type={BaseType.ARRAY}
@@ -85,10 +85,10 @@ export function HeaderSection({ knowledgeBaseId, knowledgeBase }: HeaderSectionP
                   onChange={field.onChange}
                   disabled={!headerEnabled}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
           />
-        </VarEditorField>
+        </FieldPanel>
       </Form>
     </Section>
   )

--- a/apps/web/src/components/kb/ui/sources/source-settings-panel.tsx
+++ b/apps/web/src/components/kb/ui/sources/source-settings-panel.tsx
@@ -14,8 +14,8 @@ import { Cog, FileText, ScrollText, X } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 import { CrawlSectionTree, type SitemapNode } from '../editor/crawl-section-picker'
 import { type ScheduleConfig, SyncFrequencyPicker } from '../editor/sync-frequency-picker'
@@ -185,8 +185,8 @@ function GeneralPanel({ source }: { source: KnowledgeSource }) {
       <ScrollArea className='flex min-h-0 flex-1 flex-col'>
         <div className='pb-20 [&_[data-slot=section]]:pr-5'>
           <Section title='Source' description='What this source ingests and how it’s named.'>
-            <VarEditorField orientation='vertical' className='p-0'>
-              <VarEditorFieldRow
+            <FieldPanel orientation='vertical' className='p-0' resizeId='kb-source-settings'>
+              <FieldPanelRow
                 title='Name'
                 description='Shown in the Sources list.'
                 type={BaseType.STRING}
@@ -199,11 +199,11 @@ function GeneralPanel({ source }: { source: KnowledgeSource }) {
                   placeholder='Source name'
                   disabled={update.isPending}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
 
               {isWebsite && (
                 <>
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Website URL'
                     description='The site root the crawler maps and re-syncs.'
                     type={BaseType.STRING}
@@ -215,9 +215,9 @@ function GeneralPanel({ source }: { source: KnowledgeSource }) {
                       placeholder='https://docs.example.com'
                       disabled={update.isPending}
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
 
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Only main content'
                     description='Strip nav, headers, and footers from each page.'
                     type={BaseType.STRING}
@@ -228,9 +228,9 @@ function GeneralPanel({ source }: { source: KnowledgeSource }) {
                       onChange={(v) => setMainContentOnly(Boolean(v))}
                       disabled={update.isPending}
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
 
-                  <VarEditorFieldRow
+                  <FieldPanelRow
                     title='Exclude URLs'
                     description='One path or URL per line — never ingested.'
                     type={BaseType.STRING}
@@ -243,10 +243,10 @@ function GeneralPanel({ source }: { source: KnowledgeSource }) {
                       className='font-mono text-sm'
                       disabled={update.isPending}
                     />
-                  </VarEditorFieldRow>
+                  </FieldPanelRow>
                 </>
               )}
-            </VarEditorField>
+            </FieldPanel>
           </Section>
 
           {isWebsite && (

--- a/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
@@ -243,7 +243,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
 
         <FieldPanel
           orientation='responsive'
-          className='p-0 sm:[&_[data-slot=field-row-label]]:w-50'>
+          breakpoint='md'
+          resizeId='part-form'
+          defaultLabelWidth={200}
+          className='p-0'>
           {/* Title */}
           <FieldPanelRow
             title='Title'
@@ -356,7 +359,12 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
             </button>
 
             {showSupplier && (
-              <FieldPanel className='p-0 mt-4 ' orientation='responsive'>
+              <FieldPanel
+                className='p-0 mt-4'
+                orientation='responsive'
+                breakpoint='md'
+                resizeId='part-form'
+                defaultLabelWidth={200}>
                 <VendorPartFields
                   values={vendorPartValues}
                   onChange={handleVendorPartChange}

--- a/apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
@@ -5,10 +5,10 @@ import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { toRecordId, useResourceProperty } from '~/components/resources'
 import { BaseType } from '~/components/workflow/types'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 type Direction = 'add' | 'remove'
@@ -128,9 +128,9 @@ export function StockAdjustmentPopover({
         <div className='space-y-3'>
           <h4 className='text-sm font-semibold'>Adjust Stock</h4>
 
-          <VarEditorField className='p-0'>
+          <FieldPanel className='p-0'>
             {/* Mode */}
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Mode'
               type={BaseType.ENUM}
               showIcon
@@ -147,11 +147,11 @@ export function StockAdjustmentPopover({
                 fieldOptions={quantityModeFieldOptions}
                 disabled={isPending}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
             {/* Direction */}
             {!isSetToMode && (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Direction'
                 type={BaseType.ENUM}
                 showIcon
@@ -164,11 +164,11 @@ export function StockAdjustmentPopover({
                   fieldOptions={directionFieldOptions}
                   disabled={isPending}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
 
             {/* Quantity */}
-            <VarEditorFieldRow title='Quantity' type={BaseType.NUMBER} showIcon isRequired>
+            <FieldPanelRow title='Quantity' type={BaseType.NUMBER} showIcon isRequired>
               <ConstantInputAdapter
                 value={quantity}
                 onChange={(_, val) => setQuantity(val ?? null)}
@@ -183,10 +183,10 @@ export function StockAdjustmentPopover({
                   {quantity - currentQoH}
                 </p>
               )}
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
             {/* Reason */}
-            <VarEditorFieldRow title='Reason' type={BaseType.STRING} showIcon>
+            <FieldPanelRow title='Reason' type={BaseType.STRING} showIcon>
               <ConstantInputAdapter
                 value={reason}
                 onChange={(_, val) => setReason(val ?? '')}
@@ -194,10 +194,10 @@ export function StockAdjustmentPopover({
                 placeholder='e.g. Recount, Damaged goods'
                 disabled={isPending}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
             {/* Reference */}
-            <VarEditorFieldRow title='Reference' type={BaseType.STRING} showIcon>
+            <FieldPanelRow title='Reference' type={BaseType.STRING} showIcon>
               <ConstantInputAdapter
                 value={reference}
                 onChange={(_, val) => setReference(val ?? '')}
@@ -205,11 +205,11 @@ export function StockAdjustmentPopover({
                 placeholder='e.g. PO-1234, RMA-567'
                 disabled={isPending}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
 
             {/* Adjust subparts toggle — only shown when part has subparts and in "Adjust by" mode */}
             {hasSubparts && !isSetToMode && (
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Adjust subparts'
                 type={BaseType.BOOLEAN}
                 showIcon
@@ -221,9 +221,9 @@ export function StockAdjustmentPopover({
                   fieldOptions={{ variant: 'switch' }}
                   disabled={isPending}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             )}
-          </VarEditorField>
+          </FieldPanel>
 
           {/* Info hint when adjust subparts is enabled */}
           {adjustSubparts && (

--- a/apps/web/src/components/manufacturing/parts/subpart-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/subpart-dialog.tsx
@@ -16,12 +16,12 @@ import {
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { BaseType } from '~/components/workflow/types'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 
 const SUBPART_SYSTEM_ATTRIBUTES = [
@@ -251,9 +251,9 @@ export function SubpartDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <VarEditorField className='p-0'>
+        <FieldPanel className='p-0' breakpoint='md' resizeId='subpart'>
           {/* Subpart Selection */}
-          <VarEditorFieldRow
+          <FieldPanelRow
             title='Subpart'
             description='Component to add'
             isRequired
@@ -270,10 +270,10 @@ export function SubpartDialog({
                 excludeIds: isEditMode ? undefined : excludedPartIds,
               }}
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
 
           {/* Quantity */}
-          <VarEditorFieldRow
+          <FieldPanelRow
             title='Quantity'
             description='Number of units required per parent part'
             type={BaseType.NUMBER}
@@ -288,10 +288,10 @@ export function SubpartDialog({
               placeholder='1'
               disabled={isPending}
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
 
           {/* Notes */}
-          <VarEditorFieldRow
+          <FieldPanelRow
             title='Notes'
             description='Optional notes about this component usage'
             type={BaseType.STRING}
@@ -304,8 +304,8 @@ export function SubpartDialog({
               disabled={isPending}
               fieldOptions={{ string: { multiline: true } }}
             />
-          </VarEditorFieldRow>
-        </VarEditorField>
+          </FieldPanelRow>
+        </FieldPanel>
 
         <DialogFooter>
           <Button

--- a/apps/web/src/components/manufacturing/parts/vendor-part-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/vendor-part-dialog.tsx
@@ -14,11 +14,11 @@ import {
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useState } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { api } from '~/trpc/react'
 import {
   defaultVendorPartValues,
@@ -241,10 +241,10 @@ export function VendorPartDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <VarEditorField className='p-0'>
+        <FieldPanel className='p-0' breakpoint='md' resizeId='vendor-part'>
           {/* Part Selection - only shown in contact-centric mode */}
           {isContactMode && (
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Part'
               isRequired
               validationError={errors.partId}
@@ -259,7 +259,7 @@ export function VendorPartDialog({
                 disabled={isPending || isEditMode}
                 multi={false}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
           )}
 
           {/* Shared vendor part fields */}
@@ -271,7 +271,7 @@ export function VendorPartDialog({
             disableContactEdit={isEditMode}
             showContactField={isPartMode}
           />
-        </VarEditorField>
+        </FieldPanel>
 
         <DialogFooter>
           <Button

--- a/apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
+++ b/apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
@@ -2,10 +2,10 @@
 'use client'
 
 import { getInstanceId, type RecordId, toRecordId } from '@auxx/lib/field-values/client'
+import { FieldPanelRow } from '~/components/global/forms/field-panel'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
 import { BaseType } from '~/components/workflow/types'
 import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
-import { VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 
 /**
  * Default values for vendor part form fields
@@ -60,14 +60,14 @@ export function VendorPartFields({
     <>
       {/* Contact Selection */}
       {showContactField && (
-        <VarEditorFieldRow
+        <FieldPanelRow
           title='Vendor'
           isRequired
           validationError={errors?.entityInstanceId}
           validationType='error'>
           <MultiRelationInput
             entityDefinitionId='contact'
-            className='w-full'
+            className='w-full ps-0'
             value={values.entityInstanceId ? [toRecordId('contact', values.entityInstanceId)] : []}
             onChange={(recordIds: RecordId[]) =>
               onChange('entityInstanceId', recordIds[0] ? getInstanceId(recordIds[0]) : '')
@@ -76,11 +76,11 @@ export function VendorPartFields({
             disabled={disabled || disableContactEdit}
             multi={false}
           />
-        </VarEditorFieldRow>
+        </FieldPanelRow>
       )}
 
       {/* Vendor SKU */}
-      <VarEditorFieldRow
+      <FieldPanelRow
         title='Supplier SKU'
         description='The SKU or part number used by this supplier'
         type={BaseType.STRING}
@@ -95,10 +95,10 @@ export function VendorPartFields({
           placeholder="Supplier's part number"
           disabled={disabled}
         />
-      </VarEditorFieldRow>
+      </FieldPanelRow>
 
       {/* Unit Price */}
-      <VarEditorFieldRow title='Unit Price' type={BaseType.CURRENCY} showIcon>
+      <FieldPanelRow title='Unit Price' type={BaseType.CURRENCY} showIcon>
         <ConstantInputAdapter
           value={values.unitPrice}
           onChange={(_, val) => onChange('unitPrice', val)}
@@ -107,10 +107,10 @@ export function VendorPartFields({
           disabled={disabled}
           fieldOptions={{ currency: { currencyCode: 'USD' } }}
         />
-      </VarEditorFieldRow>
+      </FieldPanelRow>
 
       {/* Tariff Rate */}
-      <VarEditorFieldRow
+      <FieldPanelRow
         title='Tariff Rate (%)'
         description='Percentage of unit price'
         type={BaseType.NUMBER}
@@ -122,10 +122,10 @@ export function VendorPartFields({
           placeholder='0'
           disabled={disabled}
         />
-      </VarEditorFieldRow>
+      </FieldPanelRow>
 
       {/* Shipping Cost */}
-      <VarEditorFieldRow
+      <FieldPanelRow
         title='Shipping Cost'
         description='Per-unit shipping/freight'
         type={BaseType.CURRENCY}
@@ -138,10 +138,10 @@ export function VendorPartFields({
           disabled={disabled}
           fieldOptions={{ currency: { currencyCode: 'USD' } }}
         />
-      </VarEditorFieldRow>
+      </FieldPanelRow>
 
       {/* Other Cost */}
-      <VarEditorFieldRow
+      <FieldPanelRow
         title='Other Cost'
         description='Insurance, brokerage, handling'
         type={BaseType.CURRENCY}
@@ -154,10 +154,10 @@ export function VendorPartFields({
           disabled={disabled}
           fieldOptions={{ currency: { currencyCode: 'USD' } }}
         />
-      </VarEditorFieldRow>
+      </FieldPanelRow>
 
       {/* Lead Time */}
-      <VarEditorFieldRow
+      <FieldPanelRow
         title='Lead Time'
         description='Days to receive order'
         type={BaseType.NUMBER}
@@ -169,10 +169,10 @@ export function VendorPartFields({
           placeholder='Days'
           disabled={disabled}
         />
-      </VarEditorFieldRow>
+      </FieldPanelRow>
 
       {/* Min Order Qty */}
-      <VarEditorFieldRow
+      <FieldPanelRow
         title='Min Order'
         description='Minimum order quantity'
         type={BaseType.NUMBER}
@@ -184,10 +184,10 @@ export function VendorPartFields({
           placeholder='Qty'
           disabled={disabled}
         />
-      </VarEditorFieldRow>
+      </FieldPanelRow>
 
       {/* Is Preferred */}
-      <VarEditorFieldRow
+      <FieldPanelRow
         title='Preferred'
         description='Mark as preferred supplier for this part'
         type={BaseType.BOOLEAN}
@@ -199,7 +199,7 @@ export function VendorPartFields({
           disabled={disabled}
           fieldOptions={{ variant: 'switch' }}
         />
-      </VarEditorFieldRow>
+      </FieldPanelRow>
     </>
   )
 }

--- a/apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/add-mcp-server-dialog.tsx
@@ -17,8 +17,8 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import type { RouterOutputs } from '~/trpc/react'
 import { api } from '~/trpc/react'
 import { useMcpOAuthPopup } from '../hooks/use-mcp-oauth-popup'
@@ -609,10 +609,8 @@ export function AddMcpServerDialog({
   function renderFields() {
     return (
       <>
-        <VarEditorField
-          orientation='responsive'
-          className='p-0 sm:[&_[data-slot=field-row-label]]:w-40'>
-          <VarEditorFieldRow
+        <FieldPanel orientation='responsive' resizeId='mcp-server' className='p-0'>
+          <FieldPanelRow
             title='Name'
             type={BaseType.STRING}
             showIcon
@@ -628,9 +626,9 @@ export function AddMcpServerDialog({
                 disabled={isSubmitting}
               />
             </div>
-          </VarEditorFieldRow>
+          </FieldPanelRow>
 
-          <VarEditorFieldRow
+          <FieldPanelRow
             title='Endpoint URL'
             type={BaseType.STRING}
             showIcon
@@ -643,9 +641,9 @@ export function AddMcpServerDialog({
               placeholder='https://example.com/mcp'
               disabled={isSubmitting}
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
 
-          <VarEditorFieldRow title='Authentication' type={BaseType.STRING} showIcon>
+          <FieldPanelRow title='Authentication' type={BaseType.STRING} showIcon>
             <FieldInputAdapter
               fieldType={FieldType.SINGLE_SELECT}
               triggerProps={{ className: 'w-full ps-0 pe-1' }}
@@ -654,11 +652,11 @@ export function AddMcpServerDialog({
               onChange={(v) => setAuth(((v as string[])[0] as AuthMode) ?? 'auto')}
               disabled={isSubmitting}
             />
-          </VarEditorFieldRow>
+          </FieldPanelRow>
 
           {auth === 'bearer' && (
             <>
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Token'
                 type={BaseType.STRING}
                 showIcon
@@ -671,8 +669,8 @@ export function AddMcpServerDialog({
                   placeholder={isUpdate ? 'Leave blank to keep current token' : 'Secret token'}
                   disabled={isSubmitting}
                 />
-              </VarEditorFieldRow>
-              <VarEditorFieldRow title='Header name' type={BaseType.STRING} showIcon>
+              </FieldPanelRow>
+              <FieldPanelRow title='Header name' type={BaseType.STRING} showIcon>
                 <FieldInputAdapter
                   fieldType={FieldType.TEXT}
                   value={headerName}
@@ -680,12 +678,12 @@ export function AddMcpServerDialog({
                   placeholder='Authorization'
                   disabled={isSubmitting}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             </>
           )}
 
           {auth === 'headers' && (
-            <VarEditorFieldRow
+            <FieldPanelRow
               title='Headers'
               type={BaseType.STRING}
               showIcon
@@ -729,12 +727,12 @@ export function AddMcpServerDialog({
                   Add header
                 </Button>
               </div>
-            </VarEditorFieldRow>
+            </FieldPanelRow>
           )}
 
           {auth === 'oauth' && (
             <>
-              <VarEditorFieldRow
+              <FieldPanelRow
                 title='Client ID'
                 type={BaseType.STRING}
                 showIcon
@@ -746,8 +744,8 @@ export function AddMcpServerDialog({
                   placeholder='Blank tries automatic registration (DCR)'
                   disabled={isSubmitting}
                 />
-              </VarEditorFieldRow>
-              <VarEditorFieldRow
+              </FieldPanelRow>
+              <FieldPanelRow
                 title='Client Secret'
                 type={BaseType.STRING}
                 showIcon
@@ -766,12 +764,12 @@ export function AddMcpServerDialog({
                   }
                   disabled={isSubmitting}
                 />
-              </VarEditorFieldRow>
+              </FieldPanelRow>
             </>
           )}
 
           {placeholders.map((p) => (
-            <VarEditorFieldRow
+            <FieldPanelRow
               key={p}
               title={p}
               type={BaseType.STRING}
@@ -787,9 +785,9 @@ export function AddMcpServerDialog({
                 placeholder={`Value for ${p}`}
                 disabled={isSubmitting}
               />
-            </VarEditorFieldRow>
+            </FieldPanelRow>
           ))}
-        </VarEditorField>
+        </FieldPanel>
 
         {auth === 'oauth' && (
           <div className='mt-4'>
@@ -805,10 +803,8 @@ export function AddMcpServerDialog({
               Advanced OAuth settings
             </button>
             {showOAuthAdvanced && (
-              <VarEditorField
-                orientation='responsive'
-                className='p-0 mt-4 sm:[&_[data-slot=field-row-label]]:w-40'>
-                <VarEditorFieldRow
+              <FieldPanel orientation='responsive' resizeId='mcp-server' className='p-0 mt-4'>
+                <FieldPanelRow
                   title='Authorize URL'
                   type={BaseType.STRING}
                   showIcon
@@ -820,8 +816,8 @@ export function AddMcpServerDialog({
                     placeholder='Blank uses OAuth discovery'
                     disabled={isSubmitting}
                   />
-                </VarEditorFieldRow>
-                <VarEditorFieldRow
+                </FieldPanelRow>
+                <FieldPanelRow
                   title='Token URL'
                   type={BaseType.STRING}
                   showIcon
@@ -833,8 +829,8 @@ export function AddMcpServerDialog({
                     placeholder='Blank uses OAuth discovery'
                     disabled={isSubmitting}
                   />
-                </VarEditorFieldRow>
-                <VarEditorFieldRow title='Scopes' type={BaseType.STRING} showIcon>
+                </FieldPanelRow>
+                <FieldPanelRow title='Scopes' type={BaseType.STRING} showIcon>
                   <FieldInputAdapter
                     fieldType={FieldType.TEXT}
                     value={scopes}
@@ -842,11 +838,11 @@ export function AddMcpServerDialog({
                     placeholder='Space-separated, e.g. read write'
                     disabled={isSubmitting}
                   />
-                </VarEditorFieldRow>
-                <VarEditorFieldRow title='Callback URL' type={BaseType.STRING} showIcon>
+                </FieldPanelRow>
+                <FieldPanelRow title='Callback URL' type={BaseType.STRING} showIcon>
                   {renderCallbackUrl()}
-                </VarEditorFieldRow>
-              </VarEditorField>
+                </FieldPanelRow>
+              </FieldPanel>
             )}
           </div>
         )}

--- a/apps/web/src/components/mcp/ui/connect-curated-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/connect-curated-dialog.tsx
@@ -14,7 +14,7 @@ import {
 import { toastError } from '@auxx/ui/components/toast'
 import { useState } from 'react'
 import { ConnectionVariableFields } from '~/components/connections/ui/connection-variable-fields'
-import { VarEditorField } from '~/components/workflow/ui/input-editor/var-editor'
+import { FieldPanel } from '~/components/global/forms/field-panel'
 import { api } from '~/trpc/react'
 import { useMcpOAuthPopup } from '../hooks/use-mcp-oauth-popup'
 
@@ -126,9 +126,7 @@ export function ConnectCuratedDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <VarEditorField
-          orientation='responsive'
-          className='p-0 sm:[&_[data-slot=field-row-label]]:w-40'>
+        <FieldPanel orientation='responsive' resizeId='mcp-server' className='p-0'>
           <ConnectionVariableFields
             variables={connectionVariables}
             values={values}
@@ -139,7 +137,7 @@ export function ConnectCuratedDialog({
             errors={errors}
             disabled={isPending}
           />
-        </VarEditorField>
+        </FieldPanel>
 
         <DialogFooter>
           <Button type='button' variant='ghost' size='sm' onClick={close} disabled={isPending}>

--- a/apps/web/src/components/mcp/ui/mcp-template-dialog.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-template-dialog.tsx
@@ -14,9 +14,9 @@ import { useMemo, useState } from 'react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { ConnectionVariableFields } from '~/components/connections/ui/connection-variable-fields'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { TemplateGalleryDialog } from '~/components/templates/ui'
 import { BaseType } from '~/components/workflow/types'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import type { RouterOutputs } from '~/trpc/react'
 import { api } from '~/trpc/react'
 import { useMcpOAuthPopup } from '../hooks/use-mcp-oauth-popup'
@@ -380,10 +380,8 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
                 </a>
               )}
             </div>
-            <VarEditorField
-              orientation='responsive'
-              className='p-0 sm:[&_[data-slot=field-row-label]]:w-40'>
-              <VarEditorFieldRow
+            <FieldPanel orientation='responsive' resizeId='mcp-server' className='p-0'>
+              <FieldPanelRow
                 title='Client ID'
                 type={BaseType.STRING}
                 showIcon
@@ -396,8 +394,8 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
                   placeholder='From your OAuth app'
                   disabled={isSubmitting}
                 />
-              </VarEditorFieldRow>
-              <VarEditorFieldRow
+              </FieldPanelRow>
+              <FieldPanelRow
                 title='Client Secret'
                 type={BaseType.STRING}
                 showIcon
@@ -414,8 +412,8 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
                   }
                   disabled={isSubmitting}
                 />
-              </VarEditorFieldRow>
-            </VarEditorField>
+              </FieldPanelRow>
+            </FieldPanel>
           </>
         )}
         {template.docsUrl && (
@@ -434,9 +432,7 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
   function renderVariableFields(template: McpTemplate) {
     return (
       <div className='flex flex-col gap-2 p-3'>
-        <VarEditorField
-          orientation='responsive'
-          className='p-0 sm:[&_[data-slot=field-row-label]]:w-40'>
+        <FieldPanel orientation='responsive' resizeId='mcp-server' className='p-0'>
           <ConnectionVariableFields
             variables={template.connectionVariables ?? []}
             values={values}
@@ -447,7 +443,7 @@ export function McpTemplateDialog({ open, onOpenChange, onConnected }: McpTempla
             errors={errors}
             disabled={isSubmitting}
           />
-        </VarEditorField>
+        </FieldPanel>
         {template.docsUrl && (
           <a
             href={template.docsUrl}

--- a/apps/web/src/components/mcp/ui/mcp-tool-run-panel.tsx
+++ b/apps/web/src/components/mcp/ui/mcp-tool-run-panel.tsx
@@ -12,8 +12,8 @@ import { AlertTriangle, Braces, Play } from 'lucide-react'
 import { type ReactNode, useMemo, useState } from 'react'
 import { topLevelArgs } from '~/components/agents/ui/detail/bindings/tool-args'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { CodeEditor, CodeLanguage } from '~/components/workflow/ui/code-editor'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
 import { argToFieldType } from '~/lib/agents/bindings/arg-to-field-type'
 import type { RouterOutputs } from '~/trpc/react'
 import { api } from '~/trpc/react'
@@ -123,11 +123,11 @@ export function McpToolRunPanel({ serverId, tool, onResult }: McpToolRunPanelPro
         toolArgs.length === 0 ? (
           <p className='px-2 py-3 text-muted-foreground text-xs'>This tool takes no inputs.</p>
         ) : (
-          <VarEditorField className='p-0'>
+          <FieldPanel className='p-0'>
             {toolArgs.map((arg) => {
               const mapped = argToFieldType(arg.schema)
               return (
-                <VarEditorFieldRow
+                <FieldPanelRow
                   key={arg.name}
                   title={arg.name}
                   description={arg.schema.description}
@@ -149,10 +149,10 @@ export function McpToolRunPanel({ serverId, tool, onResult }: McpToolRunPanelPro
                       onChange={(e) => setArg(arg.name, parseLooseJson(e.target.value))}
                     />
                   )}
-                </VarEditorFieldRow>
+                </FieldPanelRow>
               )
             })}
-          </VarEditorField>
+          </FieldPanel>
         )
       ) : (
         <CodeEditor

--- a/apps/web/src/components/webhooks/ui/webhook-endpoint-configure-form.tsx
+++ b/apps/web/src/components/webhooks/ui/webhook-endpoint-configure-form.tsx
@@ -12,7 +12,7 @@ import { ChevronRight, KeyRound, Link, Tags, TriangleAlert } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { ConnectionVariableFields } from '~/components/connections/ui/connection-variable-fields'
 import { validateConnectionVariables } from '~/components/connections/ui/connection-variable-validation'
-import { VarEditorField, VarEditorFieldRow } from '~/components/workflow/ui/input-editor/var-editor'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useWebhookEndpoint, type WebhookEndpointRow } from '../hooks/use-webhook-endpoint'
 import type { WebhookEndpointReveal } from './webhook-endpoint-created'
 import { CopyRow } from './webhook-endpoint-created'
@@ -189,9 +189,12 @@ export function WebhookEndpointConfigureForm({
 
       <div className='flex flex-col gap-2'>
         <div className='text-xs font-medium text-muted-foreground'>Configuration</div>
-        <VarEditorField
+        <FieldPanel
           orientation='responsive'
-          className='p-0 sm:[&_[data-slot=field-row-label]]:w-50!'>
+          breakpoint='md'
+          resizeId='webhook-endpoint'
+          defaultLabelWidth={200}
+          className='p-0'>
           <ConnectionVariableFields
             variables={endpointVars(values.topicSourceKind, {
               includeStripeSecret: mode === 'create',
@@ -201,7 +204,7 @@ export function WebhookEndpointConfigureForm({
             errors={errors}
             disabled={pending}
           />
-        </VarEditorField>
+        </FieldPanel>
       </div>
 
       {values.verification === 'none' && (
@@ -214,10 +217,13 @@ export function WebhookEndpointConfigureForm({
       )}
 
       {isEdit && endpoint?.hasSecret && (
-        <VarEditorField
+        <FieldPanel
           orientation='responsive'
-          className='p-0 sm:[&_[data-slot=field-row-label]]:w-50!'>
-          <VarEditorFieldRow title='Signing secret' icon={<KeyRound />} showIcon>
+          breakpoint='md'
+          resizeId='webhook-endpoint'
+          defaultLabelWidth={200}
+          className='p-0'>
+          <FieldPanelRow title='Signing secret' icon={<KeyRound />} showIcon>
             {isStripeEdit && replacingSecret ? (
               <div className='flex min-h-8 items-center gap-2 pe-1'>
                 <Input
@@ -263,8 +269,8 @@ export function WebhookEndpointConfigureForm({
                 </Button>
               </div>
             )}
-          </VarEditorFieldRow>
-        </VarEditorField>
+          </FieldPanelRow>
+        </FieldPanel>
       )}
 
       {isEdit &&

--- a/apps/web/src/lib/safe-localstorage.ts
+++ b/apps/web/src/lib/safe-localstorage.ts
@@ -8,4 +8,8 @@ export const safeLocalStorage = {
     if (typeof window === 'undefined') return // SSR guard
     localStorage.setItem(key, value)
   },
+  remove(key: string) {
+    if (typeof window === 'undefined') return // SSR guard
+    localStorage.removeItem(key)
+  },
 }


### PR DESCRIPTION
## Summary
- Renames `VarEditorField`/`VarEditorFieldRow` -> `FieldPanel`/`FieldPanelRow` (imported from `~/components/global/forms/field-panel`) across every non-workflow surface listed in `plans/ui/field-panel-migration.md`: custom-fields, kb settings, datasets, mcp, agents/ai, connections, webhooks, data-connectors, chat-widget settings, and misc app surfaces.
- Opts eligible dialog/settings-page forms into the label-column resizer (`resizeId`, converting old `[&_[data-slot=field-row-label]]:w-*` overrides to `defaultLabelWidth`, adding `breakpoint='md'` where the host is a ~500-600px dialog). Narrow popovers, drawers below the resize threshold, DnD rows, and rows without a real label column are left rename-only.
- Includes the `field-panel.tsx` definitions file and its `safe-localstorage.ts` `remove()` dependency (used by the resizer's double-click reset), plus the manufacturing/parts and custom-fields files the plan uses as already-migrated reference examples.
- Pure rename in files marked rename-only — no behavior change (the old names still work today via a deprecated re-export in `var-editor.tsx`, so this migration alone can't break anything).
- `components/workflow/**` node panels are intentionally left untouched for a later pass.

## Test plan
- [x] `grep -rn "VarEditorField" apps/web/src` outside `components/workflow/` only hits the deprecated re-export / doc comments.
- [x] `pnpm biome check` on all changed files — no new errors (a few pre-existing, unrelated warnings left as-is).
- [ ] Manual smoke test of the resized panels (kb settings, chat-widget settings, mcp dialogs, dataset form/settings) to confirm the label-column resizer works and persists per `resizeId`.