### PR TITLE
feat(kb): learned-memory management UX — entry card, trimmed editor, previews, force extraction

### DIFF
--- a/apps/web/src/components/kb/store/knowledge-base-store.ts
+++ b/apps/web/src/components/kb/store/knowledge-base-store.ts
@@ -86,6 +86,12 @@ export const useKnowledgeBaseStore = create<KnowledgeBaseStoreState>()(
         set((state) => {
           state.knowledgeBases = kbs
           const byId: Record<string, KnowledgeBase> = {}
+          // `kb.list` only returns standard KBs — carry over byId-hydrated
+          // hidden KBs (kind 'learned') so a list refetch doesn't wipe the
+          // active AI Memory KB out from under the editor.
+          for (const [id, kb] of Object.entries(state.knowledgeBasesById)) {
+            if (kb.kind !== 'standard') byId[id] = kb
+          }
           for (const kb of kbs) byId[kb.id] = kb
           state.knowledgeBasesById = byId
           state.hasLoadedOnce = true

--- a/apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
@@ -27,10 +27,12 @@ interface KBEditorFrameProps {
  */
 export function KBEditorFrame({ knowledgeBaseId, children }: KBEditorFrameProps) {
   const { knowledgeBase, isLoading } = useKnowledgeBase(knowledgeBaseId)
-  const [activePanel] = useQueryState(
+  const [panelParam] = useQueryState(
     'panel',
     parseAsStringLiteral(PANEL_VALUES).withDefault('general')
   )
+  // The learned KB ("AI Memory") is always on the article tree.
+  const activePanel = knowledgeBase?.kind === 'learned' ? 'articles' : panelParam
 
   const leftPanels = useMemo(() => {
     if (!knowledgeBase) return []

--- a/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
@@ -10,7 +10,7 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
-import { Book, Cog, Layout } from 'lucide-react'
+import { Book, Cog, Layout, Sparkles } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useEffect, useMemo } from 'react'
 import { LAYOUT_TAB_ENABLED } from '../../constant'
@@ -41,6 +41,12 @@ function getInitials(name?: string): string {
  * Persistent KB editor header — breadcrumb [Knowledge Bases ▸ KB-name dropdown],
  * action [KBPublishCluster + RadioTab General/Layout/Articles]. Sits inside
  * `MainPage` in the editor route segment layout.
+ *
+ * The learned KB ("AI Memory") gets trimmed chrome: no settings tabs (the
+ * panel is forced to the article tree), no publish cluster (it is INTERNAL
+ * and never site-published), and a plain breadcrumb instead of the KB
+ * switcher (the learned KB is excluded from `kb.list`, so the switcher
+ * neither names it nor offers it).
  */
 export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeaderProps) {
   const [panel, setPanel] = useQueryState(
@@ -48,6 +54,7 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
     parseAsStringLiteral(PANEL_VALUES).withDefault('general')
   )
   const { lockSession } = useKBPreviewHint()
+  const isLearned = knowledgeBase.kind === 'learned'
 
   // Once the user has reached the Articles panel they've found the answer the
   // hint was pointing at — never show it again this session.
@@ -63,9 +70,11 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
   return (
     <MainPageHeader
       action={
-        <div className='flex items-center gap-2'>
-          <KBPublishCluster kbId={knowledgeBaseId} />
-        </div>
+        isLearned ? undefined : (
+          <div className='flex items-center gap-2'>
+            <KBPublishCluster kbId={knowledgeBaseId} />
+          </div>
+        )
       }>
       <MainPageBreadcrumb>
         <MainPageBreadcrumbItem
@@ -73,36 +82,46 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
           href='/app/kb'
           className='hidden sm:inline-flex '
         />
-        <MainPageBreadcrumbDropdown
-          label={merged.name ?? 'Knowledge Base'}
-          icon={
-            <Avatar className='size-5 rounded'>
-              <AvatarFallback className='rounded bg-primary/10 text-[10px] text-primary'>
-                {getInitials(merged.name)}
-              </AvatarFallback>
-            </Avatar>
-          }
-          last
-          contentClassName='w-72'>
-          <KBSwitcherDropdownContent />
-        </MainPageBreadcrumbDropdown>
-      </MainPageBreadcrumb>
-      <RadioTab value={panel} onValueChange={(v) => setPanel(v as KBEditorPanel)} size='sm'>
-        <RadioTabItem value='general' tooltip='General'>
-          <Cog />
-          <span className='hidden sm:inline'>General</span>
-        </RadioTabItem>
-        {LAYOUT_TAB_ENABLED && (
-          <RadioTabItem value='layout' tooltip='Layout'>
-            <Layout />
-            <span className='hidden sm:inline'>Layout</span>
-          </RadioTabItem>
+        {isLearned ? (
+          <MainPageBreadcrumbItem
+            title={merged.name ?? 'AI Memory'}
+            icon={<Sparkles className='size-4 text-primary' />}
+            last
+          />
+        ) : (
+          <MainPageBreadcrumbDropdown
+            label={merged.name ?? 'Knowledge Base'}
+            icon={
+              <Avatar className='size-5 rounded'>
+                <AvatarFallback className='rounded bg-primary/10 text-[10px] text-primary'>
+                  {getInitials(merged.name)}
+                </AvatarFallback>
+              </Avatar>
+            }
+            last
+            contentClassName='w-72'>
+            <KBSwitcherDropdownContent />
+          </MainPageBreadcrumbDropdown>
         )}
-        <RadioTabItem value='articles' tooltip='Articles' data-kb-articles-tab=''>
-          <Book />
-          <span className='hidden sm:inline'>Articles</span>
-        </RadioTabItem>
-      </RadioTab>
+      </MainPageBreadcrumb>
+      {!isLearned && (
+        <RadioTab value={panel} onValueChange={(v) => setPanel(v as KBEditorPanel)} size='sm'>
+          <RadioTabItem value='general' tooltip='General'>
+            <Cog />
+            <span className='hidden sm:inline'>General</span>
+          </RadioTabItem>
+          {LAYOUT_TAB_ENABLED && (
+            <RadioTabItem value='layout' tooltip='Layout'>
+              <Layout />
+              <span className='hidden sm:inline'>Layout</span>
+            </RadioTabItem>
+          )}
+          <RadioTabItem value='articles' tooltip='Articles' data-kb-articles-tab=''>
+            <Book />
+            <span className='hidden sm:inline'>Articles</span>
+          </RadioTabItem>
+        </RadioTab>
+      )}
     </MainPageHeader>
   )
 }

--- a/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-page-body.tsx
@@ -33,7 +33,8 @@ export function KBEditorPageBody({ knowledgeBaseId, slug }: KBEditorPageBodyProp
 
   if (!knowledgeBase) return null
 
-  if (activePanel !== 'articles') {
+  // The learned KB ("AI Memory") has no site preview — always the editor.
+  if (activePanel !== 'articles' && knowledgeBase.kind !== 'learned') {
     return <KBPreview knowledgeBase={knowledgeBase} activeSlugPath={slug} />
   }
 

--- a/apps/web/src/components/kb/ui/editor/kb-tab-panel.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-tab-panel.tsx
@@ -4,7 +4,7 @@
 import { DrawerHeader } from '@auxx/ui/components/drawer'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { cn } from '@auxx/ui/lib/utils'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Sparkles } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { LAYOUT_TAB_ENABLED } from '../../constant'
 import type { KnowledgeBase } from '../../store/knowledge-base-store'
@@ -34,10 +34,14 @@ interface KBTabPanelProps {
  * persistence per section, so this component owns no save state of its own.
  */
 export function KBTabPanel({ knowledgeBaseId, knowledgeBase }: KBTabPanelProps) {
-  const [activePanel] = useQueryState(
+  const [panelParam] = useQueryState(
     'panel',
     parseAsStringLiteral(PANEL_VALUES).withDefault('general')
   )
+  // The learned KB ("AI Memory") has no settings tabs — the panel is always
+  // the article tree, retitled "Memory".
+  const isLearned = knowledgeBase.kind === 'learned'
+  const activePanel = isLearned ? 'articles' : panelParam
 
   const isSaving = useKnowledgeBaseStore((s) => Boolean(s.pendingDraftPatches[knowledgeBaseId]))
 
@@ -48,12 +52,18 @@ export function KBTabPanel({ knowledgeBaseId, knowledgeBase }: KBTabPanelProps) 
       <SavingIndicator isSaving={isSaving} />
     )
 
+  const title = isLearned ? (
+    <span className='flex items-center gap-1.5 text-sm font-medium'>
+      <Sparkles className='size-3.5 text-primary' />
+      Memory
+    </span>
+  ) : (
+    <span className='text-sm font-medium'>{PANEL_TITLES[activePanel]}</span>
+  )
+
   return (
     <div className='flex flex-1 flex-col overflow-hidden'>
-      <DrawerHeader
-        title={<span className='text-sm font-medium'>{PANEL_TITLES[activePanel]}</span>}
-        actions={headerActions}
-      />
+      <DrawerHeader title={title} actions={headerActions} />
 
       <ScrollArea className='flex min-h-0 flex-1 flex-col'>
         {activePanel === 'general' && (

--- a/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-tab.tsx
+++ b/apps/web/src/components/kb/ui/knowledge-bases/knowledge-bases-tab.tsx
@@ -3,6 +3,7 @@
 
 import { ListPageScroll } from '@auxx/ui/components/list-page-scroll'
 import { ListSelectionProvider } from '~/components/list-selection'
+import { AiMemorySection } from '../memory/ai-memory-section'
 import { KnowledgeBasesBulkBar } from './knowledge-bases-bulk-bar'
 import { KnowledgeBasesFilterBar } from './knowledge-bases-filter-bar'
 import { KnowledgeBasesList } from './knowledge-bases-list'
@@ -17,6 +18,7 @@ export function KnowledgeBasesTab() {
           toolbar={<KnowledgeBasesFilterBar />}
           bodyClassName='flex-1 flex flex-col min-h-0'>
           <KnowledgeBasesList />
+          <AiMemorySection />
         </ListPageScroll>
         <KnowledgeBasesBulkBar />
       </ListSelectionProvider>

--- a/apps/web/src/components/kb/ui/memory/ai-memory-section.tsx
+++ b/apps/web/src/components/kb/ui/memory/ai-memory-section.tsx
@@ -1,0 +1,50 @@
+// apps/web/src/components/kb/ui/memory/ai-memory-section.tsx
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import { ListCard } from '@auxx/ui/components/list-card'
+import { toastError } from '@auxx/ui/components/toast'
+import { Sparkles } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { SettingsSection } from '~/components/global/settings-page'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { api } from '~/trpc/react'
+
+/**
+ * "AI Memory" section on the Knowledge Bases tab — the human door into the
+ * org's learned KB. Opening the card lazily provisions the KB (idempotent)
+ * and lands in the memory-trimmed editor. Hidden without the `learnedMemory`
+ * feature flag.
+ */
+export function AiMemorySection() {
+  const router = useRouter()
+  const { hasAccess } = useFeatureFlags()
+
+  const ensureLearnedMemory = api.kb.ensureLearnedMemory.useMutation({
+    onSuccess: ({ id }) => {
+      router.push(`/app/kb/${id}/editor?panel=articles`)
+    },
+    onError: (error) => {
+      toastError({ title: 'Could not open AI Memory', description: error.message })
+    },
+  })
+
+  if (!hasAccess(FeatureKey.learnedMemory)) return null
+
+  return (
+    <SettingsSection icon={Sparkles} title='AI Memory' className='mt-8'>
+      <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
+        <ListCard
+          title='AI Memory'
+          ariaLabel='AI Memory'
+          icon={<Sparkles className='size-4' />}
+          description='What Auxx has learned from your conversations.'
+          descriptionLines={2}
+          pending={ensureLearnedMemory.isPending}
+          pendingLabel='Opening…'
+          onClick={() => ensureLearnedMemory.mutate()}
+        />
+      </div>
+    </SettingsSection>
+  )
+}

--- a/apps/web/src/components/kopilot/ui/blocks/learned-article-approval-card.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/learned-article-approval-card.tsx
@@ -1,0 +1,43 @@
+// apps/web/src/components/kopilot/ui/blocks/learned-article-approval-card.tsx
+
+'use client'
+
+import { LearnedArticlePreview } from '~/components/learned/ui/learned-article-preview'
+import type { ApprovalCardProps } from './approval-card-registry'
+import { BlockCard, type BlockCardAction, StatusIndicator } from './block-card'
+
+/**
+ * Approval card for `upsert_learned_article` — the "remember this" write door.
+ * Shows the light memory preview (title/category/description + rendered
+ * markdown) instead of the generic stringified-args dump.
+ */
+export function LearnedArticleApprovalCard({
+  args,
+  status,
+  onApprove,
+  onReject,
+}: ApprovalCardProps) {
+  const isUpdate = Boolean(args.articleId)
+  const isPending = status === 'pending'
+
+  const actions: BlockCardAction[] = isPending
+    ? [
+        { label: 'Deny', onClick: onReject },
+        { label: isUpdate ? 'Update' : 'Save', onClick: () => onApprove(), primary: true },
+      ]
+    : []
+
+  return (
+    <BlockCard
+      data-slot='learned-article-approval-card'
+      indicator={<StatusIndicator status={status} />}
+      primaryText={isUpdate ? 'Update memory' : 'Save memory'}
+      hasFooter={isPending}
+      actionLabel={isPending ? (isUpdate ? 'Update this memory?' : 'Save this memory?') : undefined}
+      actions={actions}
+      collapsible={status === 'rejected'}
+      defaultCollapsed={status === 'rejected'}>
+      <LearnedArticlePreview args={args} />
+    </BlockCard>
+  )
+}

--- a/apps/web/src/components/kopilot/ui/blocks/register-blocks.ts
+++ b/apps/web/src/components/kopilot/ui/blocks/register-blocks.ts
@@ -10,6 +10,7 @@ import { EntityCreateApprovalCard } from './entity-create-approval-card'
 import { EntityDefinitionBlock } from './entity-definition-block'
 import { EntityListBlock } from './entity-list-block'
 import { EntityUpdateApprovalCard } from './entity-update-approval-card'
+import { LearnedArticleApprovalCard } from './learned-article-approval-card'
 import { PlanStepsBlock } from './plan-steps-block'
 import { TableBlock } from './table-block'
 import { TaskCreateApprovalCard } from './task-create-approval-card'
@@ -31,3 +32,4 @@ registerApprovalCard('update_entity', EntityUpdateApprovalCard)
 registerApprovalCard('bulk_update_entity', BulkUpdateApprovalCard)
 registerApprovalCard('create_entity', EntityCreateApprovalCard)
 registerApprovalCard('create_task', TaskCreateApprovalCard)
+registerApprovalCard('upsert_learned_article', LearnedArticleApprovalCard)

--- a/apps/web/src/components/learned/ui/learned-article-preview.tsx
+++ b/apps/web/src/components/learned/ui/learned-article-preview.tsx
@@ -1,0 +1,60 @@
+// apps/web/src/components/learned/ui/learned-article-preview.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import '~/components/kopilot/styles/kopilot-prose.css'
+
+/** Args of a proposed `upsert_learned_article` call, as captured by the engine. */
+export interface LearnedArticleArgs {
+  articleId?: string
+  category?: string
+  title?: string
+  description?: string
+  markdown?: string
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  policies: 'Policies',
+  companies: 'Companies',
+  contacts: 'Contacts',
+}
+
+/**
+ * Light preview of a proposed AI-memory write: title + category + description
+ * plus the full proposed article markdown, rendered. Shared by the Today
+ * bundle card and the in-chat kopilot approval card — the reviewer sees what
+ * will be published (not a diff against the current article).
+ */
+export function LearnedArticlePreview({
+  args,
+  className,
+}: {
+  args: Record<string, unknown>
+  className?: string
+}) {
+  const { category, title, description, markdown } = args as LearnedArticleArgs
+  const categoryLabel = category ? (CATEGORY_LABELS[category] ?? category) : undefined
+
+  return (
+    <div className={cn('space-y-2 rounded-xl bg-background/60 p-3', className)}>
+      <div className='space-y-0.5'>
+        <div className='flex items-center gap-2'>
+          <span className='text-sm font-medium text-foreground'>{title ?? 'Untitled memory'}</span>
+          {categoryLabel && (
+            <span className='rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground'>
+              {categoryLabel}
+            </span>
+          )}
+        </div>
+        {description && <p className='text-xs text-muted-foreground'>{description}</p>}
+      </div>
+      {markdown && (
+        <div className='kopilot-prose max-h-64 overflow-y-auto border-t pt-2'>
+          <Markdown remarkPlugins={[remarkGfm]}>{markdown}</Markdown>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/mail/thread-header.tsx
+++ b/apps/web/src/components/mail/thread-header.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { PLATFORM_CAPABILITIES } from '@auxx/lib/channels/client'
+import { FeatureKey } from '@auxx/lib/permissions/client'
 import type { ActorId } from '@auxx/types/actor'
 import { getInstanceId, type RecordId, toRecordId } from '@auxx/types/resource'
 import { Alert } from '@auxx/ui/components/alert'
@@ -24,6 +25,7 @@ import {
   Merge,
   MoreHorizontal,
   PackageOpen,
+  Sparkles,
   Tags,
   Trash,
   Undo2,
@@ -44,6 +46,8 @@ import {
 } from '~/components/threads/store/thread-selection-store'
 import { ManualTriggerButton } from '~/components/workflow/manual-trigger-button'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { api } from '~/trpc/react'
 import { EditableText } from '../editor/editable-text'
 import { Tooltip } from '../global/tooltip'
 import { LensBadge } from '../mail-permissions/ui/lens-badge'
@@ -255,6 +259,29 @@ export function ThreadHeader() {
     if (!thread) return
     unmerge(thread.id)
   }, [unmerge, thread])
+
+  /**
+   * Force-enqueue a learned-KB extraction for this thread ("Remember this
+   * thread") — skips the resolve-trigger noise gates; the memory proposal
+   * lands in Today for approval.
+   */
+  const { hasAccess } = useFeatureFlags()
+  const rememberThread = api.thread.rememberThread.useMutation({
+    onSuccess: () => {
+      toastSuccess({
+        title: 'Learning from this thread',
+        description: 'A memory proposal will appear in Today shortly.',
+      })
+    },
+    onError: (error) => {
+      toastError({ title: 'Failed to remember thread', description: error.message })
+    },
+  })
+
+  const handleRememberThread = useCallback(() => {
+    if (!thread) return
+    rememberThread.mutate({ recordId: toRecordId('thread', thread.id) })
+  }, [thread, rememberThread])
 
   /**
    * Handle permanent deletion with confirmation
@@ -471,6 +498,12 @@ export function ThreadHeader() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align='end'>
+                {hasAccess(FeatureKey.learnedMemory) && (
+                  <DropdownMenuItem onClick={handleRememberThread}>
+                    <Sparkles />
+                    Remember this thread
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem onClick={handlePermanentlyDelete} variant='destructive'>
                   <Trash />
                   Permanently delete

--- a/apps/web/src/components/today/bundle-card.tsx
+++ b/apps/web/src/components/today/bundle-card.tsx
@@ -6,6 +6,7 @@ import type { ProposedAction, StoredBundle } from '@auxx/lib/approvals'
 import { Button } from '@auxx/ui/components/button'
 import { Card } from '@auxx/ui/components/card'
 import { toastError } from '@auxx/ui/components/toast'
+import { LearnedArticlePreview } from '~/components/learned/ui/learned-article-preview'
 import { api } from '~/trpc/react'
 
 export interface BundleCardData {
@@ -96,6 +97,15 @@ export function BundleCard({ bundle }: { bundle: BundleCardData }) {
 }
 
 function ActionRow({ action }: { action: ProposedAction }) {
+  // Memory proposals get the shared light preview (title + category +
+  // description + rendered markdown) instead of the bare summary line.
+  if (action.toolName === 'upsert_learned_article') {
+    return (
+      <li className='list-none -ml-4'>
+        <LearnedArticlePreview args={action.args} className='bg-muted/40' />
+      </li>
+    )
+  }
   return (
     <li className='text-foreground'>
       <span className='font-mono text-xs text-muted-foreground mr-2'>{action.toolName}</span>

--- a/apps/web/src/server/api/routers/kb.ts
+++ b/apps/web/src/server/api/routers/kb.ts
@@ -4,7 +4,7 @@ import { schema } from '@auxx/database'
 import { ArticleStatus } from '@auxx/database/enums'
 import { onCacheEvent } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
-import { articleToMarkdown, KBService, linkArticlesIntoKb } from '@auxx/lib/kb'
+import { articleToMarkdown, ensureLearnedKb, KBService, linkArticlesIntoKb } from '@auxx/lib/kb'
 import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
 import { TRPCError } from '@trpc/server'
 import { and, count, eq } from 'drizzle-orm'
@@ -131,6 +131,23 @@ export const knowledgeBaseRouter = createTRPCRouter({
 
   list: protectedProcedure.query(async ({ ctx }) => {
     return await getKBService(ctx).listKnowledgeBases()
+  }),
+
+  /**
+   * Idempotently provision the org's AI Memory KB (kind 'learned') and return
+   * its id — the entry point for the "AI Memory" card on the KB landing page.
+   */
+  ensureLearnedMemory: protectedProcedure.mutation(async ({ ctx }) => {
+    const organizationId = getUserOrganizationId(ctx.session)
+    if (!organizationId) {
+      throw new TRPCError({ code: 'UNAUTHORIZED', message: 'User organization context not found' })
+    }
+    await new FeaturePermissionService(ctx.db).requireAccess(
+      organizationId,
+      FeatureKey.learnedMemory
+    )
+    const { kb } = await ensureLearnedKb({ db: ctx.db, organizationId })
+    return { id: kb.id }
   }),
 
   create: protectedProcedure.input(kbCreateSchema).mutation(async ({ ctx, input }) => {

--- a/apps/web/src/server/api/routers/thread.ts
+++ b/apps/web/src/server/api/routers/thread.ts
@@ -663,6 +663,37 @@ export const threadRouter = createTRPCRouter({
     }),
 
   /**
+   * Explicit "Remember this thread" — force-enqueues a learned-KB extraction
+   * for the thread, bypassing the resolve-trigger noise gates and the
+   * `learnedExtractedAt` dedupe. The proposal lands in Today as usual.
+   */
+  rememberThread: protectedProcedure
+    .input(z.object({ recordId: recordIdSchema }))
+    .mutation(async ({ ctx, input }) => {
+      const { threadQuery, organizationId, userId } = await getServiceDependencies(ctx)
+      const { FeaturePermissionService, FeatureKey } = await import('@auxx/lib/permissions')
+      await new FeaturePermissionService(ctx.db).requireAccess(
+        organizationId,
+        FeatureKey.learnedMemory
+      )
+      const threadId = getInstanceId(input.recordId)
+      try {
+        // Visibility check — the viewer must be able to see the thread.
+        const [meta] = await threadQuery.getThreadMetaBatch([threadId], userId)
+        if (!meta) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Thread not found.' })
+        }
+        const { enqueueLearnedExtraction } = await import('@auxx/lib/jobs')
+        await enqueueLearnedExtraction({ organizationId, threadId, force: true })
+        return { success: true }
+      } catch (error: unknown) {
+        if (error instanceof TRPCError) throw error
+        handleServiceError(error, 'rememberThread', { organizationId, userId, threadId })
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to enqueue.' })
+      }
+    }),
+
+  /**
    * Unified bulk update endpoint for multiple threads.
    * Accepts RecordIds and partial ThreadUpdates.
    */

--- a/packages/lib/src/jobs/approvals/learned-extraction-job.ts
+++ b/packages/lib/src/jobs/approvals/learned-extraction-job.ts
@@ -20,19 +20,29 @@ const logger = createScopedLogger('job:learned-extraction')
 export interface LearnedExtractionJobData {
   organizationId: string
   threadId: string
+  /**
+   * Human-triggered ("Remember this thread"): skips the noise gates and the
+   * `learnedExtractedAt` dedupe — an explicit ask always runs.
+   */
+  force?: boolean
 }
 
 /**
  * Enqueue a learned-KB extraction for a thread that just resolved. The stable
  * jobId collapses a rapid archive→reopen→archive burst into one pending job;
  * once a run completes, the `learnedExtractedAt` gate (not the jobId) is what
- * prevents pointless re-extraction.
+ * prevents pointless re-extraction. Forced runs get a unique jobId (a stale
+ * completed job under the stable id would otherwise swallow the re-enqueue)
+ * and no delay.
  */
 export async function enqueueLearnedExtraction(data: LearnedExtractionJobData): Promise<void> {
   const queue = getQueue(Queues.learnedExtractionQueue)
+  const jobId = data.force
+    ? `learned-extraction:force:${data.organizationId}:${data.threadId}:${Date.now()}`
+    : `learned-extraction:${data.organizationId}:${data.threadId}`
   await queue.add('learnedExtractionJob', data, {
-    jobId: `learned-extraction:${data.organizationId}:${data.threadId}`,
-    delay: 5_000,
+    jobId,
+    delay: data.force ? 0 : 5_000,
     attempts: 2,
     backoff: { type: 'exponential', delay: 60_000 },
   })
@@ -51,7 +61,7 @@ export async function enqueueLearnedExtraction(data: LearnedExtractionJobData): 
  * failed run does NOT stamp, so BullMQ's retry gets a clean slate.
  */
 export async function learnedExtractionJob(ctx: JobContext<LearnedExtractionJobData>) {
-  const { organizationId, threadId } = ctx.job.data
+  const { organizationId, threadId, force } = ctx.job.data
 
   const features = new FeaturePermissionService()
   const enabled = await features.hasAccess(organizationId, FeatureKey.learnedMemory)
@@ -62,22 +72,25 @@ export async function learnedExtractionJob(ctx: JobContext<LearnedExtractionJobD
   })
   if (!thread) return { skipped: 'thread_not_found' }
 
-  // Noise gates — all row-local; no LLM call unless they pass.
-  const skipReason = learnedExtractionSkipReason(thread)
-  if (skipReason) return { skipped: skipReason }
+  // Noise gates — all row-local; no LLM call unless they pass. A forced run
+  // (explicit "remember this thread") bypasses them: the human is the gate.
+  if (!force) {
+    const skipReason = learnedExtractionSkipReason(thread)
+    if (skipReason) return { skipped: skipReason }
 
-  // Require at least one outbound reply — a thread nobody answered teaches
-  // nothing about how we answer. (Human vs AI authorship isn't recorded on
-  // Message rows, so outbound presence is the v1 proxy.)
-  const outbound = await database.query.Message.findFirst({
-    where: and(
-      eq(schema.Message.threadId, threadId),
-      eq(schema.Message.organizationId, organizationId),
-      eq(schema.Message.isInbound, false)
-    ),
-    columns: { id: true },
-  })
-  if (!outbound) return { skipped: 'no_outbound_reply' }
+    // Require at least one outbound reply — a thread nobody answered teaches
+    // nothing about how we answer. (Human vs AI authorship isn't recorded on
+    // Message rows, so outbound presence is the v1 proxy.)
+    const outbound = await database.query.Message.findFirst({
+      where: and(
+        eq(schema.Message.threadId, threadId),
+        eq(schema.Message.organizationId, organizationId),
+        eq(schema.Message.isInbound, false)
+      ),
+      columns: { id: true },
+    })
+    if (!outbound) return { skipped: 'no_outbound_reply' }
+  }
 
   const modelDefault = await getCachedDefaultModel(organizationId, ModelType.LLM)
   if (!modelDefault) return { skipped: 'no_default_model' }


### PR DESCRIPTION
## Summary

Phase 5 of the learned-KB (AI memory) plan — the review & management UX. Until now the learned KB was invisible: no way to browse or correct memories, generic approval cards, and no manual learning trigger.

- **AI Memory entry point**: new section on the Knowledge Bases tab (`learnedMemory`-flagged) with a provision-on-open card. Clicking calls the new `kb.ensureLearnedMemory` mutation (idempotent `ensureLearnedKb`) and opens the editor at the article tree.
- **Memory-trimmed KB editor** for `kind='learned'`: no General/Layout tabs (panel forced to `articles` everywhere `?panel=` is read), panel header retitled "Memory" ✨, no publish cluster, plain "AI Memory" breadcrumb instead of the KB switcher. Articles stay fully editable — revisions remain the history/rollback story.
- **Store fix (found in live verify)**: `setKnowledgeBases` rebuilt `knowledgeBasesById` from the clamped `kb.list` payload only, wiping the `byId`-hydrated learned KB — and since `kb.byId`'s cached data never changes, the hydrate effect never re-fired, leaving the editor on a permanent spinner. Non-`standard` KBs now carry over across list refetches.
- **Shared memory preview** (`LearnedArticlePreview`: title + category chip + description + rendered markdown), consumed by
  - a per-tool in-chat approval card registered for `upsert_learned_article` (replaces the generic stringified-args card), and
  - Today's bundle card, where memory actions render the preview instead of the bare summary line.
- **"Remember this thread"** in the thread-header menu (all members, flag-gated) → `thread.rememberThread` → learned-extraction job with `force: true`: skips the noise gates, the `learnedExtractedAt` dedupe, and the outbound-reply check (keeps flag/anchor/model gates). Forced runs get a unique jobId — the stable id would let BullMQ swallow the re-enqueue against a completed job — and no enqueue delay.

## Testing

- `learned-extraction-gates` (7) and `upsert-learned-article` (11) suites pass; biome clean on all touched files.
- Live-verified in DemoOrg1: landing section renders, card opens the trimmed editor (Policies/Companies/Contacts tree + articles load, chrome trimmed as designed).
- Pending live-verify: in-chat approval-card preview, Today bundle preview, thread-menu forced extraction (worker needs the rebuilt lib for `force`).