### PR TITLE
style(blog): drop em dashes and bottom-line headings in AI skills series

### DIFF
--- a/apps/homepage/content/blog/ai-skills-long-support-threads.mdx
+++ b/apps/homepage/content/blog/ai-skills-long-support-threads.mdx
@@ -18,13 +18,13 @@ published: true
 
 Every support team has a version of this ticket. A customer emails about a broken product. Someone replies with a troubleshooting step. Three days later the customer replies, but that rep is out, so a colleague picks it up and tries a different fix. The customer is now annoyed and copies their business partner. It escalates. The thread is forty messages deep, has three attachments and two competing theories about the root cause, and you are the fourth person to open it.
 
-You have two bad options. Read the whole thing — ten minutes you don't have — or skim the last three messages and hope you caught up. Most people skim. That's where context goes to die and "I already explained this to the last agent" gets said for the fifth time.
+You have two bad options. Read the whole thing (ten minutes you don't have) or skim the last three messages and hope you caught up. Most people skim. That's where context goes to die and "I already explained this to the last agent" gets said for the fifth time.
 
 We've written before about *whether* to use AI on long threads in [using AI to summarize long support threads](/blog/ai-summarize-support-threads). This post is the *how*: the exact skills to run, in what order, so an inherited monster thread becomes a 30-second oriented start instead of a ten-minute reading assignment.
 
 The trick isn't one big skill that does everything. It's four narrow skills, each wired to the same live thread, run as a chain where each one builds on the last: **orient, gauge, list the asks, draft.**
 
-## Step 1: Orient — Summarize Ticket
+## Step 1: Orient with Summarize Ticket
 
 Start by finding out what you're actually looking at. Summarize Ticket pulls the full thread, the internal notes, and the edit history, and hands back a structured picture.
 
@@ -44,20 +44,20 @@ Be concise and actionable. If information is missing, write "Unknown." On
 conflicting signals, prioritize the most recent information.
 ```
 
-Thirty seconds later you know the issue, what's been tried, where it stands, and what's blocking it — off the real thread, not a guess.
+Thirty seconds later you know the issue, what's been tried, where it stands, and what's blocking it, off the real thread, not a guess.
 
 > **Why it matters.** You start oriented instead of reconstructing the story from forty messages. The "current status" line alone tells you whether the ball is in your court or the customer's.
 
-> **Pro-tip.** Trust the "Unknown." The skill writes it instead of inventing detail, so when you see it, that's a real gap in the record — treat it as information, not a bug.
+> **Pro-tip.** Trust the "Unknown." The skill writes it instead of inventing detail, so when you see it, that's a real gap in the record; treat it as information, not a bug.
 
-## Step 2: Gauge — Sentiment Analysis
+## Step 2: Gauge with Sentiment Analysis
 
 Now you know the facts. Before you write anything, find out what the customer is feeling, because the same facts need a very different delivery for someone furious than for someone patient.
 
 ```
 Context
 You are a customer experience analyst reviewing a support conversation. Use
-get_thread_detail to read the ticket — sentiment is a function of the customer's
+get_thread_detail to read the ticket; sentiment is a function of the customer's
 words, not metadata.
 
 Task
@@ -67,16 +67,16 @@ neutral, satisfied, or positive) with a one-sentence reason, the trajectory
 the recommended tone for the next reply with an example phrase.
 
 Constraints
-Base the assessment only on what the customer actually said — don't infer emotions
+Base the assessment only on what the customer actually said; don't infer emotions
 the text doesn't support. If the conversation is too short to judge trajectory,
 say so.
 ```
 
-> **Why it matters.** Trajectory is the useful part. A customer who's frustrated but trending up needs a different reply than one who started calm and is now deteriorating — and you can't see that trend by skimming the last message.
+> **Why it matters.** Trajectory is the useful part. A customer who's frustrated but trending up needs a different reply than one who started calm and is now deteriorating, and you can't see that trend by skimming the last message.
 
 > **Pro-tip.** Run it on the latest message, not the whole thread. Mood is a moving target, and the tone you need to match is the one they're in right now, not the one they were in on day one.
 
-## Step 3: List the asks — Extract Action Items
+## Step 3: List the asks with Extract Action Items
 
 Long threads bury the actual requests under history. Before you draft, surface exactly what you still owe the customer.
 
@@ -91,16 +91,16 @@ deadline or urgency. Group by owner, flag anything time-sensitive, and note item
 where the owner is unclear.
 
 Constraints
-Format as a numbered checklist. Be specific — "follow up with customer" is too
+Format as a numbered checklist. Be specific: "follow up with customer" is too
 vague; "send tracking for order #1234" is actionable. Only extract items that are
-explicitly stated or clearly implied — don't invent tasks.
+explicitly stated or clearly implied; don't invent tasks.
 ```
 
 > **Why it matters.** In a forty-message thread it's genuinely easy to answer four of the customer's five questions and miss the fifth. This makes the miss impossible.
 
-> **Pro-tip.** Paste the checklist straight into the ticket's notes. Now the next person who inherits the thread — including future you — starts with the open items already listed, and nothing falls between shifts.
+> **Pro-tip.** Paste the checklist straight into the ticket's notes. Now the next person who inherits the thread, including future you, starts with the open items already listed, and nothing falls between shifts.
 
-## Step 4: Draft — Draft Reply
+## Step 4: Draft with Draft Reply
 
 Now the assistant has everything: the summary, the tone to hit, and the open items. Drafting the reply is the easy last step.
 
@@ -115,14 +115,14 @@ Draft a reply: acknowledge the concern, give a clear answer or update, state any
 actions taken or planned, and offer a concrete next step.
 
 Constraints
-Be professional, empathetic, and concise — skip filler like "I understand your
+Be professional, empathetic, and concise; skip filler like "I understand your
 frustration." Match the tone of previous agent replies. If you're missing
 information, say what's needed and who has to provide it.
 ```
 
 > **Why it matters.** Because the three earlier skills did the reading, this draft lands close to sendable. You're editing a well-informed first pass, not staring at a blank reply box.
 
-> **Pro-tip.** It's a draft, not an autosend. The chain did the reading and the scaffolding; you keep the judgment and the send button. That's the point — human where it matters, machine on the tedium.
+> **Pro-tip.** It's a draft, not an autosend. The chain did the reading and the scaffolding; you keep the judgment and the send button. That's the point: human where it matters, machine on the tedium.
 
 ## Why the chain works
 
@@ -130,8 +130,8 @@ Each step feeds the next. Orienting sets the context, gauging sets the tone, lis
 
 It also degrades gracefully. On a short, calm ticket you might only run Summarize Ticket and Draft Reply. On the inherited monster, you run all four. Same tools, scaled to the mess in front of you.
 
-## The bottom line
+## Four commands, one oriented reply
 
 Four slash commands, and a forty-message thread you didn't start becomes a summarized, tone-matched, scoped, drafted reply in the time it used to take just to read it.
 
-These four skills ship in the box. When you want to build a chain for a workflow that's specific to your team, [here's how to write your own skill](/blog/write-your-own-ai-skill) — and if you run a Shopify store, [these four skills](/blog/shopify-support-ai-skills) handle the highest-volume tickets before they ever become forty-message threads.
+These four skills ship in the box. When you want to build a chain for a workflow that's specific to your team, [here's how to write your own skill](/blog/write-your-own-ai-skill). And if you run a Shopify store, [these four skills](/blog/shopify-support-ai-skills) handle the highest-volume tickets before they ever become forty-message threads.

--- a/apps/homepage/content/blog/crm-ai-skills-pre-call.mdx
+++ b/apps/homepage/content/blog/crm-ai-skills-pre-call.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Three AI Skills That Do Your Pre-Call Homework"
-description: "Support isn't the only inbox that runs on repetitive prep. Three AI skills that research the account, brief the deal, and coach the call — off your CRM, not a blank page."
+description: "Support isn't the only inbox that runs on repetitive prep. Three AI skills that research the account, brief the deal, and coach the call, off your CRM, not a blank page."
 date: "2026-07-10"
 slug: "crm-ai-skills-pre-call"
 image: "/blog/crm-ai-skills-pre-call.jpg"
@@ -16,11 +16,11 @@ published: true
 
 ## The reps who close are the ones who prepped
 
-The salespeople who consistently close aren't smarter than the ones who don't. They're prepared. They walk into the call knowing what the company does, where the deal actually stands, and what the next step should be — and they walk out knowing what they'd do differently next time.
+The salespeople who consistently close aren't smarter than the ones who don't. They're prepared. They walk into the call knowing what the company does, where the deal actually stands, and what the next step should be, and they walk out knowing what they'd do differently next time.
 
 That preparation is real work, and it's the first thing that gets skipped when the calendar fills up. Researching the account takes twenty minutes nobody has. Reconstructing the deal state means clicking through six CRM tabs. Reviewing your own call afterward means listening back to an hour of yourself, which nobody does. So the prep quietly doesn't happen, and reps show up cold.
 
-Most of what we write about lives in the support inbox, but Auxx is a CRM as much as it's a helpdesk — [the two aren't separate products](/blog/what-is-support-crm). The same skill machinery that answers a WISMO ticket also does sales prep, because it's the same idea: a reusable prompt wired to your live records. Here are three skills that turn CRM data you already have into preparation you usually skip — one for before the call, one for during prep, one for after.
+Most of what we write about lives in the support inbox, but Auxx is a CRM as much as it's a helpdesk: [the two aren't separate products](/blog/what-is-support-crm). The same skill machinery that answers a WISMO ticket also does sales prep, because it's the same idea: a reusable prompt wired to your live records. Here are three skills that turn CRM data you already have into preparation you usually skip: one for before the call, one for during prep, one for after.
 
 ## 1. Before the call: Account Research
 
@@ -30,13 +30,13 @@ Walking into a call cold burns the first ten minutes on context you could have h
 Context
 You are researching a company using public web sources. Start with
 search_knowledge for any internal notes the org has already captured on the
-account, then fall back to public sources — the company's official site,
+account, then fall back to public sources: the company's official site,
 reputable business sites, recent news.
 
 Task
 Produce a research brief: a one-to-two-sentence snapshot of what the company does,
 firmographics (industry, HQ, size, funding status), GTM motion (PLG, sales-led,
-or enterprise), recent news (max 4-5 bullets from the last 90 days — launches,
+or enterprise), recent news (max 4-5 bullets from the last 90 days: launches,
 funding, acquisitions, leadership changes), key figureheads, and a line on their
 competitive landscape.
 
@@ -46,11 +46,11 @@ prioritize the most recent. If the company name is ambiguous, list the top 3
 likely matches.
 ```
 
-Notice it checks `search_knowledge` first — your team's existing notes on the account before it reaches for the open web, so you're not re-researching something a colleague already learned.
+Notice it checks `search_knowledge` first: your team's existing notes on the account before it reaches for the open web, so you're not re-researching something a colleague already learned.
 
 > **Why it matters.** The "recent news in the last 90 days" section is the part that earns the call. Mentioning a funding round or a product launch from last week is the difference between a rep who did their homework and one who's clearly reading off a template.
 
-> **Pro-tip.** Run it the morning of the call, not the week before. Freshness is the whole value — news from ten days ago is stale by the time you dial.
+> **Pro-tip.** Run it the morning of the call, not the week before. Freshness is the whole value; news from ten days ago is stale by the time you dial.
 
 ## 2. During prep: Deal Brief
 
@@ -65,7 +65,7 @@ any gaps.
 
 Task
 Create a deal report: a company overview (what they do plus relevant
-firmographics), and a deal summary — current stage, value, expected close date,
+firmographics), and a deal summary: current stage, value, expected close date,
 blockers (feature gaps, stakeholder alignment, security or legal, pricing,
 competition), and next steps.
 
@@ -76,7 +76,7 @@ conflicting signals, prioritize the most recent information.
 
 > **Why it matters.** Deal state is normally spread across a dozen fields and a scroll of notes. Seeing stage, value, close date, and blockers in one place means you prep for the actual objection instead of getting surprised by it on the call.
 
-> **Pro-tip.** The brief is only as good as your field hygiene — it reads what's in the CRM. If Deal Brief keeps saying "Unknown" for the close date, that's not the skill failing, that's a nudge to keep the record current.
+> **Pro-tip.** The brief is only as good as your field hygiene; it reads what's in the CRM. If Deal Brief keeps saying "Unknown" for the close date, that's not the skill failing, that's a nudge to keep the record current.
 
 ## 3. After the call: Sales Coach
 
@@ -92,7 +92,7 @@ Task
 Create a post-call coaching summary: a call overview (what it was about, the
 objective, the outcome), what the AE did well (discovery, positioning, objection
 handling, next steps, rapport), and 3-5 things to improve, prioritized by impact
-on the deal — for each, what happened, why it matters, and what to do differently.
+on the deal: for each, what happened, why it matters, and what to do differently.
 
 Constraints
 Be concise and actionable. If information is missing, write "Unknown." On
@@ -101,16 +101,16 @@ conflicting signals, prioritize the most recent information.
 
 > **Why it matters.** Call coaching almost never happens at small teams because listening back doesn't scale. This makes it a two-minute habit, and the "prioritized by deal impact" ordering means you fix the thing that actually costs you deals first.
 
-> **Pro-tip.** It only claims what the transcript supports and flags the gaps. If it can't assess your discovery because there's no transcript, treat that as the reminder to record the next one — the coaching compounds once you do.
+> **Pro-tip.** It only claims what the transcript supports and flags the gaps. If it can't assess your discovery because there's no transcript, treat that as the reminder to record the next one; the coaching compounds once you do.
 
 ## What these skills don't do
 
-They don't close the deal, and they don't replace judgment. Account Research gives you a briefing, not a strategy. Deal Brief surfaces the blockers, it doesn't clear them. Sales Coach tells you what to work on, it can't run the next call for you. Each one removes the tedious prep so the rep can spend their attention on the part only a human does — the actual conversation.
+They don't close the deal, and they don't replace judgment. Account Research gives you a briefing, not a strategy. Deal Brief surfaces the blockers, it doesn't clear them. Sales Coach tells you what to work on, it can't run the next call for you. Each one removes the tedious prep so the rep can spend their attention on the part only a human does: the actual conversation.
 
 And they depend on real data. Sales Coach needs a transcript to exist. Deal Brief needs a CRM someone actually updates. The skills make the prep effortless; they don't make the underlying data appear.
 
-## The bottom line
+## Prep beats winging it
 
-Research before, brief during, coach after — three slash commands that turn CRM data you already have into the preparation that separates the reps who close from the reps who wing it.
+Research before, brief during, coach after: three slash commands that turn CRM data you already have into the preparation that separates the reps who close from the reps who wing it.
 
 The same pattern that runs your support inbox runs your sales motion, because it's one capability pointed at different records. When you're ready to build skills for your own workflow, [here's how to write one](/blog/write-your-own-ai-skill). And if you're weighing Auxx as a CRM, start with [what a support CRM actually is](/blog/what-is-support-crm).

--- a/apps/homepage/content/blog/evaluating-ai-support-inbox.mdx
+++ b/apps/homepage/content/blog/evaluating-ai-support-inbox.mdx
@@ -18,9 +18,9 @@ published: true
 
 The support tooling market looks like the CRM market did eighteen months ago. Every product says "AI." Every demo looks magical. Every landing page promises to deflect tickets, draft replies, and give your reps their afternoons back. And it's nearly impossible to tell what's real.
 
-For a founder, this isn't a tooling decision you make once and forget. You build workflows on top of the tool. You train a team on it. You wire it into your Shopify store, your knowledge base, your macros. If the AI underneath is shallower than the demo suggested, you don't find out for three months — and by then you've built a house on it.
+For a founder, this isn't a tooling decision you make once and forget. You build workflows on top of the tool. You train a team on it. You wire it into your Shopify store, your knowledge base, your macros. If the AI underneath is shallower than the demo suggested, you don't find out for three months, and by then you've built a house on it.
 
-So this is a guide to the one thing that actually matters when you evaluate an AI helpdesk: **can the AI see your data, or is it guessing?** Everything else is a detail.
+So this is a guide to the one thing that actually matters when you evaluate an AI helpdesk: can the AI see your data, or is it guessing? Everything else is a detail.
 
 ## The three generations of "support AI"
 
@@ -28,7 +28,7 @@ The word "AI" on a helpdesk landing page could mean any of three things. They ar
 
 ### Generation 1: Rules and macros
 
-Canned replies. Keyword routing. If the subject contains "refund," apply macro #4. This is the autoresponder era, and it predates the current AI wave by a decade. It's not AI in any meaningful sense — it's a lookup table.
+Canned replies. Keyword routing. If the subject contains "refund," apply macro #4. This is the autoresponder era, and it predates the current AI wave by a decade. It's not AI in any meaningful sense; it's a lookup table.
 
 It works right up until a ticket is slightly off-script, which is most tickets. The customer says "I want my money back" instead of "refund," or asks two questions in one email, and the rule misses. Useful as scaffolding. Not intelligence.
 
@@ -36,7 +36,7 @@ It works right up until a ticket is slightly off-script, which is most tickets. 
 
 This is where most of the market lives today, and it's genuinely useful. A real language model reads the message in front of it and suggests a reply, or summarizes a thread, or drafts a response you can edit.
 
-But notice the boundary: it reasons over **the text on the screen**. It doesn't know the order shipped yesterday. It doesn't know your refund policy. It doesn't know this customer emailed twice last month about the same problem. Ask it "when will this arrive?" and it writes a fluent, confident paragraph with `[tracking number]` where the tracking number should be — because it never had one.
+But notice the boundary. It reasons over the text on the screen. It doesn't know the order shipped yesterday. It doesn't know your refund policy. It doesn't know this customer emailed twice last month about the same problem. Ask it "when will this arrive?" and it writes a fluent, confident paragraph with `[tracking number]` where the tracking number should be, because it never had one.
 
 Generation 2 is a very good writer with no access to the facts. In a demo, that's invisible. In production, your reps become the model's research department, pasting in context by hand.
 
@@ -44,7 +44,7 @@ Generation 2 is a very good writer with no access to the facts. In a demo, that'
 
 The third generation connects the prompt to your systems. Before the model writes anything, it pulls the live ticket thread, the real order and its fulfillment and tracking, the customer's history, and the relevant knowledge base article. Then it answers over reality instead of over vibes.
 
-In Auxx we call these **skills** — reusable, installable prompts that a rep runs with a slash command, each one wired to the tools and records it needs. A skill isn't a block of clever text. It's a block of clever text *plus* the plumbing to go get the facts first. That plumbing is the entire difference.
+In Auxx we call these **skills**: reusable, installable prompts that a rep runs with a slash command, each one wired to the tools and records it needs. A skill isn't a block of clever text. It's a block of clever text plus the plumbing to go get the facts first. That plumbing is the entire difference.
 
 The trap in the market is that generation-2 tools demo like generation-3 tools. The only way to tell them apart is to test the plumbing directly.
 
@@ -68,18 +68,18 @@ Ask it to answer a refund question the way your store handles refunds.
 *Failure mode:* it invents a reasonable-sounding policy that isn't yours. This is the dangerous one, because it's wrong in a way that looks right.
 
 **4. Can it act, or only talk?**
-*What to look for:* it can draft the reply, assess whether to escalate, tag, and route — not just describe what should happen.
+*What to look for:* it can draft the reply, assess whether to escalate, tag, and route, not just describe what should happen.
 *Failure mode:* it produces advice about your ticket instead of doing anything to your ticket.
 
 **5. Can your team build their own without engineering?**
 *What to look for:* a senior rep can turn their best habit into a reusable skill the whole team runs, in an afternoon, with no code.
-*Failure mode:* "let's set up a call to scope a custom workflow" — which means billable services and a roadmap you don't control.
+*Failure mode:* "let's set up a call to scope a custom workflow," which means billable services and a roadmap you don't control.
 
 ## The question everyone skips: number five
 
 Founders over-index on the built-in features and under-index on question five, and it's backwards. The highest-leverage AI capability in a support tool isn't a clever summarizer that ships in the box. It's whether your best rep can capture what makes them your best rep and hand it to everyone else.
 
-Your senior person has a routine in their head — which order to check, what to never promise, how to phrase the hard "no." Today that lives in one skull and walks out the door when they quit. A tool that lets them encode that routine as a skill, wired to your live data, turns one person's judgment into the whole team's default. That compounds. A slightly better autocomplete does not.
+Your senior person has a routine in their head: which order to check, what to never promise, how to phrase the hard "no." Today that lives in one skull and walks out the door when they quit. A tool that lets them encode that routine as a skill, wired to your live data, turns one person's judgment into the whole team's default. That compounds. A slightly better autocomplete does not.
 
 ## What AI in the inbox still doesn't fix
 
@@ -91,7 +91,7 @@ It doesn't fix undecided ownership. If no human has decided who owns refunds on 
 
 It doesn't fix understaffing. Sorting a hundred tickets faster doesn't make them ninety. If the queue is underwater, better AI gives you a very well-organized flood.
 
-## The bottom line
+## Choose accordingly
 
 When you evaluate an AI helpdesk, ignore the adjectives and test one thing: does it reach your data before it answers, or does it guess and hope you don't notice?
 
@@ -102,6 +102,6 @@ Four questions, screenshot them, take them into the demo:
 3. Did it use my policy and knowledge base?
 4. Can my team build their own?
 
-If a tool fails the first question, everything after it is theater — a very articulate guess dressed up as an answer. Evaluate accordingly.
+If a tool fails the first question, everything after it is theater: a very articulate guess dressed up as an answer. Evaluate accordingly.
 
 If you want to see what a data-wired skill actually looks like in practice, we pulled apart four of them for Shopify teams in [four AI skills every Shopify support team should steal](/blog/shopify-support-ai-skills), and made the case for why a copy-paste prompt library can never get there in [your AI prompts are blind](/blog/your-ai-prompts-are-blind).

--- a/apps/homepage/content/blog/shopify-support-ai-skills.mdx
+++ b/apps/homepage/content/blog/shopify-support-ai-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Four AI Skills Every Shopify Support Team Should Steal"
-description: "The Shopify inbox is 80% the same four questions. Here are four reusable AI skills that handle them — and pull your live order and policy data instead of guessing."
+description: "The Shopify inbox is 80% the same four questions. Here are four reusable AI skills that handle them, and pull your live order and policy data instead of guessing."
 date: "2026-05-27"
 slug: "shopify-support-ai-skills"
 image: "/blog/shopify-support-ai-skills.jpg"
@@ -16,23 +16,23 @@ published: true
 
 ## The Shopify inbox is the same four questions on repeat
 
-Open any Shopify store's support inbox on a normal Tuesday and you'll find the same four tickets, over and over. Where's my order. Can I get a refund. When will it ship / why is it late. And the handful that actually need a human. The volume is relentless and the work is low-skill, which is exactly the combination AI should own.
+Open any Shopify store's support inbox on a normal Tuesday and you'll find the same four tickets, over and over. Where's my order. Can I get a refund. When will it ship or why is it late. And the handful that actually need a human. The volume is relentless and the work is low-skill, which is exactly the combination AI should own.
 
-The catch is that most "AI support" can't answer any of them properly, because answering them requires *facts* — the real order, the real tracking, your actual refund policy — and a copy-paste ChatGPT prompt has access to none of that. (We made that whole argument in [your AI prompts are blind](/blog/your-ai-prompts-are-blind).)
+The catch is that most "AI support" can't answer any of them properly, because answering them requires *facts* (the real order, the real tracking, your actual refund policy) and a copy-paste ChatGPT prompt has access to none of that. We made that whole argument in [your AI prompts are blind](/blog/your-ai-prompts-are-blind).
 
 So this post is about skills instead. In Auxx, a **skill** is a reusable prompt your team runs with a slash command, wired to the tools and records it needs so it pulls live data before it answers. Here are four we ship in the box, what each one does, and how to get the most out of it. Steal them.
 
 Each skill below is written the same way: a bit of context that tells the assistant which live sources to pull, the exact task, and the constraints that keep it honest. You can install any of them as-is and edit them to match your store.
 
-## 1. Order Status Lookup — the WISMO killer
+## 1. Order Status Lookup: the WISMO killer
 
-"Where is my order" (WISMO) is the single biggest ticket category for most stores. It's also the most automatable, because the answer is sitting in the order record — the rep is just a very expensive lookup.
+"Where is my order" (WISMO) is the single biggest ticket category for most stores. It's also the most automatable, because the answer is sitting in the order record; the rep is just a very expensive lookup.
 
 ```
 Context
 You are a support agent looking up a customer's order. Use search_entities to
 find the order by number or by the linked contact, and get_entity to fetch the
-order's fields — order details, fulfillment status, tracking, and payment status.
+order's fields: order details, fulfillment status, tracking, and payment status.
 
 Task
 Produce an order status update: order number and date, items and quantities,
@@ -40,18 +40,18 @@ payment status, fulfillment status, tracking (carrier, number, last known
 status), and estimated delivery date.
 
 Constraints
-Be concise and factual — this is a status report, not a customer-facing message.
+Be concise and factual. This is a status report, not a customer-facing message.
 If information is missing, write "Unknown." If multiple orders exist, summarize
 the most recent and note how many others exist.
 ```
 
-Those `search_entities` and `get_entity` lines are the whole point — in the app they're live-data hooks that go fetch the real order, not instructions the model pretends to follow. It comes back with an actual tracking number, not a placeholder.
+Those `search_entities` and `get_entity` lines are the whole point: in the app they're live-data hooks that go fetch the real order, not instructions the model pretends to follow. It comes back with an actual tracking number, not a placeholder.
 
 > **Why it matters.** WISMO is high volume, emotionally low stakes, and factual. Turning it into a one-command, data-backed status report is the highest-ROI skill you can install. Reps stop tab-hopping between the helpdesk and Shopify admin.
 
-> **Pro-tip.** Pair it with Draft Reply. Run Order Status Lookup to get the facts, then Draft Reply to turn those facts into a sendable message — two slash commands from question to answer. (More on chaining skills in [turning a 40-message thread into a 30-second brief](/blog/ai-skills-long-support-threads).)
+> **Pro-tip.** Pair it with Draft Reply. Run Order Status Lookup to get the facts, then Draft Reply to turn those facts into a sendable message: two slash commands from question to answer. (More on chaining skills in [turning a 40-message thread into a 30-second brief](/blog/ai-skills-long-support-threads).)
 
-## 2. Refund Policy Response — consistency you can trust
+## 2. Refund Policy Response: consistency you can trust
 
 Refund replies are where reps improvise, and improvisation is where policy inconsistency and chargeback risk are born. One rep offers store credit, another offers a full refund, a third quotes a return window that doesn't exist. Multiply that across a team and you've trained your customers to shop for the most generous agent.
 
@@ -63,23 +63,23 @@ the refund or return policy.
 
 Task
 Draft a customer-facing response: whether the customer qualifies based on the
-policy and order details, the specific policy criteria that apply, and — if
-eligible — the process, timeline, and method. If not eligible, a clear reason
+policy and order details, the specific policy criteria that apply, and if
+eligible, the process, timeline, and method. If not eligible, a clear reason
 plus alternatives (store credit, exchange, partial refund).
 
 Constraints
-Be empathetic but direct — don't over-apologize. Cite the specific policy reason,
+Be empathetic but direct; don't over-apologize. Cite the specific policy reason,
 not just "per our policy." If no policy is available, say so and ask the customer
 for time to review.
 ```
 
 The `search_knowledge` hook is what makes this trustworthy: it reads *your* refund policy out of your knowledge base and grounds the answer in it, rather than inventing a plausible one.
 
-> **Why it matters.** It makes every rep answer refunds like your most consistent one. Same policy, same criteria, cited every time — which is exactly what keeps you out of chargeback disputes.
+> **Why it matters.** It makes every rep answer refunds like your most consistent one. Same policy, same criteria, cited every time. That's exactly what keeps you out of chargeback disputes.
 
 > **Pro-tip.** The skill is only as consistent as the policy it can read. Keep your refund and return policy in the knowledge base and keep it current. A vague policy produces vague answers; that's not the model's fault.
 
-## 3. Shipping Inquiry — lead with the status
+## 3. Shipping Inquiry: lead with the status
 
 "Did it ship?" "Why is it late?" "Can I change the address?" Shipping questions are time-sensitive and often already a little tense, because the customer is worried. A fast, accurate, data-backed answer is what stops a worried customer from becoming an angry one.
 
@@ -91,7 +91,7 @@ tracking data.
 
 Task
 Draft a customer-facing response: current fulfillment and tracking status, carrier
-and tracking number, expected delivery timeline, and — if there's a delay — an
+and tracking number, expected delivery timeline, and if there's a delay, an
 acknowledgment plus a concrete next step (reshipment, refund, investigation).
 
 Constraints
@@ -100,13 +100,13 @@ says otherwise, recommend specific next steps (check with neighbors, wait 24-48
 hours, file a carrier claim).
 ```
 
-> **Why it matters.** Shipping tickets are where a delay quietly turns into a refund request and then a bad review. Getting a precise, sourced answer out fast — including the awkward "it says delivered" case — heads off the escalation before it starts.
+> **Why it matters.** Shipping tickets are where a delay quietly turns into a refund request and then a bad review. Getting a precise, sourced answer out fast, including the awkward "it says delivered" case, heads off the escalation before it starts.
 
 > **Pro-tip.** When the message reads hot, run Sentiment Analysis first. It'll tell you whether to lead with reassurance or just get straight to the facts, and the drafted tone will match the customer's mood instead of steamrolling it.
 
-## 4. Escalation Assessment — a rubric instead of a coin flip
+## 4. Escalation Assessment: a rubric instead of a coin flip
 
-The other three skills clear the repetitive 90%. This one handles the last 10% correctly: deciding what actually needs a senior agent. Juniors get this wrong in both directions — over-escalating (and burning senior time) or under-escalating (and losing the customer). A consistent rubric fixes both.
+The other three skills clear the repetitive 90%. This one handles the last 10% correctly: deciding what actually needs a senior agent. Juniors get this wrong in both directions: over-escalating (and burning senior time) or under-escalating (and losing the customer). A consistent rubric fixes both.
 
 ```
 Context
@@ -118,7 +118,7 @@ Task
 Produce an escalation assessment: a 1-2 sentence summary, the severity signals
 (sentiment, complexity, time since first contact, repeat contacts, revenue
 impact, failed resolution attempts), a recommendation with reasoning, and a
-suggested next step — who should handle it and what they need to know.
+suggested next step (who should handle it and what they need to know).
 
 Constraints
 Be concise and actionable. If information is missing, write "Unknown." On
@@ -127,16 +127,16 @@ conflicting signals, prioritize the most recent information.
 
 > **Why it matters.** It turns escalation from a gut call that varies by rep and by mood into a repeatable judgment backed by the ticket's actual history. Senior time goes to the tickets that genuinely need it.
 
-> **Pro-tip.** On a high-volume day, run this first as a triage gate. Work the "no escalation needed" pile with the other three skills, and hand the flagged ones up with the assessment already attached — the senior agent starts oriented instead of cold.
+> **Pro-tip.** On a high-volume day, run this first as a triage gate. Work the "no escalation needed" pile with the other three skills, and hand the flagged ones up with the assessment already attached, so the senior agent starts oriented instead of cold.
 
 ## What these skills don't do
 
-They don't replace the rep. Every one of them produces a draft or an assessment a human reviews and sends. That's deliberate — the skill does the reading and the fetching, you keep the judgment and the send button.
+They don't replace the rep. Every one of them produces a draft or an assessment a human reviews and sends. That's deliberate: the skill does the reading and the fetching, you keep the judgment and the send button.
 
 And they're only as good as the data behind them. Order Status Lookup needs your store connected so the order records exist. Refund Policy Response needs the policy in your knowledge base. The skills are the easy part; keeping your data clean is the work that makes them sing.
 
-## The bottom line
+## Steal these four
 
-Four skills, a couple minutes to install, and the repetitive 90% of the Shopify inbox becomes two-slash-command work — with answers built on the real order and your real policy, not a confident guess.
+Four skills, a couple minutes to install, and the repetitive 90% of the Shopify inbox becomes two-slash-command work, with answers built on the real order and your real policy, not a guess.
 
-These four ship in the box. The bigger unlock is writing your own for the tickets that are specific to *your* store — which is exactly what we walk through in [how to write an AI skill that pulls its weight](/blog/write-your-own-ai-skill). And if you're still deciding whether AI belongs in your inbox at all, start with [the founder's guide to evaluating AI in your support inbox](/blog/evaluating-ai-support-inbox).
+These four ship in the box. The bigger unlock is writing your own for the tickets that are specific to *your* store, which is exactly what we walk through in [how to write an AI skill that pulls its weight](/blog/write-your-own-ai-skill). And if you're still deciding whether AI belongs in your inbox at all, start with [the founder's guide to evaluating AI in your support inbox](/blog/evaluating-ai-support-inbox).

--- a/apps/homepage/content/blog/write-your-own-ai-skill.mdx
+++ b/apps/homepage/content/blog/write-your-own-ai-skill.mdx
@@ -18,7 +18,7 @@ published: true
 
 The fastest rep on your team has a routine. For a shipping complaint they check the fulfillment record first, then the carrier status, then they look for whether this customer has complained before, and they never promise a delivery date they can't see. It's a good routine. It's also invisible, undocumented, and it walks out the door the day that person quits.
 
-A skill is how you get that routine out of one skull and into everyone's hands. Our [built-in skills](/blog/shopify-support-ai-skills) cover the common cases, but the real payoff comes from writing your own — the ones specific to your store, your policy, your product. This is the pattern we use to write every skill we ship, so you can write yours the same way.
+A skill is how you get that routine out of one skull and into everyone's hands. Our [built-in skills](/blog/shopify-support-ai-skills) cover the common cases, but the real payoff comes from writing your own: the ones specific to your store, your policy, your product. This is the pattern we use to write every skill we ship, so you can write yours the same way.
 
 There are two things that separate a skill that pulls its weight from a prompt that just sounds good: a **three-part structure**, and **wiring to your live data**. Here's both.
 
@@ -26,11 +26,11 @@ There are two things that separate a skill that pulls its weight from a prompt t
 
 Every skill we write has the same shape: Context, Task, Constraints. Each part does a specific job, and skipping any of them is where home-grown prompts go wrong.
 
-**Context — tell it what to fetch before it thinks.** This is the part a copy-paste prompt can't have and the reason most home-grown prompts are [blind](/blog/your-ai-prompts-are-blind). Name the live sources the answer depends on: the thread, the internal notes, the order, the knowledge base. If the answer needs a fact, the Context has to go get it.
+**Context: tell it what to fetch before it thinks.** This is the part a copy-paste prompt can't have and the reason most home-grown prompts are [blind](/blog/your-ai-prompts-are-blind). Name the live sources the answer depends on: the thread, the internal notes, the order, the knowledge base. If the answer needs a fact, the Context has to go get it.
 
-**Task — specify the exact shape of the output.** Not "help with this ticket" but "give me the issue in one sentence, then a timeline of at most five bullets, then the status from this specific list." Vague task, vague answer. A fixed shape also means every run is comparable — reps get the same structure every time instead of a paragraph one day and a list the next.
+**Task: specify the exact shape of the output.** Not "help with this ticket" but "give me the issue in one sentence, then a timeline of at most five bullets, then the status from this specific list." Vague task, vague answer. A fixed shape also means every run is comparable; reps get the same structure every time instead of a paragraph one day and a list the next.
 
-**Constraints — the guardrails that make it trustworthy.** This is where you write things like "if information is missing, write Unknown," "prefer the most recent information when signals conflict," and "if there's no ticket in context, ask which one first." These lines are what stop the model from confidently making something up. A prompt with no constraints is a prompt that will guess and sound sure about it.
+**Constraints: the guardrails that make it trustworthy.** This is where you write things like "if information is missing, write Unknown," "prefer the most recent information when signals conflict," and "if there's no ticket in context, ask which one first." These lines are what stop the model from confidently making something up. A prompt with no constraints is a prompt that will guess and sound sure about it.
 
 Here's the built-in Order Status Lookup skill with each part labeled, so you can see the pattern in something real:
 
@@ -38,7 +38,7 @@ Here's the built-in Order Status Lookup skill with each part labeled, so you can
 --- Context (what to fetch) ---
 You are a support agent looking up a customer's order. Use search_entities to
 find the order by number or by the linked contact, and get_entity to fetch the
-order's fields — details, fulfillment status, tracking, and payment status.
+order's fields: details, fulfillment status, tracking, and payment status.
 
 --- Task (the exact output) ---
 Produce an order status update: order number and date, items and quantities,
@@ -46,26 +46,26 @@ payment status, fulfillment status, tracking (carrier, number, last known
 status), and estimated delivery date.
 
 --- Constraints (the guardrails) ---
-Be concise and factual — this is a status report, not a customer-facing message.
+Be concise and factual. This is a status report, not a customer-facing message.
 If information is missing, write "Unknown." If multiple orders exist, summarize
 the most recent and note how many others exist.
 ```
 
-Write your own the same way. Start with the Task — what do you actually want back? Then work backwards to the Context — what does the model need to fetch to produce that? Then add Constraints for every way it could go wrong.
+Write your own the same way. Start with the Task: what do you actually want back? Then work backwards to the Context: what does the model need to fetch to produce that? Then add Constraints for every way it could go wrong.
 
 ## Wiring it to your data: tools and entities
 
-The Context block is only powerful because of what it can reach. In the skill editor, you don't just write the *words* "fetch the order" — you drop in an `@`-mention chip that actually fetches it. There are two kinds.
+The Context block is only powerful because of what it can reach. In the skill editor, you don't just write the *words* "fetch the order"; you drop in an `@`-mention chip that actually fetches it. There are two kinds.
 
 **Tool chips** are actions the assistant runs to go get data. The ones you'll reach for most:
 
-- `get_thread_detail` — the full ticket conversation
-- `list_notes` — internal notes on the record
-- `get_entity` — the fields of a specific record (an order, a deal)
-- `get_entity_history` — the timeline of changes
-- `search_entities` — find a record by number, name, or link
-- `search_knowledge` — your knowledge base (policies, product docs)
-- `get_transcript` — a call or meeting transcript
+- `get_thread_detail`: the full ticket conversation
+- `list_notes`: internal notes on the record
+- `get_entity`: the fields of a specific record (an order, a deal)
+- `get_entity_history`: the timeline of changes
+- `search_entities`: find a record by number, name, or link
+- `search_knowledge`: your knowledge base (policies, product docs)
+- `get_transcript`: a call or meeting transcript
 
 **Entity chips** are the record types a skill is about: `ticket`, `contact`, `order`, `deal`, `company`, `meeting`. They tell the skill what kind of thing it's working on and let it resolve the one linked to the ticket in front of the rep.
 
@@ -82,27 +82,27 @@ Use @search_entities to find the customer's @order, and @get_entity to pull its
 fulfillment and tracking. Then draft a status update for the customer.
 ```
 
-The words barely changed. What changed is that at run time the second version goes and fetches the real order — the real tracking number, the real fulfillment status — instead of asking the rep to paste it in. Two chips, and the skill went from blind to seeing.
+The words barely changed. What changed is that at run time the second version goes and fetches the real order (the real tracking number, the real fulfillment status) instead of asking the rep to paste it in. Two chips, and the skill went from blind to seeing.
 
 A note on entities: `order` and `deal` only exist once you've installed the matching setup for your store or sales motion, so those chips light up after your data's connected. `ticket`, `contact`, and the rest are there from the start.
 
 ## From your head to the whole team
 
-Once a skill is written, the lifecycle is short. You save it, and it's available to run from the composer with a slash command — the rep types `/`, picks the skill, and it runs against whatever ticket or record they're looking at. Skills you build are shared across your team, so one person's routine becomes everyone's default.
+Once a skill is written, the lifecycle is short. You save it, and it's available to run from the composer with a slash command: the rep types `/`, picks the skill, and it runs against whatever ticket or record they're looking at. Skills you build are shared across your team, so one person's routine becomes everyone's default.
 
-The lowest-effort way to start isn't a blank page. Install one of the built-in skills, run it a few times, and then edit it — tighten the Task to match how your store actually talks, add a Constraint for the mistake your team keeps making, point the Context at your knowledge base. You'll have a skill that's yours in about ten minutes, and you'll have learned the pattern by editing something that already works.
+The lowest-effort way to start isn't a blank page. Install one of the built-in skills, run it a few times, and then edit it: tighten the Task to match how your store actually talks, add a Constraint for the mistake your team keeps making, point the Context at your knowledge base. You'll have a skill that's yours in about ten minutes, and you'll have learned the pattern by editing something that already works.
 
 ## A checklist for a skill worth keeping
 
 Before you save a skill, run it against these four questions:
 
 1. Does the **Context** fetch every source the answer depends on? If it needs a fact it can't reach, it'll guess.
-2. Is the **Task** a fixed, labeled shape — not just "help with this"?
+2. Is the **Task** a fixed, labeled shape, not just "help with this"?
 3. Do the **Constraints** forbid guessing and handle the empty case (no ticket, no order, no policy)?
 4. Would your newest hire produce your best rep's answer by running it? If not, the routine in your best rep's head isn't fully written down yet.
 
-## The bottom line
+## Build your own
 
-A skill that pulls its weight is one thing: your best rep's judgment, wired to your live data, that anyone on the team can run. The three-part structure makes it reliable. The tool and entity chips make it see. And because it's reusable, it turns a routine that used to live in one person into an asset the whole team owns — one that gets better as your data does.
+A skill that pulls its weight is one thing: your best rep's judgment, wired to your live data, that anyone on the team can run. The three-part structure makes it reliable. The tool and entity chips make it see. And because it's reusable, it turns a routine that used to live in one person into an asset the whole team owns, one that gets better as your data does.
 
 The built-ins get you started. Writing your own is where the compounding is. If you want to see the pattern in finished skills, we broke down [four for Shopify support](/blog/shopify-support-ai-skills), [a chain of four for long threads](/blog/ai-skills-long-support-threads), and [three for sales prep](/blog/crm-ai-skills-pre-call).

--- a/apps/homepage/content/blog/your-ai-prompts-are-blind.mdx
+++ b/apps/homepage/content/blog/your-ai-prompts-are-blind.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Your AI Prompts Are Blind"
-description: "Everyone has a doc of 'best ChatGPT prompts for support.' They mostly don't work — not because the prompts are bad, but because the model can't see anything. Here's the fix."
+description: "Everyone has a doc of 'best ChatGPT prompts for support.' They mostly don't work, not because the prompts are bad, but because the model can't see anything. Here's the fix."
 date: "2026-06-10"
 slug: "your-ai-prompts-are-blind"
 image: "/blog/your-ai-prompts-are-blind.jpg"
@@ -26,7 +26,7 @@ Here's the uncomfortable diagnosis: the prompts aren't the problem. They're fine
 
 Think about what a good support reply actually contains. A sentence or two of acknowledgment, and then a pile of specifics: your order shipped Tuesday, here's the tracking, it's held at customs, you qualify for a refund under clause two, here's the timeline. The phrasing is maybe ten percent of the value. The other ninety percent is *facts about this specific customer and this specific order*.
 
-A copy-paste prompt has access to exactly zero percent of those facts. It knows how to write. It doesn't know anything. So you become the model's data layer — the human who fetches the order, looks up the policy, checks the tracking, and pastes it all in. You've automated the easy ten percent and kept the tedious ninety for yourself.
+A copy-paste prompt has access to exactly zero percent of those facts. It knows how to write. It doesn't know anything. So you become the model's data layer, the human who fetches the order, looks up the policy, checks the tracking, and pastes it all in. You've automated the easy ten percent and kept the tedious ninety for yourself.
 
 That's the trade nobody mentions when they hand you a prompt library. The prompt was never starving for better wording. It was starving for context.
 
@@ -42,7 +42,7 @@ Summarize this ticket and tell me what to do next.
 
 Fine words. No eyes. It can only summarize whatever text you remember to paste, and it'll guess at everything you forget.
 
-Now here's how we write the same thing in Auxx, where we call it a **skill** — a reusable prompt wired to the data it needs. This is the actual Summarize Ticket skill we ship:
+Now here's how we write the same thing in Auxx, where we call it a **skill**: a reusable prompt wired to the data it needs. This is the actual Summarize Ticket skill we ship:
 
 ```
 Context
@@ -63,30 +63,30 @@ conflicting signals, prioritize the most recent information. If there's no ticke
 in context, ask which ticket to summarize first.
 ```
 
-Read the Context block. `get_thread_detail`, `list_notes`, `get_entity_history` — those aren't decoration. In the app they're live hooks that go and fetch the real thread, the real internal notes, the real edit history before the model writes a word. The task is the same instruction as the blind version. The difference is the model now has eyes.
+Read the Context block. Those `get_thread_detail`, `list_notes`, and `get_entity_history` lines aren't decoration. In the app they're live hooks that go and fetch the real thread, the real internal notes, the real edit history before the model writes a word. The task is the same instruction as the blind version. The difference is the model now has eyes.
 
 ## The three parts that make a prompt see
 
 Every skill we ship has the same three-part shape, and each part is doing a specific job.
 
-**Context** is where the prompt goes and gets the facts. This is the part a copy-paste prompt structurally cannot have, no matter how well it's worded. It names the live sources — the thread, the notes, the order, the knowledge base — and fetches them. It's the ninety percent.
+**Context** is where the prompt goes and gets the facts. This is the part a copy-paste prompt structurally cannot have, no matter how well it's worded. It names the live sources (the thread, the notes, the order, the knowledge base) and fetches them. It's the ninety percent.
 
 **Task** is the exact shape of the output. Not "summarize this" but "give me the issue, then a timeline of at most five bullets, then the status from this specific list." A fixed shape means every run is comparable, and reps stop getting a paragraph one time and a bulleted list the next.
 
-**Constraints** are the guardrails that make it trustworthy. Write "Unknown" instead of guessing. Prefer the most recent information when signals conflict. Ask first if there's no ticket in context. These lines are what kill the confident-hallucination failure mode — the model saying something wrong in a way that looks right. A blind prompt has no constraints because it has nothing to constrain against.
+**Constraints** are the guardrails that make it trustworthy. Write "Unknown" instead of guessing. Prefer the most recent information when signals conflict. Ask first if there's no ticket in context. These lines are what kill the confident-hallucination failure mode: the model saying something wrong in a way that looks right. A blind prompt has no constraints because it has nothing to constrain against.
 
 ## Why this compounds into a moat
 
 Here's the part that matters if you're building a support operation rather than just clearing today's queue.
 
-A wired skill is reusable *and* connected. Your best rep's judgment — which order to check, what to never promise, how to structure the hard reply — gets written down once, as a skill. It pulls the same facts every time. The whole team runs it. And it gets better as your data gets better: cleaner order records, a sharper knowledge base, better notes all flow straight into every answer the skill produces.
+A wired skill is reusable *and* connected. Your best rep's judgment (which order to check, what to never promise, how to structure the hard reply) gets written down once, as a skill. It pulls the same facts every time. The whole team runs it. And it gets better as your data gets better: cleaner order records, a sharper knowledge base, better notes all flow straight into every answer the skill produces.
 
 A prompt in a browser tab can do none of that. It's frozen the moment you paste it, it fetches nothing, and it improves only when someone remembers to hand-edit the doc. One of these is an asset that appreciates. The other is a snippet that rots.
 
-## The bottom line
+## Stop collecting prompts
 
 Stop collecting prompts. Start wiring them.
 
-The measure of an AI support prompt isn't how clever it reads — anyone can write clever, that's the easy ten percent. The measure is how much of your actual data it can reach before it answers. A blind prompt makes you do the ninety percent by hand. A wired skill does it for you.
+The measure of an AI support prompt isn't how clever it reads. Anyone can write clever; that's the easy ten percent. The measure is how much of your actual data it can reach before it answers. A blind prompt makes you do the ninety percent by hand. A wired skill does it for you.
 
 If you want to see wired skills doing real work, we broke down four of them for Shopify teams in [four AI skills every Shopify support team should steal](/blog/shopify-support-ai-skills). And when you're ready to build your own, [here's how to write one that pulls its weight](/blog/write-your-own-ai-skill).


### PR DESCRIPTION
## What

Editorial pass on the 6-post AI skills series (already merged in #1117), per feedback: no em dashes, no "The bottom line" sections.

### Changes
- **Removed every em dash** across all 6 posts, reworded for flow with context-appropriate punctuation (colons, semicolons, commas, parentheses, or split sentences). Applies to body prose, skill code blocks, callouts, and the frontmatter `description` fields.
- **Dropped the generic "The bottom line" label** on every post. The closing paragraphs are kept; the heading is renamed to something content-specific so there's no labeled summary:
  - `evaluating-ai-support-inbox` → Choose accordingly
  - `your-ai-prompts-are-blind` → Stop collecting prompts
  - `shopify-support-ai-skills` → Steal these four
  - `ai-skills-long-support-threads` → Four commands, one oriented reply
  - `crm-ai-skills-pre-call` → Prep beats winging it
  - `write-your-own-ai-skill` → Build your own

Verified: 0 em dashes and 0 "bottom line" headings remain in the 6 posts. Scope is limited to those 6 `.mdx` files; no other changes.