### PR TITLE
feat(dashboards): server-side aggregate result cache (60s TTL)

### DIFF
--- a/apps/web/src/server/api/routers/dashboard.ts
+++ b/apps/web/src/server/api/routers/dashboard.ts
@@ -55,13 +55,16 @@ const visibilitySchema = z.enum(['private', 'org'])
  * can't trigger a re-fetch. The config panel still previews unsaved drafts:
  * `toChartQueryInput(draftConfig)` flows through the same endpoint. `widgetId`
  * is informational; `globalOverrides` is the viewer's live date-range/condition
- * state from the URL.
+ * state from the URL. `skipCache` bypasses the server-side aggregate cache
+ * READ (still repopulates) — for the refresh button; it must never end up in
+ * the client React Query key (refresh via a one-shot fetch/invalidate).
  */
 const widgetDataInputSchema = z.object({
   dashboardId: z.string(),
   widgetId: z.string().optional(),
   query: chartQueryInputSchema,
   globalOverrides: globalFiltersSchema.optional(),
+  skipCache: z.boolean().optional(),
 })
 
 type WidgetDataInput = z.infer<typeof widgetDataInputSchema>
@@ -265,16 +268,23 @@ export const dashboardRouter = createTRPCRouter({
 
   chartData: protectedProcedure.input(widgetDataInputSchema).query(async ({ ctx, input }) => {
     const { query } = await prepareWidgetQuery(ctx, input)
-    return unwrap(await runAggregate(ctx.db, ctx.session.organizationId, ctx.session.userId, query))
+    return unwrap(
+      await runAggregate(ctx.db, ctx.session.organizationId, ctx.session.userId, query, {
+        skipCache: input.skipCache,
+      })
+    )
   }),
 
   kpiData: protectedProcedure.input(widgetDataInputSchema).query(async ({ ctx, input }) => {
     const { cfg, query } = await prepareWidgetQuery(ctx, input)
     return unwrap(
-      await runKpi(ctx.db, ctx.session.organizationId, ctx.session.userId, {
-        base: query,
-        trend: trendSpecForWidget(cfg),
-      })
+      await runKpi(
+        ctx.db,
+        ctx.session.organizationId,
+        ctx.session.userId,
+        { base: query, trend: trendSpecForWidget(cfg) },
+        { skipCache: input.skipCache }
+      )
     )
   }),
 })

--- a/packages/lib/src/cache/__tests__/base-cache-service.test.ts
+++ b/packages/lib/src/cache/__tests__/base-cache-service.test.ts
@@ -1,0 +1,54 @@
+// packages/lib/src/cache/__tests__/base-cache-service.test.ts
+//
+// Memory-mirror pruning tests. Redis is mocked as unavailable so the service
+// runs in degraded (memory-only) mode — the map is the sole store.
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/redis', () => ({
+  getRedisClient: vi.fn(async () => {
+    throw new Error('redis unavailable (test)')
+  }),
+}))
+
+import { BaseCacheService } from '../base-cache-service'
+
+function memoryMapOf(service: BaseCacheService): Map<string, unknown> {
+  return (service as unknown as { memoryCache: Map<string, unknown> }).memoryCache
+}
+
+describe('BaseCacheService memory pruning', () => {
+  it('bounds the in-memory mirror and keeps the newest entries', async () => {
+    const service = new BaseCacheService('prune-a', 60)
+    for (let i = 0; i < 1200; i++) {
+      await service.set(`k${i}`, i)
+    }
+    expect(memoryMapOf(service).size).toBeLessThanOrEqual(1000)
+    expect(await service.get('k1199')).toBe(1199)
+    expect(await service.get('k0')).toBeNull()
+  })
+
+  it('sheds expired entries before evicting live ones', async () => {
+    const service = new BaseCacheService('prune-b', 60)
+    for (let i = 0; i < 600; i++) {
+      await service.set(`expired${i}`, i, { ttl: -1 })
+    }
+    for (let i = 0; i < 600; i++) {
+      await service.set(`live${i}`, i)
+    }
+    // Crossing the threshold swept the expired half — every live entry survives.
+    for (const probe of ['live0', 'live300', 'live599']) {
+      expect(await service.get(probe)).toBe(Number(probe.replace('live', '')))
+    }
+    expect(memoryMapOf(service).size).toBeLessThanOrEqual(1000)
+  })
+
+  it('never prunes below the threshold', async () => {
+    const service = new BaseCacheService('prune-c', 60)
+    for (let i = 0; i < 900; i++) {
+      await service.set(`k${i}`, i)
+    }
+    expect(memoryMapOf(service).size).toBe(900)
+    expect(await service.get('k0')).toBe(0)
+  })
+})

--- a/packages/lib/src/cache/aggregate-cache-service.ts
+++ b/packages/lib/src/cache/aggregate-cache-service.ts
@@ -1,0 +1,40 @@
+// packages/lib/src/cache/aggregate-cache-service.ts
+
+import { BaseCacheService } from './base-cache-service'
+
+/** Pure-TTL freshness bound for aggregate results — no write invalidation. */
+const AGGREGATE_CACHE_TTL = 60 // seconds
+
+/** Cached envelope. `computedAt` unblocks a later "updated Ns ago" affordance. */
+export interface CachedAggregate<T> {
+  result: T
+  computedAt: number
+}
+
+/**
+ * Short-TTL result cache for the aggregate engine (dashboard chart/KPI data).
+ *
+ * Keys embed the orgId (`agg:{orgId}:{queryHash}` — see
+ * `resources/aggregate/cache-key.ts`), so a per-org escape-hatch flush is a
+ * pattern invalidation; no tag sets are maintained. Pure TTL by design:
+ * dashboards tolerate ~a minute of staleness, and FieldValue writes are far
+ * too frequent to invalidate on.
+ */
+export class AggregateCacheService extends BaseCacheService {
+  constructor() {
+    super('agg', AGGREGATE_CACHE_TTL)
+  }
+
+  async read<T>(key: string): Promise<CachedAggregate<T> | null> {
+    return this.get<CachedAggregate<T>>(key)
+  }
+
+  async write<T>(key: string, result: T): Promise<void> {
+    await this.set<CachedAggregate<T>>(key, { result, computedAt: Date.now() })
+  }
+
+  /** Escape hatch: drop every cached aggregate for one org. */
+  async flushOrganization(organizationId: string): Promise<void> {
+    await this.invalidateByPattern(new RegExp(`^agg:${organizationId}:`))
+  }
+}

--- a/packages/lib/src/cache/base-cache-service.ts
+++ b/packages/lib/src/cache/base-cache-service.ts
@@ -46,6 +46,14 @@ export interface CacheEntry<T> {
  * - Graceful error handling
  * - Debug logging in development mode (NODE_ENV=development)
  */
+/**
+ * Max entries in the in-memory mirror before a prune sweep runs. Fixed-key
+ * services never get near this; high-cardinality caches (e.g. aggregate query
+ * hashes) would otherwise grow the map unboundedly — expired entries are only
+ * shed when their key happens to be re-read.
+ */
+const MEMORY_PRUNE_THRESHOLD = 1000
+
 export class BaseCacheService {
   /** In-memory cache as fallback when Redis is unavailable */
   private memoryCache = new Map<string, CacheEntry<any>>()
@@ -263,6 +271,30 @@ export class BaseCacheService {
       })
       // Still store in memory on Redis failure
       this.memoryCache.set(fullKey, entry)
+    }
+    this.pruneMemoryCache()
+  }
+
+  /**
+   * Bound the in-memory mirror: past the threshold, sweep expired entries;
+   * if still over, evict oldest-created first. Amortized behind the threshold
+   * so fixed-key services never pay for it.
+   */
+  private pruneMemoryCache(): void {
+    if (this.memoryCache.size <= MEMORY_PRUNE_THRESHOLD) return
+
+    const now = Date.now()
+    for (const [key, entry] of this.memoryCache) {
+      if (entry.expires <= now) this.memoryCache.delete(key)
+    }
+    if (this.memoryCache.size <= MEMORY_PRUNE_THRESHOLD) return
+
+    // Evict down to a low watermark, not the threshold — otherwise a map that
+    // stays at capacity would re-sort on every subsequent set.
+    const byAge = [...this.memoryCache.entries()].sort((a, b) => a[1].createdAt - b[1].createdAt)
+    const excess = this.memoryCache.size - Math.floor(MEMORY_PRUNE_THRESHOLD * 0.9)
+    for (let i = 0; i < excess; i++) {
+      this.memoryCache.delete(byAge[i]![0])
     }
   }
 

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -9,6 +9,8 @@ export type {
   WorkflowAppsAccessor,
 } from './accessor-map'
 export { ArrayAccessor, NestedRecordAccessor, RecordAccessor, ScalarAccessor } from './accessors'
+export type { CachedAggregate } from './aggregate-cache-service'
+export { AggregateCacheService } from './aggregate-cache-service'
 export { getCachedAppBySlug, getCachedPublishedApps, resolveAppSlug } from './app-cache-helpers'
 // ── App Cache Service ──
 export type {
@@ -96,6 +98,7 @@ export type { MailGrantEntry, MailGrantIndex } from './providers/mail-grant-inde
 export type { CachedPublishedWorkflow, CachedWorkflowApp } from './providers/workflow-apps-provider'
 // ── Singletons ──
 export {
+  getAggregateCache,
   getAppCache,
   getBuildUserCache,
   getOrgCache,

--- a/packages/lib/src/cache/singletons.ts
+++ b/packages/lib/src/cache/singletons.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/cache/singletons.ts
 
+import { AggregateCacheService } from './aggregate-cache-service'
 import { AppCacheService } from './app-cache-service'
 import { BuildUserCacheService } from './build-user-cache-service'
 import { OrganizationCacheService } from './org-cache-service'
@@ -16,6 +17,7 @@ import { UserCacheService } from './user-cache-service'
  * server bundles within the same Node.js process.
  */
 const globalForCache = globalThis as unknown as {
+  _auxxAggregateCache?: AggregateCacheService
   _auxxAppCache?: AppCacheService
   _auxxBuildUserCache?: BuildUserCacheService
   _auxxOrgCache?: OrganizationCacheService
@@ -78,6 +80,14 @@ export function getOrgCache(): OrganizationCacheService {
   if (!globalForCache._auxxOrgCache) initCaches()
   else ensureProvidersUpToDate()
   return globalForCache._auxxOrgCache!
+}
+
+/** Get the singleton aggregate result cache (short-TTL dashboard chart/KPI data) */
+export function getAggregateCache(): AggregateCacheService {
+  if (!globalForCache._auxxAggregateCache) {
+    globalForCache._auxxAggregateCache = new AggregateCacheService()
+  }
+  return globalForCache._auxxAggregateCache
 }
 
 /** Get the singleton token cache service for short-lived, one-time-use tokens */

--- a/packages/lib/src/resources/aggregate/cache-key.test.ts
+++ b/packages/lib/src/resources/aggregate/cache-key.test.ts
@@ -1,0 +1,125 @@
+// packages/lib/src/resources/aggregate/cache-key.test.ts
+
+import { toResourceFieldId } from '@auxx/types/field'
+import { describe, expect, it } from 'vitest'
+import type { ConditionGroup } from '../../conditions'
+import { aggregateCacheKey } from './cache-key'
+import type { AggregateQuery } from './types'
+
+const ORG = 'org_1'
+const DEF = 'def_tickets'
+const ref = (fieldId: string) => toResourceFieldId(DEF, fieldId)
+
+function baseQuery(overrides: Partial<AggregateQuery> = {}): AggregateQuery {
+  return {
+    source: { kind: 'entity', entityDefinitionId: DEF },
+    metric: { op: 'count' },
+    timezone: 'UTC',
+    ...overrides,
+  }
+}
+
+function assigneeFilter(userId: string, groupId = 'g1', conditionId = 'c1'): ConditionGroup[] {
+  return [
+    {
+      id: groupId,
+      logicalOperator: 'AND',
+      conditions: [{ id: conditionId, fieldId: ref('assignee'), operator: 'is', value: userId }],
+    },
+  ]
+}
+
+const key = (
+  query: AggregateQuery,
+  extra: { kind?: 'agg' | 'kpi'; compare?: 'previousPeriod' } = {}
+) =>
+  aggregateCacheKey({
+    kind: extra.kind ?? 'agg',
+    organizationId: ORG,
+    query,
+    compare: extra.compare,
+  })
+
+describe('aggregateCacheKey', () => {
+  it('is deterministic and org-prefixed', () => {
+    expect(key(baseQuery())).toBe(key(baseQuery()))
+    expect(key(baseQuery()).startsWith(`${ORG}:`)).toBe(true)
+  })
+
+  it('is independent of object key insertion order', () => {
+    const a: AggregateQuery = {
+      source: { kind: 'entity', entityDefinitionId: DEF },
+      metric: { op: 'count' },
+      timezone: 'UTC',
+    }
+    const b: AggregateQuery = {
+      timezone: 'UTC',
+      metric: { op: 'count' },
+      source: { entityDefinitionId: DEF, kind: 'entity' },
+    }
+    expect(key(a)).toBe(key(b))
+  })
+
+  it('treats absent and explicitly-undefined optionals identically', () => {
+    expect(key(baseQuery())).toBe(
+      key(baseQuery({ groupBy: undefined, filters: undefined, limit: undefined }))
+    )
+  })
+
+  it('normalizes date-window Dates to instants (fresh Date instances match)', () => {
+    const window = () => ({
+      fieldRef: ref('createdAt'),
+      from: new Date('2026-01-01T00:00:00Z'),
+      to: new Date('2026-02-01T00:00:00Z'),
+    })
+    expect(key(baseQuery({ dateWindow: window() }))).toBe(key(baseQuery({ dateWindow: window() })))
+    expect(key(baseQuery({ dateWindow: window() }))).not.toBe(
+      key(baseQuery({ dateWindow: { ...window(), to: new Date('2026-03-01T00:00:00Z') } }))
+    )
+  })
+
+  it('forks on organization, timezone, metric, group-by, and limit', () => {
+    const base = key(baseQuery())
+    expect(
+      aggregateCacheKey({ kind: 'agg', organizationId: 'org_2', query: baseQuery() })
+    ).not.toBe(base)
+    expect(key(baseQuery({ timezone: 'America/New_York' }))).not.toBe(base)
+    expect(key(baseQuery({ metric: { op: 'countNotEmpty', fieldRef: ref('subject') } }))).not.toBe(
+      base
+    )
+    expect(key(baseQuery({ groupBy: { fieldRef: ref('status') } }))).not.toBe(base)
+    expect(key(baseQuery({ limit: 5 }))).not.toBe(base)
+  })
+
+  it('forks on group-by granularity/sort while defaults stay stable', () => {
+    const day = key(baseQuery({ groupBy: { fieldRef: ref('createdAt'), dateGranularity: 'day' } }))
+    const week = key(
+      baseQuery({ groupBy: { fieldRef: ref('createdAt'), dateGranularity: 'week' } })
+    )
+    expect(day).not.toBe(week)
+  })
+
+  it('forks on resolved filter values (viewer-resolved `me` placeholders)', () => {
+    const userA = key(baseQuery({ filters: assigneeFilter('user_a') }))
+    const userB = key(baseQuery({ filters: assigneeFilter('user_b') }))
+    expect(userA).not.toBe(userB)
+  })
+
+  it('ignores condition/group ids and group metadata (UI bookkeeping)', () => {
+    const a = baseQuery({ filters: assigneeFilter('user_a', 'g1', 'c1') })
+    const b = baseQuery({ filters: assigneeFilter('user_a', 'g2', 'c2') })
+    const withMeta = structuredClone(b)
+    withMeta.filters![0]!.metadata = { collapsed: true }
+    withMeta.filters![0]!.order = 3
+    expect(key(a)).toBe(key(b))
+    expect(key(a)).toBe(key(withMeta))
+  })
+
+  it('forks on kind and on KPI trend compare', () => {
+    const agg = key(baseQuery())
+    const kpi = key(baseQuery(), { kind: 'kpi' })
+    const kpiTrend = key(baseQuery(), { kind: 'kpi', compare: 'previousPeriod' })
+    expect(kpi).not.toBe(agg)
+    expect(kpiTrend).not.toBe(kpi)
+  })
+})

--- a/packages/lib/src/resources/aggregate/cache-key.ts
+++ b/packages/lib/src/resources/aggregate/cache-key.ts
@@ -1,0 +1,78 @@
+// packages/lib/src/resources/aggregate/cache-key.ts
+//
+// Pure cache-key derivation for the aggregate result cache. Callers MUST pass
+// the query with filters already run through `resolveConditionContext` — that
+// is what makes `{{me}}` placeholders fork keys per viewer while everything
+// else shares across users (aggregates have no row-level permissions).
+// The identity object is normalized to JSON primitives — Dates → ISO strings,
+// absent optionals → null — so the hash can't fork on undefined-vs-missing or
+// on Date serialization quirks.
+//
+// Anything added to `AggregateQuery` later MUST either join this identity or
+// be provably display-irrelevant.
+
+import { stableHash } from '@auxx/utils/hash'
+import type { Condition, ConditionGroup } from '../../conditions'
+import type { GroupBy, TrendCompare } from '../../dashboards/client'
+import type { AggregateQuery } from './types'
+
+/** Drop per-condition UI bookkeeping (ids, metadata) — it never affects results. */
+function conditionIdentity(c: Condition): Record<string, unknown> {
+  const { id: _id, metadata: _metadata, subConditions, ...rest } = c
+  return {
+    ...rest,
+    subConditions: subConditions?.length ? subConditions.map(conditionIdentity) : null,
+  }
+}
+
+function filterIdentity(groups: ConditionGroup[]): unknown[] {
+  return groups.map((g) => ({
+    logicalOperator: g.logicalOperator,
+    conditions: g.conditions.map(conditionIdentity),
+  }))
+}
+
+function groupIdentity(g: GroupBy | undefined) {
+  if (!g) return null
+  return {
+    fieldRef: g.fieldRef,
+    dateGranularity: g.dateGranularity ?? null,
+    sort: g.sort ?? null,
+    limit: g.limit ?? null,
+    omitEmpty: g.omitEmpty ?? null,
+  }
+}
+
+/**
+ * Cache key for one aggregate run: `{orgId}:{sha256}`. The org prefix keeps a
+ * per-org flush possible via pattern invalidation.
+ */
+export function aggregateCacheKey(params: {
+  kind: 'agg' | 'kpi'
+  organizationId: string
+  /** Query with filters ALREADY context-resolved (viewer placeholders substituted). */
+  query: AggregateQuery
+  /** KPI trend comparison — forks the key because it derives a second window. */
+  compare?: TrendCompare | null
+}): string {
+  const { kind, organizationId, query, compare } = params
+  const identity = {
+    kind,
+    source: query.source,
+    metric: { op: query.metric.op, fieldRef: query.metric.fieldRef ?? null },
+    groupBy: groupIdentity(query.groupBy),
+    secondaryGroupBy: groupIdentity(query.secondaryGroupBy),
+    filters: filterIdentity(query.filters ?? []),
+    dateWindow: query.dateWindow
+      ? {
+          fieldRef: query.dateWindow.fieldRef,
+          from: query.dateWindow.from?.toISOString() ?? null,
+          to: query.dateWindow.to?.toISOString() ?? null,
+        }
+      : null,
+    timezone: query.timezone || 'UTC',
+    limit: query.limit ?? null,
+    compare: compare ?? null,
+  }
+  return `${organizationId}:${stableHash(identity)}`
+}

--- a/packages/lib/src/resources/aggregate/index.ts
+++ b/packages/lib/src/resources/aggregate/index.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/resources/aggregate/index.ts
 
+export { aggregateCacheKey } from './cache-key'
 export {
   bucketRange,
   enumerateBuckets,
@@ -7,7 +8,7 @@ export {
   isCyclicGranularity,
 } from './date-buckets'
 export { EMPTY_LABEL, resolveGroupLabels } from './group-labels'
-export { OTHER_SERIES_KEY, runAggregate, runKpi } from './run-aggregate'
+export { type AggregateRunOptions, OTHER_SERIES_KEY, runAggregate, runKpi } from './run-aggregate'
 export {
   isSystemAggregateTable,
   SYSTEM_AGGREGATE_TABLE_IDS,

--- a/packages/lib/src/resources/aggregate/run-aggregate.int.test.ts
+++ b/packages/lib/src/resources/aggregate/run-aggregate.int.test.ts
@@ -1,9 +1,10 @@
 // packages/lib/src/resources/aggregate/run-aggregate.int.test.ts
 //
 // DB-backed behavior tests for the aggregate engine (vitest.integration.config.ts
-// → auxx_test database). Field metadata comes from a mocked org cache (the
-// engine's only cache dependency); rows are seeded directly through Drizzle.
-// SQL behavior is asserted through results, never through SQL strings.
+// → auxx_test database). Field metadata comes from a mocked org cache, and the
+// aggregate result cache is a deterministic in-memory stub (no Redis in tests);
+// rows are seeded directly through Drizzle. SQL behavior is asserted through
+// results, never through SQL strings.
 
 import { type Database, schema } from '@auxx/database'
 import { createTestOrganization, createTestUser, getTestDb } from '@auxx/test-utils'
@@ -24,6 +25,7 @@ const h = vi.hoisted(() => ({
   members: [] as unknown[],
   agents: [] as unknown[],
   groups: [] as unknown[],
+  aggCache: new Map<string, { result: unknown; computedAt: number }>(),
 }))
 
 vi.mock('../../cache', async (importOriginal) => {
@@ -35,6 +37,13 @@ vi.mock('../../cache', async (importOriginal) => {
     getCachedMembers: async () => h.members,
     getCachedAgents: async () => h.agents,
     getCachedGroups: async () => h.groups,
+    // Deterministic stand-in for the aggregate result cache (no Redis here).
+    getAggregateCache: () => ({
+      read: async (key: string) => h.aggCache.get(key) ?? null,
+      write: async (key: string, result: unknown) => {
+        h.aggCache.set(key, { result, computedAt: Date.now() })
+      },
+    }),
   }
 })
 
@@ -161,6 +170,7 @@ async function setupPlayground() {
   h.members = []
   h.agents = []
   h.groups = []
+  h.aggCache.clear()
 
   const org = await createTestOrganization()
   const def = await seedDef(org.id)
@@ -775,6 +785,67 @@ describe('runKpi', () => {
       trend: { compare: 'previousPeriod' },
     })
     expect(result._unsafeUnwrap()).toEqual({ value: 1 })
+  })
+})
+
+describe('aggregate result cache', () => {
+  let p: Awaited<ReturnType<typeof setupPlayground>>
+
+  beforeEach(async () => {
+    p = await setupPlayground()
+  })
+
+  async function seedStatusRecord(name: string) {
+    const instance = await seedInstance(p.org.id, p.def.id, name)
+    await seedValue({
+      orgId: p.org.id,
+      defId: p.def.id,
+      entityId: instance.id,
+      fieldId: p.fieldIds.status,
+      optionId: 's1',
+    })
+  }
+
+  it('serves repeat calls from cache; skipCache recomputes and repopulates', async () => {
+    await seedStatusRecord('A')
+    const query = p.baseQuery({ groupBy: { fieldRef: p.ref(p.fieldIds.status) } })
+
+    const first = (await runAggregate(db(), p.org.id, undefined, query))._unsafeUnwrap()
+    expect(first.totalValue).toBe(1)
+    expect(h.aggCache.size).toBe(1)
+
+    // Mutate the data — a cached re-run must NOT see it.
+    await seedStatusRecord('B')
+    const cached = (await runAggregate(db(), p.org.id, undefined, query))._unsafeUnwrap()
+    expect(cached).toEqual(first)
+
+    // skipCache bypasses the read but still writes the fresh result back.
+    const fresh = (
+      await runAggregate(db(), p.org.id, undefined, query, { skipCache: true })
+    )._unsafeUnwrap()
+    expect(fresh.totalValue).toBe(2)
+    const afterRefresh = (await runAggregate(db(), p.org.id, undefined, query))._unsafeUnwrap()
+    expect(afterRefresh).toEqual(fresh)
+  })
+
+  it('never caches errors', async () => {
+    const result = await runAggregate(
+      db(),
+      p.org.id,
+      undefined,
+      p.baseQuery({ metric: { op: 'sum' } })
+    )
+    expect(result.isErr()).toBe(true)
+    expect(h.aggCache.size).toBe(0)
+  })
+
+  it('kpi entries key on the trend compare', async () => {
+    const base = p.baseQuery({})
+    ;(await runKpi(db(), p.org.id, undefined, { base }))._unsafeUnwrap()
+    ;(
+      await runKpi(db(), p.org.id, undefined, { base, trend: { compare: 'previousPeriod' } })
+    )._unsafeUnwrap()
+    expect(h.aggCache.size).toBe(2)
   })
 })
 

--- a/packages/lib/src/resources/aggregate/run-aggregate.ts
+++ b/packages/lib/src/resources/aggregate/run-aggregate.ts
@@ -19,7 +19,7 @@ import {
 } from '@auxx/types/field'
 import { type SQL, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
-import { getCachedResourceFields } from '../../cache'
+import { getAggregateCache, getCachedResourceFields, PromiseMemoizer } from '../../cache'
 import { type ConditionGroup, resolveConditionContext } from '../../conditions'
 import {
   DEFAULT_GROUP_LIMIT,
@@ -37,6 +37,7 @@ import { systemConditionBuilder } from '../../workflow-engine/query-builder/syst
 import { extractRequiredRelatedEntities } from '../crud/unified-handler-queries'
 import { isValidTableId, type TableId } from '../registry/field-registry'
 import { getFieldOutputKey, type ResourceField } from '../registry/field-types'
+import { aggregateCacheKey } from './cache-key'
 import { enumerateBuckets, isCyclicGranularity } from './date-buckets'
 import { type AggregateRow, buildEntityAggregateSql } from './entity-aggregate-builder'
 import { EMPTY_LABEL, resolveGroupLabels } from './group-labels'
@@ -63,6 +64,13 @@ const FETCH_CAP_MATRIX = 5000
 /** Max distinct secondary-series values; overflow buckets into `__other`. */
 const MAX_SERIES = 10
 export const OTHER_SERIES_KEY = '__other'
+
+/** Skip the cache READ (still writes) — plumbed for the widget refresh button. */
+export type AggregateRunOptions = { skipCache?: boolean }
+
+/** In-flight dedup: N concurrent identical queries in one process run 1 compute. */
+const aggregateInflight = new PromiseMemoizer<Result<AggregateResult, Error>>()
+const kpiInflight = new PromiseMemoizer<Result<KpiResult, Error>>()
 
 const NUMERIC_FIELD_TYPES = new Set<FieldType>(['NUMBER', 'CURRENCY'])
 const GRANULARITY_FIELD_TYPES = new Set<FieldType>(['DATE', 'DATETIME'])
@@ -241,7 +249,8 @@ type PreparedAggregate = {
 
 async function prepareAggregate(
   organizationId: string,
-  userId: string | undefined,
+  /** Filters already run through `resolveConditionContext` (also the cache-key input). */
+  resolvedFilters: ConditionGroup[],
   query: AggregateQuery
 ): Promise<Result<PreparedAggregate, Error>> {
   const timezone = query.timezone || 'UTC'
@@ -321,9 +330,7 @@ async function prepareAggregate(
   }
 
   // Filters → WHERE fragment
-  const filters: ConditionGroup[] = resolveConditionContext(query.filters ?? [], {
-    currentUserId: userId,
-  })
+  const filters = resolvedFilters
 
   let conditionsWhere: SQL | undefined
   if (query.source.kind === 'entity') {
@@ -492,166 +499,238 @@ function sortGroups(groups: AggregateGroup[], groupBy: ResolvedGroupBy): Aggrega
  * Run a grouped aggregate query. Group keys stay RAW (drill-down rebuilds
  * segment conditions from them); labels are display-only. Without a `groupBy`
  * the result carries the single value in `totalValue` with no groups.
+ *
+ * Results are cached for a short TTL keyed on the RESOLVED query (viewer
+ * placeholders substituted, timezone included) — safe to share across users
+ * because aggregates carry no row-level permissions. Errors are never cached;
+ * `opts.skipCache` bypasses the read but still writes (refresh = repopulate).
  */
 export async function runAggregate(
   db: Database,
   organizationId: string,
   userId: string | undefined,
-  query: AggregateQuery
+  query: AggregateQuery,
+  opts?: AggregateRunOptions
 ): Promise<Result<AggregateResult, Error>> {
   try {
-    const prepared = await prepareAggregate(organizationId, userId, query)
-    if (prepared.isErr()) return err(prepared.error)
-    const {
-      buildSql,
-      groupBy,
-      secondaryGroupBy,
-      windowField,
-      windowBounds,
-      fetchCap,
-      timezone,
-      limit,
-    } = prepared.value
-
-    const rows = await executeAggregate(db, buildSql(windowBounds))
-
-    if (!groupBy) {
-      const value = toNumber(rows[0]?.value)
-      return ok({ groups: [], totalValue: value, hasMoreGroups: false })
-    }
-
-    const overflow = rows.length > fetchCap
-    const { groups: shaped, seriesTotals } = shapeRows(
-      overflow ? rows.slice(0, fetchCap) : rows,
-      Boolean(secondaryGroupBy)
-    )
-
-    // Zero-fill date buckets: cyclic granularities always fill their key space;
-    // calendar buckets fill only when the window is bounded AND bound to the
-    // same field we group by (otherwise the axis range is unknowable).
-    if (groupBy.dateGranularity) {
-      const sameField =
-        windowField && fieldRefToKey(windowField.ref) === fieldRefToKey(groupBy.field.ref)
-      const bounded = Boolean(windowBounds?.from && windowBounds?.to)
-      let fillKeys: string[] | undefined
-      if (isCyclicGranularity(groupBy.dateGranularity)) {
-        fillKeys = enumerateBuckets(new Date(0), new Date(0), groupBy.dateGranularity, timezone)
-      } else if (sameField && bounded && windowBounds?.from && windowBounds.to) {
-        fillKeys = enumerateBuckets(
-          windowBounds.from,
-          windowBounds.to,
-          groupBy.dateGranularity,
-          timezone
-        )
-      }
-      if (fillKeys) {
-        const present = new Set(shaped.map((g) => g.key))
-        for (const key of fillKeys) {
-          if (!present.has(key)) shaped.push({ key, value: 0 })
-        }
-      }
-    }
-
-    // Labels (batched per dimension)
-    const primaryLabels = await resolveGroupLabels({
-      db,
+    const resolvedFilters = resolveConditionContext(query.filters ?? [], {
+      currentUserId: userId,
+    })
+    const cacheKey = aggregateCacheKey({
+      kind: 'agg',
       organizationId,
-      groupBy,
-      keys: shaped.map((g) => g.key),
-    })
-    let seriesLabels: Map<string | null, string> | undefined
-    let rankedSeriesKeys: Array<string | null> | undefined
-    if (secondaryGroupBy) {
-      // Global series ranking → top N keys keep their identity, the rest fold
-      // into a single `__other` series so stacked charts stay readable.
-      const ranked = [...seriesTotals.entries()].sort((a, b) => b[1] - a[1]).map(([k]) => k)
-      rankedSeriesKeys = ranked.slice(0, MAX_SERIES)
-      seriesLabels = await resolveGroupLabels({
-        db,
-        organizationId,
-        groupBy: secondaryGroupBy,
-        keys: rankedSeriesKeys,
-      })
-    }
-
-    const labeled: AggregateGroup[] = shaped.map((g) => {
-      const group: AggregateGroup = {
-        key: g.key,
-        label: primaryLabels.get(g.key) ?? g.key ?? EMPTY_LABEL,
-        value: g.value,
-      }
-      if (secondaryGroupBy && rankedSeriesKeys && seriesLabels) {
-        const kept = new Map<string | null, number>()
-        let otherTotal = 0
-        for (const [seriesKey, value] of g.series ?? []) {
-          if (rankedSeriesKeys.includes(seriesKey)) {
-            kept.set(seriesKey, value)
-          } else {
-            otherTotal += value
-          }
-        }
-        group.series = rankedSeriesKeys
-          .filter((k) => kept.has(k))
-          .map((k) => ({
-            key: k,
-            label: seriesLabels?.get(k) ?? k ?? EMPTY_LABEL,
-            value: kept.get(k) ?? 0,
-          }))
-        if (otherTotal > 0) {
-          group.series.push({ key: OTHER_SERIES_KEY, label: 'Other', value: otherTotal })
-        }
-      }
-      return group
+      query: { ...query, filters: resolvedFilters },
     })
 
-    const sorted = sortGroups(labeled, groupBy)
-    const totalValue = sorted.reduce((sum, g) => sum + g.value, 0)
-    const hasMoreGroups = overflow || sorted.length > limit
-
-    return ok({ groups: sorted.slice(0, limit), totalValue, hasMoreGroups })
+    return await aggregateInflight.memoize(cacheKey, async () => {
+      if (!opts?.skipCache) {
+        const hit = await getAggregateCache().read<AggregateResult>(cacheKey)
+        if (hit) {
+          logger.debug(`chart aggregate cache hit [${cacheKey}]`)
+          return ok(hit.result)
+        }
+      }
+      const result = await computeAggregate(db, organizationId, resolvedFilters, query)
+      if (result.isOk()) {
+        await getAggregateCache().write(cacheKey, result.value)
+      }
+      return result
+    })
   } catch (error) {
     logger.error(`runAggregate failed: ${error instanceof Error ? error.message : error}`)
     return err(error instanceof Error ? error : new Error(String(error)))
   }
 }
 
+async function computeAggregate(
+  db: Database,
+  organizationId: string,
+  resolvedFilters: ConditionGroup[],
+  query: AggregateQuery
+): Promise<Result<AggregateResult, Error>> {
+  const prepared = await prepareAggregate(organizationId, resolvedFilters, query)
+  if (prepared.isErr()) return err(prepared.error)
+  const {
+    buildSql,
+    groupBy,
+    secondaryGroupBy,
+    windowField,
+    windowBounds,
+    fetchCap,
+    timezone,
+    limit,
+  } = prepared.value
+
+  const rows = await executeAggregate(db, buildSql(windowBounds))
+
+  if (!groupBy) {
+    const value = toNumber(rows[0]?.value)
+    return ok({ groups: [], totalValue: value, hasMoreGroups: false })
+  }
+
+  const overflow = rows.length > fetchCap
+  const { groups: shaped, seriesTotals } = shapeRows(
+    overflow ? rows.slice(0, fetchCap) : rows,
+    Boolean(secondaryGroupBy)
+  )
+
+  // Zero-fill date buckets: cyclic granularities always fill their key space;
+  // calendar buckets fill only when the window is bounded AND bound to the
+  // same field we group by (otherwise the axis range is unknowable).
+  if (groupBy.dateGranularity) {
+    const sameField =
+      windowField && fieldRefToKey(windowField.ref) === fieldRefToKey(groupBy.field.ref)
+    const bounded = Boolean(windowBounds?.from && windowBounds?.to)
+    let fillKeys: string[] | undefined
+    if (isCyclicGranularity(groupBy.dateGranularity)) {
+      fillKeys = enumerateBuckets(new Date(0), new Date(0), groupBy.dateGranularity, timezone)
+    } else if (sameField && bounded && windowBounds?.from && windowBounds.to) {
+      fillKeys = enumerateBuckets(
+        windowBounds.from,
+        windowBounds.to,
+        groupBy.dateGranularity,
+        timezone
+      )
+    }
+    if (fillKeys) {
+      const present = new Set(shaped.map((g) => g.key))
+      for (const key of fillKeys) {
+        if (!present.has(key)) shaped.push({ key, value: 0 })
+      }
+    }
+  }
+
+  // Labels (batched per dimension)
+  const primaryLabels = await resolveGroupLabels({
+    db,
+    organizationId,
+    groupBy,
+    keys: shaped.map((g) => g.key),
+  })
+  let seriesLabels: Map<string | null, string> | undefined
+  let rankedSeriesKeys: Array<string | null> | undefined
+  if (secondaryGroupBy) {
+    // Global series ranking → top N keys keep their identity, the rest fold
+    // into a single `__other` series so stacked charts stay readable.
+    const ranked = [...seriesTotals.entries()].sort((a, b) => b[1] - a[1]).map(([k]) => k)
+    rankedSeriesKeys = ranked.slice(0, MAX_SERIES)
+    seriesLabels = await resolveGroupLabels({
+      db,
+      organizationId,
+      groupBy: secondaryGroupBy,
+      keys: rankedSeriesKeys,
+    })
+  }
+
+  const labeled: AggregateGroup[] = shaped.map((g) => {
+    const group: AggregateGroup = {
+      key: g.key,
+      label: primaryLabels.get(g.key) ?? g.key ?? EMPTY_LABEL,
+      value: g.value,
+    }
+    if (secondaryGroupBy && rankedSeriesKeys && seriesLabels) {
+      const kept = new Map<string | null, number>()
+      let otherTotal = 0
+      for (const [seriesKey, value] of g.series ?? []) {
+        if (rankedSeriesKeys.includes(seriesKey)) {
+          kept.set(seriesKey, value)
+        } else {
+          otherTotal += value
+        }
+      }
+      group.series = rankedSeriesKeys
+        .filter((k) => kept.has(k))
+        .map((k) => ({
+          key: k,
+          label: seriesLabels?.get(k) ?? k ?? EMPTY_LABEL,
+          value: kept.get(k) ?? 0,
+        }))
+      if (otherTotal > 0) {
+        group.series.push({ key: OTHER_SERIES_KEY, label: 'Other', value: otherTotal })
+      }
+    }
+    return group
+  })
+
+  const sorted = sortGroups(labeled, groupBy)
+  const totalValue = sorted.reduce((sum, g) => sum + g.value, 0)
+  const hasMoreGroups = overflow || sorted.length > limit
+
+  return ok({ groups: sorted.slice(0, limit), totalValue, hasMoreGroups })
+}
+
 /**
  * Run a single-value aggregate (KPI/gauge), optionally with a trend comparison.
  * Trend requires a BOUNDED window — when the resolved window is unbounded the
  * previous-window query is skipped and `previousValue` stays undefined (the UI
- * hides the trend). No fallback window is invented.
+ * hides the trend). No fallback window is invented. Cached like `runAggregate`
+ * (trend compare is part of the key).
  */
 export async function runKpi(
   db: Database,
   organizationId: string,
   userId: string | undefined,
-  params: { base: AggregateQuery; trend?: TrendSpec }
+  params: { base: AggregateQuery; trend?: TrendSpec },
+  opts?: AggregateRunOptions
 ): Promise<Result<KpiResult, Error>> {
   try {
     const base: AggregateQuery = { ...params.base, groupBy: undefined, secondaryGroupBy: undefined }
-    const prepared = await prepareAggregate(organizationId, userId, base)
-    if (prepared.isErr()) return err(prepared.error)
-    const { buildSql, windowBounds, timezone } = prepared.value
+    const resolvedFilters = resolveConditionContext(base.filters ?? [], {
+      currentUserId: userId,
+    })
+    const cacheKey = aggregateCacheKey({
+      kind: 'kpi',
+      organizationId,
+      query: { ...base, filters: resolvedFilters },
+      compare: params.trend?.compare ?? null,
+    })
 
-    const trendWindows = params.trend
-      ? deriveTrendWindows(windowBounds ?? {}, params.trend.compare, timezone)
-      : undefined
-
-    if (!trendWindows) {
-      const rows = await executeAggregate(db, buildSql(windowBounds))
-      return ok({ value: toNumber(rows[0]?.value) })
-    }
-
-    const [currentRows, previousRows] = await Promise.all([
-      executeAggregate(db, buildSql(trendWindows.current)),
-      executeAggregate(db, buildSql(trendWindows.previous)),
-    ])
-    return ok({
-      value: toNumber(currentRows[0]?.value),
-      previousValue: toNumber(previousRows[0]?.value),
+    return await kpiInflight.memoize(cacheKey, async () => {
+      if (!opts?.skipCache) {
+        const hit = await getAggregateCache().read<KpiResult>(cacheKey)
+        if (hit) {
+          logger.debug(`kpi aggregate cache hit [${cacheKey}]`)
+          return ok(hit.result)
+        }
+      }
+      const result = await computeKpi(db, organizationId, resolvedFilters, base, params.trend)
+      if (result.isOk()) {
+        await getAggregateCache().write(cacheKey, result.value)
+      }
+      return result
     })
   } catch (error) {
     logger.error(`runKpi failed: ${error instanceof Error ? error.message : error}`)
     return err(error instanceof Error ? error : new Error(String(error)))
   }
+}
+
+async function computeKpi(
+  db: Database,
+  organizationId: string,
+  resolvedFilters: ConditionGroup[],
+  base: AggregateQuery,
+  trend: TrendSpec | undefined
+): Promise<Result<KpiResult, Error>> {
+  const prepared = await prepareAggregate(organizationId, resolvedFilters, base)
+  if (prepared.isErr()) return err(prepared.error)
+  const { buildSql, windowBounds, timezone } = prepared.value
+
+  const trendWindows = trend
+    ? deriveTrendWindows(windowBounds ?? {}, trend.compare, timezone)
+    : undefined
+
+  if (!trendWindows) {
+    const rows = await executeAggregate(db, buildSql(windowBounds))
+    return ok({ value: toNumber(rows[0]?.value) })
+  }
+
+  const [currentRows, previousRows] = await Promise.all([
+    executeAggregate(db, buildSql(trendWindows.current)),
+    executeAggregate(db, buildSql(trendWindows.previous)),
+  ])
+  return ok({
+    value: toNumber(currentRows[0]?.value),
+    previousValue: toNumber(previousRows[0]?.value),
+  })
 }

--- a/packages/lib/src/resources/aggregate/types.ts
+++ b/packages/lib/src/resources/aggregate/types.ts
@@ -27,6 +27,10 @@ export type AggregateDateWindow = { fieldRef: WidgetFieldRef; from?: Date; to?: 
 /**
  * One aggregate query — what `widget-query.ts` produces from a widget config
  * and what `runAggregate`/`runKpi` consume. Field refs stay branded here.
+ *
+ * ⚠️ This type is the result-cache identity surface: any field added here must
+ * either join the identity object in `cache-key.ts` or be provably
+ * display-irrelevant (display-only config never reaches this type by design).
  */
 export type AggregateQuery = {
   /** Entity def or system table. */


### PR DESCRIPTION
## Problem

Every `dashboard.chartData` / `kpiData` call runs fresh SQL — one EAV aggregate query per chart (`LEFT JOIN "FieldValue"` per referenced field + `GROUP BY`), two for KPI-with-trend. A 12-widget tab fires 12+ concurrent scans **per viewer**, re-fired on tab switches and by every teammate viewing the same dashboard. The only mitigation was the client's 30s React Query `staleTime`, which does nothing across users or mounts.

## Approach (plans/dashboard/16-aggregate-cache.md)

Cache the final shaped `AggregateResult`/`KpiResult` **inside the engine** (`runAggregate`/`runKpi`), so any caller benefits:

- **`AggregateCacheService`** — `BaseCacheService` subclass (prefix `agg`), **60s TTL, no write invalidation** (FieldValue writes are far too frequent to invalidate on; dashboards tolerate a minute of staleness). No tag sets — keys embed the orgId, so a per-org flush is `flushOrganization()` via pattern invalidation. Envelope carries `computedAt` for a future "updated Ns ago" affordance.
- **`aggregateCacheKey()`** — `{orgId}:{stableHash(identity)}` over the **resolved** query: filters run through `resolveConditionContext` first (hoisted out of `prepareAggregate`), so `me` placeholders fork keys per viewer; viewer timezone included; Dates→ISO, `undefined`→`null`; condition/group ids + metadata stripped (client-generated UI bookkeeping that never affects results). Cross-user sharing is safe because aggregates have **no row-level permissions** — dashboard view access stays enforced in the router, above the cache.
- **`runAggregate`/`runKpi`** are now thin cached wrappers over extracted `computeAggregate`/`computeKpi`: `PromiseMemoizer` in-flight dedup (N concurrent identical queries → 1 compute per process) → cache read → compute → **write only on success** (errors can never be cached). New `opts.skipCache` bypasses the read but still repopulates — plumbed through `widgetDataInputSchema` for the future per-widget refresh button (plan 08); it must never enter the client React Query key.
- **`BaseCacheService` memory-map pruning** — the in-memory mirror was an unbounded `Map` (only shed entries on expired re-reads). Past 1000 entries it now sweeps expired entries, then evicts oldest-created down to a 0.9 watermark so a map at capacity doesn't re-sort on every write. Behavior-neutral for fixed-key services.

Out of scope by locked decision: record-list widgets (cheap id-page query, realtime-hydrated, staleness too visible), write invalidation, distributed compute lock, refresh-button UI.

## Testing

- 9 `cache-key` unit tests (determinism, key-order/Date/undefined normalization, forks on org/timezone/metric/filters/kind/trend-compare, UI-bookkeeping invariance)
- 3 `BaseCacheService` pruning unit tests
- 3 new DB integration tests: cached repeat call ignores a data mutation → `skipCache` recomputes and repopulates; errors never cached; KPI keys fork on trend compare — full int suite **24/24 green**
- Biome clean, `@auxx/lib` rebuilt

**Live-verify pending:** open a dashboard and watch `aggregate-engine` hit/miss lines in OpenObserve (reload <60s → hits; second user → hits; >60s → misses).