### PR TITLE
chore(mcp): switch postgres MCP to crystaldba/postgres-mcp

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -17,7 +17,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "export $(grep ^DATABASE_URL .env | xargs) && pnpm dlx @modelcontextprotocol/server-postgres $DATABASE_URL"
+        "export $(grep ^DATABASE_URL .env | xargs) && URI=$(echo \"$DATABASE_URL\" | sed 's/localhost/host.docker.internal/;s/127.0.0.1/host.docker.internal/') && docker run -i --rm -e DATABASE_URI=\"$URI\" crystaldba/postgres-mcp --access-mode=unrestricted"
       ]
     },
     "chrome-devtools": {


### PR DESCRIPTION
## Summary

Swaps the project-scoped Postgres MCP server from `@modelcontextprotocol/server-postgres` to the Docker-based `crystaldba/postgres-mcp` (`--access-mode=unrestricted`), which ships a richer analysis toolset (db-health checks, `explain`, index advisor, top-queries) on top of plain SQL execution.

The `DATABASE_URL` host is rewritten to `host.docker.internal` **only** when it points at `localhost`/`127.0.0.1`, so it's a no-op for anyone whose URL already targets a real host.

## Notes

- Requires Docker to be running locally to use the Postgres MCP server.