### PR TITLE
feat(mail): phase 6 hardening — retire inbox_visibility, audits, dead code

### DIFF
--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -128,7 +128,7 @@ export function InboxForm({
   // Fetch system field values for edit mode
   const { values: fieldValues, isLoading: isLoadingValues } = useSystemValues(
     recordId,
-    ['inbox_name', 'inbox_description', 'inbox_color', 'inbox_visibility', 'inbox_default_lens'],
+    ['inbox_name', 'inbox_description', 'inbox_color', 'inbox_default_lens'],
     { autoFetch: true, enabled: isEditing && !!recordId }
   )
 
@@ -217,12 +217,7 @@ export function InboxForm({
         const name = (fieldValues.inbox_name as string) ?? ''
         const description = (fieldValues.inbox_description as string) ?? ''
         const color = (fieldValues.inbox_color as string) ?? 'indigo'
-        // Pre-migration rows may lack the lens value — fall back to the legacy
-        // visibility field's equivalent floor.
-        const visibility = fieldValues.inbox_visibility ?? 'org_members'
-        const storedLens =
-          (fieldValues.inbox_default_lens as Lens | undefined) ??
-          (visibility === 'org_members' ? 'full' : 'none')
+        const storedLens = (fieldValues.inbox_default_lens as Lens | undefined) ?? 'full'
         const accessType = storedLens === 'none' ? 'restricted' : 'anyone'
         const floorLens = storedLens === 'none' ? 'full' : storedLens
         const grants = accessRows.map(rowToGrant)
@@ -383,14 +378,12 @@ export function InboxForm({
     if (!isValid) return
 
     const targetLens: Lens = data.accessType === 'anyone' ? data.floorLens : 'none'
-    const legacyVisibility = data.accessType === 'anyone' ? 'org_members' : 'custom'
 
     if (isEditing && recordId) {
       const values: Record<string, unknown> = {
         inbox_name: data.name.trim(),
         inbox_description: data.description,
         inbox_color: data.color,
-        inbox_visibility: legacyVisibility,
       }
       // Only write the floor when it changed — the write is guarded server-side
       // (managers only; sub-full floors are enterprise).
@@ -429,7 +422,6 @@ export function InboxForm({
           description: data.description,
           color: data.color,
           status: 'ACTIVE',
-          visibility: legacyVisibility,
           defaultLens: targetLens,
         })
         // Additive grants — the server already added the creator's Manager row.

--- a/apps/web/src/components/inbox/inbox-list.tsx
+++ b/apps/web/src/components/inbox/inbox-list.tsx
@@ -52,17 +52,17 @@ export function InboxList() {
     }
   }
 
-  /** Get access display based on visibility */
-  const getAccessDisplay = (visibility: Inbox['visibility'] | undefined) => {
-    switch (visibility) {
-      case 'org_members':
-        return 'All members'
-      case 'private':
-        return 'Private'
-      case 'custom':
-        return 'Custom'
+  /** Get access display based on the org-wide floor lens */
+  const getAccessDisplay = (defaultLens: Inbox['defaultLens'] | undefined) => {
+    switch (defaultLens) {
+      case 'none':
+        return 'Restricted'
+      case 'subject':
+        return 'Subject only'
+      case 'metadata':
+        return 'Activity only'
       default:
-        return visibility ?? '—'
+        return 'All members'
     }
   }
 
@@ -108,9 +108,6 @@ export function InboxList() {
             {inboxes.map((inbox) => {
               const record = records.find((r) => r.id === inbox.id)
               const status = Array.isArray(inbox.status) ? inbox.status[0] : inbox.status
-              const visibility = Array.isArray(inbox.visibility)
-                ? inbox.visibility[0]
-                : inbox.visibility
               return (
                 <TableRow
                   key={inbox.id}
@@ -132,7 +129,7 @@ export function InboxList() {
                       </div>
                     </div>
                   </TableCell>
-                  <TableCell>{getAccessDisplay(visibility)}</TableCell>
+                  <TableCell>{getAccessDisplay(inbox.defaultLens)}</TableCell>
                   <TableCell>{getStatusBadge(status)}</TableCell>
                 </TableRow>
               )

--- a/apps/web/src/components/threads/hooks/use-inbox.ts
+++ b/apps/web/src/components/threads/hooks/use-inbox.ts
@@ -17,7 +17,6 @@ export interface InboxRecord extends RecordMeta {
     inbox_description?: string
     inbox_color?: string
     inbox_status?: 'ACTIVE' | 'ARCHIVED' | 'PAUSED'
-    inbox_visibility?: 'org_members' | 'private' | 'custom'
     inbox_default_lens?: 'none' | 'metadata' | 'subject' | 'full'
   }
 }
@@ -32,10 +31,8 @@ export interface InboxItem {
   description?: string | null
   color?: string | null
   status?: 'ACTIVE' | 'ARCHIVED' | 'PAUSED'
-  visibility?: 'org_members' | 'private' | 'custom'
   /**
-   * The org-wide floor (`inbox_default_lens`), with the legacy `visibility`
-   * fallback for pre-migration rows. Drives the share popover's
+   * The org-wide floor (`inbox_default_lens`). Drives the share popover's
    * inherited-access footer and the sidebar's restricted affordance.
    */
   defaultLens: 'none' | 'metadata' | 'subject' | 'full'
@@ -91,13 +88,7 @@ export function useInboxes(): UseInboxesResult {
       description: record.fieldValues?.inbox_description ?? null,
       color: record.fieldValues?.inbox_color ?? null,
       status: record.fieldValues?.inbox_status,
-      visibility: record.fieldValues?.inbox_visibility,
-      defaultLens:
-        record.fieldValues?.inbox_default_lens ??
-        (record.fieldValues?.inbox_visibility === 'org_members' ||
-        !record.fieldValues?.inbox_visibility
-          ? 'full'
-          : 'none'),
+      defaultLens: record.fieldValues?.inbox_default_lens ?? 'full',
       myLens: lenses[record.id],
     }))
 

--- a/apps/web/src/server/api/routers/inbox.ts
+++ b/apps/web/src/server/api/routers/inbox.ts
@@ -16,7 +16,6 @@ const createInboxSchema = z.object({
   description: z.string().optional(),
   color: z.string().optional(),
   status: z.enum(['ACTIVE', 'ARCHIVED', 'PAUSED']).optional(),
-  visibility: z.enum(['org_members', 'private', 'custom']).optional(),
   defaultLens: z.enum(['none', 'metadata', 'subject', 'full']).optional(),
   settings: z.record(z.string(), z.unknown()).optional(),
 })

--- a/apps/web/src/server/api/routers/resourceAccess.ts
+++ b/apps/web/src/server/api/routers/resourceAccess.ts
@@ -10,7 +10,6 @@ import {
   checkTypeAccess,
   getInstanceAccess,
   getTypeAccess,
-  getUserAccessibleInstances,
   grantInstanceAccess,
   grantTypeAccess,
   revokeInstanceAccess,
@@ -320,20 +319,5 @@ export const resourceAccessRouter = createTRPCRouter({
     )
     .query(async ({ ctx, input }) => {
       return getTypeAccess(toContext(ctx), input.entityDefinitionId)
-    }),
-
-  /** Get instances accessible by current user for an entity type */
-  myInstances: protectedProcedure
-    .input(
-      z.object({
-        entityDefinitionId: z.string(),
-      })
-    )
-    .query(async ({ ctx, input }) => {
-      return getUserAccessibleInstances(
-        toContext(ctx),
-        ctx.session.userId,
-        input.entityDefinitionId
-      )
     }),
 })

--- a/packages/lib/src/data-migrations/migrations/034-retire-inbox-visibility.ts
+++ b/packages/lib/src/data-migrations/migrations/034-retire-inbox-visibility.ts
@@ -1,0 +1,55 @@
+// packages/lib/src/data-migrations/migrations/034-retire-inbox-visibility.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { eq, inArray } from 'drizzle-orm'
+import { getOrgCache } from '../../cache'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-034')
+
+const RETIRED_ATTR = 'inbox_visibility'
+
+/**
+ * Retire the legacy `inbox_visibility` field (mail-permissions Phase 6). Its
+ * values were converted into the `inbox_default_lens` floor by migration 033;
+ * all readers/writers switched to `defaultLens`, and the registry entry is
+ * removed in the same change. Drops the per-org `CustomField` rows and their
+ * `FieldValue` cells. Idempotent — a re-run finds nothing to delete.
+ */
+export const migration034RetireInboxVisibility: DataMigrationDef = {
+  id: '034-retire-inbox-visibility',
+  description: 'Delete the retired inbox_visibility field defs + values',
+  async run(db: Database): Promise<void> {
+    const fields = await db
+      .select({ id: schema.CustomField.id, organizationId: schema.CustomField.organizationId })
+      .from(schema.CustomField)
+      .where(eq(schema.CustomField.systemAttribute, RETIRED_ATTR))
+    if (fields.length === 0) {
+      logger.info('No inbox_visibility fields to retire')
+      return
+    }
+    const fieldIds = fields.map((f) => f.id)
+
+    const deletedValues = await db
+      .delete(schema.FieldValue)
+      .where(inArray(schema.FieldValue.fieldId, fieldIds))
+      .returning({ id: schema.FieldValue.id })
+
+    await db.delete(schema.CustomField).where(inArray(schema.CustomField.id, fieldIds))
+
+    // Field defs live in the cached resource shapes — recompute so the field
+    // disappears from forms/builders without a restart.
+    const affectedOrgs = new Set(fields.map((f) => f.organizationId))
+    for (const orgId of affectedOrgs) {
+      await getOrgCache().invalidateAndRecompute(orgId, ['customFields', 'resources'])
+    }
+
+    logger.info('Retired inbox_visibility', {
+      fields: fieldIds.length,
+      values: deletedValues.length,
+      orgsInvalidated: affectedOrgs.size,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -11,6 +11,7 @@ import { migration030RetireShopifyProductLinkId } from './migrations/030-retire-
 import { migration031BackfillThreadInboxId } from './migrations/031-backfill-thread-inbox-id'
 import { migration032BackfillThreadParticipants } from './migrations/032-backfill-thread-participants'
 import { migration033InboxVisibilityToDefaultLens } from './migrations/033-inbox-visibility-to-default-lens'
+import { migration034RetireInboxVisibility } from './migrations/034-retire-inbox-visibility'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -38,6 +39,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration031BackfillThreadInboxId,
     migration032BackfillThreadParticipants,
     migration033InboxVisibilityToDefaultLens,
+    migration034RetireInboxVisibility,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/inboxes/inbox-service.ts
+++ b/packages/lib/src/inboxes/inbox-service.ts
@@ -22,15 +22,6 @@ function getInstanceId(recordId: RecordId): string {
 }
 
 /**
- * Default-lens value for inboxes that predate the `inbox_default_lens` field
- * (data migration 033 backfills it with exactly this mapping). `org_members`
- * meant everyone-full; `private`/`custom` meant explicit grantees only.
- */
-function legacyDefaultLens(visibility: unknown): Lens {
-  return visibility === 'private' || visibility === 'custom' ? 'none' : 'full'
-}
-
-/**
  * Service for managing inboxes.
  * Uses RecordId branded types throughout for type safety.
  * Delegates core CRUD to UnifiedCrudHandler, uses ResourceAccess helpers for permissions.
@@ -65,11 +56,7 @@ export class InboxService {
       inbox_description: input.description ?? null,
       inbox_color: input.color ?? 'indigo',
       inbox_status: input.status ?? 'ACTIVE',
-      // Legacy field, kept in sync until Phase 6 removes it. The floor is
-      // defaultLens; there are no org_member ResourceAccess rows anymore.
-      // Callers still passing only `visibility` get the equivalent floor.
-      inbox_visibility: input.visibility ?? 'org_members',
-      inbox_default_lens: input.defaultLens ?? legacyDefaultLens(input.visibility),
+      inbox_default_lens: input.defaultLens ?? 'full',
       inbox_settings: input.settings ?? {},
     }
 
@@ -117,7 +104,6 @@ export class InboxService {
     if (input.color !== undefined) values.inbox_color = input.color
     if (input.status !== undefined) values.inbox_status = input.status
     if (input.settings !== undefined) values.inbox_settings = input.settings
-    if (input.visibility !== undefined) values.inbox_visibility = input.visibility
     if (input.defaultLens !== undefined) values.inbox_default_lens = input.defaultLens
 
     if (Object.keys(values).length > 0) {
@@ -409,11 +395,7 @@ export class InboxService {
       description: (item.fieldValues.inbox_description as string) ?? null,
       color: (item.fieldValues.inbox_color as string) ?? 'indigo',
       status: ((item.fieldValues.inbox_status as string) ?? 'ACTIVE') as Inbox['status'],
-      visibility: ((item.fieldValues.inbox_visibility as string) ??
-        'org_members') as Inbox['visibility'],
-      defaultLens:
-        (item.fieldValues.inbox_default_lens as string as Lens) ??
-        legacyDefaultLens(item.fieldValues.inbox_visibility),
+      defaultLens: (item.fieldValues.inbox_default_lens as string as Lens) ?? 'full',
       settings: (item.fieldValues.inbox_settings as Record<string, unknown>) ?? {},
       organizationId: item.organizationId,
       createdAt: item.createdAt,
@@ -450,11 +432,7 @@ export class InboxService {
       description: (getValue('inbox_description') as string) ?? null,
       color: (getValue('inbox_color') as string) ?? 'indigo',
       status: ((getValue('inbox_status') as string) ?? 'ACTIVE') as Inbox['status'],
-      visibility: ((getValue('inbox_visibility') as string) ??
-        'org_members') as Inbox['visibility'],
-      defaultLens:
-        (getValue('inbox_default_lens') as string as Lens) ??
-        legacyDefaultLens(getValue('inbox_visibility')),
+      defaultLens: (getValue('inbox_default_lens') as string as Lens) ?? 'full',
       settings: (getValue('inbox_settings') as Record<string, unknown>) ?? {},
       organizationId: instance.organizationId,
       createdAt: instance.createdAt,

--- a/packages/lib/src/inboxes/index.ts
+++ b/packages/lib/src/inboxes/index.ts
@@ -6,7 +6,6 @@ export type {
   Inbox,
   InboxIntegration,
   InboxStatus,
-  InboxVisibility,
   InboxWithIntegrations,
   UpdateInboxInput,
 } from './types'

--- a/packages/lib/src/inboxes/types.ts
+++ b/packages/lib/src/inboxes/types.ts
@@ -3,13 +3,6 @@
 import type { RecordId } from '@auxx/types/resource'
 import type { Lens } from '../permissions/visibility/lens'
 
-/**
- * Inbox visibility options.
- * @deprecated Superseded by `defaultLens` (mail-permissions §2.2). Kept until
- * Phase 6 removes the legacy field; new code reads/writes `defaultLens`.
- */
-export type InboxVisibility = 'org_members' | 'private' | 'custom'
-
 /** Inbox status options */
 export type InboxStatus = 'ACTIVE' | 'PAUSED' | 'ARCHIVED'
 
@@ -19,7 +12,6 @@ export interface CreateInboxInput {
   description?: string
   color?: string
   status?: InboxStatus
-  visibility?: InboxVisibility
   /** Org-wide visibility floor (defaults to `full` — everyone sees everything). */
   defaultLens?: Lens
   settings?: Record<string, unknown>
@@ -31,7 +23,6 @@ export interface UpdateInboxInput {
   description?: string
   color?: string
   status?: InboxStatus
-  visibility?: InboxVisibility
   defaultLens?: Lens
   settings?: Record<string, unknown>
 }
@@ -46,7 +37,6 @@ export interface Inbox {
   description: string | null
   color: string
   status: InboxStatus
-  visibility: InboxVisibility
   /**
    * Org-wide visibility floor: the lens every org member gets on this inbox
    * (mail-permissions §2.2). Explicit grants can only raise it.

--- a/packages/lib/src/resources/registry/resources/inbox-fields.ts
+++ b/packages/lib/src/resources/registry/resources/inbox-fields.ts
@@ -124,34 +124,6 @@ export const INBOX_FIELDS: Record<string, ResourceField> = {
     description: 'Inbox status',
   },
 
-  visibility: {
-    id: toFieldId('visibility'),
-    key: 'visibility',
-    label: 'Visibility',
-    type: BaseType.ENUM,
-    fieldType: FieldType.SINGLE_SELECT,
-    isSystem: true,
-    systemAttribute: 'inbox_visibility',
-    systemSortOrder: 'a5',
-    nullable: false,
-    defaultValue: 'org_members',
-    options: {
-      options: [
-        { value: 'org_members', label: 'All Members' },
-        { value: 'private', label: 'Private' },
-        { value: 'custom', label: 'Custom' },
-      ],
-    },
-    capabilities: {
-      filterable: true,
-      sortable: false,
-      creatable: true,
-      updatable: true,
-      configurable: false,
-    },
-    description: 'Inbox visibility setting',
-  },
-
   defaultLens: {
     id: toFieldId('defaultLens'),
     key: 'defaultLens',
@@ -179,7 +151,7 @@ export const INBOX_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     description:
-      'Org-wide visibility floor: the lens every org member gets on this inbox. Explicit grants can only raise it. Supersedes inbox_visibility (mail-permissions §2.2).',
+      'Org-wide visibility floor: the lens every org member gets on this inbox. Explicit grants can only raise it (mail-permissions §2.2).',
   },
 
   createdAt: {

--- a/packages/lib/src/seed/organization-seeder.ts
+++ b/packages/lib/src/seed/organization-seeder.ts
@@ -337,7 +337,7 @@ export class OrganizationSeeder {
       description: 'Default shared inbox for all team members',
       color: 'blue',
       status: 'ACTIVE',
-      visibility: 'org_members', // All members have access by default
+      defaultLens: 'full', // All members have access by default
     })
     logger.info('Created default shared inbox', { organizationId, inboxId: defaultInbox.id })
     // You can create additional default inboxes here if needed
@@ -498,7 +498,7 @@ export class OrganizationSeeder {
         description: 'Default shared inbox for all team members',
         color: 'blue',
         status: 'ACTIVE',
-        visibility: 'org_members',
+        defaultLens: 'full',
       })
       logger.info('Created default inbox for existing organization', { organizationId })
     }

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -196,7 +196,6 @@ export const SYSTEM_ATTRIBUTES = [
   'inbox_description',
   'inbox_color',
   'inbox_status',
-  'inbox_visibility',
   'inbox_default_lens',
   'inbox_settings',
 


### PR DESCRIPTION
## Summary

Phase 6 of `plans/mail-permissions/` (hardening + cleanup). The live restricted-org walkthrough (Phases 2–5) was verified separately on dev; this PR is the code side.

### Audits (passed, no changes needed)
- Every `buildConditionGroupsQuery` caller passes the required `viewer` (type-enforced).
- Every `SYSTEM_VISIBILITY` call site carries a one-line justification comment.
- `setVisibilityAccess` was already deleted in Phase 1.

### Retire legacy `inbox_visibility`
Values were converted to the `inbox_default_lens` floor by data migration 033; this removes the field itself:
- Registry field definition, `InboxVisibility` type, system-attribute entry.
- `InboxService` dual-write on create/update + legacy-lens fallbacks in both serializers.
- `inbox.create` router input, inbox-form dual-write, `useInboxes` fallback.
- Inbox list Access column now renders from the floor lens (All members / Subject only / Activity only / Restricted).
- **New data migration `034-retire-inbox-visibility`**: deletes the per-org CustomField rows + FieldValue cells (mirrors 030) and recomputes `customFields`/`resources` caches. Applied + verified on dev (0 visibility fields remain, 25 orgs carry the lens field).

### Dead code
- Deleted the unused `resourceAccess.myInstances` tRPC procedure (zero FE consumers). `getUserAccessibleInstances` stays — snippets/groups still use it.

## Test plan
- `vitest` green: data-migrations (10), permissions/visibility + registry (61).
- Biome clean on all touched files.
- Migration runner executed on dev; DB verified: `inbox_visibility` CustomField/FieldValue rows gone.