### PR TITLE
fix(custom-fields): persist CALC option edits and compute calc cells without a source-value arrival

### DIFF
--- a/apps/web/src/components/resources/store/calc-value-computer.test.ts
+++ b/apps/web/src/components/resources/store/calc-value-computer.test.ts
@@ -1,0 +1,133 @@
+// apps/web/src/components/resources/store/calc-value-computer.test.ts
+// Store-layer regression tests for the CALC compute pipeline. Covers the
+// paths that broke silently before: compute on source arrival (else-branch
+// rendering), literal-only formulas with zero source fields, the
+// all-sources-already-cached fetch-queue path, and recompute after a config
+// change (expression edits showing up without a reload).
+
+import type { CalcOptions } from '@auxx/lib/custom-fields/client'
+import { toResourceFieldId } from '@auxx/types/field'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ensureCalcValue, recomputeCalcField } from './calc-value-computer'
+import { computedFieldRegistry } from './computed-field-registry'
+import { fieldValueFetchQueue } from './field-value-fetch-queue'
+import { buildFieldValueKey, toRecordId, useFieldValueStore } from './field-value-store'
+
+const DEF = 'def1'
+const RECORD = toRecordId(DEF, 'rec1')
+// Bare field UUIDs (no colon), exactly how the calc editor stores sourceFields
+const SOURCE_ID = 'srcfld1'
+const CALC_ID = 'calcfld1'
+const CALC_REF = toResourceFieldId(DEF, CALC_ID)
+const SOURCE_KEY = buildFieldValueKey(RECORD, SOURCE_ID)
+const CALC_KEY = buildFieldValueKey(RECORD, CALC_ID)
+
+function registerCalc(expression: string, sourceFields: Record<string, string> = {}) {
+  computedFieldRegistry.register(CALC_REF, {
+    expression,
+    sourceFields,
+    resultFieldType: 'TEXT',
+  } as CalcOptions)
+}
+
+function calcValue() {
+  return useFieldValueStore.getState().values[CALC_KEY]
+}
+
+beforeEach(() => {
+  useFieldValueStore.getState().clearAll()
+  computedFieldRegistry.clear()
+})
+
+describe('compute on source arrival (setValues)', () => {
+  it('renders the else branch when eq() does not match', () => {
+    registerCalc(`if(eq({${SOURCE_ID}},232),"lalala","noooo")`, { [SOURCE_ID]: SOURCE_ID })
+
+    useFieldValueStore
+      .getState()
+      .setValues([{ key: SOURCE_KEY, value: { type: 'text', value: '26' } }])
+
+    expect(calcValue()).toEqual(expect.objectContaining({ type: 'text', value: 'noooo' }))
+  })
+
+  it('renders the else branch when the source value is null (empty cell)', () => {
+    registerCalc(`if({${SOURCE_ID}},"has value","empty")`, { [SOURCE_ID]: SOURCE_ID })
+
+    useFieldValueStore.getState().setValues([{ key: SOURCE_KEY, value: null }])
+
+    expect(calcValue()).toEqual(expect.objectContaining({ type: 'text', value: 'empty' }))
+  })
+})
+
+describe('ensureCalcValue', () => {
+  it('computes a literal-only formula with zero source fields', () => {
+    registerCalc('concat("a","b")')
+
+    ensureCalcValue(RECORD, CALC_REF)
+
+    expect(calcValue()).toEqual(expect.objectContaining({ type: 'text', value: 'ab' }))
+  })
+
+  it('does not write while a source value is still missing', () => {
+    registerCalc(`upper({${SOURCE_ID}})`, { [SOURCE_ID]: SOURCE_ID })
+
+    ensureCalcValue(RECORD, CALC_REF)
+
+    expect(calcValue()).toBeUndefined()
+  })
+})
+
+describe('fetch queue decomposition with all sources cached', () => {
+  it('computes the calc value instead of queueing nothing forever', () => {
+    // Source value lands BEFORE the calc field is known — no dependent
+    // recompute fired at that point.
+    useFieldValueStore
+      .getState()
+      .setValues([{ key: SOURCE_KEY, value: { type: 'text', value: '26' } }])
+    registerCalc(`if(eq({${SOURCE_ID}},232),"lalala","noooo")`, { [SOURCE_ID]: SOURCE_ID })
+
+    // Cell mounts and requests the calc column; every source is already cached.
+    const queued = fieldValueFetchQueue.queueFetchBatch([{ recordId: RECORD, fieldRef: CALC_REF }])
+
+    expect(queued).toEqual([])
+    expect(calcValue()).toEqual(expect.objectContaining({ type: 'text', value: 'noooo' }))
+  })
+
+  it('computes a zero-source formula on fetch request', () => {
+    registerCalc('"hello"')
+
+    fieldValueFetchQueue.queueFetchBatch([{ recordId: RECORD, fieldRef: CALC_REF }])
+
+    expect(calcValue()).toEqual(expect.objectContaining({ type: 'text', value: 'hello' }))
+  })
+})
+
+describe('recomputeCalcField (config change)', () => {
+  it('refreshes stale computed values after an expression edit', () => {
+    registerCalc(`if(eq({${SOURCE_ID}},232),"lalala","noooo")`, { [SOURCE_ID]: SOURCE_ID })
+    useFieldValueStore
+      .getState()
+      .setValues([{ key: SOURCE_KEY, value: { type: 'text', value: '26' } }])
+    expect(calcValue()).toEqual(expect.objectContaining({ value: 'noooo' }))
+
+    // Formula edited: same source, new literals and matching condition
+    registerCalc(`if(eq({${SOURCE_ID}},26),"matched","nope")`, { [SOURCE_ID]: SOURCE_ID })
+    recomputeCalcField(CALC_REF)
+
+    expect(calcValue()).toEqual(expect.objectContaining({ type: 'text', value: 'matched' }))
+  })
+
+  it('heals a null that a registry-race server fetch backfilled', () => {
+    // Calc key was fetched directly (registry not ready) and backfilled null,
+    // sources landed too — then the registry syncs.
+    useFieldValueStore.getState().setValues([
+      { key: SOURCE_KEY, value: { type: 'text', value: '26' } },
+      { key: CALC_KEY, value: null },
+    ])
+    registerCalc(`if(eq({${SOURCE_ID}},232),"lalala","noooo")`, { [SOURCE_ID]: SOURCE_ID })
+
+    recomputeCalcField(CALC_REF)
+
+    expect(calcValue()).toEqual(expect.objectContaining({ type: 'text', value: 'noooo' }))
+  })
+})

--- a/apps/web/src/components/resources/store/calc-value-computer.ts
+++ b/apps/web/src/components/resources/store/calc-value-computer.ts
@@ -3,14 +3,23 @@
 import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import type { FieldType } from '@auxx/database/types'
 import { formatToRawValue, formatToTypedInput } from '@auxx/lib/field-values/client'
-import { getFieldId, isResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
+import {
+  getFieldId,
+  isResourceFieldId,
+  parseResourceFieldId,
+  type ResourceFieldId,
+  toResourceFieldId,
+} from '@auxx/types/field'
 import { evaluateCalcExpression } from '@auxx/utils/calc-expression'
 import { computedFieldRegistry } from './computed-field-registry'
 import {
   buildFieldValueKey,
   type FieldValueKey,
   parseFieldValueKey,
+  parseRecordId,
+  type RecordId,
   type StoredFieldValue,
+  useFieldValueStore,
 } from './field-value-store'
 
 /**
@@ -19,6 +28,87 @@ import {
 function wrapCalcValue(value: unknown, resultType: string): StoredFieldValue {
   // Use existing formatToTypedInput which handles all field types correctly
   return formatToTypedInput(value, resultType as FieldType)
+}
+
+/**
+ * Compute a single CALC field for one record from the given value maps.
+ * Returns `undefined` while any source value is missing (still loading) so
+ * callers can defer instead of rendering a wrong value. Recurses into
+ * CALC-typed sources; `processed` guards against cycles.
+ */
+function computeCalcFieldValue(
+  recordId: RecordId,
+  calcFieldId: ResourceFieldId,
+  currentValues: Record<FieldValueKey, StoredFieldValue>,
+  newCalcValues: Record<FieldValueKey, StoredFieldValue>,
+  processed: Set<string>
+): StoredFieldValue | undefined {
+  const calcKey = buildFieldValueKey(recordId, calcFieldId)
+
+  // Avoid circular computation
+  if (processed.has(calcKey)) {
+    return newCalcValues[calcKey] ?? currentValues[calcKey]
+  }
+  processed.add(calcKey)
+
+  const config = computedFieldRegistry.getConfig(calcFieldId)
+  if (!config) return undefined
+
+  if (config.disabled) {
+    return wrapCalcValue(null, config.resultFieldType)
+  }
+
+  const { entityDefinitionId } = parseRecordId(recordId)
+
+  // Gather source values (pass TypedFieldValue directly - evaluateCalcExpression handles extraction)
+  const sourceValues: Record<string, unknown> = {}
+  let hasMissing = false
+
+  for (const [placeholder, sourceFieldId] of Object.entries(config.sourceFields)) {
+    // sourceFields store plain field UUIDs; the registry is keyed by ResourceFieldId
+    const sourceResourceFieldId = isResourceFieldId(sourceFieldId)
+      ? (sourceFieldId as ResourceFieldId)
+      : toResourceFieldId(entityDefinitionId, sourceFieldId)
+
+    // Check if source is also a CALC field that needs computing first
+    if (computedFieldRegistry.isComputed(sourceResourceFieldId)) {
+      const computed = computeCalcFieldValue(
+        recordId,
+        sourceResourceFieldId,
+        currentValues,
+        newCalcValues,
+        processed
+      )
+      if (computed === undefined) hasMissing = true
+      sourceValues[placeholder] = computed // evaluateCalcExpression handles extraction
+    } else {
+      const sourceKey = buildFieldValueKey(recordId, sourceFieldId)
+      const stored = newCalcValues[sourceKey] ?? currentValues[sourceKey]
+      if (stored === undefined) hasMissing = true
+      sourceValues[placeholder] = stored // evaluateCalcExpression handles extraction
+    }
+  }
+
+  // If any source is missing, report undefined (still loading)
+  if (hasMissing) {
+    return undefined
+  }
+
+  // Handle NAME fields (no expression, just combine firstName + lastName)
+  if (config.resultFieldType === FieldTypeEnum.NAME || !config.expression) {
+    const firstName = String(formatToRawValue(sourceValues['firstName'], 'TEXT') ?? '')
+    const lastName = String(formatToRawValue(sourceValues['lastName'], 'TEXT') ?? '')
+    return wrapCalcValue({ firstName: firstName ?? '', lastName: lastName ?? '' }, 'NAME')
+  }
+
+  // Evaluate expression for CALC fields
+  try {
+    const result = evaluateCalcExpression(config.expression, sourceValues)
+    return wrapCalcValue(result, config.resultFieldType)
+  } catch (error) {
+    console.error(`Error computing CALC field ${calcFieldId}:`, error)
+    return wrapCalcValue(null, config.resultFieldType)
+  }
 }
 
 /**
@@ -56,7 +146,7 @@ export function computeDependentCalcValues(
 
   // For each affected record, compute dependent CALC values
   for (const [recordId, changedFieldIds] of affectedRecords) {
-    const calcFieldsToCompute = new Set<string>()
+    const calcFieldsToCompute = new Set<ResourceFieldId>()
 
     // Find all CALC fields that depend on any changed field
     for (const fieldId of changedFieldIds) {
@@ -66,67 +156,16 @@ export function computeDependentCalcValues(
       }
     }
 
-    // Compute each CALC field (handles cascading dependencies)
-    const computeCalcField = (calcFieldId: string): StoredFieldValue | undefined => {
-      const calcKey = buildFieldValueKey(recordId as any, calcFieldId)
-
-      // Avoid circular computation
-      if (processed.has(calcKey)) {
-        return newCalcValues[calcKey] ?? currentValues[calcKey]
-      }
-      processed.add(calcKey)
-
-      const config = computedFieldRegistry.getConfig(calcFieldId as any)
-      if (!config) return undefined
-
-      if (config.disabled) {
-        return wrapCalcValue(null, config.resultFieldType)
-      }
-
-      // Gather source values (pass TypedFieldValue directly - evaluateCalcExpression handles extraction)
-      const sourceValues: Record<string, unknown> = {}
-      let hasMissing = false
-
-      for (const [placeholder, sourceFieldId] of Object.entries(config.sourceFields)) {
-        const sourceKey = buildFieldValueKey(recordId as any, sourceFieldId)
-
-        // Check if source is also a CALC field that needs computing first
-        if (computedFieldRegistry.isComputed(sourceFieldId as any)) {
-          const computed = computeCalcField(sourceFieldId)
-          sourceValues[placeholder] = computed // evaluateCalcExpression handles extraction
-        } else {
-          const stored = newCalcValues[sourceKey] ?? currentValues[sourceKey]
-          if (stored === undefined) hasMissing = true
-          sourceValues[placeholder] = stored // evaluateCalcExpression handles extraction
-        }
-      }
-
-      // If any source is missing, store undefined (still loading)
-      if (hasMissing) {
-        return undefined
-      }
-
-      // Handle NAME fields (no expression, just combine firstName + lastName)
-      if (config.resultFieldType === FieldTypeEnum.NAME || !config.expression) {
-        const firstName = String(formatToRawValue(sourceValues['firstName'], 'TEXT') ?? '')
-        const lastName = String(formatToRawValue(sourceValues['lastName'], 'TEXT') ?? '')
-        return wrapCalcValue({ firstName: firstName ?? '', lastName: lastName ?? '' }, 'NAME')
-      }
-
-      // Evaluate expression for CALC fields
-      try {
-        const result = evaluateCalcExpression(config.expression, sourceValues)
-        return wrapCalcValue(result, config.resultFieldType)
-      } catch (error) {
-        console.error(`Error computing CALC field ${calcFieldId}:`, error)
-        return wrapCalcValue(null, config.resultFieldType)
-      }
-    }
-
     // Compute all affected CALC fields
     for (const calcFieldId of calcFieldsToCompute) {
-      const calcKey = buildFieldValueKey(recordId as any, calcFieldId)
-      const computed = computeCalcField(calcFieldId)
+      const calcKey = buildFieldValueKey(recordId as RecordId, calcFieldId)
+      const computed = computeCalcFieldValue(
+        recordId as RecordId,
+        calcFieldId,
+        currentValues,
+        newCalcValues,
+        processed
+      )
       if (computed !== undefined) {
         newCalcValues[calcKey] = computed
       }
@@ -134,4 +173,56 @@ export function computeDependentCalcValues(
   }
 
   return newCalcValues
+}
+
+/**
+ * Compute one CALC field for one record from current store state and write it.
+ * Covers the triggers that never come from a source-value arrival: zero-source
+ * (literal-only) formulas and the all-sources-already-cached fetch path. No-op
+ * while any source value is missing/in-flight (a later `setValues` will
+ * trigger the normal dependent recompute) or while the key has a pending
+ * optimistic update.
+ */
+export function ensureCalcValue(recordId: RecordId, calcFieldId: ResourceFieldId): void {
+  const store = useFieldValueStore.getState()
+  const computed = computeCalcFieldValue(recordId, calcFieldId, store.values, {}, new Set())
+  if (computed === undefined) return
+
+  const calcKey = buildFieldValueKey(recordId, calcFieldId)
+  if (store.pendingUpdates[calcKey]) return
+  store.setValue(calcKey, computed)
+}
+
+/**
+ * Recompute a CALC field for every record of its entity definition that has
+ * values loaded in the store. Called when a calc config registers with a new
+ * or changed definition (expression edit, optimistic field update, or the
+ * registry losing the race against the initial value fetch) so stale computed
+ * values refresh without a page reload.
+ */
+export function recomputeCalcField(calcFieldId: ResourceFieldId): void {
+  const { entityDefinitionId } = parseResourceFieldId(calcFieldId)
+  const store = useFieldValueStore.getState()
+
+  // Store keys are `${entityDefId}:${entityInstId}:${fieldRefKey}` — prefix
+  // scan finds every record of this definition with anything loaded.
+  const prefix = `${entityDefinitionId}:`
+  const recordIds = new Set<RecordId>()
+  for (const key of Object.keys(store.values)) {
+    if (!key.startsWith(prefix)) continue
+    recordIds.add(parseFieldValueKey(key as FieldValueKey).recordId)
+  }
+  if (recordIds.size === 0) return
+
+  const entries: Array<{ key: FieldValueKey; value: StoredFieldValue }> = []
+  for (const recordId of recordIds) {
+    const computed = computeCalcFieldValue(recordId, calcFieldId, store.values, {}, new Set())
+    if (computed === undefined) continue
+    entries.push({ key: buildFieldValueKey(recordId, calcFieldId), value: computed })
+  }
+  if (entries.length > 0) {
+    // setValues skips keys with pending optimistic updates and cascades to
+    // dependent CALC fields.
+    useFieldValueStore.getState().setValues(entries)
+  }
 }

--- a/apps/web/src/components/resources/store/computed-field-registry.ts
+++ b/apps/web/src/components/resources/store/computed-field-registry.ts
@@ -115,25 +115,42 @@ export const computedFieldRegistry = new ComputedFieldRegistry()
 /** Track if sync has been initialized */
 let syncInitialized = false
 
+/** Did a (re)registration actually change the computed definition? */
+function configChanged(prev: ComputedFieldConfig, next: ComputedFieldConfig): boolean {
+  return (
+    prev.expression !== next.expression ||
+    prev.resultFieldType !== next.resultFieldType ||
+    prev.disabled !== next.disabled ||
+    JSON.stringify(prev.sourceFields) !== JSON.stringify(next.sourceFields)
+  )
+}
+
 /**
  * Sync CALC fields from fieldMap to registry.
  * Handles additions, updates, and removals.
+ * Returns the fieldIds whose config is new or changed, so callers can
+ * recompute already-loaded values (registration alone never recomputes).
  */
-function syncCalcFields(fieldMap: Record<string, ResourceField>) {
+function syncCalcFields(fieldMap: Record<string, ResourceField>): ResourceFieldId[] {
   const currentCalcIds = new Set(computedFieldRegistry.getAllFields().map((f) => f.fieldId))
   const newCalcIds = new Set<string>()
+  const changedIds: ResourceFieldId[] = []
+
+  const registerAndDiff = (resourceFieldId: ResourceFieldId, calcOptions: CalcOptions) => {
+    const prev = computedFieldRegistry.getConfig(resourceFieldId)
+    computedFieldRegistry.register(resourceFieldId, calcOptions)
+    const next = computedFieldRegistry.getConfig(resourceFieldId)!
+    if (!prev || configChanged(prev, next)) {
+      changedIds.push(resourceFieldId)
+    }
+  }
 
   // Register/update CALC and NAME fields
   for (const [resourceFieldId, field] of Object.entries(fieldMap)) {
     // Register CALC fields
     if (field.fieldType === FieldType.CALC && field.options?.calc) {
       newCalcIds.add(resourceFieldId)
-
-      // Register (will update if already exists)
-      computedFieldRegistry.register(
-        resourceFieldId as ResourceFieldId,
-        field.options.calc as CalcOptions
-      )
+      registerAndDiff(resourceFieldId as ResourceFieldId, field.options.calc as CalcOptions)
     }
 
     // Register NAME fields (treated as computed fields)
@@ -142,7 +159,7 @@ function syncCalcFields(fieldMap: Record<string, ResourceField>) {
       newCalcIds.add(resourceFieldId)
 
       // Convert NAME options to CalcOptions format for registry
-      computedFieldRegistry.register(resourceFieldId as ResourceFieldId, {
+      registerAndDiff(resourceFieldId as ResourceFieldId, {
         expression: '', // Empty = NAME field (no expression evaluation)
         sourceFields: {
           firstName: nameOptions.firstNameFieldId,
@@ -159,6 +176,27 @@ function syncCalcFields(fieldMap: Record<string, ResourceField>) {
       computedFieldRegistry.unregister(oldId as ResourceFieldId)
     }
   }
+
+  return changedIds
+}
+
+/**
+ * Sync the registry from a fieldMap, then recompute already-loaded values for
+ * any calc whose definition is new or changed. Recomputing on registration is
+ * what makes expression edits (including optimistic field updates) show up in
+ * cells without a reload, and heals values that were fetched before the
+ * registry was ready.
+ */
+function syncCalcFieldsAndRecompute(fieldMap: Record<string, ResourceField>) {
+  const changedIds = syncCalcFields(fieldMap)
+  if (changedIds.length === 0) return
+
+  // Lazy import: calc-value-computer statically imports this module
+  import('./calc-value-computer').then(({ recomputeCalcField }) => {
+    for (const fieldId of changedIds) {
+      recomputeCalcField(fieldId)
+    }
+  })
 }
 
 /**
@@ -172,12 +210,12 @@ export function initComputedFieldSync() {
   // Lazy import to avoid circular dependency
   import('./resource-store').then(({ useResourceStore }) => {
     // Initial sync
-    syncCalcFields(useResourceStore.getState().fieldMap)
+    syncCalcFieldsAndRecompute(useResourceStore.getState().fieldMap)
 
     // Subscribe to fieldMap changes
     useResourceStore.subscribe(
       (state) => state.fieldMap,
-      (fieldMap) => syncCalcFields(fieldMap),
+      (fieldMap) => syncCalcFieldsAndRecompute(fieldMap),
       { equalityFn: Object.is } // Only trigger on reference change
     )
   })

--- a/apps/web/src/components/resources/store/field-value-fetch-queue.ts
+++ b/apps/web/src/components/resources/store/field-value-fetch-queue.ts
@@ -4,6 +4,7 @@ import type { AiStatus, AiValueMetadata } from '@auxx/lib/realtime/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 import { isResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
 import { generateId } from '@auxx/utils/generateId'
+import { ensureCalcValue } from './calc-value-computer'
 import { computedFieldRegistry } from './computed-field-registry'
 import {
   buildFieldValueKey,
@@ -92,6 +93,13 @@ class FieldValueFetchQueue {
             queued = true
           }
         }
+        // Nothing queued means no source arrival will ever trigger a compute
+        // (zero-source literal formula, or every source already cached) —
+        // compute now from store state. ensureCalcValue no-ops while sources
+        // are still in flight from an earlier batch.
+        if (!queued) {
+          this.ensureComputedValue(recordId, normalizedRef as ResourceFieldId)
+        }
         return queued
       }
     }
@@ -142,6 +150,7 @@ class FieldValueFetchQueue {
       ) {
         const config = computedFieldRegistry.getConfig(normalizedRef as ResourceFieldId)
         if (config) {
+          let queuedForCalc = false
           for (const sourceFieldId of Object.values(config.sourceFields)) {
             const sourceKey = buildFieldValueKey(recordId, sourceFieldId)
             if (sourceKey in store.values || store.isKeyFetching(sourceKey)) continue
@@ -149,6 +158,12 @@ class FieldValueFetchQueue {
             const sourceNormalized = normalizeFieldRef(recordId, sourceFieldId)
             this.pending.push({ recordId, fieldRef: sourceNormalized, key: sourceKey })
             queued.push(sourceKey)
+            queuedForCalc = true
+          }
+          // No source arrival will trigger a compute — compute now from
+          // store state (zero-source formula or all sources cached).
+          if (!queuedForCalc) {
+            this.ensureComputedValue(recordId, normalizedRef as ResourceFieldId)
           }
           continue // Skip the computed field itself
         }
@@ -171,6 +186,17 @@ class FieldValueFetchQueue {
     }
 
     return queued
+  }
+
+  /**
+   * Compute a CALC/NAME value directly from store state when decomposition
+   * queued no source fetches — without this, zero-source formulas and
+   * calc columns whose sources are already cached never get a value.
+   */
+  private ensureComputedValue(recordId: RecordId, calcFieldId: ResourceFieldId) {
+    const key = buildFieldValueKey(recordId, calcFieldId)
+    if (key in useFieldValueStore.getState().values) return
+    ensureCalcValue(recordId, calcFieldId)
   }
 
   /**

--- a/packages/services/src/custom-fields/update-field.ts
+++ b/packages/services/src/custom-fields/update-field.ts
@@ -3,7 +3,7 @@
 import { database, schema } from '@auxx/database'
 import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import type { CustomFieldEntity, FieldType } from '@auxx/database/types'
-import type { AiOptions } from '@auxx/types/custom-field'
+import type { AiOptions, CalcOptions } from '@auxx/types/custom-field'
 import { parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
 import { and, eq } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
@@ -56,6 +56,7 @@ export interface UpdateCustomFieldInput {
   options?:
     | SelectOption[]
     | { file: FileOptions }
+    | { calc: CalcOptions }
     | { options: SelectOption[]; ai?: AiOptions }
     | (DisplayOptions & { ai?: AiOptions })
   addressComponents?: string[]
@@ -241,6 +242,16 @@ export async function updateCustomField(input: UpdateCustomFieldInput) {
     if (fieldType === FieldTypeEnum.ADDRESS_STRUCT) {
       if (addressComponents !== undefined) {
         fieldOptions.addressComponents = addressComponents
+      }
+    }
+
+    // Handle CALC field options. Without this branch the incoming `options.calc`
+    // is dropped and the stale calc from `...currentField.options` is re-saved,
+    // so expression edits silently never persist (create has this branch; update
+    // was missing it).
+    if (fieldType === FieldTypeEnum.CALC) {
+      if (options !== undefined && !Array.isArray(options) && 'calc' in options) {
+        fieldOptions.calc = (options as { calc: CalcOptions }).calc
       }
     }
 

--- a/packages/utils/src/__tests__/calc-expression.test.ts
+++ b/packages/utils/src/__tests__/calc-expression.test.ts
@@ -1,0 +1,193 @@
+// packages/utils/src/__tests__/calc-expression.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { evaluateCalcExpression, validateCalcExpression } from '../calc-expression'
+
+/** Evaluate against an empty field map (literal-only expressions). */
+const evalExpr = (expr: string, fields: Record<string, unknown> = {}) =>
+  evaluateCalcExpression(expr, fields)
+
+describe('comparison functions', () => {
+  describe('eq', () => {
+    it('matches equal string literals (case-sensitive)', () => {
+      expect(evalExpr("eq('a', 'a')")).toBe(true)
+      expect(evalExpr("eq('a', 'A')")).toBe(false)
+    })
+
+    it('compares numerically when both sides are numeric', () => {
+      expect(evalExpr("eq(2, '2')")).toBe(true)
+      expect(evalExpr('eq(2, 3)')).toBe(false)
+    })
+
+    it('treats null/undefined/missing field as empty string', () => {
+      // {missing} resolves to undefined → normalized to ''
+      expect(evalExpr("eq({missing}, '')")).toBe(true)
+      expect(evalExpr('eq({missing}, {alsoMissing})')).toBe(true)
+    })
+
+    it('reads field values', () => {
+      expect(evalExpr("eq({opt}, 'Default Title')", { opt: 'Default Title' })).toBe(true)
+      expect(evalExpr("eq({opt}, 'Default Title')", { opt: 'Red' })).toBe(false)
+    })
+  })
+
+  describe('ne', () => {
+    it('is the negation of eq', () => {
+      expect(evalExpr("ne('a', 'b')")).toBe(true)
+      expect(evalExpr("ne('a', 'a')")).toBe(false)
+      expect(evalExpr("ne(2, '2')")).toBe(false)
+    })
+  })
+
+  describe('gt/gte/lt/lte', () => {
+    it('compares numbers', () => {
+      expect(evalExpr('gt(3, 2)')).toBe(true)
+      expect(evalExpr('gt(2, 3)')).toBe(false)
+      expect(evalExpr('gte(2, 2)')).toBe(true)
+      expect(evalExpr('lt(1, 2)')).toBe(true)
+      expect(evalExpr('lte(2, 2)')).toBe(true)
+    })
+
+    it('coerces numeric strings', () => {
+      expect(evalExpr("gt('3', '2')")).toBe(true)
+    })
+
+    it('returns null when either side is non-numeric', () => {
+      expect(evalExpr("gt('abc', 2)")).toBe(null)
+      expect(evalExpr("lt(2, 'xyz')")).toBe(null)
+      expect(evalExpr("gte('foo', 'bar')")).toBe(null)
+    })
+  })
+})
+
+describe('logic functions', () => {
+  it('and is true only when all args are truthy', () => {
+    expect(evalExpr('and(true, true)')).toBe(true)
+    expect(evalExpr('and(true, false)')).toBe(false)
+    expect(evalExpr('and(1, 1, 1)')).toBe(true)
+    expect(evalExpr('and(1, 0)')).toBe(false)
+  })
+
+  it('or is true when any arg is truthy', () => {
+    expect(evalExpr('or(false, true)')).toBe(true)
+    expect(evalExpr('or(false, false)')).toBe(false)
+    expect(evalExpr('or(0, 0, 1)')).toBe(true)
+  })
+
+  it('not negates truthiness', () => {
+    expect(evalExpr('not(true)')).toBe(false)
+    expect(evalExpr('not(false)')).toBe(true)
+    expect(evalExpr("not('')")).toBe(true)
+  })
+
+  describe('isEmpty', () => {
+    it('is true for null/undefined/empty/whitespace', () => {
+      expect(evalExpr('isEmpty({missing})')).toBe(true)
+      expect(evalExpr("isEmpty('')")).toBe(true)
+      expect(evalExpr("isEmpty('   ')")).toBe(true)
+      expect(evalExpr('isEmpty({blank})', { blank: '  \t ' })).toBe(true)
+    })
+
+    it('is false for non-empty values including 0', () => {
+      expect(evalExpr("isEmpty('x')")).toBe(false)
+      expect(evalExpr('isEmpty(0)')).toBe(false)
+      expect(evalExpr('isEmpty({v})', { v: 'hello' })).toBe(false)
+    })
+  })
+})
+
+describe('joinNonEmpty', () => {
+  it('joins non-empty values with the separator', () => {
+    expect(evalExpr("joinNonEmpty(' / ', 'Grey', 'M', '43')")).toBe('Grey / M / 43')
+  })
+
+  it('skips blanks in head, middle, and tail positions', () => {
+    expect(evalExpr("joinNonEmpty(' / ', {missing}, 'M', '43')", {})).toBe('M / 43')
+    expect(evalExpr("joinNonEmpty(' / ', 'Grey', {missing}, '43')", {})).toBe('Grey / 43')
+    expect(evalExpr("joinNonEmpty(' / ', 'Grey', 'M', {missing})", {})).toBe('Grey / M')
+  })
+
+  it('skips whitespace-only values', () => {
+    expect(evalExpr("joinNonEmpty(' / ', 'Grey', '   ', '43')")).toBe('Grey / 43')
+  })
+
+  it('stringifies numeric values including 0', () => {
+    expect(evalExpr("joinNonEmpty('-', 0, 1, 2)")).toBe('0-1-2')
+  })
+})
+
+describe('nesting / composition', () => {
+  it('evaluates the canonical variant-title formula', () => {
+    const formula =
+      "if(eq({Option 1}, 'Default Title'), " +
+      '{Product Title}, ' +
+      "concat({Product Title}, ' - ', joinNonEmpty(' / ', {Option 1}, {Option 2}, {Option 3})))"
+
+    // Default Title → just the product title
+    expect(
+      evalExpr(formula, {
+        'Option 1': 'Default Title',
+        'Product Title': 'Cool Shirt',
+      })
+    ).toBe('Cool Shirt')
+
+    // Real variant → title + joined options, blank middle skipped
+    expect(
+      evalExpr(formula, {
+        'Option 1': 'Grey',
+        'Option 2': '',
+        'Option 3': '43',
+        'Product Title': 'Cool Shirt',
+      })
+    ).toBe('Cool Shirt - Grey / 43')
+  })
+})
+
+describe('regression: existing functions untouched', () => {
+  it('if tests raw truthiness', () => {
+    expect(evalExpr("if({flag}, 'yes', 'no')", { flag: true })).toBe('yes')
+    expect(evalExpr("if({flag}, 'yes', 'no')", { flag: '' })).toBe('no')
+    expect(evalExpr("if({flag}, 'yes', 'no')", { flag: 0 })).toBe('no')
+  })
+
+  it('coalesce skips null and empty string', () => {
+    expect(evalExpr('coalesce({a}, {b})', { a: null, b: 'fallback' })).toBe('fallback')
+    expect(evalExpr('coalesce({a}, {b})', { a: '', b: 'fallback' })).toBe('fallback')
+    expect(evalExpr('coalesce({a}, {b})', { a: 'first', b: 'fallback' })).toBe('first')
+  })
+})
+
+describe('validateCalcExpression', () => {
+  it('accepts the new function names', () => {
+    for (const expr of [
+      "eq({a}, 'x')",
+      'ne({a}, {b})',
+      'gt({a}, 1)',
+      'gte({a}, 1)',
+      'lt({a}, 1)',
+      'lte({a}, 1)',
+      'and({a}, {b})',
+      'or({a}, {b})',
+      'not({a})',
+      'isEmpty({a})',
+      "joinNonEmpty(' / ', {a}, {b})",
+    ]) {
+      const result = validateCalcExpression(expr)
+      expect(result.isValid, `expected ${expr} to be valid`).toBe(true)
+    }
+  })
+
+  it('extracts source fields from nested calls', () => {
+    const result = validateCalcExpression(
+      "if(eq({Option 1}, 'Default Title'), {Product Title}, {Option 2})"
+    )
+    expect(result.isValid).toBe(true)
+    expect(result.extractedFields.sort()).toEqual(['Option 1', 'Option 2', 'Product Title'])
+  })
+
+  it('still rejects unknown functions', () => {
+    const result = validateCalcExpression('bogus({a}, {b})')
+    expect(result.isValid).toBe(false)
+    expect(result.error).toContain('Unknown function')
+  })
+})

--- a/packages/utils/src/calc-expression.ts
+++ b/packages/utils/src/calc-expression.ts
@@ -13,6 +13,27 @@ export interface CalcFunction {
 }
 
 /**
+ * Shared empty-value predicate: true for null/undefined/''/whitespace-only string.
+ * Mirrors coalesce's skip rule with an added trim.
+ */
+function isEmptyValue(value: unknown): boolean {
+  return value == null || (typeof value === 'string' && value.trim() === '')
+}
+
+/**
+ * Spreadsheet-style loose equality: null/undefined ≙ ''; if both sides are numeric,
+ * compare numerically; otherwise case-sensitive string equality.
+ */
+function looseEquals(a: unknown, b: unknown): boolean {
+  const an = a ?? ''
+  const bn = b ?? ''
+  const aIsNum = an !== '' && !Number.isNaN(Number(an))
+  const bIsNum = bn !== '' && !Number.isNaN(Number(bn))
+  if (aIsNum && bIsNum) return Number(an) === Number(bn)
+  return String(an) === String(bn)
+}
+
+/**
  * Registry of available calculation functions.
  * All functions are safe (no eval) and handle null/undefined gracefully.
  */
@@ -47,6 +68,17 @@ export const CALC_FUNCTIONS: Record<string, CalcFunction> = {
     fn: (str: unknown) => String(str ?? '').length,
     minArgs: 1,
     maxArgs: 1,
+  },
+  // Registry key is lowercase because the parser lowercases function names; the
+  // display `name` keeps its camelCase spelling for the picker/help UI.
+  joinnonempty: {
+    name: 'joinNonEmpty',
+    fn: (sep: unknown, ...values: unknown[]) =>
+      values
+        .filter((v) => !isEmptyValue(v))
+        .map((v) => String(v))
+        .join(String(sep ?? '')),
+    minArgs: 2,
   },
 
   // ─────────────────────────────────────────────────────────────
@@ -117,6 +149,66 @@ export const CALC_FUNCTIONS: Record<string, CalcFunction> = {
   },
 
   // ─────────────────────────────────────────────────────────────
+  // Comparison functions
+  // ─────────────────────────────────────────────────────────────
+  eq: {
+    name: 'eq',
+    fn: (a: unknown, b: unknown) => looseEquals(a, b),
+    minArgs: 2,
+    maxArgs: 2,
+  },
+  ne: {
+    name: 'ne',
+    fn: (a: unknown, b: unknown) => !looseEquals(a, b),
+    minArgs: 2,
+    maxArgs: 2,
+  },
+  gt: {
+    name: 'gt',
+    fn: (a: unknown, b: unknown) => {
+      const x = Number(a)
+      const y = Number(b)
+      if (Number.isNaN(x) || Number.isNaN(y)) return null
+      return x > y
+    },
+    minArgs: 2,
+    maxArgs: 2,
+  },
+  gte: {
+    name: 'gte',
+    fn: (a: unknown, b: unknown) => {
+      const x = Number(a)
+      const y = Number(b)
+      if (Number.isNaN(x) || Number.isNaN(y)) return null
+      return x >= y
+    },
+    minArgs: 2,
+    maxArgs: 2,
+  },
+  lt: {
+    name: 'lt',
+    fn: (a: unknown, b: unknown) => {
+      const x = Number(a)
+      const y = Number(b)
+      if (Number.isNaN(x) || Number.isNaN(y)) return null
+      return x < y
+    },
+    minArgs: 2,
+    maxArgs: 2,
+  },
+  lte: {
+    name: 'lte',
+    fn: (a: unknown, b: unknown) => {
+      const x = Number(a)
+      const y = Number(b)
+      if (Number.isNaN(x) || Number.isNaN(y)) return null
+      return x <= y
+    },
+    minArgs: 2,
+    maxArgs: 2,
+  },
+
+  // ─────────────────────────────────────────────────────────────
   // Logic functions
   // ─────────────────────────────────────────────────────────────
   if: {
@@ -124,6 +216,28 @@ export const CALC_FUNCTIONS: Record<string, CalcFunction> = {
     fn: (cond: unknown, thenVal: unknown, elseVal: unknown) => (cond ? thenVal : elseVal),
     minArgs: 3,
     maxArgs: 3,
+  },
+  and: {
+    name: 'and',
+    fn: (...args: unknown[]) => args.every((a) => Boolean(a)),
+    minArgs: 2,
+  },
+  or: {
+    name: 'or',
+    fn: (...args: unknown[]) => args.some((a) => Boolean(a)),
+    minArgs: 2,
+  },
+  not: {
+    name: 'not',
+    fn: (x: unknown) => !x,
+    minArgs: 1,
+    maxArgs: 1,
+  },
+  isempty: {
+    name: 'isEmpty',
+    fn: (x: unknown) => isEmptyValue(x),
+    minArgs: 1,
+    maxArgs: 1,
   },
   coalesce: {
     name: 'coalesce',
@@ -459,6 +573,12 @@ export function getAvailableFunctions(): Array<{
       example: 'length({description})',
     },
     {
+      name: 'joinNonEmpty',
+      description: 'Join values with a separator, skipping empty ones',
+      signature: 'joinNonEmpty(separator, ...values)',
+      example: 'joinNonEmpty(" / ", {Option 1}, {Option 2}, {Option 3})',
+    },
+    {
       name: 'add',
       description: 'Add numbers',
       signature: 'add(...numbers)',
@@ -514,10 +634,70 @@ export function getAvailableFunctions(): Array<{
       example: 'max({a}, {b}, {c})',
     },
     {
+      name: 'eq',
+      description: 'Equal (loose: null ≙ "", numeric-aware)',
+      signature: 'eq(a, b)',
+      example: 'if(eq({Option 1}, "Default Title"), {Product Title}, {Option 1})',
+    },
+    {
+      name: 'ne',
+      description: 'Not equal',
+      signature: 'ne(a, b)',
+      example: 'ne({status}, "closed")',
+    },
+    {
+      name: 'gt',
+      description: 'Greater than (numeric; null if non-numeric)',
+      signature: 'gt(a, b)',
+      example: 'gt({quantity}, 0)',
+    },
+    {
+      name: 'gte',
+      description: 'Greater than or equal',
+      signature: 'gte(a, b)',
+      example: 'gte({stock}, {threshold})',
+    },
+    {
+      name: 'lt',
+      description: 'Less than',
+      signature: 'lt(a, b)',
+      example: 'lt({price}, 100)',
+    },
+    {
+      name: 'lte',
+      description: 'Less than or equal',
+      signature: 'lte(a, b)',
+      example: 'lte({age}, 18)',
+    },
+    {
       name: 'if',
       description: 'Conditional',
       signature: 'if(condition, then, else)',
       example: 'if({isActive}, "Yes", "No")',
+    },
+    {
+      name: 'and',
+      description: 'True if all arguments are truthy',
+      signature: 'and(...conditions)',
+      example: 'and(gt({stock}, 0), {isActive})',
+    },
+    {
+      name: 'or',
+      description: 'True if any argument is truthy',
+      signature: 'or(...conditions)',
+      example: 'or({isVip}, gt({orders}, 10))',
+    },
+    {
+      name: 'not',
+      description: 'Boolean negation',
+      signature: 'not(condition)',
+      example: 'not(isEmpty({email}))',
+    },
+    {
+      name: 'isEmpty',
+      description: 'True for null, empty, or whitespace-only',
+      signature: 'isEmpty(value)',
+      example: 'if(isEmpty({nickname}), {firstName}, {nickname})',
     },
     {
       name: 'coalesce',


### PR DESCRIPTION
## Summary

Two CALC custom-field fixes: expression edits were silently dropped on save, and the client compute pipeline only ever ran when a source value physically arrived in the field-value store — leaving cells permanently empty in every scenario where that never happens.

### Save path (`packages/services`)
`updateCustomField()` rebuilds the options blob per field type but had **no CALC branch**, so `options.calc` from the editor was discarded and the stale expression re-saved (`updatedAt` predating `createdAt` proved the row was never touched). Added the CALC branch mirroring `create-field.ts`.

### Render path (`apps/web` field-value store cluster)
Calc computation was event-driven off exactly one event: "source value landed via `setValues`/`setValue`". Fixed the four scenarios where that event never fires:

1. **Expression edits never refreshed loaded cells** — the registry re-registered the changed config but recomputed nothing; cells stayed stale until a hard reload. `syncCalcFields` now diffs configs on registration and recomputes every loaded record for new/changed calcs. Because the subscription fires on the **optimistic** fieldMap overlay, cells update instantly on save (rollback re-registers the original config and recomputes back).
2. **Literal-only formulas** (zero field refs, e.g. `concat("a","b")`) had no dependency edges and no source fetches — never computed. The fetch queue now computes directly from store state when decomposition queues nothing.
3. **All-sources-already-cached** — decomposition skipped cached sources, queued nothing, and the calc key stayed `undefined` forever (e.g. toggling a calc column on after its source column loaded). Same fix as 2.
4. **CALC-of-CALC** — the nested-source registry check used a plain field UUID against ResourceFieldId keys and always missed. Sources are now qualified before the lookup.

Mechanism: the per-field compute is extracted into a shared `computeCalcFieldValue()` (returns `undefined` while any source is still loading, so the new triggers can never write a half-loaded result) with two entry points — `ensureCalcValue(recordId, calcFieldId)` and `recomputeCalcField(calcFieldId)`.

### Expression engine (`packages/utils`)
Adds comparison/logic functions (`eq`/`ne`/`gt`/`gte`/`lt`/`lte`, `and`/`or`/`not`, `isEmpty`, `joinNonEmpty`) with spreadsheet-style loose equality (null ≙ "", numeric-aware).

## Testing

- `packages/utils` engine tests (23) and new store-layer regression tests (8) covering: else-branch render on source arrival, null source → else branch, literal-only compute, missing-source no-op, all-sources-cached fetch path, zero-source fetch path, expression-edit recompute, registry-race null heal.
- Live-verified in dev: repos table CALC column renders the else branch (`if(eq({Repo ID},232),…)`) for all rows; editing the formula's literal in the field editor updated all 34 visible cells instantly on save, no reload.