### PR TITLE
feat(dispatch): uniform drawer field defaults + request work-order/quote blocks

### DIFF
--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -12,6 +12,7 @@ import { Section } from '@auxx/ui/components/section'
 import { OverflowTabsList, type TabDefinition, Tabs, TabsContent } from '@auxx/ui/components/tabs'
 import {
   Clock,
+  FileText,
   HouseIcon,
   Layers,
   ListTodo,
@@ -21,6 +22,7 @@ import {
   ShoppingBag,
   Ticket,
   Truck,
+  Wrench,
 } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import * as React from 'react'
@@ -425,6 +427,11 @@ function TabCards({
         <Section
           key={card.value}
           title={card.label}
+          icon={
+            card.icon ? (
+              <>{React.createElement(getIconComponent(card.icon), { className: 'size-4' })}</>
+            ) : undefined
+          }
           initialOpen
           collapsible={false}
           className={
@@ -497,6 +504,8 @@ function getIconComponent(iconName: string) {
     layers: Layers,
     truck: Truck,
     'list-todo': ListTodo,
+    wrench: Wrench,
+    'file-text': FileText,
     // Add more as needed
   }
   return icons[iconName] ?? HouseIcon

--- a/apps/web/src/components/drawers/cards/service-request-related-cards.tsx
+++ b/apps/web/src/components/drawers/cards/service-request-related-cards.tsx
@@ -1,0 +1,200 @@
+// apps/web/src/components/drawers/cards/service-request-related-cards.tsx
+'use client'
+
+// Service-request drawer overview blocks for the request's related Work Orders and
+// Quotes (dispatch STATUS "uniform drawer blocks"). Each related record is a TreeRow:
+// the record's icon, its display name, a status Badge in the `secondary` slot, and a
+// TreeRowButton that opens the record. The Quotes block's create affordance is the
+// SAME TreeRow shape — clicking it runs `money.createQuoteFromRequest` + navigates,
+// gated on the one-active-quote-per-request rule (mirrors create-quote-action.tsx).
+
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import { getDefinitionId, getInstanceId, type RecordId } from '@auxx/types/resource'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { ExternalLink, Plus } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useRecord, useResource } from '~/components/resources'
+import { useSystemField } from '~/components/resources/hooks/use-field'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { RecordIcon } from '~/components/resources/ui/record-icon'
+import { useRecordLink } from '~/components/resources/utils/get-record-link'
+import { api } from '~/trpc/react'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+
+/** One-active-quote guard mirror (§F.3 createQuoteFromRequest) — matches create-quote-action.tsx. */
+const INACTIVE_QUOTE_STATUSES = ['declined', 'canceled']
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Work Orders block
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function ServiceRequestWorkOrdersCard({ recordId }: DrawerTabProps) {
+  const { values, isLoading } = useSystemValues(recordId, ['service_request_work_orders'], {
+    autoFetch: true,
+  })
+
+  const workOrderRecordIds = extractRelationshipRecordIds(values.service_request_work_orders)
+
+  if (isLoading) return <RowSkeleton />
+  if (workOrderRecordIds.length === 0) return <EmptyRow label='No work orders yet' />
+
+  return (
+    <div className='space-y-0.5 [&_[data-slot=tree-row-secondary]]:shrink-0 [&_[data-slot=tree-row-secondary]]:overflow-visible [&_[data-slot=tree-row-secondary]]:whitespace-nowrap'>
+      {workOrderRecordIds.map((id) => (
+        <RelatedRecordRow key={id} recordId={id} statusAttr='work_order_status' />
+      ))}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Quotes block (+ header-parity "Create quote")
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function ServiceRequestQuotesCard({ recordId }: DrawerTabProps) {
+  const router = useRouter()
+
+  const { values, isLoading } = useSystemValues(recordId, ['service_request_quotes'], {
+    autoFetch: true,
+  })
+  const quoteRecordIds = extractRelationshipRecordIds(values.service_request_quotes)
+
+  // Active-quote lookup mirrors the header action so the Create row appears under the
+  // exact same condition (one active quote per request).
+  const { data: activeData, refetch } = api.record.listFiltered.useQuery(
+    {
+      entityDefinitionId: 'quote',
+      filters: [
+        {
+          id: 'request-quote-lookup',
+          logicalOperator: 'AND',
+          conditions: [
+            {
+              id: 'request-quote-lookup-request',
+              fieldId: 'quote:request',
+              operator: 'is',
+              value: recordId,
+            },
+            {
+              id: 'request-quote-lookup-status',
+              fieldId: 'quote:status',
+              operator: 'not in',
+              value: INACTIVE_QUOTE_STATUSES,
+            },
+          ],
+        },
+      ],
+      limit: 1,
+      mode: 'oneshot',
+    },
+    { enabled: !!recordId }
+  )
+
+  const createQuote = api.money.createQuoteFromRequest.useMutation({
+    onSuccess: (result) => {
+      router.push(`/app/quotes/${getInstanceId(result.recordId)}`)
+    },
+    onError: (error) => {
+      toastError({ title: 'Error creating quote', description: error.message })
+      void refetch()
+    },
+  })
+
+  if (isLoading) return <RowSkeleton />
+
+  const hasActiveQuote = !!activeData?.ids[0]
+
+  return (
+    <div className='space-y-0.5 [&_[data-slot=tree-row-secondary]]:shrink-0 [&_[data-slot=tree-row-secondary]]:overflow-visible [&_[data-slot=tree-row-secondary]]:whitespace-nowrap'>
+      {quoteRecordIds.map((id) => (
+        <RelatedRecordRow key={id} recordId={id} statusAttr='quote_status' />
+      ))}
+
+      {!hasActiveQuote && (
+        <TreeRow
+          icon={<Plus className='size-4' />}
+          title={
+            <span className='text-sm text-muted-foreground'>
+              {createQuote.isPending
+                ? 'Creating quote…'
+                : quoteRecordIds.length > 0
+                  ? 'Create another quote'
+                  : 'Create quote'}
+            </span>
+          }
+          onToggleOpen={() => {
+            if (!createQuote.isPending) createQuote.mutate({ requestRecordId: recordId })
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared row primitives (uniform across both blocks)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One related record — record icon + display name + status Badge + open button. */
+function RelatedRecordRow({ recordId, statusAttr }: { recordId: RecordId; statusAttr: string }) {
+  const router = useRouter()
+  const { record } = useRecord({ recordId, enabled: true })
+  const { resource } = useResource(getDefinitionId(recordId))
+  const { values } = useSystemValues(recordId, [statusAttr], { autoFetch: true })
+  const statusField = useSystemField(statusAttr)
+  const href = useRecordLink(recordId)
+
+  const status = unwrap(values[statusAttr]) as string | undefined
+  const statusOption = statusField?.options?.options?.find((o) => o.value === status)
+  const displayName = record?.displayName ?? 'Untitled'
+
+  return (
+    <TreeRow
+      icon={
+        <RecordIcon
+          avatarUrl={record?.avatarUrl}
+          iconId={resource?.icon || 'circle'}
+          color={resource?.color || 'gray'}
+          size='xs'
+        />
+      }
+      title={<span className='truncate text-sm'>{displayName}</span>}
+      secondary={
+        status ? (
+          <Badge variant={(statusOption?.color as Variant) ?? 'secondary'} size='xs'>
+            {statusOption?.label ?? status}
+          </Badge>
+        ) : undefined
+      }
+      actions={
+        href ? (
+          <TreeRowButton persistent tooltipText='Open' onClick={() => router.push(href)}>
+            <ExternalLink />
+          </TreeRowButton>
+        ) : undefined
+      }
+    />
+  )
+}
+
+/** Empty-state row — muted single line, no actions. */
+function EmptyRow({ label }: { label: string }) {
+  return <div className='px-1 py-1.5 text-sm text-muted-foreground'>{label}</div>
+}
+
+function RowSkeleton() {
+  return (
+    <div className='flex items-center gap-2 px-1 py-1.5'>
+      <Skeleton className='size-4 rounded' />
+      <Skeleton className='h-4 w-40' />
+    </div>
+  )
+}
+
+/** Extract first element if value is an array (SINGLE_SELECT lens returns arrays). */
+function unwrap(value: unknown): unknown {
+  return Array.isArray(value) ? value[0] : value
+}

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -116,6 +116,20 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     })),
 
   // ─────────────────────────────────────────────────────────────────
+  // SERVICE REQUEST OVERVIEW CARDS — uniform related-record blocks (work
+  // orders + quotes) styled like the ticket customer block; the quotes block
+  // carries header-parity "Create quote" (create-quote-action.tsx).
+  // ─────────────────────────────────────────────────────────────────
+  'service_request:work-orders': () =>
+    import('./cards/service-request-related-cards').then((m) => ({
+      default: m.ServiceRequestWorkOrdersCard,
+    })),
+  'service_request:quotes': () =>
+    import('./cards/service-request-related-cards').then((m) => ({
+      default: m.ServiceRequestQuotesCard,
+    })),
+
+  // ─────────────────────────────────────────────────────────────────
   // INVOICE OVERVIEW CARDS (money MI1 build spec §J.1 — drawer-only entity,
   // hasDetailPage: false, so these are the invoice's ONLY UI surface)
   // ─────────────────────────────────────────────────────────────────

--- a/apps/worker/scripts/regenerate-dispatch-money-views.ts
+++ b/apps/worker/scripts/regenerate-dispatch-money-views.ts
@@ -1,0 +1,231 @@
+// apps/worker/scripts/regenerate-dispatch-money-views.ts
+/**
+ * LOCAL DEV script (no migration — dispatch/money isn't in production yet). Rebuilds the
+ * per-org DEFAULT `panel` + `dialog_create` TableViews for service_request / work_order /
+ * quote / invoice so they match the current field registry + the seed spec in
+ * `packages/lib/src/seed/entity-seeder/create-field-views.ts`.
+ *
+ * WHY: `use-field-view.ts` only falls back to the registry (`showInPanel`/`sortOrder`) when
+ * NO stored view exists. Every seeded org has a shared default `panel`/`dialog_create`
+ * TableView, and those win — so registry edits alone don't move an existing org. Older orgs'
+ * stored views were snapshotted from the OLD registry (contact mid-list, work_orders/quotes/
+ * money-totals visible), which is what this rebuilds.
+ *
+ * Identifier note: system audit fields (id/created_at/updated_at) have NO CustomField row —
+ * they surface via the static registry with resourceFieldId `<defId>:<staticKey>`. Every
+ * other field (incl. created_by_id) has a CustomField row keyed `<defId>:<cfId>`. This script
+ * emits both forms so the excluded audit fields stay hidden.
+ *
+ * Run (from repo root) under the worker runtime:
+ *   cd apps/worker && npx dotenv -e ../../.env -- node --conditions source --import tsx/esm \
+ *     scripts/regenerate-dispatch-money-views.ts
+ */
+
+import { database } from '@auxx/database'
+import { flushOrganization, onCacheEvent } from '@auxx/lib/cache'
+
+/** systemAttribute → static field key for the audit fields that have no CustomField row. */
+const STATIC_KEY: Record<string, string> = {
+  id: 'id',
+  created_at: 'createdAt',
+  updated_at: 'updatedAt',
+}
+
+interface EntitySpec {
+  /** panel excludeFields — systemAttributes hidden from the field panel */
+  panelExclude: string[]
+  /** dialog_create includeFields — systemAttributes shown (in order) in the create dialog */
+  dialogInclude: string[]
+}
+
+/** Mirrors FIELD_VIEW_CONFIGS in create-field-views.ts for these four entities. */
+const SPEC: Record<string, EntitySpec> = {
+  service_request: {
+    panelExclude: [
+      'id',
+      'created_at',
+      'updated_at',
+      'created_by_id',
+      'service_request_work_orders',
+      'service_request_quotes',
+    ],
+    dialogInclude: [
+      'service_request_title',
+      'service_request_contact',
+      'service_request_description',
+      'service_request_property_type',
+      'service_request_preferred_date',
+      'service_request_alternate_date',
+      'service_request_arrival_window',
+      'service_request_address',
+    ],
+  },
+  work_order: {
+    panelExclude: [
+      'id',
+      'created_at',
+      'updated_at',
+      'created_by_id',
+      'work_order_pricing_model',
+      'work_order_invoice_timing',
+      'work_order_quote',
+      'work_order_line_items',
+      'work_order_invoices',
+    ],
+    dialogInclude: [
+      'work_order_title',
+      'work_order_contact',
+      'work_order_priority',
+      'work_order_job_type',
+      'work_order_company',
+      'work_order_address',
+      'work_order_description',
+    ],
+  },
+  quote: {
+    panelExclude: [
+      'id',
+      'created_at',
+      'updated_at',
+      'created_by_id',
+      'quote_line_items',
+      'quote_work_orders',
+      'quote_discount_type',
+      'quote_discount_value',
+      'quote_tax_rate',
+      'quote_subtotal',
+      'quote_tax_total',
+      'quote_total',
+    ],
+    dialogInclude: ['quote_title', 'quote_contact', 'quote_request'],
+  },
+  invoice: {
+    panelExclude: [
+      'id',
+      'created_at',
+      'updated_at',
+      'created_by_id',
+      'invoice_line_items',
+      'invoice_payments',
+      'invoice_pdf_asset',
+      'invoice_discount_type',
+      'invoice_discount_value',
+      'invoice_tax_rate',
+      'invoice_subtotal',
+      'invoice_tax_total',
+      'invoice_total',
+    ],
+    dialogInclude: ['invoice_contact', 'invoice_work_order', 'invoice_due_date'],
+  },
+}
+
+interface Cf {
+  id: string
+  systemAttribute: string
+  sortOrder: string | null
+}
+
+function buildPanelConfig(defId: string, cfs: Cf[], exclude: string[]) {
+  const excludeSet = new Set(exclude)
+  const fieldVisibility: Record<string, boolean> = {}
+
+  // Static audit fields (no CustomField row) — hide via <defId>:<staticKey>
+  for (const attr of exclude) {
+    if (STATIC_KEY[attr]) fieldVisibility[`${defId}:${STATIC_KEY[attr]}`] = false
+  }
+
+  const included = cfs
+    .filter((c) => !excludeSet.has(c.systemAttribute))
+    .sort((a, b) => (a.sortOrder ?? 'zz').localeCompare(b.sortOrder ?? 'zz'))
+
+  for (const c of cfs) {
+    fieldVisibility[`${defId}:${c.id}`] = !excludeSet.has(c.systemAttribute)
+  }
+
+  return {
+    fieldOrder: included.map((c) => `${defId}:${c.id}`),
+    fieldVisibility,
+    showLabels: true,
+  }
+}
+
+function buildDialogConfig(defId: string, cfs: Cf[], include: string[]) {
+  const byAttr = new Map(cfs.map((c) => [c.systemAttribute, c]))
+  const fieldVisibility: Record<string, boolean> = {}
+
+  // Everything hidden by default, then flip the included ones on
+  for (const c of cfs) fieldVisibility[`${defId}:${c.id}`] = false
+  for (const attr of Object.keys(STATIC_KEY))
+    fieldVisibility[`${defId}:${STATIC_KEY[attr]}`] = false
+
+  const fieldOrder: string[] = []
+  for (const attr of include) {
+    const c = byAttr.get(attr)
+    if (!c) continue
+    fieldVisibility[`${defId}:${c.id}`] = true
+    fieldOrder.push(`${defId}:${c.id}`)
+  }
+
+  return { fieldOrder, fieldVisibility, showLabels: true }
+}
+
+async function main() {
+  const client = database.$client
+  const orgs = await database.query.Organization.findMany({ columns: { id: true, name: true } })
+  console.log(`Regenerating dispatch/money default views across ${orgs.length} org(s)…\n`)
+
+  let totalViews = 0
+  for (const org of orgs) {
+    let orgViews = 0
+
+    for (const [entityType, spec] of Object.entries(SPEC)) {
+      const def = await client.query(
+        `SELECT id FROM "EntityDefinition" WHERE "organizationId" = $1 AND "entityType" = $2 LIMIT 1`,
+        [org.id, entityType]
+      )
+      const defId: string | undefined = def.rows[0]?.id
+      if (!defId) continue
+
+      const cfRes = await client.query(
+        `SELECT id, "systemAttribute", "sortOrder" FROM "CustomField"
+           WHERE "organizationId" = $1 AND "entityDefinitionId" = $2 AND "systemAttribute" IS NOT NULL`,
+        [org.id, defId]
+      )
+      const cfs = cfRes.rows as Cf[]
+
+      const panel = buildPanelConfig(defId, cfs, spec.panelExclude)
+      const dialog = buildDialogConfig(defId, cfs, spec.dialogInclude)
+
+      for (const [contextType, config] of [
+        ['panel', panel],
+        ['dialog_create', dialog],
+      ] as const) {
+        const upd = await client.query(
+          `UPDATE "TableView" SET config = $1::jsonb, "updatedAt" = now()
+             WHERE "organizationId" = $2 AND "tableId" = $3 AND "contextType" = $4
+               AND "isDefault" = true AND "isShared" = true`,
+          [JSON.stringify(config), org.id, defId, contextType]
+        )
+        orgViews += upd.rowCount ?? 0
+      }
+    }
+
+    if (orgViews > 0) {
+      await flushOrganization(org.id)
+      // The view list is served from a PER-USER `userTableViews` cache (1-day TTL) that
+      // flushOrganization does NOT touch — this event invalidates it for every org member.
+      await onCacheEvent('table-view.updated', { orgId: org.id, broadcastUserKeys: true })
+      totalViews += orgViews
+      console.log(`  ✅ ${org.name ?? org.id}: ${orgViews} default view(s) rebuilt + cache flushed`)
+    }
+  }
+
+  console.log(`\nDone. ${totalViews} TableView row(s) rebuilt.`)
+  await client.end?.()
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/worker/scripts/reorder-service-request-fields.ts
+++ b/apps/worker/scripts/reorder-service-request-fields.ts
@@ -1,0 +1,90 @@
+// apps/worker/scripts/reorder-service-request-fields.ts
+/**
+ * LOCAL DEV script (no migration — dispatch isn't in production yet). Re-syncs the
+ * per-org `CustomField.sortOrder` for the `service_request` system fields to the new
+ * default order declared in
+ * `packages/lib/src/resources/registry/resources/service-request-fields.ts`:
+ *
+ *   number → title → contact → status → description → (the rest)
+ *
+ * WHY a script is needed: `sortOrder` is persisted per-org in the DB at seed time
+ * (copied from `systemSortOrder`), and the field panel / create dialog order come
+ * from that column — editing `systemSortOrder` in the registry only affects NEWLY
+ * seeded orgs. `showInPanel` (the field hides) is read live from the static registry
+ * on every merge, so those need no DB change — just a lib rebuild + this cache flush.
+ *
+ * All target attributes are `service_request_*`-prefixed (unique to that entity), so a
+ * plain systemAttribute match is safe — no entity-def scoping needed. Existing orgs
+ * that saved a custom service_request field VIEW keep their own order (by design).
+ *
+ * Run (from repo root) under the worker runtime:
+ *   cd apps/worker && npx dotenv -e ../../.env -- node --conditions source --import tsx/esm \
+ *     scripts/reorder-service-request-fields.ts
+ */
+
+import { database } from '@auxx/database'
+import { flushOrganization } from '@auxx/lib/cache'
+
+/**
+ * systemAttribute → new sortOrder — mirrors the `systemSortOrder` values in
+ * service-request-fields.ts and work-order-fields.ts. Every attribute here is
+ * uniquely prefixed (`service_request_*` / `work_order_*`), so a plain
+ * systemAttribute match is safe with no entity-def scoping.
+ */
+const SORT_ORDER: Record<string, string> = {
+  // Service request: number → title → contact → status → description → rest
+  service_request_number: 'a1',
+  service_request_title: 'a2',
+  service_request_contact: 'a3',
+  service_request_status: 'a4',
+  service_request_description: 'a5',
+  service_request_property_type: 'a6',
+  service_request_preferred_date: 'a7',
+  service_request_alternate_date: 'a8',
+  service_request_arrival_window: 'a9',
+  service_request_address: 'aA',
+  service_request_ticket: 'aB',
+  service_request_work_orders: 'aC',
+  service_request_quotes: 'aD',
+
+  // Work order: contact moved up to below title (rest keep their order)
+  work_order_contact: 'a3',
+  work_order_description: 'a4',
+  work_order_status: 'a5',
+  work_order_priority: 'a6',
+  work_order_job_type: 'a7',
+}
+
+async function main() {
+  const client = database.$client
+
+  const orgs = await database.query.Organization.findMany({ columns: { id: true, name: true } })
+  console.log(`Reordering service_request fields across ${orgs.length} org(s)…\n`)
+
+  let totalUpdated = 0
+  for (const org of orgs) {
+    let orgUpdated = 0
+    for (const [systemAttribute, sortOrder] of Object.entries(SORT_ORDER)) {
+      const res = await client.query(
+        `UPDATE "CustomField" SET "sortOrder" = $1
+           WHERE "organizationId" = $2 AND "systemAttribute" = $3`,
+        [sortOrder, org.id, systemAttribute]
+      )
+      orgUpdated += res.rowCount ?? 0
+    }
+    if (orgUpdated > 0) {
+      await flushOrganization(org.id)
+      totalUpdated += orgUpdated
+      console.log(`  ✅ ${org.name ?? org.id}: ${orgUpdated} field(s) reordered + cache flushed`)
+    }
+  }
+
+  console.log(`\nDone. ${totalUpdated} CustomField row(s) updated.`)
+  await client.end?.()
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/lib/src/resources/registry/drawer-config-types.ts
+++ b/packages/lib/src/resources/registry/drawer-config-types.ts
@@ -37,6 +37,8 @@ export interface DrawerTabCardDefinition {
   value: string
   /** Display label shown as section header */
   label: string
+  /** Optional icon name shown next to the section header (resolved in the frontend). */
+  icon?: string
   /** Position relative to default tab content */
   position?: 'before' | 'after'
   /**

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -70,6 +70,24 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     },
   },
 
+  service_request: {
+    entityType: 'service_request',
+    additionalTabs: [],
+    actions: {
+      enableArchive: true,
+      enableDelete: true,
+    },
+    // Related work orders + quotes rendered as uniform overview blocks (styled like
+    // the ticket customer block). The `workOrders`/`quotes` inverse fields are hidden
+    // from the Details field panel (showInPanel:false) so they only appear here.
+    tabCards: {
+      overview: [
+        { value: 'work-orders', label: 'Work orders', icon: 'wrench' },
+        { value: 'quotes', label: 'Quotes', icon: 'file-text' },
+      ],
+    },
+  },
+
   quote: {
     entityType: 'quote',
     // No additionalTabs — the drawer shows line items as an Overview card

--- a/packages/lib/src/resources/registry/resources/invoice-fields.ts
+++ b/packages/lib/src/resources/registry/resources/invoice-fields.ts
@@ -206,6 +206,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'invoice_discount_type',
     systemSortOrder: 'a7',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     options: { options: [...INVOICE_DISCOUNT_TYPE_OPTIONS] },
     capabilities: {
@@ -228,6 +229,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'invoice_discount_value',
     systemSortOrder: 'a8',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     capabilities: {
       filterable: true,
@@ -267,6 +269,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'invoice_tax_rate',
     systemSortOrder: 'aA',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     capabilities: {
       filterable: true,
@@ -287,6 +290,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'invoice_subtotal',
     systemSortOrder: 'aB',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     options: {
       currencyCode: 'USD',
@@ -313,6 +317,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'invoice_tax_total',
     systemSortOrder: 'aC',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     options: {
       currencyCode: 'USD',
@@ -339,6 +344,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'invoice_total',
     systemSortOrder: 'aD',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     options: {
       currencyCode: 'USD',

--- a/packages/lib/src/resources/registry/resources/quote-fields.ts
+++ b/packages/lib/src/resources/registry/resources/quote-fields.ts
@@ -273,6 +273,7 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'quote_discount_type',
     systemSortOrder: 'a9',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     options: { options: [...QUOTE_DISCOUNT_TYPE_OPTIONS] },
     capabilities: {
@@ -295,6 +296,7 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'quote_discount_value',
     systemSortOrder: 'aA',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     capabilities: {
       filterable: true,
@@ -334,6 +336,7 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'quote_tax_rate',
     systemSortOrder: 'aC',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     capabilities: {
       filterable: true,
@@ -354,6 +357,7 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'quote_subtotal',
     systemSortOrder: 'aD',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     options: {
       currencyCode: 'USD',
@@ -380,6 +384,7 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'quote_tax_total',
     systemSortOrder: 'aE',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     options: {
       currencyCode: 'USD',
@@ -406,6 +411,7 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'quote_total',
     systemSortOrder: 'aF',
+    showInPanel: false, // shown in the line-items overview card below
     nullable: true,
     options: {
       currencyCode: 'USD',

--- a/packages/lib/src/resources/registry/resources/service-request-fields.ts
+++ b/packages/lib/src/resources/registry/resources/service-request-fields.ts
@@ -115,7 +115,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RICH_TEXT,
     isSystem: true,
     systemAttribute: 'service_request_description',
-    systemSortOrder: 'a3',
+    systemSortOrder: 'a5',
     nullable: true,
     capabilities: {
       filterable: false,
@@ -135,7 +135,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.SINGLE_SELECT,
     isSystem: true,
     systemAttribute: 'service_request_property_type',
-    systemSortOrder: 'a4',
+    systemSortOrder: 'a6',
     nullable: true,
     options: { options: [...SERVICE_REQUEST_PROPERTY_TYPE_OPTIONS] },
     capabilities: {
@@ -157,7 +157,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.DATE,
     isSystem: true,
     systemAttribute: 'service_request_preferred_date',
-    systemSortOrder: 'a5',
+    systemSortOrder: 'a7',
     nullable: true,
     capabilities: {
       filterable: true,
@@ -177,7 +177,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.DATE,
     isSystem: true,
     systemAttribute: 'service_request_alternate_date',
-    systemSortOrder: 'a6',
+    systemSortOrder: 'a8',
     nullable: true,
     capabilities: {
       filterable: true,
@@ -197,7 +197,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.SINGLE_SELECT,
     isSystem: true,
     systemAttribute: 'service_request_arrival_window',
-    systemSortOrder: 'a7',
+    systemSortOrder: 'a9',
     nullable: true,
     options: { options: [...SERVICE_REQUEST_ARRIVAL_WINDOW_OPTIONS] },
     capabilities: {
@@ -219,7 +219,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RELATIONSHIP,
     isSystem: true,
     systemAttribute: 'service_request_contact',
-    systemSortOrder: 'a8',
+    systemSortOrder: 'a3',
     nullable: false,
     required: true,
     capabilities: {
@@ -251,7 +251,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.ADDRESS_STRUCT,
     isSystem: true,
     systemAttribute: 'service_request_address',
-    systemSortOrder: 'a9',
+    systemSortOrder: 'aA',
     nullable: true,
     options: { addressComponents: ['street', 'city', 'state', 'country'] },
     capabilities: {
@@ -273,7 +273,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RELATIONSHIP,
     isSystem: true,
     systemAttribute: 'service_request_ticket',
-    systemSortOrder: 'aA',
+    systemSortOrder: 'aB',
     nullable: true,
     showInDialogs: false,
     capabilities: {
@@ -305,7 +305,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.SINGLE_SELECT,
     isSystem: true,
     systemAttribute: 'service_request_status',
-    systemSortOrder: 'aB',
+    systemSortOrder: 'a4',
     nullable: false,
     options: { options: [...SERVICE_REQUEST_STATUS_OPTIONS] },
     capabilities: {
@@ -401,6 +401,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'updated_at',
     systemSortOrder: 'aF',
+    showInPanel: false,
     dbColumn: 'updatedAt',
     nullable: false,
     capabilities: {

--- a/packages/lib/src/resources/registry/resources/work-order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/work-order-fields.ts
@@ -133,7 +133,7 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RICH_TEXT,
     isSystem: true,
     systemAttribute: 'work_order_description',
-    systemSortOrder: 'a3',
+    systemSortOrder: 'a4',
     nullable: true,
     capabilities: {
       filterable: false,
@@ -153,8 +153,9 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.SINGLE_SELECT,
     isSystem: true,
     systemAttribute: 'work_order_status',
-    systemSortOrder: 'a4',
+    systemSortOrder: 'a5',
     nullable: false,
+    showInDialogs: false, // new-job dialog starts every work order at the default status
     options: { options: [...WORK_ORDER_STATUS_OPTIONS] },
     capabilities: {
       filterable: true,
@@ -175,7 +176,7 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.SINGLE_SELECT,
     isSystem: true,
     systemAttribute: 'work_order_priority',
-    systemSortOrder: 'a5',
+    systemSortOrder: 'a6',
     nullable: false,
     options: { options: [...WORK_ORDER_PRIORITY_OPTIONS] },
     capabilities: {
@@ -197,7 +198,7 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.SINGLE_SELECT,
     isSystem: true,
     systemAttribute: 'work_order_job_type',
-    systemSortOrder: 'a6',
+    systemSortOrder: 'a7',
     nullable: false,
     options: { options: [...WORK_ORDER_JOB_TYPE_OPTIONS] },
     capabilities: {
@@ -220,7 +221,7 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RELATIONSHIP,
     isSystem: true,
     systemAttribute: 'work_order_contact',
-    systemSortOrder: 'a7',
+    systemSortOrder: 'a3',
     nullable: true,
     capabilities: {
       filterable: true,
@@ -336,6 +337,7 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
     systemAttribute: 'work_order_request',
     systemSortOrder: 'aB',
     nullable: true,
+    showInDialogs: false, // set by the convert flow, not picked in the new-job dialog
     capabilities: {
       filterable: true,
       sortable: false,
@@ -496,6 +498,8 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
     systemAttribute: 'work_order_quote',
     systemSortOrder: 'aI',
     nullable: true,
+    showInPanel: false, // drawer surfaces the quote via the Origin card, not a field row
+    showInDialogs: false, // set by the convert flow, not picked in the new-job dialog
     capabilities: {
       filterable: true,
       sortable: false,

--- a/packages/lib/src/seed/entity-seeder/create-field-views.ts
+++ b/packages/lib/src/seed/entity-seeder/create-field-views.ts
@@ -28,7 +28,7 @@ interface FieldViewSeedConfig {
  * Default field view configs for core entities.
  * Uses systemAttribute (from field definitions) for reliable field identification.
  */
-const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
+export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   // ============================================================================
   // CONTACT FIELD VIEWS
   // ============================================================================
@@ -283,6 +283,10 @@ const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
       'created_by_id',
       'work_order_pricing_model', // hidden billing structure (§B) — no UI until invoicing
       'work_order_invoice_timing',
+      // surfaced via the job view's Origin card + line-items/invoice UI, not field rows
+      'work_order_quote',
+      'work_order_line_items',
+      'work_order_invoices',
     ],
   },
   {
@@ -306,10 +310,9 @@ const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
     name: 'Default Create Dialog',
     includeFields: [
       'work_order_title',
-      'work_order_status',
+      'work_order_contact',
       'work_order_priority',
       'work_order_job_type',
-      'work_order_contact',
       'work_order_company',
       'work_order_address',
       'work_order_description',
@@ -323,7 +326,15 @@ const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
     entityType: 'service_request',
     contextType: 'panel',
     name: 'Default Panel View',
-    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
+    // work_orders + quotes render as dedicated overview blocks, not field rows
+    excludeFields: [
+      'id',
+      'created_at',
+      'updated_at',
+      'created_by_id',
+      'service_request_work_orders',
+      'service_request_quotes',
+    ],
   },
   {
     entityType: 'service_request',
@@ -343,12 +354,12 @@ const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
     name: 'Default Create Dialog',
     includeFields: [
       'service_request_title',
+      'service_request_contact',
       'service_request_description',
       'service_request_property_type',
       'service_request_preferred_date',
       'service_request_alternate_date',
       'service_request_arrival_window',
-      'service_request_contact',
       'service_request_address',
     ],
   },
@@ -360,6 +371,7 @@ const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
     entityType: 'quote',
     contextType: 'panel',
     name: 'Default Panel View',
+    // money totals (discount/tax/subtotal/total) live in the line-items card below
     excludeFields: [
       'id',
       'created_at',
@@ -367,6 +379,12 @@ const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
       'created_by_id',
       'quote_line_items',
       'quote_work_orders',
+      'quote_discount_type',
+      'quote_discount_value',
+      'quote_tax_rate',
+      'quote_subtotal',
+      'quote_tax_total',
+      'quote_total',
     ],
   },
   {
@@ -441,6 +459,7 @@ const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
     entityType: 'invoice',
     contextType: 'panel',
     name: 'Default Panel View',
+    // money totals (discount/tax/subtotal/total) live in the line-items card below
     excludeFields: [
       'id',
       'created_at',
@@ -449,6 +468,12 @@ const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
       'invoice_line_items',
       'invoice_payments',
       'invoice_pdf_asset',
+      'invoice_discount_type',
+      'invoice_discount_value',
+      'invoice_tax_rate',
+      'invoice_subtotal',
+      'invoice_tax_total',
+      'invoice_total',
     ],
   },
   {
@@ -609,14 +634,21 @@ function buildFieldIdList(
     return result
   }
 
-  // Otherwise, collect all fields for this entity (excluding specified ones)
+  // Otherwise, collect all fields for this entity (excluding specified ones),
+  // ordered by the registry's systemSortOrder so the panel/table default order
+  // tracks the field registry rather than object-declaration order.
+  const collected: { resourceFieldId: string; sortOrder: string }[] = []
   for (const [key, field] of fieldMap.entries()) {
     if (!key.startsWith(`${entityType}:`)) continue
     if (excludeSet.has(field.systemAttribute)) continue
 
-    const resourceFieldId = toResourceFieldId(entityDefId, toFieldId(field.id))
-    result.push(resourceFieldId)
+    collected.push({
+      resourceFieldId: toResourceFieldId(entityDefId, toFieldId(field.id)),
+      sortOrder: field._fieldDef.systemSortOrder ?? 'zz',
+    })
   }
+  collected.sort((a, b) => a.sortOrder.localeCompare(b.sortOrder))
+  result.push(...collected.map((c) => c.resourceFieldId))
 
   return result
 }

--- a/packages/ui/src/components/tree-row.tsx
+++ b/packages/ui/src/components/tree-row.tsx
@@ -255,6 +255,7 @@ export function TreeRow({
           )}
           {secondary && (
             <span
+              data-slot='tree-row-secondary'
               className={cn(
                 'ml-1 truncate text-primary-400 text-sm',
                 secondaryFill && 'min-w-0 flex-1'


### PR DESCRIPTION
## What

Makes the record-drawer **overview** consistent across dispatch/money entities, and adds two related-record blocks to the service-request drawer.

### Field defaults (registry + seed)
- **Service request** — panel order `number → title → contact → status → description → …`; hide `work orders`, `quotes`, `id`, `updated`. Create dialog: `contact` moved below `title`.
- **Work order** — `contact` below `title`; hide `quote`, `line items`, `invoices` on the drawer; drop `status`, `service request`, `quote` from the new-job dialog.
- **Quote + invoice** — hide `discount type/value`, `tax rate`, `subtotal`, `tax total`, `total` on the drawer (already shown in the line-items card).
- `create-field-views` seed now sorts the panel/table default order by `systemSortOrder` so new orgs track the registry.

### Overview blocks
- New **Work orders** + **Quotes** blocks on the service-request drawer, rendered as `TreeRow`s (record icon, `xs` status `Badge` in `secondary`, `TreeRowButton` link). The Quotes block carries **header-parity "Create quote"** (`money.createQuoteFromRequest`, one-active-quote guard).
- `<Section>` headers get an optional `icon` via `DrawerTabCardDefinition.icon`.
- `TreeRow`'s `secondary` gets a `data-slot` so callers can override the `truncate` that was clipping the badge.

## Why the scripts (no migration)
Dispatch/money aren't in production, so no migration. But field **order** (`CustomField.sortOrder`) is persisted per-org, and every org has **stored default `panel`/`dialog_create` TableViews** that *override* the registry `showInPanel`/`sortOrder`. So two local reshape scripts:
- `reorder-service-request-fields.ts` — resyncs `CustomField.sortOrder`.
- `regenerate-dispatch-money-views.ts` — rebuilds the stored default panel/dialog views from the seed spec and invalidates both the org cache **and** the per-user `userTableViews` cache (the layer that made a first attempt look stale).

Both are idempotent and were run across all local orgs.

## Test
- Verified DemoOrg1's rebuilt views directly in the DB (panel order + visibility, dialog field sets) for all four entities.
- Registry/seed/UI files lint clean; `@auxx/lib` rebuilt.
- Browser pass on the service-request drawer still owed.