### PR TITLE
feat(calendar): source-registry layer + dispatch re-seat + meetings source

### DIFF
--- a/apps/web/src/app/(protected)/app/tickets/_components/ticket-number-form.tsx
+++ b/apps/web/src/app/(protected)/app/tickets/_components/ticket-number-form.tsx
@@ -314,7 +314,7 @@ export default function TicketNumberingSettings({
             </FieldPanel>
 
             {/* Preview Section */}
-            <div className='mt-6 rounded-xl border bg-primary-100/30 p-4'>
+            <div className='mt-6 rounded-2xl border bg-primary-100/30 p-4'>
               <div className='mb-2 text-sm font-medium'>Preview</div>
               <div className='grid grid-cols-2 gap-4'>
                 <div>

--- a/apps/web/src/components/calendar/core/sidebar-store.ts
+++ b/apps/web/src/components/calendar/core/sidebar-store.ts
@@ -1,0 +1,71 @@
+// apps/web/src/components/calendar/core/sidebar-store.ts
+
+import { create, type StateCreator, type StoreApi } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+/** Base persisted shape shared by every calendar sidebar (dispatch, `/app/calendar`, …). */
+export interface CalendarSidebarState {
+  /** Whole module sidebar, open/closed. Default open. */
+  open: boolean
+  /** Per-group collapse state, keyed by group id. Missing key = open (all groups default
+   * expanded). */
+  groupOpen: Record<string, boolean>
+  /** Inverse of source visibility, keyed by sidebar group id — `[]`/missing key = every item
+   * in that group visible, the default. Persisting the hidden set (not the selected set)
+   * means a newly added item (worker, account, …) defaults to visible without needing a
+   * migration. */
+  hidden: Record<string, string[]>
+  setOpen: (open: boolean) => void
+  setGroupOpen: (key: string, open: boolean) => void
+  toggleHidden: (group: string, id: string) => void
+  isHidden: (group: string, id: string) => boolean
+}
+
+function createBaseSlice<Extra extends object>(
+  set: StoreApi<CalendarSidebarState & Extra>['setState'],
+  get: StoreApi<CalendarSidebarState & Extra>['getState']
+): CalendarSidebarState {
+  return {
+    open: true,
+    groupOpen: {},
+    hidden: {},
+    setOpen: (open) => set({ open }),
+    setGroupOpen: (key, open) =>
+      set((state) => ({ groupOpen: { ...state.groupOpen, [key]: open } })),
+    toggleHidden: (group, id) =>
+      set((state) => {
+        const current = new Set(state.hidden[group] ?? [])
+        if (current.has(id)) current.delete(id)
+        else current.add(id)
+        return { hidden: { ...state.hidden, [group]: Array.from(current) } }
+      }),
+    isHidden: (group, id) => (get().hidden[group] ?? []).includes(id),
+  }
+}
+
+/**
+ * Factory for a module's persisted sidebar store (plan §3.3) — `open`/`groupOpen`/`hidden`
+ * plus whatever extra slice a consumer composes in (e.g. dispatch's `selectedTags`).
+ *
+ * Persist `version` is fixed at 1 with no `migrate` — per the project's few-users rule, a
+ * shape change to a consumer's persisted store (e.g. dispatch's old flat `hiddenWorkerIds` →
+ * this factory's `hidden.workers`) is handled by bumping the *consumer's* `persistKey` or
+ * accepting a one-time fresh-state drop, not by writing migration code.
+ *
+ * Consumers must use selectors (`useStore((s) => s.x)`), never destructure the whole store,
+ * per the project's Zustand convention.
+ */
+export function createCalendarSidebarStore<Extra extends object = Record<string, never>>(
+  persistKey: string,
+  extra?: StateCreator<CalendarSidebarState & Extra, [], [], Extra>
+) {
+  return create<CalendarSidebarState & Extra>()(
+    persist(
+      (set, get, api) => ({
+        ...createBaseSlice<Extra>(set, get),
+        ...(extra ? extra(set, get, api) : ({} as Extra)),
+      }),
+      { name: persistKey, version: 1 }
+    )
+  )
+}

--- a/apps/web/src/components/calendar/core/source-visibility.ts
+++ b/apps/web/src/components/calendar/core/source-visibility.ts
@@ -1,0 +1,22 @@
+// apps/web/src/components/calendar/core/source-visibility.ts
+
+/**
+ * Module-level stable empty array — returned by `hiddenIdsForGroup` when a group has no
+ * hidden entries, so a zustand selector reading it doesn't create a new reference (and churn
+ * re-renders) every call.
+ */
+const EMPTY_HIDDEN: string[] = []
+
+/**
+ * A group's hidden-id list out of the sidebar store's `hidden` map, or the stable empty array
+ * when the group has no entries yet. Safe to call with a zustand-selected `hidden` object —
+ * the stable empty avoids re-render churn.
+ */
+export function hiddenIdsForGroup(hidden: Record<string, string[]>, group: string): string[] {
+  return hidden[group] ?? EMPTY_HIDDEN
+}
+
+/** Whether `id` is in a group's already-resolved hidden-id list. */
+export function isSourceHidden(hiddenIds: string[], id: string): boolean {
+  return hiddenIds.includes(id)
+}

--- a/apps/web/src/components/calendar/core/types.ts
+++ b/apps/web/src/components/calendar/core/types.ts
@@ -1,0 +1,49 @@
+// apps/web/src/components/calendar/core/types.ts
+
+import type { EventCalendarItem, RenderEventContext } from '@auxx/ui/components/event-calendar'
+import type { ReactNode } from 'react'
+
+/**
+ * One toggleable row in the sidebar. `group` buckets rows into sidebar groups
+ * ('kinds' | 'accounts' on the calendar page; dispatch defines its own).
+ */
+export interface CalendarSourceDescriptor {
+  id: string // 'visits' | 'meetings' | `account:<credentialId>`
+  label: string
+  group: string
+  /** Resolved hex — toggle-row dot + default event color. */
+  color?: string
+}
+
+/** What a source's data hook returns for the shell's visible range. */
+export interface CalendarSourceData<E extends EventCalendarItem = EventCalendarItem> {
+  events: E[]
+  isLoading: boolean
+}
+
+/**
+ * A composed source: descriptor + range-scoped events hook + chip renderer.
+ * Hook rules apply — a page's source list must be static per mount.
+ *
+ * - `enabled` lets the shell skip the query entirely for hidden sources (not just filter the
+ *   result) — a hidden Google account shouldn't fetch.
+ * - Color stays per-surface (decision D, plan §1): the contract carries `descriptor.color` as
+ *   a default; `useEvents` may stamp per-event colors (dispatch's worker axis does; the
+ *   meetings source won't). No color logic in the shell.
+ * - Deliberately NOT in the contract (dispatch keeps these page-level, the calendar page
+ *   doesn't need them v1): resources/columns, backlog, DnD payloads, background events /
+ *   availability shading, popovers. If a second consumer needs one later, promote it then.
+ */
+export interface CalendarSource<E extends EventCalendarItem = EventCalendarItem> {
+  descriptor: CalendarSourceDescriptor
+  useEvents: (range: { from: Date; to: Date }, enabled: boolean) => CalendarSourceData<E>
+  renderEvent: (event: E, ctx: RenderEventContext) => ReactNode
+}
+
+/**
+ * Every event a source contributes carries the id of the source that produced it, so a
+ * page-level `renderEvent` can dispatch to the right source renderer. Deliberately NOT added
+ * to `EventCalendarItem` in `@auxx/ui` — the grid itself doesn't care which source an event
+ * came from.
+ */
+export type SourcedEvent = EventCalendarItem & { sourceId: string }

--- a/apps/web/src/components/calendar/core/use-calendar-range.ts
+++ b/apps/web/src/components/calendar/core/use-calendar-range.ts
@@ -1,0 +1,62 @@
+// apps/web/src/components/calendar/core/use-calendar-range.ts
+
+'use client'
+
+import { endOfDay, endOfMonth, startOfDay, startOfMonth } from 'date-fns'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/** The calendar shell's three grid modes — shared by dispatch's `BoardViewMode`. */
+export type CalendarRangeView = 'day' | 'week' | 'month'
+
+export interface DateRange {
+  from: Date
+  to: Date
+}
+
+/**
+ * Date/view/range state shared by every calendar shell consumer, extracted verbatim from
+ * `dispatch/ui/board/hooks/use-board-data.ts:41-83` (plan §3.2). `range` is fed by
+ * `EventCalendar`'s `onRangeChange` — stored by timestamp so identical ranges (same
+ * day/view recomputed) don't churn a consumer's query key.
+ */
+export function useCalendarRange(initialView: CalendarRangeView = 'day') {
+  const [date, setDate] = useState(() => new Date())
+  const [view, setView] = useState<CalendarRangeView>(initialView)
+  // Matches the calendar's own day-view range calc (`startOfDay`/`endOfDay`) so the first
+  // `onRangeChange` firing (in the calendar's mount effect) is a no-op query-key match
+  // instead of a second fetch.
+  const [range, setRange] = useState<DateRange>(() => ({
+    from: startOfDay(new Date()),
+    to: endOfDay(new Date()),
+  }))
+
+  const rangeDebounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  useEffect(() => () => clearTimeout(rangeDebounceRef.current), [])
+
+  const handleRangeChange = useCallback(
+    (from: Date, to: Date) => {
+      // The month stream reports a sliding week window on every scroll — quantize it to
+      // whole covering months so a consumer's range-scoped query key only changes when a new
+      // month scrolls into view, and debounce so a fast fling doesn't fetch every month
+      // crossed.
+      const quantizedFrom = view === 'month' ? startOfMonth(from) : from
+      const quantizedTo = view === 'month' ? endOfMonth(to) : to
+      const apply = () =>
+        setRange((prev) =>
+          prev.from.getTime() === quantizedFrom.getTime() &&
+          prev.to.getTime() === quantizedTo.getTime()
+            ? prev
+            : { from: quantizedFrom, to: quantizedTo }
+        )
+      clearTimeout(rangeDebounceRef.current)
+      if (view === 'month') {
+        rangeDebounceRef.current = setTimeout(apply, 250)
+      } else {
+        apply()
+      }
+    },
+    [view]
+  )
+
+  return { date, setDate, view, setView, range, handleRangeChange }
+}

--- a/apps/web/src/components/calendar/sources/meetings-source.tsx
+++ b/apps/web/src/components/calendar/sources/meetings-source.tsx
@@ -1,0 +1,76 @@
+// apps/web/src/components/calendar/sources/meetings-source.tsx
+//
+// Calendar source for the signed-in user's meetings (`calendar.myMeetings`) — plan
+// plans/calendar/01-source-registry-refactor.md §4 Phase 3, the honesty check that the
+// `CalendarSource` contract holds for a source whose query isn't dispatch's `getBoard`. Not
+// mounted anywhere yet; the `/app/calendar` page plan is the first consumer.
+
+'use client'
+
+import { format } from 'date-fns'
+import { useMemo } from 'react'
+import type { CalendarSource, SourcedEvent } from '~/components/calendar/core/types'
+import { api } from '~/trpc/react'
+
+/** Sky-500 — the meetings source's default toggle-dot/chip color (decision D: color is per-surface). */
+const MEETINGS_COLOR = '#0ea5e9'
+
+/**
+ * A `calendar.myMeetings` row mapped onto the shared event shape. `meetingUrl` rides along on
+ * the event for a later chip iteration (the plan defers rendering it as a link) — everything
+ * else in `MyMeetingListItem` (`title`/`startTime`/`endTime`) is required, so no fallback
+ * mapping is needed here.
+ */
+export interface MeetingEvent extends SourcedEvent {
+  meetingUrl: string | null
+}
+
+/**
+ * Calendar source for the signed-in user's meetings. Descriptor buckets it into the `'kinds'`
+ * sidebar group alongside `visits` (decision B); `useEvents` reads the already range-windowed
+ * `calendar.myMeetings` query and is skipped entirely via `enabled` when the source is hidden.
+ */
+export const meetingsSource: CalendarSource<MeetingEvent> = {
+  descriptor: {
+    id: 'meetings',
+    label: 'Meetings',
+    group: 'kinds',
+    color: MEETINGS_COLOR,
+  },
+
+  useEvents: (range, enabled) => {
+    const query = api.calendar.myMeetings.useQuery(
+      { from: range.from, to: range.to },
+      { enabled, placeholderData: (prev) => prev }
+    )
+
+    const events = useMemo<MeetingEvent[]>(
+      () =>
+        (query.data ?? []).map((meeting) => ({
+          id: meeting.id,
+          title: meeting.title,
+          start: meeting.startTime,
+          end: meeting.endTime,
+          color: MEETINGS_COLOR,
+          sourceId: 'meetings',
+          meetingUrl: meeting.meetingUrl,
+        })),
+      [query.data]
+    )
+
+    return { events, isLoading: query.isLoading }
+  },
+
+  renderEvent: (event, ctx) => (
+    <div className='flex h-full w-full min-w-0 items-center gap-1 overflow-hidden px-1'>
+      <span className='min-w-0 flex-1 truncate text-[10px] font-semibold sm:text-xs'>
+        {event.title}
+      </span>
+      {ctx.view !== 'month' && (
+        <span className='shrink-0 text-[10px] font-normal opacity-70'>
+          {format(event.start, 'p')}
+        </span>
+      )}
+    </div>
+  ),
+}

--- a/apps/web/src/components/calendar/ui/mini-calendar-section.tsx
+++ b/apps/web/src/components/calendar/ui/mini-calendar-section.tsx
@@ -1,0 +1,48 @@
+// apps/web/src/components/calendar/ui/mini-calendar-section.tsx
+
+'use client'
+
+import { MiniMonthCalendar } from '@auxx/ui/components/mini-month-calendar'
+
+interface MiniCalendarSectionProps {
+  date: Date
+  onDateChange: (date: Date) => void
+  /** The shell's current visible range — already end-inclusive (`endOfDay`/`endOfWeek`/
+   * `endOfMonth`, the `useCalendarRange` convention), so it's passed straight through to
+   * `MiniMonthCalendar`'s `visibleRange` without adjustment. */
+  visibleRange: { from: Date; to: Date }
+  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6
+  /** Per-day density counts (keyed `'yyyy-MM-dd'`), rendered as a dot under the day number. */
+  density?: Record<string, number>
+  /** Fires whenever the displayed month changes — the consumer owns the displayed-month
+   * state and its own density query (plan §3.4); this component has no internal state of
+   * its own. */
+  onMonthChange?: (month: Date) => void
+}
+
+/**
+ * Mini month calendar header, generalized from dispatch's `MiniCalendarSection` (plan §3.4) —
+ * fully controlled: the consumer owns the displayed month and computes `density`, this
+ * component only renders `MiniMonthCalendar` inside the shared bordered-section wrapper.
+ */
+export function MiniCalendarSection({
+  date,
+  onDateChange,
+  visibleRange,
+  weekStartsOn,
+  density,
+  onMonthChange,
+}: MiniCalendarSectionProps) {
+  return (
+    <div className='border-sidebar-border border-b'>
+      <MiniMonthCalendar
+        selected={date}
+        onSelect={onDateChange}
+        visibleRange={visibleRange}
+        density={density}
+        weekStartsOn={weekStartsOn}
+        onMonthChange={onMonthChange}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/calendar/ui/source-toggle-group.tsx
+++ b/apps/web/src/components/calendar/ui/source-toggle-group.tsx
@@ -1,0 +1,119 @@
+// apps/web/src/components/calendar/ui/source-toggle-group.tsx
+
+'use client'
+
+import {
+  SidebarGroup,
+  SidebarGroupCollapse,
+  SidebarMenu,
+  SidebarMenuItem,
+} from '@auxx/ui/components/sidebar'
+import { cn } from '@auxx/ui/lib/utils'
+import { Eye, EyeOff } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
+import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
+
+/** Fallback color-dot when an item has no resolved color (e.g. a source not yet color-picked). */
+const DEFAULT_TOGGLE_COLOR = '#94a3b8'
+
+interface SourceToggleRowProps {
+  id: string
+  label: string
+  color?: string
+  visible: boolean
+  onToggle: () => void
+}
+
+/**
+ * One toggleable sidebar row — color dot + label (dimmed when hidden) + hover-revealed eye
+ * toggle. Generalized from dispatch's `WorkerRow` (`dispatch/ui/sidebar/workers-group.tsx`),
+ * itself ported from the deleted `ModuleSidebarToggleItem`'s visual treatment. Exported so
+ * bespoke groups (e.g. dispatch's `WorkersGroup`, which needs worker avatars) can reuse the
+ * row without adopting `SourceToggleGroup`'s generic list rendering.
+ */
+export function SourceToggleRow({ id, label, color, visible, onToggle }: SourceToggleRowProps) {
+  return (
+    <SidebarMenuItem>
+      <SidebarItem
+        id={id}
+        name={label}
+        onClick={onToggle}
+        className={cn(!visible && 'text-muted-foreground/70')}
+        icon={
+          <span
+            className='size-2 shrink-0 rounded-full'
+            style={{ backgroundColor: color ?? DEFAULT_TOGGLE_COLOR }}
+          />
+        }
+        end={
+          visible ? (
+            <EyeOff className='hidden size-3.5 text-muted-foreground group-hover/menu-item:block' />
+          ) : (
+            <Eye className='size-3.5 text-muted-foreground opacity-60' />
+          )
+        }
+      />
+    </SidebarMenuItem>
+  )
+}
+
+interface SourceToggleGroupItem {
+  id: string
+  label: string
+  color?: string
+}
+
+interface SourceToggleGroupProps {
+  title: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  items: SourceToggleGroupItem[]
+  isHidden: (id: string) => boolean
+  onToggle: (id: string) => void
+  /** Extra dropdown-menu items rendered in the group header's 3-dot menu (e.g. "New worker"). */
+  additionalOptions?: ReactNode
+}
+
+/**
+ * One generic sidebar group of `SourceToggleRow`s — the calendar-source-registry analog of
+ * dispatch's `WorkersGroup` (plan §3.4), for groups whose rows need nothing beyond a color
+ * dot + label + visibility toggle (sidebar 'kinds'/'accounts' groups on the calendar page).
+ */
+export function SourceToggleGroup({
+  title,
+  open,
+  onOpenChange,
+  items,
+  isHidden,
+  onToggle,
+  additionalOptions,
+}: SourceToggleGroupProps) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupHeader
+        title={title}
+        isOpen={open}
+        toggleOpen={() => onOpenChange(!open)}
+        isEditMode={false}
+        onToggleEditMode={() => {}}
+        hideEditOption
+        additionalOptions={additionalOptions}
+      />
+      <SidebarGroupCollapse open={open}>
+        <SidebarMenu>
+          {items.map((item) => (
+            <SourceToggleRow
+              key={item.id}
+              id={item.id}
+              label={item.label}
+              color={item.color}
+              visible={!isHidden(item.id)}
+              onToggle={() => onToggle(item.id)}
+            />
+          ))}
+        </SidebarMenu>
+      </SidebarGroupCollapse>
+    </SidebarGroup>
+  )
+}

--- a/apps/web/src/components/dispatch/stores/dispatch-sidebar-store.ts
+++ b/apps/web/src/components/dispatch/stores/dispatch-sidebar-store.ts
@@ -1,51 +1,45 @@
 // apps/web/src/components/dispatch/stores/dispatch-sidebar-store.ts
 
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { createCalendarSidebarStore } from '~/components/calendar/core/sidebar-store'
+import { hiddenIdsForGroup } from '~/components/calendar/core/source-visibility'
 
-interface DispatchSidebarState {
-  /** Whole module sidebar, open/closed. Default open. */
-  open: boolean
-  /** Per-group collapse state, keyed by group id (`'workers' | 'tags' | 'backlog' | 'routes' |
-   * 'routes:<userId>'`). Missing key = open (all groups default expanded). */
-  groupOpen: Record<string, boolean>
-  /** Inverse of worker visibility — `[]` = every worker (and Unassigned) visible, the default.
-   * Persisting the hidden set (not the selected set) means a newly added worker defaults to
-   * visible without needing a migration. May contain the `UNASSIGNED_RESOURCE_ID` sentinel
-   * (`board/types.ts`) for the Unassigned row. */
-  hiddenWorkerIds: string[]
+/** Sidebar group id for the Workers toggle rows — the shared store's `hidden` map keys the
+ * worker inverse-visibility set under this group, may include the `UNASSIGNED_RESOURCE_ID`
+ * sentinel (`board/types.ts`) for the synthetic Unassigned row. */
+export const WORKERS_GROUP = 'workers'
+
+interface DispatchSidebarExtra {
   /** `null` = every tag visible (map mode only). */
   selectedTags: string[] | null
-  setOpen: (open: boolean) => void
-  setGroupOpen: (key: string, open: boolean) => void
-  toggleWorkerHidden: (workerId: string) => void
   setSelectedTags: (tags: string[] | null) => void
 }
 
 /**
- * Dispatch module sidebar persistence (v3 sidebar plan §1.1) — localStorage, following
- * `dock-store.ts`'s shape. Consumers must use selectors (`useDispatchSidebarStore((s) => s.x)`),
- * never destructure the whole store, per the project's Zustand convention.
+ * Dispatch module sidebar persistence (v3 sidebar plan §1.1), rebuilt on the shared
+ * `createCalendarSidebarStore` factory (plan §3.3) — localStorage `open`/`groupOpen`/`hidden`
+ * plus dispatch's own `selectedTags` composed in as the extra slice. Consumers must use
+ * selectors (`useDispatchSidebarStore((s) => s.x)`), never destructure the whole store, per
+ * the project's Zustand convention.
+ *
+ * The old flat `hiddenWorkerIds`/`toggleWorkerHidden` are gone — workers now live under
+ * `hidden.workers` (`WORKERS_GROUP`), read/written via `toggleHidden(WORKERS_GROUP, id)` or the
+ * `useHiddenWorkerIds()` convenience hook below. Persisting the hidden set (not the selected
+ * set) means a newly added worker defaults to visible without needing a migration.
+ *
+ * The factory's persist `version` is fixed at 1 with no `migrate` — per the project's
+ * few-users rule, this shape change (flat `hiddenWorkerIds` → `hidden.workers`) intentionally
+ * drops old persisted sidebar prefs once rather than writing migration code.
  */
-export const useDispatchSidebarStore = create<DispatchSidebarState>()(
-  persist(
-    (set) => ({
-      open: true,
-      groupOpen: {},
-      hiddenWorkerIds: [],
-      selectedTags: null,
-      setOpen: (open) => set({ open }),
-      setGroupOpen: (key, open) =>
-        set((state) => ({ groupOpen: { ...state.groupOpen, [key]: open } })),
-      toggleWorkerHidden: (workerId) =>
-        set((state) => {
-          const hidden = new Set(state.hiddenWorkerIds)
-          if (hidden.has(workerId)) hidden.delete(workerId)
-          else hidden.add(workerId)
-          return { hiddenWorkerIds: Array.from(hidden) }
-        }),
-      setSelectedTags: (tags) => set({ selectedTags: tags }),
-    }),
-    { name: 'dispatch-sidebar' }
-  )
+export const useDispatchSidebarStore = createCalendarSidebarStore<DispatchSidebarExtra>(
+  'dispatch-sidebar',
+  (set) => ({
+    selectedTags: null,
+    setSelectedTags: (tags) => set({ selectedTags: tags }),
+  })
 )
+
+/** Selector-stable read of the Workers group's hidden set (may include UNASSIGNED_RESOURCE_ID). */
+export function useHiddenWorkerIds(): string[] {
+  const hidden = useDispatchSidebarStore((s) => s.hidden)
+  return hiddenIdsForGroup(hidden, WORKERS_GROUP)
+}

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
@@ -3,13 +3,12 @@
 'use client'
 
 import { getOptionColorHex } from '@auxx/lib/custom-fields/client'
-import { endOfDay, endOfMonth, startOfDay, startOfMonth } from 'date-fns'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
+import { useCalendarRange } from '~/components/calendar/core/use-calendar-range'
 import { api } from '~/trpc/react'
-import { useDispatchSidebarStore } from '../../../stores/dispatch-sidebar-store'
+import { useHiddenWorkerIds } from '../../../stores/dispatch-sidebar-store'
 import {
   type BoardResourceInput,
-  type BoardViewMode,
   type BoardWorker,
   type DispatchVisitEvent,
   UNASSIGNED_RESOURCE_ID,
@@ -22,65 +21,32 @@ import {
   visitToEvent,
 } from '../utils'
 
-export interface DateRange {
-  from: Date
-  to: Date
-}
+/** Re-export of the shared shell's range type — kept here so existing importers of this hook's
+ * `DateRange` don't need to repoint (`use-board-mutations.ts`, `use-board-realtime.ts`,
+ * `use-availability-shading.ts`). */
+export type { DateRange } from '~/components/calendar/core/use-calendar-range'
 
 /**
- * Board date/view/range/filter state + the `dispatch.getBoard` query (D.3). `range` is fed
- * by `EventCalendar`'s `onRangeChange` — stored by timestamp so identical ranges (same
- * day/view recomputed) don't churn the query key.
+ * Board date/view/range/filter state + the `dispatch.getBoard` query (D.3). Date/view/range
+ * state itself is the shared `useCalendarRange()` (plan §3.2, extracted verbatim from this
+ * hook) — `range` is fed by `EventCalendar`'s `onRangeChange` — stored by timestamp so
+ * identical ranges (same day/view recomputed) don't churn the query key.
  *
  * `selectedWorkerIds`/Unassigned-column visibility (v3 sidebar plan §1.1/§1.3) derive from the
- * persisted `dispatch-sidebar` store's `hiddenWorkerIds` — the sidebar is the only writer, this
- * hook only reads it (via the `selectedWorkerIdsFromHidden`/`isWorkerHidden` adapters) so the
- * board/map/planner consumers below keep their pre-v3 `Set<string> | null` contract untouched.
+ * persisted `dispatch-sidebar` store's Workers group hidden set (`useHiddenWorkerIds`) — the
+ * sidebar is the only writer, this hook only reads it (via the
+ * `selectedWorkerIdsFromHidden`/`isWorkerHidden` adapters) so the board/map/planner consumers
+ * below keep their pre-v3 `Set<string> | null` contract untouched.
  */
 export function useBoardData() {
-  const [date, setDate] = useState(() => new Date())
-  const [view, setView] = useState<BoardViewMode>('day')
-  // Matches the calendar's own day-view range calc (`startOfDay`/`endOfDay`) so the first
-  // `onRangeChange` firing (in the calendar's mount effect) is a no-op query-key match
-  // instead of a second fetch.
-  const [range, setRange] = useState<DateRange>(() => ({
-    from: startOfDay(new Date()),
-    to: endOfDay(new Date()),
-  }))
+  const { date, setDate, view, setView, range, handleRangeChange } = useCalendarRange()
   // Board↔Map toggle (09-route-planner.md §A, contract item 7) — sibling state to the sidebar's
   // `open`, deliberately NOT a `BoardViewMode` so the month-view debounce and `view === 'day'`
   // gates stay untouched. Entering map mode doesn't change `view`; the map always renders
   // `date`'s single day.
   const [boardMode, setBoardMode] = useState<'calendar' | 'map'>('calendar')
 
-  const hiddenWorkerIds = useDispatchSidebarStore((s) => s.hiddenWorkerIds)
-
-  const rangeDebounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
-  useEffect(() => () => clearTimeout(rangeDebounceRef.current), [])
-
-  const handleRangeChange = useCallback(
-    (from: Date, to: Date) => {
-      // The month stream reports a sliding week window on every scroll — quantize it to
-      // whole covering months so the `getBoard` query key only changes when a new month
-      // scrolls into view, and debounce so a fast fling doesn't fetch every month crossed.
-      const quantizedFrom = view === 'month' ? startOfMonth(from) : from
-      const quantizedTo = view === 'month' ? endOfMonth(to) : to
-      const apply = () =>
-        setRange((prev) =>
-          prev.from.getTime() === quantizedFrom.getTime() &&
-          prev.to.getTime() === quantizedTo.getTime()
-            ? prev
-            : { from: quantizedFrom, to: quantizedTo }
-        )
-      clearTimeout(rangeDebounceRef.current)
-      if (view === 'month') {
-        rangeDebounceRef.current = setTimeout(apply, 250)
-      } else {
-        apply()
-      }
-    },
-    [view]
-  )
+  const hiddenWorkerIds = useHiddenWorkerIds()
 
   const boardQuery = api.dispatch.getBoard.useQuery(
     { from: range.from, to: range.to },

--- a/apps/web/src/components/dispatch/ui/board/visits-source.ts
+++ b/apps/web/src/components/dispatch/ui/board/visits-source.ts
@@ -1,0 +1,20 @@
+// apps/web/src/components/dispatch/ui/board/visits-source.ts
+//
+// The visits `CalendarSourceDescriptor` (plan §3.4) — the shared entry point the future
+// `/app/calendar` page will import to compose a "Visits" toggle row + `visitToEvent` mapping.
+// This is NOT a forced indirection inside dispatch itself: the board keeps calling its own
+// `dispatch.getBoard` hook directly (`use-board-data.ts`), because it needs
+// workers/backlog/workOrders from the same query, which the `CalendarSource` contract
+// deliberately doesn't model (plan §3.1). Dispatch's grid/renderEvent/popover wiring is
+// untouched by this file.
+
+import type { CalendarSourceDescriptor } from '~/components/calendar/core/types'
+
+/** Visits source descriptor — sidebar 'kinds' group row for the future `/app/calendar` page. */
+export const visitsSourceDescriptor: CalendarSourceDescriptor = {
+  id: 'visits',
+  label: 'Visits',
+  group: 'kinds',
+}
+
+export { visitToEvent } from './utils'

--- a/apps/web/src/components/dispatch/ui/sidebar/dispatch-sidebar.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/dispatch-sidebar.tsx
@@ -4,7 +4,11 @@
 
 import { ModuleSidebar } from '@auxx/ui/components/module-sidebar'
 import { useMemo } from 'react'
-import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
+import {
+  useDispatchSidebarStore,
+  useHiddenWorkerIds,
+  WORKERS_GROUP,
+} from '../../stores/dispatch-sidebar-store'
 import type { BacklogItem, BoardWorker } from '../board/types'
 import type { WeekStartIndex } from '../board/utils'
 import type {
@@ -65,8 +69,9 @@ export function DispatchSidebar({
   const setOpen = useDispatchSidebarStore((s) => s.setOpen)
   const groupOpen = useDispatchSidebarStore((s) => s.groupOpen)
   const setGroupOpen = useDispatchSidebarStore((s) => s.setGroupOpen)
-  const hiddenWorkerIds = useDispatchSidebarStore((s) => s.hiddenWorkerIds)
-  const toggleWorkerHidden = useDispatchSidebarStore((s) => s.toggleWorkerHidden)
+  const hiddenWorkerIds = useHiddenWorkerIds()
+  const toggleHidden = useDispatchSidebarStore((s) => s.toggleHidden)
+  const toggleWorkerHidden = (workerId: string) => toggleHidden(WORKERS_GROUP, workerId)
   const selectedTags = useDispatchSidebarStore((s) => s.selectedTags)
   const setSelectedTags = useDispatchSidebarStore((s) => s.setSelectedTags)
 

--- a/apps/web/src/components/dispatch/ui/sidebar/mini-calendar-section.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/mini-calendar-section.tsx
@@ -2,8 +2,8 @@
 
 'use client'
 
-import { MiniMonthCalendar } from '@auxx/ui/components/mini-month-calendar'
 import { useState } from 'react'
+import { MiniCalendarSection as GenericMiniCalendarSection } from '~/components/calendar/ui/mini-calendar-section'
 import type { WeekStartIndex } from '../board/utils'
 import { useMiniCalendarDensity } from './hooks/use-mini-calendar-density'
 
@@ -18,8 +18,12 @@ interface MiniCalendarSectionProps {
   hiddenWorkerIds: string[]
 }
 
-/** Mini month calendar header (v3 sidebar plan §1.2/§1.4) — owns the density query's displayed
- * month (via `MiniMonthCalendar`'s `onMonthChange`), independent of the board's own `date`. */
+/**
+ * Dispatch's mini month calendar header (v3 sidebar plan §1.2/§1.4, thinned onto the shared
+ * shell per plan §3.4) — owns the density query's displayed month + the
+ * `useMiniCalendarDensity` call (dispatch-shaped: filtered by worker visibility), then renders
+ * the generic `MiniCalendarSection` from `~/components/calendar/ui/` fully controlled.
+ */
 export function MiniCalendarSection({
   date,
   onDateChange,
@@ -31,15 +35,13 @@ export function MiniCalendarSection({
   const { density } = useMiniCalendarDensity(displayMonth, weekStartsOn, hiddenWorkerIds)
 
   return (
-    <div className='border-sidebar-border border-b'>
-      <MiniMonthCalendar
-        selected={date}
-        onSelect={onDateChange}
-        visibleRange={visibleRange}
-        density={density}
-        weekStartsOn={weekStartsOn}
-        onMonthChange={setDisplayMonth}
-      />
-    </div>
+    <GenericMiniCalendarSection
+      date={date}
+      onDateChange={onDateChange}
+      visibleRange={visibleRange}
+      weekStartsOn={weekStartsOn}
+      density={density}
+      onMonthChange={setDisplayMonth}
+    />
   )
 }

--- a/apps/web/src/components/dispatch/ui/sidebar/workers-group.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/workers-group.tsx
@@ -3,17 +3,11 @@
 'use client'
 
 import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
-import {
-  SidebarGroup,
-  SidebarGroupCollapse,
-  SidebarMenu,
-  SidebarMenuItem,
-} from '@auxx/ui/components/sidebar'
-import { cn } from '@auxx/ui/lib/utils'
-import { Eye, EyeOff, UserPlus } from 'lucide-react'
+import { SidebarGroup, SidebarGroupCollapse, SidebarMenu } from '@auxx/ui/components/sidebar'
+import { UserPlus } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { SourceToggleRow } from '~/components/calendar/ui/source-toggle-group'
 import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
-import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
 import { AddWorkerDialog } from '../add-worker-dialog'
 import { type BoardWorker, UNASSIGNED_RESOURCE_ID } from '../board/types'
 import { DEFAULT_WORKER_COLOR, UNASSIGNED_COLOR } from '../board/utils'
@@ -75,18 +69,18 @@ export function WorkersGroup({
       <SidebarGroupCollapse open={open}>
         <SidebarMenu>
           {workers.map((worker) => (
-            <WorkerRow
+            <SourceToggleRow
               key={worker.id}
               id={worker.id}
-              name={worker.user?.name ?? worker.user?.email ?? 'Worker'}
+              label={worker.user?.name ?? worker.user?.email ?? 'Worker'}
               color={colorByUserId.get(worker.userId) ?? DEFAULT_WORKER_COLOR}
               visible={!hidden.has(worker.userId)}
               onToggle={() => onToggleWorker(worker.userId)}
             />
           ))}
-          <WorkerRow
+          <SourceToggleRow
             id={UNASSIGNED_RESOURCE_ID}
-            name='Unassigned'
+            label='Unassigned'
             color={UNASSIGNED_COLOR}
             visible={!hidden.has(UNASSIGNED_RESOURCE_ID)}
             onToggle={() => onToggleWorker(UNASSIGNED_RESOURCE_ID)}
@@ -100,36 +94,5 @@ export function WorkersGroup({
         onAdded={() => {}}
       />
     </SidebarGroup>
-  )
-}
-
-interface WorkerRowProps {
-  id: string
-  name: string
-  color: string
-  visible: boolean
-  onToggle: () => void
-}
-
-/** One worker/unassigned row — color dot + name (dimmed when hidden) + hover-revealed eye toggle,
- * ported from the deleted `ModuleSidebarToggleItem`'s visual treatment. */
-function WorkerRow({ id, name, color, visible, onToggle }: WorkerRowProps) {
-  return (
-    <SidebarMenuItem>
-      <SidebarItem
-        id={id}
-        name={name}
-        onClick={onToggle}
-        className={cn(!visible && 'text-muted-foreground/70')}
-        icon={<span className='size-2 shrink-0 rounded-full' style={{ backgroundColor: color }} />}
-        end={
-          visible ? (
-            <EyeOff className='hidden size-3.5 text-muted-foreground group-hover/menu-item:block' />
-          ) : (
-            <Eye className='size-3.5 text-muted-foreground opacity-60' />
-          )
-        }
-      />
-    </SidebarMenuItem>
   )
 }


### PR DESCRIPTION
## Summary

Implements `plans/calendar/01-source-registry-refactor.md` (all 3 phases): extracts a generic calendar-source layer out of the dispatch board and re-seats dispatch onto it with zero behavior change. This is the foundation for the multi-source `/app/calendar` page (follow-up plan 02).

**Phase 1 — new shared module `apps/web/src/components/calendar/`**
- `core/types.ts` — the thin `CalendarSource` contract: descriptor + `useEvents(range, enabled)` hook + chip renderer, plus the `SourcedEvent` alias. `enabled` lets a shell skip the query entirely for hidden sources.
- `core/use-calendar-range.ts` — date/view/range state extracted verbatim from `use-board-data` (day-view initial-range trick, month quantization, 250ms fling debounce all intact).
- `core/sidebar-store.ts` — `createCalendarSidebarStore(persistKey, extra?)` factory: `open`/`groupOpen`/`hidden` (per-group inverse visibility sets) + composable extra slice; persist `version: 1` with no migrate.
- `core/source-visibility.ts`, `ui/mini-calendar-section.tsx` (fully controlled), `ui/source-toggle-group.tsx` (`SourceToggleRow` generalizes dispatch's `WorkerRow` — `ModuleSidebarToggleItem` referenced by the plan was deleted in #1148).

**Phase 2 — dispatch re-seated (behavior-neutral)**
- `use-board-data` consumes `useCalendarRange()`; `boardMode` and everything visit-shaped stays put; `DateRange` re-exported for existing importers.
- Sidebar store rebuilt on the factory with `selectedTags` as the extra slice; workers hidden set lives at `hidden.workers` (`WORKERS_GROUP` + `useHiddenWorkerIds()`); the `selectedWorkerIdsFromHidden`/`isWorkerHidden` adapters are unchanged.
- Dispatch's mini-calendar section is now a thin wrapper owning the displayed month + density query; `WorkersGroup` renders the shared `SourceToggleRow`.
- New `board/visits-source.ts` — the descriptor + `visitToEvent` entry point the calendar page will import; the board itself keeps calling `getBoard` directly (it needs workers/backlog/workOrders the contract deliberately doesn't model).

**Phase 3 — contract honesty check**
- `calendar/sources/meetings-source.tsx` — `CalendarSource` over `calendar.myMeetings` with a minimal chip renderer. Not mounted anywhere yet.

Also rides along: one-line `rounded-2xl` tweak on the ticket-numbering preview card.

## Behavior notes

- **One-time sidebar-prefs reset**: the persist shape change (`hiddenWorkerIds` → `hidden.workers`) is handled by the version bump dropping old state — no migration code, per the few-users rule.
- Dispatch board gains no new sources; `@auxx/ui/event-calendar` internals untouched.

## Verification

- Biome clean across all touched files.
- Browser no-change pass on the dispatch board: day/week render with columns + chips, worker toggle hides/restores the day-view column both ways, v0→v1 persist drop happened exactly once then the new `hidden.workers` shape persisted, week-cell drag-and-drop and map mode work, no new console errors.
- Not exercised: month-view fling quantization and group-collapse persistence across reload (code-inspected only).