### PR TITLE
fix(homepage): readable text over gradient cards in light mode

### DIFF
--- a/apps/homepage/src/app/solutions/customer-support-teams/_components/integration-section.tsx
+++ b/apps/homepage/src/app/solutions/customer-support-teams/_components/integration-section.tsx
@@ -219,10 +219,12 @@ export default function IntegrationSection() {
                       />
                       <div className='relative z-10'>
                         <Icon className='w-8 h-8 text-white mb-4' />
-                        <h3 className='text-lg font-semibold text-foreground mb-2'>
+                        <h3 className='text-lg font-semibold text-white dark:text-foreground mb-2'>
                           {feature.title}
                         </h3>
-                        <p className='text-sm text-muted-foreground mb-4'>{feature.description}</p>
+                        <p className='text-sm text-white/70 dark:text-muted-foreground mb-4'>
+                          {feature.description}
+                        </p>
                         <Badge variant='secondary' className='text-xs bg-illustration/50'>
                           {feature.metrics}
                         </Badge>

--- a/apps/homepage/src/app/solutions/customer-support-teams/_components/testimonials.tsx
+++ b/apps/homepage/src/app/solutions/customer-support-teams/_components/testimonials.tsx
@@ -21,16 +21,16 @@ export default function TestimonialsSection() {
                     driftAmplitude={30}
                   />
                   <div className='pointer-events-none absolute inset-0 bg-black/30' />
-                  <p className='text-muted-foreground relative z-10 text-balance text-xl font-medium'>
+                  <p className='dark:text-muted-foreground relative z-10 text-balance text-xl font-medium text-white/70'>
                     TechCorp's support team leveraged Auxx.ai to transform their customer service
                     operations,{' '}
-                    <strong className='text-foreground'>
+                    <strong className='text-white dark:text-foreground'>
                       resulting in a 60% reduction in escalations and 50% increase in agent
                       productivity.
                     </strong>
                   </p>
-                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t pt-8'>
-                    <p className='text-foreground self-end text-balance before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
+                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t border-white/15 pt-8 dark:border-border'>
+                    <p className='self-end text-balance text-white dark:text-foreground before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
                       Auxx.ai transformed our support workflow. Our agents went from drowning in
                       repetitive tickets to focusing on complex customer issues. Agent satisfaction
                       increased 50% and we're handling 3x more tickets with the same team size.
@@ -44,8 +44,12 @@ export default function TestimonialsSection() {
                         />
                       </div>
                       <div className='space-y-px'>
-                        <p className='text-sm font-medium'>Luis V.</p>
-                        <p className='text-muted-foreground text-xs'>Support Team Lead, TechCorp</p>
+                        <p className='text-sm font-medium text-white dark:text-foreground'>
+                          Luis V.
+                        </p>
+                        <p className='dark:text-muted-foreground text-xs text-white/60'>
+                          Support Team Lead, TechCorp
+                        </p>
                       </div>
                     </div>
                   </div>
@@ -58,16 +62,16 @@ export default function TestimonialsSection() {
                     driftAmplitude={30}
                   />
                   <div className='pointer-events-none absolute inset-0 bg-black/30' />
-                  <p className='text-muted-foreground relative z-10 self-end text-balance text-xl font-medium'>
+                  <p className='dark:text-muted-foreground relative z-10 self-end text-balance text-xl font-medium text-white/70'>
                     Intercept's customer support team utilized Auxx.ai's AI assistance to{' '}
-                    <strong className='text-foreground'>
+                    <strong className='text-white dark:text-foreground'>
                       reduce response time by 80% while handling 10K+ monthly tickets
                     </strong>{' '}
                     with intelligent automation and seamless agent handoffs.
                   </p>
 
-                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t pt-8'>
-                    <p className='text-foreground text-balance before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
+                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t border-white/15 pt-8 dark:border-border'>
+                    <p className='text-balance text-white dark:text-foreground before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
                       The AI integration was seamless. Within hours, our support agents had an AI
                       co-pilot handling routine tasks, suggesting responses, and escalating complex
                       issues. The system empowers our team to handle 10K tickets effortlessly.
@@ -81,8 +85,10 @@ export default function TestimonialsSection() {
                         />
                       </div>
                       <div className='space-y-px'>
-                        <p className='text-sm font-medium'>Calvin Ochoa</p>
-                        <p className='text-muted-foreground text-xs'>
+                        <p className='text-sm font-medium text-white dark:text-foreground'>
+                          Calvin Ochoa
+                        </p>
+                        <p className='dark:text-muted-foreground text-xs text-white/60'>
                           Customer Support Director, Intercept
                         </p>
                       </div>

--- a/apps/homepage/src/app/solutions/shopify-stores/_components/automation-impact.tsx
+++ b/apps/homepage/src/app/solutions/shopify-stores/_components/automation-impact.tsx
@@ -28,9 +28,11 @@ export function AutomationImpact() {
                   <div>
                     <div className='flex flex-col gap-2 mb-4'>
                       <Bot className='w-6 h-6 fill-indigo-200 dark:fill-indigo-500/30' />
-                      <h3 className='text-2xl font-semibold text-foreground'>Automation Impact</h3>
+                      <h3 className='text-2xl font-semibold text-white dark:text-foreground'>
+                        Automation Impact
+                      </h3>
                     </div>
-                    <p className='text-muted-foreground mb-6'>
+                    <p className='text-white/70 dark:text-muted-foreground mb-6'>
                       See the measurable impact of AI automation on your support operations. These
                       metrics are averaged across all Shopify stores using our platform.
                     </p>

--- a/apps/homepage/src/app/solutions/shopify-stores/_components/integration-section.tsx
+++ b/apps/homepage/src/app/solutions/shopify-stores/_components/integration-section.tsx
@@ -223,10 +223,12 @@ export default function IntegrationSection() {
                       />
                       <div className='relative z-10'>
                         <Icon className='w-8 h-8 text-white mb-4' />
-                        <h3 className='text-lg font-semibold text-foreground mb-2'>
+                        <h3 className='text-lg font-semibold text-white dark:text-foreground mb-2'>
                           {feature.title}
                         </h3>
-                        <p className='text-sm text-muted-foreground mb-4'>{feature.description}</p>
+                        <p className='text-sm text-white/70 dark:text-muted-foreground mb-4'>
+                          {feature.description}
+                        </p>
                         <Badge variant='secondary' className='text-xs bg-illustration/50'>
                           {feature.metrics}
                         </Badge>

--- a/apps/homepage/src/app/solutions/shopify-stores/_components/testimonials.tsx
+++ b/apps/homepage/src/app/solutions/shopify-stores/_components/testimonials.tsx
@@ -15,16 +15,16 @@ export default function TestimonialsSection() {
               <div className='*:ring-foreground/10 @4xl:grid-cols-2 grid gap-6 *:shadow-lg'>
                 <Card className='relative row-span-5 grid grid-rows-subgrid gap-8 overflow-hidden p-8 rounded-2xl'>
                   <RandomGradient colors={[...GRADIENT_PALETTES.aurora]} mode='hero' animated />
-                  <p className='text-muted-foreground relative z-10 text-balance text-xl font-medium'>
+                  <p className='dark:text-muted-foreground relative z-10 text-balance text-xl font-medium text-white/70'>
                     Legacy CivilWorks leveraged Auxx.ai to transform their customer support
                     operations,{' '}
-                    <strong className='text-foreground'>
+                    <strong className='text-white dark:text-foreground'>
                       resulting in an 82% reduction in support tickets and 40% increase in CSAT
                       scores.
                     </strong>
                   </p>
-                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t pt-8'>
-                    <p className='text-foreground self-end text-balance before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
+                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t border-white/15 pt-8 dark:border-border'>
+                    <p className='self-end text-balance text-white dark:text-foreground before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
                       Auxx.ai transformed our support operation. We went from drowning in tickets to
                       proactively delighting customers. Our CSAT scores increased 40% in the first
                       month, and we're handling 15K+ monthly orders effortlessly.
@@ -38,8 +38,10 @@ export default function TestimonialsSection() {
                         />
                       </div>
                       <div className='space-y-px'>
-                        <p className='text-sm font-medium'>Adriana Klooth</p>
-                        <p className='text-muted-foreground text-xs'>
+                        <p className='text-sm font-medium text-white dark:text-foreground'>
+                          Adriana Klooth
+                        </p>
+                        <p className='dark:text-muted-foreground text-xs text-white/60'>
                           Project Manager, Legacy CivilWorks Engineering, Inc
                         </p>
                       </div>
@@ -48,16 +50,16 @@ export default function TestimonialsSection() {
                 </Card>
                 <Card className='relative row-span-5 grid grid-rows-subgrid gap-8 overflow-hidden p-8 rounded-2xl'>
                   <RandomGradient colors={[...GRADIENT_PALETTES.ocean]} mode='hero' animated />
-                  <p className='text-muted-foreground relative z-10 self-end text-balance text-xl font-medium'>
+                  <p className='dark:text-muted-foreground relative z-10 self-end text-balance text-xl font-medium text-white/70'>
                     RMD Kwikform utilized Auxx.ai's Shopify integration to{' '}
-                    <strong className='text-foreground'>
+                    <strong className='text-white dark:text-foreground'>
                       reduce support tickets by 67% while handling 8K+ monthly orders
                     </strong>{' '}
                     with seamless automated responses and upselling capabilities.
                   </p>
 
-                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t pt-8'>
-                    <p className='text-foreground text-balance before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
+                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t border-white/15 pt-8 dark:border-border'>
+                    <p className='text-balance text-white dark:text-foreground before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
                       The Shopify integration was seamless. Within hours, our AI was handling order
                       status inquiries, processing returns, and even upselling complementary
                       products. The system handles our 8K monthly orders without breaking a sweat.
@@ -71,7 +73,7 @@ export default function TestimonialsSection() {
                         />
                       </div>
                       <div className='space-y-px'>
-                        <p className='text-sm font-medium'>Zachery Melton</p>
+                        <p className='text-sm font-medium text-foreground'>Zachery Melton</p>
                         <p className='text-muted-foreground text-xs'>
                           Operations Director, RMD Kwikform
                         </p>

--- a/apps/homepage/src/app/solutions/small-business/_components/automation-impact.tsx
+++ b/apps/homepage/src/app/solutions/small-business/_components/automation-impact.tsx
@@ -28,9 +28,11 @@ export function AutomationImpact() {
                   <div>
                     <div className='flex flex-col gap-2 mb-4'>
                       <Bot className='w-6 h-6 fill-indigo-200 dark:fill-indigo-500/30' />
-                      <h3 className='text-2xl font-semibold text-foreground'>Automation Impact</h3>
+                      <h3 className='text-2xl font-semibold text-white dark:text-foreground'>
+                        Automation Impact
+                      </h3>
                     </div>
-                    <p className='text-muted-foreground mb-6'>
+                    <p className='text-white/70 dark:text-muted-foreground mb-6'>
                       See the measurable impact of AI automation on your support operations. These
                       metrics are averaged across all Shopify stores using our platform.
                     </p>

--- a/apps/homepage/src/app/solutions/small-business/_components/integration-section.tsx
+++ b/apps/homepage/src/app/solutions/small-business/_components/integration-section.tsx
@@ -219,10 +219,12 @@ export default function IntegrationSection() {
                       />
                       <div className='relative z-10'>
                         <Icon className='w-8 h-8 text-white mb-4' />
-                        <h3 className='text-lg font-semibold text-foreground mb-2'>
+                        <h3 className='text-lg font-semibold text-white dark:text-foreground mb-2'>
                           {feature.title}
                         </h3>
-                        <p className='text-sm text-muted-foreground mb-4'>{feature.description}</p>
+                        <p className='text-sm text-white/70 dark:text-muted-foreground mb-4'>
+                          {feature.description}
+                        </p>
                         <Badge variant='secondary' className='text-xs bg-illustration/50'>
                           {feature.metrics}
                         </Badge>

--- a/apps/homepage/src/app/solutions/small-business/_components/testimonials.tsx
+++ b/apps/homepage/src/app/solutions/small-business/_components/testimonials.tsx
@@ -15,16 +15,16 @@ export default function TestimonialsSection() {
               <div className='*:ring-foreground/10 @4xl:grid-cols-2 grid gap-6 *:shadow-lg'>
                 <Card className='relative row-span-5 grid grid-rows-subgrid gap-8 overflow-hidden p-8 rounded-2xl'>
                   <RandomGradient colors={[...GRADIENT_PALETTES.aurora]} mode='hero' animated />
-                  <p className='text-muted-foreground relative z-10 text-balance text-xl font-medium'>
+                  <p className='dark:text-muted-foreground relative z-10 text-balance text-xl font-medium text-white/70'>
                     Bright Consulting leveraged Auxx.ai to transform their small business
                     operations,{' '}
-                    <strong className='text-foreground'>
+                    <strong className='text-white dark:text-foreground'>
                       resulting in an 85% reduction in support tickets and 45% increase in client
                       satisfaction.
                     </strong>
                   </p>
-                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t pt-8'>
-                    <p className='text-foreground self-end text-balance before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
+                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t border-white/15 pt-8 dark:border-border'>
+                    <p className='self-end text-balance text-white dark:text-foreground before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
                       Auxx.ai transformed our client support. We went from being overwhelmed by
                       inquiries to providing instant, personalized responses. Our client
                       satisfaction increased 45% in the first month, and we're serving 200+ clients
@@ -39,8 +39,10 @@ export default function TestimonialsSection() {
                         />
                       </div>
                       <div className='space-y-px'>
-                        <p className='text-sm font-medium'>Danielle K.</p>
-                        <p className='text-muted-foreground text-xs'>
+                        <p className='text-sm font-medium text-white dark:text-foreground'>
+                          Danielle K.
+                        </p>
+                        <p className='dark:text-muted-foreground text-xs text-white/60'>
                           Operations Manager, Bright Consulting
                         </p>
                       </div>
@@ -49,16 +51,16 @@ export default function TestimonialsSection() {
                 </Card>
                 <Card className='relative row-span-5 grid grid-rows-subgrid gap-8 overflow-hidden p-8 rounded-2xl'>
                   <RandomGradient colors={[...GRADIENT_PALETTES.ocean]} mode='hero' animated />
-                  <p className='text-muted-foreground relative z-10 self-end text-balance text-xl font-medium'>
+                  <p className='dark:text-muted-foreground relative z-10 self-end text-balance text-xl font-medium text-white/70'>
                     Local Services Co utilized Auxx.ai's business integration to{' '}
-                    <strong className='text-foreground'>
+                    <strong className='text-white dark:text-foreground'>
                       reduce support tickets by 70% while managing 500+ monthly inquiries
                     </strong>{' '}
                     with seamless automated responses and intelligent routing capabilities.
                   </p>
 
-                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t pt-8'>
-                    <p className='text-foreground text-balance before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
+                  <div className='relative z-10 row-span-2 grid grid-rows-subgrid gap-8 border-t border-white/15 pt-8 dark:border-border'>
+                    <p className='text-balance text-white dark:text-foreground before:mr-1 before:content-["\201C"] after:ml-1 after:content-["\201D"]'>
                       The business integration was seamless. Within hours, our AI was handling
                       appointment bookings, answering FAQs, and routing complex inquiries to the
                       right team member. The system handles our 500 monthly inquiries effortlessly.


### PR DESCRIPTION
## Summary

Solution-page cards render content over vivid/dark gradient overlays in **both** themes, but used the theme-reactive `text-foreground`/`text-muted-foreground` tokens — which turn dark in light mode and become unreadable against the gradient.

This switches those to white-based colors in light mode, with `dark:` overrides restoring the original tokens (`text-foreground`, `text-muted-foreground`, `border-border`) so **dark mode is unchanged**.

## Scope

Across `customer-support-teams`, `shopify-stores`, and `small-business`:
- **testimonials** — quote text, `<strong>` highlights, attributed quotes, dividers, and author name/title
- **integration-section** — feature-card title/description (over gradient + overlay)
- **automation-impact** — heading + paragraph sitting directly on the mesh gradient

Author name/title over the lighter bottom of the ocean gradient (Zach, Vicken) kept on the theme tokens for contrast.

Left untouched: sections whose content sits on theme-appropriate surfaces (`bg-background/50`, `bg-zinc-50`, etc.), which already read correctly in both modes.

## Test plan
- [ ] Toggle light/dark on each solution page; confirm card text is legible in both.
- [ ] Verify dark mode matches the previous appearance.