### PR TITLE
feat(dispatch): M2b job view — sections mode, work_order detail page, quote flip

### DIFF
--- a/apps/web/src/app/(protected)/app/work-orders/[workOrderId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/work-orders/[workOrderId]/page.tsx
@@ -1,0 +1,18 @@
+// apps/web/src/app/(protected)/app/work-orders/[workOrderId]/page.tsx
+
+import { DetailView } from '~/components/detail-view'
+
+type Props = { params: Promise<{ workOrderId: string }> }
+
+/**
+ * Work order (job) detail page using the universal DetailView component
+ * (dispatch M2 build spec §F.2) — the `quotes/[quoteId]` recipe. `work_order`
+ * flips `hasDetailPage: true`; the job view renders in `layout: 'sections'`
+ * mode (`DETAIL_VIEW_CONFIG_REGISTRY.work_order`).
+ */
+async function WorkOrderDetailPage({ params }: Props) {
+  const { workOrderId } = await params
+  return <DetailView apiSlug='work_order' instanceId={workOrderId} backUrl='/app/work-orders' />
+}
+
+export default WorkOrderDetailPage

--- a/apps/web/src/components/detail-view/detail-view-sections-drill-panels-registry.tsx
+++ b/apps/web/src/components/detail-view/detail-view-sections-drill-panels-registry.tsx
@@ -1,0 +1,65 @@
+// apps/web/src/components/detail-view/detail-view-sections-drill-panels-registry.tsx
+'use client'
+
+// Per-entityType `drillPanels` for `layout: 'sections'` (dispatch M2 build
+// spec §F.1/§F.3). `DetailViewSections` already accepts a `drillPanels` prop
+// (pushed via the shared `panel`/`item` nuqs params) but `DetailView` didn't
+// have a source to feed it from — this is that hookup point, the
+// `detail-view-tab-registry.tsx` recipe: a plain `entityType → panels[]`
+// lookup, code-split via `next/dynamic` so non-work_order pages never pull in
+// the dispatch bundle.
+
+import { Button } from '@auxx/ui/components/button'
+import { useNavStack } from '@auxx/ui/components/nav-stack'
+import { ChevronLeft } from 'lucide-react'
+import dynamic from 'next/dynamic'
+import type {
+  DetailViewSectionsDrillContext,
+  DetailViewSectionsDrillPanel,
+} from './detail-view-sections'
+
+const DRILL_LOADING = () => <div className='p-6 text-sm text-muted-foreground'>Loading...</div>
+
+const VisitsListPanel = dynamic(
+  () => import('../dispatch/ui/job-schedule/visits-list-panel').then((m) => m.VisitsListPanel),
+  { ssr: false, loading: DRILL_LOADING }
+)
+const VisitDetailPanel = dynamic(
+  () => import('../dispatch/ui/job-schedule/visit-detail-panel').then((m) => m.VisitDetailPanel),
+  { ssr: false, loading: DRILL_LOADING }
+)
+
+/** Back button + title — the `ProcedureDetailBar`/`agent-detail-tabs.tsx` shared-bar
+ * pattern, kept inline (generic `@auxx/ui` primitives only) so this registry stays
+ * a light, statically-imported hookup point (`detail-view.tsx` imports it eagerly). */
+function DrillBackBar({ title }: { title: string }) {
+  const { pop } = useNavStack()
+  return (
+    <div className='flex h-9 items-center gap-2 px-2'>
+      <Button variant='ghost' size='icon-xs' className='rounded-md' onClick={() => pop()}>
+        <ChevronLeft />
+      </Button>
+      <span className='text-sm font-medium'>{title}</span>
+    </div>
+  )
+}
+
+const DETAIL_VIEW_SECTIONS_DRILL_PANELS: Record<string, DetailViewSectionsDrillPanel[]> = {
+  work_order: [
+    {
+      value: 'visits',
+      bar: (ctx: DetailViewSectionsDrillContext) => (
+        <DrillBackBar title={ctx.itemId ? 'Visit' : 'Visits'} />
+      ),
+      render: (ctx) => <VisitsListPanel {...ctx} />,
+      renderItem: (ctx) => <VisitDetailPanel {...ctx} />,
+    },
+  ],
+}
+
+/** Drill panels registered for a `layout: 'sections'` entityType, or `[]`. */
+export function getDetailViewSectionsDrillPanels(
+  entityType: string
+): DetailViewSectionsDrillPanel[] {
+  return DETAIL_VIEW_SECTIONS_DRILL_PANELS[entityType] ?? []
+}

--- a/apps/web/src/components/detail-view/detail-view-sections.tsx
+++ b/apps/web/src/components/detail-view/detail-view-sections.tsx
@@ -1,0 +1,304 @@
+// apps/web/src/components/detail-view/detail-view-sections.tsx
+'use client'
+
+import { NavStack, NavStackBar, NavStackPanel, NavStackPanels } from '@auxx/ui/components/nav-stack'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Section } from '@auxx/ui/components/section'
+import { Tabs, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
+import { useQueryState } from 'nuqs'
+import * as React from 'react'
+import { parseRecordId, type RecordId } from '~/components/resources'
+import { useScrollSpy } from '~/hooks/use-scroll-spy'
+import { getDetailViewTabComponent } from './detail-view-tab-registry'
+import type { DetailViewMainTabsProps, DetailViewTabProps } from './types'
+import { getIconComponent } from './utils'
+
+// Same rationale as agent-detail-tabs.tsx (the reference wiring, dispatch M2 build
+// spec §F.1 "verbatim" structure): the tab strip lives in <NavStackBar>, OUTSIDE the
+// ScrollArea viewport, so the viewport's top edge already starts below the tabs — no
+// offset needed to land a section flush at the top.
+const SCROLL_BUFFER = 0
+// Activate a tab once its section crosses just past the top edge.
+const SPY_BUFFER = 8
+
+/**
+ * Context handed to a `DetailViewSectionsDrillPanel`'s `bar`/`render`/`renderItem`.
+ */
+export interface DetailViewSectionsDrillContext {
+  recordId: RecordId
+  entityInstanceId: string
+  record?: Record<string, unknown>
+  /** The drilled item id — the `item` nuqs query param — once this panel is on top. */
+  itemId: string | null
+  /** Push (id) / pop (null) the third stack level (`${panel.value}:item`). */
+  setItemId: (id: string | null) => void
+  /** Pop all the way back to the root sections panel. */
+  close: () => void
+}
+
+/**
+ * One additional `NavStackPanel` pushed over the sectioned root page, keyed by the
+ * `panel` nuqs query param (dispatch M2 build spec §F.1 — e.g. work_order's "visits"
+ * list). `renderItem` is optional: when provided, calling `setItemId` from within
+ * `render` pushes a third stack level (mirrors agent-detail's procedure → drill).
+ */
+export interface DetailViewSectionsDrillPanel {
+  /** Panel key. Activated when the `panel` query param equals this value. */
+  value: string
+  /** `NavStackBar` content while this panel (or its item level) is on top. */
+  bar?: React.ReactNode | ((ctx: DetailViewSectionsDrillContext) => React.ReactNode)
+  /** List-level (or single) panel body. */
+  render: (ctx: DetailViewSectionsDrillContext) => React.ReactNode
+  /** Optional item-level body — the third stack level, keyed `${value}:item`. */
+  renderItem?: (ctx: DetailViewSectionsDrillContext) => React.ReactNode
+}
+
+export interface DetailViewSectionsProps extends DetailViewMainTabsProps {
+  /**
+   * Drill panels a consumer (e.g. the work_order Schedule sections component)
+   * pushes over the root page via the shared `panel`/`item` nuqs query params —
+   * same drill mechanism as `agent-detail-tabs.tsx`'s `procedure`/`drill` params,
+   * generalized so this file stays entity-agnostic.
+   */
+  drillPanels?: DetailViewSectionsDrillPanel[]
+}
+
+/**
+ * DetailViewSections — `layout: 'sections'` main area (dispatch M2 build spec §F.1,
+ * 04-ui.md §6). Renders the registered mainTab components as stacked `<Section>`
+ * blocks on ONE scrolling column with a scroll-spy tab strip, instead of
+ * `DetailViewMainTabs`' content-swapping `TabsContent` panels. Structure mirrors
+ * `agent-detail-tabs.tsx` verbatim: `NavStack` (root = the sectioned page, drill
+ * panels pushed via nuqs) + `NavStackBar` (the scroll-spy `Tabs` strip) +
+ * `NavStackPanels` + `useScrollSpy` bound to the existing `?tab=` query state.
+ */
+export function DetailViewSections({
+  recordId,
+  entityType,
+  config,
+  activeTab,
+  onTabChange,
+  record,
+  drillPanels = [],
+}: DetailViewSectionsProps) {
+  const { entityInstanceId } = parseRecordId(recordId)
+
+  // Generic two-level drill protocol shared across every `layout: 'sections'`
+  // consumer: `panel` selects a DetailViewSectionsDrillPanel, `item` (optional)
+  // drills one level further inside it.
+  const [panel, setPanel] = useQueryState('panel')
+  const [item, setItem] = useQueryState('item')
+
+  const sectionKeys = React.useMemo(() => config.mainTabs.map((t) => t.value), [config.mainTabs])
+
+  const activeDrillPanel = React.useMemo(
+    () => drillPanels.find((p) => p.value === panel) ?? null,
+    [drillPanels, panel]
+  )
+
+  // Re-bind the scroll listener after the root ScrollArea remounts (NavStackPanels
+  // only mounts the top panel — returning from a drill recreates the viewport node).
+  const { scrollContainerRef, assignRef, scrollToSection } = useScrollSpy<string>({
+    sections: sectionKeys,
+    active: activeTab,
+    onActiveChange: onTabChange,
+    remountKey: `${panel}:${item}`,
+    spyBuffer: SPY_BUFFER,
+    scrollBuffer: SCROLL_BUFFER,
+  })
+
+  const handleTabChange = React.useCallback(
+    (value: string) => {
+      // The tab strip is only the root panel's bar, so this fires at root — clearing
+      // the drill params is defensive. Scroll the chosen section into view.
+      void setPanel(null)
+      void setItem(null)
+      onTabChange(value)
+      scrollToSection(value)
+    },
+    [onTabChange, setPanel, setItem, scrollToSection]
+  )
+
+  const stack = !panel
+    ? ['root']
+    : !item || !activeDrillPanel?.renderItem
+      ? ['root', panel]
+      : ['root', panel, `${panel}:item`]
+
+  const drillCtx = React.useCallback(
+    (): DetailViewSectionsDrillContext => ({
+      recordId,
+      entityInstanceId,
+      record,
+      itemId: item,
+      setItemId: (id) => void setItem(id),
+      close: () => {
+        void setPanel(null)
+        void setItem(null)
+      },
+    }),
+    [recordId, entityInstanceId, record, item, setItem, setPanel]
+  )
+
+  return (
+    <NavStack
+      stack={stack}
+      onStackChange={(next) => {
+        if (next.length <= 1) {
+          void setPanel(null)
+          void setItem(null)
+        } else if (next.length === 2) {
+          void setItem(null)
+        }
+      }}
+      className='flex flex-col flex-1 min-h-0 h-full'>
+      <NavStackBar className='shrink-0 border-b bg-primary-150' />
+      <NavStackPanels className='flex-1 min-h-0'>
+        <NavStackPanel
+          value='root'
+          className='h-full bg-neutral-100 dark:bg-background'
+          bar={
+            <Tabs value={activeTab} onValueChange={handleTabChange}>
+              <TabsList
+                className='w-full justify-start rounded-none bg-transparent px-2'
+                variant='outline'>
+                {config.mainTabs.map((tab) => {
+                  const Icon = getIconComponent(tab.icon)
+                  return (
+                    <TabsTrigger key={tab.value} value={tab.value} variant='outline'>
+                      <Icon className='size-3.5 mr-1.5 opacity-70' />
+                      {tab.label}
+                    </TabsTrigger>
+                  )
+                })}
+              </TabsList>
+            </Tabs>
+          }>
+          <ScrollArea
+            viewportRef={scrollContainerRef}
+            className='h-full'
+            scrollbarClassName='w-1.5 z-20'
+            noFade>
+            {config.mainTabs.map((tab) => {
+              const Icon = getIconComponent(tab.icon)
+              return (
+                <div key={tab.value} ref={assignRef(tab.value)}>
+                  <Section
+                    title={tab.label}
+                    icon={<Icon className='size-4' />}
+                    // Sections stay simultaneously visible (scroll-spy over a single
+                    // page, not an accordion) — same choice as agent-detail-tabs.tsx,
+                    // which passes collapsible={false} on every one of its sections.
+                    // It also sidesteps the one genuinely fiddly bit here: a
+                    // collapsed Section would hide QuoteLineItemsTab's own header
+                    // action strip (send/download/lifecycle buttons, §G) along with
+                    // its body.
+                    collapsible={false}
+                    initialOpen>
+                    <LazySectionTabComponent
+                      entityType={entityType}
+                      tabValue={tab.value}
+                      entityInstanceId={entityInstanceId}
+                      recordId={recordId}
+                      record={record}
+                    />
+                  </Section>
+                </div>
+              )
+            })}
+
+            {/* Spacer so the last section can scroll up to the activation line. */}
+            <div className='h-[40vh]' />
+          </ScrollArea>
+        </NavStackPanel>
+
+        {drillPanels.map((dp) => (
+          <NavStackPanel
+            key={dp.value}
+            value={dp.value}
+            className='h-full flex flex-col bg-neutral-100 dark:bg-background'
+            bar={typeof dp.bar === 'function' ? dp.bar(drillCtx()) : dp.bar}>
+            {dp.render(drillCtx())}
+          </NavStackPanel>
+        ))}
+
+        {drillPanels
+          .filter((dp) => dp.renderItem)
+          .map((dp) => (
+            <NavStackPanel
+              key={`${dp.value}:item`}
+              value={`${dp.value}:item`}
+              className='h-full flex flex-col bg-neutral-100 dark:bg-background'
+              bar={typeof dp.bar === 'function' ? dp.bar(drillCtx()) : dp.bar}>
+              {dp.renderItem?.(drillCtx())}
+            </NavStackPanel>
+          ))}
+      </NavStackPanels>
+    </NavStack>
+  )
+}
+
+/**
+ * Lazy load and render a tab component from the shared registry for `layout:
+ * 'sections'` — the `DetailViewMainTabs`-side `LazyTabComponent` twin, differing
+ * only in the `variant='section'` prop and NOT wrapping the loading/not-found
+ * fallback in a full-height `ScrollArea` (the outer `ScrollArea` in
+ * `DetailViewSections` already owns scrolling; this renders at intrinsic height).
+ */
+function LazySectionTabComponent({
+  entityType,
+  tabValue,
+  entityInstanceId,
+  recordId,
+  record,
+}: {
+  entityType: string
+  tabValue: string
+  entityInstanceId: string
+  recordId: RecordId
+  record?: Record<string, unknown>
+}) {
+  const componentLoader = getDetailViewTabComponent(entityType, tabValue)
+  const [Component, setComponent] = React.useState<React.ComponentType<DetailViewTabProps> | null>(
+    null
+  )
+  const [isLoading, setIsLoading] = React.useState(true)
+
+  React.useEffect(() => {
+    if (!componentLoader) {
+      setIsLoading(false)
+      return
+    }
+
+    setIsLoading(true)
+    componentLoader()
+      .then((mod) => {
+        setComponent(() => mod.default)
+        setIsLoading(false)
+      })
+      .catch(() => {
+        setIsLoading(false)
+      })
+  }, [componentLoader])
+
+  if (isLoading) {
+    return <div className='p-6 text-sm text-muted-foreground'>Loading...</div>
+  }
+
+  if (!Component) {
+    return (
+      <div className='p-6 text-sm text-muted-foreground'>
+        Tab component not found for {entityType}:{tabValue}
+      </div>
+    )
+  }
+
+  return (
+    <Component
+      entityInstanceId={entityInstanceId}
+      recordId={recordId}
+      record={record}
+      variant='section'
+    />
+  )
+}

--- a/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
+++ b/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
@@ -53,6 +53,18 @@ export const DETAIL_VIEW_TAB_COMPONENTS: Record<
     import('../money/ui/quote/quote-line-items-tab').then((m) => ({
       default: m.QuoteLineItemsTab,
     })),
+
+  // ─────────────────────────────────────────────────────────────────
+  // WORK ORDER (job view) TABS — dispatch M2 build spec §F.2
+  // ─────────────────────────────────────────────────────────────────
+  'work_order:schedule': () =>
+    import('../dispatch/ui/job-schedule/job-schedule-section').then((m) => ({
+      default: m.JobScheduleSection,
+    })),
+  'work_order:line-items': () =>
+    import('../dispatch/ui/job-schedule/work-order-line-items-tab').then((m) => ({
+      default: m.WorkOrderLineItemsTab,
+    })),
 }
 
 /**

--- a/apps/web/src/components/detail-view/detail-view.tsx
+++ b/apps/web/src/components/detail-view/detail-view.tsx
@@ -20,6 +20,8 @@ import { useDockStore } from '~/stores/dock-store'
 import { DetailViewActions } from './components/detail-view-actions'
 import { DetailViewMainTabs } from './detail-view-main-tabs'
 import { DetailViewNotFound } from './detail-view-not-found'
+import { DetailViewSections } from './detail-view-sections'
+import { getDetailViewSectionsDrillPanels } from './detail-view-sections-drill-panels-registry'
 import { DetailViewSidebar } from './detail-view-sidebar'
 import { DetailViewSkeleton } from './detail-view-skeleton'
 import type { DetailViewProps } from './types'
@@ -149,14 +151,26 @@ export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: De
                 },
               ]
         }>
-        <DetailViewMainTabs
-          recordId={recordId}
-          entityType={entityType}
-          config={config}
-          activeTab={mainTab ?? config.defaultTab ?? 'overview'}
-          onTabChange={setMainTab}
-          record={record}
-        />
+        {config.layout === 'sections' ? (
+          <DetailViewSections
+            recordId={recordId}
+            entityType={entityType}
+            config={config}
+            activeTab={mainTab ?? config.defaultTab ?? 'overview'}
+            onTabChange={setMainTab}
+            record={record}
+            drillPanels={getDetailViewSectionsDrillPanels(entityType)}
+          />
+        ) : (
+          <DetailViewMainTabs
+            recordId={recordId}
+            entityType={entityType}
+            config={config}
+            activeTab={mainTab ?? config.defaultTab ?? 'overview'}
+            onTabChange={setMainTab}
+            record={record}
+          />
+        )}
       </MainPageContent>
 
       {/* Mobile sidebar drawer */}

--- a/apps/web/src/components/detail-view/index.ts
+++ b/apps/web/src/components/detail-view/index.ts
@@ -7,6 +7,13 @@ export { DetailViewCardHeader } from './components/detail-view-card-header'
 export { DetailView } from './detail-view'
 export { DetailViewMainTabs } from './detail-view-main-tabs'
 export { DetailViewNotFound } from './detail-view-not-found'
+export type {
+  DetailViewSectionsDrillContext,
+  DetailViewSectionsDrillPanel,
+  DetailViewSectionsProps,
+} from './detail-view-sections'
+// layout: 'sections' main area (dispatch M2 §F.1)
+export { DetailViewSections } from './detail-view-sections'
 // Sub-components
 export { DetailViewSidebar } from './detail-view-sidebar'
 export { DetailViewSkeleton } from './detail-view-skeleton'

--- a/apps/web/src/components/detail-view/tabs/tasks-tab.tsx
+++ b/apps/web/src/components/detail-view/tabs/tasks-tab.tsx
@@ -8,8 +8,8 @@ import type { DetailViewTabProps } from '../types'
  * TasksTab - wrapper for the TasksSection component
  * Used in detail view main tabs area
  */
-export function TasksTab({ recordId }: DetailViewTabProps) {
-  return <TasksSection recordId={recordId} />
+export function TasksTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
+  return <TasksSection recordId={recordId} variant={variant} />
 }
 
 export default TasksTab

--- a/apps/web/src/components/detail-view/tabs/timeline-tab.tsx
+++ b/apps/web/src/components/detail-view/tabs/timeline-tab.tsx
@@ -5,11 +5,25 @@ import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { TimelineTab as TimelineTabCore } from '~/components/timeline'
 import type { DetailViewTabProps } from '../types'
 
+/** Recent-N entry count for the `variant='section'` preview (04-ui.md §6: "recent-N + more"). */
+const SECTION_RECENT_LIMIT = 10
+
 /**
  * TimelineTab - wrapper for the core TimelineTab component
- * Used in detail view main tabs area
+ * Used in detail view main tabs area.
+ *
+ * `variant='tab'` (default, UNCHANGED): owns its own full-height `ScrollArea` — the
+ * `TabsContent` parent gives it `flex-1 h-full` to fill.
+ * `variant='section'`: renders at intrinsic height inside a `DetailViewSections`
+ * `<Section>` — no own `ScrollArea` (the outer page owns scroll), and the core
+ * `TimelineTabCore` is capped to a recent-N page; its existing infinite-query
+ * "Load more" button (unchanged component) already IS the "Show more" affordance.
  */
-export function TimelineTab({ recordId }: DetailViewTabProps) {
+export function TimelineTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
+  if (variant === 'section') {
+    return <TimelineTabCore recordId={recordId} limit={SECTION_RECENT_LIMIT} />
+  }
+
   return (
     <ScrollArea className='flex-1'>
       <div className='p-3 sm:p-6 flex-1 flex-col flex'>

--- a/apps/web/src/components/detail-view/types.ts
+++ b/apps/web/src/components/detail-view/types.ts
@@ -18,6 +18,17 @@ export interface DetailViewTabProps {
   recordId: RecordId
   /** Record data (from useRecord) */
   record?: Record<string, unknown>
+  /**
+   * Rendering context (dispatch M2 build spec §F.1):
+   * - `'tab'` (default): the component owns a full-height flex column and its own
+   *   scroll (`TabsContent` gives it `flex-1 h-full`) — existing behavior, unchanged.
+   * - `'section'`: the component renders inside a `DetailViewSections` `<Section>` on
+   *   ONE outer-owned scroll column — it must render at intrinsic height (no own
+   *   full-height `ScrollArea`) or, if its content is inherently tall/virtualized
+   *   (e.g. a line-items table), cap itself with an internal `max-height` +
+   *   `overflow-auto` region instead of fighting the outer scroll for wheel events.
+   */
+  variant?: 'tab' | 'section'
 }
 
 /**

--- a/apps/web/src/components/detail-view/utils.ts
+++ b/apps/web/src/components/detail-view/utils.ts
@@ -2,6 +2,7 @@
 
 import {
   Box,
+  Calendar,
   Clock,
   HouseIcon,
   Layers,
@@ -32,6 +33,8 @@ const ICON_MAP: Record<string, LucideIcon> = {
   truck: Truck,
   box: Box,
   'receipt-text': ReceiptText,
+  // work_order Schedule section anchor (dispatch M2 build spec §F.2).
+  calendar: Calendar,
 }
 
 /**

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -24,6 +24,7 @@ import { useBoardRealtime } from './hooks/use-board-realtime'
 import type { DispatchVisitEvent } from './types'
 import { UNASSIGNED_RESOURCE_ID } from './types'
 import { computeOverlappingVisitIds, scalarSetting } from './utils'
+import { VisitChipContent } from './visit-chip-content'
 
 /**
  * The dispatch board (07-m2-build.md §D.2) — the `/app/dispatch` module home. Day view is
@@ -135,6 +136,12 @@ export function DispatchBoard() {
     [mutations.scheduleVisit]
   )
 
+  // The drag-overlay ghost — same chip content as the board's `renderEvent`, minus the popover.
+  const renderDragGhost = useCallback(
+    (event: DispatchVisitEvent) => <VisitChipContent event={event} />,
+    []
+  )
+
   if (!hasAccess(FeatureKey.dispatch)) {
     return (
       <EmptyState
@@ -161,7 +168,8 @@ export function DispatchBoard() {
       />
       <CalendarDndProvider<DispatchVisitEvent>
         onEventDrop={canEdit ? handleEventDrop : undefined}
-        onDragEnd={canEdit ? handleForeignDragEnd : undefined}>
+        onDragEnd={canEdit ? handleForeignDragEnd : undefined}
+        renderEvent={renderDragGhost}>
         <div className='flex flex-1 overflow-hidden'>
           {data.showBacklog && <BacklogRail items={data.backlogEvents} canEdit={canEdit} />}
           <BoardCalendarGrid

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
@@ -5,8 +5,14 @@
 import { endOfDay, startOfDay } from 'date-fns'
 import { useCallback, useMemo, useState } from 'react'
 import { api } from '~/trpc/react'
-import type { BoardResourceInput, BoardViewMode, BoardWorker, DispatchVisitEvent } from '../types'
-import { splitVisits, UNASSIGNED_COLOR, UNASSIGNED_RESOURCE_ID, visitToEvent } from '../utils'
+import {
+  type BoardResourceInput,
+  type BoardViewMode,
+  type BoardWorker,
+  type DispatchVisitEvent,
+  UNASSIGNED_RESOURCE_ID,
+} from '../types'
+import { splitVisits, UNASSIGNED_COLOR, visitToEvent } from '../utils'
 
 export interface DateRange {
   from: Date

--- a/apps/web/src/components/dispatch/ui/board/visit-actions-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/visit-actions-popover.tsx
@@ -123,7 +123,7 @@ export function VisitActionsPopoverContent({
       )}
 
       <Button asChild size='sm' variant='ghost' className='w-full justify-start'>
-        <Link href='/app/work-orders'>
+        <Link href={`/app/work-orders/${event.workOrderId}`}>
           <ExternalLink /> Open record
         </Link>
       </Button>

--- a/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
@@ -1,0 +1,147 @@
+// apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { useQueryState } from 'nuqs'
+import type { DetailViewTabProps } from '~/components/detail-view'
+import type { ExistingVisitForOverlap } from '../schedule-popover'
+import { splitJobVisits } from './job-schedule-utils'
+import { type JobVisit, type UseJobVisitsResult, useJobVisits } from './use-job-visits'
+import { VisitCard } from './visit-card'
+import { VisitTreeRow } from './visit-tree-row'
+
+/** Preview-row cap for the Upcoming/History blocks (04-ui.md §6: "1–2 TreeRow previews"). */
+const PREVIEW_LIMIT = 2
+
+/**
+ * JobScheduleSection — registered as `work_order:schedule` (dispatch M2 build
+ * spec §F.2/§F.3). Rendered inside DetailViewSections' own "Schedule"
+ * `<Section>` anchor, so this contributes the primary visit card + the
+ * Upcoming visits / History preview blocks (04-ui.md §6) without a redundant
+ * outer heading. "More" and row clicks push the `?panel=visits`/`?item=<id>`
+ * drill (the shared nuqs params `DetailViewSections` reads — any component
+ * inside the sectioned page can drive them, not just the root).
+ */
+export function JobScheduleSection({ recordId }: DetailViewTabProps) {
+  const { visits, isLoading, canEdit, mutations, existingVisits, refresh } = useJobVisits(recordId)
+  const [, setPanel] = useQueryState('panel')
+  const [, setItem] = useQueryState('item')
+
+  const { upcoming, history } = splitJobVisits(visits)
+  // The primary card's target visit — v1 is one-off (exactly one visit per job);
+  // the recurring next-upcoming rule (06 §M2c) reduces to the same row until the
+  // engine lands, so this stays jobType-agnostic.
+  const primaryVisit = upcoming[0] ?? visits[0]
+
+  const openList = () => void setPanel('visits')
+  const openItem = (visitId: string) => {
+    void setPanel('visits')
+    void setItem(visitId)
+  }
+
+  if (isLoading && visits.length === 0) {
+    return <div className='p-4 text-sm text-muted-foreground'>Loading schedule...</div>
+  }
+
+  return (
+    <div className='flex flex-col gap-4 p-4'>
+      <VisitCard
+        visit={primaryVisit}
+        canEdit={canEdit}
+        mutations={mutations}
+        existingVisits={existingVisits}
+        onRefresh={refresh}
+      />
+
+      {/* Recurring engine (M2c, 06-recurring-engine.md) fills the recurrence
+          summary/editor here; every job renders its visits jobType-agnostically
+          today (one-off has exactly one). */}
+
+      <VisitPreviewBlock
+        title='Upcoming visits'
+        visits={upcoming.slice(0, PREVIEW_LIMIT)}
+        hasMore={upcoming.length > PREVIEW_LIMIT || history.length > 0}
+        emptyLabel='No upcoming visits.'
+        canEdit={canEdit}
+        mutations={mutations}
+        existingVisits={existingVisits}
+        onRefresh={refresh}
+        onMore={openList}
+        onOpenItem={openItem}
+      />
+
+      <VisitPreviewBlock
+        title='History'
+        visits={history.slice(0, PREVIEW_LIMIT)}
+        hasMore={history.length > PREVIEW_LIMIT}
+        emptyLabel='No past visits yet.'
+        canEdit={canEdit}
+        mutations={mutations}
+        existingVisits={existingVisits}
+        onRefresh={refresh}
+        onMore={openList}
+        onOpenItem={openItem}
+      />
+    </div>
+  )
+}
+
+interface VisitPreviewBlockProps {
+  title: string
+  visits: JobVisit[]
+  hasMore: boolean
+  emptyLabel: string
+  canEdit: boolean
+  mutations: UseJobVisitsResult['mutations']
+  existingVisits: ExistingVisitForOverlap[]
+  onRefresh: () => void
+  onMore: () => void
+  onOpenItem: (visitId: string) => void
+}
+
+function VisitPreviewBlock({
+  title,
+  visits,
+  hasMore,
+  emptyLabel,
+  canEdit,
+  mutations,
+  existingVisits,
+  onRefresh,
+  onMore,
+  onOpenItem,
+}: VisitPreviewBlockProps) {
+  return (
+    <div>
+      <div className='flex items-center justify-between px-1 pb-1'>
+        <span className='text-xs font-medium uppercase text-muted-foreground'>{title}</span>
+        {hasMore && (
+          <Button variant='ghost' size='xs' onClick={onMore}>
+            More
+          </Button>
+        )}
+      </div>
+      {visits.length === 0 ? (
+        <div className='rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground'>
+          {emptyLabel}
+        </div>
+      ) : (
+        <div className='rounded-lg border'>
+          {visits.map((visit) => (
+            <VisitTreeRow
+              key={visit.id}
+              visit={visit}
+              canEdit={canEdit}
+              mutations={mutations}
+              existingVisits={existingVisits}
+              onRefresh={onRefresh}
+              onOpen={() => onOpenItem(visit.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default JobScheduleSection

--- a/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-utils.ts
+++ b/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-utils.ts
@@ -1,0 +1,44 @@
+// apps/web/src/components/dispatch/ui/job-schedule/job-schedule-utils.ts
+
+import type { Variant } from '@auxx/ui/components/badge'
+import { format } from 'date-fns'
+import type { JobVisit } from './use-job-visits'
+
+/** Badge tone per visit status — mirrors `WORK_ORDER_STATUS_OPTIONS`' color choices. */
+export const VISIT_STATUS_BADGE_VARIANT: Record<string, Variant> = {
+  scheduled: 'blue',
+  en_route: 'amber',
+  on_site: 'teal',
+  done: 'green',
+  canceled: 'red',
+}
+
+/** `EEE, MMM d · p – p` (or "Not scheduled" for a backlog row) — the visit row title. */
+export function formatVisitWindow(visit: Pick<JobVisit, 'startTime' | 'endTime'>): string {
+  if (!visit.startTime) return 'Not scheduled'
+  const start = new Date(visit.startTime)
+  const startLabel = format(start, 'EEE, MMM d · p')
+  if (!visit.endTime) return startLabel
+  const end = new Date(visit.endTime)
+  return `${startLabel} – ${format(end, 'p')}`
+}
+
+/** Visits that already ran their course — done/canceled, or a past scheduled window. */
+export function isPastVisit(visit: Pick<JobVisit, 'status' | 'endTime'>): boolean {
+  if (visit.status === 'done' || visit.status === 'canceled') return true
+  if (!visit.endTime) return false
+  return new Date(visit.endTime).getTime() < Date.now()
+}
+
+/** Newest-first split of a work order's visits into "upcoming" and "history" (07 §F.3). */
+export function splitJobVisits(visits: JobVisit[]): { upcoming: JobVisit[]; history: JobVisit[] } {
+  const upcoming: JobVisit[] = []
+  const history: JobVisit[] = []
+  for (const visit of visits) {
+    if (isPastVisit(visit)) history.push(visit)
+    else upcoming.push(visit)
+  }
+  // listVisitsForWorkOrder orders oldest-scheduled-first; history reads newest-first (§F.3).
+  history.reverse()
+  return { upcoming, history }
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/use-job-visits.ts
+++ b/apps/web/src/components/dispatch/ui/job-schedule/use-job-visits.ts
@@ -1,0 +1,103 @@
+// apps/web/src/components/dispatch/ui/job-schedule/use-job-visits.ts
+
+'use client'
+
+import { getInstanceId, type RecordId } from '@auxx/types/resource'
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useMemo } from 'react'
+import { useUser } from '~/hooks/use-user'
+import { useOrgChannel } from '~/realtime/hooks'
+import { api, type RouterOutputs } from '~/trpc/react'
+import type { ExistingVisitForOverlap } from '../schedule-popover'
+
+export type JobVisit = RouterOutputs['dispatch']['listVisits'][number]
+
+/**
+ * One work order's visits — the job view Schedule sections' data source
+ * (dispatch M2 build spec §F.3). Wraps `dispatch.listVisits`, live realtime
+ * invalidation scoped to this work order (`dispatch:visit-changed`, the
+ * `use-board-realtime.ts` recipe filtered by `payload.workOrderId`), and the
+ * same admin-gated visit mutations the board uses — mutations are admin-only
+ * client-side (`useUser().isAdminOrOwner`, the `dispatch-board.tsx` pattern);
+ * the server enforces it too (`dispatchAdminProcedure`).
+ */
+export function useJobVisits(workOrderRecordId: RecordId) {
+  const { isAdminOrOwner } = useUser()
+  const canEdit = isAdminOrOwner
+  const utils = api.useUtils()
+  const workOrderInstanceId = getInstanceId(workOrderRecordId)
+
+  const query = api.dispatch.listVisits.useQuery({ workOrderRecordId })
+  const visits = useMemo(() => query.data ?? [], [query.data])
+
+  const invalidate = useCallback(() => {
+    void utils.dispatch.listVisits.invalidate({ workOrderRecordId })
+  }, [utils, workOrderRecordId])
+
+  const onEvent = useCallback(
+    (event: string, payload: unknown) => {
+      if (event !== 'dispatch:visit-changed') return
+      const p = payload as { workOrderId?: string } | undefined
+      if (p?.workOrderId !== workOrderInstanceId) return
+      invalidate()
+    },
+    [workOrderInstanceId, invalidate]
+  )
+  useOrgChannel({ onEvent })
+
+  const onErrorToast = useCallback(
+    (title: string) => (error: { message: string }) =>
+      toastError({ title, description: error.message }),
+    []
+  )
+
+  const scheduleVisit = api.dispatch.scheduleVisit.useMutation({
+    onError: onErrorToast('Error scheduling visit'),
+    onSuccess: invalidate,
+  })
+  const unscheduleVisit = api.dispatch.unscheduleVisit.useMutation({
+    onError: onErrorToast('Error unscheduling visit'),
+    onSuccess: invalidate,
+  })
+  const setVisitStatus = api.dispatch.setVisitStatus.useMutation({
+    onError: onErrorToast('Error updating visit status'),
+    onSuccess: invalidate,
+  })
+  const dispatchVisit = api.dispatch.dispatchVisit.useMutation({
+    onError: onErrorToast('Error dispatching visit'),
+    onSuccess: invalidate,
+  })
+
+  // `SchedulePopoverContent`'s overlap-hint input (07 §D.4) — this job's own
+  // other scheduled visits (multi-visit is a planned extension; harmless no-op
+  // today since v1 is one visit per work order).
+  const existingVisits: ExistingVisitForOverlap[] = useMemo(
+    () =>
+      visits
+        .filter((v): v is JobVisit & { startTime: Date; endTime: Date } =>
+          Boolean(v.startTime && v.endTime)
+        )
+        .map((v) => ({
+          id: v.id,
+          label: 'this job',
+          startTime: v.startTime,
+          endTime: v.endTime,
+          assigneeUserId: v.assigneeUserId,
+        })),
+    [visits]
+  )
+
+  return {
+    visits,
+    isLoading: query.isLoading,
+    canEdit,
+    existingVisits,
+    mutations: { scheduleVisit, unscheduleVisit, setVisitStatus, dispatchVisit },
+    /** Re-fetch this work order's visits — pair with `SchedulePopover`'s `onScheduled`/
+     * `onUnscheduled` callbacks, since that component owns its own mutation (not one of
+     * `mutations` above) and the acting tab's own realtime echo is server-suppressed. */
+    refresh: invalidate,
+  }
+}
+
+export type UseJobVisitsResult = ReturnType<typeof useJobVisits>

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-card.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-card.tsx
@@ -1,0 +1,165 @@
+// apps/web/src/components/dispatch/ui/job-schedule/visit-card.tsx
+'use client'
+
+import { toActorId } from '@auxx/types/actor'
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { Button } from '@auxx/ui/components/button'
+import { format } from 'date-fns'
+import { Send, User } from 'lucide-react'
+import { getInitials } from '~/components/groups/utils/group-utils'
+import { useActors } from '~/components/resources/hooks/use-actor'
+import { useConfirm } from '~/hooks/use-confirm'
+import { VISIT_STATUS_FORWARD_ORDER, VISIT_STATUS_LABELS, type VisitStatus } from '../board/types'
+import { type ExistingVisitForOverlap, SchedulePopover } from '../schedule-popover'
+import type { JobVisit, UseJobVisitsResult } from './use-job-visits'
+
+export interface VisitCardProps {
+  visit: JobVisit | undefined
+  canEdit: boolean
+  mutations: UseJobVisitsResult['mutations']
+  existingVisits: ExistingVisitForOverlap[]
+  onRefresh: () => void
+}
+
+/**
+ * The Schedule section's primary card (dispatch M2 build spec §F.3, 04-ui.md
+ * §6): one-off jobs get a single visit card — assignee, time window, the
+ * visit-status stepper (`scheduled → en_route → on_site → done`), schedule/
+ * assign inline via the schedule control (#7), and the separate Dispatch
+ * (notify) action. Recurring jobs render the same card for their
+ * next-upcoming visit (the M2c engine adds the recurrence summary above it).
+ */
+export function VisitCard({
+  visit,
+  canEdit,
+  mutations,
+  existingVisits,
+  onRefresh,
+}: VisitCardProps) {
+  const [confirm, ConfirmDialog] = useConfirm()
+  const assigneeActorId = visit?.assigneeUserId ? toActorId('user', visit.assigneeUserId) : null
+  const hydratedAssignee = useActors(assigneeActorId ? [assigneeActorId] : [])
+  const assignee = assigneeActorId ? hydratedAssignee.get(assigneeActorId) : undefined
+
+  if (!visit) {
+    return (
+      <div className='rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground'>
+        No visit yet.
+      </div>
+    )
+  }
+
+  const isScheduled = Boolean(visit.startTime && visit.endTime)
+  const status = visit.status as VisitStatus
+  const currentIndex = VISIT_STATUS_FORWARD_ORDER.indexOf(status)
+  const canCancel = status !== 'canceled' && status !== 'done'
+
+  const handleDispatch = async () => {
+    if (visit.dispatchedAt) {
+      const confirmed = await confirm({
+        title: 'Re-dispatch this visit?',
+        description: 'This notifies the assignee again.',
+        confirmText: 'Re-dispatch',
+      })
+      if (!confirmed) return
+    }
+    mutations.dispatchVisit.mutate({ visitId: visit.id })
+  }
+
+  const handleCancel = async () => {
+    const confirmed = await confirm({
+      title: 'Cancel this visit?',
+      description: 'The visit is removed from the schedule. This does not cancel the job.',
+      confirmText: 'Cancel visit',
+      cancelText: 'Keep visit',
+      destructive: true,
+    })
+    if (!confirmed) return
+    mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
+  }
+
+  return (
+    <div className='space-y-3 rounded-lg border p-4'>
+      <div className='flex items-center justify-between gap-2'>
+        <div className='flex items-center gap-2'>
+          {assignee ? (
+            <>
+              <Avatar className='size-7'>
+                <AvatarImage src={assignee.avatarUrl ?? undefined} />
+                <AvatarFallback className='text-xs'>{getInitials(assignee.name)}</AvatarFallback>
+              </Avatar>
+              <span className='text-sm font-medium'>{assignee.name}</span>
+            </>
+          ) : (
+            <span className='flex items-center gap-1.5 text-sm text-muted-foreground'>
+              <User className='size-4' /> Unassigned
+            </span>
+          )}
+        </div>
+
+        {canEdit && (
+          <SchedulePopover
+            trigger={
+              <Button variant='outline' size='sm'>
+                {isScheduled ? 'Reschedule' : 'Schedule'}
+              </Button>
+            }
+            visitId={visit.id}
+            initialStartTime={visit.startTime ? new Date(visit.startTime) : undefined}
+            initialEndTime={visit.endTime ? new Date(visit.endTime) : undefined}
+            initialAssigneeUserId={visit.assigneeUserId}
+            existingVisits={existingVisits}
+            onScheduled={onRefresh}
+            onUnscheduled={onRefresh}
+          />
+        )}
+      </div>
+
+      <div className='text-sm text-muted-foreground'>
+        {isScheduled && visit.startTime && visit.endTime
+          ? `${format(new Date(visit.startTime), 'EEEE, MMMM d · p')} – ${format(new Date(visit.endTime), 'p')}`
+          : 'Not scheduled yet'}
+      </div>
+
+      {status !== 'canceled' && (
+        <div className='flex flex-wrap items-center gap-1'>
+          {VISIT_STATUS_FORWARD_ORDER.map((step, index) => (
+            <Button
+              key={step}
+              size='xs'
+              variant={index === currentIndex ? 'default' : 'outline'}
+              disabled={!canEdit || index <= currentIndex}
+              loading={
+                canEdit &&
+                mutations.setVisitStatus.isPending &&
+                mutations.setVisitStatus.variables?.status === step
+              }
+              onClick={() => mutations.setVisitStatus.mutate({ visitId: visit.id, status: step })}>
+              {VISIT_STATUS_LABELS[step]}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {canEdit && (
+        <div className='flex items-center gap-2 pt-1'>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={handleDispatch}
+            loading={mutations.dispatchVisit.isPending}
+            disabled={!visit.assigneeUserId || !isScheduled}>
+            <Send /> {visit.dispatchedAt ? 'Re-dispatch' : 'Dispatch'}
+          </Button>
+          {canCancel && (
+            <Button variant='ghost' size='sm' onClick={handleCancel}>
+              Cancel visit
+            </Button>
+          )}
+        </div>
+      )}
+
+      <ConfirmDialog />
+    </div>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
@@ -1,0 +1,138 @@
+// apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
+'use client'
+
+import { toActorId } from '@auxx/types/actor'
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { format } from 'date-fns'
+import { CalendarClock, Send, User, XCircle } from 'lucide-react'
+import type { DetailViewSectionsDrillContext } from '~/components/detail-view/detail-view-sections'
+import { getInitials } from '~/components/groups/utils/group-utils'
+import { useActors } from '~/components/resources/hooks/use-actor'
+import { useConfirm } from '~/hooks/use-confirm'
+import { VISIT_STATUS_LABELS, type VisitStatus } from '../board/types'
+import { SchedulePopover } from '../schedule-popover'
+import { formatVisitWindow, VISIT_STATUS_BADGE_VARIANT } from './job-schedule-utils'
+import { useJobVisits } from './use-job-visits'
+
+/**
+ * VisitDetailPanel — the third stack level (`visits:item`), dispatch M2 build
+ * spec §F.3: full visit info, the per-visit proof-of-work placeholder (worker
+ * mobile surface plan fills it in), the visit line items placeholder (money
+ * 01-ui #13, `visitId`-scoped — not built in this slice), and the row actions.
+ */
+export function VisitDetailPanel({ recordId, itemId }: DetailViewSectionsDrillContext) {
+  const { visits, isLoading, canEdit, mutations, existingVisits, refresh } = useJobVisits(recordId)
+  const visit = visits.find((v) => v.id === itemId)
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const assigneeActorId = visit?.assigneeUserId ? toActorId('user', visit.assigneeUserId) : null
+  const hydratedAssignee = useActors(assigneeActorId ? [assigneeActorId] : [])
+  const assignee = assigneeActorId ? hydratedAssignee.get(assigneeActorId) : undefined
+
+  if (isLoading && !visit) {
+    return <div className='p-6 text-sm text-muted-foreground'>Loading visit...</div>
+  }
+  if (!visit) {
+    return <div className='p-6 text-sm text-muted-foreground'>Visit not found.</div>
+  }
+
+  const canCancel = visit.status !== 'canceled' && visit.status !== 'done'
+
+  const handleCancel = async () => {
+    const confirmed = await confirm({
+      title: 'Cancel this visit?',
+      description: 'The visit is removed from the schedule. This does not cancel the job.',
+      confirmText: 'Cancel visit',
+      cancelText: 'Keep visit',
+      destructive: true,
+    })
+    if (!confirmed) return
+    mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
+  }
+
+  return (
+    <ScrollArea className='h-full' scrollbarClassName='w-1.5 z-20' noFade>
+      <div className='flex flex-col gap-4 p-4'>
+        <div className='flex items-center justify-between gap-2'>
+          <div className='flex flex-col gap-1'>
+            <span className='text-sm font-medium'>{formatVisitWindow(visit)}</span>
+            <Badge
+              variant={VISIT_STATUS_BADGE_VARIANT[visit.status] ?? 'default'}
+              size='sm'
+              className='w-fit'>
+              {VISIT_STATUS_LABELS[visit.status as VisitStatus] ?? visit.status}
+            </Badge>
+          </div>
+          {assignee ? (
+            <div className='flex items-center gap-2'>
+              <Avatar className='size-7'>
+                <AvatarImage src={assignee.avatarUrl ?? undefined} />
+                <AvatarFallback className='text-xs'>{getInitials(assignee.name)}</AvatarFallback>
+              </Avatar>
+              <span className='text-sm'>{assignee.name}</span>
+            </div>
+          ) : (
+            <span className='flex items-center gap-1.5 text-sm text-muted-foreground'>
+              <User className='size-4' /> Unassigned
+            </span>
+          )}
+        </div>
+
+        {visit.dispatchedAt && (
+          <div className='text-xs text-muted-foreground'>
+            Dispatched {format(new Date(visit.dispatchedAt), 'PP p')}
+          </div>
+        )}
+
+        {canEdit && (
+          <div className='flex flex-wrap items-center gap-2'>
+            <SchedulePopover
+              trigger={
+                <Button variant='outline' size='sm'>
+                  <CalendarClock /> Reschedule
+                </Button>
+              }
+              visitId={visit.id}
+              initialStartTime={visit.startTime ? new Date(visit.startTime) : undefined}
+              initialEndTime={visit.endTime ? new Date(visit.endTime) : undefined}
+              initialAssigneeUserId={visit.assigneeUserId}
+              existingVisits={existingVisits}
+              onScheduled={refresh}
+              onUnscheduled={refresh}
+            />
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => mutations.dispatchVisit.mutate({ visitId: visit.id })}
+              loading={mutations.dispatchVisit.isPending}
+              disabled={!visit.assigneeUserId || !visit.startTime}>
+              <Send /> {visit.dispatchedAt ? 'Re-dispatch' : 'Dispatch'}
+            </Button>
+            {canCancel && (
+              <Button variant='ghost' size='sm' onClick={handleCancel}>
+                <XCircle /> Cancel visit
+              </Button>
+            )}
+          </div>
+        )}
+
+        {/* Per-visit proof of work — worker mobile surface plan fills this in
+            (completion notes + photos, dispatch M2 build spec §F.3). */}
+        <div className='rounded-lg border border-dashed p-4 text-sm text-muted-foreground'>
+          Proof of work (completion notes, photos) lands with the worker mobile surface.
+        </div>
+
+        {/* Visit line items (occurrence extras) — money 01-ui #13, `visitId`-scoped.
+            Not built in this slice. */}
+        <div className='rounded-lg border border-dashed p-4 text-sm text-muted-foreground'>
+          Visit line items (occurrence extras) land with money 01-ui #13.
+        </div>
+
+        <ConfirmDialog />
+      </div>
+    </ScrollArea>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-tree-row.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-tree-row.tsx
@@ -1,0 +1,124 @@
+// apps/web/src/components/dispatch/ui/job-schedule/visit-tree-row.tsx
+'use client'
+
+import { toActorId } from '@auxx/types/actor'
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { Badge } from '@auxx/ui/components/badge'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { Calendar, CalendarClock, XCircle } from 'lucide-react'
+import { getInitials } from '~/components/groups/utils/group-utils'
+import { useActors } from '~/components/resources/hooks/use-actor'
+import { useConfirm } from '~/hooks/use-confirm'
+import { VISIT_STATUS_LABELS, type VisitStatus } from '../board/types'
+import { type ExistingVisitForOverlap, SchedulePopover } from '../schedule-popover'
+import { formatVisitWindow, VISIT_STATUS_BADGE_VARIANT } from './job-schedule-utils'
+import type { JobVisit, UseJobVisitsResult } from './use-job-visits'
+
+export interface VisitTreeRowProps {
+  visit: JobVisit
+  canEdit: boolean
+  mutations: UseJobVisitsResult['mutations']
+  existingVisits: ExistingVisitForOverlap[]
+  /** Re-fetch after `SchedulePopover`'s own mutation (it doesn't share `mutations`). */
+  onRefresh: () => void
+  /** Drill into the visit-detail panel (`setItemId(visit.id)`). */
+  onOpen: () => void
+  depth?: number
+}
+
+/**
+ * One visit row — shared by the Schedule section's Upcoming/History previews AND
+ * the drilled "visits" list panel (dispatch M2 build spec §F.3, written
+ * jobType-agnostic: "render this job's visits"). `TreeRow` everywhere per
+ * 04-ui.md §6: icon + date/window as title, assignee + status badge as
+ * `secondary`, hover actions as `TreeRowButton`s, whole row clickable to drill.
+ */
+export function VisitTreeRow({
+  visit,
+  canEdit,
+  mutations,
+  existingVisits,
+  onRefresh,
+  onOpen,
+  depth,
+}: VisitTreeRowProps) {
+  const [confirm, ConfirmDialog] = useConfirm()
+  const assigneeActorId = visit.assigneeUserId ? toActorId('user', visit.assigneeUserId) : null
+  const hydratedAssignee = useActors(assigneeActorId ? [assigneeActorId] : [])
+  const assignee = assigneeActorId ? hydratedAssignee.get(assigneeActorId) : undefined
+
+  const canCancel = visit.status !== 'canceled' && visit.status !== 'done'
+  const statusLabel = VISIT_STATUS_LABELS[visit.status as VisitStatus] ?? visit.status
+
+  const handleCancel = async () => {
+    const confirmed = await confirm({
+      title: 'Cancel this visit?',
+      description: 'The visit is removed from the schedule. This does not cancel the job.',
+      confirmText: 'Cancel visit',
+      cancelText: 'Keep visit',
+      destructive: true,
+    })
+    if (!confirmed) return
+    mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
+  }
+
+  return (
+    <>
+      <TreeRow
+        depth={depth}
+        icon={<Calendar className='size-3.5' />}
+        title={formatVisitWindow(visit)}
+        secondary={
+          <span className='inline-flex items-center gap-1.5'>
+            {assignee ? (
+              <>
+                <Avatar className='size-4'>
+                  <AvatarImage src={assignee.avatarUrl ?? undefined} />
+                  <AvatarFallback className='text-[9px]'>
+                    {getInitials(assignee.name)}
+                  </AvatarFallback>
+                </Avatar>
+                {assignee.name}
+              </>
+            ) : (
+              'Unassigned'
+            )}
+            <Badge variant={VISIT_STATUS_BADGE_VARIANT[visit.status] ?? 'default'} size='sm'>
+              {statusLabel}
+            </Badge>
+          </span>
+        }
+        onToggleOpen={onOpen}
+        actions={
+          canEdit ? (
+            <>
+              <SchedulePopover
+                trigger={
+                  <TreeRowButton tooltipText='Reschedule'>
+                    <CalendarClock />
+                  </TreeRowButton>
+                }
+                visitId={visit.id}
+                initialStartTime={visit.startTime ? new Date(visit.startTime) : undefined}
+                initialEndTime={visit.endTime ? new Date(visit.endTime) : undefined}
+                initialAssigneeUserId={visit.assigneeUserId}
+                existingVisits={existingVisits}
+                onScheduled={onRefresh}
+                onUnscheduled={onRefresh}
+              />
+              {canCancel && (
+                <TreeRowButton
+                  variant='destructive'
+                  tooltipText='Cancel visit'
+                  onClick={handleCancel}>
+                  <XCircle />
+                </TreeRowButton>
+              )}
+            </>
+          ) : undefined
+        }
+      />
+      <ConfirmDialog />
+    </>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/visits-list-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visits-list-panel.tsx
@@ -1,0 +1,73 @@
+// apps/web/src/components/dispatch/ui/job-schedule/visits-list-panel.tsx
+'use client'
+
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import type { DetailViewSectionsDrillContext } from '~/components/detail-view/detail-view-sections'
+import { splitJobVisits } from './job-schedule-utils'
+import { useJobVisits } from './use-job-visits'
+import { VisitTreeRow } from './visit-tree-row'
+
+/**
+ * VisitsListPanel — the `visits` drill panel's list level (dispatch M2 build
+ * spec §F.3): every visit on this work order, `TreeRow` rows, same actions as
+ * the Schedule section's previews. Written jobType-agnostic.
+ */
+export function VisitsListPanel({ recordId, setItemId }: DetailViewSectionsDrillContext) {
+  const { visits, isLoading, canEdit, mutations, existingVisits, refresh } = useJobVisits(recordId)
+  const { upcoming, history } = splitJobVisits(visits)
+
+  return (
+    <ScrollArea className='h-full' scrollbarClassName='w-1.5 z-20' noFade>
+      <div className='flex flex-col gap-4 p-3'>
+        {isLoading && visits.length === 0 && (
+          <div className='p-6 text-sm text-muted-foreground'>Loading visits...</div>
+        )}
+        {!isLoading && visits.length === 0 && (
+          <div className='p-6 text-center text-sm text-muted-foreground'>No visits yet.</div>
+        )}
+
+        {upcoming.length > 0 && (
+          <div>
+            <div className='px-1 pb-1 text-xs font-medium uppercase text-muted-foreground'>
+              Upcoming
+            </div>
+            <div className='rounded-lg border'>
+              {upcoming.map((visit) => (
+                <VisitTreeRow
+                  key={visit.id}
+                  visit={visit}
+                  canEdit={canEdit}
+                  mutations={mutations}
+                  existingVisits={existingVisits}
+                  onRefresh={refresh}
+                  onOpen={() => setItemId(visit.id)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {history.length > 0 && (
+          <div>
+            <div className='px-1 pb-1 text-xs font-medium uppercase text-muted-foreground'>
+              History
+            </div>
+            <div className='rounded-lg border'>
+              {history.map((visit) => (
+                <VisitTreeRow
+                  key={visit.id}
+                  visit={visit}
+                  canEdit={canEdit}
+                  mutations={mutations}
+                  existingVisits={existingVisits}
+                  onRefresh={refresh}
+                  onOpen={() => setItemId(visit.id)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
@@ -1,0 +1,42 @@
+// apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import type { DetailViewTabProps } from '~/components/detail-view'
+import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+
+/**
+ * WorkOrderLineItemsTab — registered as `work_order:line-items` (dispatch M2
+ * build spec §F.2). Wraps the document-agnostic `LineBuilder` (money MQ1
+ * build spec §H.1, which already accepts `documentType: 'work_order'` —
+ * filters lines via `line_item:workOrder` and has no billing block since
+ * `hasBilling` is quote/invoice-only) — this is the job's per-cycle line set
+ * ("what every visit bills", 04-ui.md §6 Line items section / money 01-ui
+ * #13): the header reads "Billed each visit" when the job is recurring
+ * (`work_order_job_type`).
+ */
+export function WorkOrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
+  const { values } = useSystemValues(recordId, ['work_order_job_type'], { autoFetch: true })
+  const jobType = (values.work_order_job_type as string | undefined) ?? 'one_off'
+  const isSection = variant === 'section'
+
+  return (
+    <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
+      {jobType === 'recurring' && (
+        <div className='px-4 pt-3 pb-1 text-xs font-medium text-muted-foreground'>
+          Billed each visit
+        </div>
+      )}
+      <div
+        className={cn(
+          'flex flex-col px-4 pb-4',
+          isSection ? 'max-h-[60vh] overflow-auto' : 'min-h-0 flex-1'
+        )}>
+        <LineBuilder documentRecordId={recordId} documentType='work_order' />
+      </div>
+    </div>
+  )
+}
+
+export default WorkOrderLineItemsTab

--- a/apps/web/src/components/dispatch/ui/schedule-work-order-action.tsx
+++ b/apps/web/src/components/dispatch/ui/schedule-work-order-action.tsx
@@ -1,0 +1,57 @@
+// apps/web/src/components/dispatch/ui/schedule-work-order-action.tsx
+'use client'
+
+// Work-order drawer header action (dispatch M2 build spec §F.4, the
+// create-quote-action/create-invoice-action precedent): mounts the schedule
+// control (#7, `SchedulePopover`) targeting the job's next/only visit.
+// Admin-only client-side (`dispatch-board.tsx`'s `isAdminOrOwner` pattern) —
+// scheduling mutations are admin-gated server-side too (`dispatchAdminProcedure`).
+// `<div><Tooltip><Button/></Tooltip></div>` as the popover trigger is the
+// `workflow-versions-popover.tsx` precedent for nesting a Tooltip inside a
+// `PopoverTrigger asChild` without breaking either's ref forwarding.
+
+import { Button } from '@auxx/ui/components/button'
+import { CalendarClock } from 'lucide-react'
+import { Tooltip } from '~/components/global/tooltip'
+import { useUser } from '~/hooks/use-user'
+import { api } from '~/trpc/react'
+import type { DrawerActionProps } from '../../drawers/drawer-action-registry'
+import { SchedulePopover } from './schedule-popover'
+
+export function ScheduleWorkOrderAction({ recordId }: DrawerActionProps) {
+  const { isAdminOrOwner } = useUser()
+  const utils = api.useUtils()
+  const { data: visits, isLoading } = api.dispatch.listVisits.useQuery(
+    { workOrderRecordId: recordId },
+    { enabled: isAdminOrOwner }
+  )
+
+  if (!isAdminOrOwner || isLoading) return null
+
+  // Oldest-scheduled-first with unscheduled last (§B.6) — the first non-terminal
+  // row is the one dispatchers act on; v1 is one-off (exactly one visit per job).
+  const visit = visits?.find((v) => v.status !== 'canceled' && v.status !== 'done') ?? visits?.[0]
+  if (!visit) return null
+
+  const refresh = () => void utils.dispatch.listVisits.invalidate({ workOrderRecordId: recordId })
+
+  return (
+    <SchedulePopover
+      trigger={
+        <div>
+          <Tooltip content='Schedule' allowInteraction>
+            <Button variant='ghost' size='icon-xs'>
+              <CalendarClock />
+            </Button>
+          </Tooltip>
+        </div>
+      }
+      visitId={visit.id}
+      initialStartTime={visit.startTime ? new Date(visit.startTime) : undefined}
+      initialEndTime={visit.endTime ? new Date(visit.endTime) : undefined}
+      initialAssigneeUserId={visit.assigneeUserId}
+      onScheduled={refresh}
+      onUnscheduled={refresh}
+    />
+  )
+}

--- a/apps/web/src/components/drawers/cards/work-order-customer-site-card.tsx
+++ b/apps/web/src/components/drawers/cards/work-order-customer-site-card.tsx
@@ -1,0 +1,155 @@
+// apps/web/src/components/drawers/cards/work-order-customer-site-card.tsx
+'use client'
+
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import type { RecordId } from '@auxx/types/resource'
+import { getInstanceId } from '@auxx/types/resource'
+import { Avatar, AvatarFallback } from '@auxx/ui/components/avatar'
+import { Button } from '@auxx/ui/components/button'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { getFullName, getInitials } from '@auxx/utils'
+import { ExternalLink, Mail, MapPin, Phone } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+
+const WORK_ORDER_ATTRS = ['work_order_contact', 'work_order_address'] as const
+const CONTACT_ATTRS = ['first_name', 'last_name', 'primary_email', 'phone'] as const
+
+/** ADDRESS_STRUCT shape (see `dispatch.ts` router's `addressStructSchema`). */
+interface AddressStructValue {
+  street1?: string
+  street2?: string
+  city?: string
+  state?: string
+  zipCode?: string
+  country?: string
+}
+
+/** `display-address.tsx`'s `DisplayAddressStruct` formatting, inlined for this card. */
+function formatAddress(address: AddressStructValue | null | undefined): string | null {
+  if (!address) return null
+  const streetPart = [address.street1, address.street2].filter(Boolean).join(', ')
+  const cityStatePart = [address.city, [address.state, address.zipCode].filter(Boolean).join(' ')]
+    .filter(Boolean)
+    .join(', ')
+  const parts = [streetPart, cityStatePart, address.country].filter(Boolean)
+  return parts.length > 0 ? parts.join(', ') : null
+}
+
+/**
+ * WorkOrderCustomerSiteCard — the job view's "Customer & site" sidebar card
+ * (dispatch M2 build spec §F.2, 04-ui.md §6: "Customer & site — contact/company +
+ * serviceAddress"). The `quote-customer-card.tsx` recipe, plus the service address.
+ */
+export function WorkOrderCustomerSiteCard({ recordId }: DrawerTabProps) {
+  const { values, isLoading } = useSystemValues(recordId, [...WORK_ORDER_ATTRS], {
+    autoFetch: true,
+  })
+
+  const contactRecordIds = extractRelationshipRecordIds(values.work_order_contact)
+  const contactRecordId = contactRecordIds[0]
+  const address = unwrap(values.work_order_address) as AddressStructValue | null | undefined
+  const addressLine = formatAddress(address)
+
+  if (isLoading) {
+    return (
+      <div className='space-y-2'>
+        <Skeleton className='h-12 w-full rounded-2xl' />
+      </div>
+    )
+  }
+
+  return (
+    <div className='space-y-2'>
+      {contactRecordId ? (
+        <ContactDetails contactRecordId={contactRecordId} />
+      ) : (
+        <div className='rounded-2xl border border-dashed py-3 px-3 text-center text-xs text-muted-foreground'>
+          No contact linked
+        </div>
+      )}
+      {addressLine && (
+        <div className='flex items-start gap-2 rounded-2xl border bg-primary-100/50 py-2 px-3 text-xs text-muted-foreground'>
+          <MapPin className='size-3.5 mt-0.5 shrink-0' />
+          <span>{addressLine}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Inner component — only rendered when contactRecordId is resolved. */
+function ContactDetails({ contactRecordId }: { contactRecordId: RecordId }) {
+  const router = useRouter()
+  const { values, isLoading } = useSystemValues(contactRecordId, [...CONTACT_ATTRS], {
+    autoFetch: true,
+  })
+
+  const contactInstanceId = getInstanceId(contactRecordId)
+  const firstNameStr = unwrap(values.first_name) as string | undefined
+  const lastNameStr = unwrap(values.last_name) as string | undefined
+  const emailStr = unwrap(values.primary_email) as string | undefined
+  const phoneStr = unwrap(values.phone) as string | undefined
+
+  const contactName = {
+    firstName: firstNameStr ?? undefined,
+    lastName: lastNameStr ?? undefined,
+    email: emailStr ?? undefined,
+  }
+
+  return (
+    <div className='group flex items-center justify-between bg-primary-100/50 rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
+      <div className='flex flex-row items-start gap-4'>
+        <div className='size-8 border bg-muted rounded-lg flex items-center justify-center group-hover:bg-secondary transition-colors shrink-0'>
+          <Avatar className='h-7 w-7 rounded-none shadow-none'>
+            <AvatarFallback className='rounded-none bg-transparent'>
+              {isLoading ? '...' : getInitials(contactName)}
+            </AvatarFallback>
+          </Avatar>
+        </div>
+        <div className='flex flex-col'>
+          <div className='text-sm font-medium flex flex-row items-center gap-1'>
+            {isLoading ? (
+              <Skeleton className='h-4 w-24' />
+            ) : (
+              <span>{getFullName(contactName) || 'Unnamed Customer'}</span>
+            )}
+          </div>
+          <div className='text-muted-foreground text-xs'>
+            {isLoading ? (
+              <Skeleton className='h-3 w-40 mt-0.5' />
+            ) : (
+              <div className='flex flex-col gap-0.5'>
+                {emailStr && (
+                  <div className='flex items-center gap-1.5'>
+                    <Mail className='size-3' />
+                    <span>{emailStr}</span>
+                  </div>
+                )}
+                {phoneStr && (
+                  <div className='flex items-center gap-1.5'>
+                    <Phone className='size-3' />
+                    <span>{phoneStr}</span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <Button
+        variant='ghost'
+        size='icon-sm'
+        onClick={() => router.push(`/app/contacts/${contactInstanceId}`)}>
+        <ExternalLink />
+      </Button>
+    </div>
+  )
+}
+
+/** Extract first element if value is an array. */
+function unwrap(value: unknown): unknown {
+  return Array.isArray(value) ? value[0] : value
+}

--- a/apps/web/src/components/drawers/cards/work-order-origin-card.tsx
+++ b/apps/web/src/components/drawers/cards/work-order-origin-card.tsx
@@ -1,0 +1,148 @@
+// apps/web/src/components/drawers/cards/work-order-origin-card.tsx
+'use client'
+
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import type { RecordId } from '@auxx/types/resource'
+import { getInstanceId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { format } from 'date-fns'
+import { ExternalLink, Ticket } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useSystemField } from '~/components/resources/hooks/use-field'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { TagsView } from '~/components/ui/tags-view'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+
+const REQUEST_ATTRS = [
+  'service_request_number',
+  'service_request_title',
+  'service_request_status',
+  'service_request_preferred_date',
+  'service_request_alternate_date',
+  'service_request_arrival_window',
+  'service_request_ticket',
+] as const
+
+/**
+ * WorkOrderOriginCard — the job view's "Origin" sidebar card (dispatch M2 build
+ * spec §F.2, 04-ui.md §6: "source request incl. preferred/alternate dates +
+ * arrival window — the dispatcher's scheduling hint, always visible next to the
+ * sections; plus source ticket link"). Mirrors `quote-origin-card.tsx`, resolved
+ * via `work_order_request`.
+ */
+export function WorkOrderOriginCard({ recordId }: DrawerTabProps) {
+  const { values: workOrderValues, isLoading: workOrderLoading } = useSystemValues(
+    recordId,
+    ['work_order_request'],
+    { autoFetch: true }
+  )
+
+  const requestRecordIds = extractRelationshipRecordIds(workOrderValues.work_order_request)
+  const requestRecordId = requestRecordIds[0]
+
+  if (workOrderLoading) {
+    return (
+      <div className='bg-primary-100/50 rounded-2xl border py-2 px-3'>
+        <Skeleton className='h-4 w-40' />
+      </div>
+    )
+  }
+
+  if (!requestRecordId) {
+    return (
+      <div className='rounded-2xl border border-dashed py-3 px-3 text-center text-xs text-muted-foreground'>
+        Not converted from a service request.
+      </div>
+    )
+  }
+
+  return <RequestDetails requestRecordId={requestRecordId} />
+}
+
+/** Inner component — only rendered when requestRecordId is resolved. */
+function RequestDetails({ requestRecordId }: { requestRecordId: RecordId }) {
+  const router = useRouter()
+  const { values, isLoading } = useSystemValues(requestRecordId, [...REQUEST_ATTRS], {
+    autoFetch: true,
+  })
+  const statusField = useSystemField('service_request_status')
+  const arrivalWindowField = useSystemField('service_request_arrival_window')
+
+  const requestInstanceId = getInstanceId(requestRecordId)
+  const number = unwrap(values.service_request_number) as string | undefined
+  const title = unwrap(values.service_request_title) as string | undefined
+  const status = unwrap(values.service_request_status) as string | undefined
+  const preferredDate = unwrap(values.service_request_preferred_date) as string | undefined
+  const alternateDate = unwrap(values.service_request_alternate_date) as string | undefined
+  const arrivalWindow = unwrap(values.service_request_arrival_window) as string | undefined
+  const statusOptions = statusField?.options?.options ?? []
+  const arrivalWindowOptions = arrivalWindowField?.options?.options ?? []
+
+  const ticketRecordIds = extractRelationshipRecordIds(values.service_request_ticket)
+  const ticketRecordId = ticketRecordIds[0]
+
+  return (
+    <div className='space-y-2'>
+      <div className='group flex items-center justify-between bg-primary-100/50 rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
+        <div className='flex min-w-0 flex-col gap-1'>
+          {isLoading ? (
+            <Skeleton className='h-4 w-32' />
+          ) : (
+            <span className='truncate text-sm font-medium'>
+              {number ? `${number} — ${title ?? 'Untitled request'}` : (title ?? 'Service request')}
+            </span>
+          )}
+          {!isLoading && status && (
+            <TagsView value={status} options={statusOptions} variant='pill' />
+          )}
+        </div>
+
+        <Button
+          variant='ghost'
+          size='icon-sm'
+          onClick={() => router.push(`/app/service-requests?id=${requestInstanceId}`)}>
+          <ExternalLink />
+        </Button>
+      </div>
+
+      {!isLoading && (preferredDate || alternateDate || arrivalWindow) && (
+        <div className='space-y-1 rounded-2xl border bg-primary-100/50 py-2 px-3 text-xs'>
+          {preferredDate && (
+            <div className='flex items-center justify-between'>
+              <span className='text-muted-foreground'>Preferred date</span>
+              <span>{format(new Date(preferredDate), 'PP')}</span>
+            </div>
+          )}
+          {alternateDate && (
+            <div className='flex items-center justify-between'>
+              <span className='text-muted-foreground'>Alternate date</span>
+              <span>{format(new Date(alternateDate), 'PP')}</span>
+            </div>
+          )}
+          {arrivalWindow && (
+            <div className='flex items-center justify-between'>
+              <span className='text-muted-foreground'>Arrival window</span>
+              <TagsView value={arrivalWindow} options={arrivalWindowOptions} variant='pill' />
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isLoading && ticketRecordId && (
+        <Button
+          variant='outline'
+          size='sm'
+          className='w-full justify-start'
+          onClick={() => router.push(`/app/tickets/${getInstanceId(ticketRecordId)}`)}>
+          <Ticket /> Source ticket
+        </Button>
+      )}
+    </div>
+  )
+}
+
+/** Extract first element if value is an array. */
+function unwrap(value: unknown): unknown {
+  return Array.isArray(value) ? value[0] : value
+}

--- a/apps/web/src/components/drawers/drawer-action-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-action-registry.tsx
@@ -4,6 +4,7 @@
 import type { Resource } from '@auxx/lib/resources/client'
 import type { RecordId } from '@auxx/types/resource'
 import type { ComponentType } from 'react'
+import { ScheduleWorkOrderAction } from '~/components/dispatch/ui/schedule-work-order-action'
 import { CreateInvoiceAction } from '~/components/money/ui/invoice/create-invoice-action'
 import { ContactComposeAction } from './actions/contact-compose-action'
 import { CreateNoteAction } from './actions/create-note-action'
@@ -33,7 +34,7 @@ const DRAWER_HEADER_ACTIONS: Record<string, ComponentType<DrawerActionProps>[]> 
   ticket: [TicketReplyAction, CreateNoteAction],
   part: [LinkInventorySourceAction, CreateNoteAction],
   service_request: [CreateQuoteAction, CreateNoteAction],
-  work_order: [CreateInvoiceAction, CreateNoteAction],
+  work_order: [ScheduleWorkOrderAction, CreateInvoiceAction, CreateNoteAction],
 }
 
 export function getHeaderActions(entityType: string): ComponentType<DrawerActionProps>[] {

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -131,6 +131,20 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     import('../money/ui/invoice/invoice-payments-card').then((m) => ({
       default: m.InvoicePaymentsCard,
     })),
+
+  // ─────────────────────────────────────────────────────────────────
+  // WORK ORDER (job view) SIDEBAR CARDS — dispatch M2 build spec §F.2, shared
+  // with the job view's DetailView sidebar (DetailViewSidebar reads from this
+  // same registry, see detail-view-sidebar.tsx).
+  // ─────────────────────────────────────────────────────────────────
+  'work_order:customer-site': () =>
+    import('./cards/work-order-customer-site-card').then((m) => ({
+      default: m.WorkOrderCustomerSiteCard,
+    })),
+  'work_order:origin': () =>
+    import('./cards/work-order-origin-card').then((m) => ({
+      default: m.WorkOrderOriginCard,
+    })),
 }
 
 /**

--- a/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
+++ b/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
@@ -18,6 +18,7 @@ import { parseRecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
+import { cn } from '@auxx/ui/lib/utils'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
@@ -40,7 +41,7 @@ const EXPIRABLE_STATUSES = new Set(['draft', 'sent'])
 /** Statuses where a quote can still be (re)sent (money MQ2 build spec §E.2). */
 const SENDABLE_STATUSES = new Set(['draft', 'sent'])
 
-export function QuoteLineItemsTab({ recordId }: DetailViewTabProps) {
+export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
   const router = useRouter()
   const [confirm, ConfirmDialog] = useConfirm()
   const { openCompose } = useCompose()
@@ -96,10 +97,10 @@ export function QuoteLineItemsTab({ recordId }: DetailViewTabProps) {
   const handleConvert = async () => {
     try {
       const result = await convertToWorkOrder.mutateAsync({ quoteRecordId: recordId })
-      // work_order has no detail page yet (M2) — land on the records list with
-      // the drawer open via the `?id=` convention (records-view.tsx).
+      // work_order now has a detail page (dispatch M2 build spec §F.2) — land on
+      // the job view directly instead of the records-list `?id=` drawer convention.
       const { entityInstanceId } = parseRecordId(result.recordId)
-      router.push(`/app/work-orders?id=${entityInstanceId}`)
+      router.push(`/app/work-orders/${entityInstanceId}`)
     } catch {
       // onError above already surfaced the toast.
     }
@@ -155,8 +156,17 @@ export function QuoteLineItemsTab({ recordId }: DetailViewTabProps) {
     }
   }
 
+  // `variant='section'` (dispatch M2 §F.1/§G): rendered inside a DetailViewSections
+  // <Section> on an outer-owned scroll column instead of a `TabsContent` that grants
+  // `h-full`. The header action strip below (Expired badge + send/download/lifecycle
+  // buttons) stays a normal in-flow row either way — always visible/functional, since
+  // the wrapping <Section> is non-collapsible in sections mode. Only the LineBuilder
+  // (a virtualized, scroll-owning table) needs the max-height + internal-scroll
+  // treatment so it doesn't fight the outer page for wheel events.
+  const isSection = variant === 'section'
+
   return (
-    <div className='flex h-full min-h-0 flex-col'>
+    <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
       <div className='flex items-center justify-between gap-2 px-4 py-3'>
         <div className='flex items-center gap-2'>
           {isExpired && (
@@ -261,7 +271,11 @@ export function QuoteLineItemsTab({ recordId }: DetailViewTabProps) {
         </div>
       )}
 
-      <div className='min-h-0 flex-1 px-4 pb-4'>
+      <div
+        className={cn(
+          'flex flex-col px-4 pb-4',
+          isSection ? 'max-h-[60vh] overflow-auto' : 'min-h-0 flex-1'
+        )}>
         <LineBuilder documentRecordId={recordId} documentType='quote' readOnly={readOnly} />
       </div>
 

--- a/apps/web/src/components/tasks/ui/tasks-list.tsx
+++ b/apps/web/src/components/tasks/ui/tasks-list.tsx
@@ -38,6 +38,17 @@ interface TasksListProps {
   /** Show entity reference badges on task items (useful in global mode) */
   showEntityReferences?: boolean
   className?: string
+  /**
+   * Cap the fetched page size (default: the `useTasks` default of 50). Used by the
+   * `DetailViewSections` `variant='section'` treatment (recent-N + "Show more").
+   */
+  limit?: number
+  /**
+   * When provided, the "Load more" button calls this instead of `useTasks`'
+   * `fetchNextPage` (currently a no-op placeholder, see `use-tasks.ts`) — the
+   * section-variant caller bumps its own `limit` state instead.
+   */
+  onShowMore?: () => void
 }
 
 /** Default sort config */
@@ -59,6 +70,8 @@ export function TasksList({
   onCreateClick,
   showEntityReferences = false,
   className,
+  limit,
+  onShowMore,
 }: TasksListProps) {
   // Convert Condition[] to individual filter props
   const filterProps = useMemo(() => convertConditionsToFilterProps(filters ?? []), [filters])
@@ -70,6 +83,7 @@ export function TasksList({
     priority: filterProps.priority,
     search: filterProps.search,
     includeCompleted: filterProps.includeCompleted ?? includeCompleted,
+    limit,
   })
 
   // Track collapsed state for each group
@@ -196,12 +210,12 @@ export function TasksList({
         {hasNextPage && (
           <div className='flex justify-center py-4'>
             <Button
-              onClick={fetchNextPage}
+              onClick={onShowMore ?? fetchNextPage}
               variant='ghost'
               size='sm'
               loading={isFetchingNextPage}
               loadingText='Loading...'>
-              Load more
+              {onShowMore ? 'Show more' : 'Load more'}
             </Button>
           </div>
         )}

--- a/apps/web/src/components/tasks/ui/tasks-section.tsx
+++ b/apps/web/src/components/tasks/ui/tasks-section.tsx
@@ -7,8 +7,12 @@ import { Button } from '@auxx/ui/components/button'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
 import { ListTodo, Plus } from 'lucide-react'
+import { useState } from 'react'
 import { useCreateTaskStore } from '../stores/create-task-store'
 import { TasksList } from './tasks-list'
+
+/** Recent-N page size for the `variant='section'` preview (04-ui.md §6: "recent-N + more"). */
+const SECTION_RECENT_LIMIT = 10
 
 /**
  * Props for TasksSection component
@@ -16,16 +20,47 @@ import { TasksList } from './tasks-list'
 interface TasksSectionProps {
   /** Record ID in format "entityDefinitionId:entityInstanceId" */
   recordId: RecordId
+  /**
+   * `'tab'` (default, UNCHANGED): full-height `ScrollArea` + own `<Section>` chrome —
+   * used by the record drawer and `DetailViewMainTabs` (`layout: 'tabs'`).
+   * `'section'`: intrinsic height, no own `ScrollArea` — used inside a
+   * `DetailViewSections` `<Section>` (the outer page already owns scroll AND the
+   * "Tasks" header), so this renders just a recent-N list + local "Show more"
+   * (bumps the fetched page size — `useTasks`' cursor pagination is a no-op today)
+   * + its own inline Create action.
+   */
+  variant?: 'tab' | 'section'
 }
 
 /**
  * TasksSection renders the tasks section within an entity drawer.
  * Displays a list of tasks linked to the entity with ability to create new tasks.
  */
-export function TasksSection({ recordId }: TasksSectionProps) {
+export function TasksSection({ recordId, variant = 'tab' }: TasksSectionProps) {
   const openDialog = useCreateTaskStore((s) => s.openDialog)
+  const [limit, setLimit] = useState(SECTION_RECENT_LIMIT)
 
   const handleCreate = () => openDialog({ referencedEntity: recordId })
+
+  if (variant === 'section') {
+    return (
+      <div className='flex flex-col gap-2'>
+        <div className='flex justify-end'>
+          <Button variant='ghost' size='sm' onClick={handleCreate}>
+            <Plus />
+            Create
+          </Button>
+        </div>
+        <TasksList
+          viewMode='entity'
+          recordId={recordId}
+          onCreateClick={handleCreate}
+          limit={limit}
+          onShowMore={() => setLimit((l) => l + SECTION_RECENT_LIMIT)}
+        />
+      </div>
+    )
+  }
 
   return (
     <ScrollArea className='flex-1'>

--- a/apps/worker/scripts/run-entity-migration-036.ts
+++ b/apps/worker/scripts/run-entity-migration-036.ts
@@ -1,0 +1,32 @@
+// apps/worker/scripts/run-entity-migration-036.ts
+/**
+ * One-off runner for entity migration 036 (invoice `publicToken` field, money MP1 build
+ * spec §H) across all orgs. Runs ONLY 036 — deliberately not runAllEntityMigrations, so
+ * pending migrations from parallel work stay untouched. Idempotent — safe to re-run to
+ * confirm alreadyUpToDate.
+ *
+ * Run (from repo root) under the worker runtime so the @auxx/lib import chain
+ * resolves its native ESM deps:
+ *   node --conditions source --env-file .env --import tsx/esm \
+ *     apps/worker/scripts/run-entity-migration-036.ts
+ */
+
+import { database } from '@auxx/database'
+import {
+  ALL_ENTITY_MIGRATIONS,
+  runEntityMigrationForAllOrgs,
+} from '@auxx/lib/seed/entity-migrations'
+
+async function main() {
+  const migration = ALL_ENTITY_MIGRATIONS.find((m) => m.id === '036-invoice-public-token')
+  if (!migration) throw new Error('Migration 036 not found in registry')
+
+  await runEntityMigrationForAllOrgs(database, migration)
+  console.log('done')
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -347,7 +347,10 @@ export const ModelTypeMeta: Record<
     color: 'amber',
     apiSlug: 'work-orders',
     dbTable: 'EntityInstance',
-    hasDetailPage: false,
+    // Flipped for the job view (dispatch M2 build spec §F.2) — the drawer grows
+    // its fullscreen button and `getRecordLink` starts returning
+    // `/app/work-orders/[id]` URLs. `service_request` stays drawer-only.
+    hasDetailPage: true,
   },
   service_request: {
     label: 'Service Request',

--- a/packages/lib/src/resources/registry/detail-view-config-types.ts
+++ b/packages/lib/src/resources/registry/detail-view-config-types.ts
@@ -61,10 +61,19 @@ export interface DetailViewConfig {
   defaultSidebarTab?: string
   /** Cards rendered in the sidebar (reuses DrawerTabCardDefinition for shared card component registry) */
   sidebarCards?: DrawerTabCardDefinition[]
+  /**
+   * Main-area layout mode (dispatch M2 build spec §F.1):
+   * - `'tabs'` (default): content-swapping `TabsContent` panels — unchanged ticket/contact/
+   *   part/quote behavior, rendered by `DetailViewMainTabs`.
+   * - `'sections'`: a single scroll-spy page (agent-detail pattern) — the mainTabs render as
+   *   stacked `<Section>` anchors on ONE scrolling column instead of swapped panels, rendered
+   *   by `DetailViewSections`.
+   */
+  layout?: 'tabs' | 'sections'
 }
 
 /** Entity types that have specific detail view configurations */
-export type DetailViewEntityType = 'contact' | 'ticket' | 'part' | 'entity' | 'quote'
+export type DetailViewEntityType = 'contact' | 'ticket' | 'part' | 'entity' | 'quote' | 'work_order'
 
 /** Registry type mapping entity types to their configurations */
 export type DetailViewConfigRegistry = Record<DetailViewEntityType, DetailViewConfig>

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -91,6 +91,13 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
 
   quote: {
     entityType: 'quote',
+    // Flipped to sections (dispatch M2 build spec §G — "flips to sections via
+    // config when M2 lands", money 01-ui #3/STATUS): tabs unchanged (Line items ·
+    // Timeline · Tasks). QuoteLineItemsTab already renders its status-driven header
+    // action strip as a normal in-flow row inside its `variant='section'` body — see
+    // quote-line-items-tab.tsx — so the strip stays visible/functional since
+    // DetailViewSections' <Section> wrapper is always non-collapsible.
+    layout: 'sections',
     mainTabs: [
       { value: 'line-items', label: 'Line items', icon: 'receipt-text' },
       { value: 'timeline', label: 'Timeline', icon: 'clock' },
@@ -106,6 +113,27 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     defaultSidebarTab: 'overview',
     sidebarCards: [
       { value: 'customer', label: 'Customer' },
+      { value: 'origin', label: 'Origin' },
+    ],
+  },
+
+  work_order: {
+    entityType: 'work_order',
+    // Sections mode (dispatch M2 build spec §F.1/§F.2, 04-ui.md §6): the job view
+    // is a scroll-spy page, not content-swapping tabs.
+    layout: 'sections',
+    mainTabs: [
+      { value: 'schedule', label: 'Schedule', icon: 'calendar' },
+      { value: 'line-items', label: 'Line items', icon: 'receipt-text' },
+      { value: 'timeline', label: 'Timeline', icon: 'clock' },
+      { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
+    ],
+    sidebarTabs: DEFAULT_SIDEBAR_TABS,
+    actions: {},
+    defaultTab: 'schedule',
+    defaultSidebarTab: 'overview',
+    sidebarCards: [
+      { value: 'customer-site', label: 'Customer & site' },
       { value: 'origin', label: 'Origin' },
     ],
   },

--- a/packages/ui/src/components/event-calendar/day-view.tsx
+++ b/packages/ui/src/components/event-calendar/day-view.tsx
@@ -102,7 +102,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
   )
 
   return (
-    <div data-slot='day-view' className='flex h-full flex-col'>
+    <div data-slot='day-view' className='flex flex-col'>
       {showAllDaySection && (
         <div className='border-border/70 bg-muted/50 border-t'>
           <div className='grid grid-cols-[3rem_1fr] sm:grid-cols-[3.5rem_1fr]'>
@@ -134,7 +134,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
         </div>
       )}
 
-      <div className='grid flex-1 grid-cols-[3rem_1fr] overflow-hidden border-t border-border/70 sm:grid-cols-[3.5rem_1fr]'>
+      <div className='grid flex-1 grid-cols-[3rem_1fr] border-t border-border/70 sm:grid-cols-[3.5rem_1fr]'>
         <HourGutter
           hours={hours}
           nowIndicator={

--- a/packages/ui/src/components/event-calendar/event-calendar.tsx
+++ b/packages/ui/src/components/event-calendar/event-calendar.tsx
@@ -189,7 +189,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
   const body = (
     <>
       {!hideToolbar && (
-        <div className={cn('flex items-center justify-between p-2 sm:p-4', className)}>
+        <div className='flex items-center justify-between p-2 sm:p-4'>
           <div className='flex items-center gap-1 sm:gap-4'>
             <button
               type='button'
@@ -246,7 +246,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
         </div>
       )}
 
-      <div className='flex flex-1 flex-col'>
+      <div className='flex min-h-0 flex-1 flex-col overflow-y-auto'>
         {view === 'month' && (
           <MonthView
             currentDate={date}
@@ -307,7 +307,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
 
   return (
     <div
-      className='flex flex-col rounded-lg border has-data-[slot=month-view]:flex-1'
+      className={cn('flex min-w-0 flex-col rounded-lg border', className)}
       style={
         {
           '--event-height': `${EventHeight}px`,

--- a/packages/ui/src/components/event-calendar/resource-day-view.tsx
+++ b/packages/ui/src/components/event-calendar/resource-day-view.tsx
@@ -98,7 +98,7 @@ export function ResourceDayView<T extends EventCalendarItem = EventCalendarItem>
   const gridColsStyle = { gridTemplateColumns: `repeat(${resources.length}, minmax(0, 1fr))` }
 
   return (
-    <div data-slot='resource-day-view' className='flex h-full flex-col'>
+    <div data-slot='resource-day-view' className='flex flex-col'>
       <div className='bg-background/80 border-border/70 sticky top-0 z-30 flex border-b backdrop-blur-md'>
         <div className='w-12 shrink-0 sm:w-14' />
         <div className='grid flex-1' style={gridColsStyle}>
@@ -136,7 +136,7 @@ export function ResourceDayView<T extends EventCalendarItem = EventCalendarItem>
         </div>
       )}
 
-      <div className='flex flex-1 overflow-hidden'>
+      <div className='flex flex-1'>
         <HourGutter
           hours={hours}
           nowIndicator={

--- a/packages/ui/src/components/event-calendar/week-view.tsx
+++ b/packages/ui/src/components/event-calendar/week-view.tsx
@@ -116,8 +116,8 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
   )
 
   return (
-    <div data-slot='week-view' className='flex h-full flex-col'>
-      <div className='bg-background/80 border-border/70 sticky top-0 z-30 grid grid-cols-8 border-b backdrop-blur-md'>
+    <div data-slot='week-view' className='flex flex-col'>
+      <div className='bg-background/80 border-border/70 sticky top-0 z-30 grid grid-cols-[3rem_repeat(7,minmax(0,1fr))] border-b backdrop-blur-md sm:grid-cols-[3.5rem_repeat(7,minmax(0,1fr))]'>
         <div className='text-muted-foreground/70 py-2 text-center text-sm'>
           <span className='max-[479px]:sr-only'>{format(new Date(), 'O')}</span>
         </div>
@@ -136,7 +136,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
 
       {showAllDaySection && (
         <div className='border-border/70 bg-muted/50 border-b'>
-          <div className='grid grid-cols-8'>
+          <div className='grid grid-cols-[3rem_repeat(7,minmax(0,1fr))] sm:grid-cols-[3.5rem_repeat(7,minmax(0,1fr))]'>
             <div className='border-border/70 relative'>
               <span className='text-muted-foreground/70 absolute bottom-0 left-0 h-6 w-full max-w-full pe-2 text-right text-[10px] sm:pe-4 sm:text-xs'>
                 All day
@@ -192,7 +192,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
         </div>
       )}
 
-      <div className='grid flex-1 grid-cols-8 overflow-hidden'>
+      <div className='grid flex-1 grid-cols-[3rem_repeat(7,minmax(0,1fr))] sm:grid-cols-[3.5rem_repeat(7,minmax(0,1fr))]'>
         <HourGutter
           hours={hours}
           nowIndicator={


### PR DESCRIPTION
## Summary

Implements **plans/dispatch/07-m2-build.md §F–§G** (the M2b job-view slice). Follows #1132 (M2a board).

- **DetailView `layout: 'sections'`** — generic scroll-spy sections capability following the agent-detail structure (`NavStack` + `useScrollSpy` bound to the existing `?tab=` state), a `drillPanels` registry driven by `panel`/`item` nuqs params, and `variant: 'section'` threaded through Timeline/Tasks/QuoteLineItems. The `'tabs'` path is byte-identical — every existing detail page renders unchanged.
- **work_order detail page** — `/app/work-orders/[workOrderId]` with sections **Schedule · Line items · Timeline · Tasks**; customer-site + origin sidebar cards (origin renders the source request incl. preferred/alternate dates, arrival window, source-ticket link); visit list → visit detail drill panels; the Schedule section carries the visit card (assignee, window, status stepper, inline `SchedulePopover`, Dispatch button). `ModelTypeMeta.work_order.hasDetailPage` flipped → drawer fullscreen button + record links resolve. Drawer gains a Schedule header action. Line items reuse the MQ1 `LineBuilder` (already pre-wired for `work_order`), with a "Billed each visit" header for recurring jobs.
- **Quote detail flips tabs → sections** via config — lifecycle/send/download strip confirmed rendering in section mode.
- **Board/calendar fixes to merged M2a code** (part of the diff is `packages/ui` corrections to #1132): `UNASSIGNED_RESOURCE_ID` import hotfix (runtime error), scroll ownership moved to the calendar shell, week-view gutter column alignment, drag-overlay ghost now renders the real visit chip, chip popover "Open record" deep-links to the new detail page.
- **Rides along**: `apps/worker/scripts/run-entity-migration-036.ts` — MP1's entity-migration runner that #1131 missed (not M2b work).

## Verification

- `verify-dispatch-m2.ts` re-run post-M2b: **46/46**; repo `pnpm lint` clean; static import-resolution sweep over all touched component trees clean.
- **Remaining manual (browser)**: work_order page via drawer expand; scroll-spy tabs + `?tab=` deep links; visit drills push/pop; Schedule card actions; line-items section; quote sections mode with lifecycle actions reachable.