### PR TITLE
feat(ui): fixedWeeks for stable calendar height

### DIFF
--- a/packages/ui/src/components/calendar/calendar.tsx
+++ b/packages/ui/src/components/calendar/calendar.tsx
@@ -61,6 +61,7 @@ export function Calendar(props: CalendarProps) {
     minDate,
     maxDate,
     showOutsideDays: showOutsideDaysProp,
+    fixedWeeks = false,
     hideNavigation = false,
     captionLayout = 'label',
     autoFocus,
@@ -181,6 +182,13 @@ export function Calendar(props: CalendarProps) {
       <div
         ref={containerRef}
         data-slot='calendar'
+        // Reserve a definite width so the calendar renders correctly inside width-fitting
+        // containers (e.g. `w-auto` popovers), where the fluid `w-full`/`aspect-square` day
+        // cells would otherwise collapse to zero. Each month claims ≥13rem plus gaps/padding;
+        // `min-width` still lets the grid grow to fill wider fixed-width containers.
+        style={{
+          minWidth: `calc(${numberOfMonths} * 13rem + ${numberOfMonths - 1} * 1rem + 1.5rem)`,
+        }}
         className={cn('@container relative select-none p-3', className)}>
         {!hideNavigation && captionLayout === 'label' && (
           <div
@@ -238,6 +246,7 @@ export function Calendar(props: CalendarProps) {
                   <MonthGrid
                     month={m}
                     showOutsideDays={showOutsideDays}
+                    fixedWeeks={fixedWeeks}
                     onKeyDown={onGridKeyDown}
                   />
                 )}

--- a/packages/ui/src/components/calendar/month-grid.tsx
+++ b/packages/ui/src/components/calendar/month-grid.tsx
@@ -11,14 +11,24 @@ import { getMonthWeeks, toDayKey } from './utils'
 export interface MonthGridProps {
   month: Date
   showOutsideDays: boolean
+  /** Always render 6 week rows so the grid height stays constant across months. */
+  fixedWeeks?: boolean
   onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void
 }
 
 /** Weekday header row + week rows + day cells for a single month, honoring `weekStartsOn`. */
-export function MonthGrid({ month, showOutsideDays, onKeyDown }: MonthGridProps) {
+export function MonthGrid({
+  month,
+  showOutsideDays,
+  fixedWeeks = false,
+  onKeyDown,
+}: MonthGridProps) {
   const { weekStartsOn } = useCalendarContext()
 
-  const weeks = React.useMemo(() => getMonthWeeks(month, weekStartsOn), [month, weekStartsOn])
+  const weeks = React.useMemo(
+    () => getMonthWeeks(month, weekStartsOn, fixedWeeks),
+    [month, weekStartsOn, fixedWeeks]
+  )
 
   const weekdays = React.useMemo(() => {
     const start = startOfWeek(month, { weekStartsOn })

--- a/packages/ui/src/components/calendar/types.ts
+++ b/packages/ui/src/components/calendar/types.ts
@@ -29,6 +29,11 @@ export type CalendarBaseProps = {
   /** Show leading/trailing days from adjacent months. Default true; forced false when
    * `numberOfMonths > 1`. */
   showOutsideDays?: boolean
+  /**
+   * Always render 6 week rows, padding short months with trailing days so the calendar's
+   * height never changes when paging between months. Default false.
+   */
+  fixedWeeks?: boolean
   hideNavigation?: boolean
   /**
    * `'label'` = static centered caption (default). `'dropdown'` = the date-time-picker

--- a/packages/ui/src/components/calendar/utils.ts
+++ b/packages/ui/src/components/calendar/utils.ts
@@ -1,6 +1,8 @@
 // packages/ui/src/components/calendar/utils.ts
 
 import {
+  addDays,
+  differenceInCalendarDays,
   eachDayOfInterval,
   endOfDay,
   endOfMonth,
@@ -18,10 +20,19 @@ import type { DateRange, DisabledResolverOptions } from './types'
 /**
  * Full weeks (7-day rows) covering `month`, respecting `weekStartsOn` — includes the
  * leading/trailing days from adjacent months needed to complete the first and last row.
+ *
+ * When `fixedWeeks` is set, short months (4–5 rows) are padded with trailing days to always
+ * render 6 rows, so the calendar's height stays constant across months (no layout shift).
  */
-export function getMonthWeeks(month: Date, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0): Date[][] {
+export function getMonthWeeks(
+  month: Date,
+  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 0,
+  fixedWeeks = false
+): Date[][] {
   const start = startOfWeek(startOfMonth(month), { weekStartsOn })
-  const end = endOfWeek(endOfMonth(month), { weekStartsOn })
+  const naturalEnd = endOfWeek(endOfMonth(month), { weekStartsOn })
+  const weekCount = (differenceInCalendarDays(naturalEnd, start) + 1) / 7
+  const end = fixedWeeks && weekCount < 6 ? addDays(naturalEnd, (6 - weekCount) * 7) : naturalEnd
   const days = eachDayOfInterval({ start, end })
 
   const weeks: Date[][] = []

--- a/packages/ui/src/components/mini-month-calendar.tsx
+++ b/packages/ui/src/components/mini-month-calendar.tsx
@@ -105,6 +105,9 @@ function MiniMonthCalendar({
       onMonthChange={handleMonthChange}
       weekStartsOn={weekStartsOn}
       showOutsideDays
+      // Always render 6 rows so paging between 5- and 6-week months doesn't shift the
+      // sidebar's height (and the board content below it).
+      fixedWeeks
       renderDay={renderDay}
       modifiers={modifiers}
       className={cn('p-2 [&_[data-slot=day][data-visible-range]]:bg-accent/50', className)}


### PR DESCRIPTION
## Summary

Adds a `fixedWeeks` prop to the in-house `Calendar` component so it always renders 6 week rows, keeping the grid height constant across months.

## Changes

- **`fixedWeeks` prop** on `Calendar` → `MonthGrid` → `getMonthWeeks`. When set, short months (4–5 rows) are padded with trailing days to always render 6 rows, so paging between months causes no layout shift.
- **Container min-width**: the calendar now reserves a definite `min-width` (`numberOfMonths * 13rem + gaps + padding`) so the fluid `w-full`/`aspect-square` day cells don't collapse to zero inside width-fitting containers (e.g. `w-auto` popovers).
- **`MiniMonthCalendar` opts in** to `fixedWeeks` so paging between 5- and 6-week months no longer shifts the dispatch sidebar height (and the board content below it).

## Testing

UI-only change; behavior verified in the dispatch mini-calendar (no height jump when paging months).
