### PR TITLE
feat(inventory-bridge): fold linked sources into part inventory card

### DIFF
--- a/apps/web/src/components/drawers/cards/part-inventory-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-inventory-card.tsx
@@ -20,6 +20,7 @@ import { StockAdjustmentPopover } from '~/components/manufacturing/parts/stock-a
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import type { DrawerTabProps } from '../drawer-tab-registry'
+import { PartLinkedInventorySection } from './part-linked-inventory-card'
 
 /** Map movement type values to badge color variants */
 const TYPE_COLOR_MAP: Record<string, Variant> = Object.fromEntries(
@@ -306,6 +307,9 @@ export function PartInventoryCard({ recordId, entityInstanceId }: DrawerTabProps
             </motion.div>
           )}
         </AnimatePresence>
+
+        {/* Synced inventory feeds (v9 bridge) — renders only when the part has links */}
+        <PartLinkedInventorySection partId={partId} />
       </div>
     </div>
   )

--- a/apps/web/src/components/drawers/cards/part-inventory-tab.tsx
+++ b/apps/web/src/components/drawers/cards/part-inventory-tab.tsx
@@ -3,17 +3,15 @@
 
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import { PartInventoryCard } from './part-inventory-card'
-import { PartLinkedInventoryCard } from './part-linked-inventory-card'
 
 /**
- * The part "Inventory" tab: the stock/movements card plus the linked inventory-sources console
- * (v9 bridge — renders only when the part has links).
+ * The part "Inventory" tab: the stock/movements card, which now also folds in the linked
+ * inventory-sources console (v9 bridge) as a section when the part has synced feeds.
  */
 export function PartInventoryTab(props: DrawerTabProps) {
   return (
     <div className='flex flex-col gap-3'>
       <PartInventoryCard {...props} />
-      <PartLinkedInventoryCard partId={props.entityInstanceId} />
     </div>
   )
 }

--- a/apps/web/src/components/drawers/cards/part-linked-inventory-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-linked-inventory-card.tsx
@@ -5,21 +5,23 @@ import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { ResourceBadge } from '~/components/resources/ui/resource-badge'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 
-interface PartLinkedInventoryCardProps {
+interface PartLinkedInventorySectionProps {
   /** The part's entityInstanceId. */
   partId: string
 }
 
 /**
- * Option F console — every inventory source linked to this part, with its watermark, the
- * source's current level, and (for confirm-mode links) a pending consumption delta the user
- * applies. Renders nothing when the part has no links. Divergence is signal, not error: a part
- * QoH below the source level just means stock was written off in auxx (auxx-ledger-truth).
+ * Synced-inventory section of the part inventory card: each external stock feed linked to this
+ * part with its current level, and — in confirm mode — the units it wants to deduct. Auto-deduct
+ * keeps the part in lock-step with the source; confirm mode holds the deduction for review.
+ * Renders nothing when the part has no linked feeds. Designed to nest inside `PartInventoryCard`.
  */
-export function PartLinkedInventoryCard({ partId }: PartLinkedInventoryCardProps) {
+export function PartLinkedInventorySection({ partId }: PartLinkedInventorySectionProps) {
   const [confirm, ConfirmDialog] = useConfirm()
   const utils = api.useUtils()
   const { data: links } = api.inventoryBridge.linksForPart.useQuery({ partInstanceId: partId })
@@ -39,91 +41,105 @@ export function PartLinkedInventoryCard({ partId }: PartLinkedInventoryCardProps
     onSuccess: () => void invalidate(),
   })
 
+  const handleUnlink = async (variantInstanceId: string, sourceDefId: string) => {
+    const ok = await confirm({
+      title: 'Unlink inventory source?',
+      description: 'This part will no longer deduct from this source.',
+      confirmText: 'Unlink',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (ok) unlink.mutate({ variantInstanceId, sourceDefId })
+  }
+
   if (!links || links.length === 0) return null
 
   const busy = applyPending.isPending || setMode.isPending || unlink.isPending
+  // A part usually has a single source — surface Unlink in the header; fall back to a per-row
+  // button only when several sources are linked and the header can't disambiguate.
+  const single = links.length === 1
 
   return (
-    <div className='group/entity-card bg-primary-100/50 dark:bg-[#23272e]/50 dark:border rounded-2xl relative ring-border-illustration shadow-black/6.5 shadow-md ring-1 w-full'>
-      <div className='flex flex-col gap-2 p-3'>
-        <div className='text-sm font-semibold text-neutral-400'>Inventory sources</div>
+    <div className='border-t border-border/50 pt-2 mt-1 flex flex-col gap-2'>
+      <div className='flex items-start justify-between gap-2'>
+        <div>
+          <h4 className='text-xs font-semibold text-muted-foreground'>Synced inventory</h4>
+          <p className='text-xs text-muted-foreground/70'>
+            Deducts this part when a linked source sells stock.
+          </p>
+        </div>
+        {single && (
+          <Button
+            variant='ghost'
+            size='xs'
+            disabled={busy}
+            onClick={() => handleUnlink(links[0].variantInstanceId, links[0].sourceDefId)}>
+            Unlink
+          </Button>
+        )}
+      </div>
 
-        {links.map((link) => {
-          const diverges =
-            link.currentQuantity != null && link.currentQuantity !== link.lastSeenQuantity
-          return (
-            <div
-              key={link.variantInstanceId}
-              className='flex flex-col gap-1.5 rounded-xl bg-black/[0.02] dark:bg-white/[0.02] p-2.5'>
-              <div className='flex items-center justify-between gap-2'>
-                <span className='text-sm tabular-nums'>
-                  Source {link.currentQuantity ?? '—'} · watermark {link.lastSeenQuantity}
-                </span>
+      {links.map((link) => (
+        <div key={link.variantInstanceId} className='flex flex-col'>
+          {/* Source + its current level */}
+          <TreeRow
+            title={<ResourceBadge id={link.sourceDefId} />}
+            description='Live stock level at the linked source.'
+            actions={
+              <div className='flex items-center gap-2'>
                 {link.pendingDelta > 0 && (
-                  <Badge variant='yellow'>−{link.pendingDelta} pending</Badge>
+                  <Badge variant='yellow' size='xs'>
+                    {link.pendingDelta} to deduct
+                  </Badge>
                 )}
-              </div>
-
-              {diverges && link.pendingDelta === 0 && (
-                <p className='text-xs text-muted-foreground'>
-                  Source and part have diverged — e.g. stock written off in auxx.
-                </p>
-              )}
-
-              <div className='flex items-center justify-between gap-2'>
-                <label className='flex items-center gap-2 text-xs text-muted-foreground'>
-                  <Switch
-                    checked={link.mode === 'auto'}
+                {link.pendingDelta > 0 && (
+                  <Button
+                    variant='outline'
+                    size='xs'
+                    loading={applyPending.isPending}
                     disabled={busy}
-                    onCheckedChange={(checked) =>
-                      setMode.mutate({
-                        variantInstanceId: link.variantInstanceId,
-                        mode: checked ? 'auto' : 'confirm',
-                      })
-                    }
-                  />
-                  Auto-deduct
-                </label>
-
-                <div className='flex items-center gap-1.5'>
-                  {link.pendingDelta > 0 && (
-                    <Button
-                      variant='outline'
-                      size='xs'
-                      loading={applyPending.isPending}
-                      disabled={busy}
-                      onClick={() =>
-                        applyPending.mutate({ variantInstanceId: link.variantInstanceId })
-                      }>
-                      Apply
-                    </Button>
-                  )}
+                    onClick={() =>
+                      applyPending.mutate({ variantInstanceId: link.variantInstanceId })
+                    }>
+                    Apply
+                  </Button>
+                )}
+                <span className='text-sm font-semibold tabular-nums text-foreground'>
+                  {link.currentQuantity ?? '—'}
+                </span>
+                {!single && (
                   <Button
                     variant='ghost'
                     size='xs'
                     disabled={busy}
-                    onClick={async () => {
-                      const ok = await confirm({
-                        title: 'Unlink inventory source?',
-                        description: 'This part will no longer deduct from this source.',
-                        confirmText: 'Unlink',
-                        cancelText: 'Cancel',
-                        destructive: true,
-                      })
-                      if (ok)
-                        unlink.mutate({
-                          variantInstanceId: link.variantInstanceId,
-                          sourceDefId: link.sourceDefId,
-                        })
-                    }}>
+                    onClick={() => handleUnlink(link.variantInstanceId, link.sourceDefId)}>
                     Unlink
                   </Button>
-                </div>
+                )}
               </div>
-            </div>
-          )
-        })}
-      </div>
+            }
+          />
+
+          {/* Auto-deduct toggle */}
+          <TreeRow
+            title='Auto-deduct'
+            description='Automatically lowers this part when the source sells. Off holds each change for review.'
+            actions={
+              <Switch
+                size='xs'
+                checked={link.mode === 'auto'}
+                disabled={busy}
+                onCheckedChange={(checked) =>
+                  setMode.mutate({
+                    variantInstanceId: link.variantInstanceId,
+                    mode: checked ? 'auto' : 'confirm',
+                  })
+                }
+              />
+            }
+          />
+        </div>
+      ))}
       <ConfirmDialog />
     </div>
   )

--- a/apps/web/src/server/api/routers/inventory-bridge.ts
+++ b/apps/web/src/server/api/routers/inventory-bridge.ts
@@ -71,7 +71,7 @@ export const inventoryBridgeRouter = createTRPCRouter({
       })
     ),
 
-  /** Every inventory link on a part, with watermark + current level + pending delta. */
+  /** Every inventory link on a part, with current level + pending delta (source label resolved client-side). */
   linksForPart: protectedProcedure
     .input(z.object({ partInstanceId: z.string() }))
     .query(({ ctx, input }) =>


### PR DESCRIPTION
## What

Merges the standalone `PartLinkedInventoryCard` into `PartInventoryCard` as a "Synced inventory" section, so the part's stock/movements and its external inventory feeds live in one card instead of two stacked cards on the Inventory tab.

## Changes

- **`part-linked-inventory-card.tsx`** — `PartLinkedInventoryCard` → `PartLinkedInventorySection`, redesigned to nest inside the inventory card. Each linked feed now renders as `TreeRow`s: a `ResourceBadge` source label + live level, an auto-deduct toggle, and (in confirm mode) a pending-deduction Apply. Unlink moves to the section header for the common single-source case, falling back to per-row when multiple sources are linked.
- **`part-inventory-card.tsx`** — renders `PartLinkedInventorySection` at the bottom (renders nothing when the part has no linked feeds).
- **`part-inventory-tab.tsx`** — drops the second stacked card now that the section is folded in.
- **`inventory-bridge.ts`** — `linksForPart` doc comment note: source label now resolved client-side.

## Notes

Divergence between source and part QoH remains expected (auxx-ledger-truth). No schema or API surface change.