### PR TITLE
feat(money): line-builder rewrite + instant catalog append

### DIFF
--- a/apps/web/src/components/money/hooks/use-catalog-groups.ts
+++ b/apps/web/src/components/money/hooks/use-catalog-groups.ts
@@ -6,7 +6,11 @@ import {
   type CatalogGroupEntry,
   parseCatalogGroupEntries,
 } from '~/components/money/catalog-group-types'
-import { type FieldInfo, useAllRecords } from '~/components/resources/hooks/use-all-records'
+import {
+  type AllRecordsItem,
+  type FieldInfo,
+  useAllRecords,
+} from '~/components/resources/hooks/use-all-records'
 import type { RecordMeta } from '~/components/resources/store/record-store'
 
 /** Catalog group record shape from `useAllRecords` (systemAttribute-keyed field values). */
@@ -76,6 +80,8 @@ interface UseCatalogGroupsResult {
   fields: Record<string, FieldInfo>
   isLoading: boolean
   refresh: () => void
+  /** Append a freshly created group into the `listAll` cache — skips a refetch. */
+  appendRecord: (item: AllRecordsItem) => void
 }
 
 /**
@@ -84,7 +90,7 @@ interface UseCatalogGroupsResult {
  * system. Same "small dataset, no pagination" shape as `useCatalogItems`.
  */
 export function useCatalogGroups(): UseCatalogGroupsResult {
-  const { records, entityDefinitionId, fields, isLoading, refresh } =
+  const { records, entityDefinitionId, fields, isLoading, refresh, appendRecord } =
     useAllRecords<CatalogGroupRecord>({
       apiSlug: 'catalog-groups',
       includeArchived: false,
@@ -95,5 +101,5 @@ export function useCatalogGroups(): UseCatalogGroupsResult {
     return { groups: list, groupMap: new Map(list.map((group) => [group.id, group])) }
   }, [records])
 
-  return { groups, groupMap, entityDefinitionId, fields, isLoading, refresh }
+  return { groups, groupMap, entityDefinitionId, fields, isLoading, refresh, appendRecord }
 }

--- a/apps/web/src/components/money/hooks/use-catalog-items.ts
+++ b/apps/web/src/components/money/hooks/use-catalog-items.ts
@@ -2,7 +2,11 @@
 
 import type { RecordId } from '@auxx/lib/resources/client'
 import { useMemo } from 'react'
-import { type FieldInfo, useAllRecords } from '~/components/resources/hooks/use-all-records'
+import {
+  type AllRecordsItem,
+  type FieldInfo,
+  useAllRecords,
+} from '~/components/resources/hooks/use-all-records'
 import type { RecordMeta } from '~/components/resources/store/record-store'
 
 /** Catalog item record shape from `useAllRecords` (systemAttribute-keyed field values). */
@@ -67,6 +71,8 @@ interface UseCatalogItemsResult {
   fields: Record<string, FieldInfo>
   isLoading: boolean
   refresh: () => void
+  /** Append a freshly created item into the `listAll` cache — skips a refetch. */
+  appendRecord: (item: AllRecordsItem) => void
 }
 
 /**
@@ -76,7 +82,7 @@ interface UseCatalogItemsResult {
  * only consumer, so this lives under `money/hooks` rather than `resources`.
  */
 export function useCatalogItems(): UseCatalogItemsResult {
-  const { records, entityDefinitionId, fields, isLoading, refresh } =
+  const { records, entityDefinitionId, fields, isLoading, refresh, appendRecord } =
     useAllRecords<CatalogItemRecord>({
       apiSlug: 'catalog-items',
       includeArchived: false,
@@ -87,5 +93,5 @@ export function useCatalogItems(): UseCatalogItemsResult {
     return { items: list, itemMap: new Map(list.map((item) => [item.id, item])) }
   }, [records])
 
-  return { items, itemMap, entityDefinitionId, fields, isLoading, refresh }
+  return { items, itemMap, entityDefinitionId, fields, isLoading, refresh, appendRecord }
 }

--- a/apps/web/src/components/money/ui/document-actions-cluster.tsx
+++ b/apps/web/src/components/money/ui/document-actions-cluster.tsx
@@ -1,0 +1,120 @@
+// apps/web/src/components/money/ui/document-actions-cluster.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { ButtonGroup, ButtonGroupSeparator } from '@auxx/ui/components/button-group'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { ChevronDown } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import { DetailSectionActions, DetailSectionTitleExtra } from '~/components/detail-view'
+import { DrawerCardActions } from '~/components/drawers/drawer-card-actions'
+import { Tooltip } from '~/components/global/tooltip'
+
+export interface DocumentActionsClusterProps {
+  /**
+   * Primary inline segment — the Send/Resend button. Omit to render only the
+   * chevron menu (e.g. a terminal status where the document can no longer be sent).
+   */
+  send?: {
+    label: string
+    onClick: () => void
+    isPending?: boolean
+    /**
+     * When set, the Send button renders disabled inside an interactive tooltip
+     * carrying this reason (e.g. "connect an email channel" + a settings link).
+     */
+    disabledReason?: ReactNode
+  }
+  /** aria-label for the chevron trigger. */
+  menuLabel?: string
+  /** `DropdownMenuItem` children — every secondary/lifecycle action. */
+  children: ReactNode
+}
+
+/**
+ * Shared money-document lifecycle cluster (quote + invoice) — a `ButtonGroup` with
+ * the primary Send/Resend segment + a chevron `DropdownMenu` holding every
+ * secondary/lifecycle action (Download PDF, Mark as sent, approve/decline/convert/
+ * void, return-to-draft). Mirrors {@link PublishClusterShell}'s "slots, not
+ * behavior" contract: the shell owns layout only; consumers own every handler,
+ * confirm, and menu item.
+ */
+export function DocumentActionsCluster({
+  send,
+  menuLabel = 'Document actions',
+  children,
+}: DocumentActionsClusterProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <ButtonGroup className='shrink-0'>
+        {send &&
+          (send.disabledReason ? (
+            <Tooltip allowInteraction contentComponent={send.disabledReason}>
+              <span className='inline-flex'>
+                <Button size='sm' variant='outline' className='border-r-0' disabled>
+                  {send.label}
+                </Button>
+              </span>
+            </Tooltip>
+          ) : (
+            <Button
+              size='sm'
+              variant='outline'
+              className='border-r-0'
+              loading={send.isPending}
+              loadingText='Preparing…'
+              onClick={send.onClick}>
+              {send.label}
+            </Button>
+          ))}
+
+        {send && <ButtonGroupSeparator />}
+
+        <DropdownMenuTrigger asChild>
+          <Button size='sm' variant='outline' className='px-1.5' aria-label={menuLabel}>
+            <ChevronDown />
+          </Button>
+        </DropdownMenuTrigger>
+      </ButtonGroup>
+
+      <DropdownMenuContent align='end' className='w-52'>
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/**
+ * Teleports a money-document's badge + action cluster into whichever `<Section>`
+ * header is wrapping the tab: the detail-page sections layout (badge → title slot,
+ * cluster → actions slot) or a drawer card (badge + cluster together in the single
+ * actions slot). Every portal is a no-op when its slot is absent, so the two
+ * surfaces coexist without the tab needing to know which one rendered it.
+ */
+export function DocumentSectionActions({
+  badge,
+  children,
+}: {
+  badge?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <>
+      {badge ? <DetailSectionTitleExtra>{badge}</DetailSectionTitleExtra> : null}
+      <DetailSectionActions>{children}</DetailSectionActions>
+      <DrawerCardActions>
+        <div className='flex items-center gap-2'>
+          {badge}
+          {children}
+        </div>
+      </DrawerCardActions>
+    </>
+  )
+}

--- a/apps/web/src/components/money/ui/invoice/invoice-lines-card.tsx
+++ b/apps/web/src/components/money/ui/invoice/invoice-lines-card.tsx
@@ -2,27 +2,26 @@
 'use client'
 
 // Invoice drawer's "Line items" tab card — registered as 'invoice:lines' (money MI1 build
-// spec §J.1). Adapted from the quote-line-items-tab.tsx recipe (MQ1/MQ2): the status-driven
-// header action strip (Send/resend + Download PDF + Mark as sent/Void) + Overdue badge
-// (§J.4) + the edit-sent guard banner + the shared `LineBuilder` in `documentType='invoice'`
-// mode (§J.2). The "Line items" section title itself is rendered by the drawer's `Section`
-// wrapper (base-entity-drawer.tsx) — this card renders only the action strip + body.
+// spec §J.1). Shares the quote recipe (MQ1/MQ2): the document actions cluster (Send/resend
+// + Download/Mark-as-sent/Void/return-to-draft dropdown) teleported into the drawer Section
+// header via `DocumentSectionActions`, the Overdue badge (§J.4), the edit-sent guard banner,
+// and the shared `LineBuilder` in `documentType='invoice'` mode (§J.2). The "Line items"
+// section title itself is rendered by the drawer's `Section` wrapper (base-entity-drawer.tsx).
 
-import { parseRecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
-import { Button } from '@auxx/ui/components/button'
+import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
 import { toastError } from '@auxx/ui/components/toast'
+import { Ban, Download, Send, Undo2 } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo } from 'react'
-import { useChannelsLoading } from '~/components/channels/hooks/use-channels'
-import { useDefaultChannelId } from '~/components/channels/hooks/use-default-channel'
-import { useEmailChannels } from '~/components/channels/store/channel-store'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
-import { Tooltip } from '~/components/global/tooltip'
+import {
+  DocumentActionsCluster,
+  DocumentSectionActions,
+} from '~/components/money/ui/document-actions-cluster'
 import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
+import { useDocumentSendActions } from '~/components/money/ui/use-document-send-actions'
 import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
-import { useDefaultSignature } from '~/components/signatures/hooks'
-import { useCompose } from '~/hooks/use-compose'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 
@@ -38,11 +37,9 @@ const OVERDUE_STATUSES = new Set(['sent', 'partially_paid'])
 export function InvoiceLinesCard({ recordId }: DrawerTabProps) {
   const [confirm, ConfirmDialog] = useConfirm()
   const [voidConfirm, VoidConfirmDialog] = useConfirm()
-  const { openCompose } = useCompose()
 
   const { values } = useSystemValues(recordId, [...INVOICE_STATUS_ATTRS], { autoFetch: true })
   const { save: saveSystemValues } = useSaveSystemValues(recordId)
-  const { signature: defaultSignature } = useDefaultSignature()
 
   const status = (values.invoice_status as string | undefined) ?? 'draft'
   const dueDate = values.invoice_due_date as string | null | undefined
@@ -60,6 +57,12 @@ export function InvoiceLinesCard({ recordId }: DrawerTabProps) {
   const { data: payments } = api.money.listPayments.useQuery({ invoiceRecordId: recordId })
   const canVoid = status !== 'void' && (payments?.length ?? 0) === 0
 
+  // Shared send/download flow (compose + PDF + no-channel guard).
+  const { hasEmailChannel, handleSend, handleDownload, isSending } = useDocumentSendActions(
+    recordId,
+    'invoice'
+  )
+
   const markSent = api.money.markInvoiceSent.useMutation({
     onError: (error) =>
       toastError({ title: 'Error marking invoice as sent', description: error.message }),
@@ -67,55 +70,6 @@ export function InvoiceLinesCard({ recordId }: DrawerTabProps) {
   const voidInvoice = api.money.voidInvoice.useMutation({
     onError: (error) => toastError({ title: 'Error voiding invoice', description: error.message }),
   })
-
-  // ─── Send flow (money MQ2 build spec §E.2/§E.4, composed per §H.4) ─────────
-  const channelsLoading = useChannelsLoading()
-  const emailChannels = useEmailChannels()
-  const defaultChannelId = useDefaultChannelId()
-  // Treat "still loading" as "assume available" — avoids a flash of the
-  // no-channel state before the channel list has actually loaded.
-  const hasEmailChannel = channelsLoading || emailChannels.length > 0
-
-  const prepareDocumentEmail = api.money.prepareDocumentEmail.useMutation({
-    onError: (error) =>
-      toastError({ title: 'Error preparing invoice email', description: error.message }),
-  })
-  const ensureDocumentPdf = api.money.ensureDocumentPdf.useMutation({
-    onError: (error) => toastError({ title: 'Error generating PDF', description: error.message }),
-  })
-
-  const handleSend = async () => {
-    try {
-      const prepared = await prepareDocumentEmail.mutateAsync({ recordId })
-      openCompose({
-        presetValues: {
-          to: prepared.to.map((recipient) => ({
-            id: recipient.email,
-            identifier: recipient.email,
-            identifierType: 'EMAIL',
-            name: recipient.name,
-          })),
-          subject: prepared.subject,
-          contentHtml: prepared.contentHtml,
-          attachments: [prepared.attachment],
-          integrationId: defaultChannelId,
-          signatureId: defaultSignature?.id ?? null,
-          linkTicketId: parseRecordId(recordId).entityInstanceId,
-        },
-      })
-    } catch {
-      // onError above already surfaced the toast.
-    }
-  }
-
-  const handleDownload = async () => {
-    try {
-      const { assetId } = await ensureDocumentPdf.mutateAsync({ quoteRecordId: recordId })
-      window.open(`/api/files/download/asset:${assetId}`, '_blank', 'noopener,noreferrer')
-    } catch {
-      // onError above already surfaced the toast.
-    }
-  }
 
   const handleVoid = async () => {
     const confirmed = await voidConfirm({
@@ -146,90 +100,65 @@ export function InvoiceLinesCard({ recordId }: DrawerTabProps) {
     }
   }
 
+  const sendSlot = SENDABLE_STATUSES.has(status)
+    ? {
+        label: status === 'draft' ? 'Send' : 'Resend',
+        onClick: handleSend,
+        isPending: isSending,
+        disabledReason: hasEmailChannel ? undefined : (
+          <div className='flex flex-col gap-1 text-xs'>
+            <span>Connect an email channel to send invoices.</span>
+            <Link href='/app/settings/channels' className='underline'>
+              Go to channel settings
+            </Link>
+          </div>
+        ),
+      }
+    : undefined
+
   return (
     <div className='flex h-[26rem] min-h-0 flex-col'>
-      {/* fullBleed cancels the Section's own inset (drawer-config.ts) so the table below can
-          span edge-to-edge — the header strip/banner restore padding for themselves. */}
-      <div className='flex items-center justify-between gap-2 px-3 pb-2'>
-        <div className='flex items-center gap-2'>
-          {isOverdue && (
+      <DocumentSectionActions
+        badge={
+          isOverdue ? (
             <Badge variant='amber' size='sm'>
               Overdue
             </Badge>
-          )}
-        </div>
-
-        <div className='flex items-center gap-2'>
-          {SENDABLE_STATUSES.has(status) &&
-            (hasEmailChannel ? (
-              <Button
-                variant='outline'
-                size='sm'
-                loading={prepareDocumentEmail.isPending}
-                loadingText='Preparing...'
-                onClick={handleSend}>
-                {status === 'draft' ? 'Send' : 'Resend'}
-              </Button>
-            ) : (
-              <Tooltip
-                allowInteraction
-                contentComponent={
-                  <div className='flex flex-col gap-1 text-xs'>
-                    <span>Connect an email channel to send invoices.</span>
-                    <Link href='/app/settings/channels' className='underline'>
-                      Go to channel settings
-                    </Link>
-                  </div>
-                }>
-                <span>
-                  <Button variant='outline' size='sm' disabled>
-                    Send
-                  </Button>
-                </span>
-              </Tooltip>
-            ))}
-
-          <Button
-            variant='outline'
-            size='sm'
-            loading={ensureDocumentPdf.isPending}
-            loadingText='Preparing...'
-            onClick={handleDownload}>
-            Download PDF
-          </Button>
+          ) : undefined
+        }>
+        <DocumentActionsCluster send={sendSlot} menuLabel='Invoice actions'>
+          <DropdownMenuItem onClick={handleDownload}>
+            <Download /> Download PDF
+          </DropdownMenuItem>
 
           {status === 'draft' && (
-            <Button
-              variant='outline'
-              size='sm'
-              loading={markSent.isPending}
-              loadingText='Sending...'
-              onClick={() => markSent.mutate({ invoiceRecordId: recordId })}>
-              Mark as sent
-            </Button>
+            <DropdownMenuItem onClick={() => markSent.mutate({ invoiceRecordId: recordId })}>
+              <Send /> Mark as sent
+            </DropdownMenuItem>
+          )}
+
+          {SENT_STATUSES.has(status) && (
+            <DropdownMenuItem onClick={handleEditSent}>
+              <Undo2 /> Return to draft
+            </DropdownMenuItem>
           )}
 
           {canVoid && (
-            <Button
-              variant='destructive'
-              size='sm'
-              loading={voidInvoice.isPending}
-              loadingText='Voiding...'
-              onClick={handleVoid}>
-              Void
-            </Button>
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem variant='destructive' onClick={handleVoid}>
+                <Ban /> Void
+              </DropdownMenuItem>
+            </>
           )}
-        </div>
-      </div>
+        </DocumentActionsCluster>
+      </DocumentSectionActions>
 
       {SENT_STATUSES.has(status) && (
-        <div className='mx-3 mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm'>
+        <div className='mx-3 mt-2 mb-3 flex items-center gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm'>
           <span className='text-amber-700 dark:text-amber-400'>
-            This invoice was sent — editing returns it to draft.
+            This invoice was sent — use “Return to draft” to edit it.
           </span>
-          <Button variant='outline' size='sm' onClick={handleEditSent}>
-            Edit
-          </Button>
         </div>
       )}
 

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -7,7 +7,8 @@
 // Unit cost / Total / actions) — the data-connectors mapping-editor idiom
 // (mapping-row.tsx): one shared `grid-template-columns` keeps the number columns
 // aligned across the header and every row. Line counts are small, so plain rows
-// replace the virtualized `DynamicView` embed this used to be.
+// replace the virtualized `DynamicView` embed this used to be. Row/cell markup
+// lives in `line-rows.tsx` — this file owns state, data fetching, and mutations.
 //
 // Data flow:
 // - Line cell reads: `useSystemValues` (field-value store, autoFetch).
@@ -18,19 +19,28 @@
 //   `computeLineTotal` from `@auxx/lib/money/client` over store values — the
 //   same function the server hook uses, so the optimistic footer and the
 //   stored mirrors can never disagree.
-// - Add: creates an EMPTY line record; clicking the Description cell opens the
-//   catalog picker (§H.2) which fills it in (or renames via free text).
+// - Add: pushes a purely-local "phantom draft" row (`DraftLine`, line-rows.tsx)
+//   — no mutation, no round-trip — with the catalog picker already open. The
+//   record is only created on the draft's first real commit (catalog pick,
+//   free-text name, description, qty/price blur, taxable toggle, or a
+//   catalog-group pick), carrying every value accumulated on the draft in one
+//   `record.create` call. The create result seeds the record + field-value
+//   caches directly (`useSeedCreatedRecord`) — no `refresh()` — and the draft
+//   is swapped for the now-real row. Edits that land while the create is in
+//   flight keep mutating local draft state; once it resolves, anything that
+//   changed since the snapshot was sent is flushed via `saveMultipleAsync`
+//   against the real record. An untouched draft simply vanishes on unmount.
 // - Reorder: dnd-kit sortable rows (grip handle) → `api.money.reorderLines`.
-// - Delete: `api.record.delete` + `api.money.recomputeTotals` (delete path
-//   doesn't fire field-change hooks, §F.2).
+//   Draft rows aren't part of the sortable set — they pin after the real rows.
+// - Delete: real rows → `api.record.delete` + `api.money.recomputeTotals`
+//   (delete path doesn't fire field-change hooks, §F.2). Draft rows → local
+//   splice, no network.
 
 import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
-import { computeLineTotal } from '@auxx/lib/money/client'
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
-import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
-import { cn } from '@auxx/ui/lib/utils'
+import { generateId } from '@auxx/utils'
 import {
   closestCenter,
   DndContext,
@@ -40,14 +50,8 @@ import {
   useSensors,
 } from '@dnd-kit/core'
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
-import {
-  arrayMove,
-  SortableContext,
-  useSortable,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { AlignLeft, GripVertical, Percent, Plus, ReceiptText, Trash2 } from 'lucide-react'
+import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { Plus, ReceiptText } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import {
@@ -58,11 +62,19 @@ import {
   useResource,
 } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
+import { useSeedCreatedRecord } from '~/components/resources/hooks/use-seed-created-record'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
-import { type CatalogGroupPick, type CatalogItemPick, CatalogPicker } from './catalog-picker'
-import { formatCurrency, titleCase } from './shared'
+import type { CatalogGroupPick, CatalogGroupPickLine } from './catalog-picker'
+import {
+  type DraftLine,
+  DraftLineRow,
+  freshDraft,
+  LINE_COLS,
+  LineRow,
+  relKeyForDocumentType,
+} from './line-rows'
 import { TotalsFooter } from './totals-footer'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -80,21 +92,6 @@ const PAGE_SIZE = 100
 /** Stable sort ref — `useRecordList` keys its cache off this object. */
 const LINE_SORT = [{ id: 'sortOrder', desc: false }]
 
-/**
- * Shared `grid-template-columns` for the header row and every line row (the
- * mapping-columns.ts idiom) — one template is what keeps the qty / unit cost /
- * total columns aligned. Columns: description (fills) │ qty │ unit cost │
- * total │ actions.
- */
-const LINE_COLS = 'minmax(10rem, 1fr) 4rem 6.5rem 6.5rem 5.5rem'
-
-// Module-level (stable-reference) attribute lists — `useSystemValues` memoizes
-// on the array identity, so these must never be inline literals.
-const NAME_ATTRS = ['line_item_name', 'line_item_description', 'line_item_category']
-const QTY_ATTRS = ['line_item_qty']
-const PRICE_ATTRS = ['line_item_unit_price']
-const TOTAL_ATTRS = ['line_item_qty', 'line_item_unit_price']
-const TAXABLE_ATTRS = ['line_item_taxable']
 // Document billing mirrors read for the group-explode set-if-unset checks (steps 4–5,
 // money 09-product-groups.md "Line-builder consumption") — the same attrs `TotalsFooter`
 // reads, minus the invoice-only ledger-sync mirrors this doesn't need.
@@ -117,352 +114,6 @@ interface TaxRatePreset {
   name: string
   rate: number
   isDefault?: boolean
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Cells
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Description cell — a transparent full-width button (the formula-row picker
- * idiom) that opens the catalog combobox (§H.2), doubling as free-text rename.
- * Shows the category chip inline and the description as a second muted line.
- */
-function LineNameCell({
-  recordId,
-  rowId,
-  readOnly,
-  currencyCode,
-  descriptionOpen,
-  closeDescription,
-  onSelectGroup,
-}: {
-  recordId: RecordId
-  rowId: string
-  readOnly: boolean
-  currencyCode: string
-  descriptionOpen: boolean
-  closeDescription: (lineId: string) => void
-  onSelectGroup: (pick: CatalogGroupPick) => void
-}) {
-  const { values } = useSystemValues(recordId, NAME_ATTRS, { autoFetch: true })
-  const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue()
-  const [pickerOpen, setPickerOpen] = useState(false)
-  const [descriptionDraft, setDescriptionDraft] = useState<string | null>(null)
-
-  const name = (values.line_item_name as string | undefined) ?? ''
-  const description = (values.line_item_description as string | null | undefined) ?? null
-  const category = (values.line_item_category as string | null | undefined) ?? null
-  const descriptionVisible = !!description || descriptionOpen
-
-  const handlePick = (pick: CatalogItemPick) => {
-    // COPY the catalog defaults onto the line (snapshot — catalog price changes
-    // never rewrite documents) + keep the provenance relationship.
-    void saveMultipleAsync(recordId, [
-      { fieldId: 'line_item_name', value: pick.name, fieldType: FieldType.TEXT },
-      { fieldId: 'line_item_description', value: pick.description, fieldType: FieldType.TEXT },
-      { fieldId: 'line_item_category', value: pick.category, fieldType: FieldType.SINGLE_SELECT },
-      { fieldId: 'line_item_taxable', value: pick.taxable, fieldType: FieldType.CHECKBOX },
-      { fieldId: 'line_item_unit_price', value: pick.unitPrice, fieldType: FieldType.CURRENCY },
-      {
-        fieldId: 'line_item_catalog_item',
-        value: pick.recordId,
-        fieldType: FieldType.RELATIONSHIP,
-      },
-    ])
-  }
-
-  const commitDescription = () => {
-    if (descriptionDraft === null) return
-    const next = descriptionDraft.trim()
-    saveFieldValue(recordId, 'line_item_description', next || null, FieldType.TEXT)
-    setDescriptionDraft(null)
-    if (!next) closeDescription(rowId)
-  }
-
-  return (
-    <div className='flex min-w-0 flex-1 flex-col justify-center py-1'>
-      {readOnly ? (
-        <span className='flex min-w-0 items-center gap-1.5 px-1'>
-          <span className={cn('truncate text-sm', !name && 'text-muted-foreground italic')}>
-            {name || 'Untitled line'}
-          </span>
-          {category && (
-            <span className='shrink-0 rounded-full bg-primary-100 px-1.5 py-px text-[10px] text-muted-foreground leading-tight dark:bg-primary-100/50'>
-              {titleCase(category)}
-            </span>
-          )}
-        </span>
-      ) : (
-        <CatalogPicker
-          open={pickerOpen}
-          onOpenChange={setPickerOpen}
-          initialQuery={name}
-          currencyCode={currencyCode}
-          onSelectCatalogItem={handlePick}
-          onSelectGroup={onSelectGroup}
-          onFreeText={(text) => saveFieldValue(recordId, 'line_item_name', text, FieldType.TEXT)}>
-          <Button
-            variant='transparent'
-            className={cn(
-              'h-7 min-w-0 justify-start gap-1.5 rounded-sm px-1 text-sm hover:bg-primary/5',
-              !name && 'text-muted-foreground'
-            )}>
-            <span className='truncate'>{name || 'Add item…'}</span>
-            {category && (
-              <span className='shrink-0 rounded-full bg-primary-100 px-1.5 py-px text-[10px] text-muted-foreground leading-tight dark:bg-primary-100/50'>
-                {titleCase(category)}
-              </span>
-            )}
-          </Button>
-        </CatalogPicker>
-      )}
-
-      {descriptionVisible &&
-        (readOnly ? (
-          <span className='truncate px-1 text-muted-foreground text-xs'>{description}</span>
-        ) : (
-          <input
-            value={descriptionDraft ?? description ?? ''}
-            onChange={(e) => setDescriptionDraft(e.target.value)}
-            onFocus={() => setDescriptionDraft(description ?? '')}
-            onBlur={commitDescription}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') e.currentTarget.blur()
-              if (e.key === 'Escape') {
-                setDescriptionDraft(null)
-                if (!description) closeDescription(rowId)
-              }
-            }}
-            autoFocus={!description}
-            placeholder='Description'
-            className='w-full truncate border-none bg-transparent px-1 text-muted-foreground text-xs outline-none placeholder:text-muted-foreground/60'
-          />
-        ))}
-    </div>
-  )
-}
-
-/**
- * Chromeless inline number editor — quiet at rest, editable on click (the
- * cell-treatment lock in 01-ui #1). Commits on blur/Enter.
- */
-function InlineNumberCell({
-  recordId,
-  attr,
-  fieldType,
-  readOnly,
-  currencyCode,
-}: {
-  recordId: RecordId
-  attr: 'line_item_qty' | 'line_item_unit_price'
-  fieldType: FieldType
-  readOnly: boolean
-  currencyCode: string
-}) {
-  const attrs = attr === 'line_item_qty' ? QTY_ATTRS : PRICE_ATTRS
-  const { values } = useSystemValues(recordId, attrs, { autoFetch: true })
-  const { saveFieldValue } = useSaveFieldValue()
-  const [draft, setDraft] = useState<string | null>(null)
-
-  const raw = values[attr] as number | null | undefined
-  const display =
-    attr === 'line_item_unit_price'
-      ? formatCurrency(raw ?? null, currencyCode)
-      : raw !== null && raw !== undefined
-        ? String(raw)
-        : ''
-
-  const commit = () => {
-    if (draft === null) return
-    const trimmed = draft.trim()
-    const parsed = trimmed === '' ? null : Number(trimmed)
-    setDraft(null)
-    if (parsed !== null && Number.isNaN(parsed)) return
-    // Qty is non-nullable — an emptied qty keeps its previous value.
-    if (attr === 'line_item_qty' && parsed === null) return
-    // Prices are typed in dollars but stored as integer cents (CURRENCY convention).
-    const next =
-      parsed !== null && attr === 'line_item_unit_price' ? Math.round(parsed * 100) : parsed
-    if (next === (raw ?? null)) return
-    saveFieldValue(recordId, attr, next, fieldType)
-  }
-
-  if (readOnly) {
-    return <div className='w-full px-2 text-right text-sm tabular-nums'>{display}</div>
-  }
-
-  return (
-    <input
-      value={draft ?? display}
-      onChange={(e) => setDraft(e.target.value)}
-      onFocus={() =>
-        setDraft(
-          raw !== null && raw !== undefined
-            ? String(attr === 'line_item_unit_price' ? raw / 100 : raw)
-            : ''
-        )
-      }
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter') e.currentTarget.blur()
-        if (e.key === 'Escape') setDraft(null)
-      }}
-      inputMode='decimal'
-      className={cn(
-        'h-full w-full rounded-sm border-none bg-transparent px-2 text-right text-sm tabular-nums outline-none',
-        'hover:bg-primary/5 focus:bg-primary/10'
-      )}
-    />
-  )
-}
-
-/** Read-only computed line total — `computeLineTotal` live over store values. */
-function LineTotalCell({ recordId, currencyCode }: { recordId: RecordId; currencyCode: string }) {
-  const { values } = useSystemValues(recordId, TOTAL_ATTRS, { autoFetch: true })
-
-  const qty = (values.line_item_qty as number | null | undefined) ?? 1
-  const unitPrice = (values.line_item_unit_price as number | null | undefined) ?? null
-  const lineTotal = computeLineTotal(qty, unitPrice)
-
-  return (
-    <div className='w-full px-2 text-right text-muted-foreground text-sm tabular-nums'>
-      {formatCurrency(lineTotal, currencyCode)}
-    </div>
-  )
-}
-
-/** Trailing hover actions: description toggle · taxable toggle · delete (no confirm). */
-function LineActionsCell({
-  recordId,
-  rowId,
-  toggleDescription,
-  deleteLine,
-}: {
-  recordId: RecordId
-  rowId: string
-  toggleDescription: (lineId: string) => void
-  deleteLine: (lineId: string) => void
-}) {
-  const { values } = useSystemValues(recordId, TAXABLE_ATTRS, { autoFetch: true })
-  const { saveFieldValue } = useSaveFieldValue()
-
-  const taxable = (values.line_item_taxable as boolean | undefined) !== false
-
-  return (
-    <div className='flex w-full items-center justify-end gap-1 pr-1'>
-      <TreeRowButton tooltipText='Description' onClick={() => toggleDescription(rowId)}>
-        <AlignLeft />
-      </TreeRowButton>
-      <TreeRowButton
-        tooltipText={taxable ? 'Taxable — click to exempt' : 'Tax exempt — click to tax'}
-        className={cn(!taxable && 'text-muted-foreground/40')}
-        onClick={() => saveFieldValue(recordId, 'line_item_taxable', !taxable, FieldType.CHECKBOX)}>
-        <Percent />
-      </TreeRowButton>
-      <TreeRowButton
-        variant='destructive'
-        tooltipText='Delete line'
-        onClick={() => deleteLine(rowId)}>
-        <Trash2 />
-      </TreeRowButton>
-    </div>
-  )
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Row
-// ─────────────────────────────────────────────────────────────────────────────
-
-/** One sortable line row — a GridTreeRow whose leading icon is the drag grip. */
-function LineRow({
-  record,
-  entityDefinitionId,
-  readOnly,
-  currencyCode,
-  descriptionOpen,
-  toggleDescription,
-  closeDescription,
-  deleteLine,
-  onSelectGroup,
-}: {
-  record: RecordMeta
-  entityDefinitionId: string
-  readOnly: boolean
-  currencyCode: string
-  descriptionOpen: boolean
-  toggleDescription: (lineId: string) => void
-  closeDescription: (lineId: string) => void
-  deleteLine: (lineId: string) => void
-  onSelectGroup: (recordId: RecordId, pick: CatalogGroupPick) => void
-}) {
-  const recordId = toRecordId(entityDefinitionId, record.id)
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: record.id,
-    disabled: readOnly,
-  })
-
-  return (
-    <div
-      ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
-      className={cn(isDragging && 'relative z-10 opacity-80')}>
-      <GridTreeRow
-        columns={LINE_COLS}
-        icon={
-          readOnly ? undefined : (
-            <span
-              {...attributes}
-              {...listeners}
-              className='flex cursor-grab items-center justify-center opacity-0 transition-opacity group-hover/tree-row:opacity-100'>
-              <GripVertical className='size-3.5' />
-            </span>
-          )
-        }
-        title={
-          <LineNameCell
-            recordId={recordId}
-            rowId={record.id}
-            readOnly={readOnly}
-            currencyCode={currencyCode}
-            descriptionOpen={descriptionOpen}
-            closeDescription={closeDescription}
-            onSelectGroup={(pick) => onSelectGroup(recordId, pick)}
-          />
-        }
-        cells={[
-          <InlineNumberCell
-            key='qty'
-            recordId={recordId}
-            attr='line_item_qty'
-            fieldType={FieldType.NUMBER}
-            readOnly={readOnly}
-            currencyCode={currencyCode}
-          />,
-          <InlineNumberCell
-            key='price'
-            recordId={recordId}
-            attr='line_item_unit_price'
-            fieldType={FieldType.CURRENCY}
-            readOnly={readOnly}
-            currencyCode={currencyCode}
-          />,
-          <LineTotalCell key='total' recordId={recordId} currencyCode={currencyCode} />,
-          readOnly ? (
-            <span key='actions' />
-          ) : (
-            <LineActionsCell
-              key='actions'
-              recordId={recordId}
-              rowId={record.id}
-              toggleDescription={toggleDescription}
-              deleteLine={deleteLine}
-            />
-          ),
-        ]}
-      />
-    </div>
-  )
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -500,6 +151,12 @@ export function LineBuilder({
 
   const [openDescriptionIds, setOpenDescriptionIds] = useState<Set<string>>(new Set())
   const [orderOverride, setOrderOverride] = useState<string[] | null>(null)
+  const [drafts, setDrafts] = useState<DraftLine[]>([])
+  const draftsRef = useRef<DraftLine[]>([])
+  draftsRef.current = drafts
+  // Ref-guarded (not state-derived) so a synchronous double-commit can never
+  // race two `record.create` calls for the same draft before React re-renders.
+  const creatingDraftIdsRef = useRef<Set<string>>(new Set())
 
   // Baseline filter: lines belonging to this document, via the belongs_to rel
   // (`contact-tickets-tab.tsx` precedent — `operator: 'is'` + the RecordId;
@@ -553,6 +210,7 @@ export function LineBuilder({
     isFetchingNextPage,
     fetchNextPage,
     refresh,
+    listKey,
   } = useRecordList<RecordMeta>({
     entityDefinitionId: entityDefinitionId ?? '',
     filters,
@@ -599,6 +257,9 @@ export function LineBuilder({
   const { mutateAsync: deleteInvoiceLineMutateAsync } = deleteInvoiceLine
   const { mutateAsync: createMutateAsync } = createRecord
 
+  const { saveMultipleAsync } = useSaveFieldValue()
+  const { seedCreatedRecord } = useSeedCreatedRecord()
+
   const deleteLine = useCallback(
     async (lineId: string) => {
       if (!entityDefinitionId) return
@@ -633,82 +294,182 @@ export function LineBuilder({
     ]
   )
 
-  /** Add an empty line — the Description cell's picker fills it in afterwards. */
-  const addLine = useCallback(async () => {
-    const relKey =
-      documentType === 'quote'
-        ? 'line_item_quote'
-        : documentType === 'invoice'
-          ? 'line_item_invoice'
-          : 'line_item_work_order'
-    try {
-      await createMutateAsync({
-        entityDefinitionId: 'line_item',
-        values: {
-          line_item_name: '',
-          line_item_qty: 1,
-          line_item_taxable: true,
-          line_item_sort_order: displayIdsRef.current.length,
-          [relKey]: documentRecordId,
-        },
-      })
-      refresh()
-    } catch (error) {
-      toastError({
-        title: 'Error adding line',
-        description: error instanceof Error ? error.message : 'Could not add the line',
-      })
-    }
-  }, [documentType, documentRecordId, createMutateAsync, refresh])
+  /** Draft delete (trash icon) — local splice, no network. */
+  const deleteDraft = useCallback((draftId: string) => {
+    creatingDraftIdsRef.current.delete(draftId)
+    setDrafts((prev) => prev.filter((d) => d.draftId !== draftId))
+  }, [])
 
-  const { saveMultipleAsync } = useSaveFieldValue()
+  /** "+ Add line item" — pushes a purely-local phantom draft. No mutation. */
+  const addLine = useCallback(() => {
+    setDrafts((prev) => [...prev, freshDraft(generateId())])
+  }, [])
 
   /**
-   * Explode a picked catalog group onto the document (money 09-product-groups.md
-   * "Line-builder consumption"): entry #1 fills the line whose picker was open,
-   * entries 2…N append as new lines, then the document discount/tax are
-   * set-if-unset from the group (never overwriting an existing value).
+   * Fire the draft's first `record.create`, carrying every accumulated draft
+   * value (merged with `overrides`, the field that just committed). Guarded
+   * against double-create: once a draft is already creating, subsequent
+   * commits just keep mutating local state — the in-flight create's
+   * completion handler diffs + flushes them once it resolves.
    */
-  const handleGroupPick = useCallback(
-    async (recordId: RecordId, pick: CatalogGroupPick) => {
-      if (pick.skippedCount > 0) {
-        console.warn(`Catalog group "${pick.name}" skipped ${pick.skippedCount} dangling item(s).`)
+  const createDraft = useCallback(
+    async (draftId: string, overrides: Partial<DraftLine> = {}) => {
+      if (creatingDraftIdsRef.current.has(draftId)) {
+        setDrafts((prev) => prev.map((d) => (d.draftId === draftId ? { ...d, ...overrides } : d)))
+        return
       }
-      if (pick.lines.length === 0) return
 
-      const [first, ...rest] = pick.lines
+      const draftIndex = draftsRef.current.findIndex((d) => d.draftId === draftId)
+      if (draftIndex === -1 || !entityDefinitionId) return
+      const snapshot: DraftLine = {
+        ...draftsRef.current[draftIndex],
+        ...overrides,
+        creating: true,
+      }
 
-      // Step 1: entry #1 fills the CURRENT line — the handlePick shape (catalog-picker.tsx)
-      // plus qty, which the single-item pick leaves untouched.
-      void saveMultipleAsync(recordId, [
-        { fieldId: 'line_item_name', value: first.name, fieldType: FieldType.TEXT },
-        { fieldId: 'line_item_description', value: first.description, fieldType: FieldType.TEXT },
-        {
-          fieldId: 'line_item_category',
-          value: first.category,
-          fieldType: FieldType.SINGLE_SELECT,
-        },
-        { fieldId: 'line_item_taxable', value: first.taxable, fieldType: FieldType.CHECKBOX },
-        { fieldId: 'line_item_unit_price', value: first.unitPrice, fieldType: FieldType.CURRENCY },
-        { fieldId: 'line_item_qty', value: first.qty, fieldType: FieldType.NUMBER },
-        {
-          fieldId: 'line_item_catalog_item',
-          value: toRecordId('catalog_item', first.catalogItemId),
-          fieldType: FieldType.RELATIONSHIP,
-        },
-      ])
+      creatingDraftIdsRef.current.add(draftId)
+      setDrafts((prev) => prev.map((d) => (d.draftId === draftId ? snapshot : d)))
 
-      // Step 2: entries 2…N append at the end — sequential creates (not Promise.all) so
-      // sort order + the server-side totals-recompute hooks stay deterministic; N is small.
-      // Known v1 edge: picking on a middle line still appends these at the list end.
+      const relKey = relKeyForDocumentType(documentType)
+      const values: Record<string, unknown> = {
+        line_item_qty: snapshot.qty,
+        line_item_taxable: snapshot.taxable,
+        line_item_sort_order: displayIdsRef.current.length + draftIndex,
+        [relKey]: documentRecordId,
+      }
+      if (snapshot.name) values.line_item_name = snapshot.name
+      if (snapshot.description) values.line_item_description = snapshot.description
+      if (snapshot.category) values.line_item_category = snapshot.category
+      if (snapshot.unitPriceCents !== null) values.line_item_unit_price = snapshot.unitPriceCents
+      if (snapshot.catalogItemRecordId) {
+        values.line_item_catalog_item = snapshot.catalogItemRecordId
+      }
+
+      try {
+        const result = await createMutateAsync({ entityDefinitionId: 'line_item', values })
+
+        seedCreatedRecord({
+          entityDefinitionId,
+          recordId: result.recordId,
+          listKey,
+          instance: result.instance,
+          values: [
+            { fieldId: 'line_item_name', value: snapshot.name, fieldType: FieldType.TEXT },
+            {
+              fieldId: 'line_item_description',
+              value: snapshot.description,
+              fieldType: FieldType.TEXT,
+            },
+            {
+              fieldId: 'line_item_category',
+              value: snapshot.category,
+              fieldType: FieldType.SINGLE_SELECT,
+            },
+            { fieldId: 'line_item_qty', value: snapshot.qty, fieldType: FieldType.NUMBER },
+            {
+              fieldId: 'line_item_unit_price',
+              value: snapshot.unitPriceCents,
+              fieldType: FieldType.CURRENCY,
+            },
+            {
+              fieldId: 'line_item_taxable',
+              value: snapshot.taxable,
+              fieldType: FieldType.CHECKBOX,
+            },
+          ],
+        })
+
+        // Diff whatever landed locally while the create was in flight, and
+        // flush just the changed fields against the now-real record.
+        const latest = draftsRef.current.find((d) => d.draftId === draftId) ?? snapshot
+        const changed: Array<{ fieldId: string; value: unknown; fieldType: FieldType }> = []
+        if (latest.name !== snapshot.name) {
+          changed.push({
+            fieldId: 'line_item_name',
+            value: latest.name,
+            fieldType: FieldType.TEXT,
+          })
+        }
+        if (latest.description !== snapshot.description) {
+          changed.push({
+            fieldId: 'line_item_description',
+            value: latest.description,
+            fieldType: FieldType.TEXT,
+          })
+        }
+        if (latest.category !== snapshot.category) {
+          changed.push({
+            fieldId: 'line_item_category',
+            value: latest.category,
+            fieldType: FieldType.SINGLE_SELECT,
+          })
+        }
+        if (latest.taxable !== snapshot.taxable) {
+          changed.push({
+            fieldId: 'line_item_taxable',
+            value: latest.taxable,
+            fieldType: FieldType.CHECKBOX,
+          })
+        }
+        if (latest.qty !== snapshot.qty) {
+          changed.push({
+            fieldId: 'line_item_qty',
+            value: latest.qty,
+            fieldType: FieldType.NUMBER,
+          })
+        }
+        if (latest.unitPriceCents !== snapshot.unitPriceCents) {
+          changed.push({
+            fieldId: 'line_item_unit_price',
+            value: latest.unitPriceCents,
+            fieldType: FieldType.CURRENCY,
+          })
+        }
+        if (latest.catalogItemRecordId !== snapshot.catalogItemRecordId) {
+          changed.push({
+            fieldId: 'line_item_catalog_item',
+            value: latest.catalogItemRecordId,
+            fieldType: FieldType.RELATIONSHIP,
+          })
+        }
+        if (changed.length > 0) {
+          await saveMultipleAsync(result.recordId, changed)
+        }
+
+        creatingDraftIdsRef.current.delete(draftId)
+        setDrafts((prev) => prev.filter((d) => d.draftId !== draftId))
+      } catch (error) {
+        creatingDraftIdsRef.current.delete(draftId)
+        setDrafts((prev) =>
+          prev.map((d) => (d.draftId === draftId ? { ...d, creating: false } : d))
+        )
+        toastError({
+          title: 'Error adding line',
+          description: error instanceof Error ? error.message : 'Could not add the line',
+        })
+      }
+    },
+    [
+      entityDefinitionId,
+      documentType,
+      documentRecordId,
+      createMutateAsync,
+      saveMultipleAsync,
+      seedCreatedRecord,
+      listKey,
+    ]
+  )
+
+  /**
+   * Steps 2 (append entries 2…N) + 4–5 (document discount/tax set-if-unset)
+   * of a catalog-group explode (money 09-product-groups.md "Line-builder
+   * consumption") — shared by the real-row and draft-row group-pick paths.
+   * `baseOrder` is the sort order the first of `rest` should land at.
+   */
+  const applyGroupPickRestAndBilling = useCallback(
+    async (pick: CatalogGroupPick, rest: CatalogGroupPickLine[], baseOrder: number) => {
       if (rest.length > 0) {
-        const relKey =
-          documentType === 'quote'
-            ? 'line_item_quote'
-            : documentType === 'invoice'
-              ? 'line_item_invoice'
-              : 'line_item_work_order'
-        const baseOrder = displayIdsRef.current.length
+        const relKey = relKeyForDocumentType(documentType)
         try {
           for (const [index, line] of rest.entries()) {
             await createMutateAsync({
@@ -795,6 +556,74 @@ export function LineBuilder({
     ]
   )
 
+  /**
+   * Explode a picked catalog group onto a REAL line (money 09-product-groups.md
+   * "Line-builder consumption"): entry #1 fills the line whose picker was open,
+   * entries 2…N append as new lines via {@link applyGroupPickRestAndBilling}.
+   */
+  const handleGroupPick = useCallback(
+    async (recordId: RecordId, pick: CatalogGroupPick) => {
+      if (pick.skippedCount > 0) {
+        console.warn(`Catalog group "${pick.name}" skipped ${pick.skippedCount} dangling item(s).`)
+      }
+      if (pick.lines.length === 0) return
+
+      const [first, ...rest] = pick.lines
+
+      // Step 1: entry #1 fills the CURRENT line — the handlePick shape (catalog-picker.tsx)
+      // plus qty, which the single-item pick leaves untouched.
+      void saveMultipleAsync(recordId, [
+        { fieldId: 'line_item_name', value: first.name, fieldType: FieldType.TEXT },
+        { fieldId: 'line_item_description', value: first.description, fieldType: FieldType.TEXT },
+        {
+          fieldId: 'line_item_category',
+          value: first.category,
+          fieldType: FieldType.SINGLE_SELECT,
+        },
+        { fieldId: 'line_item_taxable', value: first.taxable, fieldType: FieldType.CHECKBOX },
+        { fieldId: 'line_item_unit_price', value: first.unitPrice, fieldType: FieldType.CURRENCY },
+        { fieldId: 'line_item_qty', value: first.qty, fieldType: FieldType.NUMBER },
+        {
+          fieldId: 'line_item_catalog_item',
+          value: toRecordId('catalog_item', first.catalogItemId),
+          fieldType: FieldType.RELATIONSHIP,
+        },
+      ])
+
+      // Known v1 edge: picking on a middle line still appends `rest` at the list end.
+      await applyGroupPickRestAndBilling(pick, rest, displayIdsRef.current.length)
+    },
+    [saveMultipleAsync, applyGroupPickRestAndBilling]
+  )
+
+  /** Same explode intent as {@link handleGroupPick}, targeting a phantom draft. */
+  const handleGroupPickDraft = useCallback(
+    async (draftId: string, pick: CatalogGroupPick) => {
+      if (pick.skippedCount > 0) {
+        console.warn(`Catalog group "${pick.name}" skipped ${pick.skippedCount} dangling item(s).`)
+      }
+      if (pick.lines.length === 0) return
+
+      const [first, ...rest] = pick.lines
+
+      // Step 1: entry #1's values become THIS draft's create.
+      void createDraft(draftId, {
+        name: first.name,
+        description: first.description,
+        category: first.category,
+        taxable: first.taxable,
+        unitPriceCents: first.unitPrice,
+        qty: first.qty,
+        catalogItemRecordId: toRecordId('catalog_item', first.catalogItemId),
+      })
+
+      // Real records + every current draft occupy a sort-order slot ahead of `rest`.
+      const baseOrder = displayIdsRef.current.length + draftsRef.current.length
+      await applyGroupPickRestAndBilling(pick, rest, baseOrder)
+    },
+    [createDraft, applyGroupPickRestAndBilling]
+  )
+
   const toggleDescription = useCallback((lineId: string) => {
     setOpenDescriptionIds((prev) => {
       const next = new Set(prev)
@@ -845,10 +674,11 @@ export function LineBuilder({
 
   if (!entityDefinitionId) return null
 
-  const isEmpty = !isLoading && !isLoadingRecords && displayRecords.length === 0
+  const isEmpty =
+    !isLoading && !isLoadingRecords && displayRecords.length === 0 && drafts.length === 0
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col overflow-y-auto rounded-lg bg-primary-50 p-1 dark:bg-background'>
+    <div className='flex min-h-0 flex-1 flex-col overflow-y-auto rounded-lg'>
       {/* Header — same grid template as the rows, so the labels sit over their columns.
           The Description label offsets past the row px-1 + grip slot + title/button padding. */}
       <div
@@ -891,14 +721,25 @@ export function LineBuilder({
         </DndContext>
       )}
 
+      {/* Phantom draft rows — pinned after the real rows, never drag-sortable. */}
+      {!readOnly &&
+        drafts.map((draft) => (
+          <DraftLineRow
+            key={draft.draftId}
+            draft={draft}
+            currencyCode={currencyCode}
+            descriptionOpen={openDescriptionIds.has(draft.draftId)}
+            toggleDescription={toggleDescription}
+            closeDescription={closeDescription}
+            deleteDraft={deleteDraft}
+            createDraft={createDraft}
+            onSelectGroup={handleGroupPickDraft}
+          />
+        ))}
+
       {!readOnly && (
         <div className='border-primary-200/50 border-b px-1 py-0.5 dark:border-[#1e2227]'>
-          <Button
-            variant='ghost'
-            size='sm'
-            className='text-muted-foreground'
-            loading={createRecord.isPending}
-            onClick={addLine}>
+          <Button variant='ghost' size='sm' className='text-muted-foreground' onClick={addLine}>
             <Plus />
             Add line item
           </Button>

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -1,0 +1,651 @@
+// apps/web/src/components/money/ui/line-builder/line-rows.tsx
+
+'use client'
+
+// Row + cell components for the line-items builder (line-builder.tsx). Split
+// out once the builder file crossed the ~800-line component threshold
+// (CLAUDE.md "Component Architecture"): this file owns the presentational
+// cell views, their store-bound wrappers for real (persisted) rows, and the
+// two row shells (`LineRow` for real records, `DraftLineRow` for phantom
+// draft lines — see line-builder.tsx's file-header comment for the draft
+// lifecycle). `LineBuilder` itself (state, mutations, data fetching) stays in
+// line-builder.tsx.
+
+import { FieldType } from '@auxx/database/enums'
+import { computeLineTotal } from '@auxx/lib/money/client'
+import { Button } from '@auxx/ui/components/button'
+import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { AlignLeft, GripVertical, Percent, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { type RecordId, type RecordMeta, toRecordId } from '~/components/resources'
+import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { type CatalogGroupPick, type CatalogItemPick, CatalogPicker } from './catalog-picker'
+import { formatCurrency, titleCase } from './shared'
+
+/**
+ * Shared `grid-template-columns` for the header row and every line row (the
+ * mapping-columns.ts idiom) — one template is what keeps the qty / unit cost /
+ * total columns aligned. Columns: description (fills) │ qty │ unit cost │
+ * total │ actions.
+ */
+export const LINE_COLS = 'minmax(10rem, 1fr) 4rem 6.5rem 6.5rem 5.5rem'
+
+// Module-level (stable-reference) attribute lists — `useSystemValues` memoizes
+// on the array identity, so these must never be inline literals.
+const NAME_ATTRS = ['line_item_name', 'line_item_description', 'line_item_category']
+const QTY_ATTRS = ['line_item_qty']
+const PRICE_ATTRS = ['line_item_unit_price']
+const TOTAL_ATTRS = ['line_item_qty', 'line_item_unit_price']
+const TAXABLE_ATTRS = ['line_item_taxable']
+
+/**
+ * A phantom line row that exists only in local state until its first real
+ * commit — no `EntityInstance` behind it yet. `unitPriceCents` mirrors the
+ * CURRENCY storage convention (integer cents), matching `line_item_unit_price`.
+ */
+export interface DraftLine {
+  draftId: string
+  name: string
+  description: string | null
+  category: string | null
+  taxable: boolean
+  qty: number
+  unitPriceCents: number | null
+  catalogItemRecordId: RecordId | null
+  creating: boolean
+}
+
+export function freshDraft(draftId: string): DraftLine {
+  return {
+    draftId,
+    name: '',
+    description: null,
+    category: null,
+    taxable: true,
+    qty: 1,
+    unitPriceCents: null,
+    catalogItemRecordId: null,
+    creating: false,
+  }
+}
+
+/** The document-relationship field a new line_item is stamped with, by document type. */
+export function relKeyForDocumentType(documentType: 'quote' | 'work_order' | 'invoice'): string {
+  return documentType === 'quote'
+    ? 'line_item_quote'
+    : documentType === 'invoice'
+      ? 'line_item_invoice'
+      : 'line_item_work_order'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Presentational cells — shared by real (store-bound) rows and draft rows
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Description cell view — a transparent full-width button (the formula-row
+ * picker idiom) that opens the catalog combobox (§H.2), doubling as free-text
+ * rename. Shows the category chip inline and the description as a second
+ * muted line. Purely presentational: values + commit callbacks are props, so
+ * both the store-bound real cell and the local-state draft cell render the
+ * exact same markup/behavior.
+ */
+function LineNameCellView({
+  name,
+  description,
+  category,
+  readOnly,
+  currencyCode,
+  rowId,
+  descriptionOpen,
+  closeDescription,
+  initialPickerOpen = false,
+  onPickCatalogItem,
+  onSelectGroup,
+  onFreeText,
+  onCommitDescription,
+}: {
+  name: string
+  description: string | null
+  category: string | null
+  readOnly: boolean
+  currencyCode: string
+  rowId: string
+  descriptionOpen: boolean
+  closeDescription: (lineId: string) => void
+  /** Fresh drafts mount with the catalog picker already open. */
+  initialPickerOpen?: boolean
+  onPickCatalogItem: (pick: CatalogItemPick) => void
+  onSelectGroup: (pick: CatalogGroupPick) => void
+  onFreeText: (text: string) => void
+  onCommitDescription: (value: string | null) => void
+}) {
+  const [pickerOpen, setPickerOpen] = useState(initialPickerOpen)
+  const [descriptionDraft, setDescriptionDraft] = useState<string | null>(null)
+  const descriptionVisible = !!description || descriptionOpen
+
+  const commitDescription = () => {
+    if (descriptionDraft === null) return
+    const next = descriptionDraft.trim()
+    onCommitDescription(next || null)
+    setDescriptionDraft(null)
+    if (!next) closeDescription(rowId)
+  }
+
+  return (
+    <div className='flex min-w-0 flex-1 flex-col justify-center py-1'>
+      {readOnly ? (
+        <span className='flex min-w-0 items-center gap-1.5 px-1'>
+          <span className={cn('truncate text-sm', !name && 'text-muted-foreground italic')}>
+            {name || 'Untitled line'}
+          </span>
+          {category && (
+            <span className='shrink-0 rounded-full bg-primary-100 px-1.5 py-px text-[10px] text-muted-foreground leading-tight dark:bg-primary-100/50'>
+              {titleCase(category)}
+            </span>
+          )}
+        </span>
+      ) : (
+        <CatalogPicker
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          initialQuery={name}
+          currencyCode={currencyCode}
+          onSelectCatalogItem={onPickCatalogItem}
+          onSelectGroup={onSelectGroup}
+          onFreeText={onFreeText}>
+          <Button
+            variant='transparent'
+            className={cn(
+              'h-7 min-w-0 justify-start gap-1.5 rounded-sm px-1 text-sm hover:bg-primary/5',
+              !name && 'text-muted-foreground'
+            )}>
+            <span className='truncate'>{name || 'Add item…'}</span>
+            {category && (
+              <span className='shrink-0 rounded-full bg-primary-100 px-1.5 py-px text-[10px] text-muted-foreground leading-tight dark:bg-primary-100/50'>
+                {titleCase(category)}
+              </span>
+            )}
+          </Button>
+        </CatalogPicker>
+      )}
+
+      {descriptionVisible &&
+        (readOnly ? (
+          <span className='truncate px-1 text-muted-foreground text-xs'>{description}</span>
+        ) : (
+          <input
+            value={descriptionDraft ?? description ?? ''}
+            onChange={(e) => setDescriptionDraft(e.target.value)}
+            onFocus={() => setDescriptionDraft(description ?? '')}
+            onBlur={commitDescription}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') e.currentTarget.blur()
+              if (e.key === 'Escape') {
+                setDescriptionDraft(null)
+                if (!description) closeDescription(rowId)
+              }
+            }}
+            autoFocus={!description}
+            placeholder='Description'
+            className='w-full truncate border-none bg-transparent px-1 text-muted-foreground text-xs outline-none placeholder:text-muted-foreground/60'
+          />
+        ))}
+    </div>
+  )
+}
+
+/** Store-bound wrapper around {@link LineNameCellView} for real (persisted) line rows. */
+function LineNameCell({
+  recordId,
+  rowId,
+  readOnly,
+  currencyCode,
+  descriptionOpen,
+  closeDescription,
+  onSelectGroup,
+}: {
+  recordId: RecordId
+  rowId: string
+  readOnly: boolean
+  currencyCode: string
+  descriptionOpen: boolean
+  closeDescription: (lineId: string) => void
+  onSelectGroup: (pick: CatalogGroupPick) => void
+}) {
+  const { values } = useSystemValues(recordId, NAME_ATTRS, { autoFetch: true })
+  const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue()
+
+  const name = (values.line_item_name as string | undefined) ?? ''
+  const description = (values.line_item_description as string | null | undefined) ?? null
+  const category = (values.line_item_category as string | null | undefined) ?? null
+
+  const handlePick = (pick: CatalogItemPick) => {
+    // COPY the catalog defaults onto the line (snapshot — catalog price changes
+    // never rewrite documents) + keep the provenance relationship.
+    void saveMultipleAsync(recordId, [
+      { fieldId: 'line_item_name', value: pick.name, fieldType: FieldType.TEXT },
+      { fieldId: 'line_item_description', value: pick.description, fieldType: FieldType.TEXT },
+      { fieldId: 'line_item_category', value: pick.category, fieldType: FieldType.SINGLE_SELECT },
+      { fieldId: 'line_item_taxable', value: pick.taxable, fieldType: FieldType.CHECKBOX },
+      { fieldId: 'line_item_unit_price', value: pick.unitPrice, fieldType: FieldType.CURRENCY },
+      {
+        fieldId: 'line_item_catalog_item',
+        value: pick.recordId,
+        fieldType: FieldType.RELATIONSHIP,
+      },
+    ])
+  }
+
+  return (
+    <LineNameCellView
+      name={name}
+      description={description}
+      category={category}
+      readOnly={readOnly}
+      currencyCode={currencyCode}
+      rowId={rowId}
+      descriptionOpen={descriptionOpen}
+      closeDescription={closeDescription}
+      onPickCatalogItem={handlePick}
+      onSelectGroup={onSelectGroup}
+      onFreeText={(text) => saveFieldValue(recordId, 'line_item_name', text, FieldType.TEXT)}
+      onCommitDescription={(value) =>
+        saveFieldValue(recordId, 'line_item_description', value, FieldType.TEXT)
+      }
+    />
+  )
+}
+
+/**
+ * Chromeless inline number editor view — quiet at rest, editable on click (the
+ * cell-treatment lock in 01-ui #1). Commits on blur/Enter, no-ops if the value
+ * didn't actually change.
+ */
+function InlineNumberCellView({
+  value,
+  attr,
+  readOnly,
+  currencyCode,
+  onCommit,
+}: {
+  value: number | null
+  attr: 'line_item_qty' | 'line_item_unit_price'
+  readOnly: boolean
+  currencyCode: string
+  onCommit: (next: number | null) => void
+}) {
+  const [draft, setDraft] = useState<string | null>(null)
+
+  const display =
+    attr === 'line_item_unit_price'
+      ? formatCurrency(value ?? null, currencyCode)
+      : value !== null && value !== undefined
+        ? String(value)
+        : ''
+
+  const commit = () => {
+    if (draft === null) return
+    const trimmed = draft.trim()
+    const parsed = trimmed === '' ? null : Number(trimmed)
+    setDraft(null)
+    if (parsed !== null && Number.isNaN(parsed)) return
+    // Qty is non-nullable — an emptied qty keeps its previous value.
+    if (attr === 'line_item_qty' && parsed === null) return
+    // Prices are typed in dollars but stored as integer cents (CURRENCY convention).
+    const next =
+      parsed !== null && attr === 'line_item_unit_price' ? Math.round(parsed * 100) : parsed
+    if (next === (value ?? null)) return
+    onCommit(next)
+  }
+
+  if (readOnly) {
+    return <div className='w-full px-2 text-right text-sm tabular-nums'>{display}</div>
+  }
+
+  return (
+    <input
+      value={draft ?? display}
+      onChange={(e) => setDraft(e.target.value)}
+      onFocus={() =>
+        setDraft(
+          value !== null && value !== undefined
+            ? String(attr === 'line_item_unit_price' ? value / 100 : value)
+            : ''
+        )
+      }
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') e.currentTarget.blur()
+        if (e.key === 'Escape') setDraft(null)
+      }}
+      inputMode='decimal'
+      className={cn(
+        'h-full w-full rounded-sm border-none bg-transparent px-2 text-right text-sm tabular-nums outline-none',
+        'hover:bg-primary/5 focus:bg-primary/10'
+      )}
+    />
+  )
+}
+
+/** Store-bound wrapper around {@link InlineNumberCellView} for real line rows. */
+function InlineNumberCell({
+  recordId,
+  attr,
+  fieldType,
+  readOnly,
+  currencyCode,
+}: {
+  recordId: RecordId
+  attr: 'line_item_qty' | 'line_item_unit_price'
+  fieldType: FieldType
+  readOnly: boolean
+  currencyCode: string
+}) {
+  const attrs = attr === 'line_item_qty' ? QTY_ATTRS : PRICE_ATTRS
+  const { values } = useSystemValues(recordId, attrs, { autoFetch: true })
+  const { saveFieldValue } = useSaveFieldValue()
+
+  const raw = (values[attr] as number | null | undefined) ?? null
+
+  return (
+    <InlineNumberCellView
+      value={raw}
+      attr={attr}
+      readOnly={readOnly}
+      currencyCode={currencyCode}
+      onCommit={(next) => saveFieldValue(recordId, attr, next, fieldType)}
+    />
+  )
+}
+
+/** Read-only computed line total view — `computeLineTotal` over plain values. */
+function LineTotalCellView({
+  qty,
+  unitPrice,
+  currencyCode,
+}: {
+  qty: number
+  unitPrice: number | null
+  currencyCode: string
+}) {
+  const lineTotal = computeLineTotal(qty, unitPrice)
+  return (
+    <div className='w-full px-2 text-right text-muted-foreground text-sm tabular-nums'>
+      {formatCurrency(lineTotal, currencyCode)}
+    </div>
+  )
+}
+
+/** Store-bound wrapper around {@link LineTotalCellView} for real line rows. */
+function LineTotalCell({ recordId, currencyCode }: { recordId: RecordId; currencyCode: string }) {
+  const { values } = useSystemValues(recordId, TOTAL_ATTRS, { autoFetch: true })
+
+  const qty = (values.line_item_qty as number | null | undefined) ?? 1
+  const unitPrice = (values.line_item_unit_price as number | null | undefined) ?? null
+
+  return <LineTotalCellView qty={qty} unitPrice={unitPrice} currencyCode={currencyCode} />
+}
+
+/** Trailing hover actions view: description toggle · taxable toggle · delete (no confirm). */
+function LineActionsCellView({
+  taxable,
+  rowId,
+  toggleDescription,
+  onToggleTaxable,
+  deleteLine,
+}: {
+  taxable: boolean
+  rowId: string
+  toggleDescription: (lineId: string) => void
+  onToggleTaxable: (next: boolean) => void
+  deleteLine: (lineId: string) => void
+}) {
+  return (
+    <div className='flex w-full items-center justify-end gap-1 pr-1'>
+      <TreeRowButton tooltipText='Description' onClick={() => toggleDescription(rowId)}>
+        <AlignLeft />
+      </TreeRowButton>
+      <TreeRowButton
+        tooltipText={taxable ? 'Taxable — click to exempt' : 'Tax exempt — click to tax'}
+        className={cn(!taxable && 'text-muted-foreground/40')}
+        onClick={() => onToggleTaxable(!taxable)}>
+        <Percent />
+      </TreeRowButton>
+      <TreeRowButton
+        variant='destructive'
+        tooltipText='Delete line'
+        onClick={() => deleteLine(rowId)}>
+        <Trash2 />
+      </TreeRowButton>
+    </div>
+  )
+}
+
+/** Store-bound wrapper around {@link LineActionsCellView} for real line rows. */
+function LineActionsCell({
+  recordId,
+  rowId,
+  toggleDescription,
+  deleteLine,
+}: {
+  recordId: RecordId
+  rowId: string
+  toggleDescription: (lineId: string) => void
+  deleteLine: (lineId: string) => void
+}) {
+  const { values } = useSystemValues(recordId, TAXABLE_ATTRS, { autoFetch: true })
+  const { saveFieldValue } = useSaveFieldValue()
+
+  const taxable = (values.line_item_taxable as boolean | undefined) !== false
+
+  return (
+    <LineActionsCellView
+      taxable={taxable}
+      rowId={rowId}
+      toggleDescription={toggleDescription}
+      onToggleTaxable={(next) =>
+        saveFieldValue(recordId, 'line_item_taxable', next, FieldType.CHECKBOX)
+      }
+      deleteLine={deleteLine}
+    />
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rows
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One sortable line row — a GridTreeRow whose leading icon is the drag grip. */
+export function LineRow({
+  record,
+  entityDefinitionId,
+  readOnly,
+  currencyCode,
+  descriptionOpen,
+  toggleDescription,
+  closeDescription,
+  deleteLine,
+  onSelectGroup,
+}: {
+  record: RecordMeta
+  entityDefinitionId: string
+  readOnly: boolean
+  currencyCode: string
+  descriptionOpen: boolean
+  toggleDescription: (lineId: string) => void
+  closeDescription: (lineId: string) => void
+  deleteLine: (lineId: string) => void
+  onSelectGroup: (recordId: RecordId, pick: CatalogGroupPick) => void
+}) {
+  const recordId = toRecordId(entityDefinitionId, record.id)
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: record.id,
+    disabled: readOnly,
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(isDragging && 'relative z-10 opacity-80')}>
+      <GridTreeRow
+        columns={LINE_COLS}
+        icon={
+          readOnly ? undefined : (
+            <span
+              {...attributes}
+              {...listeners}
+              className='flex cursor-grab items-center justify-center opacity-0 transition-opacity group-hover/tree-row:opacity-100'>
+              <GripVertical className='size-3.5' />
+            </span>
+          )
+        }
+        title={
+          <LineNameCell
+            recordId={recordId}
+            rowId={record.id}
+            readOnly={readOnly}
+            currencyCode={currencyCode}
+            descriptionOpen={descriptionOpen}
+            closeDescription={closeDescription}
+            onSelectGroup={(pick) => onSelectGroup(recordId, pick)}
+          />
+        }
+        cells={[
+          <InlineNumberCell
+            key='qty'
+            recordId={recordId}
+            attr='line_item_qty'
+            fieldType={FieldType.NUMBER}
+            readOnly={readOnly}
+            currencyCode={currencyCode}
+          />,
+          <InlineNumberCell
+            key='price'
+            recordId={recordId}
+            attr='line_item_unit_price'
+            fieldType={FieldType.CURRENCY}
+            readOnly={readOnly}
+            currencyCode={currencyCode}
+          />,
+          <LineTotalCell key='total' recordId={recordId} currencyCode={currencyCode} />,
+          readOnly ? (
+            <span key='actions' />
+          ) : (
+            <LineActionsCell
+              key='actions'
+              recordId={recordId}
+              rowId={record.id}
+              toggleDescription={toggleDescription}
+              deleteLine={deleteLine}
+            />
+          ),
+        ]}
+      />
+    </div>
+  )
+}
+
+/**
+ * A phantom draft line row — same `GridTreeRow` layout as {@link LineRow}, wired
+ * to local draft state instead of the field-value store. Not drag-sortable
+ * (empty, disabled icon slot in place of the grip, so columns stay aligned).
+ * Every commit callback routes through `createDraft`, which fires the record's
+ * first `record.create` on the draft's first real edit.
+ */
+export function DraftLineRow({
+  draft,
+  currencyCode,
+  descriptionOpen,
+  toggleDescription,
+  closeDescription,
+  deleteDraft,
+  createDraft,
+  onSelectGroup,
+}: {
+  draft: DraftLine
+  currencyCode: string
+  descriptionOpen: boolean
+  toggleDescription: (lineId: string) => void
+  closeDescription: (lineId: string) => void
+  deleteDraft: (draftId: string) => void
+  createDraft: (draftId: string, overrides?: Partial<DraftLine>) => Promise<void>
+  onSelectGroup: (draftId: string, pick: CatalogGroupPick) => void
+}) {
+  return (
+    <GridTreeRow
+      columns={LINE_COLS}
+      icon={
+        <span className='flex items-center justify-center opacity-0'>
+          <GripVertical className='size-3.5' />
+        </span>
+      }
+      title={
+        <LineNameCellView
+          name={draft.name}
+          description={draft.description}
+          category={draft.category}
+          readOnly={false}
+          currencyCode={currencyCode}
+          rowId={draft.draftId}
+          descriptionOpen={descriptionOpen}
+          closeDescription={closeDescription}
+          initialPickerOpen
+          onPickCatalogItem={(pick) =>
+            void createDraft(draft.draftId, {
+              name: pick.name,
+              description: pick.description,
+              category: pick.category,
+              taxable: pick.taxable,
+              unitPriceCents: pick.unitPrice,
+              catalogItemRecordId: pick.recordId,
+            })
+          }
+          onSelectGroup={(pick) => onSelectGroup(draft.draftId, pick)}
+          onFreeText={(text) => void createDraft(draft.draftId, { name: text })}
+          onCommitDescription={(value) => void createDraft(draft.draftId, { description: value })}
+        />
+      }
+      cells={[
+        <InlineNumberCellView
+          key='qty'
+          value={draft.qty}
+          attr='line_item_qty'
+          readOnly={false}
+          currencyCode={currencyCode}
+          onCommit={(next) => {
+            if (next === null) return
+            void createDraft(draft.draftId, { qty: next })
+          }}
+        />,
+        <InlineNumberCellView
+          key='price'
+          value={draft.unitPriceCents}
+          attr='line_item_unit_price'
+          readOnly={false}
+          currencyCode={currencyCode}
+          onCommit={(next) => void createDraft(draft.draftId, { unitPriceCents: next })}
+        />,
+        <LineTotalCellView
+          key='total'
+          qty={draft.qty}
+          unitPrice={draft.unitPriceCents}
+          currencyCode={currencyCode}
+        />,
+        <LineActionsCellView
+          key='actions'
+          taxable={draft.taxable}
+          rowId={draft.draftId}
+          toggleDescription={toggleDescription}
+          onToggleTaxable={(next) => void createDraft(draft.draftId, { taxable: next })}
+          deleteLine={deleteDraft}
+        />,
+      ]}
+    />
+  )
+}

--- a/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
+++ b/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
@@ -2,37 +2,35 @@
 'use client'
 
 // Custom detail-view tab registered as "quote:line-items" (money MQ1 build spec
-// §H.3). Renders the status-driven header strip (Expired badge + send/download
-// + lifecycle actions, money MQ2 build spec §E.2/§E.4/§G) + the edit-sent guard
-// banner + the shared line builder (§H.1).
+// §H.3). Renders the shared document actions cluster (Send + lifecycle dropdown,
+// §E.2/§E.4/§G) into the wrapping <Section> header, the edit-sent guard banner,
+// and the shared line builder (§H.1).
 //
-// Header actions are NOT wired through `DetailViewActions` — that component
-// only exposes generic capability flags (enableArchive/enableMerge/…, see
-// `detail-view-config-types.ts`) with no per-entity extension point, so the
-// sanctioned fallback (per the build spec) is this tab's own header strip.
+// Header actions are teleported into the <Section> header via `DocumentSectionActions`
+// (detail-page sections layout → title/actions slots; drawer card → actions slot).
 // Two surfaces render this component: the detail page's Line-items section
-// (DETAIL_VIEW_TAB_COMPONENTS, sections layout) and the quote drawer's
-// Overview card (QuoteLinesOverviewCard below — records-view/dashboards open
-// quotes in a drawer regardless of `hasDetailPage`).
+// (DETAIL_VIEW_TAB_COMPONENTS, sections layout) and the quote drawer's Overview card
+// (QuoteLinesOverviewCard below — records-view/dashboards open quotes in a drawer
+// regardless of `hasDetailPage`).
 
 import { parseRecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
-import { Button } from '@auxx/ui/components/button'
+import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
 import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
+import { Check, Download, Send, SquareArrowOutUpRight, Undo2, X } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
-import { useChannelsLoading } from '~/components/channels/hooks/use-channels'
-import { useDefaultChannelId } from '~/components/channels/hooks/use-default-channel'
-import { useEmailChannels } from '~/components/channels/store/channel-store'
 import type { DetailViewTabProps } from '~/components/detail-view'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
-import { Tooltip } from '~/components/global/tooltip'
+import {
+  DocumentActionsCluster,
+  DocumentSectionActions,
+} from '~/components/money/ui/document-actions-cluster'
 import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
+import { useDocumentSendActions } from '~/components/money/ui/use-document-send-actions'
 import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
-import { useDefaultSignature } from '~/components/signatures/hooks'
-import { useCompose } from '~/hooks/use-compose'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 
@@ -46,13 +44,9 @@ const SENDABLE_STATUSES = new Set(['draft', 'sent'])
 export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
   const router = useRouter()
   const [confirm, ConfirmDialog] = useConfirm()
-  const { openCompose } = useCompose()
 
   const { values } = useSystemValues(recordId, [...QUOTE_STATUS_ATTRS], { autoFetch: true })
   const { save: saveSystemValues } = useSaveSystemValues(recordId)
-  // The snippet body carries no sign-off — pre-select the org default signature
-  // so the composer appends it (the composer does NOT auto-apply a default).
-  const { signature: defaultSignature } = useDefaultSignature()
 
   const status = (values.quote_status as string | undefined) ?? 'draft'
   const validUntil = values.quote_valid_until as string | null | undefined
@@ -64,6 +58,12 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
 
   // draft is the only editable state — sent/approved/declined/canceled are all read-only.
   const readOnly = status !== 'draft'
+
+  // Shared send/download flow (compose + PDF + no-channel guard).
+  const { hasEmailChannel, handleSend, handleDownload, isSending } = useDocumentSendActions(
+    recordId,
+    'quote'
+  )
 
   const markSent = api.money.markQuoteSent.useMutation({
     onError: (error) =>
@@ -80,22 +80,6 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
       toastError({ title: 'Error converting to job', description: error.message }),
   })
 
-  // ─── Send flow (money MQ2 build spec §E.2/§E.4) ─────────────────────────
-  const channelsLoading = useChannelsLoading()
-  const emailChannels = useEmailChannels()
-  const defaultChannelId = useDefaultChannelId()
-  // Treat "still loading" as "assume available" — avoids a flash of the
-  // no-channel state before the channel list has actually loaded.
-  const hasEmailChannel = channelsLoading || emailChannels.length > 0
-
-  const prepareDocumentEmail = api.money.prepareDocumentEmail.useMutation({
-    onError: (error) =>
-      toastError({ title: 'Error preparing quote email', description: error.message }),
-  })
-  const ensureDocumentPdf = api.money.ensureDocumentPdf.useMutation({
-    onError: (error) => toastError({ title: 'Error generating PDF', description: error.message }),
-  })
-
   const handleConvert = async () => {
     try {
       const result = await convertToWorkOrder.mutateAsync({ quoteRecordId: recordId })
@@ -103,39 +87,6 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
       // the job view directly instead of the records-list `?id=` drawer convention.
       const { entityInstanceId } = parseRecordId(result.recordId)
       router.push(`/app/work-orders/${entityInstanceId}`)
-    } catch {
-      // onError above already surfaced the toast.
-    }
-  }
-
-  const handleSend = async () => {
-    try {
-      const prepared = await prepareDocumentEmail.mutateAsync({ recordId })
-      openCompose({
-        presetValues: {
-          to: prepared.to.map((recipient) => ({
-            id: recipient.email,
-            identifier: recipient.email,
-            identifierType: 'EMAIL',
-            name: recipient.name,
-          })),
-          subject: prepared.subject,
-          contentHtml: prepared.contentHtml,
-          attachments: [prepared.attachment],
-          integrationId: defaultChannelId,
-          signatureId: defaultSignature?.id ?? null,
-          linkTicketId: parseRecordId(recordId).entityInstanceId,
-        },
-      })
-    } catch {
-      // onError above already surfaced the toast.
-    }
-  }
-
-  const handleDownload = async () => {
-    try {
-      const { assetId } = await ensureDocumentPdf.mutateAsync({ quoteRecordId: recordId })
-      window.open(`/api/files/download/asset:${assetId}`, '_blank', 'noopener,noreferrer')
     } catch {
       // onError above already surfaced the toast.
     }
@@ -160,122 +111,89 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
 
   // `variant='section'` (dispatch M2 §F.1/§G): rendered inside a DetailViewSections
   // <Section> on an outer-owned scroll column instead of a `TabsContent` that grants
-  // `h-full`. The header action strip below (Expired badge + send/download/lifecycle
-  // buttons) stays a normal in-flow row either way — always visible/functional, since
-  // the wrapping <Section> is non-collapsible in sections mode. Only the LineBuilder
-  // (a virtualized, scroll-owning table) needs the max-height + internal-scroll
-  // treatment so it doesn't fight the outer page for wheel events.
+  // `h-full`. The action cluster is teleported into that <Section>'s header (always
+  // visible), so only the LineBuilder — a virtualized, scroll-owning table — needs
+  // the max-height + internal-scroll treatment to avoid fighting the outer page.
   const isSection = variant === 'section'
+
+  const sendSlot = SENDABLE_STATUSES.has(status)
+    ? {
+        label: status === 'sent' ? 'Resend' : 'Send',
+        onClick: handleSend,
+        isPending: isSending,
+        disabledReason: hasEmailChannel ? undefined : (
+          <div className='flex flex-col gap-1 text-xs'>
+            <span>Connect an email channel to send quotes.</span>
+            <Link href='/app/settings/channels' className='underline'>
+              Go to channel settings
+            </Link>
+          </div>
+        ),
+      }
+    : undefined
 
   return (
     <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
-      <div className='flex items-center justify-between gap-2 px-4 py-3'>
-        <div className='flex items-center gap-2'>
-          {isExpired && (
+      <DocumentSectionActions
+        badge={
+          isExpired ? (
             <Badge variant='amber' size='sm'>
               Expired
             </Badge>
-          )}
-        </div>
-
-        <div className='flex items-center gap-2'>
-          {SENDABLE_STATUSES.has(status) &&
-            (hasEmailChannel ? (
-              <Button
-                variant='outline'
-                size='sm'
-                loading={prepareDocumentEmail.isPending}
-                loadingText='Preparing...'
-                onClick={handleSend}>
-                {status === 'sent' ? 'Resend' : 'Send'}
-              </Button>
-            ) : (
-              <Tooltip
-                allowInteraction
-                contentComponent={
-                  <div className='flex flex-col gap-1 text-xs'>
-                    <span>Connect an email channel to send quotes.</span>
-                    <Link href='/app/settings/channels' className='underline'>
-                      Go to channel settings
-                    </Link>
-                  </div>
-                }>
-                <span>
-                  <Button variant='outline' size='sm' disabled>
-                    Send
-                  </Button>
-                </span>
-              </Tooltip>
-            ))}
-
-          <Button
-            variant='outline'
-            size='sm'
-            loading={ensureDocumentPdf.isPending}
-            loadingText='Preparing...'
-            onClick={handleDownload}>
-            Download PDF
-          </Button>
+          ) : undefined
+        }>
+        <DocumentActionsCluster send={sendSlot} menuLabel='Quote actions'>
+          <DropdownMenuItem onClick={handleDownload}>
+            <Download /> Download PDF
+          </DropdownMenuItem>
 
           {status === 'draft' && (
-            <Button
-              variant='outline'
-              size='sm'
-              loading={markSent.isPending}
-              loadingText='Sending...'
-              onClick={() => markSent.mutate({ quoteRecordId: recordId })}>
-              Mark as sent
-            </Button>
+            <DropdownMenuItem onClick={() => markSent.mutate({ quoteRecordId: recordId })}>
+              <Send /> Mark as sent
+            </DropdownMenuItem>
           )}
 
           {status === 'sent' && (
             <>
-              <Button
-                variant='outline'
-                size='sm'
-                loading={approveQuote.isPending}
-                loadingText='Approving...'
-                onClick={() => approveQuote.mutate({ quoteRecordId: recordId })}>
-                Mark approved
-              </Button>
-              <Button
+              <DropdownMenuItem onClick={() => approveQuote.mutate({ quoteRecordId: recordId })}>
+                <Check /> Mark approved
+              </DropdownMenuItem>
+              <DropdownMenuItem
                 variant='destructive'
-                size='sm'
-                loading={declineQuote.isPending}
-                loadingText='Declining...'
                 onClick={() => declineQuote.mutate({ quoteRecordId: recordId })}>
-                Mark declined
-              </Button>
+                <X /> Mark declined
+              </DropdownMenuItem>
             </>
           )}
 
           {status === 'approved' && (
-            <Button
-              variant='outline'
-              size='sm'
-              loading={convertToWorkOrder.isPending}
-              loadingText='Converting...'
-              onClick={handleConvert}>
-              Convert to job
-            </Button>
+            <DropdownMenuItem onClick={handleConvert}>
+              <SquareArrowOutUpRight /> Convert to job
+            </DropdownMenuItem>
           )}
-        </div>
-      </div>
+
+          {status === 'sent' && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={handleEditSent}>
+                <Undo2 /> Return to draft
+              </DropdownMenuItem>
+            </>
+          )}
+        </DocumentActionsCluster>
+      </DocumentSectionActions>
 
       {status === 'sent' && (
-        <div className='mx-4 mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm'>
+        <div className='mx-4 mt-3 flex items-center gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm'>
           <span className='text-amber-700 dark:text-amber-400'>
-            This quote was sent — editing returns it to draft.
+            This quote was sent — use “Return to draft” to edit it.
           </span>
-          <Button variant='outline' size='sm' onClick={handleEditSent}>
-            Edit
-          </Button>
         </div>
       )}
 
       <div
         className={cn(
-          'flex flex-col pb-4',
+          'flex flex-col pb-4 pt-3',
           isSection ? 'max-h-[60vh] overflow-auto' : 'min-h-0 flex-1'
         )}>
         <LineBuilder documentRecordId={recordId} documentType='quote' readOnly={readOnly} />

--- a/apps/web/src/components/money/ui/settings/groups-list.tsx
+++ b/apps/web/src/components/money/ui/settings/groups-list.tsx
@@ -30,7 +30,7 @@ interface GroupsListProps {
  * a trailing active `Switch`.
  */
 export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) {
-  const { groups, entityDefinitionId, isLoading, refresh } = useCatalogGroups()
+  const { groups, entityDefinitionId, isLoading, refresh, appendRecord } = useCatalogGroups()
   const { itemMap } = useCatalogItems()
   const { getSetting } = useSettings({ scope: 'DOCUMENTS' })
   const taxRates = (getSetting('documents.taxRates') as TaxRate[] | null) ?? []
@@ -104,7 +104,11 @@ export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) 
       entityDefinitionId,
       values: { catalog_group_name: 'New group' },
     })
-    refresh()
+    appendRecord({
+      ...result.instance,
+      recordId: result.recordId,
+      fieldValues: { catalog_group_name: 'New group', ...result.values },
+    })
     onSelect(result.instance.id)
   }
 

--- a/apps/web/src/components/money/ui/settings/products-list.tsx
+++ b/apps/web/src/components/money/ui/settings/products-list.tsx
@@ -37,7 +37,7 @@ function CategoryIcon({ category }: { category: string }) {
  * category icon · name · price + category badge · a trailing active `Switch`.
  */
 export function ProductsList({ selectedId, onSelect, currency }: ProductsListProps) {
-  const { items, entityDefinitionId, isLoading, refresh } = useCatalogItems()
+  const { items, entityDefinitionId, isLoading, refresh, appendRecord } = useCatalogItems()
   const { fields: catalogFields } = useResourceFields('catalog-items')
   const categoryOptions = useMemo(
     () => catalogFields.find((f) => f.key === 'category')?.options?.options ?? [],
@@ -87,7 +87,11 @@ export function ProductsList({ selectedId, onSelect, currency }: ProductsListPro
       entityDefinitionId,
       values: { catalog_item_name: 'New item' },
     })
-    refresh()
+    appendRecord({
+      ...result.instance,
+      recordId: result.recordId,
+      fieldValues: { catalog_item_name: 'New item', ...result.values },
+    })
     onSelect(result.instance.id)
   }
 

--- a/apps/web/src/components/money/ui/use-document-send-actions.ts
+++ b/apps/web/src/components/money/ui/use-document-send-actions.ts
@@ -1,0 +1,87 @@
+// apps/web/src/components/money/ui/use-document-send-actions.ts
+'use client'
+
+import { parseRecordId } from '@auxx/lib/resources/client'
+import { toastError } from '@auxx/ui/components/toast'
+import { useChannelsLoading } from '~/components/channels/hooks/use-channels'
+import { useDefaultChannelId } from '~/components/channels/hooks/use-default-channel'
+import { useEmailChannels } from '~/components/channels/store/channel-store'
+import type { RecordId } from '~/components/resources'
+import { useDefaultSignature } from '~/components/signatures/hooks'
+import { useCompose } from '~/hooks/use-compose'
+import { api } from '~/trpc/react'
+
+/**
+ * Shared send/download flow for money documents (quote + invoice). Both tabs used
+ * to duplicate this verbatim (money MQ2 build spec §E.2/§E.4, composed per §H.4):
+ * `prepareDocumentEmail` → open the composer with the rendered snippet + PDF
+ * attachment, and `ensureDocumentPdf` → open the generated PDF in a new tab. The
+ * no-email-channel guard (treat "still loading" as available to avoid a flash) is
+ * owned here too. Lifecycle mutations stay per-document — only these two are shared.
+ *
+ * @param recordId - the document's RecordId
+ * @param documentLabel - lowercase noun for error toasts, e.g. `'quote'` / `'invoice'`
+ */
+export function useDocumentSendActions(recordId: RecordId, documentLabel: string) {
+  const { openCompose } = useCompose()
+  // The snippet body carries no sign-off — pre-select the org default signature
+  // so the composer appends it (the composer does NOT auto-apply a default).
+  const { signature: defaultSignature } = useDefaultSignature()
+
+  const channelsLoading = useChannelsLoading()
+  const emailChannels = useEmailChannels()
+  const defaultChannelId = useDefaultChannelId()
+  // Treat "still loading" as "assume available" — avoids a flash of the
+  // no-channel state before the channel list has actually loaded.
+  const hasEmailChannel = channelsLoading || emailChannels.length > 0
+
+  const prepareDocumentEmail = api.money.prepareDocumentEmail.useMutation({
+    onError: (error) =>
+      toastError({ title: `Error preparing ${documentLabel} email`, description: error.message }),
+  })
+  const ensureDocumentPdf = api.money.ensureDocumentPdf.useMutation({
+    onError: (error) => toastError({ title: 'Error generating PDF', description: error.message }),
+  })
+
+  const handleSend = async () => {
+    try {
+      const prepared = await prepareDocumentEmail.mutateAsync({ recordId })
+      openCompose({
+        presetValues: {
+          to: prepared.to.map((recipient) => ({
+            id: recipient.email,
+            identifier: recipient.email,
+            identifierType: 'EMAIL',
+            name: recipient.name,
+          })),
+          subject: prepared.subject,
+          contentHtml: prepared.contentHtml,
+          attachments: [prepared.attachment],
+          integrationId: defaultChannelId,
+          signatureId: defaultSignature?.id ?? null,
+          linkTicketId: parseRecordId(recordId).entityInstanceId,
+        },
+      })
+    } catch {
+      // onError above already surfaced the toast.
+    }
+  }
+
+  const handleDownload = async () => {
+    try {
+      // The endpoint's input is named `quoteRecordId` generically — invoices reuse it.
+      const { assetId } = await ensureDocumentPdf.mutateAsync({ quoteRecordId: recordId })
+      window.open(`/api/files/download/asset:${assetId}`, '_blank', 'noopener,noreferrer')
+    } catch {
+      // onError above already surfaced the toast.
+    }
+  }
+
+  return {
+    hasEmailChannel,
+    handleSend,
+    handleDownload,
+    isSending: prepareDocumentEmail.isPending,
+    isDownloading: ensureDocumentPdf.isPending,
+  }
+}

--- a/apps/web/src/components/resources/hooks/use-all-records.ts
+++ b/apps/web/src/components/resources/hooks/use-all-records.ts
@@ -41,6 +41,11 @@ export interface FieldInfo {
   type: string
 }
 
+/** Element shape of `api.record.listAll`'s `data.items` — what `appendRecord` expects. */
+export type AllRecordsItem = NonNullable<
+  ReturnType<typeof api.record.listAll.useQuery>['data']
+>['items'][number]
+
 /**
  * Result from useAllRecords hook
  */
@@ -57,6 +62,12 @@ interface UseAllRecordsResult<T = RecordMeta> {
   error: Error | null
   /** Refetch data */
   refresh: () => void
+  /**
+   * Append a freshly created item straight into the `listAll` cache — skips
+   * the `refresh()` round-trip so it appears instantly. No-op if the cache
+   * hasn't been populated yet (falls back to the next natural fetch).
+   */
+  appendRecord: (item: AllRecordsItem) => void
 }
 
 /**
@@ -109,6 +120,22 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
   // Store actions - use proper zustand selectors
   const setRecords = useRecordStore((s) => s.setRecords)
   const setFieldValues = useFieldValueStore((s) => s.setValues)
+
+  const utils = api.useUtils()
+
+  // Append a new item directly into the listAll cache (same query input as
+  // above) instead of refetching the whole list. The populate-effect below
+  // re-runs off this cache write, so the record/field-value stores get
+  // seeded for free.
+  const appendRecord = useCallback(
+    (item: AllRecordsItem) => {
+      utils.record.listAll.setData(
+        { entityDefinitionId, apiSlug, fieldIds, includeArchived },
+        (old) => (old ? { ...old, items: [...old.items, item] } : old)
+      )
+    },
+    [utils, entityDefinitionId, apiSlug, fieldIds, includeArchived]
+  )
 
   const resolvedEntityDefId = data?.entityDefinitionId ?? null
 
@@ -266,5 +293,6 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
     isLoading: shouldFetch && isLoading,
     error: error ?? null,
     refresh: refetch,
+    appendRecord,
   }
 }

--- a/apps/web/src/components/resources/hooks/use-seed-created-record.ts
+++ b/apps/web/src/components/resources/hooks/use-seed-created-record.ts
@@ -1,0 +1,87 @@
+// apps/web/src/components/resources/hooks/use-seed-created-record.ts
+
+import type { FieldType } from '@auxx/database/types'
+import { formatToTypedInput } from '@auxx/lib/field-values/client'
+import type { RecordId } from '@auxx/lib/resources/client'
+import { useCallback } from 'react'
+import {
+  buildFieldValueKey,
+  type FieldReference,
+  useFieldValueStore,
+} from '~/components/resources/store/field-value-store'
+import { type RecordMeta, useRecordStore } from '~/components/resources/store/record-store'
+import { useResourceStore } from '~/components/resources/store/resource-store'
+
+/** Minimal instance shape needed to seed a `RecordMeta` — the fields carried by
+ *  `CreateEntityResult.instance` (`@auxx/lib` `unified-handler-mutations.ts`). */
+export interface CreatedRecordInstance {
+  id: string
+  displayName: string | null
+  secondaryDisplayValue: string | null
+  avatarUrl: string | null
+  createdAt: string | Date
+  updatedAt: string | Date
+}
+
+/** One field's value to seed into the field-value store, keyed by systemAttribute. */
+export interface SeedFieldValue {
+  fieldId: string
+  value: unknown
+  fieldType: FieldType
+}
+
+/**
+ * Seed the record + field-value caches directly from a `record.create` result —
+ * the phantom-draft-line replacement for the old `refresh()` round-trip (money
+ * line-builder, MQ1 build spec §H.1). Mirrors the shapes
+ * `use-record-batch-fetcher.ts` builds for `RecordMeta` and the
+ * `resolveFieldRef` + `formatToTypedInput` pairing `use-save-field-value.ts`
+ * uses for the field-value store, so the freshly-seeded row renders
+ * identically to one hydrated from a list refetch — zero extra network calls.
+ */
+export function useSeedCreatedRecord() {
+  const seedCreatedRecord = useCallback(
+    (params: {
+      entityDefinitionId: string
+      recordId: RecordId
+      listKey: string
+      instance: CreatedRecordInstance
+      values: SeedFieldValue[]
+    }) => {
+      const { entityDefinitionId, recordId, listKey, instance, values } = params
+
+      const meta: RecordMeta = {
+        id: instance.id,
+        recordId,
+        displayName: instance.displayName ?? undefined,
+        secondaryInfo: instance.secondaryDisplayValue ?? undefined,
+        avatarUrl: instance.avatarUrl ?? undefined,
+        createdAt:
+          instance.createdAt instanceof Date
+            ? instance.createdAt.toISOString()
+            : instance.createdAt,
+        updatedAt:
+          instance.updatedAt instanceof Date
+            ? instance.updatedAt.toISOString()
+            : instance.updatedAt,
+      }
+
+      const recordStore = useRecordStore.getState()
+      recordStore.setRecords(entityDefinitionId, [meta])
+      recordStore.appendCreatedRecord(listKey, instance.id)
+
+      const systemAttributeMap = useResourceStore.getState().systemAttributeMap
+      const entries = values.map(({ fieldId, value, fieldType }) => {
+        const resourceFieldId = (systemAttributeMap[fieldId] ?? fieldId) as FieldReference
+        return {
+          key: buildFieldValueKey(recordId, resourceFieldId),
+          value: formatToTypedInput(value, fieldType),
+        }
+      })
+      useFieldValueStore.getState().setValues(entries)
+    },
+    []
+  )
+
+  return { seedCreatedRecord }
+}

--- a/apps/web/src/components/resources/store/record-store.ts
+++ b/apps/web/src/components/resources/store/record-store.ts
@@ -104,6 +104,14 @@ export interface RecordStoreState {
   /** Append IDs to list (for infinite scroll) */
   appendToList: (key: string, ids: string[], nextCursor: string | null) => void
 
+  /**
+   * Append a single freshly-created record's id to a cached list (the phantom
+   * draft "no refresh()" path) — bumps `total`, leaves `nextCursor` untouched.
+   * No-ops if the list isn't cached yet (a subsequent fetch will include it
+   * naturally) or the id is already present.
+   */
+  appendCreatedRecord: (key: string, id: string) => void
+
   // ─────────────────────────────────────────────────────────────────
   // BATCHED RECORD FETCHING (unified across resource types)
   // ─────────────────────────────────────────────────────────────────
@@ -271,6 +279,15 @@ export const useRecordStore = create<RecordStoreState>()(
             cache.ids.push(...ids)
             cache.nextCursor = nextCursor
           }
+        })
+      },
+
+      appendCreatedRecord: (key, id) => {
+        set((state) => {
+          const cache = state.lists[key]
+          if (!cache || cache.ids.includes(id)) return
+          cache.ids.push(id)
+          cache.total += 1
         })
       },
 


### PR DESCRIPTION
## Summary

Rewrites the money **line-builder** and makes catalog inserts appear instantly (no refresh round-trip).

### Line builder
- Split `line-builder.tsx` into a dedicated `line-rows.tsx`.
- Extract send/download logic into `use-document-send-actions.ts` and a shared `document-actions-cluster.tsx` reused by invoices and quotes.
- Rework `invoice-lines-card.tsx` and `quote-line-items-tab.tsx` onto the new builder.

### Instant catalog append
- `useAllRecords` gains `appendRecord` — writes a freshly-created item straight into the `listAll` cache.
- `record-store` gains `appendCreatedRecord`; new `useSeedCreatedRecord` hook seeds the record + field-value caches directly from a `record.create` result.
- Catalog groups/items hooks + settings lists use it so newly-created products/groups show up immediately.

The `resources/` hook + store additions are consumed **only** by money.

## Test plan
- [ ] Create a product/group from settings → appears without refresh
- [ ] Add/edit/remove invoice + quote line items
- [ ] Send + download document actions