### PR TITLE
feat(mail): per-channel opt-out toggle for bidirectional Gmail sync

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-routing.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
+import { ToggleCard } from '@auxx/ui/components/toggle-card'
 import { useCopy } from '@auxx/ui/hooks/use-copy'
 import {
   AlertCircle,
@@ -167,6 +168,27 @@ export default function IntegrationRouting({
     },
   })
 
+  // Two-way sync — mirror Auxx status/read changes back to the mailbox. Opt-out
+  // (absent flag ⇒ enabled); only shown for providers that support it on a
+  // personal inbox (push-back never applies to shared inboxes).
+  const showBidirectionalToggle = !!integration.supportsBidirectionalStatusSync && isPersonalChannel
+  const [bidirectionalSync, setBidirectionalSync] = useState<boolean>(
+    integration.settings?.bidirectionalSyncEnabled ?? true
+  )
+  const updateSettings = api.channel.updateSettings.useMutation({
+    onSuccess: () => utils.channel.list.invalidate(),
+    onError: (error) => {
+      toastError({ title: 'Error updating settings', description: error.message })
+    },
+  })
+  const handleBidirectionalSyncChange = (next: boolean) => {
+    setBidirectionalSync(next)
+    updateSettings.mutate({
+      integrationId: integration.id,
+      settings: { bidirectionalSyncEnabled: next },
+    })
+  }
+
   const removeIntegration = api.channel.disconnect.useMutation({
     onSuccess: () => {
       setIsRemoving(false)
@@ -251,6 +273,15 @@ export default function IntegrationRouting({
                   {new Date(integration.throttleRetryAfter).toLocaleString()}.
                 </AlertDescription>
               </Alert>
+            )}
+            {showBidirectionalToggle && (
+              <ToggleCard
+                title='Two-way sync'
+                description='When you archive, trash, or read a thread in Auxx, apply the same change in your mailbox. Changes made in your mailbox always sync into Auxx regardless.'
+                checked={bidirectionalSync}
+                onCheckedChange={handleBidirectionalSyncChange}
+                disabled={!canManage || updateSettings.isPending}
+              />
             )}
           </div>
         </SettingsSection>

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -591,6 +591,7 @@ export const channelRouter = createTRPCRouter({
           excludeSenders: z.array(z.string().toLowerCase().trim()).optional(),
           excludeRecipients: z.array(z.string().toLowerCase().trim()).optional(),
           onlyProcessRecipients: z.array(z.string().toLowerCase().trim()).optional(),
+          bidirectionalSyncEnabled: z.boolean().optional(),
         }),
       })
     )

--- a/packages/lib/src/channels/cache.ts
+++ b/packages/lib/src/channels/cache.ts
@@ -20,6 +20,23 @@ export async function getOrgChannelProviderMap(
 }
 
 /**
+ * Per-channel bidirectional-status-sync flag, keyed by integration id.
+ *
+ * Opt-out semantics: a channel is enabled unless its settings explicitly set
+ * `bidirectionalSyncEnabled === false`. Reads the `channels` cache (which
+ * carries `settings` and is invalidated by `channel.settings_updated`), so a
+ * toggle flip takes effect without a TTL wait. Absent integrations resolve to
+ * `true` via `map.get(id) ?? true` at the call site.
+ */
+export async function getOrgChannelBidirectionalSyncMap(
+  organizationId: string,
+  _db: Database
+): Promise<Map<string, boolean>> {
+  const channels = await getOrgCache().get(organizationId, 'channels')
+  return new Map(channels.map((c) => [c.id, c.settings?.bidirectionalSyncEnabled !== false]))
+}
+
+/**
  * Invalidate cached provider map for an organization.
  * Call when channels are added or removed.
  * @deprecated Use onCacheEvent('channel.connected', { orgId }) instead

--- a/packages/lib/src/channels/list.ts
+++ b/packages/lib/src/channels/list.ts
@@ -1,10 +1,12 @@
 // packages/lib/src/channels/list.ts
 
 import { type Database, schema } from '@auxx/database'
+import type { IntegrationProviderType } from '@auxx/database/types'
 import { and, count, eq, inArray, isNull, sql } from 'drizzle-orm'
 import { getCachedUserMailVisibility, getOrgCache } from '../cache'
 import { getImportCacheSize } from '../email/polling-import-cache'
 import { NotFoundError } from '../errors'
+import { getProviderCapabilities } from '../providers/provider-capabilities'
 import { Result, type TypedResult } from '../result'
 import { getIdentifier } from './internal/identifier'
 import type { ChannelCtx } from './types'
@@ -76,6 +78,9 @@ export async function list(ctx: ChannelCtx) {
       email: c.email || (c.metadata as any)?.email || undefined,
       identifier: getIdentifier({ ...c, chatWidget: c.chatWidget }),
       inboxId: c.inboxId,
+      supportsBidirectionalStatusSync: getProviderCapabilities(
+        c.provider as IntegrationProviderType
+      ).supportsBidirectionalStatusSync,
       widgetSettings: c.provider === 'chat' ? c.chatWidget : undefined,
       lastSuccessfulSync: toDate(c.lastSuccessfulSync),
       metadata: c.metadata,

--- a/packages/lib/src/channels/types.ts
+++ b/packages/lib/src/channels/types.ts
@@ -23,4 +23,11 @@ export interface ChannelSettings {
   excludeSenders?: string[]
   excludeRecipients?: string[]
   onlyProcessRecipients?: string[]
+  /**
+   * Personal-inbox push-back to the provider mailbox (bidirectional status
+   * sync). Absent ⇒ enabled (opt-out) — only an explicit `false` disables.
+   * Only meaningful on providers whose capabilities set
+   * `supportsBidirectionalStatusSync`.
+   */
+  bidirectionalSyncEnabled?: boolean
 }

--- a/packages/lib/src/jobs/messages/thread-provider-status-sync-job.ts
+++ b/packages/lib/src/jobs/messages/thread-provider-status-sync-job.ts
@@ -5,7 +5,7 @@ import { ThreadStatus } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, inArray } from 'drizzle-orm'
 import { getOrgCache } from '../../cache'
-import { getOrgChannelProviderMap } from '../../channels/cache'
+import { getOrgChannelBidirectionalSyncMap, getOrgChannelProviderMap } from '../../channels/cache'
 import type { ChannelProvider } from '../../providers/channel-provider.interface'
 import { MessageStatus } from '../../providers/channel-provider.interface'
 import type { MessageProvider } from '../../providers/message-provider-interface'
@@ -64,9 +64,10 @@ export async function enqueueProviderSyncForEligibleThreads(args: {
   const { organizationId, threads, kind, requireOwnerUserId } = args
   if (threads.length === 0) return
 
-  const [inboxes, providerMap] = await Promise.all([
+  const [inboxes, providerMap, syncMap] = await Promise.all([
     getOrgCache().get(organizationId, 'inboxes'),
     getOrgChannelProviderMap(organizationId, db),
+    getOrgChannelBidirectionalSyncMap(organizationId, db),
   ])
   const inboxById = new Map(inboxes.map((i) => [i.id, i]))
 
@@ -77,6 +78,8 @@ export async function enqueueProviderSyncForEligibleThreads(args: {
     if (!inbox?.isPersonal) continue
     if (requireOwnerUserId && inbox.ownerUserId !== requireOwnerUserId) continue
     if (providerMap.get(t.integrationId) !== ChannelProviderType.google) continue
+    // Per-channel opt-out (absent ⇒ enabled).
+    if (syncMap.get(t.integrationId) === false) continue
     const ids = threadIdsByIntegration.get(t.integrationId) ?? []
     ids.push(t.threadId)
     threadIdsByIntegration.set(t.integrationId, ids)
@@ -168,6 +171,17 @@ export const threadProviderStatusSyncJob = async (
   ctx: JobContext<ThreadProviderStatusSyncJobData>
 ): Promise<{ pushed: number; skipped: number; failed: number }> => {
   const { organizationId, integrationId, threadIds, kind = 'status' } = ctx.job.data
+
+  // Re-check the per-channel opt-out — the toggle may have flipped off between
+  // enqueue and run (absent ⇒ enabled).
+  const syncMap = await getOrgChannelBidirectionalSyncMap(organizationId, db)
+  if (syncMap.get(integrationId) === false) {
+    logger.debug('Bidirectional sync disabled for channel — skipping push', {
+      organizationId,
+      integrationId,
+    })
+    return { pushed: 0, skipped: threadIds.length, failed: 0 }
+  }
 
   const rows = await db
     .select({

--- a/packages/lib/src/providers/provider-capabilities.ts
+++ b/packages/lib/src/providers/provider-capabilities.ts
@@ -10,6 +10,7 @@ export type { ProviderCapabilities } from './types'
 export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapabilities> = {
   [IntegrationProviderType.google]: {
     supportsPersonalConnection: true,
+    supportsBidirectionalStatusSync: true,
     // Gmail capabilities
     canSend: true,
     canReply: true,
@@ -43,6 +44,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.facebook]: {
     supportsPersonalConnection: false,
+    supportsBidirectionalStatusSync: false,
     // Facebook Messenger capabilities
     canSend: true,
     canReply: true,
@@ -83,6 +85,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.instagram]: {
     supportsPersonalConnection: false,
+    supportsBidirectionalStatusSync: false,
     // Instagram Direct Message capabilities
     canSend: true,
     canReply: true,
@@ -122,6 +125,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.openphone]: {
     supportsPersonalConnection: false,
+    supportsBidirectionalStatusSync: false,
     // SMS capabilities (via OpenPhone or similar)
     canSend: true,
     canReply: true,
@@ -158,6 +162,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.mailgun]: {
     supportsPersonalConnection: false,
+    supportsBidirectionalStatusSync: false,
     // Mailgun email service capabilities
     canSend: true,
     canReply: true,
@@ -191,6 +196,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.sms]: {
     supportsPersonalConnection: false,
+    supportsBidirectionalStatusSync: false,
     // Generic SMS capabilities
     canSend: true,
     canReply: true,
@@ -227,6 +233,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.email]: {
     supportsPersonalConnection: true,
+    supportsBidirectionalStatusSync: false,
     // Generic email capabilities
     canSend: true,
     canReply: true,
@@ -260,6 +267,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.whatsapp]: {
     supportsPersonalConnection: false,
+    supportsBidirectionalStatusSync: false,
     // WhatsApp Business API capabilities
     canSend: true,
     canReply: true,
@@ -298,6 +306,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.chat]: {
     supportsPersonalConnection: false,
+    supportsBidirectionalStatusSync: false,
     // Generic chat capabilities (internal chat system)
     canSend: true,
     canReply: true,
@@ -334,6 +343,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.shopify]: {
     supportsPersonalConnection: false,
+    supportsBidirectionalStatusSync: false,
     // Shopify capabilities (not a messaging provider)
     canSend: false,
     canReply: false,
@@ -371,6 +381,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.imap]: {
     supportsPersonalConnection: true,
+    supportsBidirectionalStatusSync: false,
     // IMAP/SMTP capabilities (self-hosted, enterprise)
     canSend: true,
     canReply: true,
@@ -404,6 +415,7 @@ export const PROVIDER_CAPABILITIES: Record<IntegrationProviderType, ProviderCapa
   },
   [IntegrationProviderType.outlook]: {
     supportsPersonalConnection: true,
+    supportsBidirectionalStatusSync: false,
     // Outlook/Office 365 capabilities
     canSend: true,
     canReply: true,
@@ -458,6 +470,7 @@ export function getProviderCapabilities(
     PROVIDER_CAPABILITIES[providerType] || {
       // Default minimal capabilities
       supportsPersonalConnection: false,
+      supportsBidirectionalStatusSync: false,
       canSend: false,
       canReply: false,
       canForward: false,

--- a/packages/lib/src/providers/types.ts
+++ b/packages/lib/src/providers/types.ts
@@ -51,6 +51,14 @@ export interface ProviderCapabilities {
    */
   supportsPersonalConnection: boolean
 
+  /**
+   * Whether this provider can mirror Auxx thread status/read changes back to
+   * the provider mailbox (bidirectional status sync). Personal inboxes only,
+   * and gated per-channel by `ChannelSettings.bidirectionalSyncEnabled`. Gmail
+   * only for now; other email-likes can opt in by flipping this preset.
+   */
+  supportsBidirectionalStatusSync: boolean
+
   // Send-pipeline shape — drives MessageSenderService.validateInput, usage guard,
   // and post-send sync. Email-likes are all `true`; chat is all `false`. FB/IG
   // are currently `true` for compatibility — see provider-capabilities.ts.


### PR DESCRIPTION
## Summary

Adds a **Two-way sync** toggle to personal-inbox channel settings, letting users stop Auxx from mirroring thread status/read changes back to their provider mailbox. Mailbox → Auxx sync always continues.

Follows up on #1104 (bidirectional Gmail status & read-state sync), giving users a per-channel escape hatch.

## Behavior

- **Opt-out semantics**: absent flag ⇒ enabled; only an explicit `false` disables push-back.
- Toggle is shown **only** for providers that support it (Gmail today) on **personal** inboxes — push-back never applies to shared inboxes.

## Changes

- New `supportsBidirectionalStatusSync` provider capability (`true` for Gmail, `false` elsewhere).
- `ChannelSettings.bidirectionalSyncEnabled` + `channel.updateSettings` input.
- `getOrgChannelBidirectionalSyncMap` reads the `channels` org cache (invalidated by `channel.settings_updated`), so a toggle flip takes effect without a TTL wait.
- Enqueue-time filter in `enqueueProviderSyncForEligibleThreads` + run-time re-check in `threadProviderStatusSyncJob` (toggle may flip between enqueue and run).
- `ToggleCard` in `integration-routing.tsx`, gated on capability + personal inbox + manage permission.

## Test plan

- [ ] Toggle appears only for personal Gmail inboxes; hidden for shared/other providers.
- [ ] Disabling stops Auxx→Gmail push (archive/trash/read); Gmail→Auxx sync still works.
- [ ] Re-enabling resumes push without a cache TTL wait.