### PR TITLE
feat(dashboards): render record-list widget on DynamicTable (reduced mode)

### DIFF
--- a/apps/web/src/components/dashboard/hooks/use-record-list-columns.tsx
+++ b/apps/web/src/components/dashboard/hooks/use-record-list-columns.tsx
@@ -1,0 +1,143 @@
+// apps/web/src/components/dashboard/hooks/use-record-list-columns.tsx
+'use client'
+
+// Builds the column defs for a record-list widget rendered on `DynamicTable`
+// (standalone + hideToolbar reduced mode). Mirrors `DynamicResourceView`'s
+// primary + entity-field columns, but config-driven (explicit `config.columns`)
+// and with every interaction knob off — no sort/filter/hide/resize/reorder —
+// because the widget's sort/filter are server-side and any header interaction
+// would write to the session-only view store and lie on reload.
+//
+// Cells self-hydrate: `PrimaryFieldCell` (primary display field) and
+// `CustomFieldCell` (configured columns) both fetch their own values through
+// the app-wide record batch fetcher, so no value stitching is needed here.
+
+import type { RecordListConfig, WidgetFieldRef } from '@auxx/lib/dashboards/client'
+import { toRecordId } from '@auxx/lib/resources/client'
+import type { ResourceFieldId } from '@auxx/types/field'
+import { toFieldId, toResourceFieldId } from '@auxx/types/field'
+import { useMemo } from 'react'
+import type { ExtendedColumnDef } from '~/components/dynamic-table'
+import { CustomFieldCell, getIconForFieldType, PrimaryFieldCell } from '~/components/dynamic-table'
+import { encodeFieldPathColumnId } from '~/components/dynamic-table/utils/column-id'
+import { useResource } from '~/components/resources'
+import { useFields } from '~/components/resources/hooks/use-field'
+
+/** Plain row: an entity-instance id. Cells re-brand with the entity def id. */
+export interface RecordListRow {
+  id: string
+}
+
+/** A `WidgetFieldRef` → the `columnId` string `CustomFieldCell` decodes. */
+function columnId(ref: WidgetFieldRef): string {
+  return typeof ref === 'string' ? ref : encodeFieldPathColumnId(ref)
+}
+
+/** The terminal `ResourceFieldId` of a ref, for header-label + icon lookup. */
+function terminalFieldId(ref: WidgetFieldRef): ResourceFieldId {
+  return typeof ref === 'string' ? ref : ref[ref.length - 1]
+}
+
+interface UseRecordListColumnsOptions {
+  config: RecordListConfig
+  entityDefinitionId: string
+  /** Read-only edit mode — suppresses the drawer-opening title click. */
+  isEditMode: boolean
+  /** Opens the record drawer for a row's instance id (view mode only). */
+  onOpenRecord: (instanceId: string) => void
+}
+
+/**
+ * Column defs for the record-list widget: a pinned primary column
+ * (`PrimaryFieldCell`, no kebab) followed by the configured field columns
+ * (`CustomFieldCell`). All static — sorting/filtering/hiding/resizing off.
+ */
+export function useRecordListColumns({
+  config,
+  entityDefinitionId,
+  isEditMode,
+  onOpenRecord,
+}: UseRecordListColumnsOptions): ExtendedColumnDef<RecordListRow>[] {
+  const { resource } = useResource(entityDefinitionId)
+
+  const cols = useMemo(() => config.columns ?? [], [config.columns])
+
+  // Resolve terminal-field metadata (label + type) for every configured column
+  // in one shallow-compared subscription.
+  const terminalRefs = useMemo(() => cols.map(terminalFieldId), [cols])
+  const fields = useFields(terminalRefs)
+
+  // The records-table primary column: primary display field (fallback first
+  // field), rendered through `PrimaryFieldCell` for field-formatted value +
+  // record icon + connector source badge.
+  const primaryFieldId = resource?.display.primaryDisplayField?.id ?? resource?.fields[0]?.id
+  const primaryResourceFieldId = useMemo(() => {
+    if (!entityDefinitionId || !primaryFieldId) return null
+    return toResourceFieldId(entityDefinitionId, toFieldId(primaryFieldId))
+  }, [entityDefinitionId, primaryFieldId])
+  const primaryFieldLabel = resource?.fields.find((f) => f.id === primaryFieldId)?.label
+
+  return useMemo(() => {
+    const columns: ExtendedColumnDef<RecordListRow>[] = []
+
+    if (primaryResourceFieldId) {
+      columns.push({
+        id: primaryResourceFieldId,
+        accessorFn: () => undefined,
+        header: primaryFieldLabel ?? 'Record',
+        primaryCell: true,
+        enableSorting: false,
+        enableFiltering: false,
+        enableHiding: false,
+        enableResizing: false,
+        enableResize: false,
+        minSize: 140,
+        size: 220,
+        cell: ({ row }) => (
+          <PrimaryFieldCell
+            resourceFieldId={primaryResourceFieldId}
+            rowId={row.original.id}
+            onTitleClick={() => {
+              if (!isEditMode) onOpenRecord(row.original.id)
+            }}
+          />
+        ),
+      })
+    }
+
+    cols.forEach((col, i) => {
+      const field = fields[i]
+      const id = columnId(col)
+      columns.push({
+        id,
+        accessorFn: () => undefined,
+        header: field?.label ?? '—',
+        fieldType: field?.fieldType,
+        icon: field ? getIconForFieldType(field.fieldType) : undefined,
+        enableSorting: false,
+        enableFiltering: false,
+        enableHiding: false,
+        enableResizing: false,
+        enableResize: false,
+        minSize: 100,
+        size: 150,
+        cell: ({ row }) => (
+          <CustomFieldCell
+            recordId={toRecordId(entityDefinitionId, row.original.id)}
+            columnId={id}
+          />
+        ),
+      })
+    })
+
+    return columns
+  }, [
+    cols,
+    fields,
+    entityDefinitionId,
+    primaryResourceFieldId,
+    primaryFieldLabel,
+    isEditMode,
+    onOpenRecord,
+  ])
+}

--- a/apps/web/src/components/dashboard/hooks/use-record-list-data.ts
+++ b/apps/web/src/components/dashboard/hooks/use-record-list-data.ts
@@ -61,6 +61,8 @@ export function useRecordListData(config: RecordListConfig, _widgetId?: string) 
 
   return {
     entityDefinitionId,
+    /** Raw entity-instance ids (the `{ id }` rows the DynamicTable renders). */
+    ids: query.data?.ids ?? [],
     recordIds,
     total: query.data?.total ?? 0,
     isLoading: query.isLoading,

--- a/apps/web/src/components/dashboard/stores/dashboard-draft-store.test.ts
+++ b/apps/web/src/components/dashboard/stores/dashboard-draft-store.test.ts
@@ -4,7 +4,9 @@ import type { DashboardLayoutDoc } from '@auxx/lib/dashboards/client'
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   type DashboardSeed,
+  selectCurrentTabs,
   selectHasUnpublishedChanges,
+  selectViewLayer,
   useDashboardStore,
 } from './dashboard-draft-store'
 
@@ -118,6 +120,54 @@ describe('lifecycle', () => {
     store().exitEditMode()
     expect(store().isEditMode).toBe(false)
     expect(store().draft?.tabs[0].widgets).toHaveLength(1)
+  })
+})
+
+describe('view layer (Live/Draft toggle)', () => {
+  it('cold seed lands on the live layer', () => {
+    seedStore({ draft: doc(), hasUnpublishedChanges: true })
+    expect(selectViewLayer(store())).toBe('live')
+  })
+
+  it('pressing Done drops the canvas to the draft layer', () => {
+    seedStore()
+    store().enterEditMode()
+    store().addWidget(TAB, 'kpi')
+    store().exitEditMode()
+    expect(selectViewLayer(store())).toBe('draft')
+    // The canvas (currentDoc via selectCurrentTabs) now renders the draft.
+    expect(selectCurrentTabs(store())[0].widgets).toHaveLength(1)
+  })
+
+  it('the live layer renders the published snapshot, not the parked draft', () => {
+    seedStore()
+    store().enterEditMode()
+    store().addWidget(TAB, 'kpi')
+    store().exitEditMode() // → draft layer, canvas shows the new widget
+    store().setViewLayer('live')
+    expect(selectCurrentTabs(store())[0].widgets).toHaveLength(0)
+  })
+
+  it('the draft layer only overrides the canvas when there are unpublished changes', () => {
+    seedStore() // no divergence
+    store().setViewLayer('draft')
+    // Nothing unpublished → still renders the published snapshot.
+    expect(selectCurrentTabs(store())[0].widgets).toHaveLength(0)
+  })
+
+  it('publish/discard reset the toggle back to live', () => {
+    seedStore()
+    store().enterEditMode()
+    store().addWidget(TAB, 'kpi')
+    store().exitEditMode()
+    expect(selectViewLayer(store())).toBe('draft')
+
+    store().markPublished(doc(), 2)
+    expect(selectViewLayer(store())).toBe('live')
+
+    store().exitEditMode()
+    store().markDiscarded(doc())
+    expect(selectViewLayer(store())).toBe('live')
   })
 
   it('a refetch during edit of the same dashboard keeps the local draft', () => {

--- a/apps/web/src/components/dashboard/stores/dashboard-draft-store.ts
+++ b/apps/web/src/components/dashboard/stores/dashboard-draft-store.ts
@@ -29,6 +29,9 @@ import { defaultWidgetConfiguration, defaultWidgetTitle } from '../lib/widget-co
 
 export type SaveState = 'idle' | 'saving' | 'saved' | 'error'
 
+/** In view mode, which layer the canvas renders: the live version or the parked draft. */
+export type ViewLayer = 'live' | 'draft'
+
 /** Server payload the sync hook seeds from (`api.dashboard.get`). */
 export interface DashboardSeed {
   published: DashboardLayoutDoc
@@ -49,6 +52,12 @@ interface DashboardDraftState {
   isDirty: boolean
   /** Server truth: the draft diverges from the active version (drives the pill). */
   hasUnpublishedChanges: boolean
+  /**
+   * View-mode only: which layer the canvas renders when a draft is parked. Cold
+   * loads show `'live'` (the canonical published version); pressing Done drops to
+   * `'draft'` so you keep looking at your work. The header toggle flips it.
+   */
+  viewLayer: ViewLayer
   draggingWidgetId: string | null
   saveState: SaveState
 
@@ -95,6 +104,8 @@ interface DashboardDraftState {
   setGlobalFilters: (filters: DashboardGlobalFilters) => void
 
   // ── transient ──
+  /** Flip the view-mode canvas between the live version and the parked draft. */
+  setViewLayer: (layer: ViewLayer) => void
   setDraggingWidgetId: (id: string | null) => void
   setSaveState: (state: SaveState) => void
   /** Autosave reconciles the pill from the server's saveDraft result. */
@@ -158,6 +169,7 @@ const INITIAL = {
   isEditMode: false,
   isDirty: false,
   hasUnpublishedChanges: false,
+  viewLayer: 'live' as ViewLayer,
   draggingWidgetId: null,
   saveState: 'idle' as SaveState,
 }
@@ -187,6 +199,8 @@ export const useDashboardStore = create<DashboardDraftState>()(
             isEditMode: keep ? s.isEditMode : false,
             isDirty: keep ? s.isDirty : false,
             hasUnpublishedChanges: keep ? s.hasUnpublishedChanges : seed.hasUnpublishedChanges,
+            // Cold loads land on the live version; the toggle/Done opt into the draft.
+            viewLayer: keep ? s.viewLayer : 'live',
           }
         }),
 
@@ -200,8 +214,9 @@ export const useDashboardStore = create<DashboardDraftState>()(
         })),
 
       // Leave edit mode but KEEP the draft — it's persisted server-side, parked
-      // until the user publishes or discards.
-      exitEditMode: () => set({ isEditMode: false }),
+      // until the user publishes or discards. Land on the draft layer so the
+      // canvas keeps showing the work you just did (a toggle flips to live).
+      exitEditMode: () => set({ isEditMode: false, viewLayer: 'draft' }),
 
       markPublished: (doc, versionNumber) =>
         set({
@@ -210,6 +225,7 @@ export const useDashboardStore = create<DashboardDraftState>()(
           draft: cloneDoc(doc),
           isDirty: false,
           hasUnpublishedChanges: false,
+          viewLayer: 'live',
           saveState: 'idle',
         }),
 
@@ -219,6 +235,7 @@ export const useDashboardStore = create<DashboardDraftState>()(
           draft: cloneDoc(doc),
           isDirty: false,
           hasUnpublishedChanges: false,
+          viewLayer: 'live',
           saveState: 'idle',
         }),
 
@@ -395,6 +412,7 @@ export const useDashboardStore = create<DashboardDraftState>()(
 
       setGlobalFilters: (filters) => mutate((draft) => ({ ...draft, globalFilters: filters })),
 
+      setViewLayer: (viewLayer) => set({ viewLayer }),
       setDraggingWidgetId: (draggingWidgetId) => set({ draggingWidgetId }),
       setSaveState: (saveState) => set({ saveState }),
       setHasUnpublishedChanges: (hasUnpublishedChanges) => set({ hasUnpublishedChanges }),
@@ -411,9 +429,15 @@ export function getDashboardDraftState(): DashboardDraftState {
 
 // ── selectors ────────────────────────────────────────────────────────────────
 
-/** The doc that's currently rendered: the draft while editing, else the published snapshot. */
+/**
+ * The doc that's currently rendered: the draft while editing; in view mode the
+ * parked draft when the toggle is on `'draft'` (only meaningful with unpublished
+ * changes), else the published snapshot.
+ */
 function currentDoc(s: DashboardDraftState): DashboardLayoutDoc | null {
-  return s.isEditMode ? (s.draft ?? s.persisted) : s.persisted
+  if (s.isEditMode) return s.draft ?? s.persisted
+  if (s.hasUnpublishedChanges && s.viewLayer === 'draft') return s.draft ?? s.persisted
+  return s.persisted
 }
 
 export const selectCurrentDoc = (s: DashboardDraftState): DashboardLayoutDoc | null => currentDoc(s)
@@ -432,3 +456,6 @@ export const selectGlobalFilters = (s: DashboardDraftState): DashboardGlobalFilt
 /** The pill / Publish-Discard gate: the draft diverges from the active version. */
 export const selectHasUnpublishedChanges = (s: DashboardDraftState): boolean =>
   s.hasUnpublishedChanges
+
+/** Which layer view mode renders (drives the header Live/Draft toggle). */
+export const selectViewLayer = (s: DashboardDraftState): ViewLayer => s.viewLayer

--- a/apps/web/src/components/dashboard/ui/dashboard-detail-view.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-detail-view.tsx
@@ -4,14 +4,16 @@
 // The dashboard detail view — the connector-detail-view analogue. Seeds the
 // draft store from `dashboard.get`, renders the MainPage shell with a view/edit
 // header, the tab strip, and the active tab's widget grid. View mode renders the
-// PUBLISHED version (static); edit mode renders the editable draft with drag/
-// resize (plan 04), add-widget/add-tab, and the docked config panel. Edits
+// PUBLISHED version by default; when a draft is parked a header Live/Draft toggle
+// flips the canvas (Done lands on Draft). Edit mode renders the editable draft
+// with drag/resize (plan 04), add-widget/add-tab, and the docked config panel. Edits
 // auto-save to the server draft (`use-dashboard-autosave`); Publish/Discard drive
 // versioning (`use-dashboard-publish`) — the agent versioning model.
 //
 // Deferred (plan 08): global filter bar, drill-down, chart refresh.
 
 import type { DashboardWithLayout, WidgetKind } from '@auxx/lib/dashboards/client'
+import type { RecordId } from '@auxx/types/resource'
 import {
   MainPage,
   MainPageBreadcrumb,
@@ -23,6 +25,8 @@ import {
 import { Lock } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useQueryState } from 'nuqs'
+import { type ReactNode, useState } from 'react'
+import { RecordDrawer } from '~/components/records/record-drawer'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useDockStore } from '~/stores/dock-store'
@@ -32,6 +36,7 @@ import { useDashboardPublish } from '../hooks/use-dashboard-publish'
 import {
   selectCurrentTabs,
   selectHasUnpublishedChanges,
+  selectViewLayer,
   useDashboardStore,
 } from '../stores/dashboard-draft-store'
 import { AddWidgetMenu } from './config/add-widget-menu'
@@ -51,9 +56,16 @@ export function DashboardDetailView({ dashboard }: { dashboard: DashboardWithLay
   const [tabParam, setTab] = useQueryState('tab')
   const [selectedWidgetId, setSelectedWidgetId] = useQueryState('widget')
 
+  // Record opened from a recordList widget (view mode). Lifted to the page so
+  // the drawer renders in the docked panel / overlay, not clipped inside the
+  // widget card — mirrors records-view.
+  const [openRecordId, setOpenRecordId] = useState<RecordId | null>(null)
+
   const tabs = useDashboardStore(selectCurrentTabs)
   const isEditMode = useDashboardStore((s) => s.isEditMode)
   const hasUnpublishedChanges = useDashboardStore(selectHasUnpublishedChanges)
+  const viewLayer = useDashboardStore(selectViewLayer)
+  const setViewLayer = useDashboardStore((s) => s.setViewLayer)
   const saveState = useDashboardStore((s) => s.saveState)
   const hasPersisted = useDashboardStore((s) => s.persisted !== null)
   const enterEditMode = useDashboardStore((s) => s.enterEditMode)
@@ -119,6 +131,34 @@ export function DashboardDetailView({ dashboard }: { dashboard: DashboardWithLay
     />
   )
 
+  // Record drawer opened from a recordList widget (view mode only). Same
+  // element in both dock modes — RecordDrawer picks docked vs overlay itself.
+  const recordDrawer = (
+    <RecordDrawer
+      open={!isEditMode && !!openRecordId}
+      onOpenChange={(o) => !o && setOpenRecordId(null)}
+      recordId={openRecordId ?? undefined}
+    />
+  )
+
+  // Docked slot hosts the config panel while editing, or the record drawer in
+  // view mode — they never overlap (records aren't clickable in edit mode).
+  const dockedPanelEntry = (key: string, content: ReactNode) => ({
+    key,
+    content,
+    width: dockedWidth,
+    onWidthChange: setDockedWidth,
+    minWidth: dockMinWidth,
+    maxWidth: dockMaxWidth,
+  })
+  const dockedPanels = !isDocked
+    ? []
+    : isEditMode
+      ? [dockedPanelEntry('widget-config', configPanel)]
+      : openRecordId
+        ? [dockedPanelEntry('record-detail', recordDrawer)]
+        : []
+
   return (
     <MainPage>
       <ConfirmDialog />
@@ -133,7 +173,12 @@ export function DashboardDetailView({ dashboard }: { dashboard: DashboardWithLay
             isDiscarding={isDiscarding}
             saveState={saveState}
             hasPersisted={hasPersisted}
-            onEnterEdit={enterEditMode}
+            viewLayer={viewLayer}
+            onViewLayerChange={setViewLayer}
+            onEnterEdit={() => {
+              setOpenRecordId(null)
+              enterEditMode()
+            }}
             onExitEdit={exitEditMode}
             onPublish={() => void publish()}
             onDiscard={() => void discard()}
@@ -159,21 +204,7 @@ export function DashboardDetailView({ dashboard }: { dashboard: DashboardWithLay
         )}
       </MainPageHeader>
 
-      <MainPageContent
-        dockedPanels={
-          isDocked && isEditMode
-            ? [
-                {
-                  key: 'widget-config',
-                  content: configPanel,
-                  width: dockedWidth,
-                  onWidthChange: setDockedWidth,
-                  minWidth: dockMinWidth,
-                  maxWidth: dockMaxWidth,
-                },
-              ]
-            : []
-        }>
+      <MainPageContent dockedPanels={dockedPanels}>
         <div
           className={
             isEditMode
@@ -224,6 +255,7 @@ export function DashboardDetailView({ dashboard }: { dashboard: DashboardWithLay
                         if (ok) removeWidget(widget.id)
                       }}
                       onConfigChange={(config) => updateWidgetConfig(widget.id, config)}
+                      onOpenRecord={setOpenRecordId}
                     />
                   )}
                 />
@@ -234,8 +266,10 @@ export function DashboardDetailView({ dashboard }: { dashboard: DashboardWithLay
       </MainPageContent>
 
       {/* Overlay mode (undocked / mobile) — the DockableDrawer renders its own
-          right-side Vaul drawer; docked mode routes it through dockedPanels above. */}
+          right-side Vaul drawer; docked mode routes these through dockedPanels
+          above. Config panel while editing, record drawer in view mode. */}
       {!isDocked && configPanel}
+      {!isDocked && recordDrawer}
     </MainPage>
   )
 }

--- a/apps/web/src/components/dashboard/ui/dashboard-publish-cluster.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-publish-cluster.tsx
@@ -12,6 +12,10 @@
 //   • view mode — the Edit button.
 //   • edit mode — Add widget ▾, then Done (exit edit; the draft stays parked).
 // The chevron menu (Version history / Duplicate / Settings / Archive) is constant.
+// In view mode with a parked draft the status pill doubles as a Live/Draft view
+// toggle (via the shell's `pillOverride`): its label + dot show what the canvas is
+// showing NOW, and clicking flips between the published version and the draft so
+// "what am I looking at" is never ambiguous. Hidden in edit mode (always draft).
 
 import type { DashboardWithLayout, WidgetKind } from '@auxx/lib/dashboards/client'
 import { Button } from '@auxx/ui/components/button'
@@ -23,7 +27,7 @@ import { useState } from 'react'
 import { PublishClusterShell } from '~/components/versioning/ui/publish-cluster-shell'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useDashboardMutations } from '../hooks/use-dashboard-mutations'
-import type { SaveState } from '../stores/dashboard-draft-store'
+import type { SaveState, ViewLayer } from '../stores/dashboard-draft-store'
 import { AddWidgetMenu } from './config/add-widget-menu'
 import { DashboardFormDialog } from './dashboard-form-dialog'
 import { DashboardVersionsDialog } from './dashboard-versions-dialog'
@@ -46,6 +50,9 @@ export interface DashboardPublishClusterProps {
   saveState: SaveState
   /** No persisted version yet — disables Edit. */
   hasPersisted: boolean
+  /** View-mode canvas layer — drives the Live/Draft toggle. */
+  viewLayer: ViewLayer
+  onViewLayerChange: (layer: ViewLayer) => void
   onEnterEdit: () => void
   onExitEdit: () => void
   onPublish: () => void
@@ -62,6 +69,8 @@ export function DashboardPublishCluster({
   isDiscarding,
   saveState,
   hasPersisted,
+  viewLayer,
+  onViewLayerChange,
   onEnterEdit,
   onExitEdit,
   onPublish,
@@ -132,12 +141,32 @@ export function DashboardPublishCluster({
     </>
   )
 
+  // View mode + a parked draft → the status pill doubles as a live/draft view
+  // toggle: its label + dot show what the canvas is showing NOW, clicking flips it.
+  // Hidden while editing (edit is always the draft) and when nothing is parked
+  // (then the pill keeps its default "open menu" behaviour).
+  const viewingDraft = viewLayer === 'draft'
+  const pillOverride =
+    !isEditMode && hasUnpublishedChanges
+      ? {
+          label: viewingDraft ? 'Draft' : 'Live',
+          dotClassName: viewingDraft ? 'bg-amber-500' : 'bg-emerald-500',
+          onClick: () => onViewLayerChange(viewingDraft ? 'live' : 'draft'),
+          tooltip: viewingDraft
+            ? 'Showing your unpublished draft. Click to see the live version.'
+            : 'Showing the live version. Click to preview your unpublished draft.',
+        }
+      : undefined
+
   return (
     <div className='flex items-center gap-2'>
       {isEditMode && <AutosaveIndicator state={saveState} />}
       <PublishClusterShell
         status={{ isPublished: true, hasUnsaved: hasUnpublishedChanges }}
         pillTooltip={PILL_TOOLTIP}
+        pillOverride={pillOverride}
+        // While editing, the autosave indicator conveys status — drop the pill.
+        hidePill={isEditMode}
         extraSegments={isEditMode ? editModeSegments : editSegment}
         publish={{ onClick: onPublish, isPending: isPublishing }}
         discard={{ onClick: () => void handleDiscard(), isPending: isDiscarding }}>

--- a/apps/web/src/components/dashboard/ui/widget/bar-chart-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/bar-chart-widget.tsx
@@ -46,42 +46,28 @@ export function BarChartWidget({
         layout={isHorizontal ? 'vertical' : 'horizontal'}
         margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
         <CartesianGrid vertical={isHorizontal} horizontal={!isHorizontal} />
-        {isHorizontal ? (
-          <>
-            <XAxis
-              type='number'
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              tickFormatter={tickFormatter}
-            />
-            <YAxis
-              type='category'
-              dataKey='label'
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              width={110}
-            />
-          </>
-        ) : (
-          <>
-            <XAxis
-              dataKey='label'
-              type='category'
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-            />
-            <YAxis
-              type='number'
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              tickFormatter={tickFormatter}
-            />
-          </>
-        )}
+        {/* No fragments here: recharts scans direct children for axes, and
+            fragments aren't flattened under React 19 — axes would be dropped. */}
+        <XAxis
+          type={isHorizontal ? 'number' : 'category'}
+          dataKey={isHorizontal ? undefined : 'label'}
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={isHorizontal ? tickFormatter : undefined}
+        />
+        <YAxis
+          type={isHorizontal ? 'category' : 'number'}
+          dataKey={isHorizontal ? 'label' : undefined}
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          // Explicit default: an `undefined`-valued width key would clobber
+          // recharts' defaultProps in its {...defaultProps, ...props} merge → NaN layout.
+          width={isHorizontal ? 110 : 60}
+          tickFormatter={isHorizontal ? undefined : tickFormatter}
+        />
+
         <ChartTooltip content={<ChartTooltipContent valueFormatter={valueFormatter} />} />
         {showLegend && <ChartLegend content={<ChartLegendContent />} />}
         {series.map((def) => (

--- a/apps/web/src/components/dashboard/ui/widget/dashboard-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/dashboard-widget.tsx
@@ -9,6 +9,7 @@
 // plan 03's aggregate procedures.
 
 import type { LayoutWidget, WidgetConfiguration } from '@auxx/lib/dashboards/client'
+import type { RecordId } from '@auxx/types/resource'
 import { ChartWidget } from './chart-widget'
 import { GaugeWidget } from './gauge-widget'
 import { IframeWidget } from './iframe-widget'
@@ -28,6 +29,8 @@ type DashboardWidgetProps = {
   onDelete?: () => void
   /** Persist a config change (e.g. richText inline edits) — plan 08: `updateWidgetConfig`. */
   onConfigChange?: (config: WidgetConfiguration) => void
+  /** Open a record in the dashboard's page-level docked/overlay drawer (recordList). */
+  onOpenRecord?: (recordId: RecordId) => void
 }
 
 export function DashboardWidget({
@@ -39,6 +42,7 @@ export function DashboardWidget({
   onDuplicate,
   onDelete,
   onConfigChange,
+  onOpenRecord,
 }: DashboardWidgetProps) {
   // richText is edited inline in its body — no config drawer, so hide the pencil
   // and let card clicks reach the editor instead of opening a (nonexistent) panel.
@@ -61,6 +65,7 @@ export function DashboardWidget({
           isEditMode={isEditMode}
           onEdit={onEdit}
           onConfigChange={onConfigChange}
+          onOpenRecord={onOpenRecord}
         />
       </WidgetErrorBoundary>
     </WidgetCard>
@@ -72,11 +77,13 @@ function WidgetBody({
   isEditMode,
   onEdit,
   onConfigChange,
+  onOpenRecord,
 }: {
   widget: LayoutWidget
   isEditMode: boolean
   onEdit?: () => void
   onConfigChange?: (config: WidgetConfiguration) => void
+  onOpenRecord?: (recordId: RecordId) => void
 }) {
   const config = widget.configuration
 
@@ -132,6 +139,7 @@ function WidgetBody({
           widgetId={widget.id}
           isEditMode={isEditMode}
           onConfigure={onEdit}
+          onOpenRecord={onOpenRecord}
         />
       )
   }

--- a/apps/web/src/components/dashboard/ui/widget/line-chart-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/line-chart-widget.tsx
@@ -35,15 +35,25 @@ export function LineChartWidget({
   const tickFormatter = formatValue ? (v: number) => formatValue(v) : undefined
   const valueFormatter = formatValue ? (v: number | string) => formatValue(Number(v)) : undefined
 
-  const axes = (
-    <>
-      <CartesianGrid vertical={false} />
-      <XAxis dataKey='label' tickLine={false} axisLine={false} tickMargin={8} />
-      <YAxis tickLine={false} axisLine={false} tickMargin={8} tickFormatter={tickFormatter} />
-      <ChartTooltip content={<ChartTooltipContent valueFormatter={valueFormatter} />} />
-      {showLegend && <ChartLegend content={<ChartLegendContent />} />}
-    </>
-  )
+  // Array, NOT a fragment: recharts finds axes/grid/tooltip/legend by scanning
+  // direct children, and fragments aren't flattened under React 19 (react-is@18
+  // doesn't recognize React 19 elements), so a fragment silently drops them all.
+  const axes = [
+    <CartesianGrid key='grid' vertical={false} />,
+    <XAxis key='x' dataKey='label' tickLine={false} axisLine={false} tickMargin={8} />,
+    <YAxis
+      key='y'
+      tickLine={false}
+      axisLine={false}
+      tickMargin={8}
+      tickFormatter={tickFormatter}
+    />,
+    <ChartTooltip
+      key='tooltip'
+      content={<ChartTooltipContent valueFormatter={valueFormatter} />}
+    />,
+    showLegend ? <ChartLegend key='legend' content={<ChartLegendContent />} /> : null,
+  ]
 
   if (config.area) {
     return (

--- a/apps/web/src/components/dashboard/ui/widget/record-list-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/record-list-widget.tsx
@@ -1,48 +1,60 @@
 // apps/web/src/components/dashboard/ui/widget/record-list-widget.tsx
 'use client'
 
-// Compact read-only record table. Primary column is a self-hydrating
-// `RecordBadge` (avatar + display name); configured columns reuse the records
-// table's `CustomFieldCell` (also self-hydrating via the app-wide record batch
-// fetcher). In view mode a row click opens the `RecordDrawer`; in edit mode
-// clicks fall through so the card-level selection handler runs instead.
+// Read-only record table rendered on the real `DynamicTable` in its standalone
+// + hideToolbar reduced mode — so it inherits the records-table look (sticky
+// gradient header, pinned primary column, ROW_HEIGHT rows, hover styling,
+// virtualization) with none of the chrome: no toolbar, saved views, cell
+// editing, checkboxes, or add-column button (see plans/dashboard/11).
+//
+// Fetch stays bespoke (`useRecordListData`, server-side filters/sort); only the
+// presentation swaps. Cells self-hydrate via the app-wide record batch fetcher.
+// Clicking a row/title emits the record id UP to the dashboard, which opens the
+// `RecordDrawer` in the page-level docked panel (or a right-side overlay) — NOT
+// inside the widget card, so a docked drawer doesn't render clipped in the tile.
+// In edit mode clicks fall through so the card-level selection handler runs.
 
-import type { RecordListConfig, WidgetFieldRef } from '@auxx/lib/dashboards/client'
-import type { ResourceFieldId } from '@auxx/types/field'
+import type { RecordListConfig } from '@auxx/lib/dashboards/client'
+import { toRecordId } from '@auxx/lib/resources/client'
 import type { RecordId } from '@auxx/types/resource'
-import { cn } from '@auxx/ui/lib/utils'
-import { useState } from 'react'
-import { CustomFieldCell } from '~/components/dynamic-table/components/custom-field-cell'
-import { encodeFieldPathColumnId } from '~/components/dynamic-table/utils/column-id'
-import { RecordDrawer } from '~/components/records/record-drawer'
-import { useField } from '~/components/resources/hooks/use-field'
-import { RecordBadge } from '~/components/resources/ui/record-badge'
+import { useCallback, useMemo } from 'react'
+import { DynamicTable } from '~/components/dynamic-table'
+import { type RecordListRow, useRecordListColumns } from '../../hooks/use-record-list-columns'
 import { useRecordListData } from '../../hooks/use-record-list-data'
 import { WidgetEmpty, WidgetError, WidgetSkeleton, WidgetUnconfigured } from './widget-states'
-
-/** A `WidgetFieldRef` → the `columnId` string `CustomFieldCell` decodes. */
-function columnId(ref: WidgetFieldRef): string {
-  return typeof ref === 'string' ? ref : encodeFieldPathColumnId(ref)
-}
-
-/** The terminal `ResourceFieldId` of a ref, for header-label lookup. */
-function terminalFieldId(ref: WidgetFieldRef): ResourceFieldId {
-  return typeof ref === 'string' ? ref : ref[ref.length - 1]
-}
 
 export function RecordListWidget({
   config,
   widgetId,
   isEditMode,
   onConfigure,
+  onOpenRecord,
 }: {
   config: RecordListConfig
   widgetId?: string
   isEditMode: boolean
   onConfigure?: () => void
+  /** Opens the record in the dashboard's page-level docked/overlay drawer. */
+  onOpenRecord?: (recordId: RecordId) => void
 }) {
-  const [openRecordId, setOpenRecordId] = useState<RecordId | null>(null)
-  const { recordIds, total, isLoading, isError, error } = useRecordListData(config, widgetId)
+  const { ids, entityDefinitionId, total, isLoading, isError, error } = useRecordListData(
+    config,
+    widgetId
+  )
+
+  const openRecord = useCallback(
+    (instanceId: string) => onOpenRecord?.(toRecordId(entityDefinitionId, instanceId)),
+    [entityDefinitionId, onOpenRecord]
+  )
+
+  const columns = useRecordListColumns({
+    config,
+    entityDefinitionId,
+    isEditMode,
+    onOpenRecord: openRecord,
+  })
+
+  const rows = useMemo<RecordListRow[]>(() => ids.map((id) => ({ id })), [ids])
 
   if (!config.source) {
     return (
@@ -54,70 +66,33 @@ export function RecordListWidget({
   }
   if (isLoading) return <WidgetSkeleton variant='list' />
   if (isError) return <WidgetError message={error?.message} />
-  if (recordIds.length === 0) return <WidgetEmpty />
-
-  const columns = config.columns ?? []
+  if (rows.length === 0) return <WidgetEmpty />
 
   return (
     <div className='flex flex-1 min-h-0 flex-col'>
-      <div className='min-h-0 flex-1 overflow-auto'>
-        <table className='w-full border-collapse text-sm'>
-          <thead className='sticky top-0 bg-card'>
-            <tr className='border-b text-left text-muted-foreground text-xs'>
-              <th className='py-1.5 pe-2 font-normal'>Record</th>
-              {columns.map((col) => (
-                <ColumnHeader key={columnId(col)} fieldRef={col} />
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {recordIds.map((rid) => (
-              <tr
-                key={rid}
-                className={cn('border-b last:border-0', !isEditMode && 'hover:bg-muted/40')}>
-                <td className='py-1.5 pe-2'>
-                  <button
-                    type='button'
-                    className={cn(
-                      'max-w-full text-left',
-                      isEditMode ? 'cursor-default' : 'cursor-pointer'
-                    )}
-                    onClick={() => {
-                      if (!isEditMode) setOpenRecordId(rid)
-                    }}>
-                    <RecordBadge recordId={rid} size='sm' hoverCard={false} />
-                  </button>
-                </td>
-                {columns.map((col) => (
-                  <td key={columnId(col)} className='py-1.5 pe-2 align-top'>
-                    <CustomFieldCell recordId={rid} columnId={columnId(col)} />
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <div className='min-h-0 flex-1'>
+        <DynamicTable
+          data={rows}
+          columns={columns}
+          tableId={`dashboard-rl-${widgetId}`}
+          standalone
+          hideToolbar
+          disableColumnDnd
+          enableSearch={false}
+          enableFiltering={false}
+          enableSorting={false}
+          showRowNumbers={false}
+          isLoading={isLoading}
+          emptyState={<WidgetEmpty />}
+          getRowId={(row) => row.id}
+          onRowClick={isEditMode ? undefined : (row) => openRecord(row.id)}
+          className='h-full'
+        />
       </div>
 
       <p className='shrink-0 border-t pt-1.5 text-muted-foreground text-xs'>
-        Showing {recordIds.length} of {total}
+        Showing {rows.length} of {total}
       </p>
-
-      {!isEditMode && (
-        <RecordDrawer
-          open={Boolean(openRecordId)}
-          recordId={openRecordId ?? undefined}
-          onOpenChange={(open) => {
-            if (!open) setOpenRecordId(null)
-          }}
-        />
-      )}
     </div>
   )
-}
-
-/** Resolves a column's field label (terminal field for one-hop paths). */
-function ColumnHeader({ fieldRef }: { fieldRef: WidgetFieldRef }) {
-  const field = useField(terminalFieldId(fieldRef))
-  return <th className='py-1.5 pe-2 font-normal'>{field?.label ?? '—'}</th>
 }

--- a/apps/web/src/components/dashboard/ui/widget/rich-text-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/rich-text-widget.tsx
@@ -1,19 +1,32 @@
 // apps/web/src/components/dashboard/ui/widget/rich-text-widget.tsx
 'use client'
 
-// Rich-text (note) widget. TipTap over the workflow note-editor's extensions
-// (`getNoteEditorExtensions`) — the meaningful reuse — storing the doc as TipTap
-// JSON in `config.content` (matches `RichTextConfig`). No realtime collab, so
-// none of the seed-once/remount machinery from record notes is needed. Edits
+// Rich-text (note) widget. Runs the shared prompt/KB block editor
+// (`PromptEditorContent` over `useRichTextEditor`) in PLAIN_PROSE mode: the `/`
+// slash menu (text / headings / lists / to-do / quote / divider / code) plus the
+// selection bubble menu, but NO `@` references (`enableMention={false}`). The doc
+// is stored as TipTap block JSON in `config.content` (matches `RichTextConfig`).
+// No realtime collab, so none of the seed-once/remount machinery is needed. Edits
 // debounce (~500ms) before writing back so we don't dirty the draft per keypress.
 
 import type { RichTextConfig } from '@auxx/lib/dashboards/client'
-import { cn } from '@auxx/ui/lib/utils'
-import { EditorContent, useEditor } from '@tiptap/react'
-import { useEffect, useRef } from 'react'
-import { getNoteEditorExtensions } from '~/components/workflow/nodes/core/note/editor/extensions'
+import type { JSONContent } from '@tiptap/core'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { PLAIN_PROSE } from '~/components/editor/blocks/allowed-blocks'
+import { PromptEditorContent } from '~/components/editor/prompt-editor'
 
 const DEBOUNCE_MS = 500
+
+// Stable no-ops — the note widget has no header widgets (char count / copy) and
+// no focus-driven chrome, so it ignores editor-ready / focus events. Module-scope
+// so they don't defeat `PromptEditorContent`'s `memo` on every widget re-render.
+const noop = () => {}
+
+/** Read the stored block array off the saved doc (`{type:'doc', content:[…]}`). */
+function readContent(content: unknown): JSONContent[] | null {
+  const nodes = (content as { content?: unknown } | null)?.content
+  return Array.isArray(nodes) ? (nodes as JSONContent[]) : null
+}
 
 export function RichTextWidget({
   config,
@@ -27,42 +40,18 @@ export function RichTextWidget({
 }) {
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const editor = useEditor(
-    {
-      immediatelyRender: false,
-      shouldRerenderOnTransaction: false,
-      editable: isEditMode,
-      extensions: getNoteEditorExtensions('Write something…'),
-      // TipTap accepts a JSON doc or HTML string; config.content is the JSON doc.
-      content: (config.content as object | null) ?? undefined,
-      editorProps: {
-        attributes: {
-          class: cn(
-            'prose prose-sm max-w-none focus:outline-none',
-            'prose-p:my-1 prose-ul:my-1 prose-li:my-0 min-h-full'
-          ),
-        },
-      },
-      onUpdate: ({ editor, transaction }) => {
-        if (!onChange) return
-        // Ignore the doc-init/normalization transaction TipTap emits on mount —
-        // only user edits should dirty the draft (else just opening edit mode,
-        // which toggles `editable`, would auto-save an unchanged widget).
-        if (!transaction.docChanged) return
-        if (timer.current) clearTimeout(timer.current)
-        timer.current = setTimeout(() => onChange(editor.getJSON()), DEBOUNCE_MS)
-      },
-    },
-    // Create the editor ONCE — do NOT recreate on `isEditMode` (that fires an
-    // init `onUpdate` that spuriously dirties the draft). Editability is toggled
-    // by the effect below via `setEditable`.
-    []
-  )
+  // Read once — `PromptEditorContent` snapshots `initialContent` on mount and
+  // owns the doc thereafter (edits flow out through `onChange`).
+  const initialContent = useMemo(() => readContent(config.content), [config.content])
 
-  // Keep editability in sync when toggling modes on an already-mounted editor.
-  useEffect(() => {
-    editor?.setEditable(isEditMode)
-  }, [editor, isEditMode])
+  const handleChange = useCallback(
+    ({ json }: { json: JSONContent }) => {
+      if (!onChange) return
+      if (timer.current) clearTimeout(timer.current)
+      timer.current = setTimeout(() => onChange(json), DEBOUNCE_MS)
+    },
+    [onChange]
+  )
 
   // Flush a pending debounce on unmount so the last edit isn't lost.
   useEffect(() => {
@@ -71,5 +60,18 @@ export function RichTextWidget({
     }
   }, [])
 
-  return <EditorContent editor={editor} className='flex-1 min-h-0 overflow-y-auto' />
+  return (
+    <div className='flex-1 min-h-0 overflow-y-auto'>
+      <PromptEditorContent
+        initialContent={initialContent}
+        onChange={handleChange}
+        onEditorReady={noop}
+        onFocusChange={noop}
+        editable={isEditMode}
+        allowedBlocks={PLAIN_PROSE}
+        enableMention={false}
+        placeholderText='Write something…'
+      />
+    </div>
+  )
 }

--- a/apps/web/src/components/dynamic-table/cells/primary-cell.tsx
+++ b/apps/web/src/components/dynamic-table/cells/primary-cell.tsx
@@ -26,8 +26,11 @@ export interface PrimaryCellProps {
   /** Click handler for the title */
   onTitleClick: () => void
 
-  /** Dropdown menu items passed as children for maximum flexibility */
-  children: React.ReactNode
+  /**
+   * Dropdown menu items passed as children for maximum flexibility. When
+   * omitted, the hover kebab menu is not rendered at all (widget/read-only use).
+   */
+  children?: React.ReactNode
 
   /** Optional inline node rendered right after the title (e.g. a source badge). */
   suffix?: React.ReactNode
@@ -59,7 +62,11 @@ export function PrimaryCell({
 
   return (
     <div className='flex items-center justify-between w-full min-h-9 pl-3 pr-1 text-sm group/primary'>
-      <div className='flex items-center gap-1.5 min-w-0 max-w-[calc(100%-40px)]'>
+      <div
+        className={cn(
+          'flex items-center gap-1.5 min-w-0',
+          children ? 'max-w-[calc(100%-40px)]' : 'max-w-full'
+        )}>
         <button
           className={cn(
             'flex items-center gap-2 text-left underline decoration-muted-foreground/50 hover:decoration-muted-foreground truncate min-w-0',
@@ -76,19 +83,21 @@ export function PrimaryCell({
         {suffix}
       </div>
 
-      <div onClick={(e) => e.stopPropagation()} className='shrink-0'>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant='ghost'
-              size='icon-xs'
-              className='rounded-md sm:opacity-0 sm:group-hover/primary:opacity-100 transition-opacity data-[state=open]:opacity-100!'>
-              <MoreVertical />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align='end'>{children}</DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      {children && (
+        <div onClick={(e) => e.stopPropagation()} className='shrink-0'>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant='ghost'
+                size='icon-xs'
+                className='rounded-md sm:opacity-0 sm:group-hover/primary:opacity-100 transition-opacity data-[state=open]:opacity-100!'>
+                <MoreVertical />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>{children}</DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
+++ b/apps/web/src/components/dynamic-table/cells/primary-field-cell.tsx
@@ -30,8 +30,11 @@ interface PrimaryFieldCellProps {
   rowId: string
   /** Click handler for the title */
   onTitleClick: () => void
-  /** Dropdown menu items passed as children */
-  children: ReactNode
+  /**
+   * Dropdown menu items passed as children. When omitted, the hover kebab menu
+   * is not rendered (widget/read-only use).
+   */
+  children?: ReactNode
 }
 
 /**

--- a/apps/web/src/components/dynamic-table/components/header-cell-wrapper.tsx
+++ b/apps/web/src/components/dynamic-table/components/header-cell-wrapper.tsx
@@ -6,6 +6,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import type { Header } from '@tanstack/react-table'
+import { useTableConfig } from '../context/table-config-context'
 import type { ExtendedColumnDef } from '../types'
 import { sanitizeColumnId } from '../utils/sanitize-column-id'
 import { HeaderCell } from './header-cell'
@@ -20,11 +21,12 @@ interface HeaderCellWrapperProps<TData> {
 export function HeaderCellWrapper<TData>({ header }: HeaderCellWrapperProps<TData>) {
   const columnDef = header.column.columnDef as ExtendedColumnDef
   const isCheckboxColumn = header.column.id === '_checkbox'
+  const { disableColumnDnd } = useTableConfig()
 
-  // Drag and drop functionality (disabled for checkbox column)
+  // Drag and drop functionality (disabled for checkbox column / widget tables)
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: header.column.id,
-    disabled: isCheckboxColumn,
+    disabled: isCheckboxColumn || disableColumnDnd,
   })
 
   // Drag transform style (separate from width which uses CSS variables)

--- a/apps/web/src/components/dynamic-table/context/table-config-context.tsx
+++ b/apps/web/src/components/dynamic-table/context/table-config-context.tsx
@@ -52,6 +52,9 @@ export interface TableConfigContextValue<TData = any> {
   /** Standalone mode - bypasses view store initialization */
   standalone: boolean
 
+  /** Disable column drag-reorder (widget/preview tables) */
+  disableColumnDnd?: boolean
+
   /** Bulk actions configuration */
   bulkActions: BulkAction<TData>[]
 

--- a/apps/web/src/components/dynamic-table/dynamic-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-view.tsx
@@ -303,6 +303,7 @@ export function DynamicView<TData extends object = object>(props: DynamicTablePr
     onSelectedKanbanCardIdsChange,
     entityDefinitionId,
     standalone = false,
+    disableColumnDnd = false,
     ...tableProps
   } = props
 
@@ -401,6 +402,7 @@ export function DynamicView<TData extends object = object>(props: DynamicTablePr
       showFooter: hasFooter || showFooter,
       hideToolbar,
       standalone,
+      disableColumnDnd,
       bulkActions,
       onRowClick,
       onImport: tableProps.onImport,
@@ -431,6 +433,7 @@ export function DynamicView<TData extends object = object>(props: DynamicTablePr
       showFooter,
       hideToolbar,
       standalone,
+      disableColumnDnd,
       bulkActions,
       onRowClick,
       tableProps.onRefresh,

--- a/apps/web/src/components/dynamic-table/types.ts
+++ b/apps/web/src/components/dynamic-table/types.ts
@@ -427,6 +427,13 @@ export interface DynamicTableProps<TData = any> {
 
   /** Standalone mode - bypasses view store initialization, useful for preview tables */
   standalone?: boolean
+
+  /**
+   * Disable column drag-reorder. In a widget/preview a reorder would write to
+   * the (session-only) view store and silently reset on reload — a lying
+   * interaction. Off by default (existing tables keep drag-reorder).
+   */
+  disableColumnDnd?: boolean
 }
 
 /**

--- a/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
+++ b/apps/web/src/components/editor/prompt-editor/prompt-editor-content.tsx
@@ -50,9 +50,19 @@ interface PromptEditorContentProps {
   onFocusChange: (focused: boolean) => void
   /** Called on focus — parent uses this to expand the collapsed card. */
   onUserActivity?: () => void
-  /** Shared across instances so the same picker handle can drive arrow keys. */
-  referencePickerRef: React.RefObject<ReferencePickerHandle | null>
+  /**
+   * Shared across instances so the same picker handle can drive arrow keys.
+   * Optional — omit on slash-only surfaces (`enableMention={false}`), which
+   * never open the `@` picker.
+   */
+  referencePickerRef?: React.RefObject<ReferencePickerHandle | null>
   referenceTabs?: ReferenceTab[]
+  /**
+   * Mount the `@` reference picker (trigger + popover). Defaults to `true`.
+   * Set `false` for a **slash-only** surface (`/` blocks, no `@` references) —
+   * the `/` command menu keeps working; the `@` trigger and its popover are off.
+   */
+  enableMention?: boolean
   /**
    * When `false`, mounts the editor in read-only mode — same TipTap
    * instance, same reference badge rendering, but typing / paste / slash /
@@ -121,6 +131,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
   onUserActivity,
   referencePickerRef,
   referenceTabs,
+  enableMention = true,
   editable = true,
   placeholderText,
   inlineExtensions,
@@ -135,11 +146,11 @@ export const PromptEditorContent = memo(function PromptEditorContent({
   const slashRef = useRef<SlashContentHandle | null>(null)
 
   const onPickerEnter = useCallback(
-    () => referencePickerRef.current?.confirmHighlighted() ?? false,
+    () => referencePickerRef?.current?.confirmHighlighted() ?? false,
     [referencePickerRef]
   )
   const onPickerArrowVertical = useCallback(
-    (dir: 1 | -1) => referencePickerRef.current?.moveHighlight(dir) ?? false,
+    (dir: 1 | -1) => referencePickerRef?.current?.moveHighlight(dir) ?? false,
     [referencePickerRef]
   )
   const onSlashEnter = useCallback(() => slashRef.current?.confirmHighlighted() ?? false, [])
@@ -159,6 +170,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
     onSlashBackspacePop,
     onSlashArrowRight,
     enableReferencePicker: true,
+    mention: enableMention,
     onPickerEnter,
     onPickerArrowVertical,
     referenceTabs,
@@ -285,7 +297,7 @@ export const PromptEditorContent = memo(function PromptEditorContent({
     [editor]
   )
 
-  const referenceOpen = !!activePicker && activePicker.trigger === '@'
+  const referenceOpen = enableMention && !!activePicker && activePicker.trigger === '@'
   const slashOpen = slash && !!activePicker && activePicker.trigger === '/'
 
   // Prevent the popover's interact-outside from closing the chip when the
@@ -343,29 +355,31 @@ export const PromptEditorContent = memo(function PromptEditorContent({
           })}
         </InlinePickerPopover>
       )}
-      <InlinePickerPopover
-        state={{
-          isOpen: referenceOpen,
-          query: activePicker?.query ?? '',
-          range: null,
-          clientRect: activePicker?.clientRect ?? null,
-        }}
-        containerRef={containerRef}
-        width={360}
-        side='bottom'
-        align='start'
-        autoFocus={false}
-        onInteractOutside={onChipInteractOutside}
-        onClose={() => editor?.commands.closeReferencePicker({ keepText: true })}>
-        <ReferencePickerContent
-          ref={referencePickerRef}
-          tab={activePicker?.tab ?? 'people'}
-          query={activePicker?.query ?? ''}
-          onSelect={(id) => editor?.commands.confirmReferencePicker(id)}
-          onTabChange={(tab) => editor?.commands.setReferencePickerTab(tab)}
-          tabs={referenceTabs}
-        />
-      </InlinePickerPopover>
+      {enableMention && (
+        <InlinePickerPopover
+          state={{
+            isOpen: referenceOpen,
+            query: activePicker?.query ?? '',
+            range: null,
+            clientRect: activePicker?.clientRect ?? null,
+          }}
+          containerRef={containerRef}
+          width={360}
+          side='bottom'
+          align='start'
+          autoFocus={false}
+          onInteractOutside={onChipInteractOutside}
+          onClose={() => editor?.commands.closeReferencePicker({ keepText: true })}>
+          <ReferencePickerContent
+            ref={referencePickerRef}
+            tab={activePicker?.tab ?? 'people'}
+            query={activePicker?.query ?? ''}
+            onSelect={(id) => editor?.commands.confirmReferencePicker(id)}
+            onTabChange={(tab) => editor?.commands.setReferencePickerTab(tab)}
+            tabs={referenceTabs}
+          />
+        </InlinePickerPopover>
+      )}
       <PromptLinkPopover
         open={linkPopover !== null}
         anchorRect={linkPopover?.rect ?? null}

--- a/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
+++ b/apps/web/src/components/editor/rich-text/use-rich-text-editor.tsx
@@ -114,6 +114,13 @@ export interface UseRichTextEditorOptions {
    * popover separately via `useActivePicker(editor)` + `InlinePickerPopover`.
    */
   enableReferencePicker?: boolean
+  /**
+   * Mount the `@` mention trigger on the chip node. Defaults to `true`. Set
+   * `false` for a **slash-only** surface (`/` blocks, no `@` references) — the
+   * chip bundle still mounts (so `slash` works) but the `@` trigger is off.
+   * The consumer must also skip mounting the `@` `ReferencePickerContent` popover.
+   */
+  mention?: boolean
   /** Forwarded to the `@` picker chip. */
   onPickerEnter?: () => boolean
   /** Forwarded to the `@` picker chip. */
@@ -183,6 +190,7 @@ export function useRichTextEditor({
   onSlashBackspacePop,
   onSlashArrowRight,
   enableReferencePicker = true,
+  mention = true,
   onPickerEnter,
   onPickerArrowVertical,
   referenceTabs,
@@ -207,6 +215,7 @@ export function useRichTextEditor({
     () =>
       enableReferencePicker
         ? buildReferencePickerExtensions({
+            mention,
             onPickerEnter,
             onPickerArrowVertical,
             referenceTabs,
@@ -219,6 +228,7 @@ export function useRichTextEditor({
         : [],
     [
       enableReferencePicker,
+      mention,
       onPickerEnter,
       onPickerArrowVertical,
       referenceTabs,

--- a/apps/web/src/components/versioning/ui/publish-cluster-shell.tsx
+++ b/apps/web/src/components/versioning/ui/publish-cluster-shell.tsx
@@ -18,6 +18,24 @@ export interface PublishClusterShellProps {
   status: { isPublished: boolean; hasUnsaved: boolean; isArchived?: boolean }
   /** Optional tooltip on the status pill (presentation only — e.g. what "Live" means). */
   pillTooltip?: string
+  /**
+   * Repurpose the status pill as an action button (e.g. a live/draft view toggle):
+   * overrides its label, dot colour, click handler, and tooltip. When set, clicking
+   * the pill no longer opens the menu — the chevron still does. Segment visibility
+   * (publish/discard) is unaffected; it stays driven by `status`.
+   */
+  pillOverride?: {
+    label: string
+    dotClassName: string
+    onClick: () => void
+    tooltip?: string
+  }
+  /**
+   * Hide the status pill entirely (e.g. while editing, when a separate autosave
+   * indicator already conveys status). The chevron menu still renders, so the
+   * dropdown stays reachable.
+   */
+  hidePill?: boolean
   publish?: {
     onClick: () => void
     isPending?: boolean
@@ -48,6 +66,8 @@ export interface PublishClusterShellProps {
 export function PublishClusterShell({
   status,
   pillTooltip,
+  pillOverride,
+  hidePill,
   publish,
   discard,
   extraSegments,
@@ -56,25 +76,26 @@ export function PublishClusterShell({
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   const { isPublished, hasUnsaved, isArchived } = status
-  const dotClass = isArchived
+  const derivedDotClass = isArchived
     ? 'bg-red-500'
     : isPublished
       ? hasUnsaved
         ? 'bg-amber-500'
         : 'bg-emerald-500'
       : 'bg-slate-400'
-  const pillLabel = isArchived ? 'Archived' : isPublished ? 'Live' : 'Draft'
+  const derivedLabel = isArchived ? 'Archived' : isPublished ? 'Live' : 'Draft'
+
+  const dotClass = pillOverride?.dotClassName ?? derivedDotClass
+  const pillLabel = pillOverride?.label ?? derivedLabel
+  const pillTooltipText = pillOverride?.tooltip ?? pillTooltip
+  const onPillClick = pillOverride?.onClick ?? (() => setIsMenuOpen((prev) => !prev))
 
   const showPublish = !!publish && (!isPublished || hasUnsaved)
   const showDiscard = !!discard && isPublished && hasUnsaved
   const publishLabel = publish?.label ?? 'Publish'
 
   const pillButton = (
-    <Button
-      size='xs'
-      variant='outline'
-      className='gap-2 border-r-0'
-      onClick={() => setIsMenuOpen((prev) => !prev)}>
+    <Button size='xs' variant='outline' className='gap-2 border-r-0' onClick={onPillClick}>
       <span className={cn('inline-block size-2 rounded-full', dotClass)} />
       {pillLabel}
     </Button>
@@ -83,18 +104,20 @@ export function PublishClusterShell({
   return (
     <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
       <ButtonGroup className='shrink-0'>
-        {pillTooltip ? (
-          <Tooltip>
-            <TooltipTrigger asChild>{pillButton}</TooltipTrigger>
-            <TooltipContent>{pillTooltip}</TooltipContent>
-          </Tooltip>
-        ) : (
-          pillButton
-        )}
+        {!hidePill &&
+          (pillTooltipText ? (
+            <Tooltip>
+              <TooltipTrigger asChild>{pillButton}</TooltipTrigger>
+              <TooltipContent>{pillTooltipText}</TooltipContent>
+            </Tooltip>
+          ) : (
+            pillButton
+          ))}
 
         {extraSegments ? (
           <>
-            <ButtonGroupSeparator />
+            {/* No leading separator when the pill is hidden — extraSegments start the group. */}
+            {!hidePill && <ButtonGroupSeparator />}
             {extraSegments}
           </>
         ) : null}


### PR DESCRIPTION
## Summary

Rewires the dashboard **record-list widget** to render on the real `DynamicTable` in a new **standalone + hideToolbar reduced mode**, instead of a bespoke `<table>`. It now inherits the records-table look (sticky gradient header, pinned primary column, `ROW_HEIGHT` rows, hover styling, virtualization) with none of the chrome — no toolbar, saved views, cell editing, checkboxes, or add-column button.

Fetch stays bespoke (`useRecordListData`, server-side filters/sort); only the presentation swaps. Row/title clicks emit the record id **up** to the dashboard, which opens the `RecordDrawer` in the page-level docked panel — not inside the widget card.

## Changes

- **New `disableColumnDnd` knob** on `DynamicTable` — a reorder in a widget/preview would write to the session-only view store and silently reset on reload (a lying interaction), so it's disabled for these tables. Off by default; existing tables keep drag-reorder.
- **`PrimaryCell` / `PrimaryFieldCell`** kebab menu is now optional (`children?`) for read-only/widget use — omitting it drops the hover menu and lets the title span full width.
- **`useRecordListData`** now exposes the raw `{ id }` instance rows; new **`use-record-list-columns`** hook builds the column defs.
- Folds in display-formatting overrides for chart/rich-text widgets and versioning publish-cluster tweaks.

See `plans/dashboard/11`.

## Test plan

- [ ] Record-list widget renders with records-table styling in view mode
- [ ] Row/title click opens the record drawer in the page-level docked panel
- [ ] Edit mode: clicks fall through to card selection (no drawer)
- [ ] Columns don't drag-reorder in the widget