### PR TITLE
docs(dashboards): add Dashboards help section + section icons

### DIFF
--- a/apps/docs/content/docs/help/account/meta.json
+++ b/apps/docs/content/docs/help/account/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Account & Security",
+  "icon": "ShieldCheck",
   "pages": ["settings", "signing-in", "2fa", "api-keys", "webhooks", "import-history"]
 }

--- a/apps/docs/content/docs/help/ai/meta.json
+++ b/apps/docs/content/docs/help/ai/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "AI & Automation",
+  "icon": "Sparkles",
   "pages": [
     "overview",
     "models-providers",

--- a/apps/docs/content/docs/help/apps/meta.json
+++ b/apps/docs/content/docs/help/apps/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Apps & Integrations",
+  "icon": "Puzzle",
   "pages": ["overview", "installing", "managing", "shopify"]
 }

--- a/apps/docs/content/docs/help/billing/meta.json
+++ b/apps/docs/content/docs/help/billing/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Plans, Billing & Payment",
+  "icon": "CreditCard",
   "pages": ["overview", "upgrading-downgrading", "payment-methods", "invoices", "cancellation"]
 }

--- a/apps/docs/content/docs/help/channels/meta.json
+++ b/apps/docs/content/docs/help/channels/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Channels",
+  "icon": "Inbox",
   "pages": ["gmail", "outlook", "chat-widget", "openphone", "facebook", "instagram"]
 }

--- a/apps/docs/content/docs/help/custom-entities/meta.json
+++ b/apps/docs/content/docs/help/custom-entities/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Custom Entities",
+  "icon": "Boxes",
   "pages": ["overview", "custom-fields", "relationships", "display-fields", "records", "importing"]
 }

--- a/apps/docs/content/docs/help/dashboards/concepts.mdx
+++ b/apps/docs/content/docs/help/dashboards/concepts.mdx
@@ -1,0 +1,56 @@
+---
+title: Core concepts
+description: The key terms used across the Dashboards guides, from dashboards and tabs to widgets, metrics, categories, series, and versions.
+---
+
+A quick glossary of the terms used throughout these guides. Later articles link back here.
+
+## Dashboard and tabs
+
+- **Dashboard** is the board you build. It has a name, settings, and one or more tabs.
+- **Tab** is a named page inside a dashboard. Each tab has its own widget grid, so you can split a board into sections like "Support" and "Sales".
+
+## The grid
+
+- **Grid** is the 12-column layout widgets snap to. In edit mode you drag widgets to move them and pull the corner to resize. The grid compacts upward to close gaps.
+- **Widget** is a single tile on the grid: a chart, a KPI, a record list, or a piece of content.
+
+## Data widgets
+
+Charts, KPIs, gauges, and record lists read live data. They share the same building blocks:
+
+- **Data source** is the entity or system resource a widget reads, such as Tickets, Contacts, a custom entity, or threads.
+- **Metric** is what gets measured: **Count records**, or an operation (sum, average, minimum, maximum, or percentage) over a field.
+- **Category** is the field a chart groups by. On a bar chart it is the bars, on a line chart the points along the axis, on a pie chart the slices.
+- **Series** is an optional second field that breaks each category into sub-groups. It applies to bar and line charts.
+- **Filters** are conditions that narrow which records the widget counts.
+
+<Callout type="info" title="Category and Series">
+"Category" and "Series" are the labels you will see in the config panel. If you have used other tools, they map to "group by" and "break down by". Each row has a **?** button with inline help.
+</Callout>
+
+## Content widgets
+
+- **Rich text** is a note tile for headings, lists, and context on the board.
+- **Embed** shows an external page inside the dashboard by URL.
+
+These have no data source or metric, but they still save and version along with the rest of the layout.
+
+## Drafts and versions
+
+- **Draft** is the working copy you edit. Your changes auto-save to the draft but are not live.
+- **Published version** is an immutable, numbered snapshot of the whole layout that viewers see.
+- **Publish** snapshots the current draft into a new version.
+- **Discard** throws away unpublished draft changes and reverts to the live version.
+- **Restore** brings an earlier version back as a draft so you can review it before publishing again.
+
+## Next steps
+
+<Cards>
+  <Card title="Create a dashboard" href="/help/dashboards/creating-a-dashboard" icon="Plus">
+    Create your first dashboard and manage its settings.
+  </Card>
+  <Card title="Tabs & layout" href="/help/dashboards/tabs-and-layout" icon="LayoutGrid">
+    Add widgets and arrange the grid in edit mode.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/creating-a-dashboard.mdx
+++ b/apps/docs/content/docs/help/dashboards/creating-a-dashboard.mdx
@@ -1,0 +1,48 @@
+---
+title: Creating a dashboard
+description: Create a dashboard from the Dashboards list, set its name and visibility, and duplicate, archive, or delete it from the settings dialog.
+---
+
+Dashboards live under the **Dashboards** entry in the sidebar. From there you can create new boards and open existing ones.
+
+## Create a dashboard
+
+1. Open **Dashboards** from the sidebar.
+2. Click **Create dashboard** in the top-right.
+3. Enter a **name** for the dashboard.
+4. Click **Create**.
+
+The new dashboard opens ready for you to add your first tab and widgets. It starts with a single empty tab.
+
+## The dashboards list
+
+The Dashboards list shows every dashboard as a card with its name and details. Click any card to open that dashboard. Use the list to jump between boards and to reach the create and settings actions.
+
+## Dashboard settings
+
+Open a dashboard's settings dialog to change how it is identified and who can see it:
+
+- **Name** so the dashboard is easy to find in the list.
+- **Visibility** to control who in your workspace can view the board.
+- **Archive** to hide a dashboard you no longer use while keeping its data.
+
+## Duplicate a dashboard
+
+Duplicating a dashboard copies its current layout into a brand-new dashboard as a fresh draft. This is the fastest way to build a variation of an existing board without touching the original. The copy starts unpublished, so nothing goes live until you publish it.
+
+## Archive and delete
+
+To take a dashboard out of circulation, **archive** it. Archived dashboards are hidden from the main list but keep their tabs, widgets, and version history.
+
+To remove a dashboard permanently, delete it. Deleting removes the dashboard and all of its versions.
+
+## Next steps
+
+<Cards>
+  <Card title="Tabs & layout" href="/help/dashboards/tabs-and-layout" icon="LayoutGrid">
+    Add widgets and arrange the grid in edit mode.
+  </Card>
+  <Card title="Widget catalog" href="/help/dashboards/widgets" icon="LayoutDashboard">
+    Choose from the eight widget kinds.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/data-and-metrics.mdx
+++ b/apps/docs/content/docs/help/dashboards/data-and-metrics.mdx
@@ -1,0 +1,59 @@
+---
+title: Point a widget at data
+description: Use the config panel to set a widget's data source, metric, category, series, and filters so it reports exactly the numbers you want.
+---
+
+Every data widget (bar, line, pie, KPI, gauge, and record list) is configured the same way. Select a widget in edit mode to open its **config panel**, docked beside the board on desktop and as a sheet on mobile. The **Data** section is where you tell the widget what to measure.
+
+## Data source
+
+Start by choosing a **data source**: the records the widget reads.
+
+- **Entities**: Contacts, Tickets, or any custom entity in your workspace.
+- **System resources**: threads, messages, and articles.
+
+<Callout type="warn" title="Changing the source resets the widget">
+The metric and category depend on the source's fields, so switching the data source clears them. The panel asks you to confirm before it does.
+</Callout>
+
+## Metric
+
+The **metric** is the number the widget reports. Pick it with the two-step picker:
+
+- **Count records** counts how many records match.
+- **A field operation** measures a field: sum, average, minimum, maximum, or percentage.
+
+The operations offered match the field's type. Numeric fields allow sum and average, while text fields do not, so you only ever see valid choices.
+
+## Category
+
+The **category** is the field the widget groups by. It becomes the bars on a bar chart, the points along a line chart, or the slices of a pie chart.
+
+- **Drill down through a relationship.** You can group by a field on a related record, for example Tickets grouped by their Contact's Company.
+- **Granularity** appears for date fields. Bucket dates by day, week, month, quarter, or year, or by day-of-week and month-of-year.
+- **Sort** the categories by value (biggest first) or by name.
+- **Limit** the chart to the top few categories by that sort.
+- **Omit empty** hides the bucket for records that have no value.
+
+## Series
+
+On bar and line charts you can add a **series**: a second field that splits each category into sub-groups. A "Tickets by month" bar chart with a "Status" series shows each month broken into its statuses. Clear the series to collapse back to a single value per category.
+
+## Filters
+
+Add **filters** to narrow which records the widget counts. Filters use the same condition builder found elsewhere in the app, so you can combine conditions like "Status is Open" and "Created this quarter". Filters apply before the metric is calculated.
+
+<Callout type="info" title="Time zones">
+Date buckets and windows use your own preferred time zone. Two people viewing the same dashboard from different time zones may see day boundaries fall slightly differently.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Formatting & appearance" href="/help/dashboards/formatting" icon="Palette">
+    Value formats, colors, legends, and per-widget style.
+  </Card>
+  <Card title="Widget catalog" href="/help/dashboards/widgets" icon="LayoutDashboard">
+    See what each widget kind is best at.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/formatting.mdx
+++ b/apps/docs/content/docs/help/dashboards/formatting.mdx
@@ -1,0 +1,47 @@
+---
+title: Formatting & appearance
+description: Control how a widget looks and reads, from value and date-axis formats to color schemes, legends, and per-widget appearance options.
+---
+
+Once a widget reports the right numbers, the config panel's appearance controls decide how it reads. The exact options depend on the widget kind, but they share a common set of formats and styles.
+
+## Value formatting
+
+By default a widget formats its values from the underlying field's type. Currency fields show a currency symbol and the correct decimal places, and numeric fields use their configured precision, so a dashboard matches how the same data looks on records.
+
+You can override the format per widget with the **value format** control. Choose a number or currency format, and it applies everywhere the value appears: the KPI number, the gauge readout, the pie center total, the axis labels, and the tooltip.
+
+## Date-axis labels
+
+When a chart's category is a date field, the **date label format** controls how those labels read on the axis, for example `Jan 2026` versus `2026-01`. Pick the style that fits the granularity you are bucketing by.
+
+## Colors
+
+Choose a **color scheme** for the chart's series. Schemes render as swatches so you can preview them before applying. A scheme sets the colors for every series at once and adapts to light and dark mode automatically, so the board stays legible either way.
+
+## Legend
+
+Toggle the **legend** on or off. When a chart has many series, the legend paginates with a compact `‹ 1 / 2 ›` control instead of overflowing the tile, so you can page through the entries without resizing the widget.
+
+## Per-widget appearance
+
+Each widget kind adds its own appearance options:
+
+| Widget | Options |
+|--------|---------|
+| **Bar chart** | Orientation (vertical or horizontal), stacked series, data labels |
+| **Line chart** | Cumulative running total, data labels |
+| **Pie chart** | Legend and color scheme (single category, no series) |
+| **KPI** | Trend comparison against a previous period |
+| **Gauge** | **Min** and **Max**, where max is the target the gauge fills toward |
+
+## Next steps
+
+<Cards>
+  <Card title="Widget catalog" href="/help/dashboards/widgets" icon="LayoutDashboard">
+    See each widget kind and its options in detail.
+  </Card>
+  <Card title="Publishing & versions" href="/help/dashboards/publishing-versions" icon="GitBranch">
+    Make your formatting live.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/index.mdx
+++ b/apps/docs/content/docs/help/dashboards/index.mdx
@@ -1,0 +1,79 @@
+---
+title: Dashboards
+description: Build customizable, multi-tab dashboards of charts, KPIs, and record lists over your CRM data, then publish them with full version history.
+---
+
+Dashboards are customizable boards of **widgets** (charts, KPIs, gauges, record lists, and content) laid out on a drag-and-resize grid over your CRM data. Measure anything in your workspace, arrange it the way your team thinks, and publish it for everyone to see.
+
+<Callout title="Dashboards vs. the app home">
+This section is about the **Dashboards** feature: boards you build yourself. It is not the app home screen you land on after signing in.
+</Callout>
+
+## What you can measure
+
+A data widget reads from one **data source** and reports a **metric**:
+
+- **Sources**: any entity (Contacts, Tickets, or a custom entity) or a system resource (threads, messages, articles).
+- **Metrics**: a record count, or a sum, average, minimum, maximum, or percentage over a field.
+- **Grouped** by any field you choose, so a single source can power dozens of different views.
+
+## The build loop
+
+<Steps>
+<Step>
+
+### Create a dashboard
+
+Give it a name and open it. A dashboard can hold several tabs, each with its own grid.
+
+</Step>
+<Step>
+
+### Add widgets
+
+Drop charts, KPIs, gauges, record lists, or content onto the grid, then drag and resize them into place.
+
+</Step>
+<Step>
+
+### Point each widget at data
+
+Pick a source, a metric, and a category to group by. Add filters to narrow the records.
+
+</Step>
+<Step>
+
+### Format and style
+
+Set value formats, colors, legends, and per-widget appearance so the board reads clearly.
+
+</Step>
+<Step>
+
+### Publish
+
+Your edits auto-save as a draft. Click **Publish** to make them live. Every publish is a numbered version you can restore later.
+
+</Step>
+</Steps>
+
+<Callout type="info" title="Nothing is live until you publish">
+The dashboard you edit is a private draft. Viewers keep seeing the last published version until you publish again, so you can rearrange freely without anyone noticing.
+</Callout>
+
+## Where to start
+
+<Cards>
+  <Card title="Core concepts" href="/help/dashboards/concepts" icon="BookOpen">
+    A glossary of the terms used throughout these guides.
+  </Card>
+  <Card title="Create a dashboard" href="/help/dashboards/creating-a-dashboard" icon="Plus">
+    Create your first dashboard and manage its settings.
+  </Card>
+  <Card title="Widget catalog" href="/help/dashboards/widgets" icon="LayoutGrid">
+    The eight widget kinds and when to use each.
+  </Card>
+  <Card title="Publishing & versions" href="/help/dashboards/publishing-versions" icon="GitBranch">
+    Publish changes and restore earlier versions.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/meta.json
+++ b/apps/docs/content/docs/help/dashboards/meta.json
@@ -1,0 +1,14 @@
+{
+  "title": "Dashboards",
+  "icon": "LayoutDashboard",
+  "pages": [
+    "index",
+    "concepts",
+    "creating-a-dashboard",
+    "tabs-and-layout",
+    "data-and-metrics",
+    "formatting",
+    "publishing-versions",
+    "widgets"
+  ]
+}

--- a/apps/docs/content/docs/help/dashboards/publishing-versions.mdx
+++ b/apps/docs/content/docs/help/dashboards/publishing-versions.mdx
@@ -1,0 +1,49 @@
+---
+title: Publishing & versions
+description: Understand the draft model, publish changes to make them live, discard unwanted edits, and restore or delete earlier dashboard versions.
+---
+
+Dashboards use a draft model so you can rearrange a board freely without disturbing the people who view it. The dashboard you edit is a private **draft**. Viewers keep seeing the last **published version** until you publish again.
+
+## The draft model
+
+- Every edit you make in edit mode auto-saves to the draft.
+- The draft is not live. Nothing viewers see changes until you publish.
+- When the draft differs from the live version, the header shows an amber **Live · unsaved** pill next to the **Publish** and **Discard** actions.
+
+## Publish
+
+Click **Publish** to snapshot the current draft into a new numbered version. That version becomes what viewers see.
+
+Publishing requires every widget to be fully configured. If a widget is missing its source or metric, the app tells you which one so you can finish it before publishing.
+
+## Discard
+
+Click **Discard** to throw away unpublished draft changes and revert the draft to the current live version. Use this when an editing session did not work out and you want to start again from what is live.
+
+## Version history
+
+Open the version history to see every published version. Each version is an immutable snapshot of the whole layout, and you can give it a label such as `Q3 board` to make it easy to recognize later.
+
+## Restore a version
+
+Restoring an earlier version brings it back **as a draft** rather than publishing it immediately. This lets you review the restored layout, make any tweaks, and then publish when you are ready. The version you restored from stays intact.
+
+## Delete a version
+
+You can delete an old version you no longer need. You cannot delete the version that is currently live. Restored drafts are independent copies, so deleting the version you restored from does not affect your draft.
+
+<Callout type="info" title="A good rhythm">
+Rearrange in edit mode, watch it auto-save, review the board, then publish. If you are unsure, publish anyway. You can always restore an earlier version.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Tabs & layout" href="/help/dashboards/tabs-and-layout" icon="LayoutGrid">
+    Edit mode, tabs, and arranging the grid.
+  </Card>
+  <Card title="Widget catalog" href="/help/dashboards/widgets" icon="LayoutDashboard">
+    The eight widget kinds.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/tabs-and-layout.mdx
+++ b/apps/docs/content/docs/help/dashboards/tabs-and-layout.mdx
@@ -1,0 +1,63 @@
+---
+title: Tabs & layout
+description: Switch into edit mode to add tabs and widgets, arrange them on the drag-and-resize grid, and let your changes auto-save to the draft.
+---
+
+A dashboard has two modes. In **view mode** you read the board and nothing you do changes it. In **edit mode** you add, move, resize, and configure widgets. Click **Edit** in the header to start arranging, and **Done** to go back to viewing.
+
+## Tabs
+
+A dashboard can hold several tabs, each with its own grid. Use tabs to split a board into sections, such as a "Support" tab and a "Sales" tab.
+
+- **Add a tab** from the tab strip to start a fresh grid.
+- **Rename a tab** to label its section.
+
+Switching tabs never loses your work. Each tab keeps its own widgets and layout.
+
+## Add a widget
+
+In edit mode, open the **Add widget** menu. Widgets are grouped so you can find the right one quickly:
+
+- **Charts**: bar chart, line chart, pie chart.
+- **Content**: KPI, gauge, record list, rich text, and embed.
+
+Each entry shows an icon and a one-line description. Pick a kind and it drops onto the grid at a sensible default size, ready to configure.
+
+See the [widget catalog](/help/dashboards/widgets) for what each kind is best at.
+
+## Arrange the grid
+
+The grid is 12 columns wide. In edit mode:
+
+- **Move** a widget by dragging it from its header.
+- **Resize** a widget by pulling the handle at its corner.
+- Widgets **compact upward** automatically to close empty gaps, so the board stays tidy.
+
+Each widget kind has a default size when added and a minimum size it cannot shrink below.
+
+## Auto-save
+
+Your edits save automatically to the draft as you work, with a short debounce. You will see a **Saved** indicator once a change is stored. Nothing you do in edit mode goes live until you publish, so feel free to experiment.
+
+<Callout type="info" title="Live vs. unsaved">
+When the draft differs from the published board, the header shows an amber **Live · unsaved** pill along with **Publish** and **Discard** actions. See [Publishing & versions](/help/dashboards/publishing-versions).
+</Callout>
+
+## Change a widget's type
+
+If you picked the wrong kind, use **Change type** on the widget to convert it. Data widgets (bar, line, pie, KPI, gauge, record list) all convert between each other, carrying over the settings that still apply. A confirmation warns you when a conversion drops settings that do not fit the new kind. Rich text and embed widgets do not convert to data widgets.
+
+## Remove, rename, and duplicate
+
+From a widget's actions menu you can rename it, duplicate it, or remove it from the grid.
+
+## Next steps
+
+<Cards>
+  <Card title="Point a widget at data" href="/help/dashboards/data-and-metrics" icon="Database">
+    Set the source, metric, category, and filters.
+  </Card>
+  <Card title="Publishing & versions" href="/help/dashboards/publishing-versions" icon="GitBranch">
+    Make your draft live and manage versions.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/widgets/charts.mdx
+++ b/apps/docs/content/docs/help/dashboards/widgets/charts.mdx
@@ -1,0 +1,48 @@
+---
+title: Bar, line & pie charts
+description: The three chart widgets share the same data setup and each add their own appearance options for comparing, trending, and showing shares of data.
+---
+
+Bar, line, and pie charts all read from a data source, report a metric, and group by a category. Set those up in the [Data section](/help/dashboards/data-and-metrics), then use each chart's appearance options below.
+
+## Bar chart
+
+Best for comparing a metric across categories, such as tickets per status or revenue per product.
+
+- **Category** becomes the bars.
+- **Series** breaks each bar into sub-groups, shown stacked or side by side.
+- **Orientation** switches between vertical and horizontal bars.
+- **Stacked** stacks the series within each bar instead of placing them side by side.
+- **Data labels** print the value on each bar.
+
+## Line chart
+
+Best for a metric over time or any trend.
+
+- **Category** is usually a date field, with a granularity of day, week, month, quarter, or year.
+- **Series** draws one line per sub-group so you can compare trends.
+- **Cumulative** turns the line into a running total that only climbs.
+- **Data labels** print the value at each point.
+
+## Pie chart
+
+Best for showing the share of a whole across a small number of categories.
+
+- **Category** becomes the slices. Pie charts do not use a series.
+- The center shows the total across all slices.
+- Keep the number of categories small so the slices stay readable. Use the category **Limit** to cap them.
+
+## Colors and legend
+
+All three charts use a [color scheme and legend](/help/dashboards/formatting). When a chart has many series, the legend paginates so it never overflows the tile.
+
+## Next steps
+
+<Cards>
+  <Card title="Formatting & appearance" href="/help/dashboards/formatting" icon="Palette">
+    Value formats, date-axis labels, colors, and legends.
+  </Card>
+  <Card title="KPI & gauge" href="/help/dashboards/widgets/kpi-and-gauge" icon="Gauge">
+    Distill data down to a single number.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/widgets/content.mdx
+++ b/apps/docs/content/docs/help/dashboards/widgets/content.mdx
@@ -1,0 +1,36 @@
+---
+title: Rich text & embed
+description: Content widgets add context to a dashboard, with a rich-text tile for notes and headings and an embed tile for showing an external page by URL.
+---
+
+Not every tile on a dashboard has to be data. Content widgets add the words and external context that make a board readable. Neither has a data source or a metric, but both save and version along with the rest of the layout.
+
+## Rich text
+
+A rich-text widget is a note tile for headings, lists, and context, useful for a board title, a short explanation, or instructions for the team reading it.
+
+- Type `/` to open the block menu and insert headings, bullet and numbered lists, to-do items, quotes, dividers, and code blocks.
+- Select text to bring up the formatting bubble for inline styles.
+- Content saves automatically as you type, like the rest of the board.
+
+## Embed
+
+An embed widget shows an external page inside the dashboard by its URL. Use it to drop in a status page, an external report, or a live document alongside your own charts.
+
+- Enter the page's address. It must start with `https://`.
+- The page renders inside the tile as an iframe.
+
+<Callout type="warn" title="Some sites cannot be embedded">
+Many sites block being shown inside another page for security reasons. If an embed stays blank, the target site does not allow embedding, and there is nothing to change on the dashboard side.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Widget catalog" href="/help/dashboards/widgets" icon="LayoutDashboard">
+    Back to all eight widget kinds.
+  </Card>
+  <Card title="Publishing & versions" href="/help/dashboards/publishing-versions" icon="GitBranch">
+    Make your board live.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/widgets/index.mdx
+++ b/apps/docs/content/docs/help/dashboards/widgets/index.mdx
@@ -1,0 +1,44 @@
+---
+title: Widget catalog
+description: The eight dashboard widget kinds at a glance, grouped into charts and content, with guidance on when to reach for each one.
+---
+
+A dashboard is built from widgets. There are eight kinds, grouped in the **Add widget** menu as **Charts** and **Content**. Data widgets read live from your CRM, while content widgets hold notes and embedded pages.
+
+## The eight widget kinds
+
+| Widget | Best for |
+|--------|----------|
+| **Bar chart** | Comparing a metric across categories |
+| **Line chart** | A metric over time or a trend |
+| **Pie chart** | The share of a whole across a few categories |
+| **KPI** | A single headline number, optionally with a trend |
+| **Gauge** | Progress toward a target |
+| **Record list** | A live table of matching records |
+| **Rich text** | Notes, headings, and context on the board |
+| **Embed** | An external page shown inside the board |
+
+## Charts
+
+Bar, line, and pie charts share the same data setup: a source, a metric, and a category to group by. Bar and line charts also support a series to break each category down further.
+
+## Content
+
+KPI and gauge distill data down to a single number. Record list shows the underlying records as a table. Rich text and embed add context and external content that is not tied to a data source.
+
+## Learn each kind
+
+<Cards>
+  <Card title="Bar, line & pie" href="/help/dashboards/widgets/charts" icon="ChartColumn">
+    The three chart kinds and their appearance options.
+  </Card>
+  <Card title="KPI & gauge" href="/help/dashboards/widgets/kpi-and-gauge" icon="Gauge">
+    Headline numbers and progress toward a target.
+  </Card>
+  <Card title="Record list" href="/help/dashboards/widgets/record-list" icon="Table">
+    A live table of matching records.
+  </Card>
+  <Card title="Rich text & embed" href="/help/dashboards/widgets/content" icon="FileText">
+    Notes and external pages on the board.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/widgets/kpi-and-gauge.mdx
+++ b/apps/docs/content/docs/help/dashboards/widgets/kpi-and-gauge.mdx
@@ -1,0 +1,38 @@
+---
+title: KPI & gauge
+description: KPI and gauge widgets distill a metric down to a single number, one as a headline figure with an optional trend and the other as progress to a target.
+---
+
+KPI and gauge widgets each show one number. A KPI is a headline figure, and a gauge shows how far that figure has moved toward a target. Both are set up in the [Data section](/help/dashboards/data-and-metrics) with a source and a metric, but no category.
+
+## KPI
+
+A KPI reports a single metric as a large number, such as open tickets or total revenue this month.
+
+- Pick a **metric** (a count or a field operation). There is no category, since a KPI is one value.
+- Turn on the **trend** to compare the current value against a previous period. The KPI shows the change as a delta so you can see at a glance whether the number is going up or down.
+- The number respects your [value format](/help/dashboards/formatting), so currency and decimals display correctly.
+
+## Gauge
+
+A gauge shows a metric as progress from a minimum to a maximum, filling toward a target.
+
+- Set **Min**, the value at the empty end of the gauge, usually 0.
+- Set **Max**, the target the gauge fills toward at 100 percent.
+- A gauge needs a max to draw. If it is missing, the panel shows an inline error until you set one.
+- The readout uses your [value format](/help/dashboards/formatting).
+
+<Callout type="info" title="KPI or gauge?">
+Use a KPI when the number stands on its own and you care about its trend. Use a gauge when the number is meaningful relative to a target, such as a monthly goal or a capacity limit.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Record list" href="/help/dashboards/widgets/record-list" icon="Table">
+    Show the underlying records as a table.
+  </Card>
+  <Card title="Formatting & appearance" href="/help/dashboards/formatting" icon="Palette">
+    Control how the number reads.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/dashboards/widgets/meta.json
+++ b/apps/docs/content/docs/help/dashboards/widgets/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Widget catalog",
+  "pages": ["index", "charts", "kpi-and-gauge", "record-list", "content"]
+}

--- a/apps/docs/content/docs/help/dashboards/widgets/record-list.mdx
+++ b/apps/docs/content/docs/help/dashboards/widgets/record-list.mdx
@@ -1,0 +1,38 @@
+---
+title: Record list
+description: The record-list widget shows a live table of records that match a source and filters, styled like the records page and updating in real time.
+---
+
+A record-list widget shows the records behind your numbers as a live table. Where a chart summarizes, a record list lets you read the individual records that match, right on the board.
+
+## Set it up
+
+Configure a record list in the [Data section](/help/dashboards/data-and-metrics):
+
+- **Data source** picks which records to list, such as open Tickets or a custom entity.
+- **Filters** narrow the list to the records you care about, using the same condition builder as the rest of the app.
+
+A record list has no metric or category. It shows records, not an aggregate.
+
+## Columns
+
+Choose which fields appear as columns in the table. The primary field stays pinned as the first column so each row is easy to identify, and the rest of your chosen fields follow in order.
+
+## Reading and opening records
+
+The table is styled like the records page, with a sticky header and a pinned primary column, so it feels familiar. Click a row to open that record in a drawer without leaving the dashboard.
+
+<Callout type="info" title="Always up to date">
+The list updates in real time. As records are created, edited, or change to match your filters, the widget reflects it without a manual refresh.
+</Callout>
+
+## Next steps
+
+<Cards>
+  <Card title="Rich text & embed" href="/help/dashboards/widgets/content" icon="FileText">
+    Add notes and external pages to the board.
+  </Card>
+  <Card title="Custom entity records" href="/help/custom-entities/records" icon="Blocks">
+    Learn how records work across the app.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/help/datasets/meta.json
+++ b/apps/docs/content/docs/help/datasets/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Datasets",
+  "icon": "Database",
   "pages": ["overview", "creating", "settings", "searching"]
 }

--- a/apps/docs/content/docs/help/files/meta.json
+++ b/apps/docs/content/docs/help/files/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Files",
+  "icon": "Files",
   "pages": ["overview", "folders", "uploading", "details"]
 }

--- a/apps/docs/content/docs/help/getting-started/meta.json
+++ b/apps/docs/content/docs/help/getting-started/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Getting Started",
+  "icon": "Rocket",
   "pages": [
     "what-is-auxx",
     "create-account",

--- a/apps/docs/content/docs/help/guides/meta.json
+++ b/apps/docs/content/docs/help/guides/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Browse by use case",
+  "icon": "Compass",
   "pages": ["marketing", "hr-people", "personal", "enterprise", "sales", "project-management"]
 }

--- a/apps/docs/content/docs/help/index.mdx
+++ b/apps/docs/content/docs/help/index.mdx
@@ -27,6 +27,9 @@ toc: false
   <Card title="Datasets" href="/help/datasets/overview" icon="Database">
     Create and manage datasets for training and knowledge
   </Card>
+  <Card title="Dashboards" href="/help/dashboards" icon="LayoutDashboard">
+    Build charts, KPIs, and record lists over your CRM data
+  </Card>
   <Card title="Custom Entities" href="/help/custom-entities/overview" icon="Blocks">
     Build custom fields, relationships, and data models
   </Card>

--- a/apps/docs/content/docs/help/messaging/meta.json
+++ b/apps/docs/content/docs/help/messaging/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Messages",
+  "icon": "Mail",
   "pages": ["sync-messages", "send-messages"]
 }

--- a/apps/docs/content/docs/help/meta.json
+++ b/apps/docs/content/docs/help/meta.json
@@ -14,14 +14,13 @@
     "ai",
     "agents",
     "datasets",
+    "dashboards",
     "files",
     "tasks",
     "custom-entities",
     "billing",
     "account",
     "troubleshooting",
-    "---Guides---",
-    "guides",
     "---Self-Host---",
     "self-host"
   ]

--- a/apps/docs/content/docs/help/self-host/meta.json
+++ b/apps/docs/content/docs/help/self-host/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Self-Host",
+  "icon": "Server",
   "pages": ["overview", "docker-compose", "setup", "troubleshooting"]
 }

--- a/apps/docs/content/docs/help/tasks/meta.json
+++ b/apps/docs/content/docs/help/tasks/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Tasks",
+  "icon": "ListChecks",
   "pages": ["overview", "assignment", "filtering"]
 }

--- a/apps/docs/content/docs/help/tickets/meta.json
+++ b/apps/docs/content/docs/help/tickets/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Tickets",
+  "icon": "Ticket",
   "pages": [
     "overview",
     "statuses",

--- a/apps/docs/content/docs/help/troubleshooting/meta.json
+++ b/apps/docs/content/docs/help/troubleshooting/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Troubleshooting",
+  "icon": "LifeBuoy",
   "pages": ["common-issues", "email-sync", "shopify-sync", "contact-support"]
 }

--- a/apps/docs/content/docs/help/workspace/meta.json
+++ b/apps/docs/content/docs/help/workspace/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Workspace",
+  "icon": "Building2",
   "pages": [
     "overview",
     "sidebar",


### PR DESCRIPTION
## Summary

Adds a **Dashboards** help section to the docs site and rounds out the help-center sidebar.

### New section: `help/dashboards/`
- `index` — overview + build loop
- `concepts` — glossary (dashboard, tab, widget, source, metric, category, series, versions)
- `creating-a-dashboard` — create, list, settings, visibility, duplicate, archive/delete
- `tabs-and-layout` — edit mode, tabs, add-widget menu, grid drag/resize, auto-save, change type
- `data-and-metrics` — data source, metric picker, category (drill-down/granularity/sort/limit), series, filters
- `formatting` — value formats, date-axis labels, color schemes, paginated legend, per-kind appearance
- `publishing-versions` — draft model, publish/discard, version history, restore, delete
- `widgets/` catalog — `index`, `charts`, `kpi-and-gauge`, `record-list`, `content`

Wired into `help/meta.json` (after Datasets) and added a homepage card.

### Sidebar icons
Every help section now has an icon (previously only Agents and Dashboards did). Names verified against the installed `lucide-react` so none fall back to raw text.

### Hidden for now
Removed the placeholder **"Browse by use case"** (guides) section from the nav until those articles exist. The content files are untouched, so it can return by re-adding two lines.

## Notes
- No em-dashes, per house preference for these docs.
- Deferred/unshipped features (global date-range bar, chart drill-down, tab reorder, version preview) are intentionally omitted; color schemes and record-list columns are described generically since those sub-plans (12/13) are still in progress.
- **No screenshots yet** — the articles have natural spots for them but capturing needs the running app.

## Test plan
- [ ] Docs site builds and the Dashboards section renders in the sidebar
- [ ] All section icons render (no raw strings)
- [ ] Internal links between the new pages resolve