### PR TITLE
feat(dashboards): config field renames + inline help, paginated legend carousel

### DIFF
--- a/apps/web/src/components/dashboard/lib/legend-pages.test.ts
+++ b/apps/web/src/components/dashboard/lib/legend-pages.test.ts
@@ -1,0 +1,43 @@
+// apps/web/src/components/dashboard/lib/legend-pages.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { binIntoPages } from './legend-pages'
+
+const PAGINATOR = 60
+const GAP = 12
+
+describe('binIntoPages', () => {
+  it('returns a single page when everything fits (no paginator reserved)', () => {
+    // 3 items of 40 + 2 gaps of 12 = 144 <= 200
+    expect(binIntoPages([40, 40, 40], 200, PAGINATOR, GAP)).toEqual([[0, 1, 2]])
+  })
+
+  it('packs items across pages when they overflow, reserving paginator width', () => {
+    // total = 100*4 + 3*12 = 436 > 300 → paginate; available = 300-60-12 = 228
+    // page: 100 (+0) = 100, +12+100 = 212, +12+100 = 324 > 228 → break
+    const pages = binIntoPages([100, 100, 100, 100], 300, PAGINATOR, GAP)
+    expect(pages).toEqual([
+      [0, 1],
+      [2, 3],
+    ])
+  })
+
+  it('places an over-wide item on its own page rather than splitting it', () => {
+    // available = 200-60-12 = 128; item 1 (150) is wider than available
+    const pages = binIntoPages([50, 150, 50], 200, PAGINATOR, GAP)
+    expect(pages).toEqual([[0], [1], [2]])
+  })
+
+  it('returns [[]] for no items', () => {
+    expect(binIntoPages([], 300, PAGINATOR, GAP)).toEqual([[]])
+  })
+
+  it('returns [[]] when width is not yet measured', () => {
+    expect(binIntoPages([40, 40], 0, PAGINATOR, GAP)).toEqual([[]])
+  })
+
+  it('boundary: exact fit stays on one page', () => {
+    // 2 items of 94 + 1 gap of 12 = 200 == 200
+    expect(binIntoPages([94, 94], 200, PAGINATOR, GAP)).toEqual([[0, 1]])
+  })
+})

--- a/apps/web/src/components/dashboard/lib/legend-pages.ts
+++ b/apps/web/src/components/dashboard/lib/legend-pages.ts
@@ -1,0 +1,51 @@
+// apps/web/src/components/dashboard/lib/legend-pages.ts
+
+/**
+ * Bin legend item widths into pages that each fit the available width — the pure
+ * core of the Twenty-style paginated legend carousel.
+ *
+ * If every item fits in `containerWidth` at once, returns a single page and the
+ * caller hides the paginator (identical to a non-paginated legend). Otherwise the
+ * paginator occupies `paginatorWidth`, so items are greedily packed into
+ * `containerWidth - paginatorWidth - gap`. An item wider than the available width
+ * still gets its own page (never split).
+ *
+ * Returns arrays of item indices, one array per page. Always at least `[[]]`.
+ */
+export function binIntoPages(
+  itemWidths: number[],
+  containerWidth: number,
+  paginatorWidth: number,
+  gap: number
+): number[][] {
+  const count = itemWidths.length
+  if (count === 0 || containerWidth <= 0) return [[]]
+
+  // Everything fits on one row → no paginator.
+  const totalFull = itemWidths.reduce((sum, w) => sum + w, 0) + (count - 1) * gap
+  if (totalFull <= containerWidth) {
+    return [itemWidths.map((_, i) => i)]
+  }
+
+  const available = Math.max(0, containerWidth - paginatorWidth - gap)
+  const pages: number[][] = []
+  let current: number[] = []
+  let used = 0
+
+  for (let i = 0; i < count; i++) {
+    const w = itemWidths[i] ?? 0
+    const add = current.length === 0 ? w : gap + w
+    // Start a new page when the next item would overflow (but never leave a page empty).
+    if (current.length > 0 && used + add > available) {
+      pages.push(current)
+      current = []
+      used = 0
+    }
+    const addFresh = current.length === 0 ? w : gap + w
+    current.push(i)
+    used += addFresh
+  }
+  if (current.length > 0) pages.push(current)
+
+  return pages.length > 0 ? pages : [[]]
+}

--- a/apps/web/src/components/dashboard/ui/config/color-scheme-row.tsx
+++ b/apps/web/src/components/dashboard/ui/config/color-scheme-row.tsx
@@ -37,7 +37,9 @@ export function ColorRow({
   const current = CHART_PALETTES.find((p) => p.id === selected) ?? CHART_PALETTES[0]
 
   return (
-    <FieldPanelRow title='Color'>
+    <FieldPanelRow
+      title='Color'
+      description='Color scheme — one hue fans out into shades; “Default” uses distinct hues.'>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <PickerTrigger open={open} hasValue className='w-full ps-0 pe-1'>

--- a/apps/web/src/components/dashboard/ui/config/columns-row.tsx
+++ b/apps/web/src/components/dashboard/ui/config/columns-row.tsx
@@ -115,7 +115,9 @@ export function ColumnsRow({
   const count = managed.length + (primary ? 1 : 0)
 
   return (
-    <FieldPanelRow title='Columns'>
+    <FieldPanelRow
+      title='Columns'
+      description="The fields shown as columns, after the record's name.">
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <PickerTrigger

--- a/apps/web/src/components/dashboard/ui/config/data-source-section.tsx
+++ b/apps/web/src/components/dashboard/ui/config/data-source-section.tsx
@@ -48,7 +48,7 @@ export function DataSourceSection({
       const ok = await confirm({
         title: 'Change data source?',
         description:
-          'The metric, group-by, filters and columns depend on the current source and will be cleared.',
+          'The metric, category, series, filters and columns depend on the current source and will be cleared.',
         confirmText: 'Change source',
         cancelText: 'Cancel',
         destructive: true,
@@ -59,7 +59,10 @@ export function DataSourceSection({
   }
 
   return (
-    <FieldPanelRow title='Data source' isRequired>
+    <FieldPanelRow
+      title='Data source'
+      isRequired
+      description='The records this widget charts — an object (Contacts, Tickets, Orders…) or a system table.'>
       <ConfirmDialog />
       <ResourcePicker
         value={source ? [sourceResourceId(source)] : []}

--- a/apps/web/src/components/dashboard/ui/config/group-by-section.tsx
+++ b/apps/web/src/components/dashboard/ui/config/group-by-section.tsx
@@ -40,6 +40,7 @@ const leaf = (ref: GroupBy['fieldRef']): ResourceFieldId =>
 export function GroupBySection({
   source,
   label,
+  description,
   groupBy,
   onChange,
   isRequired,
@@ -47,6 +48,7 @@ export function GroupBySection({
 }: {
   source: WidgetSource
   label: string
+  description?: string
   groupBy: GroupBy | undefined
   onChange: (groupBy: GroupBy | undefined) => void
   isRequired?: boolean
@@ -65,6 +67,7 @@ export function GroupBySection({
     <>
       <FieldRefRow
         title={label}
+        description={description}
         isRequired={isRequired}
         source={source}
         value={groupBy?.fieldRef}
@@ -78,6 +81,7 @@ export function GroupBySection({
           {showGranularity && (
             <ConfigFieldRow
               title='Granularity'
+              description='Bucket dates by day, week, month, quarter, or year.'
               fieldType={FieldType.SINGLE_SELECT}
               fieldOptions={{ options: GRANULARITY_OPTIONS }}
               value={groupBy.dateGranularity ?? 'day'}
@@ -86,6 +90,7 @@ export function GroupBySection({
           )}
           <ConfigFieldRow
             title='Sort'
+            description='Order the categories — by value (biggest first) or by name.'
             fieldType={FieldType.SINGLE_SELECT}
             fieldOptions={{ options: SORT_OPTIONS }}
             value={groupBy.sort ?? 'valueDesc'}
@@ -93,6 +98,7 @@ export function GroupBySection({
           />
           <ConfigFieldRow
             title='Limit'
+            description='Show at most this many categories (the top ones by sort).'
             fieldType={FieldType.NUMBER}
             value={groupBy.limit}
             onChange={(v) => patch({ limit: v as number | undefined })}
@@ -100,7 +106,7 @@ export function GroupBySection({
           />
           <ConfigFieldRow
             title='Omit empty'
-            description='Hide the no-value group'
+            description='Hide the bar for records with no value (the “(empty)” bucket).'
             fieldType={FieldType.CHECKBOX}
             fieldOptions={{ variant: 'switch' }}
             value={groupBy.omitEmpty ?? false}

--- a/apps/web/src/components/dashboard/ui/config/metric-field.tsx
+++ b/apps/web/src/components/dashboard/ui/config/metric-field.tsx
@@ -74,7 +74,10 @@ export function MetricField({
   }
 
   return (
-    <FieldPanelRow title='Metric' isRequired>
+    <FieldPanelRow
+      title='Metric'
+      isRequired
+      description="The number to plot and how it's calculated — count records, or sum/average/min/max a field.">
       <Popover
         open={open}
         onOpenChange={(o) => {

--- a/apps/web/src/components/dashboard/ui/config/style-section.tsx
+++ b/apps/web/src/components/dashboard/ui/config/style-section.tsx
@@ -43,6 +43,7 @@ export function RangeRows({
     <>
       <ConfigFieldRow
         title='Min'
+        description='The value at the empty end of the gauge — usually 0.'
         fieldType={FieldType.NUMBER}
         value={min}
         onChange={(v) => onChange({ rangeMin: v as number | undefined })}
@@ -50,6 +51,7 @@ export function RangeRows({
       />
       <ConfigFieldRow
         title='Max'
+        description='The target the gauge fills toward (100%).'
         fieldType={FieldType.NUMBER}
         value={max}
         onChange={(v) => onChange({ rangeMax: v as number | undefined })}
@@ -94,6 +96,7 @@ export function DateAxisFormatRow({
   return (
     <ConfigFieldRow
       title='Date label format'
+      description='How date labels read on the axis — e.g. “Jan 2026” vs “2026-01”.'
       fieldType={FieldType.SINGLE_SELECT}
       fieldOptions={{ options: DATE_LABEL_FORMAT_OPTIONS }}
       value={value ?? 'default'}
@@ -121,7 +124,7 @@ export function GlobalDateBindingRow({
   return (
     <FieldPanelRow
       title='Dashboard date range'
-      description='Which date field the dashboard-level range filters'>
+      description="Which date field this widget filters when the dashboard's date range changes — off to ignore it.">
       <FieldPicker
         entityDefinitionId={sourceResourceId(source)}
         width={280}

--- a/apps/web/src/components/dashboard/ui/config/value-format-dialog.tsx
+++ b/apps/web/src/components/dashboard/ui/config/value-format-dialog.tsx
@@ -63,7 +63,9 @@ export function ValueFormatRow({
   if (!kind) return null
 
   return (
-    <FieldPanelRow title='Value format' description='Override how this value displays'>
+    <FieldPanelRow
+      title='Value format'
+      description='How the number is displayed — decimals, currency, percentage, or compact (1.2k).'>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogTrigger asChild>
           <PickerTrigger hasValue={!!value} placeholder='Default' className='w-full ps-0 pe-1'>

--- a/apps/web/src/components/dashboard/ui/config/widget-config-bodies.tsx
+++ b/apps/web/src/components/dashboard/ui/config/widget-config-bodies.tsx
@@ -119,7 +119,8 @@ function BarChartBody({
               )}
               <GroupBySection
                 source={source}
-                label='Group by'
+                label='Category'
+                description='The field that splits the data — each distinct value becomes one bar or slice.'
                 isRequired
                 groupBy={config.groupBy}
                 onChange={(g) => update({ groupBy: g })}
@@ -132,7 +133,8 @@ function BarChartBody({
               />
               <GroupBySection
                 source={source}
-                label='Break down by'
+                label='Series'
+                description='Optionally split each bar into colored parts by a second field — one color + legend entry per value.'
                 allowClear
                 groupBy={config.secondaryGroupBy}
                 onChange={(g) => update({ secondaryGroupBy: g })}
@@ -160,6 +162,7 @@ function BarChartBody({
           <Panel>
             <ConfigFieldRow
               title='Orientation'
+              description='Bars run vertically (columns) or horizontally.'
               fieldType={FieldType.SINGLE_SELECT}
               fieldOptions={{ options: BAR_LAYOUT_OPTIONS }}
               value={config.layout ?? 'vertical'}
@@ -168,22 +171,26 @@ function BarChartBody({
             {config.secondaryGroupBy && (
               <SwitchRow
                 title='Stacked'
+                description='Stack the series into one bar instead of side-by-side.'
                 value={config.stacked}
                 onChange={(v) => update({ stacked: v })}
               />
             )}
             <SwitchRow
               title='Cumulative'
+              description='Show a running total that adds up across categories.'
               value={config.cumulative}
               onChange={(v) => update({ cumulative: v })}
             />
             <SwitchRow
               title='Data labels'
+              description='Print each value directly on the bar, point, or slice.'
               value={config.showDataLabels}
               onChange={(v) => update({ showDataLabels: v })}
             />
             <SwitchRow
               title='Legend'
+              description='Show the color key for the series.'
               value={config.showLegend ?? true}
               onChange={(v) => update({ showLegend: v })}
             />
@@ -226,7 +233,8 @@ function LineChartBody({
               )}
               <GroupBySection
                 source={source}
-                label='Group by'
+                label='Category'
+                description='The field that splits the data — each distinct value becomes one point along the axis.'
                 isRequired
                 groupBy={config.groupBy}
                 onChange={(g) => update({ groupBy: g })}
@@ -239,7 +247,8 @@ function LineChartBody({
               />
               <GroupBySection
                 source={source}
-                label='Break down by'
+                label='Series'
+                description='Optionally split into one colored line per value of a second field.'
                 allowClear
                 groupBy={config.secondaryGroupBy}
                 onChange={(g) => update({ secondaryGroupBy: g })}
@@ -265,21 +274,29 @@ function LineChartBody({
       {source && (
         <Section title='Appearance' icon={<Palette className='size-3.5' />} collapsible>
           <Panel>
-            <SwitchRow title='Area' value={config.area} onChange={(v) => update({ area: v })} />
+            <SwitchRow
+              title='Area'
+              description='Fill the space under the line.'
+              value={config.area}
+              onChange={(v) => update({ area: v })}
+            />
             {config.secondaryGroupBy && (
               <SwitchRow
                 title='Stacked'
+                description='Stack the series instead of overlapping them.'
                 value={config.stacked}
                 onChange={(v) => update({ stacked: v })}
               />
             )}
             <SwitchRow
               title='Cumulative'
+              description='Show a running total that adds up across categories.'
               value={config.cumulative}
               onChange={(v) => update({ cumulative: v })}
             />
             <SwitchRow
               title='Legend'
+              description='Show the color key for the series.'
               value={config.showLegend ?? true}
               onChange={(v) => update({ showLegend: v })}
             />
@@ -322,7 +339,8 @@ function PieChartBody({
               )}
               <GroupBySection
                 source={source}
-                label='Group by'
+                label='Category'
+                description='The field that splits the data — each distinct value becomes one slice.'
                 isRequired
                 groupBy={config.groupBy}
                 onChange={(g) => update({ groupBy: g })}
@@ -354,21 +372,29 @@ function PieChartBody({
       {source && (
         <Section title='Appearance' icon={<Palette className='size-3.5' />} collapsible>
           <Panel>
-            <SwitchRow title='Donut' value={config.donut} onChange={(v) => update({ donut: v })} />
+            <SwitchRow
+              title='Donut'
+              description='Show as a donut with a hollow center.'
+              value={config.donut}
+              onChange={(v) => update({ donut: v })}
+            />
             {config.donut && (
               <SwitchRow
                 title='Center total'
+                description='Show the grand total in the middle of the donut.'
                 value={config.showCenterTotal}
                 onChange={(v) => update({ showCenterTotal: v })}
               />
             )}
             <SwitchRow
               title='Data labels'
+              description='Print each value directly on the slice.'
               value={config.showDataLabels}
               onChange={(v) => update({ showDataLabels: v })}
             />
             <SwitchRow
               title='Legend'
+              description='Show the color key for the slices.'
               value={config.showLegend ?? true}
               onChange={(v) => update({ showLegend: v })}
             />
@@ -413,6 +439,7 @@ function KpiBody({
               )}
               <ConfigFieldRow
                 title='Prefix'
+                description='Text shown before the number, like $.'
                 fieldType={FieldType.TEXT}
                 value={config.prefix}
                 onChange={(v) => update({ prefix: (v as string) || undefined })}
@@ -420,6 +447,7 @@ function KpiBody({
               />
               <ConfigFieldRow
                 title='Suffix'
+                description='Text shown after the number, like hrs or %.'
                 fieldType={FieldType.TEXT}
                 value={config.suffix}
                 onChange={(v) => update({ suffix: (v as string) || undefined })}
@@ -455,6 +483,7 @@ function KpiBody({
             <Panel>
               <FieldRefRow
                 title='Date field'
+                description='The date field used to define the current and prior periods.'
                 isRequired
                 source={source}
                 value={config.trend.dateFieldRef || undefined}
@@ -473,6 +502,7 @@ function KpiBody({
               />
               <ConfigFieldRow
                 title='Compare to'
+                description='Compare against the previous period or the same period last year.'
                 fieldType={FieldType.SINGLE_SELECT}
                 fieldOptions={{ options: TREND_COMPARE_OPTIONS }}
                 value={config.trend.compare}
@@ -556,6 +586,7 @@ function GaugeBody({
           <Panel>
             <SwitchRow
               title='Data labels'
+              description='Print the value on the gauge.'
               value={config.showDataLabels}
               onChange={(v) => update({ showDataLabels: v })}
             />
@@ -599,6 +630,7 @@ function RecordListBody({
               />
               <FieldRefRow
                 title='Sort by'
+                description='The field the rows are ordered by.'
                 source={source}
                 value={config.sort?.fieldRef}
                 onChange={(ref) =>
@@ -609,12 +641,14 @@ function RecordListBody({
               {config.sort && (
                 <SwitchRow
                   title='Descending'
+                  description='Largest or newest first.'
                   value={config.sort.desc}
                   onChange={(v) => config.sort && update({ sort: { ...config.sort, desc: v } })}
                 />
               )}
               <ConfigFieldRow
                 title='Rows'
+                description='How many rows to show per page.'
                 fieldType={FieldType.NUMBER}
                 value={config.pageSize}
                 onChange={(v) => update({ pageSize: v as number | undefined })}
@@ -655,6 +689,7 @@ function IframeBody({
       <Panel>
         <ConfigFieldRow
           title='URL'
+          description='The page to embed — it must allow being shown in a frame.'
           fieldType={FieldType.TEXT}
           value={config.url ?? ''}
           onChange={(v) => update({ url: (v as string) || null })}

--- a/apps/web/src/components/dashboard/ui/widget/bar-chart-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/bar-chart-widget.tsx
@@ -12,13 +12,13 @@ import type { BarChartConfig } from '@auxx/lib/dashboards/client'
 import {
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from '@auxx/ui/components/chart'
 import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from 'recharts'
 import type { ChartRow, SeriesDef } from '../../lib/chart-transform'
 import { toChartConfig } from '../../lib/chart-transform'
+import { PaginatedChartLegend } from './paginated-chart-legend'
 
 export function BarChartWidget({
   config,
@@ -69,7 +69,7 @@ export function BarChartWidget({
         />
 
         <ChartTooltip content={<ChartTooltipContent valueFormatter={valueFormatter} />} />
-        {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+        {showLegend && <ChartLegend content={<PaginatedChartLegend />} />}
         {series.map((def) => (
           <Bar
             key={def.id}

--- a/apps/web/src/components/dashboard/ui/widget/line-chart-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/line-chart-widget.tsx
@@ -9,13 +9,13 @@ import type { LineChartConfig } from '@auxx/lib/dashboards/client'
 import {
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from '@auxx/ui/components/chart'
 import { Area, AreaChart, CartesianGrid, Line, LineChart, XAxis, YAxis } from 'recharts'
 import type { ChartRow, SeriesDef } from '../../lib/chart-transform'
 import { toChartConfig } from '../../lib/chart-transform'
+import { PaginatedChartLegend } from './paginated-chart-legend'
 
 export function LineChartWidget({
   config,
@@ -52,7 +52,7 @@ export function LineChartWidget({
       key='tooltip'
       content={<ChartTooltipContent valueFormatter={valueFormatter} />}
     />,
-    showLegend ? <ChartLegend key='legend' content={<ChartLegendContent />} /> : null,
+    showLegend ? <ChartLegend key='legend' content={<PaginatedChartLegend />} /> : null,
   ]
 
   if (config.area) {

--- a/apps/web/src/components/dashboard/ui/widget/paginated-chart-legend.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/paginated-chart-legend.tsx
@@ -1,0 +1,183 @@
+// apps/web/src/components/dashboard/ui/widget/paginated-chart-legend.tsx
+'use client'
+
+// Twenty-style paginated chart legend. Replaces shadcn's single-row
+// `ChartLegendContent` (which never wraps and overflows on many series): items
+// live on one non-wrapping row with a left `‹ N/M ›` paginator that
+// transform-slides between width-fitted pages. Fed as recharts
+// `<ChartLegend content={<PaginatedChartLegend />} />`; resolves labels/colors
+// from the chart config via the shared `useChart`/`getPayloadConfigFromPayload`.
+
+import { Button } from '@auxx/ui/components/button'
+import { getPayloadConfigFromPayload, useChart } from '@auxx/ui/components/chart'
+import { cn } from '@auxx/ui/lib/utils'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import type { LegendProps } from 'recharts'
+import { binIntoPages } from '../../lib/legend-pages'
+
+/** Gap between legend items, in px. Must match the flex `gap` below. */
+const ITEM_GAP = 12
+/** Width the paginator reserves when items don't all fit on one row, in px. */
+const PAGINATOR_WIDTH = 84
+/** Max label width before ellipsis, matching Twenty's ~80px cap. */
+const LABEL_MAX_WIDTH = 96
+
+type ResolvedItem = { key: string; label: string; color: string }
+
+function LegendSwatch({ color }: { color: string }) {
+  return (
+    <span
+      className='h-2 w-2 shrink-0 rounded-[2px]'
+      style={{ backgroundColor: color }}
+      aria-hidden
+    />
+  )
+}
+
+/** One swatch + truncated label. Shared by the measure pass and the visible track. */
+function LegendItem({ item }: { item: ResolvedItem }) {
+  return (
+    <span className='flex items-center gap-1.5 whitespace-nowrap text-muted-foreground text-xs'>
+      <LegendSwatch color={item.color} />
+      <span className='truncate' style={{ maxWidth: LABEL_MAX_WIDTH }} title={item.label}>
+        {item.label}
+      </span>
+    </span>
+  )
+}
+
+export function PaginatedChartLegend({
+  payload,
+  nameKey,
+  verticalAlign = 'bottom',
+}: Pick<LegendProps, 'payload' | 'verticalAlign'> & { nameKey?: string }) {
+  const { config } = useChart()
+
+  const items = useMemo<ResolvedItem[]>(() => {
+    if (!payload?.length) return []
+    return payload.map((item) => {
+      const key = `${nameKey || item.dataKey || 'value'}`
+      const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      const label = itemConfig?.label ?? item.value
+      return {
+        key: `${item.value}`,
+        label: typeof label === 'string' ? label : `${item.value}`,
+        color: item.color ?? 'var(--muted-foreground)',
+      }
+    })
+  }, [payload, nameKey, config])
+
+  const rootRef = useRef<HTMLDivElement>(null)
+  const measureRef = useRef<HTMLDivElement>(null)
+  const [containerWidth, setContainerWidth] = useState(0)
+  const [itemWidths, setItemWidths] = useState<number[]>([])
+  const [page, setPage] = useState(0)
+
+  // Container width via ResizeObserver on our own root (recharts sizes the
+  // legend wrapper to the chart width).
+  useEffect(() => {
+    const el = rootRef.current
+    if (!el) return
+    setContainerWidth(Math.floor(el.getBoundingClientRect().width))
+    const observer = new ResizeObserver((entries) => {
+      setContainerWidth(Math.floor(entries[0]?.contentRect.width ?? 0))
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  // Measure each item's natural width from the hidden pass. `items` is the
+  // re-measure trigger (its labels drive the hidden-pass widths), even though the
+  // body reads the DOM, not `items` directly.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional trigger dep
+  useLayoutEffect(() => {
+    const el = measureRef.current
+    if (!el) return
+    const widths = Array.from(el.children).map((c) => (c as HTMLElement).offsetWidth)
+    setItemWidths((prev) =>
+      prev.length === widths.length && prev.every((w, i) => w === widths[i]) ? prev : widths
+    )
+  }, [items])
+
+  const pages = useMemo(
+    () => binIntoPages(itemWidths, containerWidth, PAGINATOR_WIDTH, ITEM_GAP),
+    [itemWidths, containerWidth]
+  )
+
+  // Clamp the active page when a resize collapses the page count.
+  useEffect(() => {
+    setPage((p) => Math.min(p, Math.max(0, pages.length - 1)))
+  }, [pages.length])
+
+  if (!items.length) return null
+
+  const showPaginator = pages.length > 1
+  const atFirst = page <= 0
+  const atLast = page >= pages.length - 1
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn(
+        'flex h-6 w-full items-center gap-2',
+        verticalAlign === 'top' ? 'pb-3' : 'pt-3'
+      )}>
+      {/* Hidden measure pass — same markup as the visible items so widths match. */}
+      <div
+        ref={measureRef}
+        aria-hidden
+        className='pointer-events-none invisible absolute flex w-max'
+        style={{ gap: ITEM_GAP }}>
+        {items.map((item) => (
+          <LegendItem key={item.key} item={item} />
+        ))}
+      </div>
+
+      {showPaginator && (
+        <div className='flex shrink-0 items-center gap-0.5'>
+          <Button
+            variant='ghost'
+            size='icon-xs'
+            disabled={atFirst}
+            aria-label='Previous legend page'
+            onClick={() => setPage((p) => Math.max(0, p - 1))}>
+            <ChevronLeft />
+          </Button>
+          <span className='min-w-8 text-center text-muted-foreground text-xs tabular-nums'>
+            {page + 1}/{pages.length}
+          </span>
+          <Button
+            variant='ghost'
+            size='icon-xs'
+            disabled={atLast}
+            aria-label='Next legend page'
+            onClick={() => setPage((p) => Math.min(pages.length - 1, p + 1))}>
+            <ChevronRight />
+          </Button>
+        </div>
+      )}
+
+      {/* Viewport: one page-wide slide per page, translated into view. */}
+      <div className='relative min-w-0 flex-1 overflow-hidden'>
+        <div
+          className='flex transition-transform duration-200 ease-out motion-reduce:transition-none'
+          // translateX % is relative to the track's own width (pages.length
+          // viewports wide), so divide by pages.length to slide one viewport per page.
+          style={{ transform: `translateX(-${(page * 100) / pages.length}%)` }}>
+          {pages.map((pageIndices, pageIdx) => (
+            <div
+              key={pageIdx}
+              className='flex shrink-0 basis-full items-center justify-center'
+              style={{ gap: ITEM_GAP }}>
+              {pageIndices.map((i) => {
+                const item = items[i]
+                return item ? <LegendItem key={item.key} item={item} /> : null
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/dashboard/ui/widget/pie-chart-widget.tsx
+++ b/apps/web/src/components/dashboard/ui/widget/pie-chart-widget.tsx
@@ -11,13 +11,13 @@ import {
   type ChartConfig,
   ChartContainer,
   ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from '@auxx/ui/components/chart'
 import { Cell, Label, Pie, PieChart } from 'recharts'
 import type { ChartAggregateResult } from '../../lib/chart-transform'
 import { toPieRows } from '../../lib/chart-transform'
+import { PaginatedChartLegend } from './paginated-chart-legend'
 
 export function PieChartWidget({
   config,
@@ -86,7 +86,7 @@ export function PieChartWidget({
             />
           )}
         </Pie>
-        {showLegend && <ChartLegend content={<ChartLegendContent nameKey='label' />} />}
+        {showLegend && <ChartLegend content={<PaginatedChartLegend nameKey='label' />} />}
       </PieChart>
     </ChartContainer>
   )

--- a/packages/lib/src/dashboards/client.ts
+++ b/packages/lib/src/dashboards/client.ts
@@ -689,8 +689,8 @@ export function droppedFieldsOnConvert(from: WidgetConfiguration, toKind: Widget
     if (configured && to[key] === undefined) dropped.push(label)
   }
 
-  check('groupBy', 'Group by', Boolean(f.groupBy?.fieldRef))
-  check('secondaryGroupBy', 'Secondary breakdown', Boolean(f.secondaryGroupBy?.fieldRef))
+  check('groupBy', 'Category', Boolean(f.groupBy?.fieldRef))
+  check('secondaryGroupBy', 'Series', Boolean(f.secondaryGroupBy?.fieldRef))
   check('trend', 'Trend', Boolean(f.trend))
   check('prefix', 'Prefix', Boolean(f.prefix))
   check('suffix', 'Suffix', Boolean(f.suffix))

--- a/packages/lib/src/dashboards/convert.test.ts
+++ b/packages/lib/src/dashboards/convert.test.ts
@@ -136,9 +136,9 @@ describe('droppedFieldsOnConvert', () => {
     expect(droppedFieldsOnConvert(bar, 'lineChart')).toEqual([])
   })
 
-  it('bar → kpi reports the group-by and secondary breakdown', () => {
+  it('bar → kpi reports the category and series', () => {
     expect(droppedFieldsOnConvert(bar, 'kpi')).toEqual(
-      expect.arrayContaining(['Group by', 'Secondary breakdown'])
+      expect.arrayContaining(['Category', 'Series'])
     )
   })
 

--- a/packages/ui/src/components/chart.tsx
+++ b/packages/ui/src/components/chart.tsx
@@ -311,4 +311,8 @@ export {
   ChartLegend,
   ChartLegendContent,
   ChartStyle,
+  // Exposed for custom legend content (e.g. the dashboards' paginated legend)
+  // that needs to resolve labels/colors from the chart config the same way.
+  useChart,
+  getPayloadConfigFromPayload,
 }


### PR DESCRIPTION
## Summary

Two dashboards config/UX improvements (plans 14 + 15).

**Plan 14 — clearer config labels + inline help**
- Rename config fields to plainer labels: **Group by → Category**, **Break down by → Series**. Labels only — stored config keys are unchanged.
- Add an inline "?" help `description` to every config row across all widget bodies (bar/line/pie/KPI/gauge/record-list/iframe).
- Convert-drop warnings (`droppedFieldsOnConvert`) now surface the new labels ("Category" / "Series").

**Plan 15 — paginated legend carousel**
- Twenty-style paginated legend for bar/line/pie charts so wide legends page through instead of overflowing.
- New `legend-pages.ts` helper (+ tests) and `PaginatedChartLegend` component; charts render via `@auxx/ui` chart legend support.

## Test plan
- [x] `legend-pages` unit tests
- [ ] Live-verify legend paging + config help tooltips in the dashboard editor