### PR TITLE
feat(homepage): reporting platform page + nav tweaks

### DIFF
--- a/apps/homepage/src/app/_components/main/header.tsx
+++ b/apps/homepage/src/app/_components/main/header.tsx
@@ -1,5 +1,6 @@
 'use client'
 import {
+  BarChart3,
   BookOpen,
   Cloud,
   Code,
@@ -66,25 +67,25 @@ const platformGroups: PlatformGroup[] = [
       {
         href: '/platform/crm',
         name: 'CRM',
-        description: 'Contacts, companies, and full customer history',
+        description: 'Contacts, companies & history',
         icon: <Users className='stroke-foreground fill-green-500/15' />,
       },
       {
         href: '/platform/ai/kopilot',
         name: 'Kopilot',
-        description: 'Workspace copilot grounded in your data',
+        description: 'AI grounded in your data',
         icon: <Sparkles className='stroke-foreground fill-amber-500/15' />,
       },
       {
         href: '/platform/data-model',
         name: 'Knowledge base',
-        description: 'Self-serve articles and AI grounding',
+        description: 'Self-serve help articles',
         icon: <Library className='stroke-foreground fill-yellow-500/15' />,
       },
       {
         href: '/platform/data-model',
         name: 'Datasets',
-        description: 'Upload PDFs, docs, and pages for AI to use',
+        description: 'Docs & PDFs for AI',
         icon: <Database className='stroke-foreground fill-cyan-500/15' />,
       },
     ],
@@ -95,13 +96,13 @@ const platformGroups: PlatformGroup[] = [
       {
         href: '/platform/workflow',
         name: 'Workflow',
-        description: 'Automate and streamline processes',
+        description: 'Automate your processes',
         icon: <GitBranch className='stroke-foreground fill-purple-500/15' />,
       },
       {
         href: '/platform/integration',
         name: 'Integration',
-        description: 'Connect all your business tools',
+        description: 'Connect your business tools',
         icon: <Plug className='stroke-foreground fill-orange-500/15' />,
       },
     ],
@@ -112,13 +113,13 @@ const platformGroups: PlatformGroup[] = [
       {
         href: '/platform/ticketing',
         name: 'Ticketing',
-        description: 'Route, prioritize, and resolve at volume',
+        description: 'Resolve tickets at volume',
         icon: <Cloud className='stroke-foreground fill-teal-500/15' />,
       },
       {
         href: '/platform/manufacturing',
         name: 'Manufacturing',
-        description: 'Parts, vendors, and production data',
+        description: 'Parts, vendors & production',
         icon: <Shield className='stroke-foreground fill-blue-500/15' />,
       },
     ],
@@ -129,7 +130,7 @@ const platformGroups: PlatformGroup[] = [
       {
         href: '/platform/messaging',
         name: 'Messaging',
-        description: 'Shared inbox with AI-suggested replies',
+        description: 'Shared inbox with AI replies',
         icon: <MessagesSquare className='stroke-foreground fill-blue-500/15' />,
       },
       // {
@@ -140,9 +141,26 @@ const platformGroups: PlatformGroup[] = [
       // },
     ],
   },
+  {
+    name: 'Insights',
+    links: [
+      {
+        href: '/platform/reporting',
+        name: 'Reporting',
+        description: 'Live dashboards & analytics',
+        icon: <BarChart3 className='stroke-foreground fill-sky-500/15' />,
+      },
+    ],
+  },
 ]
 
 const platformLinks: FeatureLink[] = platformGroups.flatMap((group) => group.links)
+
+// Single-item groups (e.g. Communication, Insights) are paired side by side
+// in the mega-menu while keeping their own section titles.
+const singlePlatformGroups: PlatformGroup[] = platformGroups.filter(
+  (group) => group.links.length === 1
+)
 
 const useCases: FeatureLink[] = [
   {
@@ -401,7 +419,7 @@ const NavMenu = ({ docsUrl }: { docsUrl: string }) => {
               <div className='bg-card row-span-2 grid grid-rows-subgrid gap-1 rounded-xl border p-1 pt-3'>
                 <ul className='space-y-1'>
                   {platformGroups
-                    .filter((group) => group.links.length > 0)
+                    .filter((group) => group.links.length > 1)
                     .map((group) => (
                       <li key={group.name}>
                         <span className='text-muted-foreground ml-2 text-xs uppercase tracking-wide'>
@@ -420,6 +438,28 @@ const NavMenu = ({ docsUrl }: { docsUrl: string }) => {
                         </ul>
                       </li>
                     ))}
+                  {singlePlatformGroups.length > 0 && (
+                    <li className='grid grid-cols-2 gap-x-2'>
+                      {singlePlatformGroups.map((group) => (
+                        <div key={group.name}>
+                          <span className='text-muted-foreground ml-2 text-xs uppercase tracking-wide'>
+                            {group.name}
+                          </span>
+                          <ul className='mt-1'>
+                            {group.links.map((feature, index) => (
+                              <ListItem
+                                key={index}
+                                href={feature.href}
+                                title={feature.name}
+                                description={feature.description}>
+                                {feature.icon}
+                              </ListItem>
+                            ))}
+                          </ul>
+                        </div>
+                      ))}
+                    </li>
+                  )}
                 </ul>
               </div>
               <div className='flex flex-col gap-1'>

--- a/apps/homepage/src/app/platform/messaging/_components/messaging-hero.tsx
+++ b/apps/homepage/src/app/platform/messaging/_components/messaging-hero.tsx
@@ -3,6 +3,7 @@
 import { MessagesSquare } from 'lucide-react'
 import { motion } from 'motion/react'
 import { ShaderGradientBg } from '~/app/_components/shader-gradient-bg'
+import { useTheme } from '~/lib/theme'
 import { ImageIllustration } from './image-illustration'
 
 const AnimatedGroup = ({ children, variants }: { children: React.ReactNode; variants: any }) => {
@@ -14,6 +15,11 @@ const AnimatedGroup = ({ children, variants }: { children: React.ReactNode; vari
 }
 
 export default function MessagingHero() {
+  const { theme } = useTheme()
+  // `midnight` is a dark palette that reads as a heavy blob on the light page,
+  // so use a soft light palette in light mode.
+  const palette = theme === 'dark' ? 'midnight' : 'candy'
+
   return (
     <main role='main' className='overflow-hidden border-b'>
       <section className='bg-muted relative'>
@@ -22,7 +28,7 @@ export default function MessagingHero() {
           animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
           transition={{ duration: 2, ease: 'easeInOut' }}
           className='absolute inset-0'>
-          <ShaderGradientBg preset='hero' palette='midnight' uniforms={{ timeSpeed: 0.7 }} />
+          <ShaderGradientBg preset='hero' palette={palette} uniforms={{ timeSpeed: 0.7 }} />
         </motion.div>
 
         <div className='perspective-dramatic pb-20 pt-24 md:pt-32 lg:py-44'>

--- a/apps/homepage/src/app/platform/reporting/_components/build-dashboards-section.tsx
+++ b/apps/homepage/src/app/platform/reporting/_components/build-dashboards-section.tsx
@@ -1,0 +1,50 @@
+// apps/homepage/src/app/platform/reporting/_components/build-dashboards-section.tsx
+
+import { GitBranch, LayoutGrid, PanelsTopLeft } from 'lucide-react'
+import { MockDashboardGrid } from '../_mocks'
+
+const beats = [
+  {
+    icon: LayoutGrid,
+    name: 'Drag, drop, resize',
+    description: 'Arrange widgets on a flexible grid that snaps into place.',
+  },
+  {
+    icon: PanelsTopLeft,
+    name: 'Multi-tab dashboards',
+    description: 'One dashboard per audience — overview, team, AI — in tabs.',
+  },
+  {
+    icon: GitBranch,
+    name: 'Versioned publishing',
+    description: 'Edit live, then Publish or Discard. Viewers only ever see the published version.',
+  },
+]
+
+export default function BuildDashboardsSection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Build a dashboard in minutes.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            Compose KPIs, charts, and record lists into one screen your whole team opens every
+            morning.
+          </p>
+        </div>
+        <MockDashboardGrid className='mx-auto mt-12 max-w-3xl' />
+        <ul className='mx-auto mt-12 grid max-w-4xl gap-x-6 gap-y-8 sm:grid-cols-3'>
+          {beats.map((beat) => (
+            <li key={beat.name} className='space-y-2'>
+              <beat.icon className='text-muted-foreground size-5' />
+              <div className='text-foreground font-medium'>{beat.name}</div>
+              <p className='text-muted-foreground text-sm'>{beat.description}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_components/collaborate-section.tsx
+++ b/apps/homepage/src/app/platform/reporting/_components/collaborate-section.tsx
@@ -1,0 +1,28 @@
+// apps/homepage/src/app/platform/reporting/_components/collaborate-section.tsx
+
+import { MockDashboardGrid } from '../_mocks'
+
+export default function CollaborateSection() {
+  return (
+    <section className='bg-muted/30 border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='grid items-center gap-12 lg:grid-cols-2'>
+          <MockDashboardGrid variant='collaborate' className='max-lg:order-last' />
+          <div className='lg:max-w-md lg:justify-self-end'>
+            <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+              Publish once. Everyone sees it.
+            </h2>
+            <p className='text-muted-foreground mt-4 text-lg'>
+              Edit a dashboard live without breaking what your team relies on. Your changes stay in
+              a working draft until you hit Publish — then everyone gets the new version at once.
+            </p>
+            <p className='text-muted-foreground mt-4'>
+              Changed your mind? Discard the draft and the published dashboard never knew. No broken
+              charts in the Monday standup.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_components/customize-section.tsx
+++ b/apps/homepage/src/app/platform/reporting/_components/customize-section.tsx
@@ -1,0 +1,259 @@
+// apps/homepage/src/app/platform/reporting/_components/customize-section.tsx
+'use client'
+
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { useState } from 'react'
+import {
+  AI_IMPACT,
+  AI_RATE_BY_CHANNEL,
+  AI_RATE_BY_TAG,
+  AI_RATE_BY_TEAM,
+  CONFIG_OPTIONS,
+  CONTACT_TREND,
+  CONTACTS_BY_COMPANY,
+  CONTACTS_BY_TAG,
+  MockBarChart,
+  MockCard,
+  MockConfigPanel,
+  MockDonut,
+  MockGauge,
+  MockKpiTile,
+  MockLineChart,
+  MockRecordList,
+  type MockWidgetConfig,
+  RECENT_CONTACTS,
+  RECENT_TICKETS,
+  TICKET_TREND,
+  TICKET_TREND_BY_CHANNEL,
+  TICKETS_BY_CHANNEL,
+  TICKETS_BY_TAG_QUARTER,
+  TICKETS_BY_TEAM,
+} from '../_mocks'
+
+const CATEGORY_LABELS: Record<string, string> = {
+  team: 'team',
+  channel: 'channel',
+  tag: 'tag',
+  company: 'company',
+}
+
+/** name/value split for the current source + metric + category */
+function categoryData({ source, metric, category }: MockWidgetConfig) {
+  if (metric === 'aiRate') {
+    if (category === 'channel') return AI_RATE_BY_CHANNEL
+    if (category === 'tag') return AI_RATE_BY_TAG
+    return AI_RATE_BY_TEAM
+  }
+  if (source === 'contacts') {
+    return category === 'tag' ? CONTACTS_BY_TAG : CONTACTS_BY_COMPANY
+  }
+  if (category === 'channel') return TICKETS_BY_CHANNEL
+  if (category === 'tag') return TICKETS_BY_TAG_QUARTER
+  return TICKETS_BY_TEAM
+}
+
+function previewTitle({ source, metric, category }: MockWidgetConfig) {
+  if (metric === 'aiRate') return `AI-resolved rate by ${CATEGORY_LABELS[category]}`
+  return `${source === 'contacts' ? 'Contacts' : 'Tickets'} by ${CATEGORY_LABELS[category]}`
+}
+
+function WidgetPreview({ config }: { config: MockWidgetConfig }) {
+  const { source, metric, kind, series } = config
+  const data = categoryData(config)
+  const total = source === 'contacts' ? 402 : 625
+
+  switch (kind) {
+    case 'bar':
+      return (
+        <MockBarChart
+          data={data}
+          horizontal={config.category === 'company'}
+          label={
+            metric === 'aiRate' ? 'AI-resolved %' : source === 'contacts' ? 'Contacts' : 'Tickets'
+          }
+          className='h-48'
+        />
+      )
+    case 'line': {
+      if (metric === 'aiRate') {
+        return (
+          <MockLineChart
+            data={AI_IMPACT}
+            xKey='week'
+            series={[{ key: 'rate', label: 'AI-resolved %', colorVar: 'report-c4' }]}
+            showXAxis
+            className='h-48'
+          />
+        )
+      }
+      if (source === 'tickets' && series === 'channel') {
+        return (
+          <MockLineChart
+            data={TICKET_TREND_BY_CHANNEL}
+            xKey='week'
+            series={[
+              { key: 'email', label: 'Email', colorVar: 'report-c1' },
+              { key: 'chat', label: 'Chat', colorVar: 'report-c2' },
+            ]}
+            showXAxis
+            className='h-48'
+          />
+        )
+      }
+      return (
+        <MockLineChart
+          data={source === 'contacts' ? CONTACT_TREND : TICKET_TREND}
+          xKey='week'
+          series={[
+            {
+              key: 'total',
+              label: source === 'contacts' ? 'Contacts' : 'Tickets',
+              colorVar: 'report-c1',
+            },
+          ]}
+          showXAxis
+          className='h-48'
+        />
+      )
+    }
+    case 'pie': {
+      if (metric === 'aiRate') {
+        return (
+          <MockDonut
+            data={[
+              { key: 'ai', name: 'AI-resolved', value: 58 },
+              { key: 'rest', name: 'Human-handled', value: 42 },
+            ]}
+            slotVars={['report-c4', 'report-rest']}
+            centerValue='58%'
+            centerLabel='AI-resolved'
+          />
+        )
+      }
+      // fold >4 slices into "Other" so slot colors never cycle
+      const slices =
+        data.length > 4
+          ? [
+              ...data.slice(0, 3),
+              { name: 'Other', value: data.slice(3).reduce((sum, d) => sum + d.value, 0) },
+            ]
+          : data
+      return (
+        <MockDonut
+          data={slices.map((d) => ({ key: d.name, name: d.name, value: d.value }))}
+          centerValue={String(total)}
+          centerLabel={source === 'contacts' ? 'contacts' : 'tickets'}
+        />
+      )
+    }
+    case 'kpi':
+      return metric === 'aiRate' ? (
+        <MockKpiTile
+          label='AI-resolved this quarter'
+          value={58}
+          suffix='%'
+          deltaLabel='▲ 6 pts'
+          spark={AI_IMPACT.map((d) => ({ x: d.week, y: d.rate }))}
+          className='py-4'
+        />
+      ) : (
+        <MockKpiTile
+          label={source === 'contacts' ? 'Contacts this quarter' : 'Tickets this quarter'}
+          value={total}
+          deltaLabel={source === 'contacts' ? '▲ 6%' : '▲ 9%'}
+          spark={(source === 'contacts' ? CONTACT_TREND : TICKET_TREND).map((d) => ({
+            x: d.week,
+            y: d.total,
+          }))}
+          className='py-4'
+        />
+      )
+    case 'gauge':
+      return metric === 'aiRate' ? (
+        <MockGauge value={58} label='of all tickets' className='py-2' />
+      ) : (
+        <MockGauge
+          value={source === 'contacts' ? 67 : 78}
+          label={source === 'contacts' ? 'of quarterly goal' : 'of weekly goal'}
+          colorVar='report-c1'
+          className='py-2'
+        />
+      )
+    case 'list':
+      return (
+        <MockRecordList
+          tickets={source === 'contacts' ? RECENT_CONTACTS : RECENT_TICKETS}
+          className='py-2'
+        />
+      )
+  }
+}
+
+export default function CustomizeSection() {
+  const [config, setConfig] = useState<MockWidgetConfig>({
+    source: 'tickets',
+    metric: 'count',
+    category: 'team',
+    series: 'none',
+    kind: 'bar',
+  })
+  const reducedMotion = useReducedMotion()
+
+  const applyPatch = (patch: Partial<MockWidgetConfig>) => {
+    setConfig((prev) => {
+      const next = { ...prev, ...patch }
+      // snap dependent fields to valid options when the source changes
+      const options = CONFIG_OPTIONS[next.source]
+      if (!options.metrics.some((m) => m.value === next.metric)) {
+        next.metric = options.metrics[0].value
+      }
+      if (!options.categories.some((c) => c.value === next.category)) {
+        next.category = options.categories[0].value
+      }
+      if (next.source !== 'tickets' || next.metric !== 'count') next.series = 'none'
+      return next
+    })
+  }
+
+  const subtitle =
+    config.series === 'channel' && config.kind === 'line'
+      ? 'Weekly volume · split by channel'
+      : `Grouped by ${CATEGORY_LABELS[config.category]} · this quarter`
+
+  return (
+    <section className='bg-muted/30 border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Every chart, your way.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            Pick a source, a metric, and a breakdown — then flip between six widget types until the
+            data reads the way you think.
+          </p>
+        </div>
+        <div className='mx-auto mt-12 grid max-w-4xl items-center gap-8 lg:grid-cols-[minmax(0,5fr)_minmax(0,6fr)]'>
+          <div className='bg-card ring-border rounded-2xl p-5 shadow-sm ring-1'>
+            <div className='text-muted-foreground mb-4 text-xs font-medium uppercase tracking-wide'>
+              Widget settings
+            </div>
+            <MockConfigPanel config={config} onChange={applyPatch} />
+          </div>
+          <MockCard layered title={previewTitle(config)} subtitle={subtitle}>
+            <AnimatePresence mode='wait' initial={false}>
+              <motion.div
+                key={`${config.kind}-${config.source}-${config.metric}-${config.category}-${config.series}`}
+                initial={reducedMotion ? false : { opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={reducedMotion ? undefined : { opacity: 0, y: -4 }}
+                transition={{ duration: 0.2 }}
+                className='mt-3'>
+                <WidgetPreview config={config} />
+              </motion.div>
+            </AnimatePresence>
+          </MockCard>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_components/data-exploration-grid.tsx
+++ b/apps/homepage/src/app/platform/reporting/_components/data-exploration-grid.tsx
@@ -1,0 +1,139 @@
+// apps/homepage/src/app/platform/reporting/_components/data-exploration-grid.tsx
+'use client'
+
+import { Filter, Layers, Paintbrush, TrendingUp } from 'lucide-react'
+import {
+  CONTACTS_BY_COMPANY,
+  CSAT_TREND,
+  MockBarChart,
+  MockCard,
+  MockDonut,
+  MockGauge,
+  MockKpiTile,
+  MockLineChart,
+  TICKETS_BY_TAG,
+  TICKETS_PER_DAY,
+} from '../_mocks'
+
+const capabilities = [
+  {
+    icon: Layers,
+    name: 'Group your way',
+    description: 'Category plus a second series breakdown — team by channel, tag by status.',
+  },
+  {
+    icon: Filter,
+    name: 'Filter anything',
+    description: 'The same condition builder you use everywhere else, on every widget.',
+  },
+  {
+    icon: TrendingUp,
+    name: 'Compare over time',
+    description: 'KPI trends and date buckets — day, week, month — with deltas built in.',
+  },
+  {
+    icon: Paintbrush,
+    name: 'Format to match',
+    description: 'Values render like their fields: currencies, durations, percentages.',
+  },
+]
+
+const examples = [
+  {
+    title: 'Tickets created per day',
+    chart: (
+      <MockBarChart
+        data={TICKETS_PER_DAY.map((d) => ({ name: d.day, value: d.value }))}
+        className='h-36'
+        showTooltip={false}
+      />
+    ),
+  },
+  {
+    title: 'Avg resolution time',
+    chart: (
+      <MockKpiTile
+        label='Across all channels'
+        value={2.4}
+        fractionDigits={1}
+        suffix=' h'
+        deltaLabel='▼ 23%'
+      />
+    ),
+  },
+  {
+    title: 'Contacts per company',
+    chart: (
+      <MockBarChart
+        data={CONTACTS_BY_COMPANY}
+        horizontal
+        label='Contacts'
+        className='h-36'
+        showTooltip={false}
+      />
+    ),
+  },
+  {
+    title: 'AI-resolved rate',
+    chart: <MockGauge value={58} label='of all tickets' />,
+  },
+  {
+    title: 'CSAT trend',
+    chart: (
+      <MockLineChart
+        data={CSAT_TREND}
+        xKey='week'
+        series={[{ key: 'score', label: 'CSAT', colorVar: 'report-c2' }]}
+        className='h-36'
+        showTooltip={false}
+      />
+    ),
+  },
+  {
+    title: 'Tickets by tag',
+    chart: (
+      <MockDonut
+        data={TICKETS_BY_TAG.map((t) => ({ key: t.tag, name: t.tag, value: t.count }))}
+        showLegend={false}
+        centerValue='131'
+        centerLabel='tickets'
+      />
+    ),
+  },
+]
+
+export default function DataExplorationGrid() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Powerful data exploration.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            Report on any entity in your workspace — tickets, contacts, companies, even parts — with
+            the fields you already track.
+          </p>
+        </div>
+
+        <ul className='mx-auto mt-12 grid max-w-4xl gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-4'>
+          {capabilities.map((capability) => (
+            <li key={capability.name} className='space-y-2'>
+              <capability.icon className='text-muted-foreground size-5' />
+              <div className='text-foreground font-medium'>{capability.name}</div>
+              <p className='text-muted-foreground text-sm'>{capability.description}</p>
+            </li>
+          ))}
+        </ul>
+
+        <div className='mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+          {examples.map((example) => (
+            <MockCard key={example.title} title={example.title}>
+              <div className='mt-2 flex h-40 flex-col justify-center'>{example.chart}</div>
+            </MockCard>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_components/drill-down-section.tsx
+++ b/apps/homepage/src/app/platform/reporting/_components/drill-down-section.tsx
@@ -1,0 +1,29 @@
+// apps/homepage/src/app/platform/reporting/_components/drill-down-section.tsx
+
+import { MockDrillDown } from '../_mocks'
+
+export default function DrillDownSection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='grid items-center gap-12 lg:grid-cols-2'>
+          <div className='lg:max-w-md'>
+            <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+              Drill down to the ticket that matters.
+            </h2>
+            <p className='text-muted-foreground mt-4 text-lg'>
+              Every bar, slice, and count is a door. Click any segment of a chart and see exactly
+              which tickets, contacts, or companies are behind the number — then open the record
+              right there.
+            </p>
+            <p className='text-muted-foreground mt-4'>
+              Group tickets by tag, team, channel, or any custom field. Add a second breakdown when
+              one dimension isn't enough. No exports, no pivot tables.
+            </p>
+          </div>
+          <MockDrillDown />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_components/featured-reports.tsx
+++ b/apps/homepage/src/app/platform/reporting/_components/featured-reports.tsx
@@ -1,0 +1,72 @@
+// apps/homepage/src/app/platform/reporting/_components/featured-reports.tsx
+'use client'
+
+import {
+  AI_IMPACT,
+  CONTACTS_BY_COMPANY,
+  MockBarChart,
+  MockCard,
+  MockDonut,
+  MockLineChart,
+  TICKET_STATUS,
+} from '../_mocks'
+
+const reports = [
+  {
+    eyebrow: 'Support Performance',
+    title: 'How fast are we resolving?',
+    caption: 'Resolved vs open vs escalated, straight from your ticket data.',
+    chart: <MockDonut data={TICKET_STATUS} centerValue='68%' centerLabel='resolved' />,
+  },
+  {
+    eyebrow: 'AI Impact',
+    title: 'What is Kopilot handling?',
+    caption: 'The share of tickets AI resolves end-to-end, week over week.',
+    chart: (
+      <MockLineChart
+        data={AI_IMPACT}
+        xKey='week'
+        series={[{ key: 'rate', label: 'AI-resolved %', colorVar: 'report-c4' }]}
+        showXAxis
+        className='h-44'
+      />
+    ),
+  },
+  {
+    eyebrow: 'Customer Health',
+    title: 'Where are our contacts?',
+    caption: 'Contacts grouped by company, tag, or any custom field.',
+    chart: <MockBarChart data={CONTACTS_BY_COMPANY} horizontal label='Contacts' className='h-44' />,
+  },
+]
+
+export default function FeaturedReports() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Answers to the questions you ask every week.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            Start from a report that already understands support and CRM data — then make it yours.
+          </p>
+        </div>
+        <div className='mt-12 grid gap-6 md:grid-cols-3'>
+          {reports.map((report) => (
+            <div key={report.eyebrow} className='flex flex-col'>
+              <div className='text-muted-foreground text-xs font-medium uppercase tracking-wide'>
+                {report.eyebrow}
+              </div>
+              <h3 className='text-foreground mt-1 text-lg font-medium'>{report.title}</h3>
+              <p className='text-muted-foreground mb-4 mt-1 text-sm'>{report.caption}</p>
+              <MockCard className='mt-auto' contentClassName='min-h-52'>
+                {report.chart}
+              </MockCard>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_components/reporting-final-cta.tsx
+++ b/apps/homepage/src/app/platform/reporting/_components/reporting-final-cta.tsx
@@ -1,0 +1,35 @@
+// apps/homepage/src/app/platform/reporting/_components/reporting-final-cta.tsx
+
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+
+export default function ReportingFinalCta() {
+  return (
+    <section
+      data-theme='dark'
+      className='border-foreground/10 relative overflow-hidden border-b bg-zinc-950 text-zinc-50'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_bottom,_rgba(255,255,255,0.08),_transparent_60%)]'
+      />
+      <div className='relative z-10 mx-auto max-w-4xl px-6 py-24 text-center md:py-32'>
+        <h2 className='text-balance text-5xl font-semibold tracking-tight md:text-6xl'>
+          Own the numbers. Start with a free trial.
+        </h2>
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start Free Trial</Link>
+          </Button>
+          <Button
+            asChild
+            size='sm'
+            variant='outline'
+            className='border-zinc-700 bg-transparent text-zinc-50 hover:bg-zinc-900'>
+            <Link href={config.urls.demo}>Try Demo</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_components/reporting-hero-tiles.tsx
+++ b/apps/homepage/src/app/platform/reporting/_components/reporting-hero-tiles.tsx
@@ -1,0 +1,76 @@
+// apps/homepage/src/app/platform/reporting/_components/reporting-hero-tiles.tsx
+'use client'
+
+import { motion, useReducedMotion } from 'motion/react'
+import {
+  AI_RESOLVED_KPI,
+  MockBarChart,
+  MockCard,
+  MockKpiTile,
+  MockLegend,
+  MockLineChart,
+  RESOLUTION_TIME,
+  TICKETS_BY_TEAM,
+} from '../_mocks'
+
+/** The three floating dashboard tiles under the hero headline. */
+export function ReportingHeroTiles() {
+  const reducedMotion = useReducedMotion()
+
+  const tiles = [
+    <MockCard key='kpi' layered contentClassName='h-full'>
+      <MockKpiTile
+        label='AI-resolved this week'
+        value={AI_RESOLVED_KPI.value}
+        deltaLabel={AI_RESOLVED_KPI.deltaLabel}
+        spark={AI_RESOLVED_KPI.spark}
+      />
+    </MockCard>,
+    <MockCard
+      key='line'
+      layered
+      title='Median resolution time'
+      subtitle='Minutes to resolve · last 8 weeks'
+      contentClassName='h-full'>
+      <MockLineChart
+        data={RESOLUTION_TIME}
+        xKey='week'
+        series={[
+          { key: 'email', label: 'Email', colorVar: 'report-c1' },
+          { key: 'chat', label: 'Chat', colorVar: 'report-c2' },
+        ]}
+        className='mt-3 h-24'
+      />
+      <MockLegend
+        items={[
+          { label: 'Email', colorVar: 'report-c1' },
+          { label: 'Chat', colorVar: 'report-c2' },
+        ]}
+      />
+    </MockCard>,
+    <MockCard
+      key='bar'
+      layered
+      title='Tickets by team'
+      subtitle='Open tickets right now'
+      contentClassName='h-full'>
+      <MockBarChart data={TICKETS_BY_TEAM} horizontal className='mt-3 h-28' />
+    </MockCard>,
+  ]
+
+  return (
+    <div className='mx-auto mt-16 grid max-w-5xl items-stretch gap-4 text-left sm:grid-cols-2 lg:grid-cols-3'>
+      {tiles.map((tile, i) => (
+        <motion.div
+          key={tile.key}
+          initial={reducedMotion ? false : { opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-10% 0px' }}
+          transition={{ duration: 0.5, delay: i * 0.12 }}
+          className='last:max-lg:hidden lg:even:-translate-y-3'>
+          {tile}
+        </motion.div>
+      ))}
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_components/reporting-hero.tsx
+++ b/apps/homepage/src/app/platform/reporting/_components/reporting-hero.tsx
@@ -1,0 +1,42 @@
+// apps/homepage/src/app/platform/reporting/_components/reporting-hero.tsx
+
+import { ChartLine } from 'lucide-react'
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+import { ReportingHeroTiles } from './reporting-hero-tiles'
+
+export default function ReportingHero() {
+  return (
+    <section className='bg-muted/50 relative overflow-hidden border-b'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-x-0 top-0 -z-10 h-[600px] bg-[radial-gradient(ellipse_at_top,_var(--color-primary)/10,_transparent_60%)]'
+      />
+      <div className='mx-auto max-w-6xl px-6 pb-20 pt-32 text-center md:pt-40 lg:pt-48'>
+        <div className='border-foreground/10 bg-muted/40 mx-auto inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs'>
+          <ChartLine className='size-3.5 text-sky-500' />
+          <span className='text-muted-foreground'>Reporting & Dashboards</span>
+        </div>
+
+        <h1 className='mt-6 text-balance text-5xl font-semibold tracking-tight md:text-7xl'>
+          Reports for the teams who answer.
+        </h1>
+        <p className='text-muted-foreground relative mx-auto mt-4 max-w-2xl text-balance text-lg'>
+          Live dashboards over every ticket, contact, and conversation — no BI tool required.
+        </p>
+
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start Free Trial</Link>
+          </Button>
+          <Button asChild size='sm' variant='outline'>
+            <Link href={config.urls.demo}>Try Demo</Link>
+          </Button>
+        </div>
+
+        <ReportingHeroTiles />
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/index.ts
+++ b/apps/homepage/src/app/platform/reporting/_mocks/index.ts
@@ -1,0 +1,46 @@
+// apps/homepage/src/app/platform/reporting/_mocks/index.ts
+
+export { MockBarChart } from './mock-bar-chart'
+export { CHART_VARS_CLASS, MockCard, MockLegend } from './mock-card'
+export {
+  CONFIG_OPTIONS,
+  type MockCategory,
+  MockConfigPanel,
+  type MockMetric,
+  type MockSeriesOption,
+  type MockSource,
+  type MockWidgetConfig,
+  type MockWidgetKind,
+  WIDGET_KINDS,
+} from './mock-config-panel'
+export { MockDashboardGrid } from './mock-dashboard-grid'
+export { MockDonut } from './mock-donut'
+export { MockDrillDown } from './mock-drill-down'
+export { MockGauge } from './mock-gauge'
+export { MockKpiTile } from './mock-kpi-tile'
+export { MockLineChart, type MockSeries } from './mock-line-chart'
+export { MockRecordList } from './mock-record-list'
+export {
+  AI_IMPACT,
+  AI_RATE_BY_CHANNEL,
+  AI_RATE_BY_TAG,
+  AI_RATE_BY_TEAM,
+  AI_RESOLVED_KPI,
+  CONTACT_TREND,
+  CONTACTS_BY_COMPANY,
+  CONTACTS_BY_TAG,
+  CSAT_TREND,
+  type DrillDownTicket,
+  RECENT_CONTACTS,
+  RECENT_TICKETS,
+  RESOLUTION_TIME,
+  type RecordRow,
+  TICKET_STATUS,
+  TICKET_TREND,
+  TICKET_TREND_BY_CHANNEL,
+  TICKETS_BY_CHANNEL,
+  TICKETS_BY_TAG,
+  TICKETS_BY_TAG_QUARTER,
+  TICKETS_BY_TEAM,
+  TICKETS_PER_DAY,
+} from './sample-data'

--- a/apps/homepage/src/app/platform/reporting/_mocks/mock-bar-chart.tsx
+++ b/apps/homepage/src/app/platform/reporting/_mocks/mock-bar-chart.tsx
@@ -1,0 +1,59 @@
+// apps/homepage/src/app/platform/reporting/_mocks/mock-bar-chart.tsx
+'use client'
+
+import { Bar, BarChart, XAxis, YAxis } from 'recharts'
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from '~/components/ui/chart'
+import { cn } from '~/lib/utils'
+
+interface MockBarChartProps {
+  data: { name: string; value: number }[]
+  /** chart slot var, e.g. 'report-c1' */
+  colorVar?: string
+  /** horizontal = bars run left→right with category labels on the y-axis */
+  horizontal?: boolean
+  label?: string
+  className?: string
+  showTooltip?: boolean
+}
+
+/** Theme-aware bar chart with rounded data-ends and a per-bar hover tooltip. */
+export function MockBarChart({
+  data,
+  colorVar = 'report-c1',
+  horizontal = false,
+  label = 'Tickets',
+  className,
+  showTooltip = true,
+}: MockBarChartProps) {
+  const config = { value: { label, color: `var(--${colorVar})` } }
+
+  return (
+    <ChartContainer config={config} className={cn('aspect-auto h-40 w-full', className)}>
+      {horizontal ? (
+        <BarChart
+          data={data}
+          layout='vertical'
+          margin={{ top: 0, right: 8, bottom: 0, left: 0 }}
+          barSize={14}>
+          <XAxis type='number' hide />
+          <YAxis
+            type='category'
+            dataKey='name'
+            tickLine={false}
+            axisLine={false}
+            width={64}
+            fontSize={11}
+          />
+          {showTooltip && <ChartTooltip cursor={false} content={<ChartTooltipContent />} />}
+          <Bar dataKey='value' fill='var(--color-value)' radius={[0, 4, 4, 0]} />
+        </BarChart>
+      ) : (
+        <BarChart data={data} margin={{ top: 4, right: 0, bottom: 0, left: 0 }} barSize={32}>
+          <XAxis dataKey='name' tickLine={false} axisLine={false} tickMargin={6} fontSize={11} />
+          {showTooltip && <ChartTooltip cursor={false} content={<ChartTooltipContent />} />}
+          <Bar dataKey='value' fill='var(--color-value)' radius={[4, 4, 0, 0]} />
+        </BarChart>
+      )}
+    </ChartContainer>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/mock-card.tsx
+++ b/apps/homepage/src/app/platform/reporting/_mocks/mock-card.tsx
@@ -1,0 +1,90 @@
+// apps/homepage/src/app/platform/reporting/_mocks/mock-card.tsx
+
+import { cn } from '~/lib/utils'
+
+/**
+ * Fixed 4-slot categorical palette for every reporting mock (sky → violet →
+ * amber → emerald), stepped per theme so each slot clears contrast + CVD
+ * checks on both surfaces. Applied as local CSS vars because the homepage
+ * themes via `data-theme='dark'`, which the shadcn ChartStyle `.dark`
+ * selector never matches. Assign slots in order, never cycled.
+ */
+export const CHART_VARS_CLASS =
+  '[--report-c1:var(--color-sky-500)] [--report-c2:var(--color-violet-500)] [--report-c3:var(--color-amber-500)] [--report-c4:var(--color-emerald-500)] [--report-rest:var(--color-zinc-200)] dark:[--report-c1:var(--color-sky-600)] dark:[--report-c3:var(--color-amber-600)] dark:[--report-c4:var(--color-emerald-600)] dark:[--report-rest:var(--color-zinc-700)]'
+
+interface MockCardProps {
+  title?: React.ReactNode
+  subtitle?: React.ReactNode
+  /** Layered before/after border chrome (hero tiles). Off = flat widget card. */
+  layered?: boolean
+  className?: string
+  contentClassName?: string
+  children: React.ReactNode
+}
+
+/**
+ * Card chrome for the reporting chart mocks. `layered` reproduces the stacked
+ * border treatment from `visualization-illustration.tsx`; the flat variant is
+ * a plain dashboard-widget card for grids.
+ */
+export function MockCard({
+  title,
+  subtitle,
+  layered = false,
+  className,
+  contentClassName,
+  children,
+}: MockCardProps) {
+  const body = (
+    <div
+      className={cn(
+        'bg-illustration ring-border-illustration relative z-10 rounded-2xl border border-transparent p-5 shadow-xl shadow-black/10 ring-1',
+        !layered && 'rounded-xl p-4 shadow-sm',
+        CHART_VARS_CLASS,
+        contentClassName
+      )}>
+      {title != null && <div className='text-foreground text-sm font-medium'>{title}</div>}
+      {subtitle != null && <div className='text-muted-foreground mt-0.5 text-xs'>{subtitle}</div>}
+      {children}
+    </div>
+  )
+
+  if (!layered) return <div className={className}>{body}</div>
+
+  return (
+    <div
+      className={cn(
+        'before:bg-background before:border-border after:border-border after:bg-background/50 before:z-1 relative px-4 pt-6 before:absolute before:inset-x-6 before:bottom-0 before:top-4 before:rounded-2xl before:border after:absolute after:inset-x-9 after:bottom-0 after:top-2 after:rounded-2xl after:border',
+        className
+      )}>
+      {body}
+    </div>
+  )
+}
+
+/**
+ * Small colored-dot legend row used under multi-series charts. `colorVar` is
+ * a chart slot name (`report-c1` … `report-c4`); render inside an element
+ * carrying `CHART_VARS_CLASS` (MockCard does this automatically).
+ */
+export function MockLegend({
+  items,
+  className,
+}: {
+  items: { label: string; colorVar: string }[]
+  className?: string
+}) {
+  return (
+    <div className={cn('mt-2 flex flex-wrap items-center gap-x-4 gap-y-1', className)}>
+      {items.map((item) => (
+        <div key={item.label} className='flex items-center gap-1.5'>
+          <span
+            className='size-1.5 rounded-full'
+            style={{ backgroundColor: `var(--${item.colorVar})` }}
+          />
+          <span className='text-muted-foreground text-xs'>{item.label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/mock-config-panel.tsx
+++ b/apps/homepage/src/app/platform/reporting/_mocks/mock-config-panel.tsx
@@ -1,0 +1,164 @@
+// apps/homepage/src/app/platform/reporting/_mocks/mock-config-panel.tsx
+'use client'
+
+import { BarChart3, ChartLine, ChartPie, ChevronDown, Gauge, Hash, Rows3 } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+export type MockWidgetKind = 'bar' | 'line' | 'pie' | 'kpi' | 'gauge' | 'list'
+export type MockSource = 'tickets' | 'contacts'
+export type MockMetric = 'count' | 'aiRate'
+export type MockCategory = 'team' | 'channel' | 'tag' | 'company'
+export type MockSeriesOption = 'none' | 'channel'
+
+export interface MockWidgetConfig {
+  source: MockSource
+  metric: MockMetric
+  category: MockCategory
+  series: MockSeriesOption
+  kind: MockWidgetKind
+}
+
+export const WIDGET_KINDS: { kind: MockWidgetKind; label: string; icon: React.ElementType }[] = [
+  { kind: 'bar', label: 'Bar', icon: BarChart3 },
+  { kind: 'line', label: 'Line', icon: ChartLine },
+  { kind: 'pie', label: 'Pie', icon: ChartPie },
+  { kind: 'kpi', label: 'KPI', icon: Hash },
+  { kind: 'gauge', label: 'Gauge', icon: Gauge },
+  { kind: 'list', label: 'Record list', icon: Rows3 },
+]
+
+/** Valid options per source — switching source snaps the other fields to these. */
+export const CONFIG_OPTIONS: Record<
+  MockSource,
+  {
+    metrics: { value: MockMetric; label: string }[]
+    categories: { value: MockCategory; label: string }[]
+  }
+> = {
+  tickets: {
+    metrics: [
+      { value: 'count', label: 'Count of tickets' },
+      { value: 'aiRate', label: 'AI-resolved %' },
+    ],
+    categories: [
+      { value: 'team', label: 'Team' },
+      { value: 'channel', label: 'Channel' },
+      { value: 'tag', label: 'Tag' },
+    ],
+  },
+  contacts: {
+    metrics: [{ value: 'count', label: 'Count of contacts' }],
+    categories: [
+      { value: 'company', label: 'Company' },
+      { value: 'tag', label: 'Tag' },
+    ],
+  },
+}
+
+function SelectRow({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: { value: string; label: string }[]
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className='grid grid-cols-[5.5rem_1fr] items-center gap-2'>
+      <span className='text-muted-foreground text-xs'>{label}</span>
+      <div className='relative'>
+        <select
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          aria-label={label}
+          className='bg-background ring-border hover:ring-foreground/25 w-full cursor-pointer appearance-none rounded-md py-1.5 pl-2.5 pr-7 text-xs font-medium outline-none ring-1 transition-shadow'>
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <ChevronDown className='text-muted-foreground pointer-events-none absolute right-2 top-1/2 size-3 -translate-y-1/2' />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Working replica of the widget config panel: source → metric → category →
+ * series selects plus the six chart-type chips, all driving the live preview.
+ */
+export function MockConfigPanel({
+  config,
+  onChange,
+  className,
+}: {
+  config: MockWidgetConfig
+  onChange: (patch: Partial<MockWidgetConfig>) => void
+  className?: string
+}) {
+  const options = CONFIG_OPTIONS[config.source]
+  const seriesOptions =
+    config.source === 'tickets' && config.metric === 'count'
+      ? [
+          { value: 'none', label: 'None' },
+          { value: 'channel', label: 'Channel' },
+        ]
+      : [{ value: 'none', label: 'None' }]
+
+  return (
+    <div className={cn('space-y-2.5', className)}>
+      <SelectRow
+        label='Source'
+        value={config.source}
+        options={[
+          { value: 'tickets', label: 'Tickets' },
+          { value: 'contacts', label: 'Contacts' },
+        ]}
+        onChange={(source) => onChange({ source: source as MockSource })}
+      />
+      <SelectRow
+        label='Metric'
+        value={config.metric}
+        options={options.metrics}
+        onChange={(metric) => onChange({ metric: metric as MockMetric })}
+      />
+      <SelectRow
+        label='Category'
+        value={config.category}
+        options={options.categories}
+        onChange={(category) => onChange({ category: category as MockCategory })}
+      />
+      <SelectRow
+        label='Series'
+        value={config.series}
+        options={seriesOptions}
+        onChange={(series) => onChange({ series: series as MockSeriesOption })}
+      />
+      <div className='grid grid-cols-[5.5rem_1fr] items-start gap-2 pt-1'>
+        <span className='text-muted-foreground pt-1 text-xs'>Chart type</span>
+        <div className='flex flex-wrap gap-1.5'>
+          {WIDGET_KINDS.map(({ kind: k, label, icon: Icon }) => (
+            <button
+              key={k}
+              type='button'
+              onClick={() => onChange({ kind: k })}
+              aria-pressed={config.kind === k}
+              className={cn(
+                'flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium ring-1 transition-colors',
+                config.kind === k
+                  ? 'bg-foreground text-background ring-foreground'
+                  : 'bg-background text-muted-foreground ring-border hover:text-foreground'
+              )}>
+              <Icon className='size-3' />
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/mock-dashboard-grid.tsx
+++ b/apps/homepage/src/app/platform/reporting/_mocks/mock-dashboard-grid.tsx
@@ -1,0 +1,158 @@
+// apps/homepage/src/app/platform/reporting/_mocks/mock-dashboard-grid.tsx
+'use client'
+
+import { GripVertical } from 'lucide-react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { useEffect, useState } from 'react'
+import { cn } from '~/lib/utils'
+import { MockCard } from './mock-card'
+import { MockDonut } from './mock-donut'
+import { MockKpiTile } from './mock-kpi-tile'
+import { MockLineChart } from './mock-line-chart'
+import { MockRecordList } from './mock-record-list'
+import { AI_IMPACT, AI_RESOLVED_KPI, RECENT_TICKETS, TICKET_STATUS } from './sample-data'
+
+function Widget({
+  title,
+  children,
+  className,
+}: {
+  title: string
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <MockCard
+      title={
+        <span className='flex items-center justify-between gap-2'>
+          {title}
+          <GripVertical className='text-muted-foreground/50 size-3.5 opacity-0 transition-opacity group-hover/widget:opacity-100' />
+        </span>
+      }
+      className={cn('group/widget', className)}
+      contentClassName='h-full'>
+      {children}
+    </MockCard>
+  )
+}
+
+/** Cycles between the product's amber "unsaved changes" pill and the published state. */
+function PublishPill() {
+  const reducedMotion = useReducedMotion()
+  const [published, setPublished] = useState(true)
+
+  useEffect(() => {
+    if (reducedMotion) return
+    const interval = setInterval(() => setPublished((p) => !p), 2800)
+    return () => clearInterval(interval)
+  }, [reducedMotion])
+
+  return (
+    <AnimatePresence mode='wait' initial={false}>
+      <motion.span
+        key={String(published)}
+        initial={reducedMotion ? false : { opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={reducedMotion ? undefined : { opacity: 0, y: -4 }}
+        transition={{ duration: 0.2 }}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium',
+          published
+            ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
+            : 'bg-amber-500/10 text-amber-700 dark:text-amber-400'
+        )}>
+        <span
+          className={cn('size-1.5 rounded-full', published ? 'bg-emerald-500' : 'bg-amber-500')}
+        />
+        {published ? 'Published · v12' : 'Live · unsaved changes'}
+      </motion.span>
+    </AnimatePresence>
+  )
+}
+
+const AVATARS = [
+  '/images/avatars/carolin.jpg',
+  '/images/avatars/luis.jpg',
+  '/images/avatars/rey.jpg',
+]
+
+interface MockDashboardGridProps {
+  /** 'build' shows tabs + drag affordances; 'collaborate' adds the publish pill + viewer avatars */
+  variant?: 'build' | 'collaborate'
+  className?: string
+}
+
+/** A miniature multi-widget dashboard echoing the product's drag-and-resize grid editor. */
+export function MockDashboardGrid({ variant = 'build', className }: MockDashboardGridProps) {
+  return (
+    <div
+      className={cn(
+        'bg-background/60 ring-border rounded-2xl p-3 shadow-xl shadow-black/10 ring-1 backdrop-blur',
+        className
+      )}>
+      <div className='flex items-center justify-between gap-2 px-1 pb-2'>
+        <div className='flex items-center gap-1'>
+          {['Overview', 'Team', 'AI'].map((tab, i) => (
+            <span
+              key={tab}
+              className={cn(
+                'rounded-md px-2 py-1 text-xs',
+                i === 0 ? 'bg-muted text-foreground font-medium' : 'text-muted-foreground'
+              )}>
+              {tab}
+            </span>
+          ))}
+        </div>
+        {variant === 'collaborate' ? (
+          <div className='flex items-center gap-2'>
+            <div className='flex -space-x-1.5'>
+              {AVATARS.map((src) => (
+                <img
+                  key={src}
+                  src={src}
+                  alt=''
+                  className='ring-background size-5 rounded-full object-cover ring-2'
+                />
+              ))}
+            </div>
+            <PublishPill />
+          </div>
+        ) : (
+          <span className='bg-foreground text-background rounded-md px-2 py-1 text-[10px] font-medium'>
+            Publish
+          </span>
+        )}
+      </div>
+      <div className='grid grid-cols-2 gap-2'>
+        <Widget title='AI-resolved this week'>
+          <MockKpiTile
+            label='Tickets'
+            value={AI_RESOLVED_KPI.value}
+            deltaLabel={AI_RESOLVED_KPI.deltaLabel}
+            className='mt-2'
+          />
+        </Widget>
+        <Widget title='Ticket status'>
+          <MockDonut
+            data={TICKET_STATUS}
+            showLegend={false}
+            centerValue='68%'
+            centerLabel='resolved'
+          />
+        </Widget>
+        <Widget title='AI-resolved rate' className='max-sm:hidden'>
+          <MockLineChart
+            data={AI_IMPACT}
+            xKey='week'
+            series={[{ key: 'rate', label: 'AI-resolved %', colorVar: 'report-c4' }]}
+            className='mt-2 h-28'
+            showTooltip={false}
+          />
+        </Widget>
+        <Widget title='Newest tickets' className='max-sm:hidden'>
+          <MockRecordList tickets={RECENT_TICKETS} className='mt-1' />
+        </Widget>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/mock-donut.tsx
+++ b/apps/homepage/src/app/platform/reporting/_mocks/mock-donut.tsx
@@ -1,0 +1,72 @@
+// apps/homepage/src/app/platform/reporting/_mocks/mock-donut.tsx
+'use client'
+
+import { Cell, Pie, PieChart } from 'recharts'
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from '~/components/ui/chart'
+import { cn } from '~/lib/utils'
+import { MockLegend } from './mock-card'
+
+const SLOT_VARS = ['report-c1', 'report-c2', 'report-c3', 'report-c4']
+
+interface MockDonutProps {
+  data: { key: string; name: string; value: number }[]
+  /** Big number in the donut hole, e.g. '68%' */
+  centerValue?: string
+  centerLabel?: string
+  className?: string
+  showLegend?: boolean
+  /** Override the per-slice slot vars (e.g. a neutral 'report-rest' remainder) */
+  slotVars?: string[]
+}
+
+/** Theme-aware donut with a center stat and a dot legend. Slots assigned in fixed order. */
+export function MockDonut({
+  data,
+  centerValue,
+  centerLabel,
+  className,
+  showLegend = true,
+  slotVars = SLOT_VARS,
+}: MockDonutProps) {
+  const config = Object.fromEntries(
+    data.map((d, i) => [d.key, { label: d.name, color: `var(--${slotVars[i % slotVars.length]})` }])
+  )
+
+  return (
+    <div className={className}>
+      <div className='relative'>
+        <ChartContainer config={config} className='aspect-auto h-40 w-full'>
+          <PieChart margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+            <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+            <Pie
+              data={data}
+              dataKey='value'
+              nameKey='name'
+              innerRadius={52}
+              outerRadius={72}
+              paddingAngle={2}
+              strokeWidth={0}>
+              {data.map((d, i) => (
+                <Cell key={d.key} fill={`var(--${slotVars[i % slotVars.length]})`} />
+              ))}
+            </Pie>
+          </PieChart>
+        </ChartContainer>
+        {centerValue && (
+          <div className='pointer-events-none absolute inset-0 flex flex-col items-center justify-center'>
+            <div className='text-foreground text-2xl font-semibold tracking-tight'>
+              {centerValue}
+            </div>
+            {centerLabel && <div className='text-muted-foreground text-xs'>{centerLabel}</div>}
+          </div>
+        )}
+      </div>
+      {showLegend && (
+        <MockLegend
+          className={cn('justify-center')}
+          items={data.map((d, i) => ({ label: d.name, colorVar: slotVars[i % slotVars.length] }))}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/mock-drill-down.tsx
+++ b/apps/homepage/src/app/platform/reporting/_mocks/mock-drill-down.tsx
@@ -1,0 +1,82 @@
+// apps/homepage/src/app/platform/reporting/_mocks/mock-drill-down.tsx
+'use client'
+
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { useState } from 'react'
+import { cn } from '~/lib/utils'
+import { MockCard } from './mock-card'
+import { MockRecordList } from './mock-record-list'
+import { TICKETS_BY_TAG } from './sample-data'
+
+/**
+ * Interactive group-by → drill-down mock: click a tag bar and the underlying
+ * tickets slide in below, mirroring the product's drill-down to the record
+ * drawer.
+ */
+export function MockDrillDown({ className }: { className?: string }) {
+  const [selectedTag, setSelectedTag] = useState(TICKETS_BY_TAG[0].tag)
+  const reducedMotion = useReducedMotion()
+  const max = Math.max(...TICKETS_BY_TAG.map((t) => t.count))
+  const selected = TICKETS_BY_TAG.find((t) => t.tag === selectedTag) ?? TICKETS_BY_TAG[0]
+
+  return (
+    <MockCard
+      layered
+      title='Tickets by tag'
+      subtitle='This month · click a tag to drill down'
+      className={className}>
+      <div className='mt-4 space-y-1.5'>
+        {TICKETS_BY_TAG.map((row) => {
+          const isSelected = row.tag === selectedTag
+          return (
+            <button
+              key={row.tag}
+              type='button'
+              onClick={() => setSelectedTag(row.tag)}
+              aria-pressed={isSelected}
+              className={cn(
+                'group grid w-full grid-cols-[4.5rem_1fr_2rem] items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors',
+                isSelected ? 'bg-muted/80' : 'hover:bg-muted/50'
+              )}>
+              <span
+                className={cn(
+                  'truncate text-xs',
+                  isSelected ? 'text-foreground font-medium' : 'text-muted-foreground'
+                )}>
+                {row.tag}
+              </span>
+              <span className='bg-muted relative h-3.5 overflow-hidden rounded-sm'>
+                <span
+                  className={cn(
+                    'absolute inset-y-0 left-0 rounded-sm bg-[var(--report-c1)] transition-[width] duration-500',
+                    !isSelected && 'opacity-60 group-hover:opacity-80'
+                  )}
+                  style={{ width: `${(row.count / max) * 100}%` }}
+                />
+              </span>
+              <span className='text-muted-foreground text-right text-xs tabular-nums'>
+                {row.count}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className='border-border/70 mt-4 border-t pt-3'>
+        <div className='text-muted-foreground text-[10px] font-medium uppercase tracking-wide'>
+          {selected.tag} · {selected.count} tickets
+        </div>
+        <AnimatePresence mode='wait' initial={false}>
+          <motion.div
+            key={selected.tag}
+            initial={reducedMotion ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reducedMotion ? undefined : { opacity: 0, y: -4 }}
+            transition={{ duration: 0.25 }}>
+            <MockRecordList tickets={selected.tickets} className='mt-1' />
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </MockCard>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/mock-gauge.tsx
+++ b/apps/homepage/src/app/platform/reporting/_mocks/mock-gauge.tsx
@@ -1,0 +1,55 @@
+// apps/homepage/src/app/platform/reporting/_mocks/mock-gauge.tsx
+'use client'
+
+import { PolarAngleAxis, RadialBar, RadialBarChart } from 'recharts'
+import { ChartContainer } from '~/components/ui/chart'
+import { cn } from '~/lib/utils'
+
+interface MockGaugeProps {
+  /** 0–100 */
+  value: number
+  valueLabel?: string
+  label?: string
+  colorVar?: string
+  className?: string
+}
+
+/** Radial gauge with a center stat, e.g. "AI-resolved rate 58%". */
+export function MockGauge({
+  value,
+  valueLabel,
+  label,
+  colorVar = 'report-c4',
+  className,
+}: MockGaugeProps) {
+  const config = { value: { label: label ?? 'Rate', color: `var(--${colorVar})` } }
+  const data = [{ name: label ?? 'Rate', value }]
+
+  return (
+    <div className={cn('relative', className)}>
+      <ChartContainer config={config} className='aspect-auto h-36 w-full'>
+        <RadialBarChart
+          data={data}
+          startAngle={220}
+          endAngle={-40}
+          innerRadius={56}
+          outerRadius={76}>
+          <PolarAngleAxis type='number' domain={[0, 100]} angleAxisId={0} tick={false} />
+          <RadialBar
+            dataKey='value'
+            background
+            cornerRadius={4}
+            fill='var(--color-value)'
+            angleAxisId={0}
+          />
+        </RadialBarChart>
+      </ChartContainer>
+      <div className='pointer-events-none absolute inset-0 flex flex-col items-center justify-center'>
+        <div className='text-foreground text-2xl font-semibold tracking-tight'>
+          {valueLabel ?? `${value}%`}
+        </div>
+        {label && <div className='text-muted-foreground text-xs'>{label}</div>}
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/mock-kpi-tile.tsx
+++ b/apps/homepage/src/app/platform/reporting/_mocks/mock-kpi-tile.tsx
@@ -1,0 +1,87 @@
+// apps/homepage/src/app/platform/reporting/_mocks/mock-kpi-tile.tsx
+'use client'
+
+import NumberFlow from '@number-flow/react'
+import { useInView } from 'motion/react'
+import { useId, useRef } from 'react'
+import { Area, AreaChart } from 'recharts'
+import { ChartContainer } from '~/components/ui/chart'
+import { cn } from '~/lib/utils'
+
+interface MockKpiTileProps {
+  label: string
+  value: number
+  /** e.g. '▲ 18%' — rendered in emerald when positive, amber when negative */
+  deltaLabel?: string
+  deltaTone?: 'positive' | 'negative'
+  suffix?: string
+  fractionDigits?: number
+  spark?: { x: string; y: number }[]
+  className?: string
+}
+
+/**
+ * Animated KPI counter (counts up when scrolled into view) with an optional
+ * trend sparkline. NumberFlow respects prefers-reduced-motion on its own.
+ */
+export function MockKpiTile({
+  label,
+  value,
+  deltaLabel,
+  deltaTone = 'positive',
+  suffix,
+  fractionDigits = 0,
+  spark,
+  className,
+}: MockKpiTileProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const inView = useInView(ref, { once: true, margin: '-10% 0px' })
+  const gradientId = useId().replace(/:/g, '')
+
+  return (
+    <div ref={ref} className={className}>
+      <div className='text-muted-foreground text-xs'>{label}</div>
+      <div className='mt-1 flex items-baseline gap-2'>
+        <NumberFlow
+          value={inView ? value : 0}
+          format={{ maximumFractionDigits: fractionDigits }}
+          suffix={suffix}
+          className='text-foreground text-3xl font-semibold tracking-tight'
+        />
+        {deltaLabel && (
+          <span
+            className={cn(
+              'text-xs font-medium',
+              deltaTone === 'positive'
+                ? 'text-emerald-600 dark:text-emerald-500'
+                : 'text-amber-600 dark:text-amber-500'
+            )}>
+            {deltaLabel}
+          </span>
+        )}
+      </div>
+      {spark && (
+        <ChartContainer
+          config={{ y: { label, color: 'var(--report-c1)' } }}
+          className='mt-3 aspect-auto h-10 w-full'>
+          <AreaChart data={spark} margin={{ top: 2, right: 0, bottom: 0, left: 0 }}>
+            <defs>
+              <linearGradient id={gradientId} x1='0' y1='0' x2='0' y2='1'>
+                <stop offset='0%' stopColor='var(--color-y)' stopOpacity={0.4} />
+                <stop offset='100%' stopColor='var(--color-y)' stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+            <Area
+              dataKey='y'
+              type='monotone'
+              stroke='var(--color-y)'
+              strokeWidth={2}
+              fill={`url(#${gradientId})`}
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        </ChartContainer>
+      )}
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/mock-line-chart.tsx
+++ b/apps/homepage/src/app/platform/reporting/_mocks/mock-line-chart.tsx
@@ -1,0 +1,80 @@
+// apps/homepage/src/app/platform/reporting/_mocks/mock-line-chart.tsx
+'use client'
+
+import { useId } from 'react'
+import { Area, AreaChart, XAxis } from 'recharts'
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '~/components/ui/chart'
+import { cn } from '~/lib/utils'
+
+export interface MockSeries {
+  key: string
+  label: string
+  /** chart slot var, e.g. 'report-c1' */
+  colorVar: string
+}
+
+interface MockLineChartProps {
+  data: Record<string, string | number>[]
+  xKey: string
+  series: MockSeries[]
+  className?: string
+  showXAxis?: boolean
+  showTooltip?: boolean
+}
+
+/** Theme-aware area/line chart with gradient fills and a hover tooltip. */
+export function MockLineChart({
+  data,
+  xKey,
+  series,
+  className,
+  showXAxis = false,
+  showTooltip = true,
+}: MockLineChartProps) {
+  const gradientPrefix = useId().replace(/:/g, '')
+  const config = Object.fromEntries(
+    series.map((s) => [s.key, { label: s.label, color: `var(--${s.colorVar})` }])
+  ) satisfies ChartConfig
+
+  return (
+    <ChartContainer config={config} className={cn('aspect-auto h-40 w-full', className)}>
+      <AreaChart data={data} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
+        <defs>
+          {series.map((s) => (
+            <linearGradient
+              key={s.key}
+              id={`${gradientPrefix}-${s.key}`}
+              x1='0'
+              y1='0'
+              x2='0'
+              y2='1'>
+              <stop offset='0%' stopColor={`var(--color-${s.key})`} stopOpacity={0.35} />
+              <stop offset='100%' stopColor={`var(--color-${s.key})`} stopOpacity={0.02} />
+            </linearGradient>
+          ))}
+        </defs>
+        {showXAxis && (
+          <XAxis dataKey={xKey} tickLine={false} axisLine={false} tickMargin={6} fontSize={10} />
+        )}
+        {showTooltip && (
+          <ChartTooltip cursor={false} content={<ChartTooltipContent indicator='line' />} />
+        )}
+        {series.map((s) => (
+          <Area
+            key={s.key}
+            dataKey={s.key}
+            type='monotone'
+            stroke={`var(--color-${s.key})`}
+            strokeWidth={2}
+            fill={`url(#${gradientPrefix}-${s.key})`}
+          />
+        ))}
+      </AreaChart>
+    </ChartContainer>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/mock-record-list.tsx
+++ b/apps/homepage/src/app/platform/reporting/_mocks/mock-record-list.tsx
@@ -1,0 +1,43 @@
+// apps/homepage/src/app/platform/reporting/_mocks/mock-record-list.tsx
+
+import { cn } from '~/lib/utils'
+import type { RecordRow } from './sample-data'
+
+const statusClasses: Record<string, string> = {
+  Open: 'bg-sky-500/10 text-sky-700 dark:text-sky-400',
+  Resolved: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+  Escalated: 'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+  Customer: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+  Lead: 'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+  VIP: 'bg-violet-500/10 text-violet-700 dark:text-violet-400',
+}
+
+/** Compact record table, mirroring the product's record-list widget. */
+export function MockRecordList({
+  tickets,
+  className,
+}: {
+  tickets: RecordRow[]
+  className?: string
+}) {
+  return (
+    <div className={cn('divide-border/70 divide-y', className)}>
+      {tickets.map((ticket) => (
+        <div key={ticket.id} className='grid grid-cols-[auto_1fr_auto] items-center gap-2 py-1.5'>
+          <span className='text-muted-foreground w-11 font-mono text-[10px]'>{ticket.id}</span>
+          <div className='min-w-0'>
+            <div className='text-foreground truncate text-xs font-medium'>{ticket.subject}</div>
+            <div className='text-muted-foreground truncate text-[10px]'>{ticket.contact}</div>
+          </div>
+          <span
+            className={cn(
+              'rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+              statusClasses[ticket.status] ?? 'bg-muted text-muted-foreground'
+            )}>
+            {ticket.status}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/reporting/_mocks/sample-data.ts
+++ b/apps/homepage/src/app/platform/reporting/_mocks/sample-data.ts
@@ -1,0 +1,259 @@
+// apps/homepage/src/app/platform/reporting/_mocks/sample-data.ts
+
+/**
+ * All hardcoded series for the reporting-page chart mocks live here so the
+ * numbers stay consistent with the surrounding copy. Chart slot colors are
+ * defined in `mock-card.tsx` (`CHART_VARS_CLASS`).
+ */
+
+/** Hero KPI — "AI-resolved this week" */
+export const AI_RESOLVED_KPI = {
+  value: 1284,
+  deltaLabel: '▲ 18%',
+  spark: [
+    { x: 'W1', y: 640 },
+    { x: 'W2', y: 720 },
+    { x: 'W3', y: 690 },
+    { x: 'W4', y: 810 },
+    { x: 'W5', y: 900 },
+    { x: 'W6', y: 980 },
+    { x: 'W7', y: 1090 },
+    { x: 'W8', y: 1284 },
+  ],
+}
+
+/** Hero + featured — "Median resolution time" in minutes, Email vs Chat, trending down */
+export const RESOLUTION_TIME = [
+  { week: 'W1', email: 96, chat: 45 },
+  { week: 'W2', email: 88, chat: 41 },
+  { week: 'W3', email: 91, chat: 38 },
+  { week: 'W4', email: 74, chat: 33 },
+  { week: 'W5', email: 66, chat: 29 },
+  { week: 'W6', email: 58, chat: 24 },
+  { week: 'W7', email: 47, chat: 21 },
+  { week: 'W8', email: 41, chat: 18 },
+]
+
+/** Hero + customize — "Tickets by team" */
+export const TICKETS_BY_TEAM = [
+  { name: 'Support', value: 342 },
+  { name: 'Success', value: 187 },
+  { name: 'Ops', value: 96 },
+]
+
+/** Featured — "Support Performance" donut */
+export const TICKET_STATUS = [
+  { key: 'resolved', name: 'Resolved', value: 812 },
+  { key: 'open', name: 'Open', value: 264 },
+  { key: 'escalated', name: 'Escalated', value: 118 },
+]
+
+/** Featured + grid — "AI-resolved %" over 8 weeks, climbing */
+export const AI_IMPACT = [
+  { week: 'W1', rate: 22 },
+  { week: 'W2', rate: 28 },
+  { week: 'W3', rate: 31 },
+  { week: 'W4', rate: 38 },
+  { week: 'W5', rate: 42 },
+  { week: 'W6', rate: 47 },
+  { week: 'W7', rate: 53 },
+  { week: 'W8', rate: 58 },
+]
+
+/** Featured + grid — "Contacts by company" */
+export const CONTACTS_BY_COMPANY = [
+  { name: 'Acme Inc', value: 124 },
+  { name: 'Northwind', value: 98 },
+  { name: 'Globex', value: 76 },
+  { name: 'Initech', value: 61 },
+  { name: 'Umbrella', value: 43 },
+]
+
+export interface DrillDownTicket {
+  id: string
+  subject: string
+  contact: string
+  status: 'Open' | 'Resolved' | 'Escalated'
+}
+
+/** Drill-down — tickets grouped by tag, each with its underlying records */
+export const TICKETS_BY_TAG: {
+  tag: string
+  count: number
+  tickets: DrillDownTicket[]
+}[] = [
+  {
+    tag: 'Refunds',
+    count: 48,
+    tickets: [
+      { id: '#4821', subject: 'Refund for damaged blender', contact: 'Mia Chen', status: 'Open' },
+      { id: '#4809', subject: 'Double charge on order 1042', contact: 'Leo Park', status: 'Open' },
+      {
+        id: '#4793',
+        subject: 'Return label never arrived',
+        contact: 'Ana Souza',
+        status: 'Resolved',
+      },
+      { id: '#4771', subject: 'Partial refund request', contact: 'Tom Hale', status: 'Escalated' },
+    ],
+  },
+  {
+    tag: 'Shipping',
+    count: 36,
+    tickets: [
+      { id: '#4830', subject: 'Package stuck in transit', contact: 'Ravi Patel', status: 'Open' },
+      { id: '#4812', subject: 'Wrong address on order', contact: 'Emma Voss', status: 'Resolved' },
+      { id: '#4788', subject: 'Expedite to overnight?', contact: 'Kai Tanaka', status: 'Resolved' },
+    ],
+  },
+  {
+    tag: 'Returns',
+    count: 29,
+    tickets: [
+      {
+        id: '#4825',
+        subject: 'Exchange for a larger size',
+        contact: 'Sofia Marin',
+        status: 'Open',
+      },
+      { id: '#4801', subject: 'Return window question', contact: 'Jon Berg', status: 'Resolved' },
+      { id: '#4779', subject: 'Item arrived opened', contact: 'Lena Kroll', status: 'Escalated' },
+    ],
+  },
+  {
+    tag: 'Billing',
+    count: 18,
+    tickets: [
+      { id: '#4818', subject: 'Update card on file', contact: 'Omar Aziz', status: 'Resolved' },
+      { id: '#4795', subject: 'Invoice for order 1031', contact: 'Ines Roca', status: 'Open' },
+    ],
+  },
+]
+
+/** Grid — tickets created per day (last 14 days) */
+export const TICKETS_PER_DAY = [
+  { day: '1', value: 34 },
+  { day: '2', value: 41 },
+  { day: '3', value: 38 },
+  { day: '4', value: 52 },
+  { day: '5', value: 47 },
+  { day: '6', value: 22 },
+  { day: '7', value: 18 },
+  { day: '8', value: 44 },
+  { day: '9', value: 49 },
+  { day: '10', value: 55 },
+  { day: '11', value: 43 },
+  { day: '12', value: 51 },
+  { day: '13', value: 27 },
+  { day: '14', value: 24 },
+]
+
+/** Grid — CSAT trend */
+export const CSAT_TREND = [
+  { week: 'W1', score: 4.2 },
+  { week: 'W2', score: 4.3 },
+  { week: 'W3', score: 4.2 },
+  { week: 'W4', score: 4.4 },
+  { week: 'W5', score: 4.5 },
+  { week: 'W6', score: 4.6 },
+  { week: 'W7', score: 4.7 },
+  { week: 'W8', score: 4.8 },
+]
+
+/** Dashboard-grid mock — compact record list */
+export const RECENT_TICKETS: DrillDownTicket[] = [
+  { id: '#4832', subject: 'Where is my order?', contact: 'Nora Vik', status: 'Open' },
+  { id: '#4831', subject: 'Cancel subscription', contact: 'Sam Ortiz', status: 'Open' },
+  { id: '#4829', subject: 'Warranty on mixer', contact: 'Ada Lin', status: 'Resolved' },
+]
+
+// ── Customize-section config matrix ─────────────────────────────────────────
+// Tickets total 625 this quarter, contacts total 402 — every category split
+// below sums to those totals so the preview stays coherent while switching.
+
+export const TICKETS_BY_CHANNEL = [
+  { name: 'Email', value: 402 },
+  { name: 'Chat', value: 148 },
+  { name: 'Social', value: 75 },
+]
+
+export const TICKETS_BY_TAG_QUARTER = [
+  { name: 'Refunds', value: 214 },
+  { name: 'Shipping', value: 168 },
+  { name: 'Returns', value: 133 },
+  { name: 'Billing', value: 110 },
+]
+
+export const CONTACTS_BY_TAG = [
+  { name: 'Customer', value: 214 },
+  { name: 'Lead', value: 118 },
+  { name: 'VIP', value: 70 },
+]
+
+/** AI-resolved % per category slice */
+export const AI_RATE_BY_TEAM = [
+  { name: 'Support', value: 52 },
+  { name: 'Success', value: 61 },
+  { name: 'Ops', value: 48 },
+]
+
+export const AI_RATE_BY_CHANNEL = [
+  { name: 'Email', value: 55 },
+  { name: 'Chat', value: 66 },
+  { name: 'Social', value: 41 },
+]
+
+export const AI_RATE_BY_TAG = [
+  { name: 'Refunds', value: 49 },
+  { name: 'Shipping', value: 63 },
+  { name: 'Returns', value: 57 },
+  { name: 'Billing', value: 71 },
+]
+
+/** Weekly totals for the line previews */
+export const TICKET_TREND = [
+  { week: 'W1', total: 480 },
+  { week: 'W2', total: 510 },
+  { week: 'W3', total: 495 },
+  { week: 'W4', total: 540 },
+  { week: 'W5', total: 560 },
+  { week: 'W6', total: 585 },
+  { week: 'W7', total: 600 },
+  { week: 'W8', total: 625 },
+]
+
+export const CONTACT_TREND = [
+  { week: 'W1', total: 348 },
+  { week: 'W2', total: 355 },
+  { week: 'W3', total: 362 },
+  { week: 'W4', total: 370 },
+  { week: 'W5', total: 376 },
+  { week: 'W6', total: 384 },
+  { week: 'W7', total: 392 },
+  { week: 'W8', total: 402 },
+]
+
+/** Weekly ticket volume split Email vs Chat (Series = Channel on the line preview) */
+export const TICKET_TREND_BY_CHANNEL = [
+  { week: 'W1', email: 310, chat: 118 },
+  { week: 'W2', email: 325, chat: 124 },
+  { week: 'W3', email: 318, chat: 120 },
+  { week: 'W4', email: 345, chat: 132 },
+  { week: 'W5', email: 355, chat: 138 },
+  { week: 'W6', email: 370, chat: 146 },
+  { week: 'W7', email: 382, chat: 150 },
+  { week: 'W8', email: 402, chat: 148 },
+]
+
+export interface RecordRow {
+  id: string
+  subject: string
+  contact: string
+  status: string
+}
+
+export const RECENT_CONTACTS: RecordRow[] = [
+  { id: '#C214', subject: 'Mia Chen', contact: 'Acme Inc', status: 'Customer' },
+  { id: '#C213', subject: 'Leo Park', contact: 'Northwind', status: 'Lead' },
+  { id: '#C212', subject: 'Ana Souza', contact: 'Globex', status: 'VIP' },
+]

--- a/apps/homepage/src/app/platform/reporting/page.tsx
+++ b/apps/homepage/src/app/platform/reporting/page.tsx
@@ -1,0 +1,47 @@
+// apps/homepage/src/app/platform/reporting/page.tsx
+import type { Metadata } from 'next'
+import { config } from '~/lib/config'
+import LogoCloudTwo from '../../_components/logo-cloud'
+import FooterSection from '../../_components/main/footer-section'
+import Header from '../../_components/main/header'
+import { BreadcrumbJsonLd } from '../../_components/seo/breadcrumb-json-ld'
+import BuildDashboardsSection from './_components/build-dashboards-section'
+import CollaborateSection from './_components/collaborate-section'
+import CustomizeSection from './_components/customize-section'
+import DataExplorationGrid from './_components/data-exploration-grid'
+import DrillDownSection from './_components/drill-down-section'
+import FeaturedReports from './_components/featured-reports'
+import ReportingFinalCta from './_components/reporting-final-cta'
+import ReportingHero from './_components/reporting-hero'
+
+export const metadata: Metadata = {
+  title: `Reporting & Dashboards | ${config.shortName}`,
+  description: `Build live dashboards over every ticket, contact, and conversation. ${config.shortName} turns your support and CRM data into charts, KPIs, and shareable reports.`,
+}
+
+export default function ReportingPage() {
+  return (
+    <div id='root' className='bg-background relative h-screen overflow-y-auto'>
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', href: 'https://auxx.ai' },
+          { name: 'Platform', href: 'https://auxx.ai/platform' },
+          { name: 'Reporting' },
+        ]}
+      />
+      <Header />
+      <main>
+        <ReportingHero />
+        <FeaturedReports />
+        <LogoCloudTwo />
+        <DrillDownSection />
+        <CustomizeSection />
+        <BuildDashboardsSection />
+        <CollaborateSection />
+        <DataExplorationGrid />
+        <ReportingFinalCta />
+      </main>
+      <FooterSection />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add a new `/platform/reporting` marketing page (hero, feature sections, and self-contained chart mocks under `_mocks/`).
- Shorten the platform mega-menu descriptions in the header so they no longer truncate under `line-clamp-1`, and pair the single-item groups (Communication, Insights) side by side while keeping their section titles.
- Make the messaging hero gradient theme-aware: light palette (`candy`) in light mode instead of the dark `midnight` palette that read as a heavy blob on the light page. Dark mode still uses `midnight`.

## Testing
- Biome lint clean on all touched files.
- Verified the messaging hero renders a soft light gradient with readable text in light mode via the local dev server.