### PR TITLE
feat(dispatch): route planner restyle + worker day-gating + engine hook fixes

### DIFF
--- a/apps/web/src/app/(protected)/app/dispatch/page.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/page.tsx
@@ -1,13 +1,12 @@
 // apps/web/src/app/(protected)/app/dispatch/page.tsx
 
-import { MainPageContent } from '@auxx/ui/components/main-page'
 import { DispatchBoard } from '~/components/dispatch/ui/board/dispatch-board'
 
-/** Module home — the M2a dispatch board (07-m2-build.md §D.2). */
+/**
+ * Module home — the M2a dispatch board (07-m2-build.md §D.2). `DispatchBoard` renders
+ * `MainPageContent` itself (schedule-page pattern) so the route planner's Routes drawer can
+ * dock into its panel frame.
+ */
 export default function DispatchHome() {
-  return (
-    <MainPageContent>
-      <DispatchBoard />
-    </MainPageContent>
-  )
+  return <DispatchBoard />
 }

--- a/apps/web/src/components/dispatch/ui/board/board-toolbar.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-toolbar.tsx
@@ -4,6 +4,7 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import { Separator } from '@auxx/ui/components/separator'
 import { endOfWeek, format, startOfWeek } from 'date-fns'
 import {
   CalendarDays,
@@ -13,7 +14,9 @@ import {
   LayoutGrid,
   Map as MapIcon,
   PanelLeft,
+  PanelRight,
 } from 'lucide-react'
+import { Tooltip } from '~/components/global/tooltip'
 import { DateTimePicker } from '~/components/pickers/date-time-picker'
 import { TagFilterPopover } from '../route-planner/tag-filter-popover'
 import type { BoardViewMode, BoardWorker } from './types'
@@ -21,6 +24,11 @@ import { goToNextDate, goToPreviousDate, viewedMonthStart, type WeekStartIndex }
 import { WorkerFilterPopover } from './worker-filter-popover'
 
 export type BoardMode = 'calendar' | 'map'
+
+/** `RadioTab size='sm'` is h-8 — one notch above the toolbar's h-7 button scale, so both
+ * segmented controls take a height + item-padding override to sit flush with `icon-sm`. */
+const RADIO_TAB_CLASS = 'h-7'
+const RADIO_TAB_ITEM_CLASS = 'px-2'
 
 interface BoardToolbarProps {
   date: Date
@@ -35,6 +43,11 @@ interface BoardToolbarProps {
   onShowBacklogChange: (show: boolean) => void
   boardMode: BoardMode
   onBoardModeChange: (mode: BoardMode) => void
+  /** Map-mode planner panels (route-planner restyle): the toolbar owns both toggles. */
+  plannerShowBacklog: boolean
+  onPlannerShowBacklogChange: (show: boolean) => void
+  plannerShowStops: boolean
+  onPlannerShowStopsChange: (show: boolean) => void
   /** Distinct `work_order.tags` across the route planner's visible day (map mode only). */
   tags: string[]
   selectedTags: Set<string> | null
@@ -57,10 +70,13 @@ function dateLabel(view: BoardViewMode, date: Date, weekStartsOn: WeekStartIndex
 }
 
 /**
- * Board toolbar (07 §D.2, extended by 09-route-planner.md §A): date nav, Day/Week/Month
- * `RadioTab`, the day-view worker filter, the backlog-rail toggle, and the Board↔Map segmented
- * control. Map mode hides the Day/Week/Month switch (route planning is single-day), always
- * shows the worker filter, and adds the tag/region filter next to it.
+ * Board toolbar (07 §D.2, extended by 09-route-planner.md §A) on the workflow-toolbar design
+ * scale (`gap-1 p-1`, ghost h-7 buttons, `Separator` group dividers, tooltips). Ordered to avoid
+ * layout shifts when toggling Board↔Map: the stable prefix (left-panel toggle, Board/Map switch,
+ * date nav with a fixed-width label) never moves; mode-conditional controls (Day/Week/Month vs
+ * tag filter) swap in the region after it, and the map-only right-panel toggle is anchored at
+ * the far right past the spacer. The left-panel toggle is mode-appropriate: calendar backlog
+ * rail vs planner backlog overlay.
  */
 export function BoardToolbar({
   date,
@@ -75,6 +91,10 @@ export function BoardToolbar({
   onShowBacklogChange,
   boardMode,
   onBoardModeChange,
+  plannerShowBacklog,
+  onPlannerShowBacklogChange,
+  plannerShowStops,
+  onPlannerShowStopsChange,
   tags,
   selectedTags,
   onSelectedTagsChange,
@@ -83,27 +103,53 @@ export function BoardToolbar({
   // regardless of whatever Day/Week/Month `view` the calendar was last left on — date nav and
   // the label both step/format as a day while map mode is active.
   const effectiveView: BoardViewMode = boardMode === 'map' ? 'day' : view
+  const isMap = boardMode === 'map'
+  const leftPanelOpen = isMap ? plannerShowBacklog : showBacklog
+  const toggleLeftPanel = () =>
+    isMap ? onPlannerShowBacklogChange(!plannerShowBacklog) : onShowBacklogChange(!showBacklog)
 
   return (
-    <div className='flex flex-wrap items-center gap-2 border-b p-2'>
-      <Button variant='outline' size='sm' onClick={() => onShowBacklogChange(!showBacklog)}>
-        <PanelLeft />
-      </Button>
+    <div className='flex flex-wrap items-center gap-1 border-b p-1'>
+      <Tooltip content={isMap ? 'Toggle backlog panel' : 'Toggle backlog rail'}>
+        <Button
+          variant={leftPanelOpen ? 'secondary' : 'ghost'}
+          size='icon-sm'
+          onClick={toggleLeftPanel}>
+          <PanelLeft />
+        </Button>
+      </Tooltip>
+
+      <RadioTab
+        value={boardMode}
+        onValueChange={(v) => onBoardModeChange(v as BoardMode)}
+        size='sm'
+        className={RADIO_TAB_CLASS}>
+        <RadioTabItem value='calendar' tooltip='Board' className={RADIO_TAB_ITEM_CLASS}>
+          <LayoutGrid />
+          <span className='hidden sm:inline'>Board</span>
+        </RadioTabItem>
+        <RadioTabItem value='map' tooltip='Map' className={RADIO_TAB_ITEM_CLASS}>
+          <MapIcon />
+          <span className='hidden sm:inline'>Map</span>
+        </RadioTabItem>
+      </RadioTab>
+
+      <Separator orientation='vertical' className='h-6' />
 
       <div className='flex items-center gap-1'>
-        <Button variant='outline' size='sm' onClick={() => onDateChange(new Date())}>
+        <Button variant='ghost' size='sm' onClick={() => onDateChange(new Date())}>
           Today
         </Button>
         <Button
           variant='ghost'
-          size='icon'
+          size='icon-sm'
           onClick={() => onDateChange(goToPreviousDate(effectiveView, date, weekStartsOn))}
           aria-label='Previous'>
           <ChevronLeft />
         </Button>
         <Button
           variant='ghost'
-          size='icon'
+          size='icon-sm'
           onClick={() => onDateChange(goToNextDate(effectiveView, date, weekStartsOn))}
           aria-label='Next'>
           <ChevronRight />
@@ -113,30 +159,37 @@ export function BoardToolbar({
           onChange={(value) => value && onDateChange(value)}
           mode='date'
           notClearable>
-          <Button variant='ghost' size='sm'>
+          {/* Fixed width — the label re-formats per view/day and must not shift its neighbors. */}
+          <Button variant='ghost' size='sm' className='w-44 justify-center truncate'>
             {dateLabel(effectiveView, date, weekStartsOn)}
           </Button>
         </DateTimePicker>
       </div>
 
-      {boardMode !== 'map' && (
-        <RadioTab value={view} onValueChange={(v) => onViewChange(v as BoardViewMode)} size='sm'>
-          <RadioTabItem value='day' size='sm' tooltip='Day'>
+      <Separator orientation='vertical' className='h-6' />
+
+      {!isMap && (
+        <RadioTab
+          value={view}
+          onValueChange={(v) => onViewChange(v as BoardViewMode)}
+          size='sm'
+          className={RADIO_TAB_CLASS}>
+          <RadioTabItem value='day' tooltip='Day' className={RADIO_TAB_ITEM_CLASS}>
             <CalendarDays />
             <span className='hidden sm:inline'>Day</span>
           </RadioTabItem>
-          <RadioTabItem value='week' size='sm' tooltip='Week'>
+          <RadioTabItem value='week' tooltip='Week' className={RADIO_TAB_ITEM_CLASS}>
             <CalendarRange />
             <span className='hidden sm:inline'>Week</span>
           </RadioTabItem>
-          <RadioTabItem value='month' size='sm' tooltip='Month'>
+          <RadioTabItem value='month' tooltip='Month' className={RADIO_TAB_ITEM_CLASS}>
             <CalendarDays />
             <span className='hidden sm:inline'>Month</span>
           </RadioTabItem>
         </RadioTab>
       )}
 
-      {(view === 'day' || boardMode === 'map') && (
+      {(view === 'day' || isMap) && (
         <WorkerFilterPopover
           workers={workers}
           selectedWorkerIds={selectedWorkerIds}
@@ -144,25 +197,22 @@ export function BoardToolbar({
         />
       )}
 
-      {boardMode === 'map' && (
+      {isMap && (
         <TagFilterPopover tags={tags} selectedTags={selectedTags} onChange={onSelectedTagsChange} />
       )}
 
-      <RadioTab
-        value={boardMode}
-        onValueChange={(v) => onBoardModeChange(v as BoardMode)}
-        size='sm'>
-        <RadioTabItem value='calendar' size='sm' tooltip='Board'>
-          <LayoutGrid />
-          <span className='hidden sm:inline'>Board</span>
-        </RadioTabItem>
-        <RadioTabItem value='map' size='sm' tooltip='Map'>
-          <MapIcon />
-          <span className='hidden sm:inline'>Map</span>
-        </RadioTabItem>
-      </RadioTab>
-
       <div className='flex-1' />
+
+      {isMap && (
+        <Tooltip content='Toggle routes panel'>
+          <Button
+            variant={plannerShowStops ? 'secondary' : 'ghost'}
+            size='icon-sm'
+            onClick={() => onPlannerShowStopsChange(!plannerShowStops)}>
+            <PanelRight />
+          </Button>
+        </Tooltip>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -5,16 +5,21 @@
 import { weekStartToIndex } from '@auxx/lib/availability/client'
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { CalendarDndProvider } from '@auxx/ui/components/event-calendar'
+import { type DockedPanelConfig, MainPageContent } from '@auxx/ui/components/main-page'
 import type { DragEndEvent } from '@dnd-kit/core'
 import { addMinutes } from 'date-fns'
 import { Lock } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
+import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { useDockStore } from '~/stores/dock-store'
 import { useRoutePlannerData } from '../route-planner/hooks/use-route-planner-data'
+import { PlannerDndProvider } from '../route-planner/planner-dnd-provider'
 import { RoutePlannerView } from '../route-planner/route-planner-view'
+import { RoutesDrawer } from '../route-planner/routes-drawer'
 import type { ExistingVisitForOverlap } from '../schedule-popover'
 import { BacklogRail } from './backlog-rail'
 import { BoardCalendarGrid } from './board-calendar-grid'
@@ -34,9 +39,13 @@ import { VisitChipContent } from './visit-chip-content'
  * color-coded; month is display-only. All writes funnel through `dispatch.scheduleVisit`
  * (drag/resize/rail-drop) or the chip popover's status/dispatch mutations.
  *
- * `boardMode === 'map'` (09-route-planner.md §A) swaps the calendar grid for `RoutePlannerView`
- * inside the same flex row — `CalendarDndProvider` stays mounted either way (the planner mounts
- * its OWN nested `DndContext`, so its draggables never reach the calendar's drop handlers).
+ * `boardMode === 'map'` (09-route-planner.md §A) swaps the calendar grid for `RoutePlannerView`.
+ * The two drag contexts are mode-exclusive: `PlannerDndProvider` mounts ABOVE `MainPageContent`
+ * (this component owns it, not the page — the docked Routes panel renders in `MainPageContent`'s
+ * frame and must stay inside the planner's `DndContext`), while `CalendarDndProvider` wraps only
+ * the calendar branch so its draggables bind to their own nearest context. The Routes stop lists
+ * follow the standard dock wiring (`schedule-page.tsx` pattern): docked → `dockedPanels` entry,
+ * not docked → overlay `RoutesDrawer`.
  */
 export function DispatchBoard() {
   const { hasAccess } = useFeatureFlags()
@@ -162,74 +171,137 @@ export function DispatchBoard() {
     []
   )
 
+  const isMap = data.boardMode === 'map'
+  const isDocked = useEffectiveDockState()
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+
+  // Standard docked-panel wiring (`schedule-page.tsx` pattern): when docked, the Routes drawer
+  // renders inside MainPageContent's panel frame; when not, it mounts below as the overlay.
+  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
+    if (!isMap || !isDocked || !data.plannerShowStops) return []
+    return [
+      {
+        key: 'planner-routes',
+        content: (
+          <RoutesDrawer
+            board={planner.board}
+            filters={planner.filters}
+            geometryByWorker={planner.geometryByWorker}
+            date={planner.window}
+            open
+            onOpenChange={data.setPlannerShowStops}
+          />
+        ),
+        width: dockedWidth,
+        onWidthChange: setDockedWidth,
+        minWidth: 320,
+        maxWidth: 800,
+      },
+    ]
+  }, [
+    isMap,
+    isDocked,
+    data.plannerShowStops,
+    data.setPlannerShowStops,
+    planner.board,
+    planner.filters,
+    planner.geometryByWorker,
+    planner.window,
+    dockedWidth,
+    setDockedWidth,
+  ])
+
   if (!hasAccess(FeatureKey.dispatch)) {
     return (
-      <EmptyState
-        icon={Lock}
-        title='Dispatch Not Available'
-        description='Upgrade your plan to use quoting and dispatch.'
-        button={<div className='h-12' />}
-      />
+      <MainPageContent>
+        <EmptyState
+          icon={Lock}
+          title='Dispatch Not Available'
+          description='Upgrade your plan to use quoting and dispatch.'
+          button={<div className='h-12' />}
+        />
+      </MainPageContent>
     )
   }
 
   return (
-    <div className='flex h-full flex-col overflow-hidden'>
-      <BoardToolbar
-        date={data.date}
-        onDateChange={data.setDate}
-        view={data.view}
-        onViewChange={data.setView}
-        weekStartsOn={weekStartsOn}
-        workers={data.allWorkers}
-        selectedWorkerIds={data.selectedWorkerIds}
-        onSelectedWorkerIdsChange={data.setSelectedWorkerIds}
-        showBacklog={data.showBacklog}
-        onShowBacklogChange={data.setShowBacklog}
-        boardMode={data.boardMode}
-        onBoardModeChange={data.setBoardMode}
-        tags={plannerTags}
-        selectedTags={planner.filters.tags}
-        onSelectedTagsChange={(tags) => planner.setFilters({ ...planner.filters, tags })}
-      />
-      <CalendarDndProvider<DispatchVisitEvent>
-        onEventDrop={canEdit ? handleEventDrop : undefined}
-        onDragEnd={canEdit ? handleForeignDragEnd : undefined}
-        renderEvent={renderDragGhost}>
-        <div className='flex flex-1 overflow-hidden'>
-          {data.boardMode === 'map' ? (
+    <PlannerDndProvider
+      board={planner.board}
+      window={planner.window}
+      geometryByWorker={planner.geometryByWorker}>
+      <MainPageContent dockedPanels={dockedPanels}>
+        <div className='flex h-full flex-col overflow-hidden'>
+          <BoardToolbar
+            date={data.date}
+            onDateChange={data.setDate}
+            view={data.view}
+            onViewChange={data.setView}
+            weekStartsOn={weekStartsOn}
+            workers={data.allWorkers}
+            selectedWorkerIds={data.selectedWorkerIds}
+            onSelectedWorkerIdsChange={data.setSelectedWorkerIds}
+            showBacklog={data.showBacklog}
+            onShowBacklogChange={data.setShowBacklog}
+            boardMode={data.boardMode}
+            onBoardModeChange={data.setBoardMode}
+            plannerShowBacklog={data.plannerShowBacklog}
+            onPlannerShowBacklogChange={data.setPlannerShowBacklog}
+            plannerShowStops={data.plannerShowStops}
+            onPlannerShowStopsChange={data.setPlannerShowStops}
+            tags={plannerTags}
+            selectedTags={planner.filters.tags}
+            onSelectedTagsChange={(tags) => planner.setFilters({ ...planner.filters, tags })}
+          />
+          {isMap ? (
             <RoutePlannerView
               board={planner.board}
               window={planner.window}
               geometryByWorker={planner.geometryByWorker}
               filters={planner.filters}
               isLoading={planner.isLoading}
+              showBacklog={data.plannerShowBacklog}
             />
           ) : (
-            <>
-              {data.showBacklog && <BacklogRail items={data.backlogEvents} canEdit={canEdit} />}
-              <BoardCalendarGrid
-                date={data.date}
-                onDateChange={data.setDate}
-                view={data.view}
-                weekStartsOn={weekStartsOn}
-                resources={data.resources}
-                backgroundEvents={backgroundEvents}
-                events={data.events}
-                overlappingIds={overlappingIds}
-                canEdit={canEdit}
-                mutations={mutations}
-                existingVisits={existingVisits}
-                activeVisitId={activeVisitId}
-                onActiveVisitChange={setActiveVisitId}
-                onRangeChange={data.handleRangeChange}
-                onEventResize={handleEventResize}
-                isNonWorkingDay={isNonWorkingDay}
-              />
-            </>
+            <CalendarDndProvider<DispatchVisitEvent>
+              onEventDrop={canEdit ? handleEventDrop : undefined}
+              onDragEnd={canEdit ? handleForeignDragEnd : undefined}
+              renderEvent={renderDragGhost}>
+              <div className='flex flex-1 overflow-hidden'>
+                {data.showBacklog && <BacklogRail items={data.backlogEvents} canEdit={canEdit} />}
+                <BoardCalendarGrid
+                  date={data.date}
+                  onDateChange={data.setDate}
+                  view={data.view}
+                  weekStartsOn={weekStartsOn}
+                  resources={data.resources}
+                  backgroundEvents={backgroundEvents}
+                  events={data.events}
+                  overlappingIds={overlappingIds}
+                  canEdit={canEdit}
+                  mutations={mutations}
+                  existingVisits={existingVisits}
+                  activeVisitId={activeVisitId}
+                  onActiveVisitChange={setActiveVisitId}
+                  onRangeChange={data.handleRangeChange}
+                  onEventResize={handleEventResize}
+                  isNonWorkingDay={isNonWorkingDay}
+                />
+              </div>
+            </CalendarDndProvider>
           )}
         </div>
-      </CalendarDndProvider>
-    </div>
+        {isMap && !isDocked && (
+          <RoutesDrawer
+            board={planner.board}
+            filters={planner.filters}
+            geometryByWorker={planner.geometryByWorker}
+            date={planner.window}
+            open={data.plannerShowStops}
+            onOpenChange={data.setPlannerShowStops}
+          />
+        )}
+      </MainPageContent>
+    </PlannerDndProvider>
   )
 }

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
@@ -40,6 +40,10 @@ export function useBoardData() {
   // deliberately NOT a `BoardViewMode` so the month-view debounce and `view === 'day'` gates stay
   // untouched. Entering map mode doesn't change `view`; the map always renders `date`'s single day.
   const [boardMode, setBoardMode] = useState<'calendar' | 'map'>('calendar')
+  // Map-mode panel visibility — lifted here (not `RoutePlannerView` local state) so the one
+  // board toolbar owns both toggles; the planner renders no header of its own.
+  const [plannerShowBacklog, setPlannerShowBacklog] = useState(true)
+  const [plannerShowStops, setPlannerShowStops] = useState(true)
 
   const rangeDebounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   useEffect(() => () => clearTimeout(rangeDebounceRef.current), [])
@@ -147,6 +151,10 @@ export function useBoardData() {
     setShowBacklog,
     boardMode,
     setBoardMode,
+    plannerShowBacklog,
+    setPlannerShowBacklog,
+    plannerShowStops,
+    setPlannerShowStops,
     resources,
     colorByUserId,
     workOrderById,

--- a/apps/web/src/components/dispatch/ui/board/utils.ts
+++ b/apps/web/src/components/dispatch/ui/board/utils.ts
@@ -6,6 +6,7 @@ import {
   addMonths,
   addWeeks,
   endOfWeek,
+  startOfDay,
   startOfMonth,
   startOfWeek,
   subDays,
@@ -26,6 +27,30 @@ export function nextVisitStatus(current: VisitStatus): VisitStatus | null {
   const index = VISIT_STATUS_FORWARD_ORDER.indexOf(current)
   if (index === -1 || index === VISIT_STATUS_FORWARD_ORDER.length - 1) return null
   return VISIT_STATUS_FORWARD_ORDER[index + 1]!
+}
+
+/**
+ * Where a visit's scheduled day sits relative to the viewer's local today. Execution
+ * actions (advance to en route / on site / complete) are day-of actions — they render
+ * only for 'today' and 'past' ('past' additionally gets an overdue hint). Day boundaries
+ * are always client-local, matching the board's client-computed day-window convention.
+ */
+export type VisitDayContext = 'unscheduled' | 'past' | 'today' | 'future'
+
+export function getVisitDayContext(
+  startTime: Date | null | undefined,
+  endTime?: Date | null
+): VisitDayContext {
+  if (!startTime) return 'unscheduled'
+  const todayStart = startOfDay(new Date())
+  if (startOfDay(startTime) > todayStart) return 'future'
+  if (startOfDay(endTime ?? startTime) < todayStart) return 'past'
+  return 'today'
+}
+
+/** Execution (status-advance) actions only make sense once the visit's day has arrived. */
+export function isExecutionReady(context: VisitDayContext): boolean {
+  return context === 'today' || context === 'past'
 }
 
 /** Fallback chip color when a worker has none set. */

--- a/apps/web/src/components/dispatch/ui/board/visit-actions-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/visit-actions-popover.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
-import { ArrowLeft, CalendarClock, ExternalLink, Send } from 'lucide-react'
+import { ArrowLeft, CalendarClock, ExternalLink, Send, TriangleAlert } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
 import { useConfirm } from '~/hooks/use-confirm'
@@ -12,7 +12,7 @@ import { SchedulePopoverContent } from '../schedule-popover'
 import type { useBoardMutations } from './hooks/use-board-mutations'
 import type { DispatchVisitEvent } from './types'
 import { VISIT_STATUS_LABELS } from './types'
-import { nextVisitStatus } from './utils'
+import { getVisitDayContext, isExecutionReady, nextVisitStatus } from './utils'
 
 interface VisitActionsPopoverContentProps {
   event: DispatchVisitEvent
@@ -39,7 +39,7 @@ export function VisitActionsPopoverContent({
 
   if (mode === 'reschedule') {
     return (
-      <div className='w-72'>
+      <div className='w-80'>
         <div className='flex items-center gap-1 border-b p-2'>
           <Button variant='ghost' size='icon' className='size-6' onClick={() => setMode('actions')}>
             <ArrowLeft />
@@ -61,6 +61,8 @@ export function VisitActionsPopoverContent({
 
   const next = nextVisitStatus(event.status)
   const canCancel = event.status !== 'canceled' && event.status !== 'done'
+  const dayContext = getVisitDayContext(event.start, event.end)
+  const isOverdue = dayContext === 'past' && event.status !== 'done' && event.status !== 'canceled'
 
   const handleDispatch = async () => {
     if (event.dispatchedAt) {
@@ -84,11 +86,16 @@ export function VisitActionsPopoverContent({
           </div>
         )}
         <div className='text-muted-foreground text-xs'>{VISIT_STATUS_LABELS[event.status]}</div>
+        {isOverdue && (
+          <div className='flex items-center gap-1 text-xs text-amber-600 dark:text-amber-500'>
+            <TriangleAlert className='size-3' /> Overdue — not completed
+          </div>
+        )}
       </div>
 
       {canEdit && (
         <div className='flex flex-col gap-1.5 pt-1'>
-          {next && (
+          {next && isExecutionReady(dayContext) && (
             <Button
               size='sm'
               variant='outline'

--- a/apps/web/src/components/dispatch/ui/board/worker-filter-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/worker-filter-popover.tsx
@@ -42,7 +42,7 @@ export function WorkerFilterPopover({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant='outline' size='sm'>
+        <Button variant='ghost' size='sm'>
           <Users /> {label}
         </Button>
       </PopoverTrigger>

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-card.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-card.tsx
@@ -9,12 +9,13 @@ import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { EmptySection } from '@auxx/ui/components/section'
 import { TreeRowButton } from '@auxx/ui/components/tree-row'
 import { format } from 'date-fns'
-import { CalendarClock, Send, User, XCircle } from 'lucide-react'
+import { CalendarClock, Send, TriangleAlert, User, XCircle } from 'lucide-react'
 import { getInitials } from '~/components/groups/utils/group-utils'
 import type { RecordId } from '~/components/resources'
 import { useActors } from '~/components/resources/hooks/use-actor'
 import { useConfirm } from '~/hooks/use-confirm'
 import { VISIT_STATUS_FORWARD_ORDER, VISIT_STATUS_LABELS, type VisitStatus } from '../board/types'
+import { getVisitDayContext, isExecutionReady } from '../board/utils'
 import { type ExistingVisitForOverlap, SchedulePopover } from '../schedule-popover'
 import type { JobVisit, UseJobVisitsResult } from './use-job-visits'
 
@@ -61,9 +62,16 @@ export function VisitCard({
   const canCancel = status !== 'canceled' && status !== 'done'
   const canDispatch = canEdit && Boolean(visit.assigneeUserId) && isScheduled
 
+  const start = visit.startTime ? new Date(visit.startTime) : null
+  const end = visit.endTime ? new Date(visit.endTime) : null
+  const dayContext = getVisitDayContext(start, end)
+  const isOverdue = dayContext === 'past' && status !== 'done' && status !== 'canceled'
+
   const handleStatusChange = (next: string) => {
     // Forward-only, mirroring the server transition rules — RadioTab fires for
-    // any item, so ignore clicks on the current/past steps.
+    // any item, so ignore clicks on the current/past steps. Future-dated visits
+    // are read-only (execution actions are day-of only).
+    if (!isExecutionReady(dayContext)) return
     if (VISIT_STATUS_FORWARD_ORDER.indexOf(next as VisitStatus) <= currentIndex) return
     mutations.setVisitStatus.mutate({ visitId: visit.id, status: next as VisitStatus })
   }
@@ -91,9 +99,6 @@ export function VisitCard({
     if (!confirmed) return
     mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
   }
-
-  const start = visit.startTime ? new Date(visit.startTime) : null
-  const end = visit.endTime ? new Date(visit.endTime) : null
 
   return (
     <div className='group/tree-row space-y-2.5 rounded-2xl border bg-primary-100/50 py-2.5 px-3'>
@@ -186,22 +191,34 @@ export function VisitCard({
       </div>
 
       {status !== 'canceled' && (
-        <RadioTab
-          value={status}
-          onValueChange={handleStatusChange}
-          size='sm'
-          radioGroupClassName='grid w-full grid-cols-4'
-          className='border border-primary-200 flex w-full'>
-          {VISIT_STATUS_FORWARD_ORDER.map((step, index) => (
-            <RadioTabItem
-              key={step}
-              value={step}
-              size='sm'
-              disabled={!canEdit || index < currentIndex || mutations.setVisitStatus.isPending}>
-              {VISIT_STATUS_LABELS[step]}
-            </RadioTabItem>
-          ))}
-        </RadioTab>
+        <>
+          {isOverdue && (
+            <div className='flex items-center gap-1 text-xs text-amber-600 dark:text-amber-500'>
+              <TriangleAlert className='size-3' /> Overdue — not completed
+            </div>
+          )}
+          <RadioTab
+            value={status}
+            onValueChange={handleStatusChange}
+            size='sm'
+            radioGroupClassName='grid w-full grid-cols-4'
+            className='border border-primary-200 flex w-full'>
+            {VISIT_STATUS_FORWARD_ORDER.map((step, index) => (
+              <RadioTabItem
+                key={step}
+                value={step}
+                size='sm'
+                disabled={
+                  !isExecutionReady(dayContext) ||
+                  !canEdit ||
+                  index < currentIndex ||
+                  mutations.setVisitStatus.isPending
+                }>
+                {VISIT_STATUS_LABELS[step]}
+              </RadioTabItem>
+            ))}
+          </RadioTab>
+        </>
       )}
 
       <ConfirmDialog />

--- a/apps/web/src/components/dispatch/ui/recurrence/recurrence-pattern-fields.tsx
+++ b/apps/web/src/components/dispatch/ui/recurrence/recurrence-pattern-fields.tsx
@@ -2,7 +2,9 @@
 'use client'
 
 import type { NthWeekdayOrdinal, RecurrencePattern, Weekday } from '@auxx/lib/recurrence/client'
+import { Button } from '@auxx/ui/components/button'
 import { Input } from '@auxx/ui/components/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { RadioGroup, RadioGroupItem } from '@auxx/ui/components/radio-group'
 import {
   Select,
@@ -12,6 +14,9 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { ToggleGroup, ToggleGroupItem } from '@auxx/ui/components/toggle-group'
+import { format, parseISO } from 'date-fns'
+import { useState } from 'react'
+import { DateTimePickerContent } from '~/components/pickers/date-time-picker'
 import { orderedWeekdays } from './recurrence-utils'
 
 const WEEKDAY_ABBREVIATIONS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
@@ -26,10 +31,88 @@ const NTH_OPTIONS: { value: string; label: string; nth: NthWeekdayOrdinal }[] = 
 
 type EndCondition = 'never' | 'until' | 'count'
 
-function endConditionOf(pattern: RecurrencePattern): EndCondition {
-  if (pattern.until) return 'until'
-  if (pattern.count) return 'count'
+function endConditionOf(value: Pick<RecurrencePattern, 'until' | 'count'>): EndCondition {
+  if (value.until) return 'until'
+  if (value.count) return 'count'
   return 'never'
+}
+
+export interface RecurrenceEndFieldsProps {
+  value: Pick<RecurrencePattern, 'until' | 'count'>
+  onChange: (next: { until?: string; count?: number }) => void
+  className?: string
+}
+
+/**
+ * The "Ends" radio group (never / on date / after N visits) — extracted so the schedule
+ * popover can render it once per Repeats selection (custom AND preset alike) rather than
+ * only inside the Custom editor. Mutual exclusivity (`until`/`count`) is enforced here.
+ */
+export function RecurrenceEndFields({ value, onChange, className }: RecurrenceEndFieldsProps) {
+  const endCondition = endConditionOf(value)
+  const [datePickerOpen, setDatePickerOpen] = useState(false)
+
+  const setEndCondition = (next: EndCondition) => {
+    if (next === 'never') onChange({ until: undefined, count: undefined })
+    else if (next === 'until')
+      onChange({ until: value.until ?? new Date().toISOString().slice(0, 10), count: undefined })
+    else onChange({ count: value.count ?? 1, until: undefined })
+  }
+
+  return (
+    <div className={className}>
+      <span className='text-xs text-muted-foreground'>Ends</span>
+      <RadioGroup
+        value={endCondition}
+        onValueChange={(v) => setEndCondition(v as EndCondition)}
+        className='gap-1.5'>
+        <label className='flex items-center gap-2 text-sm'>
+          <RadioGroupItem value='never' size='sm' /> Never
+        </label>
+        <div className='flex items-center gap-2 text-sm'>
+          <label className='flex items-center gap-2'>
+            <RadioGroupItem value='until' size='sm' /> On date
+          </label>
+          <Popover open={datePickerOpen} onOpenChange={setDatePickerOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant='outline'
+                size='sm'
+                disabled={endCondition !== 'until'}
+                className='h-7 w-36 justify-start font-normal'>
+                {value.until ? format(parseISO(value.until), 'PP') : 'Pick date'}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className='w-auto p-0' align='start'>
+              <DateTimePickerContent
+                mode='date'
+                noConfirm
+                value={value.until ? parseISO(value.until) : undefined}
+                onChange={(d) => {
+                  onChange({ until: d ? format(d, 'yyyy-MM-dd') : undefined, count: undefined })
+                  setDatePickerOpen(false)
+                }}
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
+        <label className='flex items-center gap-2 text-sm'>
+          <RadioGroupItem value='count' size='sm' /> After
+          <Input
+            type='number'
+            min={1}
+            disabled={endCondition !== 'count'}
+            value={value.count ?? 1}
+            onChange={(e) =>
+              onChange({ count: Number.parseInt(e.target.value, 10) || 1, until: undefined })
+            }
+            className='h-7 w-16'
+          />
+          visits
+        </label>
+      </RadioGroup>
+    </div>
+  )
 }
 
 export interface RecurrencePatternFieldsProps {
@@ -37,6 +120,12 @@ export interface RecurrencePatternFieldsProps {
   onChange: (next: RecurrencePattern) => void
   /** Org `weekStart` setting, as a date-fns index — controls weekday chip order. */
   weekStartIndex: 0 | 1 | 6
+  /**
+   * Omit the embedded "Ends" section — the schedule popover renders `RecurrenceEndFields`
+   * itself (shared across all Repeats modes, not just Custom). The billing schedule editor
+   * leaves this unset since it has no separate Ends control of its own.
+   */
+  hideEndCondition?: boolean
   className?: string
 }
 
@@ -51,10 +140,10 @@ export function RecurrencePatternFields({
   value,
   onChange,
   weekStartIndex,
+  hideEndCondition,
   className,
 }: RecurrencePatternFieldsProps) {
   const weekdayOrder = orderedWeekdays(weekStartIndex)
-  const endCondition = endConditionOf(value)
 
   const setFrequency = (frequency: RecurrencePattern['frequency']) => {
     if (frequency === value.frequency) return
@@ -93,17 +182,6 @@ export function RecurrencePatternFields({
         nthWeekday: value.nthWeekday ?? { nth: 1, weekday: 1 },
       })
     }
-  }
-
-  const setEndCondition = (next: EndCondition) => {
-    if (next === 'never') onChange({ ...value, until: undefined, count: undefined })
-    else if (next === 'until')
-      onChange({
-        ...value,
-        until: value.until ?? new Date().toISOString().slice(0, 10),
-        count: undefined,
-      })
-    else onChange({ ...value, count: value.count ?? 1, until: undefined })
   }
 
   return (
@@ -229,45 +307,15 @@ export function RecurrencePatternFields({
           </div>
         )}
 
-        <div className='flex flex-col gap-2 border-t pt-2'>
-          <span className='text-xs text-muted-foreground'>Ends</span>
-          <RadioGroup
-            value={endCondition}
-            onValueChange={(v) => setEndCondition(v as EndCondition)}
-            className='gap-1.5'>
-            <label className='flex items-center gap-2 text-sm'>
-              <RadioGroupItem value='never' size='sm' /> Never
-            </label>
-            <label className='flex items-center gap-2 text-sm'>
-              <RadioGroupItem value='until' size='sm' /> On date
-              <Input
-                type='date'
-                disabled={endCondition !== 'until'}
-                value={value.until ?? ''}
-                onChange={(e) => onChange({ ...value, until: e.target.value, count: undefined })}
-                className='h-7 w-36'
-              />
-            </label>
-            <label className='flex items-center gap-2 text-sm'>
-              <RadioGroupItem value='count' size='sm' /> After
-              <Input
-                type='number'
-                min={1}
-                disabled={endCondition !== 'count'}
-                value={value.count ?? 1}
-                onChange={(e) =>
-                  onChange({
-                    ...value,
-                    count: Number.parseInt(e.target.value, 10) || 1,
-                    until: undefined,
-                  })
-                }
-                className='h-7 w-16'
-              />
-              visits
-            </label>
-          </RadioGroup>
-        </div>
+        {!hideEndCondition && (
+          <div className='border-t pt-2'>
+            <RecurrenceEndFields
+              value={value}
+              onChange={(ends) => onChange({ ...value, until: ends.until, count: ends.count })}
+              className='flex flex-col gap-2'
+            />
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/dispatch/ui/recurrence/recurrence-utils.ts
+++ b/apps/web/src/components/dispatch/ui/recurrence/recurrence-utils.ts
@@ -17,12 +17,12 @@ export function scalarSetting(value: unknown): string | null {
 
 /**
  * Classify an existing `RecurrencePattern` back into a Repeats preset, or `'custom'` when it
- * doesn't match one of the three canned shapes (multi-weekday, nth-weekday, daily, or any end
- * condition all fall through to Custom).
+ * doesn't match one of the three canned shapes (multi-weekday, nth-weekday, or daily all fall
+ * through to Custom). End conditions (`until`/`count`) no longer force Custom — the schedule
+ * popover edits Ends independently of the preset via `RecurrenceEndFields`.
  */
 export function classifyRecurrencePreset(pattern: RecurrencePattern | null): RecurrencePreset {
   if (!pattern) return 'none'
-  if (pattern.until || pattern.count) return 'custom'
   if (pattern.frequency === 'weekly' && (pattern.weekdays?.length ?? 0) === 1) {
     if (pattern.interval === 1) return 'weekly'
     if (pattern.interval === 2) return 'biweekly'

--- a/apps/web/src/components/dispatch/ui/route-planner/backlog-pane.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/backlog-pane.tsx
@@ -30,7 +30,8 @@ function matchesTagFilter(
 }
 
 /**
- * Route planner left pane (design doc §E, seam contract's `BacklogPane`): two labeled groups —
+ * Route planner backlog (design doc §E, seam contract's `BacklogPane`) — floats over the map's
+ * left edge in `route-planner-view.tsx`'s translucent overlay wrapper: two labeled groups —
  * unscheduled work (`board.backlog`, `startTime: null`) and today's unassigned visits
  * (`board.visits` with `assigneeUserId: null`, matching the board's own "Unassigned" column
  * semantics). Both tag-filtered. Rows are `useDraggable` sources for the planner's own
@@ -60,7 +61,7 @@ export function BacklogPane({ board, filters, onFocusVisit }: BacklogPaneProps) 
   )
 
   return (
-    <div className='flex w-72 shrink-0 flex-col gap-3 overflow-y-auto border-r p-2'>
+    <div className='flex h-full w-72 flex-col gap-3 overflow-y-auto p-2'>
       <BacklogGroup
         title='Unscheduled'
         visits={unscheduled}

--- a/apps/web/src/components/dispatch/ui/route-planner/planner-dnd-provider.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/planner-dnd-provider.tsx
@@ -1,0 +1,51 @@
+// apps/web/src/components/dispatch/ui/route-planner/planner-dnd-provider.tsx
+
+'use client'
+
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { useRoutePlannerDragEnd } from './hooks/use-route-planner-mutations'
+import type { PlannerBoard, PlannerDayWindow, RouteGeometry } from './types'
+
+interface PlannerDndProviderProps {
+  board: PlannerBoard
+  window: PlannerDayWindow
+  geometryByWorker: Record<string, RouteGeometry | undefined>
+  children: React.ReactNode
+}
+
+/**
+ * The route planner's `DndContext` (backlog rows, stop-list sortables, worker-list droppables).
+ * Lives ABOVE `MainPageContent` in `dispatch-board.tsx` — NOT inside `RoutePlannerView` — so the
+ * Routes panel keeps its drag context in BOTH homes: the overlay `RoutesDrawer` (portaled, React
+ * context flows through portals) and the docked `MainPageContent` panel (a sibling of the board,
+ * unreachable from any provider mounted inside it). Calendar mode mounts `CalendarDndProvider`
+ * INSIDE this one, so calendar draggables still bind to their own nearest context.
+ */
+export function PlannerDndProvider({
+  board,
+  window,
+  geometryByWorker,
+  children,
+}: PlannerDndProviderProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor)
+  )
+
+  const handleDragEnd = useRoutePlannerDragEnd({ board, window, geometryByWorker })
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      {children}
+    </DndContext>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/route-planner/route-planner-view.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/route-planner-view.tsx
@@ -2,22 +2,9 @@
 
 'use client'
 
-import { Button } from '@auxx/ui/components/button'
-import {
-  closestCenter,
-  DndContext,
-  KeyboardSensor,
-  PointerSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core'
-import { PanelLeft, PanelRight } from 'lucide-react'
 import { useState } from 'react'
 import { BacklogPane } from './backlog-pane'
-import { useRoutePlannerDragEnd } from './hooks/use-route-planner-mutations'
 import { PlannerMap } from './planner-map'
-import { StopListPanel } from './stop-list-panel'
 import type { PlannerBoard, PlannerDayWindow, PlannerFilters, RouteGeometry } from './types'
 
 interface RoutePlannerViewProps {
@@ -26,23 +13,24 @@ interface RoutePlannerViewProps {
   geometryByWorker: Record<string, RouteGeometry | undefined>
   filters: PlannerFilters
   isLoading: boolean
+  /** Panel visibility lives in `use-board-data.ts` — the board toolbar owns the toggle. */
+  showBacklog: boolean
 }
 
 /**
- * Route planner three-pane layout (09-route-planner.md §A/§H): left `BacklogPane`, center
- * `PlannerMap`, right `StopListPanel` — all sharing this one `board`/`filters`/`geometryByWorker`
- * read (`use-route-planner-data.ts`, owned by `dispatch-board.tsx` since the toolbar's tag
- * filter needs the same distinct-tags list). Mounts its OWN `DndContext` — backlog rows and
- * stop-list rows register against it, independent of the board's `CalendarDndProvider` (which
- * stays mounted around this component in calendar↔map toggling, but plays no part here).
+ * Route planner map surface (09-route-planner.md §A/§E, restyled): a full-bleed `PlannerMap`
+ * with the `BacklogPane` floating over its left edge (translucent + `backdrop-blur-sm`) — no
+ * header of its own; panel toggles moved to `BoardToolbar`. The stop lists are NOT here: they
+ * live in `routes-drawer.tsx`, mounted by `dispatch-board.tsx` (overlay drawer or docked
+ * `MainPageContent` panel), and the shared drag context is `planner-dnd-provider.tsx`, mounted
+ * ABOVE `MainPageContent` so backlog↔stop-list drags reach both homes. All planner surfaces
+ * share the one `board`/`filters`/`geometryByWorker` read (`use-route-planner-data.ts`, owned
+ * by `dispatch-board.tsx` since the toolbar's tag filter needs the same distinct-tags list).
  *
  * `ApplyTimesDialog` isn't rendered here even though it's a 2B component that appears in this
  * tree — `StopListPanel`'s `WorkerStopSection` already owns a per-worker instance of it
  * (its "Apply times" button lives there per the design doc's own file split). A second,
  * view-level trigger would just be a confusing duplicate entry point to the same write.
- *
- * Panels collapse to an absolutely-positioned overlay under `md` so the map stays full-bleed on
- * phone widths; the toggle buttons stay reachable at every width.
  */
 export function RoutePlannerView({
   board,
@@ -50,18 +38,9 @@ export function RoutePlannerView({
   geometryByWorker,
   filters,
   isLoading,
+  showBacklog,
 }: RoutePlannerViewProps) {
-  const [showBacklog, setShowBacklog] = useState(true)
-  const [showStopList, setShowStopList] = useState(true)
   const [focusedVisitId, setFocusedVisitId] = useState<string | null>(null)
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
-    useSensor(KeyboardSensor)
-  )
-
-  const handleDragEnd = useRoutePlannerDragEnd({ board, window, geometryByWorker })
 
   // `focusedVisitId` is threaded to the map for a future pan/highlight-on-hover affordance
   // (design doc §E) — kept as local state here since 2B's `PinPopoverContent` reads its own
@@ -69,47 +48,25 @@ export function RoutePlannerView({
   void focusedVisitId
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-      <div className='flex h-full flex-1 flex-col overflow-hidden'>
-        <div className='flex items-center gap-2 border-b p-2'>
-          <Button variant='outline' size='sm' onClick={() => setShowBacklog((v) => !v)}>
-            <PanelLeft />
-          </Button>
-          <div className='flex-1' />
-          {isLoading && <span className='text-muted-foreground text-xs'>Loading…</span>}
-          <Button variant='outline' size='sm' onClick={() => setShowStopList((v) => !v)}>
-            <PanelRight />
-          </Button>
+    <div className='relative min-h-0 flex-1 overflow-hidden'>
+      <PlannerMap
+        board={board}
+        filters={filters}
+        geometryByWorker={geometryByWorker}
+        window={window}
+      />
+
+      {isLoading && (
+        <div className='bg-background/80 text-muted-foreground absolute top-2 left-1/2 z-20 -translate-x-1/2 rounded-md px-2 py-1 text-xs backdrop-blur-sm'>
+          Loading…
         </div>
+      )}
 
-        <div className='relative flex flex-1 overflow-hidden'>
-          {showBacklog && (
-            <div className='absolute inset-y-0 left-0 z-10 bg-background md:relative md:z-0'>
-              <BacklogPane board={board} filters={filters} onFocusVisit={setFocusedVisitId} />
-            </div>
-          )}
-
-          <div className='relative min-w-0 flex-1'>
-            <PlannerMap
-              board={board}
-              filters={filters}
-              geometryByWorker={geometryByWorker}
-              window={window}
-            />
-          </div>
-
-          {showStopList && (
-            <div className='absolute inset-y-0 right-0 z-10 bg-background md:relative md:z-0'>
-              <StopListPanel
-                board={board}
-                filters={filters}
-                geometryByWorker={geometryByWorker}
-                date={window}
-              />
-            </div>
-          )}
+      {showBacklog && (
+        <div className='bg-background/70 absolute inset-y-0 left-0 z-10 border-r backdrop-blur-sm'>
+          <BacklogPane board={board} filters={filters} onFocusVisit={setFocusedVisitId} />
         </div>
-      </div>
-    </DndContext>
+      )}
+    </div>
   )
 }

--- a/apps/web/src/components/dispatch/ui/route-planner/routes-drawer.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/routes-drawer.tsx
@@ -1,0 +1,68 @@
+// apps/web/src/components/dispatch/ui/route-planner/routes-drawer.tsx
+
+'use client'
+
+import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
+import { DrawerHeader } from '@auxx/ui/components/drawer'
+import { Route } from 'lucide-react'
+import { DockToggleButton } from '~/components/global/dock-toggle-button'
+import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockStore } from '~/stores/dock-store'
+import { StopListPanel } from './stop-list-panel'
+import type { PlannerBoard, PlannerDayWindow, PlannerFilters, RouteGeometry } from './types'
+
+interface RoutesDrawerProps {
+  board: PlannerBoard
+  filters: PlannerFilters
+  geometryByWorker: Record<string, RouteGeometry | undefined>
+  date: PlannerDayWindow
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * The route planner's stop lists in the standard drawer shell (`visit-drawer.tsx` pattern):
+ * `DockableDrawer` + `DrawerHeader` with the dock toggle, global docked width. Reads dock state
+ * itself; `dispatch-board.tsx` routes it into `MainPageContent`'s `dockedPanels` when docked, or
+ * renders it as the overlay drawer when not. `overlay={false}` — the map behind must stay
+ * pannable/clickable while the drawer is open (the default transparent overlay swallows every
+ * background pointer event). Must render inside `PlannerDndProvider` (both homes do).
+ */
+export function RoutesDrawer({
+  board,
+  filters,
+  geometryByWorker,
+  date,
+  open,
+  onOpenChange,
+}: RoutesDrawerProps) {
+  const isDocked = useEffectiveDockState()
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+
+  return (
+    <DockableDrawer
+      open={open}
+      onOpenChange={onOpenChange}
+      isDocked={isDocked}
+      width={dockedWidth}
+      onWidthChange={setDockedWidth}
+      minWidth={320}
+      maxWidth={800}
+      title='Routes'
+      overlay={false}>
+      <DrawerHeader
+        icon={<Route className='size-4 text-muted-foreground' />}
+        title='Routes'
+        onClose={() => onOpenChange(false)}
+        actions={<DockToggleButton />}
+      />
+      <StopListPanel
+        board={board}
+        filters={filters}
+        geometryByWorker={geometryByWorker}
+        date={date}
+      />
+    </DockableDrawer>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/route-planner/stop-list-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/stop-list-panel.tsx
@@ -47,7 +47,8 @@ interface StopListPanelProps {
 }
 
 /**
- * Route planner right pane (design doc §E, seam contract's `StopListPanel`): one collapsible
+ * Route planner stop lists (design doc §E, seam contract's `StopListPanel`) — hosted in
+ * `route-planner-view.tsx`'s right Drawer: one collapsible
  * section per visible worker, each a `@dnd-kit/sortable` `SortableContext` over that worker's
  * day stops (`routeOrder` asc, nulls last). Drag-reorder within a section writes `setRouteOrder`
  * optimistically; dragging a row (or a backlog-pane row) between sections is handled by
@@ -64,7 +65,7 @@ export function StopListPanel({ board, filters, geometryByWorker, date }: StopLi
   const workOrderById = new Map(board.workOrders.map((w) => [w.id, w]))
 
   return (
-    <div className='flex w-80 shrink-0 flex-col gap-2 overflow-y-auto border-l p-2'>
+    <div className='flex min-h-0 w-full flex-1 flex-col gap-2 overflow-y-auto p-2'>
       {visibleWorkers.map((worker) => (
         <WorkerStopSection
           key={worker.id}

--- a/apps/web/src/components/dispatch/ui/route-planner/tag-filter-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/tag-filter-popover.tsx
@@ -42,7 +42,7 @@ export function TagFilterPopover({ tags, selectedTags, onChange }: TagFilterPopo
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant='outline' size='sm'>
+        <Button variant='ghost' size='sm'>
           <Tag /> {label}
         </Button>
       </PopoverTrigger>

--- a/apps/web/src/components/dispatch/ui/schedule-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/schedule-popover.tsx
@@ -19,6 +19,7 @@ import {
 } from '@auxx/ui/components/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { RadioGroup, RadioGroupItem } from '@auxx/ui/components/radio-group'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import {
   Select,
   SelectContent,
@@ -39,7 +40,10 @@ import type { RecordId } from '~/components/resources'
 import { useActors, useAvailableActors } from '~/components/resources/hooks/use-actor'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
-import { RecurrencePatternFields } from './recurrence/recurrence-pattern-fields'
+import {
+  RecurrenceEndFields,
+  RecurrencePatternFields,
+} from './recurrence/recurrence-pattern-fields'
 import {
   buildPresetPattern,
   classifyRecurrencePreset as classifyPreset,
@@ -153,6 +157,9 @@ function ScheduleContent({
   const [customPattern, setCustomPattern] = useState<RecurrencePattern>(
     defaultCustomPattern(initialStartTime ?? undefined)
   )
+  // Ends (until/count) live independently of the preset/custom pattern now — the schedule
+  // popover edits them via one `RecurrenceEndFields` regardless of Repeats mode.
+  const [ends, setEnds] = useState<{ until?: string; count?: number }>({})
   const [repeatsTouched, setRepeatsTouched] = useState(false)
   const [chooserScope, setChooserScope] = useState<'this' | 'following' | 'all'>('this')
   const initializedFromRuleRef = useRef(false)
@@ -167,15 +174,16 @@ function ScheduleContent({
     const pattern = recurrenceQuery.data.pattern as unknown as RecurrencePattern
     const preset = classifyPreset(pattern)
     setRepeatMode(preset)
-    if (preset === 'custom') setCustomPattern(pattern)
+    setEnds({ until: pattern.until, count: pattern.count })
+    if (preset === 'custom') setCustomPattern({ ...pattern, until: undefined, count: undefined })
   }, [recurrenceQuery.data, recurrenceQuery.isLoading])
 
   const effectivePattern = useMemo((): RecurrencePattern | null => {
     if (repeatMode === 'none') return null
-    if (repeatMode === 'custom') return customPattern
+    if (repeatMode === 'custom') return { ...customPattern, until: ends.until, count: ends.count }
     if (!startTime) return null
-    return buildPresetPattern(repeatMode, startTime)
-  }, [repeatMode, customPattern, startTime])
+    return { ...buildPresetPattern(repeatMode, startTime), until: ends.until, count: ends.count }
+  }, [repeatMode, customPattern, startTime, ends])
 
   const recurrenceSummary = useMemo(() => {
     if (!effectivePattern) return null
@@ -195,7 +203,9 @@ function ScheduleContent({
           : repeatMode !== 'none' && startTime
             ? buildPresetPattern(repeatMode, startTime)
             : defaultCustomPattern(startTime)
-      setCustomPattern(seed)
+      // Ends live in the separate `ends` state now — strip them from the seed so they aren't
+      // duplicated inside `customPattern`.
+      setCustomPattern({ ...seed, until: undefined, count: undefined })
     }
     setRepeatMode(nextMode)
   }
@@ -342,7 +352,7 @@ function ScheduleContent({
 
   if (current?.id === 'assignee') {
     return (
-      <div className={cn('w-72', className)}>
+      <div className={cn('w-80', className)}>
         <CommandBreadcrumb rootLabel='Schedule' />
         <ActorPickerContent
           value={assigneeActorId ? [assigneeActorId] : []}
@@ -362,7 +372,7 @@ function ScheduleContent({
 
   if (current?.id === 'datetime') {
     return (
-      <div className={cn('w-auto', className)}>
+      <div className={cn('w-80', className)}>
         <CommandBreadcrumb rootLabel='Schedule' />
         <DateTimePickerContent
           value={startTime}
@@ -371,6 +381,7 @@ function ScheduleContent({
             pop()
           }}
           mode='datetime'
+          className='w-full min-w-0'
         />
       </div>
     )
@@ -378,7 +389,7 @@ function ScheduleContent({
 
   if (current?.id === 'endtime') {
     return (
-      <div className={cn('w-auto', className)}>
+      <div className={cn('w-80', className)}>
         <CommandBreadcrumb rootLabel='Schedule' />
         <DateTimePickerContent
           value={customEndTime ?? endTime}
@@ -388,160 +399,181 @@ function ScheduleContent({
             pop()
           }}
           mode='time'
+          className='w-full min-w-0'
         />
       </div>
     )
   }
 
   return (
-    <div className={cn('w-72 space-y-3 p-3', className)}>
-      <Button
-        variant='outline'
-        size='sm'
-        className='w-full justify-start'
-        onClick={() => push({ id: 'assignee', label: 'Assignee' })}>
-        {assigneeActor ? (
-          <>
-            <Avatar className='size-4'>
-              <AvatarImage src={assigneeActor.avatarUrl ?? undefined} />
-              <AvatarFallback className='text-[9px]'>
-                {getInitials(assigneeActor.name)}
-              </AvatarFallback>
-            </Avatar>
-            {assigneeActor.name}
-          </>
-        ) : (
-          <>
-            <User /> Unassigned
-          </>
-        )}
-      </Button>
+    <div className={cn('flex min-h-0 w-80 flex-col', className)}>
+      <ScrollArea className='min-h-0 flex-1'>
+        <div className='space-y-3 p-3'>
+          <Button
+            variant='outline'
+            size='sm'
+            className='w-full justify-start'
+            onClick={() => push({ id: 'assignee', label: 'Assignee' })}>
+            {assigneeActor ? (
+              <>
+                <Avatar className='size-4'>
+                  <AvatarImage src={assigneeActor.avatarUrl ?? undefined} />
+                  <AvatarFallback className='text-[9px]'>
+                    {getInitials(assigneeActor.name)}
+                  </AvatarFallback>
+                </Avatar>
+                {assigneeActor.name}
+              </>
+            ) : (
+              <>
+                <User /> Unassigned
+              </>
+            )}
+          </Button>
 
-      <Button
-        variant='outline'
-        size='sm'
-        className='w-full justify-start'
-        onClick={() => push({ id: 'datetime', label: 'Date & time' })}>
-        <Calendar />
-        {startTime ? format(startTime, 'PPP p') : 'Select date & time'}
-      </Button>
+          <Button
+            variant='outline'
+            size='sm'
+            className='w-full justify-start'
+            onClick={() => push({ id: 'datetime', label: 'Date & time' })}>
+            <Calendar />
+            {startTime ? format(startTime, 'PPP p') : 'Select date & time'}
+          </Button>
 
-      <div className='flex gap-2'>
-        <Select
-          value={duration}
-          onValueChange={(v) => {
-            // Custom drills into the end-time page — the duration only flips to
-            // 'custom' once a time is actually picked there.
-            if (v === 'custom') {
-              push({ id: 'endtime', label: 'End time' })
-              return
-            }
-            setDuration(v as DurationValue)
-          }}>
-          <SelectTrigger size='sm' className='flex-1 min-w-0'>
-            <SelectValue placeholder='Duration' />
-          </SelectTrigger>
-          <SelectContent>
-            {DURATION_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          <div className='flex gap-2'>
+            <Select
+              value={duration}
+              onValueChange={(v) => {
+                // Custom drills into the end-time page — the duration only flips to
+                // 'custom' once a time is actually picked there.
+                if (v === 'custom') {
+                  push({ id: 'endtime', label: 'End time' })
+                  return
+                }
+                setDuration(v as DurationValue)
+              }}>
+              <SelectTrigger size='sm' className='flex-1 min-w-0'>
+                <SelectValue placeholder='Duration' />
+              </SelectTrigger>
+              <SelectContent>
+                {DURATION_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
 
-        <Button
-          variant='outline'
-          size='sm'
-          className='flex-1 min-w-0 justify-start'
-          onClick={() => push({ id: 'endtime', label: 'End time' })}>
-          <Clock />
-          {endTime ? format(endTime, 'p') : 'End time'}
-        </Button>
-      </div>
+            <Button
+              variant='outline'
+              size='sm'
+              className='flex-1 min-w-0 justify-start'
+              onClick={() => push({ id: 'endtime', label: 'End time' })}>
+              <Clock />
+              {endTime ? format(endTime, 'p') : 'End time'}
+            </Button>
+          </div>
 
-      {workOrderRecordId && (
-        <div className='space-y-2'>
-          <Select
-            value={repeatMode}
-            onValueChange={(v) => handleRepeatModeChange(v as RecurrencePreset)}>
-            <SelectTrigger size='sm' className='w-full'>
-              <SelectValue placeholder='Repeats' />
-            </SelectTrigger>
-            <SelectContent>
-              {/* Selecting None on an existing rule is out of scope for v1 (06 §6) — ending a
-                  series happens via the Pause/End engagement actions, not this control. */}
-              {!hasExistingRule && <SelectItem value='none'>Does not repeat</SelectItem>}
-              <SelectItem value='weekly'>Weekly</SelectItem>
-              <SelectItem value='biweekly'>Every 2 weeks</SelectItem>
-              <SelectItem value='monthly'>Monthly</SelectItem>
-              <SelectItem value='custom'>Custom...</SelectItem>
-            </SelectContent>
-          </Select>
+          {workOrderRecordId && (
+            <div className='space-y-2'>
+              <Select
+                value={repeatMode}
+                onValueChange={(v) => handleRepeatModeChange(v as RecurrencePreset)}>
+                <SelectTrigger size='sm' className='w-full'>
+                  <SelectValue placeholder='Repeats' />
+                </SelectTrigger>
+                <SelectContent>
+                  {/* Selecting None on an existing rule is out of scope for v1 (06 §6) — ending
+                      a series happens via the Pause/End engagement actions, not this control. */}
+                  {!hasExistingRule && <SelectItem value='none'>Does not repeat</SelectItem>}
+                  <SelectItem value='weekly'>Weekly</SelectItem>
+                  <SelectItem value='biweekly'>Every 2 weeks</SelectItem>
+                  <SelectItem value='monthly'>Monthly</SelectItem>
+                  <SelectItem value='custom'>Custom...</SelectItem>
+                </SelectContent>
+              </Select>
 
-          {recurrenceSummary && (
-            <p className='px-0.5 text-xs text-muted-foreground'>{recurrenceSummary}</p>
-          )}
+              {repeatMode === 'custom' && (
+                <RecurrencePatternFields
+                  value={customPattern}
+                  onChange={setCustomPattern}
+                  weekStartIndex={weekStartIndex}
+                  hideEndCondition
+                />
+              )}
 
-          {repeatMode === 'custom' && (
-            <RecurrencePatternFields
-              value={customPattern}
-              onChange={setCustomPattern}
-              weekStartIndex={weekStartIndex}
-            />
-          )}
-
-          {wantsRecurrenceWrite && !patternValid && (
-            <p className='px-0.5 text-xs text-destructive'>
-              Pick at least one weekday, or fix the end condition, to save this pattern.
-            </p>
-          )}
-        </div>
-      )}
-
-      {showChooser && (
-        <div className='space-y-1.5 rounded-md border p-2'>
-          <div className='text-xs font-medium text-muted-foreground'>Apply to</div>
-          <RadioGroup
-            value={chooserScope}
-            onValueChange={(v) => setChooserScope(v as 'this' | 'following' | 'all')}
-            className='gap-1.5'>
-            <label className='flex items-center gap-2 text-sm'>
-              <RadioGroupItem value='this' size='sm' /> This visit
-            </label>
-            <label className='flex items-center gap-2 text-sm'>
-              <RadioGroupItem value='following' size='sm' /> This and following
-            </label>
-            <label className='flex items-center gap-2 text-sm'>
-              <RadioGroupItem value='all' size='sm' /> All visits
-            </label>
-          </RadioGroup>
-        </div>
-      )}
-
-      {hints.length > 0 && (
-        <div className='space-y-1 rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-400'>
-          {hints.map((hint) => (
-            <div key={hint} className='flex items-center gap-1.5'>
-              <AlertTriangle className='size-3 shrink-0' />
-              {hint}
+              {repeatMode !== 'none' && (
+                <div className='rounded-md border p-2'>
+                  <RecurrenceEndFields
+                    value={ends}
+                    onChange={(next) => {
+                      setRepeatsTouched(true)
+                      setEnds(next)
+                    }}
+                    className='flex flex-col gap-2'
+                  />
+                </div>
+              )}
             </div>
-          ))}
-        </div>
-      )}
+          )}
 
-      <div className='flex items-center justify-between gap-2 pt-1'>
-        <Button
-          variant='ghost'
-          size='sm'
-          onClick={handleUnschedule}
-          loading={unscheduleVisit.isPending}
-          disabled={!initialStartTime}>
-          Unschedule
-        </Button>
-        <Button size='sm' onClick={handleSave} loading={isSaving} disabled={!canSave}>
-          Save
-        </Button>
+          {showChooser && (
+            <div className='space-y-1.5 rounded-md border p-2'>
+              <div className='text-xs font-medium text-muted-foreground'>Apply to</div>
+              <RadioGroup
+                value={chooserScope}
+                onValueChange={(v) => setChooserScope(v as 'this' | 'following' | 'all')}
+                className='gap-1.5'>
+                <label className='flex items-center gap-2 text-sm'>
+                  <RadioGroupItem value='this' size='sm' /> This visit
+                </label>
+                <label className='flex items-center gap-2 text-sm'>
+                  <RadioGroupItem value='following' size='sm' /> This and following
+                </label>
+                <label className='flex items-center gap-2 text-sm'>
+                  <RadioGroupItem value='all' size='sm' /> All visits
+                </label>
+              </RadioGroup>
+            </div>
+          )}
+
+          {hints.length > 0 && (
+            <div className='space-y-1 rounded-md border border-amber-500/30 bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-400'>
+              {hints.map((hint) => (
+                <div key={hint} className='flex items-center gap-1.5'>
+                  <AlertTriangle className='size-3 shrink-0' />
+                  {hint}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+
+      <div className='space-y-2 border-t p-3'>
+        {recurrenceSummary && (
+          <p className='px-0.5 text-xs text-muted-foreground'>{recurrenceSummary}</p>
+        )}
+
+        {wantsRecurrenceWrite && !patternValid && (
+          <p className='px-0.5 text-xs text-destructive'>
+            Pick at least one weekday, or fix the end condition, to save this pattern.
+          </p>
+        )}
+
+        <div className='flex items-center justify-between gap-2'>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={handleUnschedule}
+            loading={unscheduleVisit.isPending}
+            disabled={!initialStartTime}>
+            Unschedule
+          </Button>
+          <Button size='sm' onClick={handleSave} loading={isSaving} disabled={!canSave}>
+            Save
+          </Button>
+        </div>
       </div>
     </div>
   )
@@ -567,7 +599,7 @@ export function SchedulePopover({
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      <PopoverContent className='p-0' align='start'>
+      <PopoverContent className='w-80 p-0' align='start'>
         <SchedulePopoverContent {...contentProps} />
       </PopoverContent>
     </Popover>

--- a/apps/web/src/components/schedule/ui/visit-detail-content.tsx
+++ b/apps/web/src/components/schedule/ui/visit-detail-content.tsx
@@ -101,6 +101,8 @@ export function VisitDetailContent({ visitId }: VisitDetailContentProps) {
                   visitId={visit.id}
                   status={visit.status}
                   hasContact={!!visit.workOrder.contactDisplayName}
+                  startTime={visit.startTime}
+                  endTime={visit.endTime}
                 />
               </div>
             </Section>

--- a/apps/web/src/components/schedule/ui/visit-status-button.tsx
+++ b/apps/web/src/components/schedule/ui/visit-status-button.tsx
@@ -17,8 +17,10 @@ import {
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { toastError } from '@auxx/ui/components/toast'
-import { MoreVertical } from 'lucide-react'
+import { endOfDay, format } from 'date-fns'
+import { Clock, MoreVertical } from 'lucide-react'
 import { useState } from 'react'
+import { getVisitDayContext } from '~/components/dispatch/ui/board/utils'
 import { api } from '~/trpc/react'
 import { VisitCloseChooser } from './visit-close-chooser'
 
@@ -59,14 +61,28 @@ interface VisitStatusButtonProps {
   /** Whether the work order has a customer attached — threaded to the close chooser's
    * "Close job & invoice" disabled state (08 §3). */
   hasContact: boolean
+  /** Scheduled window — used to gate day-of advance actions (`getVisitDayContext`). A
+   * future-dated visit shows a muted "Starts <date>" chip instead of the advance button. */
+  startTime: Date | null
+  endTime?: Date | null
 }
 
 /**
  * Advancing status button + overflow ("Undo last") + the close chooser it opens on
  * "Complete…". Manages the chooser's open state internally so callers only need the visit's
  * `id`/`status` (+ `hasContact`, threaded through to the chooser).
+ *
+ * "Start travel"/"Arrived" are day-of actions: for a visit scheduled on a future day, the
+ * advance button (and the undo dropdown) are replaced by a muted, non-interactive "Starts …"
+ * chip — the server enforces the same rule via `advanceMyVisit`'s `clientDayEnd` guard.
  */
-export function VisitStatusButton({ visitId, status, hasContact }: VisitStatusButtonProps) {
+export function VisitStatusButton({
+  visitId,
+  status,
+  hasContact,
+  startTime,
+  endTime,
+}: VisitStatusButtonProps) {
   const [chooserOpen, setChooserOpen] = useState(false)
   const utils = api.useUtils()
 
@@ -86,15 +102,30 @@ export function VisitStatusButton({ visitId, status, hasContact }: VisitStatusBu
     )
   }
 
+  const dayContext = getVisitDayContext(startTime, endTime)
   const step = ADVANCE_STEP[status]
   const undoTo = UNDO_STEP[status]
+
+  if (dayContext === 'future') {
+    return (
+      <div className='flex items-center gap-2'>
+        <Badge variant='zinc' size='sm'>
+          <Clock />
+          Starts {format(startTime as Date, 'EEE, MMM d')}
+        </Badge>
+        {/* M3 "location sharing active" indicator lands here (02-tracking-pipeline.md §1). */}
+      </div>
+    )
+  }
 
   return (
     <div className='flex items-center gap-2'>
       {step ? (
         <Button
           className='flex-1'
-          onClick={() => advance.mutate({ visitId, to: step.to })}
+          onClick={() =>
+            advance.mutate({ visitId, to: step.to, clientDayEnd: endOfDay(new Date()) })
+          }
           loading={advance.isPending}
           loadingText='Updating…'>
           {step.label}
@@ -116,7 +147,9 @@ export function VisitStatusButton({ visitId, status, hasContact }: VisitStatusBu
           </DropdownMenuTrigger>
           <DropdownMenuContent align='end'>
             <DropdownMenuItem
-              onClick={() => advance.mutate({ visitId, to: undoTo })}
+              onClick={() =>
+                advance.mutate({ visitId, to: undoTo, clientDayEnd: endOfDay(new Date()) })
+              }
               disabled={advance.isPending}>
               Undo last
             </DropdownMenuItem>

--- a/apps/web/src/server/api/routers/dispatch.ts
+++ b/apps/web/src/server/api/routers/dispatch.ts
@@ -335,13 +335,20 @@ export const dispatchRouter = createTRPCRouter({
       })
     }),
   advanceMyVisit: dispatchProcedure
-    .input(z.object({ visitId: z.string(), to: z.enum(['scheduled', 'en_route', 'on_site']) }))
+    .input(
+      z.object({
+        visitId: z.string(),
+        to: z.enum(['scheduled', 'en_route', 'on_site']),
+        clientDayEnd: z.date(),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       return advanceMyVisit({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         visitId: input.visitId,
         to: input.to,
+        clientDayEnd: input.clientDayEnd,
       })
     }),
   closeMyVisit: dispatchProcedure

--- a/apps/worker/scripts/run-entity-migration-039.ts
+++ b/apps/worker/scripts/run-entity-migration-039.ts
@@ -1,0 +1,32 @@
+// apps/worker/scripts/run-entity-migration-039.ts
+/**
+ * One-off runner for entity migration 039 (`work_order.tags` field — route planner build
+ * contract item 10, plans/dispatch/09-route-planner.md §B) across all orgs. Runs ONLY 039 —
+ * deliberately not runAllEntityMigrations, so pending migrations from parallel work stay
+ * untouched. Idempotent — safe to re-run to confirm alreadyUpToDate.
+ *
+ * Run (from repo root) under the worker runtime so the @auxx/lib import chain
+ * resolves its native ESM deps:
+ *   node --conditions source --env-file .env --import tsx/esm \
+ *     apps/worker/scripts/run-entity-migration-039.ts
+ */
+
+import { database } from '@auxx/database'
+import {
+  ALL_ENTITY_MIGRATIONS,
+  runEntityMigrationForAllOrgs,
+} from '@auxx/lib/seed/entity-migrations'
+
+async function main() {
+  const migration = ALL_ENTITY_MIGRATIONS.find((m) => m.id === '039-work-order-tags')
+  if (!migration) throw new Error('Migration 039 not found in registry')
+
+  await runEntityMigrationForAllOrgs(database, migration)
+  console.log('done')
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/worker/scripts/verify-dispatch-route-planner.ts
+++ b/apps/worker/scripts/verify-dispatch-route-planner.ts
@@ -22,10 +22,14 @@
  * directly, since those aren't exposed by any lib mutation) go through
  * `database.$client.query('UPDATE ...', [...])` (the WS1 raw-delete precedent).
  *
- * MAPBOX_ACCESS_TOKEN / MAPTILER_API_KEY are asserted unset in the test env (confirmed against
- * `.env`) so the fallback/no-key paths are exercised for real, not simulated; `geocoder.ts`'s
- * `setGeocodeFetcherForTesting` test seam stubs the MapTiler response for the geocode-hook
- * sub-tests, restored to `undefined` in a `finally`.
+ * MAPBOX_ACCESS_TOKEN / MAPTILER_API_KEY are force-deleted from `process.env` at the top of this
+ * file, before any lib call reads them, so the fallback/no-key paths are exercised for real, not
+ * simulated — both `geocoder.ts`'s `geocode()` and `directions.ts`'s `fetchMapboxLegs()` read
+ * their key/token at CALL time (no top-level `process.env` caching), so a delete at any point
+ * before the first call takes effect. This is necessary because a MapTiler *test* key has since
+ * been added to the root `.env` for other features; `geocoder.ts`'s `setGeocodeFetcherForTesting`
+ * test seam stubs the MapTiler response for the geocode-hook sub-tests, restored to `undefined`
+ * in a `finally`.
  *
  * BUG FOUND + FIXED (documented in the verify report): `autoGenerateWorkOrderNumber`
  * (packages/lib/src/resources/hooks/work-order-hooks.ts) appended `work_order_number` to the
@@ -64,6 +68,12 @@ import { setGeocodeFetcherForTesting } from '@auxx/lib/geocoding'
 import { UnifiedCrudHandler } from '@auxx/lib/resources'
 import { migration039WorkOrderTags } from '@auxx/lib/seed/entity-migrations/migrations/039-work-order-tags'
 import { getRedisData } from '@auxx/redis'
+
+// Force-unset before any lib import/call reads them (both are read at call time — see file
+// header) — a MapTiler TEST key has since been added to the root `.env` for other features, but
+// this script needs the real no-key/fallback paths, not the keyed path.
+delete process.env.MAPTILER_API_KEY
+delete process.env.MAPBOX_ACCESS_TOKEN
 
 let pass = 0
 let fail = 0

--- a/apps/worker/scripts/verify-dispatch-ws1.ts
+++ b/apps/worker/scripts/verify-dispatch-ws1.ts
@@ -31,6 +31,14 @@
  * precedent) — reads use the `database.query.*` relational API (operators arrive as callback
  * args, no import needed) and the two raw-table deletes use `database.$client.query(...)`.
  *
+ * `advanceMyVisit` now requires `clientDayEnd` (the day-gate guard added alongside the visit
+ * detail page's future-dated "Starts …" chip — forward advances on a visit scheduled after
+ * `clientDayEnd` are rejected; undo is exempt). Every pre-existing `advanceMyVisit` call below
+ * passes `FAR_FUTURE` so none of them are affected by the new guard — the visits those calls
+ * exercise are either unscheduled (`startTime` null, guard is a no-op regardless of
+ * `clientDayEnd`) or not testing the date gate. Section 8 below is the dedicated coverage for
+ * the guard itself, using a real `endOfToday()` boundary.
+ *
  * Run (from repo root) under the worker runtime:
  *   cd apps/worker && npx dotenv -e ../../.env -- node --conditions source --import tsx/esm \
  *     scripts/verify-dispatch-ws1.ts
@@ -50,6 +58,18 @@ import {
 import { BadRequestError, ForbiddenError, NotFoundError } from '@auxx/lib/errors'
 import { getMyMeeting, listMyMeetings } from '@auxx/lib/recording/calendar'
 import { UnifiedCrudHandler } from '@auxx/lib/resources'
+
+/** `clientDayEnd` for `advanceMyVisit` calls that aren't exercising the day-gate guard (section
+ * 8) — a date far enough out that it never itself trips the "scheduled for a future day" check. */
+const FAR_FUTURE = new Date('2099-01-01T00:00:00Z')
+
+/** The worker's client-local end-of-today — the real boundary the day-gate guard compares
+ * `visit.startTime` against (section 8). */
+function endOfToday(): Date {
+  const d = new Date()
+  d.setHours(23, 59, 59, 999)
+  return d
+}
 
 let pass = 0
 let fail = 0
@@ -231,7 +251,13 @@ async function main() {
     )
 
     const advanceForbidden = await expectThrow(() =>
-      advanceMyVisit({ organizationId, userId: otherUserId, visitId: v1.id, to: 'en_route' })
+      advanceMyVisit({
+        organizationId,
+        userId: otherUserId,
+        visitId: v1.id,
+        to: 'en_route',
+        clientDayEnd: FAR_FUTURE,
+      })
     )
     check(
       'advanceMyVisit throws ForbiddenError for a visit assigned to a different user',
@@ -262,6 +288,7 @@ async function main() {
         userId,
         visitId: 'nonexistent-visit-id-000000',
         to: 'en_route',
+        clientDayEnd: FAR_FUTURE,
       })
     )
     check(
@@ -290,6 +317,7 @@ async function main() {
       userId,
       visitId: v1.id,
       to: 'en_route',
+      clientDayEnd: FAR_FUTURE,
     })
     check(
       'advanceMyVisit succeeds for the owner (scheduled->en_route)',
@@ -500,15 +528,33 @@ async function main() {
     await assignVisit({ organizationId, userId, visitId: v4.id, assigneeUserId: userId })
 
     const rejectOnSite = await expectThrow(() =>
-      advanceMyVisit({ organizationId, userId, visitId: v4.id, to: 'on_site' })
+      advanceMyVisit({
+        organizationId,
+        userId,
+        visitId: v4.id,
+        to: 'on_site',
+        clientDayEnd: FAR_FUTURE,
+      })
     )
     check('reject: scheduled->on_site', rejectOnSite instanceof BadRequestError, rejectOnSite)
     const rejectDone = await expectThrow(() =>
-      advanceMyVisit({ organizationId, userId, visitId: v4.id, to: 'done' })
+      advanceMyVisit({
+        organizationId,
+        userId,
+        visitId: v4.id,
+        to: 'done',
+        clientDayEnd: FAR_FUTURE,
+      })
     )
     check('reject: scheduled->done', rejectDone instanceof BadRequestError, rejectDone)
 
-    const step1 = await advanceMyVisit({ organizationId, userId, visitId: v4.id, to: 'en_route' })
+    const step1 = await advanceMyVisit({
+      organizationId,
+      userId,
+      visitId: v4.id,
+      to: 'en_route',
+      clientDayEnd: FAR_FUTURE,
+    })
     check('allow: scheduled->en_route', step1.status === 'en_route', step1.status)
     check(
       'allow: scheduled->en_route delegates to setVisitStatus (WO rolls up to en_route)',
@@ -516,29 +562,59 @@ async function main() {
     )
 
     const rejectEnRouteDone = await expectThrow(() =>
-      advanceMyVisit({ organizationId, userId, visitId: v4.id, to: 'done' })
+      advanceMyVisit({
+        organizationId,
+        userId,
+        visitId: v4.id,
+        to: 'done',
+        clientDayEnd: FAR_FUTURE,
+      })
     )
     check('reject: en_route->done', rejectEnRouteDone instanceof BadRequestError, rejectEnRouteDone)
 
-    const step2 = await advanceMyVisit({ organizationId, userId, visitId: v4.id, to: 'on_site' })
+    const step2 = await advanceMyVisit({
+      organizationId,
+      userId,
+      visitId: v4.id,
+      to: 'on_site',
+      clientDayEnd: FAR_FUTURE,
+    })
     check('allow: en_route->on_site', step2.status === 'on_site', step2.status)
     check(
       'allow: en_route->on_site delegates to setVisitStatus (WO rolls up to on_site)',
       (await woStatus(organizationId, wo4.instance.id)) === 'on_site'
     )
 
-    const undo1 = await advanceMyVisit({ organizationId, userId, visitId: v4.id, to: 'en_route' })
+    const undo1 = await advanceMyVisit({
+      organizationId,
+      userId,
+      visitId: v4.id,
+      to: 'en_route',
+      clientDayEnd: FAR_FUTURE,
+    })
     check('allow (undo): on_site->en_route', undo1.status === 'en_route', undo1.status)
     check(
       'undo does not roll the WO status backward (forward-only guard, stays on_site)',
       (await woStatus(organizationId, wo4.instance.id)) === 'on_site'
     )
 
-    const undo2 = await advanceMyVisit({ organizationId, userId, visitId: v4.id, to: 'scheduled' })
+    const undo2 = await advanceMyVisit({
+      organizationId,
+      userId,
+      visitId: v4.id,
+      to: 'scheduled',
+      clientDayEnd: FAR_FUTURE,
+    })
     check('allow (undo): en_route->scheduled', undo2.status === 'scheduled', undo2.status)
 
     const rejectScheduledScheduled = await expectThrow(() =>
-      advanceMyVisit({ organizationId, userId, visitId: v4.id, to: 'scheduled' })
+      advanceMyVisit({
+        organizationId,
+        userId,
+        visitId: v4.id,
+        to: 'scheduled',
+        clientDayEnd: FAR_FUTURE,
+      })
     )
     check(
       'reject: scheduled->scheduled (not a listed transition)',
@@ -553,9 +629,95 @@ async function main() {
     await assignVisit({ organizationId, userId, visitId: v4b.id, assigneeUserId: userId })
     await setVisitStatus({ organizationId, userId, visitId: v4b.id, status: 'done' })
     const rejectDoneEnRoute = await expectThrow(() =>
-      advanceMyVisit({ organizationId, userId, visitId: v4b.id, to: 'en_route' })
+      advanceMyVisit({
+        organizationId,
+        userId,
+        visitId: v4b.id,
+        to: 'en_route',
+        clientDayEnd: FAR_FUTURE,
+      })
     )
     check('reject: done->en_route', rejectDoneEnRoute instanceof BadRequestError, rejectDoneEnRoute)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 4b. advanceMyVisit day-gate guard (`clientDayEnd`) — forward-only, undo exempt
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('4b: advanceMyVisit day-gate guard')
+    const tomorrowStart = new Date(now.getTime() + 1 * 24 * 60 * 60 * 1000)
+    const wo4c = await createWO('day-gate future forward-reject')
+    const v4c = await firstVisit(wo4c.instance.id)
+    await assignVisit({ organizationId, userId, visitId: v4c.id, assigneeUserId: userId })
+    await scheduleVisit({
+      organizationId,
+      userId,
+      visitId: v4c.id,
+      startTime: tomorrowStart,
+      endTime: new Date(tomorrowStart.getTime() + 60 * 60 * 1000),
+    })
+    const rejectFutureForward = await expectThrow(() =>
+      advanceMyVisit({
+        organizationId,
+        userId,
+        visitId: v4c.id,
+        to: 'en_route',
+        clientDayEnd: endOfToday(),
+      })
+    )
+    check(
+      'reject: forward advance on a tomorrow-scheduled visit with clientDayEnd=today',
+      rejectFutureForward instanceof BadRequestError,
+      rejectFutureForward
+    )
+
+    const wo4d = await createWO('day-gate future undo-exempt')
+    const v4d = await firstVisit(wo4d.instance.id)
+    await assignVisit({ organizationId, userId, visitId: v4d.id, assigneeUserId: userId })
+    await scheduleVisit({
+      organizationId,
+      userId,
+      visitId: v4d.id,
+      startTime: tomorrowStart,
+      endTime: new Date(tomorrowStart.getTime() + 60 * 60 * 1000),
+    })
+    // Force en_route via the admin `setVisitStatus` path directly — `advanceMyVisit` itself
+    // can't reach en_route on a future visit (that's exactly the forward-reject case above).
+    await setVisitStatus({ organizationId, userId, visitId: v4d.id, status: 'en_route' })
+    const undoFuture = await advanceMyVisit({
+      organizationId,
+      userId,
+      visitId: v4d.id,
+      to: 'scheduled',
+      clientDayEnd: endOfToday(),
+    })
+    check(
+      'allow: undo on a future-dated visit succeeds regardless of clientDayEnd (guard is forward-only)',
+      undoFuture.status === 'scheduled',
+      undoFuture.status
+    )
+
+    const yesterdayStart = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000)
+    const wo4e = await createWO('day-gate past forward-allowed')
+    const v4e = await firstVisit(wo4e.instance.id)
+    await assignVisit({ organizationId, userId, visitId: v4e.id, assigneeUserId: userId })
+    await scheduleVisit({
+      organizationId,
+      userId,
+      visitId: v4e.id,
+      startTime: yesterdayStart,
+      endTime: new Date(yesterdayStart.getTime() + 60 * 60 * 1000),
+    })
+    const pastForward = await advanceMyVisit({
+      organizationId,
+      userId,
+      visitId: v4e.id,
+      to: 'en_route',
+      clientDayEnd: endOfToday(),
+    })
+    check(
+      'allow: forward advance on a past-dated visit still succeeds (guard only blocks the future)',
+      pastForward.status === 'en_route',
+      pastForward.status
+    )
 
     // ══════════════════════════════════════════════════════════════════════
     // 5. closeMyVisit matrix — the MI2 collision resolution

--- a/packages/lib/src/dispatch/my-schedule.ts
+++ b/packages/lib/src/dispatch/my-schedule.ts
@@ -350,12 +350,25 @@ const ADVANCE_TRANSITIONS: Record<string, VisitStatus[]> = {
   on_site: ['en_route'],
 }
 
+/**
+ * The subset of `ADVANCE_TRANSITIONS` that move a visit FORWARD (vs. the "Undo last" pair,
+ * `en_route→scheduled`/`on_site→en_route`) — only forward advances are day-gated below.
+ */
+const FORWARD_TRANSITIONS = new Set<string>(['scheduled->en_route', 'en_route->on_site'])
+
 /** Input for {@link advanceMyVisit}. */
 export interface AdvanceMyVisitInput {
   organizationId: string
   userId: string
   visitId: string
   to: VisitStatus
+  /**
+   * The worker's client-local end-of-today (day boundaries are always client-computed in this
+   * repo — never server `startOfDay`, a prod-TZ bug). Gates FORWARD advances only: a visit
+   * scheduled after this instant is a future day, so "Start travel"/"Arrived" are rejected.
+   * Undo transitions are exempt — they must keep working regardless of date.
+   */
+  clientDayEnd: Date
 }
 
 /**
@@ -364,15 +377,22 @@ export interface AdvanceMyVisitInput {
  * `on_site→en_route`. Delegates to `setVisitStatus` so mirror/roll-up/broadcast/record-rules
  * fire identically to the board's admin path.
  *
- * @throws {BadRequestError} for any transition outside the allowed set.
+ * @throws {BadRequestError} for any transition outside the allowed set, or for a FORWARD
+ *   advance on a visit scheduled after `clientDayEnd` (a future day — day-of actions only).
  */
 export async function advanceMyVisit(input: AdvanceMyVisitInput): Promise<WorkOrderVisitRow> {
-  const { organizationId, userId, visitId, to } = input
+  const { organizationId, userId, visitId, to, clientDayEnd } = input
   const visit = await loadOwnVisit(organizationId, userId, visitId)
 
   const allowed = ADVANCE_TRANSITIONS[visit.status] ?? []
   if (!allowed.includes(to)) {
     throw new BadRequestError(`Cannot advance visit from '${visit.status}' to '${to}'`)
+  }
+
+  if (FORWARD_TRANSITIONS.has(`${visit.status}->${to}`) && visit.startTime) {
+    if (visit.startTime > clientDayEnd) {
+      throw new BadRequestError('Visit is scheduled for a future day')
+    }
   }
 
   return setVisitStatus({ organizationId, userId, visitId, status: to })

--- a/packages/lib/src/dispatch/visit-hooks.ts
+++ b/packages/lib/src/dispatch/visit-hooks.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/dispatch/visit-hooks.ts
 
 import { database, schema } from '@auxx/database'
+import { extractValue, type TypedFieldValue } from '@auxx/types'
 import { parseRecordId } from '@auxx/types/resource'
 import { and, eq } from 'drizzle-orm'
 import type { EntityFieldChangeHandler } from '../field-hooks/types'
@@ -50,8 +51,10 @@ function formatAddressForGeocode(value: Record<string, unknown>): string {
 export const geocodeOnAddressChange: EntityFieldChangeHandler = async (event) => {
   if (event.field.systemAttribute !== 'work_order_address') return
 
-  const addressValue = event.newValue as Record<string, unknown> | null
-  if (!addressValue) return
+  const typed = event.newValue as TypedFieldValue | TypedFieldValue[] | null
+  const first = Array.isArray(typed) ? typed[0] : typed
+  const addressValue = first ? (extractValue(first) as Record<string, unknown> | null) : null
+  if (!addressValue || typeof addressValue !== 'object') return
 
   const line = formatAddressForGeocode(addressValue)
   const result = await geocode(line)

--- a/packages/lib/src/resources/hooks/work-order-hooks.ts
+++ b/packages/lib/src/resources/hooks/work-order-hooks.ts
@@ -16,7 +16,7 @@ const autoGenerateWorkOrderNumber: SystemHook = async ({
 }) => {
   if (operation !== 'create') return values
   const { recordNumber } = await recordNumbering.create(organizationId, 'work_order')
-  return { ...values, [field.id]: recordNumber }
+  return { [field.id]: recordNumber, ...values, [field.id]: recordNumber }
 }
 
 /**

--- a/packages/ui/src/components/dockable-drawer.tsx
+++ b/packages/ui/src/components/dockable-drawer.tsx
@@ -60,6 +60,12 @@ interface DockableDrawerProps {
   children: React.ReactNode
   /** Accessible title for the drawer (required for screen readers) */
   title?: string
+  /**
+   * Render the (transparent) overlay in undocked mode. The overlay swallows every pointer
+   * event outside the drawer — pass `false` when the page behind must stay interactive
+   * (e.g. the dispatch route planner's map).
+   */
+  overlay?: boolean
   /** Optional portal target ref for docked mode - content will be portaled here when docked */
   portalTarget?: React.RefObject<HTMLElement | null>
   /** Identifies which panel this is (for filtering in tabbed/side-by-side mode) */
@@ -83,6 +89,7 @@ export function DockableDrawer({
   maxWidth = 800,
   children,
   title = 'Details',
+  overlay = true,
   portalTarget,
   panelType,
 }: DockableDrawerProps) {
@@ -132,7 +139,7 @@ export function DockableDrawer({
         minWidth={minWidth}
         maxWidth={maxWidth}
         onWidthChange={onWidthChange}>
-        <DrawerOverlay className='bg-transparent' />
+        {overlay && <DrawerOverlay className='bg-transparent' />}
         <DrawerContent>
           <DrawerHandle />
           <DrawerTitle className='sr-only'>{title}</DrawerTitle>


### PR DESCRIPTION
## Summary

Route-planner **M3 UI restyle** and **worker-schedule (WS1)** hardening, plus two entity-engine hook fixes surfaced by the dispatch verify pass.

## Changes

**Route planner (M3)**
- Single toolbar, full-bleed map, backlog blur-overlay
- `DockableDrawer`-based routes drawer + a planner DnD provider (adds a new `overlay={false}` prop to `DockableDrawer`)

**Worker schedule (WS1)**
- `advanceMyVisit` now gates **forward** transitions (`scheduled→en_route`, `en_route→on_site`) on a client-computed `clientDayEnd`. Day boundaries are always client-side in this repo (server `startOfDay` is a prod-TZ bug), so a visit scheduled for a future day rejects day-of actions. Undo transitions (`en_route→scheduled`, `on_site→en_route`) stay exempt.

**Engine hook fixes**
- `geocodeOnAddressChange` read the raw `FieldValue` wrapper instead of `extractValue(event.newValue)` — the address geocode was a prod no-op.
- Work-order number hook forces the generated `recordNumber` to win over any incoming value.

**Misc**
- Board / recurrence / schedule-popover UI polish
- Updated verify scripts + entity-migration 039 runner

## Test plan

- [ ] Open the route planner — map is full-bleed, backlog overlay + routes drawer behave
- [ ] Worker schedule: "Start travel"/"Arrived" on a future-day visit is rejected; today's visit advances; Undo works on any day
- [ ] Changing a work-order address triggers geocoding
- [ ] Creating a work order assigns a sequential number

🤖 Generated with [Claude Code](https://claude.com/claude-code)