### PR TITLE
feat(mail): read/unread toggle, assignee polish, T for tags

### DIFF
--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -44,12 +44,13 @@ import { DrawerContextProvider } from '~/components/drawers/drawer-context'
 import { EmptyState } from '~/components/global/empty-state'
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions'
+// import SearchBar from '~/components/mail/mail-searchbar'
+import BulkActionToolbar from '~/components/mail/bulk-action-toolbar'
 import {
   MailFilterProvider,
   type SortDirection,
   type SortOption,
 } from '~/components/mail/mail-filter-context'
-// import SearchBar from '~/components/mail/mail-searchbar'
 import { ThreadList } from '~/components/mail/mail-thread-list'
 // import { ProposedActionsView } from './proposed-actions-view'
 import { MailSearchBar } from '~/components/mail/searchbar'
@@ -670,6 +671,9 @@ function MailboxInner({
                 'flex flex-row h-full flex-1 overflow-hidden bg-secondary',
                 'max-sm:dark:bg-primary-100 sm:dark:bg-muted-50'
               )}>
+              {/* Bulk action toolbar — mounted once here (portal-rendered, store-driven)
+                so split view doesn't stack two instances and double-fire hotkeys. */}
+              <BulkActionToolbar />
               {/* ThreadList panel */}
               <div
                 style={layoutMode === 'split' ? { width: threadListWidth } : undefined}

--- a/apps/web/src/components/mail/assignee-chip.tsx
+++ b/apps/web/src/components/mail/assignee-chip.tsx
@@ -3,6 +3,7 @@
 
 import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
 import { useActor } from '~/components/resources/hooks'
 
@@ -42,9 +43,11 @@ export function AssigneeChip({ assigneeId, className }: AssigneeChipProps) {
       .substring(0, 2) || '?'
 
   return (
-    <Avatar className={cn('size-4 shrink-0', className)} title={name}>
-      <AvatarImage src={assignee?.image || undefined} alt={name} />
-      <AvatarFallback className='text-[8px] text-muted-foreground'>{initials}</AvatarFallback>
-    </Avatar>
+    <SimpleTooltip content={name} side='right' delayDuration={300}>
+      <Avatar className={cn('size-4 shrink-0', className)}>
+        <AvatarImage src={assignee?.avatarUrl || undefined} alt={name} />
+        <AvatarFallback className='text-[8px] text-muted-foreground'>{initials}</AvatarFallback>
+      </Avatar>
+    </SimpleTooltip>
   )
 }

--- a/apps/web/src/components/mail/bulk-action-toolbar.tsx
+++ b/apps/web/src/components/mail/bulk-action-toolbar.tsx
@@ -6,7 +6,18 @@ import { getInstanceId, type RecordId } from '@auxx/types/resource'
 import { ActionBar, type ActionBarAction } from '@auxx/ui/components/action-bar'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { useHotkey } from '@tanstack/react-hotkeys'
-import { Archive, Ban, Merge, Play, Tags, Trash, Trash2, UserPlus } from 'lucide-react'
+import {
+  Archive,
+  Ban,
+  Mail,
+  MailOpen,
+  Merge,
+  Play,
+  Tags,
+  Trash,
+  Trash2,
+  UserPlus,
+} from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/shallow'
 import { ActorPicker } from '~/components/pickers/actor-picker'
@@ -64,6 +75,12 @@ export default function BulkActionToolbar() {
   const tagEntityDefId = tagResource?.entityDefinitionId ?? undefined
   const { resource: threadResource } = useResource('thread')
   const threadEntityDefId = threadResource?.entityDefinitionId ?? undefined
+
+  // Aggregate read state: true if ANY selected thread is unread. Drives the
+  // toggle direction (any unread → mark all read; else mark all unread).
+  const anySelectedUnread = useThreadStore(
+    useShallow((s) => selectedThreadIds.some((id) => s.threads.get(id)?.isUnread))
+  )
 
   // Subscribe to tagIds of all selected threads — recomputes on any optimistic update.
   const selectedThreadsTagIds = useThreadStore(
@@ -126,11 +143,28 @@ export default function BulkActionToolbar() {
     [updateBulk, selectedThreadIds, selectionCount, clearSelection]
   )
 
+  const handleToggleRead = useCallback(() => {
+    // Any unread → mark all read; otherwise mark all unread.
+    updateBulk(selectedThreadIds, { isUnread: !anySelectedUnread })
+    toastSuccess({
+      title: `${selectionCount} threads marked as ${anySelectedUnread ? 'read' : 'unread'}`,
+    })
+    clearSelection()
+  }, [updateBulk, selectedThreadIds, selectionCount, anySelectedUnread, clearSelection])
+
   // --- Keyboard shortcuts ---
   useHotkey(
     'D',
     () => {
       if (selectionCount > 0 && !isBulkUpdating) handleArchive()
+    },
+    { enabled: open, conflictBehavior: 'allow' }
+  )
+
+  useHotkey(
+    'U',
+    () => {
+      if (selectionCount > 0 && !isBulkUpdating) handleToggleRead()
     },
     { enabled: open, conflictBehavior: 'allow' }
   )
@@ -152,7 +186,7 @@ export default function BulkActionToolbar() {
   )
 
   useHotkey(
-    'L',
+    'T',
     () => {
       if (selectionCount > 0) {
         const btn = document.querySelector<HTMLButtonElement>('[data-action-id="tags"] button')
@@ -316,11 +350,20 @@ export default function BulkActionToolbar() {
         tooltip: 'Mark selected as spam',
       },
       {
+        id: 'read',
+        label: anySelectedUnread ? 'Mark read' : 'Mark unread',
+        icon: anySelectedUnread ? MailOpen : Mail,
+        onClick: handleToggleRead,
+        disabled: isBulkUpdating || disabled,
+        shortcut: 'U',
+        tooltip: anySelectedUnread ? 'Mark selected as read' : 'Mark selected as unread',
+      },
+      {
         id: 'tags',
         label: 'Tags',
         icon: Tags,
         disabled: tagBulk.isPending || disabled,
-        shortcut: 'L',
+        shortcut: 'T',
         tooltip: 'Apply tags',
         picker: {
           component: TagPicker,
@@ -395,6 +438,8 @@ export default function BulkActionToolbar() {
       handleArchive,
       handleTrash,
       handleSpam,
+      handleToggleRead,
+      anySelectedUnread,
       handleAssign,
       handleTagChange,
       handlePermanentlyDelete,

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -236,7 +236,9 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                 ) : hasDraft ? (
                   <div className='size-2 rounded-full bg-red-500' />
                 ) : isUnread ? (
-                  <div className='size-2 rounded-full bg-blue-500' />
+                  <Tooltip content='Mark as read' shortcut='U'>
+                    <div className='size-2 rounded-full bg-blue-500' />
+                  </Tooltip>
                 ) : null}
               </div>
             </div>
@@ -276,6 +278,11 @@ export const CompactThreadItem = memo(function CompactThreadItem({
               )}
             </div>
 
+            {/* Assignee avatar - fixed slot to avoid layout shift */}
+            <div className='flex w-5 shrink-0 items-center justify-center ms-1.5'>
+              {thread.assigneeId && <AssigneeChip assigneeId={thread.assigneeId as ActorId} />}
+            </div>
+
             {/* Tags */}
             {hasTags && (
               <div
@@ -302,7 +309,6 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                 )}>
                 {myLens === 'metadata' ? 'No access to subject' : thread.subject || '(no subject)'}
               </span>
-              {thread.assigneeId && <AssigneeChip assigneeId={thread.assigneeId as ActorId} />}
               {thread.hasShares && (
                 <Share2 className='size-3 shrink-0 text-muted-foreground' aria-label='Shared' />
               )}
@@ -322,7 +328,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                   isFocused || isMenuOpen ? 'flex opacity-100' : 'opacity-0 pointer-events-none'
                 )}
                 onClick={(e) => e.stopPropagation()}>
-                <Tooltip content='Done' shortcut='D'>
+                <Tooltip content='Done' shortcut='D' delayDuration={300}>
                   <Button
                     variant='ghost'
                     size='icon'
@@ -331,7 +337,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                     <Archive className='size-3.5' />
                   </Button>
                 </Tooltip>
-                <Tooltip content='Trash' shortcut='#'>
+                <Tooltip content='Trash' shortcut='#' delayDuration={300}>
                   <Button
                     variant='ghost'
                     size='icon'
@@ -340,7 +346,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                     <Trash2 className='size-3.5' />
                   </Button>
                 </Tooltip>
-                <Tooltip content='Spam' shortcut='!'>
+                <Tooltip content='Spam' shortcut='!' delayDuration={300}>
                   <Button
                     variant='ghost'
                     size='icon'
@@ -349,7 +355,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                     <ShieldAlert className='size-3.5' />
                   </Button>
                 </Tooltip>
-                <Tooltip content='Assign' shortcut='A'>
+                <Tooltip content='Assign' shortcut='A' delayDuration={300}>
                   <Button
                     variant='ghost'
                     size='icon'
@@ -358,7 +364,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
                     <UserRound className='size-3.5' />
                   </Button>
                 </Tooltip>
-                <Tooltip content='Tag' shortcut='L'>
+                <Tooltip content='Tag' shortcut='T' delayDuration={300}>
                   <Button
                     variant='ghost'
                     size='icon'

--- a/apps/web/src/components/mail/mail-thread-list.tsx
+++ b/apps/web/src/components/mail/mail-thread-list.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mail/mail-thread-list.tsx
 'use client'
 
+import type { ActorId } from '@auxx/types/actor'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
@@ -31,6 +32,7 @@ import { TagPicker } from '~/components/tags/ui/tag-picker'
 import {
   useFocusedThreadShortcuts,
   useSelectionReset,
+  useThread,
   useThreadKeyboardNav,
   useThreadList,
   useThreadMutation,
@@ -44,7 +46,6 @@ import {
 } from '~/components/threads/store'
 import { MassWorkflowTriggerDialog } from '~/components/workflow/mass-workflow-trigger-dialog'
 import { api } from '~/trpc/react'
-import BulkActionToolbar from './bulk-action-toolbar'
 import { CompactDraftItem } from './compact-draft-item'
 import { CompactThreadItem, CompactThreadItemSkeleton } from './compact-thread-item'
 import { type SortOption, useMailFilter } from './mail-filter-context'
@@ -162,12 +163,21 @@ export const ThreadList = memo(function ThreadList({
   const { update: updateThread } = useThreadMutation()
   const handleFocusedAssign = useCallback(
     (actorIds: string[]) => {
-      if (assignPickerThreadId && actorIds.length > 0) {
-        updateThread(assignPickerThreadId, { assigneeId: actorIds[0] })
-      }
+      if (!assignPickerThreadId) return
+      // Empty selection (re-clicking the assignee) unassigns — mirror the header.
+      updateThread(assignPickerThreadId, { assigneeId: actorIds[0] ?? null })
     },
     [assignPickerThreadId, updateThread]
   )
+
+  // Current assignee of the focused thread, so the picker pre-selects it on open
+  const { thread: assignPickerThread } = useThread({
+    threadId: assignPickerThreadId ?? '',
+    enabled: !!assignPickerThreadId,
+  })
+  const assignPickerValue = assignPickerThread?.assigneeId
+    ? [assignPickerThread.assigneeId as ActorId]
+    : []
 
   // Reset selection when filter changes
   useSelectionReset(filter.filter)
@@ -270,7 +280,6 @@ export const ThreadList = memo(function ThreadList({
   return (
     <div className={cn('relative flex h-full w-full flex-col', isEmpty && 'flex-1')}>
       <ThreadListMenu threadIds={threadIds} />
-      <BulkActionToolbar />
       {workflowThreadId && (
         <MassWorkflowTriggerDialog
           open={workflowDialogOpen}
@@ -299,7 +308,10 @@ export const ThreadList = memo(function ThreadList({
           open={assignPickerOpen}
           onOpenChange={handleAssignPickerOpenChange}
           anchorRef={assignAnchorRef}
+          value={assignPickerValue}
           onChange={handleFocusedAssign}
+          multi={false}
+          target='user'
           emptyLabel='Assign'
           align='end'
           side='bottom'

--- a/apps/web/src/components/mail/thread-display.tsx
+++ b/apps/web/src/components/mail/thread-display.tsx
@@ -13,7 +13,6 @@ import { useActiveThreadId, useHasMultipleSelected } from '~/components/threads/
 import { useCompose } from '~/hooks/use-compose'
 import { useUser } from '~/hooks/use-user'
 import { EmptyState } from '../global/empty-state'
-import BulkActionToolbar from './bulk-action-toolbar'
 import { useMailFilter } from './mail-filter-context'
 import ThreadDetails from './thread-details'
 import { ThreadProvider } from './thread-provider'
@@ -84,7 +83,6 @@ export function ThreadDisplay({ centered, expectedThreadId }: ThreadDisplayProps
           )}
         </>
       )}
-      <BulkActionToolbar />
       {thread && viewMode !== 'edit' ? (
         <ThreadProvider threadId={thread.id}>
           <ThreadDetails centered={centered} />

--- a/apps/web/src/components/mail/thread-header.tsx
+++ b/apps/web/src/components/mail/thread-header.tsx
@@ -130,8 +130,8 @@ export function ThreadHeader() {
     conflictBehavior: 'allow',
   })
 
-  // L — Open tag picker (anchored to the header's tag button)
-  useHotkey('L', () => setOpen(true), { enabled: shortcutsEnabled, conflictBehavior: 'allow' })
+  // T — Open tag picker (anchored to the header's tag button)
+  useHotkey('T', () => setOpen(true), { enabled: shortcutsEnabled, conflictBehavior: 'allow' })
 
   // --- Handlers ---
 
@@ -305,7 +305,7 @@ export function ThreadHeader() {
             <ThreadMergeBadge mergeData={thread.mergeData} />
           </div>
           <div data-slot='thread-header-actions' className=' flex items-center '>
-            <Tooltip content={isDone ? 'Unarchive' : 'Archive'} shortcut='D'>
+            <Tooltip content={isDone ? 'Unarchive' : 'Archive'} shortcut='D' delayDuration={300}>
               <Button
                 variant='ghost'
                 size='icon'
@@ -317,7 +317,10 @@ export function ThreadHeader() {
               </Button>
             </Tooltip>
 
-            <Tooltip content={isTrash ? 'Restore from trash' : 'Trash Thread'} shortcut='#'>
+            <Tooltip
+              content={isTrash ? 'Restore from trash' : 'Trash Thread'}
+              shortcut='#'
+              delayDuration={300}>
               <Button
                 variant='ghost'
                 size='icon'
@@ -329,7 +332,10 @@ export function ThreadHeader() {
               </Button>
             </Tooltip>
             {isEmailChannel && (
-              <Tooltip content={isSpam ? 'Not spam' : 'Mark as spam'} shortcut='!'>
+              <Tooltip
+                content={isSpam ? 'Not spam' : 'Mark as spam'}
+                shortcut='!'
+                delayDuration={300}>
                 <Button
                   variant='ghost'
                   size='icon'
@@ -347,7 +353,7 @@ export function ThreadHeader() {
               </Tooltip>
             )}
 
-            <Tooltip content='Apply Tags' shortcut='L'>
+            <Tooltip content='Apply Tags' shortcut='T' delayDuration={300}>
               <Button
                 ref={tagButtonRef}
                 variant='ghost'
@@ -372,7 +378,7 @@ export function ThreadHeader() {
               />
             )}
             <ManualTriggerButton recordId={toRecordId('thread', thread.id)}>
-              <Tooltip content='Run workflow' shortcut='W'>
+              <Tooltip content='Run workflow' shortcut='W' delayDuration={300}>
                 <Button
                   variant='ghost'
                   size='icon'
@@ -396,7 +402,10 @@ export function ThreadHeader() {
               target='user'
               emptyLabel='Assign'>
               <div>
-                <Tooltip content={assignee ? assignee.name || 'Assigned' : 'Assign'} shortcut='A'>
+                <Tooltip
+                  content={assignee ? assignee.name || 'Assigned' : 'Assign'}
+                  shortcut='A'
+                  delayDuration={300}>
                   <Button
                     variant='ghost'
                     size='icon'
@@ -436,7 +445,7 @@ export function ThreadHeader() {
               side='bottom'
               emptyLabel='Merge into thread…'>
               <div>
-                <Tooltip content='Merge into…'>
+                <Tooltip content='Merge into…' delayDuration={300}>
                   <Button
                     variant='ghost'
                     size='icon'

--- a/apps/web/src/components/threads/hooks/use-focused-thread-shortcuts.ts
+++ b/apps/web/src/components/threads/hooks/use-focused-thread-shortcuts.ts
@@ -15,7 +15,7 @@ import { getThreadStoreState } from '../store/thread-store'
 import { useThreadMutation } from './use-thread-mutation'
 
 /**
- * Registers action shortcuts (D, #, !, W, L, A) for the focused thread (compact/list view)
+ * Registers action shortcuts (D, #, !, U, W, T, A) for the focused thread (compact/list view)
  * or the active thread (split view) when no focus cursor is set.
  * Disabled when bulk mode is active so bulk shortcuts take priority.
  * Returns UI state (workflow dialog, tag picker) for rendering by the parent component.
@@ -98,6 +98,20 @@ export function useFocusedThreadShortcuts() {
     conflictBehavior: 'allow',
   })
 
+  // U — Mark read / unread (toggle). Not an anchored popover, so it works in
+  // both list and detail view (gated on actionsEnabled, like D/#/!).
+  useHotkey(
+    'U',
+    () => {
+      if (!targetThreadId || isUpdating) return
+      const isUnread = getThreadStoreState().getThread(targetThreadId)?.isUnread
+      // Stay put (no advanceFocus) — read-state toggle isn't triage; a second U
+      // reverses it on the same thread.
+      update(targetThreadId, { isUnread: !isUnread })
+    },
+    { enabled: actionsEnabled, conflictBehavior: 'allow' }
+  )
+
   // W — Open workflow dialog
   useHotkey(
     'W',
@@ -153,12 +167,12 @@ export function useFocusedThreadShortcuts() {
     [setFocusLocked]
   )
 
-  // L — Open tag picker
+  // T — Open tag picker
   const [tagPickerOpen, setTagPickerOpen] = useState(false)
   const [tagPickerThreadId, setTagPickerThreadId] = useState<string | null>(null)
 
   useHotkey(
-    'L',
+    'T',
     () => {
       if (targetThreadId) {
         setTagPickerThreadId(targetThreadId)

--- a/apps/web/src/components/threads/hooks/use-thread-keyboard-nav.ts
+++ b/apps/web/src/components/threads/hooks/use-thread-keyboard-nav.ts
@@ -152,12 +152,17 @@ export function useThreadKeyboardNav({
     conflictBehavior: 'allow',
   })
 
-  // Escape - clear selection. Defer to open Radix popovers/dropdowns so they
-  // can dismiss themselves first (Dialog/Drawer stop propagation on their own).
+  // Escape - clear selection (and close the open thread). Radix popovers,
+  // dropdowns, dialogs and drawers dismiss on Escape via a capture-phase
+  // listener that calls preventDefault() before their content unmounts. That
+  // teardown is synchronous under React 19's discrete-event flushing, so a
+  // DOM-presence check here always runs too late (the layer is already gone).
+  // Guard on event.defaultPrevented instead: if a Radix layer already consumed
+  // the Escape, skip clearing so the first Escape only closes that layer.
   useHotkey(
     'Escape',
-    () => {
-      if (document.querySelector('[data-radix-popper-content-wrapper]')) return
+    (event) => {
+      if (event.defaultPrevented) return
       useThreadSelectionStore.getState().clearSelection()
     },
     { enabled, conflictBehavior: 'allow' }
@@ -170,7 +175,6 @@ export function useThreadKeyboardNav({
       const store = useThreadSelectionStore.getState()
       const currentMode = store.viewMode
       store.toggleViewMode()
-      toast.info(currentMode === 'view' ? 'Edit mode enabled' : 'View mode enabled')
     },
     { enabled, conflictBehavior: 'allow' }
   )

--- a/apps/web/src/components/threads/hooks/use-thread-read-status.ts
+++ b/apps/web/src/components/threads/hooks/use-thread-read-status.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/threads/hooks/use-thread-read-status.ts
 
+import { toRecordId } from '@auxx/types/resource'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useRef } from 'react'
 import { type ThreadCountContext, useCountUpdates } from '~/components/mail/hooks'
@@ -17,6 +18,10 @@ interface UseThreadReadStatusResult {
  * Hook to get and mutate thread read status.
  * Uses granular selector on ThreadStore for optimal re-renders.
  * Integrates with mail counts store for optimistic count updates.
+ *
+ * Writes go through the unified `thread.update` endpoint (`{ isUnread }`), which
+ * routes read-state to UnreadService on the server — the single write path
+ * shared with bulk/`U`-shortcut read toggles.
  *
  * @example
  * const { isUnread, markAsRead } = useThreadReadStatus('thread123')
@@ -42,10 +47,11 @@ export function useThreadReadStatus(threadId: string | null): UseThreadReadStatu
   // Count update helpers (no views for now - views need to be passed from context)
   const { onMarkAsRead, onMarkAsUnread, rollback } = useCountUpdates()
 
-  // Single mutation with optimistic updates
-  const readStatus = api.thread.readStatus.useMutation({
-    onMutate: ({ isRead }) => {
-      if (!threadId || !thread || !currentUserId) return
+  // Unified update endpoint with optimistic updates. `isUnread` is peeled off
+  // server-side and applied via UnreadService.
+  const readStatus = api.thread.update.useMutation({
+    onMutate: ({ updates }) => {
+      if (!threadId || !thread || !currentUserId || updates.isUnread === undefined) return
 
       // Build context from current thread state
       const context: ThreadCountContext = {
@@ -57,19 +63,19 @@ export function useThreadReadStatus(threadId: string | null): UseThreadReadStatu
       }
 
       // Update ThreadStore (for UI)
-      updateThread(threadId, { isUnread: !isRead })
+      updateThread(threadId, { isUnread: updates.isUnread })
 
       // Update counts (for sidebar badges)
-      if (isRead) {
-        onMarkAsRead([context], currentUserId)
-      } else {
+      if (updates.isUnread) {
         onMarkAsUnread([context], currentUserId)
+      } else {
+        onMarkAsRead([context], currentUserId)
       }
     },
     onError: (error, variables) => {
-      // Rollback ThreadStore
-      if (threadId) {
-        updateThread(threadId, { isUnread: variables.isRead })
+      // Rollback ThreadStore to the pre-toggle state
+      if (threadId && variables.updates.isUnread !== undefined) {
+        updateThread(threadId, { isUnread: !variables.updates.isUnread })
       }
       // Rollback counts
       rollback()
@@ -85,12 +91,15 @@ export function useThreadReadStatus(threadId: string | null): UseThreadReadStatu
     isUnread: isUnread ?? true,
     markAsRead: useCallback(() => {
       if (threadId) {
-        mutateRef.current({ threadId, isRead: true })
+        mutateRef.current({
+          recordId: toRecordId('thread', threadId),
+          updates: { isUnread: false },
+        })
       }
     }, [threadId]),
     markAsUnread: useCallback(() => {
       if (threadId) {
-        mutateRef.current({ threadId, isRead: false })
+        mutateRef.current({ recordId: toRecordId('thread', threadId), updates: { isUnread: true } })
       }
     }, [threadId]),
   }

--- a/apps/web/src/server/api/routers/thread.ts
+++ b/apps/web/src/server/api/routers/thread.ts
@@ -32,13 +32,35 @@ import {
   UnreadService,
 } from '@auxx/lib/threads'
 import { createScopedLogger } from '@auxx/logger'
-import { recordIdSchema } from '@auxx/types/resource'
+import { getInstanceId, recordIdSchema } from '@auxx/types/resource'
 import { TRPCError } from '@trpc/server'
 import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
 
 const logger = createScopedLogger('thread-router')
+
+/**
+ * Route an `isUnread` field peeled off a unified thread update to the
+ * UnreadService, which owns read-state storage, sidebar count deltas, and
+ * realtime fan-out (with socket-id echo-suppression). `isUnread` is the inverse
+ * of the service's `isRead`. This keeps read/unread on the single
+ * `update`/`updateBulk` write path while the actual work stays in one service.
+ */
+async function setThreadsReadFromUpdates(
+  ctx: {
+    session: { userId: string; organizationId: string }
+    headers?: { get?: (key: string) => string | null }
+  },
+  threadIds: string[],
+  isUnread: boolean
+): Promise<void> {
+  const { userId, organizationId } = ctx.session
+  const socketId = ctx.headers?.get?.('x-realtime-socket-id') ?? undefined
+  const viewer = await getCachedUserMailVisibility(userId, organizationId)
+  const unreadService = new UnreadService(organizationId, userId, viewer, socketId)
+  await unreadService.setReadStatus(threadIds, !isUnread)
+}
 
 // Participant Input Schema (reusable)
 const ParticipantInputSchema = z.object({
@@ -606,6 +628,9 @@ export const threadRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { threadMutation, organizationId, userId } = await getServiceDependencies(ctx)
+      // Read/unread is stored & fanned out by UnreadService — peel it off the
+      // unified payload and forward any remaining field updates to the service.
+      const { isUnread, ...rest } = input.updates
       try {
         logger.info('API: Unified thread update', {
           recordId: input.recordId,
@@ -613,7 +638,18 @@ export const threadRouter = createTRPCRouter({
           userId,
           organizationId,
         })
-        return await threadMutation.update(input.recordId, input.updates as any)
+        if (isUnread !== undefined) {
+          await setThreadsReadFromUpdates(ctx, [getInstanceId(input.recordId)], isUnread)
+        }
+        if (Object.keys(rest).length > 0) {
+          return await threadMutation.update(input.recordId, rest as any)
+        }
+        return {
+          id: getInstanceId(input.recordId),
+          success: true,
+          updatedFields: input.updates,
+          timestamp: new Date(),
+        }
       } catch (error: unknown) {
         if (error instanceof TRPCError) throw error
         handleServiceError(error, 'threadMutation.update', {
@@ -639,12 +675,15 @@ export const threadRouter = createTRPCRouter({
           assigneeId: z.string().nullable().optional(),
           inboxId: recordIdSchema.nullable().optional(),
           ticketId: recordIdSchema.nullable().optional(),
+          isUnread: z.boolean().optional(),
           mergedIntoThreadId: recordIdSchema.nullable().optional(),
         }),
       })
     )
     .mutation(async ({ ctx, input }) => {
       const { threadMutation, organizationId, userId } = await getServiceDependencies(ctx)
+      // Read/unread routes through UnreadService; forward the rest (if any).
+      const { isUnread, ...rest } = input.updates
       try {
         logger.info('API: Unified bulk thread update', {
           count: input.recordIds.length,
@@ -652,7 +691,14 @@ export const threadRouter = createTRPCRouter({
           userId,
           organizationId,
         })
-        return await threadMutation.updateBulk(input.recordIds, input.updates as any)
+        if (isUnread !== undefined) {
+          const threadIds = input.recordIds.map((recordId) => getInstanceId(recordId))
+          await setThreadsReadFromUpdates(ctx, threadIds, isUnread)
+        }
+        if (Object.keys(rest).length > 0) {
+          return await threadMutation.updateBulk(input.recordIds, rest as any)
+        }
+        return { count: input.recordIds.length }
       } catch (error: unknown) {
         if (error instanceof TRPCError) throw error
         handleServiceError(error, 'threadMutation.updateBulk', {
@@ -759,20 +805,6 @@ export const threadRouter = createTRPCRouter({
     const { userId, organizationId } = ctx.session
     return await getMailCounts(organizationId, userId)
   }),
-  readStatus: protectedProcedure
-    .input(
-      z.object({
-        threadId: z.union([z.string(), z.array(z.string())]),
-        isRead: z.boolean(),
-      })
-    )
-    .mutation(async ({ ctx, input }) => {
-      const { userId, organizationId } = ctx.session
-      const socketId = ctx.headers?.get?.('x-realtime-socket-id') ?? undefined
-      const viewer = await getCachedUserMailVisibility(userId, organizationId)
-      const unreadService = new UnreadService(organizationId, userId, viewer, socketId)
-      await unreadService.setReadStatus(input.threadId, input.isRead)
-    }),
   /**
    * Retry sending a failed message
    * Delegates to MessageSenderService for proper retry handling

--- a/packages/lib/src/threads/thread-mutation.service.ts
+++ b/packages/lib/src/threads/thread-mutation.service.ts
@@ -34,7 +34,6 @@ export interface ThreadUpdates {
   inboxId?: RecordId | null
   /** Ticket RecordId (format: "ticket:instanceId") or null to unlink */
   ticketId?: RecordId | null
-  isUnread?: boolean
   /**
    * Merge routing field. When set to a Thread RecordId, the corresponding
    * `update`/`updateBulk` call routes through {@link ThreadMergeService.merge}
@@ -228,9 +227,6 @@ export class ThreadMutationService {
           dbUpdates.primaryEntityDefinitionId = null
         }
       }
-
-      // isUnread is handled separately via UnreadService, but for now we skip it
-      // The frontend store handles optimistic updates for read status
 
       if (Object.keys(dbUpdates).length === 0) {
         return {


### PR DESCRIPTION
## Summary
- Adds a `U` shortcut and bulk-toolbar action to toggle thread read/unread state, routed through the unified `thread.update`/`updateBulk` endpoints — `isUnread` is peeled off server-side and forwarded to `UnreadService`, replacing the old dedicated `thread.readStatus` mutation so there's a single write path.
- Rebinds the tag-picker shortcut from `L` to `T` (frees up `L`), consistently across the header, focused-thread shortcuts, and bulk toolbar.
- Moves the assignee avatar into a fixed slot with a tooltip to avoid layout shift; pre-selects the current assignee when opening the picker from the thread list.
- Mounts `BulkActionToolbar` once in `mail-box.tsx` instead of twice (list + detail view), preventing double-fired hotkeys in split view.
- Fixes an Escape-key race with open Radix popovers/dialogs by checking `event.defaultPrevented` instead of a DOM-presence check, which ran too late under React 19's synchronous teardown.

## Test plan
- [ ] Toggle read/unread via `U` on a focused thread (list and split view) and via the bulk toolbar with multiple threads selected
- [ ] Verify sidebar unread counts update optimistically and roll back on error
- [ ] Open tag picker via `T` from header, focused-thread shortcut, and bulk toolbar
- [ ] Assign/reassign a thread from the list view picker and confirm current assignee pre-selects
- [ ] Press Escape with a popover open — first Escape closes the popover only, second clears selection