### PR TITLE
feat(workflow): historical-run node Results, run deep-linking, truthful branch status

### DIFF
--- a/apps/web/src/app/(protected)/app/workflows/_components/executions/execution-tracing-view.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/_components/executions/execution-tracing-view.tsx
@@ -21,17 +21,25 @@ import type { FlowNode } from '~/components/workflow/types'
 export function ExecutionTracingView() {
   const activeRun = useRunStore((state) => state.activeRun)
   const displayExecutions = useRunStore((state) => state.displayExecutions)
+  const runViewMode = useRunStore((state) => state.runViewMode)
   const getLoopIterations = useRunStore((state) => state.getLoopIterations)
   const graphSnapshot = useRunStore((state) => state.graphSnapshot)
 
   // Use stored graph snapshot for node data
   const nodes = graphSnapshot?.nodes as FlowNode[] | undefined
 
-  console.log('displayExecutions', displayExecutions)
+  // This view only renders completed/historical runs — branch status reflects
+  // executed nodes only (pending placeholders mean "never reached").
+  const runFinished =
+    runViewMode === 'previous' ||
+    activeRun?.status === WorkflowRunStatus.SUCCEEDED ||
+    activeRun?.status === WorkflowRunStatus.FAILED ||
+    activeRun?.status === WorkflowRunStatus.STOPPED
+
   // Cache grouped executions to avoid recomputing on every render
   const groupedExecutions = useMemo(
-    () => groupExecutionsByBranch(displayExecutions, nodes),
-    [displayExecutions, nodes]
+    () => groupExecutionsByBranch(displayExecutions, nodes, runFinished),
+    [displayExecutions, nodes, runFinished]
   )
 
   // Show empty state when no executions but workflow exists

--- a/apps/web/src/app/(protected)/app/workflows/_components/executions/workflow-execution-detail-drawer.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/_components/executions/workflow-execution-detail-drawer.tsx
@@ -3,12 +3,14 @@
 'use client'
 
 import type { WorkflowRunEntity } from '@auxx/database/types'
+import { Button } from '@auxx/ui/components/button'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
 import { DrawerHeader } from '@auxx/ui/components/drawer'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { OverflowTabsList, Tabs, TabsContent } from '@auxx/ui/components/tabs'
-import { ListChecks, Loader2, Medal, Route } from 'lucide-react'
+import { ListChecks, Loader2, Medal, Route, SquarePen } from 'lucide-react'
+import { useQueryState } from 'nuqs'
 import { useEffect, useState } from 'react'
 import { useDockPortal } from '~/components/global/dock-portal-provider'
 import { DockToggleButton } from '~/components/global/dock-toggle-button'
@@ -48,6 +50,18 @@ export function WorkflowExecutionDetailDrawer({
   // Store actions
   const showPrevious = useRunStore((state) => state.showPrevious)
   const clearRun = useRunStore((state) => state.clearRun)
+
+  // Same-page nuqs params: deep-link the run into the editor without navigating
+  const [, setRunId] = useQueryState('runId', { history: 'replace' })
+  const [, setMode] = useQueryState('t')
+
+  // Open this run on the canvas (read-only, per-node results). The editor's
+  // useRunDeepLink hydrates from `runId`; the store already holds the run so it
+  // loads instantly.
+  const handleOpenInEditor = () => {
+    setRunId(run.id)
+    setMode('editor')
+  }
 
   // Fetch complete run data with node executions
   const { data: completeRun, isLoading } = api.workflow.getWorkflowRun.useQuery(
@@ -92,7 +106,15 @@ export function WorkflowExecutionDetailDrawer({
             </div>
           }
           onClose={() => onOpenChange(false)}
-          actions={<DockToggleButton />}
+          actions={
+            <div className='flex items-center gap-1'>
+              <Button variant='outline' size='sm' onClick={handleOpenInEditor}>
+                <SquarePen />
+                Open in editor
+              </Button>
+              <DockToggleButton />
+            </div>
+          }
         />
 
         {/* Loading state */}

--- a/apps/web/src/components/workflow/editor/workflow-editor.tsx
+++ b/apps/web/src/components/workflow/editor/workflow-editor.tsx
@@ -10,6 +10,7 @@ import { WorkflowCanvas } from '../canvas/workflow-canvas'
 import { WorkflowToolbar } from '../canvas/workflow-toolbar'
 import {
   useEagerAppOutputs,
+  useRunDeepLink,
   useWorkflowBlocks,
   useWorkflowInit,
   useWorkflowShortcuts,
@@ -54,6 +55,9 @@ const WorkflowEditorInner = memo<{
 
   // Eagerly fetch computed outputs for app nodes (e.g., Shopify)
   useEagerAppOutputs()
+
+  // Rehydrate a historical run from the `runId` URL param (survives remounts)
+  useRunDeepLink()
 
   // Initialize test input sync
   useTestInputSync()

--- a/apps/web/src/components/workflow/hooks/index.ts
+++ b/apps/web/src/components/workflow/hooks/index.ts
@@ -39,6 +39,7 @@ export {
   useRegistryVersion,
   useTriggerDefinitions,
 } from './use-registry'
+export { useRunDeepLink } from './use-run-deep-link'
 export {
   // type RunNodeResult,
   type LoopExecutionContext,

--- a/apps/web/src/components/workflow/hooks/use-run-deep-link.ts
+++ b/apps/web/src/components/workflow/hooks/use-run-deep-link.ts
@@ -1,0 +1,68 @@
+// apps/web/src/components/workflow/hooks/use-run-deep-link.ts
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useQueryState } from 'nuqs'
+import { useEffect, useRef } from 'react'
+import { api } from '~/trpc/react'
+import { usePanelStore } from '../store/panel-store'
+import { useRunStore } from '../store/run-store'
+
+/**
+ * Hydrates a historical run from the `runId` URL query param.
+ *
+ * The run selection lives only in zustand, which is wiped when the editor
+ * unmounts (e.g. switching Editor → Executions → Editor). This hook restores it
+ * from the URL on mount: it fetches the run, loads it into the run store
+ * read-only, and opens the run panel — mirroring what RunHistory does on click.
+ *
+ * Mounted once inside the editor (under WorkflowStoreProvider). The zustand
+ * store never touches the router; components that dismiss a run clear the param.
+ */
+export function useRunDeepLink() {
+  const [runId, setRunId] = useQueryState('runId', { history: 'replace' })
+  const activeRun = useRunStore((state) => state.activeRun)
+  const isRunning = useRunStore((state) => state.isRunning)
+  const showPrevious = useRunStore((state) => state.showPrevious)
+  const openedForRef = useRef<string | null>(null)
+
+  // Fetch only when the param points at a run we don't already have loaded and
+  // we're not mid-run. React Query caches, so remounts rehydrate instantly.
+  const needsFetch = !!runId && activeRun?.id !== runId && !isRunning
+
+  const { data, error } = api.workflow.getWorkflowRun.useQuery(
+    { runId: runId! },
+    { enabled: needsFetch }
+  )
+
+  // Load the fetched run into the store read-only
+  useEffect(() => {
+    if (data && needsFetch) {
+      showPrevious(data as any)
+    }
+  }, [data, needsFetch, showPrevious])
+
+  // Open the run panel once when the deep-linked run becomes active (covers both
+  // the fetch path and the direct handoff from the Executions drawer). Guarded so
+  // it doesn't fight the user re-closing the panel.
+  useEffect(() => {
+    if (runId && activeRun?.id === runId) {
+      if (openedForRef.current !== runId) {
+        openedForRef.current = runId
+        usePanelStore.getState().openRunPanel()
+      }
+    } else if (!runId) {
+      openedForRef.current = null
+    }
+  }, [runId, activeRun?.id])
+
+  // Run not found (deleted, or belongs to another workflow): drop the param
+  useEffect(() => {
+    if (error) {
+      toastError({
+        title: 'Run unavailable',
+        description: 'This run could not be loaded.',
+      })
+      setRunId(null)
+    }
+  }, [error, setRunId])
+}

--- a/apps/web/src/components/workflow/nodes/shared/single-run-result-tab.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/single-run-result-tab.tsx
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/nodes/shared/single-run-result-tab.tsx
 
+import { WorkflowRunStatus } from '@auxx/database/enums'
 import type { WorkflowNodeExecutionEntity as WorkflowNodeExecution } from '@auxx/database/types'
 import { inferJsonSchema } from '@auxx/lib/json-schema/client'
 import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
@@ -11,6 +12,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   Clock,
+  MinusCircle,
   Play,
   Workflow,
   XCircle,
@@ -22,7 +24,7 @@ import CodeEditor, { CodeLanguage } from '~/components/workflow/ui/code-editor'
 import type { SchemaRoot } from '~/components/workflow/ui/json-schema-types'
 import Section from '~/components/workflow/ui/section'
 import { useDemo } from '~/hooks/use-demo'
-import { useRunSingleNode } from '../../hooks'
+import { useReadOnly, useRunSingleNode } from '../../hooks'
 import { TraceRenderBoundary } from '../../panels/run/components/trace-render-boundary'
 import { useRunStore } from '../../store/run-store'
 import { unifiedNodeRegistry } from '../unified-registry'
@@ -56,6 +58,9 @@ export const SingleRunResultTab = memo(function SingleRunResultTab({
   // Get data from hooks inside the component
   const { result: runResult, isRunning } = useRunSingleNode(nodeId)
   const nodeExecution = useRunStore((state) => state.getNodeExecution(nodeId))
+  const runViewMode = useRunStore((state) => state.runViewMode)
+  const activeRun = useRunStore((state) => state.activeRun)
+  const { isReadOnly } = useReadOnly()
 
   // Use single data source - prefer nodeExecution from workflow runs, fallback to runResult from single runs
   const execution: WorkflowNodeExecution | undefined = nodeExecution || runResult || undefined
@@ -159,26 +164,48 @@ export const SingleRunResultTab = memo(function SingleRunResultTab({
   }
   // No result yet
   if (!execution) {
+    // Viewing a historical run: this node wasn't part of the executed path.
+    // Show a dedicated "not executed" state instead of the runnable empty state.
+    if (runViewMode === 'previous' && activeRun) {
+      const failedBeforeReaching = activeRun.status === WorkflowRunStatus.FAILED
+      return (
+        <div className='relative flex flex-1 w-full items-center justify-center'>
+          <div className='flex flex-col items-center justify-center text-center p-8 pt-0'>
+            <MinusCircle className='mb-2 size-8 text-muted-foreground' />
+            <h3 className='text-medium mb-0'>Not executed in Run #{activeRun.sequenceNumber}</h3>
+            <div className='max-w-xs text-sm text-muted-foreground'>
+              {failedBeforeReaching
+                ? 'The run failed before reaching this node.'
+                : "This node was skipped — its branch wasn't taken, or the run stopped before reaching it."}
+            </div>
+          </div>
+        </div>
+      )
+    }
+
     return (
       <div className='relative flex flex-1 w-full items-center justify-center'>
         <div className='flex flex-col items-center justify-center text-center p-8 pt-0'>
           <AlertCircle className='mb-2 size-8 text-muted-foreground' />
           <h3 className='text-medium mb-0'>No execution results yet.</h3>
           <div className='text-sm text-muted-foreground mb-2'>Run the node to see output.</div>
-          <Button
-            variant='outline'
-            size='sm'
-            onClick={() => {
-              if (isDemo) {
-                setLimitDialogOpen(true)
-                return
-              }
-              onRun?.()
-            }}
-            disabled={isRunning || !onRun}>
-            <Play />
-            Run this node
-          </Button>
+          {/* Hide the Run button when the editor is read-only — running is impossible there */}
+          {!isReadOnly && (
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => {
+                if (isDemo) {
+                  setLimitDialogOpen(true)
+                  return
+                }
+                onRun?.()
+              }}
+              disabled={isRunning || !onRun}>
+              <Play />
+              Run this node
+            </Button>
+          )}
           <LimitReachedDialog
             open={limitDialogOpen}
             onOpenChange={setLimitDialogOpen}

--- a/apps/web/src/components/workflow/panels/run/components/branch-group.tsx
+++ b/apps/web/src/components/workflow/panels/run/components/branch-group.tsx
@@ -66,10 +66,19 @@ function getStatusVariant(
       return 'warning'
     case NodeRunningStatus.Pending:
     case NodeRunningStatus.Waiting:
+    case NodeRunningStatus.Skipped:
       return 'secondary'
     default:
       return 'default'
   }
+}
+
+/**
+ * Human-readable label for a branch status badge
+ */
+function getStatusLabel(status: NodeRunningStatus): string {
+  if (status === NodeRunningStatus.Skipped) return 'Skipped'
+  return status
 }
 
 /**
@@ -87,6 +96,8 @@ function getBorderColor(status?: NodeRunningStatus): string {
     case NodeRunningStatus.Pending:
     case NodeRunningStatus.Waiting:
       return 'border-gray-500/20'
+    case NodeRunningStatus.Skipped:
+      return 'border-muted/30'
     default:
       return 'border-border/50'
   }
@@ -135,7 +146,7 @@ export function BranchGroup({
         <span className='text-muted-foreground'>{displayLabel}</span>
         {status && (
           <Badge variant={statusVariant} className='text-xs px-1.5 py-0'>
-            {status}
+            {getStatusLabel(status)}
           </Badge>
         )}
       </button>

--- a/apps/web/src/components/workflow/panels/run/run-history.tsx
+++ b/apps/web/src/components/workflow/panels/run/run-history.tsx
@@ -6,6 +6,7 @@ import InfiniteScroll from '@auxx/ui/components/infinite-scroll'
 import { PopoverContent } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
 import { Activity, CheckCircle2, Loader2, StopCircle, XCircle } from 'lucide-react'
+import { useQueryState } from 'nuqs'
 import { memo, useCallback, useEffect, useState } from 'react'
 import { useWorkflowStore } from '~/components/workflow/store'
 import { useRunStore } from '~/components/workflow/store/run-store'
@@ -42,6 +43,9 @@ StatusIcon.displayName = 'StatusIcon'
 export const RunHistory = memo<RunHistoryProps>(({ className, onRunSelect }) => {
   const [loadingRunId, setLoadingRunId] = useState<string | null>(null)
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
+
+  // Mirror the selected run into the URL so it survives editor remounts
+  const [, setRunId] = useQueryState('runId', { history: 'replace' })
 
   // Get workflowAppId from workflow store
   const workflowAppId = useWorkflowStore((state) => state.workflowAppId)
@@ -103,9 +107,10 @@ export const RunHistory = memo<RunHistoryProps>(({ className, onRunSelect }) => 
   const handleRunClick = useCallback(
     (runId: string) => {
       setSelectedRunId(runId)
+      setRunId(runId)
       onRunSelect?.(runId)
     },
-    [onRunSelect]
+    [onRunSelect, setRunId]
   )
 
   return (

--- a/apps/web/src/components/workflow/panels/run/tabs/tracing-tab.tsx
+++ b/apps/web/src/components/workflow/panels/run/tabs/tracing-tab.tsx
@@ -23,6 +23,7 @@ export function TracingTab() {
   const activeRun = useRunStore((state) => state.activeRun)
   const displayExecutions = useRunStore((state) => state.displayExecutions)
   const isRunning = useRunStore((state) => state.isRunning)
+  const runViewMode = useRunStore((state) => state.runViewMode)
   const getLoopIterations = useRunStore((state) => state.getLoopIterations)
   const graphSnapshot = useRunStore((state) => state.graphSnapshot)
   const workflowAppId = useWorkflowStore((state) => state.workflowAppId)
@@ -32,12 +33,20 @@ export function TracingTab() {
   // This ensures loop-child filtering matches the tree that produced the tracing data
   const nodes = (graphSnapshot?.nodes ?? store.getState().nodes) as FlowNode[] | undefined
 
+  // A finished run (historical view or terminal live status) reports branch
+  // status from executed nodes only — pending placeholders mean "never reached".
+  const runFinished =
+    runViewMode === 'previous' ||
+    activeRun?.status === WorkflowRunStatus.SUCCEEDED ||
+    activeRun?.status === WorkflowRunStatus.FAILED ||
+    activeRun?.status === WorkflowRunStatus.STOPPED
+
   // Cache grouped executions to avoid recomputing on every render
   // This is especially important since groupExecutionsByBranch was called twice per render
   // (once in the main map, once for calculating parallelBranchIndex)
   const groupedExecutions = useMemo(
-    () => groupExecutionsByBranch(displayExecutions, nodes),
-    [displayExecutions, nodes]
+    () => groupExecutionsByBranch(displayExecutions, nodes, runFinished),
+    [displayExecutions, nodes, runFinished]
   )
 
   const { stopWorkflow } = useWorkflowRun()

--- a/apps/web/src/components/workflow/panels/run/utils/group-executions.ts
+++ b/apps/web/src/components/workflow/panels/run/utils/group-executions.ts
@@ -29,10 +29,35 @@ export interface BranchExecutionGroup {
 export type ExecutionGroup = SingleExecutionGroup | BranchExecutionGroup
 
 /**
- * Determine the overall status of a branch based on its executions
+ * Determine the overall status of a branch based on its executions.
+ *
+ * @param executions - Node executions belonging to the branch
+ * @param runFinished - True when the run has completed (historical view or a
+ *   terminal live status). Pending placeholders then mean "never reached", not
+ *   "still coming", so branch status is derived from executed nodes only.
  */
-function getBranchStatus(executions: WorkflowNodeExecution[]): NodeRunningStatus {
-  if (executions.length === 0) return NodeRunningStatus.Pending
+function getBranchStatus(
+  executions: WorkflowNodeExecution[],
+  runFinished = false
+): NodeRunningStatus {
+  if (executions.length === 0) {
+    return runFinished ? NodeRunningStatus.Skipped : NodeRunningStatus.Pending
+  }
+
+  if (runFinished) {
+    // Pending placeholders are nodes the run never reached — ignore them and
+    // judge the branch by the nodes that actually executed.
+    const executed = executions.filter((e) => e.status !== NodeRunningStatus.Pending)
+    if (executed.length === 0) return NodeRunningStatus.Skipped
+    if (
+      executed.some(
+        (e) => e.status === NodeRunningStatus.Failed || e.status === NodeRunningStatus.Exception
+      )
+    ) {
+      return NodeRunningStatus.Failed
+    }
+    return NodeRunningStatus.Succeeded
+  }
 
   // If any failed/exception, branch is failed
   if (
@@ -76,11 +101,14 @@ function getBranchStatus(executions: WorkflowNodeExecution[]): NodeRunningStatus
  *
  * @param executions - Ordered list of node executions
  * @param nodes - Workflow graph nodes (optional, for loop child filtering)
+ * @param runFinished - True when the run has completed; makes branch status
+ *   reflect only executed nodes (see getBranchStatus)
  * @returns Array of execution groups (single or branch)
  */
 export function groupExecutionsByBranch(
   executions: WorkflowNodeExecution[],
-  nodes?: FlowNode[]
+  nodes?: FlowNode[],
+  runFinished = false
 ): ExecutionGroup[] {
   // Filter out loop children - they should only render inside LoopExecutionCard
   const topLevelExecutions = executions.filter((execution) => {
@@ -194,7 +222,7 @@ export function groupExecutionsByBranch(
         branchId: branchId || 'source',
         executions: branchExecutions,
         depth,
-        status: getBranchStatus(branchExecutions),
+        status: getBranchStatus(branchExecutions, runFinished),
       }
       groups.push(group)
       i = j

--- a/apps/web/src/components/workflow/ui/run-info.tsx
+++ b/apps/web/src/components/workflow/ui/run-info.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@auxx/ui/components/badge'
 import { X } from 'lucide-react'
+import { useQueryState } from 'nuqs'
 import { memo, useCallback } from 'react'
 import { formatRelativeDate } from '~/utils/date'
 import { useRunStore } from '../store/run-store'
@@ -11,10 +12,12 @@ import { useRunStore } from '../store/run-store'
  */
 export const RunInfo = memo(function RunInfo() {
   const activeRun = useRunStore((state) => state.activeRun)
+  const [, setRunId] = useQueryState('runId', { history: 'replace' })
 
   const handleClearActiveRun = useCallback(() => {
     useRunStore.getState().clearRun()
-  }, [])
+    setRunId(null)
+  }, [setRunId])
 
   if (!activeRun) {
     return null

--- a/apps/web/src/hooks/use-workflow-run.tsx
+++ b/apps/web/src/hooks/use-workflow-run.tsx
@@ -3,6 +3,7 @@
 import { WorkflowEventType } from '@auxx/lib/workflow-engine/types'
 import { toastError } from '@auxx/ui/components/toast'
 import { useStoreApi } from '@xyflow/react'
+import { useQueryState } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRunEvents } from '~/components/workflow/hooks/run-hooks/use-run-events'
 import { type ExecutionEvent, useRunStore } from '~/components/workflow/store/run-store'
@@ -63,6 +64,9 @@ const WORKFLOW_EVENTS = [
 export function useWorkflowRun(): WorkflowRunHookReturn {
   // Get ReactFlow store for accessing nodes and edges
   const reactFlowStore = useStoreApi()
+
+  // Clear any deep-linked historical run when a fresh run starts
+  const [, setRunId] = useQueryState('runId', { history: 'replace' })
 
   // Get run store actions
   const {
@@ -206,10 +210,13 @@ export function useWorkflowRun(): WorkflowRunHookReturn {
       // Reset run store for new execution with current graph
       resetForNewRun(nodes, edges)
 
+      // Drop any historical run deep-link — this is a brand-new run
+      setRunId(null)
+
       // Set parameters which will trigger SSE connection via useMemo
       setWorkflowRunParams({ workflowId, inputs, mode })
     },
-    [resetForNewRun, reactFlowStore]
+    [resetForNewRun, reactFlowStore, setRunId]
   )
 
   /**

--- a/packages/types/field/utils.ts
+++ b/packages/types/field/utils.ts
@@ -86,8 +86,13 @@ export interface AppFieldRefParts {
 /**
  * Is this a late-bound app-field ref (`${defSegment}:@app:${appSlug}:${appFieldKey}`)?
  * The `@app:` marker lives in the fieldId segment (everything after the first `:`).
+ *
+ * Plain FieldIds (no colon — e.g. a table column key like `status`) can never be an
+ * app-field ref, so short-circuit rather than routing them through parseResourceFieldId,
+ * which would log a spurious "malformed ResourceFieldId" error.
  */
 export function isAppFieldRef(ref: string): boolean {
+  if (!isResourceFieldId(ref)) return false
   return getFieldId(ref as ResourceFieldId).startsWith(APP_SEGMENT)
 }
 


### PR DESCRIPTION
Implements `plans/workflow/v2/06-historical-run-node-results.md`.

## Problem
Viewing a historical run showed a node's **Result** tab as *"No execution results yet. Run the node to see output."* — with a live "Run this node" button in read-only mode. Switching Editor → Executions → Editor silently wiped the loaded run. And tracing branch labels read "pending" on both branches of a finished IF/ELSE.

## Changes

**Phase 1 — skipped-node Result state**
- Historical view + no execution → dedicated **"Not executed in Run #N"** state, no Run button (FAILED-run variant: "the run failed before reaching it").
- Generic empty state hides the Run button whenever the editor is read-only.

**Phase 2 — `runId` URL param + editor hydration**
- New `useRunDeepLink` hook (mounted in the editor) rehydrates the run read-only from a `runId` nuqs param on mount; React Query cache makes remounts instant.
- Run-history picker writes the param; it's cleared on dismissal (`run-info` X) and on a new run (`startRun`). The zustand store never touches the router.
- Net effect: Editor → Executions → Editor keeps the run badge, read-only mode, and node results.

**Phase 3 — Executions drawer deep link**
- "Open in editor" header action sets `runId` + `t=editor` (same-page, no navigation) and lands on the canvas with the run loaded read-only.

**Phase 4 — truthful branch status on finished runs**
- `groupExecutionsByBranch`/`getBranchStatus` take a `runFinished` flag: branch status derives from executed nodes only (pending placeholders mean "never reached"); 0-executed branches → **Skipped**. Live-run behavior unchanged.
- `branch-group` gets a Skipped badge/border + label.

**Drive-by fix**
- Silenced spurious `[parseResourceFieldId] Malformed ResourceFieldId` console errors on the Executions table: `isAppFieldRef` now short-circuits plain FieldIds instead of routing colonless column keys (`status`, `createdAt`, `totalTokens`, …) through `parseResourceFieldId`. Rebuilt `@auxx/types`.

## Verify (manual)
See the plan's Verify section — historical run node results, `?runId=` survival across tab switches, "Open in editor", dismissal, page reload, and Run #13 branch status (taken branch Succeeded, untaken Skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)