### PR TITLE
feat(money): invoice automation (MI2) — auto-draft engine, billing schedule, org invoicing settings

### DIFF
--- a/apps/web/src/app/(protected)/app/dispatch/settings/invoicing/page.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/settings/invoicing/page.tsx
@@ -1,0 +1,9 @@
+// apps/web/src/app/(protected)/app/dispatch/settings/invoicing/page.tsx
+
+import { InvoicingSettingsPage } from '~/components/money/ui/settings/invoicing-page'
+
+function DispatchInvoicingSettings() {
+  return <InvoicingSettingsPage />
+}
+
+export default DispatchInvoicingSettings

--- a/apps/web/src/app/(protected)/app/dispatch/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/settings/layout.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import { MainPageContent } from '@auxx/ui/components/main-page'
-import { Clock, CreditCard, FileText, Hash, Tags, Users } from 'lucide-react'
+import { Clock, CreditCard, FileText, Hash, Receipt, Tags, Users } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import SidebarSecondary from '~/components/global/sidebar-secondary'
 import type { SidebarProps } from '~/constants/menu'
@@ -44,6 +44,12 @@ const DISPATCH_SETTINGS: SidebarProps[] = [
         label: 'Documents',
         slug: 'documents',
         icon: <FileText />,
+      },
+      {
+        id: 'dispatch-settings-invoicing',
+        label: 'Invoicing',
+        slug: 'invoicing',
+        icon: <Receipt />,
       },
       {
         id: 'dispatch-settings-payments',

--- a/apps/web/src/components/dispatch/ui/job-schedule/billing-schedule-editor.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/billing-schedule-editor.tsx
@@ -1,0 +1,122 @@
+// apps/web/src/components/dispatch/ui/job-schedule/billing-schedule-editor.tsx
+'use client'
+
+import { detectTimezone } from '@auxx/config/client'
+import { weekStartToIndex } from '@auxx/lib/availability/client'
+import { type RecurrencePattern, recurrencePatternSchema } from '@auxx/lib/recurrence/client'
+import { Button } from '@auxx/ui/components/button'
+import { toastError } from '@auxx/ui/components/toast'
+import { useState } from 'react'
+import type { RecordId } from '~/components/resources'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+import { RecurrencePatternFields } from '../recurrence/recurrence-pattern-fields'
+import { defaultCustomPattern, scalarSetting } from '../recurrence/recurrence-utils'
+
+export interface BillingScheduleEditorProps {
+  workOrderRecordId: RecordId
+  /** The existing rule's pattern, or `null` for a fresh schedule (money MI2 build spec §K.2). */
+  existingPattern: RecurrencePattern | null
+  onClose: () => void
+}
+
+/**
+ * Billing schedule editor (money MI2 build spec §K.2) — reuses M2c's `RecurrencePatternFields`
+ * (pattern + end condition only, no time/duration/assignee — those stay null for
+ * `invoice_drafts` rules) inside a popover from the job view's Billing row. Save writes
+ * `money.setInvoiceSchedule` (whole-rule edit, §F.1 — timezone is re-detected from the browser
+ * on every save, the `schedule-popover.tsx` convention); Remove clears the rule (existing
+ * drafts are kept) behind `useConfirm`.
+ */
+export function BillingScheduleEditor({
+  workOrderRecordId,
+  existingPattern,
+  onClose,
+}: BillingScheduleEditorProps) {
+  const utils = api.useUtils()
+  const [confirm, ConfirmDialog] = useConfirm()
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const weekStart = (scalarSetting(getSetting('organization.weekStart')) ?? 'monday') as
+    | 'monday'
+    | 'sunday'
+    | 'saturday'
+  const weekStartIndex = weekStartToIndex(weekStart)
+
+  const [pattern, setPattern] = useState<RecurrencePattern>(
+    existingPattern ?? defaultCustomPattern(undefined)
+  )
+  const patternValid = recurrencePatternSchema.safeParse(pattern).success
+
+  const invalidate = () => void utils.money.getInvoiceSchedule.invalidate({ workOrderRecordId })
+
+  const setSchedule = api.money.setInvoiceSchedule.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Error saving billing schedule', description: error.message }),
+    onSuccess: () => {
+      invalidate()
+      onClose()
+    },
+  })
+  const clearSchedule = api.money.clearInvoiceSchedule.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Error removing billing schedule', description: error.message }),
+    onSuccess: () => {
+      invalidate()
+      onClose()
+    },
+  })
+
+  const handleSave = () => {
+    if (!patternValid) return
+    setSchedule.mutate({ workOrderRecordId, pattern, timezone: detectTimezone() })
+  }
+
+  const handleRemove = async () => {
+    const confirmed = await confirm({
+      title: 'Stop generating scheduled invoices?',
+      description: 'Existing drafts are kept.',
+      confirmText: 'Remove',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+    clearSchedule.mutate({ workOrderRecordId })
+  }
+
+  return (
+    <div className='w-80 space-y-3 p-3'>
+      <RecurrencePatternFields
+        value={pattern}
+        onChange={setPattern}
+        weekStartIndex={weekStartIndex}
+      />
+      {!patternValid && (
+        <p className='px-0.5 text-xs text-destructive'>
+          Pick at least one weekday, or fix the end condition, to save this pattern.
+        </p>
+      )}
+      <div className='flex items-center justify-between gap-2'>
+        {existingPattern ? (
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={handleRemove}
+            loading={clearSchedule.isPending}>
+            Remove
+          </Button>
+        ) : (
+          <span />
+        )}
+        <Button
+          size='sm'
+          onClick={handleSave}
+          loading={setSchedule.isPending}
+          disabled={!patternValid}>
+          Save
+        </Button>
+      </div>
+      <ConfirmDialog />
+    </div>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/billing-schedule-row.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/billing-schedule-row.tsx
@@ -1,0 +1,74 @@
+// apps/web/src/components/dispatch/ui/job-schedule/billing-schedule-row.tsx
+'use client'
+
+import type { RecurrencePattern } from '@auxx/lib/recurrence/client'
+import { Button } from '@auxx/ui/components/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { CalendarClock } from 'lucide-react'
+import { useState } from 'react'
+import type { RecordId } from '~/components/resources'
+import { api } from '~/trpc/react'
+import { BillingScheduleEditor } from './billing-schedule-editor'
+
+/** Static explainer copy for the two non-editable automated timings (money MI2 build spec §K.1). */
+const INVOICE_TIMING_EXPLAINER: Record<string, string> = {
+  per_visit_completed: 'Invoice drafts are created after each completed visit.',
+  on_completion: 'An invoice draft is created when the job completes.',
+  as_needed: 'Invoices are created manually.',
+}
+
+export interface BillingScheduleRowProps {
+  workOrderRecordId: RecordId
+  /** `work_order_invoice_timing` value. */
+  invoiceTiming: string
+}
+
+/**
+ * Job view Billing row (money MI2 build spec §K.1) — the reserved slot above the line-items
+ * builder. `custom_schedule` shows the recurrence summary + an editor popover (§K.2); the other
+ * automated timings get one quiet explainer line; `as_needed` explains billing stays manual.
+ * Kept as a single row, not a card, so it doesn't compete with the line items below it.
+ */
+export function BillingScheduleRow({ workOrderRecordId, invoiceTiming }: BillingScheduleRowProps) {
+  const [open, setOpen] = useState(false)
+  const scheduleQuery = api.money.getInvoiceSchedule.useQuery(
+    { workOrderRecordId },
+    { enabled: invoiceTiming === 'custom_schedule' }
+  )
+
+  if (invoiceTiming !== 'custom_schedule') {
+    const explainer = INVOICE_TIMING_EXPLAINER[invoiceTiming]
+    if (!explainer) return null
+    return (
+      <div className='flex items-center gap-1.5 px-4 pt-3 pb-1 text-xs text-muted-foreground'>
+        <CalendarClock className='size-3.5' />
+        {explainer}
+      </div>
+    )
+  }
+
+  const rule = scheduleQuery.data
+
+  return (
+    <div className='flex items-center justify-between gap-2 px-4 pt-3 pb-1'>
+      <div className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+        <CalendarClock className='size-3.5' />
+        {rule ? rule.summary : 'No billing schedule yet'}
+      </div>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button variant='ghost' size='xs'>
+            {rule ? 'Edit schedule' : 'Add billing schedule'}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className='w-auto p-0' align='end'>
+          <BillingScheduleEditor
+            workOrderRecordId={workOrderRecordId}
+            existingPattern={rule ? (rule.pattern as unknown as RecurrencePattern) : null}
+            onClose={() => setOpen(false)}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
@@ -5,6 +5,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import type { DetailViewTabProps } from '~/components/detail-view'
 import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { BillingScheduleRow } from './billing-schedule-row'
 
 /**
  * WorkOrderLineItemsTab — registered as `work_order:line-items` (dispatch M2
@@ -14,17 +15,25 @@ import { useSystemValues } from '~/components/resources/hooks/use-system-values'
  * `hasBilling` is quote/invoice-only) — this is the job's per-cycle line set
  * ("what every visit bills", 04-ui.md §6 Line items section / money 01-ui
  * #13): the header reads "Billed each visit" when the job is recurring
- * (`work_order_job_type`).
+ * (`work_order_job_type`). The Billing row (money MI2 build spec §K.1) sits
+ * above it — the reserved slot for how/when invoice drafts get generated.
  */
 export function WorkOrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
-  const { values } = useSystemValues(recordId, ['work_order_job_type'], { autoFetch: true })
+  const { values } = useSystemValues(
+    recordId,
+    ['work_order_job_type', 'work_order_invoice_timing'],
+    { autoFetch: true }
+  )
   const jobType = (values.work_order_job_type as string | undefined) ?? 'one_off'
+  const invoiceTiming =
+    (values.work_order_invoice_timing as string | undefined) ?? 'per_visit_completed'
   const isSection = variant === 'section'
 
   return (
     <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
+      <BillingScheduleRow workOrderRecordId={recordId} invoiceTiming={invoiceTiming} />
       {jobType === 'recurring' && (
-        <div className='px-4 pt-3 pb-1 text-xs font-medium text-muted-foreground'>
+        <div className='px-4 pt-1 pb-1 text-xs font-medium text-muted-foreground'>
           Billed each visit
         </div>
       )}

--- a/apps/web/src/components/money/ui/settings/invoicing-page.tsx
+++ b/apps/web/src/components/money/ui/settings/invoicing-page.tsx
@@ -1,0 +1,76 @@
+// apps/web/src/components/money/ui/settings/invoicing-page.tsx
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import { Lock, Receipt } from 'lucide-react'
+import { EmptyState } from '~/components/global/empty-state'
+import { FieldPanel } from '~/components/global/forms/field-panel'
+import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
+import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+
+/**
+ * Invoicing settings page (money MI2 build spec §O.3) — the master switch,
+ * default timing, and date basis for automated invoice drafts. Admin-gated,
+ * plain form page (availability-page recipe): one `useSettings({scope:
+ * 'DOCUMENTS'})` instance via `SettingsFieldRow`, no tabs.
+ *
+ * `defaultTiming` also write-throughs onto the two `quote_invoice_timing`/
+ * `work_order_invoice_timing` `CustomField.defaultValue` rows on save — see
+ * `packages/lib/src/settings/settings-service.ts` (`updateOrganizationSetting`).
+ */
+export function InvoicingSettingsPage() {
+  useUser({ requireRoles: ['ADMIN', 'OWNER'] })
+  const { hasAccess } = useFeatureFlags()
+
+  const breadcrumbs = [{ title: 'Dispatch Settings' }, { title: 'Invoicing' }]
+
+  if (!hasAccess(FeatureKey.dispatch)) {
+    return (
+      <SettingsPage
+        title='Invoicing'
+        description='Configure automated invoice drafts for completed jobs and visits.'
+        breadcrumbs={breadcrumbs}>
+        <EmptyState
+          icon={Lock}
+          title='Dispatch Not Available'
+          description='Upgrade your plan to use quoting and dispatch.'
+          button={<div className='h-12' />}
+        />
+      </SettingsPage>
+    )
+  }
+
+  return (
+    <SettingsPage
+      title='Invoicing'
+      description='Configure automated invoice drafts for completed jobs and visits.'
+      breadcrumbs={breadcrumbs}>
+      <div className='flex flex-col gap-8 p-3 sm:p-6'>
+        <SettingsSection
+          icon={Receipt}
+          title='Automation'
+          description='Master switch and defaults for auto-generated invoice drafts.'>
+          <FieldPanel className='mt-1 p-0' resizeId='invoicing-settings' defaultLabelWidth={220}>
+            <SettingsFieldRow
+              settingKey='documents.invoice.autoEnabled'
+              title='Automatic invoicing'
+              description='Generate invoice drafts automatically. Turning this off only stops automation — manual gather still works.'
+            />
+            <SettingsFieldRow
+              settingKey='documents.invoice.defaultTiming'
+              title='Default invoice timing'
+              description='What new quotes and jobs start as. A per-job timing setting always overrides this default.'
+            />
+            <SettingsFieldRow
+              settingKey='documents.invoice.dateBasis'
+              title='Invoice date basis'
+              description='Whether auto-generated invoices are dated to the visit or the day they were generated.'
+            />
+          </FieldPanel>
+        </SettingsSection>
+      </div>
+    </SettingsPage>
+  )
+}

--- a/apps/web/src/server/api/routers/money.ts
+++ b/apps/web/src/server/api/routers/money.ts
@@ -5,6 +5,7 @@ import { renderPreviewQuotePdf } from '@auxx/lib/documents'
 import { NotFoundError } from '@auxx/lib/errors'
 import {
   approveQuote,
+  clearInvoiceSchedule,
   convertQuoteToWorkOrder,
   createInvoiceFromWorkOrder,
   createQuoteFromRequest,
@@ -14,6 +15,7 @@ import {
   deleteManualPayment,
   disconnectPaymentAccount,
   ensureQuoteDocumentPdf,
+  getInvoiceSchedule,
   getPaymentAccount,
   listUninvoicedLines,
   markInvoiceSent,
@@ -23,11 +25,18 @@ import {
   recordManualPayment,
   refundTransaction,
   reorderLines,
+  setInvoiceSchedule,
   syncAccountState,
   voidInvoice,
 } from '@auxx/lib/money'
 import { FeaturePermissionService } from '@auxx/lib/permissions'
 import { FeatureKey } from '@auxx/lib/permissions/client'
+import {
+  describeRecurrence,
+  type RecurrencePattern,
+  recurrencePatternSchema,
+} from '@auxx/lib/recurrence'
+import { getOrganizationSetting } from '@auxx/lib/settings'
 import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, recordIdSchema } from '@auxx/types/resource'
 import { and, asc, eq } from 'drizzle-orm'
@@ -231,6 +240,65 @@ export const moneyRouter = createTRPCRouter({
         userId: ctx.session.user.id,
         lineInstanceId: entityInstanceId,
       })
+    }),
+
+  // ─── Invoice automation — billing schedule (money MI2 build spec §J) ────
+  // Deliberately member-level (`moneyProcedure`), NOT admin-gated like M2c's dispatch
+  // recurrence procedures — configuring a job's billing cadence is desk work, same tier as
+  // recording a payment (MI1 decision 8's spirit), not an account-level/destructive action.
+
+  setInvoiceSchedule: moneyProcedure
+    .input(
+      z.object({
+        workOrderRecordId: recordIdSchema,
+        pattern: recurrencePatternSchema,
+        timezone: z.string(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { entityInstanceId: workOrderInstanceId } = parseRecordId(input.workOrderRecordId)
+      return setInvoiceSchedule({
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.user.id,
+        workOrderInstanceId,
+        pattern: input.pattern,
+        timezone: input.timezone,
+      })
+    }),
+
+  clearInvoiceSchedule: moneyProcedure
+    .input(z.object({ workOrderRecordId: recordIdSchema }))
+    .mutation(async ({ ctx, input }) => {
+      const { entityInstanceId: workOrderInstanceId } = parseRecordId(input.workOrderRecordId)
+      return clearInvoiceSchedule({
+        organizationId: ctx.session.organizationId,
+        workOrderInstanceId,
+      })
+    }),
+
+  getInvoiceSchedule: moneyProcedure
+    .input(z.object({ workOrderRecordId: recordIdSchema }))
+    .query(async ({ ctx, input }) => {
+      const { entityInstanceId: workOrderInstanceId } = parseRecordId(input.workOrderRecordId)
+      const rule = await getInvoiceSchedule({
+        organizationId: ctx.session.organizationId,
+        workOrderInstanceId,
+      })
+      if (!rule) return null
+
+      const weekStart = (await getOrganizationSetting({
+        organizationId: ctx.session.organizationId,
+        key: 'organization.weekStart',
+      })) as 'monday' | 'sunday' | 'saturday'
+
+      return {
+        pattern: rule.pattern,
+        timezone: rule.timezone,
+        materializedUntil: rule.materializedUntil,
+        summary: describeRecurrence(rule.pattern as unknown as RecurrencePattern, {
+          weekStart: weekStart ?? 'monday',
+        }),
+      }
     }),
 
   recordPayment: moneyProcedure

--- a/apps/worker/scripts/run-entity-migration-038.ts
+++ b/apps/worker/scripts/run-entity-migration-038.ts
@@ -1,0 +1,32 @@
+// apps/worker/scripts/run-entity-migration-038.ts
+/**
+ * One-off runner for entity migration 038 (invoice.visitId field + seeded "Drafts" table view,
+ * money MI2 automation build, plans/dispatch/money/08-mi2-build.md §I) across all orgs. Runs
+ * ONLY 038 — deliberately not runAllEntityMigrations, so pending migrations from parallel work
+ * stay untouched. Idempotent — safe to re-run to confirm alreadyUpToDate.
+ *
+ * Run (from repo root) under the worker runtime so the @auxx/lib import chain
+ * resolves its native ESM deps:
+ *   node --conditions source --env-file .env --import tsx/esm \
+ *     apps/worker/scripts/run-entity-migration-038.ts
+ */
+
+import { database } from '@auxx/database'
+import {
+  ALL_ENTITY_MIGRATIONS,
+  runEntityMigrationForAllOrgs,
+} from '@auxx/lib/seed/entity-migrations'
+
+async function main() {
+  const migration = ALL_ENTITY_MIGRATIONS.find((m) => m.id === '038-invoice-automation')
+  if (!migration) throw new Error('Migration 038 not found in registry')
+
+  await runEntityMigrationForAllOrgs(database, migration)
+  console.log('done')
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/worker/scripts/verify-money-mi2.ts
+++ b/apps/worker/scripts/verify-money-mi2.ts
@@ -1,0 +1,1690 @@
+// apps/worker/scripts/verify-money-mi2.ts
+/**
+ * Money MI2 (Invoice Automation) end-to-end verification
+ * (plans/dispatch/money/08-mi2-build.md §M cases 1-10, §O.4 cases 12-14). Exercises the REAL
+ * trigger doors: `setVisitStatus` (§D, per_visit_completed), the `generateDraftOnCompletion`
+ * field-change hook fired by both the visit roll-up AND plain `UnifiedCrudHandler.update`
+ * (§E, on_completion), `setInvoiceSchedule`/`sweepInvoiceDrafts`/`materializeInvoiceDrafts`
+ * (§F, custom_schedule), M2c's real `pauseEngagement`/`resumeEngagement`/`endEngagement`, and
+ * the three `documents.invoice.*` org settings (§O). Also directly calls `generateInvoiceDraft`
+ * once to assert its documented `reason` contract.
+ *
+ * Creates records prefixed "[MI2-verify]" and deletes them at the end (try/finally).
+ * `WorkOrderVisit`/`RecurrenceRule` rows cascade off `EntityInstance` deletes (the
+ * verify-dispatch-recurring.ts precedent), so deleting a work order cleans up its visits and
+ * both its `work_order_visits` and `invoice_drafts` recurrence rules for free.
+ *
+ * Run (from repo root) under the worker runtime:
+ *   node --conditions source --env-file .env --import tsx/esm \
+ *     apps/worker/scripts/verify-money-mi2.ts
+ */
+
+import { database } from '@auxx/database'
+import { onCacheEvent } from '@auxx/lib/cache'
+import {
+  endEngagement,
+  pauseEngagement,
+  resumeEngagement,
+  scheduleVisit,
+  setRecurrenceRule,
+  setVisitStatus,
+} from '@auxx/lib/dispatch'
+import { AuxxError } from '@auxx/lib/errors'
+import {
+  approveQuote,
+  clearInvoiceSchedule,
+  convertQuoteToWorkOrder,
+  deleteInvoiceLine,
+  generateInvoiceDraft,
+  getInvoiceSchedule,
+  markQuoteSent,
+  setInvoiceSchedule,
+  sweepInvoiceDrafts,
+} from '@auxx/lib/money'
+import { expandOccurrences, type RecurrencePattern } from '@auxx/lib/recurrence'
+import { UnifiedCrudHandler } from '@auxx/lib/resources'
+import { getOrganizationSetting, updateOrganizationSetting } from '@auxx/lib/settings'
+
+/** Build a RecordId string without pulling in `@auxx/types` (not a worker dependency). */
+function toRecordId(entityDefinitionId: string, entityInstanceId: string) {
+  return `${entityDefinitionId}:${entityInstanceId}` as never
+}
+
+let pass = 0
+let fail = 0
+function check(name: string, ok: boolean, detail?: unknown) {
+  if (ok) {
+    pass++
+    console.log(`  ✅ ${name}`)
+  } else {
+    fail++
+    console.log(`  ❌ ${name}`, detail ?? '')
+  }
+}
+
+/** Run `fn`, expecting it to throw. Returns the caught error (or `undefined` if it didn't). */
+async function expectThrow(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+    return undefined
+  } catch (err) {
+    return err ?? new Error('threw a falsy value')
+  }
+}
+
+// ── Date helpers (plain math, no reliance on the engine's own date-fns helpers) ──
+
+function addDaysToIso(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00.000Z`)
+  d.setUTCDate(d.getUTCDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+function weekdayOfIso(iso: string): number {
+  return new Date(`${iso}T00:00:00.000Z`).getUTCDay()
+}
+
+// ── DB helpers ──
+
+async function entityDefId(organizationId: string, entityType: string) {
+  const def = await database.query.EntityDefinition.findFirst({
+    columns: { id: true },
+    where: (t, { and, eq }) =>
+      and(eq(t.organizationId, organizationId), eq(t.entityType, entityType)),
+  })
+  return def?.id ?? null
+}
+
+async function fieldId(organizationId: string, entityType: string, systemAttribute: string) {
+  const defId = await entityDefId(organizationId, entityType)
+  if (!defId) return null
+  const field = await database.query.CustomField.findFirst({
+    columns: { id: true },
+    where: (t, { and, eq }) =>
+      and(eq(t.entityDefinitionId, defId), eq(t.systemAttribute, systemAttribute)),
+  })
+  return field?.id ?? null
+}
+
+async function fieldValueByAttr(
+  organizationId: string,
+  entityType: string,
+  instanceId: string,
+  systemAttribute: string
+) {
+  const fid = await fieldId(organizationId, entityType, systemAttribute)
+  if (!fid) return null
+  const fv = await database.query.FieldValue.findFirst({
+    where: (t, { and, eq }) => and(eq(t.entityId, instanceId), eq(t.fieldId, fid)),
+  })
+  return fv ?? null
+}
+
+async function instanceExists(instanceId: string): Promise<boolean> {
+  const row = await database.query.EntityInstance.findFirst({
+    columns: { id: true },
+    where: (t, { eq }) => eq(t.id, instanceId),
+  })
+  return !!row
+}
+
+async function getVisitsSorted(workOrderInstanceId: string) {
+  return database.query.WorkOrderVisit.findMany({
+    where: (t, { eq }) => eq(t.workOrderId, workOrderInstanceId),
+    orderBy: (t, { asc }) => [asc(t.occurrenceDate), asc(t.startTime)],
+  })
+}
+
+async function getRuleFor(subjectType: string, subjectId: string) {
+  return database.query.RecurrenceRule.findFirst({
+    where: (t, { and, eq }) => and(eq(t.subjectType, subjectType), eq(t.subjectId, subjectId)),
+  })
+}
+
+async function main() {
+  const user = await database.query.User.findFirst({
+    columns: { id: true },
+    where: (t, { eq }) => eq(t.email, 'm4rkuskk@gmail.com'),
+  })
+  if (!user) throw new Error('Dev user not found')
+  const organizationId = 'u45w22ft66ymiaa19ohs7m9f' // Marki Corp (primary dev org)
+  const userId = user.id
+  console.log(`Org ${organizationId}, user ${userId}`)
+
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+
+  /** `listFiltered` helper — invoices matching one `(fieldId, value)` "is" condition. */
+  async function listInvoicesFiltered(filterFieldId: string, value: unknown): Promise<string[]> {
+    const { ids } = await handler.listFiltered({
+      entityDefinitionId: 'invoice',
+      filters: [
+        {
+          id: 'f',
+          logicalOperator: 'AND',
+          conditions: [{ id: 'c1', fieldId: filterFieldId, operator: 'is', value }],
+        },
+      ],
+      limit: 100,
+      mode: 'oneshot',
+    })
+    return ids
+  }
+
+  /** The invoice's OWNED line copies (workOrder empty) — the mi1/gather.ts "owned copies" recipe. */
+  async function listOwnedInvoiceLines(invoiceRecordId: unknown): Promise<string[]> {
+    const { ids } = await handler.listFiltered({
+      entityDefinitionId: 'line_item',
+      filters: [
+        {
+          id: 'owned-lines',
+          logicalOperator: 'AND',
+          conditions: [
+            { id: 'c1', fieldId: 'line_item:invoice', operator: 'is', value: invoiceRecordId },
+            { id: 'c2', fieldId: 'line_item:workOrder', operator: 'empty', value: null },
+          ],
+        },
+      ],
+      limit: 100,
+      mode: 'oneshot',
+    })
+    return ids
+  }
+
+  const todayIso = new Date().toISOString().slice(0, 10)
+  const todayWeekday = weekdayOfIso(todayIso)
+
+  const createdLineIds: string[] = []
+  const createdInvoiceIds: string[] = []
+  const createdWorkOrderIds: string[] = []
+  const createdQuoteIds: string[] = []
+
+  let autoEnabledChanged = false
+  let originalAutoEnabled: unknown = null
+  let defaultTimingChanged = false
+  let originalDefaultTiming: unknown = null
+  let dateBasisChanged = false
+  let originalDateBasis: unknown = null
+
+  try {
+    const contactDefId = await entityDefId(organizationId, 'contact')
+    const contact = contactDefId
+      ? await database.query.EntityInstance.findFirst({
+          columns: { id: true },
+          where: (t, { eq }) => eq(t.entityDefinitionId, contactDefId),
+        })
+      : null
+    if (!contact) throw new Error('No contact in org — cannot test invoices')
+    const contactRecordId = toRecordId('contact', contact.id)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 1. per_visit x per_visit pricing (Q2a) — real setVisitStatus door
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('1: per_visit x per_visit pricing (Q2a)')
+    const wo1 = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case1 per-visit recurring WO',
+      work_order_contact: contactRecordId,
+    })
+    createdWorkOrderIds.push(wo1.instance.id)
+    await setRecurrenceRule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo1.instance.id,
+      pattern: { frequency: 'daily', interval: 1 },
+      template: { startMinute: 540, durationMinutes: 60 },
+      timezone: 'UTC',
+      effectiveFrom: todayIso,
+    })
+    const wo1Visits = await getVisitsSorted(wo1.instance.id)
+    check(
+      'case1 setup: recurring WO materialized at least 2 visits',
+      wo1Visits.length >= 2,
+      wo1Visits.length
+    )
+    const v1 = wo1Visits[0]!
+    const v2 = wo1Visits[1]!
+
+    const jobSetLine = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case1 job-set line',
+      line_item_qty: 1,
+      line_item_unit_price: 5000,
+      line_item_taxable: true,
+      line_item_work_order: wo1.recordId,
+    })
+    createdLineIds.push(jobSetLine.instance.id)
+    const extraLineV1 = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case1 V1 extra',
+      line_item_qty: 1,
+      line_item_unit_price: 2500,
+      line_item_taxable: true,
+      line_item_work_order: wo1.recordId,
+      line_item_visit_id: v1.id,
+    })
+    createdLineIds.push(extraLineV1.instance.id)
+
+    await setVisitStatus({ organizationId, userId, visitId: v1.id, status: 'done' })
+
+    const v1Drafts = await listInvoicesFiltered('invoice:visitId', v1.id)
+    check('case1: exactly 1 draft created for V1', v1Drafts.length === 1, v1Drafts.length)
+    const v1DraftInstanceId = v1Drafts[0]!
+    createdInvoiceIds.push(v1DraftInstanceId)
+    const v1DraftRecordId = toRecordId('invoice', v1DraftInstanceId)
+
+    const v1OwnedLines = await listOwnedInvoiceLines(v1DraftRecordId)
+    check(
+      'case1: V1 draft has exactly 2 owned lines',
+      v1OwnedLines.length === 2,
+      v1OwnedLines.length
+    )
+    for (const id of v1OwnedLines) createdLineIds.push(id)
+
+    let templateCopyId: string | undefined
+    let gatheredCopyId: string | undefined
+    for (const id of v1OwnedLines) {
+      const src = await fieldValueByAttr(
+        organizationId,
+        'line_item',
+        id,
+        'line_item_source_line_id'
+      )
+      if (src?.valueText) gatheredCopyId = id
+      else templateCopyId = id
+    }
+    check(
+      'case1: found exactly one template copy + one gathered copy',
+      !!templateCopyId && !!gatheredCopyId,
+      { templateCopyId, gatheredCopyId }
+    )
+
+    const templateCopyVisitId = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      templateCopyId!,
+      'line_item_visit_id'
+    )
+    check(
+      'case1: template copy stamped with line_item_visit_id = V1',
+      templateCopyVisitId?.valueText === v1.id,
+      templateCopyVisitId?.valueText
+    )
+
+    const gatheredCopySource = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      gatheredCopyId!,
+      'line_item_source_line_id'
+    )
+    check(
+      'case1: gathered copy sourceLineId points at the extra line',
+      gatheredCopySource?.valueText === extraLineV1.instance.id,
+      gatheredCopySource?.valueText
+    )
+
+    const jobSetLineInvoiceFv = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      jobSetLine.instance.id,
+      'line_item_invoice'
+    )
+    check(
+      'case1: job-set source line NOT stamped (template semantics)',
+      !jobSetLineInvoiceFv?.relatedEntityId
+    )
+
+    const extraLineV1InvoiceFv = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      extraLineV1.instance.id,
+      'line_item_invoice'
+    )
+    check(
+      'case1: extra source line IS stamped',
+      extraLineV1InvoiceFv?.relatedEntityId === v1DraftInstanceId
+    )
+
+    const v1DraftVisitId = await fieldValueByAttr(
+      organizationId,
+      'invoice',
+      v1DraftInstanceId,
+      'invoice_visit_id'
+    )
+    check('case1: draft invoice_visit_id = V1', v1DraftVisitId?.valueText === v1.id)
+
+    const v1DraftTotal = await fieldValueByAttr(
+      organizationId,
+      'invoice',
+      v1DraftInstanceId,
+      'invoice_total'
+    )
+    const v1DraftBalance = await fieldValueByAttr(
+      organizationId,
+      'invoice',
+      v1DraftInstanceId,
+      'invoice_balance'
+    )
+    check(
+      'case1: totals computed, balance = total',
+      !!v1DraftTotal?.valueNumber &&
+        v1DraftTotal.valueNumber > 0 &&
+        v1DraftBalance?.valueNumber === v1DraftTotal.valueNumber,
+      { total: v1DraftTotal?.valueNumber, balance: v1DraftBalance?.valueNumber }
+    )
+
+    const v1DraftIssuedAt = await fieldValueByAttr(
+      organizationId,
+      'invoice',
+      v1DraftInstanceId,
+      'invoice_issued_at'
+    )
+    check(
+      'case1: issuedAt backdated to the visit occurrenceDate (dateBasis default visit_date)',
+      String(v1DraftIssuedAt?.valueDate).slice(0, 10) === v1.occurrenceDate,
+      { issuedAt: v1DraftIssuedAt?.valueDate, expected: v1.occurrenceDate }
+    )
+
+    // Re-complete V1: reset to scheduled, then done again -> no second draft (Q6 dedup).
+    await setVisitStatus({ organizationId, userId, visitId: v1.id, status: 'scheduled' })
+    await setVisitStatus({ organizationId, userId, visitId: v1.id, status: 'done' })
+    const v1DraftsAfterRecomplete = await listInvoicesFiltered('invoice:visitId', v1.id)
+    check(
+      'case1: re-completing V1 does not create a second draft',
+      v1DraftsAfterRecomplete.length === 1,
+      v1DraftsAfterRecomplete.length
+    )
+
+    // Complete V2 (no extras) -> draft with 1 template line.
+    await setVisitStatus({ organizationId, userId, visitId: v2.id, status: 'done' })
+    const v2Drafts = await listInvoicesFiltered('invoice:visitId', v2.id)
+    check('case1: exactly 1 draft created for V2', v2Drafts.length === 1, v2Drafts.length)
+    const v2DraftInstanceId = v2Drafts[0]!
+    createdInvoiceIds.push(v2DraftInstanceId)
+    const v2OwnedLines = await listOwnedInvoiceLines(toRecordId('invoice', v2DraftInstanceId))
+    check(
+      'case1: V2 draft has exactly 1 owned (template) line',
+      v2OwnedLines.length === 1,
+      v2OwnedLines.length
+    )
+    for (const id of v2OwnedLines) createdLineIds.push(id)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 2. Empty skip (Q5)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('2: empty skip (Q5)')
+    const wo2a = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case2 zero-lines WO',
+      work_order_contact: contactRecordId,
+    })
+    createdWorkOrderIds.push(wo2a.instance.id)
+    const wo2aVisit = (await getVisitsSorted(wo2a.instance.id))[0]!
+    const zeroLineErr = await expectThrow(() =>
+      setVisitStatus({ organizationId, userId, visitId: wo2aVisit.id, status: 'done' })
+    )
+    check(
+      'case2: completing a zero-line WO visit does not throw',
+      zeroLineErr === undefined,
+      zeroLineErr
+    )
+    const wo2aDrafts = await listInvoicesFiltered('invoice:visitId', wo2aVisit.id)
+    check('case2: zero-line WO produces no draft', wo2aDrafts.length === 0, wo2aDrafts.length)
+
+    const wo2b = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case2 no-contact WO',
+    })
+    createdWorkOrderIds.push(wo2b.instance.id)
+    const noContactLine = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case2 no-contact line',
+      line_item_qty: 1,
+      line_item_unit_price: 1000,
+      line_item_taxable: true,
+      line_item_work_order: wo2b.recordId,
+    })
+    createdLineIds.push(noContactLine.instance.id)
+    const wo2bVisit = (await getVisitsSorted(wo2b.instance.id))[0]!
+    const noContactErr = await expectThrow(() =>
+      setVisitStatus({ organizationId, userId, visitId: wo2bVisit.id, status: 'done' })
+    )
+    check(
+      'case2: completing a no-contact WO visit does not throw',
+      noContactErr === undefined,
+      noContactErr
+    )
+    const wo2bVisitAfter = await database.query.WorkOrderVisit.findFirst({
+      where: (t, { eq }) => eq(t.id, wo2bVisit.id),
+    })
+    check(
+      'case2: status tap succeeded despite the no-contact skip',
+      wo2bVisitAfter?.status === 'done',
+      wo2bVisitAfter?.status
+    )
+    const wo2bInvoices = await listInvoicesFiltered('invoice:workOrder', wo2b.recordId)
+    check('case2: no-contact WO produces no draft', wo2bInvoices.length === 0, wo2bInvoices.length)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 3. on_completion (Q3a + Q3i), one_off
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('3: on_completion (one_off)')
+    const wo3a = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case3a on_completion via visit roll-up',
+      work_order_contact: contactRecordId,
+      work_order_invoice_timing: 'on_completion',
+    })
+    createdWorkOrderIds.push(wo3a.instance.id)
+    const wo3aVisit = (await getVisitsSorted(wo3a.instance.id))[0]!
+    const wo3aJobSetLine = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case3a job-set line',
+      line_item_qty: 1,
+      line_item_unit_price: 4000,
+      line_item_taxable: true,
+      line_item_work_order: wo3a.recordId,
+    })
+    createdLineIds.push(wo3aJobSetLine.instance.id)
+    const wo3aExtraLine = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case3a extra',
+      line_item_qty: 1,
+      line_item_unit_price: 1500,
+      line_item_taxable: true,
+      line_item_work_order: wo3a.recordId,
+      line_item_visit_id: wo3aVisit.id,
+    })
+    createdLineIds.push(wo3aExtraLine.instance.id)
+
+    await setVisitStatus({ organizationId, userId, visitId: wo3aVisit.id, status: 'done' })
+    const wo3aStatus = await fieldValueByAttr(
+      organizationId,
+      'work_order',
+      wo3a.instance.id,
+      'work_order_status'
+    )
+    check(
+      'case3a: WO rolls up to completed',
+      wo3aStatus?.optionId === 'completed',
+      wo3aStatus?.optionId
+    )
+
+    const wo3aInvoices = await listInvoicesFiltered('invoice:workOrder', wo3a.recordId)
+    check(
+      'case3a: exactly 1 on_completion draft generated',
+      wo3aInvoices.length === 1,
+      wo3aInvoices.length
+    )
+    const wo3aDraftId = wo3aInvoices[0]!
+    createdInvoiceIds.push(wo3aDraftId)
+    const wo3aOwned = await listOwnedInvoiceLines(toRecordId('invoice', wo3aDraftId))
+    check('case3a: draft gathers both lines', wo3aOwned.length === 2, wo3aOwned.length)
+    for (const id of wo3aOwned) createdLineIds.push(id)
+    let wo3aSourcesStamped = true
+    for (const srcId of [wo3aJobSetLine.instance.id, wo3aExtraLine.instance.id]) {
+      const fv = await fieldValueByAttr(organizationId, 'line_item', srcId, 'line_item_invoice')
+      if (fv?.relatedEntityId !== wo3aDraftId) wo3aSourcesStamped = false
+    }
+    check('case3a: both sources stamped (gathered, not templated)', wo3aSourcesStamped)
+
+    // 3b: manual drawer write also fires the hook.
+    const wo3b = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case3b on_completion via manual write',
+      work_order_contact: contactRecordId,
+      work_order_invoice_timing: 'on_completion',
+    })
+    createdWorkOrderIds.push(wo3b.instance.id)
+    const wo3bLine1 = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case3b line 1',
+      line_item_qty: 1,
+      line_item_unit_price: 2000,
+      line_item_taxable: true,
+      line_item_work_order: wo3b.recordId,
+    })
+    createdLineIds.push(wo3bLine1.instance.id)
+    const wo3bLine2 = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case3b line 2',
+      line_item_qty: 1,
+      line_item_unit_price: 3000,
+      line_item_taxable: true,
+      line_item_work_order: wo3b.recordId,
+    })
+    createdLineIds.push(wo3bLine2.instance.id)
+
+    await handler.update(wo3b.recordId, { work_order_status: 'completed' })
+    const wo3bInvoices = await listInvoicesFiltered('invoice:workOrder', wo3b.recordId)
+    check(
+      'case3b: manual drawer write to completed also generates a draft',
+      wo3bInvoices.length === 1,
+      wo3bInvoices.length
+    )
+    const wo3bDraftId = wo3bInvoices[0]!
+    createdInvoiceIds.push(wo3bDraftId)
+    const wo3bOwned = await listOwnedInvoiceLines(toRecordId('invoice', wo3bDraftId))
+    check('case3b: draft gathers both lines', wo3bOwned.length === 2, wo3bOwned.length)
+    for (const id of wo3bOwned) createdLineIds.push(id)
+
+    // re-complete -> empty-skip, no dupe.
+    await handler.update(wo3b.recordId, { work_order_status: 'completed' })
+    const wo3bInvoicesAfter = await listInvoicesFiltered('invoice:workOrder', wo3b.recordId)
+    check(
+      'case3b: re-writing completed again does not create a second draft (empty-skip)',
+      wo3bInvoicesAfter.length === 1,
+      wo3bInvoicesAfter.length
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 4. on_completion x recurring — real endEngagement
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('4: on_completion x recurring (endEngagement)')
+    const wo4 = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case4 recurring on_completion',
+      work_order_contact: contactRecordId,
+    })
+    createdWorkOrderIds.push(wo4.instance.id)
+    await setRecurrenceRule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo4.instance.id,
+      pattern: { frequency: 'weekly', interval: 1, weekdays: [todayWeekday] },
+      template: { startMinute: 540, durationMinutes: 60 },
+      timezone: 'UTC',
+      effectiveFrom: todayIso,
+    })
+    await handler.update(wo4.recordId, { work_order_invoice_timing: 'on_completion' })
+    const wo4Line1 = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case4 line 1',
+      line_item_qty: 1,
+      line_item_unit_price: 6000,
+      line_item_taxable: true,
+      line_item_work_order: wo4.recordId,
+    })
+    createdLineIds.push(wo4Line1.instance.id)
+
+    await endEngagement({ organizationId, userId, workOrderInstanceId: wo4.instance.id })
+    const wo4Status = await fieldValueByAttr(
+      organizationId,
+      'work_order',
+      wo4.instance.id,
+      'work_order_status'
+    )
+    check('case4: engagement ends', wo4Status?.optionId === 'ended', wo4Status?.optionId)
+    const wo4Invoices = await listInvoicesFiltered('invoice:workOrder', wo4.recordId)
+    check(
+      'case4: endEngagement generates the final on_completion draft',
+      wo4Invoices.length === 1,
+      wo4Invoices.length
+    )
+    const wo4DraftId = wo4Invoices[0]!
+    createdInvoiceIds.push(wo4DraftId)
+    const wo4Owned = await listOwnedInvoiceLines(toRecordId('invoice', wo4DraftId))
+    check('case4: draft gathers the one line', wo4Owned.length === 1, wo4Owned.length)
+    for (const id of wo4Owned) createdLineIds.push(id)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 5. custom_schedule x fixed (Q4a)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('5: custom_schedule x fixed (Q4a)')
+    const wo5 = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case5 custom_schedule fixed',
+      work_order_contact: contactRecordId,
+      work_order_pricing_model: 'fixed',
+      work_order_invoice_timing: 'custom_schedule',
+    })
+    createdWorkOrderIds.push(wo5.instance.id)
+    const wo5JobSetLine1 = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case5 contract line 1',
+      line_item_qty: 1,
+      line_item_unit_price: 30000,
+      line_item_taxable: true,
+      line_item_work_order: wo5.recordId,
+    })
+    createdLineIds.push(wo5JobSetLine1.instance.id)
+    const wo5JobSetLine2 = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case5 contract line 2',
+      line_item_qty: 1,
+      line_item_unit_price: 5000,
+      line_item_taxable: true,
+      line_item_work_order: wo5.recordId,
+    })
+    createdLineIds.push(wo5JobSetLine2.instance.id)
+
+    const case5TargetWeekday = (todayWeekday + 3) % 7
+    const case5Pattern: RecurrencePattern = {
+      frequency: 'weekly',
+      interval: 1,
+      weekdays: [case5TargetWeekday],
+    }
+    await setInvoiceSchedule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo5.instance.id,
+      pattern: case5Pattern,
+      timezone: 'UTC',
+    })
+    const wo5InvoicesInitial = await listInvoicesFiltered('invoice:workOrder', wo5.recordId)
+    check(
+      'case5 setup: no drafts from the initial same-day materialize (off-weekday pattern)',
+      wo5InvoicesInitial.length === 0,
+      wo5InvoicesInitial.length
+    )
+
+    const case5AnchorIso = addDaysToIso(todayIso, -14)
+    const case5Boundary = new Date(`${case5AnchorIso}T01:00:00.000Z`)
+    await database.$client.query(
+      'UPDATE "RecurrenceRule" SET anchor = $1, "effectiveFrom" = $1, "materializedUntil" = $2 WHERE "subjectType" = $3 AND "subjectId" = $4',
+      [case5AnchorIso, case5Boundary, 'invoice_drafts', wo5.instance.id]
+    )
+    const case5ExpectedOccurrences = expandOccurrences(case5Pattern, {
+      anchor: case5AnchorIso,
+      timezone: 'UTC',
+      from: case5Boundary,
+      to: new Date(),
+      startMinute: 0,
+    })
+    check(
+      'case5 setup: backdating produces at least 1 due occurrence',
+      case5ExpectedOccurrences.length >= 1,
+      case5ExpectedOccurrences.length
+    )
+
+    await sweepInvoiceDrafts()
+
+    const wo5InvoicesAfterSweep = await listInvoicesFiltered('invoice:workOrder', wo5.recordId)
+    check(
+      'case5: sweep generates one draft per due occurrence',
+      wo5InvoicesAfterSweep.length === case5ExpectedOccurrences.length,
+      { actual: wo5InvoicesAfterSweep.length, expected: case5ExpectedOccurrences.length }
+    )
+    for (const id of wo5InvoicesAfterSweep) createdInvoiceIds.push(id)
+    let case5AllFullTemplateCopies = true
+    for (const invId of wo5InvoicesAfterSweep) {
+      const owned = await listOwnedInvoiceLines(toRecordId('invoice', invId))
+      for (const id of owned) createdLineIds.push(id)
+      if (owned.length !== 2) case5AllFullTemplateCopies = false
+      for (const id of owned) {
+        const src = await fieldValueByAttr(
+          organizationId,
+          'line_item',
+          id,
+          'line_item_source_line_id'
+        )
+        if (src?.valueText) case5AllFullTemplateCopies = false
+      }
+    }
+    check(
+      'case5: every draft is a full (2-line) template copy, no sourceLineId',
+      case5AllFullTemplateCopies
+    )
+    let case5SourcesNeverStamped = true
+    for (const srcId of [wo5JobSetLine1.instance.id, wo5JobSetLine2.instance.id]) {
+      const fv = await fieldValueByAttr(organizationId, 'line_item', srcId, 'line_item_invoice')
+      if (fv?.relatedEntityId) case5SourcesNeverStamped = false
+    }
+    check(
+      'case5: job-set source lines never stamped across repeated occurrences',
+      case5SourcesNeverStamped
+    )
+
+    const wo5RuleAfterSweep = await getRuleFor('invoice_drafts', wo5.instance.id)
+    check(
+      'case5: cursor (materializedUntil) advanced past the backdated boundary',
+      !!wo5RuleAfterSweep?.materializedUntil &&
+        wo5RuleAfterSweep.materializedUntil.getTime() > case5Boundary.getTime(),
+      wo5RuleAfterSweep?.materializedUntil
+    )
+
+    await sweepInvoiceDrafts()
+    const wo5InvoicesAfterSecondSweep = await listInvoicesFiltered(
+      'invoice:workOrder',
+      wo5.recordId
+    )
+    check(
+      'case5: sweeping again produces 0 new drafts (cursor holds)',
+      wo5InvoicesAfterSecondSweep.length === wo5InvoicesAfterSweep.length,
+      wo5InvoicesAfterSecondSweep.length
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 6. custom_schedule x per_visit — gather content collapses on backlog
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('6: custom_schedule x per_visit')
+    const wo6 = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case6 custom_schedule per_visit',
+      work_order_contact: contactRecordId,
+      work_order_invoice_timing: 'custom_schedule',
+    })
+    createdWorkOrderIds.push(wo6.instance.id)
+    const wo6Extra1 = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case6 extra 1',
+      line_item_qty: 1,
+      line_item_unit_price: 1200,
+      line_item_taxable: true,
+      line_item_work_order: wo6.recordId,
+    })
+    createdLineIds.push(wo6Extra1.instance.id)
+    const wo6Extra2 = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case6 extra 2',
+      line_item_qty: 1,
+      line_item_unit_price: 800,
+      line_item_taxable: true,
+      line_item_work_order: wo6.recordId,
+    })
+    createdLineIds.push(wo6Extra2.instance.id)
+
+    const case6TargetWeekday = (todayWeekday + 2) % 7
+    const case6Pattern: RecurrencePattern = {
+      frequency: 'weekly',
+      interval: 1,
+      weekdays: [case6TargetWeekday],
+    }
+    await setInvoiceSchedule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo6.instance.id,
+      pattern: case6Pattern,
+      timezone: 'UTC',
+    })
+    const case6AnchorIso = addDaysToIso(todayIso, -14)
+    const case6Boundary = new Date(`${case6AnchorIso}T01:00:00.000Z`)
+    await database.$client.query(
+      'UPDATE "RecurrenceRule" SET anchor = $1, "effectiveFrom" = $1, "materializedUntil" = $2 WHERE "subjectType" = $3 AND "subjectId" = $4',
+      [case6AnchorIso, case6Boundary, 'invoice_drafts', wo6.instance.id]
+    )
+    const case6ExpectedOccurrences = expandOccurrences(case6Pattern, {
+      anchor: case6AnchorIso,
+      timezone: 'UTC',
+      from: case6Boundary,
+      to: new Date(),
+      startMinute: 0,
+    })
+    check(
+      'case6 setup: backdating produces at least 2 due occurrences (to prove collapse)',
+      case6ExpectedOccurrences.length >= 2,
+      case6ExpectedOccurrences.length
+    )
+
+    await sweepInvoiceDrafts()
+    const wo6Invoices = await listInvoicesFiltered('invoice:workOrder', wo6.recordId)
+    check(
+      'case6: multiple missed occurrences collapse to exactly 1 gather draft',
+      wo6Invoices.length === 1,
+      wo6Invoices.length
+    )
+    const wo6DraftId = wo6Invoices[0]!
+    createdInvoiceIds.push(wo6DraftId)
+    const wo6Owned = await listOwnedInvoiceLines(toRecordId('invoice', wo6DraftId))
+    check('case6: draft gathers both accrued extras', wo6Owned.length === 2, wo6Owned.length)
+    for (const id of wo6Owned) createdLineIds.push(id)
+    let wo6SourcesStamped = true
+    for (const srcId of [wo6Extra1.instance.id, wo6Extra2.instance.id]) {
+      const fv = await fieldValueByAttr(organizationId, 'line_item', srcId, 'line_item_invoice')
+      if (fv?.relatedEntityId !== wo6DraftId) wo6SourcesStamped = false
+    }
+    check('case6: both accrued sources stamped', wo6SourcesStamped)
+
+    await sweepInvoiceDrafts()
+    const wo6InvoicesAfter = await listInvoicesFiltered('invoice:workOrder', wo6.recordId)
+    check(
+      'case6: next sweep with nothing new produces no additional draft (empty-skip)',
+      wo6InvoicesAfter.length === 1,
+      wo6InvoicesAfter.length
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 7. Pause gate (Q8a)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('7: pause gate (Q8a)')
+    const wo7 = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case7 recurring pause gate',
+      work_order_contact: contactRecordId,
+      work_order_pricing_model: 'fixed',
+    })
+    createdWorkOrderIds.push(wo7.instance.id)
+    await setRecurrenceRule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo7.instance.id,
+      pattern: { frequency: 'weekly', interval: 1, weekdays: [todayWeekday] },
+      template: { startMinute: 540, durationMinutes: 60 },
+      timezone: 'UTC',
+      effectiveFrom: todayIso,
+    })
+    await handler.update(wo7.recordId, { work_order_invoice_timing: 'custom_schedule' })
+    const wo7Line = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case7 contract line',
+      line_item_qty: 1,
+      line_item_unit_price: 9000,
+      line_item_taxable: true,
+      line_item_work_order: wo7.recordId,
+    })
+    createdLineIds.push(wo7Line.instance.id)
+
+    const case7TargetWeekday = (todayWeekday + 4) % 7
+    await setInvoiceSchedule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo7.instance.id,
+      pattern: { frequency: 'weekly', interval: 1, weekdays: [case7TargetWeekday] },
+      timezone: 'UTC',
+    })
+
+    await pauseEngagement({ organizationId, userId, workOrderInstanceId: wo7.instance.id })
+    const wo7StatusPaused = await fieldValueByAttr(
+      organizationId,
+      'work_order',
+      wo7.instance.id,
+      'work_order_status'
+    )
+    check(
+      'case7 setup: engagement paused',
+      wo7StatusPaused?.optionId === 'paused',
+      wo7StatusPaused?.optionId
+    )
+
+    const case7AnchorIso = addDaysToIso(todayIso, -14)
+    const case7Boundary = new Date(`${case7AnchorIso}T01:00:00.000Z`)
+    await database.$client.query(
+      'UPDATE "RecurrenceRule" SET anchor = $1, "effectiveFrom" = $1, "materializedUntil" = $2 WHERE "subjectType" = $3 AND "subjectId" = $4',
+      [case7AnchorIso, case7Boundary, 'invoice_drafts', wo7.instance.id]
+    )
+
+    await sweepInvoiceDrafts()
+    const wo7InvoicesWhilePaused = await listInvoicesFiltered('invoice:workOrder', wo7.recordId)
+    check(
+      'case7: paused engagement generates nothing despite a due occurrence',
+      wo7InvoicesWhilePaused.length === 0,
+      wo7InvoicesWhilePaused.length
+    )
+    const wo7RuleAfterPausedSweep = await getRuleFor('invoice_drafts', wo7.instance.id)
+    check(
+      'case7: cursor still advances while paused (no-backfill mechanic)',
+      !!wo7RuleAfterPausedSweep?.materializedUntil &&
+        wo7RuleAfterPausedSweep.materializedUntil.getTime() > case7Boundary.getTime(),
+      wo7RuleAfterPausedSweep?.materializedUntil
+    )
+
+    // 7b: resume -> next occurrence generates.
+    await resumeEngagement({ organizationId, userId, workOrderInstanceId: wo7.instance.id })
+    const wo7StatusActive = await fieldValueByAttr(
+      organizationId,
+      'work_order',
+      wo7.instance.id,
+      'work_order_status'
+    )
+    check(
+      'case7: resume -> active',
+      wo7StatusActive?.optionId === 'active',
+      wo7StatusActive?.optionId
+    )
+
+    const case7Boundary2 = new Date(`${addDaysToIso(todayIso, -7)}T01:00:00.000Z`)
+    await database.$client.query(
+      'UPDATE "RecurrenceRule" SET "materializedUntil" = $1 WHERE "subjectType" = $2 AND "subjectId" = $3',
+      [case7Boundary2, 'invoice_drafts', wo7.instance.id]
+    )
+    await sweepInvoiceDrafts()
+    const wo7InvoicesAfterResume = await listInvoicesFiltered('invoice:workOrder', wo7.recordId)
+    check(
+      'case7: resumed engagement generates on the next due occurrence',
+      wo7InvoicesAfterResume.length === 1,
+      wo7InvoicesAfterResume.length
+    )
+    for (const id of wo7InvoicesAfterResume) createdInvoiceIds.push(id)
+    for (const invId of wo7InvoicesAfterResume) {
+      const owned = await listOwnedInvoiceLines(toRecordId('invoice', invId))
+      for (const id of owned) createdLineIds.push(id)
+    }
+
+    // 7c: one_off + completed + due occurrence -> still generates (Q8 carve-out).
+    const wo7c = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case7c one_off completed carve-out',
+      work_order_contact: contactRecordId,
+      work_order_pricing_model: 'fixed',
+      work_order_invoice_timing: 'custom_schedule',
+    })
+    createdWorkOrderIds.push(wo7c.instance.id)
+    const wo7cLine = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case7c contract line',
+      line_item_qty: 1,
+      line_item_unit_price: 4400,
+      line_item_taxable: true,
+      line_item_work_order: wo7c.recordId,
+    })
+    createdLineIds.push(wo7cLine.instance.id)
+    const case7cTargetWeekday = (todayWeekday + 5) % 7
+    await setInvoiceSchedule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo7c.instance.id,
+      pattern: { frequency: 'weekly', interval: 1, weekdays: [case7cTargetWeekday] },
+      timezone: 'UTC',
+    })
+    await handler.update(wo7c.recordId, { work_order_status: 'completed' })
+    const case7cAnchorIso = addDaysToIso(todayIso, -14)
+    const case7cBoundary = new Date(`${case7cAnchorIso}T01:00:00.000Z`)
+    await database.$client.query(
+      'UPDATE "RecurrenceRule" SET anchor = $1, "effectiveFrom" = $1, "materializedUntil" = $2 WHERE "subjectType" = $3 AND "subjectId" = $4',
+      [case7cAnchorIso, case7cBoundary, 'invoice_drafts', wo7c.instance.id]
+    )
+    await sweepInvoiceDrafts()
+    const wo7cInvoices = await listInvoicesFiltered('invoice:workOrder', wo7c.recordId)
+    check(
+      'case7c: one_off completed WO still generates scheduled drafts (Q8 carve-out)',
+      wo7cInvoices.length >= 1,
+      wo7cInvoices.length
+    )
+    for (const id of wo7cInvoices) createdInvoiceIds.push(id)
+    for (const invId of wo7cInvoices) {
+      const owned = await listOwnedInvoiceLines(toRecordId('invoice', invId))
+      for (const id of owned) createdLineIds.push(id)
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 8. Rule mutations
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('8: rule mutations')
+    const wo8 = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case8 rule mutations',
+      work_order_contact: contactRecordId,
+    })
+    createdWorkOrderIds.push(wo8.instance.id)
+
+    const rejectTimingErr = await expectThrow(() =>
+      setInvoiceSchedule({
+        organizationId,
+        userId,
+        workOrderInstanceId: wo8.instance.id,
+        pattern: { frequency: 'weekly', interval: 1, weekdays: [1] },
+        timezone: 'UTC',
+      })
+    )
+    check(
+      'case8: setInvoiceSchedule rejects when timing != custom_schedule',
+      rejectTimingErr instanceof AuxxError &&
+        /Custom schedule/.test((rejectTimingErr as Error).message),
+      rejectTimingErr
+    )
+
+    await handler.update(wo8.recordId, { work_order_invoice_timing: 'custom_schedule' })
+
+    const invalidPatternErr = await expectThrow(() =>
+      setInvoiceSchedule({
+        organizationId,
+        userId,
+        workOrderInstanceId: wo8.instance.id,
+        pattern: { frequency: 'weekly', interval: 1 } as RecurrencePattern, // no weekdays
+        timezone: 'UTC',
+      })
+    )
+    check(
+      'case8: invalid pattern rejected by zod',
+      invalidPatternErr instanceof AuxxError &&
+        /Invalid recurrence pattern/.test((invalidPatternErr as Error).message),
+      invalidPatternErr
+    )
+
+    const rule8First = await setInvoiceSchedule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo8.instance.id,
+      pattern: { frequency: 'monthly', interval: 1, monthDay: 1 },
+      timezone: 'UTC',
+    })
+    const rule8Second = await setInvoiceSchedule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo8.instance.id,
+      pattern: { frequency: 'monthly', interval: 2, monthDay: 15 },
+      timezone: 'UTC',
+    })
+    check('case8: second save upserts the same rule row', rule8First.id === rule8Second.id, {
+      first: rule8First.id,
+      second: rule8Second.id,
+    })
+    const rule8Refetched = await getInvoiceSchedule({
+      organizationId,
+      workOrderInstanceId: wo8.instance.id,
+    })
+    const rule8Pattern = rule8Refetched?.pattern as unknown as RecurrencePattern | undefined
+    check(
+      'case8: upsert persisted the new pattern',
+      rule8Pattern?.monthDay === 15 && rule8Pattern?.interval === 2,
+      rule8Pattern
+    )
+
+    // Visit rule + invoice rule coexist.
+    await setRecurrenceRule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo8.instance.id,
+      pattern: { frequency: 'weekly', interval: 1, weekdays: [todayWeekday] },
+      template: { startMinute: 540, durationMinutes: 60 },
+      timezone: 'UTC',
+      effectiveFrom: todayIso,
+    })
+    const visitRule8 = await getRuleFor('work_order_visits', wo8.instance.id)
+    const invoiceRule8 = await getRuleFor('invoice_drafts', wo8.instance.id)
+    check(
+      'case8: visit rule + invoice rule coexist on the same work order',
+      !!visitRule8 && !!invoiceRule8 && visitRule8.id !== invoiceRule8.id,
+      { visitRuleId: visitRule8?.id, invoiceRuleId: invoiceRule8?.id }
+    )
+
+    // clearInvoiceSchedule deletes the rule, keeps drafts — generate one first.
+    await handler.update(wo8.recordId, { work_order_pricing_model: 'fixed' })
+    const case8Line = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case8 contract line',
+      line_item_qty: 1,
+      line_item_unit_price: 2200,
+      line_item_taxable: true,
+      line_item_work_order: wo8.recordId,
+    })
+    createdLineIds.push(case8Line.instance.id)
+    const case8AnchorIso = addDaysToIso(todayIso, -14)
+    const case8Boundary = new Date(`${case8AnchorIso}T01:00:00.000Z`)
+    await database.$client.query(
+      'UPDATE "RecurrenceRule" SET pattern = $1::jsonb, anchor = $2, "effectiveFrom" = $2, "materializedUntil" = $3 WHERE "subjectType" = $4 AND "subjectId" = $5',
+      [
+        JSON.stringify({ frequency: 'weekly', interval: 1, weekdays: [(todayWeekday + 6) % 7] }),
+        case8AnchorIso,
+        case8Boundary,
+        'invoice_drafts',
+        wo8.instance.id,
+      ]
+    )
+    await sweepInvoiceDrafts()
+    const wo8InvoicesBeforeClear = await listInvoicesFiltered('invoice:workOrder', wo8.recordId)
+    check(
+      'case8 setup: at least 1 draft exists before clearing the schedule',
+      wo8InvoicesBeforeClear.length >= 1,
+      wo8InvoicesBeforeClear.length
+    )
+    for (const id of wo8InvoicesBeforeClear) createdInvoiceIds.push(id)
+    for (const invId of wo8InvoicesBeforeClear) {
+      const owned = await listOwnedInvoiceLines(toRecordId('invoice', invId))
+      for (const id of owned) createdLineIds.push(id)
+    }
+
+    await clearInvoiceSchedule({ organizationId, workOrderInstanceId: wo8.instance.id })
+    const rule8AfterClear = await getInvoiceSchedule({
+      organizationId,
+      workOrderInstanceId: wo8.instance.id,
+    })
+    check('case8: clearInvoiceSchedule deletes the rule', rule8AfterClear === null, rule8AfterClear)
+    let wo8DraftsStillExist = true
+    for (const id of wo8InvoicesBeforeClear) {
+      if (!(await instanceExists(id))) wo8DraftsStillExist = false
+    }
+    check('case8: clearInvoiceSchedule leaves existing drafts untouched', wo8DraftsStillExist)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 9. Draft integrity
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('9: draft integrity')
+    const inv9Number = await fieldValueByAttr(
+      organizationId,
+      'invoice',
+      v1DraftInstanceId,
+      'invoice_number'
+    )
+    check(
+      'case9: generated draft carries an INV number',
+      !!inv9Number?.valueText?.startsWith('INV-'),
+      inv9Number?.valueText
+    )
+
+    // Late-completion backdate test (independent WO — five days late).
+    const wo9 = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case9 late-completion backdate',
+      work_order_contact: contactRecordId,
+    })
+    createdWorkOrderIds.push(wo9.instance.id)
+    const wo9Visit = (await getVisitsSorted(wo9.instance.id))[0]!
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000)
+    await scheduleVisit({
+      organizationId,
+      userId,
+      visitId: wo9Visit.id,
+      startTime: fiveDaysAgo,
+      endTime: new Date(fiveDaysAgo.getTime() + 60 * 60_000),
+    })
+    const wo9Line = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case9 late line',
+      line_item_qty: 1,
+      line_item_unit_price: 1800,
+      line_item_taxable: true,
+      line_item_work_order: wo9.recordId,
+      line_item_visit_id: wo9Visit.id,
+    })
+    createdLineIds.push(wo9Line.instance.id)
+
+    await setVisitStatus({ organizationId, userId, visitId: wo9Visit.id, status: 'done' })
+    const wo9Invoices = await listInvoicesFiltered('invoice:visitId', wo9Visit.id)
+    check(
+      'case9: late-completed visit generates a draft',
+      wo9Invoices.length === 1,
+      wo9Invoices.length
+    )
+    const wo9DraftId = wo9Invoices[0]!
+    createdInvoiceIds.push(wo9DraftId)
+    const wo9Owned = await listOwnedInvoiceLines(toRecordId('invoice', wo9DraftId))
+    for (const id of wo9Owned) createdLineIds.push(id)
+
+    const expectedLateDateIso = fiveDaysAgo.toISOString().slice(0, 10)
+    const wo9IssuedAt = await fieldValueByAttr(
+      organizationId,
+      'invoice',
+      wo9DraftId,
+      'invoice_issued_at'
+    )
+    check(
+      'case9: issuedAt carries the visit date, not today (Q9b backdated)',
+      String(wo9IssuedAt?.valueDate).slice(0, 10) === expectedLateDateIso,
+      { issuedAt: wo9IssuedAt?.valueDate, expected: expectedLateDateIso }
+    )
+
+    const dueDaysSetting = await getOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.dueDays',
+    })
+    const dueDays = Number(dueDaysSetting ?? 30)
+    const expectedDueDateIso = new Date(Date.now() + dueDays * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10)
+    const wo9DueDate = await fieldValueByAttr(
+      organizationId,
+      'invoice',
+      wo9DraftId,
+      'invoice_due_date'
+    )
+    check(
+      'case9: dueDate counts from generation day, never the backdated issuedAt',
+      String(wo9DueDate?.valueDate).slice(0, 10) === expectedDueDateIso,
+      { dueDate: wo9DueDate?.valueDate, expected: expectedDueDateIso }
+    )
+
+    const wo9Status = await fieldValueByAttr(
+      organizationId,
+      'invoice',
+      wo9DraftId,
+      'invoice_status'
+    )
+    check('case9: draft sits at status draft', wo9Status?.optionId === 'draft', wo9Status?.optionId)
+
+    const paidWriteErr = await expectThrow(() =>
+      handler.update(toRecordId('invoice', wo9DraftId), { invoice_status: 'paid' })
+    )
+    check(
+      'case9: manual invoice_status=paid on a generated draft is rejected (MI1 guard)',
+      paidWriteErr instanceof AuxxError,
+      paidWriteErr
+    )
+
+    // deleteInvoiceLine semantics (reuse case1's V1 draft copies).
+    await deleteInvoiceLine({ organizationId, userId, lineInstanceId: templateCopyId! })
+    createdLineIds.splice(createdLineIds.indexOf(templateCopyId!), 1)
+    const jobSetLineAfterDelete = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      jobSetLine.instance.id,
+      'line_item_invoice'
+    )
+    check(
+      'case9: deleting a template copy frees nothing (source stays unstamped)',
+      !jobSetLineAfterDelete?.relatedEntityId
+    )
+
+    await deleteInvoiceLine({ organizationId, userId, lineInstanceId: gatheredCopyId! })
+    createdLineIds.splice(createdLineIds.indexOf(gatheredCopyId!), 1)
+    const extraLineAfterDelete = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      extraLineV1.instance.id,
+      'line_item_invoice'
+    )
+    check(
+      'case9: deleting a gathered copy frees the source',
+      !extraLineAfterDelete?.relatedEntityId
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 12. Master switch (documents.invoice.autoEnabled) — §O.4
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('12: master switch (documents.invoice.autoEnabled)')
+    originalAutoEnabled = await getOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.autoEnabled',
+    })
+    await updateOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.autoEnabled',
+      value: false,
+    })
+    await onCacheEvent('org.settings.changed', { orgId: organizationId, broadcastUserKeys: true })
+    autoEnabledChanged = true
+
+    const wo12a = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case12a master-switch per_visit',
+      work_order_contact: contactRecordId,
+    })
+    createdWorkOrderIds.push(wo12a.instance.id)
+    const wo12aLine = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case12a line',
+      line_item_qty: 1,
+      line_item_unit_price: 1000,
+      line_item_taxable: true,
+      line_item_work_order: wo12a.recordId,
+    })
+    createdLineIds.push(wo12aLine.instance.id)
+    const wo12aVisit = (await getVisitsSorted(wo12a.instance.id))[0]!
+    await setVisitStatus({ organizationId, userId, visitId: wo12aVisit.id, status: 'done' })
+    const wo12aInvoices = await listInvoicesFiltered('invoice:visitId', wo12aVisit.id)
+    check(
+      'case12: per_visit door produces zero drafts while disabled',
+      wo12aInvoices.length === 0,
+      wo12aInvoices.length
+    )
+
+    const directResult = await generateInvoiceDraft({
+      organizationId,
+      workOrderInstanceId: wo12a.instance.id,
+      trigger: 'per_visit',
+      visitId: wo12aVisit.id,
+    })
+    check(
+      'case12: generateInvoiceDraft returns reason "disabled"',
+      directResult.created === false && directResult.reason === 'disabled',
+      directResult
+    )
+
+    const wo12b = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case12b master-switch on_completion',
+      work_order_contact: contactRecordId,
+      work_order_invoice_timing: 'on_completion',
+    })
+    createdWorkOrderIds.push(wo12b.instance.id)
+    const wo12bLine = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case12b line',
+      line_item_qty: 1,
+      line_item_unit_price: 1000,
+      line_item_taxable: true,
+      line_item_work_order: wo12b.recordId,
+    })
+    createdLineIds.push(wo12bLine.instance.id)
+    await handler.update(wo12b.recordId, { work_order_status: 'completed' })
+    const wo12bInvoices = await listInvoicesFiltered('invoice:workOrder', wo12b.recordId)
+    check(
+      'case12: on_completion hook produces zero drafts while disabled',
+      wo12bInvoices.length === 0,
+      wo12bInvoices.length
+    )
+
+    const wo12c = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case12c master-switch custom_schedule',
+      work_order_contact: contactRecordId,
+      work_order_pricing_model: 'fixed',
+      work_order_invoice_timing: 'custom_schedule',
+    })
+    createdWorkOrderIds.push(wo12c.instance.id)
+    const wo12cLine = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case12c contract line',
+      line_item_qty: 1,
+      line_item_unit_price: 2500,
+      line_item_taxable: true,
+      line_item_work_order: wo12c.recordId,
+    })
+    createdLineIds.push(wo12cLine.instance.id)
+    const case12cTargetWeekday = (todayWeekday + 1) % 7
+    await setInvoiceSchedule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo12c.instance.id,
+      pattern: { frequency: 'weekly', interval: 1, weekdays: [case12cTargetWeekday] },
+      timezone: 'UTC',
+    })
+    const case12cAnchorIso = addDaysToIso(todayIso, -14)
+    const case12cBoundary = new Date(`${case12cAnchorIso}T01:00:00.000Z`)
+    await database.$client.query(
+      'UPDATE "RecurrenceRule" SET anchor = $1, "effectiveFrom" = $1, "materializedUntil" = $2 WHERE "subjectType" = $3 AND "subjectId" = $4',
+      [case12cAnchorIso, case12cBoundary, 'invoice_drafts', wo12c.instance.id]
+    )
+    await sweepInvoiceDrafts()
+    const wo12cInvoices = await listInvoicesFiltered('invoice:workOrder', wo12c.recordId)
+    check(
+      'case12: sweep produces zero drafts while disabled',
+      wo12cInvoices.length === 0,
+      wo12cInvoices.length
+    )
+
+    await updateOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.autoEnabled',
+      value: true,
+    })
+    await onCacheEvent('org.settings.changed', { orgId: organizationId, broadcastUserKeys: true })
+
+    await setVisitStatus({ organizationId, userId, visitId: wo12aVisit.id, status: 'done' })
+    const wo12aInvoicesAfterFlip = await listInvoicesFiltered('invoice:visitId', wo12aVisit.id)
+    check(
+      'case12: re-triggering after flipping the switch back on generates a draft',
+      wo12aInvoicesAfterFlip.length === 1,
+      wo12aInvoicesAfterFlip.length
+    )
+    for (const id of wo12aInvoicesAfterFlip) createdInvoiceIds.push(id)
+    for (const invId of wo12aInvoicesAfterFlip) {
+      const owned = await listOwnedInvoiceLines(toRecordId('invoice', invId))
+      for (const id of owned) createdLineIds.push(id)
+    }
+
+    await updateOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.autoEnabled',
+      value: originalAutoEnabled as never,
+    })
+    await onCacheEvent('org.settings.changed', { orgId: organizationId, broadcastUserKeys: true })
+    autoEnabledChanged = false
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 13. Default timing (documents.invoice.defaultTiming) — §O.4
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('13: default timing (documents.invoice.defaultTiming)')
+    originalDefaultTiming = await getOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.defaultTiming',
+    })
+    await updateOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.defaultTiming',
+      value: 'on_completion',
+    })
+    await onCacheEvent('org.settings.changed', { orgId: organizationId, broadcastUserKeys: true })
+    defaultTimingChanged = true
+
+    const case13Quote = await handler.create('quote', {
+      quote_title: '[MI2-verify] Case13 default-timing quote',
+      quote_contact: contactRecordId,
+    })
+    createdQuoteIds.push(case13Quote.instance.id)
+    const case13QuoteTiming = await fieldValueByAttr(
+      organizationId,
+      'quote',
+      case13Quote.instance.id,
+      'quote_invoice_timing'
+    )
+    check(
+      'case13: new quote carries the new default timing',
+      case13QuoteTiming?.optionId === 'on_completion',
+      case13QuoteTiming?.optionId
+    )
+
+    const case13Wo = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case13 default-timing WO',
+      work_order_contact: contactRecordId,
+    })
+    createdWorkOrderIds.push(case13Wo.instance.id)
+    const case13WoTiming = await fieldValueByAttr(
+      organizationId,
+      'work_order',
+      case13Wo.instance.id,
+      'work_order_invoice_timing'
+    )
+    check(
+      'case13: new direct-created WO carries the new default timing',
+      case13WoTiming?.optionId === 'on_completion',
+      case13WoTiming?.optionId
+    )
+
+    const explicitQuote = await handler.create('quote', {
+      quote_title: '[MI2-verify] Case13 explicit-timing quote',
+      quote_contact: contactRecordId,
+      quote_invoice_timing: 'per_visit_completed',
+    })
+    createdQuoteIds.push(explicitQuote.instance.id)
+    await markQuoteSent({ organizationId, userId, quoteInstanceId: explicitQuote.instance.id })
+    await approveQuote({ organizationId, userId, quoteInstanceId: explicitQuote.instance.id })
+    const convertedWo = await convertQuoteToWorkOrder({
+      organizationId,
+      userId,
+      quoteInstanceId: explicitQuote.instance.id,
+    })
+    createdWorkOrderIds.push(convertedWo.instance.id)
+    const convertedWoTiming = await fieldValueByAttr(
+      organizationId,
+      'work_order',
+      convertedWo.instance.id,
+      'work_order_invoice_timing'
+    )
+    check(
+      'case13: explicit quote timing wins over the org default at convert',
+      convertedWoTiming?.optionId === 'per_visit_completed',
+      convertedWoTiming?.optionId
+    )
+
+    await updateOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.defaultTiming',
+      value: originalDefaultTiming as never,
+    })
+    await onCacheEvent('org.settings.changed', { orgId: organizationId, broadcastUserKeys: true })
+    defaultTimingChanged = false
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 14. Date basis (documents.invoice.dateBasis) — §O.4
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('14: date basis (documents.invoice.dateBasis)')
+    originalDateBasis = await getOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.dateBasis',
+    })
+    await updateOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.dateBasis',
+      value: 'creation_date',
+    })
+    await onCacheEvent('org.settings.changed', { orgId: organizationId, broadcastUserKeys: true })
+    dateBasisChanged = true
+
+    const wo14 = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case14 creation_date basis',
+      work_order_contact: contactRecordId,
+    })
+    createdWorkOrderIds.push(wo14.instance.id)
+    const wo14Visit = (await getVisitsSorted(wo14.instance.id))[0]!
+    const wo14FiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000)
+    await scheduleVisit({
+      organizationId,
+      userId,
+      visitId: wo14Visit.id,
+      startTime: wo14FiveDaysAgo,
+      endTime: new Date(wo14FiveDaysAgo.getTime() + 60 * 60_000),
+    })
+    const wo14Line = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case14 line',
+      line_item_qty: 1,
+      line_item_unit_price: 900,
+      line_item_taxable: true,
+      line_item_work_order: wo14.recordId,
+      line_item_visit_id: wo14Visit.id,
+    })
+    createdLineIds.push(wo14Line.instance.id)
+    await setVisitStatus({ organizationId, userId, visitId: wo14Visit.id, status: 'done' })
+    const wo14Invoices = await listInvoicesFiltered('invoice:visitId', wo14Visit.id)
+    check(
+      'case14: creation_date basis generates a draft',
+      wo14Invoices.length === 1,
+      wo14Invoices.length
+    )
+    const wo14DraftId = wo14Invoices[0]!
+    createdInvoiceIds.push(wo14DraftId)
+    const wo14Owned = await listOwnedInvoiceLines(toRecordId('invoice', wo14DraftId))
+    for (const id of wo14Owned) createdLineIds.push(id)
+    const wo14IssuedAt = await fieldValueByAttr(
+      organizationId,
+      'invoice',
+      wo14DraftId,
+      'invoice_issued_at'
+    )
+    check(
+      'case14: creation_date basis -> issuedAt = today, not the backdated visit date',
+      String(wo14IssuedAt?.valueDate).slice(0, 10) === todayIso,
+      { issuedAt: wo14IssuedAt?.valueDate, expected: todayIso }
+    )
+
+    // Restore to visit_date and re-verify the §9 backdate assertion holds.
+    await updateOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.dateBasis',
+      value: 'visit_date',
+    })
+    await onCacheEvent('org.settings.changed', { orgId: organizationId, broadcastUserKeys: true })
+
+    const wo14b = await handler.create('work_order', {
+      work_order_title: '[MI2-verify] Case14b visit_date basis',
+      work_order_contact: contactRecordId,
+    })
+    createdWorkOrderIds.push(wo14b.instance.id)
+    const wo14bVisit = (await getVisitsSorted(wo14b.instance.id))[0]!
+    const wo14bThreeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+    await scheduleVisit({
+      organizationId,
+      userId,
+      visitId: wo14bVisit.id,
+      startTime: wo14bThreeDaysAgo,
+      endTime: new Date(wo14bThreeDaysAgo.getTime() + 60 * 60_000),
+    })
+    const wo14bLine = await handler.create('line_item', {
+      line_item_name: '[MI2-verify] Case14b line',
+      line_item_qty: 1,
+      line_item_unit_price: 700,
+      line_item_taxable: true,
+      line_item_work_order: wo14b.recordId,
+      line_item_visit_id: wo14bVisit.id,
+    })
+    createdLineIds.push(wo14bLine.instance.id)
+    await setVisitStatus({ organizationId, userId, visitId: wo14bVisit.id, status: 'done' })
+    const wo14bInvoices = await listInvoicesFiltered('invoice:visitId', wo14bVisit.id)
+    check(
+      'case14b: visit_date basis (restored default) generates a draft',
+      wo14bInvoices.length === 1,
+      wo14bInvoices.length
+    )
+    const wo14bDraftId = wo14bInvoices[0]!
+    createdInvoiceIds.push(wo14bDraftId)
+    const wo14bOwned = await listOwnedInvoiceLines(toRecordId('invoice', wo14bDraftId))
+    for (const id of wo14bOwned) createdLineIds.push(id)
+    const wo14bIssuedAt = await fieldValueByAttr(
+      organizationId,
+      'invoice',
+      wo14bDraftId,
+      'invoice_issued_at'
+    )
+    const wo14bExpectedIso = wo14bThreeDaysAgo.toISOString().slice(0, 10)
+    check(
+      'case14b: visit_date basis -> issuedAt = backdated visit date (§9 assertion holds)',
+      String(wo14bIssuedAt?.valueDate).slice(0, 10) === wo14bExpectedIso,
+      { issuedAt: wo14bIssuedAt?.valueDate, expected: wo14bExpectedIso }
+    )
+
+    await updateOrganizationSetting({
+      organizationId,
+      key: 'documents.invoice.dateBasis',
+      value: originalDateBasis as never,
+    })
+    await onCacheEvent('org.settings.changed', { orgId: organizationId, broadcastUserKeys: true })
+    dateBasisChanged = false
+  } finally {
+    // ── Cleanup ──────────────────────────────────────────────────────────
+    console.log(
+      `Cleanup: ${createdLineIds.length} lines, ${createdInvoiceIds.length} invoices, ` +
+        `${createdWorkOrderIds.length} work orders, ${createdQuoteIds.length} quotes`
+    )
+    for (const id of [...new Set(createdLineIds)]) {
+      try {
+        await handler.delete(toRecordId('line_item', id))
+      } catch (err) {
+        console.log(
+          `  cleanup failed for line_item:${id}:`,
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+    for (const id of [...new Set(createdInvoiceIds)]) {
+      try {
+        await handler.delete(toRecordId('invoice', id))
+      } catch (err) {
+        console.log(`  cleanup failed for invoice:${id}:`, err instanceof Error ? err.message : err)
+      }
+    }
+    for (const id of [...new Set(createdWorkOrderIds)]) {
+      try {
+        await handler.delete(toRecordId('work_order', id))
+      } catch (err) {
+        console.log(
+          `  cleanup failed for work_order:${id}:`,
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+    for (const id of [...new Set(createdQuoteIds)]) {
+      try {
+        await handler.delete(toRecordId('quote', id))
+      } catch (err) {
+        console.log(`  cleanup failed for quote:${id}:`, err instanceof Error ? err.message : err)
+      }
+    }
+
+    if (autoEnabledChanged) {
+      try {
+        await updateOrganizationSetting({
+          organizationId: 'u45w22ft66ymiaa19ohs7m9f',
+          key: 'documents.invoice.autoEnabled',
+          value: originalAutoEnabled as never,
+        })
+        await onCacheEvent('org.settings.changed', {
+          orgId: 'u45w22ft66ymiaa19ohs7m9f',
+          broadcastUserKeys: true,
+        })
+      } catch (err) {
+        console.log(
+          '  cleanup failed restoring documents.invoice.autoEnabled:',
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+    if (defaultTimingChanged) {
+      try {
+        await updateOrganizationSetting({
+          organizationId: 'u45w22ft66ymiaa19ohs7m9f',
+          key: 'documents.invoice.defaultTiming',
+          value: originalDefaultTiming as never,
+        })
+        await onCacheEvent('org.settings.changed', {
+          orgId: 'u45w22ft66ymiaa19ohs7m9f',
+          broadcastUserKeys: true,
+        })
+      } catch (err) {
+        console.log(
+          '  cleanup failed restoring documents.invoice.defaultTiming:',
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+    if (dateBasisChanged) {
+      try {
+        await updateOrganizationSetting({
+          organizationId: 'u45w22ft66ymiaa19ohs7m9f',
+          key: 'documents.invoice.dateBasis',
+          value: originalDateBasis as never,
+        })
+        await onCacheEvent('org.settings.changed', {
+          orgId: 'u45w22ft66ymiaa19ohs7m9f',
+          broadcastUserKeys: true,
+        })
+      } catch (err) {
+        console.log(
+          '  cleanup failed restoring documents.invoice.dateBasis:',
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`)
+  process.exit(fail > 0 ? 1 : 0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -333,6 +333,23 @@ export async function setupSchedules() {
     }
   )
 
+  // Money MI2 invoice-draft daily sweep — every day at 03:30 UTC (08-mi2-build.md §G), 30
+  // minutes after the dispatch recurring engine's visit sweep so a same-day visit
+  // materialization can't race the billing pass.
+  await maintenanceQueue.upsertJobScheduler(
+    'invoiceDraftsJob',
+    { pattern: '30 3 * * *', tz: 'UTC' },
+    {
+      opts: {
+        attempts: 2,
+        backoff: { type: 'exponential', delay: 60000 },
+        priority: 8,
+        removeOnComplete: { count: 14 },
+        removeOnFail: { count: 30 },
+      },
+    }
+  )
+
   // Every day at 8 AM
   await maintenanceQueue.upsertJobScheduler(
     'requestDocumentSuggestionsJob',

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -17,6 +17,7 @@ import {
   demoCleanupJob,
   expiredTrialAccountCleanupJob,
   flushUsageEventsJob,
+  invoiceDraftsJob,
   type JobHandler,
   mailCountsReconcileJob,
   mcpToolsResyncJob,
@@ -193,6 +194,10 @@ const jobMappings = {
   // Dispatch recurring engine daily sweep (M2c, 06-recurring-engine.md §4.4/§5.3):
   // extends materialization horizons for active engagements + auto-ends exhausted ones.
   recurringVisitsJob,
+
+  // Money MI2 invoice-draft daily sweep (08-mi2-build.md §G): materializes `custom_schedule`
+  // invoice-draft recurrence rules whose horizon has fallen behind.
+  invoiceDraftsJob,
 
   // Global data-connector stale-run sweep (every 5 min; fails cold runs + releases
   // their connector claim so a crashed continuation chain can't strand a connector)

--- a/packages/lib/src/dispatch/lifecycle.ts
+++ b/packages/lib/src/dispatch/lifecycle.ts
@@ -8,7 +8,7 @@
 
 import { extractValue } from '@auxx/types'
 import { toRecordId } from '@auxx/types/resource'
-import { getOrgCache } from '../cache'
+import { getEntityDefIdResolver, getOrgCache } from '../cache'
 import { FieldValueService } from '../field-values/field-value-service'
 import type { VisitStatus } from './types'
 
@@ -63,7 +63,16 @@ export async function rollUpWorkOrderStatus(
   const statusField = cf.work_order_status
   if (!statusField) return
 
-  const recordId = toRecordId('work_order', workOrderId)
+  // Resolve the type-slug to the real `entityDefinitionId` UUID — the field-change hook
+  // dispatch inside `setValuesForEntity` looks up the resource by `entityDefinitionId` via
+  // `getCachedResource` (exact-match only, no type-slug fallback), so an unresolved
+  // `work_order:<id>` RecordId silently resolves to no resource → `entitySlug: ''` → every
+  // field-change hook (including MI2's `generateDraftOnCompletion`, and the generic `'*'`
+  // hooks) silently no-ops. `UnifiedCrudHandler.update` avoids this by rebuilding the
+  // RecordId with the resolved UUID before writing (unified-handler-mutations.ts:452);
+  // mirror that here since this writer bypasses the handler on purpose.
+  const resolveDefId = await getEntityDefIdResolver(organizationId)
+  const recordId = toRecordId(resolveDefId('work_order'), workOrderId)
   const fieldValueService = new FieldValueService(organizationId, userId)
 
   // Recurring engagement status (active/paused/ended) is engagement-level, never

--- a/packages/lib/src/dispatch/recurring/engagement-actions.ts
+++ b/packages/lib/src/dispatch/recurring/engagement-actions.ts
@@ -7,7 +7,7 @@
 import { database, schema } from '@auxx/database'
 import { toRecordId } from '@auxx/types/resource'
 import { and, eq, gte, or } from 'drizzle-orm'
-import { getOrgCache } from '../../cache'
+import { getEntityDefIdResolver, getOrgCache } from '../../cache'
 import { NotFoundError } from '../../errors'
 import { FieldValueService } from '../../field-values/field-value-service'
 import { publishVisitChanged } from '../broadcast'
@@ -79,9 +79,17 @@ async function writeEngagementStatus(
     .bySystemAttributes(['work_order_status'] as const)
   if (!cf.work_order_status) return
 
+  // Resolve the type-slug to the real `entityDefinitionId` UUID before writing — an
+  // unresolved `work_order:<id>` RecordId makes the field-change hook dispatch inside
+  // `setValuesForEntity` resolve to no cached resource (`getCachedResource` is an exact
+  // `id` match, no type-slug fallback), so `entitySlug` comes back `''` and every
+  // field-change hook (MI2's `generateDraftOnCompletion` included) silently no-ops even
+  // though the write itself succeeds. Mirrors `UnifiedCrudHandler.update`'s own
+  // recordId-resolution step (unified-handler-mutations.ts:452).
+  const resolveDefId = await getEntityDefIdResolver(rule.organizationId)
   const fieldValueService = new FieldValueService(rule.organizationId, userId)
   await fieldValueService.setValuesForEntity({
-    recordId: toRecordId('work_order', rule.subjectId),
+    recordId: toRecordId(resolveDefId('work_order'), rule.subjectId),
     values: [{ fieldId: cf.work_order_status.id, value: status }],
   })
 }

--- a/packages/lib/src/dispatch/recurring/materialize.ts
+++ b/packages/lib/src/dispatch/recurring/materialize.ts
@@ -14,7 +14,7 @@ import { toRecordId } from '@auxx/types/resource'
 import { format } from 'date-fns'
 import { fromZonedTime, toZonedTime } from 'date-fns-tz'
 import { and, count, eq, gte } from 'drizzle-orm'
-import { getOrgCache } from '../../cache'
+import { getEntityDefIdResolver, getOrgCache } from '../../cache'
 import { FieldValueService } from '../../field-values/field-value-service'
 import {
   expandOccurrences,
@@ -207,9 +207,18 @@ async function maybeEndExhaustedEngagement(rule: RecurrenceRuleRow): Promise<voi
   if (!cf.work_order_status) return
 
   const userId = await systemActorUserId(rule.organizationId)
+  // Resolve the type-slug to the real `entityDefinitionId` UUID before writing — an
+  // unresolved `work_order:<id>` RecordId makes `setValuesForEntity`'s field-change hook
+  // dispatch resolve to no cached resource (`getCachedResource` is an exact `id` match, no
+  // type-slug fallback), so `entitySlug` comes back `''` and every field-change hook
+  // (including MI2's on_completion `generateDraftOnCompletion`, which money MI2 build spec
+  // §H documents as consuming exactly this auto-end write "for free") silently no-ops.
+  // Mirrors `UnifiedCrudHandler.update`'s own recordId-resolution step
+  // (unified-handler-mutations.ts:452).
+  const resolveDefId = await getEntityDefIdResolver(rule.organizationId)
   const fieldValueService = new FieldValueService(rule.organizationId, userId)
   await fieldValueService.setValuesForEntity({
-    recordId: toRecordId('work_order', rule.subjectId),
+    recordId: toRecordId(resolveDefId('work_order'), rule.subjectId),
     values: [{ fieldId: cf.work_order_status.id, value: 'ended' }],
   })
   await mirrorVisitOntoWorkOrder(rule.organizationId, userId, rule.subjectId)

--- a/packages/lib/src/dispatch/visit-mutations.ts
+++ b/packages/lib/src/dispatch/visit-mutations.ts
@@ -8,6 +8,7 @@
 import { database, schema } from '@auxx/database'
 import { and, eq } from 'drizzle-orm'
 import { NotFoundError } from '../errors'
+import { maybeGenerateVisitInvoiceDraft } from '../money/auto-invoice'
 import { publishVisitChanged } from './broadcast'
 import { type LifecycleTrigger, rollUpWorkOrderStatus } from './lifecycle'
 import { mirrorVisitOntoWorkOrder } from './mirror'
@@ -201,5 +202,10 @@ export async function setVisitStatus(input: SetVisitStatusInput): Promise<WorkOr
   if (!updated) throw new NotFoundError('Visit not found')
 
   await afterVisitWrite(updated, { userId, trigger: status, excludeSocketId })
+
+  // money MI2 build spec §D (Q1a) — per_visit_completed drafts generate synchronously here;
+  // never let a billing failure fail the field tech's status tap.
+  if (status === 'done') await maybeGenerateVisitInvoiceDraft(updated)
+
   return updated
 }

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -2,6 +2,7 @@
 
 import { registerInventoryDeductionRule } from '../data-connectors/inventory-bridge-rule-action'
 import { ensureVisitOnWorkOrderCreate } from '../dispatch/visit-hooks'
+import { generateDraftOnCompletion } from '../money/auto-invoice'
 import {
   recomputeOnInvoiceBillingChange,
   recomputeOnLineChange,
@@ -71,7 +72,17 @@ export function registerAllHooks(): void {
   // Dispatch (plans/dispatch §H.1): auto-create the unscheduled WorkOrderVisit row the
   // instant a work order is created, on every create path. Keyed off the first write of
   // work_order_number (§F.4a's hook is the only writer, fires exactly once per create).
-  registerEntityFieldChangeHooks('work-orders', [ensureVisitOnWorkOrderCreate])
+  //
+  // Money MI2 build spec §E (Q3a+Q3i): generate an `on_completion` draft invoice the instant
+  // `work_order_status` lands on `completed`/`ended` — catches the visit roll-up, M2c's
+  // `endEngagement`, kanban drags, and manual drawer edits, all through this one hook.
+  // `registerEntityFieldChangeHooks` appends per-call (registry.ts:137-144), so this could
+  // also be a second call — combined into one array here since both handlers share the
+  // 'work-orders' slug and read more naturally listed together.
+  registerEntityFieldChangeHooks('work-orders', [
+    ensureVisitOnWorkOrderCreate,
+    generateDraftOnCompletion,
+  ])
 
   // Money totals engine (money MQ1 build spec §F.2, generalized to invoices in MI1 build
   // spec §G.1): recompute the mirrored subtotal/tax_total/total whenever a line's

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -149,6 +149,8 @@ export {
   type GettingStartedStats,
   sendGettingStartedEmailsJob,
 } from './maintenance/getting-started-job'
+// Money MI2 invoice-draft daily sweep
+export { invoiceDraftsJob } from './maintenance/invoice-drafts-job'
 // Mail counts reconcile (on-demand, jobId-deduped)
 export {
   type MailCountsReconcileJobData,

--- a/packages/lib/src/jobs/maintenance/invoice-drafts-job.ts
+++ b/packages/lib/src/jobs/maintenance/invoice-drafts-job.ts
@@ -1,0 +1,20 @@
+// packages/lib/src/jobs/maintenance/invoice-drafts-job.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { sweepInvoiceDrafts } from '../../money/auto-invoice'
+import type { JobContext } from '../types/job-context'
+
+const logger = createScopedLogger('invoice-drafts-job')
+
+/**
+ * Daily sweep for `custom_schedule` invoice drafts (money MI2 build spec §G): materializes
+ * every `invoice_drafts` `RecurrenceRule` whose horizon has fallen behind. Scheduled nightly
+ * via `upsertJobScheduler`, 30 minutes after the dispatch recurring engine's visit sweep (06
+ * §5.3) so a same-day visit materialization can't race the billing pass — see
+ * `apps/worker/src/workers/index.ts`.
+ */
+export async function invoiceDraftsJob(ctx: JobContext): Promise<void> {
+  logger.info('Running invoice drafts sweep', { jobId: ctx.jobId })
+  await sweepInvoiceDrafts()
+  logger.info('Invoice drafts sweep finished', { jobId: ctx.jobId })
+}

--- a/packages/lib/src/money/auto-invoice.ts
+++ b/packages/lib/src/money/auto-invoice.ts
@@ -1,0 +1,718 @@
+// packages/lib/src/money/auto-invoice.ts
+//
+// Automated draft-invoice generation (money MI2 build spec §C-§H) — the automated twin of
+// `createInvoiceFromWorkOrder` (gather.ts), sharing its shell/copy machinery instead of
+// duplicating it. Three triggers all funnel through `generateInvoiceDraft`:
+// `per_visit_completed` (§D, called from `dispatch/visit-mutations.ts`'s `setVisitStatus`),
+// `on_completion` (§E, an entity field-change hook on `work-orders`), and `custom_schedule`
+// (§F, a `RecurrenceRule` cursor materializer/sweep on the M2c pattern). Drafts never
+// auto-send (README.md:45) — every generated invoice sits at `status: 'draft'`.
+
+import { database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { TypedFieldValue } from '@auxx/types'
+import { extractValue } from '@auxx/types'
+import type { RecordId } from '@auxx/types/resource'
+import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import { fromZonedTime } from 'date-fns-tz'
+import { and, eq, isNull, lt, or } from 'drizzle-orm'
+import { getOrgCache } from '../cache'
+import {
+  getWorkOrderStatus,
+  systemActorUserId,
+  todayLocalDate,
+} from '../dispatch/recurring/materialize'
+import { BadRequestError } from '../errors'
+import type { EntityFieldChangeHandler } from '../field-hooks/types'
+import { FieldValueService } from '../field-values/field-value-service'
+import { expandOccurrences, type RecurrencePattern, recurrencePatternSchema } from '../recurrence'
+import { UnifiedCrudHandler } from '../resources/crud'
+import { getOrganizationSetting } from '../settings/settings-service'
+import {
+  copyLineOntoInvoice,
+  createInvoiceShell,
+  LINE_COPY_ATTRS,
+  listUninvoicedLines,
+} from './gather'
+import { recomputeTotals } from './totals-hooks'
+import type {
+  GenerateInvoiceDraftInput,
+  GenerateInvoiceDraftResult,
+  InvoiceScheduleQueryInput,
+  SetInvoiceScheduleInput,
+  UninvoicedLine,
+} from './types'
+
+const logger = createScopedLogger('money:auto-invoice')
+
+type RecurrenceRuleRow = typeof schema.RecurrenceRule.$inferSelect
+type WorkOrderVisitRow = typeof schema.WorkOrderVisit.$inferSelect
+
+/** Unwrap a `getFieldValues()` map entry — takes the first value if array-returned. */
+function firstTyped(
+  entry: TypedFieldValue | TypedFieldValue[] | undefined
+): TypedFieldValue | undefined {
+  if (!entry) return undefined
+  return Array.isArray(entry) ? entry[0] : entry
+}
+
+/** Local calendar date (`YYYY-MM-DD`, local midnight in `timezone`) as a UTC instant — the
+ * same local-date/UTC-instant convention `recurrence/expand.ts` and M2c's materializer use.
+ * Duplicated locally (not imported) because `dispatch/recurring/materialize.ts` doesn't
+ * export it — the M2c files are a pattern to copy, not modify. */
+function localDateStartUtc(dateIso: string, timezone: string): Date {
+  const [year, month, day] = dateIso.split('-').map(Number)
+  return fromZonedTime(new Date(year, month - 1, day), timezone)
+}
+
+/** Read `work_order_job_type` — unwraps the SINGLE_SELECT array-return convention. Mirrors
+ * `getWorkOrderStatus` (dispatch/recurring/materialize.ts), for the same field on the same
+ * entity, since that module only exports the status reader. */
+async function getWorkOrderJobType(
+  organizationId: string,
+  userId: string,
+  workOrderInstanceId: string
+): Promise<string | undefined> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['work_order_job_type'] as const)
+  if (!cf.work_order_job_type) return undefined
+
+  const fieldValueService = new FieldValueService(organizationId, userId)
+  const typed = await fieldValueService.getValue({
+    recordId: toRecordId('work_order', workOrderInstanceId),
+    fieldId: cf.work_order_job_type.id,
+  })
+  const first = Array.isArray(typed) ? typed[0] : typed
+  return first ? (extractValue(first) as string) : undefined
+}
+
+const TRIGGER_TO_TIMING: Record<GenerateInvoiceDraftInput['trigger'], string> = {
+  per_visit: 'per_visit_completed',
+  on_completion: 'on_completion',
+  custom_schedule: 'custom_schedule',
+}
+
+/**
+ * List a work order's "job-set" (template) lines — `line_item_work_order = WO` AND
+ * `line_item_visit_id` empty (money MI2 build spec §C step 2, Q2/Q4's "template" content).
+ * These are copied fresh (never stamped) by every trigger that needs a recurring charge —
+ * distinct from `listUninvoicedLines`'s per-visit/accrued "extras".
+ */
+async function listJobSetLineIds(
+  handler: UnifiedCrudHandler,
+  workOrderRecordId: RecordId
+): Promise<string[]> {
+  const { ids } = await handler.listFiltered({
+    entityDefinitionId: 'line_item',
+    filters: [
+      {
+        id: 'job-set-lines',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'job-set-lines-wo',
+            fieldId: 'line_item:workOrder',
+            operator: 'is',
+            value: workOrderRecordId,
+          },
+          {
+            id: 'job-set-lines-visit',
+            fieldId: 'line_item:visitId',
+            operator: 'empty',
+            value: null,
+          },
+        ],
+      },
+    ],
+    sorting: [{ id: 'sortOrder', desc: false }],
+    limit: 1000,
+    mode: 'oneshot',
+  })
+  return ids
+}
+
+/**
+ * The pricing-model-aware content matrix (money MI2 build spec §C step 2, Q2/Q4) — the one
+ * architectural bet in this spec. Returns the job-set line ids to template-copy (never
+ * stamped) and the uninvoiced lines to gather-copy (stamped).
+ */
+async function selectDraftContent(params: {
+  organizationId: string
+  userId: string
+  handler: UnifiedCrudHandler
+  workOrderRecordId: RecordId
+  workOrderInstanceId: string
+  trigger: GenerateInvoiceDraftInput['trigger']
+  pricingModel: string
+  visitId?: string
+}): Promise<{ templateLineIds: string[]; gatherLines: UninvoicedLine[] }> {
+  const {
+    organizationId,
+    userId,
+    handler,
+    workOrderRecordId,
+    workOrderInstanceId,
+    trigger,
+    pricingModel,
+    visitId,
+  } = params
+
+  if (trigger === 'on_completion') {
+    // Every pricingModel: a normal full gather — a per_visit-priced job's job-set line (if
+    // never gathered before) is picked up here too, exactly like a manual gather would.
+    const gatherLines = await listUninvoicedLines({ organizationId, userId, workOrderInstanceId })
+    return { templateLineIds: [], gatherLines }
+  }
+
+  if (trigger === 'per_visit') {
+    if (pricingModel !== 'per_visit') {
+      // Odd combo (§C step 2's table: fixed × per_visit) — treat as gather extras only.
+      logger.warn('fixed pricingModel with per_visit trigger — gathering extras only', {
+        organizationId,
+        workOrderInstanceId,
+        visitId,
+      })
+      const all = await listUninvoicedLines({ organizationId, userId, workOrderInstanceId })
+      return { templateLineIds: [], gatherLines: all.filter((l) => l.visitId === visitId) }
+    }
+    const templateLineIds = await listJobSetLineIds(handler, workOrderRecordId)
+    const all = await listUninvoicedLines({ organizationId, userId, workOrderInstanceId })
+    return { templateLineIds, gatherLines: all.filter((l) => l.visitId === visitId) }
+  }
+
+  // custom_schedule
+  if (pricingModel === 'fixed') {
+    const templateLineIds = await listJobSetLineIds(handler, workOrderRecordId)
+    const all = await listUninvoicedLines({ organizationId, userId, workOrderInstanceId })
+    // "extras accrued since the last occurrence" — visit-tagged lines only; the job-set
+    // template lines themselves are never stamped so they'd otherwise show up as uninvoiced
+    // forever and get double-billed alongside their fresh template copy above.
+    return { templateLineIds, gatherLines: all.filter((l) => l.visitId !== undefined) }
+  }
+  const gatherLines = await listUninvoicedLines({ organizationId, userId, workOrderInstanceId })
+  return { templateLineIds: [], gatherLines }
+}
+
+/**
+ * Generate one automated draft invoice (money MI2 build spec §C) — the automated twin of
+ * `createInvoiceFromWorkOrder`. All three triggers (§D/§E/§F) call this; it never throws for
+ * expected "nothing to do" outcomes (disabled/not-found/timing-mismatch/no-contact/duplicate/
+ * empty — all returned as `{ created: false, reason }`), so callers only need try/catch for
+ * genuinely unexpected failures. Acting user is always the org system user (public-token.ts
+ * precedent) — automated writes must not impersonate a member.
+ */
+export async function generateInvoiceDraft(
+  input: GenerateInvoiceDraftInput
+): Promise<GenerateInvoiceDraftResult> {
+  const { organizationId, workOrderInstanceId, trigger, visitId, occurrenceDate, visitDate } = input
+
+  // ─── Step 1a: master switch (FIRST check) ───────────────────────────────────
+  const autoEnabled = await getOrganizationSetting({
+    organizationId,
+    key: 'documents.invoice.autoEnabled',
+  })
+  if (autoEnabled === false) {
+    return { created: false, reason: 'disabled' }
+  }
+
+  const userId = await getOrgCache().get(organizationId, 'systemUser')
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  const cache = getOrgCache()
+  const workOrderRecordId = toRecordId('work_order', workOrderInstanceId)
+
+  // ─── Step 1b: WO exists ──────────────────────────────────────────────────────
+  const woExists = await database.query.EntityInstance.findFirst({
+    where: and(
+      eq(schema.EntityInstance.id, workOrderInstanceId),
+      eq(schema.EntityInstance.organizationId, organizationId)
+    ),
+    columns: { id: true },
+  })
+  if (!woExists) {
+    logger.warn('Skipping auto-invoice draft — work order not found', {
+      organizationId,
+      workOrderInstanceId,
+      trigger,
+    })
+    return { created: false, reason: 'not_found' }
+  }
+
+  // ─── Step 1c: invoice_timing matches the trigger (re-read at fire time) ────
+  const cf = await cache
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([
+      'work_order_invoice_timing',
+      'work_order_pricing_model',
+      'work_order_contact',
+    ] as const)
+  const woFieldIds = [
+    cf.work_order_invoice_timing,
+    cf.work_order_pricing_model,
+    cf.work_order_contact,
+  ]
+    .filter(Boolean)
+    .map((f) => f!.id)
+  const woValues = await handler.getFieldValues(workOrderRecordId, woFieldIds)
+
+  const invoiceTimingTyped = cf.work_order_invoice_timing
+    ? firstTyped(woValues.get(cf.work_order_invoice_timing.id))
+    : undefined
+  const invoiceTiming = invoiceTimingTyped
+    ? (extractValue(invoiceTimingTyped) as string)
+    : undefined
+  if (invoiceTiming !== TRIGGER_TO_TIMING[trigger]) {
+    return { created: false, reason: 'timing_mismatch' }
+  }
+
+  // ─── Step 1d: contact present (Q5 — an automated job can't throw at 3 AM) ──
+  const contactTyped = cf.work_order_contact
+    ? firstTyped(woValues.get(cf.work_order_contact.id))
+    : undefined
+  const hasContact = contactTyped?.type === 'relationship' && !!contactTyped.recordId
+  if (!hasContact) {
+    logger.warn('Skipping auto-invoice draft — work order has no contact', {
+      organizationId,
+      workOrderInstanceId,
+      trigger,
+    })
+    return { created: false, reason: 'no_contact' }
+  }
+
+  // ─── Step 1e: per_visit dedup (Q6a) ─────────────────────────────────────────
+  if (trigger === 'per_visit' && visitId) {
+    const { ids: existingDraftIds } = await handler.listFiltered({
+      entityDefinitionId: 'invoice',
+      filters: [
+        {
+          id: 'visit-dedup',
+          logicalOperator: 'AND',
+          conditions: [
+            { id: 'visit-dedup-c1', fieldId: 'invoice:visitId', operator: 'is', value: visitId },
+          ],
+        },
+      ],
+      limit: 1,
+      mode: 'oneshot',
+    })
+    if (existingDraftIds.length > 0) {
+      return { created: false, reason: 'duplicate' }
+    }
+  }
+
+  const pricingModelTyped = cf.work_order_pricing_model
+    ? firstTyped(woValues.get(cf.work_order_pricing_model.id))
+    : undefined
+  const pricingModel = pricingModelTyped ? (extractValue(pricingModelTyped) as string) : 'per_visit'
+
+  // ─── Step 2: select content (Q2/Q4 matrix) ──────────────────────────────────
+  const { templateLineIds, gatherLines } = await selectDraftContent({
+    organizationId,
+    userId,
+    handler,
+    workOrderRecordId,
+    workOrderInstanceId,
+    trigger,
+    pricingModel,
+    visitId,
+  })
+
+  // ─── Step 3: empty check (Q5) ────────────────────────────────────────────────
+  if (templateLineIds.length === 0 && gatherLines.length === 0) {
+    logger.debug('Skipping auto-invoice draft — nothing billable', {
+      organizationId,
+      workOrderInstanceId,
+      trigger,
+      visitId,
+      occurrenceDate,
+    })
+    return { created: false, reason: 'empty' }
+  }
+
+  // ─── Step 4: create the shell — issuedAt per documents.invoice.dateBasis ───
+  const dateBasis = await getOrganizationSetting({
+    organizationId,
+    key: 'documents.invoice.dateBasis',
+  })
+  let issuedAt: string | undefined
+  if (dateBasis !== 'creation_date') {
+    // visit_date (default, Q9b) — backdate to the visit's completion date / the occurrence's
+    // scheduled date. on_completion has no such date (it's engagement-level) and stays today.
+    if (trigger === 'per_visit') issuedAt = visitDate
+    else if (trigger === 'custom_schedule') issuedAt = occurrenceDate
+  }
+
+  const shell = await createInvoiceShell({
+    organizationId,
+    userId,
+    workOrderInstanceId,
+    issuedAt,
+    extraValues: trigger === 'per_visit' && visitId ? { invoice_visit_id: visitId } : undefined,
+  })
+  const {
+    handler: shellHandler,
+    cache: shellCache,
+    recordId: invoiceRecordId,
+    instanceId: invoiceInstanceId,
+  } = shell
+
+  // ─── Step 5: copy/stamp per the matrix ──────────────────────────────────────
+  const lineCf = await shellCache
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(LINE_COPY_ATTRS)
+  const lineFieldIds = Object.values(lineCf)
+    .filter(Boolean)
+    .map((f) => f!.id)
+  const fieldValueService = new FieldValueService(organizationId, userId)
+
+  for (const lineInstanceId of templateLineIds) {
+    await copyLineOntoInvoice({
+      handler: shellHandler,
+      fieldValueService,
+      lineCf,
+      lineFieldIds,
+      lineInstanceId,
+      invoiceRecordId,
+      stampSource: false,
+      extraValues: trigger === 'per_visit' && visitId ? { line_item_visit_id: visitId } : undefined,
+    })
+  }
+  for (const line of gatherLines) {
+    await copyLineOntoInvoice({
+      handler: shellHandler,
+      fieldValueService,
+      lineCf,
+      lineFieldIds,
+      lineInstanceId: line.instanceId,
+      invoiceRecordId,
+      stampSource: true,
+    })
+  }
+
+  // ─── Step 6: totals (also seeds balance = total via the ledger sync) ──────
+  await recomputeTotals({
+    organizationId,
+    userId,
+    documentType: 'invoice',
+    documentInstanceId: invoiceInstanceId,
+  })
+
+  // ─── Step 7: return — no send, no status change, draft sits at `draft` ────
+  return { created: true, recordId: invoiceRecordId, instanceId: invoiceInstanceId }
+}
+
+/**
+ * `per_visit_completed` trigger (money MI2 build spec §D, Q1a) — called from
+ * `dispatch/visit-mutations.ts`'s `setVisitStatus` when a visit lands on `done`. Never throws:
+ * a billing failure must never fail the field tech's status tap.
+ */
+export async function maybeGenerateVisitInvoiceDraft(visit: WorkOrderVisitRow): Promise<void> {
+  try {
+    const cache = getOrgCache()
+    const cf = await cache
+      .from(visit.organizationId, 'customFields')
+      .bySystemAttributes(['work_order_invoice_timing'] as const)
+    if (!cf.work_order_invoice_timing) return
+
+    const userId = await cache.get(visit.organizationId, 'systemUser')
+    const handler = new UnifiedCrudHandler(visit.organizationId, userId)
+    const workOrderRecordId = toRecordId('work_order', visit.workOrderId)
+    const values = await handler.getFieldValues(workOrderRecordId, [
+      cf.work_order_invoice_timing.id,
+    ])
+    const typed = firstTyped(values.get(cf.work_order_invoice_timing.id))
+    const timing = typed ? (extractValue(typed) as string) : undefined
+    if (timing !== 'per_visit_completed') return
+
+    const visitDate =
+      visit.occurrenceDate ??
+      (visit.startTime ? visit.startTime.toISOString().split('T')[0] : undefined)
+
+    await generateInvoiceDraft({
+      organizationId: visit.organizationId,
+      workOrderInstanceId: visit.workOrderId,
+      trigger: 'per_visit',
+      visitId: visit.id,
+      visitDate,
+    })
+  } catch (error) {
+    logger.error('Failed to generate per-visit invoice draft', {
+      visitId: visit.id,
+      workOrderId: visit.workOrderId,
+      organizationId: visit.organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * `on_completion` trigger (money MI2 build spec §E, Q3a+Q3i) — an entity field-change hook on
+ * `work-orders` watching `work_order_status` land on `completed` or `ended`. Fires on EVERY
+ * completion door (the visit roll-up, M2c's `endEngagement`, kanban drags, manual drawer
+ * edits) because field-change hooks fire on every `FieldValueService` write. No recursion risk
+ * — this handler never writes `work_order_status`. Dedup is free: gather-based content
+ * self-dedups (stamped lines don't re-gather), so a WO completed twice with nothing new is an
+ * empty-skip.
+ */
+export const generateDraftOnCompletion: EntityFieldChangeHandler = async (event) => {
+  if (event.field.systemAttribute !== 'work_order_status') return
+
+  const newTyped = firstTyped(event.newValue as TypedFieldValue | TypedFieldValue[] | undefined)
+  const newStatus = newTyped ? (extractValue(newTyped) as string) : undefined
+  if (newStatus !== 'completed' && newStatus !== 'ended') return
+
+  const { entityInstanceId: workOrderInstanceId } = parseRecordId(event.recordId)
+
+  try {
+    const cache = getOrgCache()
+    const cf = await cache
+      .from(event.organizationId, 'customFields')
+      .bySystemAttributes(['work_order_invoice_timing'] as const)
+    if (!cf.work_order_invoice_timing) return
+
+    const handler = new UnifiedCrudHandler(event.organizationId, event.userId)
+    const values = await handler.getFieldValues(event.recordId, [cf.work_order_invoice_timing.id])
+    const typed = firstTyped(values.get(cf.work_order_invoice_timing.id))
+    const timing = typed ? (extractValue(typed) as string) : undefined
+    if (timing !== 'on_completion') return
+
+    await generateInvoiceDraft({
+      organizationId: event.organizationId,
+      workOrderInstanceId,
+      trigger: 'on_completion',
+    })
+  } catch (error) {
+    logger.error('Failed to generate on-completion invoice draft', {
+      workOrderInstanceId,
+      organizationId: event.organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * Create or edit a work order's invoice-draft schedule (money MI2 build spec §F.1) — the
+ * `RecurrenceRule` row (`subjectType: 'invoice_drafts'`), mirroring M2c's `setRecurrenceRule`
+ * upsert shape without its visit-template columns (they stay null — non-visit subject).
+ * Edits are whole-rule (`effectiveFrom = today` on every save, §F.1 — invoice drafts have no
+ * per-occurrence rows to freeze, so 06 §4.3's three-way machinery does not apply).
+ * User-facing: throws normally (unlike the triggers, which never throw).
+ *
+ * @throws {BadRequestError} when the pattern fails validation, or the work order's
+ *   `work_order_invoice_timing` isn't `custom_schedule`.
+ */
+export async function setInvoiceSchedule(
+  input: SetInvoiceScheduleInput
+): Promise<RecurrenceRuleRow> {
+  const { organizationId, userId, workOrderInstanceId, pattern, timezone } = input
+
+  const parsed = recurrencePatternSchema.safeParse(pattern)
+  if (!parsed.success) {
+    throw new BadRequestError(`Invalid recurrence pattern: ${parsed.error.message}`)
+  }
+
+  const cache = getOrgCache()
+  const cf = await cache
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['work_order_invoice_timing'] as const)
+  if (cf.work_order_invoice_timing) {
+    const handler = new UnifiedCrudHandler(organizationId, userId)
+    const workOrderRecordId = toRecordId('work_order', workOrderInstanceId)
+    const values = await handler.getFieldValues(workOrderRecordId, [
+      cf.work_order_invoice_timing.id,
+    ])
+    const typed = firstTyped(values.get(cf.work_order_invoice_timing.id))
+    const timing = typed ? (extractValue(typed) as string) : undefined
+    if (timing !== 'custom_schedule') {
+      throw new BadRequestError('Set invoice timing to Custom schedule first')
+    }
+  }
+
+  const todayIso = todayLocalDate(timezone)
+
+  const existing = await database.query.RecurrenceRule.findFirst({
+    where: and(
+      eq(schema.RecurrenceRule.organizationId, organizationId),
+      eq(schema.RecurrenceRule.subjectType, 'invoice_drafts'),
+      eq(schema.RecurrenceRule.subjectId, workOrderInstanceId)
+    ),
+  })
+
+  const [rule] = existing
+    ? await database
+        .update(schema.RecurrenceRule)
+        .set({
+          pattern: pattern as unknown as Record<string, unknown>,
+          timezone,
+          effectiveFrom: todayIso,
+        })
+        .where(eq(schema.RecurrenceRule.id, existing.id))
+        .returning()
+    : await database
+        .insert(schema.RecurrenceRule)
+        .values({
+          organizationId,
+          subjectType: 'invoice_drafts',
+          subjectId: workOrderInstanceId,
+          pattern: pattern as unknown as Record<string, unknown>,
+          timezone,
+          anchor: todayIso,
+          effectiveFrom: todayIso,
+          startMinute: null,
+          durationMinutes: null,
+          defaultAssigneeUserId: null,
+        })
+        .returning()
+  if (!rule) throw new Error('Failed to upsert invoice schedule rule')
+
+  await materializeInvoiceDrafts(rule)
+  return rule
+}
+
+/**
+ * Delete a work order's invoice-draft schedule (§F.1) — existing generated drafts are
+ * untouched (it's declarative config, not materialized state, §H).
+ */
+export async function clearInvoiceSchedule(input: InvoiceScheduleQueryInput): Promise<void> {
+  const { organizationId, workOrderInstanceId } = input
+  await database
+    .delete(schema.RecurrenceRule)
+    .where(
+      and(
+        eq(schema.RecurrenceRule.organizationId, organizationId),
+        eq(schema.RecurrenceRule.subjectType, 'invoice_drafts'),
+        eq(schema.RecurrenceRule.subjectId, workOrderInstanceId)
+      )
+    )
+}
+
+/** Read a work order's invoice-draft schedule rule, or `null` if none is set (§F.1/§J). */
+export async function getInvoiceSchedule(
+  input: InvoiceScheduleQueryInput
+): Promise<RecurrenceRuleRow | null> {
+  const { organizationId, workOrderInstanceId } = input
+  const rule = await database.query.RecurrenceRule.findFirst({
+    where: and(
+      eq(schema.RecurrenceRule.organizationId, organizationId),
+      eq(schema.RecurrenceRule.subjectType, 'invoice_drafts'),
+      eq(schema.RecurrenceRule.subjectId, workOrderInstanceId)
+    ),
+  })
+  return rule ?? null
+}
+
+/**
+ * Materialize an `invoice_drafts` `RecurrenceRule` (money MI2 build spec §F.2/§F.3) — the M2c
+ * cursor pattern with generation instead of row-insertion, and one deliberate divergence:
+ * the window is `(materializedUntil ?? anchor) → now`, NEVER now + horizon (Q9b — a draft for
+ * an occurrence weeks out must not exist yet).
+ *
+ * Pause gate (§F.3, Q8a) runs first: a recurring engagement that's `paused`/`ended`/
+ * `canceled`, or a one_off engagement that's `canceled`, advances the cursor WITHOUT
+ * generating (resume-from-today, no backfill — advancing while paused IS the no-backfill
+ * mechanic). A one_off engagement that's `completed` keeps generating (Q8's carve-out —
+ * final scheduled invoices usually come after the work).
+ *
+ * Each occurrence is generated in its own try/catch (logged, not rethrown) so one bad
+ * occurrence can't leave the cursor stuck re-processing (and re-drafting) the same slot on
+ * every future sweep — `materializedUntil` always advances to `now` once the pass completes.
+ */
+export async function materializeInvoiceDrafts(rule: RecurrenceRuleRow): Promise<void> {
+  const userId = await systemActorUserId(rule.organizationId)
+  const [status, jobType] = await Promise.all([
+    getWorkOrderStatus(rule.organizationId, userId, rule.subjectId),
+    getWorkOrderJobType(rule.organizationId, userId, rule.subjectId),
+  ])
+
+  const now = new Date()
+  const isRecurring = jobType === 'recurring'
+  const skipGeneration =
+    (isRecurring && (status === 'paused' || status === 'ended' || status === 'canceled')) ||
+    (!isRecurring && status === 'canceled')
+
+  if (skipGeneration) {
+    await database
+      .update(schema.RecurrenceRule)
+      .set({ materializedUntil: now })
+      .where(eq(schema.RecurrenceRule.id, rule.id))
+    return
+  }
+
+  const pattern = rule.pattern as unknown as RecurrencePattern
+  const anchorStart = localDateStartUtc(rule.anchor, rule.timezone)
+  const boundary = rule.materializedUntil ?? anchorStart
+
+  // countConsumed (§F.2): count of prior occurrences expanded from anchor → strictly before
+  // the boundary — derived from the cursor, not a counter column (06 §4.4 principle).
+  const countConsumed = expandOccurrences(pattern, {
+    anchor: rule.anchor,
+    timezone: rule.timezone,
+    from: anchorStart,
+    to: new Date(boundary.getTime() - 1),
+    startMinute: 0,
+  }).length
+
+  const occurrences = expandOccurrences(pattern, {
+    anchor: rule.anchor,
+    timezone: rule.timezone,
+    from: boundary,
+    to: now,
+    startMinute: 0,
+    countConsumed,
+  })
+
+  for (const occurrence of occurrences) {
+    try {
+      await generateInvoiceDraft({
+        organizationId: rule.organizationId,
+        workOrderInstanceId: rule.subjectId,
+        trigger: 'custom_schedule',
+        occurrenceDate: occurrence.occurrenceDate,
+      })
+    } catch (error) {
+      logger.error('Failed to generate scheduled invoice draft', {
+        ruleId: rule.id,
+        organizationId: rule.organizationId,
+        workOrderInstanceId: rule.subjectId,
+        occurrenceDate: occurrence.occurrenceDate,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  await database
+    .update(schema.RecurrenceRule)
+    .set({ materializedUntil: now })
+    .where(eq(schema.RecurrenceRule.id, rule.id))
+}
+
+/**
+ * Daily sweep (money MI2 build spec §G) for every `invoice_drafts` `RecurrenceRule` whose
+ * horizon has fallen behind. Per-rule try/catch — one broken org must not stall the sweep
+ * (unlike M2c's visit sweep, which has no such guard because it never generates money).
+ */
+export async function sweepInvoiceDrafts(): Promise<void> {
+  const now = new Date()
+  const rules = await database.query.RecurrenceRule.findMany({
+    where: and(
+      eq(schema.RecurrenceRule.subjectType, 'invoice_drafts'),
+      or(
+        isNull(schema.RecurrenceRule.materializedUntil),
+        lt(schema.RecurrenceRule.materializedUntil, now)
+      )
+    ),
+  })
+
+  for (const rule of rules) {
+    try {
+      await materializeInvoiceDrafts(rule)
+    } catch (error) {
+      logger.error('Failed to materialize invoice drafts for rule', {
+        ruleId: rule.id,
+        organizationId: rule.organizationId,
+        workOrderInstanceId: rule.subjectId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+}

--- a/packages/lib/src/money/gather.ts
+++ b/packages/lib/src/money/gather.ts
@@ -1,8 +1,10 @@
 // packages/lib/src/money/gather.ts
 
 import { database, schema } from '@auxx/database'
+import type { CustomFieldEntity } from '@auxx/database/types'
 import type { TypedFieldValue } from '@auxx/types'
 import { extractValue } from '@auxx/types'
+import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
 import { inArray } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
@@ -39,7 +41,12 @@ const LINE_ROW_ATTRS = [
   'line_item_invoice',
 ] as const
 
-const LINE_COPY_ATTRS = [
+/**
+ * Exported so the MI2 auto-draft builder (`money/auto-invoice.ts`) can read the same field
+ * set via `cache.from(...).bySystemAttributes(LINE_COPY_ATTRS)` and pass the identically-typed
+ * result into {@link copyLineOntoInvoice} without redeclaring the attribute list.
+ */
+export const LINE_COPY_ATTRS = [
   'line_item_name',
   'line_item_description',
   'line_item_qty',
@@ -173,19 +180,37 @@ export async function listUninvoicedLines(
 }
 
 /**
- * Gather selected work-order lines onto a new invoice (money MI1 build spec §G.3). Whole-line
- * only (decision 7) — checked lines are copied verbatim, never split. Billing (discount/tax)
- * is inherited from the work order's linked quote snapshot when present, else the org's
- * default tax rate (`documents.taxRates`, the `isDefault` entry) with no discount. Source
- * lines are stamped with `line_item_invoice` (the "invoiced by" pointer, §B.3) — they are
- * NOT moved or duplicated onto the work order's own line set, which stays as-is.
+ * Create the invoice "shell" — contact + linked-quote read, billing inheritance (quote
+ * snapshot else org default tax rate), and the invoice record itself with due-date prefills
+ * (money MI1 build spec §G.3 steps 1–3). Extracted so both the manual gather flow
+ * (`createInvoiceFromWorkOrder`, below) and the MI2 auto-draft builder
+ * (`generateInvoiceDraft` in `money/auto-invoice.ts`) share one implementation instead of
+ * duplicating it.
  *
- * @returns `{ recordId, instanceId }` — the client opens `/app/invoices?id=<instanceId>`.
+ * `issuedAt`, when passed, overrides the default "today" for `invoice_issued_at` — the
+ * auto-draft builder backdates it to the visit/occurrence date (money MI2 build spec §C step
+ * 4 / Q9b). `dueDate` is ALWAYS computed from today (generation day) + org
+ * `documents.invoice.dueDays`, never from a backdated `issuedAt` — a late-generated draft
+ * must never arrive already overdue.
+ *
+ * `extraValues`, when passed, are merged into the invoice create values — the auto-draft
+ * builder uses this to stamp the hidden `invoice_visit_id` dedup field (money MI2 build spec
+ * §B, Q6a) without this function needing to know about it.
+ *
+ * The manual gather flow needs the no-contact guard to surface as a user-facing error, so it
+ * stays a throw here; the automated caller pre-checks the contact itself (money MI2 build
+ * spec Q5 — an automated job can't throw at 3 AM) and never reaches this branch.
+ *
+ * @throws {BadRequestError} when the work order has no contact.
  */
-export async function createInvoiceFromWorkOrder(
-  input: CreateInvoiceFromWorkOrderInput
-): Promise<CreateInvoiceFromWorkOrderResult> {
-  const { organizationId, userId, workOrderInstanceId, lineInstanceIds } = input
+export async function createInvoiceShell(input: {
+  organizationId: string
+  userId: string
+  workOrderInstanceId: string
+  issuedAt?: string
+  extraValues?: Record<string, unknown>
+}) {
+  const { organizationId, userId, workOrderInstanceId, issuedAt, extraValues } = input
   const handler = new UnifiedCrudHandler(organizationId, userId)
   const cache = getOrgCache()
   const workOrderRecordId = toRecordId('work_order', workOrderInstanceId)
@@ -267,8 +292,9 @@ export async function createInvoiceFromWorkOrder(
   const invoiceValues: Record<string, unknown> = {
     invoice_contact: contactRecordId,
     invoice_work_order: workOrderRecordId,
-    invoice_issued_at: today.toISOString().split('T')[0],
+    invoice_issued_at: issuedAt ?? today.toISOString().split('T')[0],
     invoice_due_date: dueDate.toISOString().split('T')[0],
+    ...extraValues,
   }
   if (discountType) invoiceValues.invoice_discount_type = discountType
   if (discountValue !== null) invoiceValues.invoice_discount_value = discountValue
@@ -276,8 +302,118 @@ export async function createInvoiceFromWorkOrder(
   if (taxRate !== null) invoiceValues.invoice_tax_rate = taxRate
 
   const createdInvoice = await handler.create('invoice', invoiceValues)
-  const invoiceRecordId = createdInvoice.recordId
-  const invoiceInstanceId = createdInvoice.instance.id
+
+  return {
+    handler,
+    cache,
+    workOrderRecordId,
+    contactRecordId,
+    quoteRecordId,
+    recordId: createdInvoice.recordId,
+    instanceId: createdInvoice.instance.id,
+  }
+}
+
+/**
+ * Copy one source line onto a draft invoice (money MI1 build spec §G.3 steps 5–6). Consumed
+ * by both `createInvoiceFromWorkOrder`'s gather loop (`stampSource: true` — the source line
+ * is marked "invoiced by" this invoice so it drops out of `listUninvoicedLines`) and the MI2
+ * auto-draft builder's template-copy branch (`stampSource: false` — Q2/Q4's per-visit/
+ * recurring "job-set lines are a template" semantics: the copy carries no `sourceLineId` and
+ * the source is never stamped, so re-triggering the same source produces fresh copies each
+ * time; `deleteInvoiceLine`'s null-`sourceLineId` branch already treats such copies as
+ * non-refunding deletes).
+ *
+ * `extraValues`, when passed, are merged into the copy's values — the auto-draft builder uses
+ * this to stamp `line_item_visit_id` on template copies.
+ */
+export async function copyLineOntoInvoice(input: {
+  handler: UnifiedCrudHandler
+  fieldValueService: FieldValueService
+  lineCf: Record<(typeof LINE_COPY_ATTRS)[number], CustomFieldEntity | null>
+  lineFieldIds: string[]
+  lineInstanceId: string
+  invoiceRecordId: RecordId
+  stampSource: boolean
+  extraValues?: Record<string, unknown>
+}): Promise<void> {
+  const {
+    handler,
+    fieldValueService,
+    lineCf,
+    lineFieldIds,
+    lineInstanceId,
+    invoiceRecordId,
+    stampSource,
+    extraValues,
+  } = input
+  const lineRecordId = toRecordId('line_item', lineInstanceId)
+  const values = await handler.getFieldValues(lineRecordId, lineFieldIds)
+  const get = (f?: { id: string }) => (f ? firstTyped(values.get(f.id)) : undefined)
+
+  const nameTyped = get(lineCf.line_item_name)
+  const descriptionTyped = get(lineCf.line_item_description)
+  const qtyTyped = get(lineCf.line_item_qty)
+  const unitPriceTyped = get(lineCf.line_item_unit_price)
+  const lineTotalTyped = get(lineCf.line_item_line_total)
+  const taxableTyped = get(lineCf.line_item_taxable)
+  const categoryTyped = get(lineCf.line_item_category)
+  const discountTyped = get(lineCf.line_item_discount)
+  const sortOrderTyped = get(lineCf.line_item_sort_order)
+  const catalogItemTyped = get(lineCf.line_item_catalog_item)
+
+  // No `line_item_work_order`, no `line_item_quote` on copies (§B.3 invariant).
+  const copyValues: Record<string, unknown> = {
+    line_item_name: nameTyped ? extractValue(nameTyped) : undefined,
+    line_item_description: descriptionTyped ? extractValue(descriptionTyped) : undefined,
+    line_item_qty: qtyTyped ? extractValue(qtyTyped) : 1,
+    line_item_unit_price: unitPriceTyped ? extractValue(unitPriceTyped) : undefined,
+    line_item_line_total: lineTotalTyped ? extractValue(lineTotalTyped) : undefined,
+    line_item_taxable: taxableTyped ? extractValue(taxableTyped) : true,
+    line_item_category: categoryTyped ? extractValue(categoryTyped) : undefined,
+    line_item_discount: discountTyped ? extractValue(discountTyped) : undefined,
+    line_item_sort_order: sortOrderTyped ? extractValue(sortOrderTyped) : undefined,
+    line_item_invoice: invoiceRecordId,
+    ...extraValues,
+  }
+  if (stampSource) {
+    copyValues.line_item_source_line_id = lineInstanceId
+  }
+  if (catalogItemTyped?.type === 'relationship') {
+    copyValues.line_item_catalog_item = catalogItemTyped.recordId
+  }
+
+  await handler.create('line_item', copyValues)
+
+  if (stampSource) {
+    // Stamp the source ("invoiced by" pointer) — publishEvents ON so visit chips/job view
+    // update live; the §G.1 guard keeps this from recomputing invoice totals (source lines
+    // still carry `line_item_work_order`).
+    await fieldValueService.setValuesForEntity({
+      recordId: lineRecordId,
+      values: [{ fieldId: 'line_item_invoice', value: invoiceRecordId }],
+    })
+  }
+}
+
+/**
+ * Gather selected work-order lines onto a new invoice (money MI1 build spec §G.3). Whole-line
+ * only (decision 7) — checked lines are copied verbatim, never split. Billing (discount/tax)
+ * is inherited from the work order's linked quote snapshot when present, else the org's
+ * default tax rate (`documents.taxRates`, the `isDefault` entry) with no discount. Source
+ * lines are stamped with `line_item_invoice` (the "invoiced by" pointer, §B.3) — they are
+ * NOT moved or duplicated onto the work order's own line set, which stays as-is.
+ *
+ * @returns `{ recordId, instanceId }` — the client opens `/app/invoices?id=<instanceId>`.
+ */
+export async function createInvoiceFromWorkOrder(
+  input: CreateInvoiceFromWorkOrderInput
+): Promise<CreateInvoiceFromWorkOrderResult> {
+  const { organizationId, userId, workOrderInstanceId, lineInstanceIds } = input
+
+  // ─── Steps 1–3: contact + quote read, billing inheritance, invoice create ──
+  const shell = await createInvoiceShell({ organizationId, userId, workOrderInstanceId })
+  const { handler, cache, recordId: invoiceRecordId, instanceId: invoiceInstanceId } = shell
 
   // ─── Step 4: re-validate requested lines (concurrency guard) ───────────────
   const lineCf = await cache
@@ -313,47 +449,14 @@ export async function createInvoiceFromWorkOrder(
   // ─── Steps 5–6: copy each source line, then stamp it as gathered ───────────
   const fieldValueService = new FieldValueService(organizationId, userId)
   for (const lineInstanceId of validLineInstanceIds) {
-    const lineRecordId = toRecordId('line_item', lineInstanceId)
-    const values = await handler.getFieldValues(lineRecordId, lineFieldIds)
-    const get = (f?: { id: string }) => (f ? firstTyped(values.get(f.id)) : undefined)
-
-    const nameTyped = get(lineCf.line_item_name)
-    const descriptionTyped = get(lineCf.line_item_description)
-    const qtyTyped = get(lineCf.line_item_qty)
-    const unitPriceTyped = get(lineCf.line_item_unit_price)
-    const lineTotalTyped = get(lineCf.line_item_line_total)
-    const taxableTyped = get(lineCf.line_item_taxable)
-    const categoryTyped = get(lineCf.line_item_category)
-    const discountTyped = get(lineCf.line_item_discount)
-    const sortOrderTyped = get(lineCf.line_item_sort_order)
-    const catalogItemTyped = get(lineCf.line_item_catalog_item)
-
-    // No `line_item_work_order`, no `line_item_quote` on copies (§B.3 invariant).
-    const copyValues: Record<string, unknown> = {
-      line_item_name: nameTyped ? extractValue(nameTyped) : undefined,
-      line_item_description: descriptionTyped ? extractValue(descriptionTyped) : undefined,
-      line_item_qty: qtyTyped ? extractValue(qtyTyped) : 1,
-      line_item_unit_price: unitPriceTyped ? extractValue(unitPriceTyped) : undefined,
-      line_item_line_total: lineTotalTyped ? extractValue(lineTotalTyped) : undefined,
-      line_item_taxable: taxableTyped ? extractValue(taxableTyped) : true,
-      line_item_category: categoryTyped ? extractValue(categoryTyped) : undefined,
-      line_item_discount: discountTyped ? extractValue(discountTyped) : undefined,
-      line_item_sort_order: sortOrderTyped ? extractValue(sortOrderTyped) : undefined,
-      line_item_invoice: invoiceRecordId,
-      line_item_source_line_id: lineInstanceId,
-    }
-    if (catalogItemTyped?.type === 'relationship') {
-      copyValues.line_item_catalog_item = catalogItemTyped.recordId
-    }
-
-    await handler.create('line_item', copyValues)
-
-    // Stamp the source ("invoiced by" pointer) — publishEvents ON so visit chips/job view
-    // update live; the §G.1 guard keeps this from recomputing invoice totals (source lines
-    // still carry `line_item_work_order`).
-    await fieldValueService.setValuesForEntity({
-      recordId: lineRecordId,
-      values: [{ fieldId: 'line_item_invoice', value: invoiceRecordId }],
+    await copyLineOntoInvoice({
+      handler,
+      fieldValueService,
+      lineCf,
+      lineFieldIds,
+      lineInstanceId,
+      invoiceRecordId,
+      stampSource: true,
     })
   }
 

--- a/packages/lib/src/money/index.ts
+++ b/packages/lib/src/money/index.ts
@@ -6,6 +6,16 @@
 // neverthrow-style, no model classes (dashboards module is the layout precedent, dispatch is
 // the direct sibling for this feature).
 
+export {
+  clearInvoiceSchedule,
+  generateDraftOnCompletion,
+  generateInvoiceDraft,
+  getInvoiceSchedule,
+  materializeInvoiceDrafts,
+  maybeGenerateVisitInvoiceDraft,
+  setInvoiceSchedule,
+  sweepInvoiceDrafts,
+} from './auto-invoice'
 export { convertQuoteToWorkOrder } from './convert-quote'
 export { createInvoiceFromWorkOrder, deleteInvoiceLine, listUninvoicedLines } from './gather'
 export { deleteInvoice, markInvoiceSent, voidInvoice } from './invoice-lifecycle'
@@ -77,7 +87,11 @@ export type {
   DiscountType,
   DocumentBillingInputs,
   DocumentTotals,
+  GenerateInvoiceDraftInput,
+  GenerateInvoiceDraftResult,
+  InvoiceDraftTrigger,
   InvoiceLifecycleInput,
+  InvoiceScheduleQueryInput,
   LineForTotals,
   ListUninvoicedLinesInput,
   MoneyMutationInput,
@@ -86,6 +100,7 @@ export type {
   RecomputeTotalsInput,
   RecordManualPaymentInput,
   ReorderLinesInput,
+  SetInvoiceScheduleInput,
   SyncInvoicePaymentStateInput,
   UninvoicedLine,
 } from './types'

--- a/packages/lib/src/money/types.ts
+++ b/packages/lib/src/money/types.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/money/types.ts
 
 import type { RecordId } from '@auxx/types/resource'
+import type { RecurrencePattern } from '../recurrence'
 
 /** Percent-of-subtotal vs flat-amount discount (mirrors `QUOTE_DISCOUNT_TYPE_OPTIONS`). */
 export type DiscountType = 'percent' | 'amount'
@@ -149,4 +150,48 @@ export interface CreateInvoiceFromWorkOrderResult {
 export interface DeleteInvoiceLineInput extends MoneyMutationInput {
   /** EntityInstance id of the line item (not the RecordId). */
   lineInstanceId: string
+}
+
+/** The three automated invoice-draft triggers (money MI2 build spec §C). */
+export type InvoiceDraftTrigger = 'per_visit' | 'on_completion' | 'custom_schedule'
+
+/** Input for `generateInvoiceDraft` (§C) — one function all three triggers call. */
+export interface GenerateInvoiceDraftInput {
+  organizationId: string
+  /** EntityInstance id of the work order (not the RecordId). */
+  workOrderInstanceId: string
+  trigger: InvoiceDraftTrigger
+  /** `per_visit` only — the dedup key (`invoice_visit_id`) + extras filter. */
+  visitId?: string
+  /** `custom_schedule` only — the occurrence's scheduled local date, used for dedup/logging
+   * context and (Q9b, `visit_date` date basis) the backdated `issuedAt`. */
+  occurrenceDate?: string
+  /** `per_visit` only — the visit's own local date (`WorkOrderVisit.occurrenceDate` else the
+   * date part of `startTime`), used for the Q9b backdated `issuedAt`. */
+  visitDate?: string
+}
+
+/** Result of `generateInvoiceDraft` — a skip carries a `reason` for logging/telemetry. */
+export type GenerateInvoiceDraftResult =
+  | {
+      created: false
+      reason: 'disabled' | 'not_found' | 'timing_mismatch' | 'no_contact' | 'duplicate' | 'empty'
+    }
+  | { created: true; recordId: RecordId; instanceId: string }
+
+/** Input for `setInvoiceSchedule` (§F.1). */
+export interface SetInvoiceScheduleInput {
+  organizationId: string
+  userId: string
+  /** EntityInstance id of the work order (not the RecordId). */
+  workOrderInstanceId: string
+  pattern: RecurrencePattern
+  timezone: string
+}
+
+/** Input shared by `clearInvoiceSchedule` / `getInvoiceSchedule` (§F.1/§J). */
+export interface InvoiceScheduleQueryInput {
+  organizationId: string
+  /** EntityInstance id of the work order (not the RecordId). */
+  workOrderInstanceId: string
 }

--- a/packages/lib/src/resources/registry/resource-registry-service.ts
+++ b/packages/lib/src/resources/registry/resource-registry-service.ts
@@ -99,6 +99,10 @@ type CustomFieldRecord = {
   dataConnectorId: string | null
   // Connector-declared external-id field (e.g. Shopify customerId)
   isIdentity: boolean
+  // New-record default (money MI2 §O.2's `documents.invoice.defaultTiming` write-through
+  // is the first consumer that depends on this actually reaching `applyDefaults` —
+  // previously dropped entirely, see `mapCustomFieldsToResourceFields` below)
+  defaultValue: string | null
 }
 
 /** EntityDefinition with display field relations and customFields loaded */
@@ -905,7 +909,11 @@ export class ResourceRegistryService {
           showInDialogs: staticField.showInDialogs,
           placeholder: staticField.placeholder,
           nullable: staticField.nullable,
-          defaultValue: staticField.defaultValue,
+          // DB CustomField.defaultValue takes priority per this function's own contract
+          // (doc comment above) — falls back to the static registry default only when the
+          // org never overrode it (fresh-org seed sets the DB row to the static default too,
+          // so this is a true override, not a silent divergence).
+          defaultValue: dbField.defaultValue ?? staticField.defaultValue,
           // Hidden is a static-only capability — not persisted in CustomField,
           // but the static registry owns the UI visibility decision for system fields.
           capabilities: {
@@ -1086,6 +1094,14 @@ export class ResourceRegistryService {
         active: true,
         isUnique: field.isUnique,
         required: field.required,
+
+        // New-record default (`createEntity`'s `applyDefaults`, unified-handler-mutations.ts:318)
+        // — was never copied from the DB row here, so `CustomField.defaultValue` writes (e.g.
+        // the settings-service.ts `documents.invoice.defaultTiming` write-through) were silently
+        // inert for every field. `mergeSystemAndCustomFields` still prefers this over
+        // `staticField.defaultValue` when set (its "DB CustomField versions take priority"
+        // contract, previously violated for this one property).
+        defaultValue: field.defaultValue ?? undefined,
 
         // Capabilities - use database values
         capabilities: {

--- a/packages/lib/src/resources/registry/resources/invoice-fields.ts
+++ b/packages/lib/src/resources/registry/resources/invoice-fields.ts
@@ -549,6 +549,31 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
       'user-editable. Mirrors the invoice_pdf_asset recipe (FieldValueService-only writer).',
   },
 
+  visitId: {
+    id: toFieldId('visitId'),
+    key: 'visitId',
+    label: 'Visit ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'invoice_visit_id',
+    systemSortOrder: 'aM',
+    showInPanel: false,
+    nullable: true,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+      hidden: true,
+    },
+    description:
+      'Plain text bridge to WorkOrderVisit — visits are not entities (dispatch lock, same ' +
+      'description style as line_item_visit_id) — per-visit auto-draft dedup key + ' +
+      'visit→invoice backlink (money MI2 build spec §I)',
+  },
+
   createdAt: {
     id: toFieldId('createdAt'),
     key: 'createdAt',

--- a/packages/lib/src/resources/registry/resources/work-order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/work-order-fields.ts
@@ -472,7 +472,7 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'work_order_invoice_timing',
     systemSortOrder: 'aH',
-    showInPanel: false, // structure-only until the invoicing module (04-ui.md invoicing model)
+    showInPanel: true, // MI2: office can see/edit invoice timing in the drawer panel
     nullable: false,
     options: { options: [...WORK_ORDER_INVOICE_TIMING_OPTIONS] },
     capabilities: {
@@ -483,7 +483,7 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
       configurable: false,
     },
     defaultValue: 'per_visit_completed',
-    description: 'When invoice drafts are generated (invoicing module, later)',
+    description: 'When invoice drafts are generated (money MI2 build spec)',
   },
 
   quote: {

--- a/packages/lib/src/seed/default-view-configs.ts
+++ b/packages/lib/src/seed/default-view-configs.ts
@@ -950,5 +950,49 @@ export const DEFAULT_VIEW_CONFIGS = {
         columnFormatting: {},
       } satisfies ViewConfig,
     },
+    {
+      name: 'Drafts',
+      description: 'Draft invoices awaiting review before they are sent (money MI2)',
+      isDefault: false,
+      config: {
+        viewType: 'table' as const,
+        columnVisibility: {
+          field_invoice_number: true,
+          field_invoice_contact: true,
+          field_invoice_status: true,
+          field_invoice_total: true,
+          field_invoice_balance: true,
+          field_invoice_due_date: true,
+        },
+        columnOrder: [
+          'field_invoice_number',
+          'field_invoice_contact',
+          'field_invoice_status',
+          'field_invoice_total',
+          'field_invoice_balance',
+          'field_invoice_due_date',
+        ],
+        columnPinning: { left: ['_checkbox', 'field_invoice_number'] },
+        sorting: [{ id: 'field_created_at', desc: true }],
+        filters: [
+          {
+            id: 'draft-invoices-group',
+            logicalOperator: 'AND',
+            conditions: [
+              {
+                id: 'draft-invoices-status',
+                fieldId: 'field_invoice_status',
+                operator: 'in',
+                value: ['draft'],
+                isConstant: true,
+              },
+            ],
+          },
+        ],
+        columnSizing: {},
+        columnLabels: {},
+        columnFormatting: {},
+      } satisfies ViewConfig,
+    },
   ],
 } as const satisfies Record<string, DefaultViewDefinition[]>

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -40,6 +40,7 @@ import { migration034QuotePdfAssetField } from './migrations/034-quote-pdf-asset
 import { migration035MoneyInvoicing } from './migrations/035-money-invoicing'
 import { migration036InvoicePublicToken } from './migrations/036-invoice-public-token'
 import { migration037WorkOrderEngagementStatuses } from './migrations/037-work-order-engagement-statuses'
+import { migration038InvoiceAutomation } from './migrations/038-invoice-automation'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -85,6 +86,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration035MoneyInvoicing,
   migration036InvoicePublicToken,
   migration037WorkOrderEngagementStatuses,
+  migration038InvoiceAutomation,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/038-invoice-automation.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/038-invoice-automation.ts
@@ -1,0 +1,151 @@
+// packages/lib/src/seed/entity-migrations/migrations/038-invoice-automation.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
+import { onCacheEvent } from '../../../cache/invalidate'
+import { INVOICE_FIELDS } from '../../../resources/registry/resources/invoice-fields'
+import { SystemUserService } from '../../../users/system-user-service'
+import { DEFAULT_VIEW_CONFIGS } from '../../default-view-configs'
+import { resolveViewConfig } from '../../entity-seeder/create-default-views'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:038')
+
+/**
+ * Migration 038: Money MI2 invoice automation groundwork.
+ *
+ * 1. Adds the hidden `invoice.visitId` field (`invoice_visit_id`) — the per-visit auto-draft
+ *    dedup key + visit→invoice backlink (money MI2 build spec §B/§I, Q6a). Mirrors the 036
+ *    `invoice.publicToken` recipe: fresh orgs get it for free via `INVOICE_FIELDS`
+ *    (entity-seeder/create-fields.ts); this migration backfills orgs that installed `invoice`
+ *    (035) before this field existed.
+ *
+ * 2. Seeds the "Drafts" saved table view (Q10a) for orgs that already ran 035's
+ *    `ensureDefaultTableViews` call. NOTE: `ensureDefaultTableViews` (helpers.ts:459) dedups
+ *    per-ENTITY, not per-view — it no-ops entirely the moment ANY TableView exists at
+ *    `entity-${invoiceDefId}` (helpers.ts:473-483), which every org that ran 035 already has
+ *    ("All Invoices" + "Outstanding"). Calling it again here would silently skip "Drafts"
+ *    forever. So this migration inserts the "Drafts" view directly, keyed by its own name for
+ *    idempotency, reusing `resolveViewConfig` (the same field-id resolution `createDefaultViews`
+ *    and `ensureDefaultTableViews` share) rather than the entity-level helper. Fresh orgs need no
+ *    backfill — `createDefaultViews` reads the now-3-entry `DEFAULT_VIEW_CONFIGS.invoice` array
+ *    directly at signup.
+ *
+ * showInPanel note: `work_order.invoiceTiming`'s `showInPanel: false → true` flip (work-order-
+ * fields.ts) needed NO migration step — `showInPanel` is never materialized onto the per-org
+ * `CustomField` row (`buildFieldOptions`/`mapCapabilities`, entity-seeder/utils.ts, carry no such
+ * key); it's read live from the static registry on every request via
+ * `mergeSystemAndCustomFields` (resource-registry-service.ts), so the flip took effect for every
+ * existing org the moment the registry file changed. No backfill in this migration.
+ *
+ * No DDL — `RecurrenceRule` (0280) already ships; MI2 needs no invoice-automation DDL.
+ *
+ * See plans/dispatch/money/08-mi2-build.md §B, §I.
+ */
+export const migration038InvoiceAutomation: EntityMigration = {
+  id: '038-invoice-automation',
+  description: 'Add invoice.visitId field + seeded "Drafts" table view (Money MI2 automation)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const invoiceDef = existing.entityDefs.get('invoice')
+    if (!invoiceDef) {
+      // Org never got MI1's invoice entity — nothing to backfill; entity-seeder brings
+      // visitId + the Drafts view along whenever invoice itself is first created.
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    const fieldMap = await ensureCustomFields(
+      db,
+      organizationId,
+      'invoice',
+      invoiceDef.id,
+      { visitId: INVOICE_FIELDS.visitId! },
+      existing,
+      state
+    )
+
+    let viewCreated = false
+    const tableId = `entity-${invoiceDef.id}`
+    const draftsViewDef = DEFAULT_VIEW_CONFIGS.invoice.find((v) => v.name === 'Drafts')
+    if (draftsViewDef) {
+      const existingDraftsView = await db
+        .select({ id: schema.TableView.id })
+        .from(schema.TableView)
+        .where(
+          and(
+            eq(schema.TableView.organizationId, organizationId),
+            eq(schema.TableView.tableId, tableId),
+            eq(schema.TableView.name, draftsViewDef.name)
+          )
+        )
+        .limit(1)
+
+      if (existingDraftsView.length === 0) {
+        // Merge in every invoice field (not just the visitId field ensured above) so `field_*`
+        // symbolic references in the Drafts config (e.g. field_invoice_status) resolve.
+        // `resolveViewConfig`/`buildFieldIdMap` (entity-seeder/create-default-views.ts) only
+        // requires each map key to start with `${entityType}:` — the value's `systemAttribute`
+        // drives the actual lookup, so the CustomField id suffix here just keeps keys unique.
+        const resolvable = new Map<string, { id: string; systemAttribute: string }>()
+        for (const field of existing.fields.values()) {
+          if (field.entityDefinitionId === invoiceDef.id) {
+            resolvable.set(`invoice:${field.id}`, {
+              id: field.id,
+              systemAttribute: field.systemAttribute,
+            })
+          }
+        }
+        for (const field of fieldMap.values()) {
+          resolvable.set(`invoice:${field.id}`, {
+            id: field.id,
+            systemAttribute: field.systemAttribute,
+          })
+        }
+
+        const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
+        const resolvedConfig = resolveViewConfig(
+          draftsViewDef.config,
+          'invoice',
+          invoiceDef.id,
+          resolvable
+        )
+
+        await db.insert(schema.TableView).values({
+          organizationId,
+          userId: systemUserId,
+          tableId,
+          name: draftsViewDef.name,
+          isDefault: draftsViewDef.isDefault ?? false,
+          isShared: true,
+          config: resolvedConfig,
+          updatedAt: new Date(),
+        })
+
+        viewCreated = true
+
+        // Every org member holds a `userTableViews` cache entry (serves tableView.listAll,
+        // 1-day TTL) — without this broadcast the seeded view stays invisible in the UI
+        // until each member's entry expires (the ensureDefaultTableViews recipe,
+        // helpers.ts:508).
+        await onCacheEvent('table-view.created', {
+          orgId: organizationId,
+          broadcastUserKeys: true,
+        })
+
+        logger.debug('Created "Drafts" table view for invoice', { organizationId })
+      }
+    }
+
+    const alreadyUpToDate = state.fieldsCreated === 0 && !viewCreated
+    if (!alreadyUpToDate) {
+      logger.info('Migration 038 applied', { organizationId, ...state, viewCreated })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -435,6 +435,45 @@ export const SETTINGS_CATALOG = {
     defaultValue: 30,
     description: 'Default number of days an invoice is due after issue (MI1 consumes)',
   },
+  'documents.invoice.autoEnabled': {
+    scope: 'DOCUMENTS',
+    access: 'org',
+    fieldType: 'CHECKBOX',
+    options: { variant: 'switch' },
+    defaultValue: true,
+    description:
+      'Master switch for automated invoice drafts (MI2) — off, every trigger no-ops; ' +
+      'manual gather is unaffected',
+  },
+  'documents.invoice.defaultTiming': {
+    scope: 'DOCUMENTS',
+    access: 'org',
+    fieldType: 'SINGLE_SELECT',
+    defaultValue: 'per_visit_completed',
+    description: 'What NEW quotes/jobs start as for invoice timing (MI2)',
+    options: {
+      options: [
+        { value: 'per_visit_completed', label: 'Per visit completed' },
+        { value: 'on_completion', label: 'On job completion' },
+        { value: 'as_needed', label: 'As needed' },
+      ],
+    },
+  },
+  'documents.invoice.dateBasis': {
+    scope: 'DOCUMENTS',
+    access: 'org',
+    fieldType: 'SINGLE_SELECT',
+    defaultValue: 'visit_date',
+    description:
+      'issuedAt policy for auto-drafts (MI2): visit/occurrence date vs generation date — ' +
+      'dueDate always counts from generation day',
+    options: {
+      options: [
+        { value: 'visit_date', label: 'Visit / occurrence date' },
+        { value: 'creation_date', label: 'Generation date' },
+      ],
+    },
+  },
   'documents.invoice.paymentInstructions': {
     scope: 'DOCUMENTS',
     access: 'org',

--- a/packages/lib/src/settings/settings-service.ts
+++ b/packages/lib/src/settings/settings-service.ts
@@ -5,12 +5,84 @@
 
 import { type Database, database as defaultDb, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { SETTINGS_CATALOG, type SettingConfig, type SettingKey } from './catalog'
 import { normalizeSettingValue } from './normalize-setting-value'
 import type { SettingScope, SettingValue } from './types'
 
 const logger = createScopedLogger('settings-service')
+
+/**
+ * The two per-org `CustomField.defaultValue` rows kept in sync with
+ * `documents.invoice.defaultTiming` (money MI2 §O.2) — quote-fields.ts:263 and
+ * work-order-fields.ts:485 materialize these per org at seed time.
+ */
+const INVOICE_TIMING_SYSTEM_ATTRIBUTES = ['quote_invoice_timing', 'work_order_invoice_timing']
+
+/**
+ * DB half of the `documents.invoice.defaultTiming` write-through (money MI2
+ * §O.2, recommended variant): updates the two org `CustomField.defaultValue`
+ * rows so every create door (dialog, Kopilot, API, quote→WO convert copy)
+ * inherits the new default through the existing field-default machinery — no
+ * create-path edits needed. Safe to run inside a transaction; call
+ * {@link bustInvoiceDefaultTimingCache} after commit if this returns `true`.
+ *
+ * Writes `CustomField` directly rather than going through
+ * `CustomFieldService.updateField()`/`updateCustomField` — both target fields
+ * are `systemAttribute`-marked, and `updateCustomField`'s `isProtectedField`
+ * guard (`packages/services/src/custom-fields/ownership.ts`) unconditionally
+ * rejects user edits to system fields; there's no `defaultValue`-only escape
+ * hatch (only `deleteField` has one, via `allowProtectedDeletion`). This
+ * mirrors the entity-migration pattern (`seed/entity-migrations/helpers.ts`),
+ * which also writes `CustomField` columns directly for system fields.
+ */
+async function writeInvoiceDefaultTimingCustomFields(params: {
+  organizationId: string
+  value: SettingValue
+  db: Database
+}): Promise<boolean> {
+  const { organizationId, value, db } = params
+  if (typeof value !== 'string') return false
+
+  const updated = await db
+    .update(schema.CustomField)
+    .set({ defaultValue: value, updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.CustomField.organizationId, organizationId),
+        inArray(schema.CustomField.systemAttribute, INVOICE_TIMING_SYSTEM_ATTRIBUTES)
+      )
+    )
+    .returning({ id: schema.CustomField.id })
+
+  return updated.length > 0
+}
+
+/**
+ * Cache half of the write-through — bust the org `customFields`/`resources`
+ * caches. Call once, after the DB transaction that wrote the rows commits
+ * (`onCacheEvent` contract).
+ */
+async function bustInvoiceDefaultTimingCache(organizationId: string): Promise<void> {
+  // Dynamic import — `../cache` transitively pulls in the org-settings cache
+  // provider, which imports this module (see `getOrganizationSetting` above
+  // for the same pattern), so a static import here would cycle.
+  const { onCacheEvent } = await import('../cache/invalidate')
+  await onCacheEvent('custom-field.updated', { orgId: organizationId })
+}
+
+/**
+ * Single-write convenience wrapper (DB write + cache bust) for the
+ * non-transactional {@link updateOrganizationSetting} path.
+ */
+async function applyInvoiceDefaultTimingWriteThrough(params: {
+  organizationId: string
+  value: SettingValue
+  db: Database
+}): Promise<void> {
+  const wrote = await writeInvoiceDefaultTimingCustomFields(params)
+  if (wrote) await bustInvoiceDefaultTimingCache(params.organizationId)
+}
 
 /**
  * Get an organization setting, ignoring user overrides.
@@ -244,6 +316,10 @@ export async function updateOrganizationSetting(params: {
       target: [schema.OrganizationSetting.organizationId, schema.OrganizationSetting.key],
       set: { value: normalizedValue, updatedAt: new Date() },
     })
+
+  if (key === 'documents.invoice.defaultTiming') {
+    await applyInvoiceDefaultTimingWriteThrough({ organizationId, value: normalizedValue, db })
+  }
 }
 
 /**
@@ -322,6 +398,7 @@ export async function batchUpdateOrganizationSettings(params: {
   db?: Database
 }): Promise<void> {
   const { organizationId, settings, db = defaultDb } = params
+  let touchedInvoiceDefaultTiming = false
 
   await db.transaction(async (tx) => {
     for (const setting of settings) {
@@ -347,8 +424,19 @@ export async function batchUpdateOrganizationSettings(params: {
           target: [schema.OrganizationSetting.organizationId, schema.OrganizationSetting.key],
           set: { value: normalizedValue, updatedAt: new Date() },
         })
+
+      if (key === 'documents.invoice.defaultTiming') {
+        const wrote = await writeInvoiceDefaultTimingCustomFields({
+          organizationId,
+          value: normalizedValue,
+          db: tx,
+        })
+        if (wrote) touchedInvoiceDefaultTiming = true
+      }
     }
   })
+
+  if (touchedInvoiceDefaultTiming) await bustInvoiceDefaultTimingCache(organizationId)
 }
 
 /** One organization setting merged with its catalog metadata. */

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -304,6 +304,7 @@ export const SYSTEM_ATTRIBUTES = [
   'invoice_notes',
   'invoice_terms',
   'invoice_pdf_asset',
+  'invoice_visit_id',
   'invoice_public_token',
   'invoice_line_items', // inverse of line_item_invoice
   'invoice_payments', // inverse of payment_invoice


### PR DESCRIPTION
## Summary

All of `plans/dispatch/money/08-mi2-build.md` §A–§O — the `work_order.invoiceTiming` triggers now generate **draft invoices** automatically (drafts never auto-send):

- **Engine** (`money/auto-invoice.ts`): `generateInvoiceDraft` with the pricing-model × trigger content matrix (per_visit template semantics — job-set lines copied per visit, never stamped; fixed × custom_schedule recurring charges), per-visit dedup via a hidden `invoice_visit_id` field, backdated `issuedAt` per the org's `documents.invoice.dateBasis` (dueDate always counts from generation day), silent skips for empty/no-contact (an automated job can't throw at 3 AM)
- **Three triggers**: the `setVisitStatus 'done'` seam · one `work_order_status` field-change hook catching `completed` AND `ended` through every door (roll-up, `endEngagement`, kanban, manual) · an `invoice_drafts` `RecurrenceRule` materializer + daily sweep (`invoiceDraftsJob`, 03:30 UTC) with the pause gate (paused/ended stop generating; one_off `completed` keeps payment plans alive)
- **Org settings**: new dispatch-settings **Invoicing** page — master switch, default timing (with write-through onto the two `CustomField.defaultValue` rows), date basis
- **UI**: job-view Billing row with schedule summary + editor (reuses M2c's `RecurrencePatternFields`), seeded **Drafts** view (entity migration 038, run on all 25 dev orgs)
- **Router**: member-level `setInvoiceSchedule`/`clearInvoiceSchedule`/`getInvoiceSchedule` (deliberate divergence from M2c's admin gating — billing cadence is desk work)

## Engine bugs found by the verify pass (fixed here)

1. **Field-change hooks silently dropped on type-slug RecordIds** — `FieldValueService` writes built with `toRecordId('work_order', id)` never resolved to the real EntityDefinition UUID, so hook dispatch found no hooks. Fixed in the three dispatch call sites (lifecycle roll-up, `writeEngagementStatus`, `maybeEndExhaustedEngagement`) via `getEntityDefIdResolver`.
2. **`CustomField.defaultValue` was inert app-wide** — never copied into runtime `ResourceField`s and always overwritten by the static registry. DB value now wins (`dbField.defaultValue ?? static`). Blast radius checked by SQL: only 4 non-null system-field defaultValue rows exist in the whole DB (all invoice-timing; one org has a stale pre-#1128 pair — separate data fix pending).

## Verification

- NEW `verify-money-mi2.ts` **75/75** (content matrix, dedup, both completion doors via real `setVisitStatus`/`endEngagement`, sweep with backdated cursors, pause gate via real `pauseEngagement`/`resumeEngagement`, draft integrity + MI1 guards, §O.4 settings cases with restore)
- Regressions: `verify-money-mi1` **58/58** · `verify-dispatch-recurring` **59/59** (re-run independently by the orchestrator)
- `pnpm lint` full repo: clean
- Entity migration 038 applied + idempotency-verified on all 25 dev orgs

## Not in this PR

- Browser pass (Billing row round-trip, Drafts view, Invoicing settings page) — verification debt, dev server needs a restart for the rebuilt `@auxx/lib` dist
- The concurrent quote-drawer/line-builder refactor in the working tree (its own PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)