### PR TITLE
perf: reduce hot-path SQL via batching, projections, and org-cache reads

### DIFF
--- a/apps/web/src/server/api/routers/favorite.ts
+++ b/apps/web/src/server/api/routers/favorite.ts
@@ -1,7 +1,5 @@
 // apps/web/src/server/api/routers/favorite.ts
 
-import type { Database } from '@auxx/database'
-import { schema } from '@auxx/database'
 import { getUserCache } from '@auxx/lib/cache'
 import {
   addFavorite,
@@ -14,8 +12,8 @@ import {
   reorderFavorites,
 } from '@auxx/lib/favorites'
 import { FAVORITE_FOLDER_TITLE_MAX, type FavoriteTargetIdsMap } from '@auxx/lib/favorites/client'
+import { findMemberByUser } from '@auxx/lib/members'
 import { TRPCError } from '@trpc/server'
-import { and, eq } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
@@ -78,25 +76,8 @@ const createFolderInput = z.object({
   title: z.string().min(1).max(FAVORITE_FOLDER_TITLE_MAX),
 })
 
-async function loadMemberContext(
-  db: Database,
-  userId: string,
-  organizationId: string
-): Promise<MemberContext> {
-  const [member] = await db
-    .select({
-      id: schema.OrganizationMember.id,
-      userId: schema.OrganizationMember.userId,
-      organizationId: schema.OrganizationMember.organizationId,
-    })
-    .from(schema.OrganizationMember)
-    .where(
-      and(
-        eq(schema.OrganizationMember.userId, userId),
-        eq(schema.OrganizationMember.organizationId, organizationId)
-      )
-    )
-    .limit(1)
+async function loadMemberContext(userId: string, organizationId: string): Promise<MemberContext> {
+  const member = await findMemberByUser(organizationId, userId)
   if (!member) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'Membership not found' })
   }
@@ -124,43 +105,43 @@ export const favoriteRouter = createTRPCRouter({
   }),
 
   add: protectedProcedure.input(addInput).mutation(async ({ ctx, input }) => {
-    const member = await loadMemberContext(ctx.db, ctx.session.userId, ctx.session.organizationId)
+    const member = await loadMemberContext(ctx.session.userId, ctx.session.organizationId)
     return unwrap(await addFavorite(member, input as Parameters<typeof addFavorite>[1], ctx.db))
   }),
 
   remove: protectedProcedure
     .input(z.object({ favoriteId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const member = await loadMemberContext(ctx.db, ctx.session.userId, ctx.session.organizationId)
+      const member = await loadMemberContext(ctx.session.userId, ctx.session.organizationId)
       unwrap(await removeFavorite(member, input.favoriteId, ctx.db))
       return { ok: true }
     }),
 
   reorder: protectedProcedure.input(reorderInput).mutation(async ({ ctx, input }) => {
-    const member = await loadMemberContext(ctx.db, ctx.session.userId, ctx.session.organizationId)
+    const member = await loadMemberContext(ctx.session.userId, ctx.session.organizationId)
     unwrap(await reorderFavorites(member, input.updates, ctx.db))
     return { ok: true }
   }),
 
   move: protectedProcedure.input(moveInput).mutation(async ({ ctx, input }) => {
-    const member = await loadMemberContext(ctx.db, ctx.session.userId, ctx.session.organizationId)
+    const member = await loadMemberContext(ctx.session.userId, ctx.session.organizationId)
     unwrap(await moveToFolder(member, input.favoriteId, input.parentFolderId, ctx.db))
     return { ok: true }
   }),
 
   createFolder: protectedProcedure.input(createFolderInput).mutation(async ({ ctx, input }) => {
-    const member = await loadMemberContext(ctx.db, ctx.session.userId, ctx.session.organizationId)
+    const member = await loadMemberContext(ctx.session.userId, ctx.session.organizationId)
     return unwrap(await createFolder(member, input.title, ctx.db))
   }),
 
   renameFolder: protectedProcedure.input(renameFolderInput).mutation(async ({ ctx, input }) => {
-    const member = await loadMemberContext(ctx.db, ctx.session.userId, ctx.session.organizationId)
+    const member = await loadMemberContext(ctx.session.userId, ctx.session.organizationId)
     unwrap(await renameFolder(member, input.folderId, input.title, ctx.db))
     return { ok: true }
   }),
 
   deleteFolder: protectedProcedure.input(folderIdInput).mutation(async ({ ctx, input }) => {
-    const member = await loadMemberContext(ctx.db, ctx.session.userId, ctx.session.organizationId)
+    const member = await loadMemberContext(ctx.session.userId, ctx.session.organizationId)
     unwrap(await deleteFolder(member, input.folderId, ctx.db))
     return { ok: true }
   }),

--- a/apps/web/src/server/api/routers/member.ts
+++ b/apps/web/src/server/api/routers/member.ts
@@ -2,12 +2,12 @@
 
 import { schema } from '@auxx/database'
 import { MemberType, OrganizationRole } from '@auxx/database/enums'
-import { onCacheEvent } from '@auxx/lib/cache'
+import { getCachedMembers, onCacheEvent } from '@auxx/lib/cache'
 import { DehydrationService } from '@auxx/lib/dehydration'
-import { MemberService } from '@auxx/lib/members'
+import { findMemberByUser, MemberService } from '@auxx/lib/members'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
-import { and, eq, ilike, or } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
 import { createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
@@ -32,27 +32,20 @@ export const memberRouter = createTRPCRouter({
       const { organizationId } = ctx.session
       const query = input.query.toLowerCase()
 
-      const rows = await ctx.db
-        .select({
-          userId: schema.OrganizationMember.userId,
-          name: schema.User.name,
-          email: schema.User.email,
-        })
-        .from(schema.OrganizationMember)
-        .innerJoin(schema.User, eq(schema.OrganizationMember.userId, schema.User.id))
-        .where(
-          and(
-            eq(schema.OrganizationMember.organizationId, organizationId),
-            eq(schema.User.userType, 'USER'),
-            or(ilike(schema.User.name, `%${query}%`), ilike(schema.User.email, `%${query}%`))
-          )
-        )
-        .limit(10)
+      const members = await getCachedMembers(organizationId)
 
-      return rows.map((row) => ({
-        id: row.userId,
-        name: row.name || row.email || 'Unknown',
-      }))
+      return members
+        .filter(
+          (m) =>
+            m.user?.userType === 'USER' &&
+            ((m.user.name ?? '').toLowerCase().includes(query) ||
+              (m.user.email ?? '').toLowerCase().includes(query))
+        )
+        .slice(0, 10)
+        .map((m) => ({
+          id: m.userId,
+          name: m.user?.name || m.user?.email || 'Unknown',
+        }))
     }),
 
   /** Get all members with optional filtering */
@@ -69,36 +62,26 @@ export const memberRouter = createTRPCRouter({
       const { organizationId } = ctx.session
       const { excludeGroupId, search } = input ?? {}
 
-      // Build where conditions
-      const whereConditions = [
-        eq(schema.OrganizationMember.organizationId, organizationId),
-        eq(schema.User.userType, 'USER'),
-      ]
+      const searchLower = search?.toLowerCase()
+      const cachedMembers = await getCachedMembers(organizationId)
 
-      if (search) {
-        whereConditions.push(
-          or(ilike(schema.User.name, `%${search}%`), ilike(schema.User.email, `%${search}%`))!
-        )
-      }
-
-      const rows = await ctx.db
-        .select({
-          id: schema.OrganizationMember.id,
-          userId: schema.OrganizationMember.userId,
-          role: schema.OrganizationMember.role,
-          status: schema.OrganizationMember.status,
-          organizationId: schema.OrganizationMember.organizationId,
-          user: {
-            id: schema.User.id,
-            name: schema.User.name,
-            email: schema.User.email,
-            image: schema.User.image,
-            userType: schema.User.userType,
-          },
+      const rows = cachedMembers
+        .filter((m) => {
+          if (m.user?.userType !== 'USER') return false
+          if (!searchLower) return true
+          return (
+            (m.user.name ?? '').toLowerCase().includes(searchLower) ||
+            (m.user.email ?? '').toLowerCase().includes(searchLower)
+          )
         })
-        .from(schema.OrganizationMember)
-        .innerJoin(schema.User, eq(schema.OrganizationMember.userId, schema.User.id))
-        .where(and(...whereConditions))
+        .map((m) => ({
+          id: m.id,
+          userId: m.userId,
+          role: m.role,
+          status: m.status,
+          organizationId: m.organizationId,
+          user: m.user!,
+        }))
 
       // Filter out members already in group if excludeGroupId provided
       if (excludeGroupId) {
@@ -138,13 +121,7 @@ export const memberRouter = createTRPCRouter({
 
   /** Get current user's membership */
   getUserMembership: protectedProcedure.query(async ({ ctx }) => {
-    const membership = await ctx.db.query.OrganizationMember.findFirst({
-      where: (members, { eq, and }) =>
-        and(
-          eq(members.organizationId, ctx.session.organizationId),
-          eq(members.userId, ctx.session.userId)
-        ),
-    })
+    const membership = await findMemberByUser(ctx.session.organizationId, ctx.session.userId)
     if (!membership) {
       throw new TRPCError({
         code: 'NOT_FOUND',

--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -357,6 +357,8 @@ export const recordRouter = createTRPCRouter({
         apiSlug: z.string().optional(),
         /** Specific field IDs to fetch (all if undefined) - branded FieldId type */
         fieldIds: z.array(z.string() as unknown as z.ZodType<FieldId>).optional(),
+        /** Specific field output keys to fetch (ignored when fieldIds is set) */
+        fieldKeys: z.array(z.string()).optional(),
         /** Include archived records */
         includeArchived: z.boolean().optional(),
       })

--- a/apps/web/src/server/api/routers/search.ts
+++ b/apps/web/src/server/api/routers/search.ts
@@ -248,12 +248,17 @@ export const searchRouter = createTRPCRouter({
         }
         case SearchOperator.TAG: {
           // Get tags using unified entity system
-          const result = await listAll({
-            organizationId,
-            userId,
-            db: ctx.db,
-            entityDefinitionId: 'tag',
-          })
+          const result = await listAll(
+            {
+              organizationId,
+              userId,
+              db: ctx.db,
+            },
+            {
+              entityDefinitionId: 'tag',
+              fieldKeys: ['title', 'tag_emoji', 'tag_color'],
+            }
+          )
           const filteredTags = result.items
             .filter((item) => {
               const title = item.fieldValues.title ?? item.displayName ?? ''

--- a/apps/web/src/server/api/routers/user.ts
+++ b/apps/web/src/server/api/routers/user.ts
@@ -1,11 +1,17 @@
 import { database as db, schema } from '@auxx/database'
-import { getUserCache, isAgentUser, onCacheEvent } from '@auxx/lib/cache'
+import {
+  getCachedMembers,
+  getOrgCache,
+  getUserCache,
+  isAgentUser,
+  onCacheEvent,
+} from '@auxx/lib/cache'
 import { MediaAssetService } from '@auxx/lib/files'
 import { isAdminOrOwner } from '@auxx/lib/members'
 import { FeaturePermissionService } from '@auxx/lib/permissions'
 import { UserSettingsService } from '@auxx/lib/settings'
 import { TRPCError } from '@trpc/server'
-import { and, count, eq, isNull } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
 
@@ -113,16 +119,8 @@ export const userRouter = createTRPCRouter({
     const featureService = new FeaturePermissionService(db)
     const features = await featureService.getOrganizationFeaturesMap(organizationId)
 
-    const [{ integrationCount }] = await db
-      .select({ integrationCount: count() })
-      .from(schema.Integration)
-      .where(
-        and(
-          eq(schema.Integration.organizationId, organizationId),
-          isNull(schema.Integration.deletedAt)
-        )
-      )
-    const hasIntegrations = integrationCount > 0
+    const channels = await getOrgCache().get(organizationId, 'channels')
+    const hasIntegrations = channels.length > 0
 
     // Fetch avatar URL if user has an avatar asset
     let avatarUrl: string | null = null
@@ -141,17 +139,13 @@ export const userRouter = createTRPCRouter({
       throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID is required' })
     }
 
-    const members = await db
-      .select({
-        id: schema.User.id,
-        name: schema.User.name,
-        email: schema.User.email,
-      })
-      .from(schema.OrganizationMember)
-      .leftJoin(schema.User, eq(schema.User.id, schema.OrganizationMember.userId))
-      .where(eq(schema.OrganizationMember.organizationId, organizationId))
+    const members = await getCachedMembers(organizationId)
 
-    return members
+    return members.map((m) => ({
+      id: m.user?.id ?? null,
+      name: m.user?.name ?? null,
+      email: m.user?.email ?? null,
+    }))
   }),
 
   settings: protectedProcedure.query(async ({ ctx }) => {

--- a/packages/lib/src/channels/list.ts
+++ b/packages/lib/src/channels/list.ts
@@ -113,18 +113,9 @@ export async function getProviderType(
   ctx: ChannelCtx,
   channelId: string
 ): Promise<TypedResult<{ provider: string }, NotFoundError>> {
-  const [row] = await ctx.db
-    .select({ provider: schema.Integration.provider })
-    .from(schema.Integration)
-    .where(
-      and(
-        eq(schema.Integration.id, channelId),
-        eq(schema.Integration.organizationId, ctx.organizationId),
-        isNull(schema.Integration.deletedAt)
-      )
-    )
-    .limit(1)
+  const providers = await getOrgCache().get(ctx.organizationId, 'channelProviders')
+  const provider = providers[channelId]
 
-  if (!row) return Result.error(new NotFoundError('Channel not found'))
-  return Result.ok({ provider: row.provider })
+  if (!provider) return Result.error(new NotFoundError('Channel not found'))
+  return Result.ok({ provider })
 }

--- a/packages/lib/src/field-hooks/post/vendor-part-triggers.ts
+++ b/packages/lib/src/field-hooks/post/vendor-part-triggers.ts
@@ -6,7 +6,7 @@ import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import { and, eq, inArray, ne } from 'drizzle-orm'
-import { requireCachedEntityDefId } from '../../cache'
+import { getOrgCache, requireCachedEntityDefId } from '../../cache'
 import { getRealtimeService, publishFieldValueUpdates } from '../../realtime'
 import type { FieldTriggerHandler } from '../types'
 
@@ -79,18 +79,11 @@ export const clearOtherPreferred: FieldTriggerHandler = async (event) => {
     if (siblingIds.length === 0) continue
 
     // 4. Clear isPreferred on siblings (direct DB update to avoid triggering recursion)
-    const isPreferredField = await database
-      .select({ id: schema.CustomField.id })
-      .from(schema.CustomField)
-      .where(
-        and(
-          eq(schema.CustomField.systemAttribute, 'vendor_part_is_preferred'),
-          eq(schema.CustomField.organizationId, organizationId)
-        )
-      )
-      .limit(1)
+    const isPreferredField = await getOrgCache()
+      .from(organizationId, 'customFields')
+      .bySystemAttribute('vendor_part_is_preferred')
 
-    const fieldId = isPreferredField[0]?.id
+    const fieldId = isPreferredField?.id
     if (!fieldId) continue
 
     await database

--- a/packages/lib/src/field-values/field-value-queries.ts
+++ b/packages/lib/src/field-values/field-value-queries.ts
@@ -3,7 +3,7 @@
 import { schema } from '@auxx/database'
 import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import type { FieldType } from '@auxx/database/types'
-import { isArrayReturnFieldType, type TypedFieldValue } from '@auxx/types'
+import { getValueType, isArrayReturnFieldType, type TypedFieldValue } from '@auxx/types'
 import {
   type FieldPath,
   type FieldReference,
@@ -12,7 +12,7 @@ import {
   type ResourceFieldId,
 } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
-import { and, asc, eq, inArray } from 'drizzle-orm'
+import { and, asc, eq, inArray, isNotNull, or, type SQL, sql } from 'drizzle-orm'
 import { findCachedResource } from '../cache'
 import type { FieldOptions, NameFieldOptions } from '../custom-fields/field-options'
 import type { AiStatus } from '../realtime/events'
@@ -473,6 +473,36 @@ async function categorizeFields(
 // =============================================================================
 
 /**
+ * Explicit FieldValue projection. `valueJson` is heavy jsonb (file/currency/
+ * address payloads, AI metadata) — it is only shipped when `valueJsonWhen`
+ * matches; other rows get NULL. Pass `true` to always include it.
+ */
+function fieldValueColumns(valueJsonWhen: SQL | true) {
+  return {
+    id: schema.FieldValue.id,
+    entityId: schema.FieldValue.entityId,
+    fieldId: schema.FieldValue.fieldId,
+    sortKey: schema.FieldValue.sortKey,
+    createdAt: schema.FieldValue.createdAt,
+    updatedAt: schema.FieldValue.updatedAt,
+    valueText: schema.FieldValue.valueText,
+    valueNumber: schema.FieldValue.valueNumber,
+    valueBoolean: schema.FieldValue.valueBoolean,
+    valueDate: schema.FieldValue.valueDate,
+    valueJson:
+      valueJsonWhen === true
+        ? schema.FieldValue.valueJson
+        : sql<unknown>`CASE WHEN ${valueJsonWhen} THEN ${schema.FieldValue.valueJson} END`,
+    optionId: schema.FieldValue.optionId,
+    relatedEntityId: schema.FieldValue.relatedEntityId,
+    relatedEntityDefinitionId: schema.FieldValue.relatedEntityDefinitionId,
+    actorId: schema.FieldValue.actorId,
+    aiStatus: schema.FieldValue.aiStatus,
+    managedByConnectorId: schema.FieldValue.managedByConnectorId,
+  }
+}
+
+/**
  * Fetch field values from the FieldValue table and convert to typed results.
  * This is the original FieldValue query, extracted into its own function.
  */
@@ -485,8 +515,19 @@ async function fetchFieldValueResults(
   fieldTypeMap: Map<string, FieldType>,
   fieldOptionsMap: Map<string, FieldOptions | undefined>
 ): Promise<TypedFieldValueResult[]> {
+  // Only json-typed fields store their value in valueJson; AI metadata
+  // piggy-backs on valueJson for ANY type when aiStatus is set. Unknown types
+  // keep valueJson for safety.
+  const jsonFieldIds = fieldIds.filter((fieldId) => {
+    const fieldType = fieldTypeMap.get(fieldId)
+    return !fieldType || getValueType(fieldType) === 'json'
+  })
+  const valueJsonWhen = jsonFieldIds.length
+    ? or(isNotNull(schema.FieldValue.aiStatus), inArray(schema.FieldValue.fieldId, jsonFieldIds))!
+    : isNotNull(schema.FieldValue.aiStatus)
+
   const rows = await ctx.db
-    .select()
+    .select(fieldValueColumns(valueJsonWhen))
     .from(schema.FieldValue)
     .where(
       and(
@@ -891,8 +932,9 @@ async function batchFetchFieldValues(
 ): Promise<Map<RecordId, TypedFieldValue | TypedFieldValue[]>> {
   const entityInstanceIds = recordIds.map((rid) => parseRecordId(rid).entityInstanceId)
 
+  // No AI-metadata read on this path — valueJson only matters for json-typed fields.
   const rows = await ctx.db
-    .select()
+    .select(fieldValueColumns(getValueType(fieldType) === 'json' ? true : sql`false`))
     .from(schema.FieldValue)
     .where(
       and(

--- a/packages/lib/src/ingest/companies/link-contact.ts
+++ b/packages/lib/src/ingest/companies/link-contact.ts
@@ -59,43 +59,27 @@ export async function linkContactToCompanyByDomain(args: LinkContactArgs): Promi
     // store the canonical `relatedEntityDefinitionId`. Server-side normalization in
     // the field-value mutation path also canonicalizes these, but resolving here
     // keeps callers consistent and avoids any type-name-prefixed RecordIds in transit.
-    const [contactDefId, companyDefId, contactEmployerField, companyPrimaryContactField] =
-      await Promise.all([
-        requireCachedEntityDefId(args.organizationId, 'contact'),
-        requireCachedEntityDefId(args.organizationId, 'company'),
-        db
-          .select({ id: schema.CustomField.id })
-          .from(schema.CustomField)
-          .where(
-            and(
-              eq(schema.CustomField.organizationId, args.organizationId),
-              eq(schema.CustomField.systemAttribute, 'contact_employer')
-            )
-          )
-          .limit(1),
-        db
-          .select({ id: schema.CustomField.id })
-          .from(schema.CustomField)
-          .where(
-            and(
-              eq(schema.CustomField.organizationId, args.organizationId),
-              eq(schema.CustomField.systemAttribute, 'company_primary_contact')
-            )
-          )
-          .limit(1),
-      ])
+    const [contactDefId, companyDefId, linkFields] = await Promise.all([
+      requireCachedEntityDefId(args.organizationId, 'contact'),
+      requireCachedEntityDefId(args.organizationId, 'company'),
+      getOrgCache()
+        .from(args.organizationId, 'customFields')
+        .bySystemAttributes(['contact_employer', 'company_primary_contact']),
+    ])
+    const contactEmployerField = linkFields.contact_employer
+    const companyPrimaryContactField = linkFields.company_primary_contact
 
     const updates: Array<Promise<unknown>> = []
 
     // Only set contact.employer if it's currently empty.
-    if (contactEmployerField[0]) {
+    if (contactEmployerField) {
       const existing = await db
         .select({ id: schema.FieldValue.id })
         .from(schema.FieldValue)
         .where(
           and(
             eq(schema.FieldValue.organizationId, args.organizationId),
-            eq(schema.FieldValue.fieldId, contactEmployerField[0].id),
+            eq(schema.FieldValue.fieldId, contactEmployerField.id),
             eq(schema.FieldValue.entityId, args.contactId),
             isNotNull(schema.FieldValue.relatedEntityId)
           )
@@ -112,14 +96,14 @@ export async function linkContactToCompanyByDomain(args: LinkContactArgs): Promi
     }
 
     // Only set company.primaryContact if it's currently empty.
-    if (companyPrimaryContactField[0]) {
+    if (companyPrimaryContactField) {
       const existing = await db
         .select({ id: schema.FieldValue.id })
         .from(schema.FieldValue)
         .where(
           and(
             eq(schema.FieldValue.organizationId, args.organizationId),
-            eq(schema.FieldValue.fieldId, companyPrimaryContactField[0].id),
+            eq(schema.FieldValue.fieldId, companyPrimaryContactField.id),
             eq(schema.FieldValue.entityId, companyId),
             isNotNull(schema.FieldValue.relatedEntityId)
           )

--- a/packages/lib/src/permissions/permission-service.ts
+++ b/packages/lib/src/permissions/permission-service.ts
@@ -400,6 +400,14 @@ export class PermissionService {
         return true
       }
 
+      // Fast path: the per-org entityDefs cache holds only this org's definitions,
+      // so a hit IS the ownership check. Misses (archived defs, custom defs without
+      // an entityType, cache staleness) fall through to the DB.
+      const cachedDefs = await getOrgCache().get(this.organizationId, 'entityDefs')
+      if (Object.values(cachedDefs).includes(definitionId)) {
+        return true
+      }
+
       const definition = await this.statements.getEntityDefinitionStatement.execute({
         definitionId,
       })

--- a/packages/lib/src/recording/calendar/participant-resolver.ts
+++ b/packages/lib/src/recording/calendar/participant-resolver.ts
@@ -1,12 +1,11 @@
 // packages/lib/src/recording/calendar/participant-resolver.ts
 
 import { database as db, schema } from '@auxx/database'
-import { createScopedLogger } from '@auxx/logger'
 import type { RecordId } from '@auxx/types/resource'
 import { getDefinitionId, getInstanceId } from '@auxx/types/resource'
-import { and, asc, eq, ilike, inArray, isNull, or, sql } from 'drizzle-orm'
+import { and, asc, eq, ilike, inArray, isNull } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
-import { getCachedCustomFields } from '../../cache'
+import { getCachedCustomFields, getCachedEntityDefId } from '../../cache'
 import type { CalendarAttendeeInput, RecordingResult, ResolvedParticipant } from './types'
 
 /**
@@ -81,35 +80,17 @@ export async function findCompanyByDomain(
       return ok(null)
     }
 
-    const [companyDefinition] = await db
-      .select({ id: schema.EntityDefinition.id })
-      .from(schema.EntityDefinition)
-      .where(
-        and(
-          eq(schema.EntityDefinition.organizationId, organizationId),
-          eq(schema.EntityDefinition.entityType, 'company')
-        )
-      )
-      .limit(1)
-
-    if (!companyDefinition) {
+    const companyDefId = await getCachedEntityDefId(organizationId, 'company')
+    if (!companyDefId) {
       return ok(null)
     }
 
-    const companyFields = await db
-      .select({ id: schema.CustomField.id })
-      .from(schema.CustomField)
-      .where(
-        and(
-          eq(schema.CustomField.organizationId, organizationId),
-          eq(schema.CustomField.entityDefinitionId, companyDefinition.id),
-          or(
-            eq(schema.CustomField.systemAttribute, 'company_website'),
-            sql`lower(${schema.CustomField.name}) = 'website'`,
-            sql`lower(${schema.CustomField.name}) = 'domain'`
-          )!
-        )
-      )
+    const allCompanyFields = await getCachedCustomFields(organizationId, companyDefId)
+    const companyFields = allCompanyFields.filter(
+      (field) =>
+        field.systemAttribute === 'company_website' ||
+        ['website', 'domain'].includes((field.name ?? '').toLowerCase())
+    )
 
     if (companyFields.length === 0) {
       return ok(null)
@@ -264,32 +245,13 @@ async function findContactEntityInstanceIdByEmail(
   organizationId: string
 ): RecordingResult<string | null> {
   try {
-    const [contactDefinition] = await db
-      .select({ id: schema.EntityDefinition.id })
-      .from(schema.EntityDefinition)
-      .where(
-        and(
-          eq(schema.EntityDefinition.organizationId, organizationId),
-          eq(schema.EntityDefinition.entityType, 'contact')
-        )
-      )
-      .limit(1)
-
-    if (!contactDefinition) {
+    const contactDefId = await getCachedEntityDefId(organizationId, 'contact')
+    if (!contactDefId) {
       return ok(null)
     }
 
-    const [emailField] = await db
-      .select({ id: schema.CustomField.id })
-      .from(schema.CustomField)
-      .where(
-        and(
-          eq(schema.CustomField.organizationId, organizationId),
-          eq(schema.CustomField.entityDefinitionId, contactDefinition.id),
-          eq(schema.CustomField.systemAttribute, 'primary_email')
-        )
-      )
-      .limit(1)
+    const contactFields = await getCachedCustomFields(organizationId, contactDefId)
+    const emailField = contactFields.find((field) => field.systemAttribute === 'primary_email')
 
     if (!emailField) {
       return ok(null)
@@ -310,7 +272,7 @@ async function findContactEntityInstanceIdByEmail(
       .where(
         and(
           eq(schema.EntityInstance.organizationId, organizationId),
-          eq(schema.EntityInstance.entityDefinitionId, contactDefinition.id),
+          eq(schema.EntityInstance.entityDefinitionId, contactDefId),
           isNull(schema.EntityInstance.archivedAt)
         )
       )

--- a/packages/lib/src/resources/crud/unified-handler-queries.ts
+++ b/packages/lib/src/resources/crud/unified-handler-queries.ts
@@ -620,6 +620,12 @@ export interface ListAllInput {
   apiSlug?: string
   /** Specific field IDs to fetch (all fields if undefined) */
   fieldIds?: FieldId[]
+  /**
+   * Specific field output keys to fetch (e.g. 'title', 'tag_color'). Ignored
+   * when fieldIds is set. Prefer this over fetching all fields — the full
+   * fan-out loads every FieldValue for up to 1000 records.
+   */
+  fieldKeys?: string[]
   /** Include archived records */
   includeArchived?: boolean
 }
@@ -790,9 +796,18 @@ export async function listAll(
   const resourceFieldIdToType = new Map<string, FieldType>()
   let fieldReferences: FieldReference[]
 
-  if (params.fieldIds && params.fieldIds.length > 0) {
+  // Resolve fieldKeys (output keys) to field IDs — callers usually know keys, not IDs.
+  // Unknown keys are dropped; an all-unknown list yields no field values (not all fields).
+  let requestedFieldIds = params.fieldIds
+  if ((!requestedFieldIds || requestedFieldIds.length === 0) && params.fieldKeys) {
+    requestedFieldIds = params.fieldKeys
+      .map((key) => fieldsMap[key]?.id)
+      .filter((id): id is string => Boolean(id)) as FieldId[]
+  }
+
+  if (requestedFieldIds && (requestedFieldIds.length > 0 || params.fieldKeys)) {
     // Use specific fields provided
-    fieldReferences = params.fieldIds.map((fieldId) => {
+    fieldReferences = requestedFieldIds.map((fieldId) => {
       const resourceFieldId = toResourceFieldId(entityDefId, fieldId)
       // Find field by id to get its key and type
       const field = fields.find((f) => f.id === fieldId)

--- a/packages/lib/src/settings/settings-service.ts
+++ b/packages/lib/src/settings/settings-service.ts
@@ -311,25 +311,25 @@ export class SettingsService {
       throw new Error(`Unknown setting: ${key}`)
     }
 
-    // Get organization setting
-    const [orgSetting] = await this.database
-      .select()
-      .from(schema.OrganizationSetting)
-      .where(
-        and(
-          eq(schema.OrganizationSetting.organizationId, organizationId),
-          eq(schema.OrganizationSetting.key, key)
+    // Injected database (e.g. transaction) → read directly for write-after-read consistency
+    if (this.database !== db) {
+      const [orgSetting] = await this.database
+        .select()
+        .from(schema.OrganizationSetting)
+        .where(
+          and(
+            eq(schema.OrganizationSetting.organizationId, organizationId),
+            eq(schema.OrganizationSetting.key, key)
+          )
         )
-      )
-      .limit(1)
-
-    // If no organization setting, return the default from catalog
-    if (!orgSetting) {
-      return settingConfig.defaultValue
+        .limit(1)
+      return orgSetting ? (orgSetting.value as SettingValue) : settingConfig.defaultValue
     }
 
-    // Return the organization setting
-    return orgSetting.value as SettingValue
+    // Org cache map already merges catalog defaults with persisted org rows
+    const { getOrgCache } = await import('../cache')
+    const settings = await getOrgCache().get(organizationId, 'orgSettings')
+    return key in settings ? settings[key]! : settingConfig.defaultValue
   }
 
   /**

--- a/packages/lib/src/tags/universal-tag-service.ts
+++ b/packages/lib/src/tags/universal-tag-service.ts
@@ -6,6 +6,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { generateId } from '@auxx/utils'
 import { randomUUID } from 'crypto'
 import { and, eq, isNotNull } from 'drizzle-orm'
+import { getOrgCache } from '../cache'
 
 const logger = createScopedLogger('universal-tag-service')
 
@@ -137,25 +138,13 @@ export class UniversalTagService {
   }
 
   /**
-   * Get the CustomField ID for thread_tags (cached per instance)
+   * Get the CustomField ID for thread_tags (org cache)
    */
-  private threadTagsFieldId: string | null = null
   private async getThreadTagsFieldId(): Promise<string | null> {
-    if (this.threadTagsFieldId) return this.threadTagsFieldId
-
-    const result = await this.db
-      .select({ id: schema.CustomField.id })
-      .from(schema.CustomField)
-      .where(
-        and(
-          eq(schema.CustomField.systemAttribute, 'thread_tags'),
-          eq(schema.CustomField.organizationId, this.organizationId)
-        )
-      )
-      .limit(1)
-
-    this.threadTagsFieldId = result[0]?.id ?? null
-    return this.threadTagsFieldId
+    const field = await getOrgCache()
+      .from(this.organizationId, 'customFields')
+      .bySystemAttribute('thread_tags')
+    return field?.id ?? null
   }
 
   /**

--- a/packages/lib/src/tasks/task-service.ts
+++ b/packages/lib/src/tasks/task-service.ts
@@ -585,39 +585,13 @@ export class TaskService {
       filteredTasks = filteredTasks.filter((t) => referencedTaskIds.has(t.id))
     }
 
-    // Load relations for each task
-    const tasksWithRelations: TaskWithRelations[] = await Promise.all(
-      filteredTasks.map(async (task) => {
-        // Get assignments - only need user IDs to convert to ActorId
-        const assignmentRows = await this.db.query.TaskAssignment.findMany({
-          where: (a, { eq, and, isNull }) => and(eq(a.taskId, task.id), isNull(a.unassignedAt)),
-          columns: { assignedToUserId: true },
-        })
-
-        // Convert to ActorId[]
-        const assignments = assignmentRows.map((a) => toActorId('user', a.assignedToUserId))
-
-        // Load only IDs
-        const referenceRows = await this.db.query.TaskReference.findMany({
-          where: (r, { eq, and, isNull }) => and(eq(r.taskId, task.id), isNull(r.deletedAt)),
-          columns: {
-            referencedEntityDefinitionId: true,
-            referencedEntityInstanceId: true,
-          },
-        })
-
-        // Convert to RecordId[]
-        const references = referenceRows.map((ref) =>
-          toRecordId(ref.referencedEntityDefinitionId, ref.referencedEntityInstanceId)
-        )
-
-        return {
-          ...task,
-          assignments,
-          references,
-        }
-      })
-    )
+    // Load relations for all tasks in two batched queries
+    const relations = await this.loadTaskRelations(filteredTasks.map((t) => t.id))
+    const tasksWithRelations: TaskWithRelations[] = filteredTasks.map((task) => ({
+      ...task,
+      assignments: relations.assignmentsByTask.get(task.id) ?? [],
+      references: relations.referencesByTask.get(task.id) ?? [],
+    }))
 
     const nextCursor = hasMore
       ? resultTasks[resultTasks.length - 1]?.createdAt?.toISOString()
@@ -696,49 +670,72 @@ export class TaskService {
       limit: 50,
     })
 
-    // Helper to load relations for tasks
-    const loadRelations = async (tasks: TaskEntity[]): Promise<TaskWithRelations[]> => {
-      return Promise.all(
-        tasks.map(async (task) => {
-          // Get assignments - only need user IDs to convert to ActorId
-          const assignmentRows = await this.db.query.TaskAssignment.findMany({
-            where: (a, { eq, and, isNull }) => and(eq(a.taskId, task.id), isNull(a.unassignedAt)),
-            columns: { assignedToUserId: true },
-          })
-
-          // Convert to ActorId[]
-          const assignments = assignmentRows.map((a) => toActorId('user', a.assignedToUserId))
-
-          // Load only IDs
-          const referenceRows = await this.db.query.TaskReference.findMany({
-            where: (r, { eq, and, isNull }) => and(eq(r.taskId, task.id), isNull(r.deletedAt)),
-            columns: {
-              referencedEntityDefinitionId: true,
-              referencedEntityInstanceId: true,
-            },
-          })
-
-          // Convert to RecordId[]
-          const references = referenceRows.map((ref) =>
-            toRecordId(ref.referencedEntityDefinitionId, ref.referencedEntityInstanceId)
-          )
-
-          return {
-            ...task,
-            assignments,
-            references,
-          }
-        })
-      )
-    }
+    // Load relations for all buckets in two batched queries
+    const allTasks = [
+      ...todayTasks,
+      ...thisWeekTasks,
+      ...upcomingTasks,
+      ...overdueTasks,
+      ...completedTasks,
+    ]
+    const relations = await this.loadTaskRelations(allTasks.map((t) => t.id))
+    const withRelations = (tasks: TaskEntity[]): TaskWithRelations[] =>
+      tasks.map((task) => ({
+        ...task,
+        assignments: relations.assignmentsByTask.get(task.id) ?? [],
+        references: relations.referencesByTask.get(task.id) ?? [],
+      }))
 
     return {
-      today: await loadRelations(todayTasks),
-      thisWeek: await loadRelations(thisWeekTasks),
-      upcoming: await loadRelations(upcomingTasks),
-      overdue: await loadRelations(overdueTasks),
-      completed: await loadRelations(completedTasks),
+      today: withRelations(todayTasks),
+      thisWeek: withRelations(thisWeekTasks),
+      upcoming: withRelations(upcomingTasks),
+      overdue: withRelations(overdueTasks),
+      completed: withRelations(completedTasks),
     }
+  }
+
+  /**
+   * Batch-load active assignments and non-deleted references for a set of tasks.
+   * Two queries total regardless of task count.
+   */
+  private async loadTaskRelations(taskIds: string[]): Promise<{
+    assignmentsByTask: Map<string, ActorId[]>
+    referencesByTask: Map<string, RecordId[]>
+  }> {
+    const assignmentsByTask = new Map<string, ActorId[]>()
+    const referencesByTask = new Map<string, RecordId[]>()
+    if (taskIds.length === 0) return { assignmentsByTask, referencesByTask }
+
+    const [assignmentRows, referenceRows] = await Promise.all([
+      this.db.query.TaskAssignment.findMany({
+        where: (a, { and, inArray, isNull }) =>
+          and(inArray(a.taskId, taskIds), isNull(a.unassignedAt)),
+        columns: { taskId: true, assignedToUserId: true },
+      }),
+      this.db.query.TaskReference.findMany({
+        where: (r, { and, inArray, isNull }) =>
+          and(inArray(r.taskId, taskIds), isNull(r.deletedAt)),
+        columns: {
+          taskId: true,
+          referencedEntityDefinitionId: true,
+          referencedEntityInstanceId: true,
+        },
+      }),
+    ])
+
+    for (const row of assignmentRows) {
+      const list = assignmentsByTask.get(row.taskId) ?? []
+      list.push(toActorId('user', row.assignedToUserId))
+      assignmentsByTask.set(row.taskId, list)
+    }
+    for (const row of referenceRows) {
+      const list = referencesByTask.get(row.taskId) ?? []
+      list.push(toRecordId(row.referencedEntityDefinitionId, row.referencedEntityInstanceId))
+      referencesByTask.set(row.taskId, list)
+    }
+
+    return { assignmentsByTask, referencesByTask }
   }
 
   /**

--- a/packages/lib/src/threads/unread-service.ts
+++ b/packages/lib/src/threads/unread-service.ts
@@ -611,14 +611,10 @@ export class UnreadService {
       // Build WHERE condition from view filters
       const whereCondition = buildConditionGroupsQuery(filters, this.organizationId)
 
-      // Count unread OPEN threads matching the filters
-      // Use subquery approach to avoid complex join issues
-
-      // Step 1: Get thread IDs that match the view filters and are OPEN
-      // Step 2: Filter to only unread (no read status or isRead=false)
-
-      // Unread threads without read status
-      const withoutStatusResult = await db
+      // Count unread OPEN threads matching the filters: unread = no read-status
+      // row for this user OR an explicit isRead=false row. One left-joined count
+      // covers both cases.
+      const unreadResult = await db
         .select({ count: count() })
         .from(schema.Thread)
         .leftJoin(
@@ -632,28 +628,11 @@ export class UnreadService {
           and(
             whereCondition,
             eq(schema.Thread.status, 'OPEN' as any),
-            isNull(schema.ThreadReadStatus.userId)
+            or(isNull(schema.ThreadReadStatus.userId), eq(schema.ThreadReadStatus.isRead, false))
           )
         )
 
-      // Unread threads with explicit unread status
-      const withUnreadStatusResult = await db
-        .select({ count: count() })
-        .from(schema.Thread)
-        .innerJoin(schema.ThreadReadStatus, eq(schema.ThreadReadStatus.threadId, schema.Thread.id))
-        .where(
-          and(
-            whereCondition,
-            eq(schema.Thread.status, 'OPEN' as any),
-            eq(schema.ThreadReadStatus.userId, this.userId),
-            eq(schema.ThreadReadStatus.isRead, false)
-          )
-        )
-
-      const totalUnread =
-        (withoutStatusResult[0]?.count ?? 0) + (withUnreadStatusResult[0]?.count ?? 0)
-
-      return { viewId: view.id, count: totalUnread }
+      return { viewId: view.id, count: unreadResult[0]?.count ?? 0 }
     })
 
     const results = await Promise.all(countPromises)


### PR DESCRIPTION
Phase 2 of `plans/performance/backend-performance-plan.md` — targeted query reduction on the hottest read/write paths. No schema changes, no API-shape changes (one additive input field).

## Changes

### 2.1 Task list N+1
`task-service.ts`: per-task `TaskAssignment`/`TaskReference` queries replaced by a shared `loadTaskRelations(taskIds)` (one `inArray` query each). `listTasks`: 2N → 2 queries. `getGroupedTasks`: batches across all 5 buckets → 2 queries total.

### 2.2 Mail sidebar view counts (step 1)
`unread-service.ts` `getViewCounts`: the two joined counts per saved view collapse into one left-joined count with `(readStatus IS NULL OR isRead = false)` — exactly equivalent since `(threadId, userId)` is unique. 2 queries/view → 1 on a path polled every 5 min + window focus. Step 2 (short-TTL Redis cache) stays open in the plan.

### 2.3 FieldValue column projection + `listAll` fieldKeys
- Explicit projection on both FieldValue batch reads. `valueJson` (heavy jsonb) only ships when the field is json-typed **or** the row carries AI metadata (`CASE WHEN aiStatus IS NOT NULL …`) — AI metadata piggy-backs on `valueJson` for any field type, so a pure per-type skip would have dropped it.
- `listAll` gains a `fieldKeys` option (project by output key; exposed on `record.listAll`). Search TAG suggestions now request `title`/`tag_emoji`/`tag_color` instead of every field of up to 1000 tags.
- **Bug fix:** the search TAG call passed one merged object to the two-argument `listAll`, so `params` was `undefined` and tag suggestions threw at runtime.

### 2.4 Org-cache bypass swaps (9 Tier-1 + 3 Tier-2 sites)
Direct Postgres queries replaced with org-cache reads: ingest company-linking field lookups, `user.me` integration check, `user.teamMembers`, favorites membership context, member `search`/`all`/`getUserMembership`, `thread_tags` field id, calendar participant resolver (def + field lookups), vendor-part trigger field id, `getProviderType`, `getOrganizationSetting`, `canAccessEntityDefinition`.

Behavior-preserving guards:
- participant resolver uses non-throwing `getCachedEntityDefId` (keeps the `ok(null)` soft-miss path)
- member pickers replicate `userType='USER'`, case-insensitive substring match, limit 10
- `getOrganizationSetting` still queries directly when an injected db/transaction is passed
- `canAccessEntityDefinition` uses the cache as a fast path with DB fallback on miss, so archived defs (filtered out of the cache) keep their current allow behavior

Note: `member.getUserMembership` now returns the cached member shape (drops `createdAt`/`updatedAt`/`chatDutyUpdatedAt`/`chatDutyUpdatedById`); it has no client consumers.

## Testing
- `packages/lib` vitest: all suites covering the touched modules pass; the 43 pre-existing failures (kopilot prompts, agent-framework, references, datasets) fail identically on `main` (verified against a clean tree).
- Biome clean on all changed files.
- Follow-up per plan: before/after `pg_stat_statements` snapshot on the Railway pgvector service.