### PR TITLE
feat(kbar): contextual palette actions + page shortcuts for more surfaces

### DIFF
--- a/apps/web/src/app/(protected)/app/connectors/page.tsx
+++ b/apps/web/src/app/(protected)/app/connectors/page.tsx
@@ -4,6 +4,7 @@
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
+import { Kbd } from '@auxx/ui/components/kbd'
 import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
 import {
   MainPage,
@@ -12,6 +13,7 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
+import { useHotkey } from '@tanstack/react-hotkeys'
 import { Lock, Plus } from 'lucide-react'
 import { useState } from 'react'
 import { ConnectorList } from '~/components/data-connectors/ui/connector-list'
@@ -19,6 +21,8 @@ import { ConnectorsBulkBar } from '~/components/data-connectors/ui/connectors-bu
 import { ConnectorsToolbar } from '~/components/data-connectors/ui/connectors-toolbar'
 import { SourceTemplateDialog } from '~/components/data-connectors/ui/source-template-dialog'
 import { EmptyState } from '~/components/global/empty-state'
+import { CommandAction, CommandContext } from '~/components/kbar/contextual'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import { ListSelectionProvider } from '~/components/list-selection'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
@@ -32,14 +36,35 @@ export default function ConnectorsPage() {
   const [search, setSearch] = useState('')
   const canConnect = hasAccess(FeatureKey.dataConnectors)
 
+  // Page-local shortcut: N opens the "Connect a source" picker.
+  useHotkey('N', () => setPickerOpen(true), { enabled: canConnect })
+
   return (
     <MainPage>
+      {canConnect && (
+        <CommandContext kind='page' label='Connectors'>
+          <CommandAction
+            label='Connect a source'
+            icon='plus'
+            keywords='connect source add data connector new'
+            shortcut={['N']}
+            priority={10}
+            perform={() => {
+              useCommandPaletteStore.getState().close()
+              setPickerOpen(true)
+            }}
+          />
+        </CommandContext>
+      )}
       <MainPageHeader
         action={
           canConnect ? (
             <Button size='sm' onClick={() => setPickerOpen(true)}>
               <Plus />
               Connect a source
+              <Kbd variant='default' size='sm'>
+                N
+              </Kbd>
             </Button>
           ) : undefined
         }>

--- a/apps/web/src/components/dashboard/ui/create-dashboard-button.tsx
+++ b/apps/web/src/components/dashboard/ui/create-dashboard-button.tsx
@@ -5,18 +5,55 @@
 // in the page header and the empty state so both entry points share one wiring.
 
 import { Button } from '@auxx/ui/components/button'
+import { Kbd } from '@auxx/ui/components/kbd'
+import { useHotkey } from '@tanstack/react-hotkeys'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
+import { CommandAction, CommandContext } from '~/components/kbar/contextual'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import { DashboardFormDialog } from './dashboard-form-dialog'
 
-export function CreateDashboardButton({ size = 'sm' }: { size?: 'sm' | 'default' }) {
+/**
+ * @param registerShortcut - When true, binds the page-local `N` shortcut, shows
+ *   the `<Kbd>` hint, and contributes the "New dashboard" cmd+k action. Set only
+ *   on the header instance so the empty-state copy doesn't double-register.
+ */
+export function CreateDashboardButton({
+  size = 'sm',
+  registerShortcut = false,
+}: {
+  size?: 'sm' | 'default'
+  registerShortcut?: boolean
+}) {
   const [open, setOpen] = useState(false)
+
+  useHotkey('N', () => setOpen(true), { enabled: registerShortcut })
 
   return (
     <>
+      {registerShortcut && (
+        <CommandContext kind='page' label='Dashboards'>
+          <CommandAction
+            label='New dashboard'
+            icon='plus'
+            keywords='new dashboard create add'
+            shortcut={['N']}
+            priority={10}
+            perform={() => {
+              useCommandPaletteStore.getState().close()
+              setOpen(true)
+            }}
+          />
+        </CommandContext>
+      )}
       <Button size={size} onClick={() => setOpen(true)}>
         <Plus />
         New dashboard
+        {registerShortcut && (
+          <Kbd variant='default' size='sm'>
+            N
+          </Kbd>
+        )}
       </Button>
       <DashboardFormDialog open={open} onOpenChange={setOpen} />
     </>

--- a/apps/web/src/components/dashboard/ui/dashboard-detail-view.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-detail-view.tsx
@@ -26,7 +26,10 @@ import { Lock } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useQueryState } from 'nuqs'
 import { type ReactNode, useState } from 'react'
+import { useFavoriteToggle } from '~/components/favorites/hooks/use-favorite-toggle'
 import { FavoriteStarButton } from '~/components/favorites/ui/favorite-star-button'
+import { CommandAction, CommandContext } from '~/components/kbar/contextual'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import { RecordDrawer } from '~/components/records/record-drawer'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
@@ -84,6 +87,10 @@ export function DashboardDetailView({ dashboard }: { dashboard: DashboardWithLay
   const persistedVersionNumber = useDashboardStore((s) => s.persistedVersionNumber)
 
   const { publish, discard, isPublishing, isDiscarding } = useDashboardPublish()
+
+  const { toggle: toggleFavorite, isFavorited } = useFavoriteToggle('DASHBOARD', {
+    dashboardId: dashboard.id,
+  })
 
   const isDocked = useEffectiveDockState()
   const dockedWidth = useDockStore((s) => s.dockedWidth)
@@ -163,6 +170,86 @@ export function DashboardDetailView({ dashboard }: { dashboard: DashboardWithLay
 
   return (
     <MainPage>
+      {/* Command-palette scope for the open dashboard. Edit-only actions mirror
+          the header cluster's affordances. */}
+      <CommandContext kind='page' label={dashboard.name}>
+        <CommandAction
+          label={isEditMode ? 'Done editing' : 'Edit dashboard'}
+          icon={isEditMode ? 'check' : 'edit'}
+          keywords='edit done toggle layout arrange'
+          priority={10}
+          perform={() => {
+            useCommandPaletteStore.getState().close()
+            if (isEditMode) {
+              exitEditMode()
+            } else {
+              setOpenRecordId(null)
+              enterEditMode()
+            }
+          }}
+        />
+        <CommandAction
+          label={isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+          icon='star'
+          keywords='favorite star bookmark pin'
+          priority={9}
+          perform={() => {
+            useCommandPaletteStore.getState().close()
+            toggleFavorite()
+          }}
+        />
+        {isEditMode && (
+          <>
+            <CommandAction
+              label='Add widget'
+              icon='plus'
+              keywords='add widget chart kpi card'
+              priority={8}
+              perform={() => {
+                useCommandPaletteStore.getState().close()
+                handleAddWidget('kpi')
+              }}
+            />
+            <CommandAction
+              label='Add tab'
+              icon='plus'
+              keywords='add tab page section'
+              priority={7}
+              perform={() => {
+                useCommandPaletteStore.getState().close()
+                const id = addTab('New tab')
+                if (id) void setTab(id)
+              }}
+            />
+          </>
+        )}
+        {hasUnpublishedChanges && (
+          <>
+            <CommandAction
+              label='Publish changes'
+              icon='send'
+              keywords='publish release live version'
+              priority={6}
+              disabled={isPublishing}
+              perform={() => {
+                useCommandPaletteStore.getState().close()
+                void publish()
+              }}
+            />
+            <CommandAction
+              label='Discard changes'
+              icon='trash'
+              keywords='discard revert reset draft'
+              priority={5}
+              disabled={isDiscarding}
+              perform={() => {
+                useCommandPaletteStore.getState().close()
+                void discard()
+              }}
+            />
+          </>
+        )}
+      </CommandContext>
       <ConfirmDialog />
       <MainPageHeader
         action={

--- a/apps/web/src/components/dashboard/ui/dashboards-list-view.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboards-list-view.tsx
@@ -29,7 +29,7 @@ import { DashboardsProvider } from './dashboards-provider'
 function DashboardsPageContent() {
   return (
     <MainPage>
-      <MainPageHeader action={<CreateDashboardButton />}>
+      <MainPageHeader action={<CreateDashboardButton registerShortcut />}>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Dashboards' href='/app/dashboards' last />
         </MainPageBreadcrumb>

--- a/apps/web/src/components/files/file-detail-drawer.tsx
+++ b/apps/web/src/components/files/file-detail-drawer.tsx
@@ -34,6 +34,8 @@ import {
 import { useCallback, useEffect, useState } from 'react'
 import { DockToggleButton } from '~/components/global/dock-toggle-button'
 import { Tooltip } from '~/components/global/tooltip'
+import { CommandAction, CommandContext } from '~/components/kbar/contextual'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useDockStore } from '~/stores/dock-store'
@@ -80,6 +82,8 @@ export function FileDetailDrawer({ file, onOpenChange, setSelectedFile }: FileDe
 
   // Store hooks for real-time updates
   const updateItem = useFileSystemStore((state) => state.updateItem)
+  const removeItems = useFileSystemStore((state) => state.removeItems)
+  const deleteFile = api.file.delete.useMutation()
   // Reset editing name when file changes
   useEffect(() => {
     setEditingName(file.name || '')
@@ -234,18 +238,36 @@ export function FileDetailDrawer({ file, onOpenChange, setSelectedFile }: FileDe
       destructive: true,
     })
 
-    if (confirmed) {
-      try {
-        // TODO: Implement actual delete functionality
-        setSelectedFile(null)
-        onOpenChange(false) // Close drawer after deletion
-      } catch (error) {
-        toastError({
-          title: 'Failed to delete file',
-          description: error instanceof Error ? error.message : 'An error occurred',
-        })
+    if (!confirmed) return
+
+    deleteFile.mutate(
+      { fileId: file.id },
+      {
+        onSuccess: () => {
+          removeItems([file.id]) // Drop from the store so the row disappears
+          setSelectedFile(null)
+          onOpenChange(false) // Close drawer after deletion
+        },
+        onError: (error) => {
+          toastError({
+            title: 'Failed to delete file',
+            description: error.message,
+          })
+        },
       }
-    }
+    )
+  }
+
+  // Close the palette before running an action so any resulting dialog/toast
+  // isn't hidden behind the overlay.
+  const closePalette = () => useCommandPaletteStore.getState().close()
+  const copyLink = () => {
+    if (file.url) void navigator.clipboard?.writeText(file.url)
+    closePalette()
+  }
+  const copyId = () => {
+    void navigator.clipboard?.writeText(file.id)
+    closePalette()
   }
 
   if (!file) return null
@@ -253,6 +275,49 @@ export function FileDetailDrawer({ file, onOpenChange, setSelectedFile }: FileDe
   const { iconId, color } = getFileIconId(file.mimeType || undefined, file.ext || undefined)
   return (
     <>
+      {/* Command-palette file scope — surfaces the open file's actions in cmd+k.
+          Priority outranks the Files page scope so this group leads while the
+          drawer is open. */}
+      <CommandContext kind='page' label={file.name || 'File'} priority={10}>
+        <CommandAction
+          label='Download'
+          icon='download'
+          keywords='download save file'
+          priority={10}
+          disabled={file.isUploading || isDownloadLoading}
+          perform={() => {
+            closePalette()
+            void handleDownload()
+          }}
+        />
+        {file.url && (
+          <CommandAction
+            label='Copy link'
+            icon='link-2'
+            keywords='copy link url share'
+            priority={6}
+            perform={copyLink}
+          />
+        )}
+        <CommandAction
+          label='Copy ID'
+          icon='copy'
+          keywords='copy id identifier'
+          priority={5}
+          perform={copyId}
+        />
+        <CommandAction
+          label='Delete'
+          icon='trash'
+          keywords='delete remove'
+          priority={1}
+          disabled={file.isUploading}
+          perform={() => {
+            closePalette()
+            void handleDelete()
+          }}
+        />
+      </CommandContext>
       <DockableDrawer
         open={true}
         onOpenChange={onOpenChange}

--- a/apps/web/src/components/files/files-management.tsx
+++ b/apps/web/src/components/files/files-management.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
+import { Kbd } from '@auxx/ui/components/kbd'
 import { toastSuccess } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import {
@@ -14,10 +15,13 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
+import { useHotkey } from '@tanstack/react-hotkeys'
 import { FolderPlus, Trash2, Upload } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { type DragDropConfig, DynamicTable } from '~/components/dynamic-table'
 import { EmptyState } from '~/components/global/empty-state'
+import { CommandAction, CommandContext } from '~/components/kbar/contextual'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import MailThreadItemDragOverlay from '~/components/mail/mail-thread-item-drag-overlay'
 import { useConfirm } from '~/hooks/use-confirm'
 import { CreateFolderDialog } from './create-folder-dialog'
@@ -156,6 +160,12 @@ export function FilesManagement({
   const [itemToRename, setItemToRename] = useState<FileItem | null>(null)
 
   const [confirm, ConfirmDialog] = useConfirm()
+
+  // Page-local shortcuts (management mode only): N = new folder, U = upload.
+  // Bound only while the upload controls are shown so file-picker dialogs that
+  // reuse this component in selection mode never grab these keys.
+  useHotkey('N', () => setCreateFolderDialogOpen(true), { enabled: shouldShowUploadControls })
+  useHotkey('U', () => setUploadDialogOpen(true), { enabled: shouldShowUploadControls })
 
   // DnD state management
   const [draggingItems, setDraggingItems] = useState<FileItem[] | null>(null)
@@ -556,6 +566,34 @@ export function FilesManagement({
         currentFolderName={currentFolderName}
         disabled={isLoading}>
         <div className={cn('min-h-0 flex flex-col flex-1', className)}>
+          {/* Command-palette scope for the Files page (management mode only). */}
+          {shouldShowUploadControls && (
+            <CommandContext kind='page' label='Files'>
+              <CommandAction
+                label='New folder'
+                icon='folder'
+                keywords='new folder create directory'
+                shortcut={['N']}
+                priority={10}
+                perform={() => {
+                  useCommandPaletteStore.getState().close()
+                  setCreateFolderDialogOpen(true)
+                }}
+              />
+              <CommandAction
+                label='Upload files'
+                icon='upload'
+                keywords='upload files add attachment'
+                shortcut={['U']}
+                priority={9}
+                perform={() => {
+                  useCommandPaletteStore.getState().close()
+                  setUploadDialogOpen(true)
+                }}
+              />
+            </CommandContext>
+          )}
+
           {/* Header with breadcrumbs and actions - conditional */}
           {shouldShowHeader && (
             <div className='flex items-center justify-between bg-primary-200 h-9 px-2 shrink-0'>
@@ -573,10 +611,16 @@ export function FilesManagement({
                       onClick={() => setCreateFolderDialogOpen(true)}>
                       <FolderPlus />
                       New Folder
+                      <Kbd variant='outline' size='sm'>
+                        N
+                      </Kbd>
                     </Button>
                     <Button size='xs' onClick={() => setUploadDialogOpen(true)}>
                       <Upload />
                       Upload Files
+                      <Kbd variant='default' size='sm'>
+                        U
+                      </Kbd>
                     </Button>
                   </>
                 )}

--- a/apps/web/src/components/kb/ui/landing/create-knowledge-base-button.tsx
+++ b/apps/web/src/components/kb/ui/landing/create-knowledge-base-button.tsx
@@ -3,9 +3,13 @@
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
+import { Kbd } from '@auxx/ui/components/kbd'
+import { useHotkey } from '@tanstack/react-hotkeys'
 import { Book, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useState } from 'react'
+import { CommandAction, CommandContext } from '~/components/kbar/contextual'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import { LimitReachedDialog } from '~/components/subscriptions/limit-reached-dialog'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
@@ -21,7 +25,16 @@ import {
  * the Connect Source button). Encapsulates the create dialog, the plan-limit gate,
  * and the post-create redirect into the new KB's editor.
  */
-export function CreateKnowledgeBaseButton() {
+/**
+ * @param registerShortcut - When true, binds the page-local `N` shortcut, shows
+ *   the `<Kbd>` hint, and contributes the cmd+k action. Set only on the shell's
+ *   header instance so empty-state copies don't double-register.
+ */
+export function CreateKnowledgeBaseButton({
+  registerShortcut = false,
+}: {
+  registerShortcut?: boolean
+} = {}) {
   const router = useRouter()
   const [isCreateKBOpen, setIsCreateKBOpen] = useState(false)
   const [limitDialogOpen, setLimitDialogOpen] = useState(false)
@@ -44,6 +57,9 @@ export function CreateKnowledgeBaseButton() {
     }
   }, [atLimit])
 
+  // Page-local shortcut: N opens the create-KB dialog (or the limit prompt).
+  useHotkey('N', handleCreateClick, { enabled: registerShortcut })
+
   const handleCreateKB = useCallback(
     async (values: KnowledgeBaseFormValues) => {
       const created = await createKnowledgeBase({ name: values.name, slug: values.slug })
@@ -57,9 +73,29 @@ export function CreateKnowledgeBaseButton() {
 
   return (
     <>
+      {registerShortcut && (
+        <CommandContext kind='page' label='Knowledge Bases'>
+          <CommandAction
+            label='Create knowledge base'
+            icon='book-open'
+            keywords='create knowledge base kb new'
+            shortcut={['N']}
+            priority={10}
+            perform={() => {
+              useCommandPaletteStore.getState().close()
+              handleCreateClick()
+            }}
+          />
+        </CommandContext>
+      )}
       <Button size='sm' className='h-7 rounded-lg' onClick={handleCreateClick}>
         <Plus />
         Create Knowledge Base
+        {registerShortcut && (
+          <Kbd variant='default' size='sm'>
+            N
+          </Kbd>
+        )}
       </Button>
       <KnowledgeBaseDialog
         open={isCreateKBOpen}

--- a/apps/web/src/components/kb/ui/landing/kb-landing-shell.tsx
+++ b/apps/web/src/components/kb/ui/landing/kb-landing-shell.tsx
@@ -12,6 +12,8 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
 import { Book, Globe, Library } from 'lucide-react'
 import { useQueryState } from 'nuqs'
+import { CommandAction, CommandContext } from '~/components/kbar/contextual'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import { ArticlesView } from '../articles/articles-view'
 import { KnowledgeBasesTab } from '../knowledge-bases/knowledge-bases-tab'
 import { KBSwitcherDropdownContent } from '../sidebar/kb-switcher'
@@ -32,8 +34,46 @@ export function KBLandingShell() {
 
   return (
     <MainPage>
+      <CommandContext kind='page' label='Knowledge Bases'>
+        <CommandAction
+          label='Go to Articles'
+          icon='file-text'
+          keywords='articles tab view knowledge'
+          priority={3}
+          perform={() => {
+            useCommandPaletteStore.getState().close()
+            void setTab('articles')
+          }}
+        />
+        <CommandAction
+          label='Go to Knowledge Bases'
+          icon='book-open'
+          keywords='knowledge bases tab view kb'
+          priority={2}
+          perform={() => {
+            useCommandPaletteStore.getState().close()
+            void setTab('knowledge-bases')
+          }}
+        />
+        <CommandAction
+          label='Go to Sources'
+          icon='globe'
+          keywords='sources tab view crawl'
+          priority={1}
+          perform={() => {
+            useCommandPaletteStore.getState().close()
+            void setTab('sources')
+          }}
+        />
+      </CommandContext>
       <MainPageHeader
-        action={tab === 'sources' ? <ConnectSourceButton /> : <CreateKnowledgeBaseButton />}>
+        action={
+          tab === 'sources' ? (
+            <ConnectSourceButton registerShortcut />
+          ) : (
+            <CreateKnowledgeBaseButton registerShortcut />
+          )
+        }>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem
             title='Knowledge Bases'

--- a/apps/web/src/components/kb/ui/sources/connect-source-button.tsx
+++ b/apps/web/src/components/kb/ui/sources/connect-source-button.tsx
@@ -10,8 +10,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
+import { Kbd } from '@auxx/ui/components/kbd'
+import { useHotkey } from '@tanstack/react-hotkeys'
 import { ClipboardPaste, FileText, Globe, Plus, ShoppingBag } from 'lucide-react'
 import { useState } from 'react'
+import { CommandAction, CommandContext } from '~/components/kbar/contextual'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import { CrawlWebsiteWizard } from '../editor/crawl-website-wizard'
 import { CreateKnowledgeSourceDialog } from '../editor/create-knowledge-source-dialog'
 
@@ -21,21 +25,62 @@ import { CreateKnowledgeSourceDialog } from '../editor/create-knowledge-source-d
  * Shopify / file-upload shown as roadmap. A source is its own container, so this
  * entry point is org-wide — KB linking happens inside the wizard / source settings.
  */
+/**
+ * @param registerShortcut - When true, binds the page-local `N` shortcut (opens
+ *   the website crawler), shows the `<Kbd>` hint, and contributes the cmd+k
+ *   actions. Set only on the shell's header instance so the sources empty-state
+ *   copy doesn't double-register.
+ */
 export function ConnectSourceButton({
   variant = 'default',
+  registerShortcut = false,
 }: {
   variant?: 'default' | 'outline'
+  registerShortcut?: boolean
 } = {}) {
   const [crawlOpen, setCrawlOpen] = useState(false)
   const [manualOpen, setManualOpen] = useState(false)
 
+  // Page-local shortcut: N opens the website crawler (the headline source).
+  useHotkey('N', () => setCrawlOpen(true), { enabled: registerShortcut })
+
   return (
     <>
+      {registerShortcut && (
+        <CommandContext kind='page' label='Knowledge Bases'>
+          <CommandAction
+            label='Crawl a website'
+            icon='globe'
+            keywords='connect source crawl website url'
+            shortcut={['N']}
+            priority={10}
+            perform={() => {
+              useCommandPaletteStore.getState().close()
+              setCrawlOpen(true)
+            }}
+          />
+          <CommandAction
+            label='Add source by manual paste'
+            icon='clipboard'
+            keywords='connect source manual paste text'
+            priority={9}
+            perform={() => {
+              useCommandPaletteStore.getState().close()
+              setManualOpen(true)
+            }}
+          />
+        </CommandContext>
+      )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant={variant} size='sm'>
             <Plus />
             Connect Source
+            {registerShortcut && (
+              <Kbd variant={variant === 'outline' ? 'outline' : 'default'} size='sm'>
+                N
+              </Kbd>
+            )}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align='end' className='w-52'>

--- a/apps/web/src/components/kopilot/ui/kopilot-page-shell.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-page-shell.tsx
@@ -4,6 +4,7 @@
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
+import { Kbd } from '@auxx/ui/components/kbd'
 import {
   MainPage,
   MainPageBreadcrumb,
@@ -12,10 +13,13 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
+import { useHotkey } from '@tanstack/react-hotkeys'
 import { Lock, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
+import { CommandAction, CommandContext } from '~/components/kbar/contextual'
+import { useCommandPaletteStore } from '~/components/kbar/store'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useKopilotSessions } from '../hooks/use-kopilot-sessions'
 import { useKopilotStore } from '../stores/kopilot-store'
@@ -71,12 +75,17 @@ export function KopilotPageShell({ sessionId }: KopilotPageShellProps) {
     router.push('/app/kopilot/new')
   }, [startNewSession, router])
 
+  const canUse = hasAccess(FeatureKey.kopilot)
+
+  // Page-local shortcut: N starts a new chat.
+  useHotkey('N', handleNewSession, { enabled: canUse })
+
   const breadcrumbLabel = useMemo(() => {
     if (!activeSessionId) return 'New chat'
     return sessionOptions.find((s) => s.value === activeSessionId)?.label ?? 'Chat'
   }, [activeSessionId, sessionOptions])
 
-  if (!hasAccess(FeatureKey.kopilot)) {
+  if (!canUse) {
     return (
       <MainPage>
         <MainPageHeader>
@@ -98,11 +107,27 @@ export function KopilotPageShell({ sessionId }: KopilotPageShellProps) {
 
   return (
     <MainPage>
+      <CommandContext kind='page' label='Chats'>
+        <CommandAction
+          label='New chat'
+          icon='plus'
+          keywords='new chat session start kopilot conversation'
+          shortcut={['N']}
+          priority={10}
+          perform={() => {
+            useCommandPaletteStore.getState().close()
+            handleNewSession()
+          }}
+        />
+      </CommandContext>
       <MainPageHeader
         action={
           <Button variant='outline' size='sm' onClick={handleNewSession}>
             <Plus />
             New chat
+            <Kbd variant='outline' size='sm'>
+              N
+            </Kbd>
           </Button>
         }>
         <MainPageBreadcrumb>


### PR DESCRIPTION
## What

Extends the distributed command-palette pattern (`CommandContext` / `CommandAction`, first used in `records-view`) to more surfaces, and adds page-local keyboard shortcuts with `<Kbd>` hints on the relevant buttons.

Shortcut mechanism: page-local single keys via `useHotkey` (default `ignoreInputs: true`, so they never fire while typing in a field), each rendered as a `<Kbd>` chip on its button and mirrored as a ⌘K row.

## Surfaces

| Location | ⌘K actions | In-page key |
|---|---|---|
| **Files** (management mode only) | New folder, Upload files | `N` / `U` + Kbd |
| **File drawer** | Download, Copy link, Copy ID, **Delete** | — (scope outranks the Files page) |
| **Connectors** | Connect a source | `N` + Kbd |
| **KB landing** | Go to Articles / Knowledge Bases / Sources + tab-aware Create KB / Crawl website / Manual paste | `N` + Kbd |
| **Kopilot shell** | New chat | `N` + Kbd |
| **Dashboards list** | New dashboard | `N` + Kbd |
| **Dashboard detail** | Edit/Done, Favorite, (edit-mode) Add widget / Add tab, (draft) Publish / Discard | — (recordList drawer reuses `RecordCommandActions`) |

## Notes

- **File drawer delete was a TODO stub** — now wired to `api.file.delete` + store `removeItems` + drawer close.
- Create buttons own their dialog state, so the hotkey/palette registration is colocated inside each button behind a `registerShortcut` prop — set only on the header instance so empty-state copies (dashboards, KB list, sources) don't double-bind `N`.
- Every palette `perform` closes the palette first (it doesn't auto-close) so the resulting dialog/toast isn't hidden behind the overlay.
- Fixed 5 icon ids that don't exist in `ICON_DATA` (`folder`, `book-open`, `file-text`, `clipboard`, `send`).

## Verification

Not yet driven in the running app. Worth a manual check of: `N`/`U` on Files, the file-drawer Delete actually removing the row (only real backend effect), and KB tab-aware `N`.
