### PR TITLE
feat(mail): regroup personal inboxes under Inbox with isolation rules

### DIFF
--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -67,6 +67,7 @@ import {
   useThreadSelectionStore,
   useViewMode,
 } from '~/components/threads'
+import { useInboxes } from '~/components/threads/hooks'
 import { useCompose } from '~/hooks/use-compose'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useUser } from '~/hooks/use-user'
@@ -223,6 +224,17 @@ function MailboxInner({
   // Get search conditions from store for condition-based filtering
   const searchConditions = useSearchConditions()
 
+  // My personal inbox ids — widen the Inbox context to the combined stream
+  // (assigned to me OR in one of my personal inboxes).
+  const { inboxes } = useInboxes()
+  const personalInboxIds = useMemo(() => {
+    if (contextType !== InternalFilterContextType.PERSONAL_INBOX || !userId) return undefined
+    const ids = inboxes
+      .filter((inbox) => inbox.isPersonal && inbox.ownerUserId === userId)
+      .map((inbox) => inbox.id)
+    return ids.length > 0 ? ids : undefined
+  }, [contextType, inboxes, userId])
+
   // For view contexts, fetch the view's saved filter conditions
   const { data: mailViewData } = api.mailView.getById.useQuery(
     { id: contextId! },
@@ -307,6 +319,7 @@ function MailboxInner({
         contextId,
         statusSlug: activeStatusSlug === 'all' ? undefined : activeStatusSlug,
         userId,
+        personalInboxIds,
       },
       searchConditions
     )
@@ -320,7 +333,15 @@ function MailboxInner({
     }
 
     return groups
-  }, [contextType, contextId, activeStatusSlug, userId, searchConditions, mailViewData])
+  }, [
+    contextType,
+    contextId,
+    activeStatusSlug,
+    userId,
+    personalInboxIds,
+    searchConditions,
+    mailViewData,
+  ])
 
   getMailboxContextType(pathname)
   const mailFilterContextValue = useMemo(

--- a/apps/web/src/app/(protected)/app/mail/_utils/mail-utils.ts
+++ b/apps/web/src/app/(protected)/app/mail/_utils/mail-utils.ts
@@ -83,6 +83,10 @@ export function parseMailboxContext(pathname: string): MailboxContext {
         contextId = pathSegments[4] // Inbox ID from path
       }
       break
+    case 'personal':
+      contextType = 'personal_channel'
+      contextId = pathSegments[4] // Personal inbox ID from path
+      break
     default:
       // Fallback for unknown context types
       contextType = 'personal_inbox'

--- a/apps/web/src/app/(protected)/app/mail/_utils/mailbox-utils.ts
+++ b/apps/web/src/app/(protected)/app/mail/_utils/mailbox-utils.ts
@@ -27,7 +27,8 @@ export function getDisplayTabsForContext(contextType: string): StatusSlug[] {
   // Personal contexts
   if (
     contextType === InternalFilterContextType.PERSONAL_ASSIGNED ||
-    contextType === InternalFilterContextType.PERSONAL_INBOX
+    contextType === InternalFilterContextType.PERSONAL_INBOX ||
+    contextType === InternalFilterContextType.PERSONAL_CHANNEL
   ) {
     return ['open', 'done', 'trash', 'spam']
   }
@@ -60,6 +61,8 @@ export function getBreadcrumbTitleForContext(contextType: string): string {
     case InternalFilterContextType.PERSONAL_ASSIGNED:
     case InternalFilterContextType.PERSONAL_INBOX:
       return 'Inbox'
+    case InternalFilterContextType.PERSONAL_CHANNEL:
+      return 'Personal'
     case InternalFilterContextType.ALL_INBOXES:
     case InternalFilterContextType.SPECIFIC_INBOX:
     case InternalFilterContextType.TAG:
@@ -136,6 +139,7 @@ export function isPersonalContext(contextType: string): boolean {
   return (
     contextType === InternalFilterContextType.PERSONAL_ASSIGNED ||
     contextType === InternalFilterContextType.PERSONAL_INBOX ||
+    contextType === InternalFilterContextType.PERSONAL_CHANNEL ||
     contextType === InternalFilterContextType.DRAFTS ||
     contextType === InternalFilterContextType.SENT
   )

--- a/apps/web/src/app/(protected)/app/mail/personal/[inboxId]/[status]/[[...threadId]]/page.tsx
+++ b/apps/web/src/app/(protected)/app/mail/personal/[inboxId]/[status]/[[...threadId]]/page.tsx
@@ -1,0 +1,25 @@
+// apps/web/src/app/(protected)/app/mail/personal/[inboxId]/[status]/[[...threadId]]/page.tsx
+
+import { Mailbox } from '../../../../_components/mail-box'
+
+type Props = {
+  params: Promise<{ inboxId: string; status: string; threadId?: string[] }>
+}
+
+/**
+ * Personal-channel inbox view (mail-permissions §11): the owner's connected
+ * mailbox with personal tabs (Open/Done/Trash/Spam). Visibility-scope
+ * guarantees only the owner sees these threads.
+ */
+export default async function PersonalInboxStatusPage({ params }: Props) {
+  const { inboxId, status } = await params
+
+  return (
+    <Mailbox
+      key={`personal-${inboxId}-${status}`}
+      contextType='personal_channel'
+      contextId={inboxId}
+      initialStatusSlug={status}
+    />
+  )
+}

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
@@ -22,6 +22,7 @@ import {
   Plus,
   RefreshCw,
   Shield,
+  UserRound,
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
@@ -41,13 +42,22 @@ interface IntegrationRoutingProps {
   integration: any // Replace with stronger typing when available
   /** Admin, or owner of this personal channel — mutating controls disable otherwise. */
   canManage: boolean
+  /**
+   * Linked inbox is personal (§11): routing is locked — the channel is
+   * permanently bound to its personal inbox (exits: admin claim or delete).
+   */
+  isPersonalChannel?: boolean
 }
 
 /**
  * IntegrationRouting component
  * Manages routing settings for an integration to inbox mapping
  */
-export default function IntegrationRouting({ integration, canManage }: IntegrationRoutingProps) {
+export default function IntegrationRouting({
+  integration,
+  canManage,
+  isPersonalChannel = false,
+}: IntegrationRoutingProps) {
   const router = useRouter()
   const { hasAccess } = useFeatureFlags()
   const [isRemoving, setIsRemoving] = useState(false)
@@ -270,7 +280,11 @@ export default function IntegrationRouting({ integration, canManage }: Integrati
               <div className='group flex items-center justify-between rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
                 <div className='flex items-center gap-3'>
                   <div className='size-8 border bg-muted rounded-lg flex items-center justify-center group-hover:bg-secondary transition-colors overflow-hidden shrink-0'>
-                    <InboxIcon className='size-4' />
+                    {isPersonalChannel ? (
+                      <UserRound className='size-4' />
+                    ) : (
+                      <InboxIcon className='size-4' />
+                    )}
                   </div>
                   <div className='flex flex-col'>
                     {isLoadingConnectedInbox ? (
@@ -279,13 +293,15 @@ export default function IntegrationRouting({ integration, canManage }: Integrati
                       <span className='text-sm font-medium'>{connectedInbox?.displayName}</span>
                     )}
                     <span className='text-xs text-muted-foreground'>
-                      Messages will be routed to this inbox
+                      {isPersonalChannel
+                        ? 'Personal channel — messages always route to this personal inbox'
+                        : 'Messages will be routed to this inbox'}
                     </span>
                   </div>
                 </div>
                 {isLoadingConnectedInbox ? (
                   <Skeleton className='h-7 w-32' />
-                ) : canManage ? (
+                ) : isPersonalChannel ? null : canManage ? (
                   <InboxPicker
                     selected={connectedInboxRecordId ? [connectedInboxRecordId] : []}
                     onChange={handleSelectInbox}
@@ -319,7 +335,8 @@ export default function IntegrationRouting({ integration, canManage }: Integrati
                 </AlertDescription>
               </Alert>
 
-              {canManage ? (
+              {/* A personal channel is always connected — never offer the picker. */}
+              {isPersonalChannel ? null : canManage ? (
                 <InboxPicker selected={[]} onChange={handleSelectInbox}>
                   <Button variant='default' loading={addIntegration.isPending}>
                     Connect to inbox

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-tabs.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-tabs.tsx
@@ -146,7 +146,11 @@ export default function IntegrationTabs() {
           )}
 
           <TabsContent value='routing' className='space-y-4'>
-            <IntegrationRouting integration={integration} canManage={canManage} />
+            <IntegrationRouting
+              integration={integration}
+              canManage={canManage}
+              isPersonalChannel={!!linkedInbox?.isPersonal}
+            />
           </TabsContent>
 
           <TabsContent value='settings' className='space-y-4'>

--- a/apps/web/src/components/global/sidebar/mail-sidebar.tsx
+++ b/apps/web/src/components/global/sidebar/mail-sidebar.tsx
@@ -14,6 +14,7 @@ export function MailSidebar() {
   const {
     isEditMode,
     inboxes,
+    myPersonalInboxes,
     mailViews,
     personalItems,
     inboxesLoading,
@@ -72,6 +73,7 @@ export function MailSidebar() {
               settings={personalItems}
               onUpdateSettings={updatePersonalItems}
               settingsLoading={settingsLoading}
+              personalInboxes={myPersonalInboxes}
             />
             <ViewsSection
               views={mailViews}

--- a/apps/web/src/components/global/sidebar/personal-mail-group.tsx
+++ b/apps/web/src/components/global/sidebar/personal-mail-group.tsx
@@ -1,7 +1,7 @@
 // ~/components/global/sidebar/personal-mail-group.tsx
 'use client'
 
-import { SidebarMenuItem } from '@auxx/ui/components/sidebar'
+import { SidebarMenuItem, SidebarMenuSubItem } from '@auxx/ui/components/sidebar'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import {
   closestCenter,
@@ -19,10 +19,12 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { FileEdit, Inbox as InboxIcon, Send } from 'lucide-react'
+import { FileEdit, Inbox as InboxIcon, Send, UserCheck, UserRound } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
+import { CollapsibleSidebarSection } from '~/components/global/sidebar/collapsible-sidebar-section'
 import { EditableSidebarItem } from '~/components/global/sidebar/editable-sidebar-item'
+import type { Inbox } from '~/components/global/sidebar/shared-inbox-group'
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
 import { useMailCountsStore } from '~/components/mail/store'
 
@@ -41,6 +43,8 @@ interface PersonalMailItemsProps {
   settings?: PersonalMenuItem[]
   onUpdateSettings: (items: PersonalMenuItem[]) => void
   settingsLoading: boolean
+  /** The current user's personal-channel inboxes (§11) — rendered under Inbox. */
+  personalInboxes?: Inbox[]
 }
 
 const DEFAULT_PERSONAL_ITEMS: PersonalMenuItem[] = [
@@ -76,13 +80,23 @@ export function PersonalMailItems({
   settings,
   onUpdateSettings,
   settingsLoading,
+  personalInboxes = [],
 }: PersonalMailItemsProps) {
   const pathname = usePathname()
   const [items, setItems] = useState<PersonalMenuItem[]>(DEFAULT_PERSONAL_ITEMS)
 
   const inboxCount = useMailCountsStore((s) => s.counts.inbox)
   const draftsCount = useMailCountsStore((s) => s.counts.drafts)
+  const sharedInboxCounts = useMailCountsStore((s) => s.counts.sharedInboxes)
   const isInitialLoading = useMailCountsStore((s) => s.isInitialLoading)
+
+  // Personal inbox unread arrives under the same `si:{inboxId}` fields as
+  // shared inboxes; the Inbox header badge rolls up assigned-to-me + personal.
+  const personalUnread = personalInboxes.reduce(
+    (sum, inbox) => sum + (sharedInboxCounts[inbox.id] ?? 0),
+    0
+  )
+  const combinedInboxCount = inboxCount + personalUnread
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -217,6 +231,51 @@ export function PersonalMailItems({
       {visibleItems
         .sort((a, b) => a.order - b.order)
         .map((item) => {
+          // With personal-channel inboxes, Inbox becomes an expandable group:
+          // "Assigned to me" + one row per owned personal inbox. The header
+          // opens the combined stream.
+          if (item.id === 'inbox' && personalInboxes.length > 0) {
+            return (
+              <CollapsibleSidebarSection
+                key={item.id}
+                title={item.name}
+                icon={item.icon}
+                href='/app/mail/inbox/open'
+                isEditMode={false}
+                defaultOpen
+                sectionId='mail.inbox'
+                count={combinedInboxCount}
+                isActive={!!pathname?.startsWith('/app/mail/inbox/')}>
+                <SidebarMenuSubItem>
+                  <SidebarItem
+                    id='assigned'
+                    name='Assigned to me'
+                    href='/app/mail/assigned/open'
+                    icon={<UserCheck className='text-muted-foreground' />}
+                    count={inboxCount}
+                    isSubmenu
+                    isActive={!!pathname?.startsWith('/app/mail/assigned')}
+                    onToggleEditMode={onToggleEditMode}
+                  />
+                </SidebarMenuSubItem>
+                {personalInboxes.map((inbox) => (
+                  <SidebarMenuSubItem key={inbox.id}>
+                    <SidebarItem
+                      id={inbox.id}
+                      name={inbox.name}
+                      href={`/app/mail/personal/${inbox.id}/open`}
+                      icon={<UserRound className='text-muted-foreground' />}
+                      count={sharedInboxCounts[inbox.id] ?? 0}
+                      isSubmenu
+                      isActive={!!pathname?.startsWith(`/app/mail/personal/${inbox.id}`)}
+                      onToggleEditMode={onToggleEditMode}
+                    />
+                  </SidebarMenuSubItem>
+                ))}
+              </CollapsibleSidebarSection>
+            )
+          }
+
           const itemHref = getItemHref(item)
           const isActive =
             pathname === itemHref || pathname?.startsWith(itemHref.replace(/\/open$/, '/'))

--- a/apps/web/src/components/global/sidebar/shared-inbox-group.tsx
+++ b/apps/web/src/components/global/sidebar/shared-inbox-group.tsx
@@ -1,11 +1,9 @@
 // ~/components/global/sidebar/shared-inbox-group.tsx
 'use client'
 
-import { toActorId } from '@auxx/types/actor'
 import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
 import { SidebarMenu, SidebarMenuSubItem } from '@auxx/ui/components/sidebar'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
 import {
   closestCenter,
@@ -24,17 +22,16 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { Inbox as InboxIcon, Mail, UserRound } from 'lucide-react'
+import { Inbox as InboxIcon, Mail } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useDndState } from '~/app/context/dnd-state-context'
 import { CollapsibleSidebarSection } from '~/components/global/sidebar/collapsible-sidebar-section'
 import { EditableSidebarItem } from '~/components/global/sidebar/editable-sidebar-item'
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
 import { InboxDialog } from '~/components/inbox/inbox-dialog'
-import { selectSharedInboxesTotal, useMailCountsStore } from '~/components/mail/store'
-import { useActor } from '~/components/resources/hooks/use-actor'
+import { useMailCountsStore } from '~/components/mail/store'
 
 export interface Inbox {
   id: string
@@ -45,24 +42,6 @@ export interface Inbox {
   /** Personal-account inbox (mail-permissions §11) — renders the owner affordance. */
   isPersonal?: boolean
   ownerUserId?: string | null
-}
-
-/**
- * Sidebar affordance for a personal inbox (§11): a user icon in place of the
- * color dot, with a "Personal — {owner}" tooltip.
- */
-function PersonalInboxIcon({ ownerUserId }: { ownerUserId?: string | null }) {
-  const { actor } = useActor({
-    actorId: ownerUserId ? toActorId('user', ownerUserId) : null,
-  })
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <UserRound className='text-muted-foreground' />
-      </TooltipTrigger>
-      <TooltipContent side='right'>Personal{actor?.name ? ` — ${actor.name}` : ''}</TooltipContent>
-    </Tooltip>
-  )
 }
 
 interface SharedInboxesSectionProps {
@@ -127,7 +106,6 @@ const DroppableInboxSidebarItem = ({
         href={itemHref}
         count={count}
         color={inbox.color || 'indigo'}
-        icon={inbox.isPersonal ? <PersonalInboxIcon ownerUserId={inbox.ownerUserId} /> : undefined}
         isSubmenu={true}
         isActive={isActive}
         editItems={editItems}
@@ -151,7 +129,12 @@ export function SharedInboxesSection({
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
 
   const sharedInboxCounts = useMailCountsStore((s) => s.counts.sharedInboxes)
-  const totalSharedCount = useMailCountsStore(selectSharedInboxesTotal)
+  // Sum over the rendered (shared-only) inboxes — `si:` counts also carry
+  // personal inbox unread, which must not inflate the Shared Inboxes badge.
+  const totalSharedCount = useMemo(
+    () => inboxes.reduce((sum, inbox) => sum + (sharedInboxCounts[inbox.id] ?? 0), 0),
+    [inboxes, sharedInboxCounts]
+  )
 
   const sensors = useSensors(
     useSensor(PointerSensor, {

--- a/apps/web/src/components/mail/store/index.ts
+++ b/apps/web/src/components/mail/store/index.ts
@@ -7,7 +7,6 @@ export {
 export {
   type CountUpdates,
   selectSharedInboxCount,
-  selectSharedInboxesTotal,
   selectViewCount,
   useMailCountsStore,
 } from './mail-counts-store'

--- a/apps/web/src/components/mail/store/mail-counts-store.ts
+++ b/apps/web/src/components/mail/store/mail-counts-store.ts
@@ -223,14 +223,6 @@ export const useMailCountsStore = create<MailCountsState>()(
 // ═══════════════════════════════════════════════════════════════════════════
 
 /**
- * Get total count for all shared inboxes combined.
- * Use this for the "Shared Inboxes" header badge.
- */
-export const selectSharedInboxesTotal = (state: MailCountsState): number => {
-  return Object.values(state.counts.sharedInboxes).reduce((sum, count) => sum + count, 0)
-}
-
-/**
  * Get count for a specific shared inbox.
  */
 export const selectSharedInboxCount = (state: MailCountsState, inboxId: string): number => {

--- a/apps/web/src/components/mail/types.ts
+++ b/apps/web/src/components/mail/types.ts
@@ -19,6 +19,7 @@ export const contextTypes = [
   'specific_inbox',
   'personal_inbox',
   'personal_assigned',
+  'personal_channel',
   'tag',
   'view',
   'drafts',

--- a/apps/web/src/components/pickers/inbox-picker.tsx
+++ b/apps/web/src/components/pickers/inbox-picker.tsx
@@ -53,9 +53,10 @@ export function InboxPicker({
   const isOpen = controlledOpen !== undefined ? controlledOpen : internalOpen
   const setIsOpen = controlledOnOpenChange || setInternalOpen
 
-  // Fetch inboxes if not provided
+  // Fetch inboxes if not provided. Personal inboxes are never valid
+  // routing/move targets (mail-permissions §11) — exclude them everywhere.
   const { inboxes: fetchedInboxes } = useInboxes()
-  const inboxes = externalInboxes || fetchedInboxes || []
+  const inboxes = (externalInboxes || fetchedInboxes || []).filter((inbox) => !inbox.isPersonal)
 
   // Dialog state for creating new inbox
   const [dialogOpen, setDialogOpen] = useState(false)

--- a/apps/web/src/hooks/use-mail-sidebar.tsx
+++ b/apps/web/src/hooks/use-mail-sidebar.tsx
@@ -4,6 +4,7 @@ import type { PersonalMenuItem } from '~/components/global/sidebar/personal-mail
 import type { Inbox } from '~/components/global/sidebar/shared-inbox-group'
 import { useInboxes } from '~/components/threads/hooks'
 import { useSettings } from '~/hooks/use-settings'
+import { useUser } from '~/hooks/use-user'
 import { api } from '~/trpc/react'
 
 export interface UseMailSidebarOptions {
@@ -37,6 +38,8 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
   // Fetch inboxes data using useInboxes hook (reactive to Zustand store updates)
   const { inboxes: rawInboxes, isLoading: inboxesLoading, refresh: refetchInboxes } = useInboxes()
 
+  const { userId } = useUser()
+
   const {
     data: mailViews,
     isLoading: mailViewsLoading,
@@ -46,9 +49,26 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
     refetchOnWindowFocus: !isEditMode,
   })
 
-  // Process inboxes: apply saved order and visibility
+  // My personal-channel inboxes (§11) — rendered under the Inbox group, never
+  // in Shared Inboxes. Other users' personal inboxes appear in nobody's sidebar.
+  const myPersonalInboxes = useMemo(
+    (): Inbox[] =>
+      (rawInboxes ?? [])
+        .filter((inbox) => inbox.isPersonal && inbox.ownerUserId === userId)
+        .map((inbox) => ({
+          id: inbox.id,
+          name: inbox.name,
+          color: inbox.color ?? 'indigo',
+          isPersonal: true,
+          ownerUserId: inbox.ownerUserId,
+        })),
+    [rawInboxes, userId]
+  )
+
+  // Process shared inboxes: apply saved order and visibility
   const processedInboxes = useMemo((): Inbox[] => {
-    if (!rawInboxes || rawInboxes.length === 0) return []
+    const sharedRawInboxes = (rawInboxes ?? []).filter((inbox) => !inbox.isPersonal)
+    if (sharedRawInboxes.length === 0) return []
 
     // 1. Get saved order and visibility settings
     const inboxOrder = (getSetting(INBOX_ORDER_SETTING_KEY) as string[]) || []
@@ -56,7 +76,7 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
       (getSetting(INBOX_VISIBILITY_SETTING_KEY) as Record<string, boolean>) || {}
 
     // 2. Create a map for quick lookup
-    const inboxMap = new Map(rawInboxes.map((inbox) => [inbox.id, inbox]))
+    const inboxMap = new Map(sharedRawInboxes.map((inbox) => [inbox.id, inbox]))
 
     // 3. Create the sorted list based on saved order
     const sortedInboxes: Inbox[] = []
@@ -78,7 +98,7 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
     })
 
     // 4. Append any inboxes not present in the saved order
-    rawInboxes.forEach((inbox) => {
+    sharedRawInboxes.forEach((inbox) => {
       if (!processedIds.has(inbox.id)) {
         sortedInboxes.push({
           id: inbox.id,
@@ -234,6 +254,7 @@ export function useMailSidebar({ scope = 'SIDEBAR' }: UseMailSidebarOptions = {}
   return {
     isEditMode,
     inboxes: processedInboxes,
+    myPersonalInboxes,
     personalItems,
     inboxesLoading,
     settingsLoading,

--- a/apps/web/src/server/api/routers/inbox.ts
+++ b/apps/web/src/server/api/routers/inbox.ts
@@ -184,6 +184,23 @@ export const inboxRouter = createTRPCRouter({
 
     await requireInboxManageAccess(inboxService, input.recordId, userId)
 
+    // Personal channels are permanently bound to their personal inbox (§11):
+    // the only sanctioned exits are admin claim or delete, and nothing routes
+    // INTO a personal inbox via this endpoint (provisioning links internally).
+    const [targetInbox, currentInbox] = await Promise.all([
+      inboxService.getInbox(input.recordId),
+      inboxService.getIntegrationInbox(input.integrationId),
+    ])
+    if (currentInbox?.isPersonal) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Personal channels cannot be re-routed' })
+    }
+    if (targetInbox?.isPersonal) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Channels cannot be routed into a personal inbox',
+      })
+    }
+
     const result = await inboxService.addIntegration(
       input.recordId,
       input.integrationId,
@@ -246,6 +263,18 @@ export const inboxRouter = createTRPCRouter({
       const inboxService = new InboxService(ctx.db, organizationId, userId)
       await requireInboxManageAccess(inboxService, input.fromInboxRecordId, userId)
       await requireInboxManageAccess(inboxService, input.toInboxRecordId, userId)
+
+      // Threads may not be moved into or out of a personal inbox (§11 isolation).
+      const [fromInbox, toInbox] = await Promise.all([
+        inboxService.getInbox(input.fromInboxRecordId),
+        inboxService.getInbox(input.toInboxRecordId),
+      ])
+      if (fromInbox?.isPersonal || toInbox?.isPersonal) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Conversations cannot be moved into or out of a personal inbox',
+        })
+      }
 
       const viewer = await getCachedUserMailVisibility(userId, organizationId)
       const threadMutation = new ThreadMutationService(

--- a/packages/lib/src/inboxes/inbox-service.ts
+++ b/packages/lib/src/inboxes/inbox-service.ts
@@ -257,6 +257,17 @@ export class InboxService {
   // ═══════════════════════════════════════════════════════════════════════════
 
   /**
+   * The inbox an integration currently routes to, if any.
+   */
+  async getIntegrationInbox(integrationId: string): Promise<Inbox | null> {
+    const link = await this.db.query.InboxIntegration.findFirst({
+      where: eq(schema.InboxIntegration.integrationId, integrationId),
+    })
+    if (!link) return null
+    return this.getInboxById(link.inboxId)
+  }
+
+  /**
    * Add an integration to an inbox
    */
   async addIntegration(

--- a/packages/lib/src/mail-query/client.ts
+++ b/packages/lib/src/mail-query/client.ts
@@ -12,6 +12,7 @@ import { getInstanceId, isRecordId, type RecordId } from '@auxx/types/resource'
 // Context to conditions converter
 export {
   buildConditionGroups,
+  buildContextConditionGroups,
   buildContextConditions,
   type ContextConditionParams,
 } from './context-to-conditions'

--- a/packages/lib/src/mail-query/context-to-conditions.ts
+++ b/packages/lib/src/mail-query/context-to-conditions.ts
@@ -11,6 +11,12 @@ export interface ContextConditionParams {
   contextId?: string
   statusSlug?: string
   userId?: string
+  /**
+   * The caller's own personal inbox ids (mail-permissions §11). When set for
+   * `personal_inbox`, the context becomes the combined stream: threads
+   * assigned to me OR in one of my personal inboxes.
+   */
+  personalInboxIds?: string[]
 }
 
 /**
@@ -55,7 +61,10 @@ export function buildContextConditions(params: ContextConditionParams): Conditio
       break
 
     case 'specific_inbox':
-      // Specific inbox filters by inbox ID
+    case 'personal_channel':
+      // Specific/personal inbox filters by inbox ID. The personal semantics
+      // (owner-only threads, personal tabs) come from visibility-scope and
+      // the route's tab set, not from extra conditions.
       if (params.contextId) {
         conditions.push({
           id: 'ctx-inbox',
@@ -205,6 +214,43 @@ export function buildContextConditions(params: ContextConditionParams): Conditio
 }
 
 /**
+ * Build all context groups for the given params.
+ *
+ * Normally a single AND group (identical to {@link buildContextConditions}).
+ * For `personal_inbox` with `personalInboxIds`, the identity filter moves into
+ * its own OR group — "assigned to me OR in one of my personal inboxes" —
+ * while status conditions stay in the AND group; the query builder ANDs the
+ * groups together.
+ */
+export function buildContextConditionGroups(params: ContextConditionParams): ConditionGroup[] {
+  const contextGroup = buildContextConditions(params)
+
+  const { contextType, userId, personalInboxIds } = params
+  if (contextType === 'personal_inbox' && userId && personalInboxIds?.length) {
+    // The assignee condition becomes one arm of the identity OR group.
+    contextGroup.conditions = contextGroup.conditions.filter((c) => c.id !== 'ctx-assignee')
+    return [
+      {
+        id: 'context-identity',
+        logicalOperator: 'OR',
+        conditions: [
+          { id: 'ctx-assignee', fieldId: 'assignee', operator: 'is', value: userId },
+          {
+            id: 'ctx-personal-inbox',
+            fieldId: 'inbox',
+            operator: 'in',
+            value: personalInboxIds,
+          },
+        ],
+      },
+      contextGroup,
+    ]
+  }
+
+  return [contextGroup]
+}
+
+/**
  * Build condition groups from context + search conditions.
  *
  * Combines context conditions (from URL routing) with search conditions (from searchbar)
@@ -252,17 +298,23 @@ export function buildConditionGroups(
       ],
     })
   } else {
-    // Build context group, but remove conditions whose fieldId
+    // Build context groups, but remove conditions whose fieldId
     // is overridden by a search condition
-    const contextGroup = buildContextConditions(contextParams)
-    if (realSearchConditions?.length) {
-      const searchFieldIds = new Set(realSearchConditions.map((c) => c.fieldId))
-      contextGroup.conditions = contextGroup.conditions.filter(
-        (c) => !searchFieldIds.has(c.fieldId)
-      )
-    }
-    if (contextGroup.conditions.length > 0) {
-      groups.push(contextGroup)
+    const contextGroups = buildContextConditionGroups(contextParams)
+    const searchFieldIds = new Set(realSearchConditions?.map((c) => c.fieldId) ?? [])
+    for (const group of contextGroups) {
+      if (group.id === 'context-identity') {
+        // The identity OR group is all-or-nothing: removing one arm would
+        // widen results, so a search on either identity field drops it whole.
+        if (searchFieldIds.has('assignee') || searchFieldIds.has('inbox')) {
+          group.conditions = []
+        }
+      } else if (searchFieldIds.size > 0) {
+        group.conditions = group.conditions.filter((c) => !searchFieldIds.has(c.fieldId))
+      }
+      if (group.conditions.length > 0) {
+        groups.push(group)
+      }
     }
   }
 

--- a/packages/lib/src/mail-query/index.ts
+++ b/packages/lib/src/mail-query/index.ts
@@ -11,6 +11,7 @@ export {
 // Context to conditions converter (frontend-safe)
 export {
   buildConditionGroups,
+  buildContextConditionGroups,
   buildContextConditions,
   type ContextConditionParams,
 } from './context-to-conditions'

--- a/packages/lib/src/mail-query/types.ts
+++ b/packages/lib/src/mail-query/types.ts
@@ -11,6 +11,7 @@ export enum InternalFilterContextType {
   VIEW = 'view', // Context: /mail/views/[viewId]/* - Uses ConditionGroup[] definition
   ALL_INBOXES = 'all_inboxes', // Context: /mail/inboxes/all/* - Org-wide view (respects user access if needed later)
   SPECIFIC_INBOX = 'specific_inbox', // Context: /mail/inboxes/[inboxId]/* - Shared inbox view
+  PERSONAL_CHANNEL = 'personal_channel', // Context: /mail/personal/[inboxId]/* - Owner's personal inbox (§11), personal tabs
   DRAFTS = 'drafts', // Standalone view: /mail/drafts - User's drafts (needs specific logic)
   SENT = 'sent', // Standalone view: /mail/sent - User's sent items (needs specific logic)
   ALL = 'all', // Standalone view: /mail/all - All messages


### PR DESCRIPTION
## Summary
- Widen the Inbox context to a combined stream: threads assigned to me OR in one of my owned personal inboxes, via a new OR condition group (`buildContextConditionGroups`).
- Add `/app/mail/personal/[inboxId]/[status]` route rendering the owner's personal-channel inbox with personal tabs (Open/Done/Trash/Spam).
- Sidebar: Inbox becomes an expandable group ("Assigned to me" + one row per owned personal inbox); Shared Inboxes total no longer double-counts personal inbox unread.
- Enforce personal-inbox isolation (§11): channel routing endpoint rejects re-routing a personal channel or routing into one; thread-move endpoint rejects moves into/out of a personal inbox; `InboxPicker` excludes personal inboxes as targets everywhere.
- Settings → channel routing UI shows a locked "Personal channel" state (no picker) when the linked inbox is personal.

## Test plan
- [ ] Verify Inbox sidebar group shows "Assigned to me" + personal inbox rows, with correct unread counts and no double-counting against Shared Inboxes
- [ ] Open `/app/mail/personal/[inboxId]/open` for an owned personal inbox and confirm thread list + personal tabs render
- [ ] Confirm the combined Inbox view (assigned to me OR personal inbox) returns the expected threads
- [ ] Attempt to move a thread into/out of a personal inbox via API — expect `BAD_REQUEST`
- [ ] Attempt to re-route a personal channel's integration, and to route a channel into a personal inbox — expect `BAD_REQUEST`
- [ ] Confirm `InboxPicker` (move/connect flows) never lists personal inboxes
- [ ] Settings → Channels → routing tab for a personal channel shows locked state with no inbox picker