### PR TITLE
fix(kbd): render meta-key icon via CSS instead of JS platform check

### DIFF
--- a/packages/ui/src/components/kbd.tsx
+++ b/packages/ui/src/components/kbd.tsx
@@ -1,7 +1,6 @@
 // packages/ui/src/components/kbd.tsx
 
 import { cn } from '@auxx/ui/lib/utils'
-import { isMac } from '@auxx/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { ChevronUp, Command, CornerDownLeft, Option } from 'lucide-react'
 import * as React from 'react'
@@ -17,7 +16,9 @@ const SHORTCUT_MAP = {
   option: Option,
   /**
    * Platform-adaptive primary modifier: renders `cmd` on Mac and `ctrl`
-   * elsewhere. Resolved at render time via {@link isMac}.
+   * elsewhere. Both icons are rendered and toggled purely by CSS via the
+   * `is-mac` class the `IS_MAC_SCRIPT` stamps on `<html>` before first paint —
+   * so the correct icon is in the very first frame with no hydration/JS flip.
    */
   meta: Command,
 } as const
@@ -77,9 +78,17 @@ interface KbdProps extends Omit<React.ComponentProps<'span'>, 'children'>, KbdGr
 
 /** Renders a shortcut as icon or text */
 function renderShortcut(key: ShortcutKey): React.ReactNode {
-  // `meta` adapts to the platform: Cmd on Mac, Ctrl elsewhere.
-  const resolvedKey = key === 'meta' ? (isMac() ? 'cmd' : 'ctrl') : key
-  const value = SHORTCUT_MAP[resolvedKey]
+  if (key === 'meta') {
+    // Platform-adaptive without SSR guesswork: render both, let the `is-mac`
+    // class (set by IS_MAC_SCRIPT in <head>, before paint) pick via CSS.
+    return (
+      <>
+        <ChevronUp className='[.is-mac_&]:hidden' />
+        <Command className='hidden [.is-mac_&]:block' />
+      </>
+    )
+  }
+  const value = SHORTCUT_MAP[key]
   if (typeof value === 'string') {
     return value
   }

--- a/packages/utils/src/browser.ts
+++ b/packages/utils/src/browser.ts
@@ -1,10 +1,12 @@
 // packages/utils/src/browser.ts
 
 /**
- * Inline script to set platform detection in <head>.
- * Run this before React hydration to avoid mismatch.
+ * Inline script to set platform detection in <head>. Runs before first paint so
+ * both the `window.__IS_MAC__` global (read by {@link isMac}) and the `is-mac`
+ * class on `<html>` (used for pure-CSS icon selection, e.g. in `Kbd`) are set
+ * before React hydrates — no mismatch, no visible icon flip.
  */
-export const IS_MAC_SCRIPT = `window.__IS_MAC__=/Mac|iPod|iPhone|iPad/.test(navigator.platform)`
+export const IS_MAC_SCRIPT = `(function(){var m=/Mac|iPod|iPhone|iPad/.test(navigator.platform);window.__IS_MAC__=m;if(m)document.documentElement.classList.add('is-mac')})()`
 
 /**
  * Check if the current platform is macOS/iOS.


### PR DESCRIPTION
## Summary
- `Kbd`'s meta-key icon (Cmd vs Ctrl/Chevron) was resolved at render time via `isMac()`, which risks an SSR/hydration mismatch and a visible icon flip on first paint.
- `IS_MAC_SCRIPT` now also stamps an `is-mac` class on `<html>` before first paint (in addition to the existing `window.__IS_MAC__` global).
- `Kbd` renders both icons and toggles visibility purely via Tailwind arbitrary variants (`[.is-mac_&]:hidden` / `[.is-mac_&]:block`) keyed off that class — correct icon in the first frame, no JS/hydration involved.

## Test plan
- [ ] Load a page with a `Kbd` meta-shortcut on Mac — Cmd icon shows immediately, no flip
- [ ] Load the same page on a non-Mac platform (or spoofed `navigator.platform`) — Ctrl/Chevron icon shows immediately
- [ ] Confirm no console hydration mismatch warnings