### PR TITLE
feat(mail): realtime per-lens channels (phase 3)

### DIFF
--- a/apps/web/src/components/threads/hooks/index.ts
+++ b/apps/web/src/components/threads/hooks/index.ts
@@ -6,6 +6,7 @@ export { type InboxItem, type InboxRecord, useInbox, useInboxes } from './use-in
 export { useMessage } from './use-message'
 export { useMessageParticipants } from './use-message-participants'
 export { useMessages } from './use-messages'
+export { useMyInboxLenses } from './use-my-inbox-lenses'
 export { useParticipant } from './use-participant'
 export { useParticipants, useParticipantsArray } from './use-participants'
 export { useSelectionReset } from './use-selection-reset'

--- a/apps/web/src/components/threads/hooks/use-inbox.ts
+++ b/apps/web/src/components/threads/hooks/use-inbox.ts
@@ -1,9 +1,11 @@
 // apps/web/src/components/threads/hooks/use-inbox.ts
 
+import type { ChannelLens } from '@auxx/lib/realtime/client'
 import type { RecordId } from '@auxx/types'
 import { useMemo } from 'react'
 import { type FieldInfo, useAllRecords } from '~/components/resources/hooks/use-all-records'
 import type { RecordMeta } from '~/components/resources/store/record-store'
+import { useMyInboxLenses } from './use-my-inbox-lenses'
 
 /**
  * Inbox record type from useAllRecords.
@@ -30,6 +32,13 @@ export interface InboxItem {
   color?: string | null
   status?: 'ACTIVE' | 'ARCHIVED' | 'PAUSED'
   visibility?: 'org_members' | 'private' | 'custom'
+  /**
+   * The viewer's effective lens on this inbox (mail-permissions §6.4).
+   * Undefined while `inbox.myLenses` is loading; never `'none'` — such
+   * inboxes still render (the record itself is org-visible), their threads
+   * simply never load.
+   */
+  myLens?: ChannelLens
 }
 
 /**
@@ -60,6 +69,7 @@ export function useInboxes(): UseInboxesResult {
   const { records, fields, isLoading, error, refresh } = useAllRecords<InboxRecord>({
     entityDefinitionId: 'inbox',
   })
+  const { lenses } = useMyInboxLenses()
 
   // Transform records to simplified inbox items
   const { inboxes, inboxMap } = useMemo(() => {
@@ -75,13 +85,14 @@ export function useInboxes(): UseInboxesResult {
       color: record.fieldValues?.inbox_color ?? null,
       status: record.fieldValues?.inbox_status,
       visibility: record.fieldValues?.inbox_visibility,
+      myLens: lenses[record.id],
     }))
 
     // Key map by recordId for direct lookup (thread.inboxId is now RecordId)
     const map = new Map<RecordId, InboxItem>(items.map((item) => [item.recordId, item]))
 
     return { inboxes: items, inboxMap: map }
-  }, [records])
+  }, [records, lenses])
 
   return {
     inboxes,

--- a/apps/web/src/components/threads/hooks/use-my-inbox-lenses.ts
+++ b/apps/web/src/components/threads/hooks/use-my-inbox-lenses.ts
@@ -1,0 +1,28 @@
+// apps/web/src/components/threads/hooks/use-my-inbox-lenses.ts
+
+'use client'
+
+import type { ChannelLens } from '@auxx/lib/realtime/client'
+import { api } from '~/trpc/react'
+
+const EMPTY_LENSES: Record<string, ChannelLens> = {}
+
+/**
+ * The caller's effective lens per inbox (mail-permissions §6.4) — the
+ * server-computed `inbox.myLenses` read over the cached `userMailVisibility`.
+ * Drives the per-lens realtime channel subscriptions in `useMailSync` and the
+ * `myLens` field on `useInboxes` items. Refetched on `visibility:changed`.
+ */
+export function useMyInboxLenses() {
+  const { data, isLoading } = api.inbox.myLenses.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  })
+  return {
+    /** inboxId → the viewer's lens; inboxes at `none` are absent. */
+    lenses: data?.lenses ?? EMPTY_LENSES,
+    /** Org admins additionally see the residual `none` (triage) channel. */
+    isAdmin: data?.isAdmin ?? false,
+    /** False until the first fetch lands — don't subscribe to anything yet. */
+    isLoaded: !isLoading && !!data,
+  }
+}

--- a/apps/web/src/components/threads/realtime/use-mail-sync.ts
+++ b/apps/web/src/components/threads/realtime/use-mail-sync.ts
@@ -14,12 +14,18 @@ import type {
   ThreadDeletedEvent,
   ThreadUpdatedEvent,
 } from '@auxx/lib/realtime/client'
+import { rooms } from '@auxx/lib/realtime/client'
 import { extractUniqueParticipantIds } from '@auxx/types'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useUser } from '~/hooks/use-user'
-import { useInboxChannels, useOrgChannel } from '~/realtime/hooks'
+import {
+  type InboxChannelEntry,
+  useInboxChannels,
+  useOrgChannel,
+  useRealtimeRoom,
+} from '~/realtime/hooks'
 import { api } from '~/trpc/react'
-import { useInboxes } from '../hooks'
+import { useMyInboxLenses } from '../hooks'
 import { useMessageListStore } from '../store/message-list-store'
 import { useMessageStore } from '../store/message-store'
 import { useParticipantStore } from '../store/participant-store'
@@ -28,24 +34,29 @@ import { useThreadStore } from '../store/thread-store'
 import { useMessageArrivalCue } from './use-message-arrival-cue'
 
 /**
- * Mail-side counterpart to `useResourceSync`. Subscribes to per-inbox channels
- * for thread/message events and to the org channel for participant events,
- * then fans events into the thread / message / message-list / participant
- * stores. Mounted once in `AuxxAppProviders`.
+ * Mail-side counterpart to `useResourceSync`. Subscribes to the viewer's
+ * per-inbox PER-LENS channels (mail-permissions §6.4) for thread/message
+ * events and to their private user channel for the per-user grantee fanout +
+ * `visibility:changed`, then fans events into the thread / message /
+ * message-list / participant stores. Mounted once in `AuxxAppProviders`.
  */
 export function useMailSync() {
   const { user } = useUser()
   const currentUserId = user?.id ?? null
 
-  const { inboxes } = useInboxes()
-
-  // Build the slug set from accessible inboxes plus the implicit `none`
-  // (unassigned-triage) channel that every org member subscribes to.
-  const slugs = useMemo(() => {
-    const list = inboxes.map((i) => i.id)
-    list.push('none')
+  // The viewer's lens per inbox — subscribe to exactly that channel variant.
+  // Admins additionally get the residual `none` (triage) channel, published
+  // at `full` only. Nothing is subscribed until the lens read lands.
+  const { lenses, isAdmin, isLoaded } = useMyInboxLenses()
+  const entries = useMemo(() => {
+    if (!isLoaded) return []
+    const list: InboxChannelEntry[] = Object.entries(lenses).map(([slug, lens]) => ({
+      slug,
+      lens,
+    }))
+    if (isAdmin) list.push({ slug: 'none', lens: 'full' })
     return list
-  }, [inboxes])
+  }, [lenses, isAdmin, isLoaded])
 
   // Store actions (selectors to avoid re-renders).
   const requestThread = useThreadStore((s) => s.requestThread)
@@ -245,7 +256,8 @@ export function useMailSync() {
   )
 
   // Inbox-channel event dispatcher. Bound across every active per-inbox room
-  // by `useInboxChannels`.
+  // by `useInboxChannels`, and reused for the per-user grantee fanout on the
+  // user channel (payloads are identical, already redacted server-side).
   const onInboxEvent = useCallback(
     (event: string, payload: unknown) => {
       switch (event) {
@@ -261,6 +273,8 @@ export function useMailSync() {
           return handleMessageUpdated(payload as MessageUpdatedEvent['data'])
         case 'message:deleted':
           return handleMessageDeleted(payload as MessageDeletedEvent['data'])
+        case 'participant:updated':
+          return handleParticipantUpdated(payload as ParticipantUpdatedEvent['data'])
         case 'mail:batch':
           return handleMailBatch(payload as MailBatchEvent['data'])
         case 'inbox:syncCompleted':
@@ -274,25 +288,46 @@ export function useMailSync() {
       handleMessageCreated,
       handleMessageUpdated,
       handleMessageDeleted,
+      handleParticipantUpdated,
       handleMailBatch,
       handleInboxSyncCompleted,
     ]
   )
 
-  // Org-channel event dispatcher (currently just participant updates).
+  // The viewer's visibility changed (grant added/revoked, inbox lens moved,
+  // role changed). Refetch `inbox.myLenses` — the `entries` memo re-derives
+  // and `useInboxChannels` resubscribes to the new per-lens channel set — and
+  // refresh everything lens-dependent that's already on screen.
+  const handleVisibilityChanged = useCallback(() => {
+    utils.inbox.myLenses.invalidate()
+    utils.thread.listIds.invalidate()
+    utils.thread.getCounts.invalidate()
+    invalidateAllContexts()
+  }, [utils, invalidateAllContexts])
+
+  // Org-channel event dispatcher — broadcast visibility changes (e.g. an
+  // inbox default-lens edit) that fan out to every member.
   const onOrgEvent = useCallback(
-    (event: string, payload: unknown) => {
-      if (event === 'participant:updated') {
-        handleParticipantUpdated(payload as ParticipantUpdatedEvent['data'])
-      }
+    (event: string, _payload: unknown) => {
+      if (event === 'visibility:changed') handleVisibilityChanged()
     },
-    [handleParticipantUpdated]
+    [handleVisibilityChanged]
+  )
+
+  // User-channel event dispatcher: targeted visibility changes + the
+  // per-user grantee/assignee mail-event fanout (§6.3).
+  const onUserEvent = useCallback(
+    (event: string, payload: unknown) => {
+      if (event === 'visibility:changed') return handleVisibilityChanged()
+      onInboxEvent(event, payload)
+    },
+    [handleVisibilityChanged, onInboxEvent]
   )
 
   // Catch-up on (re)subscribe. Pusher does NOT replay events published while a
-  // channel was mid-subscribe — and inbox channels bind in two phases (the real
-  // inboxes only after the async `inboxes` query resolves), plus rebind on
-  // every reconnect. Messages sent in those windows never reach
+  // channel was mid-subscribe — and inbox channels only bind after the async
+  // `inbox.myLenses` query resolves, plus rebind on every reconnect and on
+  // visibility changes. Messages sent in those windows never reach
   // `handleMessageCreated` and only surface on a manual refresh. So when an
   // inbox channel finishes subscribing, refetch the thread list and the
   // currently-open thread's messages to recover anything missed.
@@ -351,9 +386,10 @@ export function useMailSync() {
     []
   )
 
-  useInboxChannels(slugs, {
+  useInboxChannels(entries, {
     onEvent: onInboxEvent,
     onSubscribed: handleInboxSubscribed,
   })
   useOrgChannel({ onEvent: onOrgEvent })
+  useRealtimeRoom(currentUserId ? rooms.user(currentUserId) : null, { onEvent: onUserEvent })
 }

--- a/apps/web/src/realtime/hooks.ts
+++ b/apps/web/src/realtime/hooks.ts
@@ -2,7 +2,12 @@
 
 'use client'
 
-import type { PresenceHandlers, PresenceMember, SubscribeHandlers } from '@auxx/lib/realtime/client'
+import type {
+  ChannelLens,
+  PresenceHandlers,
+  PresenceMember,
+  SubscribeHandlers,
+} from '@auxx/lib/realtime/client'
 import { rooms } from '@auxx/lib/realtime/client'
 import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import { useUser } from '~/hooks/use-user'
@@ -107,61 +112,79 @@ export function useOrgChannel(handlers?: SubscribeHandlers): boolean {
   return useRealtimeRoom(roomKey, handlers ?? {})
 }
 
+/** One per-lens inbox channel subscription request (mail-permissions §6.4). */
+export interface InboxChannelEntry {
+  /** Raw inbox UUID, or `'none'` for the residual triage channel. */
+  slug: string
+  /** The caller's lens on that inbox — subscribe to exactly this variant. */
+  lens: ChannelLens
+}
+
 /**
- * Subscribe to a single inbox channel by slug. Pass `'none'` for the
- * unassigned-triage channel. The hook refcounts subscriptions so multiple
- * components can call it safely.
+ * Subscribe to a single per-lens inbox channel. The hook refcounts
+ * subscriptions so multiple components can call it safely.
  */
 export function useInboxChannel(
-  inboxSlug: string | null | undefined,
+  entry: InboxChannelEntry | null | undefined,
   handlers?: SubscribeHandlers
 ): boolean {
   const { organizationId } = useUser()
-  const roomKey = organizationId && inboxSlug ? rooms.orgInbox(organizationId, inboxSlug) : null
+  const roomKey =
+    organizationId && entry ? rooms.orgInbox(organizationId, entry.slug, entry.lens) : null
   return useRealtimeRoom(roomKey, handlers ?? {})
 }
 
 /**
- * Subscribe to many inbox channels at once. Manages add/remove based on the
- * given slugs. Returns the set of currently-subscribed room keys for the
- * requested slugs only (filtered from the adapter's global room map).
+ * Subscribe to many per-lens inbox channels at once. Manages add/remove based
+ * on the given entries. Returns the set of currently-subscribed room keys for
+ * the requested entries only (filtered from the adapter's global room map).
  *
- * The returned set is referentially stable until either the requested slug
+ * The returned set is referentially stable until either the requested entry
  * set changes or the adapter's subscribed-room contents change for those
- * slugs — required by the `useSyncExternalStore` snapshot contract.
- *
- * Always include `'none'` in the slug set if you want unassigned-triage events.
+ * entries — required by the `useSyncExternalStore` snapshot contract.
  */
 export function useInboxChannels(
-  slugs: readonly string[],
+  entries: readonly InboxChannelEntry[],
   handlers?: SubscribeHandlers
 ): ReadonlySet<string> {
   const { organizationId } = useUser()
   const handlersRef = useRef(handlers)
   handlersRef.current = handlers
 
-  // Stable comma-joined key so the effect only re-runs when the slug set changes.
-  const slugKey = useMemo(() => [...slugs].sort().join(','), [slugs])
+  // Stable comma-joined key so the effect only re-runs when the entry set changes.
+  const entryKey = useMemo(
+    () =>
+      entries
+        .map((e) => `${e.slug}:${e.lens}`)
+        .sort()
+        .join(','),
+    [entries]
+  )
 
   useEffect(() => {
-    if (!organizationId || !slugKey) return
-    const list = slugKey.split(',')
-    const subs = list.map((slug) =>
-      realtimeAdapter.subscribe(rooms.orgInbox(organizationId, slug), {
+    if (!organizationId || !entryKey) return
+    const subs = entryKey.split(',').map((pair) => {
+      const [slug, lens] = pair.split(':')
+      return realtimeAdapter.subscribe(rooms.orgInbox(organizationId, slug, lens as ChannelLens), {
         onEvent: (event, payload) => handlersRef.current?.onEvent?.(event, payload),
         onSubscribed: () => handlersRef.current?.onSubscribed?.(),
       })
-    )
+    })
     return () => {
       for (const s of subs) s.unsubscribe()
     }
-  }, [organizationId, slugKey])
+  }, [organizationId, entryKey])
 
   // Set of room keys we care about for this hook instance.
   const requestedKeys = useMemo<ReadonlySet<string>>(() => {
-    if (!organizationId || !slugKey) return EMPTY_ROOM_SET
-    return new Set(slugKey.split(',').map((slug) => rooms.orgInbox(organizationId, slug)))
-  }, [organizationId, slugKey])
+    if (!organizationId || !entryKey) return EMPTY_ROOM_SET
+    return new Set(
+      entryKey.split(',').map((pair) => {
+        const [slug, lens] = pair.split(':')
+        return rooms.orgInbox(organizationId, slug, lens as ChannelLens)
+      })
+    )
+  }, [organizationId, entryKey])
 
   // Cache the last returned snapshot so identity stays stable until the
   // filtered membership actually changes. `useSyncExternalStore` requires the

--- a/apps/web/src/server/api/routers/inbox.ts
+++ b/apps/web/src/server/api/routers/inbox.ts
@@ -1,7 +1,8 @@
 // apps/web/src/server/api/routers/inbox.ts
 
-import { getCachedUserMailVisibility } from '@auxx/lib/cache'
+import { getCachedUserMailVisibility, getOrgCache } from '@auxx/lib/cache'
 import { InboxService } from '@auxx/lib/inboxes'
+import { inboxLensFor, type Lens } from '@auxx/lib/permissions/visibility'
 import { ThreadMutationService } from '@auxx/lib/threads'
 import { recordIdSchema, toRecordId } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
@@ -28,6 +29,27 @@ const integrationSchema = z.object({
 })
 
 export const inboxRouter = createTRPCRouter({
+  /**
+   * The caller's effective lens per inbox (mail-permissions §6.4) — drives
+   * the FE's per-lens realtime channel subscriptions and, later, redacted
+   * rendering. Two org-cache reads, no DB. Inboxes at `none` are omitted.
+   * `isAdmin` additionally authorizes the residual `none` (triage) channel.
+   */
+  myLenses: protectedProcedure.query(async ({ ctx }) => {
+    const { organizationId } = ctx.session
+    const userId = ctx.session.user.id
+    const [viewer, inboxes] = await Promise.all([
+      getCachedUserMailVisibility(userId, organizationId),
+      getOrgCache().get(organizationId, 'inboxes'),
+    ])
+    const lenses: Record<string, Exclude<Lens, 'none'>> = {}
+    for (const inbox of inboxes) {
+      const lens = inboxLensFor(viewer, inbox.id)
+      if (lens !== 'none') lenses[inbox.id] = lens
+    }
+    return { isAdmin: viewer.isAdmin, lenses }
+  }),
+
   /**
    * Get integrations for an inbox
    */

--- a/packages/lib/src/cache/invalidate.ts
+++ b/packages/lib/src/cache/invalidate.ts
@@ -44,12 +44,12 @@ export async function onCacheEvent(
   // (§10.1): whenever an event touches `userMailVisibility`, the affected
   // users' counter hashes are stale too. Epoch bump for broadcasts (lazy
   // reconcile on next read), targeted staleness for specific users.
-  if (
-    context.orgId &&
+  const touchesMailVisibility =
+    !!context.orgId &&
     isMixedMapping(mapping) &&
     'user' in mapping &&
-    mapping.user?.includes('userMailVisibility')
-  ) {
+    !!mapping.user?.includes('userMailVisibility')
+  if (touchesMailVisibility && context.orgId) {
     const orgId = context.orgId
     const { bumpMailCountsEpoch, markMailCountsStale } = await import('../threads/mail-counts')
     if (context.broadcastUserKeys) {
@@ -98,6 +98,32 @@ export async function onCacheEvent(
     }
 
     await Promise.all(promises)
+  }
+
+  // Realtime nudge (mail-permissions §6.1): whenever an event reshaped
+  // `userMailVisibility`, tell the affected live clients so they refetch
+  // `inbox.myLenses` and re-derive their per-lens channel subscriptions.
+  // AFTER the invalidations above, so the refetch reads fresh data.
+  // Fire-and-forget — a Pusher hiccup must never fail the mutation.
+  if (touchesMailVisibility && context.orgId) {
+    const orgId = context.orgId
+    void (async () => {
+      // Lazy import — the realtime registry reads this cache module back.
+      const { getRealtimeService } = await import('../realtime')
+      const { rooms } = await import('../realtime/room-keys')
+      const realtime = getRealtimeService()
+      const payload = { organizationId: orgId }
+      if (context.broadcastUserKeys) {
+        await realtime.publish(rooms.orgPresence(orgId), 'visibility:changed', payload)
+      } else {
+        const userIds = context.userIds ?? (context.userId ? [context.userId] : [])
+        await Promise.allSettled(
+          userIds.map((userId) =>
+            realtime.publish(rooms.user(userId), 'visibility:changed', payload)
+          )
+        )
+      }
+    })().catch(() => {})
   }
 }
 

--- a/packages/lib/src/ingest/delete-messages.ts
+++ b/packages/lib/src/ingest/delete-messages.ts
@@ -34,16 +34,22 @@ export async function deleteMessagesByExternalIds(
   const messageIds = messages.map((m) => m.id)
   const affectedThreadIds = [...new Set(messages.map((m) => m.threadId).filter(Boolean))]
 
-  // Capture inboxIds before delete so we can route realtime events.
+  // Capture inboxIds + assignees before delete so we can route realtime events.
   const threadInboxRows = affectedThreadIds.length
     ? await ctx.db
-        .select({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
+        .select({
+          id: schema.Thread.id,
+          inboxId: schema.Thread.inboxId,
+          assigneeId: schema.Thread.assigneeId,
+        })
         .from(schema.Thread)
         .where(inArray(schema.Thread.id, affectedThreadIds as string[]))
     : []
   const inboxIdByThread = new Map<string, string | null>()
+  const assigneeIdByThread = new Map<string, string | null>()
   for (const row of threadInboxRows) {
     inboxIdByThread.set(row.id, row.inboxId ?? null)
+    assigneeIdByThread.set(row.id, row.assigneeId ?? null)
   }
 
   await ctx.db.delete(schema.Message).where(inArray(schema.Message.id, messageIds))
@@ -75,6 +81,7 @@ export async function deleteMessagesByExternalIds(
           messageId: msg.id,
           threadId: msg.threadId,
           inboxId: inboxIdByThread.get(msg.threadId) ?? null,
+          assigneeId: assigneeIdByThread.get(msg.threadId) ?? null,
         },
         { excludeSocketId: ctx.socketId }
       )
@@ -100,7 +107,7 @@ export async function deleteMessagesByExternalIds(
         await publishThreadDeleted(
           realtime,
           ctx.organizationId,
-          { threadId, inboxId },
+          { threadId, inboxId, assigneeId: assigneeIdByThread.get(threadId) ?? null },
           { excludeSocketId: ctx.socketId }
         )
       }

--- a/packages/lib/src/ingest/participants/find-or-create.ts
+++ b/packages/lib/src/ingest/participants/find-or-create.ts
@@ -58,7 +58,13 @@ export async function findOrCreateParticipantRecord(
   ctx: IngestContext,
   participantInput: ParticipantInputData,
   identifierType: IdentifierType,
-  messageContext?: { isInbound: boolean; role: ParticipantRole }
+  messageContext?: { isInbound: boolean; role: ParticipantRole },
+  /**
+   * The inbox the triggering message lands in — routes `participant:updated`
+   * to that inbox's lens channels (mail-permissions §6.2). Null/undefined
+   * falls back to the admin-only `none` channel.
+   */
+  inboxId?: string | null
 ): Promise<Participant> {
   if (!participantInput.identifier) {
     throw new Error('Participant identifier cannot be empty.')
@@ -165,7 +171,7 @@ export async function findOrCreateParticipantRecord(
         await publishParticipantUpdated(
           getRealtimeService(),
           ctx.organizationId,
-          { participantId: participant.id, patch },
+          { participantId: participant.id, patch, inboxId },
           { excludeSocketId: ctx.socketId }
         )
       }

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -184,6 +184,29 @@ export async function storeMessage(
       return storeIgnoredMessage(ctx, messageData)
     }
 
+    // Ingest guarantee (mail-permissions Phase 0): every thread must carry an
+    // inboxId so it can't fall into the null-inbox visibility class. Resolve it
+    // from the integration's InboxIntegration mapping when the caller didn't
+    // supply one; a failure is logged (the column stays nullable defensively).
+    // Resolved BEFORE participant processing so `participant:updated` events
+    // can route to this inbox's lens channels (Phase 3 §6.2).
+    let resolvedInboxId = messageData.inboxId ?? null
+    if (!resolvedInboxId && messageData.integrationId) {
+      const [link] = await ctx.db
+        .select({ inboxId: schema.InboxIntegration.inboxId })
+        .from(schema.InboxIntegration)
+        .where(eq(schema.InboxIntegration.integrationId, messageData.integrationId))
+        .limit(1)
+      resolvedInboxId = link?.inboxId ?? null
+      if (!resolvedInboxId) {
+        ctx.logger.error('Thread ingest could not resolve an inboxId for integration', {
+          integrationId: messageData.integrationId,
+          organizationId: messageData.organizationId,
+          externalThreadId: messageData.externalThreadId,
+        })
+      }
+    }
+
     // Resolved (role, participantId) pairs for MessageParticipant links,
     // captured while processing so the link insert doesn't re-derive
     // identifier types.
@@ -217,7 +240,8 @@ export async function storeMessage(
         ctx,
         data,
         identifierType,
-        messageContext
+        messageContext,
+        resolvedInboxId
       )
       participantCache.set(cacheKey, participantRecord)
       return participantRecord
@@ -267,27 +291,6 @@ export async function storeMessage(
     const currentMessageParticipantIds: string[] = []
     for (const participant of participantCache.values()) {
       if (participant?.id) currentMessageParticipantIds.push(participant.id)
-    }
-
-    // Ingest guarantee (mail-permissions Phase 0): every thread must carry an
-    // inboxId so it can't fall into the null-inbox visibility class. Resolve it
-    // from the integration's InboxIntegration mapping when the caller didn't
-    // supply one; a failure is logged (the column stays nullable defensively).
-    let resolvedInboxId = messageData.inboxId ?? null
-    if (!resolvedInboxId && messageData.integrationId) {
-      const [link] = await ctx.db
-        .select({ inboxId: schema.InboxIntegration.inboxId })
-        .from(schema.InboxIntegration)
-        .where(eq(schema.InboxIntegration.integrationId, messageData.integrationId))
-        .limit(1)
-      resolvedInboxId = link?.inboxId ?? null
-      if (!resolvedInboxId) {
-        ctx.logger.error('Thread ingest could not resolve an inboxId for integration', {
-          integrationId: messageData.integrationId,
-          organizationId: messageData.organizationId,
-          externalThreadId: messageData.externalThreadId,
-        })
-      }
     }
 
     // Core write set in one transaction: thread upsert → message upsert →
@@ -526,6 +529,7 @@ export async function storeMessage(
             threadId: thread.id,
             inboxId: inboxIdForChannel,
             inboxRecordId,
+            assigneeId: thread.assigneeId ?? null,
           },
           { excludeSocketId: ctx.socketId }
         )
@@ -537,6 +541,7 @@ export async function storeMessage(
           messageId: messageRecord.id,
           threadId: thread.id,
           inboxId: inboxIdForChannel,
+          assigneeId: thread.assigneeId ?? null,
         },
         { excludeSocketId: ctx.socketId }
       )

--- a/packages/lib/src/ingest/threads/update-metadata.ts
+++ b/packages/lib/src/ingest/threads/update-metadata.ts
@@ -65,6 +65,7 @@ export async function updateThreadMetadataEfficient(
     const [row] = await ctx.db
       .select({
         inboxId: schema.Thread.inboxId,
+        assigneeId: schema.Thread.assigneeId,
         messageCount: schema.Thread.messageCount,
         participantCount: schema.Thread.participantCount,
         firstMessageAt: schema.Thread.firstMessageAt,
@@ -96,6 +97,7 @@ export async function updateThreadMetadataEfficient(
       {
         threadId,
         inboxId: row.inboxId ?? null,
+        assigneeId: row.assigneeId ?? null,
         patch,
       },
       { excludeSocketId: ctx.socketId }

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -219,7 +219,7 @@ export class MessageSenderService {
       // provider-authoritative columns — accepted duplicate.
       try {
         const [threadRow] = await (this.db ?? db)
-          .select({ inboxId: schema.Thread.inboxId })
+          .select({ inboxId: schema.Thread.inboxId, assigneeId: schema.Thread.assigneeId })
           .from(schema.Thread)
           .where(eq(schema.Thread.id, threadContext.id))
           .limit(1)
@@ -230,6 +230,7 @@ export class MessageSenderService {
             messageId: composed.id,
             threadId: threadContext.id,
             inboxId: threadRow?.inboxId ?? null,
+            assigneeId: threadRow?.assigneeId ?? null,
           },
           { excludeSocketId: this.socketId }
         )

--- a/packages/lib/src/permissions/visibility/effective-lens.ts
+++ b/packages/lib/src/permissions/visibility/effective-lens.ts
@@ -31,6 +31,17 @@ export function effectiveLens(vis: UserMailVisibility, t: ThreadVisibilityInput)
   return lens
 }
 
+/**
+ * The viewer's lens on an INBOX (not a thread) — the floor every thread in it
+ * inherits before per-thread derivations. Mirrors the admin short-circuit in
+ * {@link effectiveLens}: admins are `full` everywhere except others' personal
+ * inboxes. Used by realtime subscribe auth and the FE `myLenses` read.
+ */
+export function inboxLensFor(vis: UserMailVisibility, inboxId: string): Lens {
+  if (vis.isAdmin && !vis.personalInboxIds[inboxId]) return 'full'
+  return vis.inboxLens[inboxId] ?? 'none'
+}
+
 /** Batch form — a loop over {@link effectiveLens}, keyed by thread id. */
 export function effectiveLensBatch(
   vis: UserMailVisibility,

--- a/packages/lib/src/permissions/visibility/index.ts
+++ b/packages/lib/src/permissions/visibility/index.ts
@@ -15,13 +15,14 @@ export type {
 export { isSystemViewer, SYSTEM_VISIBILITY } from './context'
 export type { DerivationRule } from './derivation-rules'
 export { DERIVATION_RULES } from './derivation-rules'
-export { effectiveLens, effectiveLensBatch } from './effective-lens'
+export { effectiveLens, effectiveLensBatch, inboxLensFor } from './effective-lens'
 export type { Lens } from './lens'
 export { ALL_LENSES, lensRank, maxLens, satisfiesLens } from './lens'
 export {
   FULL_ONLY_THREAD_FIELDS,
   MESSAGE_CONTENT_FIELDS,
   redactMessage,
+  redactMessagePatch,
   redactThreadMeta,
   redactThreadPatch,
   SUBJECT_TIER_THREAD_FIELDS,

--- a/packages/lib/src/permissions/visibility/redact.ts
+++ b/packages/lib/src/permissions/visibility/redact.ts
@@ -122,6 +122,22 @@ const REDACTED_MESSAGE_DEFAULTS: Record<string, unknown> = {
 }
 
 /**
+ * Redact a message PATCH (§6.2) — key-based: content fields are DROPPED (not
+ * blanked) below `full`, so a lower-lens realtime channel never carries body /
+ * snippet / attachment data and never clobbers store state with blanks.
+ * Messages are invisible at `metadata` — callers skip publishing entirely
+ * there rather than calling this.
+ */
+export function redactMessagePatch<T extends Record<string, unknown>>(patch: T, lens: Lens): T {
+  if (satisfiesLens(lens, 'full')) return patch
+  const out = { ...patch }
+  for (const field of MESSAGE_CONTENT_FIELDS) {
+    delete out[field]
+  }
+  return out
+}
+
+/**
  * Project a message down to `lens`. At `full` it passes through; below `full`
  * (envelope tier) content fields are blanked. Messages are invisible at
  * `metadata` — the caller returns nothing / 404 rather than calling this.

--- a/packages/lib/src/permissions/visibility/visibility.test.ts
+++ b/packages/lib/src/permissions/visibility/visibility.test.ts
@@ -3,9 +3,9 @@
 import { describe, expect, it } from 'vitest'
 import type { ThreadVisibilityInput, UserMailVisibility } from './context'
 import { isSystemViewer, SYSTEM_VISIBILITY } from './context'
-import { effectiveLens, effectiveLensBatch } from './effective-lens'
+import { effectiveLens, effectiveLensBatch, inboxLensFor } from './effective-lens'
 import { maxLens, satisfiesLens } from './lens'
-import { redactMessage, redactThreadMeta, redactThreadPatch } from './redact'
+import { redactMessage, redactMessagePatch, redactThreadMeta, redactThreadPatch } from './redact'
 
 const INBOX = 'inbox_1'
 const PERSONAL = 'inbox_personal'
@@ -235,5 +235,39 @@ describe('redactMessage', () => {
     expect(r.htmlBodyStorageLocationId).toBeNull()
     expect(r.attachments).toEqual([])
     expect(r.isInbound).toBe(true)
+  })
+})
+
+describe('redactMessagePatch (realtime §6.2)', () => {
+  it('full passes through unchanged', () => {
+    const patch = { snippet: 'preview', sendStatus: 'SENT' }
+    expect(redactMessagePatch(patch, 'full')).toBe(patch)
+  })
+
+  it('subject DROPS content keys (never blanks them onto the store)', () => {
+    const r = redactMessagePatch(
+      { snippet: 'preview', attachments: [{ id: 'a1' }], sendStatus: 'SENT' },
+      'subject'
+    )
+    expect(r).toEqual({ sendStatus: 'SENT' })
+    expect('snippet' in r).toBe(false)
+    expect('attachments' in r).toBe(false)
+  })
+})
+
+describe('inboxLensFor', () => {
+  it('admin short-circuits to full on org inboxes', () => {
+    expect(inboxLensFor(vis({ isAdmin: true }), INBOX)).toBe('full')
+  })
+
+  it("admin does NOT short-circuit on another user's personal inbox", () => {
+    const v = vis({ isAdmin: true, personalInboxIds: { [PERSONAL]: true } })
+    expect(inboxLensFor(v, PERSONAL)).toBe('none')
+  })
+
+  it('member reads the composed inbox floor, none when absent', () => {
+    const v = vis({ inboxLens: { [INBOX]: 'subject' } })
+    expect(inboxLensFor(v, INBOX)).toBe('subject')
+    expect(inboxLensFor(v, 'other_inbox')).toBe('none')
   })
 })

--- a/packages/lib/src/realtime/client/index.ts
+++ b/packages/lib/src/realtime/client/index.ts
@@ -20,8 +20,9 @@ export type {
   ThreadDeletedEvent,
   ThreadMeta,
   ThreadUpdatedEvent,
+  VisibilityChangedEvent,
 } from '../events'
-export { type RoomKind, rooms } from '../room-keys'
+export { CHANNEL_LENSES, type ChannelLens, type RoomKind, rooms } from '../room-keys'
 export { PusherRealtimeAdapter } from './adapters/pusher'
 export type {
   PresenceHandlers,

--- a/packages/lib/src/realtime/events.ts
+++ b/packages/lib/src/realtime/events.ts
@@ -363,7 +363,7 @@ export interface MessageDeletedEvent {
   }
 }
 
-/** Participant metadata changed (org channel). */
+/** Participant metadata changed (the triggering thread's inbox channels). */
 export interface ParticipantUpdatedEvent {
   event: 'participant:updated'
   data: {
@@ -403,6 +403,19 @@ export interface InboxSyncCompletedEvent {
 export interface CountsChangedEvent {
   event: 'counts:changed'
   data: { userId: string }
+}
+
+/**
+ * The viewer's mail visibility changed — a grant was added/revoked, an inbox
+ * default lens moved, or membership/role changed (mail-permissions §6.1).
+ * Published on the affected `rooms.user` channels (targeted invalidations) or
+ * the org presence channel (broadcast). Refresh signal only: the client
+ * refetches `inbox.myLenses`, re-derives its per-lens channel subscriptions,
+ * and invalidates thread lists + counts.
+ */
+export interface VisibilityChangedEvent {
+  event: 'visibility:changed'
+  data: { organizationId: string }
 }
 
 /** Union of all mail sync events. */

--- a/packages/lib/src/realtime/index.ts
+++ b/packages/lib/src/realtime/index.ts
@@ -45,7 +45,9 @@ export type {
   ThreadDeletedEvent,
   ThreadMeta,
   ThreadUpdatedEvent,
+  VisibilityChangedEvent,
 } from './events'
+export { shapeMailEventForLens } from './mail-event-shaping'
 export {
   flushMailBatch,
   publishAgentUpdated,
@@ -70,9 +72,12 @@ export {
 export { RealtimeService } from './realtime-service'
 export {
   type AuthorizeCtx,
+  CHANNEL_LENSES,
+  type ChannelLens,
   findRoom,
   findRoomByChannel,
   fromPusherChannel,
+  parseInboxRoomKey,
   type RoomDef,
   type RoomKind,
   roomKindFor,

--- a/packages/lib/src/realtime/mail-event-shaping.test.ts
+++ b/packages/lib/src/realtime/mail-event-shaping.test.ts
@@ -1,0 +1,146 @@
+// packages/lib/src/realtime/mail-event-shaping.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { MailSyncEvent } from './events'
+import { shapeMailEventForLens } from './mail-event-shaping'
+import { parseInboxRoomKey, rooms } from './room-keys'
+
+const ORG = 'org_abc-123'
+const INBOX = 'f6b2c1d0-1111-2222-3333-444455556666'
+
+describe('per-lens inbox room keys', () => {
+  it('builds and parses round-trip (UUID slugs contain dashes)', () => {
+    const key = rooms.orgInbox(ORG, INBOX, 'subject')
+    expect(key).toBe(`org-${ORG}-inbox-${INBOX}-subject`)
+    expect(parseInboxRoomKey(key)).toEqual({
+      organizationId: ORG,
+      inboxSlug: INBOX,
+      lens: 'subject',
+    })
+  })
+
+  it('parses the residual none channel', () => {
+    expect(parseInboxRoomKey(rooms.orgInbox(ORG, 'none', 'full'))).toEqual({
+      organizationId: ORG,
+      inboxSlug: 'none',
+      lens: 'full',
+    })
+  })
+
+  it('rejects legacy un-suffixed keys and bogus lenses', () => {
+    expect(parseInboxRoomKey(`org-${ORG}-inbox-${INBOX}`)).toBeNull()
+    expect(parseInboxRoomKey(`org-${ORG}-inbox-${INBOX}-admin`)).toBeNull()
+    expect(parseInboxRoomKey(`org-${ORG}-events`)).toBeNull()
+  })
+})
+
+describe('shapeMailEventForLens', () => {
+  const threadUpdated: MailSyncEvent = {
+    event: 'thread:updated',
+    data: {
+      threadId: 't1',
+      patch: { id: 't1', subject: 'Secret', status: 'OPEN', isUnread: true },
+    },
+  }
+
+  it('full passes every event through unchanged', () => {
+    expect(shapeMailEventForLens(threadUpdated, 'full')).toBe(threadUpdated)
+  })
+
+  it('none drops everything', () => {
+    expect(shapeMailEventForLens(threadUpdated, 'none')).toBeNull()
+  })
+
+  it('subject keeps subject but strips full-only fields from thread patches', () => {
+    const shaped = shapeMailEventForLens(threadUpdated, 'subject')
+    expect(shaped).not.toBeNull()
+    const patch = (shaped as Extract<MailSyncEvent, { event: 'thread:updated' }>).data.patch
+    expect(patch.subject).toBe('Secret')
+    expect(patch.status).toBe('OPEN')
+    expect('isUnread' in patch).toBe(false)
+  })
+
+  it('metadata strips the subject too', () => {
+    const shaped = shapeMailEventForLens(threadUpdated, 'metadata')
+    const patch = (shaped as Extract<MailSyncEvent, { event: 'thread:updated' }>).data.patch
+    expect('subject' in patch).toBe(false)
+    expect(patch.status).toBe('OPEN')
+  })
+
+  it('drops a thread patch that redacts to nothing (per-user unread fanout)', () => {
+    const unread: MailSyncEvent = {
+      event: 'thread:updated',
+      data: { threadId: 't1', patch: { id: 't1', isUnread: false, userId: 'u1' } },
+    }
+    expect(shapeMailEventForLens(unread, 'subject')).toBeNull()
+    expect(shapeMailEventForLens(unread, 'metadata')).toBeNull()
+    expect(shapeMailEventForLens(unread, 'full')).toBe(unread)
+  })
+
+  it('message events are invisible at metadata, envelope-only at subject', () => {
+    const created: MailSyncEvent = {
+      event: 'message:created',
+      data: { messageId: 'm1', threadId: 't1' },
+    }
+    expect(shapeMailEventForLens(created, 'metadata')).toBeNull()
+    expect(shapeMailEventForLens(created, 'subject')).toBe(created)
+
+    const updated: MailSyncEvent = {
+      event: 'message:updated',
+      data: {
+        messageId: 'm1',
+        threadId: 't1',
+        patch: { id: 'm1', threadId: 't1', snippet: 'body preview', sendStatus: 'SENT' },
+      },
+    }
+    const shaped = shapeMailEventForLens(updated, 'subject')
+    const patch = (shaped as Extract<MailSyncEvent, { event: 'message:updated' }>).data.patch
+    expect('snippet' in patch).toBe(false)
+    expect(patch.sendStatus).toBe('SENT')
+  })
+
+  it('drops a message patch that redacts to nothing', () => {
+    const contentOnly: MailSyncEvent = {
+      event: 'message:updated',
+      data: {
+        messageId: 'm1',
+        threadId: 't1',
+        patch: { id: 'm1', threadId: 't1', attachments: [] },
+      },
+    }
+    expect(shapeMailEventForLens(contentOnly, 'subject')).toBeNull()
+  })
+
+  it('shapes mail:batch recursively and drops empty frames', () => {
+    const batch: MailSyncEvent = {
+      event: 'mail:batch',
+      data: {
+        events: [
+          { event: 'message:created', data: { messageId: 'm1', threadId: 't1' } },
+          { event: 'thread:deleted', data: { threadId: 't2' } },
+        ],
+      },
+    }
+    const atMetadata = shapeMailEventForLens(batch, 'metadata')
+    expect(atMetadata).toEqual({
+      event: 'mail:batch',
+      data: { events: [{ event: 'thread:deleted', data: { threadId: 't2' } }] },
+    })
+
+    const messagesOnly: MailSyncEvent = {
+      event: 'mail:batch',
+      data: { events: [{ event: 'message:created', data: { messageId: 'm1', threadId: 't1' } }] },
+    }
+    expect(shapeMailEventForLens(messagesOnly, 'metadata')).toBeNull()
+  })
+
+  it('metadata-tier events pass through at every visible lens', () => {
+    const participant: MailSyncEvent = {
+      event: 'participant:updated',
+      data: { participantId: 'p1', patch: { id: 'p1', name: 'Bob' } },
+    }
+    expect(shapeMailEventForLens(participant, 'metadata')).toBe(participant)
+    const sync: MailSyncEvent = { event: 'inbox:syncCompleted', data: { inboxId: INBOX } }
+    expect(shapeMailEventForLens(sync, 'metadata')).toBe(sync)
+  })
+})

--- a/packages/lib/src/realtime/mail-event-shaping.ts
+++ b/packages/lib/src/realtime/mail-event-shaping.ts
@@ -1,0 +1,58 @@
+// @auxx/lib/realtime/mail-event-shaping.ts
+
+import type { Lens } from '../permissions/visibility/lens'
+import { satisfiesLens } from '../permissions/visibility/lens'
+import { redactMessagePatch, redactThreadPatch } from '../permissions/visibility/redact'
+import type { MailSyncEvent } from './events'
+
+/**
+ * Shape one mail event for a lens variant (mail-permissions §6.2) — the single
+ * projection both the per-lens inbox-channel publishers and the per-user
+ * grantee fanout run every payload through. Pure and key-based:
+ *
+ * - `thread:updated` patches go through the {@link redactThreadPatch}
+ *   ALLOWLIST, so an unclassified new field can't smuggle content to a lower
+ *   channel. An empty redacted patch drops the event.
+ * - `message:*` events don't exist below `subject` (messages are invisible at
+ *   `metadata`); `message:updated` patches lose content fields below `full`.
+ * - `thread:created` / `thread:deleted` / `inbox:syncCompleted` /
+ *   `participant:updated` carry metadata-tier data only and pass through.
+ *
+ * Returns `null` when the event has nothing to say at this lens.
+ */
+export function shapeMailEventForLens(e: MailSyncEvent, lens: Lens): MailSyncEvent | null {
+  if (lens === 'none') return null
+  switch (e.event) {
+    case 'thread:created':
+    case 'thread:deleted':
+    case 'participant:updated':
+    case 'inbox:syncCompleted':
+      return e
+    case 'thread:updated': {
+      if (lens === 'full') return e
+      const patch = redactThreadPatch(e.data.patch, lens)
+      if (!Object.keys(patch).some((k) => k !== 'id')) return null
+      return { event: 'thread:updated', data: { threadId: e.data.threadId, patch } }
+    }
+    case 'message:created':
+    case 'message:deleted':
+      return satisfiesLens(lens, 'subject') ? e : null
+    case 'message:updated': {
+      if (!satisfiesLens(lens, 'subject')) return null
+      if (lens === 'full') return e
+      const patch = redactMessagePatch(e.data.patch as Record<string, unknown>, lens)
+      if (!Object.keys(patch).some((k) => k !== 'id' && k !== 'threadId')) return null
+      return {
+        event: 'message:updated',
+        data: { messageId: e.data.messageId, threadId: e.data.threadId, patch },
+      }
+    }
+    case 'mail:batch': {
+      const events = e.data.events
+        .map((inner) => shapeMailEventForLens(inner, lens))
+        .filter((inner): inner is MailSyncEvent => inner !== null)
+      if (events.length === 0) return null
+      return { event: 'mail:batch', data: { events } }
+    }
+  }
+}

--- a/packages/lib/src/realtime/publish-helpers.ts
+++ b/packages/lib/src/realtime/publish-helpers.ts
@@ -1,5 +1,8 @@
 // @auxx/lib/realtime/publish-helpers.ts
 
+import { database, schema } from '@auxx/database'
+import { and, eq, isNotNull } from 'drizzle-orm'
+import { type Lens, maxLens } from '../permissions/visibility/lens'
 import type {
   DataConnectorSyncEvent,
   DataExportJobEvent,
@@ -7,10 +10,12 @@ import type {
   MailSyncEvent,
   MessageMeta,
   ParticipantMeta,
+  ThreadCreatedEvent,
   ThreadMeta,
 } from './events'
+import { shapeMailEventForLens } from './mail-event-shaping'
 import type { RealtimeService } from './realtime-service'
-import { rooms } from './rooms'
+import { CHANNEL_LENSES, rooms } from './rooms'
 
 const CHUNK_SIZE = 50
 
@@ -146,62 +151,171 @@ interface MailPublishOptions {
   excludeSocketId?: string
 }
 
-/** Resolve a nullable inboxId to its registry slug. `null` → `'none'`. */
-function inboxRoom(organizationId: string, inboxId: string | null): string {
-  return rooms.orgInbox(organizationId, inboxId ?? 'none')
+/**
+ * Per-thread routing facts for a mail publish (mail-permissions §6.2/§6.3).
+ * `assigneeId` powers the per-user full-payload fanout to the assignee (who
+ * may lack the inbox channel entirely); callers that don't have it handy pass
+ * `undefined` and skip that fanout leg.
+ */
+interface MailThreadTarget {
+  threadId: string
+  inboxId: string | null
+  /** Publish on the previous inbox's channels too when the thread moved. */
+  previousInboxId?: string | null
+  /** `undefined` = unknown (skip assignee fanout); `null` = unassigned. */
+  assigneeId?: string | null
 }
 
 /**
- * Publish `thread:created` on the inbox channel for the given thread.
- * `inboxId` is the raw EntityInstance id (or null for triage).
+ * Per-user grantee audience for one thread: explicit thread grants plus
+ * contact-derived grants from the cached reverse index (§3.1). The contact
+ * leg needs the thread's participant contact ids — one indexed point query,
+ * run only when the org has contact grants at all (almost always none).
+ * Best-effort: any failure returns what was resolved so far.
  */
-export async function publishThreadCreated(
+async function resolveThreadGrantAudience(
+  organizationId: string,
+  threadId: string
+): Promise<Map<string, Lens>> {
+  const audience = new Map<string, Lens>()
+  try {
+    // Lazy import — cache invalidation lazily imports realtime, so the
+    // realtime module must not statically import the cache barrel back.
+    const { getOrgCache } = await import('../cache')
+    const index = await getOrgCache().get(organizationId, 'mailGrantIndex')
+    for (const entry of index.threads[threadId] ?? []) {
+      audience.set(entry.userId, maxLens(audience.get(entry.userId) ?? 'none', entry.lens))
+    }
+    if (Object.keys(index.contacts).length > 0) {
+      const rows = await database
+        .select({ entityInstanceId: schema.ThreadParticipant.entityInstanceId })
+        .from(schema.ThreadParticipant)
+        .where(
+          and(
+            eq(schema.ThreadParticipant.threadId, threadId),
+            isNotNull(schema.ThreadParticipant.entityInstanceId)
+          )
+        )
+      for (const row of rows) {
+        for (const entry of index.contacts[row.entityInstanceId as string] ?? []) {
+          audience.set(entry.userId, maxLens(audience.get(entry.userId) ?? 'none', entry.lens))
+        }
+      }
+    }
+  } catch {
+    // Fanout is a UX nicety on top of the enforced read path — never throw.
+  }
+  return audience
+}
+
+/**
+ * Publish one mail event for a thread (§6.2/§6.3):
+ *
+ * - Inbox channels: one redacted variant per lens
+ *   (`org-{org}-inbox-{id}-{metadata|subject|full}`). A null inbox publishes
+ *   to the admin-only `none` channel at `full` only.
+ * - Per-user fanout: the assignee gets the full payload on their user
+ *   channel (they may lack the inbox channel); thread/contact grantees get
+ *   the payload redacted to their granted lens.
+ *
+ * Fire-and-forget: errors are swallowed by `Promise.allSettled`.
+ */
+async function publishMailThreadEvent(
   realtimeService: RealtimeService,
   organizationId: string,
-  args: { threadId: string; inboxId: string | null; inboxRecordId?: string | null },
+  target: MailThreadTarget,
+  event: MailSyncEvent,
   options?: MailPublishOptions
 ) {
-  await realtimeService
-    .publish(
-      inboxRoom(organizationId, args.inboxId),
-      'thread:created',
-      { threadId: args.threadId, inboxId: args.inboxRecordId ?? null },
-      options
-    )
-    .catch(() => {})
+  const tasks: Promise<boolean>[] = []
+
+  const inboxIds = new Set<string | null>([target.inboxId])
+  if (target.previousInboxId !== undefined && target.previousInboxId !== target.inboxId) {
+    inboxIds.add(target.previousInboxId ?? null)
+  }
+  for (const inboxId of inboxIds) {
+    const lenses = inboxId === null ? (['full'] as const) : CHANNEL_LENSES
+    for (const lens of lenses) {
+      const shaped = shapeMailEventForLens(event, lens)
+      if (!shaped) continue
+      tasks.push(
+        realtimeService.publish(
+          rooms.orgInbox(organizationId, inboxId ?? 'none', lens),
+          shaped.event,
+          shaped.data,
+          options
+        )
+      )
+    }
+  }
+
+  const audience = await resolveThreadGrantAudience(organizationId, target.threadId)
+  if (target.assigneeId) audience.set(target.assigneeId, 'full')
+  for (const [userId, lens] of audience) {
+    const shaped = shapeMailEventForLens(event, lens)
+    if (!shaped) continue
+    tasks.push(realtimeService.publish(rooms.user(userId), shaped.event, shaped.data, options))
+  }
+
+  await Promise.allSettled(tasks)
 }
 
 /**
- * Publish `thread:updated` with a partial patch on the inbox channel.
- * Pass `previousInboxId` when a thread's inboxId changes — the helper will
- * publish on both the old and new channels so users on each side see the
- * transition (FE drops the row from the old via filter, fetches on the new).
+ * Publish `thread:created` on the thread's inbox channels (every lens
+ * variant) + the per-user grantee fanout. `inboxId` is the raw
+ * EntityInstance id (or null for triage → admin-only `none` channel).
  */
-export async function publishThreadUpdated(
+export async function publishThreadCreated(
   realtimeService: RealtimeService,
   organizationId: string,
   args: {
     threadId: string
     inboxId: string | null
-    previousInboxId?: string | null
-    patch: Partial<ThreadMeta>
+    inboxRecordId?: string | null
+    assigneeId?: string | null
   },
   options?: MailPublishOptions
 ) {
-  const payload = { threadId: args.threadId, patch: { id: args.threadId, ...args.patch } }
-  const targets = new Set<string | null>([args.inboxId])
-  if (args.previousInboxId !== undefined && args.previousInboxId !== args.inboxId) {
-    targets.add(args.previousInboxId ?? null)
-  }
-  await Promise.allSettled(
-    Array.from(targets).map((inboxId) =>
-      realtimeService.publish(
-        inboxRoom(organizationId, inboxId),
-        'thread:updated',
-        payload,
-        options
-      )
-    )
+  await publishMailThreadEvent(
+    realtimeService,
+    organizationId,
+    args,
+    {
+      event: 'thread:created',
+      data: {
+        threadId: args.threadId,
+        inboxId: (args.inboxRecordId ?? null) as ThreadCreatedEvent['data']['inboxId'],
+      },
+    },
+    options
+  )
+}
+
+/**
+ * Publish `thread:updated` with a partial patch on the thread's inbox
+ * channels — redacted per lens variant (§6.2: the patch goes through the
+ * `redactThreadPatch` allowlist, so lower channels never carry subject /
+ * unread / unclassified fields) — plus the per-user grantee fanout.
+ *
+ * Pass `previousInboxId` when a thread's inboxId changes — the helper
+ * publishes on both the old and new channels so users on each side see the
+ * transition (FE drops the row from the old via filter, fetches on the new).
+ */
+export async function publishThreadUpdated(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  args: MailThreadTarget & { patch: Partial<ThreadMeta> },
+  options?: MailPublishOptions
+) {
+  await publishMailThreadEvent(
+    realtimeService,
+    organizationId,
+    args,
+    {
+      event: 'thread:updated',
+      data: { threadId: args.threadId, patch: { id: args.threadId, ...args.patch } },
+    },
+    options
   )
 }
 
@@ -214,41 +328,46 @@ export async function publishCountsChanged(realtimeService: RealtimeService, use
   await realtimeService.publish(rooms.user(userId), 'counts:changed', { userId }).catch(() => {})
 }
 
-/** Publish `thread:deleted` on the inbox channel. */
+/** Publish `thread:deleted` on the inbox channels + grantee fanout. */
 export async function publishThreadDeleted(
   realtimeService: RealtimeService,
   organizationId: string,
-  args: { threadId: string; inboxId: string | null },
+  args: { threadId: string; inboxId: string | null; assigneeId?: string | null },
   options?: MailPublishOptions
 ) {
-  await realtimeService
-    .publish(
-      inboxRoom(organizationId, args.inboxId),
-      'thread:deleted',
-      { threadId: args.threadId },
-      options
-    )
-    .catch(() => {})
+  await publishMailThreadEvent(
+    realtimeService,
+    organizationId,
+    args,
+    { event: 'thread:deleted', data: { threadId: args.threadId } },
+    options
+  )
 }
 
-/** Publish `message:created` on the inbox channel. */
+/**
+ * Publish `message:created` on the thread's inbox channels. Messages are
+ * invisible below `subject`, so the `metadata` variant is skipped (§6.2).
+ */
 export async function publishMessageCreated(
   realtimeService: RealtimeService,
   organizationId: string,
-  args: { messageId: string; threadId: string; inboxId: string | null },
+  args: { messageId: string; threadId: string; inboxId: string | null; assigneeId?: string | null },
   options?: MailPublishOptions
 ) {
-  await realtimeService
-    .publish(
-      inboxRoom(organizationId, args.inboxId),
-      'message:created',
-      { messageId: args.messageId, threadId: args.threadId },
-      options
-    )
-    .catch(() => {})
+  await publishMailThreadEvent(
+    realtimeService,
+    organizationId,
+    args,
+    { event: 'message:created', data: { messageId: args.messageId, threadId: args.threadId } },
+    options
+  )
 }
 
-/** Publish `message:updated` with a partial patch on the inbox channel. */
+/**
+ * Publish `message:updated` with a partial patch on the thread's inbox
+ * channels — content fields are dropped from the `subject` variant and the
+ * event is skipped at `metadata` (§6.2).
+ */
 export async function publishMessageUpdated(
   realtimeService: RealtimeService,
   organizationId: string,
@@ -256,70 +375,80 @@ export async function publishMessageUpdated(
     messageId: string
     threadId: string
     inboxId: string | null
+    assigneeId?: string | null
     patch: Partial<MessageMeta>
   },
   options?: MailPublishOptions
 ) {
-  await realtimeService
-    .publish(
-      inboxRoom(organizationId, args.inboxId),
-      'message:updated',
-      {
+  await publishMailThreadEvent(
+    realtimeService,
+    organizationId,
+    args,
+    {
+      event: 'message:updated',
+      data: {
         messageId: args.messageId,
         threadId: args.threadId,
         patch: { id: args.messageId, threadId: args.threadId, ...args.patch },
       },
-      options
-    )
-    .catch(() => {})
+    },
+    options
+  )
 }
 
-/** Publish `message:deleted` on the inbox channel. */
+/** Publish `message:deleted` on the thread's inbox channels (`subject`+). */
 export async function publishMessageDeleted(
   realtimeService: RealtimeService,
   organizationId: string,
-  args: { messageId: string; threadId: string; inboxId: string | null },
+  args: { messageId: string; threadId: string; inboxId: string | null; assigneeId?: string | null },
   options?: MailPublishOptions
 ) {
-  await realtimeService
-    .publish(
-      inboxRoom(organizationId, args.inboxId),
-      'message:deleted',
-      { messageId: args.messageId, threadId: args.threadId },
-      options
-    )
-    .catch(() => {})
+  await publishMailThreadEvent(
+    realtimeService,
+    organizationId,
+    args,
+    { event: 'message:deleted', data: { messageId: args.messageId, threadId: args.threadId } },
+    options
+  )
 }
 
 /**
- * Publish `participant:updated` on the org channel. Participants aren't
- * inbox-scoped (a contact can be on threads across many inboxes) so this
- * stays org-wide for v1.
+ * Publish `participant:updated` on the triggering thread's inbox channels
+ * (all lens variants — participants are metadata-tier). Moved off the
+ * org-wide channel in mail-permissions Phase 3 so members with no access to
+ * the inbox stop receiving contact-activity signals. `inboxId` undefined /
+ * null routes to the admin-only `none` channel.
  */
 export async function publishParticipantUpdated(
   realtimeService: RealtimeService,
   organizationId: string,
-  args: { participantId: string; patch: Partial<ParticipantMeta> },
+  args: { participantId: string; patch: Partial<ParticipantMeta>; inboxId?: string | null },
   options?: MailPublishOptions
 ) {
-  await realtimeService
-    .publish(
-      rooms.orgPresence(organizationId),
-      'participant:updated',
-      {
-        participantId: args.participantId,
-        patch: { id: args.participantId, ...args.patch },
-      },
-      options
+  const payload = {
+    participantId: args.participantId,
+    patch: { id: args.participantId, ...args.patch },
+  }
+  const inboxId = args.inboxId ?? null
+  const lenses = inboxId === null ? (['full'] as const) : CHANNEL_LENSES
+  await Promise.allSettled(
+    lenses.map((lens) =>
+      realtimeService.publish(
+        rooms.orgInbox(organizationId, inboxId ?? 'none', lens),
+        'participant:updated',
+        payload,
+        options
+      )
     )
-    .catch(() => {})
+  )
 }
 
 /**
- * Signal the end of a server-side sync cycle that touched a given inbox. The
- * client listens and invalidates `thread.listIds` for the inbox — per-message
- * events are suppressed during sync to avoid the realtime → getByIds fan-out
- * that trips the tRPC mutation rate limit.
+ * Signal the end of a server-side sync cycle that touched a given inbox — on
+ * every lens variant (it carries no content; every viewer refreshes their
+ * redacted list). The client invalidates `thread.listIds` on receipt;
+ * per-message events are suppressed during sync to avoid the realtime →
+ * getByIds fan-out that trips the tRPC mutation rate limit.
  */
 export async function publishInboxSyncCompleted(
   realtimeService: RealtimeService,
@@ -327,24 +456,30 @@ export async function publishInboxSyncCompleted(
   args: { inboxId: string | null },
   options?: MailPublishOptions
 ) {
-  await realtimeService
-    .publish(
-      inboxRoom(organizationId, args.inboxId),
-      'inbox:syncCompleted',
-      { inboxId: args.inboxId },
-      options
+  const lenses = args.inboxId === null ? (['full'] as const) : CHANNEL_LENSES
+  await Promise.allSettled(
+    lenses.map((lens) =>
+      realtimeService.publish(
+        rooms.orgInbox(organizationId, args.inboxId ?? 'none', lens),
+        'inbox:syncCompleted',
+        { inboxId: args.inboxId },
+        options
+      )
     )
-    .catch(() => {})
+  )
 }
 
 /**
- * Flush a list of mail events as one or more `mail:batch` frames on the inbox
- * channel. Used by ingest's initial-sync / polling-sync paths to coalesce
- * many events into a small number of frames. Events are chunked at
- * `CHUNK_SIZE` (50) per frame to stay under Pusher's 10KB limit.
+ * Flush a list of mail events as one or more `mail:batch` frames per inbox
+ * lens channel. Used by ingest's initial-sync / polling-sync paths to
+ * coalesce many events into a small number of frames. Each event is shaped
+ * per lens (§6.2) before chunking at `CHUNK_SIZE` (50) per frame to stay
+ * under Pusher's 10KB limit.
  *
  * Events of mixed inboxId may be passed — they are bucketed and flushed per
- * inbox. Use `inboxId = null` for triage (unassigned).
+ * inbox. Use `inboxId = null` for triage (admin-only `none` channel, `full`
+ * variant only). No per-user grantee fanout here — batch flushes are backfill
+ * traffic; grantees recover via list refetch (accepted Phase 3 gap).
  */
 export async function flushMailBatch(
   realtimeService: RealtimeService,
@@ -354,19 +489,26 @@ export async function flushMailBatch(
 ) {
   if (events.length === 0) return
 
-  const buckets = new Map<string, MailSyncEvent[]>()
+  const buckets = new Map<string | null, MailSyncEvent[]>()
   for (const { inboxId, event } of events) {
-    const slug = inboxId ?? 'none'
-    if (!buckets.has(slug)) buckets.set(slug, [])
-    buckets.get(slug)!.push(event)
+    const key = inboxId ?? null
+    if (!buckets.has(key)) buckets.set(key, [])
+    buckets.get(key)!.push(event)
   }
 
   const promises: Promise<boolean>[] = []
-  for (const [slug, list] of buckets) {
-    const roomKey = rooms.orgInbox(organizationId, slug)
-    for (let i = 0; i < list.length; i += CHUNK_SIZE) {
-      const chunk = list.slice(i, i + CHUNK_SIZE)
-      promises.push(realtimeService.publish(roomKey, 'mail:batch', { events: chunk }, options))
+  for (const [inboxId, list] of buckets) {
+    const lenses = inboxId === null ? (['full'] as const) : CHANNEL_LENSES
+    for (const lens of lenses) {
+      const shaped = list
+        .map((event) => shapeMailEventForLens(event, lens))
+        .filter((event): event is MailSyncEvent => event !== null)
+      if (shaped.length === 0) continue
+      const roomKey = rooms.orgInbox(organizationId, inboxId ?? 'none', lens)
+      for (let i = 0; i < shaped.length; i += CHUNK_SIZE) {
+        const chunk = shaped.slice(i, i + CHUNK_SIZE)
+        promises.push(realtimeService.publish(roomKey, 'mail:batch', { events: chunk }, options))
+      }
     }
   }
   await Promise.allSettled(promises)

--- a/packages/lib/src/realtime/room-keys.ts
+++ b/packages/lib/src/realtime/room-keys.ts
@@ -21,15 +21,48 @@
  */
 export type RoomKind = 'plain' | 'presence' | 'public'
 
+/**
+ * The lens variants an inbox channel is published at (mail-permissions §6.1).
+ * `none` has no channel — a `none` viewer simply isn't subscribed. The
+ * residual null-inbox (`'none'` slug) channel only exists at `full` and is
+ * admin-only.
+ */
+export type ChannelLens = 'metadata' | 'subject' | 'full'
+
+/** All inbox channel lens variants, ascending. */
+export const CHANNEL_LENSES: readonly ChannelLens[] = ['metadata', 'subject', 'full']
+
+const INBOX_ROOM_RE = /^org-(.+)-inbox-(.+)-(metadata|subject|full)$/
+
+/** Parsed shape of a per-lens inbox room key. */
+export interface InboxRoomKey {
+  organizationId: string
+  /** Raw inbox UUID, or `'none'` for residual null-inbox threads. */
+  inboxSlug: string
+  lens: ChannelLens
+}
+
+/** Parse `org-{org}-inbox-{slug}-{lens}` into its parts, or null. */
+export function parseInboxRoomKey(roomKey: string): InboxRoomKey | null {
+  const match = INBOX_ROOM_RE.exec(roomKey)
+  if (!match) return null
+  return { organizationId: match[1], inboxSlug: match[2], lens: match[3] as ChannelLens }
+}
+
 /** Typed helpers to build room keys. Mirrored on `rooms` for server callers. */
 export const rooms = {
   /** Org-wide events (records, agents, mail batches outside an inbox). */
   orgEvents: (organizationId: string): string => `org-${organizationId}-events`,
   /** Org presence room (member online/idle). */
   orgPresence: (organizationId: string): string => `org-${organizationId}`,
-  /** Per-inbox channel. `inboxSlug` is the raw inbox UUID, or `'none'` for triage. */
-  orgInbox: (organizationId: string, inboxSlug: string): string =>
-    `org-${organizationId}-inbox-${inboxSlug}`,
+  /**
+   * Per-inbox per-lens channel (mail-permissions §6.1). `inboxSlug` is the raw
+   * inbox UUID, or `'none'` for residual null-inbox threads (admin-only,
+   * published at `full` only). Viewers subscribe to exactly their own lens
+   * variant; the server publishes a redacted payload per variant.
+   */
+  orgInbox: (organizationId: string, inboxSlug: string, lens: ChannelLens): string =>
+    `org-${organizationId}-inbox-${inboxSlug}-${lens}`,
   /** Private per-user channel (notifications, personal events). */
   user: (userId: string): string => `user-${userId}`,
   /** Per-chat-thread admin channel. */

--- a/packages/lib/src/realtime/rooms.ts
+++ b/packages/lib/src/realtime/rooms.ts
@@ -12,14 +12,20 @@
  */
 
 import { database, Thread } from '@auxx/database'
-import { toRecordId } from '@auxx/types/resource'
 import { eq } from 'drizzle-orm'
-import { InboxService } from '../inboxes'
 import { findMemberByUser } from '../members'
-import { fromPusherChannel, type RoomKind, toPusherChannel } from './room-keys'
+import { getThreadLens, inboxLensFor, satisfiesLens } from '../permissions/visibility'
+import { fromPusherChannel, parseInboxRoomKey, type RoomKind, toPusherChannel } from './room-keys'
 
-export type { RoomKind } from './room-keys'
-export { fromPusherChannel, roomKindFor, rooms, toPusherChannel } from './room-keys'
+export type { ChannelLens, RoomKind } from './room-keys'
+export {
+  CHANNEL_LENSES,
+  fromPusherChannel,
+  parseInboxRoomKey,
+  roomKindFor,
+  rooms,
+  toPusherChannel,
+} from './room-keys'
 
 /**
  * Authorization context handed to every `authorize(...)` call.
@@ -78,39 +84,35 @@ async function getThreadOrgId(threadId: string): Promise<string | null> {
  * (`-inbox-`, `-events`) must come before the generic `org-` presence room.
  */
 const REGISTRY: RoomDef[] = [
-  // Per-inbox channel: `org-{orgId}-inbox-{inboxSlug}`
+  // Per-inbox per-lens channel: `org-{orgId}-inbox-{inboxSlug}-{lens}`
+  //
+  // Auth reads the cached `userMailVisibility` (mail-permissions §6.1): allow
+  // iff the caller's lens on that inbox satisfies the channel's lens. Fails
+  // CLOSED on every error — no dev bypass; a mis-scoped subscription would
+  // stream redacted-tier data to the wrong viewer.
   {
     kind: 'plain',
     match: (k) => /^org-.+-inbox-.+$/.test(k),
     authorize: async (key, ctx) => {
-      const parts = key.split('-inbox-')
-      if (parts.length !== 2) return false
-      const orgId = parts[0].replace(/^org-/, '')
-      const inboxSlug = parts[1]
-      if (!(await isOrgMember(orgId, ctx))) return false
-      // `none` (residual null-inbox threads) is admin-only — the read path
-      // treats those threads as admin+assignee only (mail-permissions
-      // decision #2), so broadcasting their subjects org-wide would leak.
-      // Phase 3 renames the channel; this flip aligns Phase 2.
-      if (inboxSlug === 'none') {
-        try {
-          const { getOrgCache } = await import('../cache')
-          const roleMap = await getOrgCache().get(orgId, 'memberRoleMap')
-          const role = roleMap[ctx.session!.userId]
-          return role === 'OWNER' || role === 'ADMIN'
-        } catch {
-          return DEV
-        }
-      }
+      if (!ctx.session) return false
+      // Un-suffixed legacy keys don't parse and never authorize.
+      const parsed = parseInboxRoomKey(key)
+      if (!parsed) return false
+      const { organizationId: orgId, inboxSlug, lens } = parsed
       try {
-        const inboxService = new InboxService(database, orgId, ctx.session!.userId)
-        const allowed = await inboxService.hasUserAccess(
-          toRecordId('inbox', inboxSlug),
-          ctx.session!.userId
-        )
-        return allowed || DEV
+        const { getCachedUserMailVisibility, getOrgCache } = await import('../cache')
+        const roleMap = await getOrgCache().get(orgId, 'memberRoleMap')
+        if (!roleMap[ctx.session.userId]) return false
+        const viewer = await getCachedUserMailVisibility(ctx.session.userId, orgId)
+        // `none` (residual null-inbox threads) is admin-only — the read path
+        // treats those threads as admin+assignee only (decision #2), so
+        // broadcasting their subjects org-wide would leak. Published at
+        // `full` only.
+        if (inboxSlug === 'none') return viewer.isAdmin
+        const myLens = inboxLensFor(viewer, inboxSlug)
+        return myLens !== 'none' && satisfiesLens(myLens, lens)
       } catch {
-        return DEV
+        return false
       }
     },
   },
@@ -143,19 +145,29 @@ const REGISTRY: RoomDef[] = [
   },
   // Chat thread (admin view): `thread-{threadId}`
   //
-  // Requires membership of the thread's owning org — without this any
-  // authenticated user of any org could subscribe to any thread channel.
-  // Phase 3 of the mail-permissions plan tightens this to
-  // `effectiveLens >= metadata`; org membership is the floor.
+  // Requires membership of the thread's owning org AND `effectiveLens >=
+  // metadata` on the thread (mail-permissions §6.5) — without the org check
+  // any authenticated user of any org could subscribe to any thread channel;
+  // without the lens check a `none` viewer would stream chat transcripts.
+  // Fails closed.
   {
     kind: 'plain',
     match: (k) => k.startsWith('thread-'),
     authorize: async (key, ctx) => {
       if (!ctx.session) return false
       const threadId = key.slice('thread-'.length)
-      const orgId = await getThreadOrgId(threadId)
-      if (!orgId) return DEV
-      return isOrgMember(orgId, ctx)
+      try {
+        const orgId = await getThreadOrgId(threadId)
+        if (!orgId) return false
+        const { getCachedUserMailVisibility, getOrgCache } = await import('../cache')
+        const roleMap = await getOrgCache().get(orgId, 'memberRoleMap')
+        if (!roleMap[ctx.session.userId]) return false
+        const viewer = await getCachedUserMailVisibility(ctx.session.userId, orgId)
+        const lens = await getThreadLens(database, orgId, viewer, threadId)
+        return satisfiesLens(lens, 'metadata')
+      } catch {
+        return false
+      }
     },
   },
   // Visitor chat session (widget-side): `chat-{sessionId}`.

--- a/packages/lib/src/threads/thread-mutation.service.ts
+++ b/packages/lib/src/threads/thread-mutation.service.ts
@@ -259,7 +259,11 @@ export class ThreadMutationService {
         .where(
           and(eq(schema.Thread.id, threadId), eq(schema.Thread.organizationId, this.organizationId))
         )
-        .returning({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
+        .returning({
+          id: schema.Thread.id,
+          inboxId: schema.Thread.inboxId,
+          assigneeId: schema.Thread.assigneeId,
+        })
 
       if (result.length === 0) {
         throw new Error(`Thread ${threadId} not found`)
@@ -291,6 +295,7 @@ export class ThreadMutationService {
             threadId,
             inboxId: result[0].inboxId ?? null,
             previousInboxId: previous?.inboxId ?? null,
+            assigneeId: result[0].assigneeId ?? null,
             patch,
           },
           { excludeSocketId: this.socketId }
@@ -560,7 +565,11 @@ export class ThreadMutationService {
             eq(schema.Thread.organizationId, this.organizationId)
           )
         )
-        .returning({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
+        .returning({
+          id: schema.Thread.id,
+          inboxId: schema.Thread.inboxId,
+          assigneeId: schema.Thread.assigneeId,
+        })
 
       const patch: Partial<ThreadMeta> = {}
       if ('status' in dbUpdates) patch.status = dbUpdates.status
@@ -587,6 +596,7 @@ export class ThreadMutationService {
                 threadId: row.id,
                 inboxId: row.inboxId ?? null,
                 previousInboxId: prevInboxIdById.get(row.id) ?? null,
+                assigneeId: row.assigneeId ?? null,
                 patch,
               },
               { excludeSocketId: this.socketId }
@@ -976,7 +986,11 @@ export class ThreadMutationService {
         .where(
           and(eq(schema.Thread.id, threadId), eq(schema.Thread.organizationId, this.organizationId))
         )
-        .returning({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
+        .returning({
+          id: schema.Thread.id,
+          inboxId: schema.Thread.inboxId,
+          assigneeId: schema.Thread.assigneeId,
+        })
 
       if (result.length === 0) {
         logger.error('Thread not found for permanent deletion.', { threadId })
@@ -986,7 +1000,11 @@ export class ThreadMutationService {
       await publishThreadDeleted(
         getRealtimeService(),
         this.organizationId,
-        { threadId, inboxId: result[0].inboxId ?? null },
+        {
+          threadId,
+          inboxId: result[0].inboxId ?? null,
+          assigneeId: result[0].assigneeId ?? null,
+        },
         { excludeSocketId: this.socketId }
       )
       await this.markCountsStale()
@@ -1025,7 +1043,11 @@ export class ThreadMutationService {
             eq(schema.Thread.organizationId, this.organizationId)
           )
         )
-        .returning({ id: schema.Thread.id, inboxId: schema.Thread.inboxId })
+        .returning({
+          id: schema.Thread.id,
+          inboxId: schema.Thread.inboxId,
+          assigneeId: schema.Thread.assigneeId,
+        })
 
       logger.info('Threads permanently deleted in bulk', {
         requestedCount: threadIds.length,
@@ -1038,7 +1060,7 @@ export class ThreadMutationService {
           publishThreadDeleted(
             realtime,
             this.organizationId,
-            { threadId: row.id, inboxId: row.inboxId ?? null },
+            { threadId: row.id, inboxId: row.inboxId ?? null, assigneeId: row.assigneeId ?? null },
             { excludeSocketId: this.socketId }
           )
         )

--- a/packages/lib/src/threads/unread-service.ts
+++ b/packages/lib/src/threads/unread-service.ts
@@ -208,6 +208,7 @@ export class UnreadService {
           {
             threadId: thread.id,
             inboxId: thread.inboxId ?? null,
+            assigneeId: thread.assigneeId ?? null,
             patch: { isUnread: !isRead, userId: targetUserId },
           },
           { excludeSocketId: this.socketId }


### PR DESCRIPTION
Phase 3 of `plans/mail-permissions/` (follows #1064, phases 0–2): realtime moves to per-inbox **per-lens** channels so redacted-tier viewers never receive payloads above their lens.

## What changed

**Channel topology (§6.1)**
- `rooms.orgInbox(orgId, inboxSlug, lens)` → `org-{org}-inbox-{id}-{metadata|subject|full}`. The un-suffixed channel is **removed** (lens is a required param; legacy keys fail `parseInboxRoomKey` and never authorize).
- Residual null-inbox traffic publishes to `org-{org}-inbox-none-full`, authorized to **org admins only**.

**Subscribe auth (`rooms.ts`)**
- Inbox channels: cached `memberRoleMap` (cross-org guard) + cached `userMailVisibility` + new `inboxLensFor(viewer, inboxId)` vs the channel lens (`satisfiesLens`). Replaces the live `InboxService.hasUserAccess` DB check.
- **Fails closed** — all `DEV` fallbacks removed from the inbox and chat-thread handlers (no env escape hatch, per plan).
- Chat `thread-{id}` (§6.5): org membership **and** `getThreadLens(...) ≥ metadata`.

**Publish shaping + fanout (§6.2/§6.3)**
- New pure `realtime/mail-event-shaping.ts` — `shapeMailEventForLens`: thread patches through the `redactThreadPatch` **allowlist** (empty ⇒ dropped, so per-user unread patches vanish below `full`); `message:*` dropped below `subject`; new `redactMessagePatch` **drops** content keys (never blanks them onto the FE store).
- Shared `publishMailThreadEvent`: three lens variants per inbox channel + per-user fanout — assignee gets the full payload on `user-{id}` (callers now pass `assigneeId`), thread/contact grantees resolved from the cached `mailGrantIndex` at their granted lens. The contact leg queries `ThreadParticipant` only when the org has any contact grants — zero extra queries for almost every org.
- `flushMailBatch` shapes each inner event per lens per inbox bucket (no grantee fanout on backfill batches — accepted gap, grantees recover on list refetch).
- `participant:updated` moves from the org channel to the triggering thread's inbox channels; `store-message` hoists its inboxId resolution above participant processing to thread it through.
- New `visibility:changed` event from `onCacheEvent` (after invalidation) whenever an event reshapes `userMailVisibility` — targeted user channels, or org broadcast on `broadcastUserKeys`.

**FE (§6.4)**
- New tRPC `inbox.myLenses` (viewer's lens per inbox from the cached context; two org-cache reads, no DB) + `useMyInboxLenses`; `useInboxes` items expose `myLens`.
- `useInboxChannels` takes `{slug, lens}` entries; `use-mail-sync` subscribes exactly the viewer's lens variant per inbox (nothing until the lens read lands; `none`-`full` for admins only), binds `user-{userId}` for the grantee fanout, and handles `visibility:changed` by refetching `myLenses` → the channel set re-derives and resubscribes.

## Validation
- Vitest: 12 files / 98 tests green across permissions/cache/threads/ingest/realtime, incl. new `mail-event-shaping.test.ts` (room-key round-trip with UUID-dash slugs, legacy-key rejection, per-lens shaping, empty-patch drops, batch recursion) and `redactMessagePatch`/`inboxLensFor` cases.
- Biome clean; `@auxx/lib` dist rebuilt. No `tsc` (repo rule).
- **Not live-verified** — the two-browser restricted-org walkthrough (covering phases 2+3) is the next step; checklists in `plans/mail-permissions/README.md`.

## Accepted gaps (documented in the plan README)
- ×3 publish volume on inbox events (self-hosted Sockudo; measure during live verification).
- No grantee fanout on sync-batch flushes.
- Revocation doesn't force-eject a live socket; FE resubscription on `visibility:changed` is the mechanism (per plan).