### PR TITLE
feat(kb): add Knowledge Bases tab to /app/kb landing

### DIFF
--- a/apps/web/src/components/kb/ui/landing/kb-landing-shell.tsx
+++ b/apps/web/src/components/kb/ui/landing/kb-landing-shell.tsx
@@ -10,9 +10,10 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
-import { Book, Globe } from 'lucide-react'
+import { Book, Globe, Library } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { ArticlesView } from '../articles/articles-view'
+import { KnowledgeBasesTab } from '../knowledge-bases/knowledge-bases-tab'
 import { KBSwitcherDropdownContent } from '../sidebar/kb-switcher'
 import { ConnectSourceButton } from '../sources/connect-source-button'
 import { SourcesProvider } from '../sources/sources-provider'
@@ -20,9 +21,10 @@ import { SourcesTab } from '../sources/sources-tab'
 import { CreateKnowledgeBaseButton } from './create-knowledge-base-button'
 
 /**
- * Landing chrome for `/app/kb`: breadcrumb + KB switcher, an `Articles | Sources`
- * tab strip (mirrors `/app/workflows`), and a header action that swaps with the tab —
- * Create Knowledge Base on Articles, Connect Source on Sources. The tab is persisted
+ * Landing chrome for `/app/kb`: breadcrumb + KB switcher, an
+ * `Articles | Knowledge Bases | Sources` tab strip (mirrors `/app/workflows`),
+ * and a header action that swaps with the tab — Create Knowledge Base on
+ * Articles/Knowledge Bases, Connect Source on Sources. The tab is persisted
  * in the `t` query param so deep links / refreshes land on the right tab.
  */
 export function KBLandingShell() {
@@ -55,6 +57,10 @@ export function KBLandingShell() {
               <Book />
               Articles
             </TabsTrigger>
+            <TabsTrigger value='knowledge-bases' variant='outline'>
+              <Library />
+              Knowledge Bases
+            </TabsTrigger>
             <TabsTrigger value='sources' variant='outline'>
               <Globe />
               Sources
@@ -63,6 +69,10 @@ export function KBLandingShell() {
 
           <TabsContent value='articles' className='flex flex-col flex-1 min-h-0'>
             <ArticlesView />
+          </TabsContent>
+
+          <TabsContent value='knowledge-bases' className='flex flex-col flex-1 min-h-0'>
+            <KnowledgeBasesTab />
           </TabsContent>
 
           <TabsContent value='sources' className='flex flex-col flex-1 min-h-0'>

--- a/packages/ui/src/components/list-card.tsx
+++ b/packages/ui/src/components/list-card.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { SimpleTooltip as Tooltip } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
 import { BadgeCheck, Loader2, MoreVertical } from 'lucide-react'
+import Link from 'next/link'
 import { Slot as SlotPrimitive } from 'radix-ui'
 import type * as React from 'react'
 
@@ -252,7 +253,11 @@ export function ListCard({
   ) : link ? (
     <SlotPrimitive.Slot className={cn(OVERLAY_CLASS, 'cursor-default')}>{link}</SlotPrimitive.Slot>
   ) : href ? (
-    <a className={cn(OVERLAY_CLASS, 'cursor-default')} href={href} aria-label={resolvedAriaLabel} />
+    <Link
+      className={cn(OVERLAY_CLASS, 'cursor-default')}
+      href={href}
+      aria-label={resolvedAriaLabel}
+    />
   ) : (
     <button
       type='button'


### PR DESCRIPTION
## Summary
- Add a **Knowledge Bases** tab between Articles and Sources on the `/app/kb` landing shell, wiring in the existing `KnowledgeBasesTab` component
- Switch `ListCard`'s `href` overlay from a plain `<a>` to `next/link` for client-side navigation

## Notes
The header action swaps with the tab — Create Knowledge Base on Articles/Knowledge Bases, Connect Source on Sources. Tab selection is persisted in the `t` query param for deep links.