### PR TITLE
refactor(fields): migrate manual forms from ConstantInputAdapter to FieldInputAdapter

### DIFF
--- a/apps/web/src/app/(protected)/app/tickets/_components/ticket-number-form.tsx
+++ b/apps/web/src/app/(protected)/app/tickets/_components/ticket-number-form.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import { BaseType } from '@auxx/lib/workflow-engine/types'
 import { Button } from '@auxx/ui/components/button'
 import { Form } from '@auxx/ui/components/form'
@@ -11,9 +12,9 @@ import { Hash } from 'lucide-react'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
-import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 import { api } from '~/trpc/react'
 
 const formSchema = z.object({
@@ -185,10 +186,10 @@ export default function TicketNumberingSettings() {
                 description='Enable to use a prefix for ticket numbers (e.g., SUP-0001)'
                 type={BaseType.BOOLEAN}
                 showIcon>
-                <ConstantInputAdapter
+                <FieldInputAdapter
+                  fieldType={FieldType.CHECKBOX}
                   value={form.watch('usePrefix')}
-                  onChange={(_, val) => form.setValue('usePrefix', val)}
-                  varType={BaseType.BOOLEAN}
+                  onChange={(val) => form.setValue('usePrefix', val as boolean)}
                   fieldOptions={{ variant: 'switch' }}
                 />
               </FieldPanelRow>
@@ -200,10 +201,10 @@ export default function TicketNumberingSettings() {
                     description='Short text to prefix the ticket number (e.g., SUP)'
                     type={BaseType.STRING}
                     showIcon>
-                    <ConstantInputAdapter
+                    <FieldInputAdapter
+                      fieldType={FieldType.TEXT}
                       value={form.watch('prefix') ?? ''}
-                      onChange={(_, val) => form.setValue('prefix', val)}
-                      varType={BaseType.STRING}
+                      onChange={(val) => form.setValue('prefix', val as string)}
                       placeholder='SUP'
                     />
                   </FieldPanelRow>
@@ -213,10 +214,10 @@ export default function TicketNumberingSettings() {
                     description='Add date component to prefix (e.g., SUP2403-0001)'
                     type={BaseType.BOOLEAN}
                     showIcon>
-                    <ConstantInputAdapter
+                    <FieldInputAdapter
+                      fieldType={FieldType.CHECKBOX}
                       value={form.watch('useDateInPrefix')}
-                      onChange={(_, val) => form.setValue('useDateInPrefix', val)}
-                      varType={BaseType.BOOLEAN}
+                      onChange={(val) => form.setValue('useDateInPrefix', val as boolean)}
                       fieldOptions={{ variant: 'switch' }}
                     />
                   </FieldPanelRow>
@@ -227,11 +228,13 @@ export default function TicketNumberingSettings() {
                       description='Format of the date component in the prefix'
                       type={BaseType.ENUM}
                       showIcon>
-                      <ConstantInputAdapter
+                      <FieldInputAdapter
+                        fieldType={FieldType.SINGLE_SELECT}
                         value={form.watch('dateFormat')}
-                        onChange={(_, val) => form.setValue('dateFormat', val)}
-                        varType={BaseType.ENUM}
-                        fieldOptions={{ enum: DATE_FORMAT_OPTIONS }}
+                        onChange={(val) =>
+                          form.setValue('dateFormat', (val as string[])[0] ?? 'YYMM')
+                        }
+                        fieldOptions={{ options: DATE_FORMAT_OPTIONS }}
                       />
                     </FieldPanelRow>
                   )}
@@ -244,10 +247,10 @@ export default function TicketNumberingSettings() {
                 description='Enable to use a suffix for ticket numbers (e.g., 0001-SUP)'
                 type={BaseType.BOOLEAN}
                 showIcon>
-                <ConstantInputAdapter
+                <FieldInputAdapter
+                  fieldType={FieldType.CHECKBOX}
                   value={form.watch('useSuffix')}
-                  onChange={(_, val) => form.setValue('useSuffix', val)}
-                  varType={BaseType.BOOLEAN}
+                  onChange={(val) => form.setValue('useSuffix', val as boolean)}
                   fieldOptions={{ variant: 'switch' }}
                 />
               </FieldPanelRow>
@@ -258,10 +261,10 @@ export default function TicketNumberingSettings() {
                   description='Text to append after the ticket number'
                   type={BaseType.STRING}
                   showIcon>
-                  <ConstantInputAdapter
+                  <FieldInputAdapter
+                    fieldType={FieldType.TEXT}
                     value={form.watch('suffix') ?? ''}
-                    onChange={(_, val) => form.setValue('suffix', val)}
-                    varType={BaseType.STRING}
+                    onChange={(val) => form.setValue('suffix', val as string)}
                     placeholder='SUP'
                   />
                 </FieldPanelRow>
@@ -273,10 +276,10 @@ export default function TicketNumberingSettings() {
                 description='Number of digits to pad the numeric part (e.g., 4 for 0001)'
                 type={BaseType.NUMBER}
                 showIcon>
-                <ConstantInputAdapter
+                <FieldInputAdapter
+                  fieldType={FieldType.NUMBER}
                   value={form.watch('paddingLength')}
-                  onChange={(_, val) => form.setValue('paddingLength', val)}
-                  varType={BaseType.NUMBER}
+                  onChange={(val) => form.setValue('paddingLength', val as number)}
                   placeholder='4'
                 />
               </FieldPanelRow>
@@ -286,10 +289,10 @@ export default function TicketNumberingSettings() {
                 description='Character(s) to separate parts (e.g., -, ., _)'
                 type={BaseType.STRING}
                 showIcon>
-                <ConstantInputAdapter
+                <FieldInputAdapter
+                  fieldType={FieldType.TEXT}
                   value={form.watch('separator')}
-                  onChange={(_, val) => form.setValue('separator', val)}
-                  varType={BaseType.STRING}
+                  onChange={(val) => form.setValue('separator', val as string)}
                   placeholder='-'
                 />
               </FieldPanelRow>

--- a/apps/web/src/components/custom-fields/ui/text-options-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/text-options-editor.tsx
@@ -2,9 +2,10 @@
 
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types/unified-types'
-import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 
 /**
  * String options for text field configuration
@@ -33,7 +34,7 @@ export function TextOptionsEditor({ options, onChange, disabled }: TextOptionsEd
   /**
    * Handle individual option changes
    */
-  const handleChange = (key: keyof TextOptions) => (_content: string, value: any) => {
+  const handleChange = (key: keyof TextOptions) => (value: unknown) => {
     onChange({ ...options, [key]: value })
   }
 
@@ -44,11 +45,11 @@ export function TextOptionsEditor({ options, onChange, disabled }: TextOptionsEd
         title='Multiline'
         description='Allow multiple lines of text (textarea)'
         type={BaseType.BOOLEAN}>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.CHECKBOX}
           value={options.multiline ?? false}
           onChange={handleChange('multiline')}
           fieldOptions={{ variant: 'switch' }}
-          varType={BaseType.BOOLEAN}
           disabled={disabled}
         />
       </FieldPanelRow>
@@ -58,10 +59,10 @@ export function TextOptionsEditor({ options, onChange, disabled }: TextOptionsEd
         title='Min Length'
         description='Minimum number of characters required'
         type={BaseType.NUMBER}>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.NUMBER}
           value={options.minLength ?? ''}
           onChange={handleChange('minLength')}
-          varType={BaseType.NUMBER}
           placeholder='No minimum'
           disabled={disabled}
         />
@@ -72,10 +73,10 @@ export function TextOptionsEditor({ options, onChange, disabled }: TextOptionsEd
         title='Max Length'
         description='Maximum number of characters allowed'
         type={BaseType.NUMBER}>
-        <ConstantInputAdapter
+        <FieldInputAdapter
+          fieldType={FieldType.NUMBER}
           value={options.maxLength ?? ''}
           onChange={handleChange('maxLength')}
-          varType={BaseType.NUMBER}
           placeholder='No maximum'
           disabled={disabled}
         />

--- a/apps/web/src/components/datasets/settings/sections/chunking-settings-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/chunking-settings-section.tsx
@@ -1,5 +1,6 @@
 // apps/web/src/components/datasets/settings/sections/chunking-settings-section.tsx
 'use client'
+import { FieldType } from '@auxx/database/enums'
 import type { ChunkSettings, DatasetEntity as Dataset } from '@auxx/database/types'
 import { BaseType } from '@auxx/lib/workflow-engine/client'
 import { Button } from '@auxx/ui/components/button'
@@ -11,9 +12,9 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import { Book, Brain, FileText, Layers, Scissors } from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
-import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 import { api } from '~/trpc/react'
 
 interface ChunkingSettingsSectionProps {
@@ -204,10 +205,10 @@ export function ChunkingSettingsSection({
                   description='Target size for each chunk in characters (100-5000)'
                   type={BaseType.NUMBER}
                   showIcon={true}>
-                  <ConstantInputAdapter
+                  <FieldInputAdapter
+                    fieldType={FieldType.NUMBER}
                     value={form.watch('size') ?? ''}
-                    onChange={(_, val) => form.setValue('size', val)}
-                    varType={BaseType.NUMBER}
+                    onChange={(val) => form.setValue('size', val as number)}
                     placeholder='1000'
                     disabled={readOnly}
                   />
@@ -218,10 +219,10 @@ export function ChunkingSettingsSection({
                   description='Overlapping characters between adjacent chunks (0-1000)'
                   type={BaseType.NUMBER}
                   showIcon={true}>
-                  <ConstantInputAdapter
+                  <FieldInputAdapter
+                    fieldType={FieldType.NUMBER}
                     value={form.watch('overlap') ?? ''}
-                    onChange={(_, val) => form.setValue('overlap', val)}
-                    varType={BaseType.NUMBER}
+                    onChange={(val) => form.setValue('overlap', val as number)}
                     placeholder='200'
                     disabled={readOnly}
                   />
@@ -232,10 +233,10 @@ export function ChunkingSettingsSection({
                   description='Split text at this delimiter. Default is double newline (paragraph breaks).'
                   type={BaseType.STRING}
                   showIcon={true}>
-                  <ConstantInputAdapter
+                  <FieldInputAdapter
+                    fieldType={FieldType.TEXT}
                     value={form.watch('delimiter') ?? ''}
-                    onChange={(_, val) => form.setValue('delimiter', val || '\n\n')}
-                    varType={BaseType.STRING}
+                    onChange={(val) => form.setValue('delimiter', (val as string) || '\n\n')}
                     placeholder='\n\n'
                     disabled={readOnly}
                   />
@@ -246,10 +247,12 @@ export function ChunkingSettingsSection({
                   description='Replace consecutive spaces, newlines, and tabs with single characters'
                   type={BaseType.BOOLEAN}
                   showIcon={true}>
-                  <ConstantInputAdapter
+                  <FieldInputAdapter
+                    fieldType={FieldType.CHECKBOX}
                     value={form.watch('preprocessing.normalizeWhitespace')}
-                    onChange={(_, val) => form.setValue('preprocessing.normalizeWhitespace', val)}
-                    varType={BaseType.BOOLEAN}
+                    onChange={(val) =>
+                      form.setValue('preprocessing.normalizeWhitespace', val as boolean)
+                    }
                     fieldOptions={{ variant: 'switch' }}
                     disabled={readOnly}
                   />
@@ -260,10 +263,12 @@ export function ChunkingSettingsSection({
                   description='Delete all URLs and email addresses from content before chunking'
                   type={BaseType.BOOLEAN}
                   showIcon={true}>
-                  <ConstantInputAdapter
+                  <FieldInputAdapter
+                    fieldType={FieldType.CHECKBOX}
                     value={form.watch('preprocessing.removeUrlsAndEmails')}
-                    onChange={(_, val) => form.setValue('preprocessing.removeUrlsAndEmails', val)}
-                    varType={BaseType.BOOLEAN}
+                    onChange={(val) =>
+                      form.setValue('preprocessing.removeUrlsAndEmails', val as boolean)
+                    }
                     fieldOptions={{ variant: 'switch' }}
                     disabled={readOnly}
                   />

--- a/apps/web/src/components/datasets/settings/sections/search-configuration-section.tsx
+++ b/apps/web/src/components/datasets/settings/sections/search-configuration-section.tsx
@@ -1,5 +1,6 @@
 // apps/web/src/components/datasets/settings/sections/search-configuration-section.tsx
 'use client'
+import { FieldType } from '@auxx/database/enums'
 import type { DatasetEntity as Dataset } from '@auxx/database/types'
 import { BaseType } from '@auxx/lib/workflow-engine/client'
 import { Button } from '@auxx/ui/components/button'
@@ -12,9 +13,9 @@ import { FileText, Lightbulb, Search, Sparkles, Zap } from 'lucide-react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { SettingsSection } from '~/components/global/settings-page'
-import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 import { api } from '~/trpc/react'
 
 interface SearchConfigurationSectionProps {
@@ -197,10 +198,10 @@ export function SearchConfigurationSection({
               description='Minimum similarity score (0.0 - 1.0)'
               type={BaseType.NUMBER}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.NUMBER}
                 value={form.watch('similarityThreshold') ?? ''}
-                onChange={(_, val) => form.setValue('similarityThreshold', val)}
-                varType={BaseType.NUMBER}
+                onChange={(val) => form.setValue('similarityThreshold', val as number)}
                 placeholder='0.7'
                 disabled={readOnly}
               />
@@ -211,10 +212,10 @@ export function SearchConfigurationSection({
               description='Maximum number of results to return'
               type={BaseType.NUMBER}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.NUMBER}
                 value={form.watch('maxResults') ?? ''}
-                onChange={(_, val) => form.setValue('maxResults', val)}
-                varType={BaseType.NUMBER}
+                onChange={(val) => form.setValue('maxResults', val as number)}
                 placeholder='20'
                 disabled={readOnly}
               />
@@ -225,10 +226,10 @@ export function SearchConfigurationSection({
               description='Include document metadata in results'
               type={BaseType.BOOLEAN}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.CHECKBOX}
                 value={form.watch('includeMetadata') ?? false}
-                onChange={(_, val) => form.setValue('includeMetadata', val)}
-                varType={BaseType.BOOLEAN}
+                onChange={(val) => form.setValue('includeMetadata', val as boolean)}
                 fieldOptions={{ variant: 'switch' }}
                 disabled={readOnly}
               />
@@ -239,12 +240,17 @@ export function SearchConfigurationSection({
               description='Algorithm for selecting and ranking results'
               type={BaseType.ENUM}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.SINGLE_SELECT}
                 value={form.watch('searchMode') ?? ''}
-                onChange={(_, val) => form.setValue('searchMode', val)}
-                varType={BaseType.ENUM}
+                onChange={(val) =>
+                  form.setValue(
+                    'searchMode',
+                    (val as string[])[0] as 'similarity' | 'mmr' | 'similarity_score_threshold'
+                  )
+                }
                 fieldOptions={{
-                  enum: [
+                  options: [
                     { label: 'Similarity', value: 'similarity' },
                     { label: 'MMR (Max Marginal Relevance)', value: 'mmr' },
                     { label: 'Score Threshold', value: 'similarity_score_threshold' },
@@ -264,10 +270,10 @@ export function SearchConfigurationSection({
               description='Enable fuzzy matching for typos and variations'
               type={BaseType.BOOLEAN}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.CHECKBOX}
                 value={form.watch('fuzzySearch') ?? false}
-                onChange={(_, val) => form.setValue('fuzzySearch', val)}
-                varType={BaseType.BOOLEAN}
+                onChange={(val) => form.setValue('fuzzySearch', val as boolean)}
                 fieldOptions={{ variant: 'switch' }}
                 disabled={readOnly}
               />
@@ -278,10 +284,10 @@ export function SearchConfigurationSection({
               description='Enable exact phrase matching with quotes'
               type={BaseType.BOOLEAN}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.CHECKBOX}
                 value={form.watch('phraseSearch') ?? false}
-                onChange={(_, val) => form.setValue('phraseSearch', val)}
-                varType={BaseType.BOOLEAN}
+                onChange={(val) => form.setValue('phraseSearch', val as boolean)}
                 fieldOptions={{ variant: 'switch' }}
                 disabled={readOnly}
               />
@@ -292,10 +298,10 @@ export function SearchConfigurationSection({
               description='Support AND, OR, NOT operators in queries'
               type={BaseType.BOOLEAN}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.CHECKBOX}
                 value={form.watch('booleanMode') ?? false}
-                onChange={(_, val) => form.setValue('booleanMode', val)}
-                varType={BaseType.BOOLEAN}
+                onChange={(val) => form.setValue('booleanMode', val as boolean)}
                 fieldOptions={{ variant: 'switch' }}
                 disabled={readOnly}
               />
@@ -306,12 +312,14 @@ export function SearchConfigurationSection({
               description='Algorithm for scoring and ranking text matches'
               type={BaseType.ENUM}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.SINGLE_SELECT}
                 value={form.watch('rankingMode') ?? ''}
-                onChange={(_, val) => form.setValue('rankingMode', val)}
-                varType={BaseType.ENUM}
+                onChange={(val) =>
+                  form.setValue('rankingMode', (val as string[])[0] as 'bm25' | 'tfidf')
+                }
                 fieldOptions={{
-                  enum: [
+                  options: [
                     { label: 'BM25 (Best Match)', value: 'bm25' },
                     { label: 'TF-IDF', value: 'tfidf' },
                   ],
@@ -326,10 +334,10 @@ export function SearchConfigurationSection({
               description='Minimum relevance score to include results'
               type={BaseType.NUMBER}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.NUMBER}
                 value={form.watch('minScore') ?? ''}
-                onChange={(_, val) => form.setValue('minScore', val)}
-                varType={BaseType.NUMBER}
+                onChange={(val) => form.setValue('minScore', val as number)}
                 placeholder='0.1'
                 disabled={readOnly}
               />
@@ -344,10 +352,10 @@ export function SearchConfigurationSection({
               description='Weight for vector search results (0.0 - 1.0)'
               type={BaseType.NUMBER}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.NUMBER}
                 value={form.watch('vectorWeight') ?? ''}
-                onChange={(_, val) => form.setValue('vectorWeight', val)}
-                varType={BaseType.NUMBER}
+                onChange={(val) => form.setValue('vectorWeight', val as number)}
                 placeholder='0.6'
                 disabled={readOnly}
               />
@@ -358,10 +366,10 @@ export function SearchConfigurationSection({
               description='Weight for text search results (0.0 - 1.0)'
               type={BaseType.NUMBER}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.NUMBER}
                 value={form.watch('textWeight') ?? ''}
-                onChange={(_, val) => form.setValue('textWeight', val)}
-                varType={BaseType.NUMBER}
+                onChange={(val) => form.setValue('textWeight', val as number)}
                 placeholder='0.4'
                 disabled={readOnly}
               />
@@ -372,12 +380,17 @@ export function SearchConfigurationSection({
               description='Method for combining vector and text results'
               type={BaseType.ENUM}
               showIcon={true}>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.SINGLE_SELECT}
                 value={form.watch('combineMethod') ?? ''}
-                onChange={(_, val) => form.setValue('combineMethod', val)}
-                varType={BaseType.ENUM}
+                onChange={(val) =>
+                  form.setValue(
+                    'combineMethod',
+                    (val as string[])[0] as 'rrf' | 'weighted_sum' | 'linear_combination'
+                  )
+                }
                 fieldOptions={{
-                  enum: [
+                  options: [
                     { label: 'Weighted Sum', value: 'weighted_sum' },
                     { label: 'Reciprocal Rank Fusion', value: 'rrf' },
                     { label: 'Linear Combination', value: 'linear_combination' },

--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -250,6 +250,7 @@ export function FieldInputAdapter({
             placeholder={placeholder}
             disabled={disabled}
             onCreate={handleOpenCreate}
+            excludeIds={fieldOptions?.excludeIds}
             triggerProps={triggerProps}
             open={open}
             onOpenChange={onOpenChange}

--- a/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import { type RecordId, toRecordId } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -15,12 +16,12 @@ import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { BaseType } from '~/components/workflow/types'
-import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 import { api } from '~/trpc/react'
 import {
   defaultVendorPartValues,
@@ -255,10 +256,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
             isRequired
             validationError={errors.title}
             validationType='error'>
-            <ConstantInputAdapter
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
               value={values.title}
-              onChange={(_, val) => handleChange('title', val)}
-              varType={BaseType.STRING}
+              onChange={(val) => handleChange('title', val)}
               placeholder='Part name'
               disabled={isPending}
             />
@@ -274,10 +275,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
             isRequired
             validationError={errors.sku}
             validationType='error'>
-            <ConstantInputAdapter
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
               value={values.sku}
-              onChange={(_, val) => handleChange('sku', val)}
-              varType={BaseType.STRING}
+              onChange={(val) => handleChange('sku', val)}
               placeholder='Unique part number'
               disabled={isPending}
             />
@@ -285,10 +286,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
 
           {/* Category */}
           <FieldPanelRow title='Category' type={BaseType.STRING} showIcon orientation='responsive'>
-            <ConstantInputAdapter
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
               value={values.category}
-              onChange={(_, val) => handleChange('category', val)}
-              varType={BaseType.STRING}
+              onChange={(val) => handleChange('category', val)}
               placeholder='Category'
               disabled={isPending}
             />
@@ -301,10 +302,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
             type={BaseType.STRING}
             orientation='responsive'
             showIcon>
-            <ConstantInputAdapter
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
               value={values.hsCode}
-              onChange={(_, val) => handleChange('hsCode', val)}
-              varType={BaseType.STRING}
+              onChange={(val) => handleChange('hsCode', val)}
               placeholder='Harmonized System Code'
               disabled={isPending}
             />
@@ -317,10 +318,10 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
             orientation='responsive'
             type={BaseType.STRING}
             showIcon>
-            <ConstantInputAdapter
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
               value={values.shopifyProductLinkId}
-              onChange={(_, val) => handleChange('shopifyProductLinkId', val)}
-              varType={BaseType.STRING}
+              onChange={(val) => handleChange('shopifyProductLinkId', val)}
               placeholder='Shopify Product ID (optional)'
               disabled={isPending}
             />
@@ -332,13 +333,13 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
             type={BaseType.STRING}
             orientation='responsive'
             showIcon>
-            <ConstantInputAdapter
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
               value={values.description}
-              onChange={(_, val) => handleChange('description', val)}
-              varType={BaseType.STRING}
+              onChange={(val) => handleChange('description', val)}
               placeholder='Enter a detailed description of the part'
               disabled={isPending}
-              fieldOptions={{ string: { multiline: true } }}
+              fieldOptions={{ multiline: true }}
             />
           </FieldPanelRow>
         </FieldPanel>

--- a/apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
+++ b/apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
@@ -1,14 +1,15 @@
 // apps/web/src/components/manufacturing/parts/stock-adjustment-popover.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { toRecordId, useResourceProperty } from '~/components/resources'
 import { BaseType } from '~/components/workflow/types'
-import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 import { api } from '~/trpc/react'
 
 type Direction = 'add' | 'remove'
@@ -117,9 +118,8 @@ export function StockAdjustmentPopover({
   const isSetToMode = quantityMode === 'set_to'
   const isPending = createRecord.isPending
 
-  const directionFieldOptions = useMemo(() => ({ enum: DIRECTION_OPTIONS }), [])
-  const quantityModeFieldOptions = useMemo(() => ({ enum: QUANTITY_MODE_OPTIONS }), [])
-  const quantityFieldOptions = useMemo(() => ({ number: { min: 0 } }), [])
+  const directionFieldOptions = useMemo(() => ({ options: DIRECTION_OPTIONS }), [])
+  const quantityModeFieldOptions = useMemo(() => ({ options: QUANTITY_MODE_OPTIONS }), [])
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -136,14 +136,14 @@ export function StockAdjustmentPopover({
               showIcon
               isRequired
               description='Adjust by a relative amount or set to an absolute quantity'>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.SINGLE_SELECT}
                 value={quantityMode}
-                onChange={(_, val) => {
-                  const mode = (val as QuantityMode) ?? 'adjust_by'
+                onChange={(val) => {
+                  const mode = ((val as string[])[0] as QuantityMode) ?? 'adjust_by'
                   setQuantityMode(mode)
                   if (mode === 'set_to') setAdjustSubparts(false)
                 }}
-                varType={BaseType.ENUM}
                 fieldOptions={quantityModeFieldOptions}
                 disabled={isPending}
               />
@@ -157,10 +157,10 @@ export function StockAdjustmentPopover({
                 showIcon
                 isRequired
                 description='Whether to add or remove stock'>
-                <ConstantInputAdapter
+                <FieldInputAdapter
+                  fieldType={FieldType.SINGLE_SELECT}
                   value={direction}
-                  onChange={(_, val) => setDirection((val as Direction) ?? 'add')}
-                  varType={BaseType.ENUM}
+                  onChange={(val) => setDirection(((val as string[])[0] as Direction) ?? 'add')}
                   fieldOptions={directionFieldOptions}
                   disabled={isPending}
                 />
@@ -169,13 +169,12 @@ export function StockAdjustmentPopover({
 
             {/* Quantity */}
             <FieldPanelRow title='Quantity' type={BaseType.NUMBER} showIcon isRequired>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.NUMBER}
                 value={quantity}
-                onChange={(_, val) => setQuantity(val ?? null)}
-                varType={BaseType.NUMBER}
+                onChange={(val) => setQuantity((val as number) ?? null)}
                 placeholder={isSetToMode ? String(currentQoH) : '0'}
                 disabled={isPending}
-                fieldOptions={quantityFieldOptions}
               />
               {isSetToMode && quantity !== null && (
                 <p className='text-xs text-muted-foreground mt-1'>
@@ -187,10 +186,10 @@ export function StockAdjustmentPopover({
 
             {/* Reason */}
             <FieldPanelRow title='Reason' type={BaseType.STRING} showIcon>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.TEXT}
                 value={reason}
-                onChange={(_, val) => setReason(val ?? '')}
-                varType={BaseType.STRING}
+                onChange={(val) => setReason((val as string) ?? '')}
                 placeholder='e.g. Recount, Damaged goods'
                 disabled={isPending}
               />
@@ -198,10 +197,10 @@ export function StockAdjustmentPopover({
 
             {/* Reference */}
             <FieldPanelRow title='Reference' type={BaseType.STRING} showIcon>
-              <ConstantInputAdapter
+              <FieldInputAdapter
+                fieldType={FieldType.TEXT}
                 value={reference}
-                onChange={(_, val) => setReference(val ?? '')}
-                varType={BaseType.STRING}
+                onChange={(val) => setReference((val as string) ?? '')}
                 placeholder='e.g. PO-1234, RMA-567'
                 disabled={isPending}
               />
@@ -214,10 +213,10 @@ export function StockAdjustmentPopover({
                 type={BaseType.BOOLEAN}
                 showIcon
                 description='Cascade this adjustment to all leaf component parts based on the bill of materials'>
-                <ConstantInputAdapter
+                <FieldInputAdapter
+                  fieldType={FieldType.CHECKBOX}
                   value={adjustSubparts}
-                  onChange={(_, val) => setAdjustSubparts(val ?? false)}
-                  varType={BaseType.BOOLEAN}
+                  onChange={(val) => setAdjustSubparts((val as boolean) ?? false)}
                   fieldOptions={{ variant: 'switch' }}
                   disabled={isPending}
                 />

--- a/apps/web/src/components/manufacturing/parts/subpart-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/subpart-dialog.tsx
@@ -1,9 +1,11 @@
 // apps/web/src/components/manufacturing/parts/subpart-dialog.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { getInstanceId, isRecordId, type RecordId } from '@auxx/lib/resources/client'
-import type { ResourceFieldId } from '@auxx/types/field'
+import type { RelationshipConfig } from '@auxx/types/custom-field'
+import { type ResourceFieldId, toResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
@@ -16,13 +18,20 @@ import {
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { BaseType } from '~/components/workflow/types'
-import { ConstantInputAdapter } from '~/components/workflow/ui/input-editor/constant-input-adapter'
 import { api } from '~/trpc/react'
+
+/** Synthetic relationship config for the ad-hoc "child part" picker (not backed by a real field) */
+const CHILD_PART_RELATIONSHIP: RelationshipConfig = {
+  inverseResourceFieldId: toResourceFieldId('part', 'id'),
+  relationshipType: 'belongs_to',
+  isInverse: false,
+}
 
 const SUBPART_SYSTEM_ATTRIBUTES = [
   'subpart_child_part',
@@ -108,26 +117,24 @@ export function SubpartDialog({
 
   // Build exclusion set: parent part + descendants + already-added child parts
   const excludedPartIds = useMemo(() => {
-    const ids: string[] = [parentPartId]
+    const ids: RecordId[] = [toRecordId(partDefId ?? 'part', parentPartId)]
 
-    // Add descendant instance IDs (prevents cycles)
+    // Add descendant RecordIds (prevents cycles)
     if (descendants) {
-      for (const rid of descendants) {
-        ids.push(getInstanceId(rid))
-      }
+      ids.push(...descendants)
     }
 
-    // Add existing child part IDs (prevents duplicates)
+    // Add existing child part RecordIds (prevents duplicates)
     for (const record of existingSubpartRecords) {
       // record.systemValues may contain the child part reference
       const childVal = (record as any).fieldValues?.subpart_child_part
       if (childVal && isRecordId(childVal)) {
-        ids.push(getInstanceId(childVal))
+        ids.push(childVal)
       }
     }
 
     return [...new Set(ids)]
-  }, [parentPartId, descendants, existingSubpartRecords])
+  }, [parentPartId, partDefId, descendants, existingSubpartRecords])
 
   // Initialize/reset values when dialog opens
   useEffect(() => {
@@ -169,12 +176,12 @@ export function SubpartDialog({
     })
   }, [])
 
-  // Handle childPartId change — extract instance ID from RecordId if needed
+  // Handle childPartId change — extract instance ID from the selected RecordId
   const handleChildPartChange = useCallback(
-    (_: string, value: any) => {
-      const rawValue = typeof value === 'string' ? value : ''
-      const instanceId = isRecordId(rawValue) ? getInstanceId(rawValue) : rawValue
-      handleChange('childPartId', instanceId)
+    (value: unknown) => {
+      const recordIds = value as RecordId[]
+      const first = recordIds[0]
+      handleChange('childPartId', first ? getInstanceId(first) : '')
     },
     [handleChange]
   )
@@ -258,15 +265,14 @@ export function SubpartDialog({
             description='Component to add'
             isRequired
             validationError={errors.childPartId}>
-            <ConstantInputAdapter
-              value={childPartRecordId}
+            <FieldInputAdapter
+              fieldType={FieldType.RELATIONSHIP}
+              value={childPartRecordId ? [childPartRecordId] : []}
               onChange={handleChildPartChange}
-              varType={BaseType.RELATION}
               placeholder='Select a component...'
               disabled={isPending || isEditMode}
               fieldOptions={{
-                relatedEntityDefinitionId: 'part',
-                relationshipType: 'belongs_to',
+                relationship: CHILD_PART_RELATIONSHIP,
                 excludeIds: isEditMode ? undefined : excludedPartIds,
               }}
             />
@@ -281,10 +287,10 @@ export function SubpartDialog({
             isRequired
             validationError={errors.quantity}
             validationType='error'>
-            <ConstantInputAdapter
+            <FieldInputAdapter
+              fieldType={FieldType.NUMBER}
               value={values.quantity}
-              onChange={(_, val) => handleChange('quantity', val ?? 1)}
-              varType={BaseType.NUMBER}
+              onChange={(val) => handleChange('quantity', val ?? 1)}
               placeholder='1'
               disabled={isPending}
             />
@@ -296,13 +302,13 @@ export function SubpartDialog({
             description='Optional notes about this component usage'
             type={BaseType.STRING}
             showIcon>
-            <ConstantInputAdapter
+            <FieldInputAdapter
+              fieldType={FieldType.TEXT}
               value={values.notes}
-              onChange={(_, val) => handleChange('notes', val ?? '')}
-              varType={BaseType.STRING}
+              onChange={(val) => handleChange('notes', val ?? '')}
               placeholder='Optional notes...'
               disabled={isPending}
-              fieldOptions={{ string: { multiline: true } }}
+              fieldOptions={{ multiline: true }}
             />
           </FieldPanelRow>
         </FieldPanel>

--- a/apps/web/src/components/shared/multi-relation-input.tsx
+++ b/apps/web/src/components/shared/multi-relation-input.tsx
@@ -44,8 +44,8 @@ export interface MultiRelationInputProps {
   /** Allow multiple selections (default: true) */
   multi?: boolean
 
-  /** IDs to exclude from search results (entityInstanceIds) */
-  excludeIds?: string[]
+  /** RecordIds to exclude from search results */
+  excludeIds?: RecordId[]
 
   /** Callback when "Create new" is clicked (for complex creation flows via dialog) */
   onCreate?: () => void
@@ -126,7 +126,7 @@ export function MultiRelationInput({
   const selectOptions = useMemo(() => {
     const items = searchResults?.items || []
     return items
-      .filter((item) => !excludeIds.includes(item.id))
+      .filter((item) => !excludeIds.includes(item.recordId as RecordId))
       .map((item) => ({
         label: item.displayName,
         value: item.recordId,

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/relation-input.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/relation-input.tsx
@@ -32,8 +32,8 @@ interface RelationInputProps extends NodeInputProps {
   relatedEntityDefinitionId?: string
   /** Relationship cardinality type (has_many, belongs_to, etc.) */
   relationshipType?: RelationshipType
-  /** Entity instance IDs to exclude from picker results */
-  excludeIds?: string[]
+  /** RecordIds to exclude from picker results */
+  excludeIds?: RecordId[]
   /** Whether to show the clear button on the picker trigger (defaults to multi value) */
   showClear?: boolean
 }

--- a/apps/web/src/components/workflow/ui/input-editor/get-input-component.ts
+++ b/apps/web/src/components/workflow/ui/input-editor/get-input-component.ts
@@ -1,6 +1,7 @@
 // apps/web/src/components/workflow/ui/input-editor/get-input-component.ts
 
 import type { RelationshipType } from '@auxx/types/custom-field'
+import type { RecordId } from '@auxx/types/resource'
 import {
   ActorInput,
   AddressInput,
@@ -98,8 +99,8 @@ export interface FieldOptions {
   relatedEntityDefinitionId?: string
   /** For RELATION types - relationship cardinality (has_many, belongs_to, etc.) */
   relationshipType?: RelationshipType
-  /** For RELATION types - entity instance IDs to exclude from picker results */
-  excludeIds?: string[]
+  /** For RELATION types - RecordIds to exclude from picker results */
+  excludeIds?: RecordId[]
   /** For ACTOR type — actor picker configuration */
   actor?: { target?: 'user' | 'group' | 'both'; multiple?: boolean }
   /** For MULTI_SELECT type — triggers MultiSelectInput instead of ArrayInput */

--- a/packages/lib/src/custom-fields/field-options.ts
+++ b/packages/lib/src/custom-fields/field-options.ts
@@ -2,6 +2,7 @@
 
 import type { FieldType } from '@auxx/database/types'
 import type { ActorOptions, RelationshipConfig, SelectOptionColor } from '@auxx/types/custom-field'
+import type { RecordId } from '@auxx/types/resource'
 
 /**
  * Unified field options interface.
@@ -97,6 +98,11 @@ export interface FieldOptions {
   // RELATIONSHIP (nested - uses RelationshipConfig from @auxx/types/custom-field)
   // ─────────────────────────────────────────────────────────────
   relationship?: RelationshipConfig
+  /**
+   * RecordIds to exclude from RELATIONSHIP picker results (e.g. cycle/duplicate prevention).
+   * Runtime-only filter passed by the caller — never persisted to CustomField.options.
+   */
+  excludeIds?: RecordId[]
 
   // ─────────────────────────────────────────────────────────────
   // ACTOR (nested - uses ActorOptions from @auxx/types/custom-field)


### PR DESCRIPTION
## Summary
- Migrates non-workflow form dialogs off the workflow-only `ConstantInputAdapter` onto `FieldInputAdapter` (the entity-field-aware input renderer), for consistency: `part-form-dialog.tsx`, `subpart-dialog.tsx`, `stock-adjustment-popover.tsx` (manufacturing/parts), `ticket-number-form.tsx`, dataset `search-configuration-section.tsx` / `chunking-settings-section.tsx`, and `text-options-editor.tsx`.
- Ad-hoc `ENUM` option lists (not backed by a real entity field) now pass through as `FieldType.SINGLE_SELECT` with `fieldOptions.options`; since `FieldInputAdapter`'s select input always returns an array, call sites unwrap with `val[0]`.
- Closes a parity gap: `FieldInputAdapter`'s RELATIONSHIP case didn't forward `excludeIds` to `MultiRelationInput` even though the underlying component and the workflow-side `RelationInput` both support it. Added `excludeIds?: RecordId[]` to `FieldOptions` (runtime-only, never persisted) and threaded it through `FieldInputAdapter` → `MultiRelationInput`.
- Unified `excludeIds` on `MultiRelationInput` from a plain `entityInstanceId` string array to `RecordId[]`, matching how the rest of the codebase identifies records; updated `subpart-dialog.tsx`'s exclusion-set builder and the workflow-side `RelationInput`/`get-input-component.ts` to match.

## Test plan
- [x] `pnpm biome check` clean on all touched files (pre-existing unrelated warnings untouched)
- [ ] Manually exercise: create/edit a Part with a vendor supplier section, add/edit a Subpart (verify cycle/duplicate exclusion still works), adjust stock via the popover, ticket numbering settings, dataset search/chunking settings, custom text field options editor