### PR TITLE
feat(workflow): create manual-trigger workflow pre-wired to a resource

### DIFF
--- a/apps/web/src/components/workflow/mass-workflow-trigger-dialog.tsx
+++ b/apps/web/src/components/workflow/mass-workflow-trigger-dialog.tsx
@@ -20,7 +20,8 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { toastError } from '@auxx/ui/components/toast'
-import { Play } from 'lucide-react'
+import { Play, Plus } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { invalidateBatchResources } from '~/components/workflow/utils/invalidate-resource'
 import { useWorkflowRunStatusStore } from '~/stores/workflow-run-status-store'
@@ -50,6 +51,7 @@ export function MassWorkflowTriggerDialog({
   recordIds,
   onSuccess,
 }: MassWorkflowTriggerDialogProps) {
+  const router = useRouter()
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string>('')
 
   // Parse first RecordId to get entityDefinitionId for querying workflows
@@ -119,6 +121,20 @@ export function MassWorkflowTriggerDialog({
     },
   })
 
+  // Create a new manual-trigger workflow pre-wired to this resource, then
+  // send the user straight into the builder to finish it.
+  const createForResource = api.workflow.createForResource.useMutation({
+    onSuccess: (created) => {
+      onOpenChange(false)
+      if (created?.id) {
+        router.push(`/app/workflows/${created.id}`)
+      }
+    },
+    onError: (error) => {
+      toastError({ title: 'Failed to create workflow', description: error.message })
+    },
+  })
+
   /** Handle workflow trigger */
   const handleTrigger = () => {
     if (!selectedWorkflowId) {
@@ -135,7 +151,7 @@ export function MassWorkflowTriggerDialog({
     })
   }
 
-  const isLoading = workflowsLoading || triggerBulk.isPending
+  const isLoading = workflowsLoading || triggerBulk.isPending || createForResource.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -175,6 +191,17 @@ export function MassWorkflowTriggerDialog({
           <Button
             variant='ghost'
             size='sm'
+            className='sm:mr-auto'
+            onClick={() => createForResource.mutate({ entityDefinitionId })}
+            disabled={isLoading || entityDefinitionId.length === 0}
+            loading={createForResource.isPending}
+            loadingText='Creating...'>
+            <Plus />
+            Create Workflow
+          </Button>
+          <Button
+            variant='ghost'
+            size='sm'
             onClick={() => onOpenChange(false)}
             disabled={isLoading}>
             Cancel
@@ -182,7 +209,7 @@ export function MassWorkflowTriggerDialog({
           <Button
             onClick={handleTrigger}
             disabled={!selectedWorkflowId || isLoading}
-            loading={isLoading}
+            loading={triggerBulk.isPending}
             size='sm'
             variant='outline'
             loadingText='Triggering...'>

--- a/apps/web/src/server/api/routers/workflow.ts
+++ b/apps/web/src/server/api/routers/workflow.ts
@@ -2,21 +2,17 @@
 
 import { schema } from '@auxx/database'
 import { WorkflowRunStatus } from '@auxx/database/enums'
+import { getCachedWorkflowAppCount } from '@auxx/lib/cache'
 import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
 import {
   triggerManualResourceWorkflow,
   triggerManualResourceWorkflowBulk,
-  type Workflow,
-  WorkflowEngine,
-  type WorkflowNode,
-  WorkflowNodeType,
 } from '@auxx/lib/workflow-engine'
 import {
-  checkEntityReadiness,
-  type RequiredEntity,
-  resolveAllAppSlugs,
-  resolveEntityRefsInGraph,
-  TemplateGraphTransformer,
+  buildTemplateWorkflowData,
+  type TemplateForCreate,
+  type TemplateWorkflowData,
+  toWorkflowAppResponse,
   WORKFLOW_TRIGGER_TYPE_VALUES,
   type WorkflowExecutionError,
   WorkflowExecutionService,
@@ -28,85 +24,13 @@ import { getWorkflowAppsByTrigger } from '@auxx/services/workflows'
 import { type RecordId, recordIdSchema } from '@auxx/types/resource'
 import { generateId } from '@auxx/utils/generateId'
 import { TRPCError } from '@trpc/server'
-import { and, count, eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
 import { createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
 import { resolveTemplateById } from '~/server/api/workflow-template-resolver'
 import { workflowTemplatesRouter } from './workflow-templates'
 
-/**
- * Convert database workflow format to workflow-engine format for validation
- */
-// Legacy resource trigger types that should map to unified resource-trigger
-const LEGACY_RESOURCE_TRIGGER_TYPES = new Set([
-  'contact-created-trigger',
-  'contact-updated-trigger',
-  'contact-deleted-trigger',
-  'ticket-created-trigger',
-  'ticket-updated-trigger',
-  'ticket-deleted-trigger',
-])
-
-function convertToEngineFormat(dbWorkflow: any): Workflow {
-  // Convert graph nodes to WorkflowNode format
-  const nodes: WorkflowNode[] = (dbWorkflow.graph?.nodes || []).map((node: any) => {
-    // Determine engine node type
-    let engineType = node.data?.type as WorkflowNodeType
-
-    // Normalize app trigger nodes: frontend stores "appId:triggerId" but
-    // the engine expects "app-trigger" or "app-polling-trigger" to recognize it as an entry point
-    if (
-      node.data?.triggerId &&
-      node.data?.appId &&
-      typeof engineType === 'string' &&
-      engineType.includes(':')
-    ) {
-      engineType = node.data?.config?.polling
-        ? WorkflowNodeType.APP_POLLING_TRIGGER
-        : WorkflowNodeType.APP_TRIGGER
-    }
-
-    // Normalize legacy resource trigger types to unified resource-trigger
-    if (typeof engineType === 'string' && LEGACY_RESOURCE_TRIGGER_TYPES.has(engineType)) {
-      engineType = WorkflowNodeType.RESOURCE_TRIGGER
-    }
-
-    return {
-      id: node.id,
-      workflowId: dbWorkflow.id,
-      nodeId: node.id,
-      type: engineType,
-      name: node.data?.title || node.data?.name || 'Untitled Node',
-      description: node.data?.description || node.data?.desc,
-      data: node.data || {},
-      metadata: {
-        position: node.position,
-        color: node.data?.color,
-        icon: node.data?.icon,
-      },
-    }
-  })
-  return {
-    id: dbWorkflow.id,
-    workflowId: dbWorkflow.id,
-    workflowAppId: dbWorkflow.workflowAppId,
-    organizationId: dbWorkflow.organizationId || '',
-    name: dbWorkflow.name || 'Untitled Workflow',
-    description: dbWorkflow.description,
-    enabled: dbWorkflow.enabled || false,
-    version: dbWorkflow.version || 1,
-    triggerType: dbWorkflow.triggerType,
-    entityDefinitionId: dbWorkflow.entityDefinitionId,
-    nodes,
-    graph: dbWorkflow.graph,
-    envVars: dbWorkflow.envVars,
-    variables: dbWorkflow.variables,
-    createdAt: dbWorkflow.createdAt || new Date(),
-    updatedAt: dbWorkflow.updatedAt || new Date(),
-    createdById: dbWorkflow.createdById,
-  }
-}
 // Create TRPC error handler for WorkflowExecutionService
 const createTRPCErrorHandler = (error: WorkflowExecutionError): never => {
   throw new TRPCError({
@@ -120,7 +44,18 @@ const createTRPCErrorHandler = (error: WorkflowExecutionError): never => {
             : 'INTERNAL_SERVER_ERROR',
     message: error.message,
   })
-} // Create workflow schema
+}
+
+/**
+ * Enforce the org's workflow limit before creating a new one.
+ * Reads the current count from the org cache (no DB query).
+ */
+async function assertWorkflowLimitNotReached(organizationId: string): Promise<void> {
+  await new FeaturePermissionService().requireLimit(organizationId, FeatureKey.workflowsLimit, () =>
+    getCachedWorkflowAppCount(organizationId)
+  )
+}
+// Create workflow schema
 const createWorkflowSchema = z.object({
   name: z.string().min(1, 'Workflow name is required'),
   description: z.string().optional(),
@@ -272,44 +207,7 @@ export const workflowRouter = createTRPCRouter({
     const workflowService = new WorkflowService(ctx.db)
     try {
       const workflowApp = await workflowService.getById(input.id, ctx.session.organizationId)
-      // Transform to maintain backward compatibility with existing UI
-      // Use draft workflow for editing
-      const workflowData = workflowApp.draftWorkflow || workflowApp.publishedWorkflow
-      const result = {
-        id: workflowApp.id,
-        name: workflowApp.name,
-        description: workflowApp.description,
-        enabled: workflowApp.enabled,
-        triggerType: workflowData?.triggerType,
-        entityDefinitionId: workflowData?.entityDefinitionId,
-        version: workflowData?.version || 1,
-        graph: workflowData?.graph,
-        variables: workflowData?.variables || [],
-        envVars: workflowData?.envVars,
-        organizationId: workflowApp.organizationId,
-        createdById: workflowApp.createdById,
-        createdAt: workflowApp.createdAt,
-        updatedAt: workflowApp.updatedAt,
-        createdBy: workflowApp.createdBy,
-        // Add WorkflowApp specific fields
-        isPublic: workflowApp.isPublic,
-        isUniversal: workflowApp.isUniversal,
-        workflowId: workflowApp.draftWorkflowId, // Return draft workflow ID for editing
-        workflows: workflowApp.workflows, // All versions
-        workflowAppId: workflowApp.id, // Include workflowAppId for frontend use
-        // Access settings
-        shareToken: workflowApp.shareToken,
-        webEnabled: workflowApp.webEnabled,
-        apiEnabled: workflowApp.apiEnabled,
-        accessMode: workflowApp.accessMode,
-        icon: workflowApp.icon,
-        config: workflowApp.config,
-        rateLimit: workflowApp.rateLimit,
-        totalRuns: workflowApp.totalRuns,
-        lastRunAt: workflowApp.lastRunAt,
-        hasPublishedVersion: !!workflowApp.workflowId,
-      }
-      return result
+      return toWorkflowAppResponse(workflowApp)
     } catch (error) {
       if (error instanceof Error && error.message === 'Workflow not found') {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Workflow not found' })
@@ -322,103 +220,66 @@ export const workflowRouter = createTRPCRouter({
    * Optionally from a template
    */
   create: protectedProcedure.input(createWorkflowSchema).mutation(async ({ ctx, input }) => {
-    // Check workflow limit
-    const featureService = new FeaturePermissionService()
-    await featureService.requireLimit(
+    await assertWorkflowLimitNotReached(ctx.session.organizationId)
+
+    // Build template data (graph, trigger, resolved app/entity refs) when creating
+    // from a template. Resolution stays here since it merges file + admin sources.
+    let templateData: TemplateWorkflowData | undefined
+    if (input.templateId) {
+      const template = await resolveTemplateById(input.templateId)
+      if (!template) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Template not found' })
+      }
+      templateData = await buildTemplateWorkflowData(
+        ctx.session.organizationId,
+        ctx.session.userId,
+        template as TemplateForCreate,
+        !!input.icon
+      )
+    }
+
+    const created = await new WorkflowService(ctx.db).create(
       ctx.session.organizationId,
-      FeatureKey.workflowsLimit,
-      async () => {
-        const [{ value }] = await ctx.db
-          .select({ value: count() })
-          .from(schema.WorkflowApp)
-          .where(eq(schema.WorkflowApp.organizationId, ctx.session.organizationId))
-        return value
-      }
+      ctx.session.userId,
+      { ...input, ...templateData }
     )
+    await recordAuditFromCtx(ctx, {
+      category: 'apps',
+      action: 'workflow.created',
+      targetType: 'WorkflowApp',
+      targetId: (created as { id?: string } | null)?.id ?? null,
+      metadata: { name: input.name, templateId: input.templateId ?? null },
+    })
+    return created
+  }),
 
-    const workflowService = new WorkflowService(ctx.db)
+  /**
+   * Create a manual-trigger workflow pre-wired to a resource.
+   *
+   * Seeds the graph with a single resource-trigger node (operation: 'manual')
+   * bound to the given entity definition, so the new workflow already targets
+   * the right resource and shows up in the "Run Workflow" dialog once the user
+   * builds it out and publishes it. Returns the created workflow app.
+   */
+  createForResource: protectedProcedure
+    .input(z.object({ entityDefinitionId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      await assertWorkflowLimitNotReached(ctx.session.organizationId)
 
-    try {
-      // If templateId is provided, fetch the template and transform it
-      let templateData: any
-
-      if (input.templateId) {
-        const template = await resolveTemplateById(input.templateId)
-
-        if (!template) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: 'Template not found' })
-        }
-
-        // Transform the template graph and data
-        const transformer = new TemplateGraphTransformer()
-        const transformed = transformer.transformTemplate(
-          {
-            graph: template.graph as any,
-            triggerType: template.triggerType ?? undefined,
-            entityDefinitionId: (template as any).entityDefinitionId ?? undefined,
-            envVars: template.envVars ?? undefined,
-            variables: template.variables ?? undefined,
-          },
-          { userId: ctx.session.userId }
-        )
-
-        // Resolve app slugs (@slug:blockId → realAppId:blockId) using caches
-        const requiredApps = (template as any).requiredApps as
-          | Array<{ appSlug: string }>
-          | undefined
-        if (requiredApps?.length) {
-          const appSlugs = requiredApps.map((a) => a.appSlug)
-          const resolvedApps = await resolveAllAppSlugs(ctx.session.organizationId, appSlugs)
-          transformer.resolveAppNodes(transformed.graph, resolvedApps)
-        }
-
-        // Resolve entity refs (@entity:slug, @field:X) using org caches
-        const requiredEntities = (template as any).requiredEntities as RequiredEntity[] | undefined
-        if (requiredEntities?.length) {
-          const readiness = await checkEntityReadiness(ctx.session.organizationId, requiredEntities)
-          // Only resolve what's available — unresolved refs stay as-is for user to fix
-          resolveEntityRefsInGraph(
-            transformed.graph,
-            requiredEntities,
-            readiness.entityIdMap,
-            readiness.fieldIdMap
-          )
-        }
-
-        templateData = {
-          graph: transformed.graph,
-          triggerType: transformed.triggerType,
-          entityDefinitionId: transformed.entityDefinitionId,
-          envVars: transformed.envVars,
-          variables: transformed.variables,
-        }
-
-        // Use template icon as fallback if user didn't pick one
-        if (!input.icon && (template as any).icon) {
-          templateData.icon = (template as any).icon
-        }
-      }
-
-      // Create the workflow with optional template data
-      const created = await workflowService.create(ctx.session.organizationId, ctx.session.userId, {
-        ...input,
-        ...templateData, // Spread template data if it exists
-      })
+      const created = await new WorkflowService(ctx.db).createForResource(
+        ctx.session.organizationId,
+        ctx.session.userId,
+        input.entityDefinitionId
+      )
       await recordAuditFromCtx(ctx, {
         category: 'apps',
         action: 'workflow.created',
         targetType: 'WorkflowApp',
         targetId: (created as { id?: string } | null)?.id ?? null,
-        metadata: { name: input.name, templateId: input.templateId ?? null },
+        metadata: { entityDefinitionId: input.entityDefinitionId },
       })
       return created
-    } catch (error) {
-      if (error instanceof TRPCError) {
-        throw error
-      }
-      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to create workflow' })
-    }
-  }),
+    }),
   /**
    * Update an existing workflow app (updates active workflow)
    */
@@ -564,94 +425,21 @@ export const workflowRouter = createTRPCRouter({
     .input(z.object({ workflowId: z.string(), versionTitle: z.string().optional() }))
     .use(notDemo('publish workflows'))
     .mutation(async ({ ctx, input }) => {
-      const versionService = new WorkflowVersionService(ctx.db)
-      try {
-        // Get the workflow app with draft workflow for validation
-        const [appResult] = await ctx.db
-          .select({ app: schema.WorkflowApp, draft: schema.Workflow })
-          .from(schema.WorkflowApp)
-          .leftJoin(schema.Workflow, eq(schema.Workflow.id, schema.WorkflowApp.draftWorkflowId))
-          .where(
-            and(
-              eq(schema.WorkflowApp.id, input.workflowId),
-              eq(schema.WorkflowApp.organizationId, ctx.session.organizationId)
-            )
-          )
-          .limit(1)
-        const workflowApp = appResult?.app
-          ? { ...appResult.app, draftWorkflow: appResult.draft ?? null }
-          : null
-        if (!workflowApp) {
-          throw new TRPCError({ code: 'NOT_FOUND', message: 'Workflow not found' })
-        }
-        if (!workflowApp.draftWorkflow) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: 'No draft workflow to publish' })
-        }
-
-        // Convert to workflow-engine format and validate
-        const engineWorkflow = convertToEngineFormat(workflowApp.draftWorkflow)
-        const workflowEngine = new WorkflowEngine()
-        await workflowEngine.getNodeRegistry().initializeWithDefaults()
-        const validationResult = await workflowEngine.validateWorkflowForPublish(engineWorkflow)
-        if (!validationResult.valid) {
-          console.error(
-            '[workflow.publish] Validation failed:',
-            JSON.stringify(
-              {
-                workflowId: input.workflowId,
-                errors: validationResult.errors,
-                warnings: validationResult.warnings,
-                nodeTypes: engineWorkflow.nodes.map((n) => ({
-                  id: n.nodeId,
-                  type: n.type,
-                  name: n.name,
-                })),
-              },
-              null,
-              2
-            )
-          )
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: `Workflow validation failed: ${validationResult.errors.join('; ')}`,
-            cause: {
-              errors: validationResult.errors,
-              warnings: validationResult.warnings,
-            },
-          })
-        }
-        // If validation passes, proceed with publishing
-        const published = await versionService.publish(
-          input.workflowId,
-          ctx.session.organizationId,
-          input.versionTitle
-        )
-        await recordAuditFromCtx(ctx, {
-          category: 'apps',
-          action: 'workflow.published',
-          targetType: 'WorkflowApp',
-          targetId: input.workflowId,
-          metadata: { versionTitle: input.versionTitle ?? null },
-        })
-        return published
-      } catch (error) {
-        // Re-throw TRPCError instances
-        if (error instanceof TRPCError) {
-          throw error
-        }
-        if (error instanceof Error) {
-          if (error.message === 'Workflow not found') {
-            throw new TRPCError({ code: 'NOT_FOUND', message: 'Workflow not found' })
-          }
-          if (error.message === 'No active workflow to publish') {
-            throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active workflow to publish' })
-          }
-        }
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to publish workflow version',
-        })
-      }
+      // The version service validates the draft and throws domain errors
+      // (NotFoundError / BadRequestError) that the tRPC layer maps to codes.
+      const published = await new WorkflowVersionService(ctx.db).publish(
+        input.workflowId,
+        ctx.session.organizationId,
+        input.versionTitle
+      )
+      await recordAuditFromCtx(ctx, {
+        category: 'apps',
+        action: 'workflow.published',
+        targetType: 'WorkflowApp',
+        targetId: input.workflowId,
+        metadata: { versionTitle: input.versionTitle ?? null },
+      })
+      return published
     }),
   /**
    * Get all versions of a workflow

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -116,6 +116,7 @@ export type {
 export { UserCacheService } from './user-cache-service'
 export {
   getCachedWorkflowApp,
+  getCachedWorkflowAppCount,
   getCachedWorkflowAppsByAppTrigger,
   getCachedWorkflowAppsByTrigger,
 } from './workflow-app-queries'

--- a/packages/lib/src/cache/workflow-app-queries.ts
+++ b/packages/lib/src/cache/workflow-app-queries.ts
@@ -46,6 +46,15 @@ export async function getCachedWorkflowAppsByAppTrigger(params: {
 }
 
 /**
+ * Get the total number of workflow apps for an organization from cache.
+ * Counts every app (enabled and disabled) — used for the create-time limit check.
+ */
+export async function getCachedWorkflowAppCount(organizationId: string): Promise<number> {
+  const { total } = await getOrgCache().from(organizationId, 'workflowApps').list()
+  return total
+}
+
+/**
  * Get workflow apps list with filtering and pagination from cache.
  * Used by the workflow list view — pure cache read, zero DB queries.
  */

--- a/packages/lib/src/workflows/create-from-template.ts
+++ b/packages/lib/src/workflows/create-from-template.ts
@@ -1,0 +1,83 @@
+// packages/lib/src/workflows/create-from-template.ts
+
+import { TemplateGraphTransformer } from './template-graph-transformer'
+import {
+  checkEntityReadiness,
+  type RequiredEntity,
+  resolveAllAppSlugs,
+  resolveEntityRefsInGraph,
+} from './template-resolution'
+import type { WorkflowCreateInput, WorkflowTriggerType } from './types'
+
+/** Minimal shape of a resolved workflow template consumed by the builder. */
+export interface TemplateForCreate {
+  graph: unknown
+  triggerType?: string | null
+  entityDefinitionId?: string | null
+  envVars?: unknown
+  variables?: unknown
+  icon?: WorkflowCreateInput['icon']
+  requiredApps?: Array<{ appSlug: string }>
+  requiredEntities?: RequiredEntity[]
+}
+
+/** Fields produced from a template that are spread into the create input. */
+export type TemplateWorkflowData = Pick<
+  WorkflowCreateInput,
+  'graph' | 'triggerType' | 'entityDefinitionId' | 'envVars' | 'variables' | 'icon'
+>
+
+/**
+ * Transform a resolved template into workflow create data: clones the graph with
+ * fresh ids, resolves app-slug and entity/field references against the org's
+ * caches, and carries over the template icon when the user didn't pick one.
+ */
+export async function buildTemplateWorkflowData(
+  organizationId: string,
+  userId: string,
+  template: TemplateForCreate,
+  hasUserIcon: boolean
+): Promise<TemplateWorkflowData> {
+  const transformer = new TemplateGraphTransformer()
+  const transformed = transformer.transformTemplate(
+    {
+      graph: template.graph as any,
+      triggerType: template.triggerType ?? undefined,
+      entityDefinitionId: template.entityDefinitionId ?? undefined,
+      envVars: template.envVars ?? undefined,
+      variables: template.variables ?? undefined,
+    },
+    { userId }
+  )
+
+  // Resolve app slugs (@slug:blockId → realAppId:blockId) using caches
+  if (template.requiredApps?.length) {
+    const resolvedApps = await resolveAllAppSlugs(
+      organizationId,
+      template.requiredApps.map((a) => a.appSlug)
+    )
+    transformer.resolveAppNodes(transformed.graph, resolvedApps)
+  }
+
+  // Resolve entity refs (@entity:slug, @field:X) using org caches.
+  // Only resolve what's available — unresolved refs stay as-is for the user to fix.
+  if (template.requiredEntities?.length) {
+    const readiness = await checkEntityReadiness(organizationId, template.requiredEntities)
+    resolveEntityRefsInGraph(
+      transformed.graph,
+      template.requiredEntities,
+      readiness.entityIdMap,
+      readiness.fieldIdMap
+    )
+  }
+
+  return {
+    graph: transformed.graph,
+    triggerType: transformed.triggerType as WorkflowTriggerType | undefined,
+    entityDefinitionId: transformed.entityDefinitionId,
+    envVars: transformed.envVars,
+    variables: transformed.variables,
+    // Use the template icon as a fallback when the user didn't choose one
+    ...(!hasUserIcon && template.icon ? { icon: template.icon } : {}),
+  }
+}

--- a/packages/lib/src/workflows/index.ts
+++ b/packages/lib/src/workflows/index.ts
@@ -1,5 +1,10 @@
 // packages/lib/src/workflows/index.ts
 
+export {
+  buildTemplateWorkflowData,
+  type TemplateForCreate,
+  type TemplateWorkflowData,
+} from './create-from-template'
 export { normalizeTemplateGraph } from './normalize-template-graph'
 export type { WorkflowGraph } from './template-graph-transformer'
 export { TemplateGraphTransformer } from './template-graph-transformer'
@@ -35,6 +40,6 @@ export {
 } from './workflow-execution-events'
 export { WorkflowExecutionService } from './workflow-execution-service'
 // Export all services
-export { WorkflowService } from './workflow-service'
+export { toWorkflowAppResponse, WorkflowService } from './workflow-service'
 export { WorkflowStatsService } from './workflow-stats-service'
 export { WorkflowVersionService } from './workflow-version-service'

--- a/packages/lib/src/workflows/workflow-service.ts
+++ b/packages/lib/src/workflows/workflow-service.ts
@@ -2,9 +2,12 @@
 
 import { type Database, schema, type Transaction } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { generateId } from '@auxx/utils/generateId'
 import { and, desc, eq, inArray } from 'drizzle-orm'
 import { onCacheEvent } from '../cache/invalidate'
+import { getCachedResources } from '../cache/org-cache-helpers'
 import { getCachedWorkflowAppsList } from '../cache/workflow-app-queries'
+import { NotFoundError } from '../errors'
 import { getQueue, Queues } from '../jobs/queues'
 import { WorkflowEngine } from '../workflow-engine/core/workflow-engine'
 import { assertMailTriggerNotPersonal } from './mail-trigger-guard'
@@ -22,6 +25,49 @@ import {
 } from './types'
 
 const logger = createScopedLogger('workflow-service')
+
+/**
+ * Flatten a workflow app + its editable (draft, falling back to published) version
+ * into the shape the web UI consumes. Draft is preferred so the builder edits the
+ * in-progress version.
+ */
+export function toWorkflowAppResponse(workflowApp: WorkflowWithDetails) {
+  const workflowData = workflowApp.draftWorkflow || workflowApp.publishedWorkflow
+  return {
+    id: workflowApp.id,
+    name: workflowApp.name,
+    description: workflowApp.description,
+    enabled: workflowApp.enabled,
+    triggerType: workflowData?.triggerType,
+    entityDefinitionId: workflowData?.entityDefinitionId,
+    version: workflowData?.version || 1,
+    graph: workflowData?.graph,
+    variables: workflowData?.variables || [],
+    envVars: workflowData?.envVars,
+    organizationId: workflowApp.organizationId,
+    createdById: workflowApp.createdById,
+    createdAt: workflowApp.createdAt,
+    updatedAt: workflowApp.updatedAt,
+    createdBy: workflowApp.createdBy,
+    // WorkflowApp-specific fields
+    isPublic: workflowApp.isPublic,
+    isUniversal: workflowApp.isUniversal,
+    workflowId: workflowApp.draftWorkflowId, // draft workflow ID for editing
+    workflows: workflowApp.workflows, // all versions
+    workflowAppId: workflowApp.id,
+    // Access settings
+    shareToken: workflowApp.shareToken,
+    webEnabled: workflowApp.webEnabled,
+    apiEnabled: workflowApp.apiEnabled,
+    accessMode: workflowApp.accessMode,
+    icon: workflowApp.icon,
+    config: workflowApp.config,
+    rateLimit: workflowApp.rateLimit,
+    totalRuns: workflowApp.totalRuns,
+    lastRunAt: workflowApp.lastRunAt,
+    hasPublishedVersion: !!workflowApp.workflowId,
+  }
+}
 
 export class WorkflowService {
   private scheduledTriggerService = new ScheduledTriggerService()
@@ -246,6 +292,68 @@ export class WorkflowService {
       logger.error('Failed to create workflow app', { error, organizationId })
       throw error
     }
+  }
+
+  /**
+   * Create a manual-trigger workflow pre-wired to a resource.
+   *
+   * Seeds the graph with a single resource-trigger node (operation: 'manual')
+   * bound to the given entity definition, so the new workflow already targets
+   * the right resource. Throws {@link NotFoundError} if the resource is unknown.
+   */
+  async createForResource(
+    organizationId: string,
+    userId: string,
+    entityDefinitionId: string
+  ): Promise<any> {
+    const resources = await getCachedResources(organizationId)
+    const resource = resources.find((r) => r.entityDefinitionId === entityDefinitionId)
+    if (!resource) {
+      throw new NotFoundError('Resource not found')
+    }
+
+    // Seed a single manual resource-trigger node bound to this resource.
+    // Shape mirrors the builder's resource-trigger default data; the builder
+    // re-enriches connection metadata on load.
+    const nodeId = generateId()
+    const label = resource.label
+    const graph = {
+      nodes: [
+        {
+          id: nodeId,
+          type: 'standard',
+          position: { x: 0, y: 0 },
+          data: {
+            id: nodeId,
+            type: 'resource-trigger',
+            selected: false,
+            resourceType: resource.id,
+            entityDefinitionId,
+            operation: 'manual',
+            title: `${label} Manual`,
+            desc: `Triggered manually on a ${label.toLowerCase()}`,
+            description: `Triggered manually on a ${label.toLowerCase()}`,
+            icon: 'Play',
+            variables: [],
+            isValid: true,
+            errors: [],
+            disabled: false,
+            outputVariables: [],
+          },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+    }
+
+    return this.create(organizationId, userId, {
+      name: `${label} Trigger`,
+      enabled: false,
+      icon: { iconId: resource.icon, color: resource.color },
+      triggerType: WorkflowTriggerType.MANUAL,
+      entityDefinitionId,
+      graph,
+    })
   }
 
   /**

--- a/packages/lib/src/workflows/workflow-version-service.ts
+++ b/packages/lib/src/workflows/workflow-version-service.ts
@@ -4,11 +4,108 @@ import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import { onCacheEvent } from '../cache/invalidate'
+import { BadRequestError, NotFoundError } from '../errors'
+import {
+  type Workflow as EngineWorkflow,
+  type WorkflowNode as EngineWorkflowNode,
+  WorkflowNodeType,
+} from '../workflow-engine/core/types'
+import { WorkflowEngine } from '../workflow-engine/core/workflow-engine'
 import { PollingTriggerService } from './polling-trigger-service'
 import { ScheduledTriggerService } from './scheduled-trigger-service'
 import { WorkflowTriggerType, type WorkflowVersion } from './types'
 
 const logger = createScopedLogger('workflow-version-service')
+
+/** Legacy resource trigger node types that map to the unified resource-trigger. */
+const LEGACY_RESOURCE_TRIGGER_TYPES = new Set([
+  'contact-created-trigger',
+  'contact-updated-trigger',
+  'contact-deleted-trigger',
+  'ticket-created-trigger',
+  'ticket-updated-trigger',
+  'ticket-deleted-trigger',
+])
+
+/**
+ * Convert a stored workflow (DB row) into the workflow-engine format used for
+ * publish-time validation.
+ */
+function toEngineFormat(dbWorkflow: any): EngineWorkflow {
+  const nodes: EngineWorkflowNode[] = (dbWorkflow.graph?.nodes || []).map((node: any) => {
+    let engineType = node.data?.type as WorkflowNodeType
+
+    // Normalize app trigger nodes: the UI stores "appId:triggerId" but the
+    // engine expects "app-trigger"/"app-polling-trigger" to treat it as an entry point.
+    if (
+      node.data?.triggerId &&
+      node.data?.appId &&
+      typeof engineType === 'string' &&
+      engineType.includes(':')
+    ) {
+      engineType = node.data?.config?.polling
+        ? WorkflowNodeType.APP_POLLING_TRIGGER
+        : WorkflowNodeType.APP_TRIGGER
+    }
+
+    // Normalize legacy resource trigger types to the unified resource-trigger.
+    if (typeof engineType === 'string' && LEGACY_RESOURCE_TRIGGER_TYPES.has(engineType)) {
+      engineType = WorkflowNodeType.RESOURCE_TRIGGER
+    }
+
+    return {
+      id: node.id,
+      workflowId: dbWorkflow.id,
+      nodeId: node.id,
+      type: engineType,
+      name: node.data?.title || node.data?.name || 'Untitled Node',
+      description: node.data?.description || node.data?.desc,
+      data: node.data || {},
+      metadata: {
+        position: node.position,
+        color: node.data?.color,
+        icon: node.data?.icon,
+      },
+    }
+  })
+  return {
+    id: dbWorkflow.id,
+    workflowId: dbWorkflow.id,
+    workflowAppId: dbWorkflow.workflowAppId,
+    organizationId: dbWorkflow.organizationId || '',
+    name: dbWorkflow.name || 'Untitled Workflow',
+    description: dbWorkflow.description,
+    enabled: dbWorkflow.enabled || false,
+    version: dbWorkflow.version || 1,
+    triggerType: dbWorkflow.triggerType,
+    entityDefinitionId: dbWorkflow.entityDefinitionId,
+    nodes,
+    graph: dbWorkflow.graph,
+    envVars: dbWorkflow.envVars,
+    variables: dbWorkflow.variables,
+    createdAt: dbWorkflow.createdAt || new Date(),
+    updatedAt: dbWorkflow.updatedAt || new Date(),
+    createdById: dbWorkflow.createdById,
+  }
+}
+
+/**
+ * Validate a draft workflow for publishing. Throws {@link BadRequestError} with
+ * the collected validation errors when the workflow is not publishable.
+ */
+async function assertDraftIsPublishable(draftWorkflow: any): Promise<void> {
+  const engine = new WorkflowEngine()
+  await engine.getNodeRegistry().initializeWithDefaults()
+  const result = await engine.validateWorkflowForPublish(toEngineFormat(draftWorkflow))
+  if (!result.valid) {
+    logger.error('Workflow validation failed for publish', {
+      workflowId: draftWorkflow?.id,
+      errors: result.errors,
+      warnings: result.warnings,
+    })
+    throw new BadRequestError(`Workflow validation failed: ${result.errors.join('; ')}`)
+  }
+}
 
 export class WorkflowVersionService {
   private scheduledTriggerService = new ScheduledTriggerService()
@@ -41,12 +138,15 @@ export class WorkflowVersionService {
       })
 
       if (!workflowApp) {
-        throw new Error('Workflow not found')
+        throw new NotFoundError('Workflow not found')
       }
 
       if (!workflowApp.draftWorkflow) {
-        throw new Error('No draft workflow to publish')
+        throw new BadRequestError('No draft workflow to publish')
       }
+
+      // Validate the draft before creating a published version
+      await assertDraftIsPublishable(workflowApp.draftWorkflow)
 
       // Get the next version number
       const latestVersion = workflowApp.workflows[0]?.version || 0


### PR DESCRIPTION
## What

Adds a left-aligned **Create Workflow** button to the mass "Run Workflow" dialog (`mass-workflow-trigger-dialog.tsx`). Clicking it creates a new workflow whose graph already contains a **manual resource-trigger** bound to the selected resource, names it `{Label} Trigger` (e.g. "Contact Trigger"), and navigates the user into the builder to finish it.

Once the user builds it out, publishes, and enables it, that workflow then shows up in this same dialog's dropdown for the resource.

## Backend / lib cleanup

New endpoint `workflow.createForResource`, plus a pass to move business logic out of the tRPC router into `@auxx/lib`. Error mapping now rides on the existing `auxxErrorMiddleware`, so the thinned procedures no longer need try/catch + manual `TRPCError` mapping.

- **`WorkflowService.createForResource`** — resolves the resource from org cache, seeds the manual resource-trigger graph, and creates the workflow. Throws `NotFoundError` on an unknown resource (→ 404 via middleware).
- **`buildTemplateWorkflowData`** (`create-from-template.ts`) — owns the template graph transform (clone graph, resolve app-slug + entity/field refs, icon fallback) that was inlined in the `create` route. `resolveTemplateById` stays in the router (merges app-layer file + admin sources).
- **`WorkflowVersionService.publish`** — now validates the draft internally (`toEngineFormat` + `assertDraftIsPublishable`, throwing `NotFoundError`/`BadRequestError`). Removes the router's duplicate fetch + engine-validation block.
- **`toWorkflowAppResponse`** mapper replaces the ~35-line inline `getById` transform.
- **Workflow limit check** reads `getCachedWorkflowAppCount()` (cache) instead of an inline DB `count()` query, deduped into `assertWorkflowLimitNotReached()`.

Net: router shrank ~230 lines; the logic now lives in lib.

## Behavior note

`create` / `createForResource` / `publish` no longer wrap unexpected errors in a friendly generic 500 message — an unexpected throw surfaces as tRPC's default INTERNAL_SERVER_ERROR (message hidden in prod), while `AuxxError` subclasses now map to their correct codes instead of being flattened. Confirmed the publish frontend only reads `error.message`.

## Test plan

- [ ] Select records in a resource list → open Run Workflow → **Create Workflow** → lands in builder with the manual resource-trigger pre-bound and titled `{Label} Trigger`
- [ ] Build it out, publish + enable → it appears in the Run Workflow dropdown for that resource
- [ ] Create from a template still works (graph/trigger/app+entity refs resolved)
- [ ] Publish an invalid draft → surfaces the validation error message