### PR TITLE
feat(dashboards): gate record drawer fullscreen by detail-page support

### DIFF
--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -37,7 +37,7 @@ import { CommandContext, RecordCommandActions } from '~/components/kbar/contextu
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions'
 import { MergeDialog } from '~/components/merge'
-import { useRecord, useResource } from '~/components/resources'
+import { resourceHasDetailPage, useRecord, useResource } from '~/components/resources'
 import { useFieldValue } from '~/components/resources/hooks/use-field-values'
 import { AvatarUploadIcon } from '~/components/resources/ui/avatar-upload-icon'
 import { RecordIcon } from '~/components/resources/ui/record-icon'
@@ -396,12 +396,15 @@ export const RecordDrawer = React.memo(function RecordDrawer({
               </Tooltip>
             )}
 
-            {/* Expand to full page */}
-            <Tooltip content='Open full page'>
-              <Button variant='ghost' size='icon-xs' onClick={handleExpand}>
-                <Expand />
-              </Button>
-            </Tooltip>
+            {/* Expand to full page — only for types that have a detail page
+                (no catch-all route; page-less system types would 404) */}
+            {resource && resourceHasDetailPage(resource) && (
+              <Tooltip content='Open full page'>
+                <Button variant='ghost' size='icon-xs' onClick={handleExpand}>
+                  <Expand />
+                </Button>
+              </Tooltip>
+            )}
           </>
         }
         cardContent={

--- a/apps/web/src/components/resources/index.ts
+++ b/apps/web/src/components/resources/index.ts
@@ -47,4 +47,9 @@ export {
 } from './store'
 
 // Utilities
-export { type GetRecordLinkOptions, getRecordLink, useRecordLink } from './utils'
+export {
+  type GetRecordLinkOptions,
+  getRecordLink,
+  resourceHasDetailPage,
+  useRecordLink,
+} from './utils'

--- a/apps/web/src/components/resources/utils/get-record-link.ts
+++ b/apps/web/src/components/resources/utils/get-record-link.ts
@@ -2,10 +2,25 @@
 
 'use client'
 
+import { type ModelType, ModelTypeMeta } from '@auxx/database/enums'
 import type { RecordId, Resource } from '@auxx/lib/resources/client'
 import { getDefinitionId, parseRecordId } from '@auxx/lib/resources/client'
 import { useMemo } from 'react'
 import { useResourceStore } from '../store/resource-store'
+
+/**
+ * Whether a resource has a full `/app/<apiSlug>/<id>` detail page.
+ *
+ * There is no catch-all route — each system type's page is a hand-authored folder,
+ * so most system types (thread, message, article, meeting, …) have none and would
+ * 404. Custom entity defs always have the generic `custom/[slug]/[id]` page. The
+ * flag for system types lives on `ModelTypeMeta.hasDetailPage` (single source of
+ * truth). Gates the record drawer's fullscreen button and the link builders below.
+ */
+export function resourceHasDetailPage(resource: Resource): boolean {
+  if (!resource.entityType) return true // custom → generic custom/[slug]/[id] route
+  return ModelTypeMeta[resource.entityType as ModelType]?.hasDetailPage ?? false
+}
 
 /**
  * Options for generating record links
@@ -66,7 +81,8 @@ export interface GetRecordLinkOptions {
  * @param recordId - RecordId in format "entityDefinitionId:entityInstanceId"
  * @param resource - The resource object (system or custom)
  * @param options - Optional configuration for the link
- * @returns The URL path
+ * @returns The URL path, or `null` when the resource has no detail page
+ *   (see {@link resourceHasDetailPage}) so callers can skip rendering a dead link
  *
  * @example
  * // Basic usage
@@ -93,7 +109,10 @@ export function getRecordLink(
   recordId: RecordId,
   resource: Resource,
   options: GetRecordLinkOptions = {}
-): string {
+): string | null {
+  // No detail page for this type → no link (avoids navigating to a 404).
+  if (!resourceHasDetailPage(resource)) return null
+
   const { entityInstanceId } = parseRecordId(recordId)
 
   // Build base path - system entities (with entityType) use /app/<slug>, custom use /app/custom/<slug>

--- a/apps/web/src/components/resources/utils/index.ts
+++ b/apps/web/src/components/resources/utils/index.ts
@@ -4,6 +4,8 @@ export type { GetRecordLinkOptions } from './get-record-link'
 export {
   // Pure function (requires resource object)
   getRecordLink,
+  // Predicate: does this resource have a full detail page?
+  resourceHasDetailPage,
   // Hook (auto-fetches resource from provider)
   useRecordLink,
 } from './get-record-link'

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -154,7 +154,22 @@ export const ModelTypes = {
  */
 export const ModelTypeMeta: Record<
   ModelType,
-  { label: string; plural: string; icon: string; color: string; apiSlug: string; dbTable: string }
+  {
+    label: string
+    plural: string
+    icon: string
+    color: string
+    apiSlug: string
+    dbTable: string
+    /**
+     * Whether this type has a full `/app/<apiSlug>/<id>` detail page (hand-authored
+     * route folder — there is no catch-all). Gates the record drawer's fullscreen
+     * button and the `getRecordLink`/`recordHref` builders via `resourceHasDetailPage`.
+     * Custom entity defs always have a page (generic `custom/[slug]/[id]`) and are
+     * handled in that helper, not here.
+     */
+    hasDetailPage: boolean
+  }
 > = {
   contact: {
     label: 'Contact',
@@ -163,6 +178,7 @@ export const ModelTypeMeta: Record<
     color: 'indigo',
     apiSlug: 'contacts',
     dbTable: 'Contact',
+    hasDetailPage: true,
   },
   ticket: {
     label: 'Ticket',
@@ -171,6 +187,7 @@ export const ModelTypeMeta: Record<
     color: 'blue',
     apiSlug: 'tickets',
     dbTable: 'Ticket',
+    hasDetailPage: true,
   },
   thread: {
     label: 'Thread',
@@ -179,6 +196,7 @@ export const ModelTypeMeta: Record<
     color: 'purple',
     apiSlug: 'threads',
     dbTable: 'Thread',
+    hasDetailPage: false,
   },
   user: {
     label: 'User',
@@ -187,6 +205,7 @@ export const ModelTypeMeta: Record<
     color: 'green',
     apiSlug: 'users',
     dbTable: 'User',
+    hasDetailPage: false,
   },
   inbox: {
     label: 'Inbox',
@@ -195,6 +214,7 @@ export const ModelTypeMeta: Record<
     color: 'indigo',
     apiSlug: 'inboxes',
     dbTable: 'Inbox',
+    hasDetailPage: false,
   },
   message: {
     label: 'Message',
@@ -203,6 +223,7 @@ export const ModelTypeMeta: Record<
     color: 'teal',
     apiSlug: 'messages',
     dbTable: 'Message',
+    hasDetailPage: false,
   },
   participant: {
     label: 'Participant',
@@ -211,6 +232,7 @@ export const ModelTypeMeta: Record<
     color: 'amber',
     apiSlug: 'participants',
     dbTable: 'Participant',
+    hasDetailPage: false,
   },
   dataset: {
     label: 'Dataset',
@@ -219,6 +241,7 @@ export const ModelTypeMeta: Record<
     color: 'purple',
     apiSlug: 'datasets',
     dbTable: 'Dataset',
+    hasDetailPage: true,
   },
   entity: {
     label: 'Entity',
@@ -227,6 +250,7 @@ export const ModelTypeMeta: Record<
     color: 'gray',
     apiSlug: 'entities',
     dbTable: 'EntityInstance',
+    hasDetailPage: false,
   },
   part: {
     label: 'Part',
@@ -235,6 +259,7 @@ export const ModelTypeMeta: Record<
     color: 'orange',
     apiSlug: 'parts',
     dbTable: 'EntityInstance',
+    hasDetailPage: true,
   },
   vendor_part: {
     label: 'Vendor Part',
@@ -243,6 +268,7 @@ export const ModelTypeMeta: Record<
     color: 'orange',
     apiSlug: 'vendor-parts',
     dbTable: 'EntityInstance',
+    hasDetailPage: false,
   },
   subpart: {
     label: 'Subpart',
@@ -251,6 +277,7 @@ export const ModelTypeMeta: Record<
     color: 'orange',
     apiSlug: 'subparts',
     dbTable: 'EntityInstance',
+    hasDetailPage: false,
   },
   stock_movement: {
     label: 'Stock Movement',
@@ -259,6 +286,7 @@ export const ModelTypeMeta: Record<
     color: 'emerald',
     apiSlug: 'stock-movements',
     dbTable: 'EntityInstance',
+    hasDetailPage: false,
   },
   company: {
     label: 'Company',
@@ -267,6 +295,7 @@ export const ModelTypeMeta: Record<
     color: 'blue',
     apiSlug: 'companies',
     dbTable: 'EntityInstance',
+    hasDetailPage: true,
   },
   meeting: {
     label: 'Meeting',
@@ -275,6 +304,7 @@ export const ModelTypeMeta: Record<
     color: 'blue',
     apiSlug: 'meetings',
     dbTable: 'EntityInstance',
+    hasDetailPage: false,
   },
   article: {
     label: 'Article',
@@ -283,6 +313,7 @@ export const ModelTypeMeta: Record<
     color: 'cyan',
     apiSlug: 'articles',
     dbTable: 'Article',
+    hasDetailPage: false,
   },
   kb: {
     label: 'Knowledge Base',
@@ -293,6 +324,7 @@ export const ModelTypeMeta: Record<
     // getRecordLink derives record hrefs as `/app/<apiSlug>/<id>`.
     apiSlug: 'kb',
     dbTable: 'KnowledgeBase',
+    hasDetailPage: true,
   },
 }
 


### PR DESCRIPTION
## Problem

The record detail drawer's **Expand ("Open full page")** button rendered unconditionally and navigated to `/app/<apiSlug>/<id>` for any system entity. There is **no catch-all route** — every full detail page is a hand-authored folder — so page-less system types (`thread`, `message`, `article`, `meeting`, `tag`, …) navigate to a **404**. This is reachable from the dashboards record-list widget (whose sources include `thread`/`message`/`article`) and app-wide via the shared link builders.

## Fix

Gate the fullscreen button — and the record link builders — on whether the resource actually has a detail page.

- **`ModelTypeMeta` gains `hasDetailPage: boolean`** (`packages/database/src/enums.ts`) — the single place every system type coexists. `true` for `contact`, `ticket`, `company`, `part`, `kb`, `dataset` (routes verified to exist); `false` for the rest.
- **`resourceHasDetailPage(resource)`** (`get-record-link.ts`) reads `ModelTypeMeta` directly — single source of truth, nothing threaded onto the `Resource` object. Custom entity defs (`entityType == null`) always have a page via the generic `custom/[slug]/[id]` route → `true`.
- **`getRecordLink` now returns `string | null`** (null when no detail page); `useRecordLink`/`recordHref` propagate it. All consumers were already null-tolerant, so no caller changes were required.
- **`RecordDrawer`** renders the Expand button only when `resource && resourceHasDetailPage(resource)`.

## Note

The set of page-backed types is `{contact, ticket, company, part, kb, dataset}` — `kb` (`kb/[knowledgeBaseId]`) and `dataset` (`datasets/[datasetId]`) routes exist, so their currently-valid links are preserved.

`@auxx/database` was rebuilt (the `enums` subpath resolves the built `dist`).

## Test plan

- [ ] Record-list widget over `thread`/`message`/`article`: row drawer shows **no** Expand button.
- [ ] Record-list widget over a custom entity / contact / ticket / company / part: Expand present → navigates correctly.
- [ ] Page-less record's `RecordBadge` / hover-card / kbar entry renders non-navigable (no dead link / no-op), page-backed types unchanged.