### PR TITLE
feat(settings): unify settings forms on a shared save-bar + dirty-draft

### DIFF
--- a/apps/web/src/components/availability/ui/availability-settings-page.tsx
+++ b/apps/web/src/components/availability/ui/availability-settings-page.tsx
@@ -5,11 +5,9 @@ import { detectTimezone } from '@auxx/config/client'
 import type { WeeklyHours } from '@auxx/lib/availability/client'
 import { weekStartToIndex } from '@auxx/lib/availability/client'
 import { FeatureKey } from '@auxx/lib/permissions/client'
-import { Button } from '@auxx/ui/components/button'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { CalendarOff, Clock, Globe, Lock } from 'lucide-react'
-import { useEffect, useState } from 'react'
 import { ExceptionListEditor } from '~/components/availability/ui/exception-list-editor'
 import {
   validateWeeklyDraft,
@@ -18,6 +16,8 @@ import {
 } from '~/components/availability/ui/weekly-hours-editor'
 import { EmptyState } from '~/components/global/empty-state'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { FormSaveBar } from '~/components/global/forms/form-save-bar'
+import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
 import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { TimeZonePicker } from '~/components/pickers/timezone-picker'
 import { SettingsFieldRow } from '~/components/settings/settings-field-row'
@@ -51,6 +51,22 @@ function buildDraftFromResponse(
   }
 }
 
+/** Collapse an editor draft to the persisted `WeeklyHours` shape (drop disabled days / empty ranges). */
+function toWeeklyHours(draft: WeeklyHoursDraft): WeeklyHours {
+  return {
+    timezone: draft.timezone,
+    days: draft.days
+      .filter((d) => d.enabled)
+      .map((d) => ({
+        dayOfWeek: d.dayOfWeek,
+        ranges: d.ranges.filter(
+          (r): r is { start: number; end: number } => r.start != null && r.end != null
+        ),
+      }))
+      .filter((d) => d.ranges.length > 0),
+  }
+}
+
 /** A catalog SINGLE_SELECT value read via `getSetting` is a scalar, but normalize defensively. */
 function scalarSetting(value: unknown): string | null {
   if (Array.isArray(value)) return (value[0] as string) ?? null
@@ -59,8 +75,9 @@ function scalarSetting(value: unknown): string | null {
 
 /**
  * Org Availability settings page (dispatch settings, 05-availability.md §E.1): weekly hours
- * (explicit save, page-owned dirty state) + holidays/exceptions (self-fetching, immediate
- * mutations). Gated like the rest of dispatch settings — admin/owner role + `FeatureKey.dispatch`.
+ * (explicit save via the shared {@link useDirtyDraft} + {@link FormSaveBar}) + holidays/exceptions
+ * (self-fetching, immediate mutations). Gated like the rest of dispatch settings — admin/owner role
+ * + `FeatureKey.dispatch`.
  */
 export function AvailabilitySettingsPage() {
   useUser({ requireRoles: ['ADMIN', 'OWNER'] })
@@ -72,28 +89,19 @@ export function AvailabilitySettingsPage() {
     subject: { type: 'organization' },
   })
 
-  const [draft, setDraft] = useState<WeeklyHoursDraft | null>(null)
-  const [dirty, setDirty] = useState(false)
-  const [snapshot, setSnapshot] = useState<WeeklyHoursDraft | null>(null)
-
-  useEffect(() => {
-    if (!weeklyQuery.isSuccess) return
-    // Never clobber in-progress edits — a background refetch (window refocus, another admin
-    // saving) must not wipe the local draft. The post-save refetch rebuilds because
-    // `onSuccess` clears `dirty` before invalidating.
-    if (dirty) return
-    const built = buildDraftFromResponse(weeklyQuery.data, detectTimezone())
-    setDraft(built)
-    setSnapshot(built)
-  }, [weeklyQuery.isSuccess, weeklyQuery.data, dirty])
-
   const saveWeeklyHours = api.availability.saveWeeklyHours.useMutation({
-    onSuccess: () => {
-      setDirty(false)
-      utils.availability.getWeeklyHours.invalidate({ subject: { type: 'organization' } })
-    },
+    onSuccess: () =>
+      utils.availability.getWeeklyHours.invalidate({ subject: { type: 'organization' } }),
     onError: (error) =>
       toastError({ title: 'Error saving weekly hours', description: error.message }),
+  })
+
+  // Rebuilt each render; `useDirtyDraft` reseeds by value, so a background refetch never wipes edits.
+  const server = buildDraftFromResponse(weeklyQuery.data ?? null, detectTimezone())
+  const { draft, patch, setDraft, dirty, save, discard } = useDirtyDraft(server, {
+    isSaving: saveWeeklyHours.isPending,
+    onSave: (next) =>
+      saveWeeklyHours.mutate({ subject: { type: 'organization' }, weekly: toWeeklyHours(next) }),
   })
 
   const weekStart = (scalarSetting(getSetting('organization.weekStart')) ?? 'monday') as
@@ -121,28 +129,6 @@ export function AvailabilitySettingsPage() {
     )
   }
 
-  function handleDiscard() {
-    setDraft(snapshot)
-    setDirty(false)
-  }
-
-  function handleSave() {
-    if (!draft) return
-    const weekly: WeeklyHours = {
-      timezone: draft.timezone,
-      days: draft.days
-        .filter((d) => d.enabled)
-        .map((d) => ({
-          dayOfWeek: d.dayOfWeek,
-          ranges: d.ranges.filter(
-            (r): r is { start: number; end: number } => r.start != null && r.end != null
-          ),
-        }))
-        .filter((d) => d.ranges.length > 0),
-    }
-    saveWeeklyHours.mutate({ subject: { type: 'organization' }, weekly })
-  }
-
   return (
     <SettingsPage
       title='Availability'
@@ -156,7 +142,7 @@ export function AvailabilitySettingsPage() {
           <FieldPanel className='mt-1 p-0' resizeId='availability-settings' defaultLabelWidth={220}>
             <SettingsFieldRow settingKey='organization.weekStart' title='Week starts on' />
             <SettingsFieldRow settingKey='organization.use24HourTime' title='Use 24-hour time' />
-            {draft && (
+            {weeklyQuery.isSuccess && (
               <FieldPanelRow
                 title='Time zone'
                 description='All weekly hours below are interpreted in this time zone.'
@@ -164,42 +150,27 @@ export function AvailabilitySettingsPage() {
                 icon={<Globe />}>
                 <TimeZonePicker
                   selected={draft.timezone}
-                  onChange={(timezone) => {
-                    setDraft({ ...draft, timezone })
-                    setDirty(true)
-                  }}
+                  onChange={(timezone) => patch({ timezone })}
                   triggerProps={{ variant: 'transparent', className: 'w-full ps-0 pe-1' }}
                 />
               </FieldPanelRow>
             )}
           </FieldPanel>
-          {draft ? (
+          {weeklyQuery.isSuccess ? (
             <div className='flex flex-col gap-3'>
               <WeeklyHoursEditor
                 value={draft}
-                onChange={(next) => {
-                  setDraft(next)
-                  setDirty(true)
-                }}
+                onChange={setDraft}
                 weekStartsOn={weekStartsOn}
                 use24HourTime={use24HourTime}
               />
-              {dirty && (
-                <div className='flex items-center justify-end gap-3 border-t pt-3'>
-                  <span className='mr-auto text-xs text-muted-foreground'>Unsaved changes</span>
-                  <Button type='button' variant='outline' size='sm' onClick={handleDiscard}>
-                    Discard
-                  </Button>
-                  <Button
-                    type='button'
-                    size='sm'
-                    disabled={!validateWeeklyDraft(draft)}
-                    loading={saveWeeklyHours.isPending}
-                    onClick={handleSave}>
-                    Save
-                  </Button>
-                </div>
-              )}
+              <FormSaveBar
+                dirty={dirty}
+                isSaving={saveWeeklyHours.isPending}
+                onSave={save}
+                onDiscard={discard}
+                saveDisabled={!validateWeeklyDraft(draft)}
+              />
             </div>
           ) : (
             <Skeleton className='h-48 w-full rounded-xl' />

--- a/apps/web/src/components/availability/ui/exception-list-editor.tsx
+++ b/apps/web/src/components/availability/ui/exception-list-editor.tsx
@@ -3,22 +3,19 @@
 
 import type { TimeRange } from '@auxx/lib/availability/client'
 import { validateRanges } from '@auxx/lib/availability/client'
+import { AutosizeInput } from '@auxx/ui/components/autosize-input'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { Input } from '@auxx/ui/components/input'
-import { SegmentedControl } from '@auxx/ui/components/segmented-control'
+import { EmptySection, Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { format, parseISO } from 'date-fns'
-import { Plus, Trash2 } from 'lucide-react'
+import { Ban, CalendarClock, CalendarOff, Clock, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { DateTimePicker } from '~/components/pickers/date-time-picker'
-import {
-  minutesToLabel,
-  TimeRangeInput,
-  type TimeRangeValue,
-} from '~/components/pickers/time-range-input'
+import { TimeRangeInput, type TimeRangeValue } from '~/components/pickers/time-range-input'
 import { api } from '~/trpc/react'
 
 /**
@@ -39,6 +36,16 @@ export interface ExceptionListEditorProps {
   className?: string
 }
 
+/** One exception group as it lives in the editor's list. */
+interface ExceptionGroup {
+  ids: string[]
+  dateFrom: string
+  dateTo: string
+  label: string | null
+  isAvailable: boolean
+  ranges: TimeRange[]
+}
+
 /** 'Dec 25, 2026' for a single date, 'Dec 25 – 26, 2026' for a contiguous range. */
 function formatExceptionDateRange(dateFrom: string, dateTo: string): string {
   const from = parseISO(dateFrom)
@@ -50,6 +57,9 @@ function formatExceptionDateRange(dateFrom: string, dateTo: string): string {
   if (sameYear) return `${format(from, 'MMM d')} – ${format(to, 'MMM d, yyyy')}`
   return `${format(from, 'MMM d, yyyy')} – ${format(to, 'MMM d, yyyy')}`
 }
+
+/** Stable per-group key — the underlying row ids identify a regrouped run. */
+const groupKey = (group: ExceptionGroup) => group.ids.join(',')
 
 /** Pill-level invalid flag — same idiom as `WeeklyHoursEditor`'s `isRangePillInvalid`. */
 function isExceptionRangeInvalid(
@@ -68,69 +78,14 @@ function isExceptionRangeInvalid(
   })
 }
 
-/** One exception group row: date(-range), label, badge, range pills, delete. */
-function ExceptionRow({
-  group,
-  use24HourTime,
-  onDelete,
-  deleting,
-}: {
-  group: {
-    ids: string[]
-    dateFrom: string
-    dateTo: string
-    label: string | null
-    isAvailable: boolean
-    ranges: TimeRange[]
-  }
-  use24HourTime: boolean
-  onDelete: () => void
-  deleting: boolean
-}) {
-  return (
-    <div className='flex items-center gap-3 rounded-lg border px-3 py-2'>
-      <div className='min-w-0 flex-1'>
-        <div className='flex flex-wrap items-center gap-2'>
-          <span className='text-sm font-medium'>
-            {formatExceptionDateRange(group.dateFrom, group.dateTo)}
-          </span>
-          <Badge variant={group.isAvailable ? 'default' : 'destructive'} size='sm'>
-            {group.isAvailable ? 'Special hours' : 'Closed'}
-          </Badge>
-          {group.label && (
-            <span className='truncate text-sm text-muted-foreground'>{group.label}</span>
-          )}
-        </div>
-        {group.isAvailable && group.ranges.length > 0 && (
-          <div className='mt-1 flex flex-wrap gap-x-2 gap-y-0.5'>
-            {group.ranges.map((range) => (
-              <span key={`${range.start}-${range.end}`} className='text-xs text-muted-foreground'>
-                {minutesToLabel(range.start, use24HourTime)} –{' '}
-                {minutesToLabel(range.end, use24HourTime)}
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
-      <Button
-        type='button'
-        variant='ghost'
-        size='icon-sm'
-        aria-label='Delete exception'
-        loading={deleting}
-        onClick={onDelete}>
-        <Trash2 className='size-3.5 text-muted-foreground' />
-      </Button>
-    </div>
-  )
-}
-
 /**
  * ExceptionListEditor
  *
  * Self-fetching per subject (05-availability.md §D — webhook-endpoints idiom: immediate
- * per-row mutations, no page-level dirty state). Lists the subject's regrouped exception
- * rows and adds new ones via an inline dashed editor card.
+ * per-row mutations, no page-level dirty state). A `Section` lists the subject's regrouped
+ * exception rows as `TreeRow`s (inline-editable name, status badge, delete); clicking a row —
+ * or "Add exception" — opens a second `Section` below holding the detail editor, whose
+ * Cancel/Apply persist a single `addException`/`updateException` mutation.
  */
 export function ExceptionListEditor({
   subject,
@@ -140,34 +95,67 @@ export function ExceptionListEditor({
   const utils = api.useUtils()
   const { data: groups, isLoading } = api.availability.listExceptions.useQuery({ subject })
 
+  const invalidate = () => utils.availability.listExceptions.invalidate({ subject })
+
   const deleteException = api.availability.deleteException.useMutation({
-    onSuccess: () => utils.availability.listExceptions.invalidate({ subject }),
+    onSuccess: invalidate,
     onError: (error) =>
       toastError({ title: 'Error deleting exception', description: error.message }),
   })
 
   const addException = api.availability.addException.useMutation({
     onSuccess: () => {
-      utils.availability.listExceptions.invalidate({ subject })
-      resetForm()
-      setAdding(false)
+      invalidate()
+      closeEditor()
     },
     onError: (error) => toastError({ title: 'Error adding exception', description: error.message }),
   })
 
-  const [adding, setAdding] = useState(false)
+  const updateException = api.availability.updateException.useMutation({
+    onSuccess: () => {
+      invalidate()
+      closeEditor()
+    },
+    onError: (error) =>
+      toastError({ title: 'Error updating exception', description: error.message }),
+  })
+
+  // Editor target: `creating` for a new exception, `editingKey` for an existing group. Both
+  // false/null → the detail Section is hidden.
+  const [creating, setCreating] = useState(false)
+  const [editingKey, setEditingKey] = useState<string | null>(null)
+
+  // Detail-editor buffer — nothing persists until Apply.
   const [dateFrom, setDateFrom] = useState<Date | undefined>(undefined)
   const [dateTo, setDateTo] = useState<Date | undefined>(undefined)
   const [label, setLabel] = useState('')
   const [isAvailable, setIsAvailable] = useState(false)
   const [ranges, setRanges] = useState<TimeRangeValue[]>([])
 
-  function resetForm() {
-    setDateFrom(undefined)
-    setDateTo(undefined)
-    setLabel('')
-    setIsAvailable(false)
-    setRanges([])
+  function seed(group: ExceptionGroup | null) {
+    setDateFrom(group ? parseISO(group.dateFrom) : undefined)
+    setDateTo(group && group.dateTo !== group.dateFrom ? parseISO(group.dateTo) : undefined)
+    setLabel(group?.label ?? '')
+    setIsAvailable(group?.isAvailable ?? false)
+    setRanges(group ? group.ranges.map((r) => ({ start: r.start, end: r.end })) : [])
+  }
+
+  function openCreate() {
+    seed(null)
+    setEditingKey(null)
+    setCreating(true)
+  }
+
+  function openEdit(group: ExceptionGroup) {
+    seed(group)
+    setCreating(false)
+    setEditingKey(groupKey(group))
+  }
+
+  function closeEditor() {
+    setCreating(false)
+    setEditingKey(null)
+    seed(null)
   }
 
   function handleModeChange(nextIsAvailable: boolean) {
@@ -189,20 +177,19 @@ export function ExceptionListEditor({
     setRanges((prev) => prev.filter((_, i) => i !== index))
   }
 
-  function handleCancel() {
-    resetForm()
-    setAdding(false)
-  }
-
   const rangesComplete = ranges.length > 0 && ranges.every((r) => r.start != null && r.end != null)
   const rangeErrors = rangesComplete ? validateRanges(ranges as TimeRange[]) : []
   const dateOrderValid = !dateFrom || !dateTo || dateTo >= dateFrom
-  const canAdd =
+  const canApply =
     !!dateFrom && dateOrderValid && (!isAvailable || (rangesComplete && rangeErrors.length === 0))
 
-  function handleAdd() {
-    if (!dateFrom || !canAdd) return
-    addException.mutate({
+  const editingGroup = editingKey ? (groups?.find((g) => groupKey(g) === editingKey) ?? null) : null
+  const editorOpen = creating || !!editingKey
+  const applying = addException.isPending || updateException.isPending
+
+  function handleApply() {
+    if (!dateFrom || !canApply) return
+    const payload = {
       subject,
       dateFrom: format(dateFrom, 'yyyy-MM-dd'),
       dateTo: dateTo ? format(dateTo, 'yyyy-MM-dd') : undefined,
@@ -211,123 +198,192 @@ export function ExceptionListEditor({
       ranges: isAvailable
         ? (ranges.filter((r) => r.start != null && r.end != null) as TimeRange[])
         : undefined,
-    })
+    }
+    if (editingGroup) {
+      updateException.mutate({ ...payload, ids: editingGroup.ids })
+    } else {
+      addException.mutate(payload)
+    }
   }
 
-  const empty = !isLoading && !adding && (groups?.length ?? 0) === 0
+  const empty = !isLoading && !creating && (groups?.length ?? 0) === 0
 
   return (
-    <div className={cn('flex flex-col gap-3', className)}>
-      <div className='flex items-center justify-end'>
-        {!adding && (
-          <Button type='button' variant='outline' size='sm' onClick={() => setAdding(true)}>
-            <Plus /> Add exception
-          </Button>
-        )}
-      </div>
-
-      {adding && (
-        <div className='flex flex-col gap-3 rounded-lg border border-dashed p-3'>
-          <div className='flex flex-wrap items-center gap-2'>
-            <DateTimePicker
-              mode='date'
-              noConfirm
-              value={dateFrom}
-              onChange={setDateFrom}
-              placeholder='From date'
-              triggerProps={{ className: 'w-[160px]' }}
-            />
-            <span className='text-sm text-muted-foreground'>to</span>
-            <DateTimePicker
-              mode='date'
-              noConfirm
-              value={dateTo}
-              onChange={setDateTo}
-              onClear={() => setDateTo(undefined)}
-              placeholder='To date (optional)'
-              triggerProps={{ className: 'w-[160px]' }}
-            />
+    <div className={cn('flex flex-col', className)}>
+      {/* Exception list */}
+      <Section
+        title='Exceptions'
+        icon={<CalendarOff className='size-4' />}
+        collapsible={false}
+        actions={
+          !creating && (
+            <Button variant='ghost' size='xs' onClick={openCreate}>
+              <Plus />
+              Add exception
+            </Button>
+          )
+        }>
+        {isLoading ? (
+          <div className='flex flex-col gap-2'>
+            <Skeleton className='h-8 w-full rounded-md' />
+            <Skeleton className='h-8 w-full rounded-md' />
           </div>
-          {!dateOrderValid && (
-            <p className='text-xs text-destructive'>End date must be on or after the start date.</p>
-          )}
-          <Input
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-            placeholder='e.g. Public holiday'
+        ) : empty ? (
+          <EmptySection
+            icon={<CalendarOff className='size-5' />}
+            title='No exceptions yet'
+            description='Add a holiday or one-off change to the schedule.'
           />
-          <SegmentedControl
-            mode='toggle'
-            toggleMode='single'
-            isPill
-            value={[isAvailable ? 1 : 0]}
-            onChange={(indices) => handleModeChange(indices[0] === 1)}
-            className='w-fit'>
-            <Button type='button' variant='outline' size='sm'>
-              Closed all day
-            </Button>
-            <Button type='button' variant='outline' size='sm'>
-              Special hours
-            </Button>
-          </SegmentedControl>
-          {isAvailable && (
-            <div className='flex flex-wrap items-center gap-1.5'>
-              {ranges.map((range, index) => (
-                <TimeRangeInput
-                  key={index}
-                  value={range}
-                  onChange={(next) => handleRangeChange(index, next)}
-                  onRemove={() => handleRemoveRange(index)}
-                  use24HourTime={use24HourTime}
-                  invalid={isExceptionRangeInvalid(range, index, ranges)}
+        ) : (
+          <div className='flex flex-col gap-0.5'>
+            {groups?.map((group) => {
+              const key = groupKey(group)
+              const selected = editingKey === key
+              const titleValue = selected ? label : (group.label ?? '')
+              return (
+                <TreeRow
+                  key={key}
+                  icon={
+                    group.isAvailable ? <Clock className='size-4' /> : <Ban className='size-4' />
+                  }
+                  isOpen={selected}
+                  onToggleOpen={() => (selected ? closeEditor() : openEdit(group))}
+                  rowClassName={
+                    selected
+                      ? 'bg-primary-100 hover:bg-primary-150'
+                      : 'bg-primary-50 hover:bg-primary-100'
+                  }
+                  title={
+                    <AutosizeInput
+                      value={titleValue}
+                      onChange={(e) => {
+                        if (!selected) openEdit(group)
+                        setLabel(e.target.value)
+                      }}
+                      onFocus={() => {
+                        if (!selected) openEdit(group)
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      placeholder='Add a name'
+                      inputClassName='bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground'
+                      minWidth={60}
+                    />
+                  }
+                  secondaryFill
+                  secondary={
+                    <span className='inline-flex items-center gap-2 text-muted-foreground'>
+                      <span className='truncate'>
+                        {formatExceptionDateRange(group.dateFrom, group.dateTo)}
+                      </span>
+                      <Badge variant={group.isAvailable ? 'outline' : 'destructive'} size='xs'>
+                        {group.isAvailable ? 'Special hours' : 'Closed'}
+                      </Badge>
+                    </span>
+                  }
+                  actions={
+                    <TreeRowButton
+                      variant='destructive'
+                      tooltipText='Delete exception'
+                      disabled={
+                        deleteException.isPending && deleteException.variables?.ids === group.ids
+                      }
+                      onClick={() => deleteException.mutate({ subject, ids: group.ids })}>
+                      <Trash2 />
+                    </TreeRowButton>
+                  }
                 />
-              ))}
+              )
+            })}
+          </div>
+        )}
+      </Section>
+
+      {/* Detail editor — the selected (or new) exception */}
+      {editorOpen && (
+        <Section
+          title={
+            editingGroup
+              ? `Exception · ${formatExceptionDateRange(editingGroup.dateFrom, editingGroup.dateTo)}`
+              : 'New exception'
+          }
+          icon={<CalendarClock className='size-4' />}
+          collapsible={false}
+          actions={
+            <div className='flex items-center gap-1'>
+              <Button variant='ghost' size='xs' onClick={closeEditor}>
+                Cancel
+              </Button>
               <Button
-                type='button'
-                variant='ghost'
-                size='icon-sm'
-                className='rounded-lg border border-dashed hover:border-primary-300 hover:bg-primary-100'
-                aria-label='Add time range'
-                onClick={handleAddRange}>
-                <Plus className='size-3.5 text-muted-foreground' />
+                variant='outline'
+                size='xs'
+                disabled={!canApply}
+                loading={applying}
+                onClick={handleApply}>
+                Apply
               </Button>
             </div>
-          )}
-          <div className='flex items-center justify-end gap-2 pt-1'>
-            <Button type='button' variant='outline' size='sm' onClick={handleCancel}>
-              Cancel
-            </Button>
-            <Button
-              type='button'
-              size='sm'
-              disabled={!canAdd}
-              loading={addException.isPending}
-              onClick={handleAdd}>
-              Add
-            </Button>
-          </div>
-        </div>
-      )}
+          }>
+          <div className='flex flex-col gap-3'>
+            <div className='flex flex-wrap items-center gap-2'>
+              <DateTimePicker
+                mode='date'
+                noConfirm
+                value={dateFrom}
+                onChange={setDateFrom}
+                placeholder='From date'
+                triggerProps={{ className: 'w-[160px]' }}
+              />
+              <span className='text-sm text-muted-foreground'>to</span>
+              <DateTimePicker
+                mode='date'
+                noConfirm
+                value={dateTo}
+                onChange={setDateTo}
+                onClear={() => setDateTo(undefined)}
+                placeholder='To date (optional)'
+                triggerProps={{ className: 'w-[160px]' }}
+              />
+            </div>
+            {!dateOrderValid && (
+              <p className='text-xs text-destructive'>
+                End date must be on or after the start date.
+              </p>
+            )}
 
-      {isLoading ? (
-        <div className='flex flex-col gap-2'>
-          <Skeleton className='h-12 w-full rounded-lg' />
-          <Skeleton className='h-12 w-full rounded-lg' />
-        </div>
-      ) : empty ? (
-        <p className='text-sm text-muted-foreground'>No exceptions yet.</p>
-      ) : (
-        <div className='flex flex-col gap-2'>
-          {groups?.map((group) => (
-            <ExceptionRow
-              key={group.ids.join(',')}
-              group={group}
-              use24HourTime={use24HourTime}
-              deleting={deleteException.isPending && deleteException.variables?.ids === group.ids}
-              onDelete={() => deleteException.mutate({ subject, ids: group.ids })}
-            />
-          ))}
-        </div>
+            <button type='button' className='w-fit' onClick={() => handleModeChange(!isAvailable)}>
+              <Badge
+                variant={isAvailable ? 'default' : 'destructive'}
+                size='sm'
+                className='cursor-pointer'>
+                {isAvailable ? 'Special hours' : 'Closed all day'}
+              </Badge>
+            </button>
+
+            {isAvailable && (
+              <div className='flex flex-wrap items-center gap-1.5'>
+                {ranges.map((range, index) => (
+                  <TimeRangeInput
+                    key={index}
+                    value={range}
+                    onChange={(next) => handleRangeChange(index, next)}
+                    onRemove={() => handleRemoveRange(index)}
+                    use24HourTime={use24HourTime}
+                    invalid={isExceptionRangeInvalid(range, index, ranges)}
+                  />
+                ))}
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon-sm'
+                  className='rounded-lg border border-dashed hover:border-primary-300 hover:bg-primary-100'
+                  aria-label='Add time range'
+                  onClick={handleAddRange}>
+                  <Plus className='size-3.5 text-muted-foreground' />
+                </Button>
+              </div>
+            )}
+          </div>
+        </Section>
       )}
     </div>
   )

--- a/apps/web/src/components/availability/ui/weekly-hours-editor.tsx
+++ b/apps/web/src/components/availability/ui/weekly-hours-editor.tsx
@@ -5,6 +5,7 @@ import { Button } from '@auxx/ui/components/button'
 import { Checkbox } from '@auxx/ui/components/checkbox'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { Switch } from '@auxx/ui/components/switch'
+import { TreeRow } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { Copy, Plus } from 'lucide-react'
 import { useCallback, useState } from 'react'
@@ -35,7 +36,6 @@ export interface WeeklyHoursEditorProps {
 }
 
 const DAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-const DAY_LABELS_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
 const DEFAULT_RANGE_START = 9 * 60 // 9:00 AM
 const DEFAULT_RANGE_END = 17 * 60 // 5:00 PM
@@ -235,16 +235,17 @@ function WeeklyDayRow({
 
   const hint = getDayHint(day)
 
+  // Single-line row (streams-section idiom): day label as the title, range pills inline in the
+  // `secondary` slot, and the enable switch + copy in `trailing`. The validation hint sits just
+  // below the row, indented under the pills.
   return (
-    <div className='flex flex-col gap-1 py-2'>
-      <div className='flex items-center gap-3'>
-        <Switch checked={day.enabled} onCheckedChange={handleToggle} disabled={readOnly} />
-        <span className='w-10 shrink-0 text-sm'>{DAY_LABELS_SHORT[day.dayOfWeek]}</span>
-        <div className='flex flex-1 flex-wrap items-center gap-1.5'>
-          {!day.enabled ? (
-            <span className='text-sm text-muted-foreground'>Closed</span>
-          ) : (
-            <>
+    <div>
+      <TreeRow
+        title={<span className='text-sm text-foreground'>{DAY_LABELS[day.dayOfWeek]}</span>}
+        secondaryFill
+        secondary={
+          day.enabled ? (
+            <span className='flex flex-wrap items-center gap-1.5'>
               {day.ranges.map((range, index) => (
                 <TimeRangeInput
                   key={index}
@@ -267,14 +268,26 @@ function WeeklyDayRow({
                   <Plus className='size-3.5 text-muted-foreground' />
                 </Button>
               )}
-            </>
-          )}
-        </div>
-        {!readOnly && (
-          <CopyHoursPopover sourceDay={day} weekStartsOn={weekStartsOn} onApply={onCopyTo} />
-        )}
-      </div>
-      {hint && <p className='pl-[52px] text-xs text-destructive'>{hint}</p>}
+            </span>
+          ) : (
+            <span className='text-muted-foreground text-sm'>Closed</span>
+          )
+        }
+        trailing={
+          <div className='flex items-center gap-1'>
+            {!readOnly && day.enabled && (
+              <CopyHoursPopover sourceDay={day} weekStartsOn={weekStartsOn} onApply={onCopyTo} />
+            )}
+            <Switch
+              size='xs'
+              checked={day.enabled}
+              onCheckedChange={handleToggle}
+              disabled={readOnly}
+            />
+          </div>
+        }
+      />
+      {hint && <p className='ps-2 pt-0.5 text-xs text-destructive'>{hint}</p>}
     </div>
   )
 }
@@ -324,7 +337,7 @@ export function WeeklyHoursEditor({
 
   return (
     <div className={cn('flex flex-col gap-3', className)}>
-      <div className={cn('flex flex-col divide-y', readOnly && 'pointer-events-none opacity-60')}>
+      <div className={cn('flex flex-col gap-0.5', readOnly && 'pointer-events-none opacity-60')}>
         {orderedIndices.map((dayOfWeek) => {
           const day = value.days.find((d) => d.dayOfWeek === dayOfWeek)
           if (!day) return null

--- a/apps/web/src/components/dispatch/ui/worker-hours-page.tsx
+++ b/apps/web/src/components/dispatch/ui/worker-hours-page.tsx
@@ -4,15 +4,17 @@
 import { detectTimezone } from '@auxx/config/client'
 import type { WeeklyHours } from '@auxx/lib/availability/client'
 import { Button } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { KbdSubmit } from '@auxx/ui/components/kbd'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
-import { useEffect, useState } from 'react'
+import { ToggleCard } from '@auxx/ui/components/toggle-card'
 import {
   validateWeeklyDraft,
   type WeeklyHoursDraft,
   WeeklyHoursEditor,
 } from '~/components/availability/ui/weekly-hours-editor'
+import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 
@@ -37,6 +39,28 @@ function buildDraftFromResponse(
   }
 }
 
+/** Collapse an editor draft to the persisted `WeeklyHours` shape (drop disabled days / empty ranges). */
+function toWeeklyHours(draft: WeeklyHoursDraft): WeeklyHours {
+  return {
+    timezone: draft.timezone,
+    days: draft.days
+      .filter((d) => d.enabled)
+      .map((d) => ({
+        dayOfWeek: d.dayOfWeek,
+        ranges: d.ranges.filter(
+          (r): r is { start: number; end: number } => r.start != null && r.end != null
+        ),
+      }))
+      .filter((d) => d.ranges.length > 0),
+  }
+}
+
+/** Page draft: the "inherit org default" switch plus (when overriding) the worker's weekly copy. */
+interface WorkerHoursState {
+  useOrgDefault: boolean
+  weekly: WeeklyHoursDraft | null
+}
+
 interface WorkerHoursPageProps {
   userId: string
   weekStartsOn: 0 | 1 | 6
@@ -48,7 +72,8 @@ interface WorkerHoursPageProps {
  * switch. ON = no worker weekly rows exist — the org's schedule renders read-only. Flipping OFF
  * seeds an editable copy of the org's current schedule (client-side; persisted on Save).
  * Flipping back ON discards the override via `useConfirm`; Save then replaces the worker's rows
- * with an empty set (deletes them), returning to inherited.
+ * with an empty set (deletes them), returning to inherited. Draft/save run on the shared
+ * {@link useDirtyDraft} + a dialog footer (10-settings-forms-unification.md).
  */
 export function WorkerHoursPage({ userId, weekStartsOn, use24HourTime }: WorkerHoursPageProps) {
   const utils = api.useUtils()
@@ -58,31 +83,39 @@ export function WorkerHoursPage({ userId, weekStartsOn, use24HourTime }: WorkerH
   const workerQuery = api.availability.getWeeklyHours.useQuery({ subject })
   const orgQuery = api.availability.getWeeklyHours.useQuery({ subject: { type: 'organization' } })
 
-  const [useOrgDefault, setUseOrgDefault] = useState(true)
-  const [draft, setDraft] = useState<WeeklyHoursDraft | null>(null)
-  const [dirty, setDirty] = useState(false)
-
-  useEffect(() => {
-    if (!workerQuery.isSuccess) return
-    if (dirty) return
-    const hasWorkerRows = workerQuery.data !== null
-    setUseOrgDefault(!hasWorkerRows)
-    setDraft(hasWorkerRows ? buildDraftFromResponse(workerQuery.data, detectTimezone()) : null)
-  }, [workerQuery.isSuccess, workerQuery.data, dirty])
-
-  const saveWeeklyHours = api.availability.saveWeeklyHours.useMutation({
-    onSuccess: () => {
-      setDirty(false)
-      utils.availability.getWeeklyHours.invalidate({ subject })
-    },
-    onError: (error) => toastError({ title: 'Error saving hours', description: error.message }),
-  })
-
   const orgDraft = buildDraftFromResponse(orgQuery.data ?? null, detectTimezone())
   const loading = !workerQuery.isSuccess || !orgQuery.isSuccess
 
-  async function handleToggleUseOrgDefault(next: boolean) {
-    if (next) {
+  const saveWeeklyHours = api.availability.saveWeeklyHours.useMutation({
+    onSuccess: () => utils.availability.getWeeklyHours.invalidate({ subject }),
+    onError: (error) => toastError({ title: 'Error saving hours', description: error.message }),
+  })
+
+  // A worker with no rows inherits the org default; present rows → an editable override.
+  const hasWorkerRows = workerQuery.data != null
+  const server: WorkerHoursState = {
+    useOrgDefault: !hasWorkerRows,
+    weekly: hasWorkerRows ? buildDraftFromResponse(workerQuery.data, detectTimezone()) : null,
+  }
+
+  const { draft, patch, dirty, save, discard } = useDirtyDraft(server, {
+    isSaving: saveWeeklyHours.isPending,
+    onSave: (next) => {
+      if (next.useOrgDefault) {
+        // Replace-all with zero rows == delete the worker's override.
+        saveWeeklyHours.mutate({
+          subject,
+          weekly: { timezone: next.weekly?.timezone ?? orgDraft.timezone, days: [] },
+        })
+        return
+      }
+      if (!next.weekly) return
+      saveWeeklyHours.mutate({ subject, weekly: toWeeklyHours(next.weekly) })
+    },
+  })
+
+  async function handleToggleUseOrgDefault(nextOn: boolean) {
+    if (nextOn) {
       const confirmed = await confirm({
         title: 'Discard custom hours?',
         description:
@@ -92,96 +125,60 @@ export function WorkerHoursPage({ userId, weekStartsOn, use24HourTime }: WorkerH
         destructive: true,
       })
       if (!confirmed) return
-      setUseOrgDefault(true)
-      setDirty(true)
+      patch({ useOrgDefault: true })
       return
     }
-    setDraft((prev) => prev ?? orgDraft)
-    setUseOrgDefault(false)
-    setDirty(true)
+    patch({ useOrgDefault: false, weekly: draft.weekly ?? orgDraft })
   }
 
-  function handleDiscard() {
-    const hasWorkerRows = workerQuery.data !== null
-    setUseOrgDefault(!hasWorkerRows)
-    setDraft(
-      hasWorkerRows ? buildDraftFromResponse(workerQuery.data ?? null, detectTimezone()) : null
-    )
-    setDirty(false)
-  }
-
-  function handleSave() {
-    if (useOrgDefault) {
-      // Replace-all with zero rows == delete the worker's override.
-      saveWeeklyHours.mutate({
-        subject,
-        weekly: { timezone: draft?.timezone ?? orgDraft.timezone, days: [] },
-      })
-      return
-    }
-    if (!draft) return
-    const weekly: WeeklyHours = {
-      timezone: draft.timezone,
-      days: draft.days
-        .filter((d) => d.enabled)
-        .map((d) => ({
-          dayOfWeek: d.dayOfWeek,
-          ranges: d.ranges.filter(
-            (r): r is { start: number; end: number } => r.start != null && r.end != null
-          ),
-        }))
-        .filter((d) => d.ranges.length > 0),
-    }
-    saveWeeklyHours.mutate({ subject, weekly })
-  }
+  const editorValue = draft.useOrgDefault ? orgDraft : (draft.weekly ?? orgDraft)
+  const saveDisabled =
+    !draft.useOrgDefault && draft.weekly != null && !validateWeeklyDraft(draft.weekly)
 
   return (
     <div className='flex flex-col gap-4 p-4'>
-      <div className='flex items-center justify-between rounded-lg border px-3 py-2.5'>
-        <div>
-          <p className='text-sm font-medium'>Use organization default</p>
-          <p className='text-xs text-muted-foreground'>
-            Follow the org's weekly hours, or set custom hours for this worker.
-          </p>
-        </div>
-        <Switch
-          checked={useOrgDefault}
-          onCheckedChange={handleToggleUseOrgDefault}
-          disabled={loading}
-        />
-      </div>
+      <ToggleCard
+        title='Use organization default'
+        description="Follow the org's weekly hours, or set custom hours for this worker."
+        checked={draft.useOrgDefault}
+        onCheckedChange={handleToggleUseOrgDefault}
+        switchSize='default'
+        disabled={loading}
+      />
 
       {loading ? (
         <Skeleton className='h-48 w-full rounded-xl' />
       ) : (
         <WeeklyHoursEditor
-          value={useOrgDefault ? orgDraft : (draft ?? orgDraft)}
-          onChange={(next) => {
-            setDraft(next)
-            setDirty(true)
-          }}
+          value={editorValue}
+          onChange={(weekly) => patch({ weekly })}
           weekStartsOn={weekStartsOn}
           use24HourTime={use24HourTime}
-          readOnly={useOrgDefault}
+          readOnly={draft.useOrgDefault}
         />
       )}
 
-      {dirty && (
-        <div className='flex items-center justify-end gap-3 border-t pt-3'>
-          <span className='mr-auto text-xs text-muted-foreground'>Unsaved changes</span>
-          <Button type='button' variant='outline' size='sm' onClick={handleDiscard}>
-            Discard
-          </Button>
-          <Button
-            type='button'
-            size='sm'
-            disabled={!useOrgDefault && draft != null && !validateWeeklyDraft(draft)}
-            loading={saveWeeklyHours.isPending}
-            onClick={handleSave}>
-            Save
-          </Button>
-        </div>
-      )}
+      <DialogFooter className='border-t pt-3'>
+        <Button
+          type='button'
+          variant='ghost'
+          size='sm'
+          onClick={discard}
+          disabled={!dirty || saveWeeklyHours.isPending}>
+          Discard
+        </Button>
+        <Button
+          type='button'
+          variant='outline'
+          size='sm'
+          onClick={save}
+          loading={saveWeeklyHours.isPending}
+          loadingText='Saving...'
+          disabled={!dirty || saveDisabled}
+          data-dialog-submit>
+          Save <KbdSubmit variant='outline' size='sm' />
+        </Button>
+      </DialogFooter>
 
       <ConfirmDialog />
     </div>

--- a/apps/web/src/components/dispatch/ui/worker-profile-page.tsx
+++ b/apps/web/src/components/dispatch/ui/worker-profile-page.tsx
@@ -3,15 +3,17 @@
 
 import type { SelectOptionColor } from '@auxx/lib/custom-fields/client'
 import { Button } from '@auxx/ui/components/button'
+import { DialogFooter } from '@auxx/ui/components/dialog'
+import { KbdSubmit } from '@auxx/ui/components/kbd'
 import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
 import { Trash2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
 import {
   type AddressStruct,
   AddressStructFields,
 } from '~/components/fields/inputs/address-struct-input-field'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
 import { ColorTagPicker } from '~/components/tags/ui/color-tag-picker'
 import { BaseType } from '~/components/workflow/types'
 import { useConfirm } from '~/hooks/use-confirm'
@@ -33,6 +35,12 @@ function normalizeAddress(value: DispatchWorkerRow['homeBase']): AddressStruct {
   return { ...value, street2: value.street2 ?? '' }
 }
 
+interface WorkerProfileDraft {
+  color: SelectOptionColor
+  homeBase: AddressStruct
+  isActive: boolean
+}
+
 interface WorkerProfilePageProps {
   worker: DispatchWorkerRow
   onRemoved: () => void
@@ -40,25 +48,13 @@ interface WorkerProfilePageProps {
 
 /**
  * Profile page (07-m2-build.md §E.1): board color, home-base address, active toggle, remove
- * action. Every field autosaves on change/blur — `upsertDispatchWorker` only writes the fields
- * present in its input, so per-page saves here never clobber the Hours/Time-off pages' state.
+ * action. Edits collect into one page-level {@link useDirtyDraft} + a dialog footer instead of
+ * autosaving per field (10-settings-forms-unification.md). Save fans out to `upsertWorker` (color +
+ * home base) and `setWorkerActive` (only when the toggle changed).
  */
 export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps) {
   const utils = api.useUtils()
   const [confirm, ConfirmDialog] = useConfirm()
-
-  const [color, setColor] = useState<SelectOptionColor>(
-    (worker.color as SelectOptionColor) ?? 'gray'
-  )
-  const [homeBase, setHomeBase] = useState<AddressStruct>(normalizeAddress(worker.homeBase))
-  const [isActive, setIsActive] = useState(worker.isActive)
-
-  // Resync local state when a different worker is opened.
-  useEffect(() => {
-    setColor((worker.color as SelectOptionColor) ?? 'gray')
-    setHomeBase(normalizeAddress(worker.homeBase))
-    setIsActive(worker.isActive)
-  }, [worker])
 
   const invalidate = () => utils.dispatch.listWorkers.invalidate()
 
@@ -80,19 +76,28 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
     onError: (error) => toastError({ title: 'Error removing worker', description: error.message }),
   })
 
-  function handleColorChange(next: SelectOptionColor) {
-    setColor(next)
-    upsertWorker.mutate({ userId: worker.userId, color: next })
+  const isSaving = upsertWorker.isPending || setWorkerActive.isPending
+
+  // Rebuilt each render from the worker prop; `useDirtyDraft` reseeds by value, so opening a
+  // different worker swaps the draft while a background `listWorkers` refetch never clobbers edits.
+  const server: WorkerProfileDraft = {
+    color: (worker.color as SelectOptionColor) ?? 'gray',
+    homeBase: normalizeAddress(worker.homeBase),
+    isActive: worker.isActive,
   }
 
-  function handleAddressBlur() {
-    upsertWorker.mutate({ userId: worker.userId, homeBase })
-  }
-
-  function handleActiveChange(next: boolean) {
-    setIsActive(next)
-    setWorkerActive.mutate({ workerId: worker.id, isActive: next })
-  }
+  const { draft, patch, dirty, save, discard } = useDirtyDraft(server, {
+    isSaving,
+    onSave: (next) => {
+      const addressChanged = JSON.stringify(next.homeBase) !== JSON.stringify(server.homeBase)
+      if (next.color !== server.color || addressChanged) {
+        upsertWorker.mutate({ userId: worker.userId, color: next.color, homeBase: next.homeBase })
+      }
+      if (next.isActive !== server.isActive) {
+        setWorkerActive.mutate({ workerId: worker.id, isActive: next.isActive })
+      }
+    },
+  })
 
   async function handleRemove() {
     const confirmed = await confirm({
@@ -116,9 +121,9 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
         <FieldPanelRow title='Board color' type={BaseType.ENUM} showIcon>
           <div className='py-2'>
             <ColorTagPicker
-              value={color}
-              onChange={handleColorChange}
-              disabled={upsertWorker.isPending}
+              value={draft.color}
+              onChange={(color) => patch({ color })}
+              disabled={isSaving}
             />
           </div>
         </FieldPanelRow>
@@ -128,12 +133,12 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
           type={BaseType.STRING}
           showIcon
           description='Used for routing on the live map (M3).'>
-          <div className='py-2' onBlur={handleAddressBlur}>
+          <div className='py-2'>
             <AddressStructFields
-              value={homeBase}
-              onChange={setHomeBase}
+              value={draft.homeBase}
+              onChange={(homeBase) => patch({ homeBase })}
               className='flex flex-col gap-2'
-              disabled={upsertWorker.isPending}
+              disabled={isSaving}
             />
           </div>
         </FieldPanelRow>
@@ -144,14 +149,14 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
           showIcon
           description='Inactive workers are hidden from the board.'>
           <Switch
-            checked={isActive}
-            onCheckedChange={handleActiveChange}
-            disabled={setWorkerActive.isPending}
+            checked={draft.isActive}
+            onCheckedChange={(isActive) => patch({ isActive })}
+            disabled={isSaving}
           />
         </FieldPanelRow>
       </FieldPanel>
 
-      <div className='flex justify-end border-t pt-3'>
+      <DialogFooter className='border-t pt-3 sm:justify-between'>
         <Button
           type='button'
           variant='ghost'
@@ -161,7 +166,28 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
           className='text-destructive hover:text-destructive'>
           <Trash2 /> Remove worker
         </Button>
-      </div>
+        <div className='flex items-center gap-2'>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={discard}
+            disabled={!dirty || isSaving}>
+            Discard
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={save}
+            loading={isSaving}
+            loadingText='Saving...'
+            disabled={!dirty}
+            data-dialog-submit>
+            Save <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </div>
+      </DialogFooter>
 
       <ConfirmDialog />
     </div>

--- a/apps/web/src/components/global/forms/form-save-bar.tsx
+++ b/apps/web/src/components/global/forms/form-save-bar.tsx
@@ -1,0 +1,63 @@
+// apps/web/src/components/global/forms/form-save-bar.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { AnimatePresence, motion } from 'motion/react'
+
+/** A touch past critical so the bar springs up with a slight overshoot (matches ConnectorSaveBar). */
+const SPRING = { type: 'spring', stiffness: 420, damping: 26 } as const
+
+export interface FormSaveBarProps {
+  /** Draft diverges from the server value — show the bar and enable Save. */
+  dirty: boolean
+  /** A save is in flight — keep the bar up with a loading Save button. */
+  isSaving: boolean
+  onSave: () => void
+  onDiscard: () => void
+  /** Left-aligned status text. */
+  label?: string
+  /** Dirty-but-invalid → Save is visible-but-disabled (e.g. an invalid weekly draft). */
+  saveDisabled?: boolean
+}
+
+/**
+ * The shared unsaved-changes bar (10-settings-forms-unification.md) — a sticky, full-width bottom
+ * bar that springs into view while a {@link useDirtyDraft} is dirty (or a save is in flight) and
+ * springs away when clean. Replaces the five hand-rolled Save/Discard idioms across the money and
+ * dispatch settings surfaces.
+ */
+export function FormSaveBar({
+  dirty,
+  isSaving,
+  onSave,
+  onDiscard,
+  label = 'Unsaved changes',
+  saveDisabled = false,
+}: FormSaveBarProps) {
+  return (
+    <AnimatePresence>
+      {(dirty || isSaving) && (
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 16 }}
+          transition={SPRING}
+          className='sticky bottom-0 z-10 flex items-center justify-end gap-3 border-t bg-background/95 py-3 backdrop-blur'>
+          <span className='mr-auto text-xs text-muted-foreground'>{label}</span>
+          <Button type='button' variant='outline' size='sm' onClick={onDiscard} disabled={isSaving}>
+            Discard
+          </Button>
+          <Button
+            type='button'
+            size='sm'
+            onClick={onSave}
+            loading={isSaving}
+            loadingText='Saving...'
+            disabled={saveDisabled}>
+            Save
+          </Button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/apps/web/src/components/global/forms/use-dirty-draft.ts
+++ b/apps/web/src/components/global/forms/use-dirty-draft.ts
@@ -1,0 +1,73 @@
+// apps/web/src/components/global/forms/use-dirty-draft.ts
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+export interface DirtyDraft<T> {
+  /** The working copy the form edits. */
+  draft: T
+  /** Shallow-merge a partial into the draft. */
+  patch: (partial: Partial<T>) => void
+  /** Full-replace the draft. */
+  setDraft: (next: T) => void
+  /** True while the draft diverges (by value) from the server value. */
+  dirty: boolean
+  /** Run `onSave(draft)`. */
+  save: () => void
+  /** Throw away edits and reseed from the server value. */
+  discard: () => void
+}
+
+/**
+ * The one dirty-draft mechanism every settings form shares (10-settings-forms-unification.md):
+ * a local working copy of some server value driving a {@link FormSaveBar} / dialog footer.
+ *
+ * `dirty` is **computed by value** (`draft` vs `server`), not a sticky flag — so editing a field
+ * and then reverting it to its original value clears `dirty` again. The generic `T` fits every
+ * surface: a `Record<SettingKey, value>` map (Documents / Invoicing), a typed worker object, a
+ * `WeeklyHoursDraft`.
+ *
+ * Callers pass the freshly-derived `server` value each render; the hook adopts a *changed* server
+ * value into the draft only while the user hasn't diverged and no save is in flight — so a
+ * background refetch never clobbers edits and a pending mutation never reverts the draft.
+ *
+ * ```tsx
+ * const { draft, patch, dirty, save, discard } = useDirtyDraft(server, {
+ *   onSave: (next) => batchUpdate(diff(next, server)),
+ *   isSaving,
+ * })
+ * ```
+ */
+export function useDirtyDraft<T extends object>(
+  server: T,
+  opts: { onSave: (draft: T) => void; isSaving?: boolean }
+): DirtyDraft<T> {
+  const { onSave, isSaving = false } = opts
+  const serverSig = JSON.stringify(server)
+  const [draft, setDraftState] = useState<T>(server)
+  const dirty = JSON.stringify(draft) !== serverSig
+
+  // The server signature the draft was last seeded from — lets us tell a genuine server change
+  // apart from the same value rebuilt each render, and detect whether the user has diverged.
+  const baselineRef = useRef(serverSig)
+
+  useEffect(() => {
+    // The `serverSig === baselineRef` guard makes the extra `server` dep a no-op when the value is
+    // unchanged (rebuilt each render) — it only proceeds on a genuine server change.
+    if (serverSig === baselineRef.current || isSaving) return
+    // Server changed under us: adopt it only if the user hasn't edited away from the previous
+    // server value; otherwise keep their edits (dirty now compares against the new server).
+    if (JSON.stringify(draft) === baselineRef.current) setDraftState(server)
+    baselineRef.current = serverSig
+  }, [serverSig, isSaving, server, draft])
+
+  const patch = (partial: Partial<T>) => {
+    setDraftState((prev) => ({ ...prev, ...partial }) as T)
+  }
+
+  const save = () => onSave(draft)
+
+  const discard = () => setDraftState(server)
+
+  return { draft, patch, setDraft: setDraftState, dirty, save, discard }
+}

--- a/apps/web/src/components/money/ui/settings/documents-page.tsx
+++ b/apps/web/src/components/money/ui/settings/documents-page.tsx
@@ -3,14 +3,20 @@
 
 import { FieldType } from '@auxx/database/enums'
 import { FeatureKey } from '@auxx/lib/permissions/client'
+import type { SettingValue } from '@auxx/lib/settings/client'
 import { getFileRefDownloadUrl, toFileRef } from '@auxx/types/file-ref'
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
 import { Building2, Eye, FileText, Lock, Palette, Receipt } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import {
+  type AddressStruct,
+  AddressStructFields,
+} from '~/components/fields/inputs/address-struct-input-field'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { EmptyState } from '~/components/global/empty-state'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { FormSaveBar } from '~/components/global/forms/form-save-bar'
+import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
 import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { SettingsFieldRow } from '~/components/settings/settings-field-row'
 import { BaseType } from '~/components/workflow/types'
@@ -20,46 +26,42 @@ import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 import { type DocumentsLogo, DocumentsLogoCell } from './documents-logo-cell'
 
-interface BusinessAddress {
-  line1: string
-  line2: string
-  city: string
-  zip: string
-  region: string
-  country: string
-}
-
 interface BusinessTaxId {
   label: string
   value: string
 }
 
-/** `documents.business` JSON blob shape (settings catalog.ts comment, 02-document-settings.md). */
+/** `documents.business` JSON blob shape — address is the canonical `AddressStruct`. */
 interface BusinessInfo {
   companyName: string
-  address: BusinessAddress
+  address: AddressStruct
   phone: string
   email: string
   website: string
   taxId: BusinessTaxId
 }
 
-const EMPTY_ADDRESS: BusinessAddress = {
-  line1: '',
-  line2: '',
-  city: '',
-  zip: '',
-  region: '',
-  country: '',
-}
 const EMPTY_TAX_ID: BusinessTaxId = { label: '', value: '' }
+
+/** Map a stored address blob (new `AddressStruct` or the legacy `{line1,line2,region,zip}`) to `AddressStruct`. */
+function normalizeAddress(raw: unknown): AddressStruct {
+  const s = (raw && typeof raw === 'object' ? raw : {}) as Record<string, string>
+  return {
+    street1: s.street1 ?? s.line1 ?? '',
+    street2: s.street2 ?? s.line2 ?? '',
+    city: s.city ?? '',
+    state: s.state ?? s.region ?? '',
+    zipCode: s.zipCode ?? s.zip ?? '',
+    country: s.country ?? '',
+  }
+}
 
 /** Merge a stored (possibly partial/old-shape) value with defaults so the form never crashes on a fresh org. */
 function normalizeBusiness(raw: unknown): BusinessInfo {
   const source = (raw && typeof raw === 'object' ? raw : {}) as Partial<BusinessInfo>
   return {
     companyName: source.companyName ?? '',
-    address: { ...EMPTY_ADDRESS, ...(source.address ?? {}) },
+    address: normalizeAddress(source.address),
     phone: source.phone ?? '',
     email: source.email ?? '',
     website: source.website ?? '',
@@ -67,12 +69,36 @@ function normalizeBusiness(raw: unknown): BusinessInfo {
   }
 }
 
+/** Scalar catalog keys the page draft owns (`documents.business` is handled separately as a blob). */
+const SCALAR_DRAFT_KEYS = [
+  'organization.currency',
+  'documents.accentColor',
+  'documents.paperSize',
+  'documents.dateFormat',
+  'documents.quote.defaultTerms',
+  'documents.quote.validDays',
+  'documents.quote.footerText',
+  'documents.quote.lineDisplay',
+  'documents.quote.showDescriptions',
+  'documents.invoice.dueDays',
+  'documents.invoice.paymentInstructions',
+  'documents.invoice.footerText',
+  'documents.invoice.lineDisplay',
+  'documents.invoice.showDescriptions',
+  'documents.invoice.showPaymentHistory',
+] as const
+
+const BUSINESS_KEY = 'documents.business'
+
+type DocumentsDraft = Record<string, SettingValue>
+
 /**
  * Documents settings page (money MQ2 §F.2) — business identity, branding, quote
  * defaults, invoice defaults. Plain form page, no tabs (02-document-settings.md
- * decision). Business info + logo are bespoke JSON-blob sections (explicit
- * save / upload cell); the rest are catalog-driven `SettingsFieldRow` autosave
- * rows on the `DOCUMENTS` scope (money MQ2 §A.2).
+ * decision). The whole page is a single page-level draft with one bottom
+ * {@link FormSaveBar}: every `SettingsFieldRow` runs controlled and feeds the draft,
+ * saved in one `batchUpdateOrganizationSettings` call (10-settings-forms-unification.md).
+ * Logo upload is the one deliberate exception — a file upload is inherently a commit.
  */
 export function DocumentsSettingsPage() {
   useUser({ requireRoles: ['ADMIN', 'OWNER'] })
@@ -100,12 +126,45 @@ export function DocumentsSettingsPage() {
 }
 
 function DocumentsSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }[] }) {
-  const { getSetting, updateOrganizationSetting, isUpdatingOrgSetting } = useSettings({
-    scope: 'DOCUMENTS',
+  // Unscoped instance: reads every documents.* key AND the GENERAL-scope `organization.currency`,
+  // and `batchUpdateOrganizationSettings` is per-key scope-aware so one call carries them all.
+  const {
+    getSetting,
+    batchUpdateOrganizationSettings,
+    updateOrganizationSetting,
+    isBatchUpdatingOrgSettings,
+  } = useSettings({})
+
+  const storedLogo = getSetting('documents.logo') as DocumentsLogo | null
+
+  // Server snapshot for every key the draft owns (logo excluded — immediate upload). Rebuilt each
+  // render; `useDirtyDraft` compares by value, so a fresh object identity never triggers a reseed.
+  const server: DocumentsDraft = { [BUSINESS_KEY]: normalizeBusiness(getSetting(BUSINESS_KEY)) }
+  for (const key of SCALAR_DRAFT_KEYS) server[key] = getSetting(key)
+
+  const { draft, patch, dirty, save, discard } = useDirtyDraft(server, {
+    isSaving: isBatchUpdatingOrgSettings,
+    onSave: (next) => {
+      const changed: Array<{ key: string; value: SettingValue }> = []
+      if (JSON.stringify(next[BUSINESS_KEY]) !== JSON.stringify(server[BUSINESS_KEY])) {
+        changed.push({ key: BUSINESS_KEY, value: next[BUSINESS_KEY] })
+      }
+      for (const key of SCALAR_DRAFT_KEYS) {
+        if (next[key] !== server[key]) changed.push({ key, value: next[key] })
+      }
+      if (changed.length > 0) batchUpdateOrganizationSettings(changed)
+    },
   })
 
-  const storedBusiness = getSetting('documents.business')
-  const storedLogo = getSetting('documents.logo') as DocumentsLogo | null
+  const business = draft[BUSINESS_KEY] as BusinessInfo
+  const patchBusiness = (next: Partial<BusinessInfo>) =>
+    patch({ [BUSINESS_KEY]: { ...business, ...next } })
+
+  /** Controlled-mode props for a catalog `SettingsFieldRow` fed by the page draft. */
+  const controlled = (key: (typeof SCALAR_DRAFT_KEYS)[number]) => ({
+    value: draft[key],
+    onChange: (value: unknown) => patch({ [key]: value as SettingValue }),
+  })
 
   const previewPdf = api.money.previewDocumentPdf.useMutation({
     onSuccess: (data) => {
@@ -134,9 +193,9 @@ function DocumentsSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }
       }>
       <div className='flex flex-col gap-8 p-3 sm:p-6'>
         <BusinessInfoSection
-          storedBusiness={storedBusiness}
-          onSaveBusiness={(next) => updateOrganizationSetting('documents.business', next)}
-          isSaving={isUpdatingOrgSetting}
+          business={business}
+          onPatchBusiness={patchBusiness}
+          currency={controlled('organization.currency')}
         />
 
         <SettingsSection
@@ -149,9 +208,21 @@ function DocumentsSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }
               onChange={(next) => updateOrganizationSetting('documents.logo', next)}
             />
             <FieldPanel className='mt-1 p-0' resizeId='documents-settings' defaultLabelWidth={200}>
-              <SettingsFieldRow settingKey='documents.accentColor' title='Accent color' />
-              <SettingsFieldRow settingKey='documents.paperSize' title='Paper size' />
-              <SettingsFieldRow settingKey='documents.dateFormat' title='Date format' />
+              <SettingsFieldRow
+                settingKey='documents.accentColor'
+                title='Accent color'
+                {...controlled('documents.accentColor')}
+              />
+              <SettingsFieldRow
+                settingKey='documents.paperSize'
+                title='Paper size'
+                {...controlled('documents.paperSize')}
+              />
+              <SettingsFieldRow
+                settingKey='documents.dateFormat'
+                title='Date format'
+                {...controlled('documents.dateFormat')}
+              />
             </FieldPanel>
           </div>
         </SettingsSection>
@@ -161,13 +232,30 @@ function DocumentsSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }
           title='Quotes'
           description='Defaults applied to new quotes and their PDFs.'>
           <FieldPanel className='mt-1 p-0' resizeId='documents-settings' defaultLabelWidth={200}>
-            <SettingsFieldRow settingKey='documents.quote.defaultTerms' title='Default terms' />
-            <SettingsFieldRow settingKey='documents.quote.validDays' title='Valid for (days)' />
-            <SettingsFieldRow settingKey='documents.quote.footerText' title='Footer text' />
-            <SettingsFieldRow settingKey='documents.quote.lineDisplay' title='Line item display' />
+            <SettingsFieldRow
+              settingKey='documents.quote.defaultTerms'
+              title='Default terms'
+              {...controlled('documents.quote.defaultTerms')}
+            />
+            <SettingsFieldRow
+              settingKey='documents.quote.validDays'
+              title='Valid for (days)'
+              {...controlled('documents.quote.validDays')}
+            />
+            <SettingsFieldRow
+              settingKey='documents.quote.footerText'
+              title='Footer text'
+              {...controlled('documents.quote.footerText')}
+            />
+            <SettingsFieldRow
+              settingKey='documents.quote.lineDisplay'
+              title='Line item display'
+              {...controlled('documents.quote.lineDisplay')}
+            />
             <SettingsFieldRow
               settingKey='documents.quote.showDescriptions'
               title='Show descriptions'
+              {...controlled('documents.quote.showDescriptions')}
             />
           </FieldPanel>
         </SettingsSection>
@@ -177,224 +265,149 @@ function DocumentsSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }
           title='Invoices'
           description='Defaults for invoice PDFs — these apply once invoicing ships (MI1); the settings save now so they are ready.'>
           <FieldPanel className='mt-1 p-0' resizeId='documents-settings' defaultLabelWidth={200}>
-            <SettingsFieldRow settingKey='documents.invoice.dueDays' title='Due (days)' />
+            <SettingsFieldRow
+              settingKey='documents.invoice.dueDays'
+              title='Due (days)'
+              {...controlled('documents.invoice.dueDays')}
+            />
             <SettingsFieldRow
               settingKey='documents.invoice.paymentInstructions'
               title='Payment instructions'
+              {...controlled('documents.invoice.paymentInstructions')}
             />
-            <SettingsFieldRow settingKey='documents.invoice.footerText' title='Footer text' />
+            <SettingsFieldRow
+              settingKey='documents.invoice.footerText'
+              title='Footer text'
+              {...controlled('documents.invoice.footerText')}
+            />
             <SettingsFieldRow
               settingKey='documents.invoice.lineDisplay'
               title='Line item display'
+              {...controlled('documents.invoice.lineDisplay')}
             />
             <SettingsFieldRow
               settingKey='documents.invoice.showDescriptions'
               title='Show descriptions'
+              {...controlled('documents.invoice.showDescriptions')}
             />
             <SettingsFieldRow
               settingKey='documents.invoice.showPaymentHistory'
               title='Show payment history'
+              {...controlled('documents.invoice.showPaymentHistory')}
             />
           </FieldPanel>
         </SettingsSection>
+
+        <FormSaveBar
+          dirty={dirty}
+          isSaving={isBatchUpdatingOrgSettings}
+          onSave={save}
+          onDiscard={discard}
+        />
       </div>
     </SettingsPage>
   )
 }
 
 interface BusinessInfoSectionProps {
-  storedBusiness: unknown
-  onSaveBusiness: (next: BusinessInfo) => void
-  isSaving: boolean
+  business: BusinessInfo
+  onPatchBusiness: (next: Partial<BusinessInfo>) => void
+  /** Controlled props for the `organization.currency` row (GENERAL scope, edited here). */
+  currency: { value: unknown; onChange: (value: unknown) => void }
 }
 
 /**
- * Bespoke `documents.business` JSON-blob form — local draft + one explicit
- * Save button (the availability weekly-hours draft/dirty pattern), since the
- * value is a single structured object rather than a scalar catalog key. Also
- * hosts the `organization.currency` row: `SettingsFieldRow` owns its own
- * `useSettings({})` instance internally (no scope filter), so it reads/writes
- * correctly here even though this page's own `useSettings` call is scoped to
- * `DOCUMENTS` (currency stays `GENERAL` — 02-document-settings.md decision).
+ * Presentational `documents.business` blob form — no local state; the whole page's
+ * {@link useDirtyDraft} owns the draft and save. The `organization.currency` row rides along as a
+ * controlled `SettingsFieldRow` (currency stays `GENERAL` scope — 02-document-settings.md decision).
  */
-function BusinessInfoSection({
-  storedBusiness,
-  onSaveBusiness,
-  isSaving,
-}: BusinessInfoSectionProps) {
-  const [draft, setDraft] = useState<BusinessInfo>(() => normalizeBusiness(storedBusiness))
-  const [dirty, setDirty] = useState(false)
-
-  useEffect(() => {
-    // Never clobber in-progress edits on a background refetch/optimistic re-render — the
-    // post-save rebuild happens because `dirty` flips false right after `handleSave`.
-    if (dirty) return
-    setDraft(normalizeBusiness(storedBusiness))
-  }, [storedBusiness, dirty])
-
-  function patch(next: Partial<BusinessInfo>) {
-    setDraft((prev) => ({ ...prev, ...next }))
-    setDirty(true)
-  }
-
-  function patchAddress(next: Partial<BusinessAddress>) {
-    patch({ address: { ...draft.address, ...next } })
-  }
-
-  function patchTaxId(next: Partial<BusinessTaxId>) {
-    patch({ taxId: { ...draft.taxId, ...next } })
-  }
-
-  function handleDiscard() {
-    setDraft(normalizeBusiness(storedBusiness))
-    setDirty(false)
-  }
-
-  function handleSave() {
-    onSaveBusiness(draft)
-    setDirty(false)
-  }
-
+function BusinessInfoSection({ business, onPatchBusiness, currency }: BusinessInfoSectionProps) {
   return (
     <SettingsSection
       icon={Building2}
       title='Business info'
       description='Printed on every quote and invoice PDF.'>
-      <div className='flex flex-col gap-3'>
-        <FieldPanel
-          orientation='responsive'
-          breakpoint='md'
-          resizeId='documents-business-info'
-          defaultLabelWidth={200}
-          className='p-0'>
-          <SettingsFieldRow settingKey='organization.currency' title='Currency' />
+      <FieldPanel
+        orientation='responsive'
+        breakpoint='md'
+        resizeId='documents-business-info'
+        defaultLabelWidth={200}
+        className='p-0'>
+        <SettingsFieldRow
+          settingKey='organization.currency'
+          title='Currency'
+          value={currency.value}
+          onChange={currency.onChange}
+        />
 
-          <FieldPanelRow title='Company name' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.companyName}
-              onChange={(value) => patch({ companyName: value as string })}
-              placeholder='Acme Co.'
+        <FieldPanelRow title='Company name' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={business.companyName}
+            onChange={(value) => onPatchBusiness({ companyName: value as string })}
+            placeholder='Acme Co.'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Address' type={BaseType.ADDRESS} showIcon>
+          <div className='py-2'>
+            <AddressStructFields
+              value={business.address}
+              onChange={(address) => onPatchBusiness({ address })}
+              className='flex flex-col gap-2'
             />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='Address line 1' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.address.line1}
-              onChange={(value) => patchAddress({ line1: value as string })}
-              placeholder='123 Main St'
-            />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='Address line 2' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.address.line2}
-              onChange={(value) => patchAddress({ line2: value as string })}
-              placeholder='Suite 100'
-            />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='City' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.address.city}
-              onChange={(value) => patchAddress({ city: value as string })}
-              placeholder='Springfield'
-            />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='ZIP / postal code' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.address.zip}
-              onChange={(value) => patchAddress({ zip: value as string })}
-              placeholder='90210'
-            />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='State / region' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.address.region}
-              onChange={(value) => patchAddress({ region: value as string })}
-              placeholder='CA'
-            />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='Country' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.address.country}
-              onChange={(value) => patchAddress({ country: value as string })}
-              placeholder='United States'
-            />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='Phone' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.phone}
-              onChange={(value) => patch({ phone: value as string })}
-              placeholder='(555) 555-0100'
-            />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='Email' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.email}
-              onChange={(value) => patch({ email: value as string })}
-              placeholder='billing@acme.com'
-            />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='Website' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.website}
-              onChange={(value) => patch({ website: value as string })}
-              placeholder='https://acme.com'
-            />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='Tax ID label' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.taxId.label}
-              onChange={(value) => patchTaxId({ label: value as string })}
-              placeholder='EIN'
-            />
-          </FieldPanelRow>
-
-          <FieldPanelRow title='Tax ID value' type={BaseType.STRING} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={draft.taxId.value}
-              onChange={(value) => patchTaxId({ value: value as string })}
-              placeholder='12-3456789'
-            />
-          </FieldPanelRow>
-        </FieldPanel>
-
-        {dirty && (
-          <div className='flex items-center justify-end gap-3 border-t pt-3'>
-            <span className='mr-auto text-xs text-muted-foreground'>Unsaved changes</span>
-            <Button
-              type='button'
-              variant='outline'
-              size='sm'
-              onClick={handleDiscard}
-              disabled={isSaving}>
-              Discard
-            </Button>
-            <Button type='button' size='sm' onClick={handleSave} loading={isSaving}>
-              Save
-            </Button>
           </div>
-        )}
-      </div>
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Phone' type={BaseType.PHONE} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.PHONE_INTL}
+            value={business.phone}
+            onChange={(value) => onPatchBusiness({ phone: value as string })}
+            placeholder='(555) 555-0100'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Email' type={BaseType.EMAIL} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.EMAIL}
+            value={business.email}
+            onChange={(value) => onPatchBusiness({ email: value as string })}
+            placeholder='billing@acme.com'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Website' type={BaseType.URL} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.URL}
+            value={business.website}
+            onChange={(value) => onPatchBusiness({ website: value as string })}
+            placeholder='https://acme.com'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Tax ID label' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={business.taxId.label}
+            onChange={(value) =>
+              onPatchBusiness({ taxId: { ...business.taxId, label: value as string } })
+            }
+            placeholder='EIN'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Tax ID value' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={business.taxId.value}
+            onChange={(value) =>
+              onPatchBusiness({ taxId: { ...business.taxId, value: value as string } })
+            }
+            placeholder='12-3456789'
+          />
+        </FieldPanelRow>
+      </FieldPanel>
     </SettingsSection>
   )
 }

--- a/apps/web/src/components/money/ui/settings/invoicing-page.tsx
+++ b/apps/web/src/components/money/ui/settings/invoicing-page.tsx
@@ -2,11 +2,15 @@
 'use client'
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
+import type { SettingValue } from '@auxx/lib/settings/client'
 import { Lock, Receipt } from 'lucide-react'
 import { EmptyState } from '~/components/global/empty-state'
 import { FieldPanel } from '~/components/global/forms/field-panel'
+import { FormSaveBar } from '~/components/global/forms/form-save-bar'
+import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
 import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
@@ -42,6 +46,43 @@ export function InvoicingSettingsPage() {
     )
   }
 
+  return <InvoicingSettingsBody breadcrumbs={breadcrumbs} />
+}
+
+/** Scalar catalog keys the Invoicing draft owns. */
+const DRAFT_KEYS = [
+  'documents.invoice.autoEnabled',
+  'documents.invoice.defaultTiming',
+  'documents.invoice.dateBasis',
+] as const
+
+function InvoicingSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }[] }) {
+  const { getSetting, batchUpdateOrganizationSettings, isBatchUpdatingOrgSettings } = useSettings({
+    scope: 'DOCUMENTS',
+  })
+
+  // Rebuilt each render; `useDirtyDraft` compares by value so a fresh identity never reseeds.
+  const server: Record<string, SettingValue> = {}
+  for (const key of DRAFT_KEYS) server[key] = getSetting(key)
+
+  const { draft, patch, dirty, save, discard } = useDirtyDraft(server, {
+    isSaving: isBatchUpdatingOrgSettings,
+    onSave: (next) => {
+      // `defaultTiming` write-throughs onto the two `*_invoice_timing` CustomField.defaultValue rows
+      // via the batch path — send only changed keys so an untouched save doesn't re-fire it.
+      const changed = DRAFT_KEYS.filter((key) => next[key] !== server[key]).map((key) => ({
+        key,
+        value: next[key],
+      }))
+      if (changed.length > 0) batchUpdateOrganizationSettings(changed)
+    },
+  })
+
+  const controlled = (key: (typeof DRAFT_KEYS)[number]) => ({
+    value: draft[key],
+    onChange: (value: unknown) => patch({ [key]: value as SettingValue }),
+  })
+
   return (
     <SettingsPage
       title='Invoicing'
@@ -57,19 +98,29 @@ export function InvoicingSettingsPage() {
               settingKey='documents.invoice.autoEnabled'
               title='Automatic invoicing'
               description='Generate invoice drafts automatically. Turning this off only stops automation — manual gather still works.'
+              {...controlled('documents.invoice.autoEnabled')}
             />
             <SettingsFieldRow
               settingKey='documents.invoice.defaultTiming'
               title='Default invoice timing'
               description='What new quotes and jobs start as. A per-job timing setting always overrides this default.'
+              {...controlled('documents.invoice.defaultTiming')}
             />
             <SettingsFieldRow
               settingKey='documents.invoice.dateBasis'
               title='Invoice date basis'
               description='Whether auto-generated invoices are dated to the visit or the day they were generated.'
+              {...controlled('documents.invoice.dateBasis')}
             />
           </FieldPanel>
         </SettingsSection>
+
+        <FormSaveBar
+          dirty={dirty}
+          isSaving={isBatchUpdatingOrgSettings}
+          onSave={save}
+          onDiscard={discard}
+        />
       </div>
     </SettingsPage>
   )

--- a/apps/web/src/components/money/ui/settings/product-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/product-editor.tsx
@@ -60,7 +60,7 @@ function ProductEditorForm({ item }: { item: CatalogItem }) {
   return (
     <div className='p-3'>
       <FieldPanel
-        orientation='responsive'
+        orientation='horizontal'
         breakpoint='md'
         resizeId='catalog-item-form'
         defaultLabelWidth={160}
@@ -95,6 +95,7 @@ function ProductEditorForm({ item }: { item: CatalogItem }) {
             fieldType={FieldType.SINGLE_SELECT}
             fieldOptions={categoryField?.options}
             value={item.category}
+            triggerProps={{ className: 'w-full ps-0 pe-1' }}
             onChange={(value) =>
               saveFieldValue(item.recordId, 'catalog_item_category', value, FieldType.SINGLE_SELECT)
             }
@@ -121,6 +122,7 @@ function ProductEditorForm({ item }: { item: CatalogItem }) {
         <FieldPanelRow title='Taxable' type={BaseType.BOOLEAN} showIcon>
           <FieldInputAdapter
             fieldType={FieldType.CHECKBOX}
+            fieldOptions={{ variant: 'switch' }}
             value={item.taxable}
             onChange={(value) =>
               saveFieldValue(item.recordId, 'catalog_item_taxable', value, FieldType.CHECKBOX)

--- a/apps/web/src/components/money/ui/settings/tax-rate-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/tax-rate-editor.tsx
@@ -2,7 +2,6 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
-import { Switch } from '@auxx/ui/components/switch'
 import { useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
@@ -53,7 +52,7 @@ function TaxRateEditorForm({ taxRate, onUpdate, onSetDefault }: TaxRateEditorFor
   return (
     <div className='p-3'>
       <FieldPanel
-        orientation='responsive'
+        orientation='horizontal'
         breakpoint='md'
         resizeId='tax-rate-form'
         defaultLabelWidth={140}
@@ -93,9 +92,14 @@ function TaxRateEditorForm({ taxRate, onUpdate, onSetDefault }: TaxRateEditorFor
           description='Preselected on new quotes and invoices'
           type={BaseType.BOOLEAN}
           showIcon>
-          <Switch
-            checked={!!taxRate.isDefault}
-            onCheckedChange={onSetDefault}
+          <FieldInputAdapter
+            fieldType={FieldType.CHECKBOX}
+            fieldOptions={{ variant: 'switch' }}
+            value={!!taxRate.isDefault}
+            onChange={(value) => {
+              // Set-only toggle: turning it on makes this the default; it can't be unset here.
+              if (value) onSetDefault()
+            }}
             disabled={taxRate.isDefault}
           />
         </FieldPanelRow>

--- a/apps/web/src/components/pickers/time-range-input.tsx
+++ b/apps/web/src/components/pickers/time-range-input.tsx
@@ -41,6 +41,9 @@ export interface TimeRangeInputProps {
 
 type Segment = 'from' | 'to'
 
+/** Segment → `TimeRangeValue` key. The UI names segments `from`/`to`; the value speaks `start`/`end`. */
+const SEGMENT_KEY: Record<Segment, 'start' | 'end'> = { from: 'start', to: 'end' }
+
 /** Convert minutes-since-midnight to a Date usable by TimeView (date portion is arbitrary) */
 function dateFromMinutes(minutes: number | null | undefined): Date | undefined {
   if (minutes == null) return undefined
@@ -107,7 +110,7 @@ export function TimeRangeInput({
       const hour24 = resolveHour24(hourStr, use24HourTime, currentDate)
       const minute = currentDate?.getMinutes() ?? 0
       const newDate = createDateWithTime(currentDate, hour24, minute)
-      onChange({ ...value, [segment]: dateToMinutes(newDate) })
+      onChange({ ...value, [SEGMENT_KEY[segment]]: dateToMinutes(newDate) })
     },
     [value, onChange, use24HourTime]
   )
@@ -117,7 +120,7 @@ export function TimeRangeInput({
       const currentDate = dateFromMinutes(segment === 'from' ? value.start : value.end)
       const hour = currentDate?.getHours() ?? 0
       const newDate = createDateWithTime(currentDate, hour, parseInt(minuteStr, 10))
-      const next = { ...value, [segment]: dateToMinutes(newDate) }
+      const next = { ...value, [SEGMENT_KEY[segment]]: dateToMinutes(newDate) }
       onChange(next)
 
       // Focus cascade: minute selection completes the segment — close it, and if this was
@@ -132,12 +135,15 @@ export function TimeRangeInput({
       const currentDate = dateFromMinutes(segment === 'from' ? value.start : value.end)
       if (!currentDate) {
         const hour24 = period === Period.PM ? 12 : 0
-        onChange({ ...value, [segment]: dateToMinutes(createDateWithTime(undefined, hour24, 0)) })
+        onChange({
+          ...value,
+          [SEGMENT_KEY[segment]]: dateToMinutes(createDateWithTime(undefined, hour24, 0)),
+        })
         return
       }
       const hour24 = to24Hour(getHourIn12HourFormat(currentDate), period)
       const newDate = createDateWithTime(currentDate, hour24, currentDate.getMinutes())
-      onChange({ ...value, [segment]: dateToMinutes(newDate) })
+      onChange({ ...value, [SEGMENT_KEY[segment]]: dateToMinutes(newDate) })
     },
     [value, onChange]
   )

--- a/apps/web/src/components/settings/settings-field-row.tsx
+++ b/apps/web/src/components/settings/settings-field-row.tsx
@@ -119,6 +119,7 @@ export function SettingsFieldRow({
     <FieldInputAdapter
       fieldType={entry.fieldType}
       fieldOptions={entry.options}
+      triggerProps={{ className: 'w-full ps-0 pe-1' }}
       value={adapterValue}
       onChange={handleAdapterChange}
       placeholder={placeholder}

--- a/apps/web/src/server/api/routers/availability.ts
+++ b/apps/web/src/server/api/routers/availability.ts
@@ -7,6 +7,7 @@ import {
   listExceptions,
   resolveAvailability,
   saveWeeklyHours,
+  updateException,
 } from '@auxx/lib/availability'
 import { z } from 'zod'
 import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
@@ -90,6 +91,29 @@ export const availabilityRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const subject = buildSubject(ctx.session.organizationId, input.subject)
       return addException(subject, {
+        dateFrom: input.dateFrom,
+        dateTo: input.dateTo,
+        label: input.label,
+        isAvailable: input.isAvailable,
+        ranges: input.ranges,
+      })
+    }),
+
+  updateException: adminProcedure
+    .input(
+      z.object({
+        subject: subjectInputSchema,
+        ids: z.array(z.string()).min(1),
+        dateFrom: isoDate,
+        dateTo: isoDate.optional(),
+        label: z.string().optional(),
+        isAvailable: z.boolean(),
+        ranges: z.array(timeRangeSchema).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const subject = buildSubject(ctx.session.organizationId, input.subject)
+      return updateException(subject, input.ids, {
         dateFrom: input.dateFrom,
         dateTo: input.dateTo,
         label: input.label,

--- a/packages/lib/src/availability/exceptions.ts
+++ b/packages/lib/src/availability/exceptions.ts
@@ -118,13 +118,14 @@ export async function listExceptions(
 }
 
 /**
- * Materialize a date-range exception into per-date rows (one row per date, or one row per
- * date-per-range for special hours) in a single transaction.
+ * Validate + materialize an exception input into the per-date `OperatingHours` insert rows
+ * (one row per date, or one row per date-per-range for special hours). Shared by
+ * {@link addException} and {@link updateException}.
  */
-export async function addException(
+async function materializeExceptionRows(
   subject: AvailabilitySubject,
   input: AddExceptionInput
-): Promise<void> {
+): Promise<Array<typeof schema.OperatingHours.$inferInsert>> {
   const dateFrom = input.dateFrom
   const dateTo = input.dateTo ?? input.dateFrom
   const dates = enumerateDates(dateFrom, dateTo)
@@ -146,7 +147,7 @@ export async function addException(
   const columns = subjectColumns(subject)
   const label = input.label ?? null
 
-  const rows = dates.flatMap((date) =>
+  return dates.flatMap((date) =>
     input.isAvailable
       ? ranges.map((range) => ({
           ...columns,
@@ -173,8 +174,47 @@ export async function addException(
           },
         ]
   )
+}
+
+/**
+ * Materialize a date-range exception into per-date rows (one row per date, or one row per
+ * date-per-range for special hours) in a single transaction.
+ */
+export async function addException(
+  subject: AvailabilitySubject,
+  input: AddExceptionInput
+): Promise<void> {
+  const rows = await materializeExceptionRows(subject, input)
+  await database.transaction(async (tx) => {
+    await tx.insert(schema.OperatingHours).values(rows)
+  })
+}
+
+/**
+ * Replace an existing exception group with a fresh materialization. The old group's rows
+ * (`ids`, always re-scoped to subject + org + `kind = 'exception'` — ids alone are never
+ * trusted) are deleted and the new per-date rows inserted in one transaction, so an edit that
+ * changes the date span, mode, or ranges never leaves stale rows behind.
+ */
+export async function updateException(
+  subject: AvailabilitySubject,
+  ids: string[],
+  input: AddExceptionInput
+): Promise<void> {
+  const rows = await materializeExceptionRows(subject, input)
 
   await database.transaction(async (tx) => {
+    if (ids.length > 0) {
+      await tx
+        .delete(schema.OperatingHours)
+        .where(
+          and(
+            subjectConditions(subject),
+            eq(schema.OperatingHours.kind, 'exception'),
+            inArray(schema.OperatingHours.id, ids)
+          )
+        )
+    }
     await tx.insert(schema.OperatingHours).values(rows)
   })
 }

--- a/packages/lib/src/availability/index.ts
+++ b/packages/lib/src/availability/index.ts
@@ -4,7 +4,7 @@
 // weekly-hours + exceptions + resolution (plans/dispatch/05-availability.md §A.2).
 // Functional + Drizzle, no model classes (money/dispatch are the direct siblings).
 
-export { addException, deleteException, listExceptions } from './exceptions'
+export { addException, deleteException, listExceptions, updateException } from './exceptions'
 export { resolveAvailability } from './resolve'
 export type {
   AddExceptionInput,

--- a/packages/lib/src/documents/pdf/parts.tsx
+++ b/packages/lib/src/documents/pdf/parts.tsx
@@ -83,7 +83,11 @@ export function BillingPartyBlock(props: {
   }
 }) {
   const { styles, business, contact } = props
-  const businessCityLine = [business.address?.city, business.address?.region, business.address?.zip]
+  const businessCityLine = [
+    business.address?.city,
+    business.address?.state,
+    business.address?.zipCode,
+  ]
     .filter(Boolean)
     .join(', ')
   const contactCityLine = [contact.city, contact.region].filter(Boolean).join(', ')
@@ -93,11 +97,11 @@ export function BillingPartyBlock(props: {
       <View style={styles.partyBlock}>
         <Text style={styles.label}>From</Text>
         <Text style={[styles.value, styles.bold]}>{business.companyName || ' '}</Text>
-        {business.address?.line1 ? (
-          <Text style={styles.value}>{business.address.line1}</Text>
+        {business.address?.street1 ? (
+          <Text style={styles.value}>{business.address.street1}</Text>
         ) : null}
-        {business.address?.line2 ? (
-          <Text style={styles.value}>{business.address.line2}</Text>
+        {business.address?.street2 ? (
+          <Text style={styles.value}>{business.address.street2}</Text>
         ) : null}
         {businessCityLine ? <Text style={styles.value}>{businessCityLine}</Text> : null}
         {business.address?.country ? (

--- a/packages/lib/src/documents/resolve-settings.ts
+++ b/packages/lib/src/documents/resolve-settings.ts
@@ -2,21 +2,46 @@
 
 import { getAllOrganizationSettings, getOrganizationSetting } from '../settings/settings-service'
 
+/** Canonical structured address (`AddressStructFields`) — `street1/street2/city/state/zipCode/country`. */
+export interface DocumentBusinessAddress {
+  street1: string
+  street2?: string
+  city: string
+  state?: string
+  zipCode: string
+  country: string
+}
+
 /** `documents.business` JSON blob — printed on quote/invoice PDFs (money MQ2 build spec §A.2). */
 export interface DocumentBusinessSettings {
   companyName?: string
-  address?: {
-    line1: string
-    line2?: string
-    city: string
-    zip: string
-    region?: string
-    country: string
-  }
+  address?: DocumentBusinessAddress
   phone?: string
   email?: string
   website?: string
   taxId?: { label: string; value: string }
+}
+
+/**
+ * Map a stored business blob's address to the canonical `AddressStruct` keys, tolerating the
+ * legacy `{line1,line2,region,zip}` shape saved before 10-settings-forms-unification.md. Few users,
+ * so this read-time shim (no ledgered DataMigration) is enough — a legacy blob self-heals on its
+ * next save from the Documents page, which now writes the new keys.
+ */
+function normalizeBusinessAddress(business: DocumentBusinessSettings): DocumentBusinessSettings {
+  const raw = business.address as Record<string, string> | undefined
+  if (!raw) return business
+  return {
+    ...business,
+    address: {
+      street1: raw.street1 ?? raw.line1 ?? '',
+      street2: raw.street2 ?? raw.line2 ?? '',
+      city: raw.city ?? '',
+      state: raw.state ?? raw.region ?? '',
+      zipCode: raw.zipCode ?? raw.zip ?? '',
+      country: raw.country ?? '',
+    },
+  }
 }
 
 /** Logo ref stored in `documents.logo` — `assetId` is what the renderer loads bytes from. */
@@ -82,7 +107,9 @@ export async function resolveDocumentSettings(
     getOrganizationSetting({ organizationId, key: 'organization.currency' }),
   ])
 
-  const business = (settings['documents.business'] as DocumentBusinessSettings | null) ?? {}
+  const business = normalizeBusinessAddress(
+    (settings['documents.business'] as DocumentBusinessSettings | null) ?? {}
+  )
   const logo = (settings['documents.logo'] as DocumentLogo | null) ?? null
 
   return {


### PR DESCRIPTION
## What

Replaces the several hand-rolled Save/Discard idioms across the **money**, **dispatch**, and **availability** settings surfaces with two shared primitives (`10-settings-forms-unification.md`).

## Primitives (`apps/web/src/components/global/forms/`)

- **`use-dirty-draft.ts`** — one dirty-draft hook: a local working copy of a server value. `dirty` is **computed by value** (editing a field then reverting it clears `dirty`), and a changed server value is adopted into the draft **only** while the user hasn't diverged and no save is in flight — so a background refetch never clobbers edits and a pending mutation never reverts the draft. Generic `T` fits a `Record<SettingKey, value>` map, a typed worker object, or a `WeeklyHoursDraft`.
- **`form-save-bar.tsx`** — the shared sticky, spring-in unsaved-changes bar (Save / Discard, loading + save-disabled states).

## Adopted across

- **Availability** — settings page + weekly-hours + exception-list editors (+ supporting `availability` router / lib `exceptions` reads).
- **Dispatch** — worker hours + worker profile pages.
- **Money settings** — documents + invoicing pages, product + tax-rate editors.
- Shared **time-range picker** and **settings-field-row** tweaks; **documents** pdf / resolve-settings tidy-ups.

## Notes

- Pure refactor toward a shared component + hook; no schema changes.
- Split out from the WS1 worker-surface PR (#1138) — these were co-resident in the working tree; disjoint file sets.