### PR TITLE
feat(data-connectors): app-connector webhook summaries; vendor-part FieldInputAdapter

### DIFF
--- a/apps/web/src/components/data-connectors/lib/describe-steering.test.ts
+++ b/apps/web/src/components/data-connectors/lib/describe-steering.test.ts
@@ -1,0 +1,37 @@
+// apps/web/src/components/data-connectors/lib/describe-steering.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { describeSteering } from './describe-steering'
+
+describe('describeSteering', () => {
+  it('renders filter + paths + debounce (the full Shopify shape)', () => {
+    expect(
+      describeSteering({
+        filter: { topic: 'inventory_levels/update' },
+        paths: ['resourceId'],
+        debounceMs: 10_000,
+      })
+    ).toBe('topic = inventory_levels/update · re-fetches by resourceId · 10s debounce')
+  })
+
+  it('renders "all deliveries" when there is no filter', () => {
+    expect(describeSteering({ paths: ['id'], debounceMs: 500 })).toBe(
+      'all deliveries · re-fetches by id · 500ms debounce'
+    )
+  })
+
+  it('surfaces empty paths as a full sync per delivery (the dangerous shape)', () => {
+    expect(describeSteering({ filter: { topic: 'orders/create' }, paths: [] })).toBe(
+      'topic = orders/create · full sync per delivery'
+    )
+  })
+
+  it('omits the debounce segment when unset or zero', () => {
+    expect(describeSteering({ filter: { topic: 'a', kind: 'b' }, paths: ['x', 'y'] })).toBe(
+      'topic = a, kind = b · re-fetches by x, y'
+    )
+    expect(describeSteering({ paths: ['x'], debounceMs: 0 })).toBe(
+      'all deliveries · re-fetches by x'
+    )
+  })
+})

--- a/apps/web/src/components/data-connectors/lib/describe-steering.ts
+++ b/apps/web/src/components/data-connectors/lib/describe-steering.ts
@@ -1,0 +1,46 @@
+// apps/web/src/components/data-connectors/lib/describe-steering.ts
+// Pure, client-safe translator: a stream's `requestConfig.webhookTrigger` (the v9
+// steering stamped from the app manifest) → one plain-language line for the read-only
+// app-connector webhook summary. Mirrors how the dispatch job actually behaves —
+// notably empty `paths` is rendered bluntly ("full sync per delivery") because that
+// shape re-crawls the whole connector on every delivery. No server imports; a local
+// structural type avoids pulling a server-only module into the client bundle.
+
+/** Per-stream webhook steering as stamped onto `requestConfig.webhookTrigger` (v9). */
+export interface StreamSteering {
+  filter?: Record<string, unknown>
+  paths?: string[]
+  debounceMs?: number
+}
+
+/**
+ * One-line human summary of a stream's webhook steering, e.g.
+ * `topic = inventory_levels/update · re-fetches by resourceId · 10s debounce`.
+ * Filter entries render as `key = value` (no filter → "all deliveries"); empty
+ * `paths` → "full sync per delivery"; the debounce segment is omitted when unset.
+ */
+export function describeSteering(steering: StreamSteering): string {
+  const segments: string[] = []
+
+  const filterEntries = Object.entries(steering.filter ?? {})
+  segments.push(
+    filterEntries.length > 0
+      ? filterEntries.map(([k, v]) => `${k} = ${String(v)}`).join(', ')
+      : 'all deliveries'
+  )
+
+  segments.push(
+    (steering.paths?.length ?? 0) > 0
+      ? `re-fetches by ${(steering.paths ?? []).join(', ')}`
+      : 'full sync per delivery'
+  )
+
+  const debounceMs = steering.debounceMs ?? 0
+  if (debounceMs > 0) {
+    segments.push(
+      debounceMs % 1000 === 0 ? `${debounceMs / 1000}s debounce` : `${debounceMs}ms debounce`
+    )
+  }
+
+  return segments.join(' · ')
+}

--- a/apps/web/src/components/data-connectors/ui/schedule-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/schedule-section.tsx
@@ -35,7 +35,12 @@ import {
   selectIsDirty,
   useConnectorDraftStore,
 } from '../stores/connector-draft-store'
-import { WebhookSignalInspector, WebhookSignalSection } from './webhook-signal-section'
+import {
+  AppWebhookSignalSummary,
+  AppWebhookSteeringSummary,
+  WebhookSignalInspector,
+  WebhookSignalSection,
+} from './webhook-signal-section'
 import { WebhookSteeringSection } from './webhook-steering-section'
 
 type Connector = NonNullable<ReturnType<typeof api.dataConnector.getById.useQuery>['data']>
@@ -201,34 +206,36 @@ function SweepCadenceSection({ connector }: { connector: Connector }) {
 export function ScheduleSection({ connector }: ScheduleSectionProps) {
   const connectionId = connector.credentialId ?? null
 
-  // App-trigger sync bridge (plans/data-connectors/v4): webhook mode is offered
-  // when the connection's app declares webhook triggers — that's the path real app
-  // connections take (the legacy provider-spec gate above matches none of them). The
-  // per-stream trigger binding lives in the stream config, not here.
   const { appInstallations, appConnections } = useAppsContext()
-  const appTriggerCapable = (() => {
+  const installation = (() => {
     const installationId =
       connector.appInstallationId ??
       appConnections.find((c) => c.id === connectionId)?.appInstallationId ??
       null
-    if (!installationId) return false
-    const inst = appInstallations.find((i) => i.installationId === installationId)
-    return (
-      (inst?.workflowTriggers?.length ?? inst?.agentTriggers?.length ?? 0) > 0 ||
-      Boolean(inst?.dataConnectors?.[0]?.webhookTrigger)
-    )
+    if (!installationId) return undefined
+    return appInstallations.find((i) => i.installationId === installationId)
   })()
-
-  // Generic WebhookEndpoints can drive a webhook-sync stream too (app-less). If the org
-  // has any, webhook mode is offered regardless of the connection's app/provider.
-  const webhookEndpoints = api.webhookEndpoint.list.useQuery()
-  const hasWebhookEndpoints = (webhookEndpoints.data?.length ?? 0) > 0
-
-  const webhookSupported = appTriggerCapable || hasWebhookEndpoints
 
   // Webhook steering (signal picker + token mapping) only applies to generic-REST
   // connectors — app connectors have a fixed fetch that ignores webhook tokens (v7).
   const isGenericRest = connector.definitionKind !== 'app'
+
+  // Generic WebhookEndpoints can drive a webhook-sync stream too (app-less). If the org
+  // has any, webhook mode is offered for generic-REST regardless of the connection's app.
+  const webhookEndpoints = api.webhookEndpoint.list.useQuery(undefined, {
+    enabled: isGenericRest,
+  })
+  const hasWebhookEndpoints = (webhookEndpoints.data?.length ?? 0) > 0
+
+  // Webhook mode gate. Generic-REST: the user binds any signal — an app trigger from
+  // the connection's app or a generic WebhookEndpoint — so either capability offers it.
+  // App connector: the signal is manifest-owned (v9) — offered ONLY when the app's
+  // catalog declares `dataConnectors[0].webhookTrigger`; without that declaration
+  // webhook mode would match no deliveries, so the option is hidden entirely.
+  const webhookSupported = isGenericRest
+    ? (installation?.workflowTriggers?.length ?? installation?.agentTriggers?.length ?? 0) > 0 ||
+      hasWebhookEndpoints
+    : Boolean(installation?.dataConnectors?.[0]?.webhookTrigger)
 
   // The window radio only makes sense when a stream declares which param carries the
   // backfill floor (templates do; bare generic-rest doesn't — Step 9 §1.2/§3.2). We
@@ -307,10 +314,11 @@ export function ScheduleSection({ connector }: ScheduleSectionProps) {
     }
   }
 
-  // Webhook mode on a generic-REST connector. The connector-level SIGNAL picker is
-  // inlined directly in the Schedule body (no longer its own "Webhook trigger" section);
-  // the per-stream STEERING stays a real section BELOW Schedule so its padding/borders
-  // match the other top-level sections (v7).
+  // The connector-level SIGNAL picker (generic-REST only — an app connector's signal is
+  // manifest-owned and rendered read-only in the app branch below) is inlined directly
+  // in the Schedule body (no longer its own "Webhook trigger" section); the per-stream
+  // STEERING editor stays a real section BELOW Schedule so its padding/borders match
+  // the other top-level sections (v7).
   const showWebhookSignal = behavior === 'webhook' && isGenericRest
   // Steering lives on the connector page (never the stream window): WebhookSteeringSection
   // inlines a single stream's editor, or lists an expandable row per stream when there are many.
@@ -382,6 +390,9 @@ export function ScheduleSection({ connector }: ScheduleSectionProps) {
           {/* Generic-REST webhook: the SIGNAL picker is inlined here, not its own section. */}
           {showWebhookSignal && <WebhookSignalSection connector={connector} />}
 
+          {/* App-connector webhook: the signal + steering are manifest-owned (v9), so
+              they render read-only — which app trigger drives the sync and which
+              deliveries steer which stream. No picker, no editor. */}
           {behavior === 'webhook' && !isGenericRest && (
             <div className='flex flex-col gap-3'>
               <EmptySection
@@ -389,6 +400,8 @@ export function ScheduleSection({ connector }: ScheduleSectionProps) {
                 title='Webhook sync'
                 description='Records update automatically as the provider sends webhook deliveries. Run the first full import with “Sync now”.'
               />
+              <AppWebhookSignalSummary connector={connector} />
+              <AppWebhookSteeringSummary streams={streamList} />
             </div>
           )}
 
@@ -421,8 +434,9 @@ export function ScheduleSection({ connector }: ScheduleSectionProps) {
       </Section>
 
       {/* The bound signal's live inspector renders its own Section, so it sits here as a
-          sibling below Schedule rather than nested in the inline signal picker. */}
-      {showWebhookSignal && <WebhookSignalInspector connector={connector} />}
+          sibling below Schedule. Both connector kinds get it (v9) — its app branch shows
+          the trigger's test/listen panel; it self-nulls when no signal is bound. */}
+      {behavior === 'webhook' && <WebhookSignalInspector connector={connector} />}
 
       {/* Steering on the connector page (inline for one stream, expandable rows for many).
           The connector-level WebhookSignalInspector above already shows the endpoint's

--- a/apps/web/src/components/data-connectors/ui/webhook-signal-section.tsx
+++ b/apps/web/src/components/data-connectors/ui/webhook-signal-section.tsx
@@ -14,9 +14,11 @@ import {
 import { WebhookEndpointInspector } from '~/components/webhooks/ui/webhook-endpoint-inspector'
 import { AppTriggerTestSection } from '~/components/workflow/apps/trigger/app-trigger-test-section'
 import type { RouterOutputs } from '~/trpc/react'
+import { describeSteering, type StreamSteering } from '../lib/describe-steering'
 import { getConnectorDraftState, useConnectorDraftStore } from '../stores/connector-draft-store'
 
 type Connector = NonNullable<RouterOutputs['dataConnector']['getById']>
+type Stream = RouterOutputs['dataConnector']['listStreams'][number]
 
 /** The connector-level webhook SIGNAL (v7): exactly one of an app trigger / endpoint. */
 type WebhookSignal = { triggerId?: string; webhookEndpointId?: string }
@@ -39,8 +41,9 @@ function savedSource(signal: WebhookSignal | undefined): BoundSource | null {
  * `connector.config.webhookTrigger`, not per-stream. Per-stream topic/token STEERING lives
  * in {@link WebhookSteeringSection}. Persists immediately via `dataConnector.update`
  * (merged into the existing config). Rendered inline inside the Schedule section's webhook
- * branch for generic-REST connectors only (app connectors can't consume a steered webhook)
- * — it is NOT its own section, so it carries no `Section` wrapper.
+ * branch for generic-REST connectors only — an app connector's signal is manifest-owned
+ * (v9), shown read-only by {@link AppWebhookSignalSummary} instead. It is NOT its own
+ * section, so it carries no `Section` wrapper.
  */
 export function WebhookSignalSection({ connector }: { connector: Connector }) {
   const { appInstallations, appConnections } = useAppsContext()
@@ -145,6 +148,94 @@ export function WebhookSignalSection({ connector }: { connector: Connector }) {
           </div>
         }
       />
+    </div>
+  )
+}
+
+/**
+ * Read-only counterpart of {@link WebhookSignalSection} for APP connectors (v9): the
+ * signal is manifest-owned (stamped onto `config.webhookTrigger` at connector creation
+ * and app roll-forward), so there is no picker — just which app trigger drives the
+ * sync. An unstamped row falls back to what the installed app's catalog declares
+ * (roll-forward restamp heals the row). Webhook mode isn't offered without that
+ * declaration, so "neither" only happens on a legacy row — renders nothing then.
+ */
+export function AppWebhookSignalSummary({ connector }: { connector: Connector }) {
+  const { appInstallations, appConnections } = useAppsContext()
+
+  const installationId = useMemo(() => {
+    if (connector.appInstallationId) return connector.appInstallationId
+    const conn = appConnections.find((c) => c.id === connector.credentialId)
+    return conn?.appInstallationId ?? null
+  }, [connector.appInstallationId, connector.credentialId, appConnections])
+
+  const installation = appInstallations.find((i) => i.installationId === installationId)
+
+  const { appSources } = useTriggerSources({
+    surface: 'workflow',
+    appIdFilter: installation?.app.id,
+  })
+
+  // Read the stamped signal draft-seeded (the commit path doesn't refetch getById, so
+  // `connector.config` can lag). The app UI never edits `webhookTrigger` — this only
+  // guards against reading a stale server prop.
+  const draftSeeded = useConnectorDraftStore((s) => s.connectorId === connector.id)
+  const draftConfig = useConnectorDraftStore((s) => s.draft.config)
+  const cfg = (draftSeeded ? draftConfig : connector.config) as {
+    webhookTrigger?: WebhookSignal
+  } | null
+  const stampedTriggerId = cfg?.webhookTrigger?.triggerId ?? null
+
+  // Unstamped row (created before v9 stamping, no roll-forward since): show what the
+  // catalog declares — the row is a projection of it (one connector per app).
+  const declaredTriggerId = installation?.dataConnectors?.[0]?.webhookTrigger?.triggerId ?? null
+  const triggerId = stampedTriggerId ?? declaredTriggerId
+
+  if (!triggerId) return null
+
+  const trigger = appSources.find((s) => s.trigger.triggerId === triggerId)?.trigger ?? null
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <TriggerSourceRow
+        icon={<Webhook className='size-4 text-muted-foreground' />}
+        title={trigger?.label ?? triggerId}
+        secondary={trigger?.description}
+      />
+      {!stampedTriggerId && (
+        <p className='text-xs text-amber-600'>
+          Declared by the app but not active on this connector yet — update the app to activate it.
+        </p>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Read-only per-stream steering summary for APP connectors (v9): which deliveries
+ * steer which stream, from the manifest-stamped `requestConfig.webhookTrigger`. The
+ * editable counterpart for generic-REST is `WebhookSteeringSection`. Renders nothing
+ * when no stream declares steering (the signal summary already tells that story).
+ */
+export function AppWebhookSteeringSummary({ streams }: { streams: Stream[] }) {
+  const steered = streams.flatMap((stream) => {
+    const steering = (stream.requestConfig as { webhookTrigger?: StreamSteering } | null)
+      ?.webhookTrigger
+    return steering ? [{ stream, steering }] : []
+  })
+  if (steered.length === 0) return null
+
+  return (
+    <div className='flex flex-col gap-1'>
+      {steered.map(({ stream, steering }) => (
+        <p key={stream.id} className='text-xs text-muted-foreground'>
+          <span className='font-medium text-foreground'>
+            {stream.streamKey ?? 'Untitled stream'}
+          </span>
+          {' — '}
+          {describeSteering(steering)}
+        </p>
+      ))}
     </div>
   )
 }

--- a/apps/web/src/components/manufacturing/parts/vendor-part-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/vendor-part-dialog.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/manufacturing/parts/vendor-part-dialog.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import { getInstanceId, isRecordId, type RecordId, toRecordId } from '@auxx/lib/field-values/client'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -14,11 +15,12 @@ import {
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useResourceProperty } from '~/components/resources'
+import { useSystemField } from '~/components/resources/hooks/use-field'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
-import { MultiRelationInput } from '~/components/shared/multi-relation-input'
 import { api } from '~/trpc/react'
 import {
   defaultVendorPartValues,
@@ -74,6 +76,10 @@ export function VendorPartDialog({
   const vendorPartDefId = useResourceProperty('vendor_part', 'id')
   const partDefId = useResourceProperty('part', 'id')
   const contactDefId = useResourceProperty('contact', 'id')
+
+  // Field definition for the Part relationship picker (contact-centric mode) — sourced live
+  // so FieldInputAdapter gets a real RelationshipConfig and can offer "create new part"
+  const partField = useSystemField('vendor_part_part')
 
   // Load initial values for edit mode via system attributes
   const { values: systemValues } = useSystemValues(recordId, VENDOR_PART_SYSTEM_ATTRIBUTES, {
@@ -249,15 +255,17 @@ export function VendorPartDialog({
               isRequired
               validationError={errors.partId}
               validationType='error'>
-              <MultiRelationInput
-                entityDefinitionId='part'
+              <FieldInputAdapter
+                fieldType={partField?.fieldType ?? FieldType.RELATIONSHIP}
+                triggerProps={{ className: 'w-full ps-0 pe-1' }}
+                fieldOptions={partField?.options}
                 value={values.partId ? [toRecordId('part', values.partId)] : []}
-                onChange={(recordIds: RecordId[]) =>
-                  handleChange('partId', recordIds[0] ? getInstanceId(recordIds[0]) : '')
-                }
+                onChange={(recordIds) => {
+                  const ids = recordIds as RecordId[]
+                  handleChange('partId', ids[0] ? getInstanceId(ids[0]) : '')
+                }}
                 placeholder='Select part...'
                 disabled={isPending || isEditMode}
-                multi={false}
               />
             </FieldPanelRow>
           )}

--- a/apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
+++ b/apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
@@ -1,11 +1,12 @@
 // apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import { getInstanceId, type RecordId, toRecordId } from '@auxx/lib/field-values/client'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanelRow } from '~/components/global/forms/field-panel'
-import { MultiRelationInput } from '~/components/shared/multi-relation-input'
+import { useSystemField } from '~/components/resources/hooks/use-field'
 import { BaseType } from '~/components/workflow/types'
-import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 
 /**
  * Default values for vendor part form fields
@@ -56,6 +57,8 @@ export function VendorPartFields({
   disableContactEdit,
   showContactField = true,
 }: VendorPartFieldsProps) {
+  const contactField = useSystemField('vendor_part_contact')
+
   return (
     <>
       {/* Contact Selection */}
@@ -65,16 +68,17 @@ export function VendorPartFields({
           isRequired
           validationError={errors?.entityInstanceId}
           validationType='error'>
-          <MultiRelationInput
-            entityDefinitionId='contact'
-            className='w-full ps-0'
+          <FieldInputAdapter
+            triggerProps={{ className: 'w-full ps-0 pe-1' }}
+            fieldType={contactField?.fieldType ?? FieldType.RELATIONSHIP}
+            fieldOptions={contactField?.options}
             value={values.entityInstanceId ? [toRecordId('contact', values.entityInstanceId)] : []}
-            onChange={(recordIds: RecordId[]) =>
-              onChange('entityInstanceId', recordIds[0] ? getInstanceId(recordIds[0]) : '')
-            }
+            onChange={(recordIds) => {
+              const ids = recordIds as RecordId[]
+              onChange('entityInstanceId', ids[0] ? getInstanceId(ids[0]) : '')
+            }}
             placeholder='Select contact...'
             disabled={disabled || disableContactEdit}
-            multi={false}
           />
         </FieldPanelRow>
       )}
@@ -88,10 +92,10 @@ export function VendorPartFields({
         isRequired
         validationError={errors?.vendorSku}
         validationType='error'>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.TEXT}
           value={values.vendorSku}
-          onChange={(_, val) => onChange('vendorSku', val)}
-          varType={BaseType.STRING}
+          onChange={(val) => onChange('vendorSku', val)}
           placeholder="Supplier's part number"
           disabled={disabled}
         />
@@ -99,13 +103,13 @@ export function VendorPartFields({
 
       {/* Unit Price */}
       <FieldPanelRow title='Unit Price' type={BaseType.CURRENCY} showIcon>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.CURRENCY}
           value={values.unitPrice}
-          onChange={(_, val) => onChange('unitPrice', val)}
-          varType={BaseType.CURRENCY}
+          onChange={(val) => onChange('unitPrice', val)}
           placeholder='0.00'
           disabled={disabled}
-          fieldOptions={{ currency: { currencyCode: 'USD' } }}
+          fieldOptions={{ currencyCode: 'USD' }}
         />
       </FieldPanelRow>
 
@@ -115,10 +119,10 @@ export function VendorPartFields({
         description='Percentage of unit price'
         type={BaseType.NUMBER}
         showIcon>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.NUMBER}
           value={values.tariffRate}
-          onChange={(_, val) => onChange('tariffRate', val)}
-          varType={BaseType.NUMBER}
+          onChange={(val) => onChange('tariffRate', val)}
           placeholder='0'
           disabled={disabled}
         />
@@ -130,13 +134,13 @@ export function VendorPartFields({
         description='Per-unit shipping/freight'
         type={BaseType.CURRENCY}
         showIcon>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.CURRENCY}
           value={values.shippingCost}
-          onChange={(_, val) => onChange('shippingCost', val)}
-          varType={BaseType.CURRENCY}
+          onChange={(val) => onChange('shippingCost', val)}
           placeholder='0.00'
           disabled={disabled}
-          fieldOptions={{ currency: { currencyCode: 'USD' } }}
+          fieldOptions={{ currencyCode: 'USD' }}
         />
       </FieldPanelRow>
 
@@ -146,13 +150,13 @@ export function VendorPartFields({
         description='Insurance, brokerage, handling'
         type={BaseType.CURRENCY}
         showIcon>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.CURRENCY}
           value={values.otherCost}
-          onChange={(_, val) => onChange('otherCost', val)}
-          varType={BaseType.CURRENCY}
+          onChange={(val) => onChange('otherCost', val)}
           placeholder='0.00'
           disabled={disabled}
-          fieldOptions={{ currency: { currencyCode: 'USD' } }}
+          fieldOptions={{ currencyCode: 'USD' }}
         />
       </FieldPanelRow>
 
@@ -162,10 +166,10 @@ export function VendorPartFields({
         description='Days to receive order'
         type={BaseType.NUMBER}
         showIcon>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.NUMBER}
           value={values.leadTime}
-          onChange={(_, val) => onChange('leadTime', val)}
-          varType={BaseType.NUMBER}
+          onChange={(val) => onChange('leadTime', val)}
           placeholder='Days'
           disabled={disabled}
         />
@@ -177,10 +181,10 @@ export function VendorPartFields({
         description='Minimum order quantity'
         type={BaseType.NUMBER}
         showIcon>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.NUMBER}
           value={values.minOrderQty}
-          onChange={(_, val) => onChange('minOrderQty', val)}
-          varType={BaseType.NUMBER}
+          onChange={(val) => onChange('minOrderQty', val)}
           placeholder='Qty'
           disabled={disabled}
         />
@@ -192,10 +196,10 @@ export function VendorPartFields({
         description='Mark as preferred supplier for this part'
         type={BaseType.BOOLEAN}
         showIcon>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.CHECKBOX}
           value={values.isPreferred}
-          onChange={(_, val) => onChange('isPreferred', val)}
-          varType={BaseType.BOOLEAN}
+          onChange={(val) => onChange('isPreferred', val)}
           disabled={disabled}
           fieldOptions={{ variant: 'switch' }}
         />


### PR DESCRIPTION
## Summary

Two independent working-tree changes bundled together.

### Data connectors — app-connector webhook read-only summaries (v9)
App connectors have a **manifest-owned** webhook signal (`config.webhookTrigger`) and per-stream steering (`requestConfig.webhookTrigger`), so there's nothing for the user to pick or edit. This renders them read-only instead of showing the generic-REST picker/editor:

- **`AppWebhookSignalSummary`** — shows which app trigger drives the sync (stamped signal, falling back to the catalog declaration with an "update the app to activate" hint for unstamped legacy rows).
- **`AppWebhookSteeringSummary`** — per-stream "which deliveries steer which stream" summary.
- **`describeSteering`** — a pure, client-safe translator turning a stream's steering into one plain-language line (e.g. `topic = inventory_levels/update · re-fetches by resourceId · 10s debounce`; empty `paths` is rendered bluntly as "full sync per delivery"). Fully unit-tested.
- Reworked the Schedule section's webhook-mode gate to split **generic-REST** (bind any signal — app trigger or generic WebhookEndpoint) from **app connectors** (offered only when the catalog declares `dataConnectors[0].webhookTrigger`). The signal inspector now renders for both connector kinds.

### Manufacturing — vendor-part fields onto FieldInputAdapter
Migrate the vendor-part dialog and fields off `MultiRelationInput` / `ConstantInputAdapter` and onto `FieldInputAdapter`. The relationship field defs (`vendor_part_part`, `vendor_part_contact`) are sourced live via `useSystemField` so the picker gets a real `RelationshipConfig` and can offer "create new part/contact".

## Test plan
- `describe-steering.test.ts` covers the full Shopify shape, no-filter, empty-paths, and debounce-omission cases.
- Manual: verify app-connector Schedule page shows read-only signal/steering; generic-REST still shows the editable picker; vendor-part dialog relationship pickers work (including create-new) and cost fields save.