### PR TITLE
feat(money): product groups — catalog bundles with picker explode (plan 09)

### DIFF
--- a/apps/web/src/components/money/catalog-group-types.ts
+++ b/apps/web/src/components/money/catalog-group-types.ts
@@ -1,0 +1,93 @@
+// apps/web/src/components/money/catalog-group-types.ts
+
+// Client-side types for `catalog_group` entries (product bundles,
+// plans/dispatch/money/09-product-groups.md). Nothing server-side reads the
+// entries array in v1 — the explode runs in the line builder — so these live
+// here instead of `@auxx/lib/money/client`; promote later if that changes.
+
+import { generateId } from '@auxx/utils'
+
+/** One row of a catalog group. Lives in `catalog_group_entries` (JSON field). */
+export interface CatalogGroupEntry {
+  /** `generateId('cge')` — stable identity for edit/reorder (the fieldMappings entry-array convention). */
+  id: string
+  /** EntityInstance id of the referenced `catalog_item` (NOT the branded RecordId). */
+  catalogItemId: string
+  /** Preset quantity, default 1. */
+  qty: number
+  /** Overrides the item's default description on insert. */
+  description?: string | null
+  /** Overrides the item's taxable flag on insert; absent = inherit from the item. */
+  taxable?: boolean
+}
+
+/** New entry for a picked catalog item, qty 1, no overrides. */
+export function newCatalogGroupEntry(catalogItemId: string): CatalogGroupEntry {
+  return { id: generateId('cge'), catalogItemId, qty: 1 }
+}
+
+/**
+ * Field-value payload for `catalog_group_entries`. The array is wrapped in an
+ * object envelope because the generic field-value save path splits top-level
+ * arrays into one row per element (multi-value convention,
+ * field-value-mutations.ts) — a bare array would not round-trip.
+ */
+export function serializeCatalogGroupEntries(entries: CatalogGroupEntry[]): {
+  entries: CatalogGroupEntry[]
+} {
+  return { entries }
+}
+
+function isCatalogGroupEntry(entry: unknown): entry is CatalogGroupEntry {
+  return (
+    !!entry &&
+    typeof entry === 'object' &&
+    typeof (entry as CatalogGroupEntry).id === 'string' &&
+    typeof (entry as CatalogGroupEntry).catalogItemId === 'string' &&
+    typeof (entry as CatalogGroupEntry).qty === 'number'
+  )
+}
+
+/**
+ * Defensively parse a raw `catalog_group_entries` field value into a valid
+ * entries array. Handles the `{ entries: [...] }` envelope (the storage shape),
+ * bare arrays, JSON strings, one-element-array read wrappers, and the
+ * `{ type: 'json', value }` typed-value shape. Rows missing the required shape
+ * are dropped — dangling `catalogItemId`s are kept (the editor surfaces them as
+ * "Deleted item" rows; the explode skips them).
+ */
+export function parseCatalogGroupEntries(raw: unknown): CatalogGroupEntry[] {
+  let value: unknown = raw
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value)
+    } catch {
+      return []
+    }
+  }
+  // Unwrap envelope/wrapper layers until we hit the entries array itself.
+  for (let depth = 0; depth < 4; depth++) {
+    if (Array.isArray(value)) {
+      if (value.length === 0 || value.some(isCatalogGroupEntry)) break
+      if (value.length === 1) {
+        value = value[0]
+        continue
+      }
+      break
+    }
+    if (value && typeof value === 'object') {
+      const obj = value as Record<string, unknown>
+      if ('entries' in obj) {
+        value = obj.entries
+        continue
+      }
+      if (obj.type === 'json' && 'value' in obj) {
+        value = obj.value
+        continue
+      }
+    }
+    break
+  }
+  if (!Array.isArray(value)) return []
+  return value.filter(isCatalogGroupEntry)
+}

--- a/apps/web/src/components/money/hooks/use-catalog-groups.ts
+++ b/apps/web/src/components/money/hooks/use-catalog-groups.ts
@@ -1,0 +1,99 @@
+// apps/web/src/components/money/hooks/use-catalog-groups.ts
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import { useMemo } from 'react'
+import {
+  type CatalogGroupEntry,
+  parseCatalogGroupEntries,
+} from '~/components/money/catalog-group-types'
+import { type FieldInfo, useAllRecords } from '~/components/resources/hooks/use-all-records'
+import type { RecordMeta } from '~/components/resources/store/record-store'
+
+/** Catalog group record shape from `useAllRecords` (systemAttribute-keyed field values). */
+export interface CatalogGroupRecord extends RecordMeta {
+  fieldValues: {
+    catalog_group_name?: string
+    catalog_group_description?: string | null
+    catalog_group_entries?: unknown
+    catalog_group_tax_rate_id?: string | null
+    catalog_group_discount_type?: string | string[] | null
+    catalog_group_discount_value?: number | null
+    catalog_group_active?: boolean
+  }
+}
+
+/** Simplified catalog group for UI consumption — SINGLE_SELECT values unwrapped, entries parsed. */
+export interface CatalogGroup {
+  id: string
+  recordId: RecordId
+  name: string
+  description: string | null
+  entries: CatalogGroupEntry[]
+  /** Id of a `documents.taxRates` preset — resolved live, not snapshotted. */
+  taxRateId: string | null
+  discountType: 'percent' | 'amount' | null
+  /** Percent = plain number; amount = integer cents (same convention as `quote_discount_value`). */
+  discountValue: number | null
+  active: boolean
+}
+
+/**
+ * `useAllRecords` surfaces SINGLE_SELECT values as one-element arrays — unwrap
+ * so scalar-typed consumers compare correctly. See CLAUDE.md memory: "SINGLE_SELECT
+ * field values are ARRAYS".
+ */
+function scalarValue<T>(value: T | T[] | null | undefined): T | undefined {
+  if (Array.isArray(value)) return value[0]
+  return value ?? undefined
+}
+
+function toCatalogGroup(record: CatalogGroupRecord): CatalogGroup {
+  return {
+    id: record.id,
+    recordId: record.recordId,
+    name: record.fieldValues.catalog_group_name ?? record.displayName ?? 'Untitled',
+    description: record.fieldValues.catalog_group_description ?? null,
+    entries: parseCatalogGroupEntries(record.fieldValues.catalog_group_entries),
+    taxRateId: record.fieldValues.catalog_group_tax_rate_id ?? null,
+    discountType:
+      (scalarValue(record.fieldValues.catalog_group_discount_type) as
+        | 'percent'
+        | 'amount'
+        | undefined) ?? null,
+    discountValue: record.fieldValues.catalog_group_discount_value ?? null,
+    active: record.fieldValues.catalog_group_active ?? true,
+  }
+}
+
+interface UseCatalogGroupsResult {
+  /** All catalog groups, active and inactive. */
+  groups: CatalogGroup[]
+  /** Lookup by entity instance id (not the branded RecordId). */
+  groupMap: Map<string, CatalogGroup>
+  /** Resolved entityDefinitionId UUID for `catalog_group`, once loaded. */
+  entityDefinitionId: string | null
+  /** Field key → { id, key, type } map, for resolving fieldIds when saving. */
+  fields: Record<string, FieldInfo>
+  isLoading: boolean
+  refresh: () => void
+}
+
+/**
+ * Fetch every catalog group (Product Groups tab, hidden `catalog_group` system
+ * entity — plans/dispatch/money/09-product-groups.md) via the generic record
+ * system. Same "small dataset, no pagination" shape as `useCatalogItems`.
+ */
+export function useCatalogGroups(): UseCatalogGroupsResult {
+  const { records, entityDefinitionId, fields, isLoading, refresh } =
+    useAllRecords<CatalogGroupRecord>({
+      apiSlug: 'catalog-groups',
+      includeArchived: false,
+    })
+
+  const { groups, groupMap } = useMemo(() => {
+    const list = records.map(toCatalogGroup)
+    return { groups: list, groupMap: new Map(list.map((group) => [group.id, group])) }
+  }, [records])
+
+  return { groups, groupMap, entityDefinitionId, fields, isLoading, refresh }
+}

--- a/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
+++ b/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
@@ -27,9 +27,10 @@ import {
 } from '@auxx/ui/components/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
-import { Package, Plus, Settings2 } from 'lucide-react'
+import { Boxes, Package, Plus, Settings2 } from 'lucide-react'
 import Link from 'next/link'
 import { type ReactNode, useMemo, useState } from 'react'
+import { parseCatalogGroupEntries } from '~/components/money/catalog-group-types'
 import type { RecordMeta } from '~/components/resources'
 import { useAllRecords } from '~/components/resources/hooks/use-all-records'
 import { useUser } from '~/hooks/use-user'
@@ -44,6 +45,33 @@ export interface CatalogItemPick {
   unitPrice: number | null
 }
 
+/** One resolved line payload inside a picked group's explode (plans/dispatch/money/09-product-groups.md). */
+export interface CatalogGroupPickLine {
+  name: string
+  description: string | null
+  category: string | null
+  taxable: boolean
+  unitPrice: number | null
+  qty: number
+  /** EntityInstance id of the `catalog_item` (NOT the branded RecordId). */
+  catalogItemId: string
+}
+
+/**
+ * Value handed to the line builder when a group is picked — resolution
+ * (entry → catalog item lookup, dangling-id skip) happens here in the picker,
+ * where both datasets are already loaded; the builder just writes.
+ */
+export interface CatalogGroupPick {
+  name: string
+  taxRateId: string | null
+  discountType: 'percent' | 'amount' | null
+  discountValue: number | null
+  lines: CatalogGroupPickLine[]
+  /** Count of entries whose `catalogItemId` no longer resolves to a catalog item. */
+  skippedCount: number
+}
+
 interface CatalogItemFieldValues {
   catalog_item_name?: string
   catalog_item_description?: string | null
@@ -56,6 +84,20 @@ interface CatalogItemFieldValues {
 
 interface CatalogItemRow extends RecordMeta {
   fieldValues: CatalogItemFieldValues
+}
+
+interface CatalogGroupFieldValues {
+  catalog_group_name?: string
+  catalog_group_description?: string | null
+  catalog_group_entries?: unknown
+  catalog_group_tax_rate_id?: string | null
+  catalog_group_discount_type?: unknown
+  catalog_group_discount_value?: number | null
+  catalog_group_active?: boolean
+}
+
+interface CatalogGroupRow extends RecordMeta {
+  fieldValues: CatalogGroupFieldValues
 }
 
 /** SINGLE_SELECT values come back as arrays — normalize to the first value. */
@@ -76,6 +118,56 @@ function titleCase(value: string): string {
   return value.length ? value[0].toUpperCase() + value.slice(1) : value
 }
 
+/**
+ * Resolve a `catalog_group` row's entries against the already-loaded catalog
+ * item records — the explode payload's shape (money 09-product-groups.md
+ * "Line-builder consumption" §1). Dangling `catalogItemId`s are skipped and
+ * counted (logged by the caller); inactive items still resolve (deliberate
+ * group membership).
+ */
+function resolveGroup(
+  group: CatalogGroupRow,
+  itemsById: Map<string, CatalogItemRow>
+): CatalogGroupPick {
+  const entries = parseCatalogGroupEntries(group.fieldValues.catalog_group_entries)
+  const lines: CatalogGroupPickLine[] = []
+  let skippedCount = 0
+
+  for (const entry of entries) {
+    const item = itemsById.get(entry.catalogItemId)
+    if (!item) {
+      skippedCount++
+      console.warn(
+        `Catalog group "${group.fieldValues.catalog_group_name ?? group.id}" references a deleted catalog item (${entry.catalogItemId}) — entry skipped.`
+      )
+      continue
+    }
+    lines.push({
+      name: item.fieldValues.catalog_item_name ?? '',
+      description: entry.description ?? item.fieldValues.catalog_item_description ?? null,
+      category: firstOf<string>(item.fieldValues.catalog_item_category),
+      taxable: entry.taxable ?? item.fieldValues.catalog_item_taxable !== false,
+      unitPrice: item.fieldValues.catalog_item_default_unit_price ?? null,
+      qty: entry.qty,
+      catalogItemId: entry.catalogItemId,
+    })
+  }
+
+  return {
+    name: group.fieldValues.catalog_group_name ?? '',
+    taxRateId: group.fieldValues.catalog_group_tax_rate_id ?? null,
+    discountType: firstOf<'percent' | 'amount'>(group.fieldValues.catalog_group_discount_type),
+    discountValue: group.fieldValues.catalog_group_discount_value ?? null,
+    lines,
+    skippedCount,
+  }
+}
+
+/** Σ resolvable-line `unitPrice × qty` — the picker's group total display. */
+function groupTotal(pick: CatalogGroupPick): number {
+  return pick.lines.reduce((sum, line) => sum + (line.unitPrice ?? 0) * line.qty, 0)
+}
+
 export interface CatalogPickerProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -84,6 +176,8 @@ export interface CatalogPickerProps {
   /** Org currency code (from `organization.currency`) for price display. */
   currencyCode?: string
   onSelectCatalogItem: (item: CatalogItemPick) => void
+  /** Picking a group explodes its resolved entries into plain line items. */
+  onSelectGroup: (group: CatalogGroupPick) => void
   /** User typed text with no catalog match — add as an ad-hoc line, no catalog rel. */
   onFreeText: (text: string) => void
   children: ReactNode
@@ -102,16 +196,35 @@ export function CatalogPicker({
   initialQuery = '',
   currencyCode = 'USD',
   onSelectCatalogItem,
+  onSelectGroup,
   onFreeText,
   children,
 }: CatalogPickerProps) {
   const [query, setQuery] = useState(initialQuery)
   const { isAdminOrOwner } = useUser()
 
-  const { records, isLoading } = useAllRecords<CatalogItemRow>({
+  const { records, isLoading: itemsLoading } = useAllRecords<CatalogItemRow>({
     apiSlug: 'catalog-items',
     enabled: open,
   })
+
+  const { records: groupRecords, isLoading: groupsLoading } = useAllRecords<CatalogGroupRow>({
+    apiSlug: 'catalog-groups',
+    enabled: open,
+  })
+
+  const groupPicks = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const itemsById = new Map(records.map((r) => [r.id, r]))
+    const active = groupRecords.filter((g) => g.fieldValues.catalog_group_active !== false)
+    const filtered = q
+      ? active.filter((g) => (g.fieldValues.catalog_group_name ?? '').toLowerCase().includes(q))
+      : active
+
+    return filtered
+      .map((row) => ({ id: row.id, pick: resolveGroup(row, itemsById) }))
+      .sort((a, b) => a.pick.name.localeCompare(b.pick.name))
+  }, [groupRecords, records, query])
 
   const groups = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -141,7 +254,7 @@ export function CatalogPicker({
       }))
   }, [records, query])
 
-  const hasAnyMatch = groups.some((g) => g.rows.length > 0)
+  const hasAnyMatch = groups.some((g) => g.rows.length > 0) || groupPicks.length > 0
 
   const handlePick = (row: CatalogItemRow) => {
     onSelectCatalogItem({
@@ -152,6 +265,11 @@ export function CatalogPicker({
       taxable: row.fieldValues.catalog_item_taxable !== false,
       unitPrice: row.fieldValues.catalog_item_default_unit_price ?? null,
     })
+    onOpenChange(false)
+  }
+
+  const handlePickGroup = (pick: CatalogGroupPick) => {
+    onSelectGroup(pick)
     onOpenChange(false)
   }
 
@@ -177,7 +295,7 @@ export function CatalogPicker({
             placeholder='Search products & services…'
           />
           <CommandList>
-            {!isLoading && !hasAnyMatch && (
+            {!(itemsLoading || groupsLoading) && !hasAnyMatch && (
               <CommandEmpty>
                 <button
                   type='button'
@@ -190,6 +308,32 @@ export function CatalogPicker({
                   </span>
                 </button>
               </CommandEmpty>
+            )}
+
+            {groupPicks.length > 0 && (
+              <CommandGroup heading='Groups'>
+                {groupPicks.map(({ id, pick }) => (
+                  <CommandItem
+                    key={id}
+                    value={`group-${id}`}
+                    onSelect={() => handlePickGroup(pick)}
+                    className='flex items-center justify-between gap-2'>
+                    <div className='flex min-w-0 items-center gap-2'>
+                      <Boxes className='size-4 shrink-0 text-muted-foreground' />
+                      <div className='flex min-w-0 flex-col'>
+                        <span className='truncate'>{pick.name}</span>
+                        <span className='truncate text-muted-foreground text-xs'>
+                          {pick.lines.length + pick.skippedCount} item
+                          {pick.lines.length + pick.skippedCount === 1 ? '' : 's'}
+                        </span>
+                      </div>
+                    </div>
+                    <span className='shrink-0 text-muted-foreground text-xs'>
+                      {formatPrice(groupTotal(pick), currencyCode)}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
             )}
 
             {groups.map(

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -61,7 +61,7 @@ import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-v
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
-import { type CatalogItemPick, CatalogPicker } from './catalog-picker'
+import { type CatalogGroupPick, type CatalogItemPick, CatalogPicker } from './catalog-picker'
 import { formatCurrency, titleCase } from './shared'
 import { TotalsFooter } from './totals-footer'
 
@@ -95,6 +95,29 @@ const QTY_ATTRS = ['line_item_qty']
 const PRICE_ATTRS = ['line_item_unit_price']
 const TOTAL_ATTRS = ['line_item_qty', 'line_item_unit_price']
 const TAXABLE_ATTRS = ['line_item_taxable']
+// Document billing mirrors read for the group-explode set-if-unset checks (steps 4–5,
+// money 09-product-groups.md "Line-builder consumption") — the same attrs `TotalsFooter`
+// reads, minus the invoice-only ledger-sync mirrors this doesn't need.
+const QUOTE_BILLING_ATTRS = [
+  'quote_discount_type',
+  'quote_discount_value',
+  'quote_tax_name',
+  'quote_tax_rate',
+]
+const INVOICE_BILLING_ATTRS = [
+  'invoice_discount_type',
+  'invoice_discount_value',
+  'invoice_tax_name',
+  'invoice_tax_rate',
+]
+
+/** Org tax rate preset (`documents.taxRates` setting, money MQ1 build spec §G.1). */
+interface TaxRatePreset {
+  id: string
+  name: string
+  rate: number
+  isDefault?: boolean
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Cells
@@ -112,6 +135,7 @@ function LineNameCell({
   currencyCode,
   descriptionOpen,
   closeDescription,
+  onSelectGroup,
 }: {
   recordId: RecordId
   rowId: string
@@ -119,6 +143,7 @@ function LineNameCell({
   currencyCode: string
   descriptionOpen: boolean
   closeDescription: (lineId: string) => void
+  onSelectGroup: (pick: CatalogGroupPick) => void
 }) {
   const { values } = useSystemValues(recordId, NAME_ATTRS, { autoFetch: true })
   const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue()
@@ -175,6 +200,7 @@ function LineNameCell({
           initialQuery={name}
           currencyCode={currencyCode}
           onSelectCatalogItem={handlePick}
+          onSelectGroup={onSelectGroup}
           onFreeText={(text) => saveFieldValue(recordId, 'line_item_name', text, FieldType.TEXT)}>
           <Button
             variant='transparent'
@@ -358,6 +384,7 @@ function LineRow({
   toggleDescription,
   closeDescription,
   deleteLine,
+  onSelectGroup,
 }: {
   record: RecordMeta
   entityDefinitionId: string
@@ -367,6 +394,7 @@ function LineRow({
   toggleDescription: (lineId: string) => void
   closeDescription: (lineId: string) => void
   deleteLine: (lineId: string) => void
+  onSelectGroup: (recordId: RecordId, pick: CatalogGroupPick) => void
 }) {
   const recordId = toRecordId(entityDefinitionId, record.id)
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -399,6 +427,7 @@ function LineRow({
             currencyCode={currencyCode}
             descriptionOpen={descriptionOpen}
             closeDescription={closeDescription}
+            onSelectGroup={(pick) => onSelectGroup(recordId, pick)}
           />
         }
         cells={[
@@ -455,6 +484,19 @@ export function LineBuilder({
   const entityDefinitionId = resource?.id
   const { getSetting } = useSettings({})
   const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
+
+  // work_order (M2 job view) has no billing fields (money MI1 build spec §J.2 precedent,
+  // mirrored from TotalsFooter) — group discount/tax set-if-unset skips entirely there.
+  const hasBilling = documentType === 'quote' || documentType === 'invoice'
+  const billingPrefix = documentType === 'invoice' ? 'invoice' : 'quote'
+  const { values: billingValues } = useSystemValues(
+    docRecordId,
+    documentType === 'invoice' ? INVOICE_BILLING_ATTRS : QUOTE_BILLING_ATTRS,
+    { autoFetch: hasBilling, enabled: hasBilling }
+  )
+  const taxRates = ((getSetting('documents.taxRates') as TaxRatePreset[] | null) ?? []).filter(
+    (r) => r && typeof r.rate === 'number'
+  )
 
   const [openDescriptionIds, setOpenDescriptionIds] = useState<Set<string>>(new Set())
   const [orderOverride, setOrderOverride] = useState<string[] | null>(null)
@@ -619,6 +661,140 @@ export function LineBuilder({
     }
   }, [documentType, documentRecordId, createMutateAsync, refresh])
 
+  const { saveMultipleAsync } = useSaveFieldValue()
+
+  /**
+   * Explode a picked catalog group onto the document (money 09-product-groups.md
+   * "Line-builder consumption"): entry #1 fills the line whose picker was open,
+   * entries 2…N append as new lines, then the document discount/tax are
+   * set-if-unset from the group (never overwriting an existing value).
+   */
+  const handleGroupPick = useCallback(
+    async (recordId: RecordId, pick: CatalogGroupPick) => {
+      if (pick.skippedCount > 0) {
+        console.warn(`Catalog group "${pick.name}" skipped ${pick.skippedCount} dangling item(s).`)
+      }
+      if (pick.lines.length === 0) return
+
+      const [first, ...rest] = pick.lines
+
+      // Step 1: entry #1 fills the CURRENT line — the handlePick shape (catalog-picker.tsx)
+      // plus qty, which the single-item pick leaves untouched.
+      void saveMultipleAsync(recordId, [
+        { fieldId: 'line_item_name', value: first.name, fieldType: FieldType.TEXT },
+        { fieldId: 'line_item_description', value: first.description, fieldType: FieldType.TEXT },
+        {
+          fieldId: 'line_item_category',
+          value: first.category,
+          fieldType: FieldType.SINGLE_SELECT,
+        },
+        { fieldId: 'line_item_taxable', value: first.taxable, fieldType: FieldType.CHECKBOX },
+        { fieldId: 'line_item_unit_price', value: first.unitPrice, fieldType: FieldType.CURRENCY },
+        { fieldId: 'line_item_qty', value: first.qty, fieldType: FieldType.NUMBER },
+        {
+          fieldId: 'line_item_catalog_item',
+          value: toRecordId('catalog_item', first.catalogItemId),
+          fieldType: FieldType.RELATIONSHIP,
+        },
+      ])
+
+      // Step 2: entries 2…N append at the end — sequential creates (not Promise.all) so
+      // sort order + the server-side totals-recompute hooks stay deterministic; N is small.
+      // Known v1 edge: picking on a middle line still appends these at the list end.
+      if (rest.length > 0) {
+        const relKey =
+          documentType === 'quote'
+            ? 'line_item_quote'
+            : documentType === 'invoice'
+              ? 'line_item_invoice'
+              : 'line_item_work_order'
+        const baseOrder = displayIdsRef.current.length
+        try {
+          for (const [index, line] of rest.entries()) {
+            await createMutateAsync({
+              entityDefinitionId: 'line_item',
+              values: {
+                line_item_name: line.name,
+                line_item_description: line.description,
+                line_item_category: line.category,
+                line_item_taxable: line.taxable,
+                line_item_unit_price: line.unitPrice,
+                line_item_qty: line.qty,
+                line_item_catalog_item: toRecordId('catalog_item', line.catalogItemId),
+                line_item_sort_order: baseOrder + index,
+                [relKey]: documentRecordId,
+              },
+            })
+          }
+        } catch (error) {
+          toastError({
+            title: 'Error adding group lines',
+            description: error instanceof Error ? error.message : 'Could not add all group lines',
+          })
+        }
+        refresh()
+      }
+
+      // Steps 4–5: document discount/tax set-if-unset — quote/invoice only, never
+      // overwriting a value the document already has.
+      if (hasBilling) {
+        const currentDiscountValue = billingValues[`${billingPrefix}_discount_value`] as
+          | number
+          | null
+          | undefined
+        if (pick.discountType && pick.discountValue !== null && currentDiscountValue == null) {
+          void saveMultipleAsync(docRecordId, [
+            {
+              fieldId: `${billingPrefix}_discount_type`,
+              value: pick.discountType,
+              fieldType: FieldType.SINGLE_SELECT,
+            },
+            {
+              fieldId: `${billingPrefix}_discount_value`,
+              value: pick.discountValue,
+              fieldType: FieldType.NUMBER,
+            },
+          ])
+        }
+
+        const currentTaxRate = billingValues[`${billingPrefix}_tax_rate`] as
+          | number
+          | null
+          | undefined
+        if (pick.taxRateId && currentTaxRate == null) {
+          // A deleted preset id silently no-ops — no tax write.
+          const preset = taxRates.find((r) => r.id === pick.taxRateId)
+          if (preset) {
+            void saveMultipleAsync(docRecordId, [
+              {
+                fieldId: `${billingPrefix}_tax_name`,
+                value: preset.name,
+                fieldType: FieldType.TEXT,
+              },
+              {
+                fieldId: `${billingPrefix}_tax_rate`,
+                value: preset.rate,
+                fieldType: FieldType.NUMBER,
+              },
+            ])
+          }
+        }
+      }
+    },
+    [
+      documentType,
+      documentRecordId,
+      docRecordId,
+      hasBilling,
+      billingPrefix,
+      billingValues,
+      taxRates,
+      saveMultipleAsync,
+      createMutateAsync,
+      refresh,
+    ]
+  )
+
   const toggleDescription = useCallback((lineId: string) => {
     setOpenDescriptionIds((prev) => {
       const next = new Set(prev)
@@ -708,6 +884,7 @@ export function LineBuilder({
                 toggleDescription={toggleDescription}
                 closeDescription={closeDescription}
                 deleteLine={deleteLine}
+                onSelectGroup={handleGroupPick}
               />
             ))}
           </SortableContext>

--- a/apps/web/src/components/money/ui/settings/group-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/group-editor.tsx
@@ -1,0 +1,589 @@
+// apps/web/src/components/money/ui/settings/group-editor.tsx
+'use client'
+
+import { FieldType } from '@auxx/database/enums'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@auxx/ui/components/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { CircleCheck, CircleDashed, CircleX, GripVertical, Pencil, Plus, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import {
+  type CatalogGroupEntry,
+  newCatalogGroupEntry,
+  serializeCatalogGroupEntries,
+} from '~/components/money/catalog-group-types'
+import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
+import { BaseType } from '~/components/workflow/types'
+import { useDebouncedCallback } from '~/hooks/use-debounced-value'
+import { useSettings } from '~/hooks/use-settings'
+import { type CatalogGroup, useCatalogGroups } from '../../hooks/use-catalog-groups'
+import { type CatalogItem, useCatalogItems } from '../../hooks/use-catalog-items'
+import { formatMoney } from './format-money'
+import type { TaxRate } from './tax-rate-types'
+
+interface GroupEditorProps {
+  selectedId: string | null
+  currency: string
+}
+
+/**
+ * Right column of the Product groups tab: a `FieldPanel` form for the
+ * selected group (name/description/tax rate/discount/active, autosaved via
+ * `useSaveFieldValue` — mirrors `product-editor.tsx`), plus an entries
+ * section below (drag-reorder, qty/description/taxable overrides).
+ */
+export function GroupEditor({ selectedId, currency }: GroupEditorProps) {
+  const { groupMap } = useCatalogGroups()
+  const group = selectedId ? groupMap.get(selectedId) : undefined
+
+  if (!group) {
+    return <div className='p-4 text-sm text-muted-foreground'>Select a product group to edit.</div>
+  }
+
+  return <GroupEditorForm key={group.id} group={group} currency={currency} />
+}
+
+function GroupEditorForm({ group, currency }: { group: CatalogGroup; currency: string }) {
+  const { itemMap, items } = useCatalogItems()
+  const { getSetting } = useSettings({ scope: 'DOCUMENTS' })
+  const taxRates = (getSetting('documents.taxRates') as TaxRate[] | null) ?? []
+
+  const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue({})
+
+  const [name, setName] = useState(group.name)
+  const [description, setDescription] = useState(group.description ?? '')
+  const [discountDraft, setDiscountDraft] = useState<string | null>(null)
+
+  const commitName = useDebouncedCallback((value: string) => {
+    saveFieldValue(group.recordId, 'catalog_group_name', value, FieldType.TEXT)
+  }, 500)
+  const commitDescription = useDebouncedCallback((value: string) => {
+    saveFieldValue(group.recordId, 'catalog_group_description', value || null, FieldType.TEXT)
+  }, 500)
+
+  // Envelope, not a bare array — the generic save path splits top-level arrays
+  // into one row per element (see serializeCatalogGroupEntries).
+  function commitEntries(next: CatalogGroupEntry[]) {
+    saveFieldValue(
+      group.recordId,
+      'catalog_group_entries',
+      serializeCatalogGroupEntries(next),
+      FieldType.JSON
+    )
+  }
+
+  // Amount discounts are stored as integer cents (CURRENCY convention); percent
+  // discounts as plain percentages — the input always shows/accepts the display
+  // unit. Mirrors the totals-footer.tsx conversion idiom.
+  const discountDisplayValue =
+    group.discountValue === null
+      ? ''
+      : String(group.discountType === 'amount' ? group.discountValue / 100 : group.discountValue)
+
+  const writeDiscount = (type: 'percent' | 'amount' | null, value: number | null) => {
+    void saveMultipleAsync(group.recordId, [
+      { fieldId: 'catalog_group_discount_type', value: type, fieldType: FieldType.SINGLE_SELECT },
+      { fieldId: 'catalog_group_discount_value', value, fieldType: FieldType.NUMBER },
+    ])
+  }
+
+  const commitDiscountValue = () => {
+    if (discountDraft === null) return
+    const trimmed = discountDraft.trim()
+    setDiscountDraft(null)
+    const parsed = trimmed === '' ? null : Number(trimmed)
+    if (parsed !== null && Number.isNaN(parsed)) return
+    const type = parsed === null ? null : (group.discountType ?? 'percent')
+    writeDiscount(type, parsed !== null && type === 'amount' ? Math.round(parsed * 100) : parsed)
+  }
+
+  // Type toggle keeps the number the user SEES stable: 10% becomes $10 (1000¢).
+  const toggleDiscountType = (type: 'percent' | 'amount') => {
+    if (group.discountValue === null) {
+      writeDiscount(type, null)
+      return
+    }
+    const displayed =
+      group.discountType === 'amount' ? group.discountValue / 100 : group.discountValue
+    writeDiscount(type, type === 'amount' ? Math.round(displayed * 100) : displayed)
+  }
+
+  const selectedTaxId = group.taxRateId ?? '__none__'
+
+  return (
+    <div className='flex flex-col gap-3 p-3'>
+      <FieldPanel
+        orientation='horizontal'
+        breakpoint='md'
+        resizeId='catalog-group-form'
+        defaultLabelWidth={140}
+        className='p-0'>
+        <FieldPanelRow title='Name' type={BaseType.STRING} showIcon isRequired>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={name}
+            onChange={(value) => {
+              setName(value as string)
+              commitName(value as string)
+            }}
+            placeholder='Group name'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Description' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            fieldOptions={{ multiline: true }}
+            value={description}
+            onChange={(value) => {
+              setDescription(value as string)
+              commitDescription(value as string)
+            }}
+            placeholder='Admin-facing note'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Tax rate' type={BaseType.STRING} showIcon>
+          <Select
+            value={selectedTaxId}
+            onValueChange={(id) =>
+              saveFieldValue(
+                group.recordId,
+                'catalog_group_tax_rate_id',
+                id === '__none__' ? null : id,
+                FieldType.TEXT
+              )
+            }>
+            <SelectTrigger className='w-full'>
+              <SelectValue placeholder='No tax' />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='__none__'>No tax</SelectItem>
+              {taxRates.map((rate) => (
+                <SelectItem key={rate.id} value={rate.id}>
+                  {rate.name} ({rate.rate}%)
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Discount' type={BaseType.NUMBER} showIcon>
+          <div className='flex items-center gap-1.5'>
+            <div className='flex overflow-hidden rounded-md border border-primary-200/60 dark:border-[#2c313a]'>
+              {(['percent', 'amount'] as const).map((type) => (
+                <button
+                  key={type}
+                  type='button'
+                  onClick={() => toggleDiscountType(type)}
+                  className={cn(
+                    'px-2 py-1 text-xs leading-none',
+                    (group.discountType ?? 'percent') === type
+                      ? 'bg-primary-150 text-foreground dark:bg-primary-100'
+                      : 'text-muted-foreground hover:bg-primary-100/60'
+                  )}>
+                  {type === 'percent' ? '%' : '$'}
+                </button>
+              ))}
+            </div>
+            <input
+              value={discountDraft ?? discountDisplayValue}
+              onChange={(e) => setDiscountDraft(e.target.value)}
+              onBlur={commitDiscountValue}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') e.currentTarget.blur()
+                if (e.key === 'Escape') setDiscountDraft(null)
+              }}
+              inputMode='decimal'
+              placeholder='0'
+              className='w-20 rounded-md border border-primary-200/60 bg-transparent px-2 py-1 text-sm tabular-nums outline-none hover:bg-primary-100/60 focus:bg-primary-100/80 dark:border-[#2c313a]'
+            />
+          </div>
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Active' type={BaseType.BOOLEAN} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.CHECKBOX}
+            fieldOptions={{ variant: 'switch' }}
+            value={group.active}
+            onChange={(value) =>
+              saveFieldValue(group.recordId, 'catalog_group_active', value, FieldType.CHECKBOX)
+            }
+          />
+        </FieldPanelRow>
+      </FieldPanel>
+
+      <EntriesSection
+        entries={group.entries}
+        itemMap={itemMap}
+        items={items}
+        currency={currency}
+        onChange={commitEntries}
+      />
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entries section — drag-reorder list + "Add item" popover
+// ─────────────────────────────────────────────────────────────────────────────
+
+function EntriesSection({
+  entries,
+  itemMap,
+  items,
+  currency,
+  onChange,
+}: {
+  entries: CatalogGroupEntry[]
+  itemMap: Map<string, CatalogItem>
+  items: CatalogItem[]
+  currency: string
+  onChange: (next: CatalogGroupEntry[]) => void
+}) {
+  const [addOpen, setAddOpen] = useState(false)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 3 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = entries.findIndex((e) => e.id === active.id)
+    const newIndex = entries.findIndex((e) => e.id === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+    onChange(arrayMove(entries, oldIndex, newIndex))
+  }
+
+  function handleAddItem(catalogItemId: string) {
+    onChange([...entries, newCatalogGroupEntry(catalogItemId)])
+    setAddOpen(false)
+  }
+
+  function handleRemove(entryId: string) {
+    onChange(entries.filter((e) => e.id !== entryId))
+  }
+
+  function handlePatch(entryId: string, patch: Partial<CatalogGroupEntry>) {
+    onChange(entries.map((e) => (e.id === entryId ? { ...e, ...patch } : e)))
+  }
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <div className='flex items-center justify-between px-1'>
+        <span className='font-medium text-muted-foreground text-xs'>Items</span>
+        <AddItemPopover
+          open={addOpen}
+          onOpenChange={setAddOpen}
+          items={items}
+          currency={currency}
+          onPick={handleAddItem}
+        />
+      </div>
+
+      {entries.length === 0 ? (
+        <div className='rounded-md border border-dashed p-4 text-center text-xs text-muted-foreground'>
+          No items yet — add one to build this group.
+        </div>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+          modifiers={[restrictToVerticalAxis]}>
+          <SortableContext items={entries.map((e) => e.id)} strategy={verticalListSortingStrategy}>
+            <div className='flex flex-col gap-0.5'>
+              {entries.map((entry) => (
+                <GroupEntryRow
+                  key={entry.id}
+                  entry={entry}
+                  item={itemMap.get(entry.catalogItemId)}
+                  currency={currency}
+                  onPatch={(patch) => handlePatch(entry.id, patch)}
+                  onRemove={() => handleRemove(entry.id)}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+    </div>
+  )
+}
+
+function GroupEntryRow({
+  entry,
+  item,
+  currency,
+  onPatch,
+  onRemove,
+}: {
+  entry: CatalogGroupEntry
+  item: CatalogItem | undefined
+  currency: string
+  onPatch: (patch: Partial<CatalogGroupEntry>) => void
+  onRemove: () => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: entry.id,
+  })
+  const [expanded, setExpanded] = useState(false)
+  const [qtyDraft, setQtyDraft] = useState<string | null>(null)
+  const [descDraft, setDescDraft] = useState<string | null>(null)
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+    opacity: isDragging ? 0.8 : 1,
+  }
+
+  const dragHandle = (
+    <span {...attributes} {...listeners} className='cursor-grab touch-none'>
+      <GripVertical className='size-4' />
+    </span>
+  )
+
+  const commitQty = () => {
+    if (qtyDraft === null) return
+    const trimmed = qtyDraft.trim()
+    setQtyDraft(null)
+    const parsed = Number(trimmed)
+    if (!trimmed || Number.isNaN(parsed) || parsed <= 0) return
+    onPatch({ qty: parsed })
+  }
+
+  const commitDescription = () => {
+    if (descDraft === null) return
+    onPatch({ description: descDraft.trim() || null })
+    setDescDraft(null)
+  }
+
+  // Tri-state cycle: inherit (absent) → taxable → not taxable → inherit.
+  function cycleTaxable() {
+    if (entry.taxable === undefined) onPatch({ taxable: true })
+    else if (entry.taxable === true) onPatch({ taxable: false })
+    else onPatch({ taxable: undefined })
+  }
+
+  // Dangling entry — the referenced catalog item no longer resolves. Deleting a
+  // product doesn't rewrite groups; this row is where staleness surfaces.
+  if (!item) {
+    return (
+      <div ref={setNodeRef} style={style}>
+        <TreeRow
+          icon={dragHandle}
+          title={<span className='text-destructive text-sm'>Deleted item</span>}
+          rowClassName='bg-destructive/5 hover:bg-destructive/10'
+          secondary={<span className='text-destructive/70 text-xs'>Qty {entry.qty}</span>}
+          actions={
+            <TreeRowButton tooltipText='Remove' variant='destructive' onClick={onRemove}>
+              <X />
+            </TreeRowButton>
+          }
+        />
+      </div>
+    )
+  }
+
+  const subtotal =
+    item.defaultUnitPriceCents === null ? null : item.defaultUnitPriceCents * entry.qty
+  const TaxableIcon =
+    entry.taxable === undefined ? CircleDashed : entry.taxable ? CircleCheck : CircleX
+  const taxableLabel =
+    entry.taxable === undefined
+      ? `Inherit (${item.taxable ? 'taxable' : 'not taxable'})`
+      : entry.taxable
+        ? 'Taxable'
+        : 'Not taxable'
+
+  return (
+    <div ref={setNodeRef} style={style} className='flex flex-col'>
+      <TreeRow
+        icon={dragHandle}
+        title={<span className={cn('text-sm', !item.active && 'opacity-60')}>{item.name}</span>}
+        rowClassName='bg-primary-50 hover:bg-primary-100'
+        secondary={
+          <span className='truncate text-muted-foreground text-xs'>
+            {formatMoney(item.defaultUnitPriceCents, currency)} × {entry.qty}
+            {subtotal !== null && ` = ${formatMoney(subtotal, currency)}`}
+          </span>
+        }
+        actions={
+          <div className='flex items-center gap-1'>
+            <input
+              value={qtyDraft ?? String(entry.qty)}
+              onChange={(e) => setQtyDraft(e.target.value)}
+              onBlur={commitQty}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') e.currentTarget.blur()
+                if (e.key === 'Escape') setQtyDraft(null)
+              }}
+              inputMode='decimal'
+              className='w-10 rounded-sm border-none bg-transparent px-1 text-right text-xs tabular-nums outline-none hover:bg-primary-100/60 focus:bg-primary-100/80'
+            />
+            <TreeRowButton
+              tooltipText='Description override'
+              onClick={() => setExpanded((v) => !v)}>
+              <Pencil />
+            </TreeRowButton>
+            <TreeRowButton tooltipText={taxableLabel} onClick={cycleTaxable}>
+              <TaxableIcon />
+            </TreeRowButton>
+            <TreeRowButton tooltipText='Remove' variant='destructive' onClick={onRemove}>
+              <X />
+            </TreeRowButton>
+          </div>
+        }
+      />
+      {expanded && (
+        <div className='pb-1.5 pl-9 pr-1'>
+          <input
+            value={descDraft ?? entry.description ?? ''}
+            onChange={(e) => setDescDraft(e.target.value)}
+            onBlur={commitDescription}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') e.currentTarget.blur()
+              if (e.key === 'Escape') setDescDraft(null)
+            }}
+            placeholder={item.description || 'Description override'}
+            className='w-full rounded-md border border-primary-200/60 bg-transparent px-2 py-1 text-xs outline-none dark:border-[#2c313a]'
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// "Add item" popover — a slim local copy of catalog-picker.tsx's grouped
+// Command list, over ACTIVE catalog items only (catalog-picker itself is
+// line-oriented and doesn't fit this shape).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function titleCase(value: string): string {
+  return value.length ? value[0].toUpperCase() + value.slice(1) : value
+}
+
+function AddItemPopover({
+  open,
+  onOpenChange,
+  items,
+  currency,
+  onPick,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  items: CatalogItem[]
+  currency: string
+  onPick: (catalogItemId: string) => void
+}) {
+  const [query, setQuery] = useState('')
+
+  const groups = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const active = items.filter((item) => item.active)
+    const filtered = q ? active.filter((item) => item.name.toLowerCase().includes(q)) : active
+
+    const byCategory = new Map<string, CatalogItem[]>()
+    for (const item of filtered) {
+      const bucket = byCategory.get(item.category) ?? []
+      bucket.push(item)
+      byCategory.set(item.category, bucket)
+    }
+
+    return [...byCategory.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([category, rows]) => ({
+        category,
+        rows: rows.sort((a, b) => a.name.localeCompare(b.name)),
+      }))
+  }, [items, query])
+
+  const hasAnyMatch = groups.some((g) => g.rows.length > 0)
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next)
+        if (next) setQuery('')
+      }}>
+      <PopoverTrigger asChild>
+        <Button variant='outline' size='xs'>
+          <Plus />
+          Add item
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='end' className='w-[280px] p-0'>
+        <Command shouldFilter={false}>
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder='Search products & services…'
+          />
+          <CommandList>
+            {!hasAnyMatch && <CommandEmpty>No active items</CommandEmpty>}
+            {groups.map(
+              (group) =>
+                group.rows.length > 0 && (
+                  <CommandGroup key={group.category} heading={titleCase(group.category)}>
+                    {group.rows.map((item) => (
+                      <CommandItem
+                        key={item.id}
+                        value={item.id}
+                        onSelect={() => onPick(item.id)}
+                        className='flex items-center justify-between gap-2'>
+                        <span className='truncate'>{item.name}</span>
+                        <span className='shrink-0 text-muted-foreground text-xs'>
+                          {formatMoney(item.defaultUnitPriceCents, currency)}
+                        </span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/money/ui/settings/groups-list.tsx
+++ b/apps/web/src/components/money/ui/settings/groups-list.tsx
@@ -1,0 +1,179 @@
+// apps/web/src/components/money/ui/settings/groups-list.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { InputSearch } from '@auxx/ui/components/input-search'
+import { Switch } from '@auxx/ui/components/switch'
+import { toastError } from '@auxx/ui/components/toast'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Boxes, Plus } from 'lucide-react'
+import { useState } from 'react'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+import { type CatalogGroup, useCatalogGroups } from '../../hooks/use-catalog-groups'
+import { useCatalogItems } from '../../hooks/use-catalog-items'
+import { formatMoney } from './format-money'
+import type { TaxRate } from './tax-rate-types'
+
+interface GroupsListProps {
+  selectedId: string | null
+  onSelect: (id: string) => void
+  currency: string
+}
+
+/**
+ * Left column of the Product groups tab: search + "Add group" above a flat
+ * `TreeRow` list (products-list.tsx master–detail recipe). Rows show a Boxes
+ * icon · name · "N items · computed total" + discount/tax badges when set ·
+ * a trailing active `Switch`.
+ */
+export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) {
+  const { groups, entityDefinitionId, isLoading, refresh } = useCatalogGroups()
+  const { itemMap } = useCatalogItems()
+  const { getSetting } = useSettings({ scope: 'DOCUMENTS' })
+  const taxRates = (getSetting('documents.taxRates') as TaxRate[] | null) ?? []
+  const [search, setSearch] = useState('')
+
+  const updateRecord = api.record.update.useMutation()
+  const createRecord = api.record.create.useMutation({
+    onError: (error) => toastError({ title: 'Error creating group', description: error.message }),
+  })
+
+  // Optimistic overlay for the active toggle — `record.update` bypasses the
+  // granular field-value store, so reflect the flip locally and invalidate
+  // `listAll` in the background rather than waiting on a full refetch.
+  const [activeOverride, setActiveOverride] = useState<Record<string, boolean>>({})
+  const effectiveActive = (group: CatalogGroup) => activeOverride[group.id] ?? group.active
+
+  function computeTotal(group: CatalogGroup): number | null {
+    let total = 0
+    let hasResolved = false
+    for (const entry of group.entries) {
+      const item = itemMap.get(entry.catalogItemId)
+      if (!item || item.defaultUnitPriceCents === null) continue
+      hasResolved = true
+      total += item.defaultUnitPriceCents * entry.qty
+    }
+    return hasResolved ? total : null
+  }
+
+  function discountBadge(group: CatalogGroup) {
+    if (!group.discountType || group.discountValue === null) return null
+    const label =
+      group.discountType === 'percent'
+        ? `${group.discountValue}% off`
+        : `${formatMoney(group.discountValue, currency)} off`
+    return (
+      <Badge variant='outline' size='xs' className='border-0 bg-primary-100 text-foreground'>
+        {label}
+      </Badge>
+    )
+  }
+
+  function taxBadge(group: CatalogGroup) {
+    if (!group.taxRateId) return null
+    const preset = taxRates.find((r) => r.id === group.taxRateId)
+    if (!preset) return null
+    return (
+      <Badge variant='outline' size='xs' className='border-0 bg-primary-100 text-foreground'>
+        {preset.name} ({preset.rate}%)
+      </Badge>
+    )
+  }
+
+  function handleToggleActive(group: CatalogGroup) {
+    const next = !effectiveActive(group)
+    setActiveOverride((prev) => ({ ...prev, [group.id]: next }))
+    updateRecord.mutate(
+      { recordId: group.recordId, values: { catalog_group_active: next } },
+      {
+        onSuccess: () => refresh(),
+        onError: (error) => {
+          setActiveOverride((prev) => ({ ...prev, [group.id]: !next }))
+          toastError({ title: 'Error updating group', description: error.message })
+        },
+      }
+    )
+  }
+
+  async function handleAdd() {
+    if (!entityDefinitionId) return
+    const result = await createRecord.mutateAsync({
+      entityDefinitionId,
+      values: { catalog_group_name: 'New group' },
+    })
+    refresh()
+    onSelect(result.instance.id)
+  }
+
+  const filtered = search
+    ? groups.filter((group) => group.name.toLowerCase().includes(search.toLowerCase()))
+    : groups
+
+  return (
+    <div className='flex flex-col gap-3 p-3'>
+      <div className='flex items-center gap-2'>
+        <InputSearch
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder='Search product groups...'
+        />
+        <Button
+          variant='outline'
+          size='sm'
+          onClick={handleAdd}
+          loading={createRecord.isPending}
+          loadingText='Adding...'
+          disabled={!entityDefinitionId}>
+          <Plus />
+          Add group
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className='p-4 text-center text-sm text-muted-foreground'>Loading…</div>
+      ) : filtered.length === 0 ? (
+        <div className='p-4 text-center text-sm text-muted-foreground'>
+          {search ? 'No matches' : 'No product groups yet — add your first one.'}
+        </div>
+      ) : (
+        <div className='flex flex-col gap-0.5'>
+          {filtered.map((group) => {
+            const total = computeTotal(group)
+            return (
+              <TreeRow
+                key={group.id}
+                icon={<Boxes className='size-4 text-muted-foreground' />}
+                title={group.name}
+                onToggleOpen={() => onSelect(group.id)}
+                rowClassName={cn(
+                  'bg-primary-100/50 hover:bg-primary-100',
+                  selectedId === group.id && 'bg-primary-100 ring-1 ring-primary-200',
+                  !effectiveActive(group) && 'opacity-60'
+                )}
+                secondary={
+                  <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+                    {group.entries.length} {group.entries.length === 1 ? 'item' : 'items'}
+                    {total !== null && ` · ${formatMoney(total, currency)}`}
+                    {discountBadge(group)}
+                    {taxBadge(group)}
+                  </span>
+                }
+                actions={
+                  <Switch
+                    size='xs'
+                    checked={effectiveActive(group)}
+                    onCheckedChange={() => handleToggleActive(group)}
+                    disabled={updateRecord.isPending}
+                  />
+                }
+              />
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/money/ui/settings/products-services-page.tsx
+++ b/apps/web/src/components/money/ui/settings/products-services-page.tsx
@@ -5,7 +5,7 @@ import { FeatureKey } from '@auxx/lib/permissions/client'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
 import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
 import { generateId } from '@auxx/utils'
-import { Lock, Package, Percent } from 'lucide-react'
+import { Boxes, Lock, Package, Percent } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
@@ -14,16 +14,19 @@ import { useMedia } from '~/hooks/use-media'
 import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { GroupEditor } from './group-editor'
+import { GroupsList } from './groups-list'
 import { ProductEditor } from './product-editor'
 import { ProductsList } from './products-list'
 import { TaxRateEditor } from './tax-rate-editor'
 import type { TaxRate } from './tax-rate-types'
 import { TaxRatesList } from './tax-rates-list'
 
-type SettingsTab = 'products' | 'tax-rates'
+type SettingsTab = 'products' | 'groups' | 'tax-rates'
 
 const TABS: { value: SettingsTab; label: string; icon: typeof Package }[] = [
   { value: 'products', label: 'Products & Services', icon: Package },
+  { value: 'groups', label: 'Product groups', icon: Boxes },
   { value: 'tax-rates', label: 'Tax rates', icon: Percent },
 ]
 
@@ -38,9 +41,12 @@ export function ProductsServicesPage() {
   const { hasAccess } = useFeatureFlags()
 
   const [tab, setTab] = useQueryState('s', { defaultValue: 'products' as string })
-  const activeTab = (tab === 'tax-rates' ? 'tax-rates' : 'products') as SettingsTab
+  const activeTab = (
+    tab === 'tax-rates' ? 'tax-rates' : tab === 'groups' ? 'groups' : 'products'
+  ) as SettingsTab
 
   const [selectedProductId, setSelectedProductId] = useState<string | null>(null)
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null)
   const [selectedTaxRateId, setSelectedTaxRateId] = useState<string | null>(null)
 
   // `useSettings({ scope })` FILTERS reads to that scope (use-settings.tsx:44-54) — currency
@@ -99,12 +105,19 @@ export function ProductsServicesPage() {
   }
 
   const selectedTaxRate = taxRates.find((r) => r.id === selectedTaxRateId) ?? null
-  const selectedId = activeTab === 'products' ? selectedProductId : selectedTaxRateId
+  const selectedId =
+    activeTab === 'products'
+      ? selectedProductId
+      : activeTab === 'groups'
+        ? selectedGroupId
+        : selectedTaxRateId
   const mobileDrawerOpen = !isDesktop && !!selectedId
 
   const editorContent =
     activeTab === 'products' ? (
       <ProductEditor selectedId={selectedProductId} />
+    ) : activeTab === 'groups' ? (
+      <GroupEditor selectedId={selectedGroupId} currency={currency} />
     ) : (
       <TaxRateEditor
         taxRate={selectedTaxRate}
@@ -134,6 +147,12 @@ export function ProductsServicesPage() {
               onSelect={setSelectedProductId}
               currency={currency}
             />
+          ) : activeTab === 'groups' ? (
+            <GroupsList
+              selectedId={selectedGroupId}
+              onSelect={setSelectedGroupId}
+              currency={currency}
+            />
           ) : (
             <TaxRatesList
               taxRates={taxRates}
@@ -151,6 +170,7 @@ export function ProductsServicesPage() {
         onOpenChange={(open) => {
           if (!open) {
             setSelectedProductId(null)
+            setSelectedGroupId(null)
             setSelectedTaxRateId(null)
           }
         }}
@@ -159,7 +179,13 @@ export function ProductsServicesPage() {
         onWidthChange={() => {}}
         minWidth={320}
         maxWidth={480}
-        title={activeTab === 'products' ? 'Edit item' : 'Edit tax rate'}>
+        title={
+          activeTab === 'products'
+            ? 'Edit item'
+            : activeTab === 'groups'
+              ? 'Edit group'
+              : 'Edit tax rate'
+        }>
         {editorContent}
       </DockableDrawer>
     </SettingsPage>

--- a/apps/worker/scripts/run-entity-migration-040.ts
+++ b/apps/worker/scripts/run-entity-migration-040.ts
@@ -1,0 +1,32 @@
+// apps/worker/scripts/run-entity-migration-040.ts
+/**
+ * One-off runner for entity migration 040 (`catalog_group` system entity — product-group
+ * bundles, plans/dispatch/money/09-product-groups.md) across all orgs. Runs ONLY 040 —
+ * deliberately not runAllEntityMigrations, so pending migrations from parallel work stay
+ * untouched. Idempotent — safe to re-run to confirm alreadyUpToDate.
+ *
+ * Run (from repo root) under the worker runtime so the @auxx/lib import chain
+ * resolves its native ESM deps:
+ *   node --conditions source --env-file .env --import tsx/esm \
+ *     apps/worker/scripts/run-entity-migration-040.ts
+ */
+
+import { database } from '@auxx/database'
+import {
+  ALL_ENTITY_MIGRATIONS,
+  runEntityMigrationForAllOrgs,
+} from '@auxx/lib/seed/entity-migrations'
+
+async function main() {
+  const migration = ALL_ENTITY_MIGRATIONS.find((m) => m.id === '040-catalog-group')
+  if (!migration) throw new Error('Migration 040 not found in registry')
+
+  await runEntityMigrationForAllOrgs(database, migration)
+  console.log('done')
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -121,6 +121,7 @@ export const ModelTypeValues = [
   'quote',
   'line_item',
   'catalog_item',
+  'catalog_group',
   'invoice',
   'payment',
 ] as const
@@ -159,6 +160,7 @@ export const ModelTypes = {
   QUOTE: 'quote',
   LINE_ITEM: 'line_item',
   CATALOG_ITEM: 'catalog_item',
+  CATALOG_GROUP: 'catalog_group',
   INVOICE: 'invoice',
   PAYMENT: 'payment',
 } as const
@@ -385,6 +387,15 @@ export const ModelTypeMeta: Record<
     icon: 'tags',
     color: 'teal',
     apiSlug: 'catalog-items',
+    dbTable: 'EntityInstance',
+    hasDetailPage: false,
+  },
+  catalog_group: {
+    label: 'Product Group',
+    plural: 'Product Groups',
+    icon: 'boxes',
+    color: 'teal',
+    apiSlug: 'catalog-groups',
     dbTable: 'EntityInstance',
     hasDetailPage: false,
   },
@@ -842,6 +853,7 @@ export const WorkflowShareAccessModeValues = ['public', 'organization'] as const
 export const EntityTypeValues = [
   'standard',
   'article',
+  'catalog_group',
   'catalog_item',
   'company',
   'contact',
@@ -1623,6 +1635,7 @@ export const WorkflowShareAccessMode = {
 export const EntityType = {
   STANDARD: 'standard',
   ARTICLE: 'article',
+  CATALOG_GROUP: 'catalog_group',
   CATALOG_ITEM: 'catalog_item',
   COMPANY: 'company',
   CONTACT: 'contact',

--- a/packages/lib/src/resources/registry/field-registry.ts
+++ b/packages/lib/src/resources/registry/field-registry.ts
@@ -5,6 +5,7 @@ import type { FieldId } from '@auxx/types/field'
 import { ENTITY_DEFINITION_TYPES } from '@auxx/types/resource'
 import type { ResourceField, ResourceFieldRegistry, ResourceTableDefinition } from './field-types'
 import { ARTICLE_FIELDS } from './resources/article-fields'
+import { CATALOG_GROUP_FIELDS } from './resources/catalog-group-fields'
 import { CATALOG_ITEM_FIELDS } from './resources/catalog-item-fields'
 import { COMPANY_FIELDS } from './resources/company-fields'
 import { CONTACT_FIELDS } from './resources/contact-fields'
@@ -120,6 +121,7 @@ export const RESOURCE_FIELD_REGISTRY: ResourceFieldRegistry = {
   quote: QUOTE_FIELDS,
   line_item: LINE_ITEM_FIELDS,
   catalog_item: CATALOG_ITEM_FIELDS,
+  catalog_group: CATALOG_GROUP_FIELDS,
   invoice: INVOICE_FIELDS,
   payment: PAYMENT_FIELDS,
 }

--- a/packages/lib/src/resources/registry/resources/catalog-group-fields.ts
+++ b/packages/lib/src/resources/registry/resources/catalog-group-fields.ts
@@ -1,0 +1,233 @@
+// packages/lib/src/resources/registry/resources/catalog-group-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import type { ResourceField } from '../field-types'
+
+/** Percent-of-subtotal vs flat-amount discount — same shape as `QUOTE_DISCOUNT_TYPE_OPTIONS`. */
+const CATALOG_GROUP_DISCOUNT_TYPE_OPTIONS = [
+  { label: 'Percent', value: 'percent', color: 'blue' },
+  { label: 'Amount', value: 'amount', color: 'purple' },
+] as const
+
+/**
+ * Field definitions for the Catalog Group resource (product-bundle "packages",
+ * plans/dispatch/money/09-product-groups.md). Hidden system entity — managed from dispatch
+ * settings, never shown in the entity sidebar. Mirrors CATALOG_ITEM_FIELDS.
+ */
+export const CATALOG_GROUP_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in', 'exists', 'not exists'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique catalog group identifier',
+  },
+
+  name: {
+    id: toFieldId('name'),
+    key: 'name',
+    label: 'Name',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'catalog_group_name',
+    systemSortOrder: 'a1',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      required: true,
+      configurable: false,
+    },
+    placeholder: 'Enter group name',
+  },
+
+  description: {
+    id: toFieldId('description'),
+    key: 'description',
+    label: 'Description',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'catalog_group_description',
+    systemSortOrder: 'a2',
+    nullable: true,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter description',
+  },
+
+  entries: {
+    id: toFieldId('entries'),
+    key: 'entries',
+    label: 'Entries',
+    type: BaseType.JSON,
+    fieldType: FieldType.JSON,
+    isSystem: true,
+    systemAttribute: 'catalog_group_entries',
+    systemSortOrder: 'a3',
+    nullable: true,
+    showInPanel: false,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'Ordered array of catalog-item entries (catalogItemId, qty, overrides)',
+  },
+
+  taxRateId: {
+    id: toFieldId('taxRateId'),
+    key: 'taxRateId',
+    label: 'Tax Rate',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'catalog_group_tax_rate_id',
+    systemSortOrder: 'a4',
+    nullable: true,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'Id of a documents.taxRates preset — resolved live at insert, not snapshotted',
+  },
+
+  discountType: {
+    id: toFieldId('discountType'),
+    key: 'discountType',
+    label: 'Discount Type',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'catalog_group_discount_type',
+    systemSortOrder: 'a5',
+    nullable: true,
+    options: { options: [...CATALOG_GROUP_DISCOUNT_TYPE_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select discount type',
+    description: 'Null = no discount',
+  },
+
+  discountValue: {
+    id: toFieldId('discountValue'),
+    key: 'discountValue',
+    label: 'Discount Value',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'catalog_group_discount_value',
+    systemSortOrder: 'a6',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'Percent = plain number, amount = integer cents (quote_discount_value convention)',
+  },
+
+  active: {
+    id: toFieldId('active'),
+    key: 'active',
+    label: 'Active',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'catalog_group_active',
+    systemSortOrder: 'a7',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    defaultValue: true,
+    description: 'Inactive groups are hidden from the picker but keep historical lines',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the catalog group is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the catalog group is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -42,6 +42,7 @@ import { migration036InvoicePublicToken } from './migrations/036-invoice-public-
 import { migration037WorkOrderEngagementStatuses } from './migrations/037-work-order-engagement-statuses'
 import { migration038InvoiceAutomation } from './migrations/038-invoice-automation'
 import { migration039WorkOrderTags } from './migrations/039-work-order-tags'
+import { migration040CatalogGroup } from './migrations/040-catalog-group'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -89,6 +90,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration037WorkOrderEngagementStatuses,
   migration038InvoiceAutomation,
   migration039WorkOrderTags,
+  migration040CatalogGroup,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/040-catalog-group.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/040-catalog-group.ts
@@ -1,0 +1,98 @@
+// packages/lib/src/seed/entity-migrations/migrations/040-catalog-group.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { CATALOG_GROUP_FIELDS } from '../../../resources/registry/resources/catalog-group-fields'
+import { SystemUserService } from '../../../users/system-user-service'
+import { SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import {
+  ensureCustomFields,
+  ensureEntityDefinitions,
+  ensureFieldViews,
+  linkDisplayFields,
+  loadExistingState,
+} from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:040')
+
+/**
+ * Migration 040: `catalog_group` — admin-defined bundles of `catalog_item` entries
+ * (plans/dispatch/money/09-product-groups.md). Def + fields + default panel/table field
+ * views. No relationships to link — `catalog_group_entries` (JSON) references catalog items
+ * by plain id inside the array, not via a `RELATIONSHIP` field.
+ *
+ * No DDL — pure EntityInstance def, mirrors 032's `catalog_item` recipe.
+ */
+export const migration040CatalogGroup: EntityMigration = {
+  id: '040-catalog-group',
+  description: 'Add catalog_group as a system entity (product-group bundles)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const entityDefIds = await ensureEntityDefinitions(
+      db,
+      organizationId,
+      SYSTEM_ENTITIES.filter((e) => e.entityType === 'catalog_group'),
+      existing,
+      state
+    )
+
+    const catalogGroupDefId = entityDefIds.get('catalog_group')
+    if (!catalogGroupDefId) {
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    const allFieldMaps = await ensureCustomFields(
+      db,
+      organizationId,
+      'catalog_group',
+      catalogGroupDefId,
+      CATALOG_GROUP_FIELDS,
+      existing,
+      state
+    )
+
+    await linkDisplayFields(db, ['catalog_group'], entityDefIds, allFieldMaps)
+
+    const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
+    await ensureFieldViews(
+      db,
+      organizationId,
+      systemUserId,
+      [
+        {
+          entityType: 'catalog_group',
+          contextType: 'panel',
+          name: 'Default Panel View',
+          excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
+        },
+        {
+          entityType: 'catalog_group',
+          contextType: 'table',
+          name: 'Default Table View',
+          excludeFields: [
+            'id',
+            'created_at',
+            'updated_at',
+            'created_by_id',
+            'catalog_group_entries',
+          ],
+        },
+      ],
+      entityDefIds,
+      allFieldMaps
+    )
+
+    const alreadyUpToDate =
+      state.entityDefsCreated === 0 && state.fieldsCreated === 0 && state.relationshipsLinked === 0
+
+    if (!alreadyUpToDate) {
+      logger.info('Migration 040 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -156,6 +156,15 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
     isVisible: false, // Internal entity, managed from dispatch settings (vendor_part recipe)
   },
   {
+    entityType: 'catalog_group',
+    apiSlug: 'catalog-groups',
+    singular: 'Product Group',
+    plural: 'Product Groups',
+    icon: 'boxes',
+    color: 'teal',
+    isVisible: false, // Internal entity, managed from dispatch settings (catalog_item recipe)
+  },
+  {
     entityType: 'quote',
     apiSlug: 'quotes',
     singular: 'Quote',
@@ -271,6 +280,10 @@ export const DISPLAY_FIELD_CONFIG: Record<string, DisplayFieldConfig> = {
     secondaryDisplayField: undefined,
   },
   catalog_item: {
+    primaryDisplayField: 'name',
+    secondaryDisplayField: undefined,
+  },
+  catalog_group: {
     primaryDisplayField: 'name',
     secondaryDisplayField: undefined,
   },

--- a/packages/lib/src/seed/entity-seeder/create-field-views.ts
+++ b/packages/lib/src/seed/entity-seeder/create-field-views.ts
@@ -453,6 +453,22 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   },
 
   // ============================================================================
+  // CATALOG GROUP FIELD VIEWS (no dialog_create — never created via generic dialog)
+  // ============================================================================
+  {
+    entityType: 'catalog_group',
+    contextType: 'panel',
+    name: 'Default Panel View',
+    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
+  },
+  {
+    entityType: 'catalog_group',
+    contextType: 'table',
+    name: 'Default Table View',
+    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id', 'catalog_group_entries'],
+  },
+
+  // ============================================================================
   // INVOICE FIELD VIEWS
   // ============================================================================
   {

--- a/packages/lib/src/seed/entity-seeder/create-fields.ts
+++ b/packages/lib/src/seed/entity-seeder/create-fields.ts
@@ -5,6 +5,7 @@ import { createScopedLogger } from '@auxx/logger'
 import type { FieldOptions } from '../../custom-fields'
 import type { ResourceField } from '../../resources/registry/field-types'
 import { ARTICLE_FIELDS } from '../../resources/registry/resources/article-fields'
+import { CATALOG_GROUP_FIELDS } from '../../resources/registry/resources/catalog-group-fields'
 import { CATALOG_ITEM_FIELDS } from '../../resources/registry/resources/catalog-item-fields'
 import { COMPANY_FIELDS } from '../../resources/registry/resources/company-fields'
 import { CONTACT_FIELDS } from '../../resources/registry/resources/contact-fields'
@@ -52,6 +53,7 @@ const FIELD_REGISTRY: Record<string, Record<string, ResourceField>> = {
   quote: QUOTE_FIELDS,
   line_item: LINE_ITEM_FIELDS,
   catalog_item: CATALOG_ITEM_FIELDS,
+  catalog_group: CATALOG_GROUP_FIELDS,
   invoice: INVOICE_FIELDS,
   payment: PAYMENT_FIELDS,
 }

--- a/packages/types/resource/utils.ts
+++ b/packages/types/resource/utils.ts
@@ -143,6 +143,7 @@ export const ENTITY_DEFINITION_TYPES = [
   'quote',
   'line_item',
   'catalog_item',
+  'catalog_group',
   'invoice',
   'payment',
 ] as const

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -286,6 +286,15 @@ export const SYSTEM_ATTRIBUTES = [
   'catalog_item_part',
   'catalog_item_line_items', // inverse of line_item_catalog_item
 
+  // ─── Catalog Group fields ───────────────────────────────────────
+  'catalog_group_name',
+  'catalog_group_description',
+  'catalog_group_entries',
+  'catalog_group_tax_rate_id',
+  'catalog_group_discount_type',
+  'catalog_group_discount_value',
+  'catalog_group_active',
+
   // ─── Invoice fields ─────────────────────────────────────────────
   'invoice_number',
   'invoice_status',


### PR DESCRIPTION
Implements plans/dispatch/money/09-product-groups.md (all phases).

## What

Admin-defined **groups of catalog items** ("bundles"): a named set of products/services with preset quantities, per-entry description/taxable overrides, an optional tax-rate preset, and an optional discount. Managed as a third tab on `/app/dispatch/settings/products`; picking a group from the line builder's catalog picker **explodes into plain line items** on the document.

## How

**Entity plumbing** — new hidden system entity `catalog_group` mirroring `catalog_item` at all 8 registration points (field registry, seeder constants/fields/views, database enums ×5, resource type union, system-attribute union) + entity migration `040-catalog-group` and its worker runner. Already applied on dev (all orgs, idempotent).

**Settings tab** — `use-catalog-groups` hook, `groups-list.tsx` (computed total, discount/tax badges, optimistic active switch), `group-editor.tsx` (FieldPanel autosave; tax-preset select; %/$ discount with cents conversion; entries section with dnd-kit reorder, inline qty, expand-on-demand description override, tri-state taxable, dangling-item "Deleted item" rows).

**Picker + explode** — "Groups" `CommandGroup` renders first in `CatalogPicker`; entries resolve against loaded items at pick time (dangling ids skipped + counted). In the builder: entry #1 fills the current line (incl. qty), entries 2…N append via sequential `record.create`; document discount/tax are **set-if-unset** (quote/invoice only, never overwriting existing values); `work_order` skips billing writes entirely.

## Plan deviation (important)

`catalog_group_entries` stores an **`{ entries: [...] }` object envelope**, not a bare array: the generic field-value save path splits top-level arrays into one FieldValue row per element (multi-value convention), so a bare JSON array does not round-trip. `serializeCatalogGroupEntries` / `parseCatalogGroupEntries` in `catalog-group-types.ts` own both directions; the parser is defensive against legacy/wrapper shapes.

## Verification (live, dev)

- Migration 040 ran across all 25 orgs — def + 7 fields + display field confirmed in Postgres
- Settings: create/rename group, add 2 entries, qty edit, 10% discount + tax preset — all round-trip through DB and render (badges, computed total `2 items · $310.00`)
- Quote explode: lines land with correct qty/price/category/taxable, sort order sequential, discount `-$31` + `Los Angeles (10%)` applied via set-if-unset, **server-side totals recompute fired** (subtotal 31000¢ → total 27990¢)
- Never-overwrite: doc pre-set to 20% / Ventura County 9% → re-pick group → both preserved
- Work order: explode works, footer shows no discount/tax rows, no billing writes, console clean
- Dangling-entry + inactive-group behavior code-verified (picker filter + skip counter + editor row)

Migration runner (already run on dev, needed on prod after merge):
`node --conditions source --env-file .env --import tsx/esm apps/worker/scripts/run-entity-migration-040.ts`