### PR TITLE
feat(inbox): settings management + unified grantee list

### DIFF
--- a/apps/web/src/components/inbox/inbox-dialog.tsx
+++ b/apps/web/src/components/inbox/inbox-dialog.tsx
@@ -2,13 +2,8 @@
 'use client'
 
 import type { RecordId } from '@auxx/lib/resources/client'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@auxx/ui/components/dialog'
+import { Dialog, DialogContent } from '@auxx/ui/components/dialog'
+import { DialogNav } from '@auxx/ui/components/dialog-nav'
 import { InboxForm } from './inbox-form'
 
 /** Props for InboxDialog */
@@ -22,31 +17,37 @@ interface InboxDialogProps {
 }
 
 /**
- * Thin modal wrapper around {@link InboxForm}. Supplies the `Dialog` shell and the
- * header; all form logic (pickers, access radio, unsaved-changes guard, delete)
- * lives in the core, which the command palette hosts directly as a page. Public API
- * is unchanged.
+ * Modal wrapper around {@link InboxForm}, a two-page `DialogNav` flow mirroring the
+ * webhook endpoint dialog: `configure` (name/color/access) and `members` (the
+ * "People & groups" drill). The command palette hosts the same form as a single
+ * page (inline grantee list). Public API is unchanged.
  */
 export function InboxDialog({ open, onOpenChange, recordId, onSuccess }: InboxDialogProps) {
   const isEditing = !!recordId
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size='sm' position='tc'>
+      <DialogContent size='content' position='tc' innerClassName='p-0'>
         <InboxForm
           open={open}
           recordId={recordId}
           onSuccess={onSuccess}
           onClose={() => onOpenChange(false)}
-          header={({ title }) => (
-            <DialogHeader>
-              <DialogTitle>{title}</DialogTitle>
-              <DialogDescription>
-                {isEditing
+          enableMembersPage
+          header={({ title, page, onBack }) => (
+            <DialogNav
+              title={title}
+              description={
+                isEditing
                   ? 'Update inbox settings.'
-                  : 'Create a new inbox to organize your messages.'}
-              </DialogDescription>
-            </DialogHeader>
+                  : 'Create a new inbox to organize your messages.'
+              }
+              onBack={page === 'members' ? onBack : undefined}
+              crumbs={[
+                { label: title, onClick: page !== 'main' ? onBack : undefined },
+                ...(page === 'members' ? [{ label: 'People & groups' }] : []),
+              ]}
+            />
           )}
         />
       </DialogContent>

--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -1,23 +1,21 @@
 // apps/web/src/components/inbox/inbox-form.tsx
 'use client'
 
-import { ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
+import { FieldType, ResourceGranteeType, ResourcePermission } from '@auxx/database/enums'
 import type { Lens, LensChoice } from '@auxx/lib/permissions/visibility/client'
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
 import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
 import { Button } from '@auxx/ui/components/button'
 import { DialogFooter } from '@auxx/ui/components/dialog'
-import { Field, FieldGroup, FieldLabel } from '@auxx/ui/components/field'
-import { Form } from '@auxx/ui/components/form'
-import { Input } from '@auxx/ui/components/input'
+import { DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
-import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
-import { Lock, Trash2, UsersIcon } from 'lucide-react'
+import { ChevronRight, Eye, Lock, Shield, Trash2, UsersIcon } from 'lucide-react'
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { AccessLevelsGuide } from '~/components/mail-permissions/ui/access-levels-guide'
 import {
   MailPermissionsUpgradeDialog,
@@ -29,11 +27,13 @@ import { useSaveSystemValues, useSystemValues } from '~/components/resources/hoo
 import { ActorBadge } from '~/components/resources/ui/actor-badge'
 import { FormColorTagPicker } from '~/components/tags/ui/color-tag-picker'
 import { useInbox } from '~/components/threads/hooks/use-inbox'
+import { BaseType } from '~/components/workflow/types'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useDirtyCheck } from '~/hooks/use-dirty-state'
 import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
 import { useUser } from '~/hooks/use-user'
 import { api } from '~/trpc/react'
+import { InboxMembersPage } from './inbox-members-page'
 
 /** A grantee row as the form edits it. */
 interface FormGrant {
@@ -42,7 +42,7 @@ interface FormGrant {
 }
 
 /** Form data for inbox form */
-interface InboxFormData {
+interface InboxFormValues {
   name: string
   description: string
   color: string
@@ -50,6 +50,15 @@ interface InboxFormData {
   /** The org-wide floor when accessType is 'anyone'. Restricted ⇒ floor `none`. */
   floorLens: Exclude<Lens, 'none'>
   grants: FormGrant[]
+}
+
+const DEFAULT_VALUES: InboxFormValues = {
+  name: '',
+  description: '',
+  color: 'indigo',
+  accessType: 'anyone',
+  floorLens: 'full',
+  grants: [],
 }
 
 /** Props for the shell-free inbox form core. */
@@ -67,9 +76,15 @@ export interface InboxFormProps {
   /** Cancel/back dismiss. Defaults to {@link onClose}; the palette routes it back
    *  to the root action list instead of closing outright. */
   onCancel?: () => void
-  /** Host-specific header. Dialogs render a `DialogHeader`; the palette omits it
-   *  (the breadcrumb supplies the title). */
-  header?: (ctx: { title: string }) => ReactNode
+  /**
+   * Drill "People & groups" into a second page (webhook-dialog style) instead of
+   * rendering the grantee list inline. Enabled by the dialog host (which has the
+   * `DialogNav` shell); the palette leaves it off and keeps the inline list.
+   */
+  enableMembersPage?: boolean
+  /** Host-specific header. Dialogs render a `DialogNav` (with a Back button on the
+   *  members page); the palette omits it (the breadcrumb supplies the title). */
+  header?: (ctx: { title: string; page: 'main' | 'members'; onBack: () => void }) => ReactNode
 }
 
 /** Map a stored ResourceAccess row to the form's grant shape. */
@@ -102,9 +117,10 @@ function grantsKey(grants: FormGrant[]): string {
  * Shell-free inbox create/edit form: all hooks/state/mutations, the Access
  * section (Everyone/Restricted cards + org-wide level + grantee list, per the
  * mail-permissions UI plan), the color picker, the unsaved-changes guard, and
- * the delete affordance. The only host seams are the `header` slot and
- * `onClose`/`onCancel`. `inbox-dialog.tsx` wraps this in a `Dialog`; the
- * command palette hosts it as a page.
+ * the delete affordance. The layout uses the shared `FieldPanel`/`FieldPanelRow`
+ * primitives (label column left, input right). The only host seams are the
+ * `header` slot and `onClose`/`onCancel`. `inbox-dialog.tsx` wraps this in a
+ * `Dialog`; the command palette hosts it as a page.
  */
 export function InboxForm({
   open,
@@ -112,9 +128,13 @@ export function InboxForm({
   onSuccess,
   onClose,
   onCancel,
+  enableMembersPage = false,
   header,
 }: InboxFormProps) {
   const cancel = onCancel ?? onClose
+
+  // Which page is showing — the `members` drill exists only when enabled.
+  const [page, setPage] = useState<'main' | 'members'>('main')
 
   // Determine if editing based on prop
   const isEditing = !!recordId
@@ -166,40 +186,37 @@ export function InboxForm({
   const initialLensRef = useRef<Lens | null>(null)
   const initialGrantsRef = useRef<string>('')
 
-  // Form setup
-  const form = useForm<InboxFormData>({
-    defaultValues: {
-      name: '',
-      description: '',
-      color: 'indigo',
-      accessType: 'anyone',
-      floorLens: 'full',
-      grants: [],
-    },
-  })
+  // Plain value bag + per-field errors (part-form-dialog pattern).
+  const [values, setValues] = useState<InboxFormValues>(DEFAULT_VALUES)
+  const [errors, setErrors] = useState<Record<string, string>>({})
 
-  // Watch form values
-  const colorValue = form.watch('color')
-  const accessType = form.watch('accessType')
-  const floorLens = form.watch('floorLens')
-  const grants = form.watch('grants')
+  const handleChange = <K extends keyof InboxFormValues>(field: K, value: InboxFormValues[K]) => {
+    setValues((prev) => ({ ...prev, [field]: value }))
+    setErrors((prev) => {
+      if (prev[field as string]) {
+        const next = { ...prev }
+        delete next[field as string]
+        return next
+      }
+      return prev
+    })
+  }
 
-  // Combined form values for dirty checking
-  // biome-ignore lint/correctness/useExhaustiveDependencies: form.watch values are intentionally used as dependencies for dirty checking
-  const formValues = useMemo(
+  // Combined snapshot for dirty checking (grants serialized for stability).
+  const formSnapshot = useMemo(
     () => ({
-      name: form.watch('name'),
-      description: form.watch('description'),
-      color: colorValue,
-      accessType,
-      floorLens,
-      grants: grantsKey(grants ?? []),
+      name: values.name,
+      description: values.description,
+      color: values.color,
+      accessType: values.accessType,
+      floorLens: values.floorLens,
+      grants: grantsKey(values.grants),
     }),
-    [form.watch('name'), form.watch('description'), colorValue, accessType, floorLens, grants]
+    [values]
   )
 
   // Track dirty state for unsaved changes warning
-  const { isDirty, setInitial } = useDirtyCheck(formValues)
+  const { isDirty, setInitial } = useDirtyCheck(formSnapshot)
 
   // Guard against accidental close when dirty. The palette hosts this form without
   // a Dialog, so the guard owns the form's own cancel/close path: the Cancel button
@@ -225,51 +242,38 @@ export function InboxForm({
         const name = (fieldValues.inbox_name as string) ?? ''
         const description = (fieldValues.inbox_description as string) ?? ''
         const color = (fieldValues.inbox_color as string) ?? 'indigo'
+        // useSystemValues now collapses SINGLE_SELECT to a scalar, so this is a
+        // plain lens string (was an array — the source of the round-trip bug).
         const storedLens = (fieldValues.inbox_default_lens as Lens | undefined) ?? 'full'
         const accessType = storedLens === 'none' ? 'restricted' : 'anyone'
-        const floorLens = storedLens === 'none' ? 'full' : storedLens
+        const floorLens = (storedLens === 'none' ? 'full' : storedLens) as Exclude<Lens, 'none'>
         const grants = accessRows.map(rowToGrant)
 
         initialLensRef.current = storedLens
         initialGrantsRef.current = grantsKey(grants)
 
-        form.reset({ name, description, color, accessType, floorLens, grants })
-        setInitial({
-          name,
-          description,
-          color,
-          accessType,
-          floorLens,
-          grants: grantsKey(grants),
-        })
+        const next = { name, description, color, accessType, floorLens, grants }
+        setValues(next)
+        setInitial({ ...next, grants: grantsKey(grants) })
       } else {
         // Create mode: reset to defaults
         isInitialized.current = true
         initialLensRef.current = null
         initialGrantsRef.current = ''
 
-        form.reset({
-          name: '',
-          description: '',
-          color: 'indigo',
-          accessType: 'anyone',
-          floorLens: 'full',
-          grants: [],
-        })
-        setInitial({
-          name: '',
-          description: '',
-          color: 'indigo',
-          accessType: 'anyone',
-          floorLens: 'full',
-          grants: '',
-        })
+        setValues(DEFAULT_VALUES)
+        setInitial({ ...DEFAULT_VALUES, grants: '' })
       }
     } else {
       // Reset flag when dialog closes
       isInitialized.current = false
     }
-  }, [open, isEditing, recordId, fieldValues, isLoadingValues, accessRows, form, setInitial])
+  }, [open, isEditing, recordId, fieldValues, isLoadingValues, accessRows, setInitial])
+
+  // Always reopen on the main page (never mid-drill from a previous session).
+  useEffect(() => {
+    if (!open) setPage('main')
+  }, [open])
 
   // Get tRPC utils for cache invalidation
   const utils = api.useUtils()
@@ -323,12 +327,7 @@ export function InboxForm({
     setInstance.isPending
 
   // Form validation
-  const isValid = (form.watch('name') ?? '').trim().length > 0
-
-  // Handle color change from the color picker
-  const handleColorChange = (color: string) => {
-    form.setValue('color', color)
-  }
+  const isValid = values.name.trim().length > 0
 
   const handleAccessTypeChange = (value: string) => {
     // Restricted means floor `none` — enterprise-gated like every sub-full floor.
@@ -336,20 +335,18 @@ export function InboxForm({
       setUpgradeOpen(true)
       return
     }
-    form.setValue('accessType', value as 'anyone' | 'restricted')
+    handleChange('accessType', value as 'anyone' | 'restricted')
   }
 
   const updateGrant = (actorId: ActorId, choice: LensChoice) => {
-    const current = form.getValues('grants') ?? []
-    const rest = current.filter((g) => g.actorId !== actorId)
-    form.setValue('grants', [...rest, { actorId, choice }])
+    const rest = values.grants.filter((g) => g.actorId !== actorId)
+    handleChange('grants', [...rest, { actorId, choice }])
   }
 
   const removeGrant = (actorId: ActorId) => {
-    const current = form.getValues('grants') ?? []
-    form.setValue(
+    handleChange(
       'grants',
-      current.filter((g) => g.actorId !== actorId)
+      values.grants.filter((g) => g.actorId !== actorId)
     )
   }
 
@@ -382,35 +379,38 @@ export function InboxForm({
   }
 
   // Handle form submission
-  const handleSubmit = async (data: InboxFormData) => {
-    if (!isValid) return
+  const handleSubmit = async () => {
+    if (!isValid) {
+      setErrors({ name: 'Name is required' })
+      return
+    }
 
-    const targetLens: Lens = data.accessType === 'anyone' ? data.floorLens : 'none'
+    const targetLens: Lens = values.accessType === 'anyone' ? values.floorLens : 'none'
 
     if (isEditing && recordId) {
-      const values: Record<string, unknown> = {
-        inbox_name: data.name.trim(),
-        inbox_description: data.description,
-        inbox_color: data.color,
+      const systemValues: Record<string, unknown> = {
+        inbox_name: values.name.trim(),
+        inbox_description: values.description,
+        inbox_color: values.color,
       }
       // Only write the floor when it changed — the write is guarded server-side
       // (managers only; sub-full floors are enterprise).
-      if (targetLens !== initialLensRef.current) values.inbox_default_lens = targetLens
+      if (targetLens !== initialLensRef.current) systemValues.inbox_default_lens = targetLens
 
-      const success = await saveSystemValues(values)
+      const success = await saveSystemValues(systemValues)
       if (!success) return
 
-      if (canManageAccess && grantsKey(data.grants) !== initialGrantsRef.current) {
+      if (canManageAccess && grantsKey(values.grants) !== initialGrantsRef.current) {
         try {
           await setInstance.mutateAsync({
             recordId,
             granteeType: ResourceGranteeType.user,
-            grants: grantsPayload(data.grants, 'user'),
+            grants: grantsPayload(values.grants, 'user'),
           })
           await setInstance.mutateAsync({
             recordId,
             granteeType: ResourceGranteeType.group,
-            grants: grantsPayload(data.grants, 'group'),
+            grants: grantsPayload(values.grants, 'group'),
           })
         } catch {
           return // toast shown by the mutation; keep the form open
@@ -422,19 +422,19 @@ export function InboxForm({
       // Flush both here so every caller gets fresh data.
       invalidateInboxes()
       onClose()
-      onSuccess?.({ id: inboxId!, name: data.name, recordId })
+      onSuccess?.({ id: inboxId!, name: values.name, recordId })
     } else {
       try {
         const created = await createInbox.mutateAsync({
-          name: data.name.trim(),
-          description: data.description,
-          color: data.color,
+          name: values.name.trim(),
+          description: values.description,
+          color: values.color,
           status: 'ACTIVE',
           defaultLens: targetLens,
         })
         // Additive grants — the server already added the creator's Manager row.
         const createdRecordId = toRecordId('inbox', created.id)
-        for (const grant of data.grants) {
+        for (const grant of values.grants) {
           const { type, id } = parseActorId(grant.actorId)
           await grantInstance.mutateAsync({
             recordId: createdRecordId,
@@ -456,165 +456,248 @@ export function InboxForm({
 
   const title = isEditing ? 'Edit Inbox' : 'Create Inbox'
 
+  const membersEmptyHint = isPersonalInbox
+    ? 'Only the owner has access. Add people or groups to share.'
+    : values.accessType === 'restricted'
+      ? 'No one has access yet. Add people or groups.'
+      : 'No individual access — everyone uses the level above.'
+  const membersSummary =
+    values.grants.length > 0
+      ? `${values.grants.length} ${values.grants.length === 1 ? 'person or group' : 'people & groups'}`
+      : 'Add people or groups'
+
+  // Page 1 — the configure form (name/color/access). A transparent `<form>` wrapper
+  // (not part of the FieldPanel look) keeps native keyboard-submit working in the
+  // palette host, which has no Dialog shell to run the Cmd+Enter handler. In the
+  // dialog host plain Enter is suppressed by DialogContent and Cmd+Enter clicks the
+  // `data-dialog-submit` button. When the members drill is on, the form pads itself
+  // inside the flush `p-0` DialogNav shell; the palette host supplies its own padding.
+  const configurePage = (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        void handleSubmit()
+      }}
+      className={enableMembersPage ? 'flex flex-col gap-4 p-4' : 'flex flex-col gap-4'}>
+      <FieldPanel
+        orientation='responsive'
+        breakpoint='md'
+        resizeId='inbox-form'
+        defaultLabelWidth={200}
+        className='p-0'>
+        {/* Name */}
+        <FieldPanelRow
+          title='Name'
+          type={BaseType.STRING}
+          showIcon
+          isRequired
+          validationError={errors.name}
+          validationType='error'>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={values.name}
+            onChange={(val) => handleChange('name', (val as string) ?? '')}
+            placeholder='Enter inbox name'
+            disabled={isPending}
+          />
+        </FieldPanelRow>
+
+        {/* Description */}
+        <FieldPanelRow title='Description' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={values.description}
+            onChange={(val) => handleChange('description', (val as string) ?? '')}
+            placeholder='Optional description'
+            disabled={isPending}
+            fieldOptions={{ multiline: true }}
+          />
+        </FieldPanelRow>
+
+        {/* Color */}
+        <FieldPanelRow title='Color' type={BaseType.ENUM} showIcon>
+          <div className='py-2'>
+            <FormColorTagPicker
+              value={values.color}
+              onChange={(color) => handleChange('color', color)}
+            />
+          </div>
+        </FieldPanelRow>
+
+        {/* Access section — org admins and inbox Managers only */}
+        {canManageAccess &&
+          (isPersonalInbox ? (
+            <FieldPanelRow title='Access' showIcon icon={<Shield />} className='@md:flex-col!'>
+              <div className='space-y-2 rounded-md border p-3'>
+                {ownerActorId && (
+                  <div className='flex items-center justify-between'>
+                    <ActorBadge actorId={ownerActorId} />
+                    <span className='text-muted-foreground text-xs'>Owner</span>
+                  </div>
+                )}
+                <p className='text-muted-foreground text-xs'>
+                  Personal account — mail here is private to its owner. Admins can see activity
+                  only; assignment and shares grant access per thread.
+                </p>
+              </div>
+            </FieldPanelRow>
+          ) : (
+            <>
+              <FieldPanelRow title='Access' showIcon icon={<Shield />} className='@md:flex-col!'>
+                <RadioGroup
+                  value={values.accessType}
+                  onValueChange={handleAccessTypeChange}
+                  className='grid gap-2 py-2 pe-2 sm:grid-cols-2'>
+                  <RadioGroupItemCard
+                    value='anyone'
+                    label='Everyone'
+                    icon={<UsersIcon />}
+                    description='Everyone in the organization, at a chosen level'
+                  />
+                  <RadioGroupItemCard
+                    value='restricted'
+                    label='Restricted'
+                    icon={<Lock />}
+                    description='Only people and groups you add below'
+                  />
+                </RadioGroup>
+              </FieldPanelRow>
+
+              {values.accessType === 'anyone' && (
+                <FieldPanelRow title='Everyone can see' showIcon icon={<Eye />}>
+                  <LensSelect
+                    value={values.floorLens}
+                    onChange={(choice) =>
+                      choice !== 'manager' &&
+                      handleChange('floorLens', choice as Exclude<Lens, 'none'>)
+                    }
+                    size='default'
+                    variant='transparent'
+                    className='w-full'
+                  />
+                </FieldPanelRow>
+              )}
+            </>
+          ))}
+      </FieldPanel>
+
+      {/* People & groups — a standalone section below the panel (like the webhook
+          Topics drill), not a FieldPanelRow. */}
+      {canManageAccess && (
+        <div className='flex flex-col gap-2'>
+          <div className='flex items-center gap-1.5 px-1 text-muted-foreground text-xs font-medium'>
+            <UsersIcon className='size-3.5' />
+            People &amp; groups
+          </div>
+          {enableMembersPage ? (
+            // Drill into the members page (webhook-topics style).
+            <button
+              type='button'
+              onClick={() => setPage('members')}
+              className='flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm hover:bg-muted/50'>
+              <span className='flex items-center gap-2 text-muted-foreground'>
+                {membersSummary}
+              </span>
+              <ChevronRight className='size-4 text-muted-foreground' />
+            </button>
+          ) : (
+            <>
+              <GranteeList
+                grants={values.grants}
+                onGrant={updateGrant}
+                onChangeLens={updateGrant}
+                onRevoke={removeGrant}
+                includeManager
+                disabled={isPending}
+                lockedActorIds={isPersonalInbox && ownerActorId ? [ownerActorId] : []}
+                emptyHint={membersEmptyHint}
+              />
+              <button
+                type='button'
+                className='mt-1 self-start text-muted-foreground text-xs underline-offset-2 hover:underline'
+                onClick={() => setGuideOpen(true)}>
+                Learn about access levels
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
+      <DialogFooter className='flex sm:justify-between!'>
+        {isEditing ? (
+          <Button
+            type='button'
+            size='sm'
+            variant='ghost'
+            onClick={handleDelete}
+            disabled={isPending}
+            className='text-destructive hover:text-destructive'>
+            <Trash2 /> Delete
+          </Button>
+        ) : (
+          <div />
+        )}
+        <div className='flex gap-2'>
+          <Button
+            type='button'
+            size='sm'
+            variant='ghost'
+            onClick={guardedClose}
+            disabled={isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            variant='outline'
+            size='sm'
+            type='submit'
+            loading={isPending}
+            loadingText='Saving...'
+            disabled={!isValid || isPending}
+            data-dialog-submit>
+            {isEditing ? 'Update Inbox' : 'Create Inbox'} <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </div>
+      </DialogFooter>
+    </form>
+  )
+
+  // Page 2 — the "People & groups" drill (dialog host only).
+  const membersPage = (
+    <InboxMembersPage
+      grants={values.grants}
+      onGrant={updateGrant}
+      onChangeLens={updateGrant}
+      onRevoke={removeGrant}
+      includeManager
+      disabled={isPending}
+      lockedActorIds={isPersonalInbox && ownerActorId ? [ownerActorId] : []}
+      emptyHint={membersEmptyHint}
+      note={
+        isPersonalInbox
+          ? 'Personal account — mail here is private to its owner. Admins can see activity only; assignment and shares grant access per thread.'
+          : undefined
+      }
+      onOpenGuide={() => setGuideOpen(true)}
+      onBack={() => setPage('main')}
+    />
+  )
+
   return (
     <>
-      {header?.({ title })}
+      {header?.({ title, page, onBack: () => setPage('main') })}
 
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(handleSubmit)}>
-          <FieldGroup className='gap-4'>
-            {/* Name field */}
-            <Field>
-              <FieldLabel>Name</FieldLabel>
-              <Input
-                {...form.register('name', { required: 'Name is required' })}
-                placeholder='Enter inbox name'
-              />
-              {form.formState.errors.name && (
-                <p className='text-sm text-destructive'>{form.formState.errors.name.message}</p>
-              )}
-            </Field>
-
-            {/* Description field */}
-            <Field>
-              <FieldLabel>Description</FieldLabel>
-              <Textarea
-                {...form.register('description')}
-                placeholder='Optional description'
-                rows={3}
-              />
-            </Field>
-
-            {/* Color field */}
-            <Field>
-              <FieldLabel>Color</FieldLabel>
-              <FormColorTagPicker value={colorValue} onChange={handleColorChange} />
-            </Field>
-
-            {/* Access section — org admins and inbox Managers only */}
-            {canManageAccess && (
-              <>
-                {isPersonalInbox ? (
-                  <Field>
-                    <FieldLabel>Access</FieldLabel>
-                    <div className='space-y-2 rounded-md border p-3'>
-                      {ownerActorId && (
-                        <div className='flex items-center justify-between'>
-                          <ActorBadge actorId={ownerActorId} />
-                          <span className='text-muted-foreground text-xs'>Owner</span>
-                        </div>
-                      )}
-                      <p className='text-muted-foreground text-xs'>
-                        Personal account — mail here is private to its owner. Admins can see
-                        activity only; assignment and shares grant access per thread.
-                      </p>
-                    </div>
-                  </Field>
-                ) : (
-                  <>
-                    <Field>
-                      <FieldLabel>Access</FieldLabel>
-                      <RadioGroup
-                        value={accessType}
-                        onValueChange={handleAccessTypeChange}
-                        className='grid gap-2 sm:grid-cols-2'>
-                        <RadioGroupItemCard
-                          value='anyone'
-                          label='Everyone'
-                          icon={<UsersIcon />}
-                          description='Everyone in the organization, at a chosen level'
-                        />
-                        <RadioGroupItemCard
-                          value='restricted'
-                          label='Restricted'
-                          icon={<Lock />}
-                          description='Only people and groups you add below'
-                        />
-                      </RadioGroup>
-                    </Field>
-
-                    {accessType === 'anyone' && (
-                      <Field>
-                        <FieldLabel>Everyone can see</FieldLabel>
-                        <LensSelect
-                          value={floorLens}
-                          onChange={(choice) =>
-                            choice !== 'manager' && form.setValue('floorLens', choice)
-                          }
-                          size='default'
-                          className='w-full'
-                        />
-                      </Field>
-                    )}
-                  </>
-                )}
-
-                <Field>
-                  <FieldLabel>People &amp; groups</FieldLabel>
-                  <GranteeList
-                    grants={grants ?? []}
-                    onGrant={updateGrant}
-                    onChangeLens={updateGrant}
-                    onRevoke={removeGrant}
-                    includeManager
-                    disabled={isPending}
-                    lockedActorIds={isPersonalInbox && ownerActorId ? [ownerActorId] : []}
-                    emptyHint={
-                      isPersonalInbox
-                        ? 'Only the owner has access. Add people or groups to share.'
-                        : accessType === 'restricted'
-                          ? 'No one has access yet. Add people or groups.'
-                          : 'No individual access — everyone uses the level above.'
-                    }
-                  />
-                  <button
-                    type='button'
-                    className='mt-1 self-start text-muted-foreground text-xs underline-offset-2 hover:underline'
-                    onClick={() => setGuideOpen(true)}>
-                    Learn about access levels
-                  </button>
-                </Field>
-              </>
-            )}
-          </FieldGroup>
-
-          <DialogFooter className='flex sm:justify-between!'>
-            {isEditing ? (
-              <Button
-                type='button'
-                size='sm'
-                variant='ghost'
-                onClick={handleDelete}
-                disabled={isPending}
-                className='text-destructive hover:text-destructive'>
-                <Trash2 /> Delete
-              </Button>
-            ) : (
-              <div />
-            )}
-            <div className='flex gap-2'>
-              <Button
-                type='button'
-                size='sm'
-                variant='ghost'
-                onClick={guardedClose}
-                disabled={isPending}>
-                Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
-              </Button>
-              <Button
-                variant='outline'
-                size='sm'
-                type='submit'
-                loading={isPending}
-                loadingText='Saving...'
-                disabled={!isValid || isPending}>
-                {isEditing ? 'Update Inbox' : 'Create Inbox'}{' '}
-                <KbdSubmit variant='outline' size='sm' />
-              </Button>
-            </div>
-          </DialogFooter>
-        </form>
-      </Form>
+      {enableMembersPage ? (
+        <DialogNavPages value={page}>
+          <DialogNavPage value='main' size='md'>
+            {configurePage}
+          </DialogNavPage>
+          <DialogNavPage value='members' size='md'>
+            {membersPage}
+          </DialogNavPage>
+        </DialogNavPages>
+      ) : (
+        configurePage
+      )}
 
       <ConfirmDialog />
       <ConfirmDeleteDialog />

--- a/apps/web/src/components/inbox/inbox-list.tsx
+++ b/apps/web/src/components/inbox/inbox-list.tsx
@@ -2,8 +2,15 @@
 'use client'
 
 import type { Inbox } from '@auxx/lib/inboxes'
+import type { RecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import {
   Table,
   TableBody,
@@ -12,7 +19,15 @@ import {
   TableHeader,
   TableRow,
 } from '@auxx/ui/components/table'
-import { InboxIcon, PlusIcon, RefreshCw } from 'lucide-react'
+import { toastError } from '@auxx/ui/components/toast'
+import {
+  InboxIcon,
+  MoreHorizontal,
+  PencilIcon,
+  PlusIcon,
+  RefreshCw,
+  Trash2Icon,
+} from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
@@ -20,13 +35,19 @@ import SettingsPage from '~/components/global/settings-page'
 import { useResource } from '~/components/resources'
 import { RecordIcon } from '~/components/resources/ui/record-icon'
 import { useInboxes } from '~/components/threads/hooks'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useUser } from '~/hooks/use-user'
+import { api } from '~/trpc/react'
 import { InboxDialog } from './inbox-dialog'
 
 /** Component for displaying the list of inboxes */
 export function InboxList() {
   const router = useRouter()
+  const utils = api.useUtils()
+  const [confirm, ConfirmDialog] = useConfirm()
   const [dialogOpen, setDialogOpen] = useState(false)
+  // recordId to edit; null opens the dialog in create mode.
+  const [editRecordId, setEditRecordId] = useState<RecordId | null>(null)
 
   useUser({
     requireOrganization: true,
@@ -35,8 +56,19 @@ export function InboxList() {
 
   // Read inboxes from the generic record store; field-value mutations flush
   // this automatically, so no manual invalidation is required after edits.
-  const { inboxes, records, isLoading: isLoadingInboxes } = useInboxes()
+  const { inboxes, records, isLoading: isLoadingInboxes, refresh } = useInboxes()
   const { resource } = useResource('inbox')
+
+  const deleteInbox = api.inbox.delete.useMutation({
+    onSuccess: () => {
+      utils.inbox.getAll.invalidate()
+      utils.record.listAll.invalidate({ entityDefinitionId: 'inbox' })
+      refresh()
+    },
+    onError: (error) => {
+      toastError({ title: 'Error deleting inbox', description: error.message })
+    },
+  })
 
   /** Get status badge based on inbox status */
   const getStatusBadge = (status: Inbox['status'] | undefined) => {
@@ -68,7 +100,26 @@ export function InboxList() {
 
   /** Open the create inbox dialog */
   const handleCreateInbox = () => {
+    setEditRecordId(null)
     setDialogOpen(true)
+  }
+
+  /** Open the inbox editor dialog for an existing inbox */
+  const handleEditInbox = (recordId: RecordId) => {
+    setEditRecordId(recordId)
+    setDialogOpen(true)
+  }
+
+  /** Delete an inbox after confirmation */
+  const handleDeleteInbox = async (inboxId: string, name: string) => {
+    const confirmed = await confirm({
+      title: 'Delete inbox?',
+      description: `This will permanently delete "${name}" and all its settings. This action cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) deleteInbox.mutate({ inboxId })
   }
 
   /** Navigate to the inbox detail page */
@@ -102,6 +153,7 @@ export function InboxList() {
               <TableHead className='w-[300px]'>Inbox</TableHead>
               <TableHead>Access</TableHead>
               <TableHead>Status</TableHead>
+              <TableHead className='w-[60px]' />
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -137,6 +189,32 @@ export function InboxList() {
                     )}
                   </TableCell>
                   <TableCell>{getStatusBadge(status)}</TableCell>
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant='ghost'
+                          size='icon-sm'
+                          aria-label='Inbox actions'
+                          onClick={(e) => e.stopPropagation()}>
+                          <MoreHorizontal />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align='end' onClick={(e) => e.stopPropagation()}>
+                        <DropdownMenuItem onClick={() => handleEditInbox(inbox.recordId)}>
+                          <PencilIcon />
+                          Edit
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          variant='destructive'
+                          disabled={deleteInbox.isPending}
+                          onClick={() => handleDeleteInbox(inbox.id, inbox.name)}>
+                          <Trash2Icon />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
                 </TableRow>
               )
             })}
@@ -157,7 +235,10 @@ export function InboxList() {
       )}
 
       {/* Dialog only renders when open */}
-      {dialogOpen && <InboxDialog open={dialogOpen} onOpenChange={setDialogOpen} />}
+      {dialogOpen && (
+        <InboxDialog open={dialogOpen} onOpenChange={setDialogOpen} recordId={editRecordId} />
+      )}
+      <ConfirmDialog />
     </SettingsPage>
   )
 }

--- a/apps/web/src/components/inbox/inbox-members-page.tsx
+++ b/apps/web/src/components/inbox/inbox-members-page.tsx
@@ -1,0 +1,106 @@
+// apps/web/src/components/inbox/inbox-members-page.tsx
+'use client'
+
+import type { LensChoice } from '@auxx/lib/permissions/visibility/client'
+import type { ActorId } from '@auxx/types/actor'
+import { Button } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { Section } from '@auxx/ui/components/section'
+import { Plus, Users } from 'lucide-react'
+import { GranteeAddButton, GranteeList } from '~/components/mail-permissions/ui/grantee-list'
+
+/** A grantee row as the form edits it (mirrors {@link InboxForm}'s FormGrant). */
+interface FormGrant {
+  actorId: ActorId
+  choice: LensChoice
+}
+
+interface InboxMembersPageProps {
+  grants: FormGrant[]
+  onGrant: (actorId: ActorId, choice: LensChoice) => void
+  onChangeLens: (actorId: ActorId, choice: LensChoice) => void
+  onRevoke: (actorId: ActorId) => void
+  /** Renders the Manager entry in each row's picker (inbox surface only). */
+  includeManager?: boolean
+  disabled?: boolean
+  /** Empty-state description. */
+  emptyHint?: string
+  /**
+   * Rows that render muted with a fixed level and no remove/change controls —
+   * the inbox owner's locked Manager grant, so the list never lies.
+   */
+  lockedActorIds?: ActorId[]
+  /** Personal-account note rendered above the list. */
+  note?: string
+  /** Opens the access-levels guide. */
+  onOpenGuide?: () => void
+  /** Returns to the configure page. */
+  onBack: () => void
+}
+
+/**
+ * The "People & groups" drill page — the second page of the inbox dialog, styled
+ * like the webhook `topics` page: a non-collapsible {@link Section} wrapping the
+ * shared {@link GranteeList} (the single grantee-row source), plus a personal
+ * note, the access-levels guide link, and a footer. Fully controlled —
+ * persistence lives in the hosting form's submit.
+ */
+export function InboxMembersPage({
+  grants,
+  onGrant,
+  onChangeLens,
+  onRevoke,
+  includeManager = false,
+  disabled = false,
+  emptyHint = 'Not shared with anyone yet.',
+  lockedActorIds = [],
+  note,
+  onOpenGuide,
+  onBack,
+}: InboxMembersPageProps) {
+  return (
+    <div className='flex flex-col'>
+      <Section
+        title='People & groups'
+        icon={<Users className='size-4' />}
+        collapsible={false}
+        actions={
+          <GranteeAddButton grants={grants} onGrant={onGrant} disabled={disabled}>
+            <Button variant='ghost' size='xs' disabled={disabled}>
+              <Plus />
+              Add
+            </Button>
+          </GranteeAddButton>
+        }>
+        {note && <p className='px-1 pb-2 text-muted-foreground text-xs'>{note}</p>}
+
+        <GranteeList
+          grants={grants}
+          onGrant={onGrant}
+          onChangeLens={onChangeLens}
+          onRevoke={onRevoke}
+          includeManager={includeManager}
+          disabled={disabled}
+          emptyHint={emptyHint}
+          lockedActorIds={lockedActorIds}
+          hideAddButton
+        />
+
+        {onOpenGuide && (
+          <button
+            type='button'
+            className='mt-2 self-start px-1 text-muted-foreground text-xs underline-offset-2 hover:underline'
+            onClick={onOpenGuide}>
+            Learn about access levels
+          </button>
+        )}
+      </Section>
+
+      <DialogFooter className='py-2 pe-3'>
+        <Button variant='outline' size='sm' type='button' onClick={onBack}>
+          Done
+        </Button>
+      </DialogFooter>
+    </div>
+  )
+}

--- a/apps/web/src/components/mail-permissions/ui/grantee-list.tsx
+++ b/apps/web/src/components/mail-permissions/ui/grantee-list.tsx
@@ -4,11 +4,17 @@
 import type { LensChoice } from '@auxx/lib/permissions/visibility/client'
 import { LENS_LABELS } from '@auxx/lib/permissions/visibility/client'
 import type { ActorId } from '@auxx/types/actor'
+import { parseActorId } from '@auxx/types/actor'
 import { Button } from '@auxx/ui/components/button'
-import { Plus, X } from 'lucide-react'
-import { useMemo } from 'react'
+import { EmptySection } from '@auxx/ui/components/section'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Plus, Trash2, Users } from 'lucide-react'
+import { type ReactNode, useMemo } from 'react'
 import { ActorPicker } from '~/components/pickers/actor-picker'
-import { ActorBadge } from '~/components/resources/ui/actor-badge'
+import { useActor } from '~/components/resources/hooks/use-actor'
+import { ActorAvatar } from '~/components/resources/ui/actor-badge'
 import { LensSelect } from './lens-select'
 
 export interface GranteeListProps {
@@ -25,13 +31,20 @@ export interface GranteeListProps {
    * the inbox creator's Manager grant, so the list never lies.
    */
   lockedActorIds?: ActorId[]
+  /**
+   * Hide the inline "Add people or groups" trigger — for surfaces that host
+   * their own {@link GranteeAddButton} (e.g. the inbox dialog's Section header).
+   */
+  hideAddButton?: boolean
 }
 
 /**
- * The reusable "who has access" list: `ActorBadge` + `LensSelect` rows with a
- * hover-revealed remove, and an ActorPicker "+ Add" trigger. Controlled and
- * dumb — persistence lives in the hosting surface's hook. New grantees
- * default to Full access.
+ * The reusable "who has access" list: one `TreeRow` per grantee — the actor's
+ * avatar in the leading icon slot, their name as the title, and a `LensSelect`
+ * plus hover-revealed remove in the actions slot. Capped off by a
+ * {@link GranteeAddButton} unless `hideAddButton` is set. Controlled and dumb —
+ * persistence lives in the hosting surface's hook. New grantees default to Full
+ * access.
  */
 export function GranteeList({
   grants,
@@ -42,9 +55,51 @@ export function GranteeList({
   disabled = false,
   emptyHint = 'Not shared with anyone yet.',
   lockedActorIds = [],
+  hideAddButton = false,
 }: GranteeListProps) {
-  const currentIds = useMemo(() => grants.map((g) => g.actorId), [grants])
   const locked = useMemo(() => new Set(lockedActorIds), [lockedActorIds])
+
+  return (
+    <div className='space-y-0.5'>
+      {grants.length === 0 ? (
+        <EmptySection
+          icon={<Users className='size-5' />}
+          title='No one added yet'
+          description={emptyHint}
+        />
+      ) : (
+        grants.map(({ actorId, choice }) => (
+          <GranteeRow
+            key={actorId}
+            actorId={actorId}
+            choice={choice}
+            isLocked={locked.has(actorId)}
+            includeManager={includeManager}
+            disabled={disabled}
+            onChangeLens={onChangeLens}
+            onRevoke={onRevoke}
+          />
+        ))
+      )}
+
+      {!hideAddButton && <GranteeAddButton grants={grants} onGrant={onGrant} disabled={disabled} />}
+    </div>
+  )
+}
+
+/**
+ * The "Add people or groups" trigger — an `ActorPicker` that grants any newly
+ * picked actor Full access. Extracted so surfaces can host it apart from the
+ * list (e.g. an inbox dialog's `Section` header `actions`). Pass `children` to
+ * override the default ghost button.
+ */
+export function GranteeAddButton({
+  grants,
+  onGrant,
+  disabled = false,
+  children,
+}: Pick<GranteeListProps, 'grants' | 'onGrant' | 'disabled'> & { children?: ReactNode }) {
+  const currentIds = useMemo(() => grants.map((g) => g.actorId), [grants])
 
   const handlePickerChange = (nextIds: ActorId[]) => {
     const existing = new Set(currentIds)
@@ -54,61 +109,78 @@ export function GranteeList({
   }
 
   return (
-    <div className='space-y-1'>
-      {grants.length === 0 ? (
-        <div className='px-1 py-2 text-muted-foreground text-sm'>{emptyHint}</div>
-      ) : (
-        grants.map(({ actorId, choice }) => {
-          const isLocked = locked.has(actorId)
-          return (
-            <div
-              key={actorId}
-              className='group flex items-center justify-between gap-2 rounded-lg px-1 py-0.5'>
-              <ActorBadge actorId={actorId} className={isLocked ? 'opacity-70' : undefined} />
-              <div className='flex items-center gap-1'>
-                {isLocked ? (
-                  <span className='pr-2 text-muted-foreground text-xs'>
-                    {LENS_LABELS[choice].label}
-                  </span>
-                ) : (
-                  <>
-                    <LensSelect
-                      value={choice}
-                      onChange={(next) => onChangeLens(actorId, next)}
-                      includeManager={includeManager}
-                      disabled={disabled}
-                      size='sm'
-                      className='h-7 w-32 border-none shadow-none'
-                    />
-                    <Button
-                      variant='ghost'
-                      size='icon'
-                      className='size-6 opacity-0 group-hover:opacity-100'
-                      disabled={disabled}
-                      aria-label='Remove access'
-                      onClick={() => onRevoke(actorId)}>
-                      <X />
-                    </Button>
-                  </>
-                )}
-              </div>
-            </div>
-          )
-        })
-      )}
-
-      <ActorPicker
-        value={currentIds}
-        onChange={handlePickerChange}
-        target='both'
-        multi
-        excludeIds={currentIds}
-        disabled={disabled}>
+    <ActorPicker
+      value={currentIds}
+      onChange={handlePickerChange}
+      target='both'
+      multi
+      excludeIds={currentIds}
+      disabled={disabled}>
+      {children ?? (
         <Button variant='ghost' size='sm' className='text-muted-foreground' disabled={disabled}>
           <Plus />
           Add people or groups
         </Button>
-      </ActorPicker>
-    </div>
+      )}
+    </ActorPicker>
+  )
+}
+
+/** A single grantee row. Resolves the actor once for the avatar + name. */
+function GranteeRow({
+  actorId,
+  choice,
+  isLocked,
+  includeManager,
+  disabled,
+  onChangeLens,
+  onRevoke,
+}: {
+  actorId: ActorId
+  choice: LensChoice
+  isLocked: boolean
+  includeManager: boolean
+  disabled: boolean
+  onChangeLens: (actorId: ActorId, choice: LensChoice) => void
+  onRevoke: (actorId: ActorId) => void
+}) {
+  const { actor, isLoading, isNotFound } = useActor({ actorId })
+  const type = actor?.type ?? parseActorId(actorId).type
+  const showLoading = isLoading && !actor
+  const name = isNotFound
+    ? 'Unknown'
+    : actor?.name || (actor?.type === 'user' && actor?.email) || 'Unknown'
+
+  return (
+    <TreeRow
+      icon={<ActorAvatar type={type} avatarUrl={actor?.avatarUrl} />}
+      title={showLoading ? <Skeleton className='h-4 w-24 rounded-full' /> : name}
+      rowClassName={cn('bg-primary-50 hover:bg-primary-100', isLocked && 'opacity-70')}
+      actions={
+        isLocked ? (
+          <span className='pr-2 text-muted-foreground text-xs'>{LENS_LABELS[choice].label}</span>
+        ) : (
+          <>
+            <LensSelect
+              value={choice}
+              onChange={(next) => onChangeLens(actorId, next)}
+              includeManager={includeManager}
+              disabled={disabled}
+              size='sm'
+              variant='transparent'
+              className='h-7 w-36'
+            />
+            <TreeRowButton
+              variant='destructive'
+              disabled={disabled}
+              aria-label='Remove access'
+              tooltipText='Remove access'
+              onClick={() => onRevoke(actorId)}>
+              <Trash2 />
+            </TreeRowButton>
+          </>
+        )
+      }
+    />
   )
 }

--- a/apps/web/src/components/mail-permissions/ui/lens-select.tsx
+++ b/apps/web/src/components/mail-permissions/ui/lens-select.tsx
@@ -59,11 +59,15 @@ export function LensSelect({
     </Badge>
   )
 
+  // Never feed Radix an unknown value — it renders the placeholder fallback and,
+  // via its hidden native <select>, warns on non-scalar values. Guards regressions.
+  const safeValue = LENS_LABELS[value] ? value : 'full'
+
   return (
     <>
-      <Select value={value} onValueChange={handleChange} disabled={disabled}>
+      <Select value={safeValue} onValueChange={handleChange} disabled={disabled}>
         <SelectTrigger size={size} variant={variant} className={className}>
-          <SelectValue placeholder='Access'>{LENS_LABELS[value]?.label}</SelectValue>
+          <SelectValue placeholder='Access'>{LENS_LABELS[safeValue]?.label}</SelectValue>
         </SelectTrigger>
         <SelectContent align='end' className='min-w-56'>
           {LENS_CHOICES.map((lens) => (

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -67,7 +67,11 @@ export const CompactThreadItem = memo(function CompactThreadItem({
     messageId: thread?.latestMessageId,
     enabled: !!thread?.latestMessageId,
   })
-  const { from: senderParticipant } = useMessageParticipants(latestMessage?.participants ?? [])
+  // Below `full`, latestMessageId is redacted to null — fall back to the
+  // thread-level envelope participants (metadata tier, present at every lens).
+  const { from: senderParticipant } = useMessageParticipants(
+    latestMessage?.participants ?? thread?.participants ?? []
+  )
   const { isUnread: readStatusUnread, markAsRead } = useThreadReadStatus(threadId)
 
   // Redacted rendering (mail-permissions): below `full` the row never looks

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -222,7 +222,11 @@ export const MailThreadItem = memo(function MailThreadItem({
     messageId: thread?.latestMessageId,
     enabled: !!thread?.latestMessageId,
   })
-  const { from: senderParticipant } = useMessageParticipants(latestMessage?.participants ?? [])
+  // Below `full`, latestMessageId is redacted to null — fall back to the
+  // thread-level envelope participants (metadata tier, present at every lens).
+  const { from: senderParticipant } = useMessageParticipants(
+    latestMessage?.participants ?? thread?.participants ?? []
+  )
   const { isUnread: readStatusUnread, markAsRead } = useThreadReadStatus(threadId)
 
   // Redacted rendering (mail-permissions): below `full` the row never looks

--- a/apps/web/src/components/resources/hooks/use-system-values.ts
+++ b/apps/web/src/components/resources/hooks/use-system-values.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/resources/hooks/use-system-values.ts
 
-import { formatToRawValue } from '@auxx/lib/field-values/client'
+import { formatToRawValue, isMultiValueFieldType } from '@auxx/lib/field-values/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
 import { useMemo } from 'react'
@@ -25,6 +25,7 @@ interface FieldInfo {
   attr: string
   resourceFieldId: ResourceFieldId
   fieldType: string
+  options?: unknown
 }
 
 /**
@@ -66,7 +67,7 @@ export function useSystemValues<T extends string>(
       if (!resourceFieldId) continue
       const field = fieldMap[resourceFieldId]
       if (!field?.fieldType) continue
-      result.push({ attr, resourceFieldId, fieldType: field.fieldType })
+      result.push({ attr, resourceFieldId, fieldType: field.fieldType, options: field.options })
     }
     return result
   }, [enabled, systemAttributes, systemAttributeMap, fieldMap])
@@ -88,9 +89,17 @@ export function useSystemValues<T extends string>(
   // Format and re-key by system attribute
   const values = useMemo(() => {
     const result = {} as Record<T, unknown>
-    for (const { attr, resourceFieldId, fieldType } of fieldInfos) {
+    for (const { attr, resourceFieldId, fieldType, options } of fieldInfos) {
       const raw = rawValues[resourceFieldId]
-      result[attr as T] = raw !== undefined ? formatToRawValue(raw, fieldType as any) : undefined
+      const formatted = raw !== undefined ? formatToRawValue(raw, fieldType as any) : undefined
+      // SINGLE_SELECT (and single-value ACTOR) come back as single-element arrays
+      // for uniform UI handling with MULTI_SELECT; collapse them to a scalar so
+      // scalar consumers (selects, comparisons) round-trip correctly. Genuinely
+      // multi-value types (MULTI_SELECT/TAGS/FILE/RELATIONSHIP) keep their arrays.
+      result[attr as T] =
+        Array.isArray(formatted) && !isMultiValueFieldType(fieldType as any, options as any)
+          ? formatted[0]
+          : formatted
     }
     return result
   }, [fieldInfos, rawValues])

--- a/apps/web/src/components/resources/ui/actor-badge.tsx
+++ b/apps/web/src/components/resources/ui/actor-badge.tsx
@@ -2,7 +2,7 @@
 
 'use client'
 
-import type { ActorId } from '@auxx/types/actor'
+import type { ActorId, ActorType } from '@auxx/types/actor'
 import { parseActorId } from '@auxx/types/actor'
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
 import { Skeleton } from '@auxx/ui/components/skeleton'
@@ -11,6 +11,33 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { Bot, Cog, User, Users, X } from 'lucide-react'
 
 import { useActor } from '~/components/resources/hooks/use-actor'
+
+/**
+ * The avatar-only half of an {@link ActorBadge}: the image with a type-aware
+ * fallback glyph (person / group / agent / system). Presentational — pass the
+ * resolved `type` + `avatarUrl`. Reused wherever the actor's icon is needed
+ * apart from the name (e.g. a TreeRow's leading icon slot).
+ */
+export function ActorAvatar({
+  type,
+  avatarUrl,
+  className,
+}: {
+  type: ActorType
+  avatarUrl?: string | null
+  /** Sizes the avatar box; the fallback glyph scales with it. Defaults to `size-4`. */
+  className?: string
+}) {
+  const Glyph = type === 'system' ? Cog : type === 'group' ? Users : type === 'agent' ? Bot : User
+  return (
+    <Avatar className={cn('size-4', className)} data-slot='actor-icon'>
+      <AvatarImage src={avatarUrl ?? undefined} />
+      <AvatarFallback className='bg-neutral-200 dark:bg-neutral-700'>
+        <Glyph data-slot='actor-fallback-icon' className='size-2.5' />
+      </AvatarFallback>
+    </Avatar>
+  )
+}
 
 /**
  * Variants for the ActorBadge component

--- a/apps/web/src/components/threads/hooks/use-inbox.ts
+++ b/apps/web/src/components/threads/hooks/use-inbox.ts
@@ -72,6 +72,14 @@ interface UseInboxesResult {
 }
 
 /**
+ * `useAllRecords` surfaces SINGLE_SELECT field values as one-element arrays
+ * (uniform UI format); unwrap so scalar-typed consumers compare correctly.
+ */
+function scalarValue<T>(value: T | T[] | undefined): T | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+/**
  * Hook to fetch all inboxes using the entity system.
  * Uses useAllRecords internally for data fetching.
  */
@@ -93,8 +101,8 @@ export function useInboxes(): UseInboxesResult {
       name: record.fieldValues?.inbox_name ?? record.displayName ?? 'Untitled',
       description: record.fieldValues?.inbox_description ?? null,
       color: record.fieldValues?.inbox_color ?? null,
-      status: record.fieldValues?.inbox_status,
-      defaultLens: record.fieldValues?.inbox_default_lens ?? 'full',
+      status: scalarValue(record.fieldValues?.inbox_status),
+      defaultLens: scalarValue(record.fieldValues?.inbox_default_lens) ?? 'full',
       myLens: lenses[record.id],
       isPersonal: record.fieldValues?.inbox_is_personal ?? false,
       ownerUserId: record.fieldValues?.inbox_owner_user_id ?? null,

--- a/apps/web/src/components/threads/store/thread-store.ts
+++ b/apps/web/src/components/threads/store/thread-store.ts
@@ -3,6 +3,7 @@
 import '~/lib/immer-config' // Enables Map/Set support for immer
 import type { ThreadClientFilter } from '@auxx/lib/mail-query/client'
 import type { ThreadMergeData } from '@auxx/lib/threads/types'
+import type { ParticipantId } from '@auxx/types'
 import type { ActorId } from '@auxx/types/actor'
 import type { StandaloneDraftMeta } from '@auxx/types/draft'
 import type { RecordId } from '@auxx/types/resource'
@@ -51,6 +52,14 @@ export interface ThreadMeta {
   // Denormalized for performance (avoid extra fetches for list display)
   latestMessageId: string | null
   latestCommentId: string | null
+
+  /**
+   * Role-prefixed ParticipantId[] of the latest message (from/replyto/to/cc/
+   * bcc). Metadata tier — present at every lens, so rows can render sender
+   * identity even when `latestMessageId` is redacted to null. Optional:
+   * absent on patches and pre-participants cached payloads.
+   */
+  participants?: ParticipantId[]
 
   /** Inbox RecordId (format: "entityDefinitionId:instanceId") or null if unassigned */
   inboxId: RecordId | null

--- a/apps/web/src/components/tickets/ticket-row.tsx
+++ b/apps/web/src/components/tickets/ticket-row.tsx
@@ -98,10 +98,9 @@ function TicketRow({ recordId, createdAt, className, onActionComplete }: Props) 
 
   const { values, isLoading } = useSystemValues(recordId, TICKET_ATTRS, { autoFetch: true })
 
-  const unwrap = (v: unknown): string => {
-    const raw = Array.isArray(v) ? v[0] : v
-    return (raw as string) ?? ''
-  }
+  // useSystemValues collapses SINGLE_SELECT (status/priority/type) to a scalar,
+  // so a plain string coercion is enough.
+  const unwrap = (v: unknown): string => (v as string) ?? ''
 
   const title = unwrap(values.ticket_title)
   const number = unwrap(values.ticket_number)

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -545,9 +545,11 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   groupMembers: { prefix: 'org:group-members', ttlSeconds: ONE_DAY },
   // Read per CRUD event by agent-trigger dispatch — same rationale as workflowApps.
   agents: { prefix: 'org:agents', ttlSeconds: ONE_DAY, localTtlMs: 5_000 },
-  // v4: + ownerUserId (§11 personal accounts). v3: + isPersonal. v2: +
-  // defaultLens (mail-permissions §2.2). Bump on shape changes.
-  inboxes: { prefix: 'org:inboxes:v4', ttlSeconds: ONE_DAY },
+  // v5: defaultLens/status normalized to scalars (were SINGLE_SELECT arrays —
+  // poisoned strict lens comparisons). v4: + ownerUserId (§11 personal
+  // accounts). v3: + isPersonal. v2: + defaultLens (mail-permissions §2.2).
+  // Bump on shape changes.
+  inboxes: { prefix: 'org:inboxes:v5', ttlSeconds: ONE_DAY },
   // Reverse thread/contact/inbox grant index for realtime publish fanout
   // (§3.1) + ingest count-delta audiences (§10.1). v2: + inboxes bucket.
   mailGrantIndex: { prefix: 'org:mail-grant-index:v2', ttlSeconds: ONE_DAY },

--- a/packages/lib/src/cache/user-cache-keys.ts
+++ b/packages/lib/src/cache/user-cache-keys.ts
@@ -96,5 +96,7 @@ export const USER_CACHE_KEY_CONFIG: Record<
   userMailViews: { prefix: 'user:mail-views', ttlSeconds: ONE_DAY },
   userTableViews: { prefix: 'user:table-views', ttlSeconds: ONE_DAY },
   userFavorites: { prefix: 'user:favorites', ttlSeconds: ONE_DAY },
-  userMailVisibility: { prefix: 'user:mail-visibility', ttlSeconds: ONE_DAY },
+  // v2: inboxLens values normalized to scalar lenses (cached entries built
+  // from the pre-v5 `inboxes` shape carried SINGLE_SELECT arrays).
+  userMailVisibility: { prefix: 'user:mail-visibility:v2', ttlSeconds: ONE_DAY },
 }

--- a/packages/lib/src/inboxes/inbox-service.ts
+++ b/packages/lib/src/inboxes/inbox-service.ts
@@ -6,7 +6,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
 import { and, eq } from 'drizzle-orm'
 import { getUserCache, onCacheEvent } from '../cache'
-import type { Lens } from '../permissions/visibility/lens'
+import { normalizeLens } from '../permissions/visibility/lens'
 import { hasPermission, setInstanceAccess } from '../resource-access/resource-access-service'
 import type { ResourceAccessContext } from '../resource-access/types'
 import { listAll, UnifiedCrudHandler } from '../resources/crud'
@@ -19,6 +19,15 @@ const logger = createScopedLogger('inbox-service')
  */
 function getInstanceId(recordId: RecordId): string {
   return parseRecordId(recordId).entityInstanceId
+}
+
+/**
+ * Field-value reads surface SINGLE_SELECT values as one-element arrays (the
+ * UI-uniform format). Unwrap to a scalar so downstream strict comparisons
+ * (`status === 'ACTIVE'`, lens checks) don't silently misfire.
+ */
+function scalarFieldValue(raw: unknown): unknown {
+  return Array.isArray(raw) ? raw[0] : raw
 }
 
 /**
@@ -398,8 +407,9 @@ export class InboxService {
       name: item.displayName ?? '',
       description: (item.fieldValues.inbox_description as string) ?? null,
       color: (item.fieldValues.inbox_color as string) ?? 'indigo',
-      status: ((item.fieldValues.inbox_status as string) ?? 'ACTIVE') as Inbox['status'],
-      defaultLens: (item.fieldValues.inbox_default_lens as string as Lens) ?? 'full',
+      status: ((scalarFieldValue(item.fieldValues.inbox_status) as string) ??
+        'ACTIVE') as Inbox['status'],
+      defaultLens: normalizeLens(item.fieldValues.inbox_default_lens),
       isPersonal: (item.fieldValues.inbox_is_personal as boolean) ?? false,
       ownerUserId: (item.fieldValues.inbox_owner_user_id as string) ?? null,
       settings: (item.fieldValues.inbox_settings as Record<string, unknown>) ?? {},
@@ -437,8 +447,9 @@ export class InboxService {
       name: instance.displayName ?? '',
       description: (getValue('inbox_description') as string) ?? null,
       color: (getValue('inbox_color') as string) ?? 'indigo',
-      status: ((getValue('inbox_status') as string) ?? 'ACTIVE') as Inbox['status'],
-      defaultLens: (getValue('inbox_default_lens') as string as Lens) ?? 'full',
+      status: ((scalarFieldValue(getValue('inbox_status')) as string) ??
+        'ACTIVE') as Inbox['status'],
+      defaultLens: normalizeLens(getValue('inbox_default_lens')),
       isPersonal: (getValue('inbox_is_personal') as boolean) ?? false,
       ownerUserId: (getValue('inbox_owner_user_id') as string) ?? null,
       settings: (getValue('inbox_settings') as Record<string, unknown>) ?? {},

--- a/packages/lib/src/messages/participant-ids.ts
+++ b/packages/lib/src/messages/participant-ids.ts
@@ -1,0 +1,76 @@
+// packages/lib/src/messages/participant-ids.ts
+
+import { type Database, schema } from '@auxx/database'
+import { type ParticipantId, toParticipantId } from '@auxx/types'
+import { inArray } from 'drizzle-orm'
+
+/**
+ * Batch-resolve role-prefixed ParticipantId[] (from → replyto → to → cc → bcc,
+ * matching the message-envelope order) for a set of message ids. Self-contained
+ * (queries Message + MessageParticipant itself) so callers that only hold ids —
+ * e.g. thread metadata resolving the latest message's envelope — don't need the
+ * full MessageQueryService. Missing/deleted messages are simply absent from the
+ * returned map.
+ */
+export async function getParticipantIdsByMessage(
+  db: Database,
+  messageIds: string[]
+): Promise<Map<string, ParticipantId[]>> {
+  const result = new Map<string, ParticipantId[]>()
+  if (messageIds.length === 0) return result
+
+  const [messages, messageParticipants] = await Promise.all([
+    db.query.Message.findMany({
+      where: inArray(schema.Message.id, messageIds),
+      columns: { id: true, fromId: true, replyToId: true },
+    }),
+    db.query.MessageParticipant.findMany({
+      where: inArray(schema.MessageParticipant.messageId, messageIds),
+      columns: { messageId: true, participantId: true, role: true },
+    }),
+  ])
+
+  const rolesByMessage = new Map<
+    string,
+    { from: string | null; replyTo: string | null; to: string[]; cc: string[]; bcc: string[] }
+  >()
+  for (const mp of messageParticipants) {
+    let entry = rolesByMessage.get(mp.messageId)
+    if (!entry) {
+      entry = { from: null, replyTo: null, to: [], cc: [], bcc: [] }
+      rolesByMessage.set(mp.messageId, entry)
+    }
+    switch (mp.role) {
+      case 'FROM':
+        entry.from = mp.participantId
+        break
+      case 'REPLY_TO':
+        entry.replyTo = mp.participantId
+        break
+      case 'TO':
+        entry.to.push(mp.participantId)
+        break
+      case 'CC':
+        entry.cc.push(mp.participantId)
+        break
+      case 'BCC':
+        entry.bcc.push(mp.participantId)
+        break
+    }
+  }
+
+  for (const message of messages) {
+    const roles = rolesByMessage.get(message.id)
+    const participants: ParticipantId[] = []
+    const fromId = message.fromId ?? roles?.from
+    if (fromId) participants.push(toParticipantId('from', fromId))
+    const replyToId = message.replyToId ?? roles?.replyTo
+    if (replyToId) participants.push(toParticipantId('replyto', replyToId))
+    for (const id of roles?.to ?? []) participants.push(toParticipantId('to', id))
+    for (const id of roles?.cc ?? []) participants.push(toParticipantId('cc', id))
+    for (const id of roles?.bcc ?? []) participants.push(toParticipantId('bcc', id))
+    result.set(message.id, participants)
+  }
+
+  return result
+}

--- a/packages/lib/src/permissions/visibility/lens.ts
+++ b/packages/lib/src/permissions/visibility/lens.ts
@@ -24,3 +24,15 @@ export const satisfiesLens = (have: Lens, need: Lens): boolean => ORDER[have] >=
 
 /** Numeric rank of a lens (for sorting / comparisons). */
 export const lensRank = (lens: Lens): number => ORDER[lens]
+
+/**
+ * Coerce an untrusted value (e.g. a SINGLE_SELECT field-value read, which
+ * surfaces as a one-element array) to a valid scalar {@link Lens}. Arrays
+ * poison every strict lens comparison downstream — `['none'] !== 'none'`
+ * skips the restricted-inbox drop, `['full'] !== 'full'` redacts full
+ * viewers — so every lens read from a field value MUST pass through here.
+ */
+export function normalizeLens(value: unknown, fallback: Lens = 'full'): Lens {
+  const scalar = Array.isArray(value) ? value[0] : value
+  return (ALL_LENSES as readonly unknown[]).includes(scalar) ? (scalar as Lens) : fallback
+}

--- a/packages/lib/src/permissions/visibility/redact.ts
+++ b/packages/lib/src/permissions/visibility/redact.ts
@@ -19,6 +19,7 @@ export const THREAD_METADATA_FIELDS: readonly (keyof ThreadMeta)[] = [
   'firstMessageAt',
   'messageCount',
   'participantCount',
+  'participants',
   'integrationId',
   'integrationProvider',
   'integrationIsExample',

--- a/packages/lib/src/permissions/visibility/visibility.test.ts
+++ b/packages/lib/src/permissions/visibility/visibility.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import type { AutomationVisibility, ThreadVisibilityInput, UserMailVisibility } from './context'
 import { isAutomationViewer, isSystemViewer, isUserViewer, SYSTEM_VISIBILITY } from './context'
 import { automationLens, effectiveLens, effectiveLensBatch, inboxLensFor } from './effective-lens'
-import { maxLens, satisfiesLens } from './lens'
+import { maxLens, normalizeLens, satisfiesLens } from './lens'
 import { redactMessage, redactMessagePatch, redactThreadMeta, redactThreadPatch } from './redact'
 
 const INBOX = 'inbox_1'
@@ -41,6 +41,32 @@ describe('lens comparators', () => {
     expect(satisfiesLens('metadata', 'subject')).toBe(false)
     expect(maxLens('metadata', 'subject')).toBe('subject')
     expect(maxLens('full', 'none')).toBe('full')
+  })
+})
+
+describe('normalizeLens', () => {
+  it('passes valid scalar lenses through', () => {
+    expect(normalizeLens('none')).toBe('none')
+    expect(normalizeLens('metadata')).toBe('metadata')
+    expect(normalizeLens('subject')).toBe('subject')
+    expect(normalizeLens('full')).toBe('full')
+  })
+
+  it('unwraps SINGLE_SELECT one-element arrays', () => {
+    // Arrays poison strict comparisons downstream: ['none'] !== 'none' skips
+    // the restricted-inbox drop, ['full'] !== 'full' redacts full viewers.
+    expect(normalizeLens(['subject'])).toBe('subject')
+    expect(normalizeLens(['none'])).toBe('none')
+    expect(normalizeLens(['full'])).toBe('full')
+  })
+
+  it('falls back on garbage', () => {
+    expect(normalizeLens(undefined)).toBe('full')
+    expect(normalizeLens(null)).toBe('full')
+    expect(normalizeLens([])).toBe('full')
+    expect(normalizeLens('FULL')).toBe('full')
+    expect(normalizeLens(['subject', 'full'])).toBe('subject')
+    expect(normalizeLens('bogus', 'none')).toBe('none')
   })
 })
 
@@ -192,6 +218,7 @@ const META: any = {
   latestMessageId: 'm1',
   messageCount: 3,
   tagIds: [],
+  participants: ['from:p1', 'to:p2'],
 }
 
 describe('redactThreadMeta', () => {
@@ -212,6 +239,14 @@ describe('redactThreadMeta', () => {
     expect(r.subject).toBe('')
     expect(r.isUnread).toBe(false)
     expect(r.latestMessageId).toBeNull()
+  })
+
+  it('keeps envelope participants at every lens (§2.2 tier table)', () => {
+    expect(redactThreadMeta(META, 'subject').participants).toEqual(['from:p1', 'to:p2'])
+    expect(redactThreadMeta(META, 'metadata').participants).toEqual(['from:p1', 'to:p2'])
+    expect(redactThreadPatch({ participants: ['from:p1'] } as any, 'metadata')).toEqual({
+      participants: ['from:p1'],
+    })
   })
 })
 

--- a/packages/lib/src/threads/thread-query.service.ts
+++ b/packages/lib/src/threads/thread-query.service.ts
@@ -32,6 +32,7 @@ import {
 } from '../mail-query/draft-condition-builder'
 import { buildMailVisibilityPredicate } from '../mail-query/visibility-scope'
 import { MailViewService } from '../mail-views/mail-view-service'
+import { getParticipantIdsByMessage } from '../messages/participant-ids'
 import type {
   MailViewer,
   ThreadVisibilityInput,
@@ -795,6 +796,13 @@ export class ThreadQueryService {
     // Note: batchGetThreadTagIds returns RecordIds (from FieldValue.relatedEntityId which stores RecordIds)
     const tagIdMap = await batchGetThreadTagIds(this.db, ids, this.organizationId)
 
+    // Latest-message envelope participants (metadata tier) — lets sub-`full`
+    // viewers see sender identity even though `latestMessageId` is blanked.
+    const participantsByMessage = await getParticipantIdsByMessage(
+      this.db,
+      threads.map((t) => t.latestMessageId).filter((id): id is string => !!id)
+    )
+
     // Threads with explicit shares (instance grants) — powers the list rows'
     // share indicator (`hasShares`, metadata tier).
     const shareRows = await this.db
@@ -934,6 +942,9 @@ export class ThreadQueryService {
           assigneeId: t.assigneeId ? toActorId('user', t.assigneeId) : null,
           latestMessageId: t.latestMessageId ?? null,
           latestCommentId: t.latestCommentId ?? null,
+          participants: t.latestMessageId
+            ? (participantsByMessage.get(t.latestMessageId) ?? [])
+            : [],
           inboxId: t.inboxId ? toRecordId(inboxEntityDefId, t.inboxId) : null,
           // Backwards-compat shim for the frontend: if the primary entity is a
           // Ticket, surface its instance id under the legacy `ticketId` key.

--- a/packages/lib/src/threads/types.ts
+++ b/packages/lib/src/threads/types.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/threads/types.ts
 
+import type { ParticipantId } from '@auxx/types'
 import type { ActorId } from '@auxx/types/actor'
 import type { RecordId } from '@auxx/types/resource'
 import type { ConditionGroup } from '../conditions/types'
@@ -153,6 +154,14 @@ export interface ThreadMeta {
   // Denormalized for performance (avoid extra fetches for list display)
   latestMessageId: string | null
   latestCommentId: string | null
+
+  /**
+   * Role-prefixed ParticipantId[] of the thread's latest message (from /
+   * replyto / to / cc / bcc). Participants are metadata-tier (§2.2 — visible
+   * at every lens), so list rows and headers can render sender identity even
+   * when `latestMessageId` is blanked below `full`.
+   */
+  participants: ParticipantId[]
 
   /** Inbox RecordId (format: "entityDefinitionId:instanceId") or null if unassigned */
   inboxId: RecordId | null


### PR DESCRIPTION
## Summary

- **Inbox settings management** — each row in Settings → Inboxes gets a `⋯` actions menu:
  - **Edit** opens the `InboxDialog` in edit mode (`recordId`) — the editor is now reachable for existing inboxes, not just create.
  - **Delete** with a destructive confirmation (`useConfirm`), calling `inbox.delete` then invalidating/refreshing the list.
- **Unified grantee list** — one `TreeRow`-based `GranteeList` is now the single source for "who has access" rows across all surfaces (settings/palette host + the inbox dialog's *People & groups* drill):
  - Extracted `ActorAvatar` from `ActorBadge`; it renders in the TreeRow leading **icon** slot with the name as the title.
  - Transparent `LensSelect` + hover-revealed `Trash2` remove (`TreeRowButton`) in the actions slot; rows carry `bg-primary-50 hover:bg-primary-100`.
  - `EmptySection` empty state.
  - Extracted `GranteeAddButton` so a surface can host the add trigger apart from the list (the inbox dialog places it in the `Section` header `actions`).
  - `InboxMembersPage` now wraps `GranteeList` (via `hideAddButton`) instead of duplicating row rendering.
- Plus supporting **mail-permissions / visibility** and **thread-query** changes bundled in this working set (lens, redact, participant-ids, inbox-service, caches, thread types/store).

## Test plan

- [ ] Settings → Inboxes: ⋯ → Edit opens the dialog in edit mode; ⋯ → Delete confirms and removes the inbox; row click still navigates to detail.
- [ ] Inbox dialog *People & groups*: add/change-lens/remove grantees; add button in the Section header; empty state renders.
- [ ] Grantee rows look identical across the command-palette host and the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)