### PR TITLE
feat(money): quote drawer lines overview card, line-builder refactor, realtime publish-key fix

### DIFF
--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -59,16 +59,6 @@ export const DRAWER_TAB_COMPONENTS: Record<
     import('./tabs/part-subparts-tab').then((m) => ({ default: m.PartSubpartsTab })),
   'part:vendors': () =>
     import('./tabs/part-vendors-tab').then((m) => ({ default: m.PartVendorsTab })),
-
-  // ─────────────────────────────────────────────────────────────────
-  // QUOTE TABS (shared with the quote detail-view main tab — the
-  // component takes DetailViewTabProps, which is prop-compatible with
-  // DrawerTabProps: both are { entityInstanceId, recordId, record? })
-  // ─────────────────────────────────────────────────────────────────
-  'quote:line-items': () =>
-    import('../money/ui/quote/quote-line-items-tab').then((m) => ({
-      default: m.QuoteLineItemsTab,
-    })),
 }
 
 /**
@@ -118,6 +108,12 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     import('./cards/quote-customer-card').then((m) => ({ default: m.QuoteCustomerCard })),
   'quote:origin': () =>
     import('./cards/quote-origin-card').then((m) => ({ default: m.QuoteOriginCard })),
+  // Drawer-only line-items block (the invoice:lines pattern) — the detail page
+  // renders its own Line-items section via DETAIL_VIEW_TAB_COMPONENTS instead.
+  'quote:lines': () =>
+    import('../money/ui/quote/quote-line-items-tab').then((m) => ({
+      default: m.QuoteLinesOverviewCard,
+    })),
 
   // ─────────────────────────────────────────────────────────────────
   // INVOICE OVERVIEW CARDS (money MI1 build spec §J.1 — drawer-only entity,

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -3,13 +3,11 @@
 'use client'
 
 // The document-agnostic line-items builder (money MQ1 build spec §H.1, 01-ui.md #1).
-// Renders a quote's (or work order's) lines on the records dynamic table in its
-// reduced mode — `DynamicView` called directly with `standalone + hideToolbar +
-// hideHeader + disableColumnDnd` and a hand-built fixed `ExtendedColumnDef[]`
-// (the `record-list-widget.tsx` precedent; `DynamicResourceView` cannot run
-// headerless/standalone, so the builder replicates its fetch layer via
-// `useResource` + `useRecordList` with a baseline ConditionGroup on the
-// `line_item:quote` / `line_item:workOrder` relationship).
+// Lines render as `GridTreeRow`s under a plain grid header (Description / Qty /
+// Unit cost / Total / actions) — the data-connectors mapping-editor idiom
+// (mapping-row.tsx): one shared `grid-template-columns` keeps the number columns
+// aligned across the header and every row. Line counts are small, so plain rows
+// replace the virtualized `DynamicView` embed this used to be.
 //
 // Data flow:
 // - Line cell reads: `useSystemValues` (field-value store, autoFetch).
@@ -20,26 +18,37 @@
 //   `computeLineTotal` from `@auxx/lib/money/client` over store values — the
 //   same function the server hook uses, so the optimistic footer and the
 //   stored mirrors can never disagree.
-// - Reorder: row DnD (`DragDropConfig.onDrop`) → `api.money.reorderLines`.
+// - Add: creates an EMPTY line record; clicking the Description cell opens the
+//   catalog picker (§H.2) which fills it in (or renames via free text).
+// - Reorder: dnd-kit sortable rows (grip handle) → `api.money.reorderLines`.
 // - Delete: `api.record.delete` + `api.money.recomputeTotals` (delete path
 //   doesn't fire field-change hooks, §F.2).
-//
-// NOTE on the ghost add-row (01-ui #1): the virtualized body has no non-record
-// row primitive (rows are hard `ROW_HEIGHT`-sized virtual items), so the
-// sanctioned fallback is used — an "Add line" row rendered in the footer slot,
-// visually attached to the bottom of the table.
 
 import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { computeLineTotal } from '@auxx/lib/money/client'
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
-import { SimpleTooltip } from '@auxx/ui/components/tooltip'
+import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { AlignLeft, Percent, ReceiptText, Trash2 } from 'lucide-react'
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react'
-import type { DragDropConfig, ExtendedColumnDef } from '~/components/dynamic-table'
-import { DynamicTableFooter, DynamicView } from '~/components/dynamic-table'
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { AlignLeft, GripVertical, Percent, Plus, ReceiptText, Trash2 } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import {
   type RecordId,
@@ -53,7 +62,7 @@ import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
 import { type CatalogItemPick, CatalogPicker } from './catalog-picker'
-import { formatCurrency, type NewLineInput, titleCase } from './shared'
+import { formatCurrency, titleCase } from './shared'
 import { TotalsFooter } from './totals-footer'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -71,6 +80,14 @@ const PAGE_SIZE = 100
 /** Stable sort ref — `useRecordList` keys its cache off this object. */
 const LINE_SORT = [{ id: 'sortOrder', desc: false }]
 
+/**
+ * Shared `grid-template-columns` for the header row and every line row (the
+ * mapping-columns.ts idiom) — one template is what keeps the qty / unit cost /
+ * total columns aligned. Columns: description (fills) │ qty │ unit cost │
+ * total │ actions.
+ */
+const LINE_COLS = 'minmax(10rem, 1fr) 4rem 6.5rem 6.5rem 5.5rem'
+
 // Module-level (stable-reference) attribute lists — `useSystemValues` memoizes
 // on the array identity, so these must never be inline literals.
 const NAME_ATTRS = ['line_item_name', 'line_item_description', 'line_item_category']
@@ -80,40 +97,29 @@ const TOTAL_ATTRS = ['line_item_qty', 'line_item_unit_price']
 const TAXABLE_ATTRS = ['line_item_taxable']
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Context — keeps the column defs static while cells reach the builder's state
-// ─────────────────────────────────────────────────────────────────────────────
-
-interface LineBuilderContextValue {
-  entityDefinitionId: string
-  readOnly: boolean
-  currencyCode: string
-  openDescriptionIds: Set<string>
-  toggleDescription: (lineId: string) => void
-  closeDescription: (lineId: string) => void
-  deleteLine: (lineId: string) => void
-}
-
-const LineBuilderContext = createContext<LineBuilderContextValue | null>(null)
-
-function useLineBuilder(): LineBuilderContextValue {
-  const ctx = useContext(LineBuilderContext)
-  if (!ctx) throw new Error('useLineBuilder must be used within LineBuilder')
-  return ctx
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Cells
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Name cell — the catalog combobox (§H.2) doubling as free-text rename. Shows
- * the category chip and the description as a second muted line when set
- * (both lines fit the fixed 38px row; see the row-height note in the report).
+ * Description cell — a transparent full-width button (the formula-row picker
+ * idiom) that opens the catalog combobox (§H.2), doubling as free-text rename.
+ * Shows the category chip inline and the description as a second muted line.
  */
-function LineNameCell({ rowId }: { rowId: string }) {
-  const { entityDefinitionId, readOnly, currencyCode, openDescriptionIds, closeDescription } =
-    useLineBuilder()
-  const recordId = toRecordId(entityDefinitionId, rowId)
+function LineNameCell({
+  recordId,
+  rowId,
+  readOnly,
+  currencyCode,
+  descriptionOpen,
+  closeDescription,
+}: {
+  recordId: RecordId
+  rowId: string
+  readOnly: boolean
+  currencyCode: string
+  descriptionOpen: boolean
+  closeDescription: (lineId: string) => void
+}) {
   const { values } = useSystemValues(recordId, NAME_ATTRS, { autoFetch: true })
   const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue()
   const [pickerOpen, setPickerOpen] = useState(false)
@@ -122,7 +128,7 @@ function LineNameCell({ rowId }: { rowId: string }) {
   const name = (values.line_item_name as string | undefined) ?? ''
   const description = (values.line_item_description as string | null | undefined) ?? null
   const category = (values.line_item_category as string | null | undefined) ?? null
-  const descriptionVisible = !!description || openDescriptionIds.has(rowId)
+  const descriptionVisible = !!description || descriptionOpen
 
   const handlePick = (pick: CatalogItemPick) => {
     // COPY the catalog defaults onto the line (snapshot — catalog price changes
@@ -150,29 +156,10 @@ function LineNameCell({ rowId }: { rowId: string }) {
   }
 
   return (
-    <div className='flex h-full w-full min-w-0 flex-col justify-center px-2'>
-      <CatalogPicker
-        open={pickerOpen}
-        onOpenChange={setPickerOpen}
-        initialQuery={name}
-        currencyCode={currencyCode}
-        onSelectCatalogItem={handlePick}
-        onFreeText={(text) => saveFieldValue(recordId, 'line_item_name', text, FieldType.TEXT)}>
-        <button
-          type='button'
-          disabled={readOnly}
-          // Row drag listeners live on the row wrapper — keep pointer-downs on
-          // editors from starting a drag.
-          onPointerDown={(e) => e.stopPropagation()}
-          className={cn(
-            'flex min-w-0 items-center gap-1.5 rounded-sm text-left',
-            !readOnly && 'hover:bg-primary-100/60 dark:hover:bg-primary-100/40'
-          )}>
-          <span
-            className={cn(
-              'truncate text-sm leading-tight',
-              !name && 'text-muted-foreground italic'
-            )}>
+    <div className='flex min-w-0 flex-1 flex-col justify-center py-1'>
+      {readOnly ? (
+        <span className='flex min-w-0 items-center gap-1.5 px-1'>
+          <span className={cn('truncate text-sm', !name && 'text-muted-foreground italic')}>
             {name || 'Untitled line'}
           </span>
           {category && (
@@ -180,14 +167,34 @@ function LineNameCell({ rowId }: { rowId: string }) {
               {titleCase(category)}
             </span>
           )}
-        </button>
-      </CatalogPicker>
+        </span>
+      ) : (
+        <CatalogPicker
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          initialQuery={name}
+          currencyCode={currencyCode}
+          onSelectCatalogItem={handlePick}
+          onFreeText={(text) => saveFieldValue(recordId, 'line_item_name', text, FieldType.TEXT)}>
+          <Button
+            variant='transparent'
+            className={cn(
+              'h-7 min-w-0 justify-start gap-1.5 rounded-sm px-1 text-sm hover:bg-primary/5',
+              !name && 'text-muted-foreground'
+            )}>
+            <span className='truncate'>{name || 'Add item…'}</span>
+            {category && (
+              <span className='shrink-0 rounded-full bg-primary-100 px-1.5 py-px text-[10px] text-muted-foreground leading-tight dark:bg-primary-100/50'>
+                {titleCase(category)}
+              </span>
+            )}
+          </Button>
+        </CatalogPicker>
+      )}
 
       {descriptionVisible &&
         (readOnly ? (
-          <span className='truncate text-[10px] text-muted-foreground leading-tight'>
-            {description}
-          </span>
+          <span className='truncate px-1 text-muted-foreground text-xs'>{description}</span>
         ) : (
           <input
             value={descriptionDraft ?? description ?? ''}
@@ -202,9 +209,8 @@ function LineNameCell({ rowId }: { rowId: string }) {
               }
             }}
             autoFocus={!description}
-            onPointerDown={(e) => e.stopPropagation()}
             placeholder='Description'
-            className='w-full truncate border-none bg-transparent text-[10px] text-muted-foreground leading-tight outline-none placeholder:text-muted-foreground/60'
+            className='w-full truncate border-none bg-transparent px-1 text-muted-foreground text-xs outline-none placeholder:text-muted-foreground/60'
           />
         ))}
     </div>
@@ -216,18 +222,18 @@ function LineNameCell({ rowId }: { rowId: string }) {
  * cell-treatment lock in 01-ui #1). Commits on blur/Enter.
  */
 function InlineNumberCell({
-  rowId,
+  recordId,
   attr,
   fieldType,
-  align = 'right',
+  readOnly,
+  currencyCode,
 }: {
-  rowId: string
+  recordId: RecordId
   attr: 'line_item_qty' | 'line_item_unit_price'
   fieldType: FieldType
-  align?: 'left' | 'right'
+  readOnly: boolean
+  currencyCode: string
 }) {
-  const { entityDefinitionId, readOnly, currencyCode } = useLineBuilder()
-  const recordId = toRecordId(entityDefinitionId, rowId)
   const attrs = attr === 'line_item_qty' ? QTY_ATTRS : PRICE_ATTRS
   const { values } = useSystemValues(recordId, attrs, { autoFetch: true })
   const { saveFieldValue } = useSaveFieldValue()
@@ -257,15 +263,7 @@ function InlineNumberCell({
   }
 
   if (readOnly) {
-    return (
-      <div
-        className={cn(
-          'w-full px-2 text-sm tabular-nums',
-          align === 'right' ? 'text-right' : 'text-left'
-        )}>
-        {display}
-      </div>
-    )
+    return <div className='w-full px-2 text-right text-sm tabular-nums'>{display}</div>
   }
 
   return (
@@ -285,20 +283,16 @@ function InlineNumberCell({
         if (e.key === 'Escape') setDraft(null)
       }}
       inputMode='decimal'
-      onPointerDown={(e) => e.stopPropagation()}
       className={cn(
-        'h-full w-full border-none bg-transparent px-2 text-sm tabular-nums outline-none',
-        'hover:bg-primary-100/60 focus:bg-primary-100/80 dark:hover:bg-primary-100/40 dark:focus:bg-primary-100/60',
-        align === 'right' ? 'text-right' : 'text-left'
+        'h-full w-full rounded-sm border-none bg-transparent px-2 text-right text-sm tabular-nums outline-none',
+        'hover:bg-primary/5 focus:bg-primary/10'
       )}
     />
   )
 }
 
 /** Read-only computed line total — `computeLineTotal` live over store values. */
-function LineTotalCell({ rowId }: { rowId: string }) {
-  const { entityDefinitionId, currencyCode } = useLineBuilder()
-  const recordId = toRecordId(entityDefinitionId, rowId)
+function LineTotalCell({ recordId, currencyCode }: { recordId: RecordId; currencyCode: string }) {
   const { values } = useSystemValues(recordId, TOTAL_ATTRS, { autoFetch: true })
 
   const qty = (values.line_item_qty as number | null | undefined) ?? 1
@@ -313,41 +307,131 @@ function LineTotalCell({ rowId }: { rowId: string }) {
 }
 
 /** Trailing hover actions: description toggle · taxable toggle · delete (no confirm). */
-function LineActionsCell({ rowId }: { rowId: string }) {
-  const { entityDefinitionId, toggleDescription, deleteLine } = useLineBuilder()
-  const recordId = toRecordId(entityDefinitionId, rowId)
+function LineActionsCell({
+  recordId,
+  rowId,
+  toggleDescription,
+  deleteLine,
+}: {
+  recordId: RecordId
+  rowId: string
+  toggleDescription: (lineId: string) => void
+  deleteLine: (lineId: string) => void
+}) {
   const { values } = useSystemValues(recordId, TAXABLE_ATTRS, { autoFetch: true })
   const { saveFieldValue } = useSaveFieldValue()
 
   const taxable = (values.line_item_taxable as boolean | undefined) !== false
 
   return (
-    <div className='flex w-full items-center justify-end gap-0.5 px-1 opacity-0 transition-opacity group-hover/tablerow:opacity-100'>
-      <SimpleTooltip content='Description'>
-        <Button variant='ghost' size='icon-sm' onClick={() => toggleDescription(rowId)}>
-          <AlignLeft />
-        </Button>
-      </SimpleTooltip>
-      <SimpleTooltip content={taxable ? 'Taxable — click to exempt' : 'Tax exempt — click to tax'}>
-        <Button
-          variant='ghost'
-          size='icon-sm'
-          className={cn(!taxable && 'text-muted-foreground/40')}
-          onClick={() =>
-            saveFieldValue(recordId, 'line_item_taxable', !taxable, FieldType.CHECKBOX)
-          }>
-          <Percent />
-        </Button>
-      </SimpleTooltip>
-      <SimpleTooltip content='Delete line'>
-        <Button
-          variant='ghost'
-          size='icon-sm'
-          className='text-destructive/70 hover:text-destructive'
-          onClick={() => deleteLine(rowId)}>
-          <Trash2 />
-        </Button>
-      </SimpleTooltip>
+    <div className='flex w-full items-center justify-end gap-1 pr-1'>
+      <TreeRowButton tooltipText='Description' onClick={() => toggleDescription(rowId)}>
+        <AlignLeft />
+      </TreeRowButton>
+      <TreeRowButton
+        tooltipText={taxable ? 'Taxable — click to exempt' : 'Tax exempt — click to tax'}
+        className={cn(!taxable && 'text-muted-foreground/40')}
+        onClick={() => saveFieldValue(recordId, 'line_item_taxable', !taxable, FieldType.CHECKBOX)}>
+        <Percent />
+      </TreeRowButton>
+      <TreeRowButton
+        variant='destructive'
+        tooltipText='Delete line'
+        onClick={() => deleteLine(rowId)}>
+        <Trash2 />
+      </TreeRowButton>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Row
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One sortable line row — a GridTreeRow whose leading icon is the drag grip. */
+function LineRow({
+  record,
+  entityDefinitionId,
+  readOnly,
+  currencyCode,
+  descriptionOpen,
+  toggleDescription,
+  closeDescription,
+  deleteLine,
+}: {
+  record: RecordMeta
+  entityDefinitionId: string
+  readOnly: boolean
+  currencyCode: string
+  descriptionOpen: boolean
+  toggleDescription: (lineId: string) => void
+  closeDescription: (lineId: string) => void
+  deleteLine: (lineId: string) => void
+}) {
+  const recordId = toRecordId(entityDefinitionId, record.id)
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: record.id,
+    disabled: readOnly,
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(isDragging && 'relative z-10 opacity-80')}>
+      <GridTreeRow
+        columns={LINE_COLS}
+        icon={
+          readOnly ? undefined : (
+            <span
+              {...attributes}
+              {...listeners}
+              className='flex cursor-grab items-center justify-center opacity-0 transition-opacity group-hover/tree-row:opacity-100'>
+              <GripVertical className='size-3.5' />
+            </span>
+          )
+        }
+        title={
+          <LineNameCell
+            recordId={recordId}
+            rowId={record.id}
+            readOnly={readOnly}
+            currencyCode={currencyCode}
+            descriptionOpen={descriptionOpen}
+            closeDescription={closeDescription}
+          />
+        }
+        cells={[
+          <InlineNumberCell
+            key='qty'
+            recordId={recordId}
+            attr='line_item_qty'
+            fieldType={FieldType.NUMBER}
+            readOnly={readOnly}
+            currencyCode={currencyCode}
+          />,
+          <InlineNumberCell
+            key='price'
+            recordId={recordId}
+            attr='line_item_unit_price'
+            fieldType={FieldType.CURRENCY}
+            readOnly={readOnly}
+            currencyCode={currencyCode}
+          />,
+          <LineTotalCell key='total' recordId={recordId} currencyCode={currencyCode} />,
+          readOnly ? (
+            <span key='actions' />
+          ) : (
+            <LineActionsCell
+              key='actions'
+              recordId={recordId}
+              rowId={record.id}
+              toggleDescription={toggleDescription}
+              deleteLine={deleteLine}
+            />
+          ),
+        ]}
+      />
     </div>
   )
 }
@@ -435,6 +519,11 @@ export function LineBuilder({
     enabled: !!entityDefinitionId,
   })
 
+  // No virtualized scroll anymore — load every page eagerly (line counts are small).
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage && !isLoading) fetchNextPage()
+  }, [hasNextPage, isFetchingNextPage, isLoading, fetchNextPage])
+
   // Optimistic display order while a reorder mutation settles. Ids missing from
   // the override (freshly added lines) append in server order.
   const displayRecords = useMemo(() => {
@@ -502,40 +591,33 @@ export function LineBuilder({
     ]
   )
 
-  const addLine = useCallback(
-    async (input: NewLineInput) => {
-      const relKey =
-        documentType === 'quote'
-          ? 'line_item_quote'
-          : documentType === 'invoice'
-            ? 'line_item_invoice'
-            : 'line_item_work_order'
-      const values: Record<string, unknown> = {
-        line_item_name: input.name,
-        line_item_qty: 1,
-        line_item_taxable: input.taxable ?? true,
-        line_item_sort_order: displayIdsRef.current.length,
-        [relKey]: documentRecordId,
-      }
-      if (input.description) values.line_item_description = input.description
-      if (input.category) values.line_item_category = input.category
-      if (input.unitPrice !== null && input.unitPrice !== undefined) {
-        values.line_item_unit_price = input.unitPrice
-      }
-      if (input.catalogItemRecordId) values.line_item_catalog_item = input.catalogItemRecordId
-
-      try {
-        await createMutateAsync({ entityDefinitionId: 'line_item', values })
-        refresh()
-      } catch (error) {
-        toastError({
-          title: 'Error adding line',
-          description: error instanceof Error ? error.message : 'Could not add the line',
-        })
-      }
-    },
-    [documentType, documentRecordId, createMutateAsync, refresh]
-  )
+  /** Add an empty line — the Description cell's picker fills it in afterwards. */
+  const addLine = useCallback(async () => {
+    const relKey =
+      documentType === 'quote'
+        ? 'line_item_quote'
+        : documentType === 'invoice'
+          ? 'line_item_invoice'
+          : 'line_item_work_order'
+    try {
+      await createMutateAsync({
+        entityDefinitionId: 'line_item',
+        values: {
+          line_item_name: '',
+          line_item_qty: 1,
+          line_item_taxable: true,
+          line_item_sort_order: displayIdsRef.current.length,
+          [relKey]: documentRecordId,
+        },
+      })
+      refresh()
+    } catch (error) {
+      toastError({
+        title: 'Error adding line',
+        description: error instanceof Error ? error.message : 'Could not add the line',
+      })
+    }
+  }, [documentType, documentRecordId, createMutateAsync, refresh])
 
   const toggleDescription = useCallback((lineId: string) => {
     setOpenDescriptionIds((prev) => {
@@ -555,195 +637,104 @@ export function LineBuilder({
     })
   }, [])
 
-  const contextValue = useMemo<LineBuilderContextValue | null>(
-    () =>
-      entityDefinitionId
-        ? {
-            entityDefinitionId,
-            readOnly,
-            currencyCode,
-            openDescriptionIds,
-            toggleDescription,
-            closeDescription,
-            deleteLine,
-          }
-        : null,
-    [
-      entityDefinitionId,
-      readOnly,
-      currencyCode,
-      openDescriptionIds,
-      toggleDescription,
-      closeDescription,
-      deleteLine,
-    ]
-  )
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
 
-  // Fixed columns — static defs, cells reach builder state through context.
-  const columns = useMemo<ExtendedColumnDef<RecordMeta>[]>(() => {
-    const interactionOff = {
-      enableSorting: false,
-      enableFiltering: false,
-      enableHiding: false,
-      enableResizing: false,
-      enableResize: false,
-      enableReorder: false,
-    } as const
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!entityDefinitionId || !over || active.id === over.id) return
+      const current = displayIdsRef.current
+      const oldIndex = current.indexOf(String(active.id))
+      const newIndex = current.indexOf(String(over.id))
+      if (oldIndex === -1 || newIndex === -1) return
 
-    const defs: ExtendedColumnDef<RecordMeta>[] = [
-      {
-        id: 'line-name',
-        accessorFn: () => undefined,
-        header: 'Item',
-        ...interactionOff,
-        minSize: 220,
-        size: 340,
-        cell: ({ row }) => <LineNameCell rowId={row.original.id} />,
-      },
-      {
-        id: 'line-qty',
-        accessorFn: () => undefined,
-        header: 'Qty',
-        ...interactionOff,
-        minSize: 60,
-        size: 70,
-        cell: ({ row }) => (
-          <InlineNumberCell
-            rowId={row.original.id}
-            attr='line_item_qty'
-            fieldType={FieldType.NUMBER}
-          />
-        ),
-      },
-      {
-        id: 'line-unit-price',
-        accessorFn: () => undefined,
-        header: 'Unit price',
-        ...interactionOff,
-        minSize: 90,
-        size: 120,
-        cell: ({ row }) => (
-          <InlineNumberCell
-            rowId={row.original.id}
-            attr='line_item_unit_price'
-            fieldType={FieldType.CURRENCY}
-          />
-        ),
-      },
-      {
-        id: 'line-total',
-        accessorFn: () => undefined,
-        header: 'Total',
-        ...interactionOff,
-        minSize: 90,
-        size: 120,
-        cell: ({ row }) => <LineTotalCell rowId={row.original.id} />,
-      },
-    ]
-
-    if (!readOnly) {
-      defs.push({
-        id: 'line-actions',
-        accessorFn: () => undefined,
-        header: '',
-        ...interactionOff,
-        minSize: 100,
-        size: 110,
-        cell: ({ row }) => <LineActionsCell rowId={row.original.id} />,
-      })
-    }
-
-    return defs
-  }, [readOnly])
-
-  // Row drag-reorder. The table's drop handler always reports 'inside' (no
-  // before/after edge detection exists) — the new index is derived from the
-  // dragged row's position relative to the target: moving down lands after
-  // the target, moving up lands before it.
-  const dragDrop = useMemo<DragDropConfig<RecordMeta>>(
-    () => ({
-      enabled: !readOnly,
-      canDrag: () => !readOnly,
-      canDrop: (draggedItems, targetRow) => !draggedItems.some((d) => d.id === targetRow.id),
-      onDrop: (draggedItems, targetRow) => {
-        if (!entityDefinitionId) return
-        const draggedIds = draggedItems.map((d) => d.id)
-        const current = displayIdsRef.current
-        const fromIndex = current.indexOf(draggedIds[0] ?? '')
-        const targetIndex = current.indexOf(targetRow.id)
-        if (fromIndex === -1 || targetIndex === -1) return
-
-        const without = current.filter((id) => !draggedIds.includes(id))
-        let insertAt = without.indexOf(targetRow.id)
-        if (insertAt === -1) return
-        if (fromIndex < targetIndex) insertAt += 1
-        const nextOrder = [...without]
-        nextOrder.splice(insertAt, 0, ...draggedIds)
-
-        setOrderOverride(nextOrder)
-        reorderMutate(
-          {
-            documentRecordId: docRecordId,
-            orderedLineRecordIds: nextOrder.map((id) => toRecordId(entityDefinitionId, id)),
+      const nextOrder = arrayMove(current, oldIndex, newIndex)
+      setOrderOverride(nextOrder)
+      reorderMutate(
+        {
+          documentRecordId: docRecordId,
+          orderedLineRecordIds: nextOrder.map((id) => toRecordId(entityDefinitionId, id)),
+        },
+        {
+          onError: (error) => {
+            setOrderOverride(null)
+            refresh()
+            toastError({ title: 'Error reordering lines', description: error.message })
           },
-          {
-            onError: (error) => {
-              setOrderOverride(null)
-              refresh()
-              toastError({ title: 'Error reordering lines', description: error.message })
-            },
-          }
-        )
-      },
-    }),
-    [readOnly, entityDefinitionId, docRecordId, reorderMutate, refresh]
+        }
+      )
+    },
+    [entityDefinitionId, docRecordId, reorderMutate, refresh]
   )
 
-  const handleScrollToBottom = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage && !isLoading) fetchNextPage()
-  }, [hasNextPage, isFetchingNextPage, isLoading, fetchNextPage])
+  if (!entityDefinitionId) return null
 
-  if (!contextValue) return null
+  const isEmpty = !isLoading && !isLoadingRecords && displayRecords.length === 0
 
   return (
-    <LineBuilderContext.Provider value={contextValue}>
-      <div className='flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg bg-primary-50 dark:bg-background'>
-        <DynamicView<RecordMeta>
-          data={displayRecords}
-          columns={columns}
-          tableId={`line-builder-${documentRecordId}`}
-          standalone
-          hideToolbar
-          hideHeader
-          disableColumnDnd
-          enableSearch={false}
-          enableFiltering={false}
-          enableSorting={false}
-          showRowNumbers={false}
-          isLoading={isLoading || isLoadingRecords}
-          getRowId={(row) => row.id}
-          onScrollToBottom={handleScrollToBottom}
-          dragDrop={dragDrop}
-          className='h-full flex-1'
-          emptyState={
-            <EmptyState
-              icon={ReceiptText}
-              title='No line items yet'
-              description='Add from the catalog or type a custom line.'
-            />
-          }>
-          <DynamicTableFooter>
-            <TotalsFooter
-              documentRecordId={docRecordId}
-              documentType={documentType}
-              readOnly={readOnly}
-              currencyCode={currencyCode}
-              lineRecordIds={lineRecordIds}
-              onAddLine={addLine}
-            />
-          </DynamicTableFooter>
-        </DynamicView>
+    <div className='flex min-h-0 flex-1 flex-col overflow-y-auto rounded-lg bg-primary-50 p-1 dark:bg-background'>
+      {/* Header — same grid template as the rows, so the labels sit over their columns.
+          The Description label offsets past the row px-1 + grip slot + title/button padding. */}
+      <div
+        className='sticky top-0 z-10 grid border-primary-200/50 border-b bg-primary-50 px-1 pb-1 text-muted-foreground text-xs dark:border-[#1e2227] dark:bg-background'
+        style={{ gridTemplateColumns: LINE_COLS }}>
+        <div className={readOnly ? 'pl-2' : 'pl-9'}>Description</div>
+        <div className='px-2 text-right'>Qty</div>
+        <div className='px-2 text-right'>Unit cost</div>
+        <div className='px-2 text-right'>Total</div>
+        <div />
       </div>
-    </LineBuilderContext.Provider>
+
+      {isEmpty && readOnly ? (
+        <EmptyState icon={ReceiptText} title='No line items' />
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+          modifiers={[restrictToVerticalAxis]}>
+          <SortableContext
+            items={displayIdsRef.current}
+            strategy={verticalListSortingStrategy}
+            disabled={readOnly}>
+            {displayRecords.map((record) => (
+              <LineRow
+                key={record.id}
+                record={record}
+                entityDefinitionId={entityDefinitionId}
+                readOnly={readOnly}
+                currencyCode={currencyCode}
+                descriptionOpen={openDescriptionIds.has(record.id)}
+                toggleDescription={toggleDescription}
+                closeDescription={closeDescription}
+                deleteLine={deleteLine}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
+      )}
+
+      {!readOnly && (
+        <div className='border-primary-200/50 border-b px-1 py-0.5 dark:border-[#1e2227]'>
+          <Button
+            variant='ghost'
+            size='sm'
+            className='text-muted-foreground'
+            loading={createRecord.isPending}
+            onClick={addLine}>
+            <Plus />
+            Add line item
+          </Button>
+        </div>
+      )}
+
+      <TotalsFooter
+        documentRecordId={docRecordId}
+        documentType={documentType}
+        readOnly={readOnly}
+        currencyCode={currencyCode}
+        lineRecordIds={lineRecordIds}
+      />
+    </div>
   )
 }

--- a/apps/web/src/components/money/ui/line-builder/shared.ts
+++ b/apps/web/src/components/money/ui/line-builder/shared.ts
@@ -1,19 +1,7 @@
 // apps/web/src/components/money/ui/line-builder/shared.ts
 
-// Shared types + formatting helpers for the line builder cluster
+// Shared formatting helpers for the line builder cluster
 // (line-builder.tsx, totals-footer.tsx).
-
-import type { RecordId } from '~/components/resources'
-
-/** Values for a new line — either a catalog pick or a free-typed one-off. */
-export interface NewLineInput {
-  name: string
-  description?: string | null
-  category?: string | null
-  taxable?: boolean
-  unitPrice?: number | null
-  catalogItemRecordId?: RecordId
-}
 
 /**
  * Format an amount in the org currency; em dash for unpriced values.

--- a/apps/web/src/components/money/ui/line-builder/totals-footer.tsx
+++ b/apps/web/src/components/money/ui/line-builder/totals-footer.tsx
@@ -2,8 +2,8 @@
 
 'use client'
 
-// Totals footer for the line builder (money MQ1 build spec §H.1): the add-line
-// row (the sanctioned ghost-row fallback) + subtotal → discount → tax → total.
+// Totals footer for the line builder (money MQ1 build spec §H.1): subtotal →
+// discount → tax → total (the add-line row lives in the builder itself).
 // All amounts are computed client-side with `computeDocumentTotals` from
 // `@auxx/lib/money/client` — the exact function the server-side recompute hook
 // uses — over the same optimistic field-value store the editors write to.
@@ -17,7 +17,6 @@ import {
   type DocumentBillingInputs,
   type LineForTotals,
 } from '@auxx/lib/money/client'
-import { Button } from '@auxx/ui/components/button'
 import {
   Select,
   SelectContent,
@@ -26,7 +25,6 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { cn } from '@auxx/ui/lib/utils'
-import { Plus } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { RecordId } from '~/components/resources'
@@ -40,8 +38,7 @@ import {
 } from '~/components/resources/store/field-value-store'
 import { useResourceStore } from '~/components/resources/store/resource-store'
 import { useSettings } from '~/hooks/use-settings'
-import { CatalogPicker } from './catalog-picker'
-import { formatCurrency, type NewLineInput } from './shared'
+import { formatCurrency } from './shared'
 
 /** Org tax rate preset (`documents.taxRates` setting, §G.1). */
 interface TaxRatePreset {
@@ -154,14 +151,12 @@ export function TotalsFooter({
   readOnly,
   currencyCode,
   lineRecordIds,
-  onAddLine,
 }: {
   documentRecordId: RecordId
   documentType: 'quote' | 'work_order' | 'invoice'
   readOnly: boolean
   currencyCode: string
   lineRecordIds: RecordId[]
-  onAddLine: (input: NewLineInput) => void
 }) {
   const isQuote = documentType === 'quote'
   const isInvoice = documentType === 'invoice'
@@ -172,7 +167,6 @@ export function TotalsFooter({
   const lines = useLinesForTotals(lineRecordIds)
   const { saveMultipleAsync } = useSaveFieldValue()
   const { getSetting } = useSettings({})
-  const [pickerOpen, setPickerOpen] = useState(false)
   const [discountDraft, setDiscountDraft] = useState<string | null>(null)
 
   // Billing inputs — the document's own mirrored fields, read through the same optimistic
@@ -254,32 +248,6 @@ export function TotalsFooter({
 
   return (
     <div className='flex flex-col'>
-      {/* Add-line row — the sanctioned fallback for the ghost add-row (§H.1). */}
-      {!readOnly && (
-        <div className='border-primary-200/50 border-b px-1 py-0.5 dark:border-[#1e2227]'>
-          <CatalogPicker
-            open={pickerOpen}
-            onOpenChange={setPickerOpen}
-            currencyCode={currencyCode}
-            onSelectCatalogItem={(pick) =>
-              onAddLine({
-                name: pick.name,
-                description: pick.description,
-                category: pick.category,
-                taxable: pick.taxable,
-                unitPrice: pick.unitPrice,
-                catalogItemRecordId: pick.recordId,
-              })
-            }
-            onFreeText={(text) => onAddLine({ name: text })}>
-            <Button variant='ghost' size='sm' className='text-muted-foreground'>
-              <Plus />
-              Add line
-            </Button>
-          </CatalogPicker>
-        </div>
-      )}
-
       {/* Totals block */}
       <div className='flex justify-end px-4 py-2'>
         <div className='w-full max-w-xs space-y-1 text-sm'>

--- a/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
+++ b/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
@@ -10,9 +10,10 @@
 // only exposes generic capability flags (enableArchive/enableMerge/…, see
 // `detail-view-config-types.ts`) with no per-entity extension point, so the
 // sanctioned fallback (per the build spec) is this tab's own header strip.
-// This is also the ONLY surface for quote lifecycle/send actions — `quote`
-// has `hasDetailPage: true` (ModelTypeMeta), so records-view navigation goes
-// straight to this detail page and never opens a quote drawer.
+// Two surfaces render this component: the detail page's Line-items section
+// (DETAIL_VIEW_TAB_COMPONENTS, sections layout) and the quote drawer's
+// Overview card (QuoteLinesOverviewCard below — records-view/dashboards open
+// quotes in a drawer regardless of `hasDetailPage`).
 
 import { parseRecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
@@ -26,6 +27,7 @@ import { useChannelsLoading } from '~/components/channels/hooks/use-channels'
 import { useDefaultChannelId } from '~/components/channels/hooks/use-default-channel'
 import { useEmailChannels } from '~/components/channels/store/channel-store'
 import type { DetailViewTabProps } from '~/components/detail-view'
+import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { Tooltip } from '~/components/global/tooltip'
 import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
 import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
@@ -273,7 +275,7 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
 
       <div
         className={cn(
-          'flex flex-col px-4 pb-4',
+          'flex flex-col pb-4',
           isSection ? 'max-h-[60vh] overflow-auto' : 'min-h-0 flex-1'
         )}>
         <LineBuilder documentRecordId={recordId} documentType='quote' readOnly={readOnly} />
@@ -282,4 +284,16 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
       <ConfirmDialog />
     </div>
   )
+}
+
+/**
+ * Drawer Overview card variant — registered as `quote:lines` in
+ * `DRAWER_TAB_CARD_COMPONENTS` (the `invoice:lines` pattern: the drawer's
+ * Section wrapper renders the "Line items" title). Forces `variant='section'`
+ * so the builder is height-capped inside the Overview scroll column. The full
+ * detail page is untouched — it renders {@link QuoteLineItemsTab} through its
+ * own `DETAIL_VIEW_TAB_COMPONENTS` registry and sections layout.
+ */
+export function QuoteLinesOverviewCard(props: DrawerTabProps) {
+  return <QuoteLineItemsTab {...props} variant='section' />
 }

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -1803,6 +1803,16 @@ export async function setValueWithBuiltIn(
   // Get field definition (cached)
   const field = await getField(ctx, fieldId)
 
+  // Client store keys are always cuid-form (`<defId>:<inst>:<defId>:<fieldId>`),
+  // but server-side callers (money totals hooks, lifecycle paths) pass alias-form
+  // record ids ('quote:<inst>') — published verbatim, those frames land in the
+  // store as orphan keys no cell subscribes to. Publish under the field's real
+  // EntityDefinition id; table-backed system resources (no entityDefinitionId on
+  // the CustomField row) keep the caller's recordId.
+  const publishRecordId = field.entityDefinitionId
+    ? toRecordId(field.entityDefinitionId, entityInstanceId)
+    : recordId
+
   // Resolve entity metadata once — shared by pre-hook, oldValue gate, and
   // post-hook so we hit the resource cache a single time per write.
   const resource = await getCachedResource(ctx.organizationId, entityDefinitionId)
@@ -1879,7 +1889,7 @@ export async function setValueWithBuiltIn(
     await deleteValue(ctx, { recordId, fieldId })
     await maybeUpdateDisplayValue(ctx, recordId, field, null)
     if (publishEvents) {
-      const key = buildFieldValueKey(recordId, fieldId as FieldId)
+      const key = buildFieldValueKey(publishRecordId, fieldId as FieldId)
       publishFieldValueUpdates(getRealtimeService(), ctx.organizationId, [{ key, value: null }], {
         excludeSocketId: ctx.socketId,
       }).catch(() => {})
@@ -1941,7 +1951,7 @@ export async function setValueWithBuiltIn(
   // directly to the store without guessing. Single-value fields publish the
   // single value.
   if (publishEvents && result.length > 0) {
-    const key = buildFieldValueKey(recordId, fieldId as FieldId)
+    const key = buildFieldValueKey(publishRecordId, fieldId as FieldId)
     const storeValue = isArrayReturn ? result : result[0]
     // When this write is an AI stage-2 commit, piggyback the `result`
     // marker onto the same realtime so clients see value + AI state in
@@ -2304,8 +2314,15 @@ export async function setBulkValues(
     const recordId = recordIds[i]!
     for (const fieldResult of result.value) {
       if (fieldResult.state !== 'complete') continue
-      const key = buildFieldValueKey(recordId, fieldResult.fieldId as FieldId)
       const cachedField = ctx.fieldCache.get(fieldResult.fieldId)
+      // Same alias-form guard as setValueWithBuiltIn's publishRecordId — bulk
+      // server-side callers (e.g. money invoice-lifecycle unstamp) pass
+      // 'line_item:<inst>' ids; publish under the field's real EntityDefinition
+      // id so the keys match client store subscriptions.
+      const publishRecordId = cachedField?.entityDefinitionId
+        ? toRecordId(cachedField.entityDefinitionId, entityInstanceIds[i]!)
+        : recordId
+      const key = buildFieldValueKey(publishRecordId, fieldResult.fieldId as FieldId)
       const fieldType = cachedField?.type as FieldType | undefined
       const fieldOptions = cachedField?.options as
         | { actor?: { multiple?: boolean }; multi?: boolean }

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -72,18 +72,19 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
 
   quote: {
     entityType: 'quote',
-    // Same Line-items tab as the quote detail view (money MQ1). The tab's own
-    // header strip carries the status-driven Send/Download/Convert actions —
-    // see quote-line-items-tab.tsx.
-    additionalTabs: [{ value: 'line-items', label: 'Line items', icon: 'receipt-text' }],
+    // No additionalTabs — the drawer shows line items as an Overview card
+    // (the invoice pattern below); the FULL detail page keeps its sections
+    // layout via the separate DETAIL_VIEW_CONFIG_REGISTRY. Drawer overview
+    // cards and detail-page sidebarCards are independent lists, so this
+    // never leaks onto the detail page.
+    additionalTabs: [],
     actions: {
       enableArchive: true,
       enableDelete: true,
     },
-    // Cards mirror the detail-view sidebar (quote:customer / quote:origin are
-    // registered in drawer-tab-registry.tsx's DRAWER_TAB_CARD_COMPONENTS).
     tabCards: {
       overview: [
+        { value: 'lines', label: 'Line items', fullBleed: true },
         { value: 'customer', label: 'Customer' },
         { value: 'origin', label: 'Origin' },
       ],

--- a/packages/lib/src/resources/registry/resources/line-item-fields.ts
+++ b/packages/lib/src/resources/registry/resources/line-item-fields.ts
@@ -46,13 +46,14 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'line_item_name',
     systemSortOrder: 'a1',
-    nullable: false,
+    // Optional — the line builder creates EMPTY lines that the catalog picker
+    // fills in afterwards.
+    nullable: true,
     capabilities: {
       filterable: true,
       sortable: true,
       creatable: true,
       updatable: true,
-      required: true,
       configurable: false,
     },
     placeholder: 'Enter line name',


### PR DESCRIPTION
## Summary

- **Quote drawer line items**: quotes opened from records views/dashboards render in a drawer, which had no lines surface — the line-items drawer TAB is replaced by an Overview card (`QuoteLinesOverviewCard`, the `invoice:lines` pattern). The full detail page keeps its sections layout untouched.
- **LineBuilder refactor**: internal context replaced with prop threading, `LineRow` extracted, shared grid column template; unused `NewLineInput` type removed.
- **Empty-line creation**: `line_item.name` is now nullable — the builder creates empty rows that the catalog picker fills afterwards.
- **Realtime publish-key fix** (`field-value-mutations.ts`): frames are now published under the field's real EntityDefinition id; alias-form record ids (`quote:<inst>`) from server-side callers (totals hooks, lifecycle paths) previously landed in the client store as orphan keys no cell subscribes to.

## Verification

Ran green with these changes in the working tree throughout the MI2 session: `verify-money-mi2` 75/75 · `verify-money-mi1` 58/58 · `verify-dispatch-recurring` 59/59 · full repo `pnpm lint` clean. No dedicated browser pass yet — the quote-drawer Overview card and empty-line flow should get one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)