### PR TITLE
feat(homepage): redesign CRM hero + add dashboards section

### DIFF
--- a/apps/homepage/src/app/page.tsx
+++ b/apps/homepage/src/app/page.tsx
@@ -15,6 +15,7 @@ import KopilotAgentsCta from './platform/ai/kopilot/_components/kopilot-agents-c
 import CrmHero from './platform/crm/_components/crm-hero'
 import DataModelWallHero from './platform/data-model/_components/data-model-wall-hero'
 import IngestionFlowSection from './platform/data-model/_components/ingestion-flow-section'
+import BuildDashboardsSection from './platform/reporting/_components/build-dashboards-section'
 import WorkflowContent from './platform/workflow/_components/workflow-content'
 
 export const metadata: Metadata = {
@@ -75,6 +76,7 @@ export default function MainPage() {
       <KopilotHomeSection />
       {/* <ProblemSolutionSection /> */}
       <StatsSection />
+      <BuildDashboardsSection />
       <IntegrationSection />
       <TestimonialsSection />
       <KopilotAgentsCta />

--- a/apps/homepage/src/app/platform/ai/_mocks/index.ts
+++ b/apps/homepage/src/app/platform/ai/_mocks/index.ts
@@ -4,6 +4,7 @@ export {
   ENTITY_COLOR_CLASS,
   type EntityColor,
   MockAppSidebar,
+  type MockSidebarRecordItem,
   type SidebarKey,
 } from './mock-app-sidebar'
 export { MockAssistantSlot } from './mock-assistant-message'

--- a/apps/homepage/src/app/platform/ai/_mocks/mock-app-sidebar.tsx
+++ b/apps/homepage/src/app/platform/ai/_mocks/mock-app-sidebar.tsx
@@ -7,14 +7,16 @@ import {
   Database,
   FileQuestion,
   FileText,
-  Folder,
   Inbox,
   type Mail,
   MessagesSquare,
+  Package,
+  ShoppingCart,
   Sparkles,
   Ticket,
   Users,
   Workflow,
+  Zap,
 } from 'lucide-react'
 import { cn } from '~/lib/utils'
 
@@ -26,21 +28,24 @@ export type SidebarKey =
   | 'workflows'
   | 'datasets'
   | 'kb'
-  | 'godela'
   | 'contacts'
   | 'tickets'
+  | 'parts'
   | 'companies'
+  | 'orders'
 
 interface MockAppSidebarProps {
   /** Which sidebar item to highlight as active. Default `'kopilot'`. */
-  activeKey?: SidebarKey
+  activeKey?: SidebarKey | (string & {})
+  /** When set, replaces the items of the `Records` group (used by persona demos). */
+  recordItems?: MockSidebarRecordItem[]
   /** Sidebar width — passed through as inline style. */
   width?: number | string
   className?: string
 }
 
 interface SidebarItem {
-  key: SidebarKey
+  key: string
   label: string
   icon: typeof Mail
   badge?: string
@@ -56,6 +61,13 @@ interface SidebarItem {
     | 'amber'
     | 'teal'
     | 'red'
+}
+
+export interface MockSidebarRecordItem {
+  key: string
+  label: string
+  icon: typeof Mail
+  entityColor: NonNullable<SidebarItem['entityColor']>
 }
 
 interface SidebarGroup {
@@ -103,15 +115,13 @@ const SIDEBAR_GROUPS: SidebarGroup[] = [
     ],
   },
   {
-    title: 'Favorites',
-    items: [{ key: 'godela', label: 'Godela', icon: Folder }],
-  },
-  {
     title: 'Records',
     items: [
       { key: 'contacts', label: 'Contacts', icon: Users, entityColor: 'blue' },
       { key: 'tickets', label: 'Tickets', icon: Ticket, entityColor: 'orange' },
+      { key: 'parts', label: 'Parts', icon: Package, entityColor: 'amber' },
       { key: 'companies', label: 'Companies', icon: Building2, entityColor: 'purple' },
+      { key: 'orders', label: 'Orders', icon: ShoppingCart, entityColor: 'green' },
     ],
   },
 ]
@@ -131,9 +141,16 @@ const SIDEBAR_GROUPS: SidebarGroup[] = [
  */
 export function MockAppSidebar({
   activeKey = 'kopilot',
+  recordItems,
   width = 220,
   className,
 }: MockAppSidebarProps) {
+  const groups = recordItems
+    ? SIDEBAR_GROUPS.map((group) =>
+        group.title === 'Records' ? { ...group, items: recordItems } : group
+      )
+    : SIDEBAR_GROUPS
+
   return (
     <aside
       style={{ width }}
@@ -144,11 +161,33 @@ export function MockAppSidebar({
       <NavUserMock />
 
       <div className='flex-1 space-y-2 overflow-hidden px-2 pb-3'>
-        {SIDEBAR_GROUPS.map((group) => (
+        <QuickActionsMock />
+        {groups.map((group) => (
           <SidebarGroupBlock key={group.title} group={group} activeKey={activeKey} />
         ))}
       </div>
     </aside>
+  )
+}
+
+/**
+ * Static facsimile of `apps/web/src/components/global/sidebar/quick-actions-nav.tsx` —
+ * the boxed command-palette trigger that sits directly below the user row.
+ */
+function QuickActionsMock() {
+  return (
+    <div className='flex h-7 items-center gap-2 rounded-md bg-mock-window px-2 text-xs text-mock-sidebar-foreground shadow-[0_0_2px_0_rgba(28,40,64,0.18),0_1px_3px_0_rgba(24,41,75,0.04)] dark:shadow-[inset_0_0_0_1px_#2f3033,0_0_2px_0_#000,0_1px_3px_0_rgba(0,0,0,0.08)]'>
+      <Zap className='size-4 shrink-0' />
+      <span className='flex-1 truncate text-left'>Quick Actions</span>
+      <span className='flex shrink-0 items-center gap-0.5'>
+        <kbd className='flex h-4 min-w-4 items-center justify-center rounded border border-mock-sidebar-border px-1 text-[10px] text-mock-sidebar-muted'>
+          ⌘
+        </kbd>
+        <kbd className='flex h-4 min-w-4 items-center justify-center rounded border border-mock-sidebar-border px-1 text-[10px] text-mock-sidebar-muted'>
+          K
+        </kbd>
+      </span>
+    </div>
   )
 }
 
@@ -169,7 +208,7 @@ function NavUserMock() {
   )
 }
 
-function SidebarGroupBlock({ group, activeKey }: { group: SidebarGroup; activeKey: SidebarKey }) {
+function SidebarGroupBlock({ group, activeKey }: { group: SidebarGroup; activeKey: string }) {
   return (
     <div>
       <div className='flex h-6 items-center rounded-md px-2 text-xs font-medium text-mock-sidebar-muted'>

--- a/apps/homepage/src/app/platform/crm/_components/crm-hero.tsx
+++ b/apps/homepage/src/app/platform/crm/_components/crm-hero.tsx
@@ -1,13 +1,12 @@
 // apps/homepage/src/app/platform/crm/_components/crm-hero.tsx
 
+import { Database } from 'lucide-react'
 import Link from 'next/link'
 import { SectionBottomFade } from '~/app/_components/main/section-bottom-fade'
-import { ShaderGradientBg } from '~/app/_components/shader-gradient-bg'
-import { AutoplayVideo } from '~/components/autoplay-video'
 import { Button } from '~/components/ui/button'
-import { videoUrl } from '~/lib/cdn'
 import { config } from '~/lib/config'
 import { cn } from '~/lib/utils'
+import { CrmBrowserDemo, EntityCanvas, EntityCardsGrid } from '../_mocks'
 
 interface CrmHeroProps {
   as?: 'h1' | 'h2'
@@ -18,77 +17,57 @@ interface CrmHeroProps {
   bottomFadeColor?: string
 }
 
+/**
+ * Attio-data-model-style hero: centered headline flanked by entity cards
+ * connected with dotted SVG relationship lines, flowing down into a mock
+ * app browser showing a contacts records view.
+ */
 export default function CrmHero({ as: Heading = 'h1', bottomFadeColor }: CrmHeroProps) {
   return (
-    <section className={cn('overflow-hidden relative', !bottomFadeColor && 'border-b')}>
-      <ShaderGradientBg preset='hero' palette='dawn' uniforms={{ timeSpeed: 0.7 }} />
+    <section className={cn('relative overflow-hidden', !bottomFadeColor && 'border-b')}>
+      {/* Dot-grid background, faded toward the edges. */}
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle,var(--color-foreground)_1px,transparent_1px)] [background-size:24px_24px] opacity-[0.06] [mask-image:radial-gradient(ellipse_at_top,black_45%,transparent_90%)]'
+      />
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-x-0 top-0 h-[600px] bg-[radial-gradient(ellipse_at_top,_var(--color-primary)/8,_transparent_60%)]'
+      />
       {bottomFadeColor && <SectionBottomFade toColor={bottomFadeColor} />}
-      <section className='bg-background/40 relative z-10'>
-        <div
-          aria-hidden
-          className='pointer-events-none absolute inset-0 z-10 mx-1 grid max-w-6xl grid-cols-3 border-x [--color-border:var(--color-border-illustration)] sm:grid-cols-4 md:mx-auto'>
-          <div className='h-full border-r border-dashed' />
-          <div className='h-full border-r border-dashed' />
-          <div className='h-full max-sm:hidden' />
-          <div className='h-full border-l border-dashed max-sm:hidden' />
-        </div>
-        <div className='relative pb-32 pt-24 md:pb-40 md:pt-36 lg:pt-40'>
-          <div className='mx-auto w-full px-6 lg:max-w-5xl'>
-            <div className='grid items-center max-lg:gap-12 lg:grid-cols-2 '>
-              <div className='sm:h-[550px]'>
-                <div className='lg:max-w-sm'>
-                  <Heading className='text-balance text-4xl font-semibold md:text-5xl'>
-                    Know Your Customers, Grow Your Business
-                  </Heading>
-                  <p className='text-muted-foreground mb-6 mt-4 text-balance text-lg'>
-                    Complete customer relationship management that scales with your success.
-                  </p>
 
-                  <div className='flex items-center gap-3'>
-                    <Button asChild size='sm'>
-                      <Link href={config.urls.signup}>Start Building</Link>
-                    </Button>
-                    <Button asChild size='sm' variant='outline'>
-                      <Link href={config.urls.demo}>Request demo</Link>
-                    </Button>
-                  </div>
-                </div>
+      <div className='relative mx-auto max-w-6xl px-6 pb-20 pt-24 md:pt-32 lg:pt-36'>
+        <EntityCanvas className='hidden lg:block' />
 
-                <div className='mt-12 grid max-w-sm grid-cols-2'>
-                  <div className='space-y-2 *:block'>
-                    <span className='text-lg font-semibold'>
-                      360 <span className='text-muted-foreground text-lg'>°</span>
-                    </span>
-                    <p className='text-muted-foreground text-balance text-sm'>
-                      <strong className='text-foreground font-medium'>Customer view</strong> with
-                      complete history and insights.
-                    </p>
-                  </div>
+        <div className='relative z-10 mx-auto max-w-2xl text-center'>
+          <div className='mx-auto inline-flex items-center gap-2 rounded-full border border-foreground/10 bg-muted/40 px-3 py-1 text-xs'>
+            <Database className='size-3.5 text-blue-500' />
+            <span className='text-muted-foreground'>CRM · One data model</span>
+          </div>
 
-                  <div className='space-y-2 *:block'>
-                    <span className='text-lg font-semibold'>
-                      10 <span className='text-muted-foreground text-lg'>X</span>
-                    </span>
-                    <p className='text-muted-foreground text-balance text-sm'>
-                      <strong className='text-foreground font-medium'>Faster</strong> customer data
-                      access and management.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div className='max-lg:max-w-[calc(100vw-3rem)] lg:-mr-6 h-[550px] z-100'>
-                <AutoplayVideo
-                  autoPlay
-                  loop
-                  muted
-                  className='size-full rounded-xl object-cover shadow-lg'
-                  src={videoUrl('contact-crm.mp4')}
-                />
-              </div>
-            </div>
+          <Heading className='mt-6 text-balance text-4xl font-semibold tracking-tight md:text-5xl lg:text-6xl'>
+            Every customer.
+            <br />
+            One record.
+          </Heading>
+          <p className='mx-auto mt-4 max-w-xl text-balance text-lg text-muted-foreground'>
+            Contacts, tickets, orders, and conversations — connected in one CRM built for support.
+          </p>
+
+          <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+            <Button asChild size='sm'>
+              <Link href={config.urls.signup}>Start for free</Link>
+            </Button>
+            <Button asChild size='sm' variant='outline'>
+              <Link href={config.urls.demo}>Talk to sales</Link>
+            </Button>
           </div>
         </div>
-      </section>
+
+        <EntityCardsGrid className='mt-14 lg:hidden' />
+
+        <CrmBrowserDemo className='relative z-10 mt-14 lg:mt-[290px]' />
+      </div>
     </section>
   )
 }

--- a/apps/homepage/src/app/platform/crm/_mocks/crm-browser-demo.tsx
+++ b/apps/homepage/src/app/platform/crm/_mocks/crm-browser-demo.tsx
@@ -1,0 +1,60 @@
+// apps/homepage/src/app/platform/crm/_mocks/crm-browser-demo.tsx
+
+'use client'
+
+import { useState } from 'react'
+import { MockAppSidebar, MockBrowserChrome, MockMainPage } from '~/app/platform/ai/_mocks'
+import { cn } from '~/lib/utils'
+import { MockRecordsTable } from './mock-records-table'
+import { MockRecordsTopbar } from './mock-records-topbar'
+import { DEFAULT_PERSONA_KEY, PERSONAS, type PersonaConfig } from './personas'
+
+/**
+ * The hero's mock app browser plus the persona switcher chips below it.
+ * Clicking a chip swaps the browser URL, sidebar Records group, top bar,
+ * and records table to that persona's workspace.
+ */
+export function CrmBrowserDemo({ className }: { className?: string }) {
+  const [activeKey, setActiveKey] = useState<PersonaConfig['key']>(DEFAULT_PERSONA_KEY)
+  const persona = PERSONAS.find((p) => p.key === activeKey) ?? PERSONAS[0]
+
+  return (
+    <div className={cn('text-left', className)}>
+      <MockBrowserChrome variant='regular' url={persona.url}>
+        <div className='flex h-[560px]'>
+          <MockAppSidebar
+            activeKey={persona.activeRecordKey}
+            recordItems={persona.records}
+            className='hidden md:flex'
+          />
+          <MockMainPage
+            header={<MockRecordsTopbar title={persona.pageTitle} newLabel={persona.newLabel} />}>
+            <MockRecordsTable persona={persona} />
+          </MockMainPage>
+        </div>
+      </MockBrowserChrome>
+
+      <div className='mt-6 flex flex-wrap items-center justify-center gap-2'>
+        {PERSONAS.map((p) => {
+          const Icon = p.chipIcon
+          const isActive = p.key === activeKey
+          return (
+            <button
+              key={p.key}
+              type='button'
+              onClick={() => setActiveKey(p.key)}
+              className={cn(
+                'flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs transition-colors',
+                isActive
+                  ? 'border-foreground/20 bg-card font-medium text-foreground shadow-md'
+                  : 'border-border/60 bg-background/60 text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+              )}>
+              <Icon className='size-3.5' />
+              {p.chipLabel}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/crm/_mocks/entity-canvas.tsx
+++ b/apps/homepage/src/app/platform/crm/_mocks/entity-canvas.tsx
@@ -1,0 +1,230 @@
+// apps/homepage/src/app/platform/crm/_mocks/entity-canvas.tsx
+
+'use client'
+
+import {
+  Barcode,
+  Boxes,
+  Briefcase,
+  Building2,
+  CircleDollarSign,
+  CircleDot,
+  Factory,
+  Flag,
+  Globe,
+  Hash,
+  Mail,
+  Package,
+  Phone,
+  ShoppingCart,
+  Ticket,
+  Truck,
+  Type,
+  User,
+  Users,
+} from 'lucide-react'
+import { motion, useReducedMotion } from 'motion/react'
+import { cn } from '~/lib/utils'
+import { EntityCard, type EntityCardData } from './entity-card'
+
+const ENTITIES: EntityCardData[] = [
+  {
+    name: 'Contact',
+    badge: 'System',
+    color: 'blue',
+    icon: Users,
+    attrs: [
+      { icon: User, label: 'Full name' },
+      { icon: Mail, label: 'Email address' },
+      { icon: Phone, label: 'Phone' },
+    ],
+    more: 12,
+  },
+  {
+    name: 'Part',
+    badge: 'Custom',
+    color: 'amber',
+    icon: Package,
+    attrs: [
+      { icon: Barcode, label: 'Part number' },
+      { icon: Factory, label: 'Supplier' },
+      { icon: Boxes, label: 'Stock' },
+    ],
+    more: 6,
+  },
+  {
+    name: 'Ticket',
+    badge: 'System',
+    color: 'orange',
+    icon: Ticket,
+    attrs: [
+      { icon: Type, label: 'Subject' },
+      { icon: CircleDot, label: 'Status' },
+      { icon: Flag, label: 'Priority' },
+    ],
+    more: 14,
+  },
+  {
+    name: 'Company',
+    badge: 'System',
+    color: 'purple',
+    icon: Building2,
+    attrs: [
+      { icon: Type, label: 'Company name' },
+      { icon: Globe, label: 'Domain' },
+      { icon: Briefcase, label: 'Industry' },
+    ],
+    more: 8,
+  },
+  {
+    name: 'Order',
+    badge: 'Custom',
+    color: 'green',
+    icon: ShoppingCart,
+    attrs: [
+      { icon: Hash, label: 'Order number' },
+      { icon: CircleDollarSign, label: 'Total' },
+      { icon: Truck, label: 'Fulfillment' },
+    ],
+    more: 9,
+  },
+]
+
+/**
+ * Fixed-coordinate design space for the desktop canvas. The canvas is a
+ * centered 1104px-wide layer (max-w-6xl minus the px-6 gutters), so card
+ * positions and SVG connector paths share one stable coordinate system —
+ * no measuring needed. Below `lg` the canvas is hidden and
+ * `EntityCardsGrid` renders instead.
+ */
+const CANVAS_W = 1104
+const CANVAS_H = 760
+
+/** [x, y] top-left card positions in canvas coordinates, keyed by ENTITIES order. */
+const CARD_POS: Array<[number, number]> = [
+  [0, 140], // Contact — flanks the headline, left
+  [848, 140], // Part — flanks the headline, right
+  [112, 480], // Ticket
+  [424, 480], // Company
+  [736, 480], // Order
+]
+
+/**
+ * Dotted relationship connectors (rounded orthogonal elbows, Attio-style).
+ * Coordinates match `CARD_POS` anchor points; the last path drops from the
+ * Company card down into the mock browser rendered below the canvas.
+ */
+const EDGE_PATHS = [
+  // Contact ↓→↓ Ticket
+  'M 128 318 V 408 Q 128 418 138 418 H 230 Q 240 418 240 428 V 478',
+  // Part ↓←↓ Order
+  'M 976 318 V 408 Q 976 418 966 418 H 874 Q 864 418 864 428 V 478',
+  // Ticket — Company
+  'M 370 568 H 422',
+  // Company — Order
+  'M 682 568 H 734',
+  // Company ↓ into the browser
+  'M 552 658 V 760',
+]
+
+/** Endpoint dots — start/end of every edge path. */
+const EDGE_DOTS: Array<[number, number]> = [
+  [128, 318],
+  [240, 478],
+  [976, 318],
+  [864, 478],
+  [370, 568],
+  [422, 568],
+  [682, 568],
+  [734, 568],
+  [552, 658],
+]
+
+/**
+ * Desktop (lg+) relationship canvas: five absolutely positioned entity
+ * cards connected by dotted SVG paths, overlaying the hero headline area.
+ * Render inside a `relative` container; pointer-events are disabled.
+ */
+export function EntityCanvas({ className }: { className?: string }) {
+  const reducedMotion = useReducedMotion()
+
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute left-1/2 top-0 -translate-x-1/2 select-none',
+        className
+      )}
+      style={{ width: CANVAS_W, height: CANVAS_H }}>
+      <svg
+        className='absolute inset-0 text-foreground/25'
+        width={CANVAS_W}
+        height={CANVAS_H}
+        viewBox={`0 0 ${CANVAS_W} ${CANVAS_H}`}
+        fill='none'>
+        {EDGE_PATHS.map((d, i) => (
+          <motion.path
+            key={d}
+            d={d}
+            stroke='currentColor'
+            strokeWidth='1.5'
+            strokeLinecap='round'
+            strokeDasharray='2 5'
+            initial={reducedMotion ? false : { pathLength: 0, opacity: 0 }}
+            whileInView={{ pathLength: 1, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.7, delay: 0.35 + i * 0.12, ease: 'easeOut' }}
+          />
+        ))}
+        {EDGE_DOTS.map(([cx, cy]) => (
+          <motion.circle
+            key={`${cx}-${cy}`}
+            cx={cx}
+            cy={cy}
+            r='3'
+            className='fill-background stroke-foreground/30'
+            strokeWidth='1.5'
+            initial={reducedMotion ? false : { opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.3, delay: 0.4 }}
+          />
+        ))}
+      </svg>
+
+      {ENTITIES.map((entity, i) => {
+        const [x, y] = CARD_POS[i]
+        return (
+          <motion.div
+            key={entity.name}
+            className='absolute'
+            style={{ left: x, top: y }}
+            initial={reducedMotion ? false : { opacity: 0, y: 10 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.45, delay: i * 0.08, ease: 'easeOut' }}>
+            <EntityCard data={entity} />
+          </motion.div>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Stacked fallback for below `lg` — same five cards, no connector lines. */
+export function EntityCardsGrid({ className }: { className?: string }) {
+  return (
+    <div className={cn('grid gap-4 sm:grid-cols-2', className)}>
+      {ENTITIES.map((entity, i) => (
+        <div
+          key={entity.name}
+          className={cn(i === ENTITIES.length - 1 && 'sm:col-span-2 sm:justify-self-center')}>
+          <EntityCard
+            data={entity}
+            className={cn('w-full', i === ENTITIES.length - 1 && 'sm:w-80')}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/crm/_mocks/entity-card.tsx
+++ b/apps/homepage/src/app/platform/crm/_mocks/entity-card.tsx
@@ -1,0 +1,71 @@
+// apps/homepage/src/app/platform/crm/_mocks/entity-card.tsx
+
+import type { LucideIcon } from 'lucide-react'
+import { Plus } from 'lucide-react'
+import { ENTITY_COLOR_CLASS, type EntityColor } from '~/app/platform/ai/_mocks'
+import { cn } from '~/lib/utils'
+
+export interface EntityCardAttr {
+  icon: LucideIcon
+  label: string
+}
+
+export interface EntityCardData {
+  name: string
+  badge: 'System' | 'Custom'
+  color: EntityColor
+  icon: LucideIcon
+  attrs: EntityCardAttr[]
+  more: number
+}
+
+/**
+ * Attio-style attribute card for the CRM hero's relationship canvas:
+ * entity header (colored icon badge + name + Standard/Custom pill),
+ * three attribute rows, and a "+ N more attributes" footer.
+ */
+export function EntityCard({ data, className }: { data: EntityCardData; className?: string }) {
+  const HeaderIcon = data.icon
+  return (
+    <div
+      className={cn(
+        'w-64 rounded-xl border border-border/70 bg-card text-card-foreground shadow-lg shadow-black/[.04]',
+        className
+      )}>
+      <div className='flex items-center gap-2 px-3 py-2.5'>
+        <span
+          className={cn(
+            'flex size-5 shrink-0 items-center justify-center rounded-md',
+            ENTITY_COLOR_CLASS[data.color]
+          )}>
+          <HeaderIcon className='size-3.5' />
+        </span>
+        <span className='flex-1 truncate text-sm font-medium'>{data.name}</span>
+        <span
+          className={cn(
+            'shrink-0 rounded-full px-2 py-0.5 text-[10px]',
+            data.badge === 'System'
+              ? 'bg-fuchsia-400/15 text-fuchsia-700 dark:bg-fuchsia-400/10 dark:text-fuchsia-400'
+              : 'border border-border/70 bg-muted/50 text-muted-foreground'
+          )}>
+          {data.badge}
+        </span>
+      </div>
+      {data.attrs.map((attr) => {
+        const Icon = attr.icon
+        return (
+          <div
+            key={attr.label}
+            className='flex items-center gap-2 border-t border-border/60 px-3 py-2 text-xs'>
+            <Icon className='size-3.5 shrink-0 text-muted-foreground' />
+            <span className='truncate text-foreground/80'>{attr.label}</span>
+          </div>
+        )
+      })}
+      <div className='flex items-center gap-2 border-t border-border/60 px-3 py-2 text-xs text-muted-foreground/80'>
+        <Plus className='size-3.5 shrink-0' />
+        <span>{data.more} more attributes</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/crm/_mocks/index.ts
+++ b/apps/homepage/src/app/platform/crm/_mocks/index.ts
@@ -1,0 +1,15 @@
+// apps/homepage/src/app/platform/crm/_mocks/index.ts
+
+export { CrmBrowserDemo } from './crm-browser-demo'
+export { EntityCanvas, EntityCardsGrid } from './entity-canvas'
+export { EntityCard, type EntityCardAttr, type EntityCardData } from './entity-card'
+export { MockRecordsTable } from './mock-records-table'
+export { MockRecordsTopbar } from './mock-records-topbar'
+export {
+  DEFAULT_PERSONA_KEY,
+  type MockCell,
+  type MockColumn,
+  nameInitials,
+  PERSONAS,
+  type PersonaConfig,
+} from './personas'

--- a/apps/homepage/src/app/platform/crm/_mocks/mock-records-table.tsx
+++ b/apps/homepage/src/app/platform/crm/_mocks/mock-records-table.tsx
@@ -1,0 +1,164 @@
+// apps/homepage/src/app/platform/crm/_mocks/mock-records-table.tsx
+
+import { ChevronDown, Columns3, ListFilter, MoreHorizontal, Search, Upload } from 'lucide-react'
+import { ENTITY_COLOR_CLASS } from '~/app/platform/ai/_mocks'
+import { cn } from '~/lib/utils'
+import { type MockCell, type MockColumn, nameInitials, type PersonaConfig } from './personas'
+
+const HIDE_CLASS: Record<NonNullable<MockColumn['hide']>, string> = {
+  md: 'hidden md:flex',
+  lg: 'hidden lg:flex',
+}
+
+/**
+ * Static facsimile of the records DynamicTable (styling reference:
+ * `/app/tickets`), driven by a persona config — toolbar, typed column
+ * headers, and cell kinds (name avatars, entity badges, status pills).
+ */
+export function MockRecordsTable({
+  persona,
+  className,
+}: {
+  persona: PersonaConfig
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'relative flex h-full min-h-0 flex-1 flex-col bg-mock-window text-mock-window-foreground',
+        className
+      )}>
+      <Toolbar viewLabel={persona.viewLabel} />
+      <div
+        className={cn(
+          persona.gridCols,
+          'h-8 items-center border-y border-mock-window-border text-xs'
+        )}>
+        <div className='flex items-center justify-center'>
+          <Checkbox />
+        </div>
+        {persona.columns.map((column) => {
+          const Icon = column.icon
+          return (
+            <div
+              key={column.label}
+              className={cn(
+                'flex items-center gap-1.5 px-2 text-mock-window-muted',
+                column.hide && HIDE_CLASS[column.hide]
+              )}>
+              <Icon className='size-3 shrink-0' />
+              <span className='truncate'>{column.label}</span>
+            </div>
+          )
+        })}
+      </div>
+      <div className='min-h-0 flex-1 overflow-hidden'>
+        {persona.rows.map((row, rowIndex) => (
+          <div
+            key={rowIndex}
+            className={cn(
+              persona.gridCols,
+              'h-9 items-center border-b border-mock-window-border/60 text-xs'
+            )}>
+            <div className='flex items-center justify-center'>
+              <Checkbox />
+            </div>
+            {row.map((cell, cellIndex) => (
+              <CellView key={cellIndex} cell={cell} hide={persona.columns[cellIndex]?.hide} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Toolbar({ viewLabel }: { viewLabel: string }) {
+  return (
+    <div className='flex items-center gap-2 px-3 py-2 text-xs'>
+      <span className='flex shrink-0 items-center gap-1 rounded-md border border-mock-window-border px-2 py-1 font-medium'>
+        {viewLabel}
+        <ChevronDown className='size-3 text-mock-window-muted' />
+      </span>
+      <MoreHorizontal className='size-3.5 shrink-0 text-mock-window-muted' />
+      <span className='hidden shrink-0 items-center gap-1.5 px-1 text-mock-window-muted sm:flex'>
+        <ListFilter className='size-3.5' />
+        Filter
+      </span>
+      <span className='hidden shrink-0 items-center gap-1.5 px-1 text-mock-window-muted md:flex'>
+        <Columns3 className='size-3.5' />
+        Columns
+      </span>
+      <span className='hidden shrink-0 items-center gap-1.5 px-1 text-mock-window-muted md:flex'>
+        <Upload className='size-3.5' />
+        Import / Export
+      </span>
+      <span className='ml-2 flex min-w-0 flex-1 items-center gap-2 rounded-md border border-mock-window-border px-2 py-1 text-mock-window-muted'>
+        <Search className='size-3.5 shrink-0' />
+        <span className='truncate'>Search records...</span>
+      </span>
+    </div>
+  )
+}
+
+function CellView({ cell, hide }: { cell: MockCell; hide?: MockColumn['hide'] }) {
+  const hideClass = hide && HIDE_CLASS[hide]
+
+  switch (cell.kind) {
+    case 'text':
+      return (
+        <div
+          className={cn(
+            'truncate px-2',
+            cell.muted && 'text-mock-window-muted',
+            hide ? cn('hidden', hide === 'md' ? 'md:block' : 'lg:block') : undefined
+          )}>
+          {cell.label}
+        </div>
+      )
+    case 'name':
+      return (
+        <div className={cn('flex min-w-0 items-center gap-2 px-2', hideClass)}>
+          <span className='flex size-5 shrink-0 items-center justify-center rounded-full bg-blue-500 text-[9px] font-semibold text-blue-50'>
+            {nameInitials(cell.label)}
+          </span>
+          <span className='truncate font-medium'>{cell.label}</span>
+        </div>
+      )
+    case 'record': {
+      const Icon = cell.icon
+      return (
+        <div className={cn('flex min-w-0 items-center gap-1.5 px-2', hideClass)}>
+          <span
+            className={cn(
+              'flex size-4 shrink-0 items-center justify-center rounded',
+              ENTITY_COLOR_CLASS[cell.color]
+            )}>
+            <Icon className='size-2.5' />
+          </span>
+          <span className='truncate'>{cell.label}</span>
+        </div>
+      )
+    }
+    case 'pill':
+      return (
+        <div
+          className={cn(
+            'min-w-0 px-2',
+            hide ? cn('hidden', hide === 'md' ? 'md:block' : 'lg:block') : undefined
+          )}>
+          <span
+            className={cn(
+              'inline-block max-w-full truncate rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+              cell.className
+            )}>
+            {cell.label}
+          </span>
+        </div>
+      )
+  }
+}
+
+function Checkbox() {
+  return <span className='size-3.5 rounded border border-mock-window-border' />
+}

--- a/apps/homepage/src/app/platform/crm/_mocks/mock-records-topbar.tsx
+++ b/apps/homepage/src/app/platform/crm/_mocks/mock-records-topbar.tsx
@@ -1,0 +1,56 @@
+// apps/homepage/src/app/platform/crm/_mocks/mock-records-topbar.tsx
+
+import { BarChart3, type LucideIcon, PanelLeft, Plus, Settings, Users } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+interface MockRecordsTopbarProps {
+  /** Page label on the left (e.g. "Support Tickets"). */
+  title: string
+  /** Primary-button label (rendered as "+ {newLabel}"). */
+  newLabel: string
+  /** Icon for the active "Records" segment. Default `Users`. */
+  tabIcon?: LucideIcon
+  className?: string
+}
+
+/**
+ * Static facsimile of the real records-page top bar (see `/app/tickets`):
+ * page label on the left, a segmented Records/Dashboard/Settings control,
+ * and a primary "+ New …" button.
+ */
+export function MockRecordsTopbar({
+  title,
+  newLabel,
+  tabIcon: TabIcon = Users,
+  className,
+}: MockRecordsTopbarProps) {
+  return (
+    <div
+      className={cn('flex items-center gap-3 pb-2 text-xs text-mock-window-foreground', className)}>
+      <div className='flex min-w-0 items-center gap-2 text-mock-window-muted'>
+        <PanelLeft className='size-3.5 shrink-0' />
+        <span className='truncate text-mock-window-foreground'>{title}</span>
+      </div>
+
+      <div className='hidden items-center gap-0.5 rounded-lg border border-mock-window-border bg-mock-panel-bg p-0.5 sm:flex'>
+        <span className='flex items-center gap-1.5 rounded-md bg-mock-window px-2.5 py-1 font-medium shadow-sm'>
+          <TabIcon className='size-3' />
+          Records
+        </span>
+        <span className='flex items-center gap-1.5 rounded-md px-2.5 py-1 text-mock-window-muted'>
+          <BarChart3 className='size-3' />
+          Dashboard
+        </span>
+        <span className='flex items-center gap-1.5 rounded-md px-2.5 py-1 text-mock-window-muted'>
+          <Settings className='size-3' />
+          Settings
+        </span>
+      </div>
+
+      <div className='ml-auto inline-flex shrink-0 items-center gap-1 rounded-md bg-blue-500 px-2 py-1 font-medium text-white'>
+        <Plus className='size-3' />
+        <span>{newLabel}</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/crm/_mocks/personas.ts
+++ b/apps/homepage/src/app/platform/crm/_mocks/personas.ts
@@ -1,0 +1,472 @@
+// apps/homepage/src/app/platform/crm/_mocks/personas.ts
+
+import {
+  Boxes,
+  Building2,
+  CircleDollarSign,
+  CircleDot,
+  Clock,
+  Cog,
+  CreditCard,
+  Factory,
+  Flag,
+  Handshake,
+  Hash,
+  Layers,
+  LifeBuoy,
+  type LucideIcon,
+  Mail,
+  MapPin,
+  Package,
+  Repeat,
+  Rocket,
+  ShoppingCart,
+  Ticket,
+  Type,
+  User,
+  Users,
+} from 'lucide-react'
+import type { EntityColor, MockSidebarRecordItem } from '~/app/platform/ai/_mocks'
+
+/** One table cell in a persona's mock records table. */
+export type MockCell =
+  | { kind: 'text'; label: string; muted?: boolean }
+  /** Initials avatar + medium-weight name (contacts, assignees). */
+  | { kind: 'name'; label: string }
+  /** Colored entity-icon badge + label (companies, parts, ticket titles). */
+  | { kind: 'record'; label: string; color: EntityColor; icon: LucideIcon }
+  | { kind: 'pill'; label: string; className: string }
+
+export interface MockColumn {
+  icon: LucideIcon
+  label: string
+  /** Column (header + cells) is hidden below this breakpoint. */
+  hide?: 'md' | 'lg'
+}
+
+export interface PersonaConfig {
+  key: 'sales' | 'support' | 'manufacturing'
+  chipLabel: string
+  chipIcon: LucideIcon
+  /** Browser chrome URL pill. */
+  url: string
+  /** Top-bar page label. */
+  pageTitle: string
+  /** Top-bar primary button label. */
+  newLabel: string
+  /** Toolbar view-picker label. */
+  viewLabel: string
+  activeRecordKey: string
+  records: MockSidebarRecordItem[]
+  /**
+   * Grid templates per breakpoint — column counts must match the visible
+   * columns: all base columns, `md:` adds `hide: 'md'`, `lg:` adds `hide: 'lg'`.
+   */
+  gridCols: string
+  columns: MockColumn[]
+  rows: MockCell[][]
+}
+
+// ---------------------------------------------------------------------------
+// Pill palettes (soft tag/status colors matching the real DynamicTable pills)
+// ---------------------------------------------------------------------------
+
+const PILL = {
+  blue: 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-400',
+  green: 'bg-green-100 text-green-700 dark:bg-green-500/15 dark:text-green-400',
+  amber: 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-400',
+  red: 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-400',
+  purple: 'bg-purple-100 text-purple-700 dark:bg-purple-500/15 dark:text-purple-400',
+  zinc: 'bg-zinc-100 text-zinc-600 dark:bg-zinc-500/15 dark:text-zinc-400',
+} as const
+
+const text = (label: string, muted = false): MockCell => ({ kind: 'text', label, muted })
+const name = (label: string): MockCell => ({ kind: 'name', label })
+const pill = (label: string, className: string): MockCell => ({ kind: 'pill', label, className })
+const company = (label: string): MockCell => ({
+  kind: 'record',
+  label,
+  color: 'purple',
+  icon: Building2,
+})
+const ticket = (label: string): MockCell => ({
+  kind: 'record',
+  label,
+  color: 'orange',
+  icon: Ticket,
+})
+const part = (label: string): MockCell => ({ kind: 'record', label, color: 'amber', icon: Package })
+const supplier = (label: string): MockCell => ({
+  kind: 'record',
+  label,
+  color: 'purple',
+  icon: Factory,
+})
+
+// ---------------------------------------------------------------------------
+// Product-led Sales — contacts with plan + MRR
+// ---------------------------------------------------------------------------
+
+const SALES_ROWS: Array<[string, string, string, [string, string], string, string]> = [
+  [
+    'Sarah Martinez',
+    'sarah@windmill.co',
+    'Windmill Co.',
+    ['Scale', PILL.purple],
+    '$1,490',
+    'Jun 24',
+  ],
+  ['Justin Jones', 'justin@brightlane.io', 'Brightlane', ['Free', PILL.zinc], '$0', 'Jun 22'],
+  ['Emily Garcia', 'emily@harborsupply.com', 'Harbor Supply', ['Pro', PILL.blue], '$490', 'Jun 19'],
+  [
+    'Michael Williams',
+    'michael@oakandiron.com',
+    'Oak & Iron',
+    ['Pro', PILL.blue],
+    '$490',
+    'Jun 17',
+  ],
+  [
+    'Rachel Brown',
+    'rachel@fernstudio.de',
+    'Fern Studio',
+    ['Scale', PILL.purple],
+    '$1,190',
+    'Jun 12',
+  ],
+  [
+    'Joshua Anderson',
+    'josh@peakoutfitters.com',
+    'Peak Outfitters',
+    ['Free', PILL.zinc],
+    '$0',
+    'Jun 10',
+  ],
+  ['Stephanie Wilson', 'steph@lumenhome.com', 'Lumen Home', ['Pro', PILL.blue], '$690', 'Jun 8'],
+  ['David Jones', 'david@cedarworks.io', 'Cedarworks', ['Trial', PILL.amber], '$0', 'Jun 5'],
+  ['Ashley Martinez', 'ashley@tidegoods.com', 'Tide Goods', ['Pro', PILL.blue], '$490', 'Jun 3'],
+  [
+    'William Rodriguez',
+    'will@northloop.co',
+    'Northloop',
+    ['Scale', PILL.purple],
+    '$2,180',
+    'May 30',
+  ],
+  ['Jessica Davis', 'jess@mapleandmain.com', 'Maple & Main', ['Trial', PILL.amber], '$0', 'May 27'],
+  ['Liam Harris', 'liam@driftwoodco.com', 'Driftwood Co.', ['Pro', PILL.blue], '$490', 'May 24'],
+]
+
+const SALES: PersonaConfig = {
+  key: 'sales',
+  chipLabel: 'Product-led Sales',
+  chipIcon: Rocket,
+  url: 'app.auxx.ai/app/contacts',
+  pageTitle: 'Contacts',
+  newLabel: 'New Contact',
+  viewLabel: 'All Contacts',
+  activeRecordKey: 'contacts',
+  records: [
+    { key: 'contacts', label: 'Contacts', icon: Users, entityColor: 'blue' },
+    { key: 'companies', label: 'Companies', icon: Building2, entityColor: 'purple' },
+    { key: 'deals', label: 'Deals', icon: Handshake, entityColor: 'green' },
+    { key: 'subscriptions', label: 'Subscriptions', icon: Repeat, entityColor: 'teal' },
+  ],
+  gridCols:
+    'grid grid-cols-[2rem_minmax(0,1.4fr)_minmax(0,1.3fr)] md:grid-cols-[2rem_minmax(0,1.4fr)_minmax(0,1.3fr)_minmax(0,1fr)_5.5rem] lg:grid-cols-[2rem_minmax(0,1.4fr)_minmax(0,1.3fr)_minmax(0,1fr)_5.5rem_5rem_6rem]',
+  columns: [
+    { icon: Type, label: 'Name' },
+    { icon: Mail, label: 'Email' },
+    { icon: Building2, label: 'Company', hide: 'md' },
+    { icon: CreditCard, label: 'Plan', hide: 'md' },
+    { icon: CircleDollarSign, label: 'MRR', hide: 'lg' },
+    { icon: Clock, label: 'Signed up', hide: 'lg' },
+  ],
+  rows: SALES_ROWS.map(([contact, email, comp, [plan, planClass], mrr, signedUp]) => [
+    name(contact),
+    text(email, true),
+    company(comp),
+    pill(plan, planClass),
+    text(mrr),
+    text(signedUp, true),
+  ]),
+}
+
+// ---------------------------------------------------------------------------
+// Support — tickets like the real /app/tickets view
+// ---------------------------------------------------------------------------
+
+const SUPPORT_ROWS: Array<[string, string, [string, string], [string, string], string, string]> = [
+  [
+    'TKT-0158',
+    'Delayed shipment inquiry',
+    ['Open', PILL.blue],
+    ['Medium', PILL.blue],
+    'Mia Chen',
+    'Sarah Martinez',
+  ],
+  [
+    'TKT-0159',
+    'Payment processing issue',
+    ['Resolved', PILL.green],
+    ['Medium', PILL.blue],
+    'Mia Chen',
+    'Justin Jones',
+  ],
+  [
+    'TKT-0163',
+    'Request for information',
+    ['Closed', PILL.zinc],
+    ['Low', PILL.zinc],
+    'Jonas Weber',
+    'Michael Williams',
+  ],
+  [
+    'TKT-0164',
+    'Missing item from order',
+    ['In Progress', PILL.amber],
+    ['High', PILL.red],
+    'Mia Chen',
+    'Sarah Martinez',
+  ],
+  [
+    'TKT-0226',
+    'Initiate product return',
+    ['Resolved', PILL.green],
+    ['Medium', PILL.blue],
+    'Jonas Weber',
+    'Emily Garcia',
+  ],
+  [
+    'TKT-0227',
+    'Return request for recent order',
+    ['Waiting', PILL.purple],
+    ['High', PILL.red],
+    'Mia Chen',
+    'Rachel Brown',
+  ],
+  [
+    'TKT-0015',
+    'Request for information',
+    ['Open', PILL.blue],
+    ['Low', PILL.zinc],
+    'Jonas Weber',
+    'Joshua Anderson',
+  ],
+  [
+    'TKT-0014',
+    'Question about account features',
+    ['In Progress', PILL.amber],
+    ['Medium', PILL.blue],
+    'Mia Chen',
+    'Stephanie Wilson',
+  ],
+  [
+    'TKT-0009',
+    'Quality issue with product',
+    ['Resolved', PILL.green],
+    ['Medium', PILL.blue],
+    'Jonas Weber',
+    'David Jones',
+  ],
+  [
+    'TKT-0019',
+    'Return request for recent order',
+    ['Waiting', PILL.purple],
+    ['Low', PILL.zinc],
+    'Mia Chen',
+    'Ashley Martinez',
+  ],
+  [
+    'TKT-0020',
+    'Request refund for defective product',
+    ['Resolved', PILL.green],
+    ['High', PILL.red],
+    'Jonas Weber',
+    'William Rodriguez',
+  ],
+  [
+    'TKT-0024',
+    'Website functionality issue',
+    ['Closed', PILL.zinc],
+    ['High', PILL.red],
+    'Mia Chen',
+    'Jessica Davis',
+  ],
+]
+
+const SUPPORT: PersonaConfig = {
+  key: 'support',
+  chipLabel: 'Support',
+  chipIcon: LifeBuoy,
+  url: 'app.auxx.ai/app/tickets',
+  pageTitle: 'Support Tickets',
+  newLabel: 'New Ticket',
+  viewLabel: 'All Tickets',
+  activeRecordKey: 'tickets',
+  records: [
+    { key: 'contacts', label: 'Contacts', icon: Users, entityColor: 'blue' },
+    { key: 'tickets', label: 'Tickets', icon: Ticket, entityColor: 'orange' },
+    { key: 'companies', label: 'Companies', icon: Building2, entityColor: 'purple' },
+    { key: 'orders', label: 'Orders', icon: ShoppingCart, entityColor: 'green' },
+  ],
+  gridCols:
+    'grid grid-cols-[2rem_minmax(0,1.6fr)_6rem] md:grid-cols-[2rem_5rem_minmax(0,1.6fr)_6rem_5.5rem_minmax(0,1fr)] lg:grid-cols-[2rem_5rem_minmax(0,1.6fr)_6rem_5.5rem_minmax(0,1fr)_minmax(0,1fr)]',
+  columns: [
+    { icon: Hash, label: 'Ticket #', hide: 'md' },
+    { icon: Type, label: 'Title' },
+    { icon: CircleDot, label: 'Status' },
+    { icon: Flag, label: 'Priority', hide: 'md' },
+    { icon: User, label: 'Assignee', hide: 'md' },
+    { icon: Users, label: 'Contact', hide: 'lg' },
+  ],
+  rows: SUPPORT_ROWS.map(
+    ([id, title, [status, statusClass], [prio, prioClass], assignee, contact]) => [
+      text(id, true),
+      ticket(title),
+      pill(status, statusClass),
+      pill(prio, prioClass),
+      name(assignee),
+      name(contact),
+    ]
+  ),
+}
+
+// ---------------------------------------------------------------------------
+// Manufacturing — parts with stock + supplier
+// ---------------------------------------------------------------------------
+
+const MFG_ROWS: Array<[string, string, string, [string, string], string, string]> = [
+  [
+    'PRT-1042',
+    'Hex bolt M8 × 40',
+    'Steelcore GmbH',
+    ['1,240', PILL.green],
+    '$0.12',
+    'Aisle 3 · Bin 12',
+  ],
+  [
+    'PRT-1044',
+    'Bearing 6204-2RS',
+    'Roton Bearings',
+    ['86', PILL.amber],
+    '$2.40',
+    'Aisle 1 · Bin 04',
+  ],
+  [
+    'PRT-1051',
+    'Drive belt B-1120',
+    'Vulcan Rubber',
+    ['312', PILL.green],
+    '$8.75',
+    'Aisle 5 · Bin 22',
+  ],
+  [
+    'PRT-1057',
+    'Motor mount bracket',
+    'Steelcore GmbH',
+    ['12', PILL.red],
+    '$14.20',
+    'Aisle 2 · Bin 08',
+  ],
+  ['PRT-1063', 'O-ring 32mm viton', 'SealTech', ['2,050', PILL.green], '$0.34', 'Aisle 4 · Bin 31'],
+  [
+    'PRT-1071',
+    'Stepper motor NEMA 23',
+    'Motion Labs',
+    ['48', PILL.amber],
+    '$28.90',
+    'Aisle 2 · Bin 15',
+  ],
+  [
+    'PRT-1078',
+    'Limit switch V-156',
+    'Elektra Parts',
+    ['430', PILL.green],
+    '$1.85',
+    'Aisle 6 · Bin 02',
+  ],
+  [
+    'PRT-1085',
+    'Aluminum plate 5mm',
+    'Steelcore GmbH',
+    ['9', PILL.red],
+    '$22.00',
+    'Aisle 7 · Bin 01',
+  ],
+  [
+    'PRT-1091',
+    'Gearbox 20:1 worm',
+    'Motion Labs',
+    ['27', PILL.amber],
+    '$64.50',
+    'Aisle 2 · Bin 19',
+  ],
+  ['PRT-1096', 'Coolant pump CP-40', 'FlowTech', ['64', PILL.green], '$38.10', 'Aisle 5 · Bin 07'],
+  [
+    'PRT-1102',
+    'Spindle collet ER32',
+    'Precision Tools',
+    ['150', PILL.green],
+    '$6.20',
+    'Aisle 1 · Bin 27',
+  ],
+  [
+    'PRT-1108',
+    'Safety relay PNOZ',
+    'Elektra Parts',
+    ['18', PILL.amber],
+    '$92.00',
+    'Aisle 6 · Bin 09',
+  ],
+]
+
+const MANUFACTURING: PersonaConfig = {
+  key: 'manufacturing',
+  chipLabel: 'Manufacturing',
+  chipIcon: Factory,
+  url: 'app.auxx.ai/app/parts',
+  pageTitle: 'Parts',
+  newLabel: 'New Part',
+  viewLabel: 'All Parts',
+  activeRecordKey: 'parts',
+  records: [
+    { key: 'parts', label: 'Parts', icon: Package, entityColor: 'amber' },
+    { key: 'suppliers', label: 'Suppliers', icon: Factory, entityColor: 'purple' },
+    { key: 'orders', label: 'Orders', icon: ShoppingCart, entityColor: 'green' },
+    { key: 'machines', label: 'Machines', icon: Cog, entityColor: 'teal' },
+    { key: 'boms', label: 'BOMs', icon: Layers, entityColor: 'indigo' },
+  ],
+  gridCols:
+    'grid grid-cols-[2rem_minmax(0,1.5fr)_5rem] md:grid-cols-[2rem_5.5rem_minmax(0,1.5fr)_minmax(0,1fr)_5rem] lg:grid-cols-[2rem_5.5rem_minmax(0,1.5fr)_minmax(0,1fr)_5rem_5.5rem_minmax(0,1fr)]',
+  columns: [
+    { icon: Hash, label: 'Part #', hide: 'md' },
+    { icon: Type, label: 'Name' },
+    { icon: Factory, label: 'Supplier', hide: 'md' },
+    { icon: Boxes, label: 'Stock' },
+    { icon: CircleDollarSign, label: 'Unit cost', hide: 'lg' },
+    { icon: MapPin, label: 'Location', hide: 'lg' },
+  ],
+  rows: MFG_ROWS.map(([id, partName, supp, [stock, stockClass], cost, location]) => [
+    text(id, true),
+    part(partName),
+    supplier(supp),
+    pill(stock, stockClass),
+    text(cost),
+    text(location, true),
+  ]),
+}
+
+export const PERSONAS: PersonaConfig[] = [SALES, SUPPORT, MANUFACTURING]
+
+/** Persona shown on load. */
+export const DEFAULT_PERSONA_KEY: PersonaConfig['key'] = 'support'
+
+/** Initials for `name` cells' avatar chips. */
+export function nameInitials(label: string): string {
+  return label
+    .split(' ')
+    .map((word) => word[0])
+    .slice(0, 2)
+    .join('')
+}

--- a/apps/homepage/src/components/logos/slack.tsx
+++ b/apps/homepage/src/components/logos/slack.tsx
@@ -5,11 +5,11 @@ type IconProps = { dark?: boolean } & SVGProps<SVGSVGElement>
 
 const Slack = ({ dark, ...props }: IconProps) => (
   <svg
-    enable-background='new 0 0 2447.6 2452.5'
+    enableBackground='new 0 0 2447.6 2452.5'
     viewBox='0 0 2447.6 2452.5'
     xmlns='http://www.w3.org/2000/svg'
     {...props}>
-    <g clip-rule='evenodd' fillRule='evenodd'>
+    <g clipRule='evenodd' fillRule='evenodd'>
       <path
         d='m897.4 0c-135.3.1-244.8 109.9-244.7 245.2-.1 135.3 109.5 245.1 244.8 245.2h244.8v-245.1c.1-135.3-109.5-245.1-244.9-245.3.1 0 .1 0 0 0m0 654h-652.6c-135.3.1-244.9 109.9-244.8 245.2-.2 135.3 109.4 245.1 244.7 245.3h652.7c135.3-.1 244.9-109.9 244.8-245.2.1-135.4-109.5-245.2-244.8-245.3z'
         fill='#36c5f0'

--- a/apps/web/src/components/logos/slack.tsx
+++ b/apps/web/src/components/logos/slack.tsx
@@ -5,11 +5,11 @@ type IconProps = { dark?: boolean } & SVGProps<SVGSVGElement>
 
 const Slack = ({ dark, ...props }: IconProps) => (
   <svg
-    enable-background='new 0 0 2447.6 2452.5'
+    enableBackground='new 0 0 2447.6 2452.5'
     viewBox='0 0 2447.6 2452.5'
     xmlns='http://www.w3.org/2000/svg'
     {...props}>
-    <g clip-rule='evenodd' fillRule='evenodd'>
+    <g clipRule='evenodd' fillRule='evenodd'>
       <path
         d='m897.4 0c-135.3.1-244.8 109.9-244.7 245.2-.1 135.3 109.5 245.1 244.8 245.2h244.8v-245.1c.1-135.3-109.5-245.1-244.9-245.3.1 0 .1 0 0 0m0 654h-652.6c-135.3.1-244.9 109.9-244.8 245.2-.2 135.3 109.4 245.1 244.7 245.3h652.7c135.3-.1 244.9-109.9 244.8-245.2.1-135.4-109.5-245.2-244.8-245.3z'
         fill='#36c5f0'

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -70,6 +70,13 @@ export const MAIL_MENU: SidebarProps[] = []
 
 export const SIDEBAR_MENU: SidebarProps[] = [
   {
+    id: 'dashboards',
+    label: 'Dashboards',
+    slug: 'dashboards',
+    icon: <LayoutDashboard />,
+    featureKey: 'dashboards',
+  },
+  {
     id: 'today',
     label: 'Today',
     slug: 'today',
@@ -107,13 +114,7 @@ export const SIDEBAR_MENU: SidebarProps[] = [
   },
   { id: 'tasks', label: 'Tasks', slug: 'tasks', icon: <CheckSquare /> },
   // Member-visible by design (no adminOnly) — dashboards are member-safe.
-  {
-    id: 'dashboards',
-    label: 'Dashboards',
-    slug: 'dashboards',
-    icon: <LayoutDashboard />,
-    featureKey: 'dashboards',
-  },
+
   {
     id: 'resources',
     label: 'Resources',


### PR DESCRIPTION
## Summary
- Redesign the CRM hero into an Attio-style data-model layout: dot-grid background, centered headline, entity cards + relationship canvas flowing into a mock records browser demo (replaces the old video/shader hero).
- Add reusable CRM persona mocks under `platform/crm/_mocks/` (entity canvas/cards, browser demo, records table/topbar, personas) that back the new hero demo.
- Add `BuildDashboardsSection` to the homepage.
- Extend the mock app sidebar: `QuickActions` trigger, `Parts`/`Orders` records, and a configurable `recordItems` prop for persona demos.
- Move **Dashboards** to the top of the web app sidebar menu.
- Fix invalid JSX attributes on the Slack logos (`enable-background`/`clip-rule` → `enableBackground`/`clipRule`) in both `apps/web` and `apps/homepage`.

## Test plan
- [ ] Homepage renders: CRM hero + dashboards section visible, responsive at mobile/desktop
- [ ] Slack logos render without React attribute warnings
- [ ] Web app sidebar shows Dashboards at the top