### PR TITLE
fix(mail): keyboard shortcuts target the open thread in detail view

### DIFF
--- a/apps/web/src/components/mail/thread-header.tsx
+++ b/apps/web/src/components/mail/thread-header.tsx
@@ -14,6 +14,8 @@ import {
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
+import { cn } from '@auxx/ui/lib/utils'
+import { useHotkey } from '@tanstack/react-hotkeys'
 import {
   Archive,
   ArchiveRestore,
@@ -29,12 +31,17 @@ import {
   Zap,
 } from 'lucide-react'
 import Link from 'next/link'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useChannel } from '~/components/channels/hooks/use-channels'
 import { RecordPicker } from '~/components/pickers/record-picker'
 import { useActor, useResource } from '~/components/resources/hooks'
 import { useThreadTags } from '~/components/tags/hooks/use-thread-tags'
 import { useInbox, useThread, useThreadMutation } from '~/components/threads/hooks'
+import {
+  useHasMultipleSelected,
+  useThreadSelectionStore,
+  useViewMode,
+} from '~/components/threads/store/thread-selection-store'
 import { ManualTriggerButton } from '~/components/workflow/manual-trigger-button'
 import { useConfirm } from '~/hooks/use-confirm'
 import { EditableText } from '../editor/editable-text'
@@ -98,6 +105,33 @@ export function ThreadHeader() {
   // Local state for tag popover
   const [open, setOpen] = useState(false)
   const tagButtonRef = useRef<HTMLButtonElement>(null)
+
+  // Local state for assign popover (controlled so the A hotkey can open it,
+  // anchored to the header's assign button instead of a hidden list row).
+  const [assignOpen, setAssignOpen] = useState(false)
+
+  // --- Detail-view action shortcuts (A/L) ---
+  // While this header is mounted it owns the anchored A/L shortcuts; the list
+  // hook yields (see useFocusedThreadShortcuts) so their popovers anchor here.
+  const hasMultipleSelected = useHasMultipleSelected()
+  const viewMode = useViewMode()
+  const setDetailHeaderThreadId = useThreadSelectionStore((s) => s.setDetailHeaderThreadId)
+
+  useEffect(() => {
+    setDetailHeaderThreadId(threadId)
+    return () => setDetailHeaderThreadId(null)
+  }, [threadId, setDetailHeaderThreadId])
+
+  const shortcutsEnabled = !!thread && !hasMultipleSelected && viewMode !== 'edit'
+
+  // A — Open assign picker (anchored to the header's assign button)
+  useHotkey('A', () => setAssignOpen(true), {
+    enabled: shortcutsEnabled,
+    conflictBehavior: 'allow',
+  })
+
+  // L — Open tag picker (anchored to the header's tag button)
+  useHotkey('L', () => setOpen(true), { enabled: shortcutsEnabled, conflictBehavior: 'allow' })
 
   // --- Handlers ---
 
@@ -301,7 +335,12 @@ export function ThreadHeader() {
                   size='icon'
                   disabled={!thread}
                   onClick={isSpam ? handleRestore : handleMarkSpam}
-                  className='rounded-full hover:bg-foreground/10'>
+                  className={cn(
+                    'rounded-full',
+                    isSpam
+                      ? 'bg-destructive text-white hover:bg-destructive/90 hover:text-white'
+                      : 'hover:bg-foreground/10'
+                  )}>
                   {isSpam ? <MailCheck /> : <MailWarning />}
                   <span className='sr-only'>{isSpam ? 'Not spam' : 'Mark as spam'}</span>
                 </Button>
@@ -349,6 +388,8 @@ export function ThreadHeader() {
 
             <ActorPicker
               key={`assignee-${thread.id}`}
+              open={assignOpen}
+              onOpenChange={setAssignOpen}
               value={assigneeValue}
               onChange={handleAssigneeChange}
               multi={false}

--- a/apps/web/src/components/threads/hooks/use-focused-thread-shortcuts.ts
+++ b/apps/web/src/components/threads/hooks/use-focused-thread-shortcuts.ts
@@ -7,9 +7,11 @@ import {
   useActiveThreadId,
   useFocusedThreadId,
   useHasMultipleSelected,
+  useIsDetailOpen,
   useThreadSelectionStore,
   useViewMode,
 } from '../store/thread-selection-store'
+import { getThreadStoreState } from '../store/thread-store'
 import { useThreadMutation } from './use-thread-mutation'
 
 /**
@@ -21,9 +23,9 @@ import { useThreadMutation } from './use-thread-mutation'
 export function useFocusedThreadShortcuts() {
   const focusedThreadId = useFocusedThreadId()
   const activeThreadId = useActiveThreadId()
-  const targetThreadId = focusedThreadId ?? activeThreadId
   const hasMultipleSelected = useHasMultipleSelected()
   const viewMode = useViewMode()
+  const isDetailOpen = useIsDetailOpen()
   const { update, isUpdating } = useThreadMutation()
 
   const isFocusLocked = useThreadSelectionStore((s) => s.isFocusLocked)
@@ -32,13 +34,25 @@ export function useFocusedThreadShortcuts() {
   const [workflowDialogOpen, setWorkflowDialogOpen] = useState(false)
   const [workflowThreadId, setWorkflowThreadId] = useState<string | null>(null)
 
-  const enabled = !!targetThreadId && !hasMultipleSelected && viewMode !== 'edit'
-  const actionsEnabled = enabled && !isFocusLocked
+  // When a thread detail is open, act on the OPEN thread (activeThreadId) and
+  // ignore the list hover cursor (focusedThreadId) — the cursor is a list-only
+  // concept and is often stale in split/detail view, which would otherwise make
+  // shortcuts hit the wrong thread. When browsing the list, prefer the cursor.
+  const targetThreadId = isDetailOpen ? activeThreadId : (focusedThreadId ?? activeThreadId)
 
-  // Advance to the next thread after a destructive action.
-  // In list/compact view (focusedThreadId set), move the focus cursor.
-  // In split view (only activeThreadId set), move the active thread so the
-  // next one auto-opens via the URL sync.
+  const enabled = !!targetThreadId && !hasMultipleSelected && viewMode !== 'edit'
+  // isFocusLocked freezes the list hover cursor while a row-anchored popover is
+  // open. It's a list-only concern — never gate the detail path on it (a stuck
+  // lock must not disable the open thread's shortcuts).
+  const actionsEnabled = enabled && (isDetailOpen || !isFocusLocked)
+  // A/L open anchored popovers tied to the list row. When a thread detail is
+  // open, its header owns these shortcuts instead so the popover anchors to a
+  // visible header button rather than the hidden/absent list row.
+  const anchoredActionsEnabled = actionsEnabled && !isDetailOpen
+
+  // Advance the list cursor to the next thread after a destructive action.
+  // Only used when browsing the list — in the detail view we stay on the thread
+  // so the same key can reverse the action.
   const advanceFocus = useCallback(() => {
     const store = useThreadSelectionStore.getState()
     const { listThreadIds, focusedThreadId: currentFocused, activeThreadId: currentActive } = store
@@ -53,41 +67,36 @@ export function useFocusedThreadShortcuts() {
     }
   }, [])
 
-  // D — Archive
-  useHotkey(
-    'D',
-    () => {
-      if (targetThreadId && !isUpdating) {
-        update(targetThreadId, { status: 'ARCHIVED' })
-        advanceFocus()
-      }
+  // Toggle a status: pressing the key on a thread already in that state restores
+  // it to OPEN (so `!` un-spams, `D` un-archives, etc). In the detail view we
+  // stay on the thread; when browsing the list we advance the cursor for triage.
+  const toggleStatus = useCallback(
+    (status: 'ARCHIVED' | 'TRASH' | 'SPAM') => {
+      if (!targetThreadId || isUpdating) return
+      const current = getThreadStoreState().getThread(targetThreadId)?.status
+      update(targetThreadId, { status: current === status ? 'OPEN' : status })
+      if (!isDetailOpen) advanceFocus()
     },
-    { enabled: actionsEnabled, conflictBehavior: 'allow' }
+    [targetThreadId, isUpdating, update, advanceFocus, isDetailOpen]
   )
 
-  // Shift+3 (#) — Trash
-  useHotkey(
-    'Shift+3',
-    () => {
-      if (targetThreadId && !isUpdating) {
-        update(targetThreadId, { status: 'TRASH' })
-        advanceFocus()
-      }
-    },
-    { enabled: actionsEnabled, conflictBehavior: 'allow' }
-  )
+  // D — Archive / unarchive
+  useHotkey('D', () => toggleStatus('ARCHIVED'), {
+    enabled: actionsEnabled,
+    conflictBehavior: 'allow',
+  })
 
-  // Shift+1 (!) — Spam
-  useHotkey(
-    'Shift+1',
-    () => {
-      if (targetThreadId && !isUpdating) {
-        update(targetThreadId, { status: 'SPAM' })
-        advanceFocus()
-      }
-    },
-    { enabled: actionsEnabled, conflictBehavior: 'allow' }
-  )
+  // Shift+3 (#) — Trash / restore
+  useHotkey('Shift+3', () => toggleStatus('TRASH'), {
+    enabled: actionsEnabled,
+    conflictBehavior: 'allow',
+  })
+
+  // Shift+1 (!) — Spam / not spam
+  useHotkey('Shift+1', () => toggleStatus('SPAM'), {
+    enabled: actionsEnabled,
+    conflictBehavior: 'allow',
+  })
 
   // W — Open workflow dialog
   useHotkey(
@@ -123,7 +132,7 @@ export function useFocusedThreadShortcuts() {
         setFocusLocked(true)
       }
     },
-    { enabled: actionsEnabled, conflictBehavior: 'allow' }
+    { enabled: anchoredActionsEnabled, conflictBehavior: 'allow' }
   )
 
   const handleAssignPickerOpenChange = useCallback(
@@ -157,7 +166,7 @@ export function useFocusedThreadShortcuts() {
         setFocusLocked(true)
       }
     },
-    { enabled: actionsEnabled, conflictBehavior: 'allow' }
+    { enabled: anchoredActionsEnabled, conflictBehavior: 'allow' }
   )
 
   const handleTagPickerOpenChange = useCallback(

--- a/apps/web/src/components/threads/store/thread-selection-store.ts
+++ b/apps/web/src/components/threads/store/thread-selection-store.ts
@@ -21,12 +21,19 @@ interface ThreadSelectionState {
   focusedThreadId: string | null
   /** When true, setFocusedThread calls are no-ops (used while popovers are anchored to a row) */
   isFocusLocked: boolean
+  /**
+   * Thread ID whose detail header is currently mounted. When set, the detail
+   * header owns the anchored action shortcuts (A/L) so their popovers anchor to
+   * the header's visible buttons instead of the (hidden/absent) list row.
+   */
+  detailHeaderThreadId: string | null
   viewMode: ViewMode
 
   setActiveThread: (id: string | null) => void
   setSelectionAnchor: (id: string | null) => void
   setFocusedThread: (id: string | null) => void
   setFocusLocked: (locked: boolean) => void
+  setDetailHeaderThreadId: (id: string | null) => void
   setSelectedThreads: (ids: string[]) => void
   addToSelection: (id: string) => void
   removeFromSelection: (id: string) => void
@@ -48,6 +55,7 @@ const initialState = {
   listThreadIds: [] as string[],
   focusedThreadId: null as string | null,
   isFocusLocked: false,
+  detailHeaderThreadId: null as string | null,
   viewMode: 'view' as ViewMode,
 }
 
@@ -70,6 +78,8 @@ export const useThreadSelectionStore = create<ThreadSelectionState>((set, get) =
   },
 
   setFocusLocked: (locked) => set({ isFocusLocked: locked }),
+
+  setDetailHeaderThreadId: (id) => set({ detailHeaderThreadId: id }),
 
   setSelectedThreads: (ids) => set({ selectedThreadIds: ids }),
 
@@ -178,6 +188,12 @@ export const useListThreadIds = () => useThreadSelectionStore((s) => s.listThrea
  * Returns the focused thread ID (keyboard cursor in compact view).
  */
 export const useFocusedThreadId = () => useThreadSelectionStore((s) => s.focusedThreadId)
+
+/**
+ * Returns whether a thread detail header is currently mounted (detail view open).
+ * When true, the detail header owns the anchored action shortcuts (A/L).
+ */
+export const useIsDetailOpen = () => useThreadSelectionStore((s) => s.detailHeaderThreadId !== null)
 
 /**
  * Returns the selected thread IDs array.


### PR DESCRIPTION
## Problem

In the mail detail view (split and list-detail), keyboard shortcuts were unreliable and mis-targeted:

- **Assign/tag popovers landed in the top-left corner** — `A`/`L` anchored to the thread's list row (`#thread-{id}`), which in detail view is hidden (zero rect) or absent (null).
- **`D` archived a different message** — shortcuts resolved their target as `focusedThreadId ?? activeThreadId`; the list hover cursor (`focusedThreadId`) is often stale in split/detail view, so actions hit the wrong thread.
- **Shortcuts "only worked sometimes"** — they were gated by `isFocusLocked` (a list-hover concern); when it stuck, all action shortcuts silently died.
- **Couldn't undo a spam from the keyboard** — `D`/`#`/`!` were one-way (always set ARCHIVED/TRASH/SPAM), only the header buttons toggled.

## Changes

- **Detail header owns `A`/`L`** via a new `detailHeaderThreadId` store flag, so the popovers anchor to the header's visible buttons.
- **Target the open thread** (`activeThreadId`) when a detail is open; ignore the stale list cursor.
- **Never gate the detail path on `isFocusLocked`** so a stuck lock can't disable shortcuts.
- **`D`/`#`/`!` now toggle** status (so `!` un-spams, `D` un-archives). In detail view they **stay on the thread** so the same key reverses the action; when browsing the list they advance the cursor for triage.
- **Spam button** in the thread header now shows a `bg-destructive` state with a white icon while the thread is spam.

## Verification

Driven end-to-end in the running app:
- Assign/tag popovers now anchor under the header buttons in both split and list-detail modes.
- `!` on the open thread → `thread.update {status: SPAM}` on the correct id, detail stays put; `!` again → `{status: OPEN}` (undo).

Files:
- `apps/web/src/components/threads/store/thread-selection-store.ts`
- `apps/web/src/components/threads/hooks/use-focused-thread-shortcuts.ts`
- `apps/web/src/components/mail/thread-header.tsx`