### PR TITLE
chore: sanitize tRPC errors, add KB list UI, clean stale mcp containers

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -17,7 +17,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "export $(grep ^DATABASE_URL .env | xargs) && URI=$(echo \"$DATABASE_URL\" | sed 's/localhost/host.docker.internal/;s/127.0.0.1/host.docker.internal/') && docker run -i --rm -e DATABASE_URI=\"$URI\" crystaldba/postgres-mcp --access-mode=unrestricted"
+        "docker ps --filter ancestor=crystaldba/postgres-mcp --format '{{.ID}} {{.RunningFor}}' | awk '/hour|day|week/ {print $1}' | xargs docker rm -f >/dev/null 2>&1; export $(grep ^DATABASE_URL .env | xargs) && URI=$(echo \"$DATABASE_URL\" | sed 's/localhost/host.docker.internal/;s/127.0.0.1/host.docker.internal/') && exec docker run -i --rm --init -e DATABASE_URI=\"$URI\" crystaldba/postgres-mcp --access-mode=unrestricted"
       ]
     },
     "chrome-devtools": {

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-base-card.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-base-card.tsx
@@ -1,0 +1,130 @@
+// apps/web/src/components/kb/ui/knowledge-bases/knowledge-base-card.tsx
+'use client'
+
+// One knowledge base tile in the Knowledge Bases tab grid: a selectable
+// ListCard with the Open / Settings / Delete menu. `name`/`slug` edits go
+// through the same draft-vs-live split the KB editor uses (see
+// use-draft-settings-autosave.ts) — name is staged via `updateDraftSettings`
+// and never auto-published from here, matching the rest of the app.
+
+import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
+import { ListCard, renderBadgeChips } from '@auxx/ui/components/list-card'
+import { Book, Lock, Settings, Trash } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
+import {
+  useBulkMode,
+  useIsPending,
+  useIsSelected,
+  useListSelection,
+  usePendingLabel,
+} from '~/components/list-selection'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useKnowledgeBaseMutations } from '../../hooks/use-knowledge-base-mutations'
+import type { KnowledgeBase } from '../../store/knowledge-base-store'
+import {
+  KnowledgeBaseDialog,
+  type KnowledgeBaseFormValues,
+} from '../dialogs/kb-knowledge-base-dialog'
+
+function publishStatusLabel(publishStatus: KnowledgeBase['publishStatus']) {
+  if (publishStatus === 'PUBLISHED') return null
+  return publishStatus === 'UNLISTED' ? 'Unlisted' : 'Private'
+}
+
+export function KnowledgeBaseCard({ knowledgeBase: kb }: { knowledgeBase: KnowledgeBase }) {
+  const router = useRouter()
+  const [confirm, ConfirmDialog] = useConfirm()
+  const [settingsOpen, setSettingsOpen] = useState(false)
+
+  const bulkMode = useBulkMode()
+  const selected = useIsSelected(kb.id)
+  const pending = useIsPending(kb.id)
+  const pendingLabel = usePendingLabel()
+  const toggle = useListSelection((s) => s.toggle)
+
+  const {
+    updateKnowledgeBase,
+    updateDraftSettings,
+    deleteKnowledgeBase,
+    isUpdating,
+    isUpdatingDraft,
+  } = useKnowledgeBaseMutations()
+
+  const handleSettingsSubmit = async (values: KnowledgeBaseFormValues) => {
+    if (values.slug !== kb.slug) {
+      await updateKnowledgeBase(kb.id, { slug: values.slug })
+    }
+    if (values.name !== kb.name) {
+      await updateDraftSettings(kb.id, { name: values.name })
+    }
+    setSettingsOpen(false)
+  }
+
+  const handleDelete = async () => {
+    const ok = await confirm({
+      title: 'Delete knowledge base?',
+      description: `"${kb.name}" and all of its articles will be removed. This cannot be undone.`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!ok) return
+    await deleteKnowledgeBase(kb.id)
+  }
+
+  const statusLabel = publishStatusLabel(kb.publishStatus)
+
+  return (
+    <>
+      <ConfirmDialog />
+      <ListCard
+        href={`/app/kb/${kb.id}/editor`}
+        ariaLabel={kb.name}
+        selectable
+        selecting={bulkMode}
+        selected={selected}
+        onSelectChange={(_, e) => toggle(kb.id, { shiftKey: e.shiftKey })}
+        pending={pending}
+        pendingLabel={pendingLabel}
+        title={kb.name}
+        icon={<Book className='size-4' />}
+        description={kb.description ?? undefined}
+        descriptionLines={2}
+        badges={renderBadgeChips(
+          statusLabel ? [{ icon: <Lock className='size-3' />, label: statusLabel }] : []
+        )}
+        menu={
+          <>
+            <DropdownMenuItem onClick={() => router.push(`/app/kb/${kb.id}/editor`)}>
+              <Book />
+              Open
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
+              <Settings />
+              Settings
+            </DropdownMenuItem>
+            <FavoriteToggleMenuItem
+              targetType='KNOWLEDGE_BASE'
+              targetIds={{ knowledgeBaseId: kb.id }}
+            />
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant='destructive' onClick={() => void handleDelete()}>
+              <Trash />
+              Delete
+            </DropdownMenuItem>
+          </>
+        }
+      />
+      <KnowledgeBaseDialog
+        mode='edit'
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        initialValues={{ name: kb.name, slug: kb.slug }}
+        isSubmitting={isUpdating || isUpdatingDraft}
+        onSubmit={(values) => void handleSettingsSubmit(values)}
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-bulk-bar.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-bulk-bar.tsx
@@ -1,0 +1,76 @@
+// apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-bulk-bar.tsx
+'use client'
+
+import { ActionBar, type ActionBarAction } from '@auxx/ui/components/action-bar'
+import { pluralize } from '@auxx/utils/strings'
+import { Trash } from 'lucide-react'
+import {
+  useBulkMode,
+  useBulkRunner,
+  useListSelection,
+  useSelectionCount,
+  useSelectionIds,
+} from '~/components/list-selection'
+import { api } from '~/trpc/react'
+import { getKnowledgeBaseStoreState } from '../../store/knowledge-base-store'
+import { useKnowledgeBasesList } from './knowledge-bases-provider'
+
+/**
+ * Floating bulk-action bar for the knowledge bases grid — currently just
+ * delete. Uses the raw `kb.delete` mutation (not `useKnowledgeBaseMutations`)
+ * so `useBulkRunner` can detect per-item failures via thrown rejections —
+ * `deleteKnowledgeBase()` swallows errors and always resolves, which would
+ * make every failure count as a success. The Zustand KB store (read by
+ * kb-switcher.tsx) is synced manually on each success instead.
+ */
+export function KnowledgeBasesBulkBar() {
+  const ids = useSelectionIds()
+  const count = useSelectionCount()
+  const bulkMode = useBulkMode()
+  const exit = useListSelection((s) => s.exit)
+  const { refetch } = useKnowledgeBasesList()
+  const { ConfirmDialog, run, isRunning } = useBulkRunner()
+  const del = api.kb.delete.useMutation()
+
+  const actions: ActionBarAction[] = [
+    {
+      id: 'delete',
+      label: 'Delete',
+      icon: Trash,
+      variant: 'destructive',
+      tooltip: 'Delete selected',
+      disabled: isRunning || count === 0,
+      onClick: () =>
+        run(
+          ids,
+          async (id) => {
+            await del.mutateAsync({ id })
+            getKnowledgeBaseStoreState().confirmKBDelete(id)
+          },
+          {
+            title: `Delete ${count} ${pluralize(count, 'knowledge base')}?`,
+            description: 'This permanently deletes them. This cannot be undone.',
+            failureTitle: 'Some knowledge bases could not be deleted',
+            onDone: () => {
+              refetch()
+              exit()
+            },
+          }
+        ),
+    },
+  ]
+
+  return (
+    <>
+      <ConfirmDialog />
+      <ActionBar
+        open={bulkMode || count > 0}
+        onOpenChange={(open) => !open && exit()}
+        selectedCount={count}
+        selectedLabel='selected'
+        actions={actions}
+        showClose
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-filter-bar.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-filter-bar.tsx
@@ -1,0 +1,28 @@
+// apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-filter-bar.tsx
+'use client'
+
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { ListBulkToggle } from '@auxx/ui/components/list-bulk-toggle'
+import { ListToolbar, ListToolbarGroup } from '@auxx/ui/components/list-toolbar'
+import { useBulkMode, useListSelection } from '~/components/list-selection'
+import { useKnowledgeBasesList } from './knowledge-bases-provider'
+
+export function KnowledgeBasesFilterBar() {
+  const { searchQuery, setSearchQuery } = useKnowledgeBasesList()
+  const bulkMode = useBulkMode()
+  const setBulkMode = useListSelection((s) => s.setBulkMode)
+
+  return (
+    <ListToolbar>
+      <InputSearch
+        value={searchQuery}
+        placeholder='Search knowledge bases...'
+        onChange={(e) => setSearchQuery(e.target.value)}
+      />
+
+      <ListToolbarGroup align='end'>
+        <ListBulkToggle active={bulkMode} onActiveChange={setBulkMode} />
+      </ListToolbarGroup>
+    </ListToolbar>
+  )
+}

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-list.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-list.tsx
@@ -1,0 +1,56 @@
+// apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-list.tsx
+'use client'
+
+import { ListCard } from '@auxx/ui/components/list-card'
+import { Library, Search } from 'lucide-react'
+import { useEffect } from 'react'
+import { EmptyState } from '~/components/global/empty-state'
+import { useListSelection } from '~/components/list-selection'
+import { CreateKnowledgeBaseButton } from '../landing/create-knowledge-base-button'
+import { KnowledgeBaseCard } from './knowledge-base-card'
+import { useKnowledgeBasesList } from './knowledge-bases-provider'
+
+export function KnowledgeBasesList() {
+  const { knowledgeBases, isLoading, searchQuery } = useKnowledgeBasesList()
+  const setItemIds = useListSelection((s) => s.setItemIds)
+
+  useEffect(() => {
+    setItemIds(knowledgeBases.map((kb) => kb.id))
+  }, [knowledgeBases, setItemIds])
+
+  if (isLoading) {
+    return (
+      <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
+        {[...Array(8)].map((_, i) => (
+          <ListCard key={`skeleton-${i}`} loading descriptionLines={2} />
+        ))}
+      </div>
+    )
+  }
+
+  if (knowledgeBases.length === 0) {
+    return searchQuery ? (
+      <EmptyState
+        icon={Search}
+        title='No knowledge bases found'
+        description='No knowledge bases match your search. Try a different term.'
+        button={<div className='h-12' />}
+      />
+    ) : (
+      <EmptyState
+        icon={Library}
+        title='No knowledge bases yet'
+        description='Create your first knowledge base to start publishing articles.'
+        button={<CreateKnowledgeBaseButton />}
+      />
+    )
+  }
+
+  return (
+    <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
+      {knowledgeBases.map((kb) => (
+        <KnowledgeBaseCard key={kb.id} knowledgeBase={kb} />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-provider.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-provider.tsx
@@ -1,0 +1,56 @@
+// apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-provider.tsx
+'use client'
+
+// Org-wide knowledge-base state for the `/app/kb` Knowledge Bases tab. Backs
+// the card grid off `kb.list` directly (not the `useKnowledgeBases()` store
+// hook — `/app/kb` never hydrates that store, see create-knowledge-base-button.tsx)
+// and filters client-side. Each row is merged draft-over-live so an unpublished
+// name/description edit shows immediately, matching kb-switcher.tsx.
+
+import { mergeDraftOverLive } from '@auxx/lib/kb/client'
+import { createContext, useContext, useMemo, useState } from 'react'
+import { api } from '~/trpc/react'
+import type { KnowledgeBase } from '../../store/knowledge-base-store'
+
+interface KnowledgeBasesContextValue {
+  knowledgeBases: KnowledgeBase[]
+  isLoading: boolean
+  searchQuery: string
+  setSearchQuery: (query: string) => void
+  refetch: () => void
+}
+
+const KnowledgeBasesContext = createContext<KnowledgeBasesContextValue | undefined>(undefined)
+
+export function KnowledgeBasesProvider({ children }: { children: React.ReactNode }) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const { data, isLoading, refetch } = api.kb.list.useQuery()
+
+  const knowledgeBases = useMemo(() => {
+    const all = (data ?? []).map((kb) => mergeDraftOverLive(kb) as KnowledgeBase)
+    const q = searchQuery.trim().toLowerCase()
+    if (!q) return all
+    return all.filter(
+      (kb) =>
+        kb.name.toLowerCase().includes(q) || (kb.description?.toLowerCase().includes(q) ?? false)
+    )
+  }, [data, searchQuery])
+
+  const value: KnowledgeBasesContextValue = {
+    knowledgeBases,
+    isLoading,
+    searchQuery,
+    setSearchQuery,
+    refetch: () => void refetch(),
+  }
+
+  return <KnowledgeBasesContext.Provider value={value}>{children}</KnowledgeBasesContext.Provider>
+}
+
+export function useKnowledgeBasesList() {
+  const context = useContext(KnowledgeBasesContext)
+  if (context === undefined) {
+    throw new Error('useKnowledgeBasesList must be used within a KnowledgeBasesProvider')
+  }
+  return context
+}

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-tab.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-tab.tsx
@@ -1,0 +1,25 @@
+// apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-tab.tsx
+'use client'
+
+import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
+import { ListSelectionProvider } from '~/components/list-selection'
+import { KnowledgeBasesBulkBar } from './knowledge-bases-bulk-bar'
+import { KnowledgeBasesFilterBar } from './knowledge-bases-filter-bar'
+import { KnowledgeBasesList } from './knowledge-bases-list'
+import { KnowledgeBasesProvider } from './knowledge-bases-provider'
+
+/** Content for the `/app/kb` Knowledge Bases tab — grid of all org KBs. */
+export function KnowledgeBasesTab() {
+  return (
+    <KnowledgeBasesProvider>
+      <ListSelectionProvider>
+        <ListPageScroll
+          toolbar={<KnowledgeBasesFilterBar />}
+          bodyClassName='flex-1 flex flex-col min-h-0'>
+          <KnowledgeBasesList />
+        </ListPageScroll>
+        <KnowledgeBasesBulkBar />
+      </ListSelectionProvider>
+    </KnowledgeBasesProvider>
+  )
+}

--- a/apps/web/src/server/api/trpc.ts
+++ b/apps/web/src/server/api/trpc.ts
@@ -68,8 +68,16 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
   errorFormatter({ shape, error }) {
     // By default, `shape` holds { code, message, data }
     // `error` is the original TRPCError with `cause`.
-    // If the cause is a ZodError, we can re-shape things.
 
+    // Unexpected errors (DB failures, etc.) carry internals like raw SQL in
+    // their message — never send those to the client. Full details are logged
+    // server-side by timingMiddleware. Intentional errors (AuxxError, ZodError,
+    // explicit TRPCError) have a specific code and keep their message.
+    if (error.code === 'INTERNAL_SERVER_ERROR') {
+      return { ...shape, message: 'Internal server error' }
+    }
+
+    // If the cause is a ZodError, we can re-shape things.
     if (error.cause instanceof ZodError) {
       const zodError = error.cause as ZodError
 


### PR DESCRIPTION
## Summary
- Sanitize `INTERNAL_SERVER_ERROR` tRPC responses so raw SQL / internal details never reach the client; full details still logged server-side via `timingMiddleware`. Intentional errors (AuxxError, ZodError, explicit TRPCError) keep their message.
- Add knowledge-bases list UI components (`knowledge-base-card`, `knowledge-bases-list`, `knowledge-bases-filter-bar`, `knowledge-bases-bulk-bar`, `knowledge-bases-provider`, `knowledge-bases-tab`) under `apps/web/src/components/kb/ui/knowledge-bases/`. Not yet wired into a route.
- Auto-remove stale `crystaldba/postgres-mcp` docker containers (running > 1 hour) on MCP startup to avoid piling up orphaned containers.

## Test plan
- [ ] Verify tRPC internal errors return a generic message to the client while full details still appear in server logs
- [ ] Verify Zod/AuxxError responses still surface their original message
- [ ] Wire up and manually test the knowledge-bases list UI once integrated into a route