### PR TITLE
feat(data-connectors): app icons + connector descriptions in source picker

### DIFF
--- a/apps/web/src/components/data-connectors/ui/source-template-dialog.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-template-dialog.tsx
@@ -9,6 +9,7 @@ import { toastError } from '@auxx/ui/components/toast'
 import { Boxes, CreditCard, Database, Github, Globe, Plug } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { type ComponentType, useMemo, useState } from 'react'
+import { AppIcon } from '~/components/apps/ui/app-icon'
 import { type TemplateGalleryCategory, TemplateGalleryDialog } from '~/components/templates/ui'
 import { api } from '~/trpc/react'
 
@@ -27,7 +28,7 @@ type SourceItem = {
 } & (
   | { kind: 'builtin'; type: 'generic-rest' }
   | { kind: 'template'; templateId: string; requiresConnection: boolean }
-  | { kind: 'app'; type: string; requiresConnection: boolean }
+  | { kind: 'app'; type: string; requiresConnection: boolean; appIconId: string }
 )
 
 /** Map a catalog `iconKey` to a lucide icon (server sends a stable key, not a component). */
@@ -113,12 +114,13 @@ export function SourceTemplateDialog({ open, onOpenChange }: SourceTemplateDialo
     const appItems: SourceItem[] = data.apps.map((a) => ({
       id: `app:${a.connectorId}`,
       name: a.label,
-      description: '',
+      description: a.description,
       categories: ['apps'],
       iconKey: a.iconKey,
       kind: 'app',
       type: a.type,
       requiresConnection: a.requiresConnection,
+      appIconId: a.appIconId,
     }))
     return [...(builtinItem ? [builtinItem] : []), ...templateItems, ...appItems]
   }, [catalog.data])
@@ -172,8 +174,12 @@ export function SourceTemplateDialog({ open, onOpenChange }: SourceTemplateDialo
       renderIcon={(item) => {
         const Icon = iconFor(item.iconKey)
         return (
-          <div className='flex size-8 shrink-0 items-center justify-center rounded-lg border bg-background'>
-            <Icon className='size-4' />
+          <div className='flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-background'>
+            {item.kind === 'app' ? (
+              <AppIcon iconId={item.appIconId} size='lg' />
+            ) : (
+              <Icon className='size-4' />
+            )}
           </div>
         )
       }}

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -221,7 +221,13 @@ export const dataConnectorRouter = createTRPCRouter({
         type: `app:${app.app.slug}`,
         connectorId: dc.id,
         label: dc.label,
+        // Connector-declared description, falling back to the app's own so a
+        // connector that omits one still reads meaningfully in the picker.
+        description: dc.description ?? app.app.description ?? '',
         iconKey: dc.iconKey,
+        // The app's real logo (raw URL) → rendered via `AppIcon`; falls back to
+        // the generic `package` glyph. Same cascade as installed-apps-provider.
+        appIconId: app.app.avatarUrl ?? 'package',
         requiresConnection: dc.requiresConnection,
         requestModel: dc.requestModel ?? ('fixed' as const),
       }))

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -306,6 +306,8 @@ export interface CatalogConnectorStream {
 export interface CatalogDataConnector {
   id: string
   label: string
+  /** One-line description shown in the connect-a-source picker (optional). */
+  description: string | null
   requiresConnection: boolean
   iconKey: string | null
   /**

--- a/packages/sdk/__fixtures__/connector-app/src/shopify-core.connector.ts
+++ b/packages/sdk/__fixtures__/connector-app/src/shopify-core.connector.ts
@@ -17,6 +17,7 @@ import shopifyCoreSync from './shopify-core.connector.server'
 export const shopifyCoreDataConnector = defineDataConnector({
   id: 'shopify.core',
   label: 'Shopify Core Data',
+  description: 'Sync orders and customers from Shopify.',
   requiresConnection: true,
   iconKey: 'shopping-bag',
   webhookTrigger: { triggerId: 'shopify.shopify-trigger' },

--- a/packages/sdk/src/root/data-connectors/define-data-connector.ts
+++ b/packages/sdk/src/root/data-connectors/define-data-connector.ts
@@ -42,6 +42,7 @@ const CONNECTOR_ID_RE = /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/
  * export const shopifyCoreDataConnector = defineDataConnector({
  *   id: 'shopify.core',
  *   label: 'Shopify Core Data',
+ *   description: 'Sync orders, products, and customers from your Shopify store.',
  *   requiresConnection: true,
  *   config: z.object({ includeDraftProducts: z.boolean().default(false) }),
  *   streams: [{ key: 'order', displayFieldKey: 'name', fields: { ... } }],

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -327,6 +327,8 @@ export interface DataConnectorDefinition<TConfigSchema extends z.ZodTypeAny = z.
   id: string
   /** Human label shown in the connector picker. */
   label: string
+  /** One-line description shown in the connect-a-source picker. */
+  description?: string
   /** Whether the connector needs the app's OAuth connection to fetch. */
   requiresConnection: boolean
   /** Connector-level config schema (filters, toggles). */

--- a/packages/sdk/src/util/__tests__/compile-and-extract-catalog-connectors.test.ts
+++ b/packages/sdk/src/util/__tests__/compile-and-extract-catalog-connectors.test.ts
@@ -38,6 +38,7 @@ describe('compileAndExtractCatalog — data connectors', () => {
     expect(connector).toMatchObject({
       id: 'shopify.core',
       label: 'Shopify Core Data',
+      description: 'Sync orders and customers from Shopify.',
       requiresConnection: true,
       iconKey: 'shopping-bag',
       webhookTrigger: { triggerId: 'shopify.shopify-trigger' },

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -264,6 +264,8 @@ export interface CatalogConnectorStream {
 export interface CatalogDataConnector {
   id: string
   label: string
+  /** One-line description shown in the connect-a-source picker (optional). */
+  description: string | null
   requiresConnection: boolean
   iconKey: string | null
   /** Connector-level config schema (JSON Schema, from the `config` zod schema). */
@@ -783,6 +785,7 @@ export async function compileAndExtractCatalog(): Promise<
     cataloguedDataConnectors.push({
       id: connector.id,
       label: connector.label,
+      description: connector.description ?? null,
       requiresConnection: Boolean(connector.requiresConnection),
       iconKey: connector.iconKey ?? null,
       configJsonSchema,
@@ -953,6 +956,7 @@ interface RawConnectorStream {
 interface RawDataConnector {
   id: string
   label: string
+  description?: string
   requiresConnection?: boolean
   iconKey?: string
   /** zod schema — projected to JSON Schema via zodToProviderToolSchema. */


### PR DESCRIPTION
## What

The **Connect a source** dialog now shows the app's real logo and a per-connector description for app connectors — instead of a generic lucide glyph and an empty description.

## Why

App connectors in the picker previously rendered with a placeholder lucide icon and no description, making them hard to recognize and unhelpful next to the richly-described templates.

## Changes

**App icons** (data was already cached):
- `dataConnector.catalog` tRPC now sends `appIconId` (`app.avatarUrl ?? 'package'`).
- `source-template-dialog` renders app items via the existing `AppIcon` (handles raw URLs + `package` fallback); templates/builtins keep their lucide glyph.

**Connector descriptions** (new authoring field):
- Added optional `description` to the SDK `DataConnectorDefinition`.
- Threaded it through both hand-synced `CatalogDataConnector` mirrors (`app-deployment.ts` + the extractor), the catalog extractor projection, and the tRPC `catalog` projection — falling back to the app's own description when a connector omits one.
- Populated the dialog's app-item description (renders automatically in the gallery list + detail).
- Covered the new field in the connector extractor test + fixture.

No DB migration (`catalog` is jsonb; older stored catalogs lack the field and hit the fallback). No cache-provider change (it forwards `catalog.dataConnectors` verbatim).

## Companion change

The Shopify connector in the `auxxai-apps` sister repo gains a `description`; it surfaces once that app is rebuilt with the updated SDK, with the app-description fallback covering the interim.

## Test

- `pnpm --filter @auxx/sdk test compile-and-extract-catalog-connectors` passes.
- Biome clean on all edited files.