### PR TITLE
docs: add Knowledge Base and Today architecture guides

### DIFF
--- a/docs/knowledge-base-architecture-guide.md
+++ b/docs/knowledge-base-architecture-guide.md
@@ -1,0 +1,432 @@
+# Knowledge Base Architecture Guide
+
+The Knowledge Base (KB) system covers the data model, the authoring editor
+(`apps/web`), the public reader site (`apps/kb`), the AI/embedding pipeline, and
+how Kopilot reads and edits articles. Verified against the implementation on
+**2026-07-09**.
+
+External content ingestion (crawling websites, manual entries, future
+connectors) is a separate but tightly-integrated system — see
+`docs/knowledge-sources-architecture-guide.md`. This guide covers only what a
+"native" KB does; Knowledge Sources is documented where it touches KB
+primitives (§2, §6).
+
+---
+
+## 1. The shape in one paragraph
+
+A **KnowledgeBase** belongs to an org. Content lives in **Article** rows, but
+an article's *tree position* and *publish state* live separately, on
+**ArticlePlacement** — one article can be placed into multiple KBs at once
+(multi-home), each placement with its own parent, sort order, and published
+revision. Every article has exactly one working **draft** (`Article.draftRevisionId`
+→ an `ArticleRevision` with `versionNumber = NULL`); publishing a placement
+snapshots the draft into a new immutable numbered revision and points that
+placement's `publishedRevisionId` at it. If `aiEnabled`, the article's content
+embeds exactly once into its **home KB's** managed **Dataset** — every KB it's
+also placed into shares that same embedding, not a duplicate. The editor in
+`apps/web` edits the one shared draft with optimistic Zustand stores; the
+public site `apps/kb` renders only published placements. Kopilot reads
+articles anywhere via `search_knowledge` / `get_article` and, on the KB editor
+page, edits the draft through markdown-first, stable-id **block-CRUD** tools,
+with a full diff engine backing version history, pre-publish review, and
+Kopilot turn review (Keep/Undo).
+
+---
+
+## 2. Data model (`packages/database/src/db/schema/`)
+
+### Core tables
+
+| Table | File | Role |
+| --- | --- | --- |
+| `KnowledgeBase` | `knowledge-base.ts` | Org-scoped KB. `kind` (`standard`\|`source` — source-KBs are hidden, see Knowledge Sources), `slug`, `customDomain`, `visibility` (PUBLIC\|INTERNAL), `publishStatus` (DRAFT\|PUBLISHED\|UNLISTED), `datasetId` (managed embeddings), `draftSettings` (JSONB staging for theme/layout), theme/color/font/nav columns. |
+| `Article` | `article.ts` | **Canonical content only** — no tree/publish state. `articleKind` (page\|category\|header\|tab\|link), `status` (DRAFT\|PUBLISHED\|ARCHIVED), `draftRevisionId` (the single working draft), `aiEnabled`, `viewsCount`. `homeKnowledgeBaseId` (NOT NULL) is the **canonical embedding owner** — provenance, not tree placement. `sourceId`/`sourceExternalId`/`sourceContentHash`/`managed` are Knowledge-Sources provenance fields (content-level, distinct from a placement being source-linked). Denormalizes `title`/`emoji`/`excerpt`/`color` from the home placement's published (falling back to draft) revision for fast sidebar render (`sync-article-denormalized-fields.ts`). |
+| `ArticlePlacement` | `article-placement.ts` | **One tree position + publish state per KnowledgeBase.** `articleId` (FK→Article, cascade), `knowledgeBaseId` (the tree-position KB — independent of `Article.homeKnowledgeBaseId`), `slug` (unique per `(knowledgeBaseId, slug)`), `parentId` (self-FK — parent *placement*, not parent article), `sortOrder`, `isPublished`, `publishedAt`, `publishedRevisionId` (per-placement, FK→ArticleRevision), `publishedById`, `hasUnpublishedChanges`, `linkedFromSourceId` (nullable FK→KnowledgeSource — `null` = native placement, set = this placement is a materialized link to source content). Invariant: ≥1 placement per article (multi-home); ≤1 placement per `(article, KB)` pair, enforced in code (`internal/placement.ts`), not a DB constraint. |
+| `ArticleRevision` | `article-revision.ts` | Versioned content. `versionNumber` (**NULL = the one draft**, integer = immutable published snapshot), `content` (HTML), `contentJson` (jsonb `ArticleNodeJSON[]`), `title`/`description`/`excerpt`/`emoji`/`color`, `coverImageId`, `editorId`, `label`. One row is pointed to by `Article.draftRevisionId`; separately, each `ArticlePlacement.publishedRevisionId` points to whichever revision that placement exposes — two placements of the same article can be at different revisions until each is republished. |
+| `KnowledgeSource` | `knowledge-source.ts` | Ingest config (`type`, `config` jsonb, `surface` publishable\|ai-only). `ownedKnowledgeBaseId` — the hidden `kind='source'` KB that homes synced articles. See `docs/knowledge-sources-architecture-guide.md`. |
+
+**Key invariant:** block ids inside `contentJson` are **stable across
+versions** — publish/restore copy the JSON verbatim, ids included. This is
+what makes id-keyed block CRUD and version diffing reliable.
+
+### Hierarchy & ordering
+
+`ArticlePlacement.parentId` builds the tree (in **placement-id space**, not
+article-id space); `articleKind` distinguishes leaf `page`s from container
+`category`/`tab`/`header` nodes and external `link`s. `sortOrder` is a
+fractional string (no renumber on reorder). Tree ordering is fully KB-scoped
+and placement-owned — `Article` itself has no ordering fields.
+
+### Multi-placement semantics
+
+**"Linking"** an article into a second KB (`kb.linkArticles` tRPC →
+`link-articles-into-kb.ts`) materializes a new `ArticlePlacement` row for an
+existing `page` article (categories/folders can't be linked); it stamps
+`linkedFromSourceId` from the article's own `sourceId` if present. This is the
+**general multi-home mechanism** — used for hand-authored articles and by
+Knowledge Sources alike, distinguished only by whether `linkedFromSourceId` is
+set. Sources didn't get unified with a separate mechanism after the fact;
+`ArticlePlacement` was introduced as part of the Sources refactor and doubles
+as the general primitive.
+
+**Publishing is per-placement, not shared.** `publishArticle` snapshots a new
+`ArticleRevision` from the canonical draft only if that specific placement is
+stale (`hasUnpublishedChanges || publishedRevisionId === null`); a placement
+whose published copy is already current just flips `isPublished=true`.
+Publishing one placement does **not** revalidate or affect other KBs the same
+article is also placed into.
+
+### Embeddings tables
+
+| Table | File | Role |
+| --- | --- | --- |
+| `Dataset` | `dataset.ts` | A KB's managed embedding store (`isManaged = true`, hidden from the datasets UI). `embeddingModel` = `"provider:model"`, `vectorDimension`, `chunkSettings`, `searchConfig`. |
+| `Document` | `document.ts` | One row **per article**, in the article's **home KB's** Dataset. `metadata.kb = { articleId, contentHash }` tracks sync state; `enabled` flips false when an article is unpublished or `aiEnabled=false`. |
+| `DocumentSegment` | `document-segment.ts` | Chunk of a Document. Multi-dim vector columns (`embedding_512…3072`) each with its own HNSW cosine index (partial: `enabled AND indexStatus='INDEXED'`), plus a generated `searchVector` tsvector for BM25. |
+
+**Search federation gap:** the schema comment on `homeKnowledgeBaseId`
+promises that "search of any KB the article is placed into federates to [the
+home] dataset." In practice `collectManagedDatasetIds`
+(`search-knowledge.ts`) only implements this for **source-linked**
+placements — it unions the KB's own dataset with datasets of any
+`KnowledgeSource` reachable via `ArticlePlacement.linkedFromSourceId` in that
+KB. Linking a **hand-authored** (non-source) article from KB-A into KB-B
+leaves the new placement's `linkedFromSourceId` null, so `search_knowledge`
+scoped to KB-B will not surface it — a real gap between the schema's stated
+generality and the current retrieval code.
+
+---
+
+## 3. Service layer (`packages/lib/src/kb/`)
+
+`KBService` (`kb-service.ts`) is a thin compatibility shim constructed as
+`new KBService(db, organizationId)`; it delegates to per-concern modules.
+
+- **KB ops** (`knowledge-base/`): `createKnowledgeBase` (+ `ensureManagedDataset`),
+  `updateKnowledgeBase` (live fields), `updateDraftSettings`/`publishPendingSettings`/
+  `discardSettingsDraft` (theme staging), `publishKnowledgeBase`, `deleteKnowledgeBase`.
+- **Article ops** (`articles/`): reads `getArticles` / `getArticleById` /
+  `getArticleBySlug` / `getArticleSlugPath`; writes `createArticle` (inserts
+  Article + draft revision + one placement in a tx), `addPlacement`
+  (idempotently adds a placement for an *existing* article into another KB),
+  `linkArticlesIntoKb` (bulk `addPlacement` for chosen `page` articles),
+  `detachArticle` (flips `Article.managed=false`, clears
+  `linkedFromSourceId` on all placements), `updateArticleDraft` (mutates the
+  shared draft revision, sets `hasUnpublishedChanges`), `updateArticleStructure`
+  (slug/parentId/aiEnabled), `moveArticle` (reparents/reorders a *placement*),
+  `updateArticlesBatch`, `deleteArticle`, `archiveArticle`/`unarchiveArticle`,
+  `discardArticleDraft` (reverts the draft to the **home placement's**
+  published baseline). **`publishArticle`** publishes one placement — snapshots
+  the draft into a new numbered revision only if stale, repoints that
+  placement's `publishedRevisionId`, clears its `hasUnpublishedChanges`
+  (optional ancestor-chain cascade).
+- **Versions & diff** (`articles/article-versions.ts`): list / restore /
+  rename, plus `getArticleDiff` (resolves `draft`/`published`/revision-id
+  sentinels, org-scoped) — the shared backend behind all three diff surfaces
+  (§6).
+- **Diff engine** (`blocks/`): `diffBlocks`/`diffBlockList` — pure, structural
+  block diff keyed on stable `attrs.id` (LCS-ordered; classifies
+  `added`/`removed`/`modified`/`moved`/`unchanged`; recurses into containers
+  like tabs/accordion/table). `inline-diff.ts` — pure word-level diff via
+  `fast-diff`, tokenized so edits land on word boundaries. `apply-patch.ts` —
+  pure splice applying an `ArticlePatch`, the engine behind Kopilot's
+  block-CRUD writes. All three are framework-free so `apps/web` client code
+  can import them directly.
+- **Markdown** (`markdown/`): `articleToMarkdown` ← `blocksToMd` (TipTap JSON →
+  markdown, for AI prompts + `.md` export), `mdToBlocks` (reverse),
+  `computeArticleJsonHash` (`hash.ts`, key-order-independent — the diff/CAS
+  primitive), `stampIds`, `block-id.ts` (sequential `b<n>` allocator,
+  high-water-mark).
+- **Sync** (`kb-sync-service.ts` + `kb-sync-queue.ts`): `syncArticle` is
+  idempotent — on publish, if `aiEnabled` and not a `link`, render to
+  markdown, hash-skip if unchanged, upsert the Document in the **home KB's**
+  Dataset, enqueue segment embedding (BullMQ, coalesced per-article jobId).
+  Unpublish → disable Document; delete → drop it.
+- **Realtime** (`realtime.ts`): publishes to Redis channel `kb:article:${articleId}`
+  with events `kb-article-patch`, `kb-article-resync`, `kb-article-lock`.
+- **Kopilot snapshot** (`kopilot-snapshot.ts`): pre-turn snapshot in Redis for
+  the diff engine / turn review (see §6).
+- Also: `article-tag-service.ts` (tag assignment), `draft-settings.ts`
+  (`KBDraftSettings` shape + merge-over-live), `sync-article-denormalized-fields.ts`
+  (recomputes `Article.title/excerpt/emoji/color` from the home placement).
+
+Internal helpers (`internal/`) — `placement.ts` is the article/placement-split
+abstraction layer (`resolvePlacement`, `toFlattenRow`, `loadPlacementRefs`);
+`flatten-article.ts` builds the `ArticleListItem`/`ArticleEditorView` DTOs the
+frontend consumes; `metadata-sync.ts` refreshes subtree slug paths on move.
+
+---
+
+## 4. Authoring editor (`apps/web`)
+
+### Routes (`app/(protected)/app/kb/`)
+- `/app/kb` — list view (`ArticlesView`, resource table).
+- `/app/kb/[knowledgeBaseId]/editor/layout.tsx` — persistent `KBEditorFrame` chrome
+  wrapped in `KnowledgeBaseProvider` (article-store survives navigation).
+- `/app/kb/[knowledgeBaseId]/editor/[[...slug]]` — article editor pane. Slug
+  convention uses a literal `~` separator for nested paths (`/editor/~/parent/child`).
+- `/app/kb/[knowledgeBaseId]/preview` — published preview.
+
+### Components (`apps/web/src/components/kb/`)
+- **`KBEditorFrame`** (`ui/editor/kb-editor-frame.tsx`) — root chrome; reads `?panel=`
+  to switch the left `KBTabPanel` between **General** (branding/colors), **Layout**
+  (header/footer nav), and **Articles** (the tree). Mounts `KopilotContext` with
+  `page='kb'` + `activeKnowledgeBaseId`.
+- **`KBArticlesPanel`** (`ui/sidebar/`) — drag-reorder tree (`@dnd-kit`), create/delete/archive.
+- **`KBEditorBody`** (`ui/editor/kb-editor-page-body.tsx`) — the pane swap
+  point. Reads `?diff=` via `useDiffParam()` (`hooks/use-diff-param.ts`, nuqs);
+  when set (`review` / `v:<revisionId>` / `kopilot`), renders
+  `<ArticleDiffPane>` in place of `<ArticleEditor>`.
+- **`ArticleEditor`** (`ui/editor/article-editor.tsx`) — right pane: header (title/emoji),
+  cover/excerpt strip, the rich-text body, publish/status footer. Goes `readOnly` with
+  an amber "Kopilot is editing" banner when a `kb-article-lock` arrives. Also
+  renders the **Kopilot turn-review banner** (§6) when a pending snapshot exists.
+- **`ArticleDiffPane` / `ArticleDiffView` / `article-diff-tree.ts`** — resolves
+  the two sides for the current `?diff=` value and renders the diff (word-level
+  inline highlight for modified blocks, colored borders for
+  added/removed/moved, per-leaf diffs inside containers). Styled to match the
+  TipTap editor, not the published site. Reused unmodified by all three diff
+  entry points (§6).
+- Dialogs: `article-settings-dialog` (slug/parent/kind/aiEnabled),
+  `article-versions-dialog` (history + per-version "Diff" button that sets
+  `?diff=v:<revisionId>`).
+
+### Rich text — TipTap (`apps/web/src/components/editor/`)
+Custom ProseMirror nodes replace StarterKit defaults:
+- **`Block`** (`kb-article/block-node.ts`) — the workhorse: text, headings, lists,
+  blockquote, code (Shiki-prehighlighted into attrs), callout (info/tip/warn/error/success),
+  image, embed (YouTube/Vimeo/Figma/…).
+- **`Panel` / `Tabs` / `Accordion`** — collapsible/tabbed containers (drag-reorder).
+- **Table** — forked TipTap table extension with cell selection.
+- Inline: marks, font/size/color, `@`-mention + reference picker, `/` slash commands,
+  drag-drop image upload, KB-scoped link popover.
+- Hooks: `useRichTextEditor` (generic node/extension setup) → `useKBArticleEditor`
+  (adds KB slash + reference pickers) → `KBArticleEditor` (React wrapper, Cmd+S etc.).
+- Shared renderer (`packages/ui/src/components/kb/article/`): `KBArticleRenderer`
+  → `KBArticleNode` (extracted node-dispatch `switch`, shared with the diff
+  view so the two never diverge) → `BlockRenderer` → `InlineRenderer`. No
+  client hooks / no server-only imports → usable inside client components,
+  which is what both the editor preview and `ArticleDiffView` rely on.
+
+### Client state — Zustand (`components/kb/store/`)
+- **`useArticleStore`** — article *metadata* + optimistic layer (pending updates,
+  optimistic creates/deletes/moves). `selectEffectiveArticle` overlays optimistic onto
+  server; mutations apply immediately, `confirmUpdate` on success, `rollbackUpdate` on error.
+- **`useKnowledgeBaseStore`** — KB settings + optimistic draft-settings patches.
+- **Content is fetched separately** via `useArticleContent` → `api.kb.getArticleById`
+  (HTML + JSON, not in the store — keeps the store light and the editor from refetch churn).
+  Also exposes `draftContentJson`/`publishedContentJson` so the pre-publish
+  diff needs no extra roundtrip.
+- Cross-tab sync: `useKbArticleChannel` subscribes to the SSE bridge of the Redis
+  realtime channel. **`kb-article-patch` is a client stub** — it just invalidates and
+  full-refetches (incremental client patch-apply was deliberately never built).
+- Autosave: 1500ms debounce → `kb.updateArticleDraft` (writes both `content` +
+  `contentJson`, emits `kb-article-resync` with `originatorSessionId` for echo suppression).
+
+### tRPC (`apps/web/src/server/api/routers/kb.ts`)
+KB: `byId`, `list`, `create`, `update`, `updateDraftSettings`,
+`publishPendingSettings`, `discardSettingsDraft`, `publishSite`, `unpublishSite`, `delete`.
+Article: `getArticles`, `getArticleById`, `getArticleBySlug`, `createArticle`,
+`linkArticles` (materialize placements for existing articles into this KB),
+`updateArticleDraft`, `updateArticleStructure`, `publishArticle`, `unpublishArticle`,
+`archiveArticle`/`unarchiveArticle`, `discardArticleDraft`, `deleteArticle`, `moveArticle`,
+`updateArticlesBatch`, `getArticleVersions`, `restoreArticleVersion`, `renameArticleVersion`,
+`exportArticleMarkdown`, `getArticleDiff` (backend for all three diff surfaces),
+`getKopilotTurnReview`/`keepKopilotTurn`/`revertKopilotTurn` (Kopilot turn
+review — Keep/Undo, §6, **shipped and wired** into the editor banner).
+
+---
+
+## 5. Public reader site (`apps/kb`, port 3002)
+
+Next.js 16 App Router, `output: 'standalone'`, `cacheComponents: true`. Shares the same
+DB and packages (`@auxx/database`, `@auxx/lib`, `@auxx/ui`).
+
+### Routing & resolution
+- `/[orgSlug]/[kbSlug]/` — homepage (redirects to first navigable article).
+- `/[orgSlug]/[kbSlug]/[...articleSlug]/` — article pages (nested slugs).
+- `/[orgSlug]/[kbSlug]/search.json` — client search index (minisearch: titles,
+  descriptions, headings, ~4KB body).
+- `/_md/[orgSlug]/[kbSlug]/[...articleSlug]` — plain markdown export (rewritten
+  from the public `.md`-suffixed URL via `proxy.ts`).
+- `/r/[articleId]` — stable-id redirect. **Placement-aware**: queries
+  `ArticlePlacement` by `articleId` ordered `desc(isPublished)` (prefers a
+  published placement when an article is multi-homed), then walks that
+  placement's `parentId` chain to build the slug path.
+- `/api/revalidate` — Bearer-token tag revalidation webhook (`KB_REVALIDATE_SECRET`).
+- `/auth/verify` — verifies an Ed25519 login token from the webapp, mints the
+  `auxx-kb.session` cookie (Redis-backed, 24h) for INTERNAL KBs / custom domains.
+
+KB resolved by `Organization.handle` + `KnowledgeBase.slug`, or by `customDomain`.
+
+### Rendering & access
+- Data loaders `loadKBPayload` / `loadKBPayloadWithContent` (`src/server/kb-data.ts`)
+  query `ArticlePlacement` (joined to `Article` + the revision it points to via
+  `publishedRevisionId`) filtered by `knowledgeBaseId`, `isPublished=true`,
+  `Article.archivedAt IS NULL` — **not** `Article.parentId`/`Article.publishedRevisionId`
+  (those don't exist on `Article` anymore). Because tree parentage lives in
+  placement-id space, the loader remaps `parentPlacementId → articleId` so the
+  returned list stays in article-id space and existing ancestor-chain subtree
+  pruning works unchanged. Cover URLs resolved in a parallel fan-out.
+- Renderer chain in `@auxx/ui/components/kb/article`: `KBArticleRenderer` →
+  `KBArticleNode` → `BlockRenderer` (block JSON → HTML) → `InlineRenderer`
+  (marks, links, `auxx://kb/article/{id}` stable links). `codeBlock` renders
+  pre-highlighted HTML from attrs.
+- Theming: `KBThemeProvider` builds CSS variables from KB columns (logos, light/dark color
+  pairs, theme type clean/muted/gradient/bold, fonts, corner style, nav). `NoFlashModeScript`
+  applies the mode cookie before paint.
+- Caching: **PUBLIC** KBs use full RSC cache (`cacheLife('max')`) keyed by tags
+  `kb:orgSlug/kbSlug` and `kb-article:orgSlug/kbSlug/slugPath`, revalidated on publish via
+  the webhook. **INTERNAL** KBs are never cached (streamed, membership-checked per request).
+  UNLISTED/INTERNAL get `robots: noindex`. **Revalidation is per-KB**: `publishArticle`
+  fires `fireKBRevalidate` only for the target `knowledgeBaseId` — publishing
+  a multi-homed article in KB-A does not revalidate KB-B's tags.
+
+---
+
+## 6. AI & Kopilot
+
+### Retrieval for ticket/email answering
+Every agent gets the `auxx:knowledge` toolset by default
+(`packages/lib/src/agents/default-toolsets.ts`), which includes
+**`search_knowledge`** (`ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts`).
+It hybrid-searches (vector + BM25, coordinated by `SearchService` →
+`VectorSearchService`/`FullTextSearchService`/`HybridSearchService`) across KB articles
+(via each KB's managed Dataset, plus any source-linked datasets — see the
+federation gap in §2) and RAG datasets. Args: `query`, `source` (kb|rag|both),
+`knowledgeBaseId?`, `datasetIds?`, `recordIds?`, `limit`. KB hits carry a `docSlug` so the
+agent can cite `[Title](auxx://doc/<docSlug>)`; RAG hits are prose-only. This is the path
+by which an answering agent grounds a reply in KB content.
+
+### Editing articles from the editor (markdown-first block-CRUD)
+`createKbCapabilities` (`ai/kopilot/capabilities/kb/index.ts`, `page='kb'`) exposes
+exactly **4 write tools**, all markdown-first and addressed by stable block id
+(the earlier 6-tool set including `update_block_text`/`update_block_attrs` was
+consolidated and those files removed):
+- Reads (free): `get_article`, `get_article_section`, `list_articles`,
+  `resolve_block_by_heading`.
+- Writes (commit straight to the draft, per-turn Undo): `insert_blocks(anchor, markdown)`,
+  `replace_block(blockId, markdown)` (rewrite a block; markdown may expand to
+  several blocks — the first keeps the id; empty markdown deletes),
+  `delete_blocks(blockIds)`, `move_blocks(blockIds, anchor)`.
+
+Anchors are `{at:'start'|'end'}`, `{at:'before'|'after', blockId}`,
+`{at:'startOf'|'endOf', containerId}`. Markdown supports rich blocks via
+fences (callout, tabs, accordion, cards, image, embed, table). A separate
+**`createKbReadCapabilities`** (`page='__global__'`) exposes just `get_article`
++ `list_articles` everywhere, so an agent can read an `@`-mentioned article off
+the KB surface.
+
+### Turn lifecycle (de-hacked — the v2 rewrite)
+Writes flow tool → `runBlockCrudOp` (`kb/tools/write-helpers.ts`) — the single
+choke point for every write: reads the draft + its content hash, **CAS-checks**
+an optional `expectedHash` tool arg against the live `preHash` (rejects with a
+`stale_content:` error if stale — chained `postHash` → next call's
+`expectedHash`), applies the patch via `apply-patch.ts`, persists via
+`updateArticleDraft(..., { bypassSnapshotClear, suppressResyncEvent })`, emits
+per-op `kb-article-patch`. The **first write of a turn** captures a
+`KopilotPreTurnSnapshot` to Redis `kb:article:${id}:preturn` (24h) and emits
+`kb-article-lock`.
+
+Turn-end is no longer bolted onto the SSE route. `PageCapability` exposes a
+proper **`lifecycle.onTurnEnd`** hook (`agent-framework/types.ts`); the
+engine's `withTurnEnd` wrapper fires it exactly once per turn from inside its
+own public entry points (`submitMessage`/`resume`) on `turn-completed` →
+`'completed'` or `turn-error`/abnormal close → `'error'` — so **both** the
+in-process SSE path and the BullMQ worker path (`process-agent-job.ts`, which
+just calls `engine.submitMessage`/`engine.resume`) get the hook for free, with
+no duck-typing and no per-surface wiring. `createKbCapabilities`'s
+`onTurnEnd` resolves the active article via `findRef(sessionContext,
+'article')`, reads the turn-scoped snapshot, and calls `finalizeKopilotKbTurn`
+(release lock, keep snapshot for review) on success or `revertKopilotKbTurn`
+(restore snapshot, unlock, clear — `expectedTurnId`-gated so a stale prior
+turn can't roll back a later one) on failure.
+
+### Kopilot turn review (Keep / Undo — shipped)
+After a Kopilot turn that edited the article, `ArticleEditor` shows a banner
+("Kopilot changed N block(s)") with **Keep** and **Undo** buttons, driven by
+`use-kopilot-review.ts` wrapping `kb.getKopilotTurnReview` /
+`kb.keepKopilotTurn` / `kb.revertKopilotTurn`. The banner shows only when a
+pending snapshot exists and Kopilot isn't currently holding the write lock;
+state is Redis-backed so it survives a page refresh. Undo relies on the
+realtime `kb-article-resync` event to repaint the editor.
+
+### One diff engine, three surfaces
+Every version is an `ArticleRevision.contentJson`. Three "diffs" are the same
+operation — `diffBlocks()` over two `contentJson` trees, rendered by one
+`<ArticleDiffView>` (§4), wired three ways via `kb.getArticleDiff` and the
+shared `?diff=` pane:
+1. **Version history** — a past revision vs published (`?diff=v:<revisionId>`,
+   from the versions dialog).
+2. **Pre-publish review** — draft vs published (`?diff=review`, "Review
+   changes" button in the publish cluster; no roundtrip, uses already-loaded
+   `draftContentJson`/`publishedContentJson`).
+3. **Kopilot turn review** — pre-turn snapshot vs current draft
+   (`?diff=kopilot`, from the review banner).
+
+### How articles surface in assistant messages
+- Inline citations: `[Title](auxx://doc/<docSlug>)` from search results.
+- Entity fences: articles are entities, so `get_article`/`list_articles` results carry a
+  `recordId` (`<entityDefinitionId>:<articleId>`) and the agent emits `auxx:entity-card`
+  (one) or `auxx:entity-list` (many). There is no dedicated `auxx:kb-article` fence —
+  entity fences cover it.
+
+### SessionContext
+`SessionRefKind` includes `'kb'` and `'article'`; `KopilotContext` sets `activeKnowledgeBaseId`/
+`activeArticleId` (origin `'surface'`), and `@`-mentions add refs (origin `'mention'`, which
+wins). Tools default their `articleId` from the active article ref when omitted.
+
+---
+
+## 7. End-to-end flows
+
+**Author publishes an article**
+`ArticleEditor` autosave → `kb.updateArticleDraft` (shared draft revision,
+`hasUnpublishedChanges=true` on this placement, `kb-article-resync`) → user
+clicks Publish → `kb.publishArticle` publishes **one placement** — snapshots
+the draft into a new numbered `ArticleRevision` if stale, repoints that
+placement's `publishedRevisionId` → `KBSyncService.syncArticle` (if
+`aiEnabled`) upserts the Document in the article's **home KB** Dataset +
+enqueues embeddings → `/api/revalidate` busts `apps/kb` cache tags for **that
+KB only** → public page serves the new revision.
+
+**Customer email answered from the KB**
+Agent runs with `auxx:knowledge` → `search_knowledge` hybrid-searches managed Datasets + RAG →
+ranked segments returned with `docSlug` → agent drafts a reply citing `auxx://doc/<docSlug>`.
+
+**Kopilot edits the open article**
+On `page='kb'` with an active article, agent calls `get_article` → block-CRUD
+writes CAS-check and patch the shared draft (`applyPatch` →
+`updateArticleDraft`), first write snapshots + locks the editor (read-only
+banner) → on turn end, `onTurnEnd` finalizes (releases lock, keeps snapshot)
+or reverts (restores snapshot) → a Keep/Undo review banner appears; Undo
+restores the pre-turn snapshot and the editor full-refetches via the
+`kb-article-patch` stub.
+
+**Author links an article into a second KB**
+`kb.linkArticles` → `linkArticlesIntoKb` → `addPlacement` materializes a new
+`ArticlePlacement` for the existing article under a chosen parent in the
+target KB, stamping `linkedFromSourceId` from the article's own `sourceId` if
+it came from a Knowledge Source. Content is shared (one draft, one home
+Dataset); publish state and tree position are independent per placement.
+
+---
+
+## 8. Key file index
+
+| Concern | Path |
+| --- | --- |
+| Schema | `packages/database/src/db/schema/{knowledge-base,article,article-placement,article-revision,dataset,document,document-segment,knowledge-source}.ts` |
+| Service | `packages/lib/src/kb/` (`kb-service.ts`, `articles/`, `knowledge-base/`, `blocks/`, `markdown/`, `internal/`, `kb-sync-service.ts`, `realtime.ts`, `kopilot-snapshot.ts`, `article-tag-service.ts`, `draft-settings.ts`, `sync-article-denormalized-fields.ts`) |
+| Editor UI | `apps/web/src/components/kb/` (`ui/editor/`, `ui/sidebar/`, `store/`, `hooks/`) |
+| Diff UI | `apps/web/src/components/kb/ui/editor/article-diff-{pane,view}.tsx`, `article-diff-tree.ts`, `hooks/use-diff-param.ts`, `hooks/use-kopilot-review.ts` |
+| TipTap nodes | `apps/web/src/components/editor/kb-article/` |
+| tRPC | `apps/web/src/server/api/routers/kb.ts` |
+| Public site | `apps/kb/src/app/`, `apps/kb/src/server/{kb-data,kb-cache}.ts` |
+| Renderer (shared) | `packages/ui/src/components/kb/article/` |
+| Kopilot KB tools | `packages/lib/src/ai/kopilot/capabilities/kb/` (`index.ts`, `tools/`, `tools/write-helpers.ts`) |
+| Kopilot search | `packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts` |
+| Embedding search | `packages/lib/src/datasets/services/search.service.ts`, `datasets/search/hybrid-search.ts` |
+| Turn-end engine hook | `packages/lib/src/ai/agent-framework/types.ts` (`onTurnEnd`), `engine.ts` (`withTurnEnd`) |
+| Knowledge Sources | `packages/lib/src/knowledge-sources/`, `docs/knowledge-sources-architecture-guide.md` |

--- a/docs/today-architecture-guide.md
+++ b/docs/today-architecture-guide.md
@@ -1,0 +1,295 @@
+# Today Architecture Guide
+
+Today is a daily-triage home tab: a headless AI agent watches CRM entities
+(deals/leads/tickets) that have gone quiet, proposes a bundle of next actions
+per entity, and the account owner triages each bundle with a single Yes/No.
+Covers the scanner, the headless agent run, the bundle data model, apply-time
+execution, and the frontend. Verified against the implementation on
+**2026-07-09**. Feature-flagged (`FeatureKey.todayInbox`, default **off**) —
+nothing here runs for an org unless the flag is enabled.
+
+Ground-truth plan (matches shipped code closely):
+`plans/follow-up/phases/phase-3e-today-ui.md`, with sibling phases
+`phase-3a-capture-mode.md` (engine capture mode), `phase-3b-headless-runner.md`,
+`phase-3c-suggestion-table.md` (`AiSuggestion` design), `phase-3d-event-triggers.md`
+(**not yet built** — see §6), `phase-4-override.md`, `phase-5-spawn.md`,
+`phase-6-polish.md` (ranking — **not yet built**, see §3).
+
+---
+
+## 1. The shape in one paragraph
+
+Every 5 minutes a BullMQ scanner (`nextActionStaleScannerJob`) sweeps orgs
+with `todayInbox` enabled, finds entities (`deals`/`leads`/`tickets`) whose
+activity has gone cold past a per-type threshold, and runs a **headless
+kopilot** (`runHeadlessSuggestion`) for each candidate: the same
+`AgentEngine`/tool-capability stack as chat, but with no session row, no
+human in the loop, and `approvalMode: 'capture'` — read-only tools execute
+for real, write tools are recorded instead of run. The model proposes 0..N
+actions and a one-line summary; a non-empty proposal is persisted as an
+**`AiSuggestion`** bundle (`status: 'FRESH'`). The Today page
+(`/app/today`) lists FRESH bundles one card at a time; **Yes** walks the
+bundle's actions in dependency order and actually invokes the tools (or
+promotes an already-created Draft to a scheduled send); **No** closes the
+bundle with no side effects undone. AI-originated sends get a 5-minute
+cancel buffer (`ScheduledMessage.source = 'AI_SUGGESTED'`), surfaced on a
+secondary `/app/today/pending` page.
+
+---
+
+## 2. Data model (`packages/database/src/db/schema/`)
+
+| Table | File | Role |
+| --- | --- | --- |
+| `AiSuggestion` | `ai-suggestion.ts` | One bundle of `ProposedAction[]` per entity per triage cycle. `entityInstanceId`/`entityDefinitionId` (denormalized), `threadId?` (context only), `ownerUserId` (snapshotted at creation — reassignment doesn't re-route), `bundle` (jsonb: `{ actions, summary, modelId, headlessTraceId, computedForLatestMessageId? }`), `actionCount` (denormalized), `computedForActivityAt` (drives FRESH→STALE), `triggerSource` (`'event'\|'stale_scan'\|'manual'\|'override'`), `status` (`FRESH → APPROVED\|PARTIALLY_APPROVED\|REJECTED\|STALE`), `outcomes` (jsonb `ActionOutcome[]`, populated on approve), `decidedById`/`decidedAt`. Partial unique index `(organizationId, entityInstanceId) WHERE status='FRESH'` — enforces **one active bundle per entity**; the scanner relies on the resulting unique-violation as a no-op signal. |
+| `SuggestionDismissal` | `suggestion-dismissal.ts` | Per-user, per-entity skip record from Reject/Snooze. `dismissedAtActivity` (entity's `lastActivityAt` at dismissal time) + optional `snoozeUntil`. The scanner's candidate query excludes an entity while `dismissedAtActivity >= entity.lastActivityAt` — so the dismissal naturally expires once new activity lands, independent of `snoozeUntil`. Unique per `(organizationId, userId, entityInstanceId)` — upserted on repeat dismissal. Dismissal is **per-user**, not org-wide. |
+| `ScheduledMessage` (extended) | `scheduled-message.ts` | Reused, not a new table. Today-specific columns: `source` (`USER_SCHEDULED\|AI_SUGGESTED\|AUTO_REPLY`), `approvedById` (who clicked Yes), `cancelledAt`/`cancelledById`, `aiSuggestionId` (FK back to the originating bundle). Indexed `(organizationId, source, approvedById, status)` for the pending-sends pill. |
+| — | — | No new tables for entity data itself — Today reads `EntityInstance` (+ two new columns, below), `Draft`, and the existing field-value system. |
+
+**`EntityInstance` gained one column**: `lastSuggestionScanAt` — bumped by the
+scanner after *every* run regardless of outcome, so a tick never re-evaluates
+an entity unless `lastActivityAt` has since advanced past it. This (not a TTL
+on suggestion rows) is the whole suppression mechanism for "already
+considered, nothing to do" — the doc comment on `AiSuggestion` notes NOOP
+runs deliberately don't insert a row, keeping the table lean.
+
+---
+
+## 3. The scanner (`packages/lib/src/jobs/approvals/next-action-stale-scanner-job.ts`)
+
+Runs every 5 minutes via BullMQ scheduler. Per enabled org:
+
+1. Resolve the org's default LLM (`getCachedDefaultModel`); skip the org
+   entirely if none is configured.
+2. For each slug in `SCANNED_ENTITY_SLUGS` (`work-items/stale-defaults.ts` —
+   currently `['deals', 'leads', 'tickets']`, hardcoded v1 table, no
+   per-template override yet): fetch up to 50 candidates where
+   `lastActivityAt` is older than the type's staleness threshold
+   (`STALE_AFTER_DAYS`: deals 7, leads 5, tickets 2, default 7),
+   `lastSuggestionScanAt IS NULL OR < lastActivityAt`, and no active
+   `SuggestionDismissal` covers the current activity — then drops candidates
+   currently in a terminal stage (`TERMINAL_STAGES`, read via
+   `FieldValueService.batchGetValues` on the resource's `stage` field).
+3. Runs `runHeadlessSuggestion` for up to 5 candidates concurrently
+   (`RUN_CONCURRENCY`), **always** bumps `lastSuggestionScanAt` on the entity
+   afterward (success, failure, or noop alike), and on a non-empty result
+   calls `createBundleFromHeadlessRun`.
+4. After the org's candidates are processed, `markStaleBundles` bulk-flips
+   any `FRESH` bundle whose `computedForActivityAt` now predates the
+   entity's current `lastActivityAt` to `STALE` in one UPDATE.
+
+**Ranking is v1-simple**: `listBundles` (§4) just orders by `createdAt`
+descending within the requested status filter — the SLA/value/confidence
+weighted score described in `phase-6-polish.md` was never built.
+
+---
+
+## 4. Headless agent run (`packages/lib/src/approvals/headless-runner.ts`)
+
+`runHeadlessSuggestion` runs the **same `AgentEngine`** used by chat Kopilot,
+wired with a minimal one-shot `AgentDefinition` (`maxIterations: 10`, no
+session persistence) instead of the full multi-agent `domain-config.ts`:
+
+- **Tool registry**: entity, knowledge, mail, actor, task, app, and MCP
+  capabilities — the same factories chat Kopilot uses (`createEntityCapabilities`
+  etc.) — but no KB or workflow-builder tools; scoped to `registry.getTools('mail')`
+  (the mail page's tool set, reused as "the general CRM toolset").
+- **Prompt**: entity header + field snapshot (`enrichEntitiesWithFieldValues`,
+  200-char/field cap) + up to 5 open linked tasks + a sanitized trigger-event
+  payload (`sanitizeEventPayloadForLLM` strips raw free-text PII) — assembled
+  fresh per run, not from chat history.
+- **`approvalMode: 'capture'`** (`agent-framework/capture-mode.ts`,
+  `types.ts:816-826`): the tool loop never pauses. A read-only tool executes
+  normally. An approval-required write tool calls its `captureMint(args, {localIndex})`
+  (if defined) to synthesize a plausible result — typically
+  `{ id: 'temp_<n>', ...predictedFields }` — without touching the database,
+  and the call is pushed onto `state.capturedActions`; downstream tool calls
+  in the same run can reference that `temp_<n>` id, so multi-step plans
+  (draft a reply → create a follow-up task referencing it) still chain
+  correctly even though nothing durable exists yet.
+- **Soft calls** are the one exception: `reply_to_thread`/`start_new_conversation`
+  called with `mode: 'draft'` (not `'send'`) run for real during the headless
+  pass — they produce a genuine `Draft` row — and are recorded via a thin
+  `wrapWithSoftCapture` wrapper as `ranDuringCapture: { output }` rather than
+  `predictedOutput`. `mode: 'send'` calls of the same tools go through the
+  normal capture path instead (queued, not executed).
+- The model ends with `[summary] <text>` or `[noop] <reason>` on its final
+  line, parsed by `parseFinalText`; soft actions and captured actions are
+  merged (`mergeActions`) into one `localIndex`-ordered `ProposedAction[]`.
+- Returns `Result.error` on model/entity failure; **partial bundles are never
+  salvaged** — apply-time expects the full action list or nothing.
+
+`ProposedAction` (`approvals/types.ts`) carries exactly one of
+`ranDuringCapture` (already happened, apply-time promotes/finalizes it) or
+`predictedOutput` (not yet happened, apply-time invokes the real tool) — no
+separate `kind` discriminator, callers branch on which field is set.
+
+---
+
+## 5. Apply-time — approving a bundle (`packages/lib/src/approvals/actions-service.ts`)
+
+`approveBundle` is the all-or-nothing execution path, invoked from
+`approvals.approve`:
+
+1. **Lock + validate**: load the bundle, reject if not `FRESH`.
+2. **Staleness re-check**: if the entity's `lastActivityAt` has advanced past
+   `bundle.computedForActivityAt` since it was computed, flip the bundle to
+   `STALE` and return a `ConflictError` — the UI shows "Out of date" rather
+   than silently acting on context that's no longer true.
+3. **Topo-sort** the bundle's actions by their `temp_<n>` dependency graph
+   (`temp-id.ts`).
+4. **Build one shared `ToolContext` + tool registry** for the whole bundle
+   (`buildApprovalToolContext` / `buildKopilotToolMap`) — mirrors the
+   headless runner's tool set (entity/knowledge/mail/actor/task/app/MCP),
+   but MCP capabilities run non-autonomous here since apply-time is executing
+   a plan a human already approved, matching the live-chat pause semantics.
+5. **Walk actions in order**:
+   - If a prior action this action depends on (via a `temp_<n>` reference in
+     its `args`) already failed, mark this one `skipped_dep_rejected` without
+     invoking anything.
+   - `ranDuringCapture` actions: `applySoftAction` reads the Draft back by id
+     and promotes it to a real `ScheduledMessage` — `source: 'AI_SUGGESTED'`,
+     `scheduledAt = now + 5min` (`SEND_BUFFER_MS`), `aiSuggestionId` linking
+     back to the bundle — then enqueues the send job. Real id substitutes for
+     any downstream `temp_<n>` reference.
+   - Captured actions: substitute resolved real ids for any `temp_<n>` in
+     `args`, look up the tool by name, and call `tool.execute()` for real.
+     The tool's own real output supplies any further `temp_<n>` substitution.
+6. **Terminal status**: `APPROVED` (all succeeded), `REJECTED` (none
+   succeeded), or `PARTIALLY_APPROVED` (mixed) — written to the bundle along
+   with the full per-action `outcomes[]` array and `decidedById`/`decidedAt`.
+   There is no re-approve-the-remainder path for a partial failure; the doc
+   comment is explicit that recovery is "the user waits for the next scanner
+   tick."
+
+`rejectBundle` just flips status to `REJECTED` — any Drafts created as soft
+actions during the headless run are **not** cleaned up (an open, deferred
+question in the plan). `snoozeBundle` does the same plus upserts a
+`SuggestionDismissal` row keyed to the entity's current `lastActivityAt`, so
+the scanner skips the entity until either activity moves or the snooze
+window lapses (whichever is later — see the schema note above).
+`cancelPendingSend` cancels a `PENDING` `ScheduledMessage` (writes
+`CANCELLED` + best-effort removes the BullMQ job — the send job re-checks
+status at fire time regardless, so a failed removal is harmless), and
+returns a distinguishable `ConflictError('send_in_flight')` if the send has
+already flipped to `PROCESSING`.
+
+---
+
+## 6. Backend surface & known gaps
+
+### tRPC (`apps/web/src/server/api/routers/approvals.ts` — `approvalsRouter`)
+Deliberately separate from the pre-existing workflow `approvalRouter` to
+avoid name collisions as the two evolve independently.
+
+| Procedure | Purpose |
+| --- | --- |
+| `list` | Paginated bundles (`ownerScope`: `mine`\|`mine_and_unassigned`\|`all`; default status filter `['FRESH']`; cursor = base64 `createdAt\|id`). |
+| `get` | Single bundle by id. |
+| `approve` | Runs `approveBundle`; maps `ConflictError` → tRPC `CONFLICT`. |
+| `reject` | Runs `rejectBundle`. |
+| `snooze` | Runs `snoozeBundle`. |
+| `cancelPendingSend` | Runs `cancelPendingSend`. |
+| `listPending` | `ScheduledMessage` rows where `source='AI_SUGGESTED', status='PENDING'`, optionally scoped to the caller (`mineOnly`, default true). |
+
+### Known gaps vs. the plan epic
+- **`phase-3d-event-triggers.md` (reactive triggers) was never built.** The
+  scanner (`triggerSource: 'stale_scan'`) is the only thing that calls
+  `runHeadlessSuggestion` today — `'event'` and `'manual'` are valid
+  `triggerSource` values in the type system but nothing produces them yet.
+  Bundles are compute-on-a-5-minute-poll only, not reactive to inbound
+  messages.
+- **`phase-6-polish.md`'s ranking model was never built** — `listBundles`
+  is recency-sorted, not the planned SLA/value/confidence score.
+- **Snooze has no frontend affordance** — the mutation and schema support
+  exist, but `BundleCard` (§7) only renders Yes/No; there's no snooze UI
+  wired up yet.
+- **Reject doesn't clean up soft-tool side effects** — a Draft created
+  during headless capture survives a Reject and sits in the org's normal
+  Drafts tab (explicitly deferred, not a bug).
+
+---
+
+## 7. Frontend (`apps/web/src/components/today/`)
+
+### Routes
+- `/app/today` (`app/(protected)/app/today/page.tsx`) — `TodayPage`.
+- `/app/today/pending` (`.../today/pending/page.tsx`) — `PendingSendsPage`.
+
+Both are client components gated by `useFeatureFlags().hasAccess(FeatureKey.todayInbox)`;
+nav entries in `constants/menu.tsx` and the kbar command palette
+(`components/kbar/actions/navigation.ts`) carry the same gate.
+
+### `TodayPage` (`today-page.tsx`)
+Queries `approvals.list` (`mine_and_unassigned`, `status: ['FRESH']`, limit
+25) and `approvals.listPending` for a "N pending sends" pill linking to the
+pending page. Renders one `BundleCard` per bundle — no virtualization,
+list-only (no keyboard triage shortcuts currently implemented despite the
+plan doc mentioning `j/k/Enter/Esc` hotkeys).
+
+### `BundleCard` (`bundle-card.tsx`)
+Shows the bundle's `summary` (or a generic "`N` actions" fallback),
+Yes/No buttons wired to `approvals.approve`/`approvals.reject`
+(`api.useUtils()` invalidates `list`/`listPending` on settle), and a
+collapsible read-only `<details>` listing each `ProposedAction`
+(`toolName` + `summary`) — **no per-action edit or partial-approval UI**;
+Choose-mode was explicitly cut from v1. A `CONFLICT` approve error (stale
+bundle) surfaces as an "Out of date" toast and re-invalidates the list.
+
+### `PendingSendsPage` (`pending-page.tsx`)
+Lists `approvals.listPending` rows with a client-side countdown to
+`scheduledAt` and a Cancel button (`approvals.cancelPendingSend`); a
+`send_in_flight` conflict surfaces as "Send in flight, can't cancel." No
+Zustand store anywhere in Today — plain React Query state throughout, with
+local `useState`/`setInterval` only for the countdown display.
+
+---
+
+## 8. End-to-end flows
+
+**A deal goes quiet and gets a bundle**
+Scanner tick (every 5 min) → deal's `lastActivityAt` older than 7 days and
+unscanned since → `runHeadlessSuggestion` runs the CRM toolset in capture
+mode against the deal's context → model proposes e.g. a drafted follow-up
+email (soft call, real `Draft` created) + a follow-up task (captured,
+`temp_1`) → `[summary] Draft check-in, add follow-up task` →
+`createBundleFromHeadlessRun` inserts a `FRESH` `AiSuggestion` →
+`EntityInstance.lastSuggestionScanAt` bumped either way.
+
+**Owner approves from Today**
+`TodayPage` renders the card → click **Yes** → `approvalsRouter.approve` →
+staleness re-check passes → topo-sort → soft action promotes the Draft to a
+`ScheduledMessage` (send in 5 min, cancellable) → captured action's
+`create_task` tool runs for real, referencing the promoted message's id if
+chained → bundle marked `APPROVED` with per-action outcomes.
+
+**Owner cancels an AI-drafted send**
+`/app/today/pending` shows the countdown row → **Cancel** before the 5-minute
+buffer elapses → `ScheduledMessage` flips to `CANCELLED`, BullMQ job removed
+(best-effort) → row disappears from the pending list.
+
+**Owner rejects instead**
+Click **No** → bundle flips to `REJECTED`, nothing executes; if the reject
+came from Snooze, a `SuggestionDismissal` is also written so the scanner
+won't re-propose for this entity until activity advances past the snoozed
+point.
+
+---
+
+## 9. Key file index
+
+| Concern | Path |
+| --- | --- |
+| Schema | `packages/database/src/db/schema/{ai-suggestion,suggestion-dismissal,scheduled-message}.ts`, `EntityInstance.lastSuggestionScanAt` |
+| Scanner job | `packages/lib/src/jobs/approvals/next-action-stale-scanner-job.ts` |
+| Staleness config | `packages/lib/src/work-items/stale-defaults.ts` |
+| Headless agent | `packages/lib/src/approvals/headless-runner.ts` |
+| Bundle CRUD | `packages/lib/src/approvals/bundle-service.ts` |
+| Apply / reject / snooze / cancel | `packages/lib/src/approvals/actions-service.ts` |
+| Types | `packages/lib/src/approvals/types.ts` (`ProposedAction`, `ActionOutcome`, `StoredBundle`) |
+| Capture-mode engine | `packages/lib/src/ai/agent-framework/capture-mode.ts`, `types.ts` (`approvalMode`, `captureMint`, `capturedActions`) |
+| tRPC | `apps/web/src/server/api/routers/approvals.ts` |
+| Frontend | `apps/web/src/components/today/` (`today-page.tsx`, `pending-page.tsx`, `bundle-card.tsx`) |
+| Routes | `apps/web/src/app/(protected)/app/today/{page.tsx,pending/page.tsx}` |
+| Feature flag | `packages/lib/src/permissions/types.ts` (`FeatureKey.todayInbox`) |
+| Plans (ground truth) | `plans/follow-up/phases/phase-3{a,b,c,d,e}-*.md`, `phase-4-override.md`, `phase-5-spawn.md`, `phase-6-polish.md` |


### PR DESCRIPTION
## Summary
- Adds `docs/knowledge-base-architecture-guide.md`: data model, authoring editor, public reader site (`apps/kb`), AI/embedding pipeline, and how Kopilot reads/edits articles. Verified against the implementation as of 2026-07-09.
- Adds `docs/today-architecture-guide.md`: the stale-entity scanner, headless-agent suggestion runs, the `AiSuggestion` bundle data model, apply-time execution, and the frontend triage UI. Verified against the implementation as of 2026-07-09. Notes open items not yet built (event triggers, ranking).

## Test plan
- [ ] Docs-only change — no runtime impact