### PR TITLE
feat(mail): personal-inbox Gmail parity — label status, names, Sent group, thread contact

### DIFF
--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -306,7 +306,7 @@ function MailboxInner({
   const activeStatusSlug = deriveActiveStatusSlug(pathname, initialStatusSlug)
 
   // Get display configuration for this mailbox context
-  const displayTabs = getDisplayTabsForContext(contextType)
+  const displayTabs = getDisplayTabsForContext(contextType, activeStatusSlug)
   const breadcrumbTitle = getBreadcrumbTitleForContext(contextType)
 
   // Build the unified filter using condition groups

--- a/apps/web/src/app/(protected)/app/mail/_utils/mailbox-utils.ts
+++ b/apps/web/src/app/(protected)/app/mail/_utils/mailbox-utils.ts
@@ -13,11 +13,17 @@ export interface MailboxDisplayConfig {
 /**
  * Determines which status tabs to display based on the contextType
  * @param contextType - The mailbox context type
+ * @param statusSlug - The active status slug (a `sent` view is tabless, mirroring the global Sent view)
  * @returns Array of StatusSlug values to display as tabs
  */
-export function getDisplayTabsForContext(contextType: string): StatusSlug[] {
-  // Contexts without standard status tabs
+export function getDisplayTabsForContext(
+  contextType: string,
+  statusSlug?: StatusSlug
+): StatusSlug[] {
+  // Contexts without standard status tabs. A personal `/sent` sub-route reuses
+  // the personal_channel context but should render tabless like global Sent.
   if (
+    statusSlug === 'sent' ||
     contextType === InternalFilterContextType.DRAFTS ||
     contextType === InternalFilterContextType.SENT
   ) {

--- a/apps/web/src/components/global/sidebar/personal-mail-group.tsx
+++ b/apps/web/src/components/global/sidebar/personal-mail-group.tsx
@@ -267,7 +267,45 @@ export function PersonalMailItems({
                       icon={<UserRound className='text-muted-foreground' />}
                       count={sharedInboxCounts[inbox.id] ?? 0}
                       isSubmenu
-                      isActive={!!pathname?.startsWith(`/app/mail/personal/${inbox.id}`)}
+                      isActive={
+                        !!pathname?.startsWith(`/app/mail/personal/${inbox.id}`) &&
+                        !pathname?.startsWith(`/app/mail/personal/${inbox.id}/sent`)
+                      }
+                      onToggleEditMode={onToggleEditMode}
+                    />
+                  </SidebarMenuSubItem>
+                ))}
+              </CollapsibleSidebarSection>
+            )
+          }
+
+          // Sent mirrors the Inbox group: header opens the combined sent stream,
+          // children are one row per owned personal inbox → that address's sent
+          // mail. Sent has no unread badge, so no counts. Flat when the user
+          // owns no personal inboxes (falls through to the default item below).
+          if (item.id === 'sent' && personalInboxes.length > 0) {
+            return (
+              <CollapsibleSidebarSection
+                key={item.id}
+                title={item.name}
+                icon={item.icon}
+                href='/app/mail/sent'
+                isEditMode={false}
+                sectionId='mail.sent'
+                isActive={
+                  pathname === '/app/mail/sent' ||
+                  (!!pathname?.startsWith('/app/mail/sent') &&
+                    !pathname?.startsWith('/app/mail/personal/'))
+                }>
+                {personalInboxes.map((inbox) => (
+                  <SidebarMenuSubItem key={inbox.id}>
+                    <SidebarItem
+                      id={`${inbox.id}-sent`}
+                      name={inbox.name}
+                      href={`/app/mail/personal/${inbox.id}/sent`}
+                      icon={<UserRound className='text-muted-foreground' />}
+                      isSubmenu
+                      isActive={!!pathname?.startsWith(`/app/mail/personal/${inbox.id}/sent`)}
                       onToggleEditMode={onToggleEditMode}
                     />
                   </SidebarMenuSubItem>

--- a/apps/web/src/components/mail/chat-message-display.tsx
+++ b/apps/web/src/components/mail/chat-message-display.tsx
@@ -22,6 +22,7 @@ import { AttachmentDisplay } from '../files/utils/attachment-display'
 import { Tooltip } from '../global/tooltip'
 import type { EmailActions } from './email-actions'
 import { SendStatusIndicator } from './send-status-indicator'
+import { initialsFor } from './utils/participant-initials'
 
 export type ChatGroupPosition = 'solo' | 'first' | 'middle' | 'last'
 
@@ -74,7 +75,7 @@ const ChatMessageDisplay = ({
 
   const isInbound = message.isInbound
   const senderName = sender?.displayName ?? 'Unknown'
-  const senderInitials = sender?.initials ?? senderName.charAt(0).toUpperCase()
+  const senderInitials = initialsFor(sender)
   const content = message.textPlain ?? message.snippet ?? ''
 
   // Read-only seam: an empty `messageActions` (e.g. the palette's

--- a/apps/web/src/components/mail/email-display.tsx
+++ b/apps/web/src/components/mail/email-display.tsx
@@ -47,6 +47,7 @@ import type { MessageType } from './email-editor/types'
 import { useHtmlBody } from './hooks/use-html-body'
 import { ParticipantList, type ParticipantListEntry } from './participant-display'
 import { SendStatusIndicator } from './send-status-indicator'
+import { initialsFor } from './utils/participant-initials'
 import { resolveInlineEmailHtml } from './utils/resolve-inline-email-html'
 import { SandboxedEmailHtml } from './utils/sandboxed-email-html'
 import { toEditorMessage } from './utils/to-editor-message'
@@ -222,7 +223,7 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
   }
 
   const isMe = !message.isInbound
-  const senderInitials = from?.displayName?.charAt(0)?.toUpperCase() ?? '?'
+  const senderInitials = initialsFor(from)
 
   // Read-only seam: a populated `messageActions` always carries `onReply`. When
   // it's empty (e.g. the palette's ReadOnlyThreadProvider) hide every action

--- a/apps/web/src/components/mail/hooks/index.ts
+++ b/apps/web/src/components/mail/hooks/index.ts
@@ -6,3 +6,4 @@ export {
   type ViewDefinition,
 } from './use-count-updates'
 export { useHtmlBody } from './use-html-body'
+export { type ThreadCounterparty, useThreadCounterparty } from './use-thread-counterparty'

--- a/apps/web/src/components/mail/hooks/use-thread-counterparty.ts
+++ b/apps/web/src/components/mail/hooks/use-thread-counterparty.ts
@@ -1,0 +1,71 @@
+// apps/web/src/components/mail/hooks/use-thread-counterparty.ts
+
+import { groupParticipantsByRole } from '@auxx/types'
+import { useMemo } from 'react'
+import { useMessages, useParticipants } from '~/components/threads/hooks'
+import type { ParticipantMeta } from '~/components/threads/store'
+
+export interface ThreadCounterparty {
+  /** Earliest external participant across the thread (FROM before TO/CC). */
+  primary: ParticipantMeta | null
+  /** Remaining external participants, in first-seen order (deduped). */
+  others: ParticipantMeta[]
+  /** FROM of the first message — used when the thread is internal-only. */
+  fallback: ParticipantMeta | null
+  isLoading: boolean
+}
+
+/**
+ * Resolve a thread's counterparty (the external person the org is talking to),
+ * so owner-initiated threads show the recipient instead of the owner.
+ *
+ * Collects participant ids in message order (FROM first, then TO, then CC),
+ * resolves them through the participant store, and returns the earliest
+ * external as `primary` with the rest as `others`. Internal-only threads fall
+ * back to the first message's FROM (today's behavior). No extra network call —
+ * reads the messages already loaded for the open thread.
+ */
+export function useThreadCounterparty(threadId: string): ThreadCounterparty {
+  const { messages, isLoading } = useMessages({ threadId })
+
+  const orderedIds = useMemo(() => {
+    const ids: string[] = []
+    const seen = new Set<string>()
+    const push = (id: string | null) => {
+      if (id && !seen.has(id)) {
+        seen.add(id)
+        ids.push(id)
+      }
+    }
+    for (const msg of messages) {
+      const grouped = groupParticipantsByRole(msg.participants)
+      push(grouped.from)
+      for (const id of grouped.to) push(id)
+      for (const id of grouped.cc) push(id)
+    }
+    return ids
+  }, [messages])
+
+  const participantMap = useParticipants(orderedIds)
+
+  const fallbackId = useMemo(() => {
+    const first = messages[0]
+    return first ? groupParticipantsByRole(first.participants).from : null
+  }, [messages])
+
+  return useMemo(() => {
+    const resolved = orderedIds
+      .map((id) => participantMap.get(id))
+      .filter((p): p is ParticipantMeta => p !== undefined)
+    const externals = resolved.filter((p) => !p.isInternal)
+    const fallback =
+      (fallbackId ? participantMap.get(fallbackId) : undefined) ?? resolved[0] ?? null
+
+    return {
+      primary: externals[0] ?? null,
+      others: externals.slice(1),
+      fallback,
+      isLoading,
+    }
+  }, [orderedIds, participantMap, fallbackId, isLoading])
+}

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -224,9 +224,11 @@ export const MailThreadItem = memo(function MailThreadItem({
   })
   // Below `full`, latestMessageId is redacted to null — fall back to the
   // thread-level envelope participants (metadata tier, present at every lens).
-  const { from: senderParticipant } = useMessageParticipants(
-    latestMessage?.participants ?? thread?.participants ?? []
-  )
+  const {
+    from: senderParticipant,
+    to: toParticipants,
+    cc: ccParticipants,
+  } = useMessageParticipants(latestMessage?.participants ?? thread?.participants ?? [])
   const { isUnread: readStatusUnread, markAsRead } = useThreadReadStatus(threadId)
 
   // Redacted rendering (mail-permissions): below `full` the row never looks
@@ -342,7 +344,18 @@ export const MailThreadItem = memo(function MailThreadItem({
       : ''
   }, [thread?.lastMessageAt])
 
-  const senderName = senderParticipant?.displayName ?? 'Unknown'
+  // Show the counterparty, not the owner: when the latest message's FROM is
+  // internal (owner-sent thread), display the first external recipient instead.
+  // Only the latest message is loaded here — no per-row messages fetch — so we
+  // scan its FROM/TO/CC and keep FROM when the thread is internal-only.
+  const displaySender = useMemo(() => {
+    if (senderParticipant && !senderParticipant.isInternal) return senderParticipant
+    const external = [senderParticipant, ...toParticipants, ...ccParticipants].find(
+      (p) => p && !p.isInternal
+    )
+    return external ?? senderParticipant ?? null
+  }, [senderParticipant, toParticipants, ccParticipants])
+  const senderName = displaySender?.displayName ?? 'Unknown'
 
   const snippet = useMemo(() => {
     if (typeof window !== 'undefined' && latestMessage?.snippet) {

--- a/apps/web/src/components/mail/message-display.tsx
+++ b/apps/web/src/components/mail/message-display.tsx
@@ -38,6 +38,7 @@ import { Tooltip } from '../global/tooltip'
 import type { EmailActions } from './email-actions'
 import { useHtmlBody } from './hooks/use-html-body'
 import { SendStatusIndicator } from './send-status-indicator'
+import { initialsFor } from './utils/participant-initials'
 import { resolveInlineEmailHtml } from './utils/resolve-inline-email-html'
 import { SandboxedEmailHtml } from './utils/sandboxed-email-html'
 
@@ -137,7 +138,7 @@ const MessageDisplay = ({ messageId, messageActions, isOpen }: MessageDisplayPro
 
   const isInbound = message.isInbound
   const senderName = sender?.displayName ?? 'Unknown'
-  const senderInitials = sender?.initials ?? senderName.charAt(0).toUpperCase()
+  const senderInitials = initialsFor(sender)
   const contactId = sender?.entityInstanceId
 
   return (

--- a/apps/web/src/components/mail/thread-participant-button.tsx
+++ b/apps/web/src/components/mail/thread-participant-button.tsx
@@ -1,59 +1,52 @@
 // apps/web/src/components/mail/thread-participant-button.tsx
 'use client'
 
-import { groupParticipantsByRole } from '@auxx/types'
 import { toRecordId } from '@auxx/types/resource'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { User } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import * as React from 'react'
+import { useThreadCounterparty } from '~/components/mail/hooks'
 import { RecordBadge, recordBadgeVariants } from '~/components/resources/ui'
-import { useMessages, useParticipant } from '~/components/threads/hooks'
+import type { ParticipantMeta } from '~/components/threads/store'
 
 interface ThreadParticipantButtonProps {
   threadId: string
 }
 
 /**
- * Compact chip in the thread header that opens the thread's primary
- * participant (the `from` of the first message) in a drawer.
+ * Compact chip in the thread header showing the thread's counterparty — the
+ * earliest EXTERNAL participant, so owner-initiated threads show the recipient
+ * rather than the owner (internal-only threads fall back to the first sender).
+ * When the thread has more than one external, a `+N` affordance opens a popover
+ * listing every external, each clickable into the same drawer.
  *
- * Routing rule:
- * - Linked contact (`entityInstanceId` set) → opens `?contactId=` and renders
- *   a `RecordBadge` so it matches every other record chip in the app.
- * - No linked contact → opens `?participantId=` and renders a chip styled with
- *   the same `recordBadgeVariants` cva so the visual stays consistent
- *   before/after promotion.
- *
- * Reads everything from the existing thread stores (`useMessages` +
- * `useParticipant`); no extra network call.
+ * Reads everything from the existing thread stores (`useThreadCounterparty` →
+ * `useMessages` + participant store); no extra network call.
  */
 export function ThreadParticipantButton({ threadId }: ThreadParticipantButtonProps) {
   const [, setContactId] = useQueryState('contactId', { defaultValue: '' })
   const [, setParticipantId] = useQueryState('participantId', { defaultValue: '' })
 
-  const { messages, isLoading: messagesLoading } = useMessages({ threadId })
-  const fromId = React.useMemo(() => {
-    const first = messages[0]
-    if (!first) return null
-    return groupParticipantsByRole(first.participants).from
-  }, [messages])
+  const { primary, others, fallback, isLoading } = useThreadCounterparty(threadId)
+  const contact = primary ?? fallback
 
-  const { participant } = useParticipant({ participantId: fromId, enabled: !!fromId })
+  const openParticipant = React.useCallback(
+    (participant: ParticipantMeta) => {
+      if (participant.entityInstanceId) {
+        void setParticipantId('')
+        void setContactId(participant.entityInstanceId)
+      } else {
+        void setContactId('')
+        void setParticipantId(participant.id)
+      }
+    },
+    [setContactId, setParticipantId]
+  )
 
-  const handleClick = React.useCallback(() => {
-    if (!participant) return
-    if (participant.entityInstanceId) {
-      void setParticipantId('')
-      void setContactId(participant.entityInstanceId)
-    } else {
-      void setContactId('')
-      void setParticipantId(participant.id)
-    }
-  }, [participant, setContactId, setParticipantId])
-
-  if (messagesLoading && !participant) {
+  if (isLoading && !contact) {
     return (
       <span className={cn(recordBadgeVariants({ variant: 'default' }))}>
         <Skeleton />
@@ -62,11 +55,55 @@ export function ThreadParticipantButton({ threadId }: ThreadParticipantButtonPro
     )
   }
 
-  if (!participant) return null
+  if (!contact) return null
 
+  return (
+    <span className='flex items-center gap-1'>
+      <ParticipantChip participant={contact} onOpen={openParticipant} />
+      {others.length > 0 && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type='button'
+              className={cn(
+                recordBadgeVariants({ variant: 'default' }),
+                'cursor-pointer text-muted-foreground'
+              )}>
+              +{others.length}
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align='start' className='flex w-56 flex-col gap-1 p-1'>
+            {[primary, ...others]
+              .filter((p): p is ParticipantMeta => !!p)
+              .map((p) => (
+                <ParticipantChip key={p.id} participant={p} onOpen={openParticipant} />
+              ))}
+          </PopoverContent>
+        </Popover>
+      )}
+    </span>
+  )
+}
+
+/**
+ * A single counterparty chip. Linked contact → `RecordBadge` (opens the contact
+ * drawer); unlinked participant → a chip styled with the same `recordBadgeVariants`
+ * cva (opens the participant drawer), so the visual stays consistent
+ * before/after contact promotion.
+ */
+function ParticipantChip({
+  participant,
+  onOpen,
+}: {
+  participant: ParticipantMeta
+  onOpen: (participant: ParticipantMeta) => void
+}) {
   if (participant.entityInstanceId) {
     return (
-      <button type='button' onClick={handleClick} className='cursor-pointer'>
+      <button
+        type='button'
+        onClick={() => onOpen(participant)}
+        className='cursor-pointer text-left'>
         <RecordBadge
           recordId={toRecordId('contact', participant.entityInstanceId)}
           variant='link'
@@ -79,8 +116,8 @@ export function ThreadParticipantButton({ threadId }: ThreadParticipantButtonPro
   return (
     <button
       type='button'
-      onClick={handleClick}
-      className={cn(recordBadgeVariants({ variant: 'link' }))}>
+      onClick={() => onOpen(participant)}
+      className={cn(recordBadgeVariants({ variant: 'link' }), 'text-left')}>
       <span className='flex size-4 items-center justify-center rounded-full bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-200'>
         <User className='size-2.5' />
       </span>

--- a/apps/web/src/components/mail/types.ts
+++ b/apps/web/src/components/mail/types.ts
@@ -11,6 +11,7 @@ export const VALID_STATUS_SLUGS = [
   'assigned',
   'unassigned',
   'all',
+  'sent', // Outbound-only view (e.g. /app/mail/personal/{id}/sent)
   'resolved', // Alias for 'done'
 ] as const
 export type StatusSlug = (typeof VALID_STATUS_SLUGS)[number] | string

--- a/apps/web/src/components/mail/utils/participant-initials.ts
+++ b/apps/web/src/components/mail/utils/participant-initials.ts
@@ -1,0 +1,36 @@
+// apps/web/src/components/mail/utils/participant-initials.ts
+
+import type { ParticipantMeta } from '~/components/threads/store'
+
+/** First letter within a word, scanning past leading punctuation. */
+function firstLetterWithinWord(word: string): string {
+  return word.match(/[a-zA-Z]/)?.[0] ?? ''
+}
+
+/**
+ * Avatar initials for a participant. Prefers the server-persisted `initials`
+ * (letter-filtered — never a stray quote/paren), then falls back to the same
+ * first-letter-within-word algorithm on `displayName`, then `?`.
+ *
+ * Fixes the raw `charAt(0)` fallbacks that turned From headers like
+ * `'Auxx-Lift Store (Shopify)' via Orders` into a `'` avatar.
+ */
+export function initialsFor(
+  participant?: Pick<ParticipantMeta, 'initials' | 'displayName'> | null
+): string {
+  const persisted = participant?.initials?.trim()
+  if (persisted) return persisted.toUpperCase()
+
+  const name = participant?.displayName?.trim()
+  if (name) {
+    const derived = name
+      .split(/\s+/)
+      .map(firstLetterWithinWord)
+      .filter(Boolean)
+      .slice(0, 2)
+      .join('')
+      .toUpperCase()
+    if (derived) return derived
+  }
+  return '?'
+}

--- a/packages/lib/scripts/repair-personal-inbox-parity.ts
+++ b/packages/lib/scripts/repair-personal-inbox-parity.ts
@@ -1,0 +1,222 @@
+// packages/lib/scripts/repair-personal-inbox-parity.ts
+//
+// One-off repair for the Gmail-parity plan (Phase 2). For each personal-channel
+// Gmail integration it:
+//   1. Pages the live Gmail INBOX (labelIds: ['INBOX']) → set of external ids.
+//   2. Threads with >=1 inbox message -> OPEN; every other thread of that
+//      integration -> ARCHIVED (skipping TRASH/SPAM). Status is the only thing
+//      persisted — no label stamping.
+//   3. Re-trims quote-led participant names and pins internal participants to
+//      their org-member profile name.
+//   4. Enqueues a mail-counts reconcile for the affected owner so badges match.
+//
+// Idempotent — safe to re-run. Run ONLY after Phase 1 ships and the backfill
+// has finished.
+//
+// Run: npx dotenv -- node --conditions source --import tsx/esm \
+//        packages/lib/scripts/repair-personal-inbox-parity.ts [integrationId]
+
+import { closePools, database as db, schema } from '@auxx/database'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { google } from 'googleapis'
+import { getCachedMembers, getOrgCache } from '../src/cache'
+import { calculateDisplayName, calculateInitials } from '../src/ingest/participants/display'
+import { getChannelAccessToken, getChannelTokens } from '../src/providers/channel-token-accessor'
+import { GoogleOAuthService } from '../src/providers/google/google-oauth'
+import { stripBoundaryQuotes } from '../src/providers/provider-utils'
+import { enqueueMailCountsReconcile } from '../src/threads/mail-counts'
+
+/* eslint-disable no-console */
+
+const SKIP_STATUSES = new Set(['TRASH', 'SPAM'])
+const onlyIntegrationId = process.argv[2]
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+/** Build an authenticated Gmail client for an integration. */
+async function buildGmailClient(integrationId: string, organizationId: string) {
+  const tokens = await getChannelTokens(integrationId)
+  const freshAccessToken = await getChannelAccessToken(integrationId)
+  const { client } = await GoogleOAuthService.getAuthenticatedClientForOrg(organizationId, {
+    ...tokens,
+    accessToken: freshAccessToken ?? tokens.accessToken,
+  })
+  return google.gmail({ version: 'v1', auth: client })
+}
+
+/** All external message ids currently carrying the Gmail INBOX label. */
+async function fetchGmailInboxIds(integrationId: string, organizationId: string) {
+  const gmail = await buildGmailClient(integrationId, organizationId)
+  const ids = new Set<string>()
+  let pageToken: string | undefined | null
+  do {
+    const res = await gmail.users.messages.list({
+      userId: 'me',
+      labelIds: ['INBOX'],
+      maxResults: 500,
+      pageToken: pageToken ?? undefined,
+      fields: 'messages/id,nextPageToken',
+    })
+    for (const m of res.data.messages ?? []) if (m.id) ids.add(m.id)
+    pageToken = res.data.nextPageToken
+  } while (pageToken)
+  return ids
+}
+
+/** Repair thread statuses for one personal Gmail integration. */
+async function repairThreadStatuses(integrationId: string, organizationId: string) {
+  const inboxExternalIds = await fetchGmailInboxIds(integrationId, organizationId)
+  console.log(`  gmail INBOX message ids: ${inboxExternalIds.size}`)
+
+  // In-memory join (backfills are dev-scale) — which threads have any INBOX message.
+  const messages = await db
+    .select({ threadId: schema.Message.threadId, externalId: schema.Message.externalId })
+    .from(schema.Message)
+    .where(eq(schema.Message.integrationId, integrationId))
+
+  const openThreadIds = new Set<string>()
+  for (const m of messages) {
+    if (m.threadId && m.externalId && inboxExternalIds.has(m.externalId)) {
+      openThreadIds.add(m.threadId)
+    }
+  }
+
+  const threads = await db
+    .select({ id: schema.Thread.id, status: schema.Thread.status })
+    .from(schema.Thread)
+    .where(eq(schema.Thread.integrationId, integrationId))
+
+  const toOpen = threads
+    .filter((t) => openThreadIds.has(t.id) && t.status === 'ARCHIVED')
+    .map((t) => t.id)
+  const toArchive = threads
+    .filter(
+      (t) => !openThreadIds.has(t.id) && t.status !== 'ARCHIVED' && !SKIP_STATUSES.has(t.status)
+    )
+    .map((t) => t.id)
+
+  for (const ids of chunk(toOpen, 500)) {
+    await db.update(schema.Thread).set({ status: 'OPEN' }).where(inArray(schema.Thread.id, ids))
+  }
+  for (const ids of chunk(toArchive, 500)) {
+    await db.update(schema.Thread).set({ status: 'ARCHIVED' }).where(inArray(schema.Thread.id, ids))
+  }
+  console.log(`  threads reopened: ${toOpen.length}, archived: ${toArchive.length}`)
+}
+
+/**
+ * Re-trim quote-led participant names and pin internal participants to their
+ * org-member profile name. Recomputes displayName + initials whenever a row is
+ * touched (fixing the stale-initials asymmetry).
+ */
+async function repairParticipants(organizationId: string) {
+  const members = await getCachedMembers(organizationId)
+  const memberByEmail = new Map<string, string>()
+  for (const m of members) {
+    if (m.user?.email && m.user.name) memberByEmail.set(m.user.email.toLowerCase(), m.user.name)
+  }
+
+  const participants = await db
+    .select({
+      id: schema.Participant.id,
+      identifier: schema.Participant.identifier,
+      name: schema.Participant.name,
+      isInternal: schema.Participant.isInternal,
+    })
+    .from(schema.Participant)
+    .where(eq(schema.Participant.organizationId, organizationId))
+
+  let updated = 0
+  for (const p of participants) {
+    const pinned = p.isInternal ? memberByEmail.get(p.identifier.toLowerCase()) : undefined
+    const cleaned = p.name ? stripBoundaryQuotes(p.name) || null : null
+    const nextName = pinned ?? cleaned
+
+    if (!nextName || nextName === p.name) continue
+    await db
+      .update(schema.Participant)
+      .set({
+        name: nextName,
+        displayName: calculateDisplayName(nextName, p.identifier),
+        initials: calculateInitials(nextName),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.Participant.id, p.id))
+    updated++
+  }
+  console.log(`  participants repaired: ${updated}`)
+}
+
+async function main() {
+  // Google integrations joined to their (personal?) inbox mapping.
+  const rows = await db
+    .select({
+      integrationId: schema.Integration.id,
+      organizationId: schema.Integration.organizationId,
+      inboxId: schema.InboxIntegration.inboxId,
+    })
+    .from(schema.Integration)
+    .innerJoin(
+      schema.InboxIntegration,
+      eq(schema.InboxIntegration.integrationId, schema.Integration.id)
+    )
+    .where(
+      and(
+        eq(schema.Integration.provider, 'google'),
+        isNull(schema.Integration.deletedAt),
+        onlyIntegrationId ? eq(schema.Integration.id, onlyIntegrationId) : undefined
+      )
+    )
+
+  const affectedOwnersByOrg = new Map<string, Set<string>>()
+  const repairedOrgs = new Set<string>()
+
+  for (const row of rows) {
+    const inboxes = await getOrgCache().get(row.organizationId, 'inboxes')
+    const inbox = inboxes.find((i) => i.id === row.inboxId)
+    if (!inbox?.isPersonal) continue
+
+    console.log(`\nRepairing integration ${row.integrationId} (inbox ${inbox.name})`)
+    try {
+      await repairThreadStatuses(row.integrationId, row.organizationId)
+    } catch (error) {
+      console.error(`  thread-status repair failed:`, (error as Error).message)
+    }
+
+    if (!repairedOrgs.has(row.organizationId)) {
+      await repairParticipants(row.organizationId)
+      repairedOrgs.add(row.organizationId)
+    }
+
+    if (inbox.ownerUserId) {
+      const set = affectedOwnersByOrg.get(row.organizationId) ?? new Set<string>()
+      set.add(inbox.ownerUserId)
+      affectedOwnersByOrg.set(row.organizationId, set)
+    }
+  }
+
+  // Reconcile counts for each affected (org, owner) so badges settle.
+  for (const [orgId, owners] of affectedOwnersByOrg) {
+    for (const userId of owners) {
+      await enqueueMailCountsReconcile(orgId, userId)
+      console.log(`Enqueued mail-counts reconcile for ${orgId} / ${userId}`)
+    }
+  }
+
+  console.log('\n✓ repair complete')
+}
+
+main()
+  .then(async () => {
+    await closePools()
+    process.exit(0)
+  })
+  .catch(async (error) => {
+    console.error(error)
+    await closePools()
+    process.exit(1)
+  })

--- a/packages/lib/src/email/email-storage.ts
+++ b/packages/lib/src/email/email-storage.ts
@@ -16,6 +16,7 @@ import {
 } from '@auxx/database/enums'
 import type { MessageEntity as Message, ThreadEntity as Thread } from '@auxx/database/types'
 import {
+  archiveThreadsByMessageExternalIds,
   batchStoreMessages,
   createContactAfterOutboundMessage,
   createIngestContext,
@@ -26,6 +27,7 @@ import {
   type IngestContext,
   type IntegrationSettings,
   normalizeOwnEmails,
+  reopenThreadsByMessageExternalIds,
   storeMessage,
 } from '../ingest'
 import { getRealtimeService, publishInboxSyncCompleted } from '../realtime'
@@ -165,6 +167,27 @@ export class MessageStorageService {
   async deleteMessagesByExternalIds(integrationId: string, externalIds: string[]): Promise<number> {
     const ctx = await this.resolveCtx(this.defaultOrganizationId)
     return deleteMessagesByExternalIds(ctx, { integrationId, externalIds })
+  }
+
+  /**
+   * Mark threads Done for personal-channel messages whose Gmail INBOX label was
+   * removed (archive as a thread-level action) instead of deleting them.
+   */
+  async archiveThreadsByMessageExternalIds(
+    integrationId: string,
+    externalIds: string[]
+  ): Promise<number> {
+    const ctx = await this.resolveCtx(this.defaultOrganizationId)
+    return archiveThreadsByMessageExternalIds(ctx, { integrationId, externalIds })
+  }
+
+  /** Reopen threads when a personal-channel message's INBOX label is re-added. */
+  async reopenThreadsByMessageExternalIds(
+    integrationId: string,
+    externalIds: string[]
+  ): Promise<number> {
+    const ctx = await this.resolveCtx(this.defaultOrganizationId)
+    return reopenThreadsByMessageExternalIds(ctx, { integrationId, externalIds })
   }
 
   async createContactAfterOutboundMessage(

--- a/packages/lib/src/ingest/archive-messages.ts
+++ b/packages/lib/src/ingest/archive-messages.ts
@@ -1,0 +1,106 @@
+// packages/lib/src/ingest/archive-messages.ts
+
+import { schema } from '@auxx/database'
+import { ThreadStatus } from '@auxx/database/enums'
+import { toRecordId } from '@auxx/types/resource'
+import { and, eq, inArray } from 'drizzle-orm'
+import { SYSTEM_VISIBILITY } from '../permissions/visibility/context'
+import { ThreadMutationService } from '../threads/thread-mutation.service'
+import type { IngestContext } from './context'
+
+/** Distinct thread ids for a set of provider message external ids. */
+async function resolveThreadIds(
+  ctx: IngestContext,
+  integrationId: string,
+  externalIds: string[]
+): Promise<string[]> {
+  if (externalIds.length === 0) return []
+  const rows = await ctx.db
+    .select({ threadId: schema.Message.threadId })
+    .from(schema.Message)
+    .where(
+      and(
+        eq(schema.Message.integrationId, integrationId),
+        inArray(schema.Message.externalId, externalIds)
+      )
+    )
+  return [...new Set(rows.map((r) => r.threadId).filter((id): id is string => !!id))]
+}
+
+/**
+ * Mark threads ARCHIVED (our "Done" state) for personal-channel messages whose
+ * Gmail INBOX label was removed. Archive is treated as a thread-level action —
+ * we don't delete the messages the way shared channels do. Reuses
+ * {@link ThreadMutationService} (SYSTEM viewer) so realtime + count deltas fire.
+ * Only flips threads currently OPEN — leaves TRASH/SPAM/already-Done untouched.
+ *
+ * Returns the number of threads archived.
+ */
+export async function archiveThreadsByMessageExternalIds(
+  ctx: IngestContext,
+  args: { integrationId: string; externalIds: string[] }
+): Promise<number> {
+  const threadIds = await resolveThreadIds(ctx, args.integrationId, args.externalIds)
+  if (threadIds.length === 0) return 0
+
+  const openThreads = await ctx.db
+    .select({ id: schema.Thread.id })
+    .from(schema.Thread)
+    .where(and(inArray(schema.Thread.id, threadIds), eq(schema.Thread.status, ThreadStatus.OPEN)))
+  if (openThreads.length === 0) return 0
+
+  const svc = new ThreadMutationService(
+    ctx.organizationId,
+    ctx.db,
+    ctx.socketId,
+    undefined,
+    SYSTEM_VISIBILITY
+  )
+  for (const t of openThreads) {
+    await svc.update(toRecordId('thread', t.id), { status: 'ARCHIVED' })
+  }
+  ctx.logger.info('Archived threads from Gmail INBOX-label removal', {
+    integrationId: args.integrationId,
+    archivedCount: openThreads.length,
+  })
+  return openThreads.length
+}
+
+/**
+ * Reopen ARCHIVED personal-channel threads when a message's Gmail INBOX label
+ * is (re)added — the inverse of {@link archiveThreadsByMessageExternalIds}.
+ * Only touches threads currently ARCHIVED.
+ *
+ * Returns the number of threads reopened.
+ */
+export async function reopenThreadsByMessageExternalIds(
+  ctx: IngestContext,
+  args: { integrationId: string; externalIds: string[] }
+): Promise<number> {
+  const threadIds = await resolveThreadIds(ctx, args.integrationId, args.externalIds)
+  if (threadIds.length === 0) return 0
+
+  const archivedThreads = await ctx.db
+    .select({ id: schema.Thread.id })
+    .from(schema.Thread)
+    .where(
+      and(inArray(schema.Thread.id, threadIds), eq(schema.Thread.status, ThreadStatus.ARCHIVED))
+    )
+  if (archivedThreads.length === 0) return 0
+
+  const svc = new ThreadMutationService(
+    ctx.organizationId,
+    ctx.db,
+    ctx.socketId,
+    undefined,
+    SYSTEM_VISIBILITY
+  )
+  for (const t of archivedThreads) {
+    await svc.update(toRecordId('thread', t.id), { status: 'OPEN' })
+  }
+  ctx.logger.info('Reopened threads from Gmail INBOX-label add', {
+    integrationId: args.integrationId,
+    reopenedCount: archivedThreads.length,
+  })
+  return archivedThreads.length
+}

--- a/packages/lib/src/ingest/inbox-meta.ts
+++ b/packages/lib/src/ingest/inbox-meta.ts
@@ -1,0 +1,39 @@
+// packages/lib/src/ingest/inbox-meta.ts
+
+import type { IngestContext } from './context'
+
+/** Personal-account metadata for an inbox, resolved from the org cache. */
+export interface InboxMeta {
+  isPersonal: boolean
+  ownerUserId: string | null
+}
+
+/**
+ * Resolve an inbox's personal-account metadata from the org `inboxes` cache
+ * (hydrated per-org — no DB round-trip). Returns null for unknown/missing
+ * inbox ids. Used at ingest time to give personal Gmail channels label-derived
+ * thread status while shared inboxes keep everything-open helpdesk semantics.
+ */
+export async function getInboxMeta(
+  ctx: IngestContext,
+  inboxId: string | null | undefined
+): Promise<InboxMeta | null> {
+  if (!inboxId) return null
+  // Lazy-import the cache barrel (heavy) at call time, matching the pattern in
+  // thread-mutation.service. The org cache memoizes the `inboxes` key, so this
+  // is an in-memory Map lookup after the first hydrate.
+  const { getOrgCache } = await import('../cache')
+  const inboxes = await getOrgCache().get(ctx.organizationId, 'inboxes')
+  const inbox = inboxes.find((i) => i.id === inboxId)
+  if (!inbox) return null
+  return { isPersonal: inbox.isPersonal, ownerUserId: inbox.ownerUserId }
+}
+
+/** Convenience predicate: is this inbox a personal account? */
+export async function isPersonalInbox(
+  ctx: IngestContext,
+  inboxId: string | null | undefined
+): Promise<boolean> {
+  const meta = await getInboxMeta(ctx, inboxId)
+  return meta?.isPersonal ?? false
+}

--- a/packages/lib/src/ingest/index.ts
+++ b/packages/lib/src/ingest/index.ts
@@ -1,5 +1,9 @@
 // packages/lib/src/ingest/index.ts
 
+export {
+  archiveThreadsByMessageExternalIds,
+  reopenThreadsByMessageExternalIds,
+} from './archive-messages'
 // Orchestrators
 export { type BatchStoreOptions, batchStoreMessages } from './batch-store-messages'
 // Companies / Domains (already existed)

--- a/packages/lib/src/ingest/participants/display.ts
+++ b/packages/lib/src/ingest/participants/display.ts
@@ -1,14 +1,20 @@
 // packages/lib/src/ingest/participants/display.ts
 
-/** Up-to-2 initials from a name string, uppercased. Letters only. */
+/**
+ * Up-to-2 initials from a name string, uppercased. Letters only.
+ *
+ * Takes the FIRST letter *within* each word (scanning past leading
+ * punctuation), not `charAt(0)` — so a punctuation-led word like
+ * `(Shopify)` still contributes `S`. Words with no letters are skipped.
+ */
 export function calculateInitials(name?: string | null): string | undefined {
   if (!name) return undefined
   return (
     name
       .trim()
       .split(/\s+/)
-      .map((word) => word.charAt(0))
-      .filter((char) => char.match(/[a-zA-Z]/))
+      .map((word) => word.match(/[a-zA-Z]/)?.[0] ?? '')
+      .filter(Boolean)
       .slice(0, 2)
       .join('')
       .toUpperCase() || undefined

--- a/packages/lib/src/ingest/participants/find-or-create.ts
+++ b/packages/lib/src/ingest/participants/find-or-create.ts
@@ -16,6 +16,7 @@ import type { ParticipantMeta } from '../../realtime/events'
 import { findOrCreateContactForParticipant } from '../contacts/find-or-create'
 import type { IngestContext } from '../context'
 import { extractRegistrableDomain, getOwnDomains, normalizeDomain } from '../domain/classifier'
+import { getInboxMeta } from '../inbox-meta'
 import type { ParticipantInputData } from '../types'
 import { calculateDisplayName, calculateInitials } from './display'
 import { normalizeIdentifier } from './normalize'
@@ -49,6 +50,37 @@ async function classifyIsInternal(
 }
 
 /**
+ * Resolve the org-member profile name for an internal participant, so display
+ * names for "us" are pinned to the member's profile rather than flip-flopping
+ * with whatever name a given message header carried. Two-tier match:
+ *   1. identifier == a member's login email → that member's `user.name`;
+ *   2. else identifier ∈ `ctx.ownEmails` (an alias) and the triggering inbox is
+ *      personal → resolve the inbox owner → that member's `user.name`.
+ * Returns null when no member name resolves (falls back to header-name policy).
+ */
+async function resolveInternalMemberName(
+  ctx: IngestContext,
+  identifier: string,
+  inboxId?: string | null
+): Promise<string | null> {
+  const lower = identifier.toLowerCase()
+  const { getCachedMembers } = await import('../../cache')
+  const members = await getCachedMembers(ctx.organizationId)
+
+  const direct = members.find((m) => m.user?.email?.toLowerCase() === lower)
+  if (direct?.user?.name) return direct.user.name
+
+  if (inboxId && ctx.ownEmails.has(lower)) {
+    const meta = await getInboxMeta(ctx, inboxId)
+    if (meta?.isPersonal && meta.ownerUserId) {
+      const owner = members.find((m) => m.userId === meta.ownerUserId)
+      if (owner?.user?.name) return owner.user.name
+    }
+  }
+  return null
+}
+
+/**
  * Upsert a Participant row and ensure it is linked to a Contact EntityInstance
  * (respecting integration record-creation mode). Updates `hasReceivedMessage`
  * and `lastSentMessageAt` when the participant is a recipient on an outbound
@@ -73,9 +105,6 @@ export async function findOrCreateParticipantRecord(
   const name = participantInput.name?.trim() || null
 
   try {
-    const initials = calculateInitials(name)
-    const displayName = calculateDisplayName(name, normalizedIdentifier)
-
     const isOutboundRecipient =
       messageContext &&
       !messageContext.isInbound &&
@@ -84,6 +113,17 @@ export async function findOrCreateParticipantRecord(
       )
 
     const isInternal = await classifyIsInternal(ctx, normalizedIdentifier, identifierType)
+
+    // Name policy (Gmail-parity plan Phase 4): pin internal participants to
+    // their org-member profile name; otherwise use the header name. Falls back
+    // to the header name when no member name resolves.
+    const pinnedName = isInternal
+      ? await resolveInternalMemberName(ctx, normalizedIdentifier, inboxId)
+      : null
+    const effectiveName = pinnedName ?? name
+
+    const initials = calculateInitials(effectiveName)
+    const displayName = calculateDisplayName(effectiveName, normalizedIdentifier)
 
     // Capture pre-upsert state so we can detect column changes for
     // participant:updated emission. Cheap point-lookup on the unique index.
@@ -111,7 +151,7 @@ export async function findOrCreateParticipantRecord(
       .values({
         identifier: normalizedIdentifier,
         identifierType,
-        name,
+        name: effectiveName,
         displayName,
         initials,
         organizationId: ctx.organizationId,
@@ -131,9 +171,13 @@ export async function findOrCreateParticipantRecord(
           schema.Participant.identifierType,
         ],
         set: {
-          ...(name !== undefined && { name }),
-          ...(displayName !== undefined && { displayName }),
-          ...(initials !== undefined && { initials }),
+          // Never downgrade a known name to a bare address: only overwrite
+          // name/displayName/initials when this message actually carries a
+          // usable name (`effectiveName !== null`). A bare-address message
+          // leaves the row's best-known name untouched; a named (or pinned
+          // internal) message updates all three together — which also fixes
+          // the stale-`initials` asymmetry the old per-field guards caused.
+          ...(effectiveName !== null && { name: effectiveName, displayName, initials }),
           updatedAt: new Date(),
           ...(isOutboundRecipient && {
             hasReceivedMessage: true,

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -6,17 +6,35 @@ import type { ParticipantEntity as Participant, ParticipantRole } from '@auxx/da
 import { toRecordId } from '@auxx/types/resource'
 import { and, eq, isNull, sql } from 'drizzle-orm'
 import { touchActivityForThreadLinks } from '../entity-instances/activity'
-import { getRealtimeService, publishMessageCreated, publishThreadCreated } from '../realtime'
+import {
+  getRealtimeService,
+  publishMessageCreated,
+  publishThreadCreated,
+  publishThreadUpdated,
+} from '../realtime'
 import { applyMailCountDeltas } from '../threads/mail-counts'
 import type { IngestContext } from './context'
 import { shouldIgnoreMessage } from './filtering/should-ignore'
 import { storeIgnoredMessage } from './filtering/store-ignored'
+import { isPersonalInbox } from './inbox-meta'
 import { findOrCreateParticipantRecord } from './participants/find-or-create'
 import { determineIdentifierType, normalizeIdentifier } from './participants/normalize'
 import { extractInternetMessageId } from './reconciliation/extract-internet-message-id'
 import { reconcileMessage } from './reconciliation/reconcile-message'
 import { updateThreadMetadataEfficient } from './threads/update-metadata'
 import type { IntegrationSettings, MessageData, ParticipantInputData } from './types'
+
+/**
+ * Map Gmail labels to a thread status for personal channels (Gmail parity).
+ * `INBOX` → OPEN; sent-only / archived / label-only mail → ARCHIVED (our "Done"
+ * state); TRASH/SPAM map straight through. Shared inboxes never call this — they
+ * keep everything-open helpdesk semantics.
+ */
+function deriveThreadStatusFromLabels(labelIds: string[]): ThreadStatus {
+  if (labelIds.includes('TRASH')) return ThreadStatus.TRASH
+  if (labelIds.includes('SPAM')) return ThreadStatus.SPAM
+  return labelIds.includes('INBOX') ? ThreadStatus.OPEN : ThreadStatus.ARCHIVED
+}
 
 /**
  * Store a single inbound/outbound message with full ingest pipeline:
@@ -207,6 +225,17 @@ export async function storeMessage(
       }
     }
 
+    // Personal-channel label-derived status (Gmail parity). Shared inboxes keep
+    // everything-open helpdesk semantics — byte-for-byte today's behavior. The
+    // `labelIds` ride in memory on `messageData` and are never persisted; we
+    // only consult them here at decision time.
+    const personalInbox = await isPersonalInbox(ctx, resolvedInboxId)
+    const labelIds = messageData.labelIds ?? []
+    const hasInboxLabel = labelIds.includes('INBOX')
+    const newThreadStatus = personalInbox
+      ? deriveThreadStatusFromLabels(labelIds)
+      : ThreadStatus.OPEN
+
     // Resolved (role, participantId) pairs for MessageParticipant links,
     // captured while processing so the link insert doesn't re-derive
     // identifier types.
@@ -307,7 +336,7 @@ export async function storeMessage(
           organizationId: messageData.organizationId,
           inboxId: resolvedInboxId,
           subject: messageData.subject ?? 'No Subject',
-          status: ThreadStatus.OPEN,
+          status: newThreadStatus,
           firstMessageAt: messageData.sentAt,
           lastMessageAt: messageData.sentAt,
           messageCount: 1,
@@ -335,6 +364,21 @@ export async function storeMessage(
       const isNewThread =
         (thread.messageCount ?? 0) === 1 &&
         thread.firstMessageAt?.getTime() === messageData.sentAt.getTime()
+
+      // Gmail parity: a thread with any INBOX message belongs in the inbox.
+      // Reopen an ARCHIVED personal-channel thread when this message carries
+      // INBOX. Never flip OPEN→ARCHIVED from a message insert (order-independent
+      // during backfill), and never reopen TRASH/SPAM. `thread.status` stays the
+      // pre-reopen value in memory so the count/realtime gates below can tell a
+      // reopen from a steady-state insert.
+      const didReopen =
+        personalInbox && !isNewThread && hasInboxLabel && thread.status === ThreadStatus.ARCHIVED
+      if (didReopen) {
+        await tx
+          .update(schema.Thread)
+          .set({ status: ThreadStatus.OPEN })
+          .where(eq(schema.Thread.id, thread.id))
+      }
 
       // An inbound reply makes the thread unread again for everyone who had
       // read it. One bounded UPDATE (rows exist only for users who read it);
@@ -457,9 +501,9 @@ export async function storeMessage(
           })
       }
 
-      return { thread, isNewThread, messageRecord, flippedUserIds }
+      return { thread, isNewThread, messageRecord, flippedUserIds, didReopen }
     })
-    const { thread, isNewThread, messageRecord, flippedUserIds } = txResult
+    const { thread, isNewThread, messageRecord, flippedUserIds, didReopen } = txResult
 
     ctx.logger.debug(
       `Created/Skipped ${resolvedParticipantLinks.length} MessageParticipant links for message ${messageRecord.id}`
@@ -497,18 +541,21 @@ export async function storeMessage(
       // reconcile queries). During sync batches this is skipped entirely —
       // the orchestrator marks counts stale once at the end.
       if (
-        (messageData.isInbound || isNewThread) &&
-        thread.status === ThreadStatus.OPEN &&
+        (didReopen || messageData.isInbound || isNewThread) &&
+        (didReopen || thread.status === ThreadStatus.OPEN) &&
         inboxIdForChannel
       ) {
-        // New-thread audience = members who see this inbox at `full` (§10.1) —
-        // sub-full viewers have no unread state, so no badge movement. Flipped
-        // users on existing threads had read rows, i.e. full access already.
-        const userIds = isNewThread
-          ? await import('../permissions/visibility/audience').then((m) =>
-              m.getFullLensAudienceForInbox(messageData.organizationId, inboxIdForChannel)
-            )
-          : flippedUserIds
+        // A reopened archived thread re-enters the inbox for the full-lens
+        // audience — same deltas as a brand-new OPEN thread. New-thread audience
+        // = members who see this inbox at `full` (§10.1) — sub-full viewers have
+        // no unread state, so no badge movement. Flipped users on existing
+        // threads had read rows, i.e. full access already.
+        const userIds =
+          isNewThread || didReopen
+            ? await import('../permissions/visibility/audience').then((m) =>
+                m.getFullLensAudienceForInbox(messageData.organizationId, inboxIdForChannel)
+              )
+            : flippedUserIds
         await applyMailCountDeltas(
           messageData.organizationId,
           userIds.map((userId) => ({
@@ -530,6 +577,18 @@ export async function storeMessage(
             inboxId: inboxIdForChannel,
             inboxRecordId,
             assigneeId: thread.assigneeId ?? null,
+          },
+          { excludeSocketId: ctx.socketId }
+        )
+      } else if (didReopen) {
+        await publishThreadUpdated(
+          realtime,
+          messageData.organizationId,
+          {
+            threadId: thread.id,
+            inboxId: inboxIdForChannel,
+            assigneeId: thread.assigneeId ?? null,
+            patch: { status: ThreadStatus.OPEN },
           },
           { excludeSocketId: ctx.socketId }
         )

--- a/packages/lib/src/mail-query/context-to-conditions.ts
+++ b/packages/lib/src/mail-query/context-to-conditions.ts
@@ -110,6 +110,23 @@ export function buildContextConditions(params: ContextConditionParams): Conditio
     // all_inboxes, all, view - no additional context conditions needed
   }
 
+  // A `sent` status slug (e.g. /app/mail/personal/{id}/sent) layers the outbound
+  // filter on top of the context (inbox) condition — same predicate as the
+  // `sent` contextType — so `personal_channel` + `sent` = inbox is X AND sent.
+  // Guarded so the global `sent` context (which already added ctx-sent) doesn't
+  // duplicate the condition.
+  if (
+    params.statusSlug?.toLowerCase() === 'sent' &&
+    !conditions.some((c) => c.fieldId === 'sent')
+  ) {
+    conditions.push({
+      id: 'ctx-sent-status',
+      fieldId: 'sent',
+      operator: 'is',
+      value: true,
+    })
+  }
+
   // Status slug conditions - map slugs to actual status values and additional conditions
   if (params.statusSlug && !['all', 'drafts', 'sent'].includes(params.statusSlug)) {
     switch (params.statusSlug.toLowerCase()) {

--- a/packages/lib/src/providers/google/messages/sync-messages.ts
+++ b/packages/lib/src/providers/google/messages/sync-messages.ts
@@ -16,6 +16,26 @@ import { convertMessagesToMessageData } from './parse-message'
 const logger = createScopedLogger('google-sync-messages')
 
 /**
+ * Whether an inbox is a personal account (org `inboxes` cache — no DB hit).
+ * Personal Gmail channels treat archive as a thread-level Done and reopen on
+ * INBOX re-add; shared inboxes keep the legacy archive-deletes behavior.
+ */
+async function isPersonalChannel(organizationId: string, inboxId: string): Promise<boolean> {
+  try {
+    const { getOrgCache } = await import('../../../cache')
+    const inboxes = await getOrgCache().get(organizationId, 'inboxes')
+    return inboxes.find((i) => i.id === inboxId)?.isPersonal ?? false
+  } catch (error) {
+    logger.warn('Failed to resolve personal-channel flag; treating as shared', {
+      organizationId,
+      inboxId,
+      error: (error as Error).message,
+    })
+    return false
+  }
+}
+
+/**
  * Input parameters for Gmail message synchronization
  */
 export interface SyncGmailMessagesInput {
@@ -213,9 +233,12 @@ async function syncViaHistory(
   let totalDeleted = 0
   let hasRetriableFailures = false
 
+  const isPersonal = await isPersonalChannel(organizationId, inboxId)
+
   logger.info('Starting history-based sync', {
     integrationId,
     startHistoryId,
+    isPersonal,
   })
 
   do {
@@ -232,7 +255,7 @@ async function syncViaHistory(
           userId: 'me',
           startHistoryId: highestHistoryId.toString(),
           pageToken: nextPageToken ?? undefined,
-          historyTypes: ['messageAdded', 'messageDeleted', 'labelRemoved'],
+          historyTypes: ['messageAdded', 'messageDeleted', 'labelRemoved', 'labelAdded'],
         }),
       {
         userId: integrationId,
@@ -246,6 +269,8 @@ async function syncViaHistory(
     const historyRecords = historyResponse.data.history || []
     const addedIds = new Set<string>()
     const deletedIds = new Set<string>()
+    const inboxRemovedIds = new Set<string>()
+    const inboxAddedIds = new Set<string>()
 
     for (const record of historyRecords) {
       if (record.messagesAdded) {
@@ -262,11 +287,19 @@ async function syncViaHistory(
           }
         }
       }
-      // Treat INBOX label removal as deletion (archived messages)
+      // INBOX label removal = archive in Gmail.
       if (record.labelsRemoved) {
         for (const labelChange of record.labelsRemoved) {
           if (labelChange.labelIds?.includes('INBOX') && labelChange.message?.id) {
-            deletedIds.add(labelChange.message.id)
+            inboxRemovedIds.add(labelChange.message.id)
+          }
+        }
+      }
+      // INBOX label add = unarchive / moved (back) into the inbox.
+      if (record.labelsAdded) {
+        for (const labelChange of record.labelsAdded) {
+          if (labelChange.labelIds?.includes('INBOX') && labelChange.message?.id) {
+            inboxAddedIds.add(labelChange.message.id)
           }
         }
       }
@@ -286,6 +319,13 @@ async function syncViaHistory(
       }
     }
 
+    // Shared channels keep the legacy behavior: archiving in Gmail deletes
+    // locally. Personal channels treat archive as a thread-level Done (handled
+    // separately below), so their INBOX-label removals are NOT deletions.
+    if (!isPersonal) {
+      for (const id of inboxRemovedIds) deletedIds.add(id)
+    }
+
     // Deduplicate: messages in both added and deleted → net result is deleted
     const finalAddedIds = [...addedIds].filter((id) => !deletedIds.has(id))
 
@@ -301,6 +341,21 @@ async function syncViaHistory(
         deletedCount: deleted,
         rawDeletedIds: deletedIds.size,
       })
+    }
+
+    // Personal-channel archive / reopen — thread-level status changes that keep
+    // the underlying messages intact. Reopen wins over archive when both fire
+    // for the same message in one page.
+    if (isPersonal && inboxRemovedIds.size > 0) {
+      const archiveIds = [...inboxRemovedIds].filter(
+        (id) => !deletedIds.has(id) && !inboxAddedIds.has(id)
+      )
+      if (archiveIds.length > 0) {
+        await storageService.archiveThreadsByMessageExternalIds(integrationId, archiveIds)
+      }
+    }
+    if (isPersonal && inboxAddedIds.size > 0) {
+      await storageService.reopenThreadsByMessageExternalIds(integrationId, [...inboxAddedIds])
     }
 
     // Fetch and store added messages

--- a/packages/lib/src/providers/provider-utils.ts
+++ b/packages/lib/src/providers/provider-utils.ts
@@ -14,6 +14,23 @@ export interface ParticipantInputData {
 }
 
 /**
+ * Strip single/double quotes that sit at a word boundary (string start/end or
+ * adjacent to whitespace), preserving in-word apostrophes.
+ *
+ * `addressparser` strips *wrapping* double quotes but not single quotes, and
+ * real-world From headers are often only partially quoted — e.g.
+ * `'Auxx-Lift Store (Shopify)' via Orders`. A naive "trim wrapping quotes"
+ * never fires there (the string doesn't end with `'`). This cleans both
+ * boundary quotes while keeping names like `O'Brien` intact.
+ */
+export function stripBoundaryQuotes(name: string): string {
+  return name
+    .replace(/(^|\s)['"]+/g, '$1')
+    .replace(/['"]+(\s|$)/g, '$1')
+    .trim()
+}
+
+/**
  * Parses a single participant string (commonly an email format like "Name <addr>" or just "addr").
  * @param participantStr The raw string from the message header (e.g., From, To, Cc).
  * @returns ParticipantInputData object or null if parsing fails.
@@ -29,7 +46,8 @@ export function parseParticipantString(participantStr: string): ParticipantInput
       const { address, name } = parsed[0]
 
       if (address) {
-        return { identifier: address, name: name || undefined, raw: trimmedStr }
+        const cleanName = name ? stripBoundaryQuotes(name) || undefined : undefined
+        return { identifier: address, name: cleanName, raw: trimmedStr }
       }
     }
   } catch (e) {
@@ -71,9 +89,10 @@ export function parseMultipleParticipants(participantsStr: string): ParticipantI
           return null
         }
 
+        const cleanName = name ? stripBoundaryQuotes(name) || undefined : undefined
         return {
           identifier: address,
-          name: name || undefined,
+          name: cleanName,
           raw: name ? `${name} <${address}>` : address,
         }
       })
@@ -96,14 +115,16 @@ export function parseMultipleParticipants(participantsStr: string): ParticipantI
  */
 export function calculateInitials(name?: string | null): string | undefined {
   if (!name) return undefined
-  return name
-    .trim()
-    .split(/\s+/) // Split by whitespace
-    .map((word) => word.charAt(0))
-    .filter((char) => char.match(/[a-zA-Z]/)) // Keep only letters
-    .slice(0, 2) // Max 2 initials
-    .join('')
-    .toUpperCase()
+  return (
+    name
+      .trim()
+      .split(/\s+/) // Split by whitespace
+      .map((word) => word.match(/[a-zA-Z]/)?.[0] ?? '') // First letter within each word
+      .filter(Boolean)
+      .slice(0, 2) // Max 2 initials
+      .join('')
+      .toUpperCase() || undefined
+  )
 }
 
 /**


### PR DESCRIPTION
Implements `plans/mail/inbox/personal-inbox-gmail-parity-plan.md` (all 5 phases). Follows the personal-inbox regroup. **No schema change, no migration.**

Fixes four issues found while backfilling a personal channel (lutz@auxx-lift.com, 32k messages).

## Phases

**1 — Label-derived thread status (Gmail parity)**
- New `packages/lib/src/ingest/inbox-meta.ts` — cache-only `isPersonalInbox`/`getInboxMeta` (reads the `inboxes` org cache; no new DB query).
- `store-message.ts` — personal channels derive new-thread status from in-memory `messageData.labelIds` (`INBOX`→Open, sent-only/archived→Done, TRASH/SPAM passthrough); shared inboxes stay Open, byte-for-byte. ARCHIVED threads reopen on a new INBOX message inside the tx (`didReopen`) with full-lens-audience count deltas + `thread:updated` realtime.
- `sync-messages.ts` — added the `labelAdded` history type; personal-channel INBOX add/remove routes to thread-level reopen/archive via `archive-messages.ts` (reuses `ThreadMutationService` with a SYSTEM viewer so realtime + counts fire). **Shared channels keep the legacy archive-deletes behavior.**

**2 — Repair script** `packages/lib/scripts/repair-personal-inbox-parity.ts` (worker runtime): pages live Gmail `INBOX`, sets thread statuses, re-trims quote names + pins internal names, enqueues per-owner mail-counts reconcile. Idempotent — run only after a fresh personal-channel sync completes.

**3 — Sent as an expandable group** — sidebar group per personal inbox (`/app/mail/personal/{id}/sent`); `'sent'` added to `VALID_STATUS_SLUGS` (tabless via `getDisplayTabsForContext`); `context-to-conditions.ts` pushes the `sent` predicate for a `sent` slug so `personal_channel + sent` = inbox X AND outbound.

**4 — Participant name policy** — never-downgrade a known name to a bare address (`effectiveName !== null` gates name/displayName/initials together) + pin internal participants to their org-member profile name; word-boundary quote strip + first-letter-within-word initials (fixes the `'` avatar); shared FE `initialsFor` used in email/message/chat displays.

**5 — Thread contact = primary external** — new `useThreadCounterparty` hook (earliest external, `+N` others popover, owner fallback); `thread-participant-button.tsx` renders primary + `+N`; `mail-thread-item.tsx` list row shows the counterparty when the latest FROM is internal (ProcessingMenu still targets the real sender).

## Verification
- `pnpm --filter @auxx/lib build` ✓; biome clean on all changed files.
- **Requires a dev restart** for web/worker to pick up the rebuilt `@auxx/lib` ingest changes.
- Live E2E (fresh sync → status buckets, Gmail archive→Done↔reopen, name pinning, Sent group, counterparty chip) + repair-script run still pending.