### PR TITLE
fix(favorites): keep sidebar favorites removable in every state

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/installed/page.tsx
@@ -96,10 +96,13 @@ export default function AppsInstalledListPage() {
                 icon={app.avatarUrl ? <AppIcon iconId={app.avatarUrl} size='sm' /> : undefined}
                 subtitle={`By ${app.developerAccount.title}`}
                 verified={app.verified}
-                headerEnd={renderBadgeChips([
-                  ...(app.isDevelopment ? [{ icon: <Code className='size-3' /> }] : []),
-                  ...(app.isInstalled ? [{ label: 'Installed' }] : []),
-                ])}
+                headerEnd={renderBadgeChips(
+                  [
+                    ...(app.isDevelopment ? [{ icon: <Code className='size-3' /> }] : []),
+                    ...(app.isInstalled ? [{ label: 'Installed' }] : []),
+                  ],
+                  { gap: 'gap-1' }
+                )}
                 menuItems={[
                   {
                     label: 'Uninstall',

--- a/apps/web/src/app/(protected)/app/settings/apps/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/apps/page.tsx
@@ -276,10 +276,13 @@ export default function IntegrationList() {
                       }
                       subtitle={`By ${app.developerAccount.title}`}
                       verified={app.verified}
-                      headerEnd={renderBadgeChips([
-                        ...(app.isDevelopment ? [{ icon: <Code className='size-3' /> }] : []),
-                        ...(app.isInstalled ? [{ label: 'Installed' }] : []),
-                      ])}
+                      headerEnd={renderBadgeChips(
+                        [
+                          ...(app.isDevelopment ? [{ icon: <Code className='size-3' /> }] : []),
+                          ...(app.isInstalled ? [{ label: 'Installed' }] : []),
+                        ],
+                        { gap: 'gap-1' }
+                      )}
                       menuItems={[
                         {
                           label: 'Uninstall',
@@ -399,12 +402,15 @@ export default function IntegrationList() {
                                   }
                                   subtitle={`By ${app.developerAccount.title}`}
                                   verified={app.verified}
-                                  headerEnd={renderBadgeChips([
-                                    ...(app.isDevelopment
-                                      ? [{ icon: <Code className='size-3' /> }]
-                                      : []),
-                                    ...(app.isInstalled ? [{ label: 'Installed' }] : []),
-                                  ])}
+                                  headerEnd={renderBadgeChips(
+                                    [
+                                      ...(app.isDevelopment
+                                        ? [{ icon: <Code className='size-3' /> }]
+                                        : []),
+                                      ...(app.isInstalled ? [{ label: 'Installed' }] : []),
+                                    ],
+                                    { gap: 'gap-1' }
+                                  )}
                                   menuItems={
                                     app.isInstalled
                                       ? [

--- a/apps/web/src/components/channels/ui/channel-card.tsx
+++ b/apps/web/src/components/channels/ui/channel-card.tsx
@@ -92,7 +92,8 @@ export function ChannelCard({ channel, inboxes }: { channel: Channel; inboxes: I
 
   const chips: ListCardBadgeChip[] = []
   if (linkedInbox) chips.push({ label: linkedInbox.name })
-  if (linkedInbox?.isPersonal) chips.push({ label: 'Personal' })
+  if (linkedInbox?.isPersonal)
+    chips.push({ label: 'P', description: 'Personal', variant: 'magenta' })
 
   const handleDisconnect = async () => {
     const confirmed = await confirm({

--- a/apps/web/src/components/favorites/hooks/use-favorite-dataset.ts
+++ b/apps/web/src/components/favorites/hooks/use-favorite-dataset.ts
@@ -11,6 +11,6 @@ export function useFavoriteDataset(datasetId: string | null | undefined) {
     { enabled: !!datasetId, staleTime: STALE_TIME, refetchOnWindowFocus: false }
   )
   const code = error?.data?.code
-  const isNotFound = code === 'NOT_FOUND' || code === 'FORBIDDEN'
+  const isNotFound = code === 'NOT_FOUND' || code === 'FORBIDDEN' || (!isLoading && !data)
   return { dataset: data, isLoading, isNotFound }
 }

--- a/apps/web/src/components/favorites/hooks/use-favorite-document.ts
+++ b/apps/web/src/components/favorites/hooks/use-favorite-document.ts
@@ -11,6 +11,9 @@ export function useFavoriteDocument(documentId: string | null | undefined) {
     { enabled: !!documentId, staleTime: STALE_TIME, refetchOnWindowFocus: false }
   )
   const code = error?.data?.code
-  const isNotFound = code === 'NOT_FOUND' || code === 'FORBIDDEN'
+  // `document.getById` returns null (not an error) for a deleted/inaccessible
+  // document, so treat settled-but-empty as not-found too — otherwise the
+  // favorite would spin on a skeleton forever.
+  const isNotFound = code === 'NOT_FOUND' || code === 'FORBIDDEN' || (!isLoading && !data)
   return { document: data, isLoading, isNotFound }
 }

--- a/apps/web/src/components/favorites/hooks/use-favorite-snippet.ts
+++ b/apps/web/src/components/favorites/hooks/use-favorite-snippet.ts
@@ -11,6 +11,6 @@ export function useFavoriteSnippet(snippetId: string | null | undefined) {
     { enabled: !!snippetId, staleTime: STALE_TIME, refetchOnWindowFocus: false }
   )
   const code = error?.data?.code
-  const isNotFound = code === 'NOT_FOUND' || code === 'FORBIDDEN'
+  const isNotFound = code === 'NOT_FOUND' || code === 'FORBIDDEN' || (!isLoading && !data)
   return { snippet: data, isLoading, isNotFound }
 }

--- a/apps/web/src/components/favorites/hooks/use-favorite-workflow.ts
+++ b/apps/web/src/components/favorites/hooks/use-favorite-workflow.ts
@@ -11,6 +11,6 @@ export function useFavoriteWorkflow(workflowId: string | null | undefined) {
     { enabled: !!workflowId, staleTime: STALE_TIME, refetchOnWindowFocus: false }
   )
   const code = error?.data?.code
-  const isNotFound = code === 'NOT_FOUND' || code === 'FORBIDDEN'
+  const isNotFound = code === 'NOT_FOUND' || code === 'FORBIDDEN' || (!isLoading && !data)
   return { workflow: data, isLoading, isNotFound }
 }

--- a/apps/web/src/components/favorites/hooks/use-remove-favorite.ts
+++ b/apps/web/src/components/favorites/hooks/use-remove-favorite.ts
@@ -1,0 +1,24 @@
+// apps/web/src/components/favorites/hooks/use-remove-favorite.ts
+'use client'
+
+import { useCallback } from 'react'
+import { api } from '~/trpc/react'
+import { useFavoritesStore } from '../store/favorites-store'
+
+/**
+ * Remove a favorite from the sidebar. Optimistically drops it from the store,
+ * then persists via tRPC. Shared by every render state (row, skeleton, broken)
+ * so a favorite is always removable — including while its target is still loading.
+ */
+export function useRemoveFavorite(favoriteId: string) {
+  const removeById = useFavoritesStore((s) => s.removeById)
+  const utils = api.useUtils()
+  const removeMutation = api.favorite.remove.useMutation({
+    onSuccess: () => void utils.favorite.list.invalidate(),
+  })
+
+  return useCallback(() => {
+    removeById(favoriteId)
+    removeMutation.mutate({ favoriteId })
+  }, [favoriteId, removeById, removeMutation])
+}

--- a/apps/web/src/components/favorites/ui/favorite-item-row.tsx
+++ b/apps/web/src/components/favorites/ui/favorite-item-row.tsx
@@ -1,13 +1,9 @@
 // apps/web/src/components/favorites/ui/favorite-item-row.tsx
 'use client'
 
-import { Button } from '@auxx/ui/components/button'
-import { cn } from '@auxx/ui/lib/utils'
-import { BookmarkX } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
-import { api } from '~/trpc/react'
-import { useFavoritesStore } from '../store/favorites-store'
+import { FavoriteRemoveButton } from './favorite-remove-button'
 
 interface FavoriteItemRowProps {
   favoriteId: string
@@ -19,43 +15,7 @@ interface FavoriteItemRowProps {
 }
 
 /** Thin wrapper around SidebarItem that adds a "Remove from favorites" action. */
-export function FavoriteItemRow({
-  favoriteId,
-  href,
-  icon,
-  title,
-  subtitle,
-  isActive,
-}: FavoriteItemRowProps) {
-  const removeById = useFavoritesStore((s) => s.removeById)
-  const utils = api.useUtils()
-  const removeMutation = api.favorite.remove.useMutation({
-    onSuccess: () => void utils.favorite.list.invalidate(),
-  })
-
-  const handleRemove = () => {
-    removeById(favoriteId)
-    removeMutation.mutate({ favoriteId })
-  }
-
-  const action = (
-    <Button
-      variant='ghost'
-      size='icon'
-      aria-label='Remove from favorites'
-      onClick={(e) => {
-        e.stopPropagation()
-        e.preventDefault()
-        handleRemove()
-      }}
-      className={cn(
-        'size-6 shrink-0 rounded-md opacity-100 sm:opacity-0 sm:group-hover/item:opacity-100',
-        'hover:bg-primary-200/50 hover:text-foreground/50 focus-visible:ring-primary/10'
-      )}>
-      <BookmarkX className='size-3.5' />
-    </Button>
-  )
-
+export function FavoriteItemRow({ favoriteId, href, icon, title, isActive }: FavoriteItemRowProps) {
   return (
     <SidebarItem
       id={favoriteId}
@@ -64,8 +24,7 @@ export function FavoriteItemRow({
       icon={icon}
       isSubmenu
       isActive={isActive}
-      action={action}
-      className={subtitle ? '' : ''}
+      action={<FavoriteRemoveButton favoriteId={favoriteId} />}
     />
   )
 }

--- a/apps/web/src/components/favorites/ui/favorite-item-skeleton.tsx
+++ b/apps/web/src/components/favorites/ui/favorite-item-skeleton.tsx
@@ -2,12 +2,41 @@
 'use client'
 
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { useEffect, useState } from 'react'
+import { FavoriteRemoveButton } from './favorite-remove-button'
+import { PrivateItem } from './private-item'
 
-export function FavoriteItemSkeleton() {
+/** How long a favorite may stay loading before we treat its target as broken. */
+const STUCK_AFTER_MS = 10_000
+
+/**
+ * Loading placeholder for a favorite whose target hasn't resolved yet.
+ *
+ * When a `favoriteId` is provided the row stays removable while loading, and if
+ * the target never resolves (e.g. a deleted item the API returns as empty, or a
+ * global store that never finishes loading) it self-heals into the broken +
+ * removable state after {@link STUCK_AFTER_MS} so the user is never stuck.
+ */
+export function FavoriteItemSkeleton({ favoriteId }: { favoriteId?: string }) {
+  const [stuck, setStuck] = useState(false)
+
+  useEffect(() => {
+    if (!favoriteId) return
+    const timer = setTimeout(() => setStuck(true), STUCK_AFTER_MS)
+    return () => clearTimeout(timer)
+  }, [favoriteId])
+
+  if (stuck && favoriteId) return <PrivateItem favoriteId={favoriteId} />
+
   return (
-    <div className='flex h-7 w-full items-center px-2'>
+    <div className='group/item flex h-7 w-full items-center px-2'>
       <Skeleton className='size-4 mr-2 shrink-0 rounded-sm' />
       <Skeleton className='h-3 w-24' />
+      {favoriteId ? (
+        <div className='ml-auto'>
+          <FavoriteRemoveButton favoriteId={favoriteId} />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/web/src/components/favorites/ui/favorite-remove-button.tsx
+++ b/apps/web/src/components/favorites/ui/favorite-remove-button.tsx
@@ -1,0 +1,30 @@
+// apps/web/src/components/favorites/ui/favorite-remove-button.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { cn } from '@auxx/ui/lib/utils'
+import { BookmarkX } from 'lucide-react'
+import { useRemoveFavorite } from '../hooks/use-remove-favorite'
+
+/** Ghost "Remove from favorites" icon button, revealed on row hover. */
+export function FavoriteRemoveButton({ favoriteId }: { favoriteId: string }) {
+  const remove = useRemoveFavorite(favoriteId)
+
+  return (
+    <Button
+      variant='ghost'
+      size='icon'
+      aria-label='Remove from favorites'
+      onClick={(e) => {
+        e.stopPropagation()
+        e.preventDefault()
+        remove()
+      }}
+      className={cn(
+        'size-6 shrink-0 rounded-md opacity-100 sm:opacity-0 sm:group-hover/item:opacity-100',
+        'hover:bg-primary-200/50 hover:text-foreground/50 focus-visible:ring-primary/10'
+      )}>
+      <BookmarkX className='size-3.5' />
+    </Button>
+  )
+}

--- a/apps/web/src/components/favorites/ui/items/article-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/article-item.tsx
@@ -17,7 +17,7 @@ export function ArticleItem({ favorite }: { favorite: FavoriteEntity<'ARTICLE'> 
   )
 
   if (isNotFound) return <PrivateItem favoriteId={favorite.id} />
-  if (isLoading || !article || !ids) return <FavoriteItemSkeleton />
+  if (isLoading || !article || !ids) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   const hasCustomIcon = !!article.emoji && !!getIcon(article.emoji)
   const isCategory = article.articleKind === 'category'

--- a/apps/web/src/components/favorites/ui/items/dashboard-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/dashboard-item.tsx
@@ -13,7 +13,7 @@ export function DashboardItem({ favorite }: { favorite: FavoriteEntity<'DASHBOAR
   const { dashboard, isLoading, isNotFound } = useFavoriteDashboard(ids?.dashboardId)
 
   if (isNotFound) return <PrivateItem favoriteId={favorite.id} />
-  if (isLoading || !dashboard || !ids) return <FavoriteItemSkeleton />
+  if (isLoading || !dashboard || !ids) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   return (
     <FavoriteItemRow

--- a/apps/web/src/components/favorites/ui/items/dataset-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/dataset-item.tsx
@@ -13,7 +13,7 @@ export function DatasetItem({ favorite }: { favorite: FavoriteEntity<'DATASET'> 
   const { dataset, isLoading, isNotFound } = useFavoriteDataset(ids?.datasetId)
 
   if (isNotFound) return <PrivateItem favoriteId={favorite.id} />
-  if (isLoading || !dataset) return <FavoriteItemSkeleton />
+  if (isLoading || !dataset) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   return (
     <FavoriteItemRow

--- a/apps/web/src/components/favorites/ui/items/document-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/document-item.tsx
@@ -13,7 +13,7 @@ export function DocumentItem({ favorite }: { favorite: FavoriteEntity<'DOCUMENT'
   const { document, isLoading, isNotFound } = useFavoriteDocument(ids?.documentId)
 
   if (isNotFound) return <PrivateItem favoriteId={favorite.id} />
-  if (isLoading || !document) return <FavoriteItemSkeleton />
+  if (isLoading || !document) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   const datasetId = ids?.datasetId
   const href = datasetId

--- a/apps/web/src/components/favorites/ui/items/entity-instance-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/entity-instance-item.tsx
@@ -29,7 +29,8 @@ export function EntityInstanceItem({ favorite }: { favorite: FavoriteEntity<'ENT
 
   if (!recordId) return null
   if (isNotFound) return <PrivateItem favoriteId={favorite.id} />
-  if (isLoading || !record || !resource || !href) return <FavoriteItemSkeleton />
+  if (isLoading || !record || !resource || !href)
+    return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   return (
     <FavoriteItemRow

--- a/apps/web/src/components/favorites/ui/items/file-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/file-item.tsx
@@ -13,7 +13,7 @@ export function FileItem({ favorite }: { favorite: FavoriteEntity<'FILE'> }) {
   const { file, isLoading, isNotFound } = useFavoriteFile(ids?.folderFileId)
 
   if (isNotFound) return <PrivateItem favoriteId={favorite.id} />
-  if (isLoading || !file) return <FavoriteItemSkeleton />
+  if (isLoading || !file) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   // Use the file's live parentId so the link still works if the file moved
   // since being favorited. Falls back to the stored folderId.

--- a/apps/web/src/components/favorites/ui/items/folder-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/folder-item.tsx
@@ -13,7 +13,7 @@ export function FolderItem({ favorite }: { favorite: FavoriteEntity<'FOLDER'> })
   const { folder, isLoading, isNotFound } = useFavoriteFolder(ids?.folderId)
 
   if (isNotFound) return <PrivateItem favoriteId={favorite.id} />
-  if (isLoading || !folder) return <FavoriteItemSkeleton />
+  if (isLoading || !folder) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   return (
     <FavoriteItemRow

--- a/apps/web/src/components/favorites/ui/items/knowledge-base-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/knowledge-base-item.tsx
@@ -13,7 +13,7 @@ export function KnowledgeBaseItem({ favorite }: { favorite: FavoriteEntity<'KNOW
   const { knowledgeBase, isLoading, isNotFound } = useFavoriteKnowledgeBase(ids?.knowledgeBaseId)
 
   if (isNotFound) return <PrivateItem favoriteId={favorite.id} />
-  if (isLoading || !knowledgeBase || !ids) return <FavoriteItemSkeleton />
+  if (isLoading || !knowledgeBase || !ids) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   return (
     <FavoriteItemRow

--- a/apps/web/src/components/favorites/ui/items/snippet-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/snippet-item.tsx
@@ -13,7 +13,7 @@ export function SnippetItem({ favorite }: { favorite: FavoriteEntity<'SNIPPET'> 
   const { snippet, isLoading, isNotFound } = useFavoriteSnippet(ids?.snippetId)
 
   if (isNotFound) return <PrivateItem favoriteId={favorite.id} />
-  if (isLoading || !snippet) return <FavoriteItemSkeleton />
+  if (isLoading || !snippet) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   return (
     <FavoriteItemRow

--- a/apps/web/src/components/favorites/ui/items/table-view-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/table-view-item.tsx
@@ -18,10 +18,10 @@ export function TableViewItem({ favorite }: { favorite: FavoriteEntity<'TABLE_VI
     { enabled: !!tableViewId, staleTime: STALE_TIME, refetchOnWindowFocus: false }
   )
   const code = error?.data?.code
-  if (code === 'NOT_FOUND' || code === 'FORBIDDEN') {
+  if (code === 'NOT_FOUND' || code === 'FORBIDDEN' || (!isLoading && !data)) {
     return <PrivateItem favoriteId={favorite.id} />
   }
-  if (isLoading || !data) return <FavoriteItemSkeleton />
+  if (isLoading) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   // Most table views live under /app/<apiSlug>?view=<id>; we don't have apiSlug
   // here, so we route through tableId which is a system table or entityDefinitionId.

--- a/apps/web/src/components/favorites/ui/items/workflow-item.tsx
+++ b/apps/web/src/components/favorites/ui/items/workflow-item.tsx
@@ -13,7 +13,7 @@ export function WorkflowItem({ favorite }: { favorite: FavoriteEntity<'WORKFLOW'
   const { workflow, isLoading, isNotFound } = useFavoriteWorkflow(ids?.workflowId)
 
   if (isNotFound) return <PrivateItem favoriteId={favorite.id} />
-  if (isLoading || !workflow) return <FavoriteItemSkeleton />
+  if (isLoading || !workflow) return <FavoriteItemSkeleton favoriteId={favorite.id} />
 
   return (
     <FavoriteItemRow

--- a/apps/web/src/components/favorites/ui/private-item.tsx
+++ b/apps/web/src/components/favorites/ui/private-item.tsx
@@ -2,27 +2,20 @@
 'use client'
 
 import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
-import { Lock, Star } from 'lucide-react'
+import { BookmarkX, Lock } from 'lucide-react'
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
-import { api } from '~/trpc/react'
-import { useFavoritesStore } from '../store/favorites-store'
+import { useRemoveFavorite } from '../hooks/use-remove-favorite'
 
-/** Rendered when a favorite's target is not accessible (404 / 403). */
+/**
+ * Rendered when a favorite's target can't be resolved — it was deleted, is no
+ * longer accessible (404 / 403), or never finished loading. Always removable.
+ */
 export function PrivateItem({ favoriteId }: { favoriteId: string }) {
-  const removeById = useFavoritesStore((s) => s.removeById)
-  const utils = api.useUtils()
-  const removeMutation = api.favorite.remove.useMutation({
-    onSuccess: () => void utils.favorite.list.invalidate(),
-  })
-
-  const handleRemove = () => {
-    removeById(favoriteId)
-    removeMutation.mutate({ favoriteId })
-  }
+  const handleRemove = useRemoveFavorite(favoriteId)
 
   const editItems = (
     <DropdownMenuItem onClick={handleRemove}>
-      <Star />
+      <BookmarkX />
       Remove from favorites
     </DropdownMenuItem>
   )
@@ -30,7 +23,7 @@ export function PrivateItem({ favoriteId }: { favoriteId: string }) {
   return (
     <SidebarItem
       id={favoriteId}
-      name='Private item'
+      name='Unavailable'
       href='#'
       icon={<Lock />}
       isSubmenu

--- a/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
@@ -78,7 +78,7 @@ export function IdentitySection({ knowledgeBaseId, knowledgeBase }: IdentitySect
     <Section title='Identity' description='URL and access for this knowledge base.'>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
-          <FieldPanel orientation='vertical' className='p-0' resizeId='kb-settings'>
+          <FieldPanel orientation='responsive' className='p-0' resizeId='kb-settings'>
             <FormField
               control={form.control}
               name='slug'
@@ -118,7 +118,7 @@ export function IdentitySection({ knowledgeBaseId, knowledgeBase }: IdentitySect
                     onChange={(v) => field.onChange((v as string[])[0] ?? 'PUBLIC')}
                     placeholder='Public'
                     disabled={isUpdating}
-                    triggerProps={{ className: 'w-full' }}
+                    triggerProps={{ className: 'ps-0 pe-1 w-full' }}
                   />
                 </FieldPanelRow>
               )}

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -49,6 +49,8 @@ const badgeVariants = cva(
           'bg-purple-500/15 text-purple-700 hover:bg-purple-500/25 dark:text-purple-400 dark:hover:bg-purple-500/20',
         fuchsia:
           'bg-fuchsia-400/15 text-fuchsia-700 hover:bg-fuchsia-400/25 dark:bg-fuchsia-400/10 dark:text-fuchsia-400 dark:hover:bg-fuchsia-400/20',
+        magenta:
+          'bg-fuchsia-500/15 text-fuchsia-700 hover:bg-fuchsia-500/25 dark:bg-fuchsia-500/10 dark:text-fuchsia-400 dark:hover:bg-fuchsia-500/20',
         pink: 'bg-pink-400/15 text-pink-700 hover:bg-pink-400/25 dark:bg-pink-400/10 dark:text-pink-400 dark:hover:bg-pink-400/20',
         rose: 'bg-rose-400/15 text-rose-700 hover:bg-rose-400/25 dark:bg-rose-400/10 dark:text-rose-400 dark:hover:bg-rose-400/20',
         zinc: 'bg-zinc-600/10 text-zinc-700 hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:hover:bg-white/10',

--- a/packages/ui/src/components/list-card.tsx
+++ b/packages/ui/src/components/list-card.tsx
@@ -1,6 +1,7 @@
 // packages/ui/src/components/list-card.tsx
 'use client'
 
+import { Badge, type Variant as BadgeVariant } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
 import {
@@ -51,6 +52,10 @@ export interface ListCardMenuItem {
 export interface ListCardBadgeChip {
   label?: string
   icon?: React.ReactNode
+  /** Badge colour variant. Defaults to `gray`. */
+  variant?: BadgeVariant
+  /** Tooltip content on hover — omit for a bare chip (no tooltip). */
+  description?: React.ReactNode
 }
 
 type ListCardSlotName = 'root' | 'title' | 'subtitle' | 'description' | 'icon' | 'footer' | 'badges'
@@ -129,19 +134,35 @@ export interface ListCardProps {
   classNames?: Partial<Record<ListCardSlotName, string>>
 }
 
-/** Renders a `{ label?, icon? }[]` chip row — handy for `badges`/`headerEnd`. */
-export function renderBadgeChips(chips: ListCardBadgeChip[]): React.ReactNode {
+/**
+ * Renders a `{ label?, icon?, variant?, description? }[]` chip row — handy for
+ * `badges`/`headerEnd`. Pass `options.gap` (a Tailwind gap class) to override the
+ * default tight `gap-0.5`, e.g. when mixing icon-only and label chips.
+ */
+export function renderBadgeChips(
+  chips: ListCardBadgeChip[],
+  options?: { gap?: string }
+): React.ReactNode {
   if (chips.length === 0) return null
   return (
-    <div className='flex flex-row items-center gap-0.5'>
-      {chips.map((chip, i) => (
-        <div
-          key={`chip-${i}`}
-          className='flex h-5 shrink-0 items-center justify-center gap-1 rounded-lg border bg-primary-100 px-1'>
-          {chip.icon}
-          {chip.label && <span className='text-xs'>{chip.label}</span>}
-        </div>
-      ))}
+    <div className={cn('flex flex-row items-center shrink-0', options?.gap ?? 'gap-0.5')}>
+      {chips.map((chip, i) => {
+        const badge = (
+          <Badge key={`chip-${i}`} size='xs' variant={chip.variant ?? 'gray'}>
+            {chip.icon}
+            {chip.label}
+          </Badge>
+        )
+        if (chip.description == null) return badge
+        return (
+          <Tooltip
+            key={`chip-${i}`}
+            content={typeof chip.description === 'string' ? chip.description : undefined}
+            contentComponent={typeof chip.description === 'string' ? undefined : chip.description}>
+            {badge}
+          </Tooltip>
+        )
+      })}
     </div>
   )
 }

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -84,7 +84,7 @@ function SimpleTooltip({
   side,
   align,
   className,
-  delayDuration = 800,
+  delayDuration = 300,
   allowInteraction = false,
   variant,
 }: SimpleTooltipProps) {


### PR DESCRIPTION
## Summary

Favorites whose target is deleted or inaccessible could get stuck on a loading skeleton with no way to remove them from the sidebar. This makes a favorite removable in **every** render state.

- **Settled-but-empty is not-found** — `document.getById` (and friends) return `null` rather than an error for a deleted/inaccessible item, so the favorite hooks now treat `!isLoading && !data` as not-found and fall through to `PrivateItem`.
- **Shared removal** — new `useRemoveFavorite` hook + `FavoriteRemoveButton`, used by the row, the skeleton, and the broken state (optimistic store drop → tRPC persist).
- **Self-healing skeleton** — a favorite still loading after 10s renders as the broken + removable `PrivateItem`, so it's never permanently stuck.
- **PrivateItem** relabeled "Unavailable" with a `BookmarkX` action.

### Supporting UI changes
- `renderBadgeChips` gains `variant` + `description` (tooltip) chip options, rebuilt on the shared `Badge`; adds a `magenta` badge variant. Channel "Personal" chip becomes a compact magenta `P` with tooltip.
- Tooltip default `delayDuration` 800ms → 300ms.
- KB identity `FieldPanel` switched to `responsive`.

## Test plan
- [ ] Favorite a document/dataset/etc., delete the target, confirm the sidebar row shows "Unavailable" and can be removed.
- [ ] Confirm a slow-loading favorite becomes removable after ~10s instead of spinning forever.
- [ ] Verify badge chips (apps Installed/Dev, channel Personal) render with correct spacing + tooltips.