### PR TITLE
fix(realtime): serve notification sounds + unify on new-message cue

### DIFF
--- a/apps/web/src/components/global/notifications/notification-center.tsx
+++ b/apps/web/src/components/global/notifications/notification-center.tsx
@@ -28,7 +28,7 @@ import { useEffect, useRef, useState } from 'react'
 import { HumanConfirmationDialog } from '~/components/workflow/dialogs/human-confirmation-dialog'
 import { useIsMobile } from '~/hooks/use-mobile'
 import { useUser } from '~/hooks/use-user'
-import { NEW_NOTIFICATION_SOUND, playNotificationSound } from '~/lib/play-notification-sound'
+import { NEW_MESSAGE_SOUND, playNotificationSound } from '~/lib/play-notification-sound'
 import { useDehydratedSettings } from '~/providers/dehydrated-state-provider'
 import { useRealtimeRoom } from '~/realtime/hooks'
 import { api } from '~/trpc/react'
@@ -175,7 +175,7 @@ export const NotificationCenter = () => {
     selectedApprovalId: undefined as string | undefined,
   })
   // Mock pending actions count - replace with actual API call when available
-  const pendingActionsCount = 3
+
   // Get notifications
   const {
     data,
@@ -475,7 +475,7 @@ export function useNotificationSubscription(userId: string) {
               count: (prev?.count ?? 0) + 1,
             }))
             // Chime in step with the badge tick, gated on the preference.
-            if (bellSoundRef.current) playNotificationSound(NEW_NOTIFICATION_SOUND)
+            if (bellSoundRef.current) playNotificationSound(NEW_MESSAGE_SOUND)
           }
           // The dropdown list spans all orgs and only fetches while open, so
           // invalidate is a no-op when closed and refetches fresh (with the

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -154,7 +154,7 @@ export async function proxy(req: NextRequest) {
 export const config = {
   matcher: [
     // Skip Next.js internals and all static files, unless found in search params
-    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|mp4|webm|ogg)).*)',
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|mp3|mp4|webm|ogg|wav|m4a|aac)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
   ],


### PR DESCRIPTION
## Problem

Notification sounds were **completely broken** — silently, for every user. The Next.js 16 proxy (`apps/web/src/proxy.ts`, renamed from `middleware.ts`) skips static files by extension, but the exclusion list omitted `mp3` (it had `mp4|webm|ogg`).

So `/sounds/new-notification.mp3` fell through to the proxy's org-handle detection → first segment `sounds` isn't a known route prefix → treated as an org handle → 307 to `/new-notification.mp3` → `/app` → auth HTML. The `<audio>` element loaded HTML and threw `MEDIA_ELEMENT_ERROR: Format error`. No sound, no console error.

This affected **both** cues, since both play `/sounds/*.mp3`:
- 🔔 notification bell — `notification-center.tsx` (mentions/approvals/record-rule `notify`)
- 💬 new-message arrival — `use-message-arrival-cue.tsx`

## Changes

1. **`proxy.ts`** — add `mp3` (plus `wav|m4a|aac`) to the static-file exclusion matcher so audio assets bypass the proxy and serve from `public/`.
2. **`notification-center.tsx`** — point the notification bell at `NEW_MESSAGE_SOUND` so both cues share one sound. `new-notification.mp3` and its constant are kept (one-line revert).

## Verification

- `curl /sounds/new-notification.mp3` → `200 audio/mpeg`, **0 redirects** (was 307 → HTML).
- In the authenticated browser: fetched all 36864 bytes; played through the exact `new Audio(src).play()` path the app uses — `playing: true`, `readyState: 4`, `currentTime` advanced. Both sounds confirmed audible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)