### PR TITLE
feat(mail): enterprise gate, inbox access UI, sharing surfaces, redacted rendering (phases 4-5)

### DIFF
--- a/apps/web/src/components/drawers/cards/contact-shared-with-card.tsx
+++ b/apps/web/src/components/drawers/cards/contact-shared-with-card.tsx
@@ -1,0 +1,55 @@
+// apps/web/src/components/drawers/cards/contact-shared-with-card.tsx
+'use client'
+
+import { toRecordId } from '@auxx/types/resource'
+import { useState } from 'react'
+import { useMailShare } from '~/components/mail-permissions/hooks/use-mail-share'
+import { AccessLevelsGuide } from '~/components/mail-permissions/ui/access-levels-guide'
+import { EnterpriseGate } from '~/components/mail-permissions/ui/enterprise-gate'
+import { GranteeList } from '~/components/mail-permissions/ui/grantee-list'
+import { useUser } from '~/hooks/use-user'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+
+/**
+ * ContactSharedWithCard — mail-permissions contact sharing (UI plan §4).
+ * People here can see ALL conversations this contact participates in — the
+ * widest blast radius in the visibility model, hence the load-bearing copy.
+ * Admin-managed (matching the server rule); other roles see a read-only list
+ * only when shares already exist.
+ */
+export function ContactSharedWithCard({ entityInstanceId }: DrawerTabProps) {
+  const { isAdminOrOwner } = useUser()
+  const [guideOpen, setGuideOpen] = useState(false)
+
+  // ResourceAccess keys contact grants by the fixed 'contact' slug.
+  const shareRecordId = toRecordId('contact', entityInstanceId)
+  const { grants, grant, changeLens, revoke } = useMailShare({ recordId: shareRecordId })
+
+  if (!isAdminOrOwner && grants.length === 0) return null
+
+  return (
+    <div className='space-y-2'>
+      <p className='text-muted-foreground text-xs'>
+        People here can see <span className='font-medium'>all conversations</span> this contact
+        participates in.
+      </p>
+      <EnterpriseGate className='w-full'>
+        <GranteeList
+          grants={grants}
+          onGrant={grant}
+          onChangeLens={changeLens}
+          onRevoke={revoke}
+          disabled={!isAdminOrOwner}
+          emptyHint='Not shared. Only inbox members see these conversations.'
+        />
+      </EnterpriseGate>
+      <button
+        type='button'
+        className='text-muted-foreground text-xs underline-offset-2 hover:underline'
+        onClick={() => setGuideOpen(true)}>
+        Learn about access levels
+      </button>
+      <AccessLevelsGuide open={guideOpen} onOpenChange={setGuideOpen} />
+    </div>
+  )
+}

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -73,6 +73,10 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     import('./cards/contact-external-identities-card').then((m) => ({
       default: m.ContactExternalIdentitiesCard,
     })),
+  'contact:shared-with': () =>
+    import('./cards/contact-shared-with-card').then((m) => ({
+      default: m.ContactSharedWithCard,
+    })),
 
   // ─────────────────────────────────────────────────────────────────
   // TICKET OVERVIEW CARDS

--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -1,28 +1,43 @@
 // apps/web/src/components/inbox/inbox-form.tsx
 'use client'
 
-import type { InboxVisibility } from '@auxx/lib/inboxes'
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import type { Lens, LensChoice } from '@auxx/lib/permissions/visibility/client'
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
 import { Button } from '@auxx/ui/components/button'
 import { DialogFooter } from '@auxx/ui/components/dialog'
 import { Field, FieldGroup, FieldLabel } from '@auxx/ui/components/field'
 import { Form } from '@auxx/ui/components/form'
 import { Input } from '@auxx/ui/components/input'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
-import { Label } from '@auxx/ui/components/label'
-import { RadioGroup, RadioGroupItem } from '@auxx/ui/components/radio-group'
+import { RadioGroup } from '@auxx/ui/components/radio-group'
+import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
-import { Trash2 } from 'lucide-react'
-import { type ReactNode, useEffect, useMemo, useRef } from 'react'
+import { Lock, Trash2, UsersIcon } from 'lucide-react'
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { MemberGroupFormField } from '~/components/pickers/member-group-form-picker'
+import { AccessLevelsGuide } from '~/components/mail-permissions/ui/access-levels-guide'
+import {
+  MailPermissionsUpgradeDialog,
+  useMailPermissionsGated,
+} from '~/components/mail-permissions/ui/enterprise-gate'
+import { GranteeList } from '~/components/mail-permissions/ui/grantee-list'
+import { LensSelect } from '~/components/mail-permissions/ui/lens-select'
 import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
 import { FormColorTagPicker } from '~/components/tags/ui/color-tag-picker'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useDirtyCheck } from '~/hooks/use-dirty-state'
 import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
+import { useUser } from '~/hooks/use-user'
 import { api } from '~/trpc/react'
+
+/** A grantee row as the form edits it. */
+interface FormGrant {
+  actorId: ActorId
+  choice: LensChoice
+}
 
 /** Form data for inbox form */
 interface InboxFormData {
@@ -30,10 +45,9 @@ interface InboxFormData {
   description: string
   color: string
   accessType: 'anyone' | 'restricted'
-  memberGroupSelection: {
-    memberIds: string[]
-    groupIds: string[]
-  }
+  /** The org-wide floor when accessType is 'anyone'. Restricted ⇒ floor `none`. */
+  floorLens: Exclude<Lens, 'none'>
+  grants: FormGrant[]
 }
 
 /** Props for the shell-free inbox form core. */
@@ -56,12 +70,39 @@ export interface InboxFormProps {
   header?: (ctx: { title: string }) => ReactNode
 }
 
+/** Map a stored ResourceAccess row to the form's grant shape. */
+function rowToGrant(row: {
+  granteeType: string
+  granteeId: string
+  permission: string
+  lens: string | null
+}): FormGrant {
+  return {
+    actorId: toActorId(row.granteeType === 'group' ? 'group' : 'user', row.granteeId),
+    choice:
+      row.permission === ResourcePermission.admin
+        ? 'manager'
+        : row.permission === ResourcePermission.edit
+          ? 'full'
+          : ((row.lens ?? 'full') as LensChoice),
+  }
+}
+
+/** Stable serialization of grants for dirty comparison. */
+function grantsKey(grants: FormGrant[]): string {
+  return grants
+    .map((g) => `${g.actorId}=${g.choice}`)
+    .sort()
+    .join(',')
+}
+
 /**
- * Shell-free inbox create/edit form: all hooks/state/mutations, the member/group +
- * color pickers, the access radio, the unsaved-changes guard, and the delete
- * affordance. The only host seams are the `header` slot and `onClose`/`onCancel`.
- * `inbox-dialog.tsx` wraps this in a `Dialog`; the command palette hosts it as a
- * page. Behavior is unchanged from the original dialog.
+ * Shell-free inbox create/edit form: all hooks/state/mutations, the Access
+ * section (Everyone/Restricted cards + org-wide level + grantee list, per the
+ * mail-permissions UI plan), the color picker, the unsaved-changes guard, and
+ * the delete affordance. The only host seams are the `header` slot and
+ * `onClose`/`onCancel`. `inbox-dialog.tsx` wraps this in a `Dialog`; the
+ * command palette hosts it as a page.
  */
 export function InboxForm({
   open,
@@ -79,18 +120,43 @@ export function InboxForm({
   // Extract inboxId from recordId for mutations
   const inboxId = recordId ? parseRecordId(recordId).entityInstanceId : null
 
+  const { isAdminOrOwner } = useUser()
+  const gated = useMailPermissionsGated()
+  const [upgradeOpen, setUpgradeOpen] = useState(false)
+  const [guideOpen, setGuideOpen] = useState(false)
+
   // Fetch system field values for edit mode
   const { values: fieldValues, isLoading: isLoadingValues } = useSystemValues(
     recordId,
-    ['inbox_name', 'inbox_description', 'inbox_color', 'inbox_visibility'],
+    ['inbox_name', 'inbox_description', 'inbox_color', 'inbox_visibility', 'inbox_default_lens'],
     { autoFetch: true, enabled: isEditing && !!recordId }
   )
+
+  // Existing instance grants (edit mode) — hydrated into the form, saved
+  // atomically on submit via the replace-all setInstance mutations.
+  const { data: accessRows } = api.resourceAccess.forInstance.useQuery(
+    { recordId: recordId ?? '' },
+    { enabled: isEditing && !!recordId }
+  )
+
+  // Managers (inbox `admin` grantees) may manage access without being org
+  // admins (delegation). Everyone else sees the form without the Access section.
+  const { data: myAccess } = api.resourceAccess.check.useQuery(
+    { recordId: recordId ?? '' },
+    { enabled: isEditing && !!recordId && !isAdminOrOwner }
+  )
+  const canManageAccess =
+    !isEditing || isAdminOrOwner || myAccess?.permission === ResourcePermission.admin
 
   // Save system values with optimistic updates
   const { save: saveSystemValues, isPending: isSavingValues } = useSaveSystemValues(recordId)
 
   // Track if form has been initialized this open cycle
   const isInitialized = useRef(false)
+  // The floor as loaded — `inbox_default_lens` is only written when it changed
+  // (writing it requires manage rights + the enterprise gate below `full`).
+  const initialLensRef = useRef<Lens | null>(null)
+  const initialGrantsRef = useRef<string>('')
 
   // Form setup
   const form = useForm<InboxFormData>({
@@ -99,13 +165,16 @@ export function InboxForm({
       description: '',
       color: 'indigo',
       accessType: 'anyone',
-      memberGroupSelection: { memberIds: [], groupIds: [] },
+      floorLens: 'full',
+      grants: [],
     },
   })
 
   // Watch form values
   const colorValue = form.watch('color')
   const accessType = form.watch('accessType')
+  const floorLens = form.watch('floorLens')
+  const grants = form.watch('grants')
 
   // Combined form values for dirty checking
   // biome-ignore lint/correctness/useExhaustiveDependencies: form.watch values are intentionally used as dependencies for dirty checking
@@ -115,8 +184,10 @@ export function InboxForm({
       description: form.watch('description'),
       color: colorValue,
       accessType,
+      floorLens,
+      grants: grantsKey(grants ?? []),
     }),
-    [form.watch('name'), form.watch('description'), colorValue, accessType]
+    [form.watch('name'), form.watch('description'), colorValue, accessType, floorLens, grants]
   )
 
   // Track dirty state for unsaved changes warning
@@ -137,48 +208,65 @@ export function InboxForm({
       if (isInitialized.current) return
 
       if (isEditing && recordId) {
-        // In edit mode, wait for values to load (inbox_name is required)
+        // In edit mode, wait for values + grants to load (inbox_name is required)
         if (isLoadingValues || fieldValues.inbox_name === undefined) return
+        if (accessRows === undefined) return
 
         isInitialized.current = true
 
         const name = (fieldValues.inbox_name as string) ?? ''
         const description = (fieldValues.inbox_description as string) ?? ''
         const color = (fieldValues.inbox_color as string) ?? 'indigo'
+        // Pre-migration rows may lack the lens value — fall back to the legacy
+        // visibility field's equivalent floor.
         const visibility = fieldValues.inbox_visibility ?? 'org_members'
-        const accessType = visibility === 'org_members' ? 'anyone' : 'restricted'
+        const storedLens =
+          (fieldValues.inbox_default_lens as Lens | undefined) ??
+          (visibility === 'org_members' ? 'full' : 'none')
+        const accessType = storedLens === 'none' ? 'restricted' : 'anyone'
+        const floorLens = storedLens === 'none' ? 'full' : storedLens
+        const grants = accessRows.map(rowToGrant)
 
-        form.reset({
+        initialLensRef.current = storedLens
+        initialGrantsRef.current = grantsKey(grants)
+
+        form.reset({ name, description, color, accessType, floorLens, grants })
+        setInitial({
           name,
           description,
           color,
           accessType,
-          memberGroupSelection: { memberIds: [], groupIds: [] },
+          floorLens,
+          grants: grantsKey(grants),
         })
-        setInitial({ name, description, color, accessType })
       } else {
         // Create mode: reset to defaults
         isInitialized.current = true
+        initialLensRef.current = null
+        initialGrantsRef.current = ''
 
         form.reset({
           name: '',
           description: '',
           color: 'indigo',
           accessType: 'anyone',
-          memberGroupSelection: { memberIds: [], groupIds: [] },
+          floorLens: 'full',
+          grants: [],
         })
         setInitial({
           name: '',
           description: '',
           color: 'indigo',
           accessType: 'anyone',
+          floorLens: 'full',
+          grants: '',
         })
       }
     } else {
       // Reset flag when dialog closes
       isInitialized.current = false
     }
-  }, [open, isEditing, recordId, fieldValues, isLoadingValues, form, setInitial])
+  }, [open, isEditing, recordId, fieldValues, isLoadingValues, accessRows, form, setInitial])
 
   // Get tRPC utils for cache invalidation
   const utils = api.useUtils()
@@ -186,21 +274,30 @@ export function InboxForm({
   // Confirmation dialog for delete
   const [confirm, ConfirmDeleteDialog] = useConfirm()
 
-  /** Invalidate both inbox query caches (tRPC getAll + entity system listAll) */
+  /** Invalidate inbox query caches + the viewer's lens map + grant rows. */
   const invalidateInboxes = () => {
     utils.inbox.getAll.invalidate()
+    utils.inbox.myLenses.invalidate()
     utils.record.listAll.invalidate({ entityDefinitionId: 'inbox' })
+    if (recordId) utils.resourceAccess.forInstance.invalidate({ recordId })
   }
 
   // Create inbox mutation
   const createInbox = api.inbox.create.useMutation({
-    onSuccess: (data) => {
-      invalidateInboxes()
-      onClose()
-      onSuccess?.({ id: data.id, name: data.name, recordId: toRecordId('inbox', data.id) })
-    },
     onError: (error) => {
       toastError({ title: 'Error creating inbox', description: error.message })
+    },
+  })
+
+  // Grant mutations — additive on create, replace-all on edit.
+  const grantInstance = api.resourceAccess.grantInstance.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Error saving access', description: error.message })
+    },
+  })
+  const setInstance = api.resourceAccess.setInstance.useMutation({
+    onError: (error) => {
+      toastError({ title: 'Error saving access', description: error.message })
     },
   })
 
@@ -215,7 +312,12 @@ export function InboxForm({
     },
   })
 
-  const isPending = createInbox.isPending || isSavingValues || deleteInbox.isPending
+  const isPending =
+    createInbox.isPending ||
+    isSavingValues ||
+    deleteInbox.isPending ||
+    grantInstance.isPending ||
+    setInstance.isPending
 
   // Form validation
   const isValid = (form.watch('name') ?? '').trim().length > 0
@@ -224,6 +326,39 @@ export function InboxForm({
   const handleColorChange = (color: string) => {
     form.setValue('color', color)
   }
+
+  const handleAccessTypeChange = (value: string) => {
+    // Restricted means floor `none` — enterprise-gated like every sub-full floor.
+    if (value === 'restricted' && gated && initialLensRef.current !== 'none') {
+      setUpgradeOpen(true)
+      return
+    }
+    form.setValue('accessType', value as 'anyone' | 'restricted')
+  }
+
+  const updateGrant = (actorId: ActorId, choice: LensChoice) => {
+    const current = form.getValues('grants') ?? []
+    const rest = current.filter((g) => g.actorId !== actorId)
+    form.setValue('grants', [...rest, { actorId, choice }])
+  }
+
+  const removeGrant = (actorId: ActorId) => {
+    const current = form.getValues('grants') ?? []
+    form.setValue(
+      'grants',
+      current.filter((g) => g.actorId !== actorId)
+    )
+  }
+
+  /** The setInstance payload for one grantee type. */
+  const grantsPayload = (allGrants: FormGrant[], type: 'user' | 'group') =>
+    allGrants
+      .filter((g) => parseActorId(g.actorId).type === type)
+      .map((g) => ({
+        granteeId: parseActorId(g.actorId).id,
+        permission: g.choice === 'manager' ? ResourcePermission.admin : ResourcePermission.view,
+        lens: g.choice === 'manager' ? undefined : g.choice,
+      }))
 
   // Handle delete with confirmation
   const handleDelete = async () => {
@@ -247,33 +382,75 @@ export function InboxForm({
   const handleSubmit = async (data: InboxFormData) => {
     if (!isValid) return
 
-    const visibility: InboxVisibility = data.accessType === 'anyone' ? 'org_members' : 'custom'
+    const targetLens: Lens = data.accessType === 'anyone' ? data.floorLens : 'none'
+    const legacyVisibility = data.accessType === 'anyone' ? 'org_members' : 'custom'
 
     if (isEditing && recordId) {
-      // Save field values with optimistic updates
-      const success = await saveSystemValues({
+      const values: Record<string, unknown> = {
         inbox_name: data.name.trim(),
         inbox_description: data.description,
         inbox_color: data.color,
-        inbox_visibility: visibility,
-      })
+        inbox_visibility: legacyVisibility,
+      }
+      // Only write the floor when it changed — the write is guarded server-side
+      // (managers only; sub-full floors are enterprise).
+      if (targetLens !== initialLensRef.current) values.inbox_default_lens = targetLens
 
-      if (success) {
-        // Field-value mutations don't invalidate inbox query caches, so picker
-        // rows and badges stay stale until the React Query staleTime expires.
-        // Flush both here so every caller gets fresh data.
+      const success = await saveSystemValues(values)
+      if (!success) return
+
+      if (canManageAccess && grantsKey(data.grants) !== initialGrantsRef.current) {
+        try {
+          await setInstance.mutateAsync({
+            recordId,
+            granteeType: ResourceGranteeType.user,
+            grants: grantsPayload(data.grants, 'user'),
+          })
+          await setInstance.mutateAsync({
+            recordId,
+            granteeType: ResourceGranteeType.group,
+            grants: grantsPayload(data.grants, 'group'),
+          })
+        } catch {
+          return // toast shown by the mutation; keep the form open
+        }
+      }
+
+      // Field-value mutations don't invalidate inbox query caches, so picker
+      // rows and badges stay stale until the React Query staleTime expires.
+      // Flush both here so every caller gets fresh data.
+      invalidateInboxes()
+      onClose()
+      onSuccess?.({ id: inboxId!, name: data.name, recordId })
+    } else {
+      try {
+        const created = await createInbox.mutateAsync({
+          name: data.name.trim(),
+          description: data.description,
+          color: data.color,
+          status: 'ACTIVE',
+          visibility: legacyVisibility,
+          defaultLens: targetLens,
+        })
+        // Additive grants — the server already added the creator's Manager row.
+        const createdRecordId = toRecordId('inbox', created.id)
+        for (const grant of data.grants) {
+          const { type, id } = parseActorId(grant.actorId)
+          await grantInstance.mutateAsync({
+            recordId: createdRecordId,
+            granteeType: type === 'group' ? ResourceGranteeType.group : ResourceGranteeType.user,
+            granteeId: id,
+            permission:
+              grant.choice === 'manager' ? ResourcePermission.admin : ResourcePermission.view,
+            lens: grant.choice === 'manager' ? undefined : grant.choice,
+          })
+        }
         invalidateInboxes()
         onClose()
-        onSuccess?.({ id: inboxId!, name: data.name, recordId })
+        onSuccess?.({ id: created.id, name: created.name, recordId: createdRecordId })
+      } catch {
+        // toasts shown by the mutations; keep the form open
       }
-    } else {
-      createInbox.mutate({
-        name: data.name.trim(),
-        description: data.description,
-        color: data.color,
-        status: 'ACTIVE',
-        visibility,
-      })
     }
   }
 
@@ -314,40 +491,67 @@ export function InboxForm({
               <FormColorTagPicker value={colorValue} onChange={handleColorChange} />
             </Field>
 
-            {/* Access fields */}
-            <Field>
-              <FieldLabel>Access</FieldLabel>
-              <RadioGroup
-                value={accessType}
-                onValueChange={(value) =>
-                  form.setValue('accessType', value as 'anyone' | 'restricted')
-                }
-                className='mt-2 flex flex-col space-y-2'>
-                <div className='flex items-center space-x-2'>
-                  <RadioGroupItem value='anyone' id='anyone' />
-                  <Label htmlFor='anyone' className='cursor-pointer'>
-                    Anyone in the organization
-                  </Label>
-                </div>
-                <div className='flex items-center space-x-2'>
-                  <RadioGroupItem value='restricted' id='restricted' />
-                  <Label htmlFor='restricted' className='cursor-pointer'>
-                    Restricted
-                  </Label>
-                </div>
-              </RadioGroup>
-            </Field>
+            {/* Access section — org admins and inbox Managers only */}
+            {canManageAccess && (
+              <>
+                <Field>
+                  <FieldLabel>Access</FieldLabel>
+                  <RadioGroup
+                    value={accessType}
+                    onValueChange={handleAccessTypeChange}
+                    className='grid gap-2 sm:grid-cols-2'>
+                    <RadioGroupItemCard
+                      value='anyone'
+                      label='Everyone'
+                      icon={<UsersIcon />}
+                      description='Everyone in the organization, at a chosen level'
+                    />
+                    <RadioGroupItemCard
+                      value='restricted'
+                      label='Restricted'
+                      icon={<Lock />}
+                      description='Only people and groups you add below'
+                    />
+                  </RadioGroup>
+                </Field>
 
-            {accessType === 'restricted' && (
-              <div className='pl-6'>
-                <MemberGroupFormField
-                  name='memberGroupSelection'
-                  control={form.control}
-                  label='Select members or groups with access'
-                  description='Only selected members and groups will have access to this inbox'
-                  disabled={isPending}
-                />
-              </div>
+                {accessType === 'anyone' && (
+                  <Field>
+                    <FieldLabel>Everyone can see</FieldLabel>
+                    <LensSelect
+                      value={floorLens}
+                      onChange={(choice) =>
+                        choice !== 'manager' && form.setValue('floorLens', choice)
+                      }
+                      size='default'
+                      className='w-full'
+                    />
+                  </Field>
+                )}
+
+                <Field>
+                  <FieldLabel>People &amp; groups</FieldLabel>
+                  <GranteeList
+                    grants={grants ?? []}
+                    onGrant={updateGrant}
+                    onChangeLens={updateGrant}
+                    onRevoke={removeGrant}
+                    includeManager
+                    disabled={isPending}
+                    emptyHint={
+                      accessType === 'restricted'
+                        ? 'No one has access yet. Add people or groups.'
+                        : 'No individual access — everyone uses the level above.'
+                    }
+                  />
+                  <button
+                    type='button'
+                    className='mt-1 self-start text-muted-foreground text-xs underline-offset-2 hover:underline'
+                    onClick={() => setGuideOpen(true)}>
+                    Learn about access levels
+                  </button>
+                </Field>
+              </>
             )}
           </FieldGroup>
 
@@ -391,6 +595,8 @@ export function InboxForm({
 
       <ConfirmDialog />
       <ConfirmDeleteDialog />
+      <MailPermissionsUpgradeDialog open={upgradeOpen} onOpenChange={setUpgradeOpen} />
+      <AccessLevelsGuide open={guideOpen} onOpenChange={setGuideOpen} />
     </>
   )
 }

--- a/apps/web/src/components/mail-permissions/hooks/use-mail-share.ts
+++ b/apps/web/src/components/mail-permissions/hooks/use-mail-share.ts
@@ -1,0 +1,150 @@
+// apps/web/src/components/mail-permissions/hooks/use-mail-share.ts
+'use client'
+
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import type { LensChoice } from '@auxx/lib/permissions/visibility/client'
+import type { ResourceAccessInfo } from '@auxx/lib/resource-access'
+import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
+import { toastError } from '@auxx/ui/components/toast'
+import { useMemo } from 'react'
+import { api } from '~/trpc/react'
+
+export interface MailShareGrant {
+  actorId: ActorId
+  choice: LensChoice
+}
+
+/**
+ * Sharing state + mutations for one mail record (`inbox:<id>`, `thread:<id>`,
+ * or `<contactDefId>:<id>`): the lens-aware grants keyed by actor, and
+ * optimistic grant / change / revoke over `resourceAccess.*`. Shared by the
+ * thread popover, the contact card, and the inbox Access section.
+ */
+export function useMailShare({
+  recordId,
+  enabled = true,
+}: {
+  recordId: string
+  enabled?: boolean
+}) {
+  const utils = api.useUtils()
+
+  const { data: rows = [], isLoading } = api.resourceAccess.forInstance.useQuery(
+    { recordId },
+    { enabled: enabled && !!recordId }
+  )
+
+  const invalidate = () => utils.resourceAccess.forInstance.invalidate({ recordId })
+
+  /** Optimistically rewrite the cached forInstance rows. */
+  const setRows = (updater: (rows: ResourceAccessInfo[]) => ResourceAccessInfo[]) => {
+    utils.resourceAccess.forInstance.setData({ recordId }, (prev) => updater(prev ?? []))
+  }
+
+  const grantInstance = api.resourceAccess.grantInstance.useMutation({
+    onMutate: async (input) => {
+      await utils.resourceAccess.forInstance.cancel({ recordId })
+      const previous = utils.resourceAccess.forInstance.getData({ recordId })
+      setRows((rows) => {
+        const rest = rows.filter(
+          (r) => !(r.granteeType === input.granteeType && r.granteeId === input.granteeId)
+        )
+        return [
+          {
+            id: `optimistic-${input.granteeType}-${input.granteeId}`,
+            entityDefinitionId: recordId.split(':')[0] ?? '',
+            entityInstanceId: recordId.split(':')[1] ?? null,
+            granteeType: input.granteeType,
+            granteeId: input.granteeId,
+            permission: input.permission,
+            lens: input.lens ?? null,
+            createdAt: new Date(),
+          },
+          ...rest,
+        ]
+      })
+      return { previous }
+    },
+    onError: (error, _input, context) => {
+      utils.resourceAccess.forInstance.setData({ recordId }, context?.previous)
+      toastError({ title: 'Error updating access', description: error.message })
+    },
+    onSettled: invalidate,
+  })
+
+  const revokeInstance = api.resourceAccess.revokeInstance.useMutation({
+    onMutate: async (input) => {
+      await utils.resourceAccess.forInstance.cancel({ recordId })
+      const previous = utils.resourceAccess.forInstance.getData({ recordId })
+      setRows((rows) =>
+        rows.filter(
+          (r) => !(r.granteeType === input.granteeType && r.granteeId === input.granteeId)
+        )
+      )
+      return { previous }
+    },
+    onError: (error, _input, context) => {
+      utils.resourceAccess.forInstance.setData({ recordId }, context?.previous)
+      toastError({ title: 'Error removing access', description: error.message })
+    },
+    onSettled: invalidate,
+  })
+
+  /** Grants as actor-keyed lens choices (admin permission renders as Manager). */
+  const grants = useMemo<MailShareGrant[]>(
+    () =>
+      rows
+        .filter(
+          (r) =>
+            r.granteeType === ResourceGranteeType.user ||
+            r.granteeType === ResourceGranteeType.group
+        )
+        .map((r) => ({
+          actorId: toActorId(
+            r.granteeType === ResourceGranteeType.group ? 'group' : 'user',
+            r.granteeId
+          ),
+          choice:
+            r.permission === ResourcePermission.admin || r.permission === ResourcePermission.edit
+              ? r.permission === ResourcePermission.admin
+                ? ('manager' as const)
+                : ('full' as const)
+              : ((r.lens ?? 'full') as LensChoice),
+        })),
+    [rows]
+  )
+
+  const toGrantee = (actorId: ActorId) => {
+    const { type, id } = parseActorId(actorId)
+    return {
+      granteeType: type === 'group' ? ResourceGranteeType.group : ResourceGranteeType.user,
+      granteeId: id,
+    }
+  }
+
+  /** Grant or change an actor's level (upsert semantics server-side). */
+  const grant = (actorId: ActorId, choice: LensChoice) => {
+    const { granteeType, granteeId } = toGrantee(actorId)
+    grantInstance.mutate({
+      recordId,
+      granteeType,
+      granteeId,
+      permission: choice === 'manager' ? ResourcePermission.admin : ResourcePermission.view,
+      lens: choice === 'manager' ? undefined : choice,
+    })
+  }
+
+  const revoke = (actorId: ActorId) => {
+    const { granteeType, granteeId } = toGrantee(actorId)
+    revokeInstance.mutate({ recordId, granteeType, granteeId })
+  }
+
+  return {
+    grants,
+    isLoading,
+    grant,
+    changeLens: grant,
+    revoke,
+    isMutating: grantInstance.isPending || revokeInstance.isPending,
+  }
+}

--- a/apps/web/src/components/mail-permissions/ui/access-levels-guide.tsx
+++ b/apps/web/src/components/mail-permissions/ui/access-levels-guide.tsx
@@ -1,0 +1,51 @@
+// apps/web/src/components/mail-permissions/ui/access-levels-guide.tsx
+'use client'
+
+import { GuideConcept, GuideConcepts, GuideDialog, GuideSection } from '@auxx/ui/components/guide'
+import { Activity, Eye, EyeOff, Heading, ShieldCheck } from 'lucide-react'
+
+/**
+ * "Learn about access levels" — the shared explainer linked from the inbox
+ * Access section and the thread share popover footer.
+ */
+export function AccessLevelsGuide({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <GuideDialog open={open} onOpenChange={onOpenChange} title='Access levels' size='lg'>
+      <GuideConcepts>
+        <GuideConcept glyph={<Eye className='size-4' />} term='Full access'>
+          Read and reply to conversations — message content, attachments, and unread state. Full
+          access is also what assignment gives on a single conversation.
+        </GuideConcept>
+        <GuideConcept glyph={<Heading className='size-4' />} term='Subject only'>
+          See who is talking, when, and subject lines — never message content or attachments.
+        </GuideConcept>
+        <GuideConcept glyph={<Activity className='size-4' />} term='Activity only'>
+          See that conversations exist: participants, timestamps, status, and tags — no subjects, no
+          content.
+        </GuideConcept>
+        <GuideConcept glyph={<EyeOff className='size-4' />} term='No access'>
+          Conversations are hidden entirely — they don't appear in lists, search, or counts.
+        </GuideConcept>
+        <GuideConcept glyph={<ShieldCheck className='size-4' />} term='Manager'>
+          Full access plus managing who can see the inbox — without needing to be an organization
+          admin.
+        </GuideConcept>
+      </GuideConcepts>
+      <GuideSection title='How access combines' cols={1}>
+        <GuideConcept term='Inbox default + individual shares'>
+          Every inbox sets a default level for the whole organization ("Everyone" at a level, or
+          "Restricted" for no default access). Individual shares — on the inbox, a single
+          conversation, or a contact — only ever raise someone's level, never lower it. Being
+          assigned a conversation always grants full access to it, and organization admins see
+          everything.
+        </GuideConcept>
+      </GuideSection>
+    </GuideDialog>
+  )
+}

--- a/apps/web/src/components/mail-permissions/ui/enterprise-gate.tsx
+++ b/apps/web/src/components/mail-permissions/ui/enterprise-gate.tsx
@@ -1,0 +1,78 @@
+// apps/web/src/components/mail-permissions/ui/enterprise-gate.tsx
+'use client'
+
+import { FeatureKey } from '@auxx/lib/types'
+import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
+import { Lock } from 'lucide-react'
+import type React from 'react'
+import { useState } from 'react'
+import { LimitReachedDialog } from '~/components/subscriptions/limit-reached-dialog'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+
+/** True when the org lacks the mail-permissions enterprise feature. */
+export function useMailPermissionsGated(): boolean {
+  const { hasAccess } = useFeatureFlags()
+  return !hasAccess(FeatureKey.mailPermissions)
+}
+
+/** The shared upgrade prompt for gated mail-permission controls. */
+export function MailPermissionsUpgradeDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <LimitReachedDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      icon={Lock}
+      title='Mail permissions'
+      description='Inbox access levels, conversation sharing, and manager delegation are available on the Enterprise plan.'
+    />
+  )
+}
+
+/**
+ * Tease-with-upgrade gating (UI plan decision 4): when the org lacks
+ * `FeatureKey.mailPermissions`, children render disabled with a small
+ * "Enterprise" badge, and any click opens the upgrade dialog. Never hides.
+ */
+export function EnterpriseGate({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  const gated = useMailPermissionsGated()
+  const [upgradeOpen, setUpgradeOpen] = useState(false)
+
+  if (!gated) return <>{children}</>
+
+  return (
+    <>
+      <div className={cn('relative inline-flex items-center gap-1.5', className)}>
+        <div aria-disabled className='pointer-events-none opacity-60'>
+          {children}
+        </div>
+        <Badge variant='outline' className='pointer-events-none text-[10px]'>
+          Enterprise
+        </Badge>
+        <button
+          type='button'
+          aria-label='Mail permissions — available on the Enterprise plan'
+          className='absolute inset-0 cursor-pointer'
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setUpgradeOpen(true)
+          }}
+        />
+      </div>
+      <MailPermissionsUpgradeDialog open={upgradeOpen} onOpenChange={setUpgradeOpen} />
+    </>
+  )
+}

--- a/apps/web/src/components/mail-permissions/ui/grantee-list.tsx
+++ b/apps/web/src/components/mail-permissions/ui/grantee-list.tsx
@@ -1,0 +1,114 @@
+// apps/web/src/components/mail-permissions/ui/grantee-list.tsx
+'use client'
+
+import type { LensChoice } from '@auxx/lib/permissions/visibility/client'
+import { LENS_LABELS } from '@auxx/lib/permissions/visibility/client'
+import type { ActorId } from '@auxx/types/actor'
+import { Button } from '@auxx/ui/components/button'
+import { Plus, X } from 'lucide-react'
+import { useMemo } from 'react'
+import { ActorPicker } from '~/components/pickers/actor-picker'
+import { ActorBadge } from '~/components/resources/ui/actor-badge'
+import { LensSelect } from './lens-select'
+
+export interface GranteeListProps {
+  grants: Array<{ actorId: ActorId; choice: LensChoice }>
+  onGrant: (actorId: ActorId, choice: LensChoice) => void
+  onChangeLens: (actorId: ActorId, choice: LensChoice) => void
+  onRevoke: (actorId: ActorId) => void
+  /** Renders the Manager entry in each row's picker (inbox surface only). */
+  includeManager?: boolean
+  disabled?: boolean
+  emptyHint?: string
+  /**
+   * Rows that render muted with a fixed level and no remove/change controls —
+   * the inbox creator's Manager grant, so the list never lies.
+   */
+  lockedActorIds?: ActorId[]
+}
+
+/**
+ * The reusable "who has access" list: `ActorBadge` + `LensSelect` rows with a
+ * hover-revealed remove, and an ActorPicker "+ Add" trigger. Controlled and
+ * dumb — persistence lives in the hosting surface's hook. New grantees
+ * default to Full access.
+ */
+export function GranteeList({
+  grants,
+  onGrant,
+  onChangeLens,
+  onRevoke,
+  includeManager = false,
+  disabled = false,
+  emptyHint = 'Not shared with anyone yet.',
+  lockedActorIds = [],
+}: GranteeListProps) {
+  const currentIds = useMemo(() => grants.map((g) => g.actorId), [grants])
+  const locked = useMemo(() => new Set(lockedActorIds), [lockedActorIds])
+
+  const handlePickerChange = (nextIds: ActorId[]) => {
+    const existing = new Set(currentIds)
+    for (const actorId of nextIds) {
+      if (!existing.has(actorId)) onGrant(actorId, 'full')
+    }
+  }
+
+  return (
+    <div className='space-y-1'>
+      {grants.length === 0 ? (
+        <div className='px-1 py-2 text-muted-foreground text-sm'>{emptyHint}</div>
+      ) : (
+        grants.map(({ actorId, choice }) => {
+          const isLocked = locked.has(actorId)
+          return (
+            <div
+              key={actorId}
+              className='group flex items-center justify-between gap-2 rounded-lg px-1 py-0.5'>
+              <ActorBadge actorId={actorId} className={isLocked ? 'opacity-70' : undefined} />
+              <div className='flex items-center gap-1'>
+                {isLocked ? (
+                  <span className='pr-2 text-muted-foreground text-xs'>
+                    {LENS_LABELS[choice].label}
+                  </span>
+                ) : (
+                  <>
+                    <LensSelect
+                      value={choice}
+                      onChange={(next) => onChangeLens(actorId, next)}
+                      includeManager={includeManager}
+                      disabled={disabled}
+                      size='sm'
+                      className='h-7 w-32 border-none shadow-none'
+                    />
+                    <Button
+                      variant='ghost'
+                      size='icon'
+                      className='size-6 opacity-0 group-hover:opacity-100'
+                      disabled={disabled}
+                      aria-label='Remove access'
+                      onClick={() => onRevoke(actorId)}>
+                      <X />
+                    </Button>
+                  </>
+                )}
+              </div>
+            </div>
+          )
+        })
+      )}
+
+      <ActorPicker
+        value={currentIds}
+        onChange={handlePickerChange}
+        target='both'
+        multi
+        excludeIds={currentIds}
+        disabled={disabled}>
+        <Button variant='ghost' size='sm' className='text-muted-foreground' disabled={disabled}>
+          <Plus />
+          Add people or groups
+        </Button>
+      </ActorPicker>
+    </div>
+  )
+}

--- a/apps/web/src/components/mail-permissions/ui/lens-badge.tsx
+++ b/apps/web/src/components/mail-permissions/ui/lens-badge.tsx
@@ -1,0 +1,38 @@
+// apps/web/src/components/mail-permissions/ui/lens-badge.tsx
+'use client'
+
+import { LENS_LABELS, type Lens } from '@auxx/lib/permissions/visibility/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
+import { Lock } from 'lucide-react'
+
+/**
+ * Small chip showing the viewer's own level on a thread ("Subject only" /
+ * "Activity only"). Rendered only below `full` — full access shows nothing.
+ */
+export function LensBadge({ lens, inboxName }: { lens: Lens; inboxName?: string | null }) {
+  if (lens === 'full' || lens === 'none') return null
+
+  const scope =
+    lens === 'subject'
+      ? 'You can see who, when, and subject lines in this conversation — not its content.'
+      : 'You can see activity in this conversation — not subjects or content.'
+  const hint = inboxName ? ` Ask a manager of ${inboxName} for access.` : ''
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant='outline' className='gap-1 text-muted-foreground'>
+          <Lock className='size-3' />
+          {LENS_LABELS[lens].label}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className='max-w-xs'>
+          {scope}
+          {hint}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/web/src/components/mail-permissions/ui/lens-select.tsx
+++ b/apps/web/src/components/mail-permissions/ui/lens-select.tsx
@@ -1,0 +1,98 @@
+// apps/web/src/components/mail-permissions/ui/lens-select.tsx
+'use client'
+
+import { LENS_CHOICES, LENS_LABELS, type LensChoice } from '@auxx/lib/permissions/visibility/client'
+import { Badge } from '@auxx/ui/components/badge'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { useState } from 'react'
+import { MailPermissionsUpgradeDialog, useMailPermissionsGated } from './enterprise-gate'
+
+interface LensSelectProps {
+  value: LensChoice
+  onChange: (value: LensChoice) => void
+  /** Renders the separator + Manager entry (inbox surface only). */
+  includeManager?: boolean
+  disabled?: boolean
+  size?: 'sm' | 'default'
+  className?: string
+}
+
+/**
+ * The one tier picker every mail-permission surface uses. Options below
+ * Full access (and the Manager entry) are enterprise-gated: without the
+ * feature they render with an "Enterprise" badge and selecting one opens
+ * the upgrade dialog instead of changing the value.
+ */
+export function LensSelect({
+  value,
+  onChange,
+  includeManager = false,
+  disabled = false,
+  size = 'sm',
+  className,
+}: LensSelectProps) {
+  const gated = useMailPermissionsGated()
+  const [upgradeOpen, setUpgradeOpen] = useState(false)
+
+  const handleChange = (next: string) => {
+    const choice = next as LensChoice
+    if (gated && choice !== 'full') {
+      setUpgradeOpen(true)
+      return
+    }
+    onChange(choice)
+  }
+
+  const enterpriseBadge = (
+    <Badge variant='outline' className='ml-2 px-1 text-[10px]'>
+      Enterprise
+    </Badge>
+  )
+
+  return (
+    <>
+      <Select value={value} onValueChange={handleChange} disabled={disabled}>
+        <SelectTrigger size={size} className={className}>
+          <SelectValue placeholder='Access'>{LENS_LABELS[value]?.label}</SelectValue>
+        </SelectTrigger>
+        <SelectContent align='end' className='min-w-56'>
+          {LENS_CHOICES.map((lens) => (
+            <SelectItem key={lens} value={lens} textValue={LENS_LABELS[lens].label}>
+              <div className='flex flex-col items-start'>
+                <span className='flex items-center'>
+                  {LENS_LABELS[lens].label}
+                  {gated && lens !== 'full' && enterpriseBadge}
+                </span>
+                <span className='text-muted-foreground text-xs'>{LENS_LABELS[lens].helper}</span>
+              </div>
+            </SelectItem>
+          ))}
+          {includeManager && (
+            <>
+              <SelectSeparator />
+              <SelectItem value='manager' textValue={LENS_LABELS.manager.label}>
+                <div className='flex flex-col items-start'>
+                  <span className='flex items-center'>
+                    {LENS_LABELS.manager.label}
+                    {gated && enterpriseBadge}
+                  </span>
+                  <span className='text-muted-foreground text-xs'>
+                    {LENS_LABELS.manager.helper}
+                  </span>
+                </div>
+              </SelectItem>
+            </>
+          )}
+        </SelectContent>
+      </Select>
+      <MailPermissionsUpgradeDialog open={upgradeOpen} onOpenChange={setUpgradeOpen} />
+    </>
+  )
+}

--- a/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
+++ b/apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
@@ -1,0 +1,153 @@
+// apps/web/src/components/mail-permissions/ui/thread-share-popover.tsx
+'use client'
+
+import { ResourcePermission } from '@auxx/database/enums'
+import { LENS_LABELS } from '@auxx/lib/permissions/visibility/client'
+import type { ActorId } from '@auxx/types/actor'
+import { toRecordId } from '@auxx/types/resource'
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { Button } from '@auxx/ui/components/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { Info, Share2 } from 'lucide-react'
+import { useState } from 'react'
+import { useMailShare } from '~/components/mail-permissions/hooks/use-mail-share'
+import { useActor } from '~/components/resources/hooks'
+import { useInbox, useThread } from '~/components/threads/hooks'
+import { useUser } from '~/hooks/use-user'
+import { api } from '~/trpc/react'
+import { Tooltip } from '../../global/tooltip'
+import { AccessLevelsGuide } from './access-levels-guide'
+import { EnterpriseGate, useMailPermissionsGated } from './enterprise-gate'
+import { GranteeList } from './grantee-list'
+
+/** A tiny stacked avatar for the share button's grantee cluster. */
+function MiniActorAvatar({ actorId }: { actorId: ActorId }) {
+  const { actor } = useActor({ actorId })
+  const name = actor?.name ?? '?'
+  return (
+    <Avatar className='size-5 border-2 border-background'>
+      <AvatarImage src={actor?.image || undefined} alt={name} />
+      <AvatarFallback className='text-[9px]'>
+        {name
+          .split(' ')
+          .map((n) => n[0])
+          .join('')
+          .toUpperCase()
+          .substring(0, 2)}
+      </AvatarFallback>
+    </Avatar>
+  )
+}
+
+/**
+ * Share button + popover for the thread header (UI plan §3): immediate-
+ * persistence grantee list over `use-mail-share`, with the inherited-access
+ * footer (inbox floor + assignee). Sharers are org admins and Managers of the
+ * thread's inbox; everyone else sees a read-only list (button hidden for them
+ * until the thread has explicit grants).
+ */
+export function ThreadSharePopover({ threadId }: { threadId: string }) {
+  const [open, setOpen] = useState(false)
+  const [guideOpen, setGuideOpen] = useState(false)
+
+  const { thread } = useThread({ threadId })
+  const { inbox } = useInbox(thread?.inboxId)
+  const { isAdminOrOwner } = useUser()
+  const gated = useMailPermissionsGated()
+
+  const recordId = toRecordId('thread', threadId)
+  const { grants, grant, changeLens, revoke } = useMailShare({ recordId })
+
+  // Inbox Managers may share without being org admins (delegation).
+  const { data: inboxAccess } = api.resourceAccess.check.useQuery(
+    { recordId: thread?.inboxId ?? '' },
+    { enabled: !!thread?.inboxId && !isAdminOrOwner }
+  )
+  const canShare = isAdminOrOwner || inboxAccess?.permission === ResourcePermission.admin
+
+  const { actor: assignee } = useActor({ actorId: thread?.assigneeId ?? undefined })
+
+  if (!thread) return null
+  // Non-sharers only get the read-only list once the thread has explicit grants.
+  if (!canShare && grants.length === 0) return null
+
+  const floor = inbox?.defaultLens ?? 'full'
+
+  const button = (
+    <Button variant='ghost' size='icon' className='rounded-full hover:bg-foreground/10'>
+      {grants.length > 0 ? (
+        <span className='-space-x-2 flex items-center'>
+          {grants.slice(0, 2).map(({ actorId }) => (
+            <MiniActorAvatar key={actorId} actorId={actorId} />
+          ))}
+          {grants.length > 2 && (
+            <Avatar className='size-5 border-2 border-background bg-muted'>
+              <AvatarFallback className='text-[9px]'>+{grants.length - 2}</AvatarFallback>
+            </Avatar>
+          )}
+        </span>
+      ) : (
+        <Share2 />
+      )}
+      <span className='sr-only'>Share</span>
+    </Button>
+  )
+
+  // Free-plan sharers get the tease; grantee-holders still see the list.
+  if (gated && grants.length === 0) {
+    return <EnterpriseGate>{button}</EnterpriseGate>
+  }
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <div>
+            <Tooltip content='Share'>{button}</Tooltip>
+          </div>
+        </PopoverTrigger>
+        <PopoverContent align='end' className='w-80 p-0'>
+          <div className='border-b px-3 py-2'>
+            <span className='font-medium text-sm'>Share conversation</span>
+          </div>
+          <div className='px-2 py-2'>
+            <GranteeList
+              grants={grants}
+              onGrant={grant}
+              onChangeLens={changeLens}
+              onRevoke={revoke}
+              disabled={!canShare || gated}
+              emptyHint='Not shared with anyone yet.'
+            />
+          </div>
+          <div className='space-y-1 border-t px-3 py-2 text-muted-foreground text-xs'>
+            {floor !== 'none' && inbox && (
+              <div className='flex items-center gap-1.5'>
+                <Info className='size-3 shrink-0' />
+                <span>
+                  Everyone in {inbox.name} — {LENS_LABELS[floor].label.toLowerCase()}
+                </span>
+              </div>
+            )}
+            {assignee && (
+              <div className='flex items-center gap-1.5'>
+                <Info className='size-3 shrink-0' />
+                <span>{assignee.name} (assignee) — full access</span>
+              </div>
+            )}
+            <button
+              type='button'
+              className='underline-offset-2 hover:underline'
+              onClick={() => {
+                setOpen(false)
+                setGuideOpen(true)
+              }}>
+              Learn about access levels
+            </button>
+          </div>
+        </PopoverContent>
+      </Popover>
+      <AccessLevelsGuide open={guideOpen} onOpenChange={setGuideOpen} />
+    </>
+  )
+}

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -10,7 +10,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { formatDistanceToNowStrict } from 'date-fns'
 import DOMPurify from 'dompurify'
-import { Archive, Clock, ShieldAlert, Tag, Trash2, UserRound } from 'lucide-react'
+import { Archive, Clock, Share2, ShieldAlert, Tag, Trash2, UserRound } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
 import { memo, useCallback, useMemo, useState } from 'react'
@@ -68,7 +68,12 @@ export const CompactThreadItem = memo(function CompactThreadItem({
     enabled: !!thread?.latestMessageId,
   })
   const { from: senderParticipant } = useMessageParticipants(latestMessage?.participants ?? [])
-  const { isUnread, markAsRead } = useThreadReadStatus(threadId)
+  const { isUnread: readStatusUnread, markAsRead } = useThreadReadStatus(threadId)
+
+  // Redacted rendering (mail-permissions): below `full` the row never looks
+  // unread (isUnread is full-tier); at `metadata` the subject is absent.
+  const myLens = thread?.myLens ?? 'full'
+  const isUnread = myLens === 'full' && readStatusUnread
 
   const toggleSelection = useThreadSelectionStore((s) => s.toggleSelection)
   const setActiveThread = useThreadSelectionStore((s) => s.setActiveThread)
@@ -288,11 +293,15 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                   'shrink-0 truncate text-xs',
                   isUnread ? 'text-foreground' : 'font-medium text-foreground/90',
                   hasTags ? 'max-w-[40%]' : 'max-w-[50%]',
-                  isLiveChat && 'font-semibold'
+                  isLiveChat && 'font-semibold',
+                  myLens === 'metadata' && 'font-normal text-muted-foreground italic'
                 )}>
-                {thread.subject || '(no subject)'}
+                {myLens === 'metadata' ? 'No access to subject' : thread.subject || '(no subject)'}
               </span>
               {thread.assigneeId && <AssigneeChip assigneeId={thread.assigneeId as ActorId} />}
+              {thread.hasShares && (
+                <Share2 className='size-3 shrink-0 text-muted-foreground' aria-label='Shared' />
+              )}
               {snippet && (
                 <>
                   <span className='shrink-0 text-muted-foreground/50'>—</span>

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -23,7 +23,16 @@ import { cn } from '@auxx/ui/lib/utils'
 import { useDraggable } from '@dnd-kit/core'
 import { formatDistanceToNowStrict } from 'date-fns'
 import DOMPurify from 'dompurify'
-import { Archive, Ban, Clock, MailWarning, Merge, MoreHorizontal, Trash2 } from 'lucide-react'
+import {
+  Archive,
+  Ban,
+  Clock,
+  MailWarning,
+  Merge,
+  MoreHorizontal,
+  Share2,
+  Trash2,
+} from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import type React from 'react'
 import { memo, useCallback, useMemo } from 'react'
@@ -214,7 +223,12 @@ export const MailThreadItem = memo(function MailThreadItem({
     enabled: !!thread?.latestMessageId,
   })
   const { from: senderParticipant } = useMessageParticipants(latestMessage?.participants ?? [])
-  const { isUnread, markAsRead } = useThreadReadStatus(threadId)
+  const { isUnread: readStatusUnread, markAsRead } = useThreadReadStatus(threadId)
+
+  // Redacted rendering (mail-permissions): below `full` the row never looks
+  // unread (isUnread is full-tier); at `metadata` the subject is absent.
+  const myLens = thread?.myLens ?? 'full'
+  const isUnread = myLens === 'full' && readStatusUnread
 
   // --- Selection store actions ---
   const toggleSelection = useThreadSelectionStore((s) => s.toggleSelection)
@@ -471,11 +485,17 @@ export const MailThreadItem = memo(function MailThreadItem({
                   className={cn(
                     'min-w-0 truncate text-xs font-medium group-aria-selected:text-background/80',
                     hasTags && 'max-w-[60%] shrink-0',
-                    isLiveChat && 'font-semibold'
+                    isLiveChat && 'font-semibold',
+                    myLens === 'metadata' && 'font-normal text-muted-foreground italic'
                   )}>
-                  {thread.subject || '(no subject)'}
+                  {myLens === 'metadata'
+                    ? 'No access to subject'
+                    : thread.subject || '(no subject)'}
                 </div>
                 {thread.assigneeId && <AssigneeChip assigneeId={thread.assigneeId as ActorId} />}
+                {thread.hasShares && (
+                  <Share2 className='size-3 shrink-0 text-muted-foreground' aria-label='Shared' />
+                )}
                 <div className='min-w-0 flex-1'>
                   <OverflowRow collapseSlot='text' className='justify-end' gap={4}>
                     {thread.tagIds?.map((tagId) => (

--- a/apps/web/src/components/mail/thread-details.tsx
+++ b/apps/web/src/components/mail/thread-details.tsx
@@ -185,13 +185,17 @@ export default function ThreadDetails({
     [lastMessage, from, to, cc]
   )
 
+  // Below `full` lens the viewer may not act — reply/forward affordances are
+  // hidden (the server rejects the sends anyway; the UI just doesn't offer).
+  const canReply = (thread?.myLens ?? 'full') === 'full'
+
   // Keyboard shortcuts: R to reply, F to forward the last message
   useHotkey(
     'R',
     () => {
       if (lastEditorMessage) emailActions.onReplyAll(lastEditorMessage)
     },
-    { enabled: !!thread && !isShowReplyBox && !isNested, conflictBehavior: 'allow' }
+    { enabled: !!thread && canReply && !isShowReplyBox && !isNested, conflictBehavior: 'allow' }
   )
 
   useHotkey(
@@ -199,7 +203,7 @@ export default function ThreadDetails({
     () => {
       if (lastEditorMessage) emailActions.onForward(lastEditorMessage)
     },
-    { enabled: !!thread && !isShowReplyBox && !isNested, conflictBehavior: 'allow' }
+    { enabled: !!thread && canReply && !isShowReplyBox && !isNested, conflictBehavior: 'allow' }
   )
 
   if (!thread) {
@@ -244,7 +248,7 @@ export default function ThreadDetails({
         </div>
 
         {/* Reply editor portal target — the editor renders here via portal when docked */}
-        <div ref={replyBoxRef} className=''>
+        <div ref={replyBoxRef} className={canReply ? '' : 'hidden'}>
           {thread.integrationIsExample ? (
             <div className='px-4 py-4 pb-[0px]'>
               <div className='rounded-md border border-dashed border-muted-foreground/30 bg-muted/30 px-4 py-3 text-sm text-muted-foreground'>

--- a/apps/web/src/components/mail/thread-header.tsx
+++ b/apps/web/src/components/mail/thread-header.tsx
@@ -39,6 +39,8 @@ import { ManualTriggerButton } from '~/components/workflow/manual-trigger-button
 import { useConfirm } from '~/hooks/use-confirm'
 import { EditableText } from '../editor/editable-text'
 import { Tooltip } from '../global/tooltip'
+import { LensBadge } from '../mail-permissions/ui/lens-badge'
+import { ThreadSharePopover } from '../mail-permissions/ui/thread-share-popover'
 import { ActorPicker } from '../pickers/actor-picker'
 import { InboxPicker } from '../pickers/inbox-picker'
 import { TagPicker } from '../pickers/tag-picker'
@@ -262,6 +264,7 @@ export function ThreadHeader() {
                 <RecordBadge recordId={thread?.inboxId} hoverCard={false} />
               </InboxPicker>
               <ThreadTicketControl />
+              <LensBadge lens={thread.myLens ?? 'full'} inboxName={inbox?.name} />
             </div>
             {isChatChannel && <ThreadHandoffControl />}
             <ThreadParticipantButton threadId={threadId} />
@@ -341,6 +344,8 @@ export function ThreadHeader() {
                 </Button>
               </Tooltip>
             </ManualTriggerButton>
+
+            <ThreadSharePopover threadId={thread.id} />
 
             <ActorPicker
               key={`assignee-${thread.id}`}

--- a/apps/web/src/components/mail/thread-messages.tsx
+++ b/apps/web/src/components/mail/thread-messages.tsx
@@ -4,7 +4,7 @@
 import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { Ban } from 'lucide-react'
+import { Ban, Lock } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { useChannel } from '~/components/channels/hooks/use-channels'
 import {
@@ -174,6 +174,45 @@ export function ThreadMessages() {
   })
 
   if (!thread) return null
+
+  // Redacted rendering (mail-permissions): below `full`, message content is
+  // blanked server-side. `subject` shows envelope rows under a locked-body
+  // notice; `metadata` has no messages at all — the notice is the whole pane.
+  const myLens = thread.myLens ?? 'full'
+  if (myLens !== 'full') {
+    const notice = (
+      <div className='px-4 pt-2'>
+        <Alert className='flex items-center gap-2'>
+          <Lock className='size-4 shrink-0' />
+          <AlertDescription>
+            Message content is hidden — you have{' '}
+            {myLens === 'subject' ? 'subject-only' : 'activity-only'} access to this conversation.
+          </AlertDescription>
+        </Alert>
+      </div>
+    )
+    if (myLens === 'metadata' || messages.length === 0) {
+      return <div className='flex flex-col pb-4'>{notice}</div>
+    }
+    return (
+      <div className='flex flex-col'>
+        {notice}
+        <div className='flex flex-col gap-4 px-4 py-2 opacity-80'>
+          {messages
+            .filter((m) => m.messageType === 'EMAIL')
+            .map((message) => (
+              <EmailDisplay
+                key={message.id}
+                messageId={message.id}
+                messageActions={messageActions}
+                isOpen={false}
+                isLastMessage={false}
+              />
+            ))}
+        </div>
+      </div>
+    )
+  }
 
   // Loading state
   if (isLoading && messages.length === 0) {

--- a/apps/web/src/components/threads/hooks/use-inbox.ts
+++ b/apps/web/src/components/threads/hooks/use-inbox.ts
@@ -18,6 +18,7 @@ export interface InboxRecord extends RecordMeta {
     inbox_color?: string
     inbox_status?: 'ACTIVE' | 'ARCHIVED' | 'PAUSED'
     inbox_visibility?: 'org_members' | 'private' | 'custom'
+    inbox_default_lens?: 'none' | 'metadata' | 'subject' | 'full'
   }
 }
 
@@ -32,6 +33,12 @@ export interface InboxItem {
   color?: string | null
   status?: 'ACTIVE' | 'ARCHIVED' | 'PAUSED'
   visibility?: 'org_members' | 'private' | 'custom'
+  /**
+   * The org-wide floor (`inbox_default_lens`), with the legacy `visibility`
+   * fallback for pre-migration rows. Drives the share popover's
+   * inherited-access footer and the sidebar's restricted affordance.
+   */
+  defaultLens: 'none' | 'metadata' | 'subject' | 'full'
   /**
    * The viewer's effective lens on this inbox (mail-permissions §6.4).
    * Undefined while `inbox.myLenses` is loading; never `'none'` — such
@@ -85,6 +92,12 @@ export function useInboxes(): UseInboxesResult {
       color: record.fieldValues?.inbox_color ?? null,
       status: record.fieldValues?.inbox_status,
       visibility: record.fieldValues?.inbox_visibility,
+      defaultLens:
+        record.fieldValues?.inbox_default_lens ??
+        (record.fieldValues?.inbox_visibility === 'org_members' ||
+        !record.fieldValues?.inbox_visibility
+          ? 'full'
+          : 'none'),
       myLens: lenses[record.id],
     }))
 

--- a/apps/web/src/components/threads/store/thread-store.ts
+++ b/apps/web/src/components/threads/store/thread-store.ts
@@ -95,6 +95,17 @@ export interface ThreadMeta {
    * been merged into this one.
    */
   mergeData?: ThreadMergeData | null
+
+  /**
+   * The viewer's effective lens on this thread (mail-permissions). Below
+   * `full`, subject/snippet/unread are redacted server-side — rows render
+   * placeholders and never look unread. Optional: absent on patches and
+   * pre-lens cached payloads (treat as `full`).
+   */
+  myLens?: 'metadata' | 'subject' | 'full'
+
+  /** True when the thread has explicit shares (drives the share indicator). */
+  hasShares?: boolean
 }
 
 /** Scheduled message metadata for display in thread conversation view */

--- a/apps/web/src/server/api/routers/inbox.ts
+++ b/apps/web/src/server/api/routers/inbox.ts
@@ -17,6 +17,7 @@ const createInboxSchema = z.object({
   color: z.string().optional(),
   status: z.enum(['ACTIVE', 'ARCHIVED', 'PAUSED']).optional(),
   visibility: z.enum(['org_members', 'private', 'custom']).optional(),
+  defaultLens: z.enum(['none', 'metadata', 'subject', 'full']).optional(),
   settings: z.record(z.string(), z.unknown()).optional(),
 })
 

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -3,6 +3,9 @@
 import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import type { ResourceAccessContext } from '@auxx/lib/resource-access'
 import {
+  assertCanManageMailSharing,
+  assertCanManageMailTypeAccess,
+  assertMailSharingFeature,
   checkAccess,
   checkTypeAccess,
   getInstanceAccess,
@@ -19,6 +22,9 @@ import type { RecordId } from '@auxx/types/resource'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
+
+/** Visibility lens on mail grants (mail-permissions §2.1). Optional everywhere. */
+const lensSchema = z.enum(['metadata', 'subject', 'full']).nullish()
 
 /** Convert tRPC context to ResourceAccessContext */
 function toContext(ctx: {
@@ -50,14 +56,20 @@ export const resourceAccessRouter = createTRPCRouter({
           ResourcePermission.edit,
           ResourcePermission.admin,
         ]),
+        lens: lensSchema,
       })
     )
     .mutation(async ({ ctx, input }) => {
-      await grantInstanceAccess(toContext(ctx), {
-        recordId: input.recordId as RecordId,
+      const context = toContext(ctx)
+      const recordId = input.recordId as RecordId
+      await assertCanManageMailSharing(context, recordId)
+      await assertMailSharingFeature(context, recordId, [input])
+      await grantInstanceAccess(context, {
+        recordId,
         granteeType: input.granteeType,
         granteeId: input.granteeId,
         permission: input.permission,
+        lens: input.lens,
       })
       await recordAuditFromCtx(ctx, {
         category: 'security',
@@ -69,6 +81,7 @@ export const resourceAccessRouter = createTRPCRouter({
           granteeType: input.granteeType,
           granteeId: input.granteeId,
           permission: input.permission,
+          lens: input.lens ?? null,
         },
       })
       return { success: true }
@@ -94,6 +107,7 @@ export const resourceAccessRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      await assertCanManageMailTypeAccess(toContext(ctx), input.entityDefinitionId)
       await grantTypeAccess(toContext(ctx), input)
       await recordAuditFromCtx(ctx, {
         category: 'security',
@@ -125,7 +139,12 @@ export const resourceAccessRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const revoked = await revokeInstanceAccess(toContext(ctx), {
+      const context = toContext(ctx)
+      await assertCanManageMailSharing(context, input.recordId as RecordId, {
+        selfRevokeGranteeId: input.granteeId,
+        selfRevokeGranteeType: input.granteeType,
+      })
+      const revoked = await revokeInstanceAccess(context, {
         recordId: input.recordId as RecordId,
         granteeType: input.granteeType,
         granteeId: input.granteeId,
@@ -159,6 +178,7 @@ export const resourceAccessRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      await assertCanManageMailTypeAccess(toContext(ctx), input.entityDefinitionId)
       const revoked = await revokeTypeAccess(toContext(ctx), input)
       await recordAuditFromCtx(ctx, {
         category: 'security',
@@ -193,17 +213,17 @@ export const resourceAccessRouter = createTRPCRouter({
               ResourcePermission.edit,
               ResourcePermission.admin,
             ]),
+            lens: lensSchema,
           })
         ),
       })
     )
     .mutation(async ({ ctx, input }) => {
-      await setInstanceAccess(
-        toContext(ctx),
-        input.recordId as RecordId,
-        input.granteeType,
-        input.grants
-      )
+      const context = toContext(ctx)
+      const recordId = input.recordId as RecordId
+      await assertCanManageMailSharing(context, recordId)
+      await assertMailSharingFeature(context, recordId, input.grants)
+      await setInstanceAccess(context, recordId, input.granteeType, input.grants)
       await recordAuditFromCtx(ctx, {
         category: 'security',
         action: 'permission.set',
@@ -239,6 +259,7 @@ export const resourceAccessRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      await assertCanManageMailTypeAccess(toContext(ctx), input.entityDefinitionId)
       await setTypeAccess(toContext(ctx), input.entityDefinitionId, input.granteeType, input.grants)
       await recordAuditFromCtx(ctx, {
         category: 'security',

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -718,6 +718,12 @@
       "import": "./dist/permissions/visibility/index.mjs",
       "default": "./src/permissions/visibility/index.ts"
     },
+    "./permissions/visibility/client": {
+      "types": "./src/permissions/visibility/client.ts",
+      "source": "./src/permissions/visibility/client.ts",
+      "import": "./dist/permissions/visibility/client.mjs",
+      "default": "./src/permissions/visibility/client.ts"
+    },
     "./placeholders": {
       "types": "./src/placeholders/index.ts",
       "source": "./src/placeholders/index.ts",

--- a/packages/lib/src/field-hooks/pre/inbox-lens-guard.ts
+++ b/packages/lib/src/field-hooks/pre/inbox-lens-guard.ts
@@ -1,0 +1,76 @@
+// packages/lib/src/field-hooks/pre/inbox-lens-guard.ts
+
+import { database, schema } from '@auxx/database'
+import { ResourcePermission } from '@auxx/database/enums'
+import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import { and, eq } from 'drizzle-orm'
+import { getCachedUserMailVisibility } from '../../cache'
+import { ForbiddenError } from '../../errors'
+import { FeaturePermissionService } from '../../permissions/feature-permission-service'
+import { FeatureKey } from '../../permissions/types'
+import { hasPermission } from '../../resource-access'
+import type { FieldPreHookHandler } from '../types'
+
+/**
+ * The field-write wall for `inbox_default_lens` (mail-permissions §7.1).
+ * The generic records path (form edits, Kopilot record tools, workflow CRUD)
+ * bypasses `InboxService`, so the actual enforcement lives here — the choke
+ * point every writer shares:
+ *
+ * - only org admins or the inbox's Managers (`admin` instance grant) may
+ *   change the floor;
+ * - setting a floor below `full` requires `FeatureKey.mailPermissions`
+ *   (Enterprise) — raising back to `full` is always allowed;
+ * - system paths without a user (provisioning, workers) pass through, and
+ *   seeder/migrations use the `bypass` set (the registry short-circuits this
+ *   hook before it runs).
+ */
+/** True when the inbox already has at least one Manager (`admin`) grant. */
+async function hasAnyManager(organizationId: string, instanceId: string): Promise<boolean> {
+  const [row] = await database
+    .select({ id: schema.ResourceAccess.id })
+    .from(schema.ResourceAccess)
+    .where(
+      and(
+        eq(schema.ResourceAccess.organizationId, organizationId),
+        eq(schema.ResourceAccess.entityDefinitionId, 'inbox'),
+        eq(schema.ResourceAccess.entityInstanceId, instanceId),
+        eq(schema.ResourceAccess.permission, ResourcePermission.admin)
+      )
+    )
+    .limit(1)
+  return !!row
+}
+
+export const guardInboxDefaultLens: FieldPreHookHandler = async (event) => {
+  // Trusted system writers (channel provisioning, workers) carry no userId.
+  if (!event.userId) return event.newValue
+
+  const ctx = { db: database, organizationId: event.organizationId, userId: event.userId }
+  const vis = await getCachedUserMailVisibility(event.userId, event.organizationId)
+  // ResourceAccess stores inbox grants under the fixed 'inbox' slug, while the
+  // records CRUD passes the definition UUID — re-key before the grant lookup.
+  const instanceId = parseRecordId(event.recordId).entityInstanceId
+  const accessRecordId = toRecordId('inbox', instanceId)
+  const canManage =
+    vis.isAdmin ||
+    (await hasPermission(ctx, accessRecordId, ResourcePermission.admin)) ||
+    // Inbox creation (any member may create) writes the initial floor BEFORE
+    // the creator's Manager grant lands — a manager-less inbox has no access
+    // to protect yet, so the ownership check is skipped (feature gate below
+    // still applies).
+    !(await hasAnyManager(event.organizationId, instanceId))
+  if (!canManage) {
+    throw new ForbiddenError('Only inbox managers can change inbox access')
+  }
+
+  const lens = event.newValue
+  if (typeof lens === 'string' && lens !== 'full') {
+    await new FeaturePermissionService(database).requireAccess(
+      event.organizationId,
+      FeatureKey.mailPermissions
+    )
+  }
+
+  return event.newValue
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -5,6 +5,7 @@ import { handleRecordRulesOnFieldChange } from '../record-rules/hook-handler'
 import { invalidateInboxCacheOnFieldChange } from './post/inbox-cache-invalidation'
 import { publishFieldChangeEvent } from './post/publish-field-change-event'
 import { touchActivityOnFieldChange } from './post/touch-activity-on-field-change'
+import { guardInboxDefaultLens } from './pre/inbox-lens-guard'
 import {
   dropUnauthorizedSystemFlag,
   rejectDeleteIfSystemTag,
@@ -69,6 +70,11 @@ export function registerAllHooks(): void {
   // - title / description / emoji / color / parent: reject edits when the
   //   record's is_system_tag is true.
   // - pre-delete: reject deletes of system tags.
+  // Inbox floor wall (mail-permissions §7.1) — only managers may change the
+  // floor, and sub-`full` floors are enterprise-gated. This hook is the
+  // actual enforcement; the inbox form / InboxService are just ergonomics.
+  registerFieldPreHooks('inboxes', 'inbox_default_lens', [guardInboxDefaultLens])
+
   registerFieldPreHooks('tags', 'is_system_tag', [dropUnauthorizedSystemFlag])
   registerFieldPreHooks('tags', 'title', [rejectIfSystemTag])
   registerFieldPreHooks('tags', 'tag_description', [rejectIfSystemTag])

--- a/packages/lib/src/permissions/types.ts
+++ b/packages/lib/src/permissions/types.ts
@@ -44,6 +44,7 @@ export enum FeatureKey {
   agentProcedures = 'agentProcedures',
   mcp = 'mcp',
   dataConnectors = 'dataConnectors',
+  mailPermissions = 'mailPermissions',
 
   // ── Static limits (count of things, not time-based) ──
   teammates = 'teammates',
@@ -166,6 +167,13 @@ export const FEATURE_REGISTRY: FeatureMetadata[] = [
     label: 'Data Connectors',
     description: 'Sync external structured records (REST APIs, apps) into the entity system.',
     group: 'Data',
+  },
+  {
+    key: FeatureKey.mailPermissions,
+    type: 'boolean',
+    label: 'Mail Permissions',
+    description: 'Inbox access levels, conversation sharing, and inbox manager delegation.',
+    group: 'Security',
   },
 
   // ── Static limits ──

--- a/packages/lib/src/permissions/visibility/client.ts
+++ b/packages/lib/src/permissions/visibility/client.ts
@@ -7,6 +7,8 @@
 
 export type { Lens } from './lens'
 export { ALL_LENSES, lensRank, maxLens, satisfiesLens } from './lens'
+export type { LensChoice, LensLabel } from './lens-labels'
+export { LENS_CHOICES, LENS_LABELS } from './lens-labels'
 export {
   FULL_ONLY_THREAD_FIELDS,
   MESSAGE_CONTENT_FIELDS,

--- a/packages/lib/src/permissions/visibility/lens-labels.ts
+++ b/packages/lib/src/permissions/visibility/lens-labels.ts
@@ -1,0 +1,32 @@
+// packages/lib/src/permissions/visibility/lens-labels.ts
+
+import type { Lens } from './lens'
+
+/**
+ * User-facing language for the lens tiers (UI plan §"User-facing language").
+ * The word "lens" never appears in UI; these labels are the single source the
+ * FE renders from so copy and redaction stay in sync.
+ *
+ * `manager` is not a lens — it maps to `permission='admin'` on an inbox grant
+ * (Full access + manage sharing), rendered as an entry in the same picker.
+ */
+export type LensChoice = Exclude<Lens, 'none'> | 'manager'
+
+export interface LensLabel {
+  label: string
+  helper: string
+}
+
+export const LENS_LABELS: Record<Lens | 'manager', LensLabel> = {
+  full: { label: 'Full access', helper: 'Read and reply to conversations' },
+  subject: {
+    label: 'Subject only',
+    helper: 'See who, when, and subject lines — not message content',
+  },
+  metadata: { label: 'Activity only', helper: 'See who and when — not subjects or content' },
+  none: { label: 'No access', helper: 'Hidden unless individually shared' },
+  manager: { label: 'Manager', helper: 'Full access + manage sharing' },
+}
+
+/** The grantable tiers in the order pickers render them (widest first). */
+export const LENS_CHOICES: readonly Exclude<Lens, 'none'>[] = ['full', 'subject', 'metadata']

--- a/packages/lib/src/permissions/visibility/redact.ts
+++ b/packages/lib/src/permissions/visibility/redact.ts
@@ -35,6 +35,8 @@ export const THREAD_METADATA_FIELDS: readonly (keyof ThreadMeta)[] = [
   'mergedIntoThreadId',
   'mergeData',
   'latestCommentId',
+  'myLens',
+  'hasShares',
 ]
 
 /** Adds to the metadata set at `subject`+. */

--- a/packages/lib/src/resource-access/index.ts
+++ b/packages/lib/src/resource-access/index.ts
@@ -2,6 +2,13 @@
 
 // Constants
 export { PERMISSION_HIERARCHY, satisfiesPermission } from './constants'
+// Mail sharing guards (mail-permissions §7)
+export {
+  assertCanManageMailSharing,
+  assertCanManageMailTypeAccess,
+  assertMailSharingFeature,
+  isMailSharingDef,
+} from './mail-sharing-guard'
 // Service functions
 export {
   checkAccess,
@@ -23,6 +30,7 @@ export type {
   CheckAccessInput,
   CheckTypeAccessInput,
   GrantInstanceAccessInput,
+  GrantLens,
   GrantTypeAccessInput,
   InstanceAccess,
   ResourceAccessContext,

--- a/packages/lib/src/resource-access/mail-sharing-guard.ts
+++ b/packages/lib/src/resource-access/mail-sharing-guard.ts
@@ -1,0 +1,157 @@
+// packages/lib/src/resource-access/mail-sharing-guard.ts
+
+import { database, schema } from '@auxx/database'
+import { ResourcePermission } from '@auxx/database/enums'
+import type { RecordId } from '@auxx/types/resource'
+import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import { and, eq } from 'drizzle-orm'
+import { getCachedUserMailVisibility } from '../cache'
+import { ForbiddenError } from '../errors'
+import { FeaturePermissionService } from '../permissions/feature-permission-service'
+import { FeatureKey } from '../permissions/types'
+import { getThreadLens } from '../permissions/visibility'
+import { hasPermission } from './resource-access-service'
+import type { GrantLens, ResourceAccessContext } from './types'
+
+/**
+ * The ResourceAccess entityDefinitionId slugs whose grants feed the mail
+ * visibility evaluator (mail-permissions §2/§7). Mutations on these go
+ * through the sharing authorization + enterprise feature gate below; every
+ * other definition keeps its existing surface-level checks.
+ */
+const MAIL_SHARING_DEFS = new Set(['inbox', 'thread', 'contact'])
+
+/** True when grants on this definition affect mail visibility. */
+export function isMailSharingDef(entityDefinitionId: string): boolean {
+  return MAIL_SHARING_DEFS.has(entityDefinitionId)
+}
+
+/**
+ * Authorization for mutating mail-visibility grants (§7):
+ * - org admins may manage sharing anywhere;
+ * - `inbox`: inbox Managers (instance `admin` grant) may manage their inbox;
+ * - `thread`: viewers with `full` on the thread who are also a Manager of the
+ *   thread's inbox (admins short-circuit above) — a sub-full viewer must never
+ *   self-raise, and full-lens members don't get to re-share by default;
+ * - `contact`: org admins only in v1 (contact shares derive to every thread
+ *   the contact participates in — the widest blast radius in the model).
+ *
+ * `selfRevokeGranteeId` allows a user to remove their OWN user grant (leave a
+ * shared thread) without manager rights. No-op for non-mail definitions.
+ */
+export async function assertCanManageMailSharing(
+  ctx: ResourceAccessContext,
+  recordId: RecordId,
+  opts?: { selfRevokeGranteeId?: string; selfRevokeGranteeType?: string }
+): Promise<void> {
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  if (!isMailSharingDef(entityDefinitionId)) return
+
+  const { organizationId, userId } = ctx
+  if (
+    opts?.selfRevokeGranteeType === 'user' &&
+    opts.selfRevokeGranteeId &&
+    opts.selfRevokeGranteeId === userId
+  ) {
+    return
+  }
+
+  const vis = await getCachedUserMailVisibility(userId, organizationId)
+  if (vis.isAdmin) return
+
+  if (entityDefinitionId === 'inbox') {
+    if (await hasPermission(ctx, recordId, ResourcePermission.admin)) return
+    throw new ForbiddenError('Only inbox managers can change inbox access')
+  }
+
+  if (entityDefinitionId === 'thread') {
+    const lens = await getThreadLens(database, organizationId, vis, entityInstanceId)
+    if (lens === 'full') {
+      const [thread] = await database
+        .select({ inboxId: schema.Thread.inboxId })
+        .from(schema.Thread)
+        .where(
+          and(
+            eq(schema.Thread.id, entityInstanceId),
+            eq(schema.Thread.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+      if (
+        thread?.inboxId &&
+        (await hasPermission(ctx, toRecordId('inbox', thread.inboxId), ResourcePermission.admin))
+      ) {
+        return
+      }
+    }
+    throw new ForbiddenError('Only admins or inbox managers can share this conversation')
+  }
+
+  // contact
+  throw new ForbiddenError('Only admins can share a contact’s conversations')
+}
+
+/**
+ * Authorization for TYPE-level grant mutations on mail definitions: org
+ * admins only. The evaluator deliberately ignores type-level view grants
+ * (April decision), but a type-level `admin` grant on `inbox` would make the
+ * grantee a Manager of every inbox — never something a non-admin may set up.
+ * No-op for non-mail definitions.
+ */
+export async function assertCanManageMailTypeAccess(
+  ctx: ResourceAccessContext,
+  entityDefinitionId: string
+): Promise<void> {
+  if (!isMailSharingDef(entityDefinitionId)) return
+  const vis = await getCachedUserMailVisibility(ctx.userId, ctx.organizationId)
+  if (vis.isAdmin) return
+  throw new ForbiddenError('Only admins can manage type-level access')
+}
+
+/**
+ * Enterprise gate for lens-bearing sharing (§7.1 / plan decision 4). Throws
+ * unless the org has `FeatureKey.mailPermissions` when the mutation:
+ * - grants a sub-`full` lens (metadata/subject shares), or
+ * - adds a NEW inbox Manager (`admin` permission) — delegation. Re-submitting
+ *   an existing Manager row (the inbox form's replace-all save includes the
+ *   non-removable creator row) stays ungated so free-plan saves don't trip.
+ *
+ * Full-lens grants stay ungated: they only widen access, which assignment
+ * already does on every plan. No-op for non-mail definitions.
+ */
+export async function assertMailSharingFeature(
+  ctx: ResourceAccessContext,
+  recordId: RecordId,
+  grants: Array<{ granteeId: string; permission: string; lens?: GrantLens | null }>
+): Promise<void> {
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  if (!isMailSharingDef(entityDefinitionId)) return
+
+  let gated = grants.some((g) => g.lens != null && g.lens !== 'full')
+
+  if (!gated && entityDefinitionId === 'inbox') {
+    const newManagers = grants.filter((g) => g.permission === ResourcePermission.admin)
+    if (newManagers.length > 0) {
+      const existing = await ctx.db
+        .select({ granteeId: schema.ResourceAccess.granteeId })
+        .from(schema.ResourceAccess)
+        .where(
+          and(
+            eq(schema.ResourceAccess.organizationId, ctx.organizationId),
+            eq(schema.ResourceAccess.entityDefinitionId, entityDefinitionId),
+            eq(schema.ResourceAccess.entityInstanceId, entityInstanceId),
+            eq(schema.ResourceAccess.permission, ResourcePermission.admin)
+          )
+        )
+      const existingIds = new Set(existing.map((r: { granteeId: string }) => r.granteeId))
+      gated = newManagers.some((g) => !existingIds.has(g.granteeId))
+    }
+  }
+
+  if (gated) {
+    await new FeaturePermissionService(ctx.db).requireAccess(
+      ctx.organizationId,
+      FeatureKey.mailPermissions
+    )
+  }
+}

--- a/packages/lib/src/resource-access/resource-access-service.ts
+++ b/packages/lib/src/resource-access/resource-access-service.ts
@@ -12,6 +12,7 @@ import type {
   CheckAccessInput,
   CheckTypeAccessInput,
   GrantInstanceAccessInput,
+  GrantLens,
   GrantTypeAccessInput,
   InstanceAccess,
   ResourceAccessContext,
@@ -76,6 +77,7 @@ export async function grantInstanceAccess(
       granteeType: input.granteeType,
       granteeId: input.granteeId,
       permission: input.permission,
+      lens: input.lens ?? null,
       grantedById: userId,
     })
     .onConflictDoUpdate({
@@ -88,6 +90,7 @@ export async function grantInstanceAccess(
       ],
       set: {
         permission: input.permission,
+        lens: input.lens ?? null,
         grantedById: userId,
         updatedAt: new Date(),
       },
@@ -208,7 +211,7 @@ export async function setInstanceAccess(
   ctx: ResourceAccessContext,
   recordId: RecordId,
   granteeType: ResourceGranteeType,
-  grants: Array<{ granteeId: string; permission: ResourcePermission }>
+  grants: Array<{ granteeId: string; permission: ResourcePermission; lens?: GrantLens | null }>
 ): Promise<void> {
   const { db, organizationId, userId } = ctx
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
@@ -237,6 +240,7 @@ export async function setInstanceAccess(
           granteeType,
           granteeId: g.granteeId,
           permission: g.permission,
+          lens: g.lens ?? null,
           grantedById: userId,
         }))
       )
@@ -551,6 +555,7 @@ export async function getInstanceAccess(
     granteeType: g.granteeType as ResourceGranteeType,
     granteeId: g.granteeId,
     permission: g.permission as ResourcePermission,
+    lens: (g.lens ?? null) as GrantLens | null,
     createdAt: g.createdAt,
   }))
 }

--- a/packages/lib/src/resource-access/types.ts
+++ b/packages/lib/src/resource-access/types.ts
@@ -14,6 +14,13 @@ export interface ResourceAccessContext {
   userId: string
 }
 
+/**
+ * Visibility lens carried on a mail grant (mail-permissions §2.1). Meaningful
+ * only for `permission='view'` rows on thread/contact/inbox — `edit`/`admin`
+ * always evaluate as `full`. `null`/absent means legacy `full`.
+ */
+export type GrantLens = 'metadata' | 'subject' | 'full'
+
 /** Input for granting access to a specific instance */
 export interface GrantInstanceAccessInput {
   /** RecordId format: "entityDefinitionId:entityInstanceId" */
@@ -21,6 +28,7 @@ export interface GrantInstanceAccessInput {
   granteeType: ResourceGranteeType
   granteeId: string
   permission: ResourcePermission
+  lens?: GrantLens | null
 }
 
 /** Input for granting type-level access (all instances) */
@@ -82,6 +90,7 @@ export interface ResourceAccessInfo {
   granteeType: ResourceGranteeType
   granteeId: string
   permission: ResourcePermission
+  lens: GrantLens | null
   createdAt: Date
 }
 

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -41,7 +41,13 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     defaultSidebarTab: 'overview',
     // Renders nothing when the contact has no external identities (card
     // returns null), so it's inert until an app/store/chat links the record.
-    sidebarCards: [{ value: 'external-identities', label: 'External identities' }],
+    sidebarCards: [
+      { value: 'external-identities', label: 'External identities' },
+      // Mail-permissions contact sharing (UI plan §4) — grants every thread
+      // this contact participates in. Admin-managed; hidden for other roles
+      // unless shares already exist.
+      { value: 'shared-with', label: 'Shared with' },
+    ],
   },
 
   ticket: {

--- a/packages/lib/src/threads/thread-query.service.ts
+++ b/packages/lib/src/threads/thread-query.service.ts
@@ -780,6 +780,20 @@ export class ThreadQueryService {
     // Note: batchGetThreadTagIds returns RecordIds (from FieldValue.relatedEntityId which stores RecordIds)
     const tagIdMap = await batchGetThreadTagIds(this.db, ids, this.organizationId)
 
+    // Threads with explicit shares (instance grants) — powers the list rows'
+    // share indicator (`hasShares`, metadata tier).
+    const shareRows = await this.db
+      .selectDistinct({ entityInstanceId: schema.ResourceAccess.entityInstanceId })
+      .from(schema.ResourceAccess)
+      .where(
+        and(
+          eq(schema.ResourceAccess.organizationId, this.organizationId),
+          eq(schema.ResourceAccess.entityDefinitionId, 'thread'),
+          inArray(schema.ResourceAccess.entityInstanceId, ids)
+        )
+      )
+    const sharedThreadIds = new Set(shareRows.map((r) => r.entityInstanceId))
+
     // Resolve inbox and ticket entityDefinitionIds from org cache
     const inboxEntityDefId = await requireCachedEntityDefId(this.organizationId, 'inbox')
     const ticketEntityDefId = await requireCachedEntityDefId(this.organizationId, 'ticket')
@@ -929,6 +943,8 @@ export class ThreadQueryService {
             ? toRecordId('thread', t.mergedIntoThreadId)
             : null,
           mergeData: (t.mergeData as ThreadMergeData | null) ?? null,
+          myLens: lens,
+          hasShares: sharedThreadIds.has(t.id),
         } satisfies ThreadMeta
 
         return redactThreadMeta(meta, lens)

--- a/packages/lib/src/threads/types.ts
+++ b/packages/lib/src/threads/types.ts
@@ -210,6 +210,21 @@ export interface ThreadMeta {
    * have been merged into this one. Null when the thread is neither.
    */
   mergeData: ThreadMergeData | null
+
+  /**
+   * The requesting viewer's effective lens on this thread (mail-permissions
+   * §4). The batch evaluator computes it anyway; exposing it powers the FE's
+   * redacted rendering (`LensBadge`, placeholder rows) without a second
+   * request. Never `'none'` — such threads are dropped from the batch.
+   */
+  myLens: 'metadata' | 'subject' | 'full'
+
+  /**
+   * True when the thread has explicit instance grants (shares). Operational
+   * metadata (metadata tier) — drives the list rows' share indicator and the
+   * header button's avatar cluster hint.
+   */
+  hasShares: boolean
 }
 
 /**

--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -127,6 +127,7 @@ const BOOLEAN_GATES = {
     agentProcedures: false,
     mcp: false,
     dataConnectors: true,
+    mailPermissions: true,
   },
   free: {
     knowledgeBase: true,
@@ -146,6 +147,7 @@ const BOOLEAN_GATES = {
     agentProcedures: false,
     mcp: false,
     dataConnectors: true,
+    mailPermissions: false,
   },
   starter: {
     knowledgeBase: true,
@@ -165,6 +167,7 @@ const BOOLEAN_GATES = {
     agentProcedures: false,
     mcp: false,
     dataConnectors: true,
+    mailPermissions: false,
   },
   growth: {
     knowledgeBase: true,
@@ -184,6 +187,7 @@ const BOOLEAN_GATES = {
     agentProcedures: false,
     mcp: false,
     dataConnectors: true,
+    mailPermissions: false,
   },
   enterprise: {
     knowledgeBase: true,
@@ -203,6 +207,7 @@ const BOOLEAN_GATES = {
     agentProcedures: false,
     mcp: false,
     dataConnectors: true,
+    mailPermissions: true,
   },
 } as const
 


### PR DESCRIPTION
Phases 4–5 of the mail-permissions plan (`plans/mail-permissions/`), following #1064 (phases 0–2) and #1066 (phase 3).

## Phase 4 — feature gate + server enforcement

- **`FeatureKey.mailPermissions`** (boolean, Security group) in the feature registry; plan gates in the billing seed — demo/enterprise `true`, free/starter/growth `false`. Roll onto live plans via the existing super-admin *update feature limits* action.
- **`ResourceAccess.lens`** plumbed through `grantInstanceAccess`/`setInstanceAccess`/`getInstanceAccess` and the `resourceAccess` router (`grantInstance`/`setInstance` accept `lens`, `forInstance` returns it).
- **New `resource-access/mail-sharing-guard.ts`** — authorization for mutating mail-visibility grants. Closes a hole left after phase 2: any org member could self-grant `full` on any thread with a single tRPC call. Now:
  - thread shares: viewer has `full` on the thread AND is org admin / Manager of the thread's inbox (self-revoke allowed)
  - inbox grants: org admins or the inbox's Managers
  - contact shares: org admins only (deviation from the plan's "admins/managers" — contact shares derive to every thread the contact touches, the widest blast radius in the model)
  - type-level grants on mail defs: admins only (a type-level inbox `admin` grant would be Manager-of-every-inbox)
  - enterprise gate: sub-`full` lens grants and NEW Manager delegations require the feature; re-submitted existing manager rows don't trip free-plan saves. Non-mail definitions (snippets, …) are untouched.
- **§7.1 field-write wall:** `FIELD_PRE_HOOKS` guard on `inbox:inbox_default_lens` — managers only, sub-`full` floors require the feature; userId-less system writes and manager-less fresh creates pass; seeder bypass is framework-level. Covers the generic records path (form edits, Kopilot tools, workflow CRUD) that bypasses `InboxService`.
- `inbox.create` accepts `defaultLens`.

## Phase 5 — UI

New feature folder `apps/web/src/components/mail-permissions/{ui,hooks}`:

- **Building blocks:** `LensSelect` (the one tier picker; below-Full options and the Manager entry render an Enterprise badge and open the upgrade dialog when gated), `EnterpriseGate` tease-wrapper, `GranteeList`, `use-mail-share` (optimistic grant/change/revoke), `LensBadge`, access-levels `GuideDialog`. User-facing labels live in `visibility/lens-labels.ts` (client-safe) — the word "lens" never appears in UI.
- **Inbox Access section** rebuilt in `inbox-form.tsx`: Everyone/Restricted radio cards + "Everyone can see" floor select + grantee list with Manager delegation, saved atomically on submit. `inbox_default_lens` is only written when changed. The Access section shows for org admins and inbox Managers (delegation); the dead `MemberGroupFormField` block is gone.
- **Thread share popover** in the thread-header actions row: avatar-cluster button when grants exist, immediate-persist grantee list, inherited-access footer (inbox floor + assignee), read-only view for grantees who can't share.
- **Contact "Shared with" sidebar card** on contact records (admin-managed, blast-radius copy).
- **`ThreadMeta.myLens` + `hasShares`** (stamped in `getThreadMetaBatch`, classified metadata-tier in the redaction allowlist).
- **Redacted rendering:** list rows show "No access to subject" at activity tier, never render unread below full, and show a share micro-icon; the thread view gets a `LensBadge`, a locked-content notice above envelope rows (subject tier) or as the whole pane (activity tier), and hides the reply portal + R/F hotkeys below full.

## Validation

- Biome clean; vitest green on all touched suites: visibility (43), realtime shaping (12), resource-access (4), threads (15).
- NOT live-verified — the combined phases 2–5 restricted-org walkthrough is the next step and the ship gate (checklists in `plans/mail-permissions/README.md`).

## Notes / follow-ups

- No unit tests yet for the two new guards (IO-heavy; covered by the upcoming live walkthrough).
- Dev DB plan rows carry old featureLimits — run the super-admin *update feature limits* action before testing gating on dev.
- Sidebar restricted-inbox lock affordance (plan §6 polish) not included.