### PR TITLE
fix(kb): improve knowledge search retrieval quality

### DIFF
--- a/packages/lib/scripts/backfill-kb-segment-links.ts
+++ b/packages/lib/scripts/backfill-kb-segment-links.ts
@@ -1,0 +1,107 @@
+// packages/lib/scripts/backfill-kb-segment-links.ts
+//
+// One-off backfill: populate `metadata.links[]` on existing KB-article
+// Documents and their DocumentSegments. Segments written before the
+// collect-references fix carry `links: []` (initialized but never populated),
+// and the sync pipeline's hash-skip means re-enqueueing sync jobs won't
+// rewrite them for unchanged content. This derives links from each article's
+// current content and jsonb-merges them in place — no re-embed.
+//   npx dotenv -- node --conditions source --import tsx/esm packages/lib/scripts/backfill-kb-segment-links.ts
+//
+// Idempotent; safe to re-run.
+
+import { database as db, schema } from '@auxx/database'
+import { and, eq, sql } from 'drizzle-orm'
+import { collectRecordLinks } from '../src/kb/markdown/collect-references'
+import type { ArticleNodeJSON } from '../src/kb/markdown/types'
+
+async function main() {
+  const docs = (
+    await db.execute(sql`
+      SELECT id, "organizationId", metadata->'kb'->>'articleId' AS "articleId"
+      FROM "Document"
+      WHERE metadata->>'contentSource' = 'kb-article'
+        AND metadata->'kb'->>'articleId' IS NOT NULL
+    `)
+  ).rows as Array<{ id: string; organizationId: string; articleId: string }>
+
+  console.log(`Found ${docs.length} KB-article documents`)
+
+  let updated = 0
+  let skippedNoLinks = 0
+  let skippedNoArticle = 0
+
+  for (const doc of docs) {
+    const article = await db.query.Article.findFirst({
+      where: and(
+        eq(schema.Article.id, doc.articleId),
+        eq(schema.Article.organizationId, doc.organizationId)
+      ),
+      with: { draftRevision: true },
+    })
+    if (!article) {
+      skippedNoArticle++
+      continue
+    }
+
+    // Mirror the sync pipeline's revision choice: managed (source-owned)
+    // articles embed their draft; standard articles embed the home
+    // placement's published revision, falling back to the draft.
+    let revision = article.draftRevision
+    if (!article.managed) {
+      const homePlacement = await db.query.ArticlePlacement.findFirst({
+        where: and(
+          eq(schema.ArticlePlacement.articleId, article.id),
+          eq(schema.ArticlePlacement.knowledgeBaseId, article.homeKnowledgeBaseId)
+        ),
+        with: { publishedRevision: true },
+      })
+      revision = homePlacement?.publishedRevision ?? article.draftRevision
+    }
+    if (!revision) {
+      skippedNoArticle++
+      continue
+    }
+
+    const links = collectRecordLinks(revision.contentJson as ArticleNodeJSON[] | null)
+    if (links.length === 0) {
+      skippedNoLinks++
+      continue
+    }
+
+    const linksJson = JSON.stringify(links)
+    await Promise.all([
+      db
+        .update(schema.DocumentSegment)
+        .set({
+          metadata: sql`
+            COALESCE(${schema.DocumentSegment.metadata}, '{}'::jsonb) ||
+            jsonb_build_object('links', ${linksJson}::jsonb)
+          `,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.DocumentSegment.documentId, doc.id)),
+      db
+        .update(schema.Document)
+        .set({
+          metadata: sql`
+            jsonb_set(
+              COALESCE(${schema.Document.metadata}, '{}'::jsonb),
+              '{kb,links}',
+              ${linksJson}::jsonb
+            )
+          `,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.Document.id, doc.id)),
+    ])
+    updated++
+  }
+
+  console.log(
+    `Done. Updated ${updated} documents, ${skippedNoLinks} had no record references, ${skippedNoArticle} had no resolvable article/revision.`
+  )
+  process.exit(0)
+}
+
+void main()

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
@@ -121,7 +121,7 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
     usageNotes:
       'For KB articles, cite individual articles in the final message via `[Title](auxx://doc/<docSlug>)` — `docSlug` is on each result. RAG segments have no citable URL; mention them in prose.',
     description:
-      "Hybrid (BM25 + vector) search across the organization's knowledge — published KB articles and uploaded RAG documents. Use for written content (articles, manuals, policies, FAQs). Do NOT use for contacts, customers, products, orders, or other entities — use search_entities for that.",
+      "Hybrid (keyword + semantic) search across the organization's knowledge — published KB articles and uploaded RAG documents. Returns the best-matching passage per article/document; follow the `articleId`/`docSlug` into get_article for full context. Use for written content (articles, manuals, policies, FAQs). Do NOT use for contacts, customers, products, orders, or other entities — use search_entities for that.",
     parameters: {
       type: 'object',
       properties: {
@@ -198,11 +198,14 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
           }
         }
 
+        // Over-fetch: results below are deduped to one segment per article
+        // (and optionally post-filtered by recordIds), so the raw segment list
+        // must be several times the requested page to survive the cuts.
         const response = await SearchService.search(
           {
             query,
             datasetIds,
-            limit: recordIds && recordIds.length > 0 ? Math.max(limit * 3, MAX_RESULTS) : limit,
+            limit: Math.min(Math.max(limit * 3, 15), 50),
             searchType: 'hybrid',
             includeMetadata: true,
           },
@@ -221,7 +224,20 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
               })
             : response.results
 
-        const trimmed = filtered.slice(0, limit)
+        // One result per article (KB) / document (RAG): results arrive score-
+        // sorted, so the first segment seen for a source is its best passage.
+        // Without this, one long article can occupy every slot and crowd out
+        // other relevant sources.
+        const seenSources = new Set<string>()
+        const grouped = filtered.filter((r) => {
+          const meta = (r.segment.metadata as any) ?? {}
+          const key = (meta.articleId as string | undefined) ?? r.segment.documentId ?? r.segment.id
+          if (seenSources.has(key)) return false
+          seenSources.add(key)
+          return true
+        })
+
+        const trimmed = grouped.slice(0, limit)
 
         // Hybrid runs vector + text in parallel via Promise.allSettled. If one
         // side throws (e.g. embedding-model mismatch), results may be missing

--- a/packages/lib/src/datasets/search/full-text-search.ts
+++ b/packages/lib/src/datasets/search/full-text-search.ts
@@ -43,11 +43,6 @@ export class FullTextSearchService {
         datasetIds,
         organizationId,
         {
-          fuzzySearch: true,
-          phraseSearch: false,
-          booleanMode: false,
-          rankingMode: 'bm25',
-          minScore: 0.1,
           includeInactive: query.includeInactive,
           filters: query.filters, // Pass filters to SQL query
         }
@@ -126,6 +121,14 @@ export class FullTextSearchService {
       // Execute optimized full-text search using stored searchVector generated column
       // searchVector is auto-computed from content by PostgreSQL
       // Reduced column selection for better performance
+      //
+      // Query parsing: `websearch_to_tsquery` (stemming, stopwords, quoted
+      // phrases), then bare `&`s are rewritten to `|` so a natural-language
+      // query matches segments containing ANY meaningful term instead of
+      // requiring ALL of them — `ts_rank_cd` still ranks segments matching
+      // more terms higher. Phrase operators (`<->`) survive untouched;
+      // `-negations` lose their AND-binding under the rewrite, which is an
+      // accepted trade-off (recall over strictness for agent queries).
       const datasetIdsArray = `{${datasetIds.join(',')}}`
       const searchResults = (
         await db.execute(sql`
@@ -136,6 +139,7 @@ export class FullTextSearchService {
           ds."tokenCount",
           ds."documentId",
           ds."organizationId",
+          ds.metadata as "segmentMetadata",
           d.id as "docId",
           d.title as "documentTitle",
           d.filename as "documentFilename",
@@ -147,16 +151,21 @@ export class FullTextSearchService {
           d."createdAt" as "documentCreatedAt",
           dt.id as "datasetId",
           dt.name as "datasetName",
-          ts_rank_cd(ds."searchVector", plainto_tsquery('english', ${searchQuery})) as rank_score
+          ts_rank_cd(ds."searchVector", tsq.q) as rank_score
         FROM "DocumentSegment" ds
         JOIN "Document" d ON ds."documentId" = d.id
         JOIN "Dataset" dt ON d."datasetId" = dt.id
+        CROSS JOIN (
+          SELECT replace(
+            websearch_to_tsquery('english', ${searchQuery})::text, ' & ', ' | '
+          )::tsquery AS q
+        ) tsq
         WHERE dt.id = ANY(${datasetIdsArray}::text[])
           AND dt."organizationId" = ${organizationId}
           AND ds.enabled = true
           AND d.enabled = true
           ${options.includeInactive ? sql`` : sql`AND dt.status = 'ACTIVE'`}
-          AND ds."searchVector" @@ plainto_tsquery('english', ${searchQuery})
+          AND ds."searchVector" @@ tsq.q
           ${filterConditions}
         ORDER BY rank_score DESC, ds."createdAt" DESC
         LIMIT 100;
@@ -243,6 +252,13 @@ export class FullTextSearchService {
             position: row.position,
             tokenCount: row.tokenCount,
             organizationId: row.organizationId,
+            // Without this, text-only hits reach consumers with no metadata:
+            // search_knowledge then mislabels KB articles as 'rag' (no
+            // docSlug/citation) and the recordIds links[] filter drops them.
+            // The vector lane returns "searchMetadata" — same content, written
+            // at embed time; ds.metadata is authored at segment creation and
+            // exists even when embedding never ran.
+            metadata: row.segmentMetadata ?? {},
             document: {
               id: row.docId,
               title: row.documentTitle,
@@ -262,7 +278,9 @@ export class FullTextSearchService {
             },
           },
           score: parseFloat(row.rank_score) || 0,
-          rank: index,
+          // 1-based, in score order — RRF fusion in hybrid-search depends on
+          // ranks being 1-based and consistent across lanes.
+          rank: index + 1,
           relevanceScore: parseFloat(row.rank_score) || 0,
           searchType: 'text',
         }) as SearchResult
@@ -334,6 +352,7 @@ export class FullTextSearchService {
           ds."tokenCount",
           ds."documentId",
           ds."organizationId",
+          ds.metadata as "segmentMetadata",
           d.id as "docId",
           d.title as "documentTitle",
           d.filename as "documentFilename",
@@ -345,14 +364,14 @@ export class FullTextSearchService {
           d."createdAt" as "documentCreatedAt",
           dt.id as "datasetId",
           dt.name as "datasetName",
-          ts_rank_cd(ds."searchVector", plainto_tsquery('english', ${searchQuery})) as rank_score
+          ts_rank_cd(ds."searchVector", websearch_to_tsquery('english', ${searchQuery})) as rank_score
         FROM "DocumentSegment" ds
         JOIN "Document" d ON ds."documentId" = d.id
         JOIN "Dataset" dt ON d."datasetId" = dt.id
         WHERE d.id = ${documentId}
           AND dt."organizationId" = ${organizationId}
           AND ds.enabled = true
-          AND ds."searchVector" @@ plainto_tsquery('english', ${searchQuery})
+          AND ds."searchVector" @@ websearch_to_tsquery('english', ${searchQuery})
         ORDER BY ds.position ASC, rank_score DESC
         LIMIT ${limit};
       `)

--- a/packages/lib/src/datasets/search/hybrid-search.ts
+++ b/packages/lib/src/datasets/search/hybrid-search.ts
@@ -48,15 +48,31 @@ export class HybridSearchService {
       const hybridOptions: HybridSearchOptions = {
         vectorWeight: queryWithWeights.vectorWeight ?? 0.6, // Configurable or default to 0.6
         textWeight: queryWithWeights.textWeight ?? 0.4, // Configurable or default to 0.4
-        combineMethod: queryWithWeights.combineMethod || 'weighted_sum',
+        // RRF by default: weighted_sum averages raw cosine similarity against
+        // raw ts_rank_cd — incomparable scales. RRF only needs each lane's
+        // rank order, which is the one thing both lanes agree on.
+        combineMethod: queryWithWeights.combineMethod || 'rrf',
         rerankingModel: queryWithWeights.rerankingModel || undefined,
+      }
+
+      // Wide-then-narrow: each lane fetches a candidate pool several times the
+      // requested page so fusion has real material to work with — fusing two
+      // `limit`-sized lists barely reorders anything. Fused results are cut
+      // back to `limit` below.
+      const limit = query.limit || 20
+      const fetchLimit = Math.min(Math.max(limit * 4, 20), 100)
+      const laneQuery: SearchQuery = {
+        ...query,
+        limit: fetchLimit,
+        offset: 0,
+        maxResults: fetchLimit,
       }
 
       // Execute both searches in parallel
       // Vector search uses datasetConfigs, full-text search uses datasetIds
       const [vectorResult, textResult] = await Promise.allSettled([
-        VectorSearchService.search(query, datasetConfigs, organizationId, userId),
-        FullTextSearchService.search(query, datasetIds, organizationId, userId),
+        VectorSearchService.search(laneQuery, datasetConfigs, organizationId, userId),
+        FullTextSearchService.search(laneQuery, datasetIds, organizationId, userId),
       ])
 
       // Handle search results and errors
@@ -103,8 +119,7 @@ export class HybridSearchService {
         ? HybridSearchService.applyFilters(combinedResults, query.filters)
         : combinedResults
 
-      // Apply pagination limits
-      const limit = query.limit || 20
+      // Apply pagination limits (the original query's, not the widened lane's)
       const offset = query.offset || 0
       const paginatedResults = filteredResults.slice(offset, offset + limit)
 
@@ -283,7 +298,8 @@ export class HybridSearchService {
     let rrfScore = 0
     let highlights: string[] = []
 
-    // RRF formula: 1 / (k + rank)
+    // RRF formula: 1 / (k + rank). Ranks are 1-based per lane (see
+    // vector-search / full-text-search rank assignment).
     if (vectorResult) {
       rrfScore += 1 / (k + (vectorResult.rank || 1))
     }
@@ -293,12 +309,19 @@ export class HybridSearchService {
       highlights = textResult.highlights || []
     }
 
+    // Normalize to 0-1 so downstream consumers (agent tools round to two
+    // decimals, quality heuristics assume a 0-1 scale) keep a meaningful
+    // score: 1.0 = ranked first in BOTH lanes, ~0.5 = first in one lane.
+    // Raw RRF tops out at 2/(k+1) ≈ 0.033 which rounds to indistinguishable.
+    const maxPossible = 2 / (k + 1)
+    const normalizedScore = rrfScore / maxPossible
+
     return {
       ...baseResult,
-      score: rrfScore,
+      score: normalizedScore,
       highlights,
       searchType: 'hybrid',
-      relevanceScore: rrfScore,
+      relevanceScore: normalizedScore,
     }
   }
 

--- a/packages/lib/src/datasets/search/vector-search.ts
+++ b/packages/lib/src/datasets/search/vector-search.ts
@@ -65,7 +65,11 @@ export class VectorSearchService {
         organizationId,
         userId,
         {
-          similarityThreshold: query.similarityThreshold || 0.7,
+          // Low floor by design: it only cuts obvious junk. Relevance ordering
+          // is the ranker's job (RRF in hybrid), and paraphrased queries
+          // routinely score 0.5-0.65 against relevant chunks — a high floor
+          // silently empties results.
+          similarityThreshold: query.similarityThreshold || 0.4,
           maxResults: query.maxResults || query.limit || 20,
           includeMetadata: query.includeMetadata !== false,
           rerank: query.rerank,
@@ -142,22 +146,23 @@ export class VectorSearchService {
     //    query with the wrong model yields a vector that lives in a different
     //    semantic space, and asking the wrong model for a dimension it can't
     //    produce throws (e.g. text-embedding-3-small max 1536 vs requested 3072).
+    //
+    //    Datasets without embedding config are SKIPPED, not fatal: they have no
+    //    vectors to search anyway, and one misconfigured dataset must not kill
+    //    the vector lane for the whole org (hybrid silently degrades to
+    //    text-only otherwise).
     const byModelDim = new Map<
       string,
       { model: string; dimension: number; datasets: DatasetConfig[] }
     >()
     for (const dataset of datasetConfigs) {
-      if (!dataset.embeddingModel) {
-        throw new VectorSearchError(
-          `Dataset ${dataset.id} is missing embeddingModel — cannot run vector search`,
-          { datasetId: dataset.id }
-        )
-      }
-      if (!dataset.vectorDimension) {
-        throw new VectorSearchError(
-          `Dataset ${dataset.id} is missing vectorDimension — cannot run vector search`,
-          { datasetId: dataset.id }
-        )
+      if (!dataset.embeddingModel || !dataset.vectorDimension) {
+        logger.warn('Skipping dataset without embedding config in vector search', {
+          datasetId: dataset.id,
+          embeddingModel: dataset.embeddingModel ?? null,
+          vectorDimension: dataset.vectorDimension ?? null,
+        })
+        continue
       }
       const key = `${dataset.embeddingModel}@${dataset.vectorDimension}`
       const group = byModelDim.get(key)
@@ -170,6 +175,9 @@ export class VectorSearchService {
           datasets: [dataset],
         })
       }
+    }
+    if (byModelDim.size === 0) {
+      return []
     }
 
     // 2. One embedding per (model, dimension) pair, in parallel
@@ -202,7 +210,7 @@ export class VectorSearchService {
     const resultGroups = await Promise.all(searchPromises)
 
     // 4. Convert to SearchResult format and merge results
-    const allResults = resultGroups.flat().map((result, index) => {
+    const allResults = resultGroups.flat().map((result) => {
       const meta = result.metadata || {}
       return {
         segment: {
@@ -229,16 +237,20 @@ export class VectorSearchService {
           },
         },
         score: result.score,
-        rank: index + 1,
+        rank: 0, // assigned after the cross-group sort below
         relevanceScore: result.score,
         searchType: 'vector' as const,
       } as SearchResult
     })
 
-    // 5. Re-sort by score and limit results
+    // 5. Re-sort by score across dimension groups, limit, then assign ranks.
+    // Ranks must reflect the FINAL order — RRF fusion in hybrid-search reads
+    // them, and per-group flatten order is meaningless.
     allResults.sort((a, b) => b.score - a.score)
 
-    return allResults.slice(0, options.maxResults || 20)
+    return allResults
+      .slice(0, options.maxResults || 20)
+      .map((result, index) => ({ ...result, rank: index + 1 }))
   }
 
   /**

--- a/packages/lib/src/kb/kb-sync-service.ts
+++ b/packages/lib/src/kb/kb-sync-service.ts
@@ -9,6 +9,7 @@ import { NullDocumentExecutionReporter } from '../datasets/events'
 import { DocumentProcessor } from '../datasets/workers/document-processor'
 import { KBService } from './kb-service'
 import { articleToMarkdown } from './markdown/article-to-markdown'
+import { collectRecordLinks } from './markdown/collect-references'
 import { computeContentHash } from './markdown/hash'
 import type { ArticleNodeJSON } from './markdown/types'
 
@@ -350,7 +351,10 @@ export class KBSyncService {
       articleSlug: homePlacementSlug,
       articleSlugPath: slugPath,
       kbSlug: kb.slug,
-      links: [] as Array<{ recordId: string; recordType?: string }>,
+      // Record links from inline `reference` nodes — stamped onto every
+      // segment so `search_knowledge`'s `recordIds` filter can scope results
+      // to articles about a specific contact/company/etc.
+      links: collectRecordLinks(revision.contentJson as ArticleNodeJSON[] | null),
     }
 
     const documentMetadata = {

--- a/packages/lib/src/kb/markdown/__tests__/collect-references.test.ts
+++ b/packages/lib/src/kb/markdown/__tests__/collect-references.test.ts
@@ -1,0 +1,92 @@
+// packages/lib/src/kb/markdown/__tests__/collect-references.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { collectRecordLinks } from '../collect-references'
+import type { ArticleNodeJSON } from '../types'
+
+const block = (content: ArticleNodeJSON extends never ? never : any[]): ArticleNodeJSON =>
+  ({ type: 'block', attrs: { blockType: 'text' }, content }) as ArticleNodeJSON
+
+describe('collectRecordLinks', () => {
+  it('returns [] for empty/null content', () => {
+    expect(collectRecordLinks(null)).toEqual([])
+    expect(collectRecordLinks([])).toEqual([])
+  })
+
+  it('collects reference nodes from plain blocks with recordType split', () => {
+    const nodes = [
+      block([
+        { type: 'text', text: 'Ask ' },
+        { type: 'reference', attrs: { id: 'contact:c_1' } },
+        { type: 'text', text: ' about ' },
+        { type: 'reference', attrs: { id: 'company:co_9' } },
+      ]),
+    ]
+    expect(collectRecordLinks(nodes)).toEqual([
+      { recordId: 'contact:c_1', recordType: 'contact' },
+      { recordId: 'company:co_9', recordType: 'company' },
+    ])
+  })
+
+  it('dedupes repeated references and drops non-RecordId ids', () => {
+    const nodes = [
+      block([
+        { type: 'reference', attrs: { id: 'contact:c_1' } },
+        { type: 'reference', attrs: { id: 'contact:c_1' } },
+        { type: 'reference', attrs: { id: 'not-a-record-id' } },
+        { type: 'reference', attrs: {} },
+      ]),
+    ]
+    expect(collectRecordLinks(nodes)).toEqual([{ recordId: 'contact:c_1', recordType: 'contact' }])
+  })
+
+  it('walks tabs, accordions, and tables', () => {
+    const nodes: ArticleNodeJSON[] = [
+      {
+        type: 'tabs',
+        attrs: {},
+        content: [
+          {
+            type: 'panel',
+            attrs: { id: 'p1', label: 'Tab' },
+            content: [block([{ type: 'reference', attrs: { id: 'contact:in_tab' } }]) as never],
+          },
+        ],
+      } as ArticleNodeJSON,
+      {
+        type: 'accordion',
+        attrs: { allowMultiple: false },
+        content: [
+          {
+            type: 'panel',
+            attrs: { id: 'p2', label: 'Section' },
+            content: [
+              block([{ type: 'reference', attrs: { id: 'company:in_accordion' } }]) as never,
+            ],
+          },
+        ],
+      } as ArticleNodeJSON,
+      {
+        type: 'table',
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableCell',
+                content: [
+                  block([{ type: 'reference', attrs: { id: 'ticket:in_table' } }]) as never,
+                ],
+              },
+            ],
+          },
+        ],
+      } as ArticleNodeJSON,
+    ]
+    expect(collectRecordLinks(nodes).map((l) => l.recordId)).toEqual([
+      'contact:in_tab',
+      'company:in_accordion',
+      'ticket:in_table',
+    ])
+  })
+})

--- a/packages/lib/src/kb/markdown/collect-references.ts
+++ b/packages/lib/src/kb/markdown/collect-references.ts
@@ -1,0 +1,63 @@
+// packages/lib/src/kb/markdown/collect-references.ts
+
+import type { ArticleNodeJSON, BlockJSON, InlineJSON } from './types'
+
+/**
+ * Record link derived from an inline `reference` node — the shape stored in
+ * `DocumentSegment.metadata.links[]` and matched by `search_knowledge`'s
+ * `recordIds` filter.
+ */
+export interface RecordLink {
+  recordId: string
+  recordType?: string
+}
+
+/**
+ * Collect the distinct record links referenced by an article's content.
+ * Walks every inline `reference` node (including those inside tabs,
+ * accordions, and tables) and keeps ids in RecordId form
+ * (`entityDefinitionId:entityInstanceId`).
+ */
+export function collectRecordLinks(nodes: ArticleNodeJSON[] | null | undefined): RecordLink[] {
+  const ids = new Set<string>()
+  for (const node of nodes ?? []) {
+    collectFromNode(node, ids)
+  }
+  return [...ids]
+    .filter((id) => id.includes(':'))
+    .map((id) => ({ recordId: id, recordType: id.slice(0, id.indexOf(':')) }))
+}
+
+function collectFromNode(node: ArticleNodeJSON, ids: Set<string>): void {
+  if (node.type === 'block') {
+    collectFromInline(node.content, ids)
+    return
+  }
+  if (node.type === 'tabs' || node.type === 'accordion') {
+    for (const panel of node.content ?? []) {
+      collectFromBlocks(panel.content, ids)
+    }
+    return
+  }
+  if (node.type === 'table') {
+    for (const row of node.content ?? []) {
+      for (const cell of row.content ?? []) {
+        collectFromBlocks(cell.content, ids)
+      }
+    }
+  }
+}
+
+function collectFromBlocks(blocks: BlockJSON[] | undefined, ids: Set<string>): void {
+  for (const block of blocks ?? []) {
+    collectFromInline(block.content, ids)
+  }
+}
+
+function collectFromInline(content: InlineJSON[] | undefined, ids: Set<string>): void {
+  for (const node of content ?? []) {
+    if (node.type !== 'reference') continue
+    const id = typeof node.attrs?.id === 'string' ? node.attrs.id : ''
+    if (id) ids.add(id)
+  }
+}


### PR DESCRIPTION
## Summary

Reworks hybrid KB/RAG knowledge search so agent (`search_knowledge`) queries reliably surface relevant passages instead of empty or lopsided results.

## Changes

**Fusion & ranking**
- Default `combineMethod` to **RRF** instead of `weighted_sum` — the old default averaged raw cosine similarity against raw `ts_rank_cd`, two incomparable scales. RRF only needs each lane's rank order.
- Widen each lane's candidate pool (`limit * 4`, capped) before fusion so RRF has real material to reorder.
- Normalize the RRF score to 0-1 (`1.0` = first in both lanes) so downstream two-decimal rounding and quality heuristics stay meaningful.

**Full-text lane** (`full-text-search.ts`)
- Parse queries with `websearch_to_tsquery` and rewrite bare `&` → `|` so a natural-language query matches ANY meaningful term (still rank-weighted toward more matches). Phrase operators survive.
- Plumb `ds.metadata` through as `segmentMetadata` so text-only KB hits keep their `docSlug`/citation and aren't mislabeled `rag` or dropped by the `recordIds` filter.
- Ranks are now 1-based, in score order (RRF depends on this).

**Vector lane** (`vector-search.ts`)
- Lower default similarity floor `0.7 → 0.4` — paraphrased queries routinely score 0.5-0.65 against relevant chunks; the high floor silently emptied results. Ordering is the ranker's job.
- Datasets missing embedding config are **skipped with a warning**, not fatal — one misconfigured dataset no longer kills the vector lane for the whole org.
- Assign ranks after the cross-group sort so they reflect final order.

**Agent tool** (`search-knowledge.ts`)
- Dedupe to one best passage per article/document so a single long article can't occupy every slot.

**Record links** (new `collect-references.ts` + backfill)
- `collectRecordLinks` walks inline `reference` nodes (incl. tabs/accordions/tables) and stamps record links onto every segment, so `search_knowledge`'s `recordIds` filter can scope results to a specific contact/company/etc.
- One-off idempotent backfill script for segments written before this fix (`links: []`), jsonb-merged in place with no re-embed.

## Testing
- `pnpm --filter @auxx/lib test collect-references` — 4 passed.