### PR TITLE
feat(record-rules): redesign settings dialog with FieldPanel + DialogNav

### DIFF
--- a/apps/web/src/components/record-rules/ui/record-rule-actions-page.tsx
+++ b/apps/web/src/components/record-rules/ui/record-rule-actions-page.tsx
@@ -1,0 +1,285 @@
+// apps/web/src/components/record-rules/ui/record-rule-actions-page.tsx
+
+'use client'
+
+import { FieldType } from '@auxx/database/enums'
+import type { RecordRuleAction } from '@auxx/lib/record-rules/client'
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { type ActorId, getActorRawId, toActorId } from '@auxx/types/actor'
+import type { SelectOption } from '@auxx/types/custom-field'
+import { Button } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { EmptySection, Section } from '@auxx/ui/components/section'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { Bell, PenLine, Plus, Settings2, Trash2, Workflow, Zap } from 'lucide-react'
+import { type ReactNode, useMemo } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { RecordRuleFieldRefInput } from './record-rule-field-ref-input'
+
+/** A published workflow from `api.workflow.list`. */
+interface WorkflowOption {
+  id: string
+  name: string
+}
+
+const ACTION_LABELS: Record<RecordRuleAction['type'], string> = {
+  notify: 'Notify members',
+  'set-field': 'Set field',
+  'enqueue-workflow': 'Run workflow',
+}
+
+const ACTION_TYPE_OPTIONS: SelectOption[] = (
+  Object.keys(ACTION_LABELS) as RecordRuleAction['type'][]
+).map((type) => ({ value: type, label: ACTION_LABELS[type] }))
+
+/** The flush-in-a-FieldPanelRow trigger sizing shared by every action input. */
+const TRIGGER_PROPS = { className: 'w-full ps-0 pe-1' } as const
+
+function ActionIcon({ type }: { type: RecordRuleAction['type'] }): ReactNode {
+  if (type === 'notify') return <Bell className='size-4' />
+  if (type === 'set-field') return <PenLine className='size-4' />
+  return <Workflow className='size-4' />
+}
+
+/** SINGLE_SELECT/ACTOR adapters emit arrays; take the first value. */
+function first(value: unknown): string {
+  const v = Array.isArray(value) ? value[0] : value
+  return typeof v === 'string' ? v : ''
+}
+
+/** 'true'/'false'/numeric strings become their typed values; everything else stays a string. */
+function coerceValue(raw: string): unknown {
+  if (raw === 'true') return true
+  if (raw === 'false') return false
+  if (raw.trim() !== '' && !Number.isNaN(Number(raw))) return Number(raw)
+  return raw
+}
+
+interface RecordRuleActionsPageProps {
+  actions: RecordRuleAction[]
+  selectedIndex: number
+  onSelectedIndexChange: (index: number) => void
+  onAdd: () => void
+  onRemove: (index: number) => void
+  onUpdate: (index: number, action: RecordRuleAction) => void
+  entityDefinitionId: string
+  fields: ResourceField[]
+  workflows: WorkflowOption[]
+  isEdit: boolean
+  canSave: boolean
+  isPending: boolean
+  onSave: () => void
+  onCancel: () => void
+}
+
+/**
+ * The rule's ordered action list as a master-detail page: a `TreeRow` list of actions with
+ * a shared `FieldPanel` editor below for the selected one — mirroring the webhook topics page.
+ */
+export function RecordRuleActionsPage({
+  actions,
+  selectedIndex,
+  onSelectedIndexChange,
+  onAdd,
+  onRemove,
+  onUpdate,
+  entityDefinitionId,
+  fields,
+  workflows,
+  isEdit,
+  canSave,
+  isPending,
+  onSave,
+  onCancel,
+}: RecordRuleActionsPageProps) {
+  const selected = actions[selectedIndex] ?? null
+
+  const workflowOptions: SelectOption[] = useMemo(
+    () => workflows.map((w) => ({ value: w.id, label: w.name })),
+    [workflows]
+  )
+
+  const summarize = (action: RecordRuleAction): string => {
+    if (action.type === 'notify')
+      return action.userIds.length > 0
+        ? `${action.userIds.length} member${action.userIds.length === 1 ? '' : 's'}`
+        : 'No members'
+    if (action.type === 'set-field')
+      return action.fieldRef
+        ? (fields.find((f) => (f.systemAttribute ?? String(f.id)) === action.fieldRef)?.label ??
+            action.fieldRef)
+        : 'No field'
+    return workflows.find((w) => w.id === action.workflowAppId)?.name || 'No workflow'
+  }
+
+  return (
+    <form
+      className='flex flex-col p-0'
+      onSubmit={(e) => {
+        e.preventDefault()
+        if (canSave) onSave()
+      }}>
+      <Section
+        title='Actions'
+        icon={<Zap className='size-4' />}
+        collapsible={false}
+        actions={
+          <Button variant='ghost' size='xs' onClick={onAdd}>
+            <Plus />
+            Add action
+          </Button>
+        }>
+        {actions.length === 0 && (
+          <EmptySection
+            icon={<Zap className='size-5' />}
+            title='No actions yet'
+            description='Add an action to run when the rule fires.'
+          />
+        )}
+        <div className='flex flex-col gap-0.5'>
+          {actions.map((action, i) => (
+            <TreeRow
+              key={i}
+              icon={<ActionIcon type={action.type} />}
+              isOpen={selectedIndex === i}
+              onToggleOpen={() => onSelectedIndexChange(i)}
+              rowClassName={
+                selectedIndex === i
+                  ? 'bg-primary-100 hover:bg-primary-150'
+                  : 'bg-primary-50 hover:bg-primary-100'
+              }
+              title={<span className='text-sm'>{ACTION_LABELS[action.type]}</span>}
+              secondary={<span className='text-xs text-muted-foreground'>{summarize(action)}</span>}
+              actions={
+                <TreeRowButton
+                  variant='destructive'
+                  tooltipText='Delete action'
+                  onClick={() => onRemove(i)}>
+                  <Trash2 />
+                </TreeRowButton>
+              }
+            />
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        title={selected ? `Configure · ${ACTION_LABELS[selected.type]}` : 'Configure'}
+        icon={<Settings2 className='size-4' />}
+        collapsible={false}>
+        {!selected ? (
+          <EmptySection
+            icon={<Settings2 className='size-5' />}
+            title='No action selected'
+            description='Select an action to configure it.'
+          />
+        ) : (
+          <FieldPanel className='p-0' breakpoint='md' resizeId='record-rule'>
+            <FieldPanelRow title='Action' isRequired>
+              <FieldInputAdapter
+                fieldType={FieldType.SINGLE_SELECT}
+                fieldOptions={{ options: ACTION_TYPE_OPTIONS }}
+                triggerProps={TRIGGER_PROPS}
+                value={selected.type}
+                onChange={(v) => {
+                  const type = first(v) as RecordRuleAction['type']
+                  if (type === 'set-field')
+                    onUpdate(selectedIndex, { type: 'set-field', fieldRef: '', value: '' })
+                  else if (type === 'enqueue-workflow')
+                    onUpdate(selectedIndex, { type: 'enqueue-workflow', workflowAppId: '' })
+                  else onUpdate(selectedIndex, { type: 'notify', userIds: [], message: '' })
+                }}
+              />
+            </FieldPanelRow>
+
+            {selected.type === 'notify' && (
+              <>
+                <FieldPanelRow title='Members' isRequired>
+                  <FieldInputAdapter
+                    fieldType={FieldType.ACTOR}
+                    fieldOptions={{ actor: { target: 'user', multiple: true } }}
+                    triggerProps={TRIGGER_PROPS}
+                    value={selected.userIds.map((id) => toActorId('user', id))}
+                    onChange={(v) =>
+                      onUpdate(selectedIndex, {
+                        ...selected,
+                        userIds: (v as ActorId[]).map(getActorRawId),
+                      })
+                    }
+                    placeholder='Add members to notify'
+                  />
+                </FieldPanelRow>
+                <FieldPanelRow title='Message' isRequired>
+                  <FieldInputAdapter
+                    fieldType={FieldType.TEXT}
+                    value={selected.message}
+                    onChange={(v) =>
+                      onUpdate(selectedIndex, { ...selected, message: String(v ?? '') })
+                    }
+                    placeholder='Notification message'
+                  />
+                </FieldPanelRow>
+              </>
+            )}
+
+            {selected.type === 'set-field' && (
+              <>
+                <FieldPanelRow title='Field' isRequired>
+                  <RecordRuleFieldRefInput
+                    entityDefinitionId={entityDefinitionId}
+                    fields={fields}
+                    value={selected.fieldRef}
+                    onChange={(ref) => onUpdate(selectedIndex, { ...selected, fieldRef: ref })}
+                    placeholder='Field to set'
+                  />
+                </FieldPanelRow>
+                <FieldPanelRow title='Value'>
+                  <FieldInputAdapter
+                    fieldType={FieldType.TEXT}
+                    value={String(selected.value ?? '')}
+                    onChange={(v) =>
+                      onUpdate(selectedIndex, { ...selected, value: coerceValue(String(v ?? '')) })
+                    }
+                    placeholder='Value'
+                  />
+                </FieldPanelRow>
+              </>
+            )}
+
+            {selected.type === 'enqueue-workflow' && (
+              <FieldPanelRow title='Workflow' isRequired>
+                <FieldInputAdapter
+                  fieldType={FieldType.SINGLE_SELECT}
+                  fieldOptions={{ options: workflowOptions }}
+                  triggerProps={TRIGGER_PROPS}
+                  value={selected.workflowAppId}
+                  onChange={(v) =>
+                    onUpdate(selectedIndex, { ...selected, workflowAppId: first(v) })
+                  }
+                  placeholder='Select workflow'
+                />
+              </FieldPanelRow>
+            )}
+          </FieldPanel>
+        )}
+      </Section>
+
+      <DialogFooter className='p-3'>
+        <Button variant='ghost' size='sm' type='button' onClick={onCancel}>
+          Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+        </Button>
+        <Button
+          variant='outline'
+          size='sm'
+          type='submit'
+          disabled={!canSave}
+          loading={isPending}
+          loadingText='Saving...'>
+          {isEdit ? 'Save changes' : 'Create rule'} <KbdSubmit variant='outline' size='sm' />
+        </Button>
+      </DialogFooter>
+    </form>
+  )
+}

--- a/apps/web/src/components/record-rules/ui/record-rule-configure-page.tsx
+++ b/apps/web/src/components/record-rules/ui/record-rule-configure-page.tsx
@@ -1,0 +1,232 @@
+// apps/web/src/components/record-rules/ui/record-rule-configure-page.tsx
+
+'use client'
+
+import { FieldType } from '@auxx/database/enums'
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import {
+  FIELD_TRANSITIONS,
+  LIFECYCLE_TRANSITIONS,
+  type RecordRuleOn,
+} from '@auxx/lib/record-rules/client'
+import { getFieldOperators, type ResourceField } from '@auxx/lib/resources/client'
+import type { SelectOption } from '@auxx/types/custom-field'
+import { Button } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { Section } from '@auxx/ui/components/section'
+import { ListFilter, Plus, Zap } from 'lucide-react'
+import { useMemo } from 'react'
+import {
+  type Condition,
+  ConditionContainer,
+  ConditionProvider,
+  type ConditionSystemConfig,
+  useConditionActions,
+} from '~/components/conditions'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { ResourcePicker } from '~/components/pickers/resource-picker/resource-picker'
+import { RecordRuleFieldRefInput } from './record-rule-field-ref-input'
+
+const EMPTY_CONDITIONS: Condition[] = []
+
+/** Human labels for every trigger the rule engine supports. */
+export const ON_LABELS: Record<RecordRuleOn, string> = {
+  changed: 'Field changed',
+  increased: 'Field increased',
+  decreased: 'Field decreased',
+  set: 'Field set (was empty)',
+  cleared: 'Field cleared',
+  created: 'Record created',
+  deleted: 'Record deleted',
+}
+
+const TRIGGER_OPTIONS: SelectOption[] = [...FIELD_TRANSITIONS, ...LIFECYCLE_TRANSITIONS].map(
+  (value) => ({ value, label: ON_LABELS[value] })
+)
+
+interface RecordRuleConfigurePageProps {
+  name: string
+  onNameChange: (value: string) => void
+  entityDefinitionId: string
+  /** Selecting a record type resets the watched field + conditions (both are def-scoped). */
+  onDefinitionChange: (entityDefinitionId: string) => void
+  on: RecordRuleOn
+  onTriggerChange: (on: RecordRuleOn) => void
+  fieldRef: string
+  onFieldRefChange: (ref: string) => void
+  groups: ConditionGroup[]
+  onGroupsChange: (groups: ConditionGroup[]) => void
+  /** Fields of the selected record type (for the watched-field picker + condition columns). */
+  fields: ResourceField[]
+  isLifecycle: boolean
+  /** Whether the definition is complete enough to move to the actions page. */
+  canContinue: boolean
+  onContinue: () => void
+  onCancel: () => void
+}
+
+/**
+ * The record-rule definition form: name, record type, trigger, watched field, and the
+ * shared condition builder — laid out with the app's `FieldPanel` primitives.
+ */
+export function RecordRuleConfigurePage({
+  name,
+  onNameChange,
+  entityDefinitionId,
+  onDefinitionChange,
+  on,
+  onTriggerChange,
+  fieldRef,
+  onFieldRefChange,
+  groups,
+  onGroupsChange,
+  fields,
+  isLifecycle,
+  canContinue,
+  onContinue,
+  onCancel,
+}: RecordRuleConfigurePageProps) {
+  // Condition builder wiring — mirrors the table filter builder.
+  const fieldDefinitions = useMemo(
+    () =>
+      fields.map((field) => ({
+        id: field.resourceFieldId ?? String(field.id),
+        label: field.label,
+        type: field.type,
+        fieldType: field.fieldType,
+        fieldKey: field.key,
+        operators: field.operatorOverrides || getFieldOperators(field),
+        options: field.options,
+      })),
+    [fields]
+  )
+
+  const conditionConfig: ConditionSystemConfig = useMemo(
+    () => ({
+      mode: 'resource',
+      entityDefinitionId,
+      fields: fieldDefinitions,
+      allowNesting: false,
+      allowReordering: true,
+      showLogicalOperators: true,
+      showGrouping: true,
+      allowGroupNaming: false,
+      allowGroupCollapse: false,
+      allowGroupReordering: true,
+      showGroupSubtext: false,
+      // defaultGroupName: 'Condition',
+      allowVarEditor: false,
+      allowConstantToggle: false,
+      allowCurrentUserPlaceholder: true,
+    }),
+    [entityDefinitionId, fieldDefinitions]
+  )
+
+  return (
+    <form
+      className='flex flex-col'
+      onSubmit={(e) => {
+        e.preventDefault()
+        if (canContinue) onContinue()
+      }}>
+      <Section title='Rule' icon={<Zap className='size-4' />} collapsible={false}>
+        <FieldPanel className='p-0' breakpoint='md' resizeId='record-rule'>
+          <FieldPanelRow title='Name' isRequired>
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
+              value={name}
+              onChange={(v) => onNameChange(String(v ?? ''))}
+              placeholder='e.g. Notify on urgent tickets'
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow title='Record type' isRequired>
+            <ResourcePicker
+              value={entityDefinitionId ? [entityDefinitionId] : []}
+              onChange={() => {}}
+              entityDefinedOnly
+              emptyLabel='Select record type…'
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              onSelectSingle={onDefinitionChange}
+            />
+          </FieldPanelRow>
+
+          <FieldPanelRow title='Trigger' isRequired description='When the rule fires.'>
+            <FieldInputAdapter
+              fieldType={FieldType.SINGLE_SELECT}
+              fieldOptions={{ options: TRIGGER_OPTIONS }}
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              value={on}
+              onChange={(v) => onTriggerChange((Array.isArray(v) ? v[0] : v) as RecordRuleOn)}
+            />
+          </FieldPanelRow>
+
+          {!isLifecycle && (
+            <FieldPanelRow
+              title='Watched field'
+              isRequired
+              description='The field whose change fires the rule.'>
+              <RecordRuleFieldRefInput
+                entityDefinitionId={entityDefinitionId}
+                fields={fields}
+                value={fieldRef}
+                onChange={onFieldRefChange}
+                placeholder={entityDefinitionId ? 'Select field…' : 'Select a record type first'}
+              />
+            </FieldPanelRow>
+          )}
+        </FieldPanel>
+      </Section>
+
+      {entityDefinitionId ? (
+        <ConditionProvider
+          conditions={EMPTY_CONDITIONS}
+          groups={groups}
+          config={conditionConfig}
+          onConditionsChange={() => {}}
+          onGroupsChange={onGroupsChange}
+          getAvailableFields={() => fieldDefinitions}
+          getFieldDefinition={(id) => fieldDefinitions.find((f) => f.id === id)}>
+          <Section
+            title='Conditions'
+            icon={<ListFilter className='size-4' />}
+            collapsible={false}
+            actions={<AddGroupButton />}>
+            <ConditionContainer
+              emptyStateText='No conditions — the rule always runs'
+              showAddButton={false}
+              showGrouping
+            />
+          </Section>
+        </ConditionProvider>
+      ) : (
+        <Section title='Conditions' icon={<ListFilter className='size-4' />} collapsible={false}>
+          <p className='text-sm text-muted-foreground'>Select a record type first.</p>
+        </Section>
+      )}
+
+      <DialogFooter className='p-3'>
+        <Button variant='ghost' size='sm' type='button' onClick={onCancel}>
+          Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+        </Button>
+        <Button variant='outline' size='sm' type='submit' disabled={!canContinue}>
+          Continue <KbdSubmit variant='outline' size='sm' />
+        </Button>
+      </DialogFooter>
+    </form>
+  )
+}
+
+/** "Add group" trigger for the conditions section header — lives inside the ConditionProvider. */
+function AddGroupButton() {
+  const { addGroup } = useConditionActions()
+  if (!addGroup) return null
+  return (
+    <Button variant='ghost' size='xs' type='button' onClick={() => addGroup()}>
+      <Plus />
+      Add group
+    </Button>
+  )
+}

--- a/apps/web/src/components/record-rules/ui/record-rule-dialog.tsx
+++ b/apps/web/src/components/record-rules/ui/record-rule-dialog.tsx
@@ -4,52 +4,19 @@
 
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import {
-  FIELD_TRANSITIONS,
   LIFECYCLE_TRANSITIONS,
   type RecordRuleAction,
   type RecordRuleOn,
 } from '@auxx/lib/record-rules/client'
-import { getFieldOperators, type ResourceField } from '@auxx/lib/resources/client'
-import { Button } from '@auxx/ui/components/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
-import { Input } from '@auxx/ui/components/input'
-import { Label } from '@auxx/ui/components/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
 import { toastError } from '@auxx/ui/components/toast'
-import { Plus, Trash2 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
-import {
-  type Condition,
-  ConditionContainer,
-  ConditionProvider,
-  type ConditionSystemConfig,
-} from '~/components/conditions'
 import { api } from '~/trpc/react'
 import { useRecordRules } from '../hooks/use-record-rules'
-
-const EMPTY_CONDITIONS: Condition[] = []
-
-const ON_LABELS: Record<RecordRuleOn, string> = {
-  changed: 'Field changed',
-  increased: 'Field increased',
-  decreased: 'Field decreased',
-  set: 'Field set (was empty)',
-  cleared: 'Field cleared',
-  created: 'Record created',
-  deleted: 'Record deleted',
-}
+import { RecordRuleActionsPage } from './record-rule-actions-page'
+import { RecordRuleConfigurePage } from './record-rule-configure-page'
 
 /** Rule shape the settings list hands to the dialog (router `list` output item). */
 export interface EditableRecordRule {
@@ -69,34 +36,30 @@ interface RecordRuleDialogProps {
   rule?: EditableRecordRule | null
 }
 
-/** 'true'/'false'/numeric strings become their typed values; everything else stays a string. */
-function coerceValue(raw: string): unknown {
-  if (raw === 'true') return true
-  if (raw === 'false') return false
-  if (raw.trim() !== '' && !Number.isNaN(Number(raw))) return Number(raw)
-  return raw
-}
-
 /**
- * Create/edit dialog for a record rule: definition + trigger + optional watched
- * field, the shared condition builder, and an ordered action list.
+ * Create/edit dialog for a record rule. A two-page `DialogNav` flow: `configure`
+ * (name, record type, trigger, watched field, conditions) → `actions` (the ordered
+ * action editor). The shell owns all form state; the pages are presentational.
  */
 export function RecordRuleDialog({ open, onClose, rule }: RecordRuleDialogProps) {
   const { create, update } = useRecordRules()
   const { data: resources } = api.resource.list.useQuery(undefined, { staleTime: 60_000 })
   const { data: workflowData } = api.workflow.list.useQuery({}, { staleTime: 60_000 })
-  const { data: memberData } = api.member.all.useQuery(undefined, { staleTime: 60_000 })
 
+  const [page, setPage] = useState<'configure' | 'actions'>('configure')
   const [name, setName] = useState('')
   const [entityDefinitionId, setEntityDefinitionId] = useState('')
   const [on, setOn] = useState<RecordRuleOn>('changed')
   const [fieldRef, setFieldRef] = useState('')
   const [groups, setGroups] = useState<ConditionGroup[]>([])
   const [actions, setActions] = useState<RecordRuleAction[]>([])
+  const [selectedActionIndex, setSelectedActionIndex] = useState(0)
 
   // Re-seed form state whenever the dialog opens.
   useEffect(() => {
     if (!open) return
+    setPage('configure')
+    setSelectedActionIndex(0)
     setName(rule?.name ?? '')
     setEntityDefinitionId(rule?.entityDefinitionId ?? '')
     setOn((rule?.on as RecordRuleOn) ?? 'changed')
@@ -116,68 +79,51 @@ export function RecordRuleDialog({ open, onClose, rule }: RecordRuleDialogProps)
   )
   const fields: ResourceField[] = useMemo(() => selectedResource?.fields ?? [], [selectedResource])
 
-  /** Ref sent to the server — systemAttribute when present (resolves everywhere), else row id. */
-  const fieldRefFor = (field: ResourceField) => field.systemAttribute ?? String(field.id)
-
-  const workflows = (workflowData?.workflows ?? []).filter((w: { enabled?: boolean }) => w.enabled)
-  const members = memberData?.members ?? []
-
-  // Condition builder wiring — mirrors the table filter builder.
-  const fieldDefinitions = useMemo(
-    () =>
-      fields.map((field) => ({
-        id: field.resourceFieldId ?? String(field.id),
-        label: field.label,
-        type: field.type,
-        fieldType: field.fieldType,
-        fieldKey: field.key,
-        operators: field.operatorOverrides || getFieldOperators(field),
-        options: field.options,
-      })),
-    [fields]
+  const workflows = useMemo(
+    () => (workflowData?.workflows ?? []).filter((w: { enabled?: boolean }) => w.enabled),
+    [workflowData]
   )
 
-  const conditionConfig: ConditionSystemConfig = useMemo(
-    () => ({
-      mode: 'resource',
-      entityDefinitionId,
-      fields: fieldDefinitions,
-      allowNesting: false,
-      allowReordering: true,
-      showLogicalOperators: true,
-      showGrouping: true,
-      allowGroupNaming: false,
-      allowGroupCollapse: false,
-      allowGroupReordering: true,
-      showGroupSubtext: false,
-      defaultGroupName: 'Condition',
-      allowVarEditor: false,
-      allowConstantToggle: false,
-      allowCurrentUserPlaceholder: true,
-    }),
-    [entityDefinitionId, fieldDefinitions]
-  )
+  const onDefinitionChange = (id: string) => {
+    setEntityDefinitionId(id)
+    setFieldRef('')
+    setGroups([])
+  }
+  const onTriggerChange = (next: RecordRuleOn) => {
+    setOn(next)
+    if (LIFECYCLE_TRANSITIONS.includes(next)) setFieldRef('')
+  }
 
   const updateAction = (index: number, next: RecordRuleAction) =>
     setActions((prev) => prev.map((a, i) => (i === index ? next : a)))
-  const removeAction = (index: number) => setActions((prev) => prev.filter((_, i) => i !== index))
+  const removeAction = (index: number) =>
+    setActions((prev) => {
+      const next = prev.filter((_, i) => i !== index)
+      setSelectedActionIndex((cur) => Math.max(0, Math.min(cur, next.length - 1)))
+      return next
+    })
   const addAction = () =>
-    setActions((prev) => [...prev, { type: 'notify', userIds: [], message: '' }])
+    setActions((prev) => {
+      const next: RecordRuleAction[] = [...prev, { type: 'notify', userIds: [], message: '' }]
+      setSelectedActionIndex(next.length - 1)
+      return next
+    })
 
   const isPending = create.isPending || update.isPending
-  const canSave =
-    name.trim() !== '' &&
-    entityDefinitionId !== '' &&
-    (isLifecycle || fieldRef !== '') &&
-    actions.length > 0
+  const canGoToActions =
+    name.trim() !== '' && entityDefinitionId !== '' && (isLifecycle || fieldRef !== '')
+  const canSave = canGoToActions && actions.length > 0
 
   const handleSave = async () => {
-    const invalidNotify = actions.find(
-      (a) => a.type === 'notify' && (a.userIds.length === 0 || a.message.trim() === '')
+    const invalidIndex = actions.findIndex(
+      (a) =>
+        (a.type === 'notify' && (a.userIds.length === 0 || a.message.trim() === '')) ||
+        (a.type === 'set-field' && !a.fieldRef) ||
+        (a.type === 'enqueue-workflow' && !a.workflowAppId)
     )
-    const invalidSetField = actions.find((a) => a.type === 'set-field' && !a.fieldRef)
-    const invalidWorkflow = actions.find((a) => a.type === 'enqueue-workflow' && !a.workflowAppId)
-    if (invalidNotify || invalidSetField || invalidWorkflow) {
+    if (invalidIndex >= 0) {
+      setSelectedActionIndex(invalidIndex)
+      setPage('actions')
       toastError({
         title: 'Incomplete action',
         description: 'Every action needs its target and content filled in.',
@@ -207,265 +153,60 @@ export function RecordRuleDialog({ open, onClose, rule }: RecordRuleDialogProps)
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent size='lg' position='tc' className='max-h-[85vh] overflow-y-auto'>
-        <DialogHeader>
-          <DialogTitle>{rule ? 'Edit rule' : 'New rule'}</DialogTitle>
-        </DialogHeader>
+      <DialogContent size='content' position='tc' innerClassName='p-0'>
+        <DialogNav
+          title={rule ? 'Edit rule' : 'New rule'}
+          description='React to record changes with conditions and actions.'
+          onBack={page === 'actions' ? () => setPage('configure') : undefined}
+          crumbs={[
+            {
+              label: name.trim() || (rule ? 'Rule' : 'New rule'),
+              onClick: page !== 'configure' ? () => setPage('configure') : undefined,
+            },
+            ...(page === 'actions' ? [{ label: 'Actions' }] : []),
+          ]}
+        />
 
-        <div className='flex flex-col gap-4'>
-          <div className='flex flex-col gap-2'>
-            <Label htmlFor='rule-name'>Name</Label>
-            <Input
-              id='rule-name'
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder='e.g. Notify on urgent tickets'
+        <DialogNavPages value={page}>
+          <DialogNavPage value='configure' size='lg'>
+            <RecordRuleConfigurePage
+              name={name}
+              onNameChange={setName}
+              entityDefinitionId={entityDefinitionId}
+              onDefinitionChange={onDefinitionChange}
+              on={on}
+              onTriggerChange={onTriggerChange}
+              fieldRef={fieldRef}
+              onFieldRefChange={setFieldRef}
+              groups={groups}
+              onGroupsChange={setGroups}
+              fields={fields}
+              isLifecycle={isLifecycle}
+              canContinue={canGoToActions}
+              onContinue={() => setPage('actions')}
+              onCancel={onClose}
             />
-          </div>
+          </DialogNavPage>
 
-          <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
-            <div className='flex flex-col gap-2'>
-              <Label>Record type</Label>
-              <Select
-                value={entityDefinitionId}
-                onValueChange={(v) => {
-                  setEntityDefinitionId(v)
-                  setFieldRef('')
-                  setGroups([])
-                }}>
-                <SelectTrigger>
-                  <SelectValue placeholder='Select record type' />
-                </SelectTrigger>
-                <SelectContent>
-                  {definitionOptions.map((r) => (
-                    <SelectItem key={r.entityDefinitionId} value={r.entityDefinitionId}>
-                      {r.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className='flex flex-col gap-2'>
-              <Label>Trigger</Label>
-              <Select
-                value={on}
-                onValueChange={(v) => {
-                  const next = v as RecordRuleOn
-                  setOn(next)
-                  if (LIFECYCLE_TRANSITIONS.includes(next)) setFieldRef('')
-                }}>
-                <SelectTrigger>
-                  <SelectValue placeholder='Select trigger' />
-                </SelectTrigger>
-                <SelectContent>
-                  {[...FIELD_TRANSITIONS, ...LIFECYCLE_TRANSITIONS].map((value) => (
-                    <SelectItem key={value} value={value}>
-                      {ON_LABELS[value]}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          {!isLifecycle && (
-            <div className='flex flex-col gap-2'>
-              <Label>Watched field</Label>
-              <Select value={fieldRef} onValueChange={setFieldRef} disabled={!entityDefinitionId}>
-                <SelectTrigger>
-                  <SelectValue
-                    placeholder={entityDefinitionId ? 'Select field' : 'Select a record type first'}
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {fields.map((field) => (
-                    <SelectItem key={String(field.id)} value={fieldRefFor(field)}>
-                      {field.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
-          <div className='flex flex-col gap-2'>
-            <Label>Conditions</Label>
-            {entityDefinitionId ? (
-              <div className='rounded-md border p-2'>
-                <ConditionProvider
-                  conditions={EMPTY_CONDITIONS}
-                  groups={groups}
-                  config={conditionConfig}
-                  onConditionsChange={() => {}}
-                  onGroupsChange={setGroups}
-                  getAvailableFields={() => fieldDefinitions}
-                  getFieldDefinition={(id) => fieldDefinitions.find((f) => f.id === id)}>
-                  <ConditionContainer
-                    emptyStateText='No conditions — the rule always runs'
-                    showAddButton
-                    showGrouping
-                  />
-                </ConditionProvider>
-              </div>
-            ) : (
-              <p className='text-sm text-muted-foreground'>Select a record type first.</p>
-            )}
-          </div>
-
-          <div className='flex flex-col gap-2'>
-            <div className='flex items-center justify-between'>
-              <Label>Actions (run in order)</Label>
-              <Button variant='outline' size='sm' onClick={addAction}>
-                <Plus />
-                Add action
-              </Button>
-            </div>
-
-            {actions.length === 0 && (
-              <p className='text-sm text-muted-foreground'>Add at least one action.</p>
-            )}
-
-            {actions.map((action, index) => (
-              <div key={`action-${index}`} className='flex flex-col gap-2 rounded-md border p-3'>
-                <div className='flex items-center gap-2'>
-                  <Select
-                    value={action.type}
-                    onValueChange={(type) => {
-                      if (type === 'set-field')
-                        updateAction(index, { type: 'set-field', fieldRef: '', value: '' })
-                      else if (type === 'enqueue-workflow')
-                        updateAction(index, { type: 'enqueue-workflow', workflowAppId: '' })
-                      else updateAction(index, { type: 'notify', userIds: [], message: '' })
-                    }}>
-                    <SelectTrigger className='w-44'>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value='notify'>Notify members</SelectItem>
-                      <SelectItem value='set-field'>Set field</SelectItem>
-                      <SelectItem value='enqueue-workflow'>Run workflow</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <div className='flex-1' />
-                  <Button variant='ghost' size='icon-sm' onClick={() => removeAction(index)}>
-                    <Trash2 />
-                  </Button>
-                </div>
-
-                {action.type === 'set-field' && (
-                  <div className='grid grid-cols-1 gap-2 sm:grid-cols-2'>
-                    <Select
-                      value={action.fieldRef}
-                      onValueChange={(v) => updateAction(index, { ...action, fieldRef: v })}>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Field to set' />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {fields.map((field) => (
-                          <SelectItem key={String(field.id)} value={fieldRefFor(field)}>
-                            {field.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <Input
-                      value={String(action.value ?? '')}
-                      onChange={(e) =>
-                        updateAction(index, { ...action, value: coerceValue(e.target.value) })
-                      }
-                      placeholder='Value'
-                    />
-                  </div>
-                )}
-
-                {action.type === 'enqueue-workflow' && (
-                  <Select
-                    value={action.workflowAppId}
-                    onValueChange={(v) => updateAction(index, { ...action, workflowAppId: v })}>
-                    <SelectTrigger>
-                      <SelectValue placeholder='Select workflow' />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {workflows.map((w: { id: string; name: string }) => (
-                        <SelectItem key={w.id} value={w.id}>
-                          {w.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-
-                {action.type === 'notify' && (
-                  <div className='flex flex-col gap-2'>
-                    <Select
-                      value=''
-                      onValueChange={(userId) => {
-                        if (!action.userIds.includes(userId))
-                          updateAction(index, { ...action, userIds: [...action.userIds, userId] })
-                      }}>
-                      <SelectTrigger>
-                        <SelectValue
-                          placeholder={
-                            action.userIds.length > 0
-                              ? `${action.userIds.length} member${action.userIds.length === 1 ? '' : 's'} selected`
-                              : 'Add members to notify'
-                          }
-                        />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {members.map((m) => (
-                          <SelectItem key={m.userId} value={m.userId}>
-                            {m.user?.name || m.user?.email || m.userId}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    {action.userIds.length > 0 && (
-                      <div className='flex flex-wrap gap-1'>
-                        {action.userIds.map((userId) => {
-                          const member = members.find((m) => m.userId === userId)
-                          return (
-                            <Button
-                              key={userId}
-                              variant='secondary'
-                              size='sm'
-                              onClick={() =>
-                                updateAction(index, {
-                                  ...action,
-                                  userIds: action.userIds.filter((id) => id !== userId),
-                                })
-                              }>
-                              {member?.user?.name || member?.user?.email || userId} ×
-                            </Button>
-                          )
-                        })}
-                      </div>
-                    )}
-                    <Input
-                      value={action.message}
-                      onChange={(e) => updateAction(index, { ...action, message: e.target.value })}
-                      placeholder='Notification message'
-                    />
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button variant='outline' onClick={onClose}>
-            Cancel
-          </Button>
-          <Button
-            onClick={() => void handleSave()}
-            disabled={!canSave}
-            loading={isPending}
-            loadingText='Saving...'>
-            {rule ? 'Save changes' : 'Create rule'}
-          </Button>
-        </DialogFooter>
+          <DialogNavPage value='actions' size='lg'>
+            <RecordRuleActionsPage
+              actions={actions}
+              selectedIndex={selectedActionIndex}
+              onSelectedIndexChange={setSelectedActionIndex}
+              onAdd={addAction}
+              onRemove={removeAction}
+              onUpdate={updateAction}
+              entityDefinitionId={entityDefinitionId}
+              fields={fields}
+              workflows={workflows}
+              isEdit={!!rule}
+              canSave={canSave}
+              isPending={isPending}
+              onSave={() => void handleSave()}
+              onCancel={onClose}
+            />
+          </DialogNavPage>
+        </DialogNavPages>
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/components/record-rules/ui/record-rule-field-ref-input.tsx
+++ b/apps/web/src/components/record-rules/ui/record-rule-field-ref-input.tsx
@@ -1,0 +1,69 @@
+// apps/web/src/components/record-rules/ui/record-rule-field-ref-input.tsx
+
+'use client'
+
+import { FieldType } from '@auxx/database/enums'
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { cn } from '@auxx/ui/lib/utils'
+import { useMemo } from 'react'
+import { FieldPicker } from '~/components/pickers/field-picker/field-picker'
+import { PickerTrigger } from '~/components/ui/picker-trigger'
+
+/**
+ * The ref format the record-rule router expects: `systemAttribute` when present
+ * (resolves in any org), otherwise the field row id.
+ */
+export function fieldRefFor(field: ResourceField): string {
+  return field.systemAttribute ?? String(field.id)
+}
+
+interface RecordRuleFieldRefInputProps {
+  /** Record type whose fields are offered. */
+  entityDefinitionId: string
+  /** The record type's fields — used to resolve the current ref's display label. */
+  fields: ResourceField[]
+  /** Current field ref (`systemAttribute` or row id). */
+  value: string
+  onChange: (ref: string) => void
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+}
+
+/**
+ * A `FieldPicker`-backed input for choosing a direct field on a record type,
+ * rendered as a {@link PickerTrigger} so it sits flush inside a `FieldPanelRow`.
+ * Relationship fields are filtered out (no drill-down) — the rule engine watches a
+ * field on the record itself, so refs are always flat (id | systemAttribute).
+ */
+export function RecordRuleFieldRefInput({
+  entityDefinitionId,
+  fields,
+  value,
+  onChange,
+  placeholder = 'Select field…',
+  disabled,
+  className,
+}: RecordRuleFieldRefInputProps) {
+  const label = useMemo(() => {
+    if (!value) return null
+    return fields.find((f) => fieldRefFor(f) === value)?.label ?? value
+  }, [value, fields])
+
+  return (
+    <FieldPicker
+      entityDefinitionId={entityDefinitionId}
+      filterField={(f) => f.fieldType !== FieldType.RELATIONSHIP}
+      onSelect={(_ref, field) => onChange(fieldRefFor(field))}
+      trigger={
+        <PickerTrigger
+          hasValue={!!value}
+          placeholder={placeholder}
+          disabled={disabled || !entityDefinitionId}
+          className={cn('w-full ps-0 pe-1', className)}>
+          {label && <span className='truncate text-sm'>{label}</span>}
+        </PickerTrigger>
+      }
+    />
+  )
+}

--- a/apps/web/src/components/record-rules/ui/record-rules-section.tsx
+++ b/apps/web/src/components/record-rules/ui/record-rules-section.tsx
@@ -147,7 +147,7 @@ export function RecordRulesSection() {
         rule={editing}
       />
       {runsFor && <RecordRuleRunsDialog rule={runsFor} open onClose={() => setRunsFor(null)} />}
-      {ConfirmDialog}
+      <ConfirmDialog />
     </SettingsSection>
   )
 }


### PR DESCRIPTION
## Summary

Rebuilds the record-rule **create/edit dialog** to use the app's standard form primitives instead of the original bare `Label` + `Select` stacks. UI only — no engine, router, or schema changes (the record-rules backend is already on `main`).

## What changed

- **Two-page `DialogNav` flow**: `configure` (definition + conditions) → `actions`. Header is back + breadcrumbs; each page owns a `DialogFooter` CTA with standard `Kbd`/`KbdSubmit` (⌘/Ctrl+Enter submits), matching the webhook endpoint dialog.
- **Configure page** (`record-rule-configure-page.tsx`): `Rule` and `Conditions` `Section`s. Name/trigger via `FieldInputAdapter` (TEXT / SINGLE_SELECT), record type via `ResourcePicker`, watched field via a flat `FieldPicker` (`record-rule-field-ref-input.tsx`, relationships filtered out). **"Add group"** moved into the Conditions section header via `useConditionActions`.
- **Actions page** (`record-rule-actions-page.tsx`): master-detail — a `TreeRow` list + a shared `FieldPanel` editor for the selected action. Member selector via `FieldInputAdapter` `FieldType.ACTOR` (`target: user`), workflow via `SINGLE_SELECT`, set-field target via the shared field-ref picker.
- `userIds` round-trip through `toActorId`/`getActorRawId` — the stored `NotifyAction` shape is unchanged. Dropped the old member `Select`/chips and the `api.member.all` query (ActorPicker resolves members from its own store).

## Files

| | |
|---|---|
| new | `record-rule-configure-page.tsx`, `record-rule-actions-page.tsx`, `record-rule-field-ref-input.tsx` |
| modified | `record-rule-dialog.tsx` (shell), `record-rules-section.tsx` (JSX fix) |

Plan: `plans/events/record-rules-settings-ui-plan.md`.

## Testing

- `biome check` clean across the touched files (also enforced by the pre-commit hook).
- ⚠️ **Not yet exercised in-browser** — verifying the live dialog was blocked by an unauthenticated session on `/app/settings/rules`. Reviewer should walk create/edit for a field rule + a lifecycle rule, and the notify/set-field/workflow action editors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)