### PR TITLE
feat(mail): personal email accounts (phase 8)

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-form.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-form.tsx
@@ -11,7 +11,9 @@ import {
 } from '@auxx/ui/components/card'
 import { Input } from '@auxx/ui/components/input'
 import { Label } from '@auxx/ui/components/label'
-import { ArrowLeft } from 'lucide-react'
+import { RadioGroup } from '@auxx/ui/components/radio-group'
+import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
+import { ArrowLeft, Lock, Users } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import SettingsPage from '~/components/global/settings-page'
@@ -33,9 +35,19 @@ export default function IntegrationForm({ type }: IntegrationFormProps) {
   // Gmail/Outlook/Facebook/Instagram all connect via the unified connections OAuth flow.
   const isOAuthChannel =
     type === 'google' || type === 'outlook' || type === 'facebook' || type === 'instagram'
-  const { data: prep, isLoading: isLoadingPrep } = api.channel.prepareConnect.useQuery(
-    { provider: type as 'google' | 'outlook' | 'facebook' | 'instagram' },
-    { enabled: isOAuthChannel }
+  // Shared-vs-Personal step (mail-permissions §11.1) — email-likes only; the
+  // server enforces eligibility regardless. Personal connects are open to
+  // every member, so the choice feeds the (admin-gated-when-shared) query.
+  const personalEligible = type === 'google' || type === 'outlook'
+  const [scope, setScope] = useState<'shared' | 'personal'>('shared')
+  const isPersonal = personalEligible && scope === 'personal'
+  const {
+    data: prep,
+    isLoading: isLoadingPrep,
+    error: prepError,
+  } = api.channel.prepareConnect.useQuery(
+    { provider: type as 'google' | 'outlook' | 'facebook' | 'instagram', personal: isPersonal },
+    { enabled: isOAuthChannel, retry: false }
   )
   const [clientId, setClientId] = useState('')
   const [clientSecret, setClientSecret] = useState('')
@@ -45,6 +57,7 @@ export default function IntegrationForm({ type }: IntegrationFormProps) {
     if (!prep) return
     const url = new URL(prep.authorizeUrl, window.location.origin)
     url.searchParams.set('returnTo', '/app/settings/channels')
+    if (isPersonal) url.searchParams.set('personal', '1')
     if (prep.requiresOwnClient) {
       url.searchParams.set('var_clientId', clientId.trim())
       url.searchParams.set('var_clientSecret', clientSecret.trim())
@@ -66,7 +79,7 @@ export default function IntegrationForm({ type }: IntegrationFormProps) {
       case 'outlook':
       case 'facebook':
       case 'instagram': {
-        if (isLoadingPrep || !prep) {
+        if (isLoadingPrep && !prep && !prepError) {
           return (
             <div className='flex items-center justify-center p-8'>
               <div className='text-sm text-muted-foreground'>Loading...</div>
@@ -74,8 +87,12 @@ export default function IntegrationForm({ type }: IntegrationFormProps) {
           )
         }
 
-        const needsOwnClient = prep.requiresOwnClient
+        const needsOwnClient = !!prep?.requiresOwnClient
         const ownClientReady = !needsOwnClient || (!!clientId.trim() && !!clientSecret.trim())
+        // A non-admin's shared query is rejected — steer them to Personal
+        // instead of dead-ending (personal connects are open to every member).
+        const sharedForbidden =
+          !!prepError && !isPersonal && prepError.data?.code === 'FORBIDDEN' && personalEligible
 
         return (
           <div className='flex flex-col space-y-3 p-3'>
@@ -89,7 +106,35 @@ export default function IntegrationForm({ type }: IntegrationFormProps) {
               </div>
             </div>
 
-            {needsOwnClient ? (
+            {personalEligible && (
+              <RadioGroup
+                value={scope}
+                onValueChange={(value) => setScope(value as 'shared' | 'personal')}
+                className='grid gap-2 sm:grid-cols-2'>
+                <RadioGroupItemCard
+                  value='shared'
+                  label='Shared inbox'
+                  icon={<Users />}
+                  description='For the whole team — mail lands in a shared inbox'
+                />
+                <RadioGroupItemCard
+                  value='personal'
+                  label='Personal account'
+                  icon={<Lock />}
+                  description='Private to you — admins see activity only'
+                />
+              </RadioGroup>
+            )}
+
+            {prepError && (
+              <p className='text-sm text-muted-foreground'>
+                {sharedForbidden
+                  ? 'Only admins can connect shared channels. Choose "Personal account" to connect your own mailbox.'
+                  : prepError.message}
+              </p>
+            )}
+
+            {prep && needsOwnClient ? (
               <div className='space-y-2 rounded-md border p-3'>
                 <p className='text-xs text-muted-foreground'>
                   {prep.ownClientReason === 'pending-approval'
@@ -116,12 +161,13 @@ export default function IntegrationForm({ type }: IntegrationFormProps) {
                   />
                 </div>
               </div>
-            ) : (
+            ) : prep ? (
               <p className='text-sm text-muted-foreground'>
-                Click the button below to authorize access to your {type} account. You will be
-                redirected to {type} to complete the authorization process.
+                {isPersonal
+                  ? `Mail from this account goes to your own private inbox — teammates only see what you assign or share. You will be redirected to ${type} to complete the authorization.`
+                  : `Click the button below to authorize access to your ${type} account. You will be redirected to ${type} to complete the authorization process.`}
               </p>
-            )}
+            ) : null}
 
             <div className='flex justify-between'>
               <Button type='button' variant='outline' onClick={handleBack}>
@@ -131,7 +177,7 @@ export default function IntegrationForm({ type }: IntegrationFormProps) {
               <Button
                 variant='info'
                 onClick={handleChannelConnect}
-                disabled={!ownClientReady || redirecting}
+                disabled={!prep || !ownClientReady || redirecting}
                 loading={redirecting}
                 loadingText='Connecting...'>
                 {`Connect to ${type}`}

--- a/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/authorize/route.ts
@@ -3,6 +3,7 @@
 import { WEBAPP_URL } from '@auxx/config/urls'
 import type { OAuth2Features } from '@auxx/database'
 import { database as db } from '@auxx/database'
+import { supportsPersonalChannelConnection } from '@auxx/lib/channels'
 import {
   resolveConnectionForRuntime,
   resolveOAuth2Client,
@@ -111,6 +112,18 @@ export async function GET(
       )
     }
 
+    // Personal channel connect (mail-permissions §11.1): mints a USER-scoped
+    // credential feeding a dedicated personal inbox. Only email-like channel
+    // providers are eligible — enforced here, fail closed, independent of the
+    // wizard UI.
+    const personal = searchParams.get('personal') === '1'
+    if (personal && !supportsPersonalChannelConnection(connDef.providerKey)) {
+      return NextResponse.json(
+        { error: 'This channel cannot be connected as a personal account' },
+        { status: 400 }
+      )
+    }
+
     // Generate CSRF state + optional PKCE verifier (RFC 7636)
     const state = crypto.randomBytes(32).toString('hex')
     const features = (connDef.oauth2Features ?? {}) as OAuth2Features
@@ -183,6 +196,7 @@ export async function GET(
         providerKey: connDef.providerKey,
         connectionName: name || connDef.label || connDef.providerKey,
         global: connDef.global,
+        ...(personal && { personal: true }),
         ...(connectionId && { connectionId }),
         ...(codeVerifier && { codeVerifier }),
         ...(validReturnTo && { returnTo: validReturnTo }),

--- a/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/callback/route.ts
@@ -259,7 +259,9 @@ export async function GET(
       name: metadata.connectionName,
       organizationId: metadata.organizationId,
       createdById: metadata.userId,
-      userId: metadata.global ? null : metadata.userId,
+      // Personal channel connect (§11) mints a USER-scoped credential even on
+      // a global definition; otherwise scope follows the definition's flag.
+      userId: metadata.personal ? metadata.userId : metadata.global ? null : metadata.userId,
       connectionData: {
         accessToken: tokens.access_token,
         refreshToken: tokens.refresh_token,
@@ -303,6 +305,7 @@ export async function GET(
         organizationId: metadata.organizationId,
         userId: metadata.userId,
         ...(metadata.connectionId && { connectionId: metadata.connectionId }),
+        ...(metadata.personal && { personal: true }),
         ...(metadata.postConnect && { extra: metadata.postConnect }),
       })
     }

--- a/apps/web/src/components/global/sidebar/shared-inbox-group.tsx
+++ b/apps/web/src/components/global/sidebar/shared-inbox-group.tsx
@@ -1,9 +1,11 @@
 // ~/components/global/sidebar/shared-inbox-group.tsx
 'use client'
 
+import { toActorId } from '@auxx/types/actor'
 import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
 import { SidebarMenu, SidebarMenuSubItem } from '@auxx/ui/components/sidebar'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
 import {
   closestCenter,
@@ -22,7 +24,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Inbox as InboxIcon, Mail } from 'lucide-react'
+import { Inbox as InboxIcon, Mail, UserRound } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useCallback, useState } from 'react'
@@ -32,6 +34,7 @@ import { EditableSidebarItem } from '~/components/global/sidebar/editable-sideba
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
 import { InboxDialog } from '~/components/inbox/inbox-dialog'
 import { selectSharedInboxesTotal, useMailCountsStore } from '~/components/mail/store'
+import { useActor } from '~/components/resources/hooks/use-actor'
 
 export interface Inbox {
   id: string
@@ -39,6 +42,27 @@ export interface Inbox {
   color: string
   unassignedCount?: number
   isVisible?: boolean
+  /** Personal-account inbox (mail-permissions §11) — renders the owner affordance. */
+  isPersonal?: boolean
+  ownerUserId?: string | null
+}
+
+/**
+ * Sidebar affordance for a personal inbox (§11): a user icon in place of the
+ * color dot, with a "Personal — {owner}" tooltip.
+ */
+function PersonalInboxIcon({ ownerUserId }: { ownerUserId?: string | null }) {
+  const { actor } = useActor({
+    actorId: ownerUserId ? toActorId('user', ownerUserId) : null,
+  })
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <UserRound className='text-muted-foreground' />
+      </TooltipTrigger>
+      <TooltipContent side='right'>Personal{actor?.name ? ` — ${actor.name}` : ''}</TooltipContent>
+    </Tooltip>
+  )
 }
 
 interface SharedInboxesSectionProps {
@@ -103,6 +127,7 @@ const DroppableInboxSidebarItem = ({
         href={itemHref}
         count={count}
         color={inbox.color || 'indigo'}
+        icon={inbox.isPersonal ? <PersonalInboxIcon ownerUserId={inbox.ownerUserId} /> : undefined}
         isSubmenu={true}
         isActive={isActive}
         editItems={editItems}

--- a/apps/web/src/components/inbox/inbox-detail.tsx
+++ b/apps/web/src/components/inbox/inbox-detail.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage from '~/components/global/settings-page'
+import { OrphanedPersonalInboxBanner } from '~/components/mail-permissions/ui/orphaned-inbox-banner'
 import { api } from '~/trpc/react'
 import { toRecordId, useResource } from '../resources'
 import { useInbox } from '../threads/hooks'
@@ -101,7 +102,10 @@ export function InboxDetail({ inboxId }: { inboxId: string }) {
               </TableBody>
             </Table>
           ) : inbox && integrations ? (
-            <InboxIntegrationsTab inboxId={inboxId} integrations={integrations} />
+            <>
+              <OrphanedPersonalInboxBanner inbox={inbox} />
+              <InboxIntegrationsTab inboxId={inboxId} integrations={integrations} />
+            </>
           ) : (
             <EmptyState
               icon={X}

--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -26,7 +26,9 @@ import {
 import { GranteeList } from '~/components/mail-permissions/ui/grantee-list'
 import { LensSelect } from '~/components/mail-permissions/ui/lens-select'
 import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
+import { ActorBadge } from '~/components/resources/ui/actor-badge'
 import { FormColorTagPicker } from '~/components/tags/ui/color-tag-picker'
+import { useInbox } from '~/components/threads/hooks/use-inbox'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useDirtyCheck } from '~/hooks/use-dirty-state'
 import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
@@ -124,6 +126,12 @@ export function InboxForm({
   const gated = useMailPermissionsGated()
   const [upgradeOpen, setUpgradeOpen] = useState(false)
   const [guideOpen, setGuideOpen] = useState(false)
+
+  // Personal-account inbox (§11): the Access section swaps the floor controls
+  // for an owner row + activity-only note; the owner's Manager row is locked.
+  const { inbox: inboxItem } = useInbox(recordId ?? undefined)
+  const isPersonalInbox = !!inboxItem?.isPersonal
+  const ownerActorId = inboxItem?.ownerUserId ? toActorId('user', inboxItem.ownerUserId) : null
 
   // Fetch system field values for edit mode
   const { values: fieldValues, isLoading: isLoadingValues } = useSystemValues(
@@ -486,39 +494,59 @@ export function InboxForm({
             {/* Access section — org admins and inbox Managers only */}
             {canManageAccess && (
               <>
-                <Field>
-                  <FieldLabel>Access</FieldLabel>
-                  <RadioGroup
-                    value={accessType}
-                    onValueChange={handleAccessTypeChange}
-                    className='grid gap-2 sm:grid-cols-2'>
-                    <RadioGroupItemCard
-                      value='anyone'
-                      label='Everyone'
-                      icon={<UsersIcon />}
-                      description='Everyone in the organization, at a chosen level'
-                    />
-                    <RadioGroupItemCard
-                      value='restricted'
-                      label='Restricted'
-                      icon={<Lock />}
-                      description='Only people and groups you add below'
-                    />
-                  </RadioGroup>
-                </Field>
-
-                {accessType === 'anyone' && (
+                {isPersonalInbox ? (
                   <Field>
-                    <FieldLabel>Everyone can see</FieldLabel>
-                    <LensSelect
-                      value={floorLens}
-                      onChange={(choice) =>
-                        choice !== 'manager' && form.setValue('floorLens', choice)
-                      }
-                      size='default'
-                      className='w-full'
-                    />
+                    <FieldLabel>Access</FieldLabel>
+                    <div className='space-y-2 rounded-md border p-3'>
+                      {ownerActorId && (
+                        <div className='flex items-center justify-between'>
+                          <ActorBadge actorId={ownerActorId} />
+                          <span className='text-muted-foreground text-xs'>Owner</span>
+                        </div>
+                      )}
+                      <p className='text-muted-foreground text-xs'>
+                        Personal account — mail here is private to its owner. Admins can see
+                        activity only; assignment and shares grant access per thread.
+                      </p>
+                    </div>
                   </Field>
+                ) : (
+                  <>
+                    <Field>
+                      <FieldLabel>Access</FieldLabel>
+                      <RadioGroup
+                        value={accessType}
+                        onValueChange={handleAccessTypeChange}
+                        className='grid gap-2 sm:grid-cols-2'>
+                        <RadioGroupItemCard
+                          value='anyone'
+                          label='Everyone'
+                          icon={<UsersIcon />}
+                          description='Everyone in the organization, at a chosen level'
+                        />
+                        <RadioGroupItemCard
+                          value='restricted'
+                          label='Restricted'
+                          icon={<Lock />}
+                          description='Only people and groups you add below'
+                        />
+                      </RadioGroup>
+                    </Field>
+
+                    {accessType === 'anyone' && (
+                      <Field>
+                        <FieldLabel>Everyone can see</FieldLabel>
+                        <LensSelect
+                          value={floorLens}
+                          onChange={(choice) =>
+                            choice !== 'manager' && form.setValue('floorLens', choice)
+                          }
+                          size='default'
+                          className='w-full'
+                        />
+                      </Field>
+                    )}
+                  </>
                 )}
 
                 <Field>
@@ -530,10 +558,13 @@ export function InboxForm({
                     onRevoke={removeGrant}
                     includeManager
                     disabled={isPending}
+                    lockedActorIds={isPersonalInbox && ownerActorId ? [ownerActorId] : []}
                     emptyHint={
-                      accessType === 'restricted'
-                        ? 'No one has access yet. Add people or groups.'
-                        : 'No individual access — everyone uses the level above.'
+                      isPersonalInbox
+                        ? 'Only the owner has access. Add people or groups to share.'
+                        : accessType === 'restricted'
+                          ? 'No one has access yet. Add people or groups.'
+                          : 'No individual access — everyone uses the level above.'
                     }
                   />
                   <button

--- a/apps/web/src/components/inbox/inbox-list.tsx
+++ b/apps/web/src/components/inbox/inbox-list.tsx
@@ -129,7 +129,13 @@ export function InboxList() {
                       </div>
                     </div>
                   </TableCell>
-                  <TableCell>{getAccessDisplay(inbox.defaultLens)}</TableCell>
+                  <TableCell>
+                    {inbox.isPersonal ? (
+                      <Badge variant='gray'>Personal</Badge>
+                    ) : (
+                      getAccessDisplay(inbox.defaultLens)
+                    )}
+                  </TableCell>
                   <TableCell>{getStatusBadge(status)}</TableCell>
                 </TableRow>
               )

--- a/apps/web/src/components/mail-permissions/ui/orphaned-inbox-banner.tsx
+++ b/apps/web/src/components/mail-permissions/ui/orphaned-inbox-banner.tsx
@@ -1,0 +1,105 @@
+// apps/web/src/components/mail-permissions/ui/orphaned-inbox-banner.tsx
+'use client'
+
+import { toActorId } from '@auxx/types/actor'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
+import { Button } from '@auxx/ui/components/button'
+import { toastError } from '@auxx/ui/components/toast'
+import { UserRound } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useActor } from '~/components/resources/hooks/use-actor'
+import type { InboxItem } from '~/components/threads/hooks/use-inbox'
+import { useInboxes } from '~/components/threads/hooks/use-inbox'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useMembersGroups } from '~/hooks/use-members-groups'
+import { useUser } from '~/hooks/use-user'
+import { api } from '~/trpc/react'
+
+/**
+ * Admin banner on an ORPHANED personal inbox (mail-permissions §11.4) — the
+ * owner left the org, sync is stopped, and an admin must decide: claim it
+ * (convert into a normal restricted org inbox, admins gain full access) or
+ * delete it (inbox + all its mail, destructive confirm). Renders nothing for
+ * non-admins, non-personal inboxes, or while the owner is still a member.
+ */
+export function OrphanedPersonalInboxBanner({ inbox }: { inbox: InboxItem }) {
+  const router = useRouter()
+  const { isAdminOrOwner } = useUser()
+  const { members, isLoading: membersLoading } = useMembersGroups()
+  const { refresh } = useInboxes()
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const { actor: owner } = useActor({
+    actorId: inbox.ownerUserId ? toActorId('user', inbox.ownerUserId) : null,
+  })
+
+  const claim = api.inbox.claimPersonal.useMutation({
+    onSuccess: () => refresh(),
+    onError: (error) => toastError({ title: 'Error claiming inbox', description: error.message }),
+  })
+  const deletePersonal = api.inbox.deletePersonal.useMutation({
+    onSuccess: () => {
+      refresh()
+      router.push('/app/settings/inbox')
+    },
+    onError: (error) => toastError({ title: 'Error deleting inbox', description: error.message }),
+  })
+
+  const orphaned =
+    inbox.isPersonal &&
+    !!inbox.ownerUserId &&
+    !membersLoading &&
+    !members.some((m) => m.userId === inbox.ownerUserId)
+
+  if (!isAdminOrOwner || !orphaned) return null
+
+  const ownerLabel = owner?.name ?? 'a former member'
+
+  const handleDelete = async () => {
+    const confirmed = await confirm({
+      title: 'Delete personal inbox?',
+      description:
+        'This permanently deletes the inbox and ALL of its mail. The data was private to its owner and cannot be recovered.',
+      confirmText: 'Delete inbox',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) deletePersonal.mutate({ inboxId: inbox.id })
+  }
+
+  return (
+    <>
+      <Alert className='mb-4'>
+        <UserRound />
+        <AlertTitle>Orphaned personal inbox</AlertTitle>
+        <AlertDescription>
+          <p>
+            This was {ownerLabel}&apos;s personal account and its owner is no longer a member.
+            Syncing has stopped. Claim it to convert it into a shared restricted inbox, or delete it
+            along with all of its mail.
+          </p>
+          <div className='mt-2 flex gap-2'>
+            <Button
+              size='sm'
+              variant='outline'
+              onClick={() => claim.mutate({ inboxId: inbox.id })}
+              loading={claim.isPending}
+              loadingText='Claiming...'>
+              Claim inbox
+            </Button>
+            <Button
+              size='sm'
+              variant='outline'
+              className='text-destructive hover:text-destructive'
+              onClick={handleDelete}
+              loading={deletePersonal.isPending}
+              loadingText='Deleting...'>
+              Delete inbox
+            </Button>
+          </div>
+        </AlertDescription>
+      </Alert>
+      <ConfirmDialog />
+    </>
+  )
+}

--- a/apps/web/src/components/threads/hooks/use-inbox.ts
+++ b/apps/web/src/components/threads/hooks/use-inbox.ts
@@ -18,6 +18,8 @@ export interface InboxRecord extends RecordMeta {
     inbox_color?: string
     inbox_status?: 'ACTIVE' | 'ARCHIVED' | 'PAUSED'
     inbox_default_lens?: 'none' | 'metadata' | 'subject' | 'full'
+    inbox_is_personal?: boolean
+    inbox_owner_user_id?: string
   }
 }
 
@@ -43,6 +45,10 @@ export interface InboxItem {
    * simply never load.
    */
   myLens?: ChannelLens
+  /** Personal-account inbox (§11) — one user's connected mailbox. */
+  isPersonal: boolean
+  /** Owner of a personal inbox; null on shared org inboxes. */
+  ownerUserId: string | null
 }
 
 /**
@@ -90,6 +96,8 @@ export function useInboxes(): UseInboxesResult {
       status: record.fieldValues?.inbox_status,
       defaultLens: record.fieldValues?.inbox_default_lens ?? 'full',
       myLens: lenses[record.id],
+      isPersonal: record.fieldValues?.inbox_is_personal ?? false,
+      ownerUserId: record.fieldValues?.inbox_owner_user_id ?? null,
     }))
 
     // Key map by recordId for direct lookup (thread.inboxId is now RecordId)

--- a/apps/web/src/hooks/use-mail-sidebar.tsx
+++ b/apps/web/src/hooks/use-mail-sidebar.tsx
@@ -70,6 +70,8 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
           name: inbox.name,
           color: inbox.color ?? 'indigo', // Default indigo color
           isVisible: inboxVisibilitySettings[inbox.id] !== false, // Default true
+          isPersonal: inbox.isPersonal,
+          ownerUserId: inbox.ownerUserId,
         })
         processedIds.add(id)
       }
@@ -83,6 +85,8 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
           name: inbox.name,
           color: inbox.color ?? 'indigo', // Default indigo color
           isVisible: inboxVisibilitySettings[inbox.id] !== false, // Default true
+          isPersonal: inbox.isPersonal,
+          ownerUserId: inbox.ownerUserId,
         })
       }
     })

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -15,6 +15,7 @@ import {
   linkChannelToInbox,
   list as listChannels,
   resolveChannelDefinitionId,
+  supportsPersonalChannelConnection,
   syncAllMessages,
   syncMessages,
   toggle as toggleChannel,
@@ -82,15 +83,21 @@ export const channelRouter = createTRPCRouter({
    * Prepare a Gmail/Outlook connect via the unified connections OAuth flow. Enforces
    * admin + channel-limit, then returns the generic authorize URL plus the platform-client
    * approval gate (§3.1) so the UI knows whether to collect a bring-your-own OAuth client.
+   *
+   * Personal connects (mail-permissions §11.1) are open to every member —
+   * the account is theirs; the channel limit still applies. The provider must
+   * support personal connection (fail closed, the authorize route re-checks).
    */
   prepareConnect: protectedProcedure
-    .input(z.object({ provider: z.enum(['google', 'outlook', 'facebook', 'instagram']) }))
+    .input(
+      z.object({
+        provider: z.enum(['google', 'outlook', 'facebook', 'instagram']),
+        personal: z.boolean().optional(),
+      })
+    )
     .query(async ({ ctx, input }) => {
       const { userId } = ctx.session
       const organizationId = getUserOrganizationId(ctx.session)
-
-      await requireAdminAccess(userId, organizationId)
-      await checkChannelLimit(ctx.db, organizationId)
 
       const PROVIDER_KEY_BY_CHANNEL = {
         google: 'gmail',
@@ -99,6 +106,19 @@ export const channelRouter = createTRPCRouter({
         instagram: 'instagram',
       } as const
       const providerKey = PROVIDER_KEY_BY_CHANNEL[input.provider]
+      const supportsPersonal = supportsPersonalChannelConnection(providerKey)
+
+      if (input.personal) {
+        if (!supportsPersonal) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'This channel cannot be connected as a personal account',
+          })
+        }
+      } else {
+        await requireAdminAccess(userId, organizationId)
+      }
+      await checkChannelLimit(ctx.db, organizationId)
       const def = await ctx.db.query.ConnectionDefinition.findFirst({
         where: (cd, { eq }) => eq(cd.providerKey, providerKey),
         columns: { oauth2ClientId: true, oauth2ClientSecret: true, platformClientApproved: true },
@@ -116,6 +136,7 @@ export const channelRouter = createTRPCRouter({
         authorizeUrl: `/api/connections/${providerKey}/oauth2/authorize`,
         requiresOwnClient: gate.requiresOwnClient,
         ownClientReason: gate.reason,
+        supportsPersonalConnection: supportsPersonal,
       }
     }),
 

--- a/apps/web/src/server/api/routers/inbox.ts
+++ b/apps/web/src/server/api/routers/inbox.ts
@@ -1,6 +1,7 @@
 // apps/web/src/server/api/routers/inbox.ts
 
 import { getCachedUserMailVisibility, getOrgCache } from '@auxx/lib/cache'
+import { claimPersonalInbox, deletePersonalInbox } from '@auxx/lib/channels'
 import { InboxService } from '@auxx/lib/inboxes'
 import { inboxLensFor, type Lens } from '@auxx/lib/permissions/visibility'
 import { ThreadMutationService } from '@auxx/lib/threads'
@@ -8,7 +9,7 @@ import { recordIdSchema, toRecordId } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
-import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+import { adminProcedure, createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
 
 /** Schema for creating an inbox */
 const createInboxSchema = z.object({
@@ -102,6 +103,52 @@ export const inboxRouter = createTRPCRouter({
       await recordAuditFromCtx(ctx, {
         category: 'integrations',
         action: 'inbox.deleted',
+        targetType: 'Inbox',
+        targetId: input.inboxId,
+      })
+      return { success: true }
+    }),
+
+  /**
+   * Claim an ORPHANED personal inbox (mail-permissions §11.4): clears the
+   * personal marker + owner, converting it into a normal restricted org
+   * inbox. Rejected while the owner is still a member.
+   */
+  claimPersonal: adminProcedure
+    .input(z.object({ inboxId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      await claimPersonalInbox({
+        organizationId,
+        adminUserId: ctx.session.user.id,
+        inboxId: input.inboxId,
+      })
+      await recordAuditFromCtx(ctx, {
+        category: 'integrations',
+        action: 'inbox.personal.claimed',
+        targetType: 'Inbox',
+        targetId: input.inboxId,
+      })
+      return { success: true }
+    }),
+
+  /**
+   * Delete an ORPHANED personal inbox (§11.4): destroys its channels'
+   * threads/messages and the inbox itself. Rejected while the owner is
+   * still a member.
+   */
+  deletePersonal: adminProcedure
+    .input(z.object({ inboxId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      await deletePersonalInbox({
+        organizationId,
+        adminUserId: ctx.session.user.id,
+        inboxId: input.inboxId,
+      })
+      await recordAuditFromCtx(ctx, {
+        category: 'integrations',
+        action: 'inbox.personal.deleted',
         targetType: 'Inbox',
         targetId: input.inboxId,
       })

--- a/apps/web/src/server/api/routers/organization.ts
+++ b/apps/web/src/server/api/routers/organization.ts
@@ -416,6 +416,19 @@ export const organizationRouter = createTRPCRouter({
           .where(eq(schema.User.id, userId))
       }
 
+      // Offboarding (mail-permissions §11.4): stop sync on the leaver's
+      // personal channels; their personal inbox stays for admin claim/delete.
+      try {
+        const { disconnectPersonalChannelsForUser } = await import('@auxx/lib/channels')
+        await disconnectPersonalChannelsForUser(organizationId, userId)
+      } catch (error) {
+        logger.error('Failed to disconnect personal channels for leaving member', {
+          organizationId,
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+
       await onCacheEvent('member.removed', { orgId: organizationId, userId })
 
       await recordAuditFromCtx(ctx, {

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -545,9 +545,9 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   groupMembers: { prefix: 'org:group-members', ttlSeconds: ONE_DAY },
   // Read per CRUD event by agent-trigger dispatch — same rationale as workflowApps.
   agents: { prefix: 'org:agents', ttlSeconds: ONE_DAY, localTtlMs: 5_000 },
-  // v3: + isPersonal (§11 groundwork). v2: + defaultLens (mail-permissions
-  // §2.2). Bump on shape changes.
-  inboxes: { prefix: 'org:inboxes:v3', ttlSeconds: ONE_DAY },
+  // v4: + ownerUserId (§11 personal accounts). v3: + isPersonal. v2: +
+  // defaultLens (mail-permissions §2.2). Bump on shape changes.
+  inboxes: { prefix: 'org:inboxes:v4', ttlSeconds: ONE_DAY },
   // Reverse thread/contact/inbox grant index for realtime publish fanout
   // (§3.1) + ingest count-delta audiences (§10.1). v2: + inboxes bucket.
   mailGrantIndex: { prefix: 'org:mail-grant-index:v2', ttlSeconds: ONE_DAY },

--- a/packages/lib/src/channels/disconnect.ts
+++ b/packages/lib/src/channels/disconnect.ts
@@ -22,9 +22,11 @@ type DbHandle = Database | Transaction
 
 /**
  * Delete threads + messages for a channel, clean up MediaAssets, and mark
- * StorageLocations for async S3 deletion.
+ * StorageLocations for async S3 deletion. Exported for the personal-inbox
+ * delete path (§11.4), which destroys channel data without the ownership
+ * validation `disconnect` performs (its integration is already soft-deleted).
  */
-async function deleteChannelData(tx: DbHandle, channelId: string, provider: string) {
+export async function deleteChannelData(tx: DbHandle, channelId: string, provider: string) {
   logger.warn(`Deleting data for channel: ${channelId} (${provider})`)
 
   if (provider === 'chat') {

--- a/packages/lib/src/channels/index.ts
+++ b/packages/lib/src/channels/index.ts
@@ -10,6 +10,13 @@ export {
 export { disconnect } from './disconnect'
 export { type CreateChannelInput, createChannel, linkChannelToInbox } from './lifecycle'
 export { countBillableChannels, getProviderType, list } from './list'
+export {
+  claimPersonalInbox,
+  deletePersonalInbox,
+  disconnectPersonalChannelsForUser,
+  provisionPersonalInbox,
+  supportsPersonalChannelConnection,
+} from './personal-connection'
 export { registerChannelHooks } from './register-hooks'
 export {
   addExcludedSender,

--- a/packages/lib/src/channels/personal-connection.ts
+++ b/packages/lib/src/channels/personal-connection.ts
@@ -1,0 +1,248 @@
+// packages/lib/src/channels/personal-connection.ts
+
+import { database as db, schema } from '@auxx/database'
+import type { IntegrationProviderType } from '@auxx/database/enums'
+import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull } from 'drizzle-orm'
+import { getOrgCache, onCacheEvent } from '../cache'
+import { clearImportCache } from '../email/polling-import-cache'
+import { ForbiddenError, NotFoundError } from '../errors'
+import { InboxService } from '../inboxes/inbox-service'
+import { enqueueStorageCleanupJob } from '../jobs/maintenance/storage-cleanup-job'
+import { GoogleOAuthService } from '../providers/google/google-oauth'
+import { OutlookOAuthService } from '../providers/outlook/outlook-oauth'
+import { PROVIDER_CAPABILITIES } from '../providers/provider-capabilities'
+import { setInstanceAccess } from '../resource-access/resource-access-service'
+import { CHANNEL_PROVIDER_TO_KEY } from './channel-connection-def'
+import { deleteChannelData } from './disconnect'
+
+const logger = createScopedLogger('personal-connection')
+
+/** ConnectionDefinition.providerKey → ChannelProviderType (inverse of CHANNEL_PROVIDER_TO_KEY). */
+const CHANNEL_PROVIDER_BY_KEY: Record<string, IntegrationProviderType> = Object.fromEntries(
+  Object.entries(CHANNEL_PROVIDER_TO_KEY).map(([provider, key]) => [
+    key,
+    provider as IntegrationProviderType,
+  ])
+)
+
+/**
+ * Whether a connection providerKey may mint a PERSONAL (user-scoped) channel
+ * credential (mail-permissions §11.1). The OAuth authorize route enforces
+ * this server-side — the wizard step is just ergonomics. Fail closed: keys
+ * that don't map to a channel provider, or map to one without the
+ * `supportsPersonalConnection` capability, return false.
+ */
+export function supportsPersonalChannelConnection(providerKey: string | null): boolean {
+  if (!providerKey) return false
+  const provider = CHANNEL_PROVIDER_BY_KEY[providerKey]
+  if (!provider) return false
+  return PROVIDER_CAPABILITIES[provider]?.supportsPersonalConnection === true
+}
+
+/**
+ * Provision the dedicated inbox for a PERSONAL channel connect (§11.1):
+ * named after the address, `isPersonal` + owner stamped, floor `none`
+ * (the §11.3 carve-out — no enterprise key needed on this system path),
+ * owner as Manager. Nothing attaches to the org's Shared Inbox.
+ *
+ * Reconnect of the user's own personal channel is a no-op; a mailbox already
+ * linked to a shared inbox (or another user's personal inbox) is rejected —
+ * `addIntegration` MOVES links, and silently rerouting an org channel's new
+ * mail into a hidden inbox must never happen (fail closed).
+ */
+export async function provisionPersonalInbox(args: {
+  organizationId: string
+  ownerUserId: string
+  integrationId: string
+  email: string
+}): Promise<void> {
+  const { organizationId, ownerUserId, integrationId, email } = args
+
+  // System-scoped service: userId-less writes pass the inbox field walls,
+  // which is exactly the trusted-provisioning carve-out they encode.
+  const inboxService = new InboxService(db, organizationId)
+
+  const existingLink = await db.query.InboxIntegration.findFirst({
+    where: eq(schema.InboxIntegration.integrationId, integrationId),
+  })
+  if (existingLink) {
+    const linkedInbox = await inboxService.getInboxById(existingLink.inboxId)
+    if (linkedInbox?.isPersonal && linkedInbox.ownerUserId === ownerUserId) {
+      logger.info('Personal channel reconnect — inbox already provisioned', {
+        integrationId,
+        inboxId: existingLink.inboxId,
+      })
+      return
+    }
+    throw new Error(
+      'This mailbox is already connected as a shared channel. Disconnect it first to connect it as a personal account.'
+    )
+  }
+
+  const inbox = await inboxService.createInbox({
+    name: email,
+    defaultLens: 'none',
+    isPersonal: true,
+    ownerUserId,
+  })
+
+  // Owner becomes the inbox Manager (createInbox only grants when the
+  // service carries a user — the system-scoped one doesn't).
+  await setInstanceAccess(
+    { db, organizationId, userId: ownerUserId },
+    inbox.recordId,
+    ResourceGranteeType.user,
+    [{ granteeId: ownerUserId, permission: ResourcePermission.admin }]
+  )
+
+  await inboxService.addIntegration(inbox.recordId, integrationId, true)
+
+  logger.info('Personal inbox provisioned', {
+    inboxId: inbox.id,
+    integrationId,
+    ownerUserId,
+  })
+}
+
+/**
+ * Offboarding step 1 (§11.4): stop sync on the removed member's personal
+ * channels WITHOUT deleting data — revoke provider access (best effort,
+ * it is their credential), soft-delete the Integration rows, clear polling
+ * caches. The inbox and its threads keep personal visibility; admins later
+ * claim or delete the orphaned inbox. NOT `disconnect()` — that destroys
+ * threads/messages, which would preempt the admin's claim-or-delete choice.
+ */
+export async function disconnectPersonalChannelsForUser(
+  organizationId: string,
+  userId: string
+): Promise<number> {
+  const rows = await db
+    .select({ id: schema.Integration.id, provider: schema.Integration.provider })
+    .from(schema.Integration)
+    .innerJoin(schema.Credential, eq(schema.Integration.credentialId, schema.Credential.id))
+    .where(
+      and(
+        eq(schema.Integration.organizationId, organizationId),
+        isNull(schema.Integration.deletedAt),
+        eq(schema.Credential.userId, userId)
+      )
+    )
+
+  for (const row of rows) {
+    try {
+      if (row.provider === 'google') await GoogleOAuthService.revokeAccess(row.id)
+      else if (row.provider === 'outlook') await OutlookOAuthService.revokeAccess(row.id)
+    } catch (error) {
+      logger.warn('Failed to revoke personal channel access, continuing disconnect', {
+        integrationId: row.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+
+    await db
+      .update(schema.Integration)
+      .set({ deletedAt: new Date(), enabled: false, updatedAt: new Date() })
+      .where(eq(schema.Integration.id, row.id))
+    await clearImportCache(row.id)
+  }
+
+  if (rows.length > 0) {
+    await onCacheEvent('channel.disconnected', { orgId: organizationId })
+    logger.info('Disconnected personal channels for removed member', {
+      organizationId,
+      userId,
+      count: rows.length,
+    })
+  }
+  return rows.length
+}
+
+/** Assert the inbox is personal and its owner is no longer an org member. */
+async function loadOrphanedPersonalInbox(
+  inboxService: InboxService,
+  organizationId: string,
+  inboxId: string
+) {
+  const inbox = await inboxService.getInboxById(inboxId)
+  if (!inbox) throw new NotFoundError('Inbox not found')
+  if (!inbox.isPersonal) throw new ForbiddenError('Not a personal inbox')
+
+  const roleMap = await getOrgCache().get(organizationId, 'memberRoleMap')
+  if (inbox.ownerUserId && roleMap[inbox.ownerUserId]) {
+    throw new ForbiddenError(
+      "This personal inbox's owner is still a member — it can only be claimed or deleted after they leave"
+    )
+  }
+  return inbox
+}
+
+/**
+ * Offboarding step 2a (§11.4): CLAIM an orphaned personal inbox — clear the
+ * personal marker + owner, converting it into a normal restricted org inbox
+ * (floor stays `none`; the admin short-circuit applies from then on). The
+ * inbox field write runs as the admin, so the field walls stay honest, and
+ * `inbox.updated` broadcasts every member's visibility recompute.
+ */
+export async function claimPersonalInbox(args: {
+  organizationId: string
+  adminUserId: string
+  inboxId: string
+}): Promise<void> {
+  const { organizationId, adminUserId, inboxId } = args
+  const inboxService = new InboxService(db, organizationId, adminUserId)
+  const inbox = await loadOrphanedPersonalInbox(inboxService, organizationId, inboxId)
+
+  await inboxService.updateInbox(inbox.recordId, { isPersonal: false, ownerUserId: null })
+
+  logger.info('Personal inbox claimed', { inboxId, adminUserId })
+}
+
+/**
+ * Offboarding step 2b (§11.4): DELETE an orphaned personal inbox — destroys
+ * its channels' threads/messages (the data was never org-visible), then the
+ * inbox itself (links + grants + instance via `deleteInbox`).
+ */
+export async function deletePersonalInbox(args: {
+  organizationId: string
+  adminUserId: string
+  inboxId: string
+}): Promise<void> {
+  const { organizationId, adminUserId, inboxId } = args
+  const inboxService = new InboxService(db, organizationId, adminUserId)
+  const inbox = await loadOrphanedPersonalInbox(inboxService, organizationId, inboxId)
+
+  const links = await db.query.InboxIntegration.findMany({
+    where: eq(schema.InboxIntegration.inboxId, inboxId),
+  })
+  for (const link of links) {
+    const [integration] = await db
+      .select({ id: schema.Integration.id, provider: schema.Integration.provider })
+      .from(schema.Integration)
+      .where(eq(schema.Integration.id, link.integrationId))
+      .limit(1)
+    if (!integration) continue
+
+    await db.transaction(async (tx) => {
+      await deleteChannelData(tx, integration.id, integration.provider)
+      await tx
+        .update(schema.Integration)
+        .set({ deletedAt: new Date(), enabled: false, updatedAt: new Date() })
+        .where(eq(schema.Integration.id, integration.id))
+    })
+    await clearImportCache(integration.id)
+    await enqueueStorageCleanupJob({
+      type: 'integration',
+      organizationId,
+      integrationId: integration.id,
+    })
+  }
+
+  await inboxService.deleteInbox(inbox.recordId)
+
+  const { bumpMailCountsEpoch } = await import('../threads/mail-counts')
+  await bumpMailCountsEpoch(organizationId)
+
+  logger.info('Personal inbox deleted', { inboxId, adminUserId, channels: links.length })
+}

--- a/packages/lib/src/channels/provisioning-hook.ts
+++ b/packages/lib/src/channels/provisioning-hook.ts
@@ -17,6 +17,7 @@ import { resolveConnectionForRuntime } from '../connections/resolve-connection-f
 import { publisher } from '../events'
 import { InboxService } from '../inboxes/inbox-service'
 import { GoogleOAuthService } from '../providers/google/google-oauth'
+import { provisionPersonalInbox } from './personal-connection'
 
 const logger = createScopedLogger('channel-provisioning-hook')
 
@@ -279,8 +280,19 @@ export const channelProvisioningHook: PostConnectHook = {
       metadataPatch,
     })
 
-    const inboxService = new InboxService(db, ctx.organizationId, ctx.userId)
-    await inboxService.addIntegrationToDefaultInbox(integration.id)
+    if (ctx.personal) {
+      // Personal account (§11): dedicated restricted inbox owned by the
+      // connector; nothing attaches to the org's Shared Inbox.
+      await provisionPersonalInbox({
+        organizationId: ctx.organizationId,
+        ownerUserId: ctx.userId,
+        integrationId: integration.id,
+        email: identity.email,
+      })
+    } else {
+      const inboxService = new InboxService(db, ctx.organizationId, ctx.userId)
+      await inboxService.addIntegrationToDefaultInbox(integration.id)
+    }
 
     await seedSync({
       integrationId: integration.id,

--- a/packages/lib/src/connections/post-connect-hooks.ts
+++ b/packages/lib/src/connections/post-connect-hooks.ts
@@ -19,6 +19,11 @@ export interface PostConnectHookContext {
   userId: string
   /** Present on reconnect/reauth — the rotated credential id (== `credentialId`). */
   connectionId?: string
+  /**
+   * The credential was minted PERSONAL (user-scoped, mail-permissions §11) —
+   * channel provisioning branches to a dedicated personal inbox.
+   */
+  personal?: boolean
   /** Opaque flow context carried through OAuth state (e.g. calendar-grant target). */
   extra?: Record<string, unknown>
 }

--- a/packages/lib/src/field-hooks/post/inbox-cache-invalidation.ts
+++ b/packages/lib/src/field-hooks/post/inbox-cache-invalidation.ts
@@ -5,9 +5,12 @@ import type { EntityFieldChangeHandler } from '../types'
 /**
  * Inbox fields whose value feeds every member's cached `userMailVisibility`
  * (mail-permissions §7.1) — changing one recomputes ALL members' contexts.
- * Phase 8 adds `inbox_is_personal` / `inbox_owner_user_id` here.
  */
-const VISIBILITY_ATTRIBUTES = new Set<string>(['inbox_default_lens'])
+const VISIBILITY_ATTRIBUTES = new Set<string>([
+  'inbox_default_lens',
+  'inbox_is_personal',
+  'inbox_owner_user_id',
+])
 
 /**
  * Post-write hook for ANY inbox field change (§7.1). Inboxes have two write

--- a/packages/lib/src/field-hooks/pre/inbox-personal-guard.ts
+++ b/packages/lib/src/field-hooks/pre/inbox-personal-guard.ts
@@ -1,0 +1,30 @@
+// packages/lib/src/field-hooks/pre/inbox-personal-guard.ts
+
+import { getCachedUserMailVisibility } from '../../cache'
+import { ForbiddenError } from '../../errors'
+import type { FieldPreHookHandler } from '../types'
+
+/**
+ * The field-write wall for `inbox_is_personal` / `inbox_owner_user_id`
+ * (mail-permissions §11). These two fields decide whether admins are capped
+ * at activity-only and whether automation can see the inbox — letting any
+ * member flip them via the generic records path (form edits, Kopilot record
+ * tools, workflow CRUD) would let a member hide an org inbox or expose a
+ * personal one.
+ *
+ * - System paths without a user (the personal connect provisioning branch,
+ *   workers) pass through — that is how the fields get stamped.
+ * - User-initiated writes are org-admin only (the claim action clears them;
+ *   an admin re-marking an inbox personal is detectable and reversible by
+ *   the other admins, per the plan's risk register).
+ */
+export const guardInboxPersonalFields: FieldPreHookHandler = async (event) => {
+  if (!event.userId) return event.newValue
+
+  const vis = await getCachedUserMailVisibility(event.userId, event.organizationId)
+  if (!vis.isAdmin) {
+    throw new ForbiddenError('Only org admins can change personal-inbox ownership')
+  }
+
+  return event.newValue
+}

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -6,6 +6,7 @@ import { invalidateInboxCacheOnFieldChange } from './post/inbox-cache-invalidati
 import { publishFieldChangeEvent } from './post/publish-field-change-event'
 import { touchActivityOnFieldChange } from './post/touch-activity-on-field-change'
 import { guardInboxDefaultLens } from './pre/inbox-lens-guard'
+import { guardInboxPersonalFields } from './pre/inbox-personal-guard'
 import {
   dropUnauthorizedSystemFlag,
   rejectDeleteIfSystemTag,
@@ -74,6 +75,11 @@ export function registerAllHooks(): void {
   // floor, and sub-`full` floors are enterprise-gated. This hook is the
   // actual enforcement; the inbox form / InboxService are just ergonomics.
   registerFieldPreHooks('inboxes', 'inbox_default_lens', [guardInboxDefaultLens])
+
+  // Personal-inbox marker wall (§11) — system paths stamp these; user writes
+  // are admin-only (claim/convert).
+  registerFieldPreHooks('inboxes', 'inbox_is_personal', [guardInboxPersonalFields])
+  registerFieldPreHooks('inboxes', 'inbox_owner_user_id', [guardInboxPersonalFields])
 
   registerFieldPreHooks('tags', 'is_system_tag', [dropUnauthorizedSystemFlag])
   registerFieldPreHooks('tags', 'title', [rejectIfSystemTag])

--- a/packages/lib/src/inboxes/inbox-service.ts
+++ b/packages/lib/src/inboxes/inbox-service.ts
@@ -59,6 +59,10 @@ export class InboxService {
       inbox_default_lens: input.defaultLens ?? 'full',
       inbox_settings: input.settings ?? {},
     }
+    // Only the personal connect provisioning path sets these — writing them
+    // unconditionally would trip the personal-fields guard for member creates.
+    if (input.isPersonal !== undefined) values.inbox_is_personal = input.isPersonal
+    if (input.ownerUserId !== undefined) values.inbox_owner_user_id = input.ownerUserId
 
     const result = await this.crudHandler.create('inbox', values)
     const recordId = toRecordId('inbox', result.instance.id)
@@ -105,6 +109,8 @@ export class InboxService {
     if (input.status !== undefined) values.inbox_status = input.status
     if (input.settings !== undefined) values.inbox_settings = input.settings
     if (input.defaultLens !== undefined) values.inbox_default_lens = input.defaultLens
+    if (input.isPersonal !== undefined) values.inbox_is_personal = input.isPersonal
+    if (input.ownerUserId !== undefined) values.inbox_owner_user_id = input.ownerUserId
 
     if (Object.keys(values).length > 0) {
       await this.crudHandler.update(recordId, values)
@@ -397,6 +403,7 @@ export class InboxService {
       status: ((item.fieldValues.inbox_status as string) ?? 'ACTIVE') as Inbox['status'],
       defaultLens: (item.fieldValues.inbox_default_lens as string as Lens) ?? 'full',
       isPersonal: (item.fieldValues.inbox_is_personal as boolean) ?? false,
+      ownerUserId: (item.fieldValues.inbox_owner_user_id as string) ?? null,
       settings: (item.fieldValues.inbox_settings as Record<string, unknown>) ?? {},
       organizationId: item.organizationId,
       createdAt: item.createdAt,
@@ -435,6 +442,7 @@ export class InboxService {
       status: ((getValue('inbox_status') as string) ?? 'ACTIVE') as Inbox['status'],
       defaultLens: (getValue('inbox_default_lens') as string as Lens) ?? 'full',
       isPersonal: (getValue('inbox_is_personal') as boolean) ?? false,
+      ownerUserId: (getValue('inbox_owner_user_id') as string) ?? null,
       settings: (getValue('inbox_settings') as Record<string, unknown>) ?? {},
       organizationId: instance.organizationId,
       createdAt: instance.createdAt,

--- a/packages/lib/src/inboxes/types.ts
+++ b/packages/lib/src/inboxes/types.ts
@@ -14,6 +14,10 @@ export interface CreateInboxInput {
   status?: InboxStatus
   /** Org-wide visibility floor (defaults to `full` — everyone sees everything). */
   defaultLens?: Lens
+  /** Personal-account inbox (§11) — set only by the personal connect provisioning path. */
+  isPersonal?: boolean
+  /** Owner of a personal inbox (§11). */
+  ownerUserId?: string
   settings?: Record<string, unknown>
 }
 
@@ -24,6 +28,9 @@ export interface UpdateInboxInput {
   color?: string
   status?: InboxStatus
   defaultLens?: Lens
+  /** Cleared (with `ownerUserId`) by the admin claim action (§11.4). */
+  isPersonal?: boolean
+  ownerUserId?: string | null
   settings?: Record<string, unknown>
 }
 
@@ -44,9 +51,11 @@ export interface Inbox {
   defaultLens: Lens
   /**
    * Personal-account marker (§11) — automation and admin short-circuits treat
-   * personal inboxes as restricted. Stamped by Phase 8; false until then.
+   * personal inboxes as restricted.
    */
   isPersonal: boolean
+  /** Owner of a personal inbox (§11). Null on shared org inboxes. */
+  ownerUserId: string | null
   settings: Record<string, unknown>
   organizationId: string
   createdAt: Date

--- a/packages/lib/src/members/member-service.ts
+++ b/packages/lib/src/members/member-service.ts
@@ -1082,6 +1082,21 @@ export class MemberService {
       })
     }
 
+    // Offboarding (mail-permissions §11.4): stop sync on the removed member's
+    // personal channels. The inbox + threads keep personal visibility; admins
+    // claim or delete the orphaned inbox explicitly. Lazy import — channels
+    // pulls the provider stack, members must not load it eagerly.
+    try {
+      const { disconnectPersonalChannelsForUser } = await import('../channels/personal-connection')
+      await disconnectPersonalChannelsForUser(organizationId, memberToRemoveId)
+    } catch (error) {
+      logger.error('Failed to disconnect personal channels for removed member', {
+        organizationId,
+        memberToRemoveId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+
     logger.info('Member removed successfully', { organizationId, memberToRemoveId, removerUserId })
     return { success: true }
   }

--- a/packages/lib/src/permissions/visibility/audience.ts
+++ b/packages/lib/src/permissions/visibility/audience.ts
@@ -6,8 +6,10 @@
  * Composed entirely from org caches: members + memberRoleMap + inboxes
  * (defaultLens floor) + the inverted inbox grants in `mailGrantIndex`.
  *
- * Personal-inbox capping (§11) is honored: admins are excluded from others'
- * personal inboxes unless explicitly granted (the set is empty until Phase 8).
+ * Personal-inbox capping (§11) is honored: on a personal inbox only the owner
+ * and explicit full-lens grantees are in the audience — admins are capped at
+ * metadata and the floor is `none` by construction (fail closed even if the
+ * floor were misconfigured).
  */
 export async function getFullLensAudienceForInbox(
   orgId: string,
@@ -27,6 +29,14 @@ export async function getFullLensAudienceForInbox(
 
   const inbox = inboxes.find((i) => i.id === inboxId)
   const audience = new Set<string>()
+
+  if (inbox?.isPersonal) {
+    if (inbox.ownerUserId) audience.add(inbox.ownerUserId)
+    for (const entry of grantIndex.inboxes[inboxId] ?? []) {
+      if (entry.lens === 'full') audience.add(entry.userId)
+    }
+    return [...audience]
+  }
 
   if (inbox?.defaultLens === 'full') {
     for (const m of members) audience.add(m.userId)

--- a/packages/lib/src/permissions/visibility/compute-user-mail-visibility.test.ts
+++ b/packages/lib/src/permissions/visibility/compute-user-mail-visibility.test.ts
@@ -103,6 +103,31 @@ describe('composeUserMailVisibility', () => {
     expect(vis.threadGrants).toEqual({ t_1: 'full' })
   })
 
+  it("collects OTHERS' personal inboxes into personalInboxIds, never the viewer's own", () => {
+    const vis = composeUserMailVisibility({
+      userId: USER,
+      role: 'ADMIN',
+      inboxes: [
+        { id: 'mine', defaultLens: 'none', isPersonal: true, ownerUserId: USER },
+        { id: 'bobs', defaultLens: 'none', isPersonal: true, ownerUserId: 'u_bob' },
+        { id: 'shared', defaultLens: 'full', isPersonal: false, ownerUserId: null },
+      ],
+      grants: [],
+    })
+    expect(vis.personalInboxIds).toEqual({ bobs: true })
+  })
+
+  it('leaves personalInboxIds empty for a non-member (fail closed, no floors)', () => {
+    const vis = composeUserMailVisibility({
+      userId: USER,
+      role: undefined,
+      inboxes: [{ id: 'bobs', defaultLens: 'none', isPersonal: true, ownerUserId: 'u_bob' }],
+      grants: [],
+    })
+    expect(vis.personalInboxIds).toEqual({})
+    expect(vis.inboxLens).toEqual({})
+  })
+
   it('fails closed for a non-member: no floors, no admin', () => {
     const vis = composeUserMailVisibility({
       userId: USER,

--- a/packages/lib/src/permissions/visibility/compute-user-mail-visibility.ts
+++ b/packages/lib/src/permissions/visibility/compute-user-mail-visibility.ts
@@ -36,8 +36,13 @@ export function composeUserMailVisibility(input: {
   userId: string
   /** From the cached memberRoleMap; undefined when not a member (→ no access). */
   role: OrganizationRole | undefined
-  /** Cached inboxes shape — id + defaultLens floor. */
-  inboxes: Array<{ id: string; defaultLens: Lens }>
+  /** Cached inboxes shape — id + defaultLens floor + personal marker (§11). */
+  inboxes: Array<{
+    id: string
+    defaultLens: Lens
+    isPersonal?: boolean
+    ownerUserId?: string | null
+  }>
   grants: VisibilityGrantRow[]
 }): UserMailVisibility {
   const { userId, role, inboxes, grants } = input
@@ -68,10 +73,14 @@ export function composeUserMailVisibility(input: {
   // Non-members get no floor at all — grants alone would be a data bug, but
   // the empty maps fail closed regardless.
   const inboxLens: Record<string, Lens> = {}
+  // OTHERS' personal inboxes (§11) — the viewer's own never caps them, so an
+  // admin-owner keeps the short-circuit on their own mailbox.
+  const personalInboxIds: Record<string, true> = {}
   if (role) {
     for (const inbox of inboxes) {
       const lens = maxLens(inbox.defaultLens, inboxGrants[inbox.id] ?? 'none')
       if (lens !== 'none') inboxLens[inbox.id] = lens
+      if (inbox.isPersonal && inbox.ownerUserId !== userId) personalInboxIds[inbox.id] = true
     }
   }
 
@@ -80,9 +89,7 @@ export function composeUserMailVisibility(input: {
     role: role ?? 'USER',
     isAdmin: role ? isAdmin : false,
     inboxLens,
-    // Personal inboxes arrive in Phase 8 — until then the set is empty and the
-    // admin short-circuit is unconditional.
-    personalInboxIds: {},
+    personalInboxIds,
     threadGrants,
     contactGrants,
     entityGrants,
@@ -148,7 +155,12 @@ export async function computeUserMailVisibility(
   return composeUserMailVisibility({
     userId,
     role: roleMap[userId],
-    inboxes: inboxes.map((i) => ({ id: i.id, defaultLens: i.defaultLens })),
+    inboxes: inboxes.map((i) => ({
+      id: i.id,
+      defaultLens: i.defaultLens,
+      isPersonal: i.isPersonal,
+      ownerUserId: i.ownerUserId,
+    })),
     grants: rows as VisibilityGrantRow[],
   })
 }

--- a/packages/lib/src/providers/provider-capabilities.ts
+++ b/packages/lib/src/providers/provider-capabilities.ts
@@ -9,6 +9,7 @@ export type { ProviderCapabilities } from './types'
  */
 export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapabilities> = {
   [IntegrationProviderType.google]: {
+    supportsPersonalConnection: true,
     // Gmail capabilities
     canSend: true,
     canReply: true,
@@ -41,6 +42,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: true,
   },
   [IntegrationProviderType.facebook]: {
+    supportsPersonalConnection: false,
     // Facebook Messenger capabilities
     canSend: true,
     canReply: true,
@@ -80,6 +82,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: false,
   },
   [IntegrationProviderType.instagram]: {
+    supportsPersonalConnection: false,
     // Instagram Direct Message capabilities
     canSend: true,
     canReply: true,
@@ -118,6 +121,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: false,
   },
   [IntegrationProviderType.openphone]: {
+    supportsPersonalConnection: false,
     // SMS capabilities (via OpenPhone or similar)
     canSend: true,
     canReply: true,
@@ -153,6 +157,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: false,
   },
   [IntegrationProviderType.mailgun]: {
+    supportsPersonalConnection: false,
     // Mailgun email service capabilities
     canSend: true,
     canReply: true,
@@ -185,6 +190,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: true,
   },
   [IntegrationProviderType.sms]: {
+    supportsPersonalConnection: false,
     // Generic SMS capabilities
     canSend: true,
     canReply: true,
@@ -220,6 +226,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: false,
   },
   [IntegrationProviderType.email]: {
+    supportsPersonalConnection: true,
     // Generic email capabilities
     canSend: true,
     canReply: true,
@@ -252,6 +259,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: true,
   },
   [IntegrationProviderType.whatsapp]: {
+    supportsPersonalConnection: false,
     // WhatsApp Business API capabilities
     canSend: true,
     canReply: true,
@@ -289,6 +297,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: false,
   },
   [IntegrationProviderType.chat]: {
+    supportsPersonalConnection: false,
     // Generic chat capabilities (internal chat system)
     canSend: true,
     canReply: true,
@@ -324,6 +333,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: false,
   },
   [IntegrationProviderType.shopify]: {
+    supportsPersonalConnection: false,
     // Shopify capabilities (not a messaging provider)
     canSend: false,
     canReply: false,
@@ -360,6 +370,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: false,
   },
   [IntegrationProviderType.imap]: {
+    supportsPersonalConnection: true,
     // IMAP/SMTP capabilities (self-hosted, enterprise)
     canSend: true,
     canReply: true,
@@ -392,6 +403,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
     supportsRichText: true,
   },
   [IntegrationProviderType.outlook]: {
+    supportsPersonalConnection: true,
     // Outlook/Office 365 capabilities
     canSend: true,
     canReply: true,
@@ -445,6 +457,7 @@ export function getProviderCapabilities(
   return (
     PROVIDER_CAPABILITIES[providerType] || {
       // Default minimal capabilities
+      supportsPersonalConnection: false,
       canSend: false,
       canReply: false,
       canForward: false,

--- a/packages/lib/src/providers/types.ts
+++ b/packages/lib/src/providers/types.ts
@@ -42,6 +42,15 @@ export interface ProviderCapabilities {
   canReact: boolean // for social media
   canShare: boolean // for social media
 
+  /**
+   * Whether a user may connect this channel as a PERSONAL account
+   * (mail-permissions §11) — a user-scoped credential feeding a dedicated
+   * personal inbox. Email-likes only; the chat widget, social DMs, and phone
+   * lines are org assets. The connect path enforces this server-side (fail
+   * closed), independent of the wizard UI.
+   */
+  supportsPersonalConnection: boolean
+
   // Send-pipeline shape — drives MessageSenderService.validateInput, usage guard,
   // and post-send sync. Email-likes are all `true`; chat is all `false`. FB/IG
   // are currently `true` for compatibility — see provider-capabilities.ts.

--- a/packages/lib/src/resources/registry/resources/inbox-fields.ts
+++ b/packages/lib/src/resources/registry/resources/inbox-fields.ts
@@ -154,6 +154,51 @@ export const INBOX_FIELDS: Record<string, ResourceField> = {
       'Org-wide visibility floor: the lens every org member gets on this inbox. Explicit grants can only raise it (mail-permissions §2.2).',
   },
 
+  isPersonal: {
+    id: toFieldId('isPersonal'),
+    key: 'isPersonal',
+    label: 'Personal',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'inbox_is_personal',
+    systemSortOrder: 'a5b',
+    nullable: false,
+    defaultValue: false,
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Personal-account inbox (mail-permissions §11): owned by one user, admins capped at activity-only, invisible to automation. Set by the personal connect flow; cleared by an admin claim.',
+  },
+
+  ownerUserId: {
+    id: toFieldId('ownerUserId'),
+    key: 'ownerUserId',
+    label: 'Owner',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'inbox_owner_user_id',
+    systemSortOrder: 'a5c',
+    nullable: true,
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'User id of the personal-inbox owner (mail-permissions §11). Null on shared org inboxes.',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -28,6 +28,7 @@ import { migration022InboxVisualRef } from './migrations/022-inbox-visual-ref'
 import { migration023ContactVisitorGeoFields } from './migrations/023-contact-visitor-geo-fields'
 import { migration024ThreadVisitFields } from './migrations/024-thread-visit-fields'
 import { migration025InboxDefaultLens } from './migrations/025-inbox-default-lens'
+import { migration026InboxPersonalFields } from './migrations/026-inbox-personal-fields'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -61,6 +62,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration023ContactVisitorGeoFields,
   migration024ThreadVisitFields,
   migration025InboxDefaultLens,
+  migration026InboxPersonalFields,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/026-inbox-personal-fields.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/026-inbox-personal-fields.ts
@@ -1,0 +1,54 @@
+// packages/lib/src/seed/entity-migrations/migrations/026-inbox-personal-fields.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { INBOX_FIELDS } from '../../../resources/registry/resources/inbox-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:026')
+
+/**
+ * Migration 026: Add the personal-account fields to the inbox entity
+ * (mail-permissions §11): `inbox_is_personal` marks an inbox as one user's
+ * connected personal mailbox (admins capped at activity-only, invisible to
+ * automation) and `inbox_owner_user_id` records who owns it. New orgs get
+ * both from `createAllFields`; this backfills the `CustomField` rows for
+ * existing orgs. No data migration needed — no personal inboxes exist yet.
+ */
+export const migration026InboxPersonalFields: EntityMigration = {
+  id: '026-inbox-personal-fields',
+  description: 'Add inbox_is_personal + inbox_owner_user_id system fields (personal accounts §11)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const inboxDef = existing.entityDefs.get('inbox')
+    if (!inboxDef) {
+      logger.warn('No inbox entity found, skipping personal fields', { organizationId })
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    await ensureCustomFields(
+      db,
+      organizationId,
+      'inbox',
+      inboxDef.id,
+      {
+        isPersonal: INBOX_FIELDS.isPersonal!,
+        ownerUserId: INBOX_FIELDS.ownerUserId!,
+      },
+      existing,
+      state
+    )
+
+    const alreadyUpToDate = state.fieldsCreated === 0
+
+    if (!alreadyUpToDate) {
+      logger.info('Migration 026 applied', { organizationId, fieldsCreated: state.fieldsCreated })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -197,6 +197,8 @@ export const SYSTEM_ATTRIBUTES = [
   'inbox_color',
   'inbox_status',
   'inbox_default_lens',
+  'inbox_is_personal',
+  'inbox_owner_user_id',
   'inbox_settings',
 
   // ─── Signature fields ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Final phase of the mail-permissions plan (`plans/mail-permissions/`, architecture §11): a user can connect an email account as **theirs** — user-scoped credential, dedicated restricted inbox named after the address, owner as Manager, **admins capped at activity-only**, invisible to automation. Ships ungated on all plans.

### Evaluator supply side
Phase 7 already shipped the admin metadata-cap, search exclusions, and automation zero-access — this PR supplies the data that activates them:
- `inbox_is_personal` + `inbox_owner_user_id` inbox fields (entity-migration `026`, auto-applied by the worker maintenance job), serializers, cached inboxes prefix v3 → v4
- `composeUserMailVisibility` populates `personalInboxIds`, **excluding the viewer's own inboxes** — an admin-owner keeps the short-circuit on their own mailbox
- **Bug fix:** `audience.ts` docstring claimed personal-inbox capping but the code had no `isPersonal` branch — a personal inbox would have counted every admin (and at floor `full`, every member) into the counts/realtime audience. Now: owner + explicit full-lens grantees only
- New pre-hook `guardInboxPersonalFields` — without it any member could flip `inbox_is_personal` via records CRUD to hide an org inbox or expose a personal one (system writes pass, user writes admin-only)

### Connect flow (§11.1)
- `supportsPersonalConnection` in `ProviderCapabilities` (google/outlook/email/imap true, rest false) + fail-closed `supportsPersonalChannelConnection(providerKey)`
- `personal=1` on the OAuth authorize route: validated server-side (400 if ineligible, independent of UI), rides the Redis state, callback mints `Credential.userId`, `PostConnectHookContext.personal`; reconnects never touch `userId`
- `channel.prepareConnect`: personal connects are open to **every member** (the account is theirs; channel limit still enforced) — shared connects stay admin-only
- `provisionPersonalInbox`: system-scoped `InboxService` (userId-less writes = the §11.3 floor-`none`-without-enterprise carve-out), owner Manager grant, skips the Shared Inbox. A mailbox already linked to a shared inbox (or someone else's personal) is **rejected** — `addIntegration` moves links, and silently rerouting org mail into a hidden inbox must never happen

### Offboarding (§11.4)
- `disconnectPersonalChannelsForUser` on member removal/leave: provider revoke + soft-delete Integration + clear polling cache, **data preserved** — deviation from the plan's "reuse `disconnect()`", which deletes threads/messages and would preempt the admin's claim-or-delete decision
- `inbox.claimPersonal` / `inbox.deletePersonal` (adminProcedure, orphan-only — rejected while the owner is still a member): claim converts to a normal restricted org inbox; delete destroys channel data + inbox (destructive confirm, storage cleanup, counts epoch bump)

### UI
Shared-vs-Personal wizard cards (google/outlook; a non-admin's shared attempt is steered to Personal instead of dead-ending) · sidebar owner icon + "Personal — {owner}" tooltip · personal inbox form Access section (owner row + "admins see activity only" note, locked owner Manager row) · "Personal" badge in inbox settings · orphaned-inbox claim/delete banner on inbox detail.

## Test plan

- [x] Biome clean; ~350 tests green across visibility / cache / resource-access / threads / realtime / inboxes / field-hooks / seed / providers / members (2 new `personalInboxIds` composition cases; 3 provider test files fail at collection pre-existing — the known agent-scope-service drizzle-mock issue)
- [ ] Live verification checklist in `plans/mail-permissions/README.md` (personal connect → admin capped / owner full, deferred Phase-7 automation items, offboarding claim/delete, fail-closed probes) — next session