### PR TITLE
perf(worker): raise event throughput and cut ingest/event-path round-trips

### DIFF
--- a/apps/lambda/src/bundle-cache.ts
+++ b/apps/lambda/src/bundle-cache.ts
@@ -1,0 +1,70 @@
+// apps/lambda/src/bundle-cache.ts
+
+/**
+ * Bounded LRU caches for app server bundles. Bundles are content-addressed
+ * (immutable SHA key) and this process is long-lived, so entries never need
+ * invalidation — only bounding.
+ *
+ * Two layers:
+ *  - bundle source strings, keyed `${appId}:${serverBundleSha}` (S3 downloads)
+ *  - compiled `Function` objects, keyed by bundle source + return-statement
+ *    (the executors wrap the same bundle differently)
+ *
+ * Only the compiled Function is cached — never its invocation result. The
+ * bundle's top-level scope must re-evaluate per call against the runtime
+ * helpers each executor injects into globalThis beforehand.
+ */
+
+const MAX_ENTRIES = 32
+
+const bundleCache = new Map<string, string>()
+
+/** Get a cached bundle source string, refreshing its LRU position. */
+export function getCachedBundle(key: string): string | undefined {
+  const code = bundleCache.get(key)
+  if (code !== undefined) {
+    bundleCache.delete(key)
+    bundleCache.set(key, code)
+  }
+  return code
+}
+
+/** Store a bundle source string, evicting the least-recently-used entry. */
+export function setCachedBundle(key: string, code: string): void {
+  if (bundleCache.size >= MAX_ENTRIES) {
+    const oldest = bundleCache.keys().next().value
+    if (oldest !== undefined) bundleCache.delete(oldest)
+  }
+  bundleCache.set(key, code)
+}
+
+/** code string → (return statement → compiled Function). String keys compare
+ * by value, so a re-downloaded identical bundle still hits. */
+const compiledCache = new Map<string, Map<string, () => any>>()
+
+/**
+ * Compile `bundleCode + '\n' + returnStatement` once and reuse the Function
+ * across invocations (each call still re-evaluates the bundle top-level).
+ */
+export function compileBundle(bundleCode: string, returnStatement: string): () => any {
+  let byReturn = compiledCache.get(bundleCode)
+  if (!byReturn) {
+    if (compiledCache.size >= MAX_ENTRIES) {
+      const oldest = compiledCache.keys().next().value
+      if (oldest !== undefined) compiledCache.delete(oldest)
+    }
+    byReturn = new Map()
+    compiledCache.set(bundleCode, byReturn)
+  } else {
+    // Refresh LRU position
+    compiledCache.delete(bundleCode)
+    compiledCache.set(bundleCode, byReturn)
+  }
+
+  let fn = byReturn.get(returnStatement)
+  if (!fn) {
+    fn = new Function(`${bundleCode}\n${returnStatement}`) as () => any
+    byReturn.set(returnStatement, fn)
+  }
+  return fn
+}

--- a/apps/lambda/src/bundle-loader.ts
+++ b/apps/lambda/src/bundle-loader.ts
@@ -5,6 +5,7 @@
  */
 
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { getCachedBundle, setCachedBundle } from './bundle-cache.ts'
 import { parseError } from './utils.ts'
 
 /** Custom S3 endpoint for non-AWS providers */
@@ -54,7 +55,12 @@ export async function loadBundle(appId: string, serverBundleSha: string): Promis
     }
   }
 
-  // Production: Download from S3
+  // Production: bundles are content-addressed (immutable SHA), so a cache
+  // hit skips the S3 round-trip entirely.
+  const cacheKey = `${appId}:${serverBundleSha}`
+  const cached = getCachedBundle(cacheKey)
+  if (cached !== undefined) return cached
+
   const bucketName = Deno.env.get('S3_PRIVATE_BUCKET')
 
   if (!bucketName) {
@@ -81,5 +87,6 @@ export async function loadBundle(appId: string, serverBundleSha: string): Promis
     key: s3Key,
   })
 
+  setCachedBundle(cacheKey, bundleCode)
   return bundleCode
 }

--- a/apps/lambda/src/executors/data-connector-executor.ts
+++ b/apps/lambda/src/executors/data-connector-executor.ts
@@ -22,6 +22,7 @@
  * See plans/data-connectors/claude/03-connectors-and-sources.md §4.
  */
 
+import { compileBundle } from '../bundle-cache.ts'
 import {
   cleanupServerRuntimeHelpers,
   getCapturedLogs,
@@ -59,8 +60,7 @@ export async function executeDataConnector(
   try {
     // Mirror the tool/workflow-block executors — append a return so we extract
     // the connector registry from the bundle's top-level scope.
-    const codeWithReturn = bundleCode + '\nreturn { __AUXX_DATA_CONNECTORS__ };'
-    const fn = new Function(codeWithReturn)
+    const fn = compileBundle(bundleCode, 'return { __AUXX_DATA_CONNECTORS__ };')
     const result = fn()
     const connectors = result.__AUXX_DATA_CONNECTORS__
 

--- a/apps/lambda/src/executors/event-executor.ts
+++ b/apps/lambda/src/executors/event-executor.ts
@@ -5,6 +5,7 @@
  * Executes app event handlers in a Deno sandbox.
  */
 
+import { compileBundle } from '../bundle-cache.ts'
 import {
   type ConsoleLog,
   cleanupServerRuntimeHelpers,
@@ -66,8 +67,7 @@ async function executeEventInSandbox(
     injectServerRuntimeHelpers(context)
 
     // Use Function constructor instead of import to access top-level variables
-    const codeWithReturn = bundleCode + '\nreturn { stdin_events_default };'
-    const fn = new Function(codeWithReturn)
+    const fn = compileBundle(bundleCode, 'return { stdin_events_default };')
     const handlers = fn()
     const stdin_events_default = handlers.stdin_events_default
 

--- a/apps/lambda/src/executors/polling-trigger-executor.ts
+++ b/apps/lambda/src/executors/polling-trigger-executor.ts
@@ -1,5 +1,6 @@
 // apps/lambda/src/executors/polling-trigger-executor.ts
 
+import { compileBundle } from '../bundle-cache.ts'
 import {
   cleanupServerRuntimeHelpers,
   getCapturedLogs,
@@ -29,9 +30,10 @@ export async function executePollingTrigger(
     // Execute bundle to register workflow blocks
     // Return stdin_workflow_block_handlers_default which properly forwards all args,
     // unlike __AUXX_WORKFLOW_BLOCKS__ which only forwards `input` in older bundles.
-    const codeWithReturn =
-      bundleCode + '\nreturn { __AUXX_WORKFLOW_BLOCKS__, stdin_workflow_block_handlers_default };'
-    const fn = new Function(codeWithReturn)
+    const fn = compileBundle(
+      bundleCode,
+      'return { __AUXX_WORKFLOW_BLOCKS__, stdin_workflow_block_handlers_default };'
+    )
     const result = fn()
     const workflowBlockHandler = result.stdin_workflow_block_handlers_default
     const workflowBlocks = result.__AUXX_WORKFLOW_BLOCKS__

--- a/apps/lambda/src/executors/server-function-executor.ts
+++ b/apps/lambda/src/executors/server-function-executor.ts
@@ -11,6 +11,7 @@
  * - Memory limit enforcement (via Lambda config)
  */
 
+import { compileBundle } from '../bundle-cache.ts'
 import {
   type ConsoleLog,
   cleanupServerRuntimeHelpers,
@@ -91,8 +92,7 @@ async function executeInSandbox(
     injectServerRuntimeHelpers(context)
 
     // 2. Use Function constructor to access top-level variables
-    const codeWithReturn = bundleCode + '\nreturn { stdin_default };'
-    const fn = new Function(codeWithReturn)
+    const fn = compileBundle(bundleCode, 'return { stdin_default };')
     const handlers = fn()
     const stdin_default = handlers.stdin_default
 

--- a/apps/lambda/src/executors/tool-executor.ts
+++ b/apps/lambda/src/executors/tool-executor.ts
@@ -17,6 +17,7 @@
  * migrate (T7/T8). Old files stay in place until T12 strips them.
  */
 
+import { compileBundle } from '../bundle-cache.ts'
 import {
   cleanupServerRuntimeHelpers,
   getCapturedLogs,
@@ -91,8 +92,7 @@ function setupSandbox(
 
   // Mirrors workflow-block-executor — append `return { __AUXX_TOOLS__ }`
   // so we extract the registry from the bundle's top-level scope.
-  const codeWithReturn = bundleCode + '\nreturn { __AUXX_TOOLS__ };'
-  const fn = new Function(codeWithReturn)
+  const fn = compileBundle(bundleCode, 'return { __AUXX_TOOLS__ };')
   const result = fn()
   const tools = result.__AUXX_TOOLS__
 

--- a/apps/lambda/src/executors/webhook-executor.ts
+++ b/apps/lambda/src/executors/webhook-executor.ts
@@ -5,6 +5,7 @@
  * Executes app webhook handlers in a Deno sandbox with Web Platform Request/Response APIs.
  */
 
+import { compileBundle } from '../bundle-cache.ts'
 import {
   type ConsoleLog,
   cleanupServerRuntimeHelpers,
@@ -68,8 +69,7 @@ async function executeWebhookInSandbox(
     injectServerRuntimeHelpers(context)
 
     // Use Function constructor to access top-level variables
-    const codeWithReturn = bundleCode + '\nreturn { stdin_webhooks_default };'
-    const fn = new Function(codeWithReturn)
+    const fn = compileBundle(bundleCode, 'return { stdin_webhooks_default };')
     const handlers = fn()
     const stdin_webhooks_default = handlers.stdin_webhooks_default
 

--- a/apps/lambda/src/executors/workflow-block-executor.ts
+++ b/apps/lambda/src/executors/workflow-block-executor.ts
@@ -5,6 +5,7 @@
  * Executes workflow blocks in a sandboxed environment with the Workflow SDK
  */
 
+import { compileBundle } from '../bundle-cache.ts'
 import {
   cleanupServerRuntimeHelpers,
   getCapturedLogs,
@@ -92,8 +93,7 @@ async function executeInSandbox(
     // appended return. `__AUXX_TOOLS__` must reach `globalThis` so router-style
     // blocks can dispatch to internal tools via `ctx.runTool` (which resolves
     // off `globalThis.__AUXX_TOOLS__`). Cleared in the `finally` below.
-    const codeWithReturn = bundleCode + '\nreturn { __AUXX_WORKFLOW_BLOCKS__, __AUXX_TOOLS__ };'
-    const fn = new Function(codeWithReturn)
+    const fn = compileBundle(bundleCode, 'return { __AUXX_WORKFLOW_BLOCKS__, __AUXX_TOOLS__ };')
     const result = fn()
     const workflowBlocks = result.__AUXX_WORKFLOW_BLOCKS__
 

--- a/apps/worker/src/inbound-email/sqs-poller.ts
+++ b/apps/worker/src/inbound-email/sqs-poller.ts
@@ -166,27 +166,31 @@ class SqsInboundEmailPoller implements InboundEmailPoller {
 
         const messages = response.Messages ?? []
 
-        for (const message of messages) {
-          if (this.isStopping) break
+        // Process the batch concurrently (max 5 per receive); each message
+        // keeps its own error isolation and permanent-failure cleanup.
+        await Promise.allSettled(
+          messages.map(async (message) => {
+            if (this.isStopping) return
 
-          try {
-            await this.processMessage(message)
-          } catch (error) {
-            const isPermanent = error instanceof PermanentProcessingError
+            try {
+              await this.processMessage(message)
+            } catch (error) {
+              const isPermanent = error instanceof PermanentProcessingError
 
-            logger.error('Failed to process inbound email SQS message', {
-              error: error instanceof Error ? error.message : String(error),
-              messageId: message.MessageId,
-              receiveCount: message.Attributes?.ApproximateReceiveCount,
-              permanent: isPermanent,
-            })
+              logger.error('Failed to process inbound email SQS message', {
+                error: error instanceof Error ? error.message : String(error),
+                messageId: message.MessageId,
+                receiveCount: message.Attributes?.ApproximateReceiveCount,
+                permanent: isPermanent,
+              })
 
-            if (isPermanent) {
-              await this.deleteMessage(message)
-              await this.deleteRawEmail(message)
+              if (isPermanent) {
+                await this.deleteMessage(message)
+                await this.deleteRawEmail(message)
+              }
             }
-          }
-        }
+          })
+        )
       } catch (error) {
         logger.error('Inbound email SQS poller receive failed', {
           error: error instanceof Error ? error.message : String(error),

--- a/apps/worker/src/workers/worker-definitions/events-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/events-worker.ts
@@ -10,6 +10,7 @@ import {
   publishToAnalyticsJob,
   sendInvitationUserJob,
   triggerAgents,
+  triggerResourceDispatch,
   triggerResourceWorkflows,
   updateWebhookLastTriggeredAt,
 } from '@auxx/lib/events/handlers'
@@ -29,6 +30,9 @@ const eventHandlersJobMappings = {
   updateWebhookLastTriggeredAt,
   createTimelineEvent,
   createAuditLog,
+  // Combined CRUD dispatcher; the standalone pair stays registered for
+  // direct-match-only events and jobs already queued at deploy time.
+  triggerResourceDispatch,
   triggerResourceWorkflows,
   triggerAgents,
   handleFieldTriggerJob,
@@ -37,10 +41,12 @@ const eventHandlersJobMappings = {
   publishThreadEventToRealtime,
 }
 
+// IO-bound handlers; concurrency > 1 drops the queue-global FIFO ordering,
+// which the handlers tolerate (idempotent upserts, out-of-order guards).
 export function startEventsWorker() {
-  return createWorker(Queues.eventsQueue, eventsJobMappings)
+  return createWorker(Queues.eventsQueue, eventsJobMappings, { concurrency: 10 })
 }
 
 export function startEventHandlersWorker() {
-  return createWorker(Queues.eventHandlersQueue, eventHandlersJobMappings)
+  return createWorker(Queues.eventHandlersQueue, eventHandlersJobMappings, { concurrency: 20 })
 }

--- a/apps/worker/src/workers/worker-definitions/message-processing-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/message-processing-worker.ts
@@ -18,5 +18,7 @@ const messageProcessingJobMappings = {
 export function startMessageProcessingWorker() {
   logger.info(`Starting worker for queue: ${Queues.messageProcessingQueue}`)
 
-  return createWorker(Queues.messageProcessingQueue, messageProcessingJobMappings)
+  return createWorker(Queues.messageProcessingQueue, messageProcessingJobMappings, {
+    concurrency: 5,
+  })
 }

--- a/apps/worker/src/workers/worker-definitions/webhook-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/webhook-worker.ts
@@ -8,5 +8,5 @@ const jobMappings = {
 }
 
 export function startWebhooksWorker() {
-  return createWorker(Queues.webhooksQueue, jobMappings)
+  return createWorker(Queues.webhooksQueue, jobMappings, { concurrency: 10 })
 }

--- a/docker-compose.self-hosted.yml
+++ b/docker-compose.self-hosted.yml
@@ -231,6 +231,8 @@ services:
         required: false
     environment:
       <<: [*common-env, *db-env, *db-pool-env, *redis-env, *url-env]
+      # Worker runs ~130 concurrent BullMQ job slots — needs more pool headroom
+      DB_POOL_MAX: "30"
       WORKER_PORT: ${WORKER_PORT:-3005}
       API_INTERNAL_URL: http://api:${API_PORT:-3007}
       LAMBDA_URL: http://lambda:${LAMBDA_PORT:-3008}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -194,6 +194,8 @@ services:
     env_file: .env
     environment:
       <<: [*common-env, *db-env, *db-pool-env, *redis-env, *url-env]
+      # Worker runs ~130 concurrent BullMQ job slots — needs more pool headroom
+      DB_POOL_MAX: "30"
       WORKER_PORT: ${WORKER_PORT:-3005}
       API_INTERNAL_URL: http://api:${API_PORT:-3007}
       LAMBDA_URL: http://lambda:${LAMBDA_PORT:-3008}

--- a/infra/secrets.ts
+++ b/infra/secrets.ts
@@ -342,8 +342,10 @@ export function getSelectedEnvVars(
     REDIS_PASSWORD,
     ELASTICACHE_TLS: process.env.ELASTICACHE_TLS || 'true',
     SUPER_ADMIN_EMAIL: getSecretValue('SUPER_ADMIN_EMAIL'),
-    // Database pool tuning per service
-    DB_POOL_MAX: app === 'web' ? '3' : app === 'api' ? '5' : '10',
+    // Database pool tuning per service. Worker gets headroom for its ~130
+    // concurrent BullMQ job slots; sized so old+new worker during a deploy
+    // (2× pool) stay well under Postgres max_connections.
+    DB_POOL_MAX: app === 'web' ? '3' : app === 'api' ? '5' : app === 'worker' ? '30' : '10',
     DB_POOL_IDLE_TIMEOUT: app === 'web' ? '10000' : '30000',
     APP_NAME: `auxx-${app}`,
   }

--- a/packages/lib/src/events/handlers/index.ts
+++ b/packages/lib/src/events/handlers/index.ts
@@ -14,6 +14,7 @@ export {
 export { publishToAnalyticsJob } from './publish-to-analytics-job'
 export { sendInvitationUserJob } from './send-invitation-user-job'
 export { triggerAgents } from './trigger-agents'
+export { triggerResourceDispatch } from './trigger-resource-dispatch'
 export {
   getEventRecordId,
   getResourceTriggerMatch,

--- a/packages/lib/src/events/handlers/publish-event-job.ts
+++ b/packages/lib/src/events/handlers/publish-event-job.ts
@@ -12,7 +12,7 @@ import { handleSyncRecordRules } from './handle-sync-record-rules'
 import { publishThreadEventToRealtime } from './publish-thread-event-to-realtime'
 import { sendInvitationUserJob } from './send-invitation-user-job'
 import { triggerAgents } from './trigger-agents'
-import { triggerResourceWorkflows } from './trigger-resource-workflows'
+import { triggerResourceDispatch } from './trigger-resource-dispatch'
 import { updateWebhookLastTriggeredAt } from './update-webhook-last-triggered'
 
 export const EventHandlers: IEventsHandlers = {
@@ -23,14 +23,9 @@ export const EventHandlers: IEventsHandlers = {
   'membership:created': [sendInvitationUserJob, createAuditLog],
 
   // Ticket events → CREATE TIMELINE
-  'ticket:created': [
-    createTimelineEvent,
-    triggerResourceWorkflows,
-    triggerAgents,
-    handleRecordRules,
-  ],
-  'ticket:updated': [createTimelineEvent, triggerResourceWorkflows, triggerAgents],
-  'ticket:deleted': [triggerResourceWorkflows, triggerAgents, handleRecordRules],
+  'ticket:created': [createTimelineEvent, triggerResourceDispatch, handleRecordRules],
+  'ticket:updated': [createTimelineEvent, triggerResourceDispatch],
+  'ticket:deleted': [triggerResourceDispatch, handleRecordRules],
   'ticket:status:changed': [createTimelineEvent, triggerAgents],
   'ticket:assignee:added': [triggerAgents],
   'ticket:assignee:removed': [triggerAgents],
@@ -86,19 +81,9 @@ export const EventHandlers: IEventsHandlers = {
   'webhook:delivery:created': [updateWebhookLastTriggeredAt],
 
   // Contact events → CREATE TIMELINE + TRIGGER WORKFLOWS
-  'contact:created': [
-    createTimelineEvent,
-    triggerResourceWorkflows,
-    triggerAgents,
-    handleRecordRules,
-  ],
-  'contact:updated': [createTimelineEvent, triggerResourceWorkflows, triggerAgents],
-  'contact:deleted': [
-    createTimelineEvent,
-    triggerResourceWorkflows,
-    triggerAgents,
-    handleRecordRules,
-  ],
+  'contact:created': [createTimelineEvent, triggerResourceDispatch, handleRecordRules],
+  'contact:updated': [createTimelineEvent, triggerResourceDispatch],
+  'contact:deleted': [createTimelineEvent, triggerResourceDispatch, handleRecordRules],
   'contact:merged': [createTimelineEvent],
   'contact:field:updated': [createTimelineEvent],
   'contact:group:added': [createTimelineEvent],
@@ -114,44 +99,24 @@ export const EventHandlers: IEventsHandlers = {
   'comment:referenced': [triggerAgents],
 
   // Entity instance events → CREATE TIMELINE + ENTITY TRIGGERS + WORKFLOWS
-  'entity:created': [
-    createTimelineEvent,
-    triggerResourceWorkflows,
-    triggerAgents,
-    handleRecordRules,
-  ],
-  'entity:updated': [createTimelineEvent, triggerResourceWorkflows, triggerAgents],
-  'entity:deleted': [
-    createTimelineEvent,
-    triggerResourceWorkflows,
-    triggerAgents,
-    handleRecordRules,
-  ],
+  'entity:created': [createTimelineEvent, triggerResourceDispatch, handleRecordRules],
+  'entity:updated': [createTimelineEvent, triggerResourceDispatch],
+  'entity:deleted': [createTimelineEvent, triggerResourceDispatch, handleRecordRules],
   'entity:field:updated': [createTimelineEvent],
 
   // Stock movement events → ENTITY TRIGGERS (inventory QoH recalculation) + WORKFLOWS
-  'stock_movement:created': [triggerResourceWorkflows, triggerAgents, handleRecordRules],
-  'stock_movement:deleted': [triggerResourceWorkflows, triggerAgents, handleRecordRules],
+  'stock_movement:created': [triggerResourceDispatch, handleRecordRules],
+  'stock_movement:deleted': [triggerResourceDispatch, handleRecordRules],
 
   // Vendor part / subpart events → ENTITY TRIGGERS (BOM cost recalculation) + WORKFLOWS
-  'vendor_part:created': [triggerResourceWorkflows, triggerAgents, handleRecordRules],
-  'vendor_part:deleted': [triggerResourceWorkflows, triggerAgents, handleRecordRules],
-  'subpart:created': [triggerResourceWorkflows, triggerAgents, handleRecordRules],
-  'subpart:deleted': [triggerResourceWorkflows, triggerAgents, handleRecordRules],
+  'vendor_part:created': [triggerResourceDispatch, handleRecordRules],
+  'vendor_part:deleted': [triggerResourceDispatch, handleRecordRules],
+  'subpart:created': [triggerResourceDispatch, handleRecordRules],
+  'subpart:deleted': [triggerResourceDispatch, handleRecordRules],
 
   // Company events → TIMELINE + ENTITY TRIGGERS (website enrichment on create) + WORKFLOWS
-  'company:created': [
-    createTimelineEvent,
-    triggerResourceWorkflows,
-    triggerAgents,
-    handleRecordRules,
-  ],
-  'company:deleted': [
-    createTimelineEvent,
-    triggerResourceWorkflows,
-    triggerAgents,
-    handleRecordRules,
-  ],
+  'company:created': [createTimelineEvent, triggerResourceDispatch, handleRecordRules],
+  'company:deleted': [createTimelineEvent, triggerResourceDispatch, handleRecordRules],
 
   // Field trigger events → FIELD TRIGGER HANDLERS
   'field:trigger': [handleFieldTriggerJob],
@@ -168,10 +133,10 @@ export const EventHandlers: IEventsHandlers = {
 export const publishEventJob = async (job: Job<AuxxEvent>) => {
   const event = job.data
   const handlers = EventHandlers[event.type]
-
-  const queue = getQueue(Queues.eventHandlersQueue)
   if (!handlers?.length) return
-  handlers.forEach((handler) => {
-    queue.add(handler.name, event)
-  })
+
+  // One awaited round-trip; an enqueue failure fails the job (BullMQ retries)
+  // instead of being silently dropped.
+  const queue = getQueue(Queues.eventHandlersQueue)
+  await queue.addBulk(handlers.map((handler) => ({ name: handler.name, data: event })))
 }

--- a/packages/lib/src/events/handlers/trigger-agents.ts
+++ b/packages/lib/src/events/handlers/trigger-agents.ts
@@ -8,7 +8,11 @@ import { Queues } from '../../jobs/queues/types'
 import { fetchResourceById } from '../../resources/resource-fetcher'
 import { parseRecordId } from '../../resources/resource-id'
 import type { AuxxEvent } from '../types'
-import { getEventRecordId, getResourceTriggerMatch } from './trigger-resource-workflows'
+import {
+  getEventRecordId,
+  getResourceTriggerMatch,
+  type ResourceFetcher,
+} from './trigger-resource-workflows'
 
 const logger = createScopedLogger('trigger-agents')
 
@@ -27,7 +31,15 @@ const logger = createScopedLogger('trigger-agents')
  * All trigger reads come from the org `agents` cache — see
  * plans/kopilot/agents/cache/plan.md.
  */
-export const triggerAgents = async ({ data: event }: { data: AuxxEvent }) => {
+export const triggerAgents = async ({ data: event }: { data: AuxxEvent }) =>
+  dispatchAgentTriggers(event, fetchResourceById)
+
+/**
+ * Core agent-trigger dispatch with an injectable record fetcher so the
+ * combined CRUD dispatcher (`trigger-resource-dispatch.ts`) can share one
+ * `fetchResourceById` result with the workflow dispatcher.
+ */
+export const dispatchAgentTriggers = async (event: AuxxEvent, fetchResource: ResourceFetcher) => {
   const organizationId = (event.data as { organizationId?: string }).organizationId
   if (!organizationId) {
     logger.debug('Skipping agent triggers — event has no organizationId', { type: event.type })
@@ -61,7 +73,7 @@ export const triggerAgents = async ({ data: event }: { data: AuxxEvent }) => {
 
     if (crudMatches.length > 0) {
       const recordId = getEventRecordId(event, match)
-      const resourceData = recordId ? await fetchResourceById(recordId, organizationId) : null
+      const resourceData = recordId ? await fetchResource(recordId, organizationId) : null
       const payload = (resourceData ?? event.data) as Record<string, unknown>
 
       for (const m of crudMatches) {

--- a/packages/lib/src/events/handlers/trigger-resource-dispatch.ts
+++ b/packages/lib/src/events/handlers/trigger-resource-dispatch.ts
@@ -1,0 +1,34 @@
+// packages/lib/src/events/handlers/trigger-resource-dispatch.ts
+
+import type { RecordId } from '@auxx/types/resource'
+import { fetchResourceById } from '../../resources/resource-fetcher'
+import type { AuxxEvent } from '../types'
+import { dispatchAgentTriggers } from './trigger-agents'
+import { dispatchResourceWorkflows, type ResourceFetcher } from './trigger-resource-workflows'
+
+/**
+ * Combined CRUD-event dispatcher: runs the workflow and agent dispatchers in
+ * one job with a memoized `fetchResourceById`, so an event that matches both
+ * a workflow and an agent trigger resolves the record (multi-join + field
+ * values) once instead of twice. The fetch stays lazy — each dispatcher
+ * early-exits on no-match before touching it.
+ *
+ * Replaces the separate `triggerResourceWorkflows` + `triggerAgents` job
+ * pairs in the `EventHandlers` map; the standalone handlers remain registered
+ * for events that only need one of them (and for in-flight jobs).
+ */
+export const triggerResourceDispatch = async ({ data: event }: { data: AuxxEvent }) => {
+  const memo = new Map<string, Promise<any | null>>()
+  const fetchResource: ResourceFetcher = (recordId: RecordId, organizationId: string) => {
+    const key = `${organizationId}:${recordId}`
+    let pending = memo.get(key)
+    if (!pending) {
+      pending = fetchResourceById(recordId, organizationId)
+      memo.set(key, pending)
+    }
+    return pending
+  }
+
+  await dispatchResourceWorkflows(event, fetchResource)
+  await dispatchAgentTriggers(event, fetchResource)
+}

--- a/packages/lib/src/events/handlers/trigger-resource-workflows.ts
+++ b/packages/lib/src/events/handlers/trigger-resource-workflows.ts
@@ -96,11 +96,25 @@ export function getEventRecordId(event: AuxxEvent, match: ResourceTriggerMatch):
   return toRecordId(match.entityDefinitionId, instanceId)
 }
 
+/** Fetches the full resolved record for an event's subject resource. */
+export type ResourceFetcher = (recordId: RecordId, organizationId: string) => Promise<any | null>
+
 /**
  * Event handler that triggers workflows when resource events occur.
  * Fetches matching workflows and queues execution jobs.
  */
-export const triggerResourceWorkflows = async ({ data: event }: { data: AuxxEvent }) => {
+export const triggerResourceWorkflows = async ({ data: event }: { data: AuxxEvent }) =>
+  dispatchResourceWorkflows(event, fetchResourceById)
+
+/**
+ * Core workflow dispatch with an injectable record fetcher so the combined
+ * CRUD dispatcher (`trigger-resource-dispatch.ts`) can share one
+ * `fetchResourceById` result with the agent dispatcher.
+ */
+export const dispatchResourceWorkflows = async (
+  event: AuxxEvent,
+  fetchResource: ResourceFetcher
+) => {
   // 1. Map event to workflow trigger criteria
   const match = getResourceTriggerMatch(event)
   if (!match) {
@@ -138,7 +152,7 @@ export const triggerResourceWorkflows = async ({ data: event }: { data: AuxxEven
     return
   }
 
-  const resourceData = await fetchResourceById(recordId, event.data.organizationId)
+  const resourceData = await fetchResource(recordId, event.data.organizationId)
   if (!resourceData) {
     logger.warn('Resource not found, skipping workflows', {
       recordId,

--- a/packages/lib/src/events/publisher.ts
+++ b/packages/lib/src/events/publisher.ts
@@ -1,6 +1,11 @@
+// packages/lib/src/events/publisher.ts
+
+import { createScopedLogger } from '@auxx/logger'
 import { getQueue } from '../jobs/queues'
 import { Queues } from '../jobs/queues/types'
 import type { AuxxEvent } from './types'
+
+const logger = createScopedLogger('events:publisher')
 
 /**
  * Responsible for publishing events to the event bus and webhooks
@@ -20,10 +25,22 @@ export const publisher = {
     const eventsQueue = getQueue(Queues.eventsQueue)
     const webhooksQueue = getQueue(Queues.webhooksQueue)
 
-    eventsQueue.add('createEventJob', event)
-    eventsQueue.add('publishEventJob', event)
-    eventsQueue.add('publishToAnalyticsJob', event)
-
-    webhooksQueue.add('processWebhookJob', event)
+    // One awaited round-trip per queue. Errors are logged, not thrown —
+    // many callers fire-and-forget and must not get unhandled rejections.
+    try {
+      await Promise.all([
+        eventsQueue.addBulk([
+          { name: 'createEventJob', data: event },
+          { name: 'publishEventJob', data: event },
+          { name: 'publishToAnalyticsJob', data: event },
+        ]),
+        webhooksQueue.add('processWebhookJob', event),
+      ])
+    } catch (error) {
+      logger.error('Failed to enqueue event', {
+        eventType: event.type,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
   },
 }

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -183,10 +183,10 @@ export async function storeMessage(
       return storeIgnoredMessage(ctx, messageData)
     }
 
-    const participantInputsWithRoles: Array<{
-      role: ParticipantRole
-      data: ParticipantInputData
-    }> = []
+    // Resolved (role, participantId) pairs for MessageParticipant links,
+    // captured while processing so the link insert doesn't re-derive
+    // identifier types.
+    const resolvedParticipantLinks: Array<{ role: ParticipantRole; participantId: string }> = []
 
     // Per-message cache (NOT per-batch) — dedupes when the same identifier
     // appears in multiple roles on this message, and the iteration below is
@@ -232,8 +232,14 @@ export async function storeMessage(
 
     for (const { role, data } of allInputs) {
       if (data?.identifier) {
-        participantInputsWithRoles.push({ role, data })
-        await processAndCacheParticipant(data, role)
+        const participant = await processAndCacheParticipant(data, role)
+        if (participant?.id) {
+          resolvedParticipantLinks.push({ role, participantId: participant.id })
+        } else {
+          ctx.logger.error(
+            `Participant record missing for ${data.identifier} while collecting MessageParticipant links.`
+          )
+        }
       } else {
         ctx.logger.warn('Skipping participant input due to missing identifier', { role })
       }
@@ -262,75 +268,61 @@ export async function storeMessage(
       if (participant?.id) currentMessageParticipantIds.push(participant.id)
     }
 
-    const threadData = await ctx.db
-      .insert(schema.Thread)
-      .values({
-        externalId: messageData.externalThreadId,
-        integrationId: messageData.integrationId,
-        organizationId: messageData.organizationId,
-        inboxId: messageData.inboxId ?? null,
-        subject: messageData.subject ?? 'No Subject',
-        status: ThreadStatus.OPEN,
-        firstMessageAt: messageData.sentAt,
-        lastMessageAt: messageData.sentAt,
-        messageCount: 1,
-        participantCount: currentMessageParticipantIds.length,
-      })
-      .onConflictDoUpdate({
-        target: [schema.Thread.integrationId, schema.Thread.externalId],
-        set: {
-          subject: messageData.subject || undefined,
-          inboxId: messageData.inboxId ?? undefined,
-        },
-      })
-      .returning({
-        id: schema.Thread.id,
-        inboxId: schema.Thread.inboxId,
-        messageCount: schema.Thread.messageCount,
-        firstMessageAt: schema.Thread.firstMessageAt,
-        lastMessageAt: schema.Thread.lastMessageAt,
-        participantCount: schema.Thread.participantCount,
-      })
+    // Core write set in one transaction: thread upsert → message upsert →
+    // latestMessageId → MessageParticipant links. One pool acquire, atomic.
+    // Participant upserts stay OUTSIDE — they publish realtime events and
+    // create contacts, which must not run inside a transaction holding a
+    // connection against the 30s idle-in-transaction timeout.
+    const { thread, isNewThread, messageRecord } = await ctx.db.transaction(async (tx) => {
+      const threadData = await tx
+        .insert(schema.Thread)
+        .values({
+          externalId: messageData.externalThreadId,
+          integrationId: messageData.integrationId,
+          organizationId: messageData.organizationId,
+          inboxId: messageData.inboxId ?? null,
+          subject: messageData.subject ?? 'No Subject',
+          status: ThreadStatus.OPEN,
+          firstMessageAt: messageData.sentAt,
+          lastMessageAt: messageData.sentAt,
+          messageCount: 1,
+          participantCount: currentMessageParticipantIds.length,
+        })
+        .onConflictDoUpdate({
+          target: [schema.Thread.integrationId, schema.Thread.externalId],
+          set: {
+            subject: messageData.subject || undefined,
+            inboxId: messageData.inboxId ?? undefined,
+          },
+        })
+        .returning({
+          id: schema.Thread.id,
+          inboxId: schema.Thread.inboxId,
+          messageCount: schema.Thread.messageCount,
+          firstMessageAt: schema.Thread.firstMessageAt,
+          lastMessageAt: schema.Thread.lastMessageAt,
+          participantCount: schema.Thread.participantCount,
+        })
 
-    const thread = threadData[0]
-    const isNewThread =
-      (thread.messageCount ?? 0) === 1 &&
-      thread.firstMessageAt?.getTime() === messageData.sentAt.getTime()
+      const thread = threadData[0]
+      const isNewThread =
+        (thread.messageCount ?? 0) === 1 &&
+        thread.firstMessageAt?.getTime() === messageData.sentAt.getTime()
 
-    const messageRecords = await ctx.db
-      .insert(schema.Message)
-      .values({
-        externalThreadId: messageData.externalThreadId,
-        threadId: thread.id,
-        organizationId: messageData.organizationId,
-        integrationId: messageData.integrationId,
-        historyId: messageData.historyId ? Number(messageData.historyId) : null,
-        createdAt: messageData.createdTime,
-        updatedAt: new Date(),
-        sentAt: messageData.sentAt,
-        receivedAt: messageData.receivedAt,
-        internetMessageId: extractInternetMessageId(messageData) || messageData.internetMessageId,
-        subject: messageData.subject ?? '',
-        hasAttachments: messageData.hasAttachments,
-        textHtml: messageData.htmlBodyStorageLocationId ? null : messageData.textHtml,
-        textPlain: messageData.textPlain,
-        snippet: messageData.snippet,
-        htmlBodyStorageLocationId: messageData.htmlBodyStorageLocationId ?? null,
-        metadata: messageData.metadata || null,
-        isInbound: messageData.isInbound,
-        isFirstInThread: isNewThread,
-        fromId: senderParticipantId,
-        replyToId: firstReplyToParticipantId,
-      })
-      .onConflictDoUpdate({
-        target: [schema.Message.integrationId, schema.Message.externalId],
-        set: {
+      const messageRecords = await tx
+        .insert(schema.Message)
+        .values({
+          externalThreadId: messageData.externalThreadId,
           threadId: thread.id,
+          organizationId: messageData.organizationId,
+          integrationId: messageData.integrationId,
           historyId: messageData.historyId ? Number(messageData.historyId) : null,
+          createdAt: messageData.createdTime,
           updatedAt: new Date(),
           sentAt: messageData.sentAt,
           receivedAt: messageData.receivedAt,
-          subject: messageData.subject || '',
+          internetMessageId: extractInternetMessageId(messageData) || messageData.internetMessageId,
+          subject: messageData.subject ?? '',
           hasAttachments: messageData.hasAttachments,
           textHtml: messageData.htmlBodyStorageLocationId ? null : messageData.textHtml,
           textPlain: messageData.textPlain,
@@ -338,53 +330,60 @@ export async function storeMessage(
           htmlBodyStorageLocationId: messageData.htmlBodyStorageLocationId ?? null,
           metadata: messageData.metadata || null,
           isInbound: messageData.isInbound,
+          isFirstInThread: isNewThread,
           fromId: senderParticipantId,
           replyToId: firstReplyToParticipantId,
-        },
-      })
-      .returning({ id: schema.Message.id })
-
-    const messageRecord = messageRecords[0]
-
-    if (isNewThread && messageRecord?.id) {
-      await ctx.db
-        .update(schema.Thread)
-        .set({ latestMessageId: messageRecord.id })
-        .where(eq(schema.Thread.id, thread.id))
-    }
-
-    const messageParticipantData: any[] = []
-    for (const { role, data } of participantInputsWithRoles) {
-      if (!data?.identifier) continue
-      const identifierType = await determineIdentifierType(
-        ctx,
-        data.identifier,
-        messageData.integrationId
-      )
-      const normalizedId = normalizeIdentifier(data.identifier, identifierType)
-      const participantId = participantCache.get(`${identifierType}:${normalizedId}`)?.id
-      if (participantId) {
-        messageParticipantData.push({
-          messageId: messageRecord.id,
-          participantId,
-          role,
         })
-      } else {
-        ctx.logger.error(
-          `Participant ID not found in cache for ${normalizedId} while creating MessageParticipant links.`
-        )
-      }
-    }
-    if (messageParticipantData.length > 0) {
-      await ctx.db
-        .insert(schema.MessageParticipant)
-        .values(messageParticipantData)
-        .onConflictDoNothing()
+        .onConflictDoUpdate({
+          target: [schema.Message.integrationId, schema.Message.externalId],
+          set: {
+            threadId: thread.id,
+            historyId: messageData.historyId ? Number(messageData.historyId) : null,
+            updatedAt: new Date(),
+            sentAt: messageData.sentAt,
+            receivedAt: messageData.receivedAt,
+            subject: messageData.subject || '',
+            hasAttachments: messageData.hasAttachments,
+            textHtml: messageData.htmlBodyStorageLocationId ? null : messageData.textHtml,
+            textPlain: messageData.textPlain,
+            snippet: messageData.snippet,
+            htmlBodyStorageLocationId: messageData.htmlBodyStorageLocationId ?? null,
+            metadata: messageData.metadata || null,
+            isInbound: messageData.isInbound,
+            fromId: senderParticipantId,
+            replyToId: firstReplyToParticipantId,
+          },
+        })
+        .returning({ id: schema.Message.id })
 
-      ctx.logger.debug(
-        `Created/Skipped ${messageParticipantData.length} MessageParticipant links for message ${messageRecord.id}`
-      )
-    }
+      const messageRecord = messageRecords[0]
+
+      if (isNewThread && messageRecord?.id) {
+        await tx
+          .update(schema.Thread)
+          .set({ latestMessageId: messageRecord.id })
+          .where(eq(schema.Thread.id, thread.id))
+      }
+
+      if (resolvedParticipantLinks.length > 0) {
+        await tx
+          .insert(schema.MessageParticipant)
+          .values(
+            resolvedParticipantLinks.map(({ role, participantId }) => ({
+              messageId: messageRecord.id,
+              participantId,
+              role,
+            }))
+          )
+          .onConflictDoNothing()
+      }
+
+      return { thread, isNewThread, messageRecord }
+    })
+
+    ctx.logger.debug(
+      `Created/Skipped ${resolvedParticipantLinks.length} MessageParticipant links for message ${messageRecord.id}`
+    )
 
     const shouldUpdateThreadMetadata =
       !isNewThread &&

--- a/packages/lib/src/record-rules/batch.test.ts
+++ b/packages/lib/src/record-rules/batch.test.ts
@@ -11,6 +11,7 @@ const h = vi.hoisted(() => {
   return {
     executeRuleAction: vi.fn(async () => 'ok' as const),
     insertRecordRuleRun: vi.fn(async () => {}),
+    insertRecordRuleRuns: vi.fn(async () => {}),
     fetchResourceById: vi.fn(),
     getCachedResourceFields: vi.fn(async () => []),
     nativeHandler: vi.fn(async () => {}),
@@ -24,7 +25,10 @@ vi.mock('./actions', () => ({
   executeRuleAction: h.executeRuleAction,
   getNativeRuleHandler: h.getNativeRuleHandler,
 }))
-vi.mock('./store', () => ({ insertRecordRuleRun: h.insertRecordRuleRun }))
+vi.mock('./store', () => ({
+  insertRecordRuleRun: h.insertRecordRuleRun,
+  insertRecordRuleRuns: h.insertRecordRuleRuns,
+}))
 vi.mock('../resources/resource-fetcher', () => ({ fetchResourceById: h.fetchResourceById }))
 vi.mock('../cache', () => ({ getCachedResourceFields: h.getCachedResourceFields }))
 
@@ -76,8 +80,9 @@ describe('fireRecordRulesBatch — native actions', () => {
       organizationId: 'org_1',
       userId: undefined,
     })
-    // Per D11: one run row PER record.
-    expect(h.insertRecordRuleRun).toHaveBeenCalledTimes(3)
+    // Per D11: one run row PER record, written as ONE batch insert.
+    expect(h.insertRecordRuleRuns).toHaveBeenCalledTimes(1)
+    expect(h.insertRecordRuleRuns.mock.calls[0][1]).toHaveLength(3)
     // Native path bypasses the per-record executor.
     expect(h.executeRuleAction).not.toHaveBeenCalled()
   })
@@ -97,7 +102,8 @@ describe('fireRecordRulesBatch — native actions', () => {
     })
     expect(h.nativeHandler).toHaveBeenCalledTimes(1)
     expect(h.nativeHandler.mock.calls[0][0]).toMatchObject({ recordIds: ['def_1:i1'] })
-    expect(h.insertRecordRuleRun).toHaveBeenCalledTimes(1)
+    expect(h.insertRecordRuleRuns).toHaveBeenCalledTimes(1)
+    expect(h.insertRecordRuleRuns.mock.calls[0][1]).toHaveLength(1)
   })
 
   it('unknown handler key → outcome failed, logged run row, never throws', async () => {
@@ -105,8 +111,8 @@ describe('fireRecordRulesBatch — native actions', () => {
     await fireRecordRulesBatch([nativeRule], { ...baseCtx, events: [fieldEvent('i1', 'a', 'b')] })
 
     expect(h.nativeHandler).not.toHaveBeenCalled()
-    expect(h.insertRecordRuleRun).toHaveBeenCalledTimes(1)
-    expect(h.insertRecordRuleRun.mock.calls[0][1]).toMatchObject({ status: 'failed' })
+    expect(h.insertRecordRuleRuns).toHaveBeenCalledTimes(1)
+    expect(h.insertRecordRuleRuns.mock.calls[0][1][0]).toMatchObject({ status: 'failed' })
   })
 
   it('propagates userId to the native handler', async () => {

--- a/packages/lib/src/record-rules/engine.ts
+++ b/packages/lib/src/record-rules/engine.ts
@@ -14,7 +14,7 @@ import { type RecordId, toRecordId, toRecordIds } from '@auxx/types/resource'
 import { evaluateConditions, normalizeStatusConditions } from '../conditions/evaluate'
 import { executeRuleAction, getNativeRuleHandler } from './actions'
 import { makeSnapshotResolver, type RecordSnapshot } from './resolver'
-import { insertRecordRuleRun } from './store'
+import { insertRecordRuleRun, insertRecordRuleRuns } from './store'
 import { matchesFieldTransition } from './transitions'
 import type {
   CachedRecordRule,
@@ -344,10 +344,12 @@ export async function fireRecordRulesBatch(
       logger.debug('Native rule completed', { ruleId: rule.id, records: recordIds.length })
     }
 
-    // One run row per record (D11 — system-rule firings are fully debuggable).
-    for (const event of eventByInstance.values()) {
-      try {
-        await insertRecordRuleRun(database, {
+    // One run row per record (D11 — system-rule firings are fully debuggable),
+    // written as a single batch INSERT per rule firing.
+    try {
+      await insertRecordRuleRuns(
+        database,
+        [...eventByInstance.values()].map((event) => ({
           organizationId: ctx.organizationId,
           ruleId: rule.id,
           entityInstanceId: event.entityInstanceId,
@@ -357,13 +359,13 @@ export async function fireRecordRulesBatch(
           newValue: event.newValue,
           outcomes,
           status,
-        })
-      } catch (error) {
-        logger.error('Failed to write record-rule run log (native batch)', {
-          ruleId: rule.id,
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
+        }))
+      )
+    } catch (error) {
+      logger.error('Failed to write record-rule run log (native batch)', {
+        ruleId: rule.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
     }
   }
 }

--- a/packages/lib/src/record-rules/record-rules.test.ts
+++ b/packages/lib/src/record-rules/record-rules.test.ts
@@ -19,7 +19,10 @@ const h = vi.hoisted(() => ({
 
 vi.mock('@auxx/database', () => ({ database: {} }))
 vi.mock('./actions', () => ({ executeRuleAction: h.executeRuleAction }))
-vi.mock('./store', () => ({ insertRecordRuleRun: h.insertRecordRuleRun }))
+vi.mock('./store', () => ({
+  insertRecordRuleRun: h.insertRecordRuleRun,
+  insertRecordRuleRuns: vi.fn(async () => {}),
+}))
 vi.mock('../resources/resource-fetcher', () => ({ fetchResourceById: h.fetchResourceById }))
 vi.mock('../cache', () => ({ getCachedResourceFields: h.getCachedResourceFields }))
 

--- a/packages/lib/src/record-rules/store.ts
+++ b/packages/lib/src/record-rules/store.ts
@@ -283,17 +283,25 @@ export interface RecordRuleRunInput {
 
 /** Best-effort execution log — a failed insert must never break the firing. */
 export async function insertRecordRuleRun(db: Database, input: RecordRuleRunInput) {
-  await db.insert(schema.RecordRuleRun).values({
-    organizationId: input.organizationId,
-    ruleId: input.ruleId,
-    entityInstanceId: input.entityInstanceId,
-    source: input.source,
-    fieldId: input.fieldId ?? null,
-    oldValue: input.oldValue ?? null,
-    newValue: input.newValue ?? null,
-    outcomes: input.outcomes,
-    status: input.status,
-  })
+  await insertRecordRuleRuns(db, [input])
+}
+
+/** Batch variant: one INSERT for a whole native-rule firing (one row per record). */
+export async function insertRecordRuleRuns(db: Database, inputs: RecordRuleRunInput[]) {
+  if (inputs.length === 0) return
+  await db.insert(schema.RecordRuleRun).values(
+    inputs.map((input) => ({
+      organizationId: input.organizationId,
+      ruleId: input.ruleId,
+      entityInstanceId: input.entityInstanceId,
+      source: input.source,
+      fieldId: input.fieldId ?? null,
+      oldValue: input.oldValue ?? null,
+      newValue: input.newValue ?? null,
+      outcomes: input.outcomes,
+      status: input.status,
+    }))
+  )
 }
 
 export async function listRecordRuleRuns(


### PR DESCRIPTION
## Summary

Phase 3 of `plans/performance/backend-performance-plan.md` — the worker & ingest throughput items. All findings were re-verified against source before implementation; the plan file is updated with the amendments below.

### 3.1 + 3.2 — Queue concurrency + DB pool
- Explicit BullMQ concurrency (was default **1**, serializing every event): `eventsQueue` 10, `eventHandlersQueue` 20, `webhooksQueue` 10, `messageProcessingQueue` 5. `maintenance`/`oauth2Refresh` deliberately stay at 1.
- Worker `DB_POOL_MAX` 10 → **30** (`infra/secrets.ts` + docker-compose worker overrides). 30 not 50: Railway deploys run old+new worker simultaneously (2× pool mid-rollout).
- Accepted trade-off: concurrency 1 gave an accidental queue-global FIFO; handlers tolerate out-of-order (idempotent upserts, `upstreamUpdatedAt` guard, per-execution rule-chain guards).

### 3.3 — `store-message` transaction (narrowed scope)
- Thread upsert → message upsert → `latestMessageId` → `MessageParticipant` links run in **one transaction**. Participant upserts stay outside — they publish realtime events and create contacts, which must not run inside a tx holding a connection against the 30s idle-in-transaction timeout. The unique-violation recovery select also stays outside (would fail inside an aborted tx).
- Participant links are captured as `(role, participantId)` pairs in the first pass, removing the duplicate `determineIdentifierType` second loop.

### 3.4 — Inbound SQS batch parallelized
- `Promise.allSettled` over the batch of 5, preserving per-message `PermanentProcessingError` cleanup. Not a new race class — polled sync already runs `storeMessage` at concurrency 5–10.

### 3.5 — Event fan-out batched + awaited
- `publisher.publishLater`: awaited `addBulk` + try/catch-log (fire-and-forget callers get no unhandled rejections).
- `publishEventJob`: awaited `addBulk` — enqueue failures now fail the job (BullMQ retry) instead of silently dropping.

### 3.6 — Lambda bundle + compiled-function LRU
- New `apps/lambda/src/bundle-cache.ts`: bounded LRU (32) for S3 bundle strings keyed `appId:sha`, and compiled `Function`s keyed by bundle source + return-statement wrapper (executors wrap the same bundle differently).
- Only the compiled `Function` is cached, never its invocation result — bundle top-level re-evaluates per call against per-call injected runtime helpers. `code-executor.ts` untouched (per-node user code, unique per execution).

### 3.7 — Merged CRUD dispatchers
- `triggerResourceWorkflows` + `triggerAgents` were separate BullMQ jobs each running `fetchResourceById` for the same event. New `triggerResourceDispatch` runs both in one job with a memoized **lazy** fetch (only fetches when a dispatcher has matches). Standalone handlers stay registered for direct-match-only events and in-flight jobs at deploy time.

### 3.8 — Batched record-rule run logs
- `insertRecordRuleRuns` batch variant; native-rule path writes one `INSERT` per firing (one row per record preserved — D11).

## Deploy note

⚠️ Set `DB_POOL_MAX=30` on the **Railway worker service** — prod env lives in the dashboard, not in code.

## Testing

- Record-rules suite 71/71 (expectations updated for batched insert); ingest suites 37/37; `deno check` clean on all changed lambda files; Biome clean.
- Full `@auxx/lib` suite has 44 pre-existing failures — verified identical on a clean worktree at `main` HEAD (unrelated to this change).