### PR TITLE
feat(workflow): per-node trace renderers + shopify-review seed scenario

### DIFF
--- a/apps/web/src/app/admin/organizations/[id]/page.tsx
+++ b/apps/web/src/app/admin/organizations/[id]/page.tsx
@@ -202,6 +202,8 @@ export default function OrganizationDetailsPage() {
     { value: 'superadmin-test' as const, label: 'Test (10x heavy)' },
     { value: 'development' as const, label: 'Development' },
     { value: 'testing' as const, label: 'Testing (minimal)' },
+    // Not idempotent: re-running additively creates the 8 threads again
+    { value: 'shopify-review' as const, label: 'Shopify review threads (once per org)' },
   ]
 
   /**

--- a/apps/web/src/components/workflow/nodes/core/ai/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/ai/trace-renderer.tsx
@@ -1,0 +1,68 @@
+// apps/web/src/components/workflow/nodes/core/ai/trace-renderer.tsx
+
+'use client'
+
+import { ChevronRight, Sparkles } from 'lucide-react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { BlockCard } from '~/components/kopilot/ui/blocks/block-card'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+interface AiOutputs {
+  text?: string
+  structured_output?: unknown
+  tool_results?: Array<Record<string, unknown>>
+}
+
+/** Collapsed JSON details section used for structured output / tool results. */
+function CollapsedJson({ title, value }: { title: string; value: unknown }) {
+  return (
+    <details className='group rounded-xl bg-background ring-1 ring-border'>
+      <summary className='flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground select-none'>
+        <ChevronRight className='size-3 transition-transform group-open:rotate-90' />
+        {title}
+      </summary>
+      <pre className='max-h-[200px] overflow-auto p-2 pt-0 font-mono text-xs'>
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </details>
+  )
+}
+
+/**
+ * Preview for AI node executions — the generated text rendered as markdown,
+ * with structured output and tool results as collapsed sections.
+ */
+export function AiTraceRenderer({ execution }: TraceRendererProps) {
+  const outputs = (execution.outputs ?? {}) as AiOutputs
+
+  if (!outputs.text && outputs.structured_output === undefined) {
+    return <TraceRawJson value={execution.outputs} />
+  }
+
+  return (
+    <BlockCard
+      data-slot='ai-trace-renderer'
+      indicator={<Sparkles className='size-3 text-muted-foreground' />}
+      primaryText='Generated Text'
+      hasFooter={false}>
+      <div className='space-y-2 p-1'>
+        {outputs.text && (
+          <div className='prose prose-sm dark:prose-invert max-w-none text-sm'>
+            <Markdown remarkPlugins={[remarkGfm]}>{outputs.text}</Markdown>
+          </div>
+        )}
+        {outputs.structured_output !== undefined && outputs.structured_output !== null && (
+          <CollapsedJson title='Structured output' value={outputs.structured_output} />
+        )}
+        {!!outputs.tool_results?.length && (
+          <CollapsedJson
+            title={`Tool results (${outputs.tool_results.length})`}
+            value={outputs.tool_results}
+          />
+        )}
+      </div>
+    </BlockCard>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/core/answer/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/answer/panel.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { Label } from '@auxx/ui/components/label'
 import {
@@ -100,6 +101,18 @@ export const AnswerPanel: React.FC<AnswerPanelProps> = memo(({ nodeId, data }) =
   const handleTextChange = useCallback(
     (value: string) => {
       setNodeData({ ...nodeData, text: value })
+    },
+    [nodeData, setNodeData]
+  )
+
+  const testBehavior = nodeData.test_behavior || 'default'
+
+  const handleTestBehaviorChange = useCallback(
+    (value: string) => {
+      setNodeData({
+        ...nodeData,
+        test_behavior: value as AnswerNodeData['test_behavior'],
+      })
     },
     [nodeData, setNodeData]
   )
@@ -414,6 +427,50 @@ export const AnswerPanel: React.FC<AnswerPanelProps> = memo(({ nodeId, data }) =
             />
           </VarEditorField>
         </Field>
+      </Section>
+
+      {/* Section 3: Test Mode */}
+      <Section
+        title='Test Mode'
+        description='Send behavior during testing and review'
+        initialOpen={false}
+        open={testBehavior !== 'default'}
+        collapsible={testBehavior !== 'default'}
+        className={testBehavior !== 'default' ? undefined : '[&_[data-slot=section]]:pb-0'}
+        actions={
+          <Select
+            value={testBehavior}
+            onValueChange={handleTestBehaviorChange}
+            disabled={isReadOnly}>
+            <SelectTrigger size='sm' variant='transparent'>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='default'>Default (dry run during test runs)</SelectItem>
+              <SelectItem value='live'>Live</SelectItem>
+              <SelectItem value='dry_run'>Dry run (never send)</SelectItem>
+              <SelectItem value='draft'>Draft</SelectItem>
+            </SelectContent>
+          </Select>
+        }>
+        {testBehavior === 'live' && (
+          <Alert variant='blue'>
+            <AlertTitle>Live Mode</AlertTitle>
+            <AlertDescription>
+              Test runs of this workflow will send real emails from the connected inbox.
+            </AlertDescription>
+          </Alert>
+        )}
+        {(testBehavior === 'dry_run' || testBehavior === 'draft') && (
+          <Alert variant='warning'>
+            <AlertTitle>{testBehavior === 'draft' ? 'Draft Mode' : 'Dry Run Mode'}</AlertTitle>
+            <AlertDescription>
+              {testBehavior === 'draft'
+                ? 'Replies are saved as drafts on the thread instead of being sent (even in live runs) until this is set back to Default.'
+                : 'This node will not send real emails (even in live runs) until this is set back to Default.'}
+            </AlertDescription>
+          </Alert>
+        )}
       </Section>
     </BasePanel>
   )

--- a/apps/web/src/components/workflow/nodes/core/answer/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/answer/schema.ts
@@ -38,6 +38,7 @@ export const answerNodeDataSchema = baseNodeDataSchema.extend({
   attachmentFiles: z.array(z.string()).optional(),
   attachmentFilesModes: z.array(z.boolean()).optional(),
   saveAsDraft: z.boolean().optional(),
+  test_behavior: z.enum(['default', 'live', 'dry_run', 'draft']).optional(),
   fieldModes: z.record(z.string(), z.boolean()).optional(),
 })
 
@@ -64,6 +65,7 @@ export const answerDefaultData: Partial<AnswerNodeData> = {
   attachmentFiles: [],
   attachmentFilesModes: [],
   saveAsDraft: false,
+  test_behavior: 'default',
 }
 
 /**

--- a/apps/web/src/components/workflow/nodes/core/answer/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/answer/trace-renderer.tsx
@@ -1,0 +1,131 @@
+// apps/web/src/components/workflow/nodes/core/answer/trace-renderer.tsx
+
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { BlockCard, type BlockCardAction } from '~/components/kopilot/ui/blocks/block-card'
+import { RecipientChip } from '~/components/kopilot/ui/blocks/recipient-chip'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+interface AnswerOutputs {
+  sent?: boolean
+  isDraft?: boolean
+  draftId?: string
+  dryRun?: boolean
+  messageId?: string
+  threadId?: string
+  messageType?: string
+  subject?: string
+  to?: string[]
+  cc?: string[]
+  text?: string
+  timestamp?: string
+}
+
+const MESSAGE_TYPE_LABELS: Record<string, string> = {
+  new: 'New Message',
+  reply: 'Reply',
+  replyAll: 'Reply All',
+}
+
+/**
+ * Email preview for the Answer node's execution output — renders the drafted /
+ * dry-run / sent email (recipients, subject, body) instead of raw JSON.
+ */
+export function AnswerTraceRenderer({ execution }: TraceRendererProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const outputs = (execution.outputs ?? {}) as AnswerOutputs
+
+  const handleOpenThread = () => {
+    if (!outputs.threadId) return
+    const onMailRoute = pathname?.startsWith('/app/mail/') ?? false
+    const basePath = onMailRoute ? pathname : '/app/mail/inboxes/all/unassigned'
+    const params = new URLSearchParams(onMailRoute ? searchParams.toString() : '')
+    params.set('tid', outputs.threadId)
+    router.push(`${basePath}?${params.toString()}`)
+  }
+
+  // Pre-enrichment runs (draft/live sends persisted before subject/text landed
+  // in every branch) have nothing to preview — show the raw outputs instead.
+  if (!outputs.text && !outputs.subject) {
+    return <TraceRawJson value={execution.outputs} />
+  }
+
+  const badge = outputs.dryRun ? (
+    <Badge variant='amber'>Dry run</Badge>
+  ) : outputs.isDraft ? (
+    <Badge variant='blue'>Draft</Badge>
+  ) : outputs.sent ? (
+    <Badge variant='green'>Sent</Badge>
+  ) : null
+
+  const indicatorColor = outputs.dryRun
+    ? 'bg-amber-500'
+    : outputs.isDraft
+      ? 'bg-blue-500'
+      : 'bg-emerald-500'
+
+  const time = outputs.timestamp
+    ? new Date(outputs.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : null
+
+  const actions: BlockCardAction[] =
+    outputs.isDraft && outputs.threadId
+      ? [{ label: 'Open draft in thread', onClick: handleOpenThread, primary: true }]
+      : []
+
+  return (
+    <BlockCard
+      data-slot='answer-trace-renderer'
+      indicator={<div className={`size-2 rounded-full ${indicatorColor}`} />}
+      primaryText={MESSAGE_TYPE_LABELS[outputs.messageType ?? ''] ?? 'Email'}
+      secondaryText={
+        <span className='inline-flex items-center gap-1.5 text-xs'>
+          {badge}
+          {time && <span>{time}</span>}
+        </span>
+      }
+      hasFooter={actions.length > 0}
+      actions={actions}>
+      <div className='space-y-2 p-1'>
+        {!!(outputs.to?.length || outputs.cc?.length) && (
+          <div className='inline-flex flex-wrap items-center gap-1 text-xs text-muted-foreground'>
+            {!!outputs.to?.length && (
+              <>
+                <span>To:</span>
+                {outputs.to.map((v, i) => (
+                  <RecipientChip key={`to-${i}-${v}`} value={v} />
+                ))}
+              </>
+            )}
+            {!!outputs.cc?.length && (
+              <>
+                <span className='ml-2'>Cc:</span>
+                {outputs.cc.map((v, i) => (
+                  <RecipientChip key={`cc-${i}-${v}`} value={v} />
+                ))}
+              </>
+            )}
+          </div>
+        )}
+        {outputs.subject && <div className='text-sm font-medium'>{outputs.subject}</div>}
+        {outputs.text && (
+          <div className='h-40 rounded-xl bg-background p-2 ring-1 ring-border'>
+            <ScrollArea
+              className='h-full'
+              scrollbarClassName='w-1 mr-0.5 data-[hovering]:opacity-0 hover:!opacity-100'
+              allowScrollChaining>
+              <div className='whitespace-pre-wrap text-sm'>{outputs.text}</div>
+            </ScrollArea>
+          </div>
+        )}
+      </div>
+    </BlockCard>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/core/answer/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/answer/types.ts
@@ -36,6 +36,9 @@ export interface AnswerNodeData extends BaseNodeData {
   attachmentFiles?: string[]
   attachmentFilesModes?: boolean[]
   saveAsDraft?: boolean // When true, creates a draft instead of sending
+  // Per-node send behavior override: default = dry-run during test runs,
+  // live = always send, dry_run = never send, draft = save as thread draft
+  test_behavior?: 'default' | 'live' | 'dry_run' | 'draft'
   fieldModes?: Record<string, boolean> // Track constant/variable mode per field
 }
 

--- a/apps/web/src/components/workflow/nodes/core/crud/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/crud/trace-renderer.tsx
@@ -1,0 +1,73 @@
+// apps/web/src/components/workflow/nodes/core/crud/trace-renderer.tsx
+
+'use client'
+
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
+import { Badge } from '@auxx/ui/components/badge'
+import { AlertCircle, Database } from 'lucide-react'
+import { BlockCard } from '~/components/kopilot/ui/blocks/block-card'
+import { EntityCardItem } from '~/components/kopilot/ui/blocks/entity-card-item'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+interface CrudOutputs {
+  id?: string
+  deleted?: boolean
+  success?: boolean
+  error?: string
+}
+
+const OPERATION_BADGES: Record<string, { label: string; variant: 'green' | 'blue' | 'red' }> = {
+  create: { label: 'Created', variant: 'green' },
+  update: { label: 'Updated', variant: 'blue' },
+  delete: { label: 'Deleted', variant: 'red' },
+}
+
+/**
+ * Preview for CRUD node executions — the affected record as a live-hydrated
+ * entity card with an operation badge. resourceType/operation come from
+ * executionMetadata, not outputs.
+ */
+export function CrudTraceRenderer({ execution }: TraceRendererProps) {
+  const outputs = (execution.outputs ?? {}) as CrudOutputs
+  const metadata = (execution.executionMetadata ?? {}) as {
+    operation?: string
+    resourceType?: string
+  }
+
+  // Error-continue output — the node was configured to continue on failure
+  if (outputs.success === false) {
+    return (
+      <Alert variant='destructive'>
+        <AlertCircle />
+        <AlertTitle>Operation failed</AlertTitle>
+        <AlertDescription>{outputs.error || 'The record operation failed.'}</AlertDescription>
+      </Alert>
+    )
+  }
+
+  const operation = metadata.operation
+  const badge = operation ? OPERATION_BADGES[operation] : undefined
+
+  if (!outputs.id || !metadata.resourceType) {
+    return <TraceRawJson value={execution.outputs} />
+  }
+
+  return (
+    <BlockCard
+      data-slot='crud-trace-renderer'
+      indicator={<Database className='size-3 text-muted-foreground' />}
+      primaryText={metadata.resourceType}
+      secondaryText={badge && <Badge variant={badge.variant}>{badge.label}</Badge>}
+      hasFooter={false}>
+      {outputs.deleted || operation === 'delete' ? (
+        <div className='flex items-center gap-2 p-2 text-sm text-muted-foreground'>
+          <span>Record deleted</span>
+          <span className='truncate font-mono text-[10px] opacity-70'>{outputs.id}</span>
+        </div>
+      ) : (
+        <EntityCardItem recordId={`${metadata.resourceType}:${outputs.id}`} />
+      )}
+    </BlockCard>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/core/end/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/end/trace-renderer.tsx
@@ -1,0 +1,81 @@
+// apps/web/src/components/workflow/nodes/core/end/trace-renderer.tsx
+
+'use client'
+
+import type { ContentSegment, WorkflowFileData } from '@auxx/lib/workflow-engine/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Flag, Paperclip } from 'lucide-react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { BlockCard } from '~/components/kopilot/ui/blocks/block-card'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+interface EndOutputs {
+  message?: string
+  contentSegments?: ContentSegment[]
+  status?: 'success' | 'error'
+  completedAt?: string
+}
+
+/** Flatten file / file-array segments into a single file list for chips. */
+function collectFiles(segments?: ContentSegment[]): WorkflowFileData[] {
+  if (!segments) return []
+  return segments.flatMap((segment) => {
+    if (segment.type === 'file') return [segment.value]
+    if (segment.type === 'file-array') return segment.value
+    return []
+  })
+}
+
+/**
+ * Preview for End node executions — the completion message rendered as
+ * markdown, with any file content segments shown as small chips.
+ */
+export function EndTraceRenderer({ execution }: TraceRendererProps) {
+  const outputs = (execution.outputs ?? {}) as EndOutputs
+
+  if (!outputs.message && !outputs.contentSegments?.length) {
+    return <TraceRawJson value={execution.outputs} />
+  }
+
+  const files = collectFiles(outputs.contentSegments)
+  const badge =
+    outputs.status === 'error' ? (
+      <Badge variant='red'>Error</Badge>
+    ) : outputs.status === 'success' ? (
+      <Badge variant='green'>Success</Badge>
+    ) : null
+
+  return (
+    <BlockCard
+      data-slot='end-trace-renderer'
+      indicator={<Flag className='size-3 text-muted-foreground' />}
+      primaryText='Output'
+      secondaryText={badge}
+      hasFooter={false}>
+      <div className='space-y-2 p-1'>
+        {outputs.message && (
+          <div className='prose prose-sm dark:prose-invert max-w-none text-sm'>
+            <Markdown remarkPlugins={[remarkGfm]}>{outputs.message}</Markdown>
+          </div>
+        )}
+        {files.length > 0 && (
+          <div className='flex flex-wrap gap-1'>
+            {files.map((file) => (
+              <a
+                key={file.id}
+                href={file.url}
+                target='_blank'
+                rel='noreferrer'
+                className='inline-flex items-center gap-1 rounded-full bg-background px-2 py-1 text-xs ring-1 ring-border hover:bg-muted/50'>
+                <Paperclip className='size-3' />
+                <span className='max-w-[160px] truncate'>{file.filename}</span>
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+    </BlockCard>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/core/find/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/find/trace-renderer.tsx
@@ -1,0 +1,65 @@
+// apps/web/src/components/workflow/nodes/core/find/trace-renderer.tsx
+
+'use client'
+
+import { EntityListBlock } from '~/components/kopilot/ui/blocks/entity-list-block'
+import { ThreadListBlock } from '~/components/kopilot/ui/blocks/thread-list-block'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+interface FindQueryInfo {
+  resource_type?: string
+  find_mode?: string
+  total_conditions?: number
+  limit_applied?: number
+}
+
+/**
+ * Preview for Find node executions — result records as a hydrated entity list
+ * (threads get the thread list treatment). The records array sits under a
+ * dynamic key (the resource's lowercased plural name), so locate it by finding
+ * the array-valued output key.
+ */
+export function FindTraceRenderer({ execution }: TraceRendererProps) {
+  const outputs = (execution.outputs ?? {}) as Record<string, unknown>
+  const queryInfo = (outputs.query_info ?? {}) as FindQueryInfo
+  const resourceType = queryInfo.resource_type
+
+  if (!resourceType) {
+    return <TraceRawJson value={execution.outputs} />
+  }
+
+  // Records live under the resource's plural name — findOne returns a single
+  // object, find returns an array. Normalize to an array of rows with ids.
+  const recordsValue = Object.entries(outputs).find(
+    ([key, value]) =>
+      key !== 'query_info' && (Array.isArray(value) || (typeof value === 'object' && value))
+  )?.[1]
+  const records = (Array.isArray(recordsValue) ? recordsValue : [recordsValue]).filter(
+    (r): r is { id: string } =>
+      !!r && typeof r === 'object' && typeof (r as { id?: unknown }).id === 'string'
+  )
+
+  const count = typeof outputs.count === 'number' ? outputs.count : records.length
+  const summaryParts = [
+    `${count} result${count === 1 ? '' : 's'}`,
+    queryInfo.total_conditions ? `${queryInfo.total_conditions} condition(s)` : null,
+    queryInfo.find_mode === 'findOne' ? 'find one' : null,
+  ].filter(Boolean)
+
+  return (
+    <div>
+      <div className='px-1 pb-1 text-xs text-muted-foreground'>{summaryParts.join(' · ')}</div>
+      {records.length === 0 ? (
+        <div className='p-2 text-sm text-muted-foreground'>No records found</div>
+      ) : resourceType === 'thread' ? (
+        <ThreadListBlock data={{ threadIds: records.map((r) => r.id) }} skipEntrance />
+      ) : (
+        <EntityListBlock
+          data={{ recordIds: records.map((r) => `${resourceType}:${r.id}`) }}
+          skipEntrance
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/core/http/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/http/trace-renderer.tsx
@@ -1,0 +1,84 @@
+// apps/web/src/components/workflow/nodes/core/http/trace-renderer.tsx
+
+'use client'
+
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { ChevronRight, Globe } from 'lucide-react'
+import { BlockCard } from '~/components/kopilot/ui/blocks/block-card'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+interface HttpOutputs {
+  status?: number
+  statusText?: string
+  headers?: Record<string, string>
+  success?: boolean
+  body?: unknown
+  /** Present when error_strategy is 'none' — request failed but node continued. */
+  error?: string
+}
+
+interface HttpInputs {
+  url?: string
+  method?: string
+}
+
+/** Collapsed JSON details section used for the response body. */
+function CollapsedJson({ title, value }: { title: string; value: unknown }) {
+  return (
+    <details className='group rounded-xl bg-background ring-1 ring-border'>
+      <summary className='flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground select-none'>
+        <ChevronRight className='size-3 transition-transform group-open:rotate-90' />
+        {title}
+      </summary>
+      <pre className='max-h-[200px] overflow-auto p-2 pt-0 font-mono text-xs'>
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </details>
+  )
+}
+
+/** Status class → badge color: 2xx green, 3xx blue, 4xx amber, 5xx/network red. */
+function statusVariant(status?: number): Variant {
+  if (status == null) return 'gray'
+  if (status >= 200 && status < 300) return 'green'
+  if (status >= 300 && status < 400) return 'blue'
+  if (status >= 400 && status < 500) return 'amber'
+  if (status >= 500) return 'red'
+  return 'gray'
+}
+
+/**
+ * Preview for HTTP node executions — method + URL (from `execution.inputs`,
+ * populated from the preprocessor's interpolated request, not `outputs`),
+ * a status pill colored by response class, and the response body as
+ * collapsed JSON.
+ */
+export function HttpTraceRenderer({ execution }: TraceRendererProps) {
+  const outputs = (execution.outputs ?? {}) as HttpOutputs
+  const inputs = (execution.inputs ?? {}) as HttpInputs
+
+  if (outputs.status === undefined && !outputs.error) {
+    return <TraceRawJson value={execution.outputs} />
+  }
+
+  const statusLabel = [outputs.status, outputs.statusText].filter(Boolean).join(' ')
+
+  return (
+    <BlockCard
+      data-slot='http-trace-renderer'
+      indicator={<Globe className='size-3 text-muted-foreground' />}
+      primaryText={[inputs.method, inputs.url].filter(Boolean).join(' ') || 'HTTP Request'}
+      secondaryText={
+        <Badge variant={statusVariant(outputs.status)}>
+          {statusLabel || outputs.error || 'Failed'}
+        </Badge>
+      }
+      hasFooter={false}>
+      <div className='space-y-2 p-1'>
+        {outputs.error && <div className='text-xs text-destructive'>{outputs.error}</div>}
+        {outputs.body !== undefined && <CollapsedJson title='Response body' value={outputs.body} />}
+      </div>
+    </BlockCard>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/core/human/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/human/panel.tsx
@@ -365,6 +365,7 @@ export const HumanConfirmationNodePanel = memo<HumanConfirmationNodePanelProps>(
           initialOpen={false}
           open={inputs.test_behavior === 'live'}
           collapsible={inputs.test_behavior === 'live'}
+          className={inputs.test_behavior === 'live' ? undefined : '[&_[data-slot=section]]:pb-0'}
           actions={
             <Select
               value={inputs.test_behavior || 'always_approve'}

--- a/apps/web/src/components/workflow/nodes/core/human/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/human/trace-renderer.tsx
@@ -1,0 +1,133 @@
+// apps/web/src/components/workflow/nodes/core/human/trace-renderer.tsx
+
+'use client'
+
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { UserCheck } from 'lucide-react'
+import { BlockCard, StatusIndicator } from '~/components/kopilot/ui/blocks/block-card'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+/**
+ * `outputs` shape varies by phase (verified against
+ * action-nodes/human-confirmation.ts + the resume-side services):
+ * - Live, still paused: `{ approval_request_id, expires_at, assignee_count, notification_methods }`.
+ * - Live, resumed (approval-response-service.ts / approval-timeout-job.ts): the paused
+ *   fields above merged with `{ outcome, approvalRequestId, respondedBy?, respondedAt?,
+ *   comment?, timedOutAt?, cancelledBy?, cancelledAt?, cancelReason? }`. `outcome` is an
+ *   unnormalized string across call sites: 'approve' | 'deny' (respond), 'denied' (cancel),
+ *   'timeout' (timeout job).
+ * - Test/dry-run mode (handleTestMode): `{ test_mode: true, outcome: 'approved' | 'denied'
+ *   | 'timeout', test_behavior }`.
+ */
+interface HumanConfirmationOutputs {
+  approval_request_id?: string
+  approvalRequestId?: string
+  expires_at?: string
+  assignee_count?: number
+  notification_methods?: { in_app?: boolean; email?: boolean }
+  outcome?: string
+  respondedBy?: string
+  respondedAt?: string
+  comment?: string
+  timedOutAt?: string
+  cancelledBy?: string
+  cancelledAt?: string
+  cancelReason?: string
+  test_mode?: boolean
+  test_behavior?: string
+}
+
+type Outcome = 'approved' | 'denied' | 'timeout'
+
+/** Normalize the inconsistent `outcome` casing across call sites (see above). */
+function normalizeOutcome(raw?: string): Outcome | undefined {
+  if (!raw) return undefined
+  if (raw.startsWith('approv')) return 'approved'
+  if (raw.startsWith('den')) return 'denied'
+  if (raw === 'timeout') return 'timeout'
+  return undefined
+}
+
+const OUTCOME_BADGES: Record<Outcome, { label: string; variant: Variant }> = {
+  approved: { label: 'Approved', variant: 'green' },
+  denied: { label: 'Denied', variant: 'red' },
+  timeout: { label: 'Timed out', variant: 'amber' },
+}
+
+/**
+ * Preview for Human Confirmation node executions — a status dot + outcome
+ * badge, assignee count and expiry while pending, and the responder/comment
+ * (or timeout/cancel details) once resolved. A separate chip flags test-mode
+ * runs, which report their own synthetic outcome.
+ */
+export function HumanConfirmationTraceRenderer({ execution }: TraceRendererProps) {
+  const outputs = (execution.outputs ?? {}) as HumanConfirmationOutputs
+
+  const hasAnyKnownField =
+    outputs.approval_request_id || outputs.approvalRequestId || outputs.outcome || outputs.test_mode
+  if (!hasAnyKnownField) {
+    return <TraceRawJson value={execution.outputs} />
+  }
+
+  const outcome = normalizeOutcome(outputs.outcome)
+  const badge = outcome ? OUTCOME_BADGES[outcome] : undefined
+  const indicatorStatus: 'pending' | 'approved' | 'rejected' =
+    outcome === 'approved' ? 'approved' : outcome === 'denied' ? 'rejected' : 'pending'
+
+  const expiresAt = outputs.expires_at
+    ? new Date(outputs.expires_at).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' })
+    : null
+  const respondedAt = outputs.respondedAt
+    ? new Date(outputs.respondedAt).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' })
+    : null
+
+  return (
+    <BlockCard
+      data-slot='human-confirmation-trace-renderer'
+      indicator={<StatusIndicator status={indicatorStatus} />}
+      primaryText='Human Review'
+      secondaryText={
+        <span className='inline-flex items-center gap-1.5 text-xs'>
+          {outputs.test_mode && <Badge variant='purple'>Test</Badge>}
+          {badge ? (
+            <Badge variant={badge.variant}>{badge.label}</Badge>
+          ) : (
+            <Badge variant='amber'>Pending</Badge>
+          )}
+        </span>
+      }
+      hasFooter={false}>
+      <div className='space-y-1.5 p-1 text-sm'>
+        {!outcome && (
+          <div className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+            <UserCheck className='size-3' />
+            {typeof outputs.assignee_count === 'number' && (
+              <span>
+                {outputs.assignee_count} assignee{outputs.assignee_count === 1 ? '' : 's'}
+              </span>
+            )}
+            {expiresAt && <span>· expires {expiresAt}</span>}
+          </div>
+        )}
+        {outcome === 'timeout' && (
+          <div className='text-xs text-muted-foreground'>Expired without a response.</div>
+        )}
+        {(outputs.respondedBy || outputs.comment) && (
+          <div className='text-xs text-muted-foreground'>
+            {outputs.respondedBy && <span>By {outputs.respondedBy}</span>}
+            {outputs.respondedBy && respondedAt && <span> · </span>}
+            {respondedAt && <span>{respondedAt}</span>}
+            {outputs.comment && <div className='mt-0.5 whitespace-pre-wrap'>{outputs.comment}</div>}
+          </div>
+        )}
+        {outputs.cancelledBy && (
+          <div className='text-xs text-muted-foreground'>
+            Cancelled by {outputs.cancelledBy}
+            {outputs.cancelReason && <div className='mt-0.5'>{outputs.cancelReason}</div>}
+          </div>
+        )}
+      </div>
+    </BlockCard>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/core/index.ts
+++ b/apps/web/src/components/workflow/nodes/core/index.ts
@@ -35,10 +35,13 @@ import { WaitNode, WaitNodePanel } from '~/components/workflow/nodes/core/wait'
 import { WebhookNode, WebhookPanel } from '~/components/workflow/nodes/core/webhook'
 import { type NodeDefinition, NodeType } from '~/components/workflow/types'
 import { aiDefinition } from './ai'
+import { AiTraceRenderer } from './ai/trace-renderer'
 import { answerDefinition } from './answer'
+import { AnswerTraceRenderer } from './answer/trace-renderer'
 import { ChunkerNode, ChunkerPanel, chunkerDefinition } from './chunker'
 import { codeDefinition } from './code'
 import { CrudNode, CrudPanel, crudDefinition } from './crud'
+import { CrudTraceRenderer } from './crud/trace-renderer'
 import { DatasetNode, DatasetPanel, datasetDefinition } from './dataset'
 import { dateTimeNodeDefinition } from './date-time'
 import {
@@ -47,12 +50,17 @@ import {
   documentExtractorDefinition,
 } from './document-extractor'
 import { endDefinition } from './end'
+import { EndTraceRenderer } from './end/trace-renderer'
 import { FindNode, FindPanel, findDefinition } from './find'
+import { FindTraceRenderer } from './find/trace-renderer'
 import { formatNodeDefinition } from './format'
 import { httpNodeDefinition } from './http'
+import { HttpTraceRenderer } from './http/trace-renderer'
 import { humanConfirmationDefinition } from './human'
+import { HumanConfirmationTraceRenderer } from './human/trace-renderer'
 import { ifElseDefinition } from './if-else'
 import { informationExtractorDefinition } from './information-extractor'
+import { InformationExtractorTraceRenderer } from './information-extractor/trace-renderer'
 import {
   KnowledgeRetrievalNode,
   KnowledgeRetrievalPanel,
@@ -62,6 +70,7 @@ import { listNodeDefinition } from './list'
 import { loopDefinition } from './loop'
 import { ManualNode, ManualPanel, manualDefinition } from './manual'
 import { messageReceivedDefinition } from './message-received'
+import { MessageReceivedTraceRenderer } from './message-received/trace-renderer'
 import { noteDefinition } from './note'
 import {
   ResourceTriggerNode,
@@ -74,6 +83,7 @@ import {
   scheduledTriggerDefinition,
 } from './scheduled'
 import { textClassifierDefinition } from './text-classifier'
+import { TextClassifierTraceRenderer } from './text-classifier/trace-renderer'
 import { varAssignDefinition } from './var-assign'
 import { waitDefinition } from './wait'
 import { webhookDefinition } from './webhook'
@@ -94,10 +104,20 @@ import { INPUT_NODE_DEFINITIONS, INPUT_NODE_TYPES } from '../inputs'
  */
 export const NODE_DEFINITIONS: NodeDefinition[] = [
   // Core workflow nodes
-  { ...answerDefinition, component: AnswerNode, panel: AnswerPanel },
+  {
+    ...answerDefinition,
+    component: AnswerNode,
+    panel: AnswerPanel,
+    traceRenderer: AnswerTraceRenderer,
+  },
   { ...codeDefinition, component: CodeNode, panel: CodePanel },
   { ...ifElseDefinition, component: IfElseNode, panel: IfElsePanel },
-  { ...messageReceivedDefinition, component: MessageReceivedNode, panel: MessageReceivedPanel },
+  {
+    ...messageReceivedDefinition,
+    component: MessageReceivedNode,
+    panel: MessageReceivedPanel,
+    traceRenderer: MessageReceivedTraceRenderer,
+  },
   { ...webhookDefinition, component: WebhookNode, panel: WebhookPanel },
   {
     ...webhookTriggerDefinition,
@@ -107,18 +127,29 @@ export const NODE_DEFINITIONS: NodeDefinition[] = [
   { ...scheduledTriggerDefinition, component: ScheduledTriggerNode, panel: ScheduledTriggerPanel },
   { ...manualDefinition, component: ManualNode, panel: ManualPanel },
   { ...resourceTriggerDefinition, component: ResourceTriggerNode, panel: ResourceTriggerPanel },
-  { ...aiDefinition, component: AiNode, panel: AiPanel },
-  { ...endDefinition, component: EndNode, panel: EndPanel },
+  { ...aiDefinition, component: AiNode, panel: AiPanel, traceRenderer: AiTraceRenderer },
+  { ...endDefinition, component: EndNode, panel: EndPanel, traceRenderer: EndTraceRenderer },
   { ...noteDefinition, component: NoteNode, panel: NotePanel },
-  { ...textClassifierDefinition, component: TextClassifierNode, panel: TextClassifierPanel },
+  {
+    ...textClassifierDefinition,
+    component: TextClassifierNode,
+    panel: TextClassifierPanel,
+    traceRenderer: TextClassifierTraceRenderer,
+  },
   {
     ...informationExtractorDefinition,
     component: InformationExtractorNode,
     panel: InformationExtractorPanel,
+    traceRenderer: InformationExtractorTraceRenderer,
   },
   { ...varAssignDefinition, component: VarAssignNode, panel: VarAssignPanel },
   { ...dateTimeNodeDefinition, component: DateTimeNode, panel: DateTimePanel },
-  { ...httpNodeDefinition, component: HttpNode, panel: HttpNodePanel },
+  {
+    ...httpNodeDefinition,
+    component: HttpNode,
+    panel: HttpNodePanel,
+    traceRenderer: HttpTraceRenderer,
+  },
   { ...waitDefinition, component: WaitNode, panel: WaitNodePanel },
   { ...listNodeDefinition, component: ListNode, panel: ListPanel as any },
   { ...formatNodeDefinition, component: FormatNode, panel: FormatPanel },
@@ -127,9 +158,10 @@ export const NODE_DEFINITIONS: NodeDefinition[] = [
     ...humanConfirmationDefinition,
     component: HumanConfirmationNode,
     panel: HumanConfirmationNodePanel,
+    traceRenderer: HumanConfirmationTraceRenderer,
   },
-  { ...findDefinition, component: FindNode, panel: FindPanel },
-  { ...crudDefinition, component: CrudNode, panel: CrudPanel },
+  { ...findDefinition, component: FindNode, panel: FindPanel, traceRenderer: FindTraceRenderer },
+  { ...crudDefinition, component: CrudNode, panel: CrudPanel, traceRenderer: CrudTraceRenderer },
   {
     ...documentExtractorDefinition,
     component: DocumentExtractorNode,

--- a/apps/web/src/components/workflow/nodes/core/information-extractor/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/information-extractor/trace-renderer.tsx
@@ -1,0 +1,71 @@
+// apps/web/src/components/workflow/nodes/core/information-extractor/trace-renderer.tsx
+
+'use client'
+
+import { ChevronRight, ScanSearch } from 'lucide-react'
+import { BlockCard } from '~/components/kopilot/ui/blocks/block-card'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+/** camelCase / snake_case → "Title Case" for extracted field keys */
+function formatFieldKey(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/^./, (c) => c.toUpperCase())
+}
+
+/**
+ * Preview for Information Extractor node executions — the extracted object
+ * IS `execution.outputs` itself (top-level keys are the extracted fields, not
+ * nested under `structured_output`). Scalars render as label/value rows;
+ * nested objects/arrays render as collapsed JSON. Not entity-backed, so
+ * `kopilot-field-row` (which requires an entityDefinitionId) doesn't apply.
+ */
+export function InformationExtractorTraceRenderer({ execution }: TraceRendererProps) {
+  const outputs = execution.outputs
+
+  if (!outputs || typeof outputs !== 'object' || Array.isArray(outputs)) {
+    return <TraceRawJson value={outputs} />
+  }
+
+  const entries = Object.entries(outputs as Record<string, unknown>)
+  if (entries.length === 0) {
+    return <TraceRawJson value={outputs} />
+  }
+
+  const isScalar = (value: unknown) =>
+    value === null || ['string', 'number', 'boolean'].includes(typeof value)
+  const scalars = entries.filter(([, value]) => value === undefined || isScalar(value))
+  const complex = entries.filter(([, value]) => value !== undefined && !isScalar(value))
+
+  return (
+    <BlockCard
+      data-slot='information-extractor-trace-renderer'
+      indicator={<ScanSearch className='size-3 text-muted-foreground' />}
+      primaryText='Extracted Data'
+      hasFooter={false}>
+      <div className='space-y-1 p-1'>
+        {scalars.map(([key, value]) => (
+          <div key={key} className='flex min-h-[26px] w-full items-center gap-1 text-sm'>
+            <div className='w-[120px] shrink-0 truncate text-neutral-400'>
+              {formatFieldKey(key)}
+            </div>
+            <div className='min-w-0 flex-1 truncate font-medium'>{String(value ?? '')}</div>
+          </div>
+        ))}
+        {complex.map(([key, value]) => (
+          <details key={key} className='group rounded-xl bg-background ring-1 ring-border'>
+            <summary className='flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground select-none'>
+              <ChevronRight className='size-3 transition-transform group-open:rotate-90' />
+              {formatFieldKey(key)}
+            </summary>
+            <pre className='max-h-[200px] overflow-auto p-2 pt-0 font-mono text-xs'>
+              {JSON.stringify(value, null, 2)}
+            </pre>
+          </details>
+        ))}
+      </div>
+    </BlockCard>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/core/message-received/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/message-received/trace-renderer.tsx
@@ -1,0 +1,30 @@
+// apps/web/src/components/workflow/nodes/core/message-received/trace-renderer.tsx
+
+'use client'
+
+import { ThreadListBlock } from '~/components/kopilot/ui/blocks/thread-list-block'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+interface MessageReceivedOutputs {
+  messageId?: string
+  subject?: string
+  triggeredAt?: string
+  threadId?: string
+}
+
+/**
+ * Preview for Message Received trigger executions — the triggering thread,
+ * so a reviewer can see "what fired this run" at a glance. Legacy runs
+ * persisted before `threadId` was added to this node's output fall back to
+ * raw JSON.
+ */
+export function MessageReceivedTraceRenderer({ execution }: TraceRendererProps) {
+  const outputs = (execution.outputs ?? {}) as MessageReceivedOutputs
+
+  if (!outputs.threadId) {
+    return <TraceRawJson value={execution.outputs} />
+  }
+
+  return <ThreadListBlock data={{ threadIds: [outputs.threadId] }} skipEntrance />
+}

--- a/apps/web/src/components/workflow/nodes/core/text-classifier/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/text-classifier/trace-renderer.tsx
@@ -1,0 +1,54 @@
+// apps/web/src/components/workflow/nodes/core/text-classifier/trace-renderer.tsx
+
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Progress } from '@auxx/ui/components/progress'
+import { Tag } from 'lucide-react'
+import { BlockCard } from '~/components/kopilot/ui/blocks/block-card'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+interface TextClassifierOutputs {
+  category?: string
+  /** 0-1 float, clamped by parseClassificationResult */
+  confidence?: number
+  reasoning?: string
+}
+
+/**
+ * Preview for Text Classifier node executions — the chosen category as a
+ * badge, confidence as a small progress bar + percentage, and the model's
+ * reasoning as muted supporting text.
+ */
+export function TextClassifierTraceRenderer({ execution }: TraceRendererProps) {
+  const outputs = (execution.outputs ?? {}) as TextClassifierOutputs
+
+  if (!outputs.category && typeof outputs.confidence !== 'number') {
+    return <TraceRawJson value={execution.outputs} />
+  }
+
+  const pct =
+    typeof outputs.confidence === 'number'
+      ? Math.round(Math.max(0, Math.min(1, outputs.confidence)) * 100)
+      : null
+
+  return (
+    <BlockCard
+      data-slot='text-classifier-trace-renderer'
+      indicator={<Tag className='size-3 text-muted-foreground' />}
+      primaryText='Classification'
+      hasFooter={false}>
+      <div className='space-y-2 p-1'>
+        <div className='flex items-center gap-2'>
+          {outputs.category && <Badge variant='blue'>{outputs.category}</Badge>}
+          {pct !== null && <span className='text-xs text-muted-foreground'>{pct}%</span>}
+        </div>
+        {pct !== null && <Progress value={pct} className='h-1.5' />}
+        {outputs.reasoning && (
+          <div className='text-xs text-muted-foreground'>{outputs.reasoning}</div>
+        )}
+      </div>
+    </BlockCard>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/shared/base/base-panel.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/base/base-panel.tsx
@@ -609,6 +609,7 @@ export const BasePanel = memo<BasePanelProps>(
                 <TabsContent value='result' className='flex-1 flex flex-col p-0 mt-0'>
                   <SingleRunResultTab
                     nodeId={nodeId}
+                    nodeType={nodeType}
                     onRun={handleRun}
                     onApplySchema={handleApplySchema}
                     inferredSchema={nodeData?.inferredSchema}

--- a/apps/web/src/components/workflow/nodes/shared/generic-app-trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/generic-app-trace-renderer.tsx
@@ -1,0 +1,70 @@
+// apps/web/src/components/workflow/nodes/shared/generic-app-trace-renderer.tsx
+
+'use client'
+
+import { Blocks, ChevronRight } from 'lucide-react'
+import { BlockCard } from '~/components/kopilot/ui/blocks/block-card'
+import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
+import type { TraceRendererProps } from '~/components/workflow/types/registry'
+
+/** camelCase / snake_case → "Title Case" for output keys */
+function formatFieldKey(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/^./, (c) => c.toUpperCase())
+}
+
+/**
+ * Fallback preview for app-block executions (`appId:blockId` node types). App
+ * outputs are un-schematized pass-through data, so this must tolerate anything:
+ * top-level scalars render as label/value rows, objects and arrays nest as
+ * collapsed JSON.
+ */
+export function GenericAppTraceRenderer({ execution }: TraceRendererProps) {
+  const outputs = execution.outputs
+
+  if (!outputs || typeof outputs !== 'object' || Array.isArray(outputs)) {
+    return <TraceRawJson value={outputs} />
+  }
+
+  const entries = Object.entries(outputs as Record<string, unknown>)
+  if (entries.length === 0) {
+    return <TraceRawJson value={outputs} />
+  }
+
+  const isScalar = (value: unknown) =>
+    value === null || ['string', 'number', 'boolean'].includes(typeof value)
+  const scalars = entries.filter(([, value]) => value === undefined || isScalar(value))
+  const complex = entries.filter(([, value]) => value !== undefined && !isScalar(value))
+
+  return (
+    <BlockCard
+      data-slot='generic-app-trace-renderer'
+      indicator={<Blocks className='size-3 text-muted-foreground' />}
+      primaryText='Output'
+      hasFooter={false}>
+      <div className='space-y-1 p-1'>
+        {scalars.map(([key, value]) => (
+          <div key={key} className='flex min-h-[26px] w-full items-center gap-1 text-sm'>
+            <div className='w-[120px] shrink-0 truncate text-neutral-400'>
+              {formatFieldKey(key)}
+            </div>
+            <div className='min-w-0 flex-1 truncate font-medium'>{String(value ?? '')}</div>
+          </div>
+        ))}
+        {complex.map(([key, value]) => (
+          <details key={key} className='group rounded-xl bg-background ring-1 ring-border'>
+            <summary className='flex cursor-pointer items-center gap-1 px-2 py-1.5 text-xs font-medium text-muted-foreground select-none'>
+              <ChevronRight className='size-3 transition-transform group-open:rotate-90' />
+              {formatFieldKey(key)}
+            </summary>
+            <pre className='max-h-[200px] overflow-auto p-2 pt-0 font-mono text-xs'>
+              {JSON.stringify(value, null, 2)}
+            </pre>
+          </details>
+        ))}
+      </div>
+    </BlockCard>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/shared/single-run-result-tab.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/single-run-result-tab.tsx
@@ -23,11 +23,15 @@ import type { SchemaRoot } from '~/components/workflow/ui/json-schema-types'
 import Section from '~/components/workflow/ui/section'
 import { useDemo } from '~/hooks/use-demo'
 import { useRunSingleNode } from '../../hooks'
+import { TraceRenderBoundary } from '../../panels/run/components/trace-render-boundary'
 import { useRunStore } from '../../store/run-store'
+import { unifiedNodeRegistry } from '../unified-registry'
 
 export interface SingleRunResultTabProps {
   /** Node ID */
   nodeId: string
+  /** Node type — fallback when the execution row's nodeType is empty (single-node runs) */
+  nodeType?: string
   /** Handler for running the node */
   onRun?: () => void
   /** Callback to store inferred schema on node data. Parent provides via useNodeCrud. */
@@ -41,6 +45,7 @@ export interface SingleRunResultTabProps {
  */
 export const SingleRunResultTab = memo(function SingleRunResultTab({
   nodeId,
+  nodeType,
   onRun,
   onApplySchema,
   inferredSchema,
@@ -230,6 +235,14 @@ export const SingleRunResultTab = memo(function SingleRunResultTab({
       </div>
     )
   }
+  // Trace preview — single-node runs may persist an empty nodeType, so fall
+  // back to the panel-provided node type
+  const effectiveNodeType = execution.nodeType || nodeType
+  const TraceRenderer = effectiveNodeType
+    ? unifiedNodeRegistry.getTraceRenderer(effectiveNodeType)
+    : null
+  const hasOutputs = !!outputData && Object.keys(outputData).length > 0
+
   // Completed state
   return (
     <>
@@ -258,6 +271,18 @@ export const SingleRunResultTab = memo(function SingleRunResultTab({
           )}
         </div>
       </div>
+
+      {/* Preview */}
+      {TraceRenderer && hasOutputs && (
+        <Section initialOpen title='Preview'>
+          <div className='px-3 pb-3'>
+            {/* The raw Output Data section sits below — render nothing on failure */}
+            <TraceRenderBoundary fallback={null}>
+              <TraceRenderer execution={execution} />
+            </TraceRenderBoundary>
+          </div>
+        </Section>
+      )}
 
       {/* Input data */}
       {inputData && Object.keys(inputData).length > 0 && (

--- a/apps/web/src/components/workflow/nodes/unified-registry.ts
+++ b/apps/web/src/components/workflow/nodes/unified-registry.ts
@@ -1,8 +1,10 @@
 // apps/web/src/components/workflow/nodes/unified-registry.ts
 
 import type React from 'react'
+import type { TraceRendererProps } from '../types'
 import { NodeCategory, type NodeDefinition, type ValidationResult } from '../types'
 import { getIcon } from '../utils/icon-helper'
+import { GenericAppTraceRenderer } from './shared/generic-app-trace-renderer'
 
 /** Whether trigger nodes can be deleted, copied, collapsed, or disabled */
 export const ALLOW_TRIGGER_DELETE = true
@@ -314,6 +316,18 @@ class UnifiedNodeRegistry {
   getPanel(nodeType: string): React.ComponentType<{ nodeId: string }> | undefined {
     const definition = this.getDefinition(nodeType)
     return definition?.panel
+  }
+
+  /**
+   * Get the trace ("Preview") renderer for a node type. App blocks are typed
+   * `appId:blockId` and not in NODE_DEFINITIONS — they fall back to a generic
+   * field-row renderer.
+   */
+  getTraceRenderer(nodeType: string): React.ComponentType<TraceRendererProps> | null {
+    const definition = this.getDefinition(nodeType)
+    if (definition?.traceRenderer) return definition.traceRenderer
+    if (!definition && nodeType.includes(':')) return GenericAppTraceRenderer
+    return null
   }
 
   /**

--- a/apps/web/src/components/workflow/panels/run/components/node-execution-card.tsx
+++ b/apps/web/src/components/workflow/panels/run/components/node-execution-card.tsx
@@ -18,6 +18,7 @@ import {
   Clock,
   Coins,
   Copy,
+  Eye,
   FileInput,
   FileOutput,
   FileText,
@@ -25,9 +26,10 @@ import {
   Loader2,
 } from 'lucide-react'
 import type React from 'react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { NodeRunningStatus } from '~/components/workflow/types'
 import { unifiedNodeRegistry } from '../../../nodes/unified-registry'
+import { TraceRenderBoundary } from './trace-render-boundary'
 
 interface NodeExecutionCardProps {
   execution: WorkflowNodeExecution
@@ -115,11 +117,22 @@ const getStatusIcon = (status: NodeRunningStatus) => {
  */
 export function NodeExecutionCard({ execution, workflowStatus, children }: NodeExecutionCardProps) {
   const [expanded, setExpanded] = useState(false)
-  const [activeTab, setActiveTab] = useState<'outputs' | 'inputs' | 'process' | 'metadata'>(
-    'outputs'
-  )
+  const TraceRenderer = unifiedNodeRegistry.getTraceRenderer(execution.nodeType)
+  const [activeTab, setActiveTab] = useState<
+    'preview' | 'outputs' | 'inputs' | 'process' | 'metadata'
+  >(TraceRenderer && execution.outputs ? 'preview' : 'outputs')
   const outputsCopy = useCopy({ toastMessage: 'Outputs copied to clipboard' })
   const inputsCopy = useCopy({ toastMessage: 'Inputs copied to clipboard' })
+
+  // Live runs: outputs stream in after mount — re-default to Preview when they
+  // arrive while the card is still collapsed (what the reviewer sees on expand).
+  const hadOutputs = useRef(!!execution.outputs)
+  useEffect(() => {
+    if (!hadOutputs.current && execution.outputs && TraceRenderer && !expanded) {
+      setActiveTab('preview')
+    }
+    hadOutputs.current = !!execution.outputs
+  }, [execution.outputs, TraceRenderer, expanded])
 
   // Get node icon from registry
   const nodeIcon = unifiedNodeRegistry.getNodeIcon(execution.nodeType, 'h-4 w-4')
@@ -133,6 +146,24 @@ export function NodeExecutionCard({ execution, workflowStatus, children }: NodeE
   const displayStatus = computeDisplayStatus(execution.status, workflowStatus, !!execution.error)
 
   const showChildren = expanded && displayStatus !== NodeRunningStatus.Pending
+
+  // Raw outputs JSON — shared between the Outputs tab and the Preview fallback
+  const rawOutputs = execution.outputs && (
+    <div className='relative group'>
+      <Button
+        variant='ghost'
+        size='icon'
+        className='absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground size-7'
+        onClick={() => outputsCopy.copy(JSON.stringify(execution.outputs, null, 2))}
+        aria-label='Copy outputs'>
+        {outputsCopy.copied ? <Check className='h-3.5 w-3.5' /> : <Copy className='h-3.5 w-3.5' />}
+      </Button>
+      <pre className='p-3 bg-muted rounded-md text-xs overflow-auto max-h-[300px] font-mono'>
+        {JSON.stringify(execution.outputs, null, 2)}
+      </pre>
+    </div>
+  )
+
   return (
     <div
       className={cn(
@@ -211,10 +242,21 @@ export function NodeExecutionCard({ execution, workflowStatus, children }: NodeE
         <div className='p-2'>
           <RadioTab
             value={activeTab}
-            onValueChange={(value) => setActiveTab(value as 'outputs' | 'inputs' | 'metadata')}
+            onValueChange={(value) =>
+              setActiveTab(value as 'preview' | 'outputs' | 'inputs' | 'metadata')
+            }
             size='sm'
-            radioGroupClassName='grid w-full grid-cols-3 after:rounded-2xl'
+            radioGroupClassName={cn(
+              'grid w-full after:rounded-2xl',
+              TraceRenderer ? 'grid-cols-4' : 'grid-cols-3'
+            )}
             className='border border-primary-50 h-8 w-full rounded-2xl'>
+            {TraceRenderer && (
+              <RadioTabItem value='preview' size='sm' className='gap-1'>
+                <Eye className='size-3.5!' />
+                Preview
+              </RadioTabItem>
+            )}
             <RadioTabItem value='outputs' size='sm' className='gap-1'>
               <FileOutput className='size-3.5!' />
               Outputs
@@ -229,29 +271,19 @@ export function NodeExecutionCard({ execution, workflowStatus, children }: NodeE
             </RadioTabItem>
           </RadioTab>
 
-          {activeTab === 'outputs' && (
+          {activeTab === 'preview' && TraceRenderer && (
             <div className='mt-3'>
-              {execution.outputs && (
-                <div className='relative group'>
-                  <Button
-                    variant='ghost'
-                    size='icon'
-                    className='absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground size-7'
-                    onClick={() => outputsCopy.copy(JSON.stringify(execution.outputs, null, 2))}
-                    aria-label='Copy outputs'>
-                    {outputsCopy.copied ? (
-                      <Check className='h-3.5 w-3.5' />
-                    ) : (
-                      <Copy className='h-3.5 w-3.5' />
-                    )}
-                  </Button>
-                  <pre className='p-3 bg-muted rounded-md text-xs overflow-auto max-h-[300px] font-mono'>
-                    {JSON.stringify(execution.outputs, null, 2)}
-                  </pre>
-                </div>
+              {execution.outputs ? (
+                <TraceRenderBoundary fallback={rawOutputs}>
+                  <TraceRenderer execution={execution} />
+                </TraceRenderBoundary>
+              ) : (
+                <p className='text-sm text-muted-foreground py-8 text-center'>No output yet</p>
               )}
             </div>
           )}
+
+          {activeTab === 'outputs' && <div className='mt-3'>{rawOutputs}</div>}
 
           {activeTab === 'inputs' && (
             <div className='mt-3'>

--- a/apps/web/src/components/workflow/panels/run/components/trace-render-boundary.tsx
+++ b/apps/web/src/components/workflow/panels/run/components/trace-render-boundary.tsx
@@ -1,0 +1,43 @@
+// apps/web/src/components/workflow/panels/run/components/trace-render-boundary.tsx
+
+'use client'
+
+import { Component, type ReactNode } from 'react'
+
+interface TraceRenderBoundaryProps {
+  /** Rendered when the trace renderer throws (corrupt/legacy outputs). */
+  fallback?: ReactNode
+  children: ReactNode
+}
+
+/**
+ * Error boundary around node trace ("Preview") renderers — a renderer crashing on
+ * unexpected output shapes must never take down the run panel or the node panel.
+ */
+export class TraceRenderBoundary extends Component<
+  TraceRenderBoundaryProps,
+  { hasError: boolean }
+> {
+  state = { hasError: false }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  render() {
+    if (this.state.hasError) return this.props.fallback ?? null
+    return this.props.children
+  }
+}
+
+/**
+ * Raw-JSON fallback body for trace renderers that decide their outputs are not
+ * renderable (e.g. legacy runs missing enriched fields).
+ */
+export function TraceRawJson({ value }: { value: unknown }) {
+  return (
+    <pre className='p-3 bg-muted rounded-md text-xs overflow-auto max-h-[300px] font-mono'>
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  )
+}

--- a/apps/web/src/components/workflow/types/index.ts
+++ b/apps/web/src/components/workflow/types/index.ts
@@ -40,7 +40,12 @@ export { getNodeTypeDisplayName, isNodeType, NodeType } from './node-types'
 // Output variable types
 export type { OutputVariable } from './output-variables'
 export { createOutputVariable } from './output-variables'
-export type { NodeDefinition, NodePanelProps, ValidationResult } from './registry'
+export type {
+  NodeDefinition,
+  NodePanelProps,
+  TraceRendererProps,
+  ValidationResult,
+} from './registry'
 // Registry types
 export { NodeCategory } from './registry'
 

--- a/apps/web/src/components/workflow/types/registry.ts
+++ b/apps/web/src/components/workflow/types/registry.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/types/registry.ts
 
+import type { WorkflowNodeExecutionEntity } from '@auxx/database/types'
 import type { WorkflowTriggerType } from '@auxx/lib/workflow-engine/client'
 import type { ComponentType } from 'react'
 import type { UnifiedOutputVariablesFunction } from './output-variables'
@@ -40,6 +41,14 @@ export interface NodePanelProps {
 }
 
 /**
+ * Props for a node type's trace ("Preview") renderer
+ */
+export interface TraceRendererProps {
+  /** The node execution being inspected (outputs, metadata, status, error). */
+  execution: WorkflowNodeExecutionEntity
+}
+
+/**
  * Node definition for the registry (flattened data version)
  */
 export interface NodeDefinition<TData = any> {
@@ -55,6 +64,8 @@ export interface NodeDefinition<TData = any> {
   schema: any // Simplified to avoid Zod typing complexity
   component?: ComponentType<any> // The React component to render this node (for dynamic lookup)
   panel?: ComponentType<NodePanelProps> // Panel component for the node
+  /** Optional pretty renderer for this node type's execution output ("Preview" trace tab). */
+  traceRenderer?: ComponentType<TraceRendererProps>
   validator?: (data: TData) => ValidationResult // Validation function
   triggerType?: WorkflowTriggerType // Only set for trigger nodes
   canConnect?: boolean // Whether this node can connect to other nodes (default: true)

--- a/apps/web/src/server/api/routers/admin.ts
+++ b/apps/web/src/server/api/routers/admin.ts
@@ -407,7 +407,7 @@ export const adminRouter = createTRPCRouter({
         organizationId: z.string(),
         mode: z.enum(['reset', 'additive']),
         scenario: z
-          .enum(['demo', 'development', 'testing', 'superadmin-test'])
+          .enum(['demo', 'development', 'testing', 'superadmin-test', 'shopify-review'])
           .optional()
           .default('demo'),
       })

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/answer.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/answer.ts
@@ -41,6 +41,14 @@ interface AnswerNodeData {
   attachmentFiles?: string[]
   attachmentFilesModes?: boolean[]
   saveAsDraft?: boolean
+  /**
+   * Per-node send behavior override (mirrors the human-in-the-loop node's Test Mode).
+   * - 'default': send in production, dry-run in builder test runs
+   * - 'live': always really send, even in test runs
+   * - 'dry_run': never send, trace-only
+   * - 'draft': persist as a thread draft instead of sending
+   */
+  test_behavior?: 'default' | 'live' | 'dry_run' | 'draft'
 }
 
 /**
@@ -242,12 +250,29 @@ export class AnswerProcessor extends BaseNodeProcessor {
           }))
         : undefined
 
-    // 5. Check modes
-    const saveAsDraft = config.saveAsDraft ?? false
-    const isDryRun = contextManager.isDebugMode()
+    // 5. Determine effective send mode. test_behavior overrides the global debug flag in both
+    // directions; 'live' does NOT override a configured saveAsDraft (live means "don't
+    // simulate", not "skip the configured draft step").
+    const behavior = config.test_behavior ?? 'default'
+    const isDebug = contextManager.isDebugMode()
+    type SendMode = 'send' | 'dryRun' | 'draft'
+    const mode: SendMode =
+      behavior === 'dry_run'
+        ? 'dryRun'
+        : behavior === 'draft'
+          ? 'draft'
+          : config.saveAsDraft
+            ? 'draft'
+            : behavior === 'live'
+              ? 'send'
+              : isDebug
+                ? 'dryRun'
+                : 'send'
+    // Auditability: stamp the override in metadata when a non-default behavior is set
+    const testBehaviorMetadata = behavior !== 'default' ? { testBehavior: behavior } : {}
 
     // Draft path — runs even in dry-run mode (drafts are safe, non-destructive)
-    if (saveAsDraft) {
+    if (mode === 'draft') {
       try {
         const draftService = new DraftService(context.db, context.organizationId, context.userId)
 
@@ -314,6 +339,13 @@ export class AnswerProcessor extends BaseNodeProcessor {
             isDraft: true,
             draftId: draft.id,
             threadId: threadId || undefined,
+            messageType,
+            integrationId,
+            subject: resolvedSubject || undefined,
+            to: resolvedTo,
+            cc: resolvedCc.length > 0 ? resolvedCc : undefined,
+            bcc: resolvedBcc.length > 0 ? resolvedBcc : undefined,
+            text: resolvedText,
             timestamp: new Date().toISOString(),
             recipientCount: resolvedTo.length + resolvedCc.length + resolvedBcc.length,
           },
@@ -321,6 +353,7 @@ export class AnswerProcessor extends BaseNodeProcessor {
             messageType,
             integrationId,
             saveAsDraft: true,
+            ...testBehaviorMetadata,
           },
           outputHandle: 'source',
         }
@@ -330,7 +363,7 @@ export class AnswerProcessor extends BaseNodeProcessor {
         })
         throw error
       }
-    } else if (isDryRun) {
+    } else if (mode === 'dryRun') {
       // Dry run send path (existing behavior)
       contextManager.log('INFO', node.name, 'DryRun: Skipping message send', {
         messageType,
@@ -369,6 +402,14 @@ export class AnswerProcessor extends BaseNodeProcessor {
           cc: resolvedCc.length > 0 ? resolvedCc : undefined,
           bcc: resolvedBcc.length > 0 ? resolvedBcc : undefined,
           text: resolvedText,
+          timestamp: new Date().toISOString(),
+          recipientCount: resolvedTo.length + resolvedCc.length + resolvedBcc.length,
+        },
+        metadata: {
+          messageType,
+          integrationId,
+          dryRun: true,
+          ...testBehaviorMetadata,
         },
         outputHandle: 'source',
       }
@@ -429,6 +470,13 @@ export class AnswerProcessor extends BaseNodeProcessor {
           sent: true,
           messageId: result.id,
           threadId: result.threadId,
+          messageType,
+          integrationId,
+          subject: resolvedSubject || undefined,
+          to: resolvedTo,
+          cc: resolvedCc.length > 0 ? resolvedCc : undefined,
+          bcc: resolvedBcc.length > 0 ? resolvedBcc : undefined,
+          text: resolvedText,
           timestamp: new Date().toISOString(),
           recipientCount:
             toParticipants.length + (ccParticipants?.length || 0) + (bccParticipants?.length || 0),
@@ -437,6 +485,7 @@ export class AnswerProcessor extends BaseNodeProcessor {
           messageType,
           integrationId,
           dryRun: false,
+          ...testBehaviorMetadata,
         },
         outputHandle: 'source',
       }

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/message-received.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/message-received.ts
@@ -116,6 +116,7 @@ export class MessageReceivedProcessor extends BaseNodeProcessor {
         messageId: context.message.id,
         subject: context.message.subject,
         triggeredAt: new Date(),
+        threadId: context.message.threadId,
       },
       outputHandle: 'source', // Standard output for trigger nodes
     }

--- a/packages/seed/src/domains/communication.domain.ts
+++ b/packages/seed/src/domains/communication.domain.ts
@@ -2,11 +2,12 @@
 // Communication domain refinements for support threads and messages with comprehensive seeding
 
 import { createId } from '@paralleldrive/cuid2'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, inArray, sql } from 'drizzle-orm'
 import { ContentEngine } from '../generators/content-engine'
 import {
   EXAMPLE_CONVERSATIONS,
   type ExampleConversation,
+  personas,
 } from '../generators/example-conversations'
 import type {
   SeedingContext,
@@ -172,14 +173,26 @@ export class CommunicationDomain {
     const inboxIds = this.generateThreadInboxIds()
     const metadata = this.generateThreadMetadata()
 
+    // Scripted threads that end on an unanswered customer message should read as an
+    // open, unassigned inbox item with a recent lastMessageAt so they sort to the top.
+    for (let i = 0; i < this.scenario.scales.threads; i++) {
+      if (this.isScriptedThreadEndingOnCustomer(i)) {
+        statuses[i] = 'OPEN'
+        assigneeIds[i] = null
+        lastMessageAt[i] = new Date(Date.now() - i * 60_000)
+      }
+    }
+
     // Store participant assignments for later use in message generation
     this.threadParticipantAssignments.clear()
 
     // Insert threads with REAL participant IDs
     const threadRows = []
     for (let i = 0; i < this.scenario.scales.threads; i++) {
-      // Assign 1 customer + 1 support agent to each thread
-      const customerParticipant = customerParticipants[i % customerParticipants.length]
+      // Assign 1 customer + 1 support agent to each thread. Scripted threads match the
+      // conversation's persona by email (participant SELECT order is unspecified —
+      // see resolveCustomerParticipant); everything else round-robins.
+      const customerParticipant = this.resolveCustomerParticipant(i, customerParticipants)
       const supportParticipant = supportParticipants[i % supportParticipants.length]
 
       const threadId = ids[i]!
@@ -251,14 +264,20 @@ export class CommunicationDomain {
     // Insert ThreadParticipant records
     await this.seedThreadParticipants(db, schema, participantMap)
 
-    // Generate and insert Messages (now with proper participant relationships)
-    await this.seedMessages(db, schema, organizationId)
+    // Generate and insert Messages (now with proper participant relationships). Pass the
+    // just-generated thread ids so seedMessages can scope its query to this batch and map
+    // by id — critical for additive seeding into an org with pre-existing real threads
+    // (e.g. the shopify-review scenario), where a query over ALL of the org's threads
+    // would risk matching scripted conversations onto real, unrelated threads.
+    await this.seedMessages(db, schema, organizationId, ids)
 
-    // Update threads with latestMessageId (required for UI to resolve sender)
-    await this.updateThreadLatestMessageIds(db, schema, organizationId)
+    // Update threads with latestMessageId (required for UI to resolve sender).
+    // Scoped to the just-generated ids — additive seeds must not write to the
+    // org's pre-existing real threads.
+    await this.updateThreadLatestMessageIds(db, schema, organizationId, ids)
 
-    // Generate and insert thread tag associations (via FieldValue)
-    await this.seedThreadTags(db, schema, organizationId)
+    // Generate and insert thread tag associations (via FieldValue), same scoping
+    await this.seedThreadTags(db, schema, organizationId, ids)
   }
 
   /**
@@ -389,17 +408,22 @@ export class CommunicationDomain {
   private async updateThreadLatestMessageIds(
     db: any,
     schema: any,
-    organizationId: string
+    organizationId: string,
+    threadIds: string[]
   ): Promise<void> {
     console.log('🔗 Updating thread latestMessageId...')
 
-    const result = await db.execute(sql`
+    if (threadIds.length === 0) return
+    const threadIdArray = sql.raw(`ARRAY[${threadIds.map((id) => `'${id}'`).join(',')}]`)
+
+    await db.execute(sql`
       UPDATE "Thread" t
       SET "latestMessageId" = sub."latestId"
       FROM (
         SELECT DISTINCT ON ("threadId") "threadId", "id" AS "latestId"
         FROM "Message"
         WHERE "organizationId" = ${organizationId}
+          AND "threadId" = ANY(${threadIdArray})
         ORDER BY "threadId", "sentAt" DESC NULLS LAST, "id" DESC
       ) sub
       WHERE t."id" = sub."threadId"
@@ -416,7 +440,12 @@ export class CommunicationDomain {
    * @param schema - Database schema
    * @param organizationId - Organization ID to filter threads and tags
    */
-  private async seedThreadTags(db: any, schema: any, organizationId: string): Promise<void> {
+  private async seedThreadTags(
+    db: any,
+    schema: any,
+    organizationId: string,
+    threadIds: string[]
+  ): Promise<void> {
     console.log('🏷️  Generating tag-thread associations...')
 
     // Find the thread_tags custom field
@@ -472,11 +501,14 @@ export class CommunicationDomain {
       return
     }
 
-    // Get existing threads
+    // Only tag the threads generated by this run — an org-wide query would stamp
+    // seed tags onto pre-existing real threads during additive seeding
     const threads = await db
       .select({ id: schema.Thread.id })
       .from(schema.Thread)
-      .where(sql`${schema.Thread.organizationId} = ${organizationId}`)
+      .where(
+        and(eq(schema.Thread.organizationId, organizationId), inArray(schema.Thread.id, threadIds))
+      )
 
     if (threads.length === 0) {
       console.log('⚠️  No threads found, skipping tag associations')
@@ -544,13 +576,24 @@ export class CommunicationDomain {
    * @param db - Drizzle database instance
    * @param schema - Database schema
    * @param organizationId - Organization ID to filter threads
+   * @param threadIds - Ids of the threads just generated by insertDirectly, index-aligned
+   *   with the subjects/conversations generated for this run. Scoping the query to these
+   *   ids (rather than every thread in the org) matters for additive seeding into an org
+   *   with pre-existing real threads.
    */
-  private async seedMessages(db: any, schema: any, organizationId: string): Promise<void> {
+  private async seedMessages(
+    db: any,
+    schema: any,
+    organizationId: string,
+    threadIds: string[]
+  ): Promise<void> {
     console.log('✉️  Generating messages for threads...')
 
     const { schema: dbSchema } = await import('@auxx/database')
 
-    // Get existing threads
+    // Get the threads just generated by insertDirectly. DB return order is unspecified, so
+    // map by id → the original generation index (via threadIdToIndex below) rather than
+    // relying on forEach position for scripted conversation matching.
     const threads = await db
       .select({
         id: schema.Thread.id,
@@ -559,12 +602,16 @@ export class CommunicationDomain {
         organizationId: schema.Thread.organizationId,
       })
       .from(schema.Thread)
-      .where(sql`${schema.Thread.organizationId} = ${organizationId}`)
+      .where(
+        and(eq(schema.Thread.organizationId, organizationId), inArray(schema.Thread.id, threadIds))
+      )
 
     if (threads.length === 0) {
       console.log('⚠️  No threads found, skipping message generation')
       return
     }
+
+    const threadIdToIndex = new Map(threadIds.map((id, index) => [id, index]))
 
     // Get all participants with contact info
     const participants = await db
@@ -599,12 +646,11 @@ export class CommunicationDomain {
       `  📊 Distribution: ${threads.length} threads × ~${messagesPerThread} messages = ~${threads.length * messagesPerThread} total`
     )
 
-    threads.forEach((thread: any, threadIndex: number) => {
-      // Example scenario: map each thread to its scripted conversation (by subject) and
-      // use the script's message count/bodies instead of the random content generator.
-      const exampleConversation = this.scenario.isExample
-        ? EXAMPLE_CONVERSATIONS.find((c) => c.subject === thread.subject)
-        : undefined
+    threads.forEach((thread: any, forEachIndex: number) => {
+      // Map each thread back to its original generation index (DB return order is
+      // unspecified) and, for scripted scenarios, to its scripted conversation.
+      const threadIndex = threadIdToIndex.get(thread.id) ?? forEachIndex
+      const exampleConversation = this.getScriptedConversation(threadIndex)
 
       const messageCount = exampleConversation
         ? exampleConversation.messages.length
@@ -834,21 +880,67 @@ export class CommunicationDomain {
 
   // ---- Thread Generator Methods ----
 
-  /** generateThreadSubjects creates realistic support thread subjects. */
+  /** generateThreadSubjects creates thread subjects. Scripted scenarios (`isExample` or
+   * `scriptedConversations`) take EXAMPLE_CONVERSATIONS[i] for thread i (no cycling —
+   * cycling would produce duplicate subjects across a large scenario like demo, which
+   * would break index-based conversation matching in seedMessages); any threads beyond
+   * the script count fall back to the random content generator. The `[Example] ` prefix
+   * is only applied for the `example` scenario. */
   private generateThreadSubjects(): string[] {
-    if (this.scenario.isExample) {
-      return Array.from(
-        { length: this.scenario.scales.threads },
-        (_, i) => EXAMPLE_CONVERSATIONS[i % EXAMPLE_CONVERSATIONS.length]!.subject
-      )
+    const isScripted = Boolean(this.scenario.scriptedConversations || this.scenario.isExample)
+    if (!isScripted) {
+      const emails = this.content.generateRealisticEmails(this.scenario.scales.threads)
+      return emails.map((email) => email.subject)
     }
-    const emails = this.content.generateRealisticEmails(this.scenario.scales.threads)
-    return emails.map((email) => email.subject)
+
+    const prefix = this.scenario.isExample ? '[Example] ' : ''
+    const scriptedCount = Math.min(this.scenario.scales.threads, EXAMPLE_CONVERSATIONS.length)
+    const remainder = this.scenario.scales.threads - scriptedCount
+    const randomSubjects =
+      remainder > 0
+        ? this.content.generateRealisticEmails(remainder).map((email) => email.subject)
+        : []
+
+    return Array.from({ length: this.scenario.scales.threads }, (_, i) =>
+      i < scriptedCount
+        ? `${prefix}${EXAMPLE_CONVERSATIONS[i]!.subject}`
+        : randomSubjects[i - scriptedCount]!
+    )
   }
 
-  /** getExampleConversationForIndex returns the scripted thread content at a given thread index. */
-  private getExampleConversationForIndex(index: number): ExampleConversation {
-    return EXAMPLE_CONVERSATIONS[index % EXAMPLE_CONVERSATIONS.length]!
+  /** getScriptedConversation returns thread `index`'s scripted conversation, when the
+   * scenario has scripted conversations enabled and the index is within script bounds. */
+  private getScriptedConversation(index: number): ExampleConversation | undefined {
+    if (!(this.scenario.scriptedConversations || this.scenario.isExample)) return undefined
+    return EXAMPLE_CONVERSATIONS[index]
+  }
+
+  /** isScriptedThreadEndingOnCustomer returns true when thread `index` is scripted and
+   * its conversation's final message is from the customer (an open, unanswered question
+   * the AI-reply workflow could act on). */
+  private isScriptedThreadEndingOnCustomer(index: number): boolean {
+    const conversation = this.getScriptedConversation(index)
+    if (!conversation) return false
+    return conversation.messages[conversation.messages.length - 1]?.from === 'customer'
+  }
+
+  /**
+   * resolveCustomerParticipant picks the customer participant for thread `index`. Scripted
+   * threads match their conversation's persona by EMAIL — the participant SELECT in
+   * `insertDirectly` has no ORDER BY, so DB return order is unspecified and matching by
+   * index would silently pair the wrong persona/contact with the wrong thread. Falls back
+   * to round-robin for non-scripted threads or if no participant matches the persona email.
+   */
+  private resolveCustomerParticipant(index: number, customerParticipants: any[]): any {
+    const conversation = this.getScriptedConversation(index)
+    if (conversation) {
+      const persona = personas[index]
+      const match = persona
+        ? customerParticipants.find((p) => p.identifier === persona.email)
+        : undefined
+      if (match) return match
+    }
+    return customerParticipants[index % customerParticipants.length]
   }
 
   /** generateIntegrationTypes creates realistic integration types. */

--- a/packages/seed/src/domains/crm.domain.ts
+++ b/packages/seed/src/domains/crm.domain.ts
@@ -3,6 +3,7 @@
 
 import { createId } from '@paralleldrive/cuid2'
 import { and, eq, sql } from 'drizzle-orm'
+import { personas } from '../generators/example-conversations'
 import type { SeedingContext, SeedingScenario } from '../types'
 
 /** CompanyRoster describes the curated companies seeded for demo/screenshot scenarios. */
@@ -579,7 +580,7 @@ export class CrmDomain {
       const companiesByDomain = await this.seedCompanies(handler)
 
       // Contacts — some emails use company domains so linking has signal.
-      await this.seedContacts(handler, Array.from(companiesByDomain.keys()))
+      await this.seedContacts(db, schema, handler, org.id, Array.from(companiesByDomain.keys()))
 
       // Participants (direct insert, mirrors contact EntityInstances)
       await this.seedParticipants(db, schema, org.id)
@@ -647,18 +648,42 @@ export class CrmDomain {
 
   /**
    * seedContacts generates and creates contact records via UnifiedCrudHandler.
-   * When company domains are available, ~60% of contacts get business-domain emails
-   * distributed round-robin across companies; the rest use personal email domains.
+   * When `scriptedConversations` is on, the first `personas.length` contacts come from
+   * the persona roster (so message signatures match a real contact); any remaining
+   * contacts needed to reach `scales.customers` fall back to the generated names below.
+   * Otherwise, when company domains are available, ~60% of contacts get business-domain
+   * emails distributed round-robin across companies; the rest use personal email domains.
    */
-  private async seedContacts(handler: any, companyDomains: string[]): Promise<void> {
+  private async seedContacts(
+    db: any,
+    schema: any,
+    handler: any,
+    organizationId: string,
+    companyDomains: string[]
+  ): Promise<void> {
     console.log('📇 Generating contacts via UnifiedCrudHandler...')
 
     const contactCount = this.scenario.scales.customers
+    const scriptedPersonas = this.scenario.scriptedConversations ? personas : []
     const businessCount =
       companyDomains.length > 0 ? Math.min(contactCount, Math.ceil(contactCount * 0.6)) : 0
 
     const contactValues = []
     for (let i = 0; i < contactCount; i++) {
+      const persona = scriptedPersonas[i]
+      if (persona) {
+        const [firstName, ...rest] = persona.name.split(' ')
+        contactValues.push({
+          primary_email: persona.email,
+          first_name: firstName,
+          last_name: rest.join(' '),
+          phone: this.generatePhone(i),
+          job_title: this.generateJobTitle(i),
+          contact_status: 'ACTIVE',
+        })
+        continue
+      }
+
       const firstName = this.generateFirstName(i)
       const lastName = this.generateLastName(i)
       const domain =
@@ -674,8 +699,31 @@ export class CrmDomain {
       })
     }
 
-    if (contactValues.length > 0) {
-      const { created, errors } = await handler.bulkCreate('contact', contactValues, {
+    // Re-seeding must not double up contacts: generated emails are deterministic by
+    // index and persona emails are fixed, so skip any whose primary_email already
+    // exists on the org (the historical duplicate-contact source).
+    const existingEmailRows = await db
+      .select({ valueText: schema.FieldValue.valueText })
+      .from(schema.FieldValue)
+      .innerJoin(schema.CustomField, sql`${schema.FieldValue.fieldId} = ${schema.CustomField.id}`)
+      .where(
+        sql`${schema.CustomField.systemAttribute} = 'primary_email' AND ${schema.CustomField.organizationId} = ${organizationId}`
+      )
+    const existingEmails = new Set(
+      existingEmailRows
+        .map((row: any) => row.valueText?.toLowerCase())
+        .filter((email: string | undefined) => !!email)
+    )
+    const newContactValues = contactValues.filter(
+      (value) => !existingEmails.has(value.primary_email.toLowerCase())
+    )
+    const skippedCount = contactValues.length - newContactValues.length
+    if (skippedCount > 0) {
+      console.log(`  ↩️  Skipped ${skippedCount} contacts whose email already exists in the org`)
+    }
+
+    if (newContactValues.length > 0) {
+      const { created, errors } = await handler.bulkCreate('contact', newContactValues, {
         skipEvents: true,
       })
 

--- a/packages/seed/src/engine/organization-seeder.ts
+++ b/packages/seed/src/engine/organization-seeder.ts
@@ -24,7 +24,13 @@ export class OrganizationSeeder {
   static async seedOrganization(
     organizationId: string,
     mode: 'reset' | 'additive',
-    scenario: 'demo' | 'development' | 'testing' | 'superadmin-test' | 'example' = 'demo'
+    scenario:
+      | 'demo'
+      | 'development'
+      | 'testing'
+      | 'superadmin-test'
+      | 'example'
+      | 'shopify-review' = 'demo'
   ): Promise<SeedingResult> {
     const webhookCoordinator = new OrganizationWebhookCoordinator(organizationId)
     let webhookState: Awaited<ReturnType<typeof webhookCoordinator.disconnectAll>> | null = null
@@ -123,7 +129,13 @@ export class OrganizationSeeder {
    */
   static async resetAndSeed(
     organizationId: string,
-    scenario: 'demo' | 'development' | 'testing' | 'superadmin-test' | 'example' = 'demo'
+    scenario:
+      | 'demo'
+      | 'development'
+      | 'testing'
+      | 'superadmin-test'
+      | 'example'
+      | 'shopify-review' = 'demo'
   ): Promise<SeedingResult> {
     return OrganizationSeeder.seedOrganization(organizationId, 'reset', scenario)
   }
@@ -133,7 +145,13 @@ export class OrganizationSeeder {
    */
   static async addSeedData(
     organizationId: string,
-    scenario: 'demo' | 'development' | 'testing' | 'superadmin-test' | 'example' = 'demo'
+    scenario:
+      | 'demo'
+      | 'development'
+      | 'testing'
+      | 'superadmin-test'
+      | 'example'
+      | 'shopify-review' = 'demo'
   ): Promise<SeedingResult> {
     return OrganizationSeeder.seedOrganization(organizationId, 'additive', scenario)
   }
@@ -208,7 +226,13 @@ export class OrganizationSeeder {
   private static async seedOrganizationDirectly(
     organizationId: string,
     ownerId: string,
-    scenarioName: 'demo' | 'development' | 'testing' | 'superadmin-test' | 'example'
+    scenarioName:
+      | 'demo'
+      | 'development'
+      | 'testing'
+      | 'superadmin-test'
+      | 'example'
+      | 'shopify-review'
   ): Promise<void> {
     try {
       logger.info('seedOrganizationDirectly: Starting', { organizationId, ownerId, scenarioName })
@@ -220,6 +244,7 @@ export class OrganizationSeeder {
       const { testingScenario } = await import('../scenarios/testing.scenario')
       const { superadminTestScenario } = await import('../scenarios/superadmin-test.scenario')
       const { exampleScenario } = await import('../scenarios/example.scenario')
+      const { shopifyReviewScenario } = await import('../scenarios/shopify-review.scenario')
       logger.info('seedOrganizationDirectly: Scenarios loaded')
 
       // Select scenario
@@ -229,6 +254,7 @@ export class OrganizationSeeder {
         testing: testingScenario,
         'superadmin-test': superadminTestScenario,
         example: exampleScenario,
+        'shopify-review': shopifyReviewScenario,
       }
       const scenario = scenarioMap[scenarioName]
       logger.info('seedOrganizationDirectly: Scenario selected', { scenarioName })
@@ -377,6 +403,41 @@ export class OrganizationSeeder {
         })
       }
 
+      // shopify-review guards — fail BEFORE any domain runs so an aborted seed
+      // leaves nothing behind (no persona contacts without threads, no duplicates).
+      if (scenarioName === 'shopify-review') {
+        // No mock-integration fallback for this scenario (see above) — a threads-only
+        // seed that silently seeds nothing is a failure, so fail loudly instead.
+        if (context.services.integrations.length === 0 && scenario.scales.threads > 0) {
+          throw new Error(
+            `Cannot seed scenario "shopify-review" for organization ${organizationId}: ` +
+              'the organization has no connected integrations. Connect an inbox first, then re-run the seed.'
+          )
+        }
+
+        // Thread ids are freshly generated per run, so re-running would duplicate the
+        // scripted threads/messages. Abort when the org already has them.
+        const { and, inArray: inArrayOp } = await import('drizzle-orm')
+        const { EXAMPLE_CONVERSATIONS } = await import('../generators/example-conversations')
+        const scriptedSubjects = EXAMPLE_CONVERSATIONS.map((c) => c.subject)
+        const alreadySeeded = await db
+          .select({ id: schema.Thread.id })
+          .from(schema.Thread)
+          .where(
+            and(
+              eq(schema.Thread.organizationId, organizationId),
+              inArrayOp(schema.Thread.subject, scriptedSubjects)
+            )
+          )
+          .limit(1)
+        if (alreadySeeded.length > 0) {
+          throw new Error(
+            `Organization ${organizationId} already contains shopify-review sample threads — ` +
+              're-running would duplicate them. Delete the existing sample threads first if you need a fresh set.'
+          )
+        }
+      }
+
       const domainOptions = { organizationId }
 
       // Seed domains directly
@@ -401,12 +462,15 @@ export class OrganizationSeeder {
       await crm.insertDirectly(db)
       logger.info('seedOrganizationDirectly: CRM domain complete')
 
-      // Organization
-      logger.info('seedOrganizationDirectly: Seeding organization domain')
-      console.log('💾 Inserting organization data...')
-      const organization = new OrganizationDomain(scenarioWithRefinements, context, domainOptions)
-      await organization.insertDirectly(db)
-      logger.info('seedOrganizationDirectly: Organization domain complete')
+      // Organization (skipped for shopify-review — it's an additive injection into an
+      // existing org and shouldn't touch that org's tags/snippets/settings rows)
+      if (scenarioName !== 'shopify-review') {
+        logger.info('seedOrganizationDirectly: Seeding organization domain')
+        console.log('💾 Inserting organization data...')
+        const organization = new OrganizationDomain(scenarioWithRefinements, context, domainOptions)
+        await organization.insertDirectly(db)
+        logger.info('seedOrganizationDirectly: Organization domain complete')
+      }
 
       // Tickets
       if (scenario.scales.tickets > 0) {

--- a/packages/seed/src/generators/example-conversations.ts
+++ b/packages/seed/src/generators/example-conversations.ts
@@ -1,163 +1,211 @@
 // packages/seed/src/generators/example-conversations.ts
-// Scripted, realistic conversations seeded into new real accounts so the inbox
-// doesn't feel empty on first load. Each conversation renders as one thread with
-// 3–4 alternating customer/agent messages.
+// Scripted, realistic Shopify order-support conversations. Seeded into new real
+// accounts (the `example` scenario), reused by the `demo` scenario to fill its
+// first threads with believable content, and injected standalone into existing
+// orgs via the `shopify-review` scenario for Shopify app-review demos. Each
+// conversation renders as one thread with 3-4 alternating customer/agent
+// messages. Subjects are stored WITHOUT any branding prefix — callers that want
+// the `[Example] ` prefix (only the `example` scenario) apply it at generation
+// time, in `CommunicationDomain`.
 
 /** ExampleConversation describes a single thread's scripted content. */
 export interface ExampleConversation {
-  /** subject is the thread subject (already prefixed with `[Example] `). */
+  /** subject is the thread subject, unprefixed. */
   subject: string
   /** messages alternate between customer (inbound) and agent (outbound). */
   messages: Array<{ from: 'customer' | 'agent'; body: string }>
 }
 
-/** EXAMPLE_CONVERSATIONS renders to 8 threads with ~28 messages total. */
+/** ExamplePersona identifies the customer behind a scripted conversation, so
+ * seeded contacts/participants can match the signature in the message body. */
+export interface ExamplePersona {
+  /** name is the customer's display name (matches the message sign-off). */
+  name: string
+  /** email is the customer's seeded contact email. */
+  email: string
+}
+
+/**
+ * personas is index-aligned with EXAMPLE_CONVERSATIONS — `personas[i]` is the
+ * customer on `EXAMPLE_CONVERSATIONS[i]`.
+ */
+export const personas: ExamplePersona[] = [
+  { name: 'Jordan Lee', email: 'jordan.lee@gmail.com' },
+  { name: 'Priya Nair', email: 'priya.nair@outlook.com' },
+  { name: 'Devon Brooks', email: 'devon.brooks@yahoo.com' },
+  { name: 'Riley Morgan', email: 'riley.morgan@icloud.com' },
+  { name: 'Taylor Reed', email: 'taylor.reed@gmail.com' },
+  { name: 'Avery Chen', email: 'avery.chen@hotmail.com' },
+  { name: 'Casey Kim', email: 'casey.kim@gmail.com' },
+  { name: 'Noor Ahmed', email: 'noor.ahmed@outlook.com' },
+]
+
+/**
+ * EXAMPLE_CONVERSATIONS renders to 8 Shopify order-support threads (28 messages
+ * total), index-aligned with `personas`. Order numbers follow dev-store style
+ * (`#1001`-`#1042`, sequential, no letter prefix) so the reply workflow's order
+ * lookup queries something a real Shopify test store could contain. Four of the
+ * eight end on an unanswered customer message — an open question the AI-reply
+ * workflow can plausibly act on; the rest keep a resolved back-and-forth shape.
+ */
 export const EXAMPLE_CONVERSATIONS: ExampleConversation[] = [
   {
-    subject: "[Example] Where's my order #A-10432?",
+    // Resolved — ends on an agent message.
+    subject: "Where's my order #1001?",
     messages: [
       {
         from: 'customer',
-        body: `Hi there,\n\nI placed order #A-10432 on Tuesday and the tracking page says it's still "in transit" but hasn't updated in four days. Could you check on the status and let me know when I should expect it?\n\nThanks,\nJamie`,
+        body: `Hi, I placed order #1001 last Monday and the tracking page still just says "Label created" — no movement in three days. Can you check what's going on?\n\nThanks,\nJordan`,
       },
       {
         from: 'agent',
-        body: `Hi Jamie,\n\nThanks for reaching out. I looked up order #A-10432 — it left our warehouse on Tuesday evening and is currently with the carrier. The stall in tracking updates usually means it's sitting at a regional sort facility; I'm seeing an estimated delivery of this Friday.\n\nI'll keep an eye on it, and if it hasn't moved by tomorrow I'll open a trace with the carrier.\n\nBest,\nSam`,
+        body: `Hi Jordan,\n\nThanks for flagging this — I checked #1001 and the good news is it actually left our warehouse yesterday afternoon; the carrier's scan just hadn't caught up with the tracking page yet. It's now showing in transit with an estimated delivery of this Thursday.\n\nI'll keep watching it and reach out if that changes.\n\nBest,\nSam`,
       },
       {
         from: 'customer',
-        body: `That works, thanks for checking! Please let me know if anything changes before Friday.`,
+        body: `That's a relief, thank you for checking so quickly!`,
       },
       {
         from: 'agent',
-        body: `Will do. I've set a reminder on our end and you'll hear from me either way.\n\n— Sam`,
+        body: `Anytime — you're all set. Reply here if Thursday comes and goes without it.\n\n— Sam`,
       },
     ],
   },
   {
-    subject: '[Example] Wrong size — need to exchange',
+    // Open — ends on an unanswered customer question.
+    subject: 'Order #1012 — wrong size, exchange request',
     messages: [
       {
         from: 'customer',
-        body: `Hello,\n\nI ordered the charcoal hoodie in a medium last week (order #A-10388) but it's running small on me. Is it possible to exchange it for a large? I haven't worn it — tags are still on.\n\nThanks!\nPriya`,
+        body: `Hello,\n\nI ordered the Aria dress in a medium last week (order #1012) but it's noticeably too snug. Could I exchange it for a large instead? Everything's unworn with tags still on.\n\nThanks,\nPriya`,
       },
       {
         from: 'agent',
-        body: `Hi Priya,\n\nAbsolutely, happy to swap that out for you. I'm sending over a prepaid return label now — just drop the medium back in the original packaging and pop it in any mailbox.\n\nI've also reserved a large in charcoal under your account; as soon as we scan the return, it'll ship out the same day.\n\nBest,\nMorgan`,
+        body: `Hi Priya,\n\nOf course — happy to get that swapped out. Before I send a return label, can you confirm the color/style code on the tag (should start with ARIA-)? We're low on stock in a couple of the large sizes and I want to reserve the right one for you before it sells out.\n\nBest,\nMorgan`,
       },
       {
         from: 'customer',
-        body: `Amazing, thank you! I'll drop it off tomorrow morning.`,
+        body: `It's ARIA-BLK-M on the tag — hoping the black is still in stock in a large! Let me know if I should just go ahead and place a new order instead so I'm not stuck waiting.`,
       },
     ],
   },
   {
-    subject: '[Example] Refund status check',
+    // Resolved — ends on an agent message.
+    subject: 'Refund status for returned order #1005',
     messages: [
       {
         from: 'customer',
-        body: `Hi,\n\nI returned order #A-10211 on the 12th and UPS confirmed delivery to your warehouse last Friday. I still haven't seen the refund on my card — can you check on this?\n\nThanks,\nDevon`,
+        body: `Hi,\n\nI returned order #1005 on the 12th and the carrier confirmed delivery to your warehouse last Friday. I still haven't seen a refund hit my card — could you check on this?\n\nThanks,\nDevon`,
       },
       {
         from: 'agent',
-        body: `Hi Devon,\n\nThanks for the nudge. I see the return was received and inspected yesterday, and the refund was issued to your original payment method this morning. Banks typically take 3–5 business days to post it, so you should see it on your statement by the end of the week.\n\nIf it hasn't shown up by Monday, reply here and I'll dig into the transaction ID.\n\nBest,\nAlex`,
+        body: `Hi Devon,\n\nThanks for the nudge. I can see the return was received and inspected yesterday, and the refund was issued to your original payment method this morning. Banks usually take 3–5 business days to post it, so it should show on your statement by the end of the week.\n\nIf it's still not there by Monday, reply here and I'll pull the transaction ID for you.\n\nBest,\nAlex`,
       },
       {
         from: 'customer',
-        body: `Perfect, appreciate the quick update.`,
+        body: `Perfect, appreciate the quick update — I'll keep an eye on my statement.`,
+      },
+      {
+        from: 'agent',
+        body: `Sounds good. Talk soon if it doesn't show up!\n\n— Alex`,
       },
     ],
   },
   {
-    subject: '[Example] Can I change my shipping address?',
+    // Open — ends on an unanswered customer question.
+    subject: 'Change shipping address on order #1023',
     messages: [
       {
         from: 'customer',
-        body: `Hi support,\n\nI just placed order #A-10501 but realized I typed my old apartment number in the shipping address. Is it too late to change it to 482 Pine St., Apt 7B instead of 3A? The rest of the address is correct.\n\nThanks!\nRiley`,
+        body: `Hi support,\n\nI just placed order #1023 a few minutes ago but realized I typed my old apartment number. Is it too late to change the shipping address to 482 Pine St., Apt 7B instead of 3A? Everything else on the order is correct.\n\nThanks!\nRiley`,
       },
       {
         from: 'agent',
-        body: `Hi Riley,\n\nGood catch — I was able to update the shipping address on #A-10501 to 482 Pine St., Apt 7B before it hit the pick queue. The order should ship out tomorrow to the new address, and you'll get an updated confirmation email shortly.\n\nLet me know if anything else looks off.\n\nBest,\nJordan`,
+        body: `Hi Riley,\n\nGood catch — orders sit in the queue for about 30 minutes before they're picked, so there's still time. Can you confirm the order is under the same email you're messaging from, and that the zip code stays 98104? I want to make sure I'm updating the right one before it locks in.\n\nBest,\nJordan`,
       },
       {
         from: 'customer',
-        body: `You're a lifesaver, thanks!`,
+        body: `Yes, same email, and the zip is still 98104 — just the apartment number needs fixing. Can you confirm once it's updated?`,
       },
     ],
   },
   {
-    subject: '[Example] Damaged item — photos attached',
+    // Open — ends on an unanswered customer question.
+    subject: 'Order #1017 arrived damaged — replacement request',
     messages: [
       {
         from: 'customer',
-        body: `Hello,\n\nMy order #A-10344 arrived today and the ceramic mug inside was shattered — looks like the box took a hit in transit. I've attached a couple of photos of the damage and the packaging.\n\nWhat's the best way to get a replacement?\n\nThanks,\nTaylor`,
+        body: `Hello,\n\nMy order #1017 arrived today and the ceramic mug inside was shattered — looks like the box took a hit in transit. I've attached photos of the damage and the packaging.\n\nWhat's the best way to get a replacement?\n\nThanks,\nTaylor`,
       },
       {
         from: 'agent',
-        body: `Hi Taylor,\n\nSo sorry about that — a broken mug is the last thing anyone wants to unbox. Thanks for sending the photos; that's all I needed on our end.\n\nI've put a replacement on the way at no charge (order #A-10502), and you don't need to send the broken one back. You should see tracking within the hour.\n\nBest,\nCasey`,
+        body: `Hi Taylor,\n\nSo sorry about that — thanks for sending the photos, that's exactly what I needed. I can get a free replacement on its way today, but first: do you want the exact same mug reshipped, or would you rather swap for a different color while we're at it? No charge either way.\n\nBest,\nCasey`,
       },
       {
         from: 'customer',
-        body: `Wow, that was fast. Thanks so much!`,
-      },
-      {
-        from: 'agent',
-        body: `Happy to help! Enjoy the (intact) mug.\n\n— Casey`,
+        body: `Let's do the same one again, please — just want it in one piece this time! Could you make sure it's packed a bit more securely as well?`,
       },
     ],
   },
   {
-    subject: '[Example] Duplicate charge on last invoice',
+    // Resolved — ends on an agent message.
+    subject: 'Charged twice for order #1009',
     messages: [
       {
         from: 'customer',
-        body: `Hi,\n\nI'm looking at my card statement and it shows two charges for $89.00 from you on the same day — I only placed one order (#A-10422). Can you confirm whether one of those is a pending auth that will drop off, or do I need a refund?\n\nThanks,\nAvery`,
+        body: `Hi,\n\nI'm looking at my card statement and it shows two charges of $89.00 from you on the same day, but I only placed one order (#1009). Can you confirm whether one is a pending authorization that'll drop off, or do I need a refund?\n\nThanks,\nAvery`,
       },
       {
         from: 'agent',
-        body: `Hi Avery,\n\nThanks for flagging that. I pulled up #A-10422 — the second charge is a pending authorization that was placed when your card initially declined and then succeeded on retry. It should fall off your statement automatically within 3 business days; no action needed on your end, and only one charge will ultimately settle.\n\nIf it's still sitting there on Friday, reply back and I'll reach out to our payment processor directly.\n\nBest,\nPat`,
+        body: `Hi Avery,\n\nThanks for flagging that. I pulled up #1009 — the second charge is a pending authorization that was placed when your card initially declined and then went through on retry. It should fall off your statement automatically within 3 business days; no action needed on your end, and only one charge will ultimately settle.\n\nIf it's still sitting there by Friday, reply back and I'll escalate to our payment processor directly.\n\nBest,\nPat`,
       },
       {
         from: 'customer',
-        body: `Got it, thanks for clarifying. I'll keep an eye on it.`,
+        body: `Got it, thanks for clarifying — I'll keep an eye on it.`,
+      },
+      {
+        from: 'agent',
+        body: `Anytime. Reach out if Friday comes and it's still doubled up.\n\n— Pat`,
       },
     ],
   },
   {
-    subject: '[Example] How do I cancel my subscription?',
+    // Open — ends on an unanswered customer question.
+    subject: 'Cancel order #1031 before it ships',
     messages: [
       {
         from: 'customer',
-        body: `Hi,\n\nI'd like to cancel my monthly subscription for the coffee beans (subscription ID SUB-4412). Not because of any issue — just trying to cut down on recurring charges for a bit. What's the best way to handle this?\n\nThanks,\nLee`,
+        body: `Hi,\n\nI need to cancel order #1031 if it hasn't shipped yet — I accidentally ordered the wrong color. Please let me know if I'm in time.\n\nThanks,\nCasey`,
       },
       {
         from: 'agent',
-        body: `Hi Lee,\n\nTotally understand — I went ahead and cancelled SUB-4412 for you. You won't be charged for any future deliveries, and your most recent shipment (already on its way) is still yours to keep.\n\nIf you change your mind, just reply here and I can reinstate it at the same price tier. No pressure either way.\n\nBest,\nQuinn`,
+        body: `Hi Casey,\n\nI checked #1031 and it's still in our pick queue, so there's a good chance we can catch it — but our warehouse does a cutoff run in the next hour. Can you confirm you'd like a full cancellation rather than an exchange for the correct color? I can move faster if I know which one to process.\n\nBest,\nRiley`,
       },
       {
         from: 'customer',
-        body: `Appreciate you making that painless. Might be back in a few months!`,
+        body: `A full cancellation is fine, I'll just reorder the right color separately. Please confirm as soon as it's stopped!`,
       },
     ],
   },
   {
-    subject: '[Example] Product question before I buy',
+    // Resolved — ends on an agent message.
+    subject: "Discount code didn't apply on order #1027",
     messages: [
       {
         from: 'customer',
-        body: `Hello,\n\nQuick question before I check out — does the leather tote (SKU TOTE-221) fit a 15" laptop? I can't tell from the dimensions on the product page. Also, is the interior lined?\n\nThanks!\nNoor`,
+        body: `Hello,\n\nI used the code WELCOME15 at checkout on order #1027 but the total charged doesn't reflect the 15% discount. Can you check what happened?\n\nThanks,\nNoor`,
       },
       {
         from: 'agent',
-        body: `Hi Noor,\n\nGreat question — yes, the TOTE-221 comfortably fits a 15" laptop (most 16" laptops squeeze in too, though it's snug). The interior is lined with a natural canvas and has one zippered pocket plus two open slip pockets.\n\nLet me know if you'd like me to send over any additional photos of the inside.\n\nBest,\nRowan`,
+        body: `Hi Noor,\n\nThanks for catching that — looking at #1027, the code was entered correctly but had expired the day before your order (it was a launch-week promo). Since this was a first-purchase mix-up, I've gone ahead and manually applied the 15% as a refund to your original payment method — you should see $13.35 back within a few business days.\n\nBest,\nRowan`,
       },
       {
         from: 'customer',
-        body: `Perfect, that's exactly what I needed. Placing my order now!`,
+        body: `That's really kind of you, thank you for sorting it out!`,
       },
       {
         from: 'agent',
-        body: `Awesome — enjoy, and reply here any time if anything comes up.\n\n— Rowan`,
+        body: `Happy to help — welcome aboard, and enjoy the order!\n\n— Rowan`,
       },
     ],
   },

--- a/packages/seed/src/scenarios/demo.scenario.ts
+++ b/packages/seed/src/scenarios/demo.scenario.ts
@@ -39,4 +39,5 @@ export const demoScenario: SeedingScenarioDefinition = {
       professionalContent: true,
     },
   },
+  scriptedConversations: true,
 }

--- a/packages/seed/src/scenarios/shopify-review.scenario.ts
+++ b/packages/seed/src/scenarios/shopify-review.scenario.ts
@@ -1,0 +1,49 @@
+// packages/seed/src/scenarios/shopify-review.scenario.ts
+// Minimal scenario for additively injecting scripted Shopify order-support
+// threads into an EXISTING org (e.g. the Shopify app-review reviewer's org) via
+// superadmin re-seed. Unlike `example`, this creates no companies, tickets, or
+// mock integration — threads land on the org's real, already-connected
+// integration so the reviewer can demo the AI-reply workflow on real Mail.
+
+import type { SeedingScenarioDefinition } from '../types'
+
+/** shopifyReviewScenario seeds 8 scripted Shopify order threads (28 messages)
+ * and their persona contacts into an existing org, nothing else. */
+export const shopifyReviewScenario: SeedingScenarioDefinition = {
+  name: 'shopify-review',
+  description: 'Shopify order-issue sample threads for app-review orgs',
+  globalCount: 8,
+  scales: {
+    organizations: 1,
+    users: 1,
+    customers: 8, // one contact per conversation persona
+    companies: 0,
+    products: 0,
+    orders: 0,
+    threads: 8,
+    messages: 28, // must equal EXAMPLE_CONVERSATIONS' actual total
+    tickets: 0,
+    datasets: 0,
+    workflows: 0,
+  },
+  features: {
+    authentication: false,
+    testUsers: false,
+    activeSessions: false,
+    aiAnalysis: false,
+    metrics: false,
+    richContent: true,
+  },
+  dataQuality: {
+    realisticContent: 'high',
+    relationships: 'enhanced',
+    distributions: 'business-ready',
+    visualOptimizations: {
+      positiveMetrics: true,
+      activeConversations: true,
+      varietyInData: true,
+      professionalContent: true,
+    },
+  },
+  scriptedConversations: true, // no isExample → no [Example] prefix, no mock integration
+}

--- a/packages/seed/src/types.ts
+++ b/packages/seed/src/types.ts
@@ -10,6 +10,7 @@ export type SeedingScenarioName =
   | 'demo'
   | 'example'
   | 'superadmin-test'
+  | 'shopify-review'
 
 /** AuthSeederResult captures authentication entities shared with downstream refinements. */
 export interface AuthSeederResult {
@@ -153,6 +154,9 @@ export interface SeedingScenarioDefinition {
   dataQuality: ScenarioDataQuality
   /** isExample marks rows as starter data visible to real users — adds [Example] prefix to user-visible names. */
   isExample?: boolean
+  /** scriptedConversations routes thread/message content through EXAMPLE_CONVERSATIONS
+   * instead of the random generator. `isExample: true` implies this. */
+  scriptedConversations?: boolean
   /** performance optionally stores scenario-specific performance flags. */
   performance?: {
     /** batchSize configures streaming/batch insertion sizing. */


### PR DESCRIPTION
## Summary
- Add per-node-type **Preview** trace renderers surfaced in the workflow run panel — `ai`, `answer`, `crud`, `end`, `find`, `http`, `human`, `information-extractor`, `message-received`, `text-classifier`, plus a generic app-node renderer.
- Introduce a `traceRenderer` field on `NodeDefinition` (typed via new `TraceRendererProps`) so node types can opt into a pretty execution-output view, wrapped in a trace-render error boundary.
- Wire answer-node `test_behavior` support (schema/types/panel + engine action node).
- Add the `shopify-review` seed scenario with supporting seed domain / generator / organization-seeder updates.

## Test plan
- [ ] Run a workflow and open the run panel; confirm each node type renders its Preview tab and falls back gracefully on error.
- [ ] Seed the `shopify-review` scenario and verify the org/conversations look correct.