### PR TITLE
fix(drawer): scope contact conversations tab highlight + tab order

### DIFF
--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -154,8 +154,8 @@ export function BaseEntityDrawer({
   const tabs = React.useMemo(() => {
     if (!drawerConfig) return []
 
-    const baseTabs = [
-      { value: 'overview', label: 'Overview', icon: HouseIcon },
+    const overviewTab = { value: 'overview', label: 'Overview', icon: HouseIcon }
+    const trailingTabs = [
       { value: 'timeline', label: 'Timeline', icon: Clock },
       { value: 'comments', label: 'Comments', icon: MessagesSquare },
       { value: 'tasks', label: 'Tasks', icon: ListTodo },
@@ -169,7 +169,8 @@ export function BaseEntityDrawer({
         icon: getIconComponent(tab.icon),
       }))
 
-    return [...baseTabs, ...additionalTabs]
+    // Overview first, then entity-specific tabs, then the shared timeline/comments/tasks tabs
+    return [overviewTab, ...additionalTabs, ...trailingTabs]
   }, [drawerConfig, hasAccess])
 
   // Tab order persistence

--- a/apps/web/src/components/drawers/tabs/contact-conversations-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/contact-conversations-tab.tsx
@@ -143,7 +143,7 @@ export function ContactConversationsTab({ entityInstanceId, record }: DrawerTabP
               sortDirection: 'desc',
               filterConditions: filter,
             }}>
-            <div className='space-y-2 p-4 pb-6'>
+            <div className='space-y-2 pb-6'>
               {threadIds.map((threadId) => (
                 <MailThreadItem
                   key={threadId}

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -272,7 +272,13 @@ export const MailThreadItem = memo(function MailThreadItem({
   const isMultiSelected = scopedSelectedIds
     ? scopedSelectedIds.includes(threadId)
     : globalIsSelected
-  const isActive = useIsThreadActive(threadId)
+  // `activeThreadId` is a single app-wide value set by the mailbox detail pane.
+  // Embedded mini-lists (ticket/contact tabs) announce themselves via
+  // scopedSelectedIds and drive their own highlight, so they must NOT inherit
+  // the mailbox's open-thread highlight — otherwise a thread open in the mailbox
+  // lights up in every embedded list that happens to render it.
+  const globalIsActive = useIsThreadActive(threadId)
+  const isActive = scopedSelectedIds ? false : globalIsActive
   const isHighlighted = isActive || isMultiSelected
   const isProcessing = useIsRecordProcessing(toRecordId('thread', threadId))
 


### PR DESCRIPTION
## What

Three small fixes to the record drawer / contact Conversations tab.

### 1. Tab order
Default drawer tab order is now **Overview → entity-specific tabs → Timeline, Comments, Tasks** (previously the shared tabs came before the entity-specific ones). User-saved reordering still wins via `applyTabOrder`, so this only affects the out-of-the-box default.

### 2. Bleed-through highlight (the actual bug)
Opening a thread in the mailbox set the app-wide `activeThreadId`. Embedded thread mini-lists (contact/ticket drawer tabs) render the same `MailThreadItem`, which asked the **global** store `is this thread active?` — so a thread open in the mailbox lit up blue in the drawer's Conversations tab too.

Fix: gate `isActive` on `scopedSelectedIds`. Embedded lists already announce themselves by providing scoped selection, so they no longer inherit the mailbox's open-thread highlight. The main mailbox (no scoped selection) is unchanged. Clicking a row inside the tab still highlights it — that rides on the tab's own `selectedThreadIds`.

### 3. Padding
Removed a stray `p-4` on the Conversations thread list wrapper.

## Test
- Mailbox highlighting unchanged.
- Open a thread in the mailbox, then open a contact drawer → Conversations tab showing that same thread: row is no longer pre-highlighted; clicking it in the tab still highlights it.