### PR TITLE
fix(seed): resolve kanban view-config keys to bare field ids

### DIFF
--- a/packages/lib/src/seed/entity-seeder/create-default-views.ts
+++ b/packages/lib/src/seed/entity-seeder/create-default-views.ts
@@ -181,18 +181,24 @@ export function resolveViewConfig(
     .filter((g): g is ConditionGroup => g !== null)
 
   // Resolve kanban.groupByFieldId / primaryFieldId / cardFields (symbolic field_* ids).
+  // Kanban keys use BARE field ids (NOT composite `<defId>:<fieldId>` ResourceFieldIds like the
+  // table keys above): every client writer stores `ResourceField.id` and every reader compares
+  // against it (dynamic-view.tsx / kanban-view-body.tsx `selectFields.find(f => f.id === ...)`),
+  // converting to a composite ref only at render. A composite here silently fails that lookup
+  // and the view falls back to a table.
   // kanban.columnOrder / collapsedColumns / columnSettings are keyed by the groupBy
   // field's OPTION VALUES, not field ids (kanbanConfigSchema, view-config.ts:69-75) —
   // left untouched.
+  const resolveBare = (fieldKey: string): string | null => fieldIdMap.get(fieldKey) ?? null
   const kanban = config.kanban
     ? {
         ...config.kanban,
-        groupByFieldId: resolve(config.kanban.groupByFieldId) ?? config.kanban.groupByFieldId,
+        groupByFieldId: resolveBare(config.kanban.groupByFieldId) ?? config.kanban.groupByFieldId,
         primaryFieldId: config.kanban.primaryFieldId
-          ? (resolve(config.kanban.primaryFieldId) ?? config.kanban.primaryFieldId)
+          ? (resolveBare(config.kanban.primaryFieldId) ?? config.kanban.primaryFieldId)
           : undefined,
         cardFields: config.kanban.cardFields
-          ?.map((fieldKey) => resolve(fieldKey))
+          ?.map((fieldKey) => resolveBare(fieldKey))
           .filter((v): v is string => v !== null),
       }
     : undefined


### PR DESCRIPTION
## Summary

Seeded kanban views ("Request Pipeline"/"Quote Pipeline") rendered as tables under a kanban icon. `resolveViewConfig` ran the kanban block (`groupByFieldId`/`primaryFieldId`/`cardFields`) through the same resolver as the table keys, emitting composite `<defId>:<fieldId>` ResourceFieldIds — but the client convention for kanban keys is **bare field ids**: every writer stores `ResourceField.id` (kanban-view-settings, create-view dialog, `tableView.create`) and every reader compares against it (`selectFields.find(f => f.id === ...)` in `dynamic-view.tsx` / `kanban-view-body.tsx`), converting to a composite ref only at render. A composite id silently fails that lookup, so `isKanbanView` was false and the view fell back to the table body. `primaryFieldId`/`cardFields` would have double-prefixed too.

The fix keeps the composite convention for table keys (`columnVisibility`/`columnOrder`/`columnPinning`/`sorting`) and resolves the kanban keys to bare ids, with the convention documented at the seam — this is the one place both conventions meet.

Considered instead normalizing the kanban keys to composite ids everywhere: that's ~15 client sites across 6 files, widening the `selectFields` projection, plus a data migration over every existing user-created kanban view (prod included). Bare is the de-facto convention everywhere except this resolver, so the resolver moves.

Why it was never caught: no entity template seeded a kanban view before service_request/quote — this resolver branch had never run against a real render.

The entity migrations (029/030/032) call this same shared resolver via `ensureDefaultTableViews`, so they seed correct configs wherever they haven't run yet — no migration-file changes needed. Already-seeded dev rows were fixed with a one-off SQL (strip the `<defId>:` prefix on the 50 seeded pipeline views) + `userTableViews` cache flush; production never received these rows.

## Test plan

- [x] `pnpm biome check` clean on the changed file
- [x] DB spot-check: seeded "Request Pipeline" `groupByFieldId` now byte-identical to a client-created kanban view's on the same entity def
- [ ] Browser: `/app/service-requests` and `/app/quotes` render the seeded pipelines as kanban by default (pending dev-server restart for unrelated MQ1 subpaths)