### PR TITLE
feat(kb): interactive AI-memory write door — "remember this" in kopilot chat

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -35,7 +35,10 @@ import {
   LAST_PAGE_KEY,
   resolveContinuationSurface,
 } from '@auxx/lib/ai/kopilot'
-import { createToolDepsFactory } from '@auxx/lib/ai/kopilot/capabilities'
+import {
+  createLearnedKbCapabilities,
+  createToolDepsFactory,
+} from '@auxx/lib/ai/kopilot/capabilities'
 import { createMcpCapabilities } from '@auxx/lib/ai/mcp'
 import { getCachedAgentById } from '@auxx/lib/cache'
 import { ForbiddenError } from '@auxx/lib/errors'
@@ -581,6 +584,11 @@ async function runInProcessPath(params: {
   registry.register(createSuggestRepliesGlobalCapability(getToolDeps))
   if (page === 'agents.builder') {
     registry.register(await createAgentsBuilderCapabilities(getToolDeps, organizationId))
+  }
+  // Explicit "remember this" door into the AI memory (learned KB). The tool is
+  // approval-gated in-chat; the flag keeps the whole AI-memory feature per-org.
+  if (await new FeaturePermissionService().hasAccess(organizationId, FeatureKey.learnedMemory)) {
+    registry.register(createLearnedKbCapabilities(getToolDeps))
   }
   // App-backed AI tools (plans/kopilot/apps/README.md §7).
   // Async — bridge pulls the org-cache `installedApps` row and runs

--- a/packages/lib/src/agents/__tests__/builtin-installed-row.test.ts
+++ b/packages/lib/src/agents/__tests__/builtin-installed-row.test.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/agents/__tests__/builtin-installed-row.test.ts
 
 import { describe, expect, it } from 'vitest'
+import { BUILTIN_TOOLSETS } from '../builtin-app'
 import { getBuiltinAuxxInstalledRow } from '../builtin-installed-row'
 
 describe('getBuiltinAuxxInstalledRow — enriched tool projection', () => {
@@ -31,6 +32,13 @@ describe('getBuiltinAuxxInstalledRow — enriched tool projection', () => {
       // The serializer strips the meta keys the LLM/editor never needs.
       expect(tool.outputsJsonSchema.$schema).toBeUndefined()
       expect(tool.outputsJsonSchema.id).toBeUndefined()
+    }
+  })
+
+  it('every projected tool references a declared toolset (filterToolsByToolsets drops unknown slugs)', () => {
+    const knownSlugs = new Set(BUILTIN_TOOLSETS.map((ts) => ts.slug))
+    for (const tool of tools) {
+      expect(knownSlugs, `toolset for ${tool.registeredName}`).toContain(tool.toolsetSlug)
     }
   })
 

--- a/packages/lib/src/ai/kopilot/__tests__/tool-slug-coverage.test.ts
+++ b/packages/lib/src/ai/kopilot/__tests__/tool-slug-coverage.test.ts
@@ -38,6 +38,17 @@ const ALWAYS_ON_TOOLS = new Set<string>([
   // Global chip-rendering tool (page `__global__`), reusable across every
   // Kopilot surface — not gated by an org toolset.
   'suggest_replies',
+  // Learned-KB (AI memory) write door — registered only by the flag-gated
+  // interactive registry and the headless extraction runner; approval-gated,
+  // so not org-toolset-gated.
+  'upsert_learned_article',
+  // Records-page view tools — mounted by page context (record-view capability),
+  // not gated by an org toolset.
+  'create_table_view',
+  'list_table_views',
+  'preview_table_view',
+  'set_default_table_view',
+  'update_table_view',
 ])
 
 const CAPABILITIES_DIR = join(__dirname, '..', 'capabilities')

--- a/packages/lib/src/ai/kopilot/capabilities/learned/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/learned/index.ts
@@ -7,17 +7,19 @@ const GLOBAL_PAGE = '__global__'
 
 /**
  * Learned-KB (AI memory) write capability. Registered by runs that are allowed
- * to propose memory writes — the learned-extraction headless runner and,
- * later, the explicit "remember this" flow. Not part of the default
- * interactive registry: recall happens via the Knowledge Catalog + read tools;
- * this capability only adds the approval-gated write door.
+ * to propose memory writes: the learned-extraction headless runner (which
+ * supplies its own system prompt) and the interactive kopilot registry when
+ * the `learnedMemory` feature flag is on — the explicit "remember this" door,
+ * where `requiresApproval` renders an in-chat approval card and approving
+ * executes + publishes. Recall stays read-side (Knowledge Catalog + read
+ * tools); this capability only adds the approval-gated write door.
  */
 export function createLearnedKbCapabilities(getDeps: GetToolDeps): PageCapability {
   return {
     page: GLOBAL_PAGE,
     tools: [createUpsertLearnedArticleTool(getDeps)],
     systemPromptAddition:
-      "You can save durable organizational knowledge to the learned knowledge base (AI memory) with upsert_learned_article. Only save reusable knowledge — policies, product facts, how humans chose to answer, stable customer facts — never one-off details. Before creating an article, check the Knowledge Catalog for an existing article on the topic and update it instead (read it with get_article first and preserve its content, especially human edits). Articles about a specific contact or company belong in the 'contacts'/'companies' categories with their recordId; topical knowledge goes in 'policies'.",
+      "You can save durable organizational knowledge to the learned knowledge base (AI memory) with upsert_learned_article. In conversation, reach for it when the user explicitly asks you to remember something (\"remember this\", \"save this for next time\") or when they state a durable correction/policy worth keeping — the write is approval-gated, so proposing is safe. Only save reusable knowledge — policies, product facts, how humans chose to answer, stable customer facts — never one-off details. Before creating an article, check the Knowledge Catalog for an existing article on the topic and update it instead (read it with get_article first and preserve its content, especially human edits). Articles about a specific contact or company belong in the 'contacts'/'companies' categories with their recordId; topical knowledge goes in 'policies'.",
     capabilities: ['Save durable knowledge to the AI memory (learned knowledge base)'],
   }
 }

--- a/packages/lib/src/ai/kopilot/capabilities/learned/tools/upsert-learned-article.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/learned/tools/upsert-learned-article.ts
@@ -47,7 +47,10 @@ export function createUpsertLearnedArticleTool(getDeps: GetToolDeps): AgentToolD
   return {
     name: 'upsert_learned_article',
     displayName: 'Save learned article',
-    toolsetSlug: 'auxx:learned:write',
+    // Always-on (no toolsetSlug): availability is controlled by where the
+    // capability is registered (learnedMemory-flagged interactive registry +
+    // the headless extraction runner), not by per-org/agent toolset config.
+    // Safe because every write is approval-gated.
     requiresApproval: true,
     outputSchema: UpsertLearnedArticleOutput,
     exampleOutput: {


### PR DESCRIPTION
## Summary

Phase 4 of the learned-KB (AI memory) plan: an explicit "remember this" door in interactive kopilot chat. Instead of a separate `remember_this` tool that re-runs the headless extractor, the chat registry gets the existing approval-gated `upsert_learned_article` tool directly — the model already has the conversation and the user's exact phrasing, and approve-in-chat = execute + publish (the same trust gate as Today, but immediate).

- `upsert_learned_article` is an **always-on tool** (no `toolsetSlug`), like the plan tools and `suggest_replies`: availability is controlled by where the capability is registered, never by per-org/agent toolset config. Safe because every write is approval-gated. A toolset-based cut was tried first and dropped: orgs with a customized master toolset list never auto-pick up new toolsets, which left the model narrating a tool it couldn't call.
- The kopilot stream route registers `createLearnedKbCapabilities` behind the `learnedMemory` feature flag. The customer chat-widget runtime builds its own registry and is untouched — no write door leaks to visitors.
- The capability's `systemPromptAddition` is rewritten for the interactive framing: explicit "remember this" asks and durable corrections only, catalog-check-then-update before creating.
- New guard test: every catalog-projected built-in tool's `toolsetSlug` must exist in `BUILTIN_TOOLSETS` (unknown slugs are silently dropped by `filterToolsByToolsets`). Also fixes `tool-slug-coverage.test.ts`, which was red on main (`upsert_learned_article` plus 5 record-view table-view tools missing from its lists).

## Verification

Live-verified end-to-end in DemoOrg1 (`learnedMemory` enabled), both paths:

- **Create:** "please remember this: approved dealers get a 20% dealer discount…" → model checks the AI Memory catalog → in-chat approval card with full args → Approve → article "Dealer discount and invoicing policy" PUBLISHED under Policies in the learned KB → dataset document INDEXED ~2s after publish.
- **Update:** follow-up "also remember: the discount never applies to shipping" → model finds the article in the catalog, reads it with `get_article`, proposes the upsert with the existing `articleId` → Approve → republished (3 revisions) + re-indexed.

`packages/lib` test suites for agents/kopilot/approvals pass (310 tests). Remaining red files on main (`caller-preamble`, `agent-procedure-step`, `search-knowledge`) are pre-existing and unrelated.

Plan: `plans/memory/learned-kb-plan.md` (Phase 4 implementation notes). Next: Phase 5 UX (article-diff bundle card + an AI Memory browse/correct entry point).