### PR TITLE
feat(records): calendar as third table view type

### DIFF
--- a/apps/web/src/components/dynamic-table/components/calendar/calendar-view-body.tsx
+++ b/apps/web/src/components/dynamic-table/components/calendar/calendar-view-body.tsx
@@ -1,0 +1,123 @@
+// apps/web/src/components/dynamic-table/components/calendar/calendar-view-body.tsx
+'use client'
+
+import type { FieldType } from '@auxx/database/types'
+import { toRecordId } from '@auxx/lib/resources/client'
+import type { EventCalendarItem } from '@auxx/ui/components/event-calendar'
+import { EventCalendar } from '@auxx/ui/components/event-calendar'
+import { useCallback } from 'react'
+import { useCalendarRange } from '~/components/calendar/core/use-calendar-range'
+import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
+import { useTableConfig } from '../../context/table-config-context'
+import { useViewMetadata } from '../../context/view-metadata-context'
+import { useCalendarConfig, useTableFilters } from '../../stores/store-selectors'
+import { useCalendarEvents } from './use-calendar-events'
+
+/**
+ * Calendar view body — read path (plan §3.2) + interactions (plan §3.3). Month
+ * range (`useCalendarRange`, the dispatch board's shared shell hook) drives
+ * `useCalendarEvents`'s range-scoped `record.listFiltered` query; returned ids
+ * hydrate through the shared field-value store, so chips repaint for free on
+ * optimistic drag writes and realtime patches.
+ */
+export function CalendarViewBody() {
+  const { tableId, entityDefinitionId } = useTableConfig()
+  const { onCardClick, onAddNew } = useViewMetadata()
+  const calendarConfig = useCalendarConfig(tableId)
+  const viewFilters = useTableFilters(tableId)
+  const { saveBulkMultipleFields } = useSaveFieldValue()
+
+  // Month only (plan §3.2 pt.1) — `weekStartsOn` doesn't affect the month window (it only
+  // quantizes the week stream), so the hook's Monday default is fine unwired.
+  const { date, setDate, range, handleRangeChange } = useCalendarRange('month')
+
+  const { events, dateField, endField } = useCalendarEvents(
+    entityDefinitionId,
+    calendarConfig,
+    range,
+    viewFilters
+  )
+
+  // Drag to reschedule (plan §3.3) — `event` is the pre-drag original item (its
+  // `start`/`end` are untouched), `newStart`/`newEnd` are the drop's computed,
+  // duration-preserving position. Kanban's drag-write precedent has no
+  // canEdit/permission gate; this mirrors that. `saveBulkMultipleFields` is
+  // optimistic (setValueOptimistic → confirm/rollback + toastError on failure),
+  // so the store repaints the chip immediately and rolls back on error without
+  // any handling needed here.
+  const handleEventDrop = useCallback(
+    (event: EventCalendarItem, newStart: Date, newEnd: Date) => {
+      if (!entityDefinitionId || !calendarConfig?.dateFieldId || !dateField?.fieldType) return
+
+      const fieldValues: Array<{ fieldId: string; value: unknown; fieldType: FieldType }> = [
+        {
+          fieldId: calendarConfig.dateFieldId,
+          value: newStart,
+          fieldType: dateField.fieldType as FieldType,
+        },
+      ]
+
+      // Only shift the end field if this event actually had a real span — a
+      // point-in-time chip (end === start) must not gain an end value it never had.
+      const hadRealEnd = event.end.getTime() !== event.start.getTime()
+      if (calendarConfig.endDateFieldId && endField?.fieldType && hadRealEnd) {
+        fieldValues.push({
+          fieldId: calendarConfig.endDateFieldId,
+          value: newEnd,
+          fieldType: endField.fieldType as FieldType,
+        })
+      }
+
+      saveBulkMultipleFields([toRecordId(entityDefinitionId, event.id)], fieldValues)
+    },
+    [
+      entityDefinitionId,
+      calendarConfig?.dateFieldId,
+      calendarConfig?.endDateFieldId,
+      dateField,
+      endField,
+      saveBulkMultipleFields,
+    ]
+  )
+
+  // Click empty day to create (plan §3.3) — prefill the date axis and hand off
+  // to whatever create-dialog seam the host wired through `onAddNew`
+  // (`records-view.tsx` stores presets and opens `EntityInstanceDialog`). Degrades
+  // to a no-op when the host doesn't support presets (e.g. a future non-records
+  // consumer of the calendar view), matching `onCardClick?.`'s optional-chain style.
+  const handleSlotClick = useCallback(
+    (startTime: Date) => {
+      if (!calendarConfig?.dateFieldId) return
+      onAddNew?.({ [calendarConfig.dateFieldId]: startTime })
+    },
+    [calendarConfig?.dateFieldId, onAddNew]
+  )
+
+  if (!calendarConfig?.dateFieldId) {
+    return (
+      <div className='flex items-center justify-center h-64 text-muted-foreground'>
+        Calendar view requires a date field configuration.
+      </div>
+    )
+  }
+
+  return (
+    // min-h-0 + overflow-hidden bound the flex chain so the virtualized month
+    // stream gets a real scrollport instead of rendering at full stream height.
+    <div className='flex flex-col relative h-full flex-1 min-h-0 overflow-hidden'>
+      <EventCalendar
+        date={date}
+        view='month'
+        onDateChange={setDate}
+        onViewChange={() => {}}
+        onRangeChange={handleRangeChange}
+        events={events}
+        onEventClick={(event) => onCardClick?.({ id: event.id })}
+        onEventDrop={handleEventDrop}
+        onSlotClick={handleSlotClick}
+        hideToolbar
+        className='flex-1 min-h-0'
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/dynamic-table/components/calendar/use-calendar-events.ts
+++ b/apps/web/src/components/dynamic-table/components/calendar/use-calendar-events.ts
@@ -1,0 +1,277 @@
+// apps/web/src/components/dynamic-table/components/calendar/use-calendar-events.ts
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { getOptionColorHex } from '@auxx/lib/custom-fields/client'
+import { formatToDisplayValue, formatToRawValue } from '@auxx/lib/field-values/client'
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { toRecordId } from '@auxx/lib/resources/client'
+import { toResourceFieldId } from '@auxx/types/field'
+import type { TypedFieldValue } from '@auxx/types/field-value'
+import type { EventCalendarItem } from '@auxx/ui/components/event-calendar'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import type { DateRange } from '~/components/calendar/core/use-calendar-range'
+import { useResource, useResourceFields } from '~/components/resources'
+import { fieldValueFetchQueue } from '~/components/resources/store/field-value-fetch-queue'
+import {
+  buildFieldValueKey,
+  type StoredFieldValue,
+  useFieldValueStore,
+} from '~/components/resources/store/field-value-store'
+import { api } from '~/trpc/react'
+import type { CalendarViewConfig } from '../../types'
+
+/** `record.listFiltered` caps `limit` at 500 (router); this bounds the oneshot drain
+ * loop itself — a month denser than 5000 records goes unfetched past the cap rather
+ * than looping forever. */
+const PAGE_LIMIT = 500
+const MAX_PAGES = 10
+
+/**
+ * `after`/`before` are strict `>`/`<` on `FieldValue.valueDate`
+ * (`entity-condition-builder.ts`), not inclusive — a naive `[range.from, range.to]`
+ * window silently drops records that land exactly on a month boundary at midnight.
+ * Widen by 1ms on each side so the boundary instants are included.
+ */
+function buildRangeFilterGroup(dateFieldId: string, range: DateRange): ConditionGroup {
+  const after = new Date(range.from.getTime() - 1).toISOString()
+  const before = new Date(range.to.getTime() + 1).toISOString()
+  return {
+    id: 'calendar-range',
+    logicalOperator: 'AND',
+    conditions: [
+      { id: 'calendar-range-after', fieldId: dateFieldId, operator: 'after', value: after },
+      { id: 'calendar-range-before', fieldId: dateFieldId, operator: 'before', value: before },
+    ],
+  }
+}
+
+/**
+ * Record ids on the calendar's date axis within `range`, honoring the view's own saved
+ * filters (`viewFilters`) plus an injected range condition group. Pure `(entityDefinitionId,
+ * config, range, viewFilters) → { ids, isLoading }` — extractable per plan §5 (a records-view
+ * "source" for the personal calendar would reuse this shape unchanged).
+ *
+ * `record.listFiltered`'s snapshot-cursor mode doesn't fit a range query (no stable cursor to
+ * page from as the range itself changes), so this drains `mode:'oneshot'` pages directly
+ * instead of reusing `useRecordList`.
+ */
+export function useCalendarRecordIds(
+  entityDefinitionId: string | undefined,
+  config: CalendarViewConfig | undefined,
+  range: DateRange,
+  viewFilters: ConditionGroup[]
+): { ids: string[]; isLoading: boolean } {
+  const utils = api.useUtils()
+  const dateFieldId = config?.dateFieldId
+
+  const filters = useMemo(() => {
+    if (!dateFieldId) return []
+    return [...viewFilters, buildRangeFilterGroup(dateFieldId, range)]
+  }, [viewFilters, dateFieldId, range])
+
+  // Deterministic key — `filters` is plain JSON-serializable condition data, and `range` is
+  // reduced to timestamps so an unchanged (quantized, debounced) range doesn't churn the key.
+  const query = useQuery({
+    queryKey: [
+      'calendar-record-ids',
+      entityDefinitionId,
+      range.from.getTime(),
+      range.to.getTime(),
+      JSON.stringify(filters),
+    ],
+    queryFn: async () => {
+      const ids: string[] = []
+      let offset = 0
+      for (let page = 0; page < MAX_PAGES; page++) {
+        const result = await utils.record.listFiltered.fetch({
+          entityDefinitionId: entityDefinitionId as string,
+          filters,
+          limit: PAGE_LIMIT,
+          offset,
+          mode: 'oneshot',
+        })
+        ids.push(...result.ids)
+        if (!result.hasMore) break
+        offset += result.ids.length
+      }
+      return ids
+    },
+    enabled: Boolean(entityDefinitionId && dateFieldId),
+    staleTime: 30_000,
+  })
+
+  return { ids: query.data ?? [], isLoading: query.isFetching }
+}
+
+/**
+ * Read-path top-level hook: drains ids for `range` (`useCalendarRecordIds`), hydrates the
+ * configured fields through the shared field-value fetch queue (kanban's exact
+ * `queueFetchBatch` pattern — idempotent, so re-running this effect on every render is a
+ * no-op once cached), and maps to `EventCalendarItem[]`. Chips read from the zustand
+ * field-value store, so optimistic drag writes (`calendar-view-body.tsx`'s
+ * `onEventDrop`, plan §3.3) and realtime patches repaint for free.
+ */
+export function useCalendarEvents(
+  entityDefinitionId: string | undefined,
+  config: CalendarViewConfig | undefined,
+  range: DateRange,
+  viewFilters: ConditionGroup[]
+): {
+  events: EventCalendarItem[]
+  isLoading: boolean
+  /** The resolved date-axis field — Phase 3 writes reuse this for `fieldType`
+   *  instead of re-deriving it from `useResourceFields`. */
+  dateField: ResourceField | undefined
+  /** The resolved end-date field, if `config.endDateFieldId` is set. */
+  endField: ResourceField | undefined
+} {
+  const { fields } = useResourceFields(entityDefinitionId)
+  const { resource } = useResource(entityDefinitionId)
+
+  const { ids, isLoading } = useCalendarRecordIds(entityDefinitionId, config, range, viewFilters)
+
+  const dateField = useMemo(
+    () => fields?.find((f) => f.id === config?.dateFieldId),
+    [fields, config?.dateFieldId]
+  )
+  const endField = useMemo(
+    () => fields?.find((f) => f.id === config?.endDateFieldId),
+    [fields, config?.endDateFieldId]
+  )
+  const colorField = useMemo(
+    () => fields?.find((f) => f.id === config?.colorFieldId),
+    [fields, config?.colorFieldId]
+  )
+
+  // Title field: view config's `primaryFieldId`, else the entity's own identity/primary
+  // display field (kanban's `primaryFieldId` derivation precedent, `kanban-view-body.tsx`).
+  const primaryFieldId = config?.primaryFieldId ?? resource?.display.primaryDisplayField?.id
+  const primaryField = useMemo(
+    () => fields?.find((f) => f.id === primaryFieldId),
+    [fields, primaryFieldId]
+  )
+
+  const fieldIdsToHydrate = useMemo(() => {
+    const ordered = [
+      config?.dateFieldId,
+      config?.endDateFieldId,
+      config?.colorFieldId,
+      primaryFieldId,
+    ].filter((id): id is string => Boolean(id))
+    return [...new Set(ordered)]
+  }, [config?.dateFieldId, config?.endDateFieldId, config?.colorFieldId, primaryFieldId])
+
+  // Hydration — queue field-value fetches for every returned id × configured field
+  // (kanban-view-body.tsx:102-118's exact pattern). `queueFetchBatch` is a no-op for
+  // keys already cached/in-flight, so this effect re-running on every render (ids is a new
+  // array each query resolution, not every render) never storms requests.
+  useEffect(() => {
+    if (!entityDefinitionId || fieldIdsToHydrate.length === 0 || ids.length === 0) return
+    fieldValueFetchQueue.queueFetchBatch(
+      ids.flatMap((id) =>
+        fieldIdsToHydrate.map((fieldId) => ({
+          recordId: toRecordId(entityDefinitionId, id),
+          fieldRef: toResourceFieldId(entityDefinitionId, fieldId),
+        }))
+      )
+    )
+  }, [entityDefinitionId, ids, fieldIdsToHydrate])
+
+  // One shallow-compared selector across every (record, field) pair the calendar needs —
+  // mirrors `useFieldValues`'s single-record pattern, extended to many records. Only
+  // re-renders when one of these specific values changes, not on unrelated store writes.
+  // The map MUST stay flat (`recordId:fieldId` → stored value): useShallow compares
+  // top-level values by reference, so nested per-record objects (rebuilt every snapshot)
+  // would fail equality every time — React's "getSnapshot should be cached" infinite loop.
+  const storedValues = useFieldValueStore(
+    useShallow((state) => {
+      if (!entityDefinitionId) return {}
+      const map: Record<string, StoredFieldValue | undefined> = {}
+      for (const id of ids) {
+        const recordId = toRecordId(entityDefinitionId, id)
+        for (const fieldId of fieldIdsToHydrate) {
+          const fieldRef = toResourceFieldId(entityDefinitionId, fieldId)
+          map[`${id}:${fieldId}`] = state.values[buildFieldValueKey(recordId, fieldRef)]
+        }
+      }
+      return map
+    })
+  )
+
+  const events = useMemo<EventCalendarItem[]>(() => {
+    if (!entityDefinitionId || !config?.dateFieldId) return []
+
+    const result: EventCalendarItem[] = []
+    for (const id of ids) {
+      const stored = (fieldId: string | undefined) =>
+        fieldId ? storedValues[`${id}:${fieldId}`] : undefined
+
+      // Multi-value date fields: first row wins (plan §3.2 pt.4).
+      const dateRaw = formatToRawValue(stored(config.dateFieldId), dateField?.fieldType ?? 'DATE')
+      const dateValue = Array.isArray(dateRaw) ? dateRaw[0] : dateRaw
+      if (dateValue == null) continue // defensive — the range filter already excludes these
+      const start = new Date(dateValue as string)
+      if (Number.isNaN(start.getTime())) continue
+
+      let end = start
+      if (config.endDateFieldId && endField) {
+        const endRaw = formatToRawValue(stored(config.endDateFieldId), endField.fieldType)
+        const endValue = Array.isArray(endRaw) ? endRaw[0] : endRaw
+        if (endValue != null) {
+          const candidateEnd = new Date(endValue as string)
+          if (!Number.isNaN(candidateEnd.getTime()) && candidateEnd > start) end = candidateEnd
+        }
+      }
+
+      let color: string | undefined
+      if (config.colorFieldId && colorField) {
+        const colorRaw = formatToRawValue(stored(config.colorFieldId), colorField.fieldType)
+        // SINGLE_SELECT values are arrays (standing repo gotcha) — raw[0] ?? null.
+        const colorValue = Array.isArray(colorRaw) ? (colorRaw[0] ?? null) : colorRaw
+        const option = colorField.options?.options?.find(
+          (o) => o.value === colorValue || o.id === colorValue
+        )
+        if (option?.color) color = getOptionColorHex(option.color)
+      }
+
+      // Title: primaryFieldId's display value (kanban-card.tsx:80-86 precedent — handles both
+      // TypedFieldValue objects and raw scalars already in the store).
+      let title = 'Untitled'
+      const primaryValue = stored(primaryFieldId)
+      if (primaryValue != null) {
+        if (typeof primaryValue === 'object' && 'type' in primaryValue) {
+          const formatted = formatToDisplayValue(
+            primaryValue as TypedFieldValue,
+            primaryField?.fieldType ?? 'TEXT'
+          )
+          if (typeof formatted === 'string' && formatted) title = formatted
+        } else {
+          title = String(primaryValue) || 'Untitled'
+        }
+      }
+
+      // Field-level truth (`CustomField.options.includeTime`, `field-options.ts`) rather than
+      // the fieldType-only approximation — a DATE field only renders all-day when it doesn't
+      // also carry a time-of-day.
+      const allDay = !dateField?.options?.includeTime
+
+      result.push({ id, title, start, end, allDay, color })
+    }
+    return result
+  }, [
+    entityDefinitionId,
+    config,
+    ids,
+    storedValues,
+    dateField,
+    endField,
+    colorField,
+    primaryFieldId,
+    primaryField,
+  ])
+
+  return { events, isLoading, dateField, endField }
+}

--- a/apps/web/src/components/dynamic-table/components/dialogs/create-view-dialog.tsx
+++ b/apps/web/src/components/dynamic-table/components/dialogs/create-view-dialog.tsx
@@ -30,7 +30,7 @@ import type {
   SortingState,
   VisibilityState,
 } from '@tanstack/react-table'
-import { LayoutGrid, Table2 } from 'lucide-react'
+import { Calendar, LayoutGrid, Table2 } from 'lucide-react'
 import { useState } from 'react'
 import { useViewMutations } from '../../hooks/use-view-mutations'
 import type { TableView, ViewConfig } from '../../types'
@@ -42,6 +42,12 @@ interface SelectField {
   options?: { options?: Array<{ id: string; label: string; color?: string }> }
 }
 
+/** DATE/DATETIME field for the calendar view's date axis */
+interface DateField {
+  id: string
+  name: string
+}
+
 export interface CreateViewDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -49,6 +55,8 @@ export interface CreateViewDialogProps {
   views: TableView[]
   /** SINGLE_SELECT fields available for kanban grouping */
   selectFields?: SelectField[]
+  /** DATE/DATETIME fields available for the calendar view's date axis */
+  dateFields?: DateField[]
   /** Entity definition ID for field creation */
   entityDefinitionId?: string
   /** Current filters to pre-populate when creating a new view */
@@ -74,27 +82,37 @@ export function CreateViewDialog({
   tableId,
   views,
   selectFields,
+  dateFields,
   entityDefinitionId,
   currentFilters,
   onViewCreated,
   currentTableState,
 }: CreateViewDialogProps) {
   const [newViewName, setNewViewName] = useState('')
-  const [viewType, setViewType] = useState<'table' | 'kanban'>('table')
+  const [viewType, setViewType] = useState<'table' | 'kanban' | 'calendar'>('table')
   const [selectedFieldId, setSelectedFieldId] = useState<string>('')
   const [isCreatingField, setIsCreatingField] = useState(false)
   const [newFieldName, setNewFieldName] = useState('')
+  const [selectedDateFieldId, setSelectedDateFieldId] = useState<string>('')
 
   const { createView } = useViewMutations(tableId)
+  const hasDateFields = (dateFields ?? []).length > 0
 
   /** Handle view creation */
   const handleCreateView = async () => {
     // For kanban, need either a selected field or a new field name
     if (viewType === 'kanban' && !selectedFieldId && !newFieldName.trim()) return
+    // For calendar, a date field is required
+    if (viewType === 'calendar' && !selectedDateFieldId) return
 
     // Generate name if not provided
     const existingNames = new Set(views.map((v) => v.name))
-    const baseTitle = viewType === 'kanban' ? 'Kanban View' : 'Table View'
+    const baseTitle =
+      viewType === 'kanban'
+        ? 'Kanban View'
+        : viewType === 'calendar'
+          ? 'Calendar View'
+          : 'Table View'
     const viewName = newViewName.trim() || incrementTitle(baseTitle, existingNames)
 
     const config: ViewConfig = {
@@ -109,6 +127,11 @@ export function CreateViewDialog({
         kanban: {
           // Use empty string if creating new field - backend will populate
           groupByFieldId: selectedFieldId || '',
+        },
+      }),
+      ...(viewType === 'calendar' && {
+        calendar: {
+          dateFieldId: selectedDateFieldId,
         },
       }),
     }
@@ -144,6 +167,7 @@ export function CreateViewDialog({
     setSelectedFieldId('')
     setNewFieldName('')
     setIsCreatingField(false)
+    setSelectedDateFieldId('')
   }
 
   /** Handle dialog close */
@@ -186,7 +210,7 @@ export function CreateViewDialog({
             <Label>View Type</Label>
             <RadioGroup
               value={viewType}
-              onValueChange={(v) => setViewType(v as 'table' | 'kanban')}>
+              onValueChange={(v) => setViewType(v as 'table' | 'kanban' | 'calendar')}>
               <RadioGroupItemCard
                 label='Table'
                 value='table'
@@ -199,8 +223,33 @@ export function CreateViewDialog({
                 icon={<LayoutGrid />}
                 description='Organize records on a pipeline'
               />
+              <RadioGroupItemCard
+                label='Calendar'
+                value='calendar'
+                icon={<Calendar />}
+                disabled={!hasDateFields}
+                description={
+                  hasDateFields
+                    ? 'Organize records on a date-based month grid'
+                    : 'Requires a DATE or DATETIME field on this entity'
+                }
+              />
             </RadioGroup>
           </div>
+
+          {/* Date field selector for calendar */}
+          {viewType === 'calendar' && (
+            <div className='space-y-2 flex flex-col'>
+              <Label>Date field</Label>
+              <Combobox
+                options={(dateFields ?? []).map((f) => ({ value: f.id, label: f.name }))}
+                placeholder='Select a date field...'
+                emptyText='No date fields found'
+                value={selectedDateFieldId}
+                onChangeValue={setSelectedDateFieldId}
+              />
+            </div>
+          )}
 
           {/* Field selector for kanban */}
           {viewType === 'kanban' && (
@@ -280,7 +329,8 @@ export function CreateViewDialog({
             loadingText='Creating...'
             disabled={
               createView.isPending ||
-              (viewType === 'kanban' && !selectedFieldId && !newFieldName.trim())
+              (viewType === 'kanban' && !selectedFieldId && !newFieldName.trim()) ||
+              (viewType === 'calendar' && !selectedDateFieldId)
             }>
             Create View <KbdSubmit variant='outline' size='sm' />
           </Button>

--- a/apps/web/src/components/dynamic-table/components/table-toolbar/calendar-view-settings.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/calendar-view-settings.tsx
@@ -1,0 +1,455 @@
+// apps/web/src/components/dynamic-table/components/table-toolbar/calendar-view-settings.tsx
+'use client'
+
+import { fieldTypeOptions } from '@auxx/lib/custom-fields/types'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Command,
+  CommandBreadcrumb,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandNavigableItem,
+  CommandNavigation,
+  CommandRadioGroup,
+  CommandRadioItem,
+  CommandSeparator,
+  CommandSortable,
+  CommandSortableItem,
+  type NavigationItem,
+  useCommandNavigation,
+} from '@auxx/ui/components/command'
+import { EntityIcon } from '@auxx/ui/components/icons'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { CalendarDays, CalendarRange, IdCard, Palette, Plus, Settings2, Trash2 } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import { Tooltip } from '~/components/global/tooltip'
+import { useTableConfig } from '../../context/table-config-context'
+import { useViewMetadata } from '../../context/view-metadata-context'
+import { useUpdateCalendarConfig } from '../../stores/store-actions'
+import { useCalendarConfig } from '../../stores/store-selectors'
+
+/** Navigation item type for CalendarViewSettings */
+interface SettingsNavigationItem extends NavigationItem {
+  id: string
+  label: string
+  type: 'dateField' | 'endDateField' | 'colorField' | 'primaryField' | 'add-field'
+}
+
+/** Props for CalendarViewSettings */
+interface CalendarViewSettingsProps {
+  className?: string
+}
+
+/** Sentinel value for "None" radio items — clears the corresponding optional field id. */
+const NONE_VALUE = '__none__'
+
+/**
+ * Root stack component - main menu with date-axis fields and card fields.
+ * Mirrors `KanbanViewSettings`'s Popover + CommandNavigation shape (kanban-view-settings.tsx).
+ */
+function RootStack() {
+  const { push } = useCommandNavigation<SettingsNavigationItem>()
+  const { tableId } = useTableConfig()
+  const { customFields, dateFields, selectFields } = useViewMetadata()
+
+  const calendarConfig = useCalendarConfig(tableId)
+  const updateCalendarConfig = useUpdateCalendarConfig(tableId)
+
+  const cardFields = calendarConfig?.cardFields ?? []
+
+  const dateField = useMemo(
+    () => dateFields?.find((f) => f.id === calendarConfig?.dateFieldId),
+    [dateFields, calendarConfig?.dateFieldId]
+  )
+  const endDateField = useMemo(
+    () => dateFields?.find((f) => f.id === calendarConfig?.endDateFieldId),
+    [dateFields, calendarConfig?.endDateFieldId]
+  )
+  const colorField = useMemo(
+    () => selectFields?.find((f) => f.id === calendarConfig?.colorFieldId),
+    [selectFields, calendarConfig?.colorFieldId]
+  )
+  const primaryField = useMemo(
+    () => customFields?.find((f) => f.id === calendarConfig?.primaryFieldId),
+    [customFields, calendarConfig?.primaryFieldId]
+  )
+
+  /** Navigate to a sub-stack */
+  const handleNavigate = useCallback(
+    (type: SettingsNavigationItem['type'], label: string) => {
+      push({ id: type, label, type })
+    },
+    [push]
+  )
+
+  /** Handle card fields reorder (optimistic via store) */
+  const handleCardFieldsReorder = useCallback(
+    (newOrder: string[]) => {
+      updateCalendarConfig({ cardFields: newOrder })
+    },
+    [updateCalendarConfig]
+  )
+
+  /** Handle removing a card field (optimistic via store) */
+  const handleRemoveCardField = useCallback(
+    (fieldId: string) => {
+      updateCalendarConfig({
+        cardFields: cardFields.filter((id) => id !== fieldId),
+      })
+    },
+    [cardFields, updateCalendarConfig]
+  )
+
+  return (
+    <CommandList>
+      {/* View Settings Group */}
+      <CommandGroup heading='View Settings'>
+        <CommandNavigableItem
+          item={{ id: 'dateField', label: 'Date field', type: 'dateField' }}
+          hasChildren
+          onSelect={() => handleNavigate('dateField', 'Date field')}>
+          <CalendarDays />
+          <span className='flex-1'>Date field</span>
+          <span className='text-xs text-muted-foreground truncate max-w-24'>
+            {dateField?.name ?? 'Not set'}
+          </span>
+        </CommandNavigableItem>
+
+        <CommandNavigableItem
+          item={{ id: 'endDateField', label: 'End date field', type: 'endDateField' }}
+          hasChildren
+          onSelect={() => handleNavigate('endDateField', 'End date field')}>
+          <CalendarRange />
+          <span className='flex-1'>End date field</span>
+          <span className='text-xs text-muted-foreground truncate max-w-24'>
+            {endDateField?.name ?? 'Not set'}
+          </span>
+        </CommandNavigableItem>
+
+        <CommandNavigableItem
+          item={{ id: 'colorField', label: 'Color field', type: 'colorField' }}
+          hasChildren
+          onSelect={() => handleNavigate('colorField', 'Color field')}>
+          <Palette />
+          <span className='flex-1'>Color field</span>
+          <span className='text-xs text-muted-foreground truncate max-w-24'>
+            {colorField?.name ?? 'Not set'}
+          </span>
+        </CommandNavigableItem>
+
+        <CommandNavigableItem
+          item={{ id: 'primaryField', label: 'Primary field', type: 'primaryField' }}
+          hasChildren
+          onSelect={() => handleNavigate('primaryField', 'Primary field')}>
+          <IdCard />
+          <span className='flex-1'>Primary field</span>
+          <span className='text-xs text-muted-foreground truncate max-w-24'>
+            {primaryField?.name ?? 'Not set'}
+          </span>
+        </CommandNavigableItem>
+      </CommandGroup>
+
+      <CommandSeparator />
+      {/* Card Fields Group - Sortable */}
+      <CommandGroup heading='Card Fields'>
+        {cardFields.length === 0 ? (
+          <div className='text-sm text-muted-foreground px-2'>No card fields configured</div>
+        ) : (
+          <CommandSortable items={cardFields} onReorder={handleCardFieldsReorder}>
+            {cardFields.map((fieldId) => {
+              const field = customFields?.find((f) => f.id === fieldId)
+              return (
+                <CommandSortableItem key={fieldId} id={fieldId} className='py-0 pe-0.5'>
+                  <span className='truncate flex-1 flex items-center'>
+                    {field?.name ?? fieldId}
+                  </span>
+                  <button
+                    type='button'
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleRemoveCardField(fieldId)
+                    }}
+                    className='shrink-0  size-6.5 flex items-center justify-center rounded-full hover:bg-bad-100 hover:text-bad-500'>
+                    <Trash2 className='size-3' />
+                  </button>
+                </CommandSortableItem>
+              )
+            })}
+          </CommandSortable>
+        )}
+      </CommandGroup>
+
+      <CommandSeparator />
+
+      {/* Add Card Field */}
+      <CommandGroup>
+        <CommandNavigableItem
+          item={{ id: 'add-field', label: 'Add card field', type: 'add-field' }}
+          hasChildren
+          onSelect={() => handleNavigate('add-field', 'Add card field')}>
+          <Plus />
+          <span>Add card field</span>
+        </CommandNavigableItem>
+      </CommandGroup>
+    </CommandList>
+  )
+}
+
+/** Date field selection stack - required, no clear option. */
+function DateFieldStack() {
+  const { tableId } = useTableConfig()
+  const { dateFields } = useViewMetadata()
+
+  const calendarConfig = useCalendarConfig(tableId)
+  const updateCalendarConfig = useUpdateCalendarConfig(tableId)
+
+  const handleSelectField = useCallback(
+    (fieldId: string) => {
+      updateCalendarConfig({ dateFieldId: fieldId })
+    },
+    [updateCalendarConfig]
+  )
+
+  return (
+    <CommandList>
+      <CommandGroup>
+        <div className='text-xs text-muted-foreground px-2 pb-1'>
+          Records are placed on the month grid by this field. Multi-value date fields use their
+          first value.
+        </div>
+      </CommandGroup>
+      <CommandSeparator />
+      <CommandRadioGroup value={calendarConfig?.dateFieldId} onValueChange={handleSelectField}>
+        {(dateFields ?? []).map((field) => (
+          <CommandRadioItem key={field.id} value={field.id}>
+            {field.name}
+          </CommandRadioItem>
+        ))}
+      </CommandRadioGroup>
+      {(dateFields ?? []).length === 0 && (
+        <CommandEmpty>No DATE or DATETIME fields on this entity</CommandEmpty>
+      )}
+    </CommandList>
+  )
+}
+
+/** End date field selection stack - nullable (clears the span back to a point-in-time chip). */
+function EndDateFieldStack() {
+  const { tableId } = useTableConfig()
+  const { dateFields } = useViewMetadata()
+
+  const calendarConfig = useCalendarConfig(tableId)
+  const updateCalendarConfig = useUpdateCalendarConfig(tableId)
+
+  const handleSelectField = useCallback(
+    (fieldId: string) => {
+      updateCalendarConfig({ endDateFieldId: fieldId === NONE_VALUE ? undefined : fieldId })
+    },
+    [updateCalendarConfig]
+  )
+
+  return (
+    <CommandList>
+      <CommandRadioGroup
+        value={calendarConfig?.endDateFieldId ?? NONE_VALUE}
+        onValueChange={handleSelectField}>
+        <CommandRadioItem value={NONE_VALUE}>None</CommandRadioItem>
+        {(dateFields ?? [])
+          .filter((f) => f.id !== calendarConfig?.dateFieldId)
+          .map((field) => (
+            <CommandRadioItem key={field.id} value={field.id}>
+              {field.name}
+            </CommandRadioItem>
+          ))}
+      </CommandRadioGroup>
+    </CommandList>
+  )
+}
+
+/** Color field selection stack - SINGLE_SELECT only, nullable. */
+function ColorFieldStack() {
+  const { tableId } = useTableConfig()
+  const { selectFields } = useViewMetadata()
+
+  const calendarConfig = useCalendarConfig(tableId)
+  const updateCalendarConfig = useUpdateCalendarConfig(tableId)
+
+  const handleSelectField = useCallback(
+    (fieldId: string) => {
+      updateCalendarConfig({ colorFieldId: fieldId === NONE_VALUE ? undefined : fieldId })
+    },
+    [updateCalendarConfig]
+  )
+
+  return (
+    <CommandList>
+      <CommandRadioGroup
+        value={calendarConfig?.colorFieldId ?? NONE_VALUE}
+        onValueChange={handleSelectField}>
+        <CommandRadioItem value={NONE_VALUE}>None</CommandRadioItem>
+        {(selectFields ?? []).map((field) => (
+          <CommandRadioItem key={field.id} value={field.id}>
+            {field.name}
+          </CommandRadioItem>
+        ))}
+      </CommandRadioGroup>
+      {(selectFields ?? []).length === 0 && (
+        <CommandEmpty>No SINGLE_SELECT fields on this entity</CommandEmpty>
+      )}
+    </CommandList>
+  )
+}
+
+/** Primary (title) field selection stack - nullable, falls back to the entity's identity field. */
+function PrimaryFieldStack() {
+  const { tableId } = useTableConfig()
+  const { customFields } = useViewMetadata()
+
+  const calendarConfig = useCalendarConfig(tableId)
+  const updateCalendarConfig = useUpdateCalendarConfig(tableId)
+
+  const handleSelectField = useCallback(
+    (fieldId: string) => {
+      updateCalendarConfig({ primaryFieldId: fieldId === NONE_VALUE ? undefined : fieldId })
+    },
+    [updateCalendarConfig]
+  )
+
+  return (
+    <CommandList>
+      <CommandRadioGroup
+        value={calendarConfig?.primaryFieldId ?? NONE_VALUE}
+        onValueChange={handleSelectField}>
+        <CommandRadioItem value={NONE_VALUE}>Entity default</CommandRadioItem>
+        {(customFields ?? []).map((field) => (
+          <CommandRadioItem key={field.id} value={field.id}>
+            {field.name}
+          </CommandRadioItem>
+        ))}
+      </CommandRadioGroup>
+    </CommandList>
+  )
+}
+
+/** Add card field stack - search and add fields to cards (mirrors kanban's `AddCardFieldStack`). */
+function AddCardFieldStack() {
+  const { tableId } = useTableConfig()
+  const { customFields } = useViewMetadata()
+
+  const calendarConfig = useCalendarConfig(tableId)
+  const updateCalendarConfig = useUpdateCalendarConfig(tableId)
+  const [search, setSearch] = useState('')
+
+  const cardFields = calendarConfig?.cardFields ?? []
+
+  /** Fields available to add (not already in cardFields) */
+  const availableFields = useMemo(() => {
+    const currentFieldIds = new Set(cardFields)
+    return (customFields ?? []).filter((f) => !currentFieldIds.has(f.id))
+  }, [customFields, cardFields])
+
+  /** Filtered fields based on search */
+  const filteredFields = useMemo(() => {
+    if (!search) return availableFields
+    const query = search.toLowerCase()
+    return availableFields.filter((f) => f.name.toLowerCase().includes(query))
+  }, [availableFields, search])
+
+  /** Handle adding a field */
+  const handleAddField = useCallback(
+    (fieldId: string) => {
+      updateCalendarConfig({
+        cardFields: [...cardFields, fieldId],
+      })
+    },
+    [cardFields, updateCalendarConfig]
+  )
+
+  return (
+    <>
+      <CommandInput placeholder='Search fields...' value={search} onValueChange={setSearch} />
+      <CommandList>
+        <CommandEmpty>No fields found.</CommandEmpty>
+        {filteredFields.length > 0 && (
+          <CommandGroup>
+            {filteredFields.map((field) => (
+              <CommandItem
+                key={field.id}
+                value={field.id}
+                onSelect={() => handleAddField(field.id)}
+                className='ps-0.5 py-0'>
+                <EntityIcon
+                  iconId={field.fieldType ? fieldTypeOptions[field.fieldType].iconId : 'circle'}
+                  variant='default'
+                  size='default'
+                />
+                {field.name}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </>
+  )
+}
+
+/**
+ * Main content component that renders based on navigation state
+ */
+function CalendarViewSettingsContent() {
+  const { current } = useCommandNavigation<SettingsNavigationItem>()
+
+  if (current?.type === 'dateField') {
+    return <DateFieldStack />
+  }
+  if (current?.type === 'endDateField') {
+    return <EndDateFieldStack />
+  }
+  if (current?.type === 'colorField') {
+    return <ColorFieldStack />
+  }
+  if (current?.type === 'primaryField') {
+    return <PrimaryFieldStack />
+  }
+  if (current?.type === 'add-field') {
+    return <AddCardFieldStack />
+  }
+
+  return <RootStack />
+}
+
+/**
+ * CalendarViewSettings component
+ * Manages calendar-specific view settings — date axis (start/end), chip color,
+ * primary (title) field, and card fields — mirroring `KanbanViewSettings`'s shape.
+ */
+export function CalendarViewSettings({ className }: CalendarViewSettingsProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <div className={className}>
+          <Tooltip content='Calendar settings'>
+            <Button variant='ghost' size='sm'>
+              <Settings2 className='size-3' />
+              <span className='hidden @lg/controls:block'>Settings</span>
+            </Button>
+          </Tooltip>
+        </div>
+      </PopoverTrigger>
+
+      <PopoverContent className='w-[280px] p-0' align='start'>
+        <CommandNavigation<SettingsNavigationItem>>
+          <Command shouldFilter={false}>
+            <CommandBreadcrumb rootLabel='Settings' />
+            <CalendarViewSettingsContent />
+          </Command>
+        </CommandNavigation>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/dynamic-table/components/table-toolbar/index.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/index.tsx
@@ -46,6 +46,7 @@ import {
   useTableViews,
 } from '../../stores/store-selectors'
 import type { ViewConfig, ViewType } from '../../types'
+import { CalendarViewSettings } from './calendar-view-settings'
 import { ColumnManager } from './column-manager'
 import { KanbanViewSettings } from './kanban-view-settings'
 import { RecordsGuideDialog } from './records-guide-dialog'
@@ -97,7 +98,7 @@ export function TableToolbar<TData = any>({
   } = useTableConfig()
 
   const { table } = useTableInstance<TData>()
-  const { selectFields } = useViewMetadata()
+  const { selectFields, dateFields } = useViewMetadata()
 
   // View state from stores
   const views = useTableViews(tableId)
@@ -112,6 +113,7 @@ export function TableToolbar<TData = any>({
   // Determine view type
   const viewType: ViewType = (currentView?.config as ViewConfig)?.viewType ?? 'table'
   const isKanbanView = viewType === 'kanban'
+  const isCalendarView = viewType === 'calendar'
 
   // Check if current filters differ from the active view's saved filters
   const hasUnsavedFilters = useMemo(() => {
@@ -207,6 +209,7 @@ export function TableToolbar<TData = any>({
           onSave={saveCurrentView}
           onReset={resetViewChanges}
           selectFields={selectFields}
+          dateFields={dateFields}
           entityDefinitionId={entityDefinitionId}
           currentFilters={filters}
           openCreateDialog={isCreateDialogOpen}
@@ -239,9 +242,15 @@ export function TableToolbar<TData = any>({
         </Button>
       )}
 
-      {/* Columns/Settings Button - different component for kanban vs table */}
+      {/* Columns/Settings Button - different component for kanban/calendar vs table */}
       <div className='group-data-[search-expanded]/toolbar:hidden'>
-        {isKanbanView ? <KanbanViewSettings /> : <ColumnManager />}
+        {isKanbanView ? (
+          <KanbanViewSettings />
+        ) : isCalendarView ? (
+          <CalendarViewSettings />
+        ) : (
+          <ColumnManager />
+        )}
       </div>
 
       {/* Import / Export Dropdown */}

--- a/apps/web/src/components/dynamic-table/components/table-toolbar/view-selector.tsx
+++ b/apps/web/src/components/dynamic-table/components/table-toolbar/view-selector.tsx
@@ -30,6 +30,7 @@ import type {
   VisibilityState,
 } from '@tanstack/react-table'
 import {
+  Calendar,
   Check,
   ChevronDown,
   Copy,
@@ -60,6 +61,12 @@ interface SelectField {
   options?: { options?: Array<{ id: string; label: string; color?: string }> }
 }
 
+/** DATE/DATETIME field for the calendar view's date axis */
+interface DateField {
+  id: string
+  name: string
+}
+
 interface ViewSelectorProps {
   views: TableView[]
   activeView: TableView | null
@@ -71,6 +78,8 @@ interface ViewSelectorProps {
   onReset?: () => void
   /** SINGLE_SELECT fields available for kanban grouping */
   selectFields?: SelectField[]
+  /** DATE/DATETIME fields available for the calendar view's date axis */
+  dateFields?: DateField[]
   /** Entity definition ID for field creation */
   entityDefinitionId?: string
   /** Current filters to pre-populate when creating a new view */
@@ -96,6 +105,7 @@ export function ViewSelector({
   onSave,
   onReset,
   selectFields,
+  dateFields,
   entityDefinitionId,
   currentFilters,
   openCreateDialog,
@@ -274,6 +284,8 @@ export function ViewSelector({
                           {/* View type icon */}
                           {view.config.viewType === 'kanban' ? (
                             <LayoutGrid className='size-3.5 text-muted-foreground' />
+                          ) : view.config.viewType === 'calendar' ? (
+                            <Calendar className='size-3.5 text-muted-foreground' />
                           ) : (
                             <Table2 className='size-3.5 text-muted-foreground' />
                           )}
@@ -382,6 +394,7 @@ export function ViewSelector({
         tableId={tableId}
         views={views}
         selectFields={selectFields}
+        dateFields={dateFields}
         entityDefinitionId={entityDefinitionId}
         currentFilters={currentFilters}
         onViewCreated={onViewSelect}

--- a/apps/web/src/components/dynamic-table/context/view-metadata-context.tsx
+++ b/apps/web/src/components/dynamic-table/context/view-metadata-context.tsx
@@ -20,11 +20,16 @@ export interface ViewMetadataContextValue<TData = any> {
   /** Custom fields (for kanban cards) */
   customFields: CustomField[]
 
+  /** DATE/DATETIME fields (for the calendar view's date-axis pickers) */
+  dateFields: Array<{ id: string; name: string }>
+
   /** Entity label for "New X" buttons */
   entityLabel?: string
 
-  /** Callback when "New" button is clicked */
-  onAddNew?: () => void
+  /** Callback when "New" button is clicked. Optional `presetValues`
+   *  (`{ fieldId: value }`) lets the calendar view's click-empty-day-to-create
+   *  prefill the create dialog. */
+  onAddNew?: (presetValues?: Record<string, unknown>) => void
 
   /** Callback when kanban card is clicked */
   onCardClick?: (card: TData) => void

--- a/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
@@ -85,8 +85,10 @@ export interface DynamicResourceViewProps<TRow extends RecordMeta = RecordMeta> 
   embedded?: boolean
   /** Selection change callback (passthrough from DynamicView). */
   onRowSelectionChange?: (rows: Set<string>) => void
-  /** Add-new button handler (primary column "+ New" / empty-state CTA). */
-  onAddNew?: () => void
+  /** Add-new button handler (primary column "+ New" / empty-state CTA). Optional
+   *  `presetValues` lets the calendar view's click-empty-day-to-create prefill
+   *  the create dialog. */
+  onAddNew?: (presetValues?: Record<string, unknown>) => void
   /** Optional override for the kanban "New X" label (defaults to resource.label). */
   entityLabel?: string
   /** Kanban card click handler. */

--- a/apps/web/src/components/dynamic-table/dynamic-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-view.tsx
@@ -4,6 +4,7 @@
 import { cn } from '@auxx/ui/lib/utils'
 import { Children, isValidElement, useCallback, useMemo, useRef, useState } from 'react'
 import { useResourceFields } from '~/components/resources/hooks'
+import { CalendarViewBody } from './components/calendar/calendar-view-body'
 import { FloatingBulkActionBar } from './components/floating-bulk-action-bar'
 import { KanbanViewBody } from './components/kanban-view-body'
 import { TableBody } from './components/table-body'
@@ -32,6 +33,7 @@ import { useReconciledColumns } from './hooks/use-reconciled-columns'
 import { useDynamicTableStore } from './stores/dynamic-table-store'
 import { useColumnOrder } from './stores/store-selectors'
 import type {
+  CalendarViewConfig,
   CustomField,
   DynamicTableProps,
   KanbanViewConfig,
@@ -141,6 +143,8 @@ function DynamicViewInner<TData extends object>({
   // Determine view type
   const viewType: ViewType = (currentView?.config as ViewConfig)?.viewType ?? 'table'
   const kanbanConfig: KanbanViewConfig | undefined = (currentView?.config as ViewConfig)?.kanban
+  const calendarConfig: CalendarViewConfig | undefined = (currentView?.config as ViewConfig)
+    ?.calendar
 
   // Get groupBy field for kanban validation
   const groupByField = useMemo(() => {
@@ -150,6 +154,9 @@ function DynamicViewInner<TData extends object>({
 
   // Check if kanban view is valid
   const isKanbanView = viewType === 'kanban' && !!groupByField
+
+  // Check if calendar view is valid (needs a configured date axis)
+  const isCalendarView = viewType === 'calendar' && !!calendarConfig?.dateFieldId
 
   // Table-selected rows (for table view)
   const tableState = table.getState()
@@ -246,6 +253,21 @@ function DynamicViewInner<TData extends object>({
     )
   }
 
+  // Calendar view manages its own scroll (EventCalendar month grid) — no wrapper needed
+  if (isCalendarView) {
+    return (
+      <div className='flex flex-col relative h-full flex-1'>
+        {toolbar}
+        {isInitialLoading ? (
+          <TableContentSkeleton rowCount={12} showCheckbox={enableCheckbox} columnCount={5} />
+        ) : (
+          <CalendarViewBody />
+        )}
+        {overlays}
+      </div>
+    )
+  }
+
   // Table view — toolbar outside, table body inside TableScrollArea
   return (
     <div className='flex flex-col relative h-full flex-1'>
@@ -331,6 +353,17 @@ export function DynamicView<TData extends object = object>(props: DynamicTablePr
   const customFields = useMemo(() => {
     if (!fields) return []
     return fields.filter((f): f is CustomField => !!f.id)
+  }, [fields])
+
+  // DATE/DATETIME fields for the calendar view's date-axis pickers (TIME excluded)
+  const dateFields = useMemo(() => {
+    if (!fields) return []
+    return fields
+      .filter(
+        (f): f is ResourceField & { id: string } =>
+          !!f.id && (f.fieldType === 'DATE' || f.fieldType === 'DATETIME') && f.active !== false
+      )
+      .map((f) => ({ id: f.id, name: f.name ?? f.label }))
   }, [fields])
 
   // Read columnOrder from store for reconciliation
@@ -466,6 +499,7 @@ export function DynamicView<TData extends object = object>(props: DynamicTablePr
     () => ({
       selectFields,
       customFields,
+      dateFields,
       entityLabel,
       onAddNew,
       onCardClick,
@@ -478,6 +512,7 @@ export function DynamicView<TData extends object = object>(props: DynamicTablePr
     [
       selectFields,
       customFields,
+      dateFields,
       entityLabel,
       onAddNew,
       onCardClick,

--- a/apps/web/src/components/dynamic-table/index.tsx
+++ b/apps/web/src/components/dynamic-table/index.tsx
@@ -8,6 +8,7 @@ export { viewConfigSchema } from '@auxx/lib/conditions/client'
 export { PrimaryCell, type PrimaryCellProps } from './cells/primary-cell'
 export { PrimaryFieldCell } from './cells/primary-field-cell'
 export { BulkActionBar } from './components/bulk-action-bar'
+export { CalendarViewBody } from './components/calendar/calendar-view-body'
 export { CopyableLinkCell } from './components/copyable-link-cell'
 export { CustomFieldCell } from './components/custom-field-cell'
 export { DragPreview } from './components/drag-preview'
@@ -45,6 +46,7 @@ export { useDynamicTable } from './hooks/use-dynamic-table'
 export type {
   BulkAction,
   BulkWriteResult,
+  CalendarViewConfig,
   CellAction,
   CellAddress,
   CellRange,

--- a/apps/web/src/components/dynamic-table/stores/store-actions.ts
+++ b/apps/web/src/components/dynamic-table/stores/store-actions.ts
@@ -9,7 +9,7 @@ import type {
   VisibilityState,
 } from '@tanstack/react-table'
 import { useCallback } from 'react'
-import type { ColumnFormatting, KanbanViewConfig } from '../types'
+import type { CalendarViewConfig, ColumnFormatting, KanbanViewConfig } from '../types'
 import { useDynamicTableStore } from './dynamic-table-store'
 
 // ─── Filter Actions ───────────────────────────────────────────────────────────
@@ -184,6 +184,25 @@ export function useUpdateKanbanConfig(tableId: string) {
       } else {
         const current = s.sessionConfigs[tableId]?.kanban ?? {}
         s.updateSessionConfig(tableId, { kanban: { ...current, ...changes } as KanbanViewConfig })
+      }
+    },
+    [tableId]
+  )
+}
+
+/** Get action to update calendar config */
+export function useUpdateCalendarConfig(tableId: string) {
+  return useCallback(
+    (changes: Partial<CalendarViewConfig>) => {
+      const s = useDynamicTableStore.getState()
+      const viewId = s.activeViewIds[tableId]
+      if (viewId) {
+        s.updateCalendarConfig(viewId, changes)
+      } else {
+        const current = s.sessionConfigs[tableId]?.calendar ?? {}
+        s.updateSessionConfig(tableId, {
+          calendar: { ...current, ...changes } as CalendarViewConfig,
+        })
       }
     },
     [tableId]

--- a/apps/web/src/components/dynamic-table/stores/store-selectors.ts
+++ b/apps/web/src/components/dynamic-table/stores/store-selectors.ts
@@ -9,7 +9,13 @@ import type {
   VisibilityState,
 } from '@tanstack/react-table'
 import { useShallow } from 'zustand/react/shallow'
-import type { ColumnFormatting, KanbanViewConfig, TableView, ViewConfig } from '../types'
+import type {
+  CalendarViewConfig,
+  ColumnFormatting,
+  KanbanViewConfig,
+  TableView,
+  ViewConfig,
+} from '../types'
 import {
   EMPTY_COLUMN_FORMATTING,
   EMPTY_COLUMN_LABELS,
@@ -198,7 +204,7 @@ export function useColumnFormatting(tableId: string): Record<string, ColumnForma
 }
 
 /** Get view type for current table/view */
-export function useViewType(tableId: string): 'table' | 'kanban' {
+export function useViewType(tableId: string): 'table' | 'kanban' | 'calendar' {
   const viewId = useDynamicTableStore((s) => s.activeViewIds[tableId])
   return useDynamicTableStore((s) => {
     if (!viewId) return s.sessionConfigs[tableId]?.viewType ?? 'table'
@@ -213,6 +219,17 @@ export function useKanbanConfig(tableId: string): KanbanViewConfig | undefined {
     useShallow((s) => {
       if (!viewId) return s.sessionConfigs[tableId]?.kanban
       return s.pendingConfigs[viewId]?.kanban ?? s.viewConfigs[viewId]?.kanban
+    })
+  )
+}
+
+/** Get calendar config for current table/view */
+export function useCalendarConfig(tableId: string): CalendarViewConfig | undefined {
+  const viewId = useDynamicTableStore((s) => s.activeViewIds[tableId])
+  return useDynamicTableStore(
+    useShallow((s) => {
+      if (!viewId) return s.sessionConfigs[tableId]?.calendar
+      return s.pendingConfigs[viewId]?.calendar ?? s.viewConfigs[viewId]?.calendar
     })
   )
 }

--- a/apps/web/src/components/dynamic-table/stores/store-types.ts
+++ b/apps/web/src/components/dynamic-table/stores/store-types.ts
@@ -9,7 +9,13 @@ import type {
   VisibilityState,
 } from '@tanstack/react-table'
 import type { StateCreator } from 'zustand'
-import type { ColumnFormatting, KanbanViewConfig, TableView, ViewConfig } from '../types'
+import type {
+  CalendarViewConfig,
+  ColumnFormatting,
+  KanbanViewConfig,
+  TableView,
+  ViewConfig,
+} from '../types'
 
 // ============================================================================
 // UI CONFIG TYPE (everything except filters)
@@ -25,8 +31,9 @@ export interface TableUIConfig {
   columnLabels?: Record<string, string>
   columnFormatting?: Record<string, ColumnFormatting>
   rowHeight?: 'compact' | 'normal' | 'spacious'
-  viewType?: 'table' | 'kanban'
+  viewType?: 'table' | 'kanban' | 'calendar'
   kanban?: KanbanViewConfig
+  calendar?: CalendarViewConfig
 }
 
 /** Default UI config */
@@ -89,6 +96,7 @@ export interface UISlice {
   updateViewConfig: (viewId: string, changes: Partial<TableUIConfig>) => void
   updateSessionConfig: (tableId: string, changes: Partial<TableUIConfig>) => void
   updateKanbanConfig: (viewId: string, changes: Partial<KanbanViewConfig>) => void
+  updateCalendarConfig: (viewId: string, changes: Partial<CalendarViewConfig>) => void
   resetToSaved: (viewId: string) => void
   getSessionConfig: (tableId: string) => TableUIConfig
 }

--- a/apps/web/src/components/dynamic-table/stores/ui-slice.ts
+++ b/apps/web/src/components/dynamic-table/stores/ui-slice.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/dynamic-table/stores/ui-slice.ts
 
-import type { KanbanViewConfig } from '../types'
+import type { CalendarViewConfig, KanbanViewConfig } from '../types'
 import type { SliceCreator, UISlice } from './store-types'
 import { DEFAULT_UI_CONFIG } from './store-types'
 
@@ -38,6 +38,16 @@ export const createUISlice: SliceCreator<UISlice> = (set, get) => ({
 
     get().updateViewConfig(viewId, {
       kanban: { ...currentKanban, ...changes } as KanbanViewConfig,
+    })
+  },
+
+  updateCalendarConfig: (viewId, changes) => {
+    const saved = get().viewConfigs[viewId]
+    const pending = get().pendingConfigs[viewId]
+    const currentCalendar = pending?.calendar ?? saved?.calendar ?? {}
+
+    get().updateViewConfig(viewId, {
+      calendar: { ...currentCalendar, ...changes } as CalendarViewConfig,
     })
   },
 

--- a/apps/web/src/components/dynamic-table/types.ts
+++ b/apps/web/src/components/dynamic-table/types.ts
@@ -16,6 +16,7 @@ export type { TargetTimeInStatus }
 
 // Re-export types from schema (inferred from Zod = always in sync with validation)
 export type {
+  CalendarViewConfig,
   CheckboxColumnFormatting,
   ColumnFormatting,
   CurrencyColumnFormatting,
@@ -415,8 +416,10 @@ export interface DynamicTableProps<TData = any> {
   /** Entity label for "New X" buttons in kanban */
   entityLabel?: string
 
-  /** Callback when "New" button is clicked in primary column header */
-  onAddNew?: () => void
+  /** Callback when "New" button is clicked in primary column header. Optional
+   *  `presetValues` (`{ fieldId: value }`) lets a caller (e.g. the calendar
+   *  view's click-empty-day-to-create) prefill the create dialog. */
+  onAddNew?: (presetValues?: Record<string, unknown>) => void
 
   /** Callback when kanban card is clicked */
   onCardClick?: (card: TData) => void

--- a/apps/web/src/components/dynamic-table/utils/view-config.ts
+++ b/apps/web/src/components/dynamic-table/utils/view-config.ts
@@ -9,7 +9,13 @@ import type {
   SortingState,
   VisibilityState,
 } from '@tanstack/react-table'
-import type { ColumnFormatting, ExtendedColumnDef, KanbanViewConfig, ViewConfig } from '../types'
+import type {
+  CalendarViewConfig,
+  ColumnFormatting,
+  ExtendedColumnDef,
+  KanbanViewConfig,
+  ViewConfig,
+} from '../types'
 
 /**
  * Snapshot of the table state that can be persisted as a view configuration.
@@ -160,6 +166,8 @@ export function normalizeViewConfig(config?: Partial<ViewConfig> | null): ViewCo
     viewType: config?.viewType ?? 'table',
     // Preserve kanban configuration if present
     kanban: config?.kanban ? cloneKanbanConfig(config.kanban) : undefined,
+    // Preserve calendar configuration if present
+    calendar: config?.calendar ? cloneCalendarConfig(config.calendar) : undefined,
   }
 }
 
@@ -176,6 +184,19 @@ function cloneKanbanConfig(kanban: KanbanViewConfig): KanbanViewConfig {
     columnSettings: kanban.columnSettings
       ? Object.fromEntries(Object.entries(kanban.columnSettings).map(([k, v]) => [k, { ...v }]))
       : undefined,
+  }
+}
+
+/**
+ * Clone a calendar configuration to avoid accidental mutations.
+ */
+function cloneCalendarConfig(calendar: CalendarViewConfig): CalendarViewConfig {
+  return {
+    dateFieldId: calendar.dateFieldId,
+    endDateFieldId: calendar.endDateFieldId,
+    colorFieldId: calendar.colorFieldId,
+    primaryFieldId: calendar.primaryFieldId,
+    cardFields: calendar.cardFields ? [...calendar.cardFields] : undefined,
   }
 }
 

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -20,6 +20,7 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
+import { useQueryClient } from '@tanstack/react-query'
 import { Archive, Combine, Database, FileText, Play, Plus, SquarePen, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
@@ -138,6 +139,13 @@ export function RecordsView({
   const [editingInstance, setEditingInstance] = useState<EntityRow | null>(null)
   const [selectedRowIds, setSelectedRowIds] = useState<Set<string>>(new Set())
 
+  // Preset field values for the create dialog — set by the calendar view's
+  // click-empty-day-to-create (plan §3.3, `onAddNew(presetValues)`).
+  const [createPresetValues, setCreatePresetValues] = useState<Record<string, unknown> | undefined>(
+    undefined
+  )
+  const queryClient = useQueryClient()
+
   // Drawer state - synced to URL via ?id= param
   const [selectedInstanceId, setSelectedInstanceId] = useQueryState(
     'id',
@@ -206,6 +214,7 @@ export function RecordsView({
       } else {
         setEditingInstance(row)
       }
+      setCreatePresetValues(undefined)
       setIsCreateDialogOpen(true)
     },
     [setIsCreateDialogOpen, onEditRecord, entityDefinitionId]
@@ -224,14 +233,23 @@ export function RecordsView({
 
   const handleDialogSaved = useCallback(() => {
     setEditingInstance(null)
+    setCreatePresetValues(undefined)
     refresh()
-  }, [refresh])
+    // The calendar view's id list is a standalone `useQuery` keyed
+    // `['calendar-record-ids', ...]` (not a tRPC `record.listFiltered` query),
+    // so it's outside the generic `record:created` realtime handler's
+    // `utils.record.listFiltered.invalidate` reach — invalidate it explicitly
+    // so a record created via the click-empty-day-to-create dialog shows up on
+    // the calendar without waiting out the query's 30s staleTime.
+    queryClient.invalidateQueries({ queryKey: ['calendar-record-ids'] })
+  }, [refresh, queryClient])
 
   const handleDialogOpenChange = useCallback(
     (open: boolean) => {
       setIsCreateDialogOpen(open)
       if (!open) {
         setEditingInstance(null)
+        setCreatePresetValues(undefined)
       }
     },
     [setIsCreateDialogOpen]
@@ -753,7 +771,10 @@ export function RecordsView({
       emptyState={emptyStateElement}
       dockedPanels={dockedPanels}
       onRowSelectionChange={handleRowSelectionChange}
-      onAddNew={() => setIsCreateDialogOpen(true)}
+      onAddNew={(presetValues) => {
+        setCreatePresetValues(presetValues)
+        setIsCreateDialogOpen(true)
+      }}
       entityLabel={resource.label}
       onCardClick={handleOpenDrawer}
       onAddCard={() => setIsCreateDialogOpen(true)}
@@ -897,6 +918,7 @@ export function RecordsView({
             editingInstance ? toRecordId(entityDefinitionId, editingInstance.id) : undefined
           }
           onSaved={handleDialogSaved}
+          presetValues={createPresetValues}
         />
       )}
 

--- a/packages/lib/src/ai/kopilot/capabilities/record-views/tools/list-table-views.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/record-views/tools/list-table-views.ts
@@ -13,7 +13,7 @@ interface ViewSummary {
   name: string
   isDefault: boolean
   isShared: boolean
-  viewType: 'table' | 'kanban'
+  viewType: 'table' | 'kanban' | 'calendar'
   filterCount: number
   sort?: { field: string; direction: 'asc' | 'desc' }
 }
@@ -27,7 +27,7 @@ function summarizeView(
   const config = (view.config ?? {}) as {
     filters?: Array<{ conditions?: unknown[] }>
     sorting?: Array<{ id: string; desc: boolean }>
-    viewType?: 'table' | 'kanban'
+    viewType?: 'table' | 'kanban' | 'calendar'
   }
 
   const filterCount = (config.filters ?? []).reduce(

--- a/packages/lib/src/conditions/client.ts
+++ b/packages/lib/src/conditions/client.ts
@@ -43,6 +43,7 @@ export type {
   ConditionValueSource,
 } from './types'
 export type {
+  CalendarViewConfig,
   CheckboxColumnFormatting,
   ColumnFormatting,
   CurrencyColumnFormatting,
@@ -56,6 +57,7 @@ export type {
 } from './view-config'
 // View config schemas and types
 export {
+  calendarConfigSchema,
   columnFormattingSchema,
   currencyFormattingSchema,
   dateFormattingSchema,

--- a/packages/lib/src/conditions/index.ts
+++ b/packages/lib/src/conditions/index.ts
@@ -35,6 +35,7 @@ export type {
   ConditionValueSource,
 } from './types'
 export type {
+  CalendarViewConfig,
   CheckboxColumnFormatting,
   ColumnFormatting,
   CurrencyColumnFormatting,
@@ -51,6 +52,7 @@ export type {
 // View config schemas and types
 // Field view config exports
 export {
+  calendarConfigSchema,
   checkboxFormattingSchema,
   columnFormattingSchema,
   createDefaultFieldViewConfig,

--- a/packages/lib/src/conditions/view-config.ts
+++ b/packages/lib/src/conditions/view-config.ts
@@ -76,6 +76,24 @@ export const kanbanConfigSchema = z.object({
 })
 
 // ============================================================================
+// CALENDAR SCHEMAS
+// ============================================================================
+
+/** Calendar view config schema */
+export const calendarConfigSchema = z.object({
+  /** Required axis — a DATE or DATETIME CustomField id. */
+  dateFieldId: z.string(),
+  /** Optional end — chips span [date, end]; absent → point-in-time chip. */
+  endDateFieldId: z.string().optional(),
+  /** Optional SINGLE_SELECT field whose option color tints the chip. */
+  colorFieldId: z.string().optional(),
+  /** Chip title field; falls back to the entity's identity/primary field. */
+  primaryFieldId: z.string().optional(),
+  /** Extra fields for tooltip/expanded chip (kanban cardFields vocabulary). */
+  cardFields: z.array(z.string()).optional().default([]),
+})
+
+// ============================================================================
 // VIEW CONFIG SCHEMA (SINGLE SOURCE OF TRUTH)
 // ============================================================================
 
@@ -95,8 +113,9 @@ export const viewConfigSchema = z.object({
   columnLabels: z.record(z.string(), z.string()).optional(),
   columnFormatting: z.record(z.string(), columnFormattingSchema).optional(),
   rowHeight: z.enum(['compact', 'normal', 'spacious']).optional(),
-  viewType: z.enum(['table', 'kanban']).optional().default('table'),
+  viewType: z.enum(['table', 'kanban', 'calendar']).optional().default('table'),
   kanban: kanbanConfigSchema.optional(),
+  calendar: calendarConfigSchema.optional(),
 })
 
 // ============================================================================
@@ -111,6 +130,7 @@ export type CheckboxColumnFormatting = z.infer<typeof checkboxFormattingSchema>
 export type ColumnFormatting = z.infer<typeof columnFormattingSchema>
 export type KanbanColumnSettings = z.infer<typeof kanbanColumnSettingsSchema>
 export type KanbanViewConfig = z.infer<typeof kanbanConfigSchema>
+export type CalendarViewConfig = z.infer<typeof calendarConfigSchema>
 export type ViewConfig = z.infer<typeof viewConfigSchema>
 export type ViewType = ViewConfig['viewType']
 


### PR DESCRIPTION
## Summary

Adds a **calendar** view type to the dynamic-table, alongside `table` and `board` — records with a date field render as chips on a month calendar.

### What's included
- New `dynamic-table/components/calendar/`: `CalendarViewBody` + `useCalendarEvents` (month-range `record.listFiltered` query, ids hydrated through the shared field-value store).
- `calendar-view-settings` toolbar to pick the date field (+ optional end-date field); store config (`dateFieldId`/`endDateFieldId`), `view-config` + `conditions` plumbing, and view-selector / create-view-dialog entries.
- **Interactions**: drag-to-reschedule writes optimistically via `saveBulkMultipleFields`; click-empty-day prefills the create dialog.
- `records-view` wires `onAddNew(presetValues)` and explicit `calendar-record-ids` query invalidation so newly-created records appear on the calendar without waiting out staleTime.
- Kopilot `list-table-views` surfaces the new viewType.

Uses only `EventCalendar` props already on `main` — independent of the event-calendar PR.

## Test plan
- [ ] Create a calendar view, pick a date field → records render as chips
- [ ] Drag a chip to a new day → date field updates (optimistic + persists)
- [ ] Click an empty day → create dialog opens prefilled with that date
- [ ] Newly-created record shows on the calendar immediately