### PR TITLE
fix(files): sniff remote image types + soft-skip unsupported thumbnails; raise Gmail sync limits

### DIFF
--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -528,7 +528,7 @@ export function InboxForm({
         {canManageAccess &&
           (isPersonalInbox ? (
             <FieldPanelRow title='Access' showIcon icon={<Shield />} className='@md:flex-col!'>
-              <div className='space-y-2 rounded-md border p-3'>
+              <div className='space-y-2 rounded-[13px] border p-3 mb-1 me-1 -ms-1'>
                 {ownerActorId && (
                   <div className='flex items-center justify-between'>
                     <ActorBadge actorId={ownerActorId} />
@@ -536,8 +536,8 @@ export function InboxForm({
                   </div>
                 )}
                 <p className='text-muted-foreground text-xs'>
-                  Personal account — mail here is private to its owner. Admins can see activity
-                  only; assignment and shares grant access per thread.
+                  Personal account: mail here is private to its owner. Admins can see activity only;
+                  assignment and shares grant access per thread.
                 </p>
               </div>
             </FieldPanelRow>

--- a/packages/lib/src/files/core/image-processing.ts
+++ b/packages/lib/src/files/core/image-processing.ts
@@ -8,6 +8,18 @@ import { ALLOWED_IMAGE_TYPES, THUMBNAIL_LIMITS, THUMBNAIL_PRESETS } from './thum
 const logger = createScopedLogger('image-processing')
 
 /**
+ * Thrown when source bytes are not a thumbnailable image type (unknown or
+ * unsupported format). Deterministic — callers should treat it as a soft skip
+ * rather than a retryable failure.
+ */
+export class UnsupportedImageError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UnsupportedImageError'
+  }
+}
+
+/**
  * Validate source image buffer
  */
 export async function validateSource(
@@ -24,7 +36,7 @@ export async function validateSource(
   // Detect actual file type from magic bytes
   const fileType = await fileTypeFromBuffer(buffer)
   if (!fileType) {
-    throw new Error('Unable to determine file type from content')
+    throw new UnsupportedImageError('Unable to determine file type from content')
   }
 
   // Log mismatch but don't fail
@@ -37,7 +49,7 @@ export async function validateSource(
 
   // Check if image type is supported
   if (!ALLOWED_IMAGE_TYPES.includes(fileType.mime as any)) {
-    throw new Error(`Unsupported image type: ${fileType.mime}`)
+    throw new UnsupportedImageError(`Unsupported image type: ${fileType.mime}`)
   }
 
   // Get image metadata to check pixel limits

--- a/packages/lib/src/files/core/thumbnail-processor.worker.ts
+++ b/packages/lib/src/files/core/thumbnail-processor.worker.ts
@@ -2,4 +2,9 @@
 // Worker-only processing entrypoint for thumbnail generation.
 // This module imports image-processing primitives that may transitively load sharp.
 
-export { getMimeTypeForFormat, processImage, validateSource } from './image-processing'
+export {
+  getMimeTypeForFormat,
+  processImage,
+  UnsupportedImageError,
+  validateSource,
+} from './image-processing'

--- a/packages/lib/src/files/fetch-remote-image.ts
+++ b/packages/lib/src/files/fetch-remote-image.ts
@@ -1,7 +1,9 @@
 // packages/lib/src/files/fetch-remote-image.ts
 
 import { createScopedLogger } from '@auxx/logger'
+import { fileTypeFromBuffer } from 'file-type'
 import { createMediaAssetService } from './core/media-asset-service'
+import { ALLOWED_IMAGE_TYPES } from './core/thumbnail-types'
 import { createStorageManager } from './storage/storage-manager'
 
 /**
@@ -11,9 +13,10 @@ import { createStorageManager } from './storage/storage-manager'
  * and by the extension's avatar upload endpoint (LinkedIn profile / company
  * avatar URLs captured during Save to Auxx).
  *
- * Flow: SSRF-guard the URL → fetch with timeout → validate content-type + size
- * → upload bytes to S3 → create StorageLocation → create MediaAsset+Version →
- * return `asset:<id>` ref consumable by FILE fields.
+ * Flow: SSRF-guard the URL → fetch with timeout → sniff the real image type
+ * from magic bytes and enforce the thumbnailable allowlist → upload bytes to S3
+ * → create StorageLocation → create MediaAsset+Version → return `asset:<id>`
+ * ref consumable by FILE fields.
  */
 
 const logger = createScopedLogger('files:fetch-remote-image')
@@ -67,11 +70,6 @@ export async function fetchAndStoreRemoteImage(
     throw new Error(`Fetch failed: HTTP ${res.status}`)
   }
 
-  const contentType = (res.headers.get('content-type') || 'image/x-icon').split(';')[0]!.trim()
-  if (!contentType.startsWith('image/')) {
-    throw new Error(`Unsupported content-type: ${contentType}`)
-  }
-
   const buf = Buffer.from(await res.arrayBuffer())
   if (buf.byteLength === 0) {
     throw new Error('Empty response body')
@@ -80,14 +78,29 @@ export async function fetchAndStoreRemoteImage(
     throw new Error(`Response too large: ${buf.byteLength} > ${maxBytes}`)
   }
 
+  // Determine the real image type from magic bytes rather than trusting the
+  // Content-Type header — many `/favicon.ico` URLs serve PNG bytes labelled
+  // `image/x-icon` (and vice versa). Only accept types the thumbnail pipeline
+  // can actually render (validateSource enforces the same allowlist); otherwise
+  // we'd store a logo asset that deterministically fails avatar-thumbnail
+  // generation downstream (e.g. genuine `.ico` favicons).
+  const detected = await fileTypeFromBuffer(buf)
+  const mimeType = detected?.mime
+  if (
+    !mimeType ||
+    !ALLOWED_IMAGE_TYPES.includes(mimeType as (typeof ALLOWED_IMAGE_TYPES)[number])
+  ) {
+    throw new Error(`Unsupported image type: ${mimeType ?? 'undetected'}`)
+  }
+
   const storageManager = createStorageManager(organizationId)
-  const key = `${organizationId}/${pathPrefix}/${Date.now()}-${cryptoRandomHex()}${extensionFor(contentType)}`
+  const key = `${organizationId}/${pathPrefix}/${Date.now()}-${cryptoRandomHex()}${extensionFor(mimeType)}`
 
   const storageLocation = await storageManager.uploadContent({
     provider: 'S3',
     key,
     content: buf,
-    mimeType: contentType,
+    mimeType,
     size: buf.byteLength,
     visibility: 'PUBLIC',
     organizationId,
@@ -99,7 +112,7 @@ export async function fetchAndStoreRemoteImage(
       kind: 'SYSTEM_BLOB',
       purpose,
       name,
-      mimeType: contentType,
+      mimeType,
       size: BigInt(buf.byteLength),
       isPrivate: false,
       organizationId,
@@ -112,14 +125,14 @@ export async function fetchAndStoreRemoteImage(
     organizationId,
     purpose,
     assetId: asset.id,
-    mimeType: contentType,
+    mimeType,
     size: buf.byteLength,
   })
 
   return {
     assetId: asset.id,
     ref: `asset:${asset.id}`,
-    mimeType: contentType,
+    mimeType,
     size: buf.byteLength,
   }
 }

--- a/packages/lib/src/jobs/maintenance/generate-thumbnail-job.ts
+++ b/packages/lib/src/jobs/maintenance/generate-thumbnail-job.ts
@@ -8,6 +8,7 @@ import { MediaAssetService } from '../../files/core/media-asset-service'
 import {
   getMimeTypeForFormat,
   processImage,
+  UnsupportedImageError,
   validateSource,
 } from '../../files/core/thumbnail-processor.worker'
 import type {
@@ -250,18 +251,30 @@ export const generateThumbnailJob = async (ctx: JobContext): Promise<void> => {
       await publishAvatarResolved({ orgId, ...avatarResolved })
     }
   } catch (error) {
+    // Clear processing cache regardless of outcome
+    const redis = await getRedisClient()
+    if (redis) {
+      await redis.del(`processing:thumb-${key}`)
+    }
+
+    // Unsupported / undetectable source types (e.g. `.ico` favicons captured
+    // during company enrichment) can never succeed — treat as a soft skip so
+    // BullMQ doesn't burn its retry budget on a deterministic failure.
+    if (error instanceof UnsupportedImageError) {
+      logger.warn('Skipping thumbnail — unsupported source image type', {
+        versionId,
+        preset,
+        error: error.message,
+      })
+      return
+    }
+
     logger.error('Failed to generate thumbnail', {
       versionId,
       preset,
       error: error instanceof Error ? error.message : 'Unknown error',
       stack: error instanceof Error ? error.stack : undefined,
     })
-
-    // Clear processing cache on error
-    const redis = await getRedisClient()
-    if (redis) {
-      await redis.del(`processing:thumb-${key}`)
-    }
 
     throw error
   }

--- a/packages/lib/src/providers/google/google-provider.ts
+++ b/packages/lib/src/providers/google/google-provider.ts
@@ -854,6 +854,7 @@ export class GoogleProvider
       const query = since ? `after:${Math.floor(since.getTime() / 1000)}` : ''
       let nextPageToken: string | undefined | null
       let highestHistoryId = BigInt(0)
+      let pageCount = 0
 
       do {
         const listResponse = await executeWithThrottle(
@@ -881,6 +882,14 @@ export class GoogleProvider
         for (const msg of messages) {
           if (msg.id) addedMessageIds.push(msg.id)
         }
+
+        pageCount++
+        logger.info('Fetched message list page', {
+          integrationId: this.integrationId,
+          page: pageCount,
+          pageSize: messages.length,
+          totalIds: addedMessageIds.length,
+        })
 
         // We need to get historyId from the first batch of actual messages
         const firstMsg = messages[0]

--- a/packages/lib/src/utils/rate-limiter/provider-configs.ts
+++ b/packages/lib/src/utils/rate-limiter/provider-configs.ts
@@ -76,9 +76,12 @@ export const ENHANCED_PROVIDER_LIMITS: Partial<
 
     // Context-specific limits for different operations
     contexts: {
-      // Message sync operations
+      // Message sync operations (messages.list pagination, threads.get,
+      // interactive modify/trash). Kept well under Gmail's real 15k units/min
+      // per-user ceiling to avoid 429s. Governs the ID-listing phase throughput:
+      // 1000 units/min ÷ 5 (messages.list cost) = ~200 pages/min.
       sync: {
-        maxRequests: 100,
+        maxRequests: 1000,
         perInterval: 60000, // per minute
         maxConcurrent: 10,
       },


### PR DESCRIPTION
## Summary

- **Remote image fetch** (`fetchAndStoreRemoteImage`): detect the real image type from magic bytes via `file-type` instead of trusting the `Content-Type` header (many `/favicon.ico` URLs serve PNG bytes labelled `image/x-icon`, and vice versa). Only accept types in the thumbnailable allowlist so we never store a logo asset that deterministically fails avatar-thumbnail generation downstream.
- **Thumbnail job**: `validateSource` now throws a typed `UnsupportedImageError`; `generate-thumbnail-job` treats it as a soft skip (warn + return) instead of burning BullMQ retries on a deterministic failure. The Redis `processing:thumb-*` key is now cleared on every error path, not just retryable ones.
- **Gmail sync**: raise the `sync` rate-limit context from 100 to 1000 requests/min (≈200 `messages.list` pages/min at 5 units each — still well under Gmail's 15k units/min per-user ceiling) and log each fetched list page for sync observability.
- **Inbox form**: minor styling/copy tweak to the personal-inbox Access panel.

## Test plan

- [ ] Trigger company enrichment with a domain whose favicon is a genuine `.ico` — asset is rejected up front, no thumbnail job retry storm
- [ ] Enrich with a favicon URL serving PNG labelled `image/x-icon` — stored with correct mime/extension and thumbnails generate
- [ ] Run a large Gmail initial sync — list pages logged, no 429s