### PR TITLE
feat(parts): definition-icon fallback in relation pickers + system TAGS options

### DIFF
--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -251,6 +251,7 @@ export function FieldInputAdapter({
             disabled={disabled}
             onCreate={handleOpenCreate}
             excludeIds={fieldOptions?.excludeIds}
+            showDefinitionIcon={fieldOptions?.showDefinitionIcon}
             triggerProps={triggerProps}
             open={open}
             onOpenChange={onOpenChange}

--- a/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
@@ -285,6 +285,7 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
             <FieldInputAdapter
               fieldType={FieldType.TAGS}
               fieldOptions={categoryField?.options}
+              triggerProps={{ className: 'ps-0 pe-1 w-full' }}
               value={values.category}
               onChange={(val) => handleChange('category', val)}
               placeholder='Add categories'

--- a/apps/web/src/components/manufacturing/parts/subpart-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/subpart-dialog.tsx
@@ -18,7 +18,7 @@ import {
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { generateId } from '@auxx/utils/generateId'
-import { Plus, X } from 'lucide-react'
+import { Plus, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
@@ -335,30 +335,13 @@ export function SubpartDialog({
           </FieldPanel>
         ) : (
           <div className='flex flex-col gap-3 max-h-[55vh] overflow-y-auto pe-1'>
-            {rows.map((row, index) => (
-              <div
-                key={row.key}
-                className='relative rounded-lg border border-border/60 bg-muted/20 p-3'>
-                {rows.length > 1 && (
-                  <div className='mb-2 flex items-center justify-between'>
-                    <span className='text-xs font-medium text-muted-foreground'>
-                      Component {index + 1}
-                    </span>
-                    <Button
-                      type='button'
-                      variant='ghost'
-                      size='xs'
-                      onClick={() => removeRow(row.key)}
-                      disabled={isPending}
-                      aria-label='Remove component'>
-                      <X />
-                    </Button>
-                  </div>
-                )}
-
-                <FieldPanel className='p-0' breakpoint='md' resizeId='subpart'>
+            {rows.map((row) => (
+              <div key={row.key} className='flex flex-row items-start gap-1'>
+                <FieldPanel className='flex-1 p-0' breakpoint='md' resizeId='subpart'>
                   <FieldPanelRow
                     title='Subpart'
+                    type={BaseType.RELATION}
+                    showIcon
                     description='Component to add'
                     isRequired
                     validationError={errors[`${row.key}.childPartId`]}>
@@ -372,11 +355,13 @@ export function SubpartDialog({
                         const first = recordIds[0]
                         updateRow(row.key, 'childPartId', first ? getInstanceId(first) : '')
                       }}
+                      triggerProps={{ className: 'ps-0 pe-1 w-full' }}
                       placeholder='Select a component...'
                       disabled={isPending}
                       fieldOptions={{
                         relationship: CHILD_PART_RELATIONSHIP,
                         excludeIds: excludedForRow(row.key),
+                        showDefinitionIcon: true,
                       }}
                     />
                   </FieldPanelRow>
@@ -413,6 +398,19 @@ export function SubpartDialog({
                     />
                   </FieldPanelRow>
                 </FieldPanel>
+
+                {rows.length > 1 && (
+                  <Button
+                    type='button'
+                    variant='destructive-hover'
+                    className='rounded-lg'
+                    size='icon-xs'
+                    onClick={() => removeRow(row.key)}
+                    disabled={isPending}
+                    aria-label='Remove component'>
+                    <Trash2 />
+                  </Button>
+                )}
               </div>
             ))}
 

--- a/apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
+++ b/apps/web/src/components/manufacturing/parts/vendor-part-fields.tsx
@@ -71,7 +71,7 @@ export function VendorPartFields({
           <FieldInputAdapter
             triggerProps={{ className: 'w-full ps-0 pe-1' }}
             fieldType={contactField?.fieldType ?? FieldType.RELATIONSHIP}
-            fieldOptions={contactField?.options}
+            fieldOptions={{ ...contactField?.options, showDefinitionIcon: true }}
             value={values.entityInstanceId ? [toRecordId('company', values.entityInstanceId)] : []}
             onChange={(recordIds) => {
               const ids = recordIds as RecordId[]

--- a/apps/web/src/components/shared/multi-relation-input.tsx
+++ b/apps/web/src/components/shared/multi-relation-input.tsx
@@ -3,11 +3,13 @@
 'use client'
 
 import type { RecordId } from '@auxx/lib/resources/client'
+import type { SelectOptionColor } from '@auxx/types/custom-field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
 import { useCallback, useMemo, useState } from 'react'
 import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
+import { useResource } from '~/components/resources/hooks/use-resource'
 import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import { api } from '~/trpc/react'
 import { RecordBadge } from '../resources/ui'
@@ -47,6 +49,12 @@ export interface MultiRelationInputProps {
   /** RecordIds to exclude from search results */
   excludeIds?: RecordId[]
 
+  /**
+   * When true, picker rows with no avatar fall back to the related EntityDefinition's
+   * icon/color (matching the selected chips). Default: false.
+   */
+  showDefinitionIcon?: boolean
+
   /** Callback when "Create new" is clicked (for complex creation flows via dialog) */
   onCreate?: () => void
 
@@ -82,6 +90,7 @@ export function MultiRelationInput({
   maxDisplayItems = 3,
   multi = true,
   excludeIds = [],
+  showDefinitionIcon = false,
   onCreate,
   createLabel,
   triggerProps,
@@ -110,6 +119,9 @@ export function MultiRelationInput({
     return Array.isArray(entityDefinitionId) ? entityDefinitionId[0] : entityDefinitionId
   }, [entityDefinitionId])
 
+  // EntityDefinition icon/color fallback for records without an avatar (opt-in)
+  const { resource } = useResource(showDefinitionIcon ? tableId : null)
+
   // Search for items when popover is open
   const { data: searchResults, isLoading: isSearching } = api.record.search.useQuery(
     {
@@ -131,8 +143,12 @@ export function MultiRelationInput({
         label: item.displayName,
         value: item.recordId,
         avatarUrl: item.avatarUrl,
+        // Fall back to the EntityDefinition's icon/color when the record has no avatar
+        ...(showDefinitionIcon
+          ? { icon: resource?.icon, color: resource?.color as SelectOptionColor | undefined }
+          : {}),
       }))
-  }, [searchResults, excludeIds])
+  }, [searchResults, excludeIds, showDefinitionIcon, resource?.icon, resource?.color])
 
   /**
    * Handle selection change from MultiSelectPicker

--- a/packages/lib/src/custom-fields/field-options.ts
+++ b/packages/lib/src/custom-fields/field-options.ts
@@ -103,6 +103,12 @@ export interface FieldOptions {
    * Runtime-only filter passed by the caller — never persisted to CustomField.options.
    */
   excludeIds?: RecordId[]
+  /**
+   * When true, RELATIONSHIP picker rows fall back to the related EntityDefinition's
+   * icon/color for records that have no avatar (selected chips already do this).
+   * Runtime-only UI flag passed by the caller — never persisted to CustomField.options.
+   */
+  showDefinitionIcon?: boolean
 
   // ─────────────────────────────────────────────────────────────
   // ACTOR (nested - uses ActorOptions from @auxx/types/custom-field)

--- a/packages/services/src/custom-fields/update-field.ts
+++ b/packages/services/src/custom-fields/update-field.ts
@@ -122,13 +122,29 @@ export async function updateCustomField(input: UpdateCustomFieldInput) {
   // frontend and only stripped `systemAttribute` from the patch below. This
   // closes that hole and extends it to app-owned fields (only uninstall edits
   // those).
+  //
+  // Exception: TAGS options are user-grown data, not configuration — every
+  // newly typed tag persists through this route as an options-only patch
+  // (see select-input-field.tsx handleOptionsChange). Allow that patch on
+  // system TAGS fields; everything else (name, type, …) stays locked, and
+  // app-owned fields stay fully locked.
   if (isProtectedField(currentField)) {
-    return err({
-      code: 'ACCESS_DENIED' as const,
-      message: currentField.appInstallationId
-        ? 'This field is managed by an installed app and cannot be edited'
-        : 'System fields cannot be edited',
-    })
+    const isTagsOptionsOnlyPatch =
+      !currentField.appInstallationId &&
+      currentField.type === FieldTypeEnum.TAGS &&
+      options !== undefined &&
+      type === undefined &&
+      isUnique === undefined &&
+      addressComponents === undefined &&
+      Object.values(data).every((v) => v === undefined)
+    if (!isTagsOptionsOnlyPatch) {
+      return err({
+        code: 'ACCESS_DENIED' as const,
+        message: currentField.appInstallationId
+          ? 'This field is managed by an installed app and cannot be edited'
+          : 'System fields cannot be edited',
+      })
+    }
   }
 
   const fieldType = type || currentField.type


### PR DESCRIPTION
## Summary

- **Definition-icon fallback in relation pickers.** Adds an opt-in `showDefinitionIcon` flag so picker rows without an avatar fall back to the related `EntityDefinition`'s icon/color — matching what the selected chips already render. Wired through `FieldOptions` → `FieldInputAdapter` → `MultiRelationInput` and enabled for the subpart component, vendor company, and part category pickers.
- **Subpart dialog restyle.** Replaces the per-component header + `X` button with an inline destructive trash button beside each row and a tighter flex layout.
- **System TAGS options.** `updateCustomField` now allows options-only patches on system `TAGS` fields, so newly typed tags persist while name/type/etc. stay locked. App-owned fields remain fully locked.

## Notes

- The local `.mcp.json` Postgres-MCP tweak was intentionally left out of this PR (unrelated dev tooling).

## Test plan

- [ ] Open a part's subpart dialog — component rows show the definition icon in the picker and the trash button removes extra rows.
- [ ] Vendor company + category pickers show definition-icon fallback for records without avatars.
- [ ] Add a new tag to a system TAGS field and confirm it persists.