### PR TITLE
Schedule future-dated engineering blog posts

### DIFF
--- a/apps/homepage/content/blog/connections-part-1-one-model-for-every-connection.mdx
+++ b/apps/homepage/content/blog/connections-part-1-one-model-for-every-connection.mdx
@@ -1,0 +1,238 @@
+---
+title: "Connections, Part 1: One Model for Every Connection"
+description: "How we collapsed OAuth2, client-credentials, API keys, and multi-field secrets into one blueprint table and one instance table — and made auth application declarative data instead of per-provider code. Part 1 of a two-part series."
+date: "2026-08-11"
+slug: "connections-part-1-one-model-for-every-connection"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["oauth", "security", "secrets", "postgres", "typescript", "open-source"]
+published: true
+---
+
+Every platform eventually grows five half-compatible ways to store an API key. Nobody plans it. The email integration ships first and stores its OAuth tokens on its own table. The workflow engine arrives and adds "credential types" with a registry of per-provider classes. The AI features need provider keys, so those get a table. An app platform shows up, and apps obviously need their own connections. MCP servers land, and they have opinions about OAuth too. Five features, five stores, five hand-rolled copies of `buildAuthHeaders`, five different answers to "when does this token get refreshed?"
+
+We had exactly this. Then we collapsed all of it into two tables — one blueprint, one instance — and made "how does this credential become request auth" a piece of declarative data instead of code. This two-part series is about that model:
+
+1. **This post** covers the data model: the two tables, the `connectionType` discriminator, the exactly-one-owner constraint (with a Postgres gotcha worth knowing), and declarative auth application.
+2. **[Part 2](/blog/connections-part-2-secret-lifecycle)** is the secret lifecycle: masking, merge-never-replace editing, and the token refresh machinery — the part everyone gets wrong.
+
+The code lives mostly in `packages/lib/src/connections/` and `packages/credentials/src/`. Auxx.ai is [open source](https://github.com/auxxai/auxx), so you can read along.
+
+## Blueprint and instance
+
+The whole model is two tables.
+
+`ConnectionDefinition` is the blueprint: what a connection to a given provider *is*. Its OAuth endpoints, its scopes, which form fields the user fills in, how the resolved credential gets applied to a request. There is one row per provider-and-method, and it carries no user data.
+
+`Credential` is the instance: one organization's actual connection. The encrypted tokens, the account email, the expiry timestamp. Every credential points at the definition that shaped it:
+
+```typescript
+// packages/database/src/db/schema/credential.ts
+export const Credential = pgTable('Credential', {
+  organizationId: text().notNull(),
+  /** Discriminator: which credential family owns this row. */
+  kind: text().notNull().default('connection'), // 'app' | 'mcp' | 'connection'
+  // Direct link to the provider blueprint (any owner).
+  connectionDefinitionId: text().references(() => ConnectionDefinition.id),
+
+  /** AES-256-GCM blob — secrets ONLY (tokens, keys, passwords). */
+  encryptedSecrets: text().notNull(),
+  /** Plaintext non-secret companion data: scopes, account email, shop domain… */
+  metadata: jsonb().$type<Record<string, unknown>>().default({}).notNull(),
+
+  // OAuth2 expiry and refresh tracking (expiresAt is the ONLY home of expiry)
+  expiresAt: timestamp({ precision: 3 }),
+  // ...
+})
+```
+
+The important claim is what sits on top of these two tables: email channels, installed apps, MCP servers, workflow HTTP nodes, and [AI provider keys](/blog/multi-provider-ai-system-part-1) are *all* `Credential` rows. When the Gmail channel needs an access token, it goes through the same resolver as a Shopify app connection or an Anthropic API key. One decrypt path, one refresh path, one place to get auth right.
+
+Before this, each of those was its own little fiefdom. Channels stored tokens on the integration row and ran their own OAuth refresh. Workflow credentials had a registry of `ICredentialType` classes. The differences between them were accidents of when they were written, not design.
+
+## Four connection types, one discriminator
+
+The blueprint's central column is `connectionType`, and it has exactly four values:
+
+| Type | What it means | Token production |
+| --- | --- | --- |
+| `oauth2-code` | Browser redirect, user consents | Refresh token rotation |
+| `client-credentials` | Server-minted M2M OAuth2 | Re-mint from client id/secret |
+| `secret` | API key or multi-field secret bag | None — the secret is the credential |
+| `none` | No auth (public APIs) | None |
+
+The deliberate move here is what `client-credentials` is *not*: it is not a separate feature. It reuses the same OAuth2 minting columns as `oauth2-code` — token URL, client id/secret, scopes — minus the browser-redirect fields, because there is no browser. The schema comment says it plainly:
+
+```typescript
+// packages/database/src/db/schema/connection-definition.ts
+// Connection type: oauth2-code, client-credentials, secret, none.
+// `client-credentials` is the server-minted M2M OAuth2 grant — same minting
+// columns as oauth2-code (sans the browser-redirect fields), downstream an
+// ordinary bearer connection.
+connectionType: text().notNull(),
+```
+
+"Downstream an ordinary bearer connection" is the payoff. Once a token exists, nothing that consumes the connection cares how it was produced. The HTTP transport, the auth application, the runtime resolver — they all see a bearer token. Only the token-production path (mint vs. refresh, covered in part 2) knows the difference. UPS and FedEx connect with `client-credentials`; Gmail connects with `oauth2-code`; a request through either looks identical from the transport's point of view.
+
+`secret` covers everything from a single Telegram bot token to a Postgres connection's `host` + `port` + `user` + `password`. The definition declares its form fields as `connectionVariables` — a JSONB array where each variable carries a key, a label, a field type, and crucially a `secret` flag that decides whether the value is encrypted or stored as plain metadata. The connect form is rendered entirely from this array. Adding a new secret-type provider is data entry, not code.
+
+## Exactly one owner, enforced in Postgres
+
+A definition is owned by exactly one of three things: an app (apps ship their own connection methods — we covered that platform in [Building Your Own App Store](/blog/building-your-own-app-store-part-1)), an MCP server, or the platform itself via a `providerKey` string like `gmail` or `postgres`.
+
+"Exactly one" is the kind of invariant that quietly rots if you only enforce it in application code. Somebody writes a seeding script, forgets a field, and now a row has two owners and the resolver picks one at random. So it lives in the database:
+
+```typescript
+// packages/database/src/db/schema/connection-definition.ts
+check(
+  'ConnectionDefinition_owner_check',
+  sql`(("appId" IS NOT NULL)::int
+     + ("mcpServerId" IS NOT NULL)::int
+     + ("providerKey" IS NOT NULL)::int) = 1
+   AND ("appId" IS NULL OR "key" IS NOT NULL)`
+),
+```
+
+The `::int` cast trick sums the three "is present" booleans and requires the sum to be exactly 1. Cheap, readable, impossible to bypass.
+
+The second clause of that constraint — app rows must carry a `key` — exists because of a Postgres behavior that bites almost everyone once. We wanted "no duplicate connection methods per app version," which sounds like a partial unique index:
+
+```typescript
+// Distinct methods per app/version. Partial (apps only).
+uniqueIndex('ConnectionDefinition_app_key_major_idx')
+  .on(table.appId, table.key, table.major)
+  .where(sql`"appId" IS NOT NULL`),
+```
+
+Here is the gotcha: **Postgres treats NULLs as distinct in unique indexes.** If `key` is allowed to be NULL, then `(app_123, NULL, 1)` and `(app_123, NULL, 1)` are two *different* index entries, and your unique index enforces nothing. Every app-owned row with a NULL `key` sails past it. The index looks like protection and provides none.
+
+The fix is in the CHECK constraint above: app-owned rows *must* have a `key`, so the NULL case can never reach the index. The comment in the schema file spells it out — "else the partial unique index above is toothless — Postgres treats NULLs as distinct." We hit the same trap a second time on `Credential`, where "at most one default connection per (org, app)" needed a partial index scoped with `"userId" IS NULL` in the predicate, because NULL-userId rows would otherwise all count as distinct in a composite unique.
+
+(Postgres 15 added `NULLS NOT DISTINCT` for exactly this. If you can require it, use it. We support the constraint-plus-partial-index pattern because it also documents the invariant.)
+
+## Auth as data: `authApply`
+
+The single biggest source of duplicated code in the old world was the last step: taking a resolved credential and putting it on an HTTP request. Every consumer had its own copy. The workflow HTTP node had `buildAuthHeaders` with a switch statement per auth style. Each data connector reimplemented it. The differences were bugs waiting to be found.
+
+Now the definition *declares* it, as JSONB:
+
+```typescript
+// packages/database/src/db/schema/connection-definition.ts
+export type AuthInsertion =
+  | { in: 'header'; name: string; format?: string }
+  | { in: 'basic'; userField?: string; passwordField?: string }
+  | { in: 'query'; name: string; format?: string }
+
+export type AuthApply =
+  | AuthInsertion
+  | { insertions: AuthInsertion[]; headers?: Record<string, string> }
+```
+
+Three insertion kinds cover essentially every REST API we have met: set a header, do HTTP Basic from two fields, or append a query parameter. Templates interpolate `{value}` — the resolved token or secret — and any `{fieldKey}` from the connection variables. The canonical case is one constant:
+
+```typescript
+// packages/lib/src/connections/auth-apply.ts
+/** The canonical bearer-token application: `Authorization: Bearer <token>`. */
+export const BEARER_AUTH: AuthApply = {
+  in: 'header',
+  name: 'Authorization',
+  format: 'Bearer {value}',
+}
+```
+
+The multi-insertion form exists because real providers are weird. Supabase wants the same key in *both* an `apikey` header and an `Authorization` header. Notion wants a constant `Notion-Version` header on every request alongside the bearer token — that is the `headers` bag, applied verbatim with no interpolation.
+
+One function interprets the spec, and it is the only place a resolved connection becomes request auth:
+
+```typescript
+// packages/lib/src/connections/auth-apply.ts
+export function applyAuth(
+  req: RequestParts,
+  conn: RuntimeConnectionAuthData,
+  spec: AuthApply | null | undefined
+): RequestParts {
+  if (!spec) return req
+  const insertions = 'insertions' in spec ? spec.insertions : [spec]
+  let out: RequestParts = req
+  for (const ins of insertions) {
+    out = applyInsertion(out, conn, ins)
+  }
+  // ...constant headers merged verbatim
+  return out
+}
+```
+
+There is one ergonomic default worth calling out. App authors writing an `oauth2-code` definition almost never think about `authApply`, because an OAuth2 access token is *always* a bearer token. So when a definition declares nothing, the resolver falls back:
+
+```typescript
+export function defaultAuthApply(
+  connectionType: 'oauth2-code' | 'client-credentials' | 'secret'
+): AuthApply | null {
+  return connectionType === 'oauth2-code' || connectionType === 'client-credentials'
+    ? BEARER_AUTH
+    : null
+}
+```
+
+Secret connections get no default — an API key could go anywhere, so the definition must say where. And `authApply` is deliberately `null` for database and email connections: those are secret bags a driver reads via `connection.fields`, not HTTP request auth, and they never reach `applyAuth` at all.
+
+## Secrets and metadata never share a column
+
+Every credential splits its data across two columns, and the split is a security boundary, not a convenience.
+
+`encryptedSecrets` holds tokens, keys, and passwords — nothing else — as an AES-256-GCM box with a `v2:` version prefix. `metadata` holds everything that is useful but not secret: OAuth scopes, the connected account's email, the Shopify shop domain, plain connection variables. Metadata is plain JSONB you can query, index, and display without a decrypt.
+
+The discipline this buys is that "show me the user's connections" never touches ciphertext, and nothing sensitive ever leaks into a queryable column because someone found it convenient. One companion rule: `expiresAt` lives as a real column on `Credential` and is *the only home of expiry*. Earlier versions had expiry data both inside the encrypted blob and outside it, and they disagreed exactly when it mattered. The schema comment is now load-bearing documentation.
+
+## One resolver, shared transports
+
+Everything converges at `packages/lib/src/connections/resolve-connection-for-runtime.ts`. Give it any owner — an `appId`, an `mcpServerId`, a `providerKey`, or a specific `connectionId` — and it finds the definition, finds the credential, decrypts, lazily refreshes an expiring token (part 2's subject), and hands back one shape:
+
+```typescript
+export interface RuntimeConnectionData {
+  id: string
+  type: ConnectionType
+  /** The resolved token (oauth2) or API secret. */
+  value: string
+  /** Merged connection-variable map (plain + secret-flagged). */
+  fields?: Record<string, string>
+  authApply?: AuthApply | null
+  /** Request origin from the definition's baseUrlTemplate, e.g. 'https://acme.myshopify.com'. */
+  baseUrl?: string
+}
+```
+
+Note `baseUrl`. A definition can declare a `baseUrlTemplate` like `https://{shop}.myshopify.com` or `https://api.telegram.org/bot{value}`, interpolated from the same variables at resolve time. A consumer can then make a request with just a relative path — `/admin/api/2024-10/orders.json` — and the connection contributes its own origin.
+
+The HTTP transport is where it all lands. Auth runs last, after URL assembly, so query-style auth appends to the finished URL:
+
+```typescript
+// packages/lib/src/connections/transports/http.ts
+let parts: RequestParts = { headers, url: buildUrl(resolveUrl(req.url, conn), req.query) }
+if (conn) parts = applyAuth(parts, conn, conn.authApply)
+```
+
+Data connectors syncing Shopify orders, the workflow HTTP node, and connection-backed agent tools all sit on this transport. A SQL transport shares the same `RuntimeConnectionData` interface for connections whose "auth" is a driver reading `conn.fields` — its `query()` signature is locked even though the Postgres implementation lands with its first consumer.
+
+And because the resolver dispatches on `connectionType` rather than on `kind`, every credential family got lazy token refresh for free. Email channels are the cleanest example: `getChannelAccessToken` in `packages/lib/src/providers/channel-token-accessor.ts` resolves the channel's credential through this exact seam. The Gmail SDK provider still owns message operations, but it stopped owning OAuth the day this landed.
+
+## What the model refuses to know
+
+The test of a unification like this is what *doesn't* exist. There is no `GmailToken` table. There is no per-provider refresh job. There is no switch statement over provider names in the transport. A new REST provider is a `ConnectionDefinition` row: a `connectionType`, some `connectionVariables`, an `authApply`, maybe a `baseUrlTemplate`. The connect form renders itself from the variables, the resolver resolves it, and the transport authenticates with it — no new code on any of those paths.
+
+The part we have not covered is the part with the sharpest edges: what happens to the secret itself over its lifetime. How do you let a user edit one field of a multi-field secret without the form ever seeing the others? How do you refresh a token that three workers want to refresh simultaneously? Why does a fixed refresh-ahead window make short-lived tokens *permanently* expiring?
+
+That is [Part 2](/blog/connections-part-2-secret-lifecycle).
+
+If you want to read ahead, the entry points are:
+
+- `packages/database/src/db/schema/connection-definition.ts`, the blueprint table
+- `packages/database/src/db/schema/credential.ts`, the instance table
+- `packages/lib/src/connections/auth-apply.ts`, declarative auth application
+- `packages/lib/src/connections/resolve-connection-for-runtime.ts`, the one resolver
+
+Auxx.ai is open source. PRs welcome.

--- a/apps/homepage/content/blog/connections-part-2-secret-lifecycle.mdx
+++ b/apps/homepage/content/blog/connections-part-2-secret-lifecycle.mdx
@@ -1,0 +1,251 @@
+---
+title: "Connections, Part 2: The Secret Lifecycle — Masking, Merging, Refreshing"
+description: "Editing, masking, and refreshing credentials without ever sending a secret back to the browser: sentinels, nesting-aware merges, and single-flight OAuth refresh. Part 2 of a two-part series on our connections model."
+date: "2026-08-18"
+slug: "connections-part-2-secret-lifecycle"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["oauth", "security", "secrets", "postgres", "typescript", "open-source"]
+published: true
+---
+
+There is one invariant our entire credential system is built around, and it fits in a sentence: **a plaintext secret crosses the wire exactly once — at creation — and the browser never sees it again.** Not on the edit form, not in an API response, not in a "reveal" endpoint. After the moment a user types a secret and hits save, the only thing the client ever receives back is a sentinel that means "a value is set."
+
+That sounds obvious. Almost nobody does it. Open the settings page of your favorite SaaS tool, pop the network tab, and edit an API key. You will be surprised how often the stored secret comes back to prefill the form.
+
+This is part 2 of a two-part series on our connections model:
+
+1. **[Part 1](/blog/connections-part-1-one-model-for-every-connection)** covered the data model: one blueprint table, one instance table, and declarative auth application.
+2. **This post** is the secret's lifetime: how it is stored, how it is edited without ever being read back, and how OAuth tokens stay fresh without stampedes.
+
+Auxx.ai is [open source](https://github.com/auxxai/auxx), so every claim here is checkable in the repo.
+
+## The box
+
+Secrets live in a single `encryptedSecrets` text column on `Credential`, as an AES-256-GCM box with a versioned format:
+
+```typescript
+// packages/credentials/src/crypto/secret-box.ts
+/**
+ * Encrypt a secrets object to the versioned format:
+ * `v2:` + base64(iv(12) ‖ authTag(16) ‖ ciphertext).
+ */
+export function encryptSecrets(secrets: Record<string, unknown>): string {
+  const iv = crypto.randomBytes(IV_LENGTH)
+  const cipher = crypto.createCipheriv('aes-256-gcm', getKey(), iv)
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(secrets), 'utf8'),
+    cipher.final(),
+  ])
+  const authTag = cipher.getAuthTag()
+  return V2_PREFIX + Buffer.concat([iv, authTag, ciphertext]).toString('base64')
+}
+```
+
+The `v2:` prefix is doing real work: it makes the format self-describing, which lets us run *two decryption policies* against the same primitives.
+
+Credential secrets decrypt **strictly** — `decryptSecrets` throws on anything without the `v2:` prefix, because an unencrypted credential secret is a bug, full stop. But `ConnectionDefinition` columns like `oauth2ClientSecret` decrypt **leniently**: `decryptValue` returns a non-`v2:` payload unchanged. That one policy difference is what made encrypting those columns deployable at all — you can ship the code that reads encrypted values *before* the backfill that encrypts existing rows, and plaintext dev seeds keep working. Deploy-then-backfill, no flag day.
+
+Inside the box, the JSON has a small conventional shape: OAuth tokens at `accessToken` / `refreshToken`, a bare API key at `secret`, and multi-field connection variables nested under `fields` (`host`, `password`, `client_secret`, …). That nesting matters enormously in a minute.
+
+## The sentinel: what the browser actually sees
+
+When a user opens the edit form for an existing connection, the server has to seed the form with *something* for each secret field. It sends this:
+
+```typescript
+// packages/credentials/src/crypto/client.ts
+/**
+ * Sentinel a form submits in place of an unchanged masked secret.
+ * The server strips it instead of persisting it.
+ */
+export const HIDDEN_VALUE = '__HIDDEN__'
+
+export function maskForEdit(fields: MaskField[], stored: Record<string, unknown>) {
+  const values: Record<string, string> = {}
+  for (const field of fields) {
+    const raw = stored[field.key]
+    if (field.secret) {
+      values[field.key] = raw != null && raw !== '' ? HIDDEN_VALUE : ''
+    } else {
+      values[field.key] = raw == null ? '' : String(raw)
+    }
+  }
+  return values
+}
+```
+
+A secret field with a stored value becomes the literal string `__HIDDEN__` — an "is set" marker, nothing more. A secret field with nothing stored becomes `''`, so the form knows to render it as required. Plain fields come back real, because they were never secrets.
+
+Note the loop: only *declared* fields are emitted. The projection iterates the definition's field list, not the stored bag, so system-provisioned keys — `accessToken`, `client_id`, anything an app wrote programmatically — are structurally excluded from the response. There is no denylist to keep updated; keys the form didn't declare simply never exist in the projection.
+
+The save path is the mirror image. The client submits the form bag back, and any secret field still carrying the sentinel is dropped before the write:
+
+```typescript
+// packages/credentials/src/crypto/client.ts — resolveForWrite
+if (field.secret) {
+  if (isMasked(value)) continue // unchanged → let the store merge keep existing
+  secrets[field.key] = value
+}
+```
+
+`isMasked` accepts two shapes: the exact `HIDDEN_VALUE` sentinel, and anything matching the mask-shape regex `/^.{2,4}\*+.{2,4}$/` — a few characters, a run of asterisks, a few characters. The second case is defensive: some display surfaces show a `maskValue`-style preview like `sk-a****3xyz`, and if a client ever echoes one of those back, persisting it would silently corrupt the stored secret. Both shapes mean "the user didn't touch this," and both are stripped.
+
+One more detail from `maskValue` itself: secrets shorter than ten characters return a *fixed-length* full mask (`********`) rather than a proportional one. A mask that shrinks with the secret leaks the secret's length, and "this API key is six characters" is information an attacker shouldn't get for free.
+
+The whole module — sentinel, regex, projection, split — lives in `packages/credentials/src/crypto/client.ts`, and it is client-safe *by construction*: no Node crypto, no database imports, nothing but pure functions. The browser bundle can import the exact code the server uses to decide what is masked, so the two sides can never disagree about what the sentinel is.
+
+## Merge, never replace
+
+Dropping the sentinel creates an obligation: if the submitted bag no longer contains `client_secret`, the write path must *keep* the stored `client_secret`, not delete it. Every credential write is therefore a merge, and the merge has to be nesting-aware.
+
+Recall the stored shape — multi-field secrets live *under* `fields`, as siblings of the tokens:
+
+```json
+{
+  "accessToken": "ya29...",
+  "refreshToken": "1//0g...",
+  "fields": { "client_id": "...", "client_secret": "..." }
+}
+```
+
+A naive flat merge — `{ ...existing, ...partial }` where `partial` is `{ client_secret: 'new' }` — writes `client_secret` at the top level and leaves the real one under `fields` untouched. Worse, a flat merge of `{ fields: { client_secret: 'new' } }` *replaces the whole `fields` object*, silently wiping `client_id`. We know because an early version did exactly that. The fix is a dedicated store function that merges one level down:
+
+```typescript
+// packages/credentials/src/store/merge-secret-fields.ts
+const existingFields = (existing.fields ?? {}) as Record<string, unknown>
+const mergedFields = { ...existingFields }
+for (const [key, value] of Object.entries(partial)) {
+  if (value === undefined || value === '') continue // keep existing
+  mergedFields[key] = value
+}
+const merged = { ...existing, fields: mergedFields }
+```
+
+Three properties, each one a bug we no longer have: blank or absent fields keep their stored value (the "leave it empty to keep it" edit semantics); edited fields overwrite only themselves; and sibling keys — `accessToken`, `refreshToken`, `secret` — are untouched by the `...existing` spread, so editing a connection variable can never clobber a live token.
+
+The edit surface funnels everything through one function, `mergeManualConnectionEdit` in `packages/lib/src/connections/merge-manual-edit.ts`: multi-field secrets go through `mergeSecretFields`, a bare API key merges at `secrets.secret`, and plain variables read-modify-write into `metadata.connectionVariables`. Both the platform reconnect path and the app reconnect path call it, so there is exactly one place where "editing a connection" is defined.
+
+Put the last two sections together and you get the full loop. Read: decrypt server-side, project through `maskForEdit`, send sentinels. Write: strip sentinels through `resolveForWrite`, merge the survivors into the encrypted bag. The plaintext secret existed in transit once, on creation, and never again.
+
+## Refreshing without stampedes
+
+OAuth access tokens expire, and the naive strategy — refresh when a request 401s — means every expiry costs a failed request. So we refresh *ahead* of expiry. The obvious implementation is a fixed window: refresh whenever less than two minutes remain.
+
+The fixed window has a failure mode we hit in production. Some providers issue tokens with very short lifetimes — MCP servers in particular hand out tokens living only a few minutes. If the token's whole lifetime is at or under your refresh-ahead window, the token is *always* "expiring": every single call triggers a refresh, and since many providers rotate the refresh token on each use, you churn through rotations as fast as you make requests. The window has to be proportional:
+
+```typescript
+// packages/lib/src/credentials/ensure-fresh-credential-token.ts
+/**
+ * Refresh-ahead window: `min(120s, 25% of token lifetime)`. A fixed window
+ * would make any token with a TTL at or under it permanently "expiring".
+ */
+function expirySkewMs(input: { expiresAt: Date; lastRefreshAt?: Date | null; createdAt?: Date }) {
+  const issuedAt = input.lastRefreshAt ?? input.createdAt
+  if (!issuedAt) return MAX_SKEW_MS
+  const lifetimeMs = input.expiresAt.getTime() - issuedAt.getTime()
+  if (lifetimeMs <= 0) return MAX_SKEW_MS
+  return Math.min(MAX_SKEW_MS, lifetimeMs * SKEW_LIFETIME_FRACTION)
+}
+```
+
+A one-hour Google token refreshes two minutes early. A five-minute MCP token refreshes seventy-five seconds early. Neither is ever permanently expiring.
+
+The second production problem is concurrency. A busy org has workers, web requests, and scheduled jobs all resolving the same credential; when its token nears expiry, they all decide to refresh at once. With rotate-on-use refresh tokens this is not merely wasteful — it is destructive: two concurrent refreshes race, and the loser persists a refresh token the provider has already invalidated. The credential is now dead and the user has to reconnect.
+
+So refresh is single-flight, per credential, via a Redis `SET NX` lock:
+
+```typescript
+const acquired = await redis.set(lockKey(credentialId), '1', 'EX', 30, 'NX')
+if (!acquired) {
+  // Someone else is refreshing — wait for the lock to clear, then let the
+  // caller re-read whatever the winner persisted.
+  for (let i = 0; i < LOCK_POLLS; i++) {
+    await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_DELAY_MS))
+    if (!(await redis.get(lockKey(credentialId)))) break
+  }
+  return true
+}
+```
+
+Losers don't fail and don't refresh — they poll briefly for the lock to clear, then return `true`, which tells the caller "the stored secrets may have changed, re-read them." The 30-second TTL bounds a crashed holder.
+
+Two policy decisions in this function are worth stating out loud, because both invert the instinct to fail safe.
+
+First: **if Redis is down, refresh anyway, without the lock.** The comment in the code says it in five words — "correctness beats stampede protection." A missed lock risks a redundant refresh; refusing to refresh guarantees requests go out with an expired token. We take the race.
+
+Second: **the function never throws.** A failed refresh logs a warning and leaves the stored token in place. Maybe the token still works; maybe the provider is having a bad minute; either way the caller's 401 retry path — which calls back in with `force: true`, skipping the expiry check entirely — owns the live failure. Refresh is an optimization layered on a correct slow path, and an optimization that can take down the request it was optimizing is not one.
+
+## Two grants, one seam, inverted triggers
+
+Part 1 made the claim that `client-credentials` is "downstream just a bearer connection." The token-production seam is where the two grants actually differ, and the difference is a beautiful little inversion.
+
+Both route through `ensureFreshCredentialToken`. For the `refresh_token` grant, a credential with no `expiresAt` means *we can't tell when this token dies* — so do nothing, and let the 401 path handle it if it's dead. For `client-credentials`, the same missing `expiresAt` means the opposite: *no token has ever been minted* — so mint one right now, before the first request:
+
+```typescript
+if (grant === 'refresh_token' && !hasRefreshToken) return false
+if (!force) {
+  if (!expiresAt) {
+    // refresh: can't tell → 401 path owns it. client-credentials: no token yet → mint now.
+    if (grant === 'refresh_token') return false
+  }
+  // ...else: shared skew-window check
+}
+```
+
+Identical state, opposite meanings, one `if`. From there the grants diverge into `refreshCredentialTokens` and `mintClientCredentialToken` in `packages/lib/src/connections/oauth2-token-grants.ts` — but both POST through a single shared `postOAuth2TokenRequest` helper that handles `basic-auth` vs. `request-body` client authentication identically, so the two grants can never drift on header handling. And a rotation detail that guards against a common provider behavior: `refreshToken: tokenData.refresh_token || secrets.refreshToken` — providers that don't rotate the refresh token simply omit it from the response, and overwriting the stored one with `undefined` would orphan the credential.
+
+## Two failure surfaces, deliberately separate
+
+When refresh fails, two different audiences need two different answers.
+
+The *retry machinery* needs "how many times in a row has this failed?" That's `consecutiveRefreshFailures`, a plain counter on the credential — a circuit breaker that stops the scheduled refresh job from hammering a provider. A recognizably permanent failure (an invalid refresh token) jumps the counter straight to the open threshold instead of incrementing, because retrying an invalid grant five times is just five more log lines.
+
+The *user* needs "do I have to reconnect?" That's a separate classified layer: `lastAuthError` (the classified error type, e.g. `invalid_grant`), `lastAuthErrorAt`, and a `requiresReauth` boolean that the UI renders as the reconnect banner. Mixing these up gives you either a scary "reconnect your account" banner for a transient network blip, or a silent breaker that never tells the user their revoked token needs attention.
+
+The recovery path ties them together. A successful refresh doesn't just store the new token — it clears *everything*:
+
+```typescript
+// packages/credentials/src/store/record-refresh.ts — recordRefreshSuccess
+.set({
+  consecutiveRefreshFailures: 0,
+  requiresReauth: false,
+  lastAuthError: null,
+  lastAuthErrorAt: null,
+  lastRefreshAt: now,
+  expiresAt: options.expiresAt,
+})
+```
+
+A fresh token *is* the proof of health. Without this, a credential that recovered on its own keeps showing "Auth required" forever — a bug we shipped once and now enforce against by making `recordRefreshSuccess` and `recordRefreshFailure` the only writers of the breaker fields.
+
+## No fallbacks at the edges
+
+The last piece is a policy about failure at the consumption edge. Our email channels — Gmail, Outlook — get their access tokens through this whole stack via `getChannelAccessToken` in `packages/lib/src/providers/channel-token-accessor.ts`, and that function has a property we defend in review: **there is no stored-token fallback.**
+
+```typescript
+// Reads go ONLY through the resolver — there is no stored-token fallback: an
+// unlinked credential or a resolver failure returns null so the caller fails
+// loudly rather than silently serving a stale/unrefreshed token.
+```
+
+The tempting version reads the credential row directly when the resolver fails — after all, there's probably a token sitting right there. But a fallback like that converts every resolver bug into a *silent* one: the channel keeps limping along on a stale token that works until it doesn't, at 3 a.m., with no error pointing at the actual cause. Returning `null` means an unlinked credential fails on the first send with a clear log line, while the credential is still fresh in someone's memory. Loud and early beats quiet and eventual.
+
+## The whole lifecycle, in one paragraph
+
+A secret is typed once and encrypted into a versioned AES-256-GCM box. Every read after that is a server-side reveal; the browser only ever sees `__HIDDEN__`. Edits strip the sentinel and merge — nesting-aware, blank-keeps-existing — so no field can clobber its siblings. OAuth tokens refresh ahead of expiry through a proportional window, single-flight behind a Redis lock, with failures counted by a breaker for the machines and classified into a reconnect signal for the humans. And when any of it fails, it fails loudly at the edge instead of silently serving yesterday's token.
+
+That's the series. [Part 1](/blog/connections-part-1-one-model-for-every-connection) was the model — one blueprint table, one instance table, auth as data. This part was the lifecycle that keeps the model trustworthy. Together they're why adding a new provider to Auxx.ai is a row of declarative data, and why our AI keys, [app connections](/blog/building-your-own-app-store-part-1), MCP servers, and email channels all get masking, merging, and refresh for free.
+
+Entry points, if you want to dig in:
+
+- `packages/credentials/src/crypto/client.ts`, the client-safe sentinel/mask/split core
+- `packages/credentials/src/crypto/secret-box.ts`, the encryption box and both decrypt policies
+- `packages/credentials/src/store/merge-secret-fields.ts`, the nesting-aware merge
+- `packages/lib/src/credentials/ensure-fresh-credential-token.ts`, single-flight refresh
+- `packages/lib/src/connections/oauth2-token-grants.ts`, the two grants
+
+Auxx.ai is open source. PRs welcome.

--- a/apps/homepage/content/blog/data-connectors-part-1-streams-mappings-sink.mdx
+++ b/apps/homepage/content/blog/data-connectors-part-1-streams-mappings-sink.mdx
@@ -1,0 +1,221 @@
+---
+title: "Building a Data Connector Engine, Part 1: Streams, Mappings, and the Entity Sink"
+description: "How we built the sync engine that pulls Shopify orders, Stripe customers, and any REST API into our entity system: streams, recursive mapping trees, and one choke-point writer. Part 1 of a three-part series."
+date: "2026-07-07"
+slug: "data-connectors-part-1-streams-mappings-sink"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["sync", "integrations", "postgres", "drizzle", "typescript", "open-source"]
+published: true
+---
+
+Every external system disagrees with every other external system about everything: pagination, ids, nesting, timestamps, deletes. If you build one integration at a time, you rebuild the same sync engine at a time, and each copy has its own bugs.
+
+So we built the engine once. Data Connectors is the machinery that pulls external records — Shopify customers, Stripe subscriptions, any JSON-over-HTTP API — into our [custom-fields entity system](/blog/custom-fields-part-1-entity-definitions) and keeps them correct through webhooks, crashes, rate limits, and multi-thousand-record backfills. This is not a "we integrated Shopify" post. It is a walkthrough of the generic spine that makes every integration the same integration.
+
+The plan for the series:
+
+1. **This post** covers the data model and the write path: streams, the recursive mapping tree, and the entity sink that is the only thing allowed to write.
+2. **[Part 2](/blog/data-connectors-part-2-identity-relationships-reconciliation)** is about identity: how a record stays the *same* record across re-syncs, how cross-record references resolve, and how orphans get reconciled without archiving half your CRM.
+3. **[Part 3](/blog/data-connectors-part-3-slices-webhooks-scale)** is the orchestration layer: bounded resumable slices, opaque cursors, the webhook philosophy, and async bulk exports.
+
+The engine lives in `packages/lib/src/data-connectors/`, with the provider-agnostic orchestration shell in `packages/lib/src/sync-core/`. Auxx.ai is [open source](https://github.com/auxxai/auxx), so you can read along.
+
+## The shape of the problem
+
+We wanted one spine where three very different kinds of connectors are interchangeable: a no-code generic REST connector a user configures in the UI, a third-party app connector running in a sandbox (our Shopify app lives in a separate repo and ships its connector as data), and a dependency-free fixture connector we use to prove the spine in tests.
+
+The whole resolution surface is one function, in `packages/lib/src/data-connectors/connectors/registry.ts`:
+
+```typescript
+export function connectorFor(type: string, context?: AppConnectorContext): DataConnectorDefinition {
+  if (type.startsWith('app:')) return appConnectorAdapter(type, context)
+  const builtin = BUILTIN_CONNECTORS[type] // 'generic-rest', 'fixture'
+  if (!builtin) throw new NotFoundError(`Unknown data connector type: ${type}`)
+  return builtin
+}
+```
+
+The rule downstream of this function is absolute: the orchestrator never branches on provider. Provider-specific logic belongs inside the connector's `fetch`, nowhere else. That single constraint is what keeps the engine an engine instead of a pile of if-statements.
+
+It also has a compounding payoff: new SaaS integrations become *data*, not code. A template in `packages/lib/src/data-connectors/templates/defs/stripe.json` seeds a generic-rest connector pre-wired with an endpoint, streams, and recommended field mappings. Nobody writes a Stripe connector class.
+
+## Five control tables
+
+The persistent model is five tables, all in `packages/database/src/db/schema/`:
+
+| Table | Role |
+|-------|------|
+| `DataConnector` | The definition: type, config (endpoint, filters, webhook signal), the bound credential, schedule, status. |
+| `DataConnectorStream` | One fetch = one source schema. Holds the request config, the inferred/declared `sourceSchema`, and the durable per-stream sync `state` (phase, cursor, watermark). |
+| `DataConnectorMapping` | The fan-out. One row per target entity definition a fetch lands in, with a self-FK `parentMappingId` for nested subtrees. |
+| `DataConnectorItem` | The durable binding between one upstream record and one entity instance, per mapping. The heart of identity — Part 2 is mostly about this table. |
+| `DataConnectorRun` | The health ledger: one row per sync with per-category counts, a progress snapshot, and a heartbeat. |
+
+The split that matters most is stream vs. mapping. A **stream** says how to fetch — path, params, pagination, incremental config. A **mapping** says where a piece of the fetched payload lands. One stream fans out to N mappings, which is how a single `GET /orders.json` produces Orders, Line Items, *and* enriched Contacts in one pass.
+
+## The connector contract: records and checkpoints
+
+A connector's only job is to fetch and yield raw payloads, one page at a time, with a resume point between pages. The contract, from `packages/lib/src/data-connectors/types.ts`:
+
+```typescript
+interface ConnectorRecord {
+  streamKey: string
+  fields: unknown        // the RAW payload (array OR object) — the source schema mirrors this
+  externalId?: string    // optional hint, used only for a whole-record root
+  deleted?: boolean      // tombstone — an explicit upstream delete
+  contentHash?: string   // optional; the sink computes a sorted-key hash if absent
+}
+
+interface ConnectorCheckpoint {
+  __checkpoint: true
+  cursor?: SyncCursor    // resume the NEXT page from here; absent ⇒ that was the last page
+  watermark?: string     // max watermark observed through this page
+}
+
+type ConnectorYield = ConnectorRecord | ConnectorCheckpoint
+
+interface FetchResult {
+  records: AsyncIterable<ConnectorYield>  // lazy — records interleaved with checkpoints
+  nextState: ConnectorStreamState
+}
+```
+
+Two decisions in here shaped everything downstream.
+
+First, `fields` is the *raw* payload — for generic REST it is literally the HTTP response body. The connector does no mapping. That means the source schema the mapping UI shows is exactly what a test-fetch returns, so what you configure against and what syncs at 3 a.m. can never diverge.
+
+Second, the checkpoint sentinel interleaved into the record stream. A connector emits one after every page it finishes yielding. The engine never interprets the cursor inside it; it just persists it and hands it back on the next fetch. This one type is what makes the sliced, crash-resumable orchestration in Part 3 possible — the slice runner can stop at any page boundary and know exactly where to pick up.
+
+## Owned vs. contributing: the target is a choice
+
+The first design decision a mapping encodes: does this connector *own* its destination, or does it *contribute* to one that already exists?
+
+**Owned mode** provisions a new entity definition and owns it. Shopify Orders is a definition your org did not have before the connector existed. The connector creates the fields (read-only in the grid — `isUpdatable: false`, because hand-editing a synced field is a lie that lasts until the next sync), stamps provenance at the column level, and is allowed to archive records that vanish upstream.
+
+**Contributing mode** writes field-by-field into a definition that already exists — including the system `contact` and `ticket` definitions the helpdesk runs on. A Shopify customer contributes an email, a name, and a total-spent figure onto a Contact that may also be co-owned by a Stripe connector and edited by humans. Contributing mode has per-field ownership, protects shared editable fields with conservative merge strategies, and **never** archives an instance on absence — other owners share it.
+
+This choice is per-mapping, not per-connector. Our Shopify connector uses both in one sync: orders and line items as owned definitions, customers contributing into `contact`.
+
+## One fetch fans out via a recursive mapping tree
+
+Here is the part we like best. A raw payload like a Shopify order is a tree: the order, an embedded `customer` object, a `line_items` array. The mapping layer mirrors that shape with a tree of `DataConnectorMapping` rows connected by the self-FK `parentMappingId`. Each mapping declares a `rootPath` — `''` for the whole record, `customer` for an embedded object, `line_items[]` for each array element — and child mappings extract *relative to their parent's subtree*.
+
+`mapRecord` in `packages/lib/src/data-connectors/map-record.ts` is a pure recursive walk:
+
+```typescript
+const walk = (mapping, parent, parentExternalId) => {
+  for (const { value: subtree, index } of extractSubtrees(parent, mapping.rootPath)) {
+    const externalId = resolveExternalId(mapping, subtree, index, parentExternalId, rootHintId)
+
+    writes.push({
+      mapping,
+      projected: {
+        externalId,
+        fields: evaluateFields(mapping, subtree),
+        identityCandidates: identityCandidates(mapping, subtree),
+        pendingRelations: [],
+      },
+      parentRelation, // the relationship edge back to the parent instance
+    })
+
+    // Recurse into children RELATIVE to this subtree.
+    for (const child of childrenOf.get(mapping.row.id) ?? []) {
+      walk(child, subtree, externalId)
+    }
+  }
+}
+```
+
+One order record in, N projected writes out: one for the Order, one per Line Item, one for the Customer, each carrying the edge that links it back to its parent.
+
+Field values inside a mapping are CALC expressions — the same formula language our computed custom fields use. A one-click mapping is the degenerate `{source}` token; a composite is `concat({first_name}, ' ', {last_name})`. The `sourceFields` map binds each placeholder to a subtree-relative path, so the same expression works whether the mapping sits at the root or three levels deep.
+
+The orchestrator around the walk, `sinkSourceRecord` in `packages/lib/src/data-connectors/sink-source-record.ts`, enforces one ordering rule: **parents are written before children**, so when a line item's relationship edge resolves, the order it points at already exists. It also handles tombstones — a record with `deleted: true` archives every projected binding instead of upserting anything.
+
+## jsonb gotchas as design constraints
+
+Two of our early bugs came from the same root cause, and both turned into durable design rules.
+
+Postgres `jsonb` does not preserve key order. It normalizes objects, and keys come back sorted however Postgres pleases. Two consequences:
+
+**Field mappings are an array of entries, not a keyed object.** Each entry carries a stable generated `id` that the UI and patch operations address; nothing keys by the target field:
+
+```typescript
+interface FieldMapping {
+  id: string                              // stable entry id — React key + patch handle, never reused
+  targetFieldRef: ResourceFieldId | null  // null = unassigned draft, skipped at runtime
+  expression: string                      // CALC: '{source}' or 'concat({sku},{variant})'
+  sourceFields: Record<string, string>    // placeholder → subtree-relative source path
+  identityRole?: { kind: 'externalId'; order?: number } | { kind: 'match'; normalize?: IdentityNormalize }
+  mergeStrategy?: FieldMergeStrategy
+}
+```
+
+An entry survives before it has a target (a draft formula), and retargeting a binding does not re-key anything. If we had keyed the map by target field, both of those would have been migrations.
+
+**Change detection hashes with sorted keys, never `JSON.stringify`.** The sink skips unchanged records by content hash. Our first version stringified the mapped fields — and because jsonb reorders keys on the round-trip, records read back from the database hashed differently than the ones just mapped, so every re-sync looked like a change. Thousands of no-op writes per run, invisible until you looked at the `updated` counters. The fix is a sorted-key hash, and it is now a rule enforced in one place:
+
+```typescript
+// entity-sink.ts — sorted-key hash, immune to jsonb key reordering
+const contentHash = stableHash({ fields: record.fields, displayName: record.displayName })
+if (bound?.entityInstanceId && bound.contentHash === contentHash) {
+  await touchItem(ctx.db, bound.id, ctx.runId)  // still mark "seen this run"
+  ctx.counters.skipped += 1
+  return
+}
+```
+
+Note the `touchItem` even on a skip. "Seen this run" drives orphan reconciliation (Part 2), so a skipped record must still prove it exists.
+
+## The entity sink is the only writer
+
+Everything above produces `ProjectedRecord`s. Exactly one code path consumes them: `packages/lib/src/data-connectors/sinks/entity-sink.ts`. Whether the fetch came from built-in lib code, a sandboxed app, a scheduled backfill, or a webhook-steered point fetch, all entity writes funnel through this file, and it writes through the same `UnifiedCrudHandler` the rest of the platform uses — so every value passes the typed field-value converters, and nothing a connector syncs can bypass validation.
+
+Having one choke point is what makes per-field merge strategies enforceable. Each binding declares how the connector is allowed to write:
+
+```typescript
+type FieldMergeStrategy =
+  | 'overwrite'             // the connector owns this field's value
+  | 'fill_blank'            // write only when the target is empty
+  | 'connector_owned_only'  // write only fields this connector established
+  | 'manual_review'         // log a conflict, never write
+  | 'ignore'
+```
+
+`fill_blank` is the workhorse for contributing mode. A Shopify customer's name fills an empty Contact name but never clobbers one a support agent typed in:
+
+```typescript
+if (strategy === 'fill_blank') {
+  const cur = current ? rawOf(current.get(fieldId)) : undefined
+  if (isBlank(cur)) writeSet[fieldId] = value
+  continue
+}
+```
+
+There is a subtle interaction between `overwrite` and the content-hash skip that bit us. The hash covers the *source* only, so a hand-edit on the destination is invisible to it: someone edits a synced cell in the grid, the source has not changed, and the connector skips forever — an `overwrite` field that never re-asserts itself. The fix is a drift check: contributing writes stamp `FieldValue.managedByConnectorId`, and once per mapping per slice one bulk query finds bound instances whose overwrite cells lost that stamp. Those records bypass the skip and get re-asserted, which re-stamps the marker and heals them.
+
+One more thing the sink does that matters at scale: writes go out with `skipEvents: true`. A 5,000-record backfill firing the full per-write event fan-out — field hooks, activity timeline, the [BullMQ event bus](/blog/bullmq-job-queue-architecture-part-1), realtime — would be a self-inflicted storm. Instead the sink accumulates a compact manifest of changes to fields that automation rules actually watch, and publishes a single `sync:records:changed` event when the run finalizes. Automations still react to synced data; they just react once.
+
+## What the engine refuses to know
+
+Tally what never appeared in this post: no Shopify API shapes, no Stripe endpoints, no OAuth. The engine knows streams, mappings, projected records, and the sink contract. Provider knowledge lives behind `fetch` and nowhere else. That is the whole trick, and it is the same trick as our [agent engine](/blog/agent-engine-part-1-domain-agnostic-harness): own the loop, make the domain plug in.
+
+## Next up
+
+We can now turn one raw API payload into a tree of entity writes. What we have not answered is the question that makes sync *sync* rather than import: when the same Shopify customer arrives for the fifth time, how does the engine know it is the same record — and when a customer disappears upstream, who is allowed to archive what?
+
+That is [Part 2](/blog/data-connectors-part-2-identity-relationships-reconciliation): identity resolution, the bind table, pending relationships, and reconciliation.
+
+If you want to read ahead, the entry points are:
+
+- `packages/lib/src/data-connectors/connectors/types.ts`, the connector contract
+- `packages/lib/src/data-connectors/map-record.ts`, the recursive mapping walk
+- `packages/lib/src/data-connectors/sink-source-record.ts`, the fan-out orchestrator
+- `packages/lib/src/data-connectors/sinks/entity-sink.ts`, the only writer
+
+Auxx.ai is [open source](https://github.com/auxxai/auxx). PRs welcome.

--- a/apps/homepage/content/blog/data-connectors-part-2-identity-relationships-reconciliation.mdx
+++ b/apps/homepage/content/blog/data-connectors-part-2-identity-relationships-reconciliation.mdx
@@ -1,0 +1,214 @@
+---
+title: "Building a Data Connector Engine, Part 2: Identity, Relationships, and Reconciliation"
+description: "How synced records stay the same record: the identity cascade, the bind table, deferred relationship resolution, and why deletes are the hardest part of sync. Part 2 of a three-part series."
+date: "2026-07-14"
+slug: "data-connectors-part-2-identity-relationships-reconciliation"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["sync", "integrations", "postgres", "drizzle", "typescript", "open-source"]
+published: true
+---
+
+The hard part of a sync engine is not fetching data. It is that the same Shopify customer will arrive a thousand times — from a backfill, a nightly delta, a webhook, a manual re-sync — and every single arrival has to land on the same record, forever, even after someone renames the customer, changes their email, or edits the mapping config.
+
+Get identity wrong and you get duplicates, which users forgive once. Get deletion wrong and you archive live customer records, which they do not forgive at all. This post is about how our data connector engine handles both.
+
+The plan for the series:
+
+1. **[Part 1](/blog/data-connectors-part-1-streams-mappings-sink)** covered the data model and the write path: streams, the recursive mapping tree, and the entity sink.
+2. **This post** is identity and correctness: the three-step identity cascade, the bind table, pending relationships, and orphan reconciliation.
+3. **[Part 3](/blog/data-connectors-part-3-slices-webhooks-scale)** is the orchestration layer: bounded resumable slices, opaque cursors, webhooks, and async bulk exports.
+
+The code lives in `packages/lib/src/data-connectors/`. Auxx.ai is [open source](https://github.com/auxxai/auxx), so everything quoted here is real.
+
+## The bind table
+
+The obvious way to remember which entity record corresponds to which upstream record is to stamp `externalId` on the entity row. We did not do that, and the reasons compound.
+
+Instead there is a dedicated table, `DataConnectorItem` — one row per (mapping, upstream record), binding an `externalId` to an `entityInstanceId`. Its unique index *is* the identity model:
+
+```typescript
+// packages/database/src/db/schema/data-connector-item.ts
+uniqueIndex('DataConnectorItem_dataConnectorId_mappingId_externalId_key').using(
+  'btree',
+  table.dataConnectorId.asc().nullsLast(),
+  table.mappingId.asc().nullsLast(),
+  table.externalId.asc().nullsLast()
+)
+```
+
+Why a bind table beats a stamped column:
+
+- **Multi-source records.** A Contact enriched by both Shopify and Stripe has *two* upstream identities. A single `externalId` column forces the sources to fight; two bind rows coexist.
+- **Per-mapping identity.** One fetch fans out to several mappings (Part 1), and each projected subtree has its own external id. The binding is keyed by mapping, so an order and its embedded customer bind independently even though they came from one payload.
+- **Bookkeeping lives off the entity row.** The item row carries the content hash, the pending relationship edges, an upstream version stamp, and `lastSeenRunId` — all sync plumbing that has no business polluting a CRM record.
+- **Provenance without ambiguity.** A `mintedInstance` boolean records whether this connector *created* the instance or merely matched and enriched a pre-existing one. When you delete a connector and choose "delete synced records," only minted records go — a Contact that existed before the connector and got enriched by it survives. We originally stamped `integrationSource` on the entity row for this; the boolean on the binding replaced it because the row-level stamp could not answer "who created it" once two sources wrote the same record.
+
+## The identity cascade
+
+Every projected record entering the sink (`packages/lib/src/data-connectors/sinks/entity-sink.ts`) resolves its target instance through an ordered cascade. Trimmed from `upsertRecord`:
+
+```typescript
+// 1. Exact bind — the steady-state match, hit on every re-sync after the first.
+const bound = await findItem(ctx.db, ctx.connector.id, mapping.row.id, record.externalId)
+let instanceId = bound?.entityInstanceId ?? null
+
+// 2. Def-keyed reuse — another mapping of this connector already bound
+//    (definition, externalId). An embedded Order → Customer branch converges
+//    on the Customers stream's Contact instead of minting a duplicate.
+if (!instanceId) {
+  const shared = await findItemByDef(
+    ctx.db, ctx.connector.id, mapping.entityDefinitionId, record.externalId
+  )
+  instanceId = shared?.entityInstanceId ?? null
+}
+
+// 3. Secondary match keys — adopt an existing record (e.g. by normalized email).
+if (!instanceId) {
+  const resolved = await resolveIdentity(ctx, mapping, record, refToConcrete)
+  instanceId = resolved.instanceId
+}
+
+// 4. Still nothing → create, then bind. The binding makes steps 2–4 one-time events.
+```
+
+Step 3 is what makes contributing mode humane. A field mapping can be flagged with an identity role:
+
+```typescript
+identityRole?:
+  | { kind: 'externalId'; order?: number }          // (part of) the upstream stable id
+  | { kind: 'match'; normalize?: IdentityNormalize } // a SECONDARY match key
+```
+
+A Shopify customer mapping flags `email` as a `match` key with `normalize: 'email'`. On first contact — no binding yet — the sink looks for an existing Contact whose email equals the source value after normalization:
+
+```typescript
+function normalizeMatch(value: unknown, normalize?: 'email' | 'phone' | 'domain' | 'none'): string {
+  const s = String(value ?? '').trim()
+  if (normalize === 'email') return s.toLowerCase()
+  if (normalize === 'domain')
+    return s.toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '')
+  return s
+}
+```
+
+If it finds one, it adopts it and writes the binding. From then on, step 1 wins on the exact index and the match logic never runs again for that record. Matching is a *bootstrap*, not the steady state — that distinction matters, because match keys are mutable (people change emails) while the binding is not.
+
+The `externalId` role is the other half. The external id of a subtree used to be a silent heuristic (`id`, else `externalId`, else a synthetic `parent:index`). Now the user — or the connector's manifest — explicitly designates which field is the upstream stable id, as an ordered fallback chain (`id → email`, first non-null wins). Because the designation is a normal CALC binding, a composite key like `{sku}-{variant}` costs no new mechanism. The heuristic still exists, but only as the pre-filled default: a wrong guess is now visible and overridable instead of silently mis-keying every record.
+
+One war story from this exact area. Connection-scoped app fields meant one entity definition could hold *two* `customerId` fields — one per connected store — and a `.find()` in our materialization code grabbed the first field carrying an identity role, regardless of which connection it belonged to. Records from store B got their identity stamped onto store A's field. The fix was embarrassingly small (check all candidates with `.some()` against the right connection instead of taking the first), but the lesson generalizes: identity code must never say "first match wins" over a set that can legitimately contain more than one.
+
+## Races and out-of-order arrivals
+
+Two guards in the sink exist purely because reality is concurrent.
+
+The def-keyed reuse read (step 2) is deliberately best-effort — no lock. Two streams first-contacting the same customer in the same instant can still double-create. We accepted that: the window is one record wide, one time, and a lock across every record write would cost more than the rare duplicate it prevents.
+
+The out-of-order guard is stricter. Webhook deliveries for the same record can race: event A fetches version 1, event B fetches version 2, A's write lands last, and last-write-wins persists stale data. When both the incoming record and the binding carry an upstream `updatedAt`, the sink drops a strictly-older write:
+
+```typescript
+if (
+  bound?.entityInstanceId &&
+  bound.upstreamUpdatedAt &&
+  record.upstreamUpdatedAt &&
+  record.upstreamUpdatedAt.getTime() < bound.upstreamUpdatedAt.getTime()
+) {
+  await touchItem(ctx.db, bound.id, ctx.runId) // still counts as "seen"
+  ctx.counters.skipped += 1
+  return
+}
+```
+
+The version stamp lives on the binding — again, sync plumbing kept off the entity row.
+
+## Relationships resolve later, on purpose
+
+A line item points at a product. An order points at a customer. But sync order is not dependency order: the order may arrive before the product catalog has ever synced. You cannot write a relationship to a record that does not exist yet.
+
+So cross-record references never write directly. The mapping layer emits them as *pending relations* on the binding row:
+
+```typescript
+pendingRelations: Array<{
+  fieldKey: string                 // the relationship field to write on THIS instance
+  targetDef: string | null         // the target's entity definition
+  targetExternalId: string | null  // the target's upstream id; null = CLEAR (FK went empty)
+}>
+```
+
+A separate pass, `packages/lib/src/data-connectors/relationship-pass.ts`, runs after the streams finish. For each pending edge it resolves the target *def-keyed* — by (connector, target definition, external id), through whichever mapping happened to sync it — and writes the real relationship field value:
+
+```typescript
+const target = rel.targetDef
+  ? await findItemByDef(ctx.db, ctx.connector.id, rel.targetDef, rel.targetExternalId)
+  : null
+if (!target?.entityInstanceId) {
+  stillPending.push(rel) // target not synced yet — defer to a later run
+  ctx.counters.relationshipWarnings += 1
+  continue
+}
+await ctx.crud.update(parentRecordId, { [rel.fieldKey]: targetRecordId }, undefined, {
+  skipSnapshotInvalidation: true,
+})
+```
+
+Three properties fall out of this design. It is **self-deferring**: an unresolved edge stays pending and resolves on any later run, with a `relationshipWarnings` counter surfacing how many are still dangling. It is **build-order independent**: an earlier version froze a pointer to the mapping that owned the target, which broke the moment you reordered mappings; keying by definition made ordering irrelevant. And it handles **clears**: a foreign key that goes empty upstream produces a pending relation with a null target, which nulls the field exactly once — guarded by a `linkedRelations` ledger of edges the connector actually set, so it never clears an edge a human created.
+
+Cardinality gets one more trick. A `belongs_to` edge stamps the parent's field directly. A `has_many` edge can't — you don't write "all line items" onto the order. Instead `sink-source-record.ts` side-flips it: each child gets the inverse `belongs_to` edge pointing at the parent, and the parent's collection syncs automatically through the entity system's inverse-field machinery from [our custom fields series](/blog/custom-fields-part-1-entity-definitions).
+
+## Deletes are the hardest part of sync
+
+Ask anyone who has built one of these: creates are easy, updates are annoying, deletes are where the engineering lives. Most APIs will happily tell you everything that exists and nothing about what stopped existing. You are left inferring deletion from *absence* — and absence is exactly what a partial fetch, a crashed run, and a filtered query also look like.
+
+Our rules, in `packages/lib/src/data-connectors/reconciliation.ts`:
+
+**Orphan reconciliation runs only where absence is meaningful.** Every record the sink touches gets stamped with `lastSeenRunId` — even content-hash skips. After a run that crawled *everything*, a binding not stamped with this run's id is an orphan:
+
+```typescript
+export async function reconcileOrphans(ctx: SyncCtx, streams: ReconcilableStream[]) {
+  for (const { syncMode, mappings } of streams) {
+    if (syncMode !== 'snapshot') continue     // incremental: absence ≠ deletion — ALWAYS
+    for (const mapping of mappings) {
+      if (mapping.targetMode !== 'owned') continue  // never archive co-owned records
+      if (mapping.linkMode !== 'upsert') continue
+      if (mapping.orphanBehavior === 'ignore') continue
+
+      const items = await entitySink.listExistingItems(ctx, mapping)
+      for (const item of items) {
+        if (item.lastSeenRunId === ctx.runId) continue // seen this run
+        await entitySink.archiveRecord(ctx, item, mapping.orphanBehavior)
+      }
+    }
+  }
+}
+```
+
+Each `continue` is a scar. Incremental streams fetch watermark deltas — they did not see every record, so absence proves nothing, and deletes on those streams must come from explicit signals (a tombstone record, an event-feed `*.deleted`, a webhook delete). Contributing mappings never archive, period — the instance is co-owned by other connectors and by humans. And archiving itself has one more guard: under def-keyed sharing, one instance can be bound by several mappings, so `archiveRecord` archives the instance only when *no other live binding* of the connector still references it.
+
+**Reconciliation is gated behind a completion latch.** This is the invariant we consider non-negotiable: a partial backfill must never archive records it simply hasn't reached yet. In the sliced orchestration (Part 3), a backfill spans many bounded jobs across multiple streams. The shared slice runner fires `finalizeBackfill` exactly once, when a stream's backfill genuinely exhausts — and the connector-side source gates even that behind an atomic per-connector latch (`initConnectorBackfillLatch`, seeded to the stream count) so only the *last* stream to finish triggers reconciliation and the relationship pass. A crash mid-backfill leaves the phase at `backfill`; the retry resumes from the checkpoint and reconciliation waits.
+
+**A periodic sweep catches what webhooks miss.** A webhook-driven connector that misses a delete delivery would hold the ghost record forever. The scheduled sweep re-runs the backfill machinery: snapshot streams do a full re-crawl and archive true orphans; incremental streams do a cheap watermark catch-up and — per the rule above — archive nothing.
+
+## Provisioning happens lazily, and loudly
+
+One last correctness layer sits before any record flows. A connector's target schema — owned definitions, provisioned fields, late-bound `@app:` field references — is materialized at sync start (`materializeConnectorTargets` in `packages/lib/src/data-connectors/provisioning.ts`), idempotently keyed so re-runs are near-no-ops.
+
+Then a pre-flight pass in the orchestrator resolves every distinct `targetFieldRef` the mappings reference, once, against the connector's bound connection. If any ref cannot resolve, the sync refuses to start and parks the connector with the error. The alternative — which we lived through — is thousands of per-record "unresolved ref, skipping field" drops that present as a *successful* run with mysteriously empty columns. One visible setup error beats a silent one repeated five thousand times. (The per-record resolver in the sink still exists, backed by the [org-level cache](/blog/how-we-implemented-caching-part-1), but after pre-flight it only catches genuine mid-run anomalies.)
+
+## Next up
+
+We now have records that keep their identity across a thousand arrivals, relationships that resolve whenever their targets show up, and deletes that only fire when absence actually proves something. What we have quietly assumed all along is that a sync can *finish* — that a worker can hold a job long enough to crawl an entire Shopify store.
+
+It can't, and it shouldn't. [Part 3](/blog/data-connectors-part-3-slices-webhooks-scale) is the orchestration layer: budgeted slices that checkpoint after every page, the three-state commit verdict that decides when a cursor may advance, opaque cursors across six pagination styles, and why a webhook is a signal but never the truth.
+
+If you want to read ahead:
+
+- `packages/lib/src/data-connectors/sinks/entity-sink.ts`, the identity cascade
+- `packages/database/src/db/schema/data-connector-item.ts`, the bind table
+- `packages/lib/src/data-connectors/relationship-pass.ts`, deferred edges
+- `packages/lib/src/data-connectors/reconciliation.ts`, orphan handling
+
+Auxx.ai is [open source](https://github.com/auxxai/auxx). PRs welcome.

--- a/apps/homepage/content/blog/data-connectors-part-3-slices-webhooks-scale.mdx
+++ b/apps/homepage/content/blog/data-connectors-part-3-slices-webhooks-scale.mdx
@@ -1,0 +1,215 @@
+---
+title: "Building a Data Connector Engine, Part 3: Slices, Webhooks, and Surviving 50,000 Records"
+description: "The orchestration layer of our sync engine: bounded resumable slices, a three-state commit verdict, opaque cursors across six pagination styles, and why the webhook is the signal but the fetch is the truth. Part 3 of a three-part series."
+date: "2026-07-21"
+slug: "data-connectors-part-3-slices-webhooks-scale"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["sync", "integrations", "postgres", "drizzle", "typescript", "open-source"]
+published: true
+---
+
+A sync that works on 50 records and dies on 50,000 is not a sync engine; it is a demo. The failure is always the same shape: one worker job tries to crawl an entire upstream dataset, holds its lock for minutes, hits a rate limit or a deploy or a crash somewhere around page 40 — and starts over from page 1.
+
+This final post is about the orchestration layer that makes our data connectors boring at scale: syncs as chains of bounded, resumable slices, a commit protocol for when a cursor may advance, and a webhook model with one rule we will defend to the death.
+
+The plan for the series:
+
+1. **[Part 1](/blog/data-connectors-part-1-streams-mappings-sink)** covered the data model and the write path: streams, mapping trees, and the entity sink.
+2. **[Part 2](/blog/data-connectors-part-2-identity-relationships-reconciliation)** was identity and correctness: the bind table, deferred relationships, and reconciliation.
+3. **This post** is the orchestration layer: slices, cursors, webhooks, and async bulk exports.
+
+The provider-agnostic spine lives in `packages/lib/src/sync-core/`, the connector-side orchestration in `packages/lib/src/data-connectors/`. Auxx.ai is [open source](https://github.com/auxxai/auxx), so you can read every line quoted here in context.
+
+## A sync is a chain of slices
+
+The core idea: a sync run is not one job. It is a *chain* of short jobs, each of which fetches a few pages, sinks them, checkpoints an opaque cursor onto the stream row, and re-enqueues its successor on our [BullMQ queue layer](/blog/bullmq-job-queue-architecture-part-1). Each slice is bounded by a budget, and it stops at whichever limit it hits first:
+
+```typescript
+// sync-core/contracts.ts
+interface SliceBudget {
+  maxPages: number    // hard cap on pages fetched in one slice
+  maxRecords: number  // hard cap on records processed
+  maxMs: number       // wall-clock for ACTIVE work — NOT counting throttle waits
+}
+
+// slice-orchestrator.ts — the production tuning
+export const SLICE_BUDGET = { maxPages: 20, maxRecords: 5_000, maxMs: 25_000 } as const
+export const SLICE_LOCK_DURATION_MS = 90_000
+```
+
+`maxMs` sits well under the BullMQ `lockDuration`, so a slice can never outlive its lock. And a slice **never sleeps on a throttle while holding that lock** — when the upstream says 429, the connector throws immediately (the sliced source sets `rateLimitOverride: { maxRetries: 0 }` on the transport), and the *re-enqueue delay* carries the backoff instead. Workers work or they yield; they do not nap.
+
+The shared runner in `packages/lib/src/sync-core/slice-runner.ts` runs exactly one slice and returns a directive — `reenqueue`, `complete`, or `failed`. The chain is nothing more than the worker acting on `reenqueue`. And because the cursor is checkpointed after *every* slice, a crashed worker, a deploy, or a swept-stale run resumes from the last committed page. Never page 1. On a 50,000-record backfill that difference is the difference between an engine and a prayer.
+
+Two guardrails ride along the chain. A per-run ingest ceiling parks a runaway backfill (`paused`, resumable from the checkpoint) rather than letting a mis-targeted endpoint ingest unbounded volume. And stale-run detection keys on a heartbeat, not a start time — a chain spanning twenty minutes of short jobs is perfectly healthy, so `sweepStaleConnectorRuns` fails only runs whose `heartbeatAt` (bumped by every slice's ledger fold) has gone cold, then releases the connector claim so the next trigger can resume.
+
+## The three-state commit verdict
+
+The subtle question in any checkpointed system: when is it safe to advance the cursor? A binary answer — advance on success, hold on failure — has a fatal corner: a poison record at a page boundary either blocks the cursor forever or vanishes silently. So the verdict is three-state, and the core enforces it:
+
+```typescript
+// sync-core/contracts.ts
+type SliceCommit =
+  | 'all'                // clean slice — advance the cursor
+  | 'partial-retriable'  // transient failure (429, 5xx, timeout) — HOLD the cursor, re-fetch
+  | 'partial-permanent'  // poison records that will never parse — ADVANCE past them
+```
+
+`partial-retriable` holds ground so nothing is lost; `partial-permanent` gives up ground deliberately so one malformed record cannot wedge a 50,000-record backfill, feeding the run's `failed` counter instead.
+
+Rate limits get the most interesting treatment, in `packages/lib/src/data-connectors/connector-slice-loop.ts`. Whether a 429 is retriable depends on *when* it hit:
+
+```typescript
+} catch (error) {
+  if (error instanceof ConnectorRateLimitError) {
+    rateLimitWaitMs += error.retryAfterMs ?? 0
+    // Made progress this slice → commit it and advance; the next slice resumes
+    // at the last good page and re-hits the limit after the backoff delay.
+    if (pages > 0) {
+      return { recordsProcessed, pagesProcessed: pages, nextCursor,
+               hasMore: true, commit: 'all', rateLimitWaitMs }
+    }
+    // Zero progress (throttled on the first page) → hold the cursor, back off.
+    return { recordsProcessed: 0, pagesProcessed: 0,
+             hasMore: true, commit: 'partial-retriable', rateLimitWaitMs }
+  }
+  throw error // permanent — the runner closes the run as failed
+}
+```
+
+A throttle after three good pages is not a failure; it is a slice that ended early. Commit the three pages, advance, pace the next slice by `retryAfterMs`. Only a throttle with zero progress holds the cursor.
+
+The runner adds two more invariants. Ledger folds are idempotent: each slice's counter contribution carries the serialized post-slice cursor as a `checkpointKey`, so a BullMQ job replay that already committed cannot double-count `created`/`updated`. And a stall guard counts consecutive slices that advanced, claimed more pages, and moved *nothing* — the signature of an upstream replaying the same page while signalling `has_more` — and fails the run after a couple of strikes instead of spinning a warm-heartbeat continuation chain forever.
+
+## Opaque cursors, six pagination dialects
+
+The engine never interprets a cursor. It persists this and hands it back:
+
+```typescript
+// sync-core/contracts.ts
+interface SyncCursor {
+  kind: 'token' | 'nextUrl' | 'headerLocator' | 'offset' | 'pageNumber' | 'historyId' | 'deltaLink'
+  value: string
+}
+```
+
+`kind` is advisory metadata for debugging; the core branches on it never. Underneath, the generic-REST connector speaks six pagination dialects, configured per stream:
+
+| Kind | Resume token | Example |
+|------|--------------|---------|
+| `cursor` | body field, or a field of the last record | Stripe `starting_after`, Shopify page cursors |
+| `page` | incrementing page number | plain sequential pages |
+| `offset` | computed offset, 0- or 1-based | QuickBooks `STARTPOSITION` |
+| `link-header` | `Link: <url>; rel="next"` header | classic REST hypermedia |
+| `next-url` | full next-page URL in the body | Salesforce `nextRecordsUrl` |
+| `none` | — | single-page endpoints |
+
+App connectors — like our Shopify app, which lives in a separate repo and runs sandboxed — do not even expose their pagination. The app returns one page per `execute` call plus its own cursor, and a tiny codec round-trips it through the engine as an opaque token:
+
+```typescript
+// connectors/app-connector-state.ts
+export function decodeCursor(cursor?: SyncCursor): unknown {
+  if (!cursor || typeof cursor.value !== 'string') return undefined
+  try {
+    return JSON.parse(cursor.value)
+  } catch {
+    return undefined // a malformed/legacy cursor must never fail a live sync
+  }
+}
+
+export function encodeCursor(value: unknown): SyncCursor {
+  return { kind: 'token', value: JSON.stringify(value) }
+}
+```
+
+That silent `catch` is deliberate. Cursors are durable state that outlives deploys; when we changed the cursor format once, connectors in the wild still held the old shape. Decoding tolerantly — a bad cursor means "start fresh," never "crash the sync" — turned a would-be incident into a slightly slower run.
+
+## The webhook is the signal; the fetch is the truth
+
+Now the philosophical hill. When a webhook delivery arrives — `orders/updated`, with a payload that looks temptingly like the whole order — we never write that payload into the entity system. Ever.
+
+Webhook payloads are the least trustworthy data an integration receives: they get truncated, they race each other, providers version them separately from their read APIs, and they arrive shaped differently from what your mappings were configured against. So a delivery does exactly one thing: it *steers* a targeted run of the normal fetch. Per-stream config declares which payload paths become `{path}` placeholders in the regular request template:
+
+```typescript
+// types.ts — per-stream steering (trimmed)
+interface StreamWebhookTrigger {
+  filter?: Record<string, unknown>  // topic discrimination, e.g. { topic: 'orders/create' }
+  paths: string[]                   // payload paths exposed as {path} placeholders
+  deleteWhen?: { tokenTruthy?: string } | { topicEquals?: string }
+  deleteExternalIdPath?: string     // the externalId to archive on a delete event
+}
+```
+
+A pure resolver (`packages/lib/src/data-connectors/webhook-steer.ts`) turns delivery plus config into a directive:
+
+```typescript
+export type WebhookSteer =
+  | { kind: 'fetch'; triggerContext: Record<string, string> }
+  | { kind: 'delete'; externalId: string | null }
+```
+
+A delete archives by external id and skips the fetch. Everything else runs `definition.fetch` seeded with the resolved `triggerContext` — same auth, same base URL, same mappings, same entity sink as a bulk sync, just pointed at `GET /orders/{resourceId}` instead of the whole collection. The webhook told us *something changed*; the API tells us *what it is now*. One flagship app multiplexes 22 topics through a single trigger, and the per-stream `filter` picks the subset each stream cares about.
+
+The equally important half is what a steered run refuses to do, in `packages/lib/src/data-connectors/connector-webhook.ts`. It opens a run row so the delivery shows up in the UI — but closes it as `partial`, runs **no orphan reconciliation** (a run that observed one record and then reconciled would archive every *other* record in the collection), and **never advances the watermark or cursor** (webhook events are out-of-band of the steady delta floor; letting them move it would punch holes in the next incremental run). It is a point write, not a sync. Idempotency comes free from Part 1's machinery: event-id dedup at the receiver plus the sink's content-hash skip.
+
+How deliveries get verified, deduplicated, and dispatched before any of this — the inbound webhook endpoint layer with its HMAC verification and topic extraction — deserves its own write-up; we'll cover the inbound webhook verification layer in a future post.
+
+## Async bulk exports: polling without holding a lock
+
+Some providers refuse to paginate big reads at all. Shopify Bulk Operations and Salesforce Bulk API 2.0 take a query, run it asynchronously server-side, and eventually hand back a result file. The naive integration holds a worker for the duration: submit, poll, poll, poll, download. Minutes of lock for seconds of work.
+
+We modeled it on the machinery we already had: an async export is a slice chain where a slice is a *phase of the job*, not a page. From `packages/lib/src/data-connectors/async-export/slice-loop.ts`:
+
+```typescript
+if (state.stage === 'poll') {
+  const status = await driver.poll(state.handle)
+
+  if (status.state === 'running') {
+    const polls = (state.polls ?? 0) + 1
+    return step({ ...state, polls }, pollDelayMs(polls)) // re-enqueue, capped backoff
+  }
+  if (status.state === 'completed') {
+    // Move to download on the NEXT slice — don't chain a multi-minute
+    // download onto a poll slice.
+    return step({ stage: 'download', url: status.url }, 0)
+  }
+  // failed / expired → re-initiate, bounded; past the budget, fail the run.
+}
+```
+
+A poll slice does no record work and returns in milliseconds; "waiting for the export" is spread across many tiny re-enqueued jobs with capped exponential backoff (5s to 60s), and the phase state rides the same opaque `SyncCursor` as everything else. The only provider-specific code is a three-method driver: `initiate`, `poll`, `download`.
+
+The download phase has one delight. Bulk exports emit *flat* JSONL — an order on one line, each line item on its own line pointing back via `__parentId`, in no guaranteed order. Part 1's mapping trees want nested records, so a provider-neutral helper re-nests the file before it hits the sink:
+
+```typescript
+// async-export/restitch.ts — index all rows first, then link, so a child
+// arriving before its parent (or grandchildren in any order) still nests.
+export function restitchByParentId(rows: Iterable<unknown>, options: RestitchOptions = {}): Rec[]
+```
+
+Because it mutates shared references in the index, grandchildren come along for free: a child attached to its parent already carries its own attached children. After restitching, a bulk export is indistinguishable from paginated fetch output, and the entire mapping/sink spine applies unchanged.
+
+## What we'd do differently
+
+The cross-connection throttle is still a stub. The slice loop handles per-request 429s well, but the `ThrottleHandle` seam — meant to share one rate budget across every source hitting the same upstream account — is currently a no-op passthrough. Two connectors on one Shopify store can still gang up on its limit and take turns backing off instead of coordinating.
+
+Downloads aren't resumable mid-file. A cancelled async-export download re-fetches the whole file; the content-hash skip makes the re-sink idempotent, so it is correct but wasteful. Splitting the download into resumable chunks is deferred until a real dataset makes us.
+
+## Closing the series
+
+Three posts, one design stance: put all the provider chaos behind one narrow contract, and make everything downstream of it boring. Connectors fetch raw pages and emit checkpoints (Part 1). Identity lives in a bind table and deletes require proof (Part 2). Orchestration is bounded slices that checkpoint relentlessly, and webhooks steer fetches rather than being trusted (this post). The payoff is that "add a Stripe integration" is a JSON template, and a 50,000-record backfill is just a longer chain of the same 25-second jobs.
+
+The entry points, if you want to go deeper:
+
+- `packages/lib/src/sync-core/contracts.ts`, the whole shared spine in ~200 lines of types
+- `packages/lib/src/sync-core/slice-runner.ts`, cursor-safety and checkpointing
+- `packages/lib/src/data-connectors/slice-orchestrator.ts`, the continuation chain
+- `packages/lib/src/data-connectors/webhook-steer.ts` and `connector-webhook.ts`, the steering model
+- `packages/lib/src/data-connectors/async-export/`, bulk exports as sliced phases
+
+Auxx.ai is [open source](https://github.com/auxxai/auxx). PRs welcome.

--- a/apps/homepage/content/blog/email-ingestion-pipeline.mdx
+++ b/apps/homepage/content/blog/email-ingestion-pipeline.mdx
@@ -1,0 +1,397 @@
+---
+title: "How an Email Becomes a Ticket: Inside Our Ingestion Pipeline"
+description: "Gmail push notifications, Outlook Graph subscriptions, and raw SES MIME all converge on one ingest function. A deep dive into the dedup cascade, threading, rate limits, and realtime fan-out that turn email into support tickets."
+date: "2026-08-25"
+slug: "email-ingestion-pipeline"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["email", "gmail", "outlook", "webhooks", "typescript", "open-source"]
+published: true
+---
+
+Every email arrives twice.
+
+Send a reply from our app and we write it to the database immediately, so the agent sees it in the thread without waiting. Then, seconds later, Gmail's push notification fires: "something changed in this mailbox." We sync, and the provider hands us the exact same message back — with a different ID, in a different shape, through a different code path. Naive ingestion stores it again. Now the customer's thread has two copies of your reply, or worse, two threads.
+
+This isn't an edge case. It's the steady state of any helpdesk that both sends and syncs email. The same duplication happens when a teammate is CC'd on two connected mailboxes, when a webhook and a scheduled poll race each other, and when a sync retries after a partial failure. If your ingestion isn't idempotent, email will find every hole.
+
+This post walks through how an email becomes a ticket in Auxx.ai: three very different transports converging on one choke point, the dedup cascade that keeps threads clean, and the small decisions — trusting provider thread IDs, promoting placeholder IDs, lazy attachment fetching — that make the whole thing boring in production. Auxx.ai is [open source](https://github.com/auxxai/auxx), so every file mentioned here is real code you can read.
+
+## Three doors, one room
+
+Email reaches us through three transports:
+
+1. **Gmail** — Google Cloud Pub/Sub push notifications, backed by the Gmail History API.
+2. **Outlook** — Microsoft Graph change subscriptions, backed by delta queries.
+3. **Forwarded mail** — raw MIME received by AWS SES, dropped in S3, handed off through SQS to a worker.
+
+Plus a fourth path that isn't a transport at all: a BullMQ polling subsystem that periodically syncs every mailbox regardless of whether push is working. More on that later.
+
+The critical design decision is that none of these paths writes messages directly. They all normalize into a common `MessageData` shape and call one function: `storeMessage` in `packages/lib/src/ingest/store-message.ts`. Reconciliation, participant resolution, thread upserts, metadata updates, and realtime fan-out live in exactly one place. When we fixed the double-arrival bug, we fixed it for all three doors at once.
+
+## The webhook is a doorbell, not a delivery
+
+Neither Gmail nor Microsoft delivers email content through their webhooks. Both send a notification that means "something changed — come look." The Gmail Pub/Sub payload is just an email address and a history ID:
+
+```typescript
+// apps/web/src/app/api/google/webhook/route.ts
+const dataStr = Buffer.from(body.message.data, 'base64').toString('utf-8')
+const data = JSON.parse(dataStr) // { emailAddress, historyId }
+
+const [integration] = await db
+  .select({ id, organizationId, lastHistoryId })
+  .from(schema.Integration)
+  .where(and(
+    eq(schema.Integration.provider, 'google'),
+    eq(schema.Integration.enabled, true),
+    sql`${schema.Integration.metadata} ->> 'email' = ${data.emailAddress}`
+  ))
+```
+
+Microsoft's notification carries a subscription ID and a resource path, but we treat it the same way. Both handlers end in the identical line: kick off an incremental sync for that integration. The webhook carries zero content; the sync machinery does all the work. This has a pleasant consequence — a dropped, duplicated, or reordered webhook can't corrupt anything. The worst case is a sync that finds nothing new.
+
+One detail that bites people: **always acknowledge**. If no integration matches a Pub/Sub message, we still return 200, because a 4xx/5xx makes Pub/Sub retry forever against an address that will never resolve. Same for Graph. The webhook handler's job is to be cheap, safe, and un-crashable.
+
+## Two philosophies of webhook security
+
+Here's where Google and Microsoft diverge sharply.
+
+**Google signs its pushes.** Every Pub/Sub push carries a Google-issued JWT in the `Authorization` header. We verify it against Google's public JWKS keys — RS256, with an allowlist of audiences and issuers:
+
+```typescript
+// apps/web/src/app/api/google/webhook/route.ts
+const publicKey = await getSigningKey(decoded.header.kid) // from googleapis JWKS
+const verified = jwt.verify(token, publicKey, {
+  algorithms: ['RS256'],
+  audience: [
+    WEBAPP_URL,
+    'https://pubsub.googleapis.com/google.pubsub.v1.Subscriber',
+    configService.get<string>('GOOGLE_PUBSUB_SERVICE_ACCOUNT_EMAIL'),
+  ].filter(Boolean),
+  issuer: ['https://accounts.google.com', 'googleidtoken.googleapis.com'],
+})
+```
+
+This is real cryptographic proof of origin. No shared secrets to rotate, nothing stored in your database that an attacker could steal to forge notifications.
+
+**Microsoft uses a handshake plus a shared secret.** When you create a Graph subscription, Microsoft immediately calls your endpoint with a `validationToken` you must echo back as plain text — proof that you own the URL:
+
+```typescript
+// apps/web/src/app/api/outlook/webhook/route.ts
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const validationToken = new URL(req.url).searchParams.get('validationToken')
+  if (validationToken) {
+    return new NextResponse(validationToken, {
+      status: 200,
+      headers: { 'Content-Type': 'text/plain' },
+    })
+  }
+  return NextResponse.json({ status: 'ok', timestamp: Date.now() })
+}
+```
+
+After that, every notification carries back the `clientState` secret you set at subscription time. We generate one per integration, store it in the integration's metadata, and compare with a constant-time equality check (`timingSafeStringEqual`) so response timing can't leak the secret byte by byte. It works, but it's a weaker guarantee than Google's: anyone who obtains the secret can forge notifications, so it has to be treated like a credential.
+
+## Cursors: history IDs vs delta links
+
+Both providers give you incremental sync, and both can invalidate your cursor. The failure modes differ.
+
+**Gmail** hands out monotonically increasing history IDs. You register a watch on the inbox:
+
+```typescript
+// packages/lib/src/providers/google/webhooks/setup-webhook.ts
+const response = await gmail.users.watch({
+  userId: 'me',
+  requestBody: {
+    topicName,                        // Pub/Sub topic
+    labelIds: ['INBOX'],              // watch only the inbox
+    labelFilterBehavior: 'INCLUDE',
+  },
+})
+// persist response.data.historyId and response.data.expiration
+```
+
+Then on every sync you call `users.history.list` from your persisted `lastHistoryId`, collecting `messageAdded`, `messageDeleted`, and `labelRemoved` records (we treat removal of the `INBOX` label as a deletion — an archived message shouldn't sit in the helpdesk as unresolved). Gmail's history log is finite, though: come back after too long and the API returns 404. Our sync catches that and falls back to a full `messages.list` pass, rebuilding the cursor from the highest history ID it sees.
+
+The subtle part is *when to advance the cursor*. If a page of history contained a message we failed to ingest for a transient reason — a 429, a storage hiccup — advancing `lastHistoryId` past that page silently drops the message forever. So we track a `safeHistoryId` that only moves when a page had zero retriable failures:
+
+```typescript
+// packages/lib/src/providers/google/messages/sync-messages.ts
+if (result.retriableFailures.length > 0 || failedFetchIds.length > 0) {
+  hasRetriableFailures = true // historyId will not advance past this page
+}
+if (!hasRetriableFailures) {
+  safeHistoryId = highestHistoryId
+}
+// ...
+const effectiveHistoryId = hasRetriableFailures ? safeHistoryId : highestHistoryId
+```
+
+The next cycle re-reads the failed page. Ingestion is idempotent (that's the whole second half of this post), so re-processing already-stored messages costs a few no-op upserts and nothing else. Cursor safety is cheap when dedup is free.
+
+**Outlook** replaces the numeric cursor with an opaque delta link. You run a delta query against the inbox, page through with the Graph SDK's `PageIterator`, and the final page hands you a new delta link to persist. Two Outlook-specific traps are worth knowing about:
+
+First, Outlook message IDs are *not stable by default*. Move a message to another folder and its ID changes — catastrophic if that ID is your dedup key. Graph fixes this with an opt-in header we send on every request:
+
+```typescript
+// packages/lib/src/providers/outlook/outlook-provider.ts
+const IMMUTABLE_ID_PREFER =
+  `odata.maxpagesize=${OUTLOOK_MAX_PAGE_SIZE}, IdType="ImmutableId"`
+
+response = await this.client.api(url)
+  .headers({ Prefer: IMMUTABLE_ID_PREFER })
+  .get()
+
+const pageIterator = new PageIterator(this.client, response, callback, {
+  headers: { Prefer: IMMUTABLE_ID_PREFER },
+})
+```
+
+Miss that header on even one code path and you'll chase phantom duplicates for weeks.
+
+Second, delta links expire too — Graph returns a 410 instead of Gmail's 404. We detect it, reset to a fresh delta query, and resync. And the same cursor-safety rule applies: the delta link only advances when the batch had no retriable ingest failures.
+
+Fetching message bodies is also a study in contrasts that ends in the same number. Gmail has a dedicated batch endpoint; we cap it at 20 messages per request because larger batches started drawing per-item 429s, and retry stragglers in batches of 5 with exponential backoff. Microsoft Graph's generic `/$batch` endpoint has a hard documented limit of — also 20.
+
+Side by side:
+
+| | Gmail | Outlook (Microsoft Graph) |
+| --- | --- | --- |
+| Push transport | Cloud Pub/Sub push | Change subscription → HTTPS callback |
+| Notification payload | `{ emailAddress, historyId }` | Subscription ID + resource path |
+| Webhook auth | Google-signed JWT verified via JWKS | `validationToken` echo + `clientState` secret |
+| Incremental cursor | Numeric `historyId` | Opaque delta link |
+| Cursor expiry | 404 → full message-list resync | 410 → reset delta query |
+| Registration lifetime | Watch expires (~1 week), renew | Subscription ~3 days max, renew |
+| Stable message IDs | Native | Only with `Prefer: IdType="ImmutableId"` |
+| Batch fetch limit | 20 (self-imposed, 429s above that) | 20 (documented `/$batch` limit) |
+
+Both registrations decay, which is one more reason push can never be the only tier.
+
+## The third door: raw MIME over SES
+
+Some customers don't connect a mailbox at all — they forward `support@their-domain.com` to an address we host. That mail arrives at AWS SES, which writes the raw MIME to S3 and invokes a deliberately tiny Lambda (`apps/mail-ingress`). The Lambda does one thing: validate the event shape with Zod and enqueue a versioned pointer to SQS.
+
+```typescript
+// apps/mail-ingress/src/ses-inbound-receiver.ts
+interface SesInboundQueueMessage {
+  version: 1
+  provider: 'ses'
+  sesMessageId: string
+  s3Bucket: string
+  s3Key: string
+  recipients: string[]
+  receivedAt: string
+}
+```
+
+No parsing, no database access, no business logic in the Lambda. Everything interesting happens in the worker (`apps/worker/src/inbound-email/`), which long-polls the queue and processes each pointer: fetch the raw email from S3, parse the MIME, resolve which organization's channel owns the recipient address, check the sender allowlist, and ingest.
+
+The error handling is the part worth copying. A malformed email will never parse successfully no matter how many times you retry it, so the processor throws a typed `PermanentProcessingError` for poison messages, and the poller treats the two failure classes differently:
+
+```typescript
+// apps/worker/src/inbound-email/sqs-poller.ts
+try {
+  await this.processMessage(message) // deletes SQS message on success
+} catch (error) {
+  const isPermanent = error instanceof PermanentProcessingError
+  if (isPermanent) {
+    await this.deleteMessage(message)  // don't retry poison
+    await this.deleteRawEmail(message) // clean up the S3 object too
+  }
+  // transient errors: do nothing — visibility timeout expires, SQS redelivers
+}
+```
+
+Transient failures cost nothing to handle: we simply don't delete the message, and SQS redelivers it after the visibility timeout. Ordering, retry, and backoff are the queue's job, not ours.
+
+The SES path also has a threading problem the OAuth paths don't: there's no provider to assign a thread ID. We derive one from the MIME headers ourselves — and this is the *only* place in the codebase where we do:
+
+```typescript
+// packages/lib/src/email/inbound/inbound-email-processor.ts
+function deriveExternalThreadId(message): string {
+  const firstReference = message.references?.split(/\s+/).find(Boolean)
+  return (
+    firstReference ||           // root of the References chain
+    message.inReplyTo ||        // direct parent
+    message.internetMessageId || // this message starts a thread
+    `ses:${message.sesMessageId}`
+  )
+}
+```
+
+## The polling safety net
+
+Push breaks. Watches expire mid-week, subscriptions lapse, webhooks get eaten by deploys. The polling subsystem (`packages/lib/src/jobs/polling/`) is what makes those failures invisible: a scanner job runs every five minutes, finds integrations whose effective sync mode is polling — or whose push registration has gone quiet — and enqueues sync jobs with a 30-second claim cooldown so overlapping scanners can't double-enqueue. IMAP accounts, which have no push at all, live entirely on this tier.
+
+The point isn't that polling is a legacy fallback. It's that push is an *optimization* of polling. Every mailbox is guaranteed to sync eventually; push just makes "eventually" feel like "instantly." Because both paths run the exact same idempotent sync, a webhook and a scheduled poll racing each other produce no duplicates — the second one finds nothing to do. The job infrastructure underneath this is its own story, which we covered in [our BullMQ series](/blog/bullmq-job-queue-architecture-part-1).
+
+## The choke point: a dedup cascade
+
+Everything above is plumbing to get a normalized `MessageData` into `storeMessage`. Now the real problem: is this message new?
+
+We answer with a cascade of checks, ordered from most to least reliable.
+
+**Tier 1: the Internet Message-ID.** Every email carries a globally unique `Message-ID` header, assigned once by the originating server and preserved across every hop. It's the one identifier that survives the double-arrival problem — the copy we wrote locally at send time and the copy Gmail syncs back share it, even though their provider IDs differ. So it's the first check, scoped to the organization:
+
+```typescript
+// packages/lib/src/ingest/store-message.ts
+const existingByMsgId = await ctx.db
+  .select({ id, threadId, externalId, textPlain, textHtml })
+  .from(schema.Message)
+  .where(and(
+    eq(schema.Message.organizationId, messageData.organizationId),
+    eq(schema.Message.internetMessageId, messageData.internetMessageId)
+  ))
+  .limit(1)
+```
+
+On a hit we don't insert — we *merge*. The provider's copy wins for external IDs, timestamps, and history IDs; our local copy's body is kept if the provider's is missing. The row ends up as the union of both arrivals. Before this check even runs its course, a dedicated reconciler handles the sharpest version of the race: it looks for messages with `sendStatus` of `PENDING` or `SENT` matching the incoming Message-ID — "is this the sync-back of something we just sent?" — with a subject-plus-five-minute-window fallback for providers that mangle headers.
+
+**Tier 2: the provider ID.** If there's no Message-ID match, we check `(integrationId, externalId)` — has this exact provider message been stored through this exact integration before? This catches straightforward re-syncs: an expired-cursor full resync, an overlapping poll, a retried page.
+
+**Tier 3: the heuristic.** Last resort, for genuinely degenerate cases where IDs are absent or mismatched: find the thread by its external thread ID, then look for a message within ±2 minutes of the incoming `sentAt` with the same sender and a similar subject. "Similar" is deliberately dumb:
+
+```typescript
+// packages/lib/src/ingest/reconciliation/is-similar-subject.ts
+const normalize = (s: string) =>
+  s.toLowerCase().replace(/^(re:|fwd:|fw:)\s*/gi, '').trim()
+
+if (normalized1 === normalized2) return true
+// handles truncated subjects
+if (normalized1.includes(normalized2) || normalized2.includes(normalized1)) return true
+```
+
+Strip reply prefixes, compare, allow substring containment for providers that truncate. No Levenshtein, no embeddings. The heuristic is a tie-breaker inside a thread and a time window, not a general matcher — keeping it dumb keeps its false-positive surface tiny.
+
+And if all three tiers miss but the insert still hits a unique-constraint violation — two workers ingesting the same message in the same instant — the error handler catches Postgres error `23505`, re-selects by `(integrationId, externalId)`, and returns the winner. The database constraint is the final tier of the cascade.
+
+## Placeholder promotion
+
+When you hit send in our app, the provider hasn't assigned IDs yet — the API call is still in flight. But the message and thread rows need to exist *now*, with unique external IDs, or the UI can't show them. So locally-created rows get placeholder IDs: `pending_`, `draft_`, `new_` prefixes.
+
+Reconciliation is where placeholders get promoted. When the provider's copy arrives with the real thread ID, we check whether the matched thread is still wearing a placeholder and swap it:
+
+```typescript
+// packages/lib/src/ingest/store-message.ts
+const ext = thread?.externalId
+if (
+  !ext ||
+  ext.startsWith('new_') ||
+  ext.startsWith('pending_') ||
+  ext.startsWith('draft_') ||
+  (ext.includes('-') && ext.length === 36) // bare UUID fallback
+) {
+  await ctx.db
+    .update(schema.Thread)
+    .set({ externalId: messageData.externalThreadId })
+    .where(eq(schema.Thread.id, existingMessage.threadId))
+}
+```
+
+This matters because thread identity hangs on that column. Threads upsert with `onConflictDoUpdate` targeting `[integrationId, externalId]`:
+
+```typescript
+await ctx.db.insert(schema.Thread)
+  .values({ externalId: messageData.externalThreadId, integrationId, /* ... */ })
+  .onConflictDoUpdate({
+    target: [schema.Thread.integrationId, schema.Thread.externalId],
+    set: { subject: messageData.subject || undefined },
+  })
+```
+
+If the thread were still holding `pending_abc123` when the customer's reply arrived carrying the real Gmail thread ID, the upsert would find no conflict and create a second thread. The conversation forks; the agent answers half of it. Promotion is what keeps one conversation in one row.
+
+## Threading: trust the provider
+
+There's a tempting rabbit hole here: implement RFC 5322 threading yourself. Walk `References` and `In-Reply-To` chains, build the conversation graph, handle clients that omit headers, handle mailing-list managers that rewrite them.
+
+We don't. Gmail already computed a `threadId`; Outlook already computed a `conversationId`. Both providers have spent two decades tuning their conversation grouping against every broken mail client in existence, and — more importantly — their grouping is what the *user sees* in their own mailbox. If we re-derived threads and disagreed with Gmail, we'd be wrong even when we were right: the support agent's view wouldn't match the mailbox it mirrors.
+
+So the rule is: the provider's thread ID is the thread key, full stop. Header-walking exists in exactly one place — the SES path, where there's no provider to defer to — and subject similarity exists in exactly one place, as a tie-breaker inside the reconciliation heuristic. Threading heuristics are a liability you should scope as narrowly as possible.
+
+## Rate limits and backoff
+
+Gmail's quota system is priced per operation, not per request — a send costs 20× a fetch. Every Gmail API call goes through a throttler that knows the real cost table:
+
+```typescript
+// packages/lib/src/utils/rate-limiter/provider-configs.ts
+export const GMAIL_QUOTA_COSTS = {
+  'messages.get': 5,
+  'messages.list': 5,
+  'messages.send': 100,
+  'messages.batchGet': 50,
+  'messages.import': 250,
+  // ...
+}
+```
+
+A throttler that counts requests instead of quota units will happily let a burst of sends exhaust a per-user quota that a thousand fetches wouldn't dent. Costing each call correctly means backpressure kicks in before Google starts rejecting.
+
+When a sync fails anyway, the failure is priced too. BullMQ retries the job a few times; only on the *final* attempt do we mark the integration as throttled, with exponential backoff from 30 seconds to a one-hour cap:
+
+```typescript
+// packages/lib/src/jobs/messages/sync-single-channel-messages-job.ts
+const newCount = (integration?.throttleFailureCount ?? 0) + 1
+const backoffMs = Math.min(
+  BASE_THROTTLE_BACKOFF_MS * 2 ** (newCount - 1), // 30s, 60s, 120s...
+  MAX_THROTTLE_BACKOFF_MS                          // capped at 1h
+)
+```
+
+The polling scanner respects `throttleRetryAfter`, so a failing mailbox stops being hammered without anyone paging. One success resets the counter. And users can cancel a long-running sync: the job checks a `SyncJob` status flag and exits gracefully rather than being killed mid-batch — which matters, because a killed batch is exactly the "page with retriable failures" case the cursor-safety logic exists for.
+
+## Attachments are lazy, bodies are offloaded
+
+A naive sync downloads every attachment inline. Ours never stores bytes in the message row at all. HTML bodies get uploaded to object storage first; the message row stores an `htmlBodyStorageLocationId` and nulls `textHtml`. If the body upload fails, we degrade gracefully — store the message with inline HTML rather than losing it.
+
+Attachments are stricter. Gmail embeds small parts directly in the message payload and requires a separate API call per large part, so we fetch only what's needed — and only for messages that turned out to be *new*:
+
+```typescript
+// packages/lib/src/providers/google/messages/gmail-inbound-content-ingestor.ts
+const { messageId, isNew } = await this.storageService.storeMessage(messageData)
+
+if (!isNew) {
+  // reconciled with an existing row — its attachments already exist
+  return messageId
+}
+const { resolved, failedCount } = await fetchAllGmailAttachmentBytes(
+  messageData.externalId, providerAttachments, fetchContext
+)
+```
+
+That `isNew` check is the dedup cascade paying rent: every reconciled double-arrival skips its attachment fetches entirely, which on a Gmail resync is most of the API budget. Downstream, the app never touches the bytes either — attachments are served to the browser as short-lived signed URLs straight from object storage.
+
+## The last mile: counts and fan-out
+
+After a message lands, the thread's denormalized metadata — `messageCount`, `firstMessageAt`, `lastMessageAt`, `latestMessageId`, `participantCount` — is recomputed in a single SQL statement with correlated subqueries (`updateThreadMetadataEfficient`). One round trip, always consistent with the actual rows, and deliberately fail-soft: a metadata failure logs and swallows rather than rolling back an ingested message.
+
+Then the frontend finds out. Every stored message publishes a realtime event — with one crucial suppression:
+
+```typescript
+// packages/lib/src/ingest/store-message.ts
+if (ctx.inSyncBatch) {
+  // batch sync: just record the inbox as touched;
+  // one `inbox:syncCompleted` fires per inbox at the end
+  ctx.touchedInboxIds.add(inboxIdForChannel)
+} else {
+  if (isNewThread) {
+    await publishThreadCreated(realtime, orgId, { threadId, inboxId },
+      { excludeSocketId: ctx.socketId })
+  }
+  await publishMessageCreated(realtime, orgId, { messageId, threadId, inboxId },
+    { excludeSocketId: ctx.socketId })
+}
+```
+
+Two details here. `excludeSocketId` solves the realtime cousin of the double-arrival problem: the tab that sent a reply already rendered it optimistically, so echoing the event back would make the message flicker or double-render — the originating socket is excluded from the fan-out. And during batch syncs, per-message events are suppressed entirely. A 2,000-message backfill emitting 2,000 `message:created` events would make every open tab refetch 2,000 times; instead the orchestrator emits one `inbox:syncCompleted` per touched inbox and the frontend refreshes its thread list once.
+
+## Boring by design
+
+The pipeline, end to end: three transports normalize into one `MessageData` shape; webhooks act as doorbells that trigger cursor-based syncs; polling guarantees the syncs happen even when the doorbells don't ring; and a single ingest function makes every arrival idempotent through a cascade that starts with the one identifier email actually guarantees. Every hard-won rule — advance cursors only past clean pages, trust provider thread IDs, promote placeholders, fetch attachments only for new messages — exists because the naive version corrupted a real thread at some point.
+
+If you're connecting your own support mailbox, the user-facing side of all this lives in our [Gmail](/blog/gmail-customer-support-guide) and [Outlook](/blog/outlook-customer-support-guide) guides. And that realtime fan-out at the end — the channels, the auth, why we run our own websocket infrastructure — is where the story continues, in [our self-hosted realtime series](/blog/self-hosted-realtime-part-1-sockudo-rooms-auth).

--- a/apps/homepage/content/blog/inbound-webhooks-providers-as-data.mdx
+++ b/apps/homepage/content/blog/inbound-webhooks-providers-as-data.mdx
@@ -1,0 +1,230 @@
+---
+title: "Verifying Anyone's Webhook: Providers as Data, Not Code"
+description: "How one parametric, timing-safe HMAC verifier and a handful of data presets replaced ~10 hand-rolled signature checks — and the real bugs (throw-on-length-mismatch, non-constant-time compares) we dug out along the way."
+date: "2026-09-08"
+slug: "inbound-webhooks-providers-as-data"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["webhooks", "security", "hmac", "redis", "typescript", "open-source"]
+published: true
+---
+
+There is a URL in our API that accepts a POST from anyone on the internet, with no session, no API key, and no allowlist. That is not a bug report. It is what a webhook receiver *is*: a public, unauthenticated endpoint whose entire security model is "prove you signed these bytes with a secret only we two know."
+
+We needed users to be able to point *any* provider at us — Stripe, Shopify, GitHub, Typeform, some internal tool with a bearer token, some tool with no signature at all — without us shipping a code change per provider. When we audited what we already had, we found roughly ten hand-rolled copies of the same HMAC check scattered across the codebase, and at least two of them were subtly wrong in ways that only a security review catches. This post is about the replacement: **one** parametric, timing-safe verifier, with every provider's signature scheme described as *data*, plus the ingress hardening around it.
+
+The code lives in `packages/lib/src/webhooks/inbound/` and `apps/api/src/routes/webhooks.ts`. Auxx.ai is [open source](https://github.com/auxxai/auxx), so every snippet below is the real thing.
+
+## The id IS the capability
+
+The control table is deliberately boring. A `WebhookEndpoint` row (`packages/database/src/db/schema/webhook-endpoint.ts`) is bound to nothing — no app, no connection, no OAuth identity. It has a name, a verification mode, an encrypted secret, and some signature-shape columns. That's it.
+
+Two design decisions follow from that.
+
+First, the public URL is **derived, never stored**:
+
+```typescript
+/** The public inbound URL for an endpoint — derived from its id, never persisted. */
+export function webhookEndpointUrl(id: string): string {
+  return getApiUrl(`/webhooks/endpoint/${id}`)
+}
+```
+
+There is no URL column to drift out of sync with the routing table, no migration when the API domain changes, and no way for two rows to claim the same path. The cuid in the URL *is* the capability — unguessable, and resolving to exactly one row.
+
+Second, because the id resolves to exactly one org, there is no wrong-org check possible on ingress. The receiver loads the endpoint by id, reads `organizationId` off the row, and that's the tenant. A whole class of confused-deputy bug — "delivery for org A processed under org B" — is structurally unrepresentable.
+
+## Providers as presets
+
+The core claim of this post: a webhook provider's signature scheme is not a code path. It is five or six fields of data.
+
+```typescript
+/** A provider's verification knowledge as data — the unit `verifyWebhook` dispatches on. */
+export interface WebhookVerifyPreset {
+  scheme: WebhookScheme // 'hmac' | 'stripe-sig' | 'shared-token'
+  /** Lowercased header carrying the signature or token. */
+  header: string
+  algo?: HmacAlgo // 'sha256' | 'sha1'
+  encoding?: HmacEncoding // 'base64' | 'hex'
+  /** Header prefix to strip before compare (Meta 'sha256='). */
+  prefix?: string
+  /** Builds the signed message from the raw body. Default identity. */
+  signedPayload?: (rawBody: string) => string
+  /** stripe-sig only — replay tolerance window in seconds. Default 300. */
+  toleranceSec?: number
+}
+```
+
+With that shape, `packages/lib/src/webhooks/inbound/presets.ts` reads like a field guide instead of a module of verify functions:
+
+```typescript
+/** Shopify: HMAC-SHA256 over the raw body, base64, in `x-shopify-hmac-sha256`. */
+export const shopifyPreset: WebhookVerifyPreset = {
+  scheme: 'hmac',
+  header: 'x-shopify-hmac-sha256',
+  algo: 'sha256',
+  encoding: 'base64',
+}
+
+/** Meta (Facebook / Instagram): HMAC-SHA256 hex, `sha256=`-prefixed. */
+export const metaPreset: WebhookVerifyPreset = {
+  scheme: 'hmac',
+  header: 'x-hub-signature-256',
+  algo: 'sha256',
+  encoding: 'hex',
+  prefix: 'sha256=',
+}
+```
+
+Shopify and Meta differ by encoding and a prefix. Svix-style providers differ by a `v1,` prefix and a base64-decoded key. Mailgun signs `${timestamp}${token}` instead of the body — that's what `signedPayload` is for. In every case the *logic* is the same, so it lives in one place, `verifyHmacSignature`, and a preset is a data entry. Adding a provider is a diff you can review in ten seconds, and there is exactly one implementation to get right.
+
+A small dispatcher (`verify/index.ts`) routes a preset to the right primitive:
+
+```typescript
+export function verifyWebhook(
+  preset: WebhookVerifyPreset,
+  input: { rawBody: string; headers: Record<string, string>; secret: string | null }
+): boolean {
+  const { rawBody, headers, secret } = input
+  if (!secret) return false
+
+  switch (preset.scheme) {
+    case 'stripe-sig':
+      return verifyStripeSignature({ rawBody, header: headers[preset.header] ?? '', secret })
+    case 'shared-token':
+      return timingSafeStringEqual(headers[preset.header] ?? '', secret)
+    default:
+      return verifyHmacSignature({ rawBody, signature: headers[preset.header] ?? '', secret, ...preset })
+  }
+}
+```
+
+No secret means no trust: `secret: null` returns `false`, never "skip verification."
+
+## Bug archaeology
+
+Consolidating ten copies into one is only worth doing if the one copy is *correct*, and this is where the audit got interesting. The comments in the new code name the bugs it replaced, because the bugs are the reason the code looks the way it does.
+
+**Bug class one: `timingSafeEqual` throws.** Node's `crypto.timingSafeEqual` requires equal-length buffers and *throws* on a mismatch. That sounds pedantic until an attacker (or just a misconfigured provider — we found this one via OpenPhone deliveries) sends a signature of the wrong length and your verify path becomes an unhandled exception instead of a clean 401. Depending on the surrounding code, that's a 500, a crashed worker, or a retry storm.
+
+**Bug class two: plain `!==`.** Two of the hand-rolled copies — the Facebook and Instagram receivers — compared HMAC digests with ordinary string inequality. String comparison short-circuits on the first differing byte, which leaks how much of the signature was correct through response timing. Byte-at-a-time signature forgery over the network is harder than the textbook makes it sound, but "constant-time compare for secrets" is table stakes, and we were not meeting it in two places.
+
+Both classes die in one eleven-line function, and everything in the system routes through it:
+
+```typescript
+// packages/lib/src/webhooks/inbound/verify/compare.ts
+import { timingSafeEqual } from 'node:crypto'
+
+/**
+ * Constant-time string equality that tolerates length mismatch (returns false
+ * rather than throwing).
+ */
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  return ab.length === bb.length && timingSafeEqual(ab, bb)
+}
+```
+
+The length check itself is not constant-time, and that's fine — the length of an HMAC digest is public knowledge (32 bytes for SHA-256). What must be constant-time is the comparison of equal-length candidates, and it is.
+
+**Bug class three: verifying re-serialized JSON.** The subtlest one. The provider signed the exact bytes it sent. If your framework parses the body into an object and you compute the HMAC over `JSON.stringify(parsed)`, you are verifying a *different byte sequence* — key order, whitespace, and unicode escaping all differ — and verification fails intermittently in ways that look like the provider's fault. So the ingress reads the raw body once, before any parsing, and every verify function takes `rawBody`. The type doc says it outright: *"The RAW request bytes (HMAC is never computed over re-serialized JSON)."* Parsing happens **after** the signature passes, and if the body isn't JSON we keep the raw string rather than failing.
+
+## Four modes, two secret directions
+
+User-created endpoints expose four verification modes:
+
+| Mode | What it checks | Who mints the secret |
+|---|---|---|
+| `none` | Nothing — open URL, flagged in the UI | nobody |
+| `token` | Constant-time compare of a `Bearer` header (or `?token=`) against the secret | **Auxx mints**, you paste it into the provider |
+| `hmac` | HMAC over the raw body vs. a configurable signature header/prefix/encoding | **Auxx mints**, you paste it into the provider |
+| `stripe` | Stripe's `t=,v1=` scheme over `${t}.${rawBody}`, with replay window | **Stripe mints** (`whsec_…`), you paste it into Auxx |
+
+The column that matters isn't the algorithm — it's the last one. For `token` and `hmac`, we generate `randomBytes(32).toString('base64url')` and the user configures their sender with it. For `stripe`, the direction inverts: Stripe generates the signing secret when you register the endpoint in their dashboard, and the user pastes *their* secret into *us*. Same table, same encrypted column, opposite provenance. Get this wrong in the UX and users end up pasting our secret into a field Stripe will never read, wondering why every delivery 401s.
+
+## Stripe's replay window stays
+
+It was tempting to treat Stripe as "just HMAC with a funny header format." It is not, and flattening it would have been a downgrade. The dedicated verifier (`verify/stripe-sig.ts`) is behaviorally faithful to Stripe's own `constructEvent`, and the file comment explains why: dropping the timestamp window *"would make this primitive WEAKER than the SDK it replaces."*
+
+```typescript
+const { t, v1 } = parseStripeSigHeader(header) // t=<ts>,v1=<hmac>,v1=<hmac>,…
+
+// Replay protection — reject a stale (or future-dated) timestamp.
+const ts = Number.parseInt(t, 10)
+const now = Math.floor(Date.now() / 1000)
+if (Math.abs(now - ts) > toleranceSec) return false // default 300s
+
+const expected = createHmac('sha256', secret)
+  .update(`${t}.${rawBody}`, 'utf8')
+  .digest('hex')
+return v1.some((sig) => timingSafeStringEqual(sig, expected))
+```
+
+Two details do real work here. The timestamp is *inside* the signed payload (`${t}.${rawBody}`), so an attacker who captured a valid delivery can't just refresh `t` — changing it invalidates the signature, and keeping it trips the 300-second window. And the header can carry *multiple* `v1` signatures: during secret rotation Stripe signs with both old and new keys, so we accept **any** matching `v1`, exactly as their SDK does. A stricter-looking "first signature must match" check would break every customer mid-rotation.
+
+## Secrets are shown exactly once
+
+Every secret in this system is AES-256-GCM encrypted at rest via the same secret box the connections system uses (we covered its envelope format in [the secret lifecycle post](/blog/connections-part-2-secret-lifecycle)). The service layer (`packages/lib/src/webhooks/webhook-endpoint/service.ts`) enforces a one-time-reveal rule: `createWebhookEndpoint` and `rotateWebhookEndpointSecret` return the plaintext of a freshly minted secret once, and no read path ever returns it again — the UI projection masks it down to a boolean:
+
+```typescript
+export interface WebhookEndpointSummary {
+  // ...
+  hasSecret: boolean // the secret never leaves the server
+}
+```
+
+If you lose the secret, you rotate it. There is no "show secret" button to build, no audit question about who viewed it, and no plaintext sitting in a tRPC response cache. The update path enforces the invariant from the other side too: you can't switch an endpoint *into* `token` or `hmac` mode while it has no stored secret — rotate first, then switch.
+
+## Dedupe: sha256 of the bytes, and fail open
+
+Providers redeliver. Networks duplicate. Our idempotency check is deliberately primitive: hash the raw body, `SET NX` a marker in Redis, drop the delivery if the marker already existed.
+
+```typescript
+// apps/api/src/routes/webhooks.ts
+const eventId = createHash('sha256').update(rawBody).digest('hex')
+const deduped = await dedupeWebhookEvent('webhook-endpoint-dedup', `${endpointId}:${eventId}`, 300)
+if (deduped) return c.json({ ok: true, duplicate: true }, 200)
+```
+
+No configured id header to trust, no per-provider event-id extraction — identical bytes within the five-minute window are the same event, by definition. The interesting decision is in the helper's failure mode (`dedupe/redis.ts`): if Redis is unreachable, it returns `false` — *process the event*. The file comment states the philosophy so nobody "fixes" it later: **"better a dup than a miss, and downstream sinks dedupe too."** A webhook you drop is gone forever; a webhook you process twice hits consumers that are idempotent anyway. Dedupe here is an optimization, not a correctness gate, so it fails open.
+
+## Defense in depth on a public POST
+
+Verification proves authenticity, but an unauthenticated endpoint also has to survive garbage and abuse *before* it spends any real work. The ingress (`handleWebhookEndpoint`) layers cheap checks first:
+
+**Body cap, checked twice.** The declared `Content-Length` is compared against a 1 MB cap *before* the body is read — no point buffering a claimed 500 MB upload just to reject it — then the actual byte length is re-checked after reading, because `Content-Length` is attacker-controlled and can lie in both directions.
+
+**Per-endpoint rate limit.** A fixed-window `INCR` + `EXPIRE` counter in Redis, 60 requests a minute per endpoint. And once again it fails open: Redis down means deliveries flow, not a self-inflicted outage of every customer's webhooks. The same reasoning as dedupe — the limiter protects *us* on the margin; it is not load-bearing for correctness.
+
+**Order matters.** Cap → load endpoint → rate limit → verify → dedupe → parse. Every step is cheaper than the one after it, and JSON parsing — the step most likely to be handed adversarial input — happens only after the signature has already proven the sender holds the secret.
+
+## One endpoint, many topics
+
+A Stripe account sends `payment_intent.succeeded`, `invoice.paid`, and thirty other event types through one URL. Forcing an endpoint per event type would be miserable, so an endpoint can declare a `topicSource` — extract the topic from a header (GitHub's `x-github-event`) or a JSON path (Stripe's `type`) — and the receiver stamps every delivery with it.
+
+On top of that sits a topic *catalog*: the endpoint row carries a `topics` array, and each entry can hold a JSON Schema describing one delivery's payload — inferred from a real captured delivery (with the sample's event id kept for provenance) or hand-authored. That schema is what turns a webhook from "a blob arrived" into something the rest of the platform can bind fields against: agent triggers, workflow nodes, and [data-connector stream steering](/blog/data-connectors-part-3-slices-webhooks-scale) all pick a `(endpoint, topic)` pair and get a typed payload shape to map from. An endpoint with no `topicSource` still works — every delivery matches, topic `''`.
+
+## After the 401s: fan-out and the inspector
+
+Once a delivery is verified, deduped, and topic-stamped, the receiver does exactly two things and returns 200 fast.
+
+It fans out to three queue jobs, keyed on `(endpointId, topic)` — one delivery, three independent consumers:
+
+```typescript
+await appTriggerQueue.add('dispatchWebhookEndpoint', dispatchPayload) // workflows
+await appTriggerQueue.add('dispatchWebhookEndpointToAgents', dispatchPayload) // agent triggers
+await appTriggerQueue.add('dispatchWebhookEndpointToConnectors', dispatchPayload) // sync steering
+```
+
+And it `LPUSH`es the delivery into a per-endpoint Redis list, trimmed to the last 50 and expiring after five minutes. That list feeds a live SSE stream in the app — a delivery inspector where you watch real payloads arrive while you're wiring a provider up. Anyone who has debugged webhooks by tailing production logs knows why this feature exists. It's also where "infer a JSON Schema from a captured delivery" gets its captures. A throttled `lastEventAt` stamp (at most one DB write per endpoint per minute, gated by another Redis `NX` key) gives the endpoint list a cheap liveness signal.
+
+## Closing
+
+The security posture of this whole system comes down to a few sentences. Raw bytes are sacred: verify what was sent, never what you re-serialized. Comparison of secrets is constant-time and length-guarded, in exactly one function everybody imports. Providers are rows of data over one verifier, because ten copies of crypto code means ten chances to write `!==`. Availability machinery — dedupe, rate limiting — fails open by explicit philosophy, while authenticity checks never do. A missing secret is a rejection, not a skip.
+
+None of it is novel cryptography. All of it is the difference between a webhook receiver you trust on the public internet and ten copies of one you don't. The code is in `packages/lib/src/webhooks/inbound/` — [read it, or point your own webhooks at it](https://github.com/auxxai/auxx).

--- a/apps/homepage/content/blog/record-rules-automation-engine.mdx
+++ b/apps/homepage/content/blog/record-rules-automation-engine.mdx
@@ -1,0 +1,301 @@
+---
+title: "Record Rules: Building an Automation Engine That Survives Bulk Sync"
+description: "Every CRM has 'when field X changes, do Y' automation. The hard part nobody writes about is what happens when 50,000 records change at once with events suppressed — our answer is a change manifest that turns O(records) events into O(1)."
+date: "2026-09-01"
+slug: "record-rules-automation-engine"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["automation", "events", "sync", "postgres", "typescript", "open-source"]
+published: true
+---
+
+Every CRM has record automation. "When priority changes to urgent, notify the manager." "When a deal closes, kick off a workflow." The trigger-condition-action model is forty years old and there is nothing interesting left to say about it.
+
+Here is the part nobody writes about: what happens when 50,000 records change at once because a connector sync ran, and every one of those writes deliberately suppressed its events?
+
+Bulk writers cannot afford per-record event fan-out. Our connector sink and CSV importer write with `skipEvents: true`, because a 50k-record sync that fired the full per-write pipeline — field hooks, activity, timeline, the event bus, realtime — would enqueue hundreds of thousands of jobs into workers that process one at a time. So bulk writes are silent. Which means your automations silently never fire on synced data. The rule that notifies you when an order flips to `refunded` works perfectly when a human edits the field and does nothing when Shopify tells you the same thing through a sync.
+
+This post is about how we solved that: a per-run change manifest that turns O(records) events into **O(1) events per sync**, and the engine behind it. Along the way: why transition direction lives on the rule instead of in conditions, why we deleted our compile-time trigger registries, and an honest accounting of the at-most-once delivery trade we made and the backstop it forces.
+
+The code lives in `packages/lib/src/record-rules/`. Auxx.ai is [open source](https://github.com/auxxai/auxx), so you can read along.
+
+## The model: transitions live on the rule
+
+A record rule is a row: watch this field on this [entity definition](/blog/custom-fields-part-1-entity-definitions) (or the record lifecycle), and when the transition matches and conditions hold, run these actions.
+
+The transition selector is where the first real design decision hides:
+
+```typescript
+/** Transition selector. Direction semantics live on the rule, NOT in conditions. */
+export type RecordRuleOn =
+  | 'changed'
+  | 'increased'
+  | 'decreased'
+  | 'set'
+  | 'cleared'
+  | 'created'
+  | 'deleted'
+```
+
+Field rules (`changed | increased | decreased | set | cleared`) require a `fieldId`. Lifecycle rules (`created | deleted`) have `fieldId = null`. That invariant is enforced at the store layer, and the two dispatch paths index on exactly those columns.
+
+Why does direction — increased, decreased, set, cleared — live on the rule instead of in the condition builder? Because the condition evaluator only ever sees one snapshot. Our conditions system (`ConditionGroup[]`, the same evaluator that powers table filters and workflow branches) evaluates a record's *current* state. "Decreased" is not a property of a state; it is a property of an (old, new) pair. Trying to express old→new comparisons in a single-snapshot evaluator means either threading phantom "previous value" fields through every condition context or building a second evaluator. We did neither. The rule carries the direction, and a small dedicated matcher handles it:
+
+```typescript
+export function matchesFieldTransition(on: RecordRuleOn, oldValue: unknown, newValue: unknown) {
+  switch (on) {
+    case 'changed':
+      return !valuesEqual(oldValue, newValue)
+    case 'increased': {
+      const prev = asNumber(oldValue)
+      const next = asNumber(newValue)
+      return prev !== null && next !== null && next > prev
+    }
+    case 'set':
+      return isEmpty(oldValue) && !isEmpty(newValue)
+    case 'cleared':
+      return !isEmpty(oldValue) && isEmpty(newValue)
+    // ...
+  }
+}
+```
+
+The split buys us the whole conditions system for free. Cross-field conditions, relationship-path references ("only when the linked company's tier is enterprise") — all of it works in rules with zero new evaluator code, because conditions only ever answer "does the current snapshot match," and the transition matcher answers "did the change qualify."
+
+One small trap worth pulling out of `valuesEqual`: comparing jsonb values with `JSON.stringify` is wrong, because Postgres reorders object keys on the round-trip. An old value read back from a run row would never stringify-equal an identical new value captured in writer key order. We serialize with sorted keys everywhere a jsonb value gets compared or hashed.
+
+## Actions: ordered, continue-and-report
+
+A rule carries an ordered array of actions, from a union of four:
+
+| Action | What it does |
+| --- | --- |
+| `set-field` | write a value onto the triggering record, as the system user |
+| `enqueue-workflow` | enqueue a published workflow with the record snapshot as payload |
+| `notify` | in-app notification to specific members |
+| `native` | invoke a code-registered handler — server-declared only |
+
+Failure semantics are continue-and-report: one failed action never blocks the rest, and every action's outcome lands on an execution-log row (`RecordRuleRun`) as `{ actionIndex, type, status, error? }`. A rule's run is `ok`, `partial`, or `failed`, and you can open the run history in the settings UI and see exactly which action broke.
+
+The `native` variant deserves a closer look, because it carries a structural invariant:
+
+```typescript
+/**
+ * Does an action list contain a native action? THE shared predicate for routing a rule
+ * between the two dispatch doors ... A rule is all-native or native-free, never mixed.
+ */
+export function hasNativeAction(actions: readonly RecordRuleAction[]): boolean {
+  return actions.some((a) => a.type === 'native')
+}
+```
+
+A rule is all-native or native-free, never mixed — enforced at the store on the DB path and at declaration time for system rules. Native actions are how our internal recalculation logic rides the engine (more on that below), and they are server-declared only. The tRPC action schema literally has no `native` variant, so the public API cannot construct one; the store check is the second lock on the same door:
+
+```typescript
+if (hasNativeAction(input.actions) && !input.managed) {
+  throw new BadRequestError('Native actions are server-declared only')
+}
+```
+
+Why the all-or-nothing rule shape? Because native rules dispatch through a *batched* door (one handler call for N records) and everything else dispatches per record. A mixed rule would need to be split across both paths and its run log would lie about ordering. Forbidding the mix keeps the two doors exact complements — both call `hasNativeAction`, so they cannot drift.
+
+## Four doors, one engine
+
+Writes reach the engine through four dispatch sites:
+
+```
+             WRITE SOURCE                    DOOR                        ENGINE
+  ─────────────────────────────   ──────────────────────────   ───────────────────────
+  interactive / API field write → '*' field-hook seam          ┐
+  interactive bulk (native only) → batched field-trigger door  ┤
+  record created / deleted        → lifecycle event bus         ┼─▶ fireRecordRules[Batch]
+  connector sync / CSV import     → sync:records:changed        ┘    match → conditions → actions
+                                    (the change manifest)            + RecordRuleRun log
+```
+
+Door 1 is the interactive path: a wildcard field-change hook fires inline on every interactive or API field write, looks up the cached rules for that field, and runs the non-native ones. Door 1b is its native complement: a batched field-trigger collector that fires only native rules, and batches them under bulk edits so a 200-row bulk update triggers one recalculation, not 200. Door 2 is the record lifecycle bus, handling `created`/`deleted` rules from the event system. Door 3 is the sync manifest, which is the point of this post.
+
+All four converge on two engine entry points — `fireRecordRules` for a single record event, `fireRecordRulesBatch` for a batch — and the batch path routes internally on `hasNativeAction`: non-native rules go through the per-record path (one snapshot load shared by all of a record's rules), native rules get their handler invoked **once across the whole batch** with the full `recordIds[]`, while still logging one run row per record so every firing stays debuggable.
+
+The rules themselves come from the [org cache](/blog/how-we-implemented-caching-part-1), not the table. The hot dispatch path never issues a rules query; the cached set is invalidated on every rule mutation and on custom-field changes.
+
+## The problem: `skipEvents` makes synced data invisible
+
+Now the headline problem. Our [data-connector sink](/blog/data-connectors-part-1-streams-mappings-sink) — the component that writes synced Shopify orders, contacts, and inventory into the entity system — writes with `skipEvents: true`. So does the CSV importer. This is not an oversight; it is load-bearing. The per-write fan-out is expensive by design, because interactive writes are rare and each one deserves the full treatment. Sync writes arrive fifty thousand at a time.
+
+But `skipEvents` suppresses *everything*: field hooks, the event bus, workflows, webhooks, realtime. Door 1 never fires. Door 2 never fires. From the reactive system's point of view, synced data does not change. Your `refunded` rule is enabled, correctly configured, and permanently asleep for exactly the writes it was built for.
+
+The naive fix is to un-suppress: publish per-record events from the sync path. We measured what that means. A 50k-record sync would enqueue hundreds of thousands of jobs into event workers that intentionally run at concurrency 1. The queue backlog would starve every other event consumer in the org for hours. Per-record events during bulk sync are not slow — they are an outage.
+
+So we went the other way: if the writes are batched, the event should be too.
+
+## The fix: a per-run change manifest
+
+During a sync run, the writer accumulates a `SyncChangeManifest` — a compact record of what changed:
+
+```typescript
+SyncChangeManifest {
+  version: 1
+  truncated: boolean                                    // caps hit (5000 changed / 10000 lifecycle)
+  changes: Record<RecordId, Record<outputKey, {o?, n}>> // subscribed field writes, old→new
+  createdRecordIds: RecordId[]                          // only if the def has a `created` rule
+  archivedRecordIds: RecordId[]                         // only if the def has a `deleted` rule
+  createdValues?: Record<RecordId, Record<sysAttr, raw>> // raw create values for native handlers
+}
+```
+
+Three properties make this survive scale instead of just relocating the problem.
+
+**It captures subscribed fields only.** Before the run starts, the writer derives a subscription index from the cached rules: which fields and lifecycle transitions does *some enabled rule* actually watch, per definition? A sync touching 40 fields on a def where one rule watches `financial_status` captures old→new for exactly that one field. And the degenerate case is genuinely free:
+
+```typescript
+/** Build a collector from a pre-computed subscription index (pure — testable). */
+export function createManifestCollector(subs: SyncRuleSubscriptions): ManifestCollector {
+  if (Object.keys(subs).length === 0) return NOOP_COLLECTOR
+  return new RealCollector(subs)
+}
+```
+
+An org with no rules gets a no-op stub. The sink calls the collector unconditionally at its write sites; the gating lives inside. Zero rules means zero captured bytes and zero extra reads — the feature costs nothing until someone uses it.
+
+**It folds across sliced jobs.** A bulk sync is not one process. Our sync core slices work into separate queue jobs that run concurrently across streams, so the collector is per-slice, and each slice folds its fragment into the run row under a row lock:
+
+```typescript
+export async function foldRunManifest(db, runId, fragment) {
+  if (!fragment) return
+  const { mergeManifests } = await import('../record-rules/sync-manifest-collector')
+  await db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({ manifest: schema.DataConnectorRun.manifest })
+      .from(schema.DataConnectorRun)
+      .where(eq(schema.DataConnectorRun.id, runId))
+      .for('update')
+    const merged = mergeManifests(row?.manifest ?? null, fragment)
+    await tx.update(schema.DataConnectorRun).set({ manifest: merged })
+      .where(eq(schema.DataConnectorRun.id, runId))
+  })
+}
+```
+
+`SELECT ... FOR UPDATE`, merge in memory, write back. Race-safe across sibling slices without any coordination beyond the row lock. The merge itself has one subtle rule: per field, the *first* fragment's old value wins and the *last* new value wins — including old-value *absence*. A record created and then updated in the same run must fold to "created with final value," not "changed from its creation value," or a `set` rule (which checks that the old value was empty) would never fire on it.
+
+**It publishes one event per run.** At finalize, the sync publishes a single `sync:records:changed` event carrying pointers only — `{ source, organizationId, runId }`. The manifest stays on the run row; the event is a doorbell, not a payload. That is the O(1) claim: a sync that touches one subscribed record and a sync that touches fifty thousand both cost the event system exactly one job.
+
+The consumer (door 3) resolves the manifest from the run row, transition-matches every captured field write against the cached rules, and calls `fireRecordRulesBatch` with `source: 'sync'`. It even plans snapshots intelligently: when a rule's conditions only reference fields that are in the manifest, it builds a partial snapshot from the captured values and skips the database entirely; records that need more get one bulk fetch across the whole run.
+
+## At-most-once, and the backstop it forces
+
+Here is where we made a trade worth being honest about.
+
+The manifest event can be delivered twice. A re-entered finalize can re-publish it; BullMQ can redeliver the consumer's job. And rule actions carry no idempotency of their own — `notify` twice is two notifications, `enqueue-workflow` twice is two workflow runs. So the consumer claims the manifest exactly once, with a row-atomic compare-and-swap, *before* firing anything:
+
+```typescript
+/**
+ * B2: atomically claim a run's manifest for once-only consumption. Returns true for
+ * exactly ONE caller per run (`UPDATE … WHERE manifestConsumedAt IS NULL RETURNING`
+ * is row-atomic); every redelivered `sync:records:changed` after that must no-op.
+ */
+export async function claimRunManifestConsumed(db, runId): Promise<boolean> {
+  const rows = await db
+    .update(schema.DataConnectorRun)
+    .set({ manifestConsumedAt: new Date() })
+    .where(and(eq(T.id, runId), isNull(T.manifestConsumedAt)))
+    .returning({ id: T.id })
+  return rows.length > 0
+}
+```
+
+Claim-before-fire makes the system **at-most-once by design**. If the consumer crashes halfway through firing, the remainder is lost — the claim is already stamped, and a retry no-ops. We chose lost-event over double-event deliberately: a missed notification is an annoyance, a duplicated inventory deduction is corrupted data.
+
+But at-most-once has a consequence that has to be engineered around, not wished away. A lost firing will *never* come back. The field value is already written; the next sync sees no change; the manifest will not re-capture it. For cosmetic reactions that is fine. For ledger-like consumers — our inventory deduction, which decrements part stock when a linked source quantity drops — a lost firing means a silently wrong ledger, forever.
+
+So the contract for ledger-like consumers is: the event is a fast path, never the source of truth. The inventory bridge keeps its own watermark, advanced with a compare-and-swap only when the reaction actually lands, and pairs it with a reconcile pass that re-derives the correct state from *absolute* values on every sync. When the event fires, the reconcile finds nothing to do. When the event was lost, the reconcile catches it on the next run. This is the same pattern stream-processing people reach for with Kafka consumers; it just usually is not framed around CRM inventory. The framing does not change the math: at-most-once plus a state-derived reconcile equals eventual correctness with fast common-case latency.
+
+## Deleting the compile-time trigger registries
+
+Before this engine existed, our internal automations — BOM cost recalculation when a vendor price changes, quantity-on-hand recomputation when a stock movement lands, company enrichment on create — lived in two hard-coded registries: `FIELD_TRIGGERS` and `ENTITY_TRIGGERS`, keyed by field and entity type at compile time.
+
+We deleted both. Not primarily for uniformity — for sync visibility. The code triggers rode the same `publishEvents` gate as everything else, which means a vendor price arriving via connector sync silently skipped its cost recalc, exactly the bug class the manifest was built to kill. Re-expressing the triggers as rules on the same engine bought them door 3 for free.
+
+They became *system rules*: code-declared, RecordRule-shaped, never stored:
+
+```typescript
+export interface SystemRuleDeclaration {
+  /** Stable key — becomes the cached rule id (`system:<key>`). */
+  key: string
+  name: string
+  /** Entity definition slug this rule targets. */
+  defSlug: string
+  /** Field rules reference the field by systemAttribute. Omit for lifecycle rules. */
+  fieldRef?: { systemAttribute: string }
+  on: RecordRuleOn
+  /** Ordered actions — ALL native (server-declared). */
+  actions: RecordRuleAction[]
+}
+```
+
+`declareSystemRules([...])` registers declarations at module init. At cache-compute time, a resolver maps each declaration to the org's concrete ids — definition by slug, field by system attribute within the definition — and drops any the org lacks. The cached rule set is the **union** of DB rows and resolved system rules, so the four doors dispatch both kinds identically and cannot tell them apart. The native handlers are thin wrappers that call the original trigger functions unchanged; the fourteen manufacturing rules migrated without touching their recalculation logic.
+
+The run log needed one accommodation: `RecordRuleRun.ruleId` is plain text with no foreign key, because `system:mfg-vendor-part-cost` is not a row. (Its sibling `entityInstanceId` has no FK either — `deleted` rules must log runs for records that no longer exist. We learned the FK lesson via a migration that dropped it after every system-rule insert failed.)
+
+## Managed rules: when a system rule can't reach
+
+System rules key off *stable* slugs — `vendor-parts`, `stock-movements`, definitions Auxx ships to every org identically. But some automations need to target definitions that only exist per-org. An inventory source like `shopify_variants` is a connector-owned definition with a different id in every org that installs it. No slug-keyed declaration can name it.
+
+For those, the feature flow provisions a real DB row with a `managed` discriminator:
+
+```typescript
+// Managed rules are provisioned by a feature flow, not the generic builder. They MAY
+// carry `native` actions and are edit/delete-locked in the UI; only `enabled` is
+// user-toggleable. A nullable text discriminator (not a boolean) so a future managed
+// feature knows WHICH feature owns the row.
+managed: text().$type<'inventory' | null>(),
+```
+
+A managed row is the one place a DB rule may carry a native action — `assertRuleShape` allows it only when the marker is set, and only server-side feature code can set it. The discriminator is a string, not a boolean, so teardown knows which feature owns which rows. Users see managed rules in the settings list but can only toggle them.
+
+## Never throw, never recurse forever
+
+An automation engine sits inside other people's code paths — a field write, an event handler, a sync finalize. It must never break its host. Every failure in the engine degrades to a logged outcome on the run row; `fireRecordRules` and `fireRecordRulesBatch` do not have a throwing path.
+
+The subtler hazard is recursion. A rule's `set-field` action writes a field — which fires the field-change hook inline — which may match another rule — whose action writes another field. Two rules pointed at each other is an infinite loop written in a settings UI. The guard is an `AsyncLocalStorage` chain:
+
+```typescript
+/** Max rule→action→rule re-entrancy within one causal chain. */
+const MAX_RULE_DEPTH = 3
+
+interface RuleChainState {
+  depth: number
+  /** `${ruleId}:${entityInstanceId}` pairs that already fired in this chain. */
+  seen: Set<string>
+}
+
+const ruleChain = new AsyncLocalStorage<RuleChainState>()
+```
+
+Each firing runs its actions inside a child chain state with `depth + 1` and the pair added to the seen-set. A rule that already fired for the same record within one causal chain is skipped; anything deeper than three hops is cut off with a warning. `AsyncLocalStorage` matters here because the chain crosses async boundaries — the write, the inline hook, the next rule's actions — without any explicit context threading through the CRUD layer.
+
+## Open problems, honestly
+
+One known sharp edge remains, and it is self-inflicted. The cached rule union — DB rows plus resolved system rules — has a one-day TTL and is invalidated by rule and field mutations. But it is *not* versioned by the system-rule declaration set. Deploy a build that adds or changes a system-rule declaration, and every org keeps serving the stale union until its TTL expires: the new trigger silently does not fire for up to a day. We found this the way you would expect — a freshly shipped system rule doing nothing in production while every test passed.
+
+Today's mitigation is a manual cache-flush script run after declaration changes, which is exactly as fragile as it sounds. The real fix is mechanical and unbuilt: hash the declaration keys into the cached value and recompute on mismatch, or flush the key on boot. DB-row rules are unaffected — their mutations invalidate correctly — but "remember to run the script" is not an invariant, and we are not pretending otherwise.
+
+## Closing
+
+The trigger-condition-action model was the easy 20 percent. The remaining 80 was making it hold under the write patterns a real system produces: transitions that need an (old, new) pair a snapshot evaluator cannot see, bulk syncs that suppress the very events automations depend on, delivery guarantees that force ledger consumers to carry their own reconcile, and internal triggers that deserved the same dispatch machinery as user rules instead of a privileged side channel.
+
+The manifest is the piece we would defend hardest. Capture only what rules subscribe to, fold fragments under a row lock, ring one doorbell per run. O(1) events per sync is a small claim to state and a surprisingly deep one to keep true.
+
+If you want to read the code, start with:
+
+- `packages/lib/src/record-rules/engine.ts`, the two entry points
+- `packages/lib/src/record-rules/sync-manifest-collector.ts`, the collector and the fold
+- `packages/lib/src/events/handlers/handle-sync-record-rules.ts`, door 3
+- `packages/lib/src/record-rules/system-rules.ts`, the declaration resolver
+
+Auxx.ai is [open source](https://github.com/auxxai/auxx). PRs welcome.

--- a/apps/homepage/content/blog/self-hosted-realtime-part-1-sockudo-rooms-auth.mdx
+++ b/apps/homepage/content/blog/self-hosted-realtime-part-1-sockudo-rooms-auth.mdx
@@ -1,0 +1,246 @@
+---
+title: "Self-Hosted Realtime, Part 1: Sockudo, Rooms, and Channel Auth"
+description: "How we replaced hosted Pusher with a single Rust container and built a typed room registry with ACL dispatch on top of the Pusher protocol. Part 1 of a two-part series on our realtime architecture."
+date: "2026-07-28"
+slug: "self-hosted-realtime-part-1-sockudo-rooms-auth"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["realtime", "websockets", "pusher", "react", "typescript", "open-source"]
+published: true
+---
+
+We replaced hosted Pusher with a single Rust container, and not one line of our publishing or subscribing code changed. That is not a brag about our abstraction layer — it is a fact about the Pusher protocol, which has quietly become a de-facto standard with multiple independent server implementations.
+
+This is the first of two posts on how realtime works at Auxx.ai:
+
+1. **This post** covers the server side: why we self-host, the deployment (one Dockerfile, a fistful of env vars), the typed room registry, and how channel auth becomes an ACL dispatch.
+2. **[Part 2](/blog/self-hosted-realtime-part-2-client-patterns)** is the client side: echo suppression via socket ids, refcounted subscriptions with `useSyncExternalStore`, realtime-driven query invalidation, and keeping collaborative TipTap editors in sync without CRDTs.
+
+Auxx.ai is [open source](https://github.com/auxxai/auxx), so every file mentioned here is readable in full.
+
+## Why self-host at all
+
+Hosted Pusher is genuinely good software, and we ran on it for a long time. But we publish a lot of small messages. Every field edit, every incoming email, every data-connector sync progress frame, every presence idle-flip fans out over websockets. At that volume, per-message pricing stops being a rounding error, and the round-trip through someone else's cloud adds latency we can see.
+
+The usual objection to self-hosting realtime is operational: websocket servers are stateful, connection-heavy, and annoying to run. That objection dissolved when we realized the Pusher *protocol* outlived any single vendor. `pusher-js` on the client and the `pusher` npm package on the server speak a documented wire protocol, and several open-source servers implement it.
+
+We picked [Sockudo](https://sockudo.io) — an actively maintained, open-source, Pusher-protocol-compatible websocket server written in Rust. It lives in our monorepo as `apps/echtzeit` ("realtime" in German), and the entire app is a Dockerfile:
+
+```dockerfile
+# apps/echtzeit/Dockerfile
+FROM ghcr.io/sockudo/sockudo:4.6.0
+
+ENV HOST=0.0.0.0 \
+    PORT=6001 \
+    APP_MANAGER_DRIVER=memory \
+    SSL_ENABLED=false \
+    HTTP_API_USAGE_ENABLED=false \
+    SOCKUDO_DEFAULT_APP_ENABLED=true \
+    SOCKUDO_DEFAULT_APP_ENABLE_CLIENT_MESSAGES=false \
+    WEBSOCKET_MAX_PAYLOAD_KB=100
+
+EXPOSE 6001 9601
+```
+
+There is no `package.json`, no `node_modules`, no config file. Sockudo prefers TOML config but every knob we need has a documented environment variable, so we run env-only and avoid config-schema drift across versions. Locally it runs as a Docker Compose service next to Postgres and Redis; in production it is one Railway service running the pinned image, so dev and prod execute byte-identical binaries.
+
+Two deployment details deserve a callout, because both bit us.
+
+**Credential parity is the number one footgun.** Sockudo's `SOCKUDO_DEFAULT_APP_ID/KEY/SECRET` must be *identical* to the `PUSHER_APP_ID/KEY/SECRET` the app services use. Channel auth is an HMAC signed with the shared secret; if the values drift, the transport stays healthy, the health checks stay green, and every single private-channel subscription silently fails. On Railway we point both sides at the same shared variables so parity is structural, not disciplinary.
+
+**Allowed origins fail permanently, not loudly.** Sockudo can restrict which origins may open a websocket. If an origin doesn't match, the client receives `pusher:error` code `4009` — which sits in Pusher's do-not-reconnect band (4000–4099). That is a *permanent silent failure*, not a visible retry loop. We currently leave the list empty (our embeddable chat widget lives on arbitrary customer domains and shares the app), but if you ever set one: port matters, scheme matters, and `*.example.com` does not match the bare `example.com`.
+
+Note also `SOCKUDO_DEFAULT_APP_ENABLE_CLIENT_MESSAGES=false`. Every event in our system is server-published. We will come back to why.
+
+## Opaque room keys, not channel strings
+
+The Pusher protocol has three channel families, distinguished by prefix: public channels (no auth), `private-` channels (server-signed subscription), and `presence-` channels (signed, plus a member roster). The prefix is load-bearing — it decides whether the client hits your auth endpoint at all.
+
+Scattering those prefixes through application code is how you end up with a subscription to `private-org-123` on one screen and `presence-org-123` on another, which are *different channels*. So we made room identity opaque. Callers never write channel strings; they build a key through typed helpers:
+
+```typescript
+// packages/lib/src/realtime/room-keys.ts
+export const rooms = {
+  /** Org-wide events (records, agents, mail batches outside an inbox). */
+  orgEvents: (organizationId: string) => `org-${organizationId}-events`,
+  /** Org presence room (member online/idle). */
+  orgPresence: (organizationId: string) => `org-${organizationId}`,
+  /** Per-inbox channel. */
+  orgInbox: (organizationId: string, inboxSlug: string) =>
+    `org-${organizationId}-inbox-${inboxSlug}`,
+  /** Private per-user channel (notifications, personal events). */
+  user: (userId: string) => `user-${userId}`,
+  /** Per-chat-thread admin channel. */
+  chatThread: (threadId: string) => `thread-${threadId}`,
+  /** Visitor's chat session (widget-side). */
+  chatSession: (sessionId: string) => `chat-${sessionId}`,
+}
+```
+
+A single regex table maps every key to its kind, and the Pusher prefix is derived from the kind in exactly one function:
+
+```typescript
+export function roomKindFor(roomKey: string): RoomKind | null {
+  if (/^org-.+-inbox-.+$/.test(roomKey)) return 'plain'
+  if (/^org-.+-events$/.test(roomKey)) return 'plain'
+  if (roomKey.startsWith('org-')) return 'presence'
+  if (roomKey.startsWith('user-')) return 'plain'
+  if (roomKey.startsWith('thread-')) return 'plain'
+  if (roomKey.startsWith('chat-')) return 'public'
+  return null
+}
+
+export function toPusherChannel(roomKey: string): string | null {
+  const kind = roomKindFor(roomKey)
+  if (!kind) return null
+  if (kind === 'presence') return `presence-${roomKey}`
+  if (kind === 'public') return roomKey
+  return `private-${roomKey}`
+}
+```
+
+Order matters in that table — the specific `-inbox-` and `-events` patterns must run before the generic `org-` presence match, because matching is greedy.
+
+Here is the part that looks like duplication and isn't: this file exists *twice*, conceptually. `room-keys.ts` is client-safe — pure string functions, no imports beyond types. `rooms.ts` re-exports all of it and adds the server-only piece: an `authorize()` function per room family, which touches the database, the inbox service, and membership checks. The browser bundle imports `room-keys.ts` and never pulls in a line of DB code. We could have unified them behind clever conditional exports; keeping the split dumb and visible has been worth more.
+
+## Channel auth is an ACL dispatch
+
+When `pusher-js` wants to join a `private-` or `presence-` channel, it POSTs the socket id and channel name to your auth endpoint and expects back an HMAC signature. Most codebases implement this as a pile of `if (channel.startsWith(...))` in a route handler. Ours is a registry dispatch.
+
+The server registry has one entry per room family — a matcher and an ACL:
+
+```typescript
+// packages/lib/src/realtime/rooms.ts
+const REGISTRY: RoomDef[] = [
+  // Per-inbox channel: `org-{orgId}-inbox-{inboxSlug}`
+  {
+    kind: 'plain',
+    match: (k) => /^org-.+-inbox-.+$/.test(k),
+    authorize: async (key, ctx) => {
+      const [orgPart, inboxSlug] = key.split('-inbox-')
+      const orgId = orgPart.replace(/^org-/, '')
+      if (!(await isOrgMember(orgId, ctx))) return false
+      if (inboxSlug === 'none') return true // triage: open to all members
+      const inboxService = new InboxService(database, orgId, ctx.session!.userId)
+      return inboxService.hasUserAccess(toRecordId('inbox', inboxSlug), ctx.session!.userId)
+    },
+  },
+  // Private user channel: `user-{userId}`
+  {
+    kind: 'plain',
+    match: (k) => k.startsWith('user-'),
+    authorize: (key, ctx) =>
+      !!ctx.session && ctx.session.userId === key.slice('user-'.length),
+  },
+  // ...org events, org presence, threads, visitor channels
+]
+```
+
+The auth route itself is thin — it parses the form body, resolves the session, and hands off to `RealtimeService.authorize()`. That method does one thing worth stealing:
+
+```typescript
+// packages/lib/src/realtime/realtime-service.ts
+async authorize(socketId, channelName, ctx, userData) {
+  const roomKey = fromPusherChannel(channelName)
+  if (!roomKey) return null
+  const def = findRoom(roomKey)
+  if (!def) return null
+  // Reject if the channel prefix doesn't match the registered kind.
+  const expected = toPusherChannel(roomKey)
+  if (expected !== channelName) return null
+
+  const allowed = await def.authorize(roomKey, ctx)
+  if (!allowed) return null
+  return this.provider.authenticate(socketId, channelName, userData)
+}
+```
+
+It strips the prefix to recover the room key, then *recomputes* the expected channel name from the registry and compares. A client that asks to join `private-org-123` — the org presence room, registered as a `presence-` channel — gets rejected even though the org membership ACL would have passed. Without that check, a malicious or buggy client could subscribe to a presence room as a private channel and dodge the roster semantics, or vice versa. The kind is part of the room's identity, so auth enforces it.
+
+Adding a new room family is now a three-line ritual: one helper on `rooms`, one branch in `roomKindFor`, one registry entry with its ACL. There is nowhere else to forget.
+
+## The deliberately public channel
+
+One room family is unsigned on purpose: `chat-{sessionId}`, the visitor-side channel of our support chat widget.
+
+The widget bootstraps on an arbitrary customer's website before any session or identity exists. Requiring signed auth there means standing up an anonymous-credential flow just to receive your own transcript echo. Instead, the channel is a raw public Pusher channel: the name embeds a random, unguessable session id, and the only thing published on it is that visitor's own conversation. Once a visitor is identified, the private `visitor-{participantId}` and `thread-{threadId}` channels take over with real passport-signed auth (Part 2 covers how the widget signs those).
+
+Security-by-unguessable-name is a deliberate, scoped trade — the same one Google Docs makes with "anyone with the link." The registry still carries an entry for `chat-` rooms so key resolution works, with a comment admitting that its `authorize` hook is unreachable: Pusher never asks the server to sign a public channel.
+
+## Typed events, and why the server publishes everything
+
+Every event that crosses the wire has a TypeScript shape in `packages/lib/src/realtime/events.ts` — `fieldValues:updated`, `record:created`, `thread:updated`, `message:created`, `dataConnector:sync`, about two dozen in all. Payloads are partial-by-design patches: missing key means "don't touch", `null` means "clear". The client applies them to Zustand stores without refetching (how field-value events drive the frontend store is its own post — see [the custom fields sync engine](/blog/custom-fields-part-3-frontend-sync-engine)).
+
+Server code never calls the provider directly. Each event family gets a publish helper that owns its room routing and its chunking:
+
+```typescript
+// packages/lib/src/realtime/publish-helpers.ts
+export async function publishMessageCreated(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  args: { messageId: string; threadId: string; inboxId: string | null },
+  options?: { excludeSocketId?: string }
+) {
+  await realtimeService
+    .publish(
+      inboxRoom(organizationId, args.inboxId),
+      'message:created',
+      { messageId: args.messageId, threadId: args.threadId },
+      options
+    )
+    .catch(() => {})
+}
+```
+
+Note the `.catch(() => {})`. Publishing is fire-and-forget everywhere: a realtime hiccup must never fail the mutation that triggered it. Realtime is an accelerant, not a source of truth — the truth is in Postgres, and Part 2 shows how the client recovers when events are missed.
+
+The helpers also encode payload discipline. The Pusher protocol caps event payloads (10KB on hosted Pusher; we raised Sockudo's cap to 100KB for headroom but kept the discipline), so `publishFieldValueUpdates` chunks entries 50 at a time, and bulk paths like data-connector backfills don't publish per-record events at all — they emit one coarse `records:invalidated` per entity definition per slice, and the client refetches once instead of drowning in a firehose.
+
+This is also why client events are disabled at the server. Pusher lets clients broadcast directly to each other on presence channels, and it is tempting for things like "user is idle." We route even that through the server: a tRPC mutation calls `publishMemberUpdate`, which emits a custom `member-update` event on the presence channel. Every event on the wire has therefore passed through code we control — validated, typed, and attributable. `SOCKUDO_DEFAULT_APP_ENABLE_CLIENT_MESSAGES=false` makes the policy mechanical.
+
+One clarification, since we also stream AI responses: token streaming in [our agent engine](/blog/agent-engine-part-1-domain-agnostic-harness) rides SSE, not websockets. SSE fits a one-shot, one-consumer stream tied to a request; the websocket layer is for fan-out to whoever happens to be looking. Different problems, different transports.
+
+## The fallback seam
+
+We kept hosted Pusher as a config-level fallback, and it costs almost nothing to maintain. The server provider branches once, on `PUSHER_HOST`:
+
+```typescript
+// packages/lib/src/realtime/providers/pusher.ts
+if (host) {
+  const port = String(configService.get<number>('PUSHER_PORT') ?? 443)
+  const useTLS = configService.get<boolean>('PUSHER_USE_TLS') !== false
+  this.pusher = new Pusher({ appId, key, secret, host, port, useTLS })
+  logger.info('Pusher initialized (self-hosted Sockudo)', { host, port, useTLS })
+} else if (cluster) {
+  this.pusher = new Pusher({ appId, key, secret, cluster, useTLS: true })
+  logger.info('Pusher initialized (hosted cloud)')
+}
+```
+
+The client adapter mirrors the same branch, with one dev-quality-of-life detail: transports are gated on TLS, so a plain-`ws` localhost container doesn't send `pusher-js` into a wss upgrade retry loop:
+
+```typescript
+// packages/lib/src/realtime/client/adapters/pusher.ts
+enabledTransports: config.forceTLS === false ? ['ws'] : ['ws', 'wss'],
+```
+
+Unset `PUSHER_HOST` and the whole system falls back to Pusher cloud. That seam is what made the migration boring: we flipped environments one at a time, and the room registry, the ACLs, the publish helpers, and every consumer were none the wiser. When your abstraction survives swapping the entire transport vendor underneath it, the abstraction is drawn at the right line.
+
+## Next up
+
+Everything so far is the easy half. The server publishes typed events into authorized rooms — fine. The hard half is what the client does with them: how the tab that *caused* a mutation avoids double-applying its own event, how forty components share one channel without forty subscriptions, what happens to subscriptions when a user switches organizations, and how far you can push "collaborative" text editing on plain events before you need CRDTs.
+
+That is [Part 2](/blog/self-hosted-realtime-part-2-client-patterns).
+
+If you want to read ahead, the entry points are:
+
+- `apps/echtzeit/README.md`, the deployment story
+- `packages/lib/src/realtime/room-keys.ts` and `rooms.ts`, the two halves of the registry
+- `packages/lib/src/realtime/realtime-service.ts`, publish + authorize
+- `apps/web/src/app/api/pusher/auth/route.ts`, the auth endpoint
+
+PRs welcome.

--- a/apps/homepage/content/blog/self-hosted-realtime-part-2-client-patterns.mdx
+++ b/apps/homepage/content/blog/self-hosted-realtime-part-2-client-patterns.mdx
@@ -1,0 +1,250 @@
+---
+title: "Self-Hosted Realtime, Part 2: Echo Suppression, Refcounting, and Live Editors"
+description: "The client side of our realtime stack: one header that kills echo everywhere, refcounted subscriptions with useSyncExternalStore, and collaborative-ish TipTap editors without CRDTs. Part 2 of a two-part series."
+date: "2026-08-04"
+slug: "self-hosted-realtime-part-2-client-patterns"
+category:
+  slug: "coding"
+  title: "Coding"
+authors:
+  - name: "Markus Klooth"
+    image: "/images/avatars/markus.jpg"
+tags: ["realtime", "websockets", "pusher", "react", "typescript", "open-source"]
+published: true
+---
+
+The hardest bug class in a realtime UI isn't a missed event. It's the event you receive that you shouldn't act on — the echo of your own mutation arriving a hundred milliseconds after your optimistic update already applied it, and stomping it.
+
+This is the second of two posts on how realtime works at Auxx.ai:
+
+1. **[Part 1](/blog/self-hosted-realtime-part-1-sockudo-rooms-auth)** covered the server: self-hosting Sockudo (a Rust, Pusher-protocol-compatible websocket server), the typed room registry, and channel auth as ACL dispatch.
+2. **This post** is the client: echo suppression via one tRPC header, refcounted channel subscriptions with `useSyncExternalStore`, realtime-driven React Query invalidation, and how far we push live TipTap editors without CRDTs.
+
+Auxx.ai is [open source](https://github.com/auxxai/auxx); every file here is in the repo.
+
+## One header kills echo everywhere
+
+Here is the failure. You type a field value. The client applies it optimistically, fires the tRPC mutation, the server writes it and publishes `fieldValues:updated` to the org channel. Your tab is subscribed to the org channel. The event arrives, and the store applies "new" data on top of state that may have already moved on — a keystroke lost, a cursor jump, a chip flickering out and back.
+
+Most teams fix this per feature: a "pending mutations" set here, a timestamp comparison there, an `isOwnEvent` flag somewhere else. Every one of those is a reimplementation of the same idea, and each has its own bugs. The Pusher protocol already has the primitive: `trigger()` accepts a `socket_id` parameter, and the connection with that id is excluded from delivery. The only problem is plumbing — the socket id lives in the browser, and the publish happens on the server.
+
+So we thread it through the one pipe every mutation already travels: tRPC headers. The client attaches its live socket id to *every* request:
+
+```typescript
+// apps/web/src/trpc/react.tsx
+unstable_httpBatchStreamLink({
+  url: getBaseUrl() + '/api/trpc',
+  headers: () => {
+    const headers = new Headers()
+    headers.set('x-trpc-source', 'nextjs-react')
+    const socketId = getRealtimeSocketId()
+    if (socketId) {
+      headers.set('x-realtime-socket-id', socketId)
+    }
+    return headers
+  },
+}),
+```
+
+`getRealtimeSocketId()` is a non-reactive read off the adapter — it's for headers, not rendering, so it triggers no re-renders and costs nothing. Server-side, any mutation that publishes reads the header and passes it down:
+
+```typescript
+// apps/web/src/server/api/routers/fieldValue.ts
+const service = new FieldValueService(
+  ctx.session.organizationId,
+  ctx.session.user.id,
+  ctx.db,
+  ctx.headers.get('x-realtime-socket-id') ?? undefined
+)
+```
+
+...and the provider forwards it as Pusher's exclusion param:
+
+```typescript
+// packages/lib/src/realtime/providers/pusher.ts
+const params: Record<string, string> = {}
+if (options?.excludeSocketId) {
+  params.socket_id = options.excludeSocketId
+}
+await this.pusher.trigger(channel, event, data, params)
+```
+
+That's the whole trick. The originating tab trusts its optimistic state; every *other* tab and teammate gets the event. No per-feature dedup logic, no timestamps, no flags. When we audit a new mutation, the checklist item is one line: does it thread `excludeSocketId`?
+
+The interesting cases are the ones that deliberately *don't*. Worker-originated publishes — data-connector sync progress, CSV export jobs, AI autofill results — have no originating browser socket, and the tab that clicked "Sync now" absolutely should light up. Those helpers omit the option on purpose, and the doc comments say so. Echo suppression is for "I already applied this," not "I asked for this."
+
+## A refcounted registry under `useSyncExternalStore`
+
+The org channel is subscribed by the field-value sync engine, the presence roster, the agent-detail refresher, the notification badge, and a dozen other hooks — often several of them mounted at once. Naively, that's a dozen Pusher subscriptions to the same channel, a dozen auth round-trips, and a teardown ordering nightmare.
+
+The adapter (`packages/lib/src/realtime/client/adapters/pusher.ts`) collapses them with a refcounted registry. First subscriber to a room key creates the Pusher channel and binds one `bind_global` listener; later subscribers just add their handler to a set and bump the count:
+
+```typescript
+let entry = this.rooms.get(roomKey)
+if (!entry) {
+  const channel = this.pusher.subscribe(channelName)
+  entry = { channel, refCount: 0, handlers: new Set() }
+  const globalListener = (event: string, payload: unknown) => {
+    if (event.startsWith('pusher:')) return // internals filtered
+    const current = this.rooms.get(roomKey)
+    if (!current) return
+    for (const h of current.handlers) h.onEvent?.(event, payload)
+  }
+  channel.bind_global(globalListener)
+  this.rooms.set(roomKey, entry)
+}
+entry.handlers.add(handlers)
+entry.refCount += 1
+```
+
+Unsubscribe decrements; the channel is torn down only when the count hits zero. One socket, one channel object, one listener per room, however many consumers.
+
+React sees this store through `useSyncExternalStore`, and the detail that makes it work is snapshot identity. The adapter keeps two views of its state: the live `Map<roomKey, RoomEntry>` that drives subscriptions, and a frozen `Set<string>` snapshot exposed to React — replaced with a new reference *only when membership changes*:
+
+```typescript
+private rooms = new Map<string, RoomEntry>()
+private roomsSnapshot: ReadonlySet<string> = new Set()
+
+getRoomMapSnapshot = (): ReadonlySet<string> => this.roomsSnapshot
+
+private refreshRoomsSnapshot() {
+  this.roomsSnapshot = new Set(this.rooms.keys())
+}
+```
+
+`useSyncExternalStore` calls the snapshot function on every notification and re-renders when the reference changes. Return a fresh `new Set(...)` each call and every message on any channel re-renders every subscribed component — the app "works" and is molasses. Keep one frozen reference and swap it only on subscribe/unsubscribe, and a thousand events flow through with zero renders. Snapshot identity stability is the entire difference between "works" and "works at scale."
+
+Two more adapter behaviors earn their keep:
+
+**Pre-connect buffering.** React mounts children before parents run effects, so a deep component's `useRealtimeRoom` often fires before the layout-level provider calls `connect()`. Instead of dropping or throwing, subscriptions land in a `pendingSubs` queue and are replayed when the connection comes up — and the returned handle's `unsubscribe` works correctly whether the replay happened yet or not.
+
+**Late-join replay.** Pusher fires `subscription_succeeded` once per channel. A second consumer attaching to an already-subscribed room would never see it — so it would never run its catch-up logic, and on presence channels would never see the roster. The adapter detects `channel.subscribed` and replays `onSubscribed` (and the member snapshot) to the new handler via `queueMicrotask`, matching the ordering of a fresh subscription.
+
+## Org switches, and knowing what to keep
+
+Auxx.ai users can belong to multiple organizations and switch between them without a page load. Realtime subscriptions are org-scoped, so a switch has to tear down the old org's rooms — otherwise they linger in the refcount store and the old org's events keep flowing into the new org's UI.
+
+The lifecycle hook does surgical teardown with a predicate:
+
+```typescript
+// apps/web/src/realtime/use-realtime-lifecycle.ts
+if (previousOrgRef.current && previousOrgRef.current !== organizationId) {
+  const stalePrefix = `org-${previousOrgRef.current}`
+  realtimeAdapter.unsubscribeMatching(
+    (key) =>
+      key === stalePrefix || key.startsWith(`${stalePrefix}-`) || key.startsWith('thread-')
+  )
+}
+```
+
+Torn down: the old org's presence room, its `-events` and per-inbox channels, and every `thread-*` room (chat threads belong to exactly one org). Deliberately kept: `user-{userId}` — the same human crossed orgs, and their personal notification channel shouldn't blink. Feature hooks then re-subscribe naturally on the next render with the new org id. The teardown handles the past; React handles the future.
+
+## Realtime → React Query, one hook shape everywhere
+
+Most of our realtime consumers don't apply payloads at all. They treat events as *invalidation signals* for React Query. The pattern is small enough to show whole:
+
+```typescript
+// apps/web/src/components/agents/hooks/use-agent-realtime.ts
+export function useAgentRealtime() {
+  const utils = api.useUtils()
+
+  const onEvent = useCallback(
+    (event: string) => {
+      if (event === 'agent:updated') {
+        void utils.agent.getById.invalidate()
+        void utils.agent.list.invalidate()
+      }
+      if (event === 'procedure:updated') {
+        void utils.procedure.getById.invalidate()
+        void utils.procedure.list.invalidate()
+      }
+    },
+    [utils]
+  )
+
+  useOrgChannel({ onEvent })
+}
+```
+
+Subscribe to a room, invalidate the queries the event names. The server stays honest (payloads carry ids, not denormalized state that can drift), the client stays simple (React Query owns fetching, caching, dedup), and the refcounted adapter means ten such hooks cost one channel. We have this exact shape for mail, agents, data connectors, notifications, table views, eval cases — new features copy the file and rename the events.
+
+The heavyweight consumers — the mail sync engine (`use-mail-sync.ts`) and the field-value store covered in [the custom fields series](/blog/custom-fields-part-3-frontend-sync-engine) — apply partial patches into Zustand stores instead, because a full refetch per keystroke-sized event would be absurd. But even they fall back to coarse invalidation for bulk paths: sync backfills suppress per-message events server-side and emit one `inbox:syncCompleted`, and the client answers with one `thread.listIds.invalidate()`.
+
+One honest wrinkle: Pusher does not replay events published while a channel was mid-subscribe, and our inbox channels bind in two phases (the real inbox list arrives from an async query). Messages landing in that window would simply vanish until a manual refresh. So `use-mail-sync.ts` treats every `onSubscribed` — including re-subscribes after reconnect — as a catch-up trigger: refetch the thread list and reconcile the open thread's messages additively, appending only missing ids so nothing flashes. Realtime is the accelerant; the catch-up path is the guarantee.
+
+## Live TipTap editors without CRDTs
+
+Several of our TipTap surfaces are fed content from outside their own `onUpdate` — autosave echoes from the server, AI tools writing into an open procedure editor, a teammate editing the same record's notes. The naive wiring (`useEffect` that calls `setContent` whenever the prop changes) destroys the editor: every save echo resets the cursor, open slash-command chips vanish, and fast typists lose keystrokes.
+
+Our fix is a gate, `useExternalContentSync`, built on one idea: *canonically fingerprint every doc, and refuse to apply a doc you've already seen.*
+
+```typescript
+// apps/web/src/components/editor/inline-picker/hooks/use-external-content-sync.ts
+useEffect(() => {
+  if (!editor || editor.isDestroyed) return
+  const key = canonicalKey(incoming)
+  if (key === lastAppliedKeyRef.current) return
+  // Echo of one of our own recent edits — the editor has typed past this
+  // version, so applying it would revert live edits. Trust the editor.
+  if (localEditSetRef.current.has(key)) return
+  if (isPickerOpenRef.current) {
+    pendingRef.current = incoming
+    return
+  }
+  applyContent(editor, incoming)
+  lastAppliedKeyRef.current = key
+}, [editor, incoming, applyContent, canonicalKey])
+```
+
+The pieces:
+
+**Canonical keys, not `JSON.stringify`.** Content round-trips through a Postgres JSONB column, and JSONB does not preserve key order. The same doc comes back with keys shuffled, so a naive stringify compares unequal and the hook re-applies your own content on every save echo. `canonicalKey` is a key-order-insensitive `stableStringify`, and the editor's own `applyContent` uses it too, skipping the `setContent` entirely when the docs already match.
+
+**A ring of recent local edits, not just the last one.** The editor stamps every outbound change: `onUpdate` calls `markLocalEdit(stableStringify(json))`. Keys go into a bounded 64-entry ring. When a server echo arrives late — after you've typed three more characters — it matches an entry in the ring and is skipped, even though it's no longer the *most recent* local state. Keeping only the last key isn't enough; save echoes arrive out of order with typing.
+
+**Deferral while a picker is open.** An inbound apply while a slash-command chip is open would destroy the chip mid-interaction. Incoming content is stashed and flushed the moment the picker closes — unless a local edit superseded it in the meantime, in which case the stash is dropped.
+
+For *replacing* content wholesale — a teammate's Kopilot tool rewrote the procedure you have open — patching an editor in place is the wrong tool. Those editors are seed-once by design, keyed on `${procedureId}:${reloadKey}`; the realtime handler invalidates the query and bumps `reloadKey`, and the editor remounts cleanly with the new doc.
+
+Now the honest part: **this is not collaborative editing.** There is no merging. If two people type into the same document in the same second, last write wins and somebody's sentence is gone. What this architecture actually delivers is: your own echoes never hurt you, external replacements land cleanly when you're not typing, and read-only viewers of a document see it update live. That covers a CRM's real concurrency profile — one active writer, N viewers, occasional machine writers — for a few hundred lines of hook code.
+
+The moment your product needs two humans typing in one paragraph — cursors, per-character merging, offline edits reconciling — stop extending this and reach for Yjs. TipTap's collaboration layer is built on it, and a CRDT is the correct data structure for that problem. We know precisely where our line is: suppression and replacement, yes; merging, no. Knowing where the line is *before* you cross it is the difference between a pragmatic pattern and technical debt.
+
+## Two clients by design
+
+Our embeddable chat widget also speaks realtime — and it does not use any of the adapter code above. It ships its own dependency-free client, `packages/chat/src/transport/realtime-client.ts`: one shared Pusher socket per widget, a refcounted channel registry with per-caller handles, and nothing else.
+
+That sounds like a DRY violation. It's a bundle boundary. The widget loads on arbitrary customer websites where every kilobyte is somebody else's page weight; the admin adapter sits in a lib package that assumes our monorepo's world. The two implementations *mirror each other's design* — the comments in each point at the other — but share zero code, on purpose. Don't DRY across a bundle-size boundary; you'll ship your whole world to someone else's homepage.
+
+The one genuinely widget-specific piece is auth. Widget visitors don't have session cookies; they have a short-lived signed "passport." The Pusher auth handler is installed once for the connection but reads the passport *at call time*, so token refresh keeps working across the socket's lifetime:
+
+```typescript
+// packages/chat/src/transport/realtime-client.ts
+customHandler: async ({ socketId, channelName }, callback) => {
+  const { passport } = await getChatPassport(channelId)
+  const res = await fetch(`${getApiBase()}/api/chat/pusher/auth`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${passport}` },
+    body: new URLSearchParams({ socket_id: socketId, channel_name: channelName }),
+  })
+  // ...
+}
+```
+
+Pusher only invokes the handler for `private-` channels, so the public `chat-{sessionId}` transcript channel from Part 1 rides the same socket with no auth at all. And when a passport goes stale mid-session, a `subscription_error` triggers exactly one passport-clearing re-subscribe per channel — re-subscribing re-runs the auth handler, which mints a fresh passport — guarded so a hard auth failure can't spin.
+
+## Closing the series
+
+Two posts, one system. The server half is almost boring on purpose: a pinned Rust container speaking a protocol that outlived its vendor, a room registry where every channel's ACL lives in one table, and publish helpers that make payload discipline structural. The client half is where realtime products are actually won or lost: one header that ends echo bugs as a category, snapshot identity that keeps a thousand events from becoming a thousand renders, invalidation hooks cheap enough to copy per feature, and an editor sync gate that knows exactly which problems it refuses to solve.
+
+If you take one thing: centralize echo suppression in your RPC client. Every team building on websockets reinvents it per feature, and it's one header.
+
+Entry points, if you want to dig:
+
+- `packages/lib/src/realtime/client/adapters/pusher.ts`, the refcounted adapter
+- `apps/web/src/trpc/react.tsx`, the socket-id header
+- `apps/web/src/components/threads/realtime/use-mail-sync.ts`, the heavyweight consumer
+- `apps/web/src/components/editor/inline-picker/hooks/use-external-content-sync.ts`, the editor gate
+- `packages/chat/src/transport/realtime-client.ts`, the widget client
+
+Auxx.ai is open source. PRs welcome.

--- a/apps/homepage/src/app/_components/sections/hero-illustration.tsx
+++ b/apps/homepage/src/app/_components/sections/hero-illustration.tsx
@@ -20,8 +20,6 @@ export const HeroIllustration = () => {
     <>
       <div className='@container perspective-dramatic overflow-x-clip pb-20 lg:pb-32'>
         <div className='rotate-x-[0.125deg] before:z-1 before:bg-linear-to-b relative mx-auto max-w-7xl px-3 sm:px-0 before:absolute before:inset-0 before:inset-x-4 before:top-0 before:rounded-2xl before:from-blue-950 before:opacity-20 before:mix-blend-color lg:px-12 lg:before:inset-x-12'>
-          <div className='bg-linear-to-b from-foreground rotate-66 absolute inset-0 z-10 mx-auto w-8 -translate-y-44 rounded-full opacity-5 blur-xl' />
-          <div className='bg-linear-to-b from-foreground rotate-66 absolute inset-0 z-10 mx-auto w-16 -translate-y-32 translate-x-44 rounded-full opacity-20 blur-2xl' />
           <div className='bg-foreground/5 border-foreground/5 group relative rounded-[15px] border p-0.5'>
             <div className='bg-background aspect-video ring-foreground/10 relative w-full origin-top overflow-hidden rounded-xl p-1 shadow ring-1'>
               <AutoplayVideo

--- a/apps/homepage/src/app/blog/[slug]/page.tsx
+++ b/apps/homepage/src/app/blog/[slug]/page.tsx
@@ -10,6 +10,10 @@ import { config } from '~/lib/config'
 import { mdxComponents } from '../_components/mdx-components'
 import { PostHeader } from '../_components/post-header'
 
+// Re-render hourly so future-dated posts appear on their release date.
+// Slugs not in generateStaticParams (unreleased posts) render on demand.
+export const revalidate = 3600
+
 export function generateStaticParams() {
   return getAllSlugs().map((slug) => ({ slug }))
 }

--- a/apps/homepage/src/app/blog/category/[slug]/page.tsx
+++ b/apps/homepage/src/app/blog/category/[slug]/page.tsx
@@ -7,6 +7,9 @@ import { config } from '~/lib/config'
 import { BlogLayout } from '../../_components/blog-layout'
 import { BlogListWithPagination } from '../../_components/blog-list-with-pagination'
 
+// Re-render hourly so future-dated posts appear on their release date.
+export const revalidate = 3600
+
 export function generateStaticParams() {
   return getAllCategories().map((cat) => ({ slug: cat.slug }))
 }

--- a/apps/homepage/src/app/blog/page.tsx
+++ b/apps/homepage/src/app/blog/page.tsx
@@ -6,6 +6,9 @@ import { config } from '~/lib/config'
 import { BlogLayout } from './_components/blog-layout'
 import { BlogListWithPagination } from './_components/blog-list-with-pagination'
 
+// Re-render hourly so future-dated posts appear on their release date.
+export const revalidate = 3600
+
 export const metadata: Metadata = {
   title: `Blog | ${config.shortName}`,
   description:

--- a/apps/homepage/src/app/blog/rss.xml/route.ts
+++ b/apps/homepage/src/app/blog/rss.xml/route.ts
@@ -3,6 +3,9 @@
 import { getHomepageUrl } from '@auxx/config/client'
 import { getAllPosts } from '~/lib/blog'
 
+// Re-render hourly so future-dated posts appear on their release date.
+export const revalidate = 3600
+
 export function GET() {
   const baseUrl = getHomepageUrl()
   const posts = getAllPosts()

--- a/apps/homepage/src/app/sitemap.ts
+++ b/apps/homepage/src/app/sitemap.ts
@@ -4,6 +4,9 @@ import { getHomepageUrl } from '@auxx/config/client'
 import type { MetadataRoute } from 'next'
 import { getAllPosts } from '~/lib/blog'
 
+// Re-render hourly so future-dated posts appear on their release date.
+export const revalidate = 3600
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = getHomepageUrl()
   const posts = getAllPosts()

--- a/apps/homepage/src/lib/blog.ts
+++ b/apps/homepage/src/lib/blog.ts
@@ -8,11 +8,20 @@ import type { BlogPost, Category } from '~/types/blog'
 
 const CONTENT_DIR = path.join(process.cwd(), 'content', 'blog')
 
+/**
+ * A post is visible once its date has passed (dates parse as UTC midnight).
+ * Combined with ISR revalidation on the blog routes, this lets us commit
+ * future-dated posts that go live automatically without a redeploy.
+ */
+function isReleased(date: string): boolean {
+  return new Date(date).getTime() <= Date.now()
+}
+
 function parseMdxFile(filePath: string): BlogPost | null {
   const raw = fs.readFileSync(filePath, 'utf-8')
   const { data, content } = matter(raw)
 
-  if (!data.published) return null
+  if (!data.published || !isReleased(data.date)) return null
 
   const stats = readingTime(content)
 
@@ -57,7 +66,7 @@ export function getPostBySlug(slug: string): { post: BlogPost; content: string }
     const raw = fs.readFileSync(filePath, 'utf-8')
     const { data, content } = matter(raw)
 
-    if (data.slug === slug && data.published) {
+    if (data.slug === slug && data.published && isReleased(data.date)) {
       const stats = readingTime(content)
       return {
         post: {


### PR DESCRIPTION
## What

Adds 10 future-dated engineering deep-dives and introduces release-date gating so posts can be committed ahead of time and go live automatically.

### New posts (staggered Jul–Sep 2026)
- Connections, Part 1 & 2
- Building a Data Connector Engine, Parts 1–3
- How an Email Becomes a Ticket (ingestion pipeline)
- Verifying Anyone's Webhook: Providers as Data
- Record Rules: an automation engine that survives bulk sync
- Self-Hosted Realtime, Part 1 & 2

### Release scheduling
- `blog.ts`: `isReleased()` hides a post until its `date` has passed (dates parse as UTC midnight). Applied in both the list (`parseMdxFile`) and single-post (`getPostBySlug`) paths.
- Added `export const revalidate = 3600` (ISR) to the blog index, post, category, RSS, and sitemap routes so scheduled posts appear on their date **without a redeploy**.

### Misc
- `hero-illustration`: removed two stray blur accent divs.

## Why

Lets us write a backlog of posts now and drip them out on a schedule, no manual deploy per post.