### PR TITLE
feat(ui): event-calendar selection ring + Notion tick-grid + drag polish

### DIFF
--- a/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
@@ -127,6 +127,7 @@ export function BoardCalendarGrid({
       backgroundEvents={backgroundEvents}
       events={events}
       renderEvent={renderEvent}
+      selectedEventId={activeVisitId}
       onEventClick={handleEventClick}
       onEventResize={canEdit && view !== 'month' ? onEventResize : undefined}
       hideToolbar

--- a/apps/web/src/components/schedule/ui/schedule-calendar.tsx
+++ b/apps/web/src/components/schedule/ui/schedule-calendar.tsx
@@ -70,6 +70,8 @@ interface ScheduleCalendarProps {
   onVisitClick: (visitId: string) => void
   onMeetingClick: (meetingId: string) => void
   onTaskClick: (task: TaskEvent['task']) => void
+  /** Event id whose detail drawer/sheet is open — draws the in-color selection ring. */
+  selectedEventId?: string | null
 }
 
 /**
@@ -86,6 +88,7 @@ export function ScheduleCalendar({
   onVisitClick,
   onMeetingClick,
   onTaskClick,
+  selectedEventId,
 }: ScheduleCalendarProps) {
   const open = useScheduleSidebarStore((s) => s.open)
   const setOpen = useScheduleSidebarStore((s) => s.setOpen)
@@ -170,6 +173,7 @@ export function ScheduleCalendar({
         events={events}
         renderEvent={renderEvent}
         onEventClick={handleEventClick}
+        selectedEventId={selectedEventId}
         weekStartsOn={weekStartsOn}
         hideToolbar
         className='flex-1'

--- a/apps/web/src/components/schedule/ui/schedule-page.tsx
+++ b/apps/web/src/components/schedule/ui/schedule-page.tsx
@@ -236,6 +236,7 @@ export function SchedulePage() {
             onVisitClick={handleVisitClick}
             onMeetingClick={setOpenMeetingId}
             onTaskClick={setOpenTask}
+            selectedEventId={openVisitId ?? openMeetingId ?? openTask?.id ?? null}
           />
         )}
       </MainPageContent>

--- a/packages/ui/src/components/event-calendar/agenda-view.tsx
+++ b/packages/ui/src/components/event-calendar/agenda-view.tsx
@@ -16,6 +16,8 @@ interface AgendaViewProps<T extends EventCalendarItem = EventCalendarItem> {
   events: T[]
   onEventSelect: (event: T) => void
   renderEvent?: RenderEvent<T>
+  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
+  selectedEventId?: string | null
 }
 
 export function AgendaView<T extends EventCalendarItem = EventCalendarItem>({
@@ -23,6 +25,7 @@ export function AgendaView<T extends EventCalendarItem = EventCalendarItem>({
   events,
   onEventSelect,
   renderEvent,
+  selectedEventId,
 }: AgendaViewProps<T>) {
   const days = useMemo(() => {
     return Array.from({ length: AgendaDaysToShow }, (_, i) => addDays(new Date(currentDate), i))
@@ -65,6 +68,7 @@ export function AgendaView<T extends EventCalendarItem = EventCalendarItem>({
                     event={event}
                     view='agenda'
                     onClick={(e) => handleEventClick(event, e)}
+                    isSelected={event.id === selectedEventId}
                     renderEvent={renderEvent}
                   />
                 ))}

--- a/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
+++ b/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
@@ -33,6 +33,8 @@ interface CalendarDndContextValue<T extends EventCalendarItem = EventCalendarIte
   activeId: UniqueIdentifier | null
   activeView: DraggableView | null
   currentTime: Date | null
+  /** Resource id of the hovered cell (resource view) — lets the drop outline pick its column. */
+  currentResourceId: string | null
   eventHeight: number | null
 }
 
@@ -43,6 +45,7 @@ const CalendarDndContext = createContext<CalendarDndContextValue>({
   activeId: null,
   activeView: null,
   currentTime: null,
+  currentResourceId: null,
   eventHeight: null,
 })
 
@@ -79,6 +82,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null)
   const [activeView, setActiveView] = useState<DraggableView | null>(null)
   const [currentTime, setCurrentTime] = useState<Date | null>(null)
+  const [currentResourceId, setCurrentResourceId] = useState<string | null>(null)
   const [eventHeight, setEventHeight] = useState<number | null>(null)
 
   const sensors = useSensors(
@@ -116,12 +120,18 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
     const { over } = event
     if (!over || !activeEvent || !over.data.current) return
 
-    const { date, time } = over.data.current as { date?: Date; time?: number }
+    const { date, time, resourceId } = over.data.current as {
+      date?: Date
+      time?: number
+      resourceId?: string
+    }
     // A foreign droppable (e.g. the module sidebar's Backlog group, `{type: 'sidebar-backlog'}`)
     // has no `date` — nothing to snap the drag-ghost time to. `onDragEnd`'s own `overData.date`
     // check already keeps `onEventDrop` from firing on it; this just stops an `Invalid Date`
     // (`new Date(undefined)`) from being written into `currentTime` while hovering over it.
     if (!date) return
+
+    setCurrentResourceId(resourceId ?? null)
 
     if (time !== undefined && activeView !== 'month') {
       const newTime = new Date(date)
@@ -148,6 +158,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
     setActiveId(null)
     setActiveView(null)
     setCurrentTime(null)
+    setCurrentResourceId(null)
     setEventHeight(null)
   }
 
@@ -205,13 +216,19 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
           activeId,
           activeView,
           currentTime,
+          currentResourceId,
           eventHeight,
         }}>
         {children}
 
+        {/* The floating copy that follows the pointer — kept translucent (origin stays solid
+            in place) and darkened so it reads as "the thing being moved", with the drop
+            outline showing through underneath. */}
         <DragOverlay adjustScale={false} dropAnimation={null}>
           {activeEvent && activeView && (
-            <div style={{ width: '100%', height: eventHeight ? `${eventHeight}px` : 'auto' }}>
+            <div
+              className='opacity-80'
+              style={{ width: '100%', height: eventHeight ? `${eventHeight}px` : 'auto' }}>
               <EventItem
                 event={activeEvent}
                 view={activeView as CalendarView}

--- a/packages/ui/src/components/event-calendar/constants.ts
+++ b/packages/ui/src/components/event-calendar/constants.ts
@@ -13,8 +13,31 @@ export const EventHeight = 24
 /** Vertical gap (px) between stacked month-view event chips. */
 export const EventGap = 4
 
-/** Height (px) of one hour row in week/day/resource views. */
-export const WeekCellsHeight = 72
+/**
+ * Notion-style tick grid: the vertical hour grid is derived from a 5-minute
+ * tick of a fixed pixel height, so a single knob (`GridTickHeight`) rescales
+ * the whole timed grid. These mirror Notion Calendar's `--grid-tick-*` vars.
+ */
+export const GridTickHeight = 4
+export const GridTickMinutes = 5
+
+/** Minutes in an hour — the tick→hour multiplier (`60 / GridTickMinutes` ticks per hour). */
+const MinutesPerHour = 60
+
+/**
+ * Height (px) of one hour row in week/day/resource views — the single source
+ * both the JS position math and the `--week-cells-height` CSS `calc()` read.
+ * Derived from the tick grid: 4px × (60 / 5) = 48px (Notion parity).
+ */
+export const WeekCellsHeight = GridTickHeight * (MinutesPerHour / GridTickMinutes)
+
+/** Height (px) of the sticky day-header row (weekday + date). Mirrors Notion's `--grid-header-height`. */
+export const GridHeaderHeight = 53
+
+/** All-day lane chip metrics (px) — Notion's `--grid-all-day-chip-*`. */
+export const GridAllDayChipHeight = 19
+export const GridAllDayChipSpacing = 2
+export const GridAllDayPaddingTop = 3
 
 /** Number of days shown in agenda view. */
 export const AgendaDaysToShow = 30

--- a/packages/ui/src/components/event-calendar/current-time-line.tsx
+++ b/packages/ui/src/components/event-calendar/current-time-line.tsx
@@ -14,7 +14,7 @@ export function CurrentTimeGutterLabel({ position, label }: { position: number; 
       style={{ top: `${position}%` }}>
       <span
         className={cn(
-          '-translate-y-1/2 rounded-full px-1.5 py-0.5 text-sm font-semibold whitespace-nowrap',
+          '-translate-y-1/2 rounded-full px-1.5 py-0.5 text-[10px] font-semibold whitespace-nowrap',
           CurrentTimeLabelClass
         )}>
         {label}
@@ -23,11 +23,18 @@ export function CurrentTimeGutterLabel({ position, label }: { position: number; 
   )
 }
 
-/** The 2px accent line spanning a single day/resource column, aligned to `position`. */
+/**
+ * The hairline "now" indicator spanning a single day/resource column, aligned
+ * to `position` — a 1px accent rule with a small leading dot at the gutter
+ * edge (Notion-calendar look).
+ */
 export function CurrentTimeLine({ position }: { position: number }) {
   return (
-    <div className='pointer-events-none absolute inset-x-0 z-20' style={{ top: `${position}%` }}>
-      <div className={cn('h-0.5 w-full -translate-y-1/2', CurrentTimeLineClass)} />
+    <div
+      className='pointer-events-none absolute inset-x-0 z-20 flex -translate-y-1/2 items-center'
+      style={{ top: `${position}%` }}>
+      <span className={cn('-ml-1 size-2 shrink-0 rounded-full', CurrentTimeLineClass)} />
+      <div className={cn('h-px w-full', CurrentTimeLineClass)} />
     </div>
   )
 }

--- a/packages/ui/src/components/event-calendar/day-view.tsx
+++ b/packages/ui/src/components/event-calendar/day-view.tsx
@@ -10,6 +10,7 @@ import { BackgroundEventsLayer } from './background-events'
 import { EndHour, StartHour, WeekCellsHeight } from './constants'
 import { CurrentTimeLine } from './current-time-line'
 import { DraggableEvent } from './draggable-event'
+import { DropPreview } from './drop-preview'
 import { DroppableCell } from './droppable-cell'
 import { EventItem } from './event-item'
 import { useCurrentTimeIndicator } from './hooks/use-current-time-indicator'
@@ -26,6 +27,8 @@ interface DayViewProps<T extends EventCalendarItem = EventCalendarItem> {
   onSlotClick?: (startTime: Date) => void
   onEventResize?: (event: T, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
+  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
+  selectedEventId?: string | null
 }
 
 /** Big date header — day + month bold, year regular, weekday name below. */
@@ -49,6 +52,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
   onSlotClick,
   onEventResize,
   renderEvent,
+  selectedEventId,
 }: DayViewProps<T>) {
   const hours = useMemo(() => {
     const dayStart = startOfDay(currentDate)
@@ -124,6 +128,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
                     allDayLane
                     isFirstDay={isFirstDay}
                     isLastDay={isLastDay}
+                    isSelected={event.id === selectedEventId}
                     renderEvent={renderEvent}>
                     <div>{event.title}</div>
                   </EventItem>
@@ -172,10 +177,13 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
                   height={positioned.height}
                   onResize={onEventResize}
                   renderEvent={renderEvent}
+                  isSelected={positioned.event.id === selectedEventId}
                 />
               </div>
             </div>
           ))}
+
+          <DropPreview day={currentDate} />
 
           {currentTimeVisible && <CurrentTimeLine position={currentTimePosition} />}
 

--- a/packages/ui/src/components/event-calendar/draggable-event.tsx
+++ b/packages/ui/src/components/event-calendar/draggable-event.tsx
@@ -22,6 +22,8 @@ interface DraggableEventProps<T extends EventCalendarItem = EventCalendarItem> {
   height?: number
   isFirstDay?: boolean
   isLastDay?: boolean
+  /** Active selection — the event whose detail/popover is open. Draws the in-color ring. */
+  isSelected?: boolean
   renderEvent?: RenderEvent<T>
   /** Enables the bottom-edge resize handle — only meaningful in week/day/resource. */
   onResize?: (event: T, newEnd: Date) => void
@@ -35,6 +37,7 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
   height,
   isFirstDay = true,
   isLastDay = true,
+  isSelected,
   renderEvent,
   onResize,
 }: DraggableEventProps<T>) {
@@ -86,16 +89,17 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
     }
   }
 
-  // Don't render if this event is being dragged (the DragOverlay ghost stands in for it).
-  if (isDragging || activeId === `${event.id}-${view}`) {
-    return <div ref={setNodeRef} className='opacity-0' style={{ height: height || 'auto' }} />
-  }
+  // While this event is the drag source, the origin stays put and solid — the translucent
+  // DragOverlay copy is the "moving" one — so we neither hide the origin nor apply the
+  // pointer `transform` to it (that would make the origin chase the cursor as a second ghost).
+  const isDragSource = isDragging || activeId === `${event.id}-${view}`
 
   const effectiveHeight = isResizing && previewHeight !== null ? previewHeight : height
 
-  const style = transform
-    ? { transform: CSS.Translate.toString(transform), height: effectiveHeight || 'auto' }
-    : { height: effectiveHeight || 'auto' }
+  const style =
+    transform && !isDragSource
+      ? { transform: CSS.Translate.toString(transform), height: effectiveHeight || 'auto' }
+      : { height: effectiveHeight || 'auto' }
 
   return (
     <div
@@ -111,7 +115,7 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
         showTime={showTime}
         isFirstDay={isFirstDay}
         isLastDay={isLastDay}
-        isDragging={isDragging}
+        isSelected={isSelected}
         onClick={onClick}
         onMouseDown={handleMouseDown}
         onTouchStart={handleTouchStart}

--- a/packages/ui/src/components/event-calendar/drop-preview.tsx
+++ b/packages/ui/src/components/event-calendar/drop-preview.tsx
@@ -1,0 +1,49 @@
+// packages/ui/src/components/event-calendar/drop-preview.tsx
+
+'use client'
+
+import { differenceInMinutes, isSameDay } from 'date-fns'
+
+import { useCalendarDnd } from './calendar-dnd-context'
+import { StartHour, WeekCellsHeight } from './constants'
+
+interface DropPreviewProps {
+  /** The column's day — the outline shows only when the snapped drop target lands here. */
+  day: Date
+  /** Resource column id (resource view only) — the outline shows only when the hovered cell matches. */
+  resourceId?: string
+}
+
+/**
+ * Dashed outline marking the snapped landing slot while a timed event is
+ * dragged over this column. Reads the live (already quarter-hour-snapped)
+ * `currentTime` from the DnD context and paints a block at that time for the
+ * dragged event's duration — the "where it will land" affordance. Renders
+ * nothing unless a timed drag is in progress and its target resolves to this
+ * exact column.
+ */
+export function DropPreview({ day, resourceId }: DropPreviewProps) {
+  const { activeEvent, currentTime, activeView, currentResourceId } = useCalendarDnd()
+
+  // No timed drag in flight, or a month drag (whole-day, no time slot to outline).
+  if (!activeEvent || !currentTime || activeView === 'month') return null
+  if (!isSameDay(currentTime, day)) return null
+  // Resource view packs many same-day columns side by side — gate on the hovered resource too.
+  if (resourceId !== undefined && currentResourceId !== resourceId) return null
+
+  const startMinutes = (currentTime.getHours() - StartHour) * 60 + currentTime.getMinutes()
+  const durationMinutes = differenceInMinutes(
+    new Date(activeEvent.end),
+    new Date(activeEvent.start)
+  )
+  const top = (startMinutes / 60) * WeekCellsHeight
+  // Floor a zero/negative duration to a single quarter-hour so the outline is always visible.
+  const height = Math.max((durationMinutes / 60) * WeekCellsHeight, WeekCellsHeight / 4)
+
+  return (
+    <div
+      className='border-primary/70 bg-primary/5 pointer-events-none absolute inset-x-0.5 z-30 rounded-md border-2 border-dashed'
+      style={{ top, height }}
+    />
+  )
+}

--- a/packages/ui/src/components/event-calendar/event-calendar.tsx
+++ b/packages/ui/src/components/event-calendar/event-calendar.tsx
@@ -30,7 +30,17 @@ import { type CSSProperties, type ReactNode, useEffect, useMemo } from 'react'
 
 import { AgendaView } from './agenda-view'
 import { CalendarDndProvider, useCalendarDnd } from './calendar-dnd-context'
-import { AgendaDaysToShow, EventGap, EventHeight, WeekCellsHeight } from './constants'
+import {
+  AgendaDaysToShow,
+  EventGap,
+  EventHeight,
+  GridAllDayChipHeight,
+  GridAllDayChipSpacing,
+  GridAllDayPaddingTop,
+  GridHeaderHeight,
+  GridTickHeight,
+  GridTickMinutes,
+} from './constants'
 import { DayView, DayViewHeader } from './day-view'
 import { MonthView } from './month-view'
 import { ResourceDayView } from './resource-day-view'
@@ -58,6 +68,8 @@ export interface EventCalendarProps<T extends EventCalendarItem = EventCalendarI
   resources?: CalendarResource[]
   backgroundEvents?: BackgroundEvent[]
   renderEvent?: RenderEvent<T>
+  /** Id of the actively-selected event (its detail/popover open) — draws the in-color ring. */
+  selectedEventId?: string | null
   onEventClick?: (event: T) => void
   onSlotClick?: (startTime: Date, resourceId?: string) => void
   /** The calendar never mutates — every write (move or resize) round-trips through these. */
@@ -88,6 +100,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
   resources,
   backgroundEvents,
   renderEvent,
+  selectedEventId,
   onEventClick,
   onSlotClick,
   onEventDrop,
@@ -277,6 +290,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
             onEventSelect={handleEventSelect}
             onSlotClick={handleSlotClick}
             renderEvent={renderEvent}
+            selectedEventId={selectedEventId}
             onDateChange={onDateChange}
             onVisibleRangeChange={onRangeChange}
             isNonWorkingDay={isNonWorkingDay}
@@ -292,6 +306,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
             onSlotClick={handleSlotClick}
             onEventResize={onEventResize}
             renderEvent={renderEvent}
+            selectedEventId={selectedEventId}
             onDateChange={onDateChange}
             onVisibleRangeChange={onRangeChange}
           />
@@ -305,6 +320,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
             onSlotClick={handleSlotClick}
             onEventResize={onEventResize}
             renderEvent={renderEvent}
+            selectedEventId={selectedEventId}
           />
         )}
         {view === 'resource' &&
@@ -318,6 +334,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
               onSlotClick={handleSlotClick}
               onEventResize={onEventResize}
               renderEvent={renderEvent}
+              selectedEventId={selectedEventId}
             />
           ) : null)}
         {view === 'agenda' && (
@@ -326,6 +343,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
             events={events}
             onEventSelect={handleEventSelect}
             renderEvent={renderEvent}
+            selectedEventId={selectedEventId}
           />
         )}
       </div>
@@ -339,7 +357,15 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
         {
           '--event-height': `${EventHeight}px`,
           '--event-gap': `${EventGap}px`,
-          '--week-cells-height': `${WeekCellsHeight}px`,
+          // Notion-style tick grid: the hour-row height derives from the 5-minute
+          // tick, so every timed cell/position scales off one knob.
+          '--grid-tick-height': `${GridTickHeight}px`,
+          '--grid-tick-minutes': `${GridTickMinutes}`,
+          '--week-cells-height': `calc(var(--grid-tick-height) * 60 / var(--grid-tick-minutes))`,
+          '--grid-header-height': `${GridHeaderHeight}px`,
+          '--grid-all-day-chip-height': `${GridAllDayChipHeight}px`,
+          '--grid-all-day-chip-spacing': `${GridAllDayChipSpacing}px`,
+          '--grid-all-day-padding-top': `${GridAllDayPaddingTop}px`,
         } as CSSProperties
       }>
       {withinAmbientProvider ? (

--- a/packages/ui/src/components/event-calendar/event-item.tsx
+++ b/packages/ui/src/components/event-calendar/event-item.tsx
@@ -9,8 +9,10 @@ import { useMemo } from 'react'
 import type { CalendarView, EventCalendarItem, RenderEvent } from './types'
 import {
   eventColorVar,
+  eventSelectedRingClass,
   eventSolidBgClass,
   eventTintBgClass,
+  eventTintBgStrongClass,
   eventTintTextClass,
   getBorderRadiusClasses,
 } from './utils'
@@ -24,6 +26,7 @@ interface EventWrapperProps {
   isFirstDay?: boolean
   isLastDay?: boolean
   isDragging?: boolean
+  isSelected?: boolean
   onClick?: (e: React.MouseEvent) => void
   className?: string
   children: React.ReactNode
@@ -33,12 +36,13 @@ interface EventWrapperProps {
   onTouchStart?: (e: React.TouchEvent) => void
 }
 
-// Shared interactive wrapper — dnd listeners/attributes, focus ring, drag state.
+// Shared interactive wrapper — dnd listeners/attributes, focus ring, drag/selected state.
 function EventWrapper({
   event,
   isFirstDay = true,
   isLastDay = true,
   isDragging,
+  isSelected,
   onClick,
   className,
   children,
@@ -53,10 +57,14 @@ function EventWrapper({
       className={cn(
         'focus-visible:border-ring focus-visible:ring-ring/50 flex h-full w-full overflow-hidden text-left font-medium transition outline-none select-none focus-visible:ring-[3px] data-dragging:cursor-grabbing data-dragging:shadow-lg',
         getBorderRadiusClasses(isFirstDay, isLastDay),
+        // Selected ring last so it wins over the resting look (but focus-visible:ring-[3px]
+        // still layers on top when the chip is keyboard-focused).
+        isSelected && eventSelectedRingClass,
         className
       )}
       style={eventColorVar(event.color)}
       data-dragging={isDragging || undefined}
+      data-selected={isSelected || undefined}
       onClick={onClick}
       onMouseDown={onMouseDown}
       onTouchStart={onTouchStart}
@@ -73,6 +81,8 @@ interface EventItemProps<T extends EventCalendarItem = EventCalendarItem> {
   /** Renders the rounded-full all-day-lane pill styling regardless of `view`. */
   allDayLane?: boolean
   isDragging?: boolean
+  /** Active selection — the event whose detail/popover is open. Draws the in-color ring. */
+  isSelected?: boolean
   onClick?: (e: React.MouseEvent) => void
   showTime?: boolean
   /** Overrides the displayed start/end while dragging (see calendar-dnd-context). */
@@ -93,6 +103,7 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
   view,
   allDayLane,
   isDragging,
+  isSelected,
   onClick,
   showTime,
   currentTime,
@@ -125,6 +136,11 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
     [displayStart, displayEnd]
   )
 
+  // Dragged chips get an emphasized fill so they read as visibly "darker" than the
+  // solid origin left behind. Swapped in for `eventTintBgClass` (never both) to avoid
+  // two competing `background-color` utilities.
+  const tintBg = isDragging ? eventTintBgStrongClass : eventTintBgClass
+
   const getEventTime = () => {
     if (event.allDay) return 'All day'
     if (durationMinutes < 45) return formatTimeWithOptionalMinutes(displayStart)
@@ -150,10 +166,11 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
         isFirstDay={isFirstDay}
         isLastDay={isLastDay}
         isDragging={isDragging}
+        isSelected={isSelected}
         onClick={onClick}
         className={cn(
           'items-center gap-1.5 rounded-full px-2 py-1 text-[10px] sm:text-xs',
-          eventTintBgClass,
+          tintBg,
           className
         )}
         dndListeners={dndListeners}
@@ -187,10 +204,11 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
         isFirstDay={isFirstDay}
         isLastDay={isLastDay}
         isDragging={isDragging}
+        isSelected={isSelected}
         onClick={onClick}
         className={cn(
           'mt-[var(--event-gap)] h-[var(--event-height)] items-center gap-1.5 rounded-md px-1 text-[10px] sm:px-1.5 sm:text-xs',
-          eventTintBgClass,
+          tintBg,
           eventTintTextClass,
           'hover:brightness-105 dark:hover:brightness-110',
           className
@@ -221,12 +239,13 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
         isFirstDay={isFirstDay}
         isLastDay={isLastDay}
         isDragging={isDragging}
+        isSelected={isSelected}
         onClick={onClick}
         className={cn(
           'px-1.5 py-1 sm:px-2',
           durationMinutes < 45 ? 'items-center' : 'flex-col',
           view === 'resource' || view === 'week' ? 'text-[10px] sm:text-xs' : 'text-xs',
-          eventTintBgClass,
+          tintBg,
           className
         )}
         dndListeners={dndListeners}
@@ -266,9 +285,11 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
       className={cn(
         'focus-visible:border-ring focus-visible:ring-ring/50 flex w-full flex-col gap-1 rounded-xl p-2 text-left transition outline-none focus-visible:ring-[3px]',
         eventTintBgClass,
+        isSelected && eventSelectedRingClass,
         className
       )}
       style={eventColorVar(event.color)}
+      data-selected={isSelected || undefined}
       onClick={onClick}
       onMouseDown={onMouseDown}
       onTouchStart={onTouchStart}

--- a/packages/ui/src/components/event-calendar/hooks/use-current-time-indicator.ts
+++ b/packages/ui/src/components/event-calendar/hooks/use-current-time-indicator.ts
@@ -12,7 +12,7 @@ export interface UseCurrentTimeIndicatorResult {
   currentTimePosition: number
   /** Whether "now" falls within `currentDate`'s day. */
   currentTimeVisible: boolean
-  /** Pre-formatted "HH:mm" label for the gutter pill. */
+  /** Pre-formatted 12-hour "h:mm a" label for the gutter pill (e.g. "9:44 AM"). */
   currentTimeLabel: string
 }
 
@@ -50,7 +50,7 @@ export function useCurrentTimeIndicator(
       setResult({
         currentTimePosition: position,
         currentTimeVisible: isSameDay(now, currentDate),
-        currentTimeLabel: format(now, 'HH:mm'),
+        currentTimeLabel: format(now, 'h:mm a'),
       })
     }
 

--- a/packages/ui/src/components/event-calendar/hour-gutter.tsx
+++ b/packages/ui/src/components/event-calendar/hour-gutter.tsx
@@ -16,9 +16,9 @@ interface HourGutterProps {
 
 /**
  * Fixed-width hour-label column shared by day/week/resource grids — labels
- * render "00:00"-style (24h), centered, with a hairline rule under each hour
- * row. No vertical border against the grid — the gutter reads as a clean
- * label rail rather than a boxed cell.
+ * render "9 AM"-style (12h, matching the app's en-US convention), small and
+ * muted, straddling each hour rule (Notion-calendar look). No vertical border
+ * against the grid — the gutter reads as a clean label rail, not a boxed cell.
  */
 export function HourGutter({ hours, nowIndicator, className }: HourGutterProps) {
   return (
@@ -28,8 +28,8 @@ export function HourGutter({ hours, nowIndicator, className }: HourGutterProps) 
           key={hour.toISOString()}
           className='relative flex h-[var(--week-cells-height)] items-start justify-center border-b border-border/70 last:border-b-0'>
           {index > 0 && (
-            <span className='text-foreground/50 -translate-y-1/2 text-sm font-medium'>
-              {format(hour, 'HH:mm')}
+            <span className='text-muted-foreground/70 -translate-y-1/2 text-[10px] font-medium'>
+              {format(hour, 'h a')}
             </span>
           )}
         </div>

--- a/packages/ui/src/components/event-calendar/month-view.tsx
+++ b/packages/ui/src/components/event-calendar/month-view.tsx
@@ -48,6 +48,8 @@ interface MonthWeekRowProps<T extends EventCalendarItem = EventCalendarItem> {
   onEventSelect: (event: T) => void
   onSlotClick?: (startTime: Date) => void
   renderEvent?: RenderEvent<T>
+  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
+  selectedEventId?: string | null
   isNonWorkingDay?: (date: Date) => boolean
 }
 
@@ -66,6 +68,7 @@ function MonthWeekRowInner<T extends EventCalendarItem = EventCalendarItem>({
   onEventSelect,
   onSlotClick,
   renderEvent,
+  selectedEventId,
   isNonWorkingDay,
 }: MonthWeekRowProps<T>) {
   const weekStart = weekStartAt(index)
@@ -139,6 +142,7 @@ function MonthWeekRowInner<T extends EventCalendarItem = EventCalendarItem>({
                         view='month'
                         isFirstDay={isFirstDay}
                         isLastDay={isLastDay}
+                        isSelected={event.id === selectedEventId}
                         renderEvent={renderEvent}>
                         <div className='invisible' aria-hidden={true}>
                           {!event.allDay && <span>{format(new Date(event.start), 'h:mm')} </span>}
@@ -156,6 +160,7 @@ function MonthWeekRowInner<T extends EventCalendarItem = EventCalendarItem>({
                       onClick={(e) => handleEventClick(event, e)}
                       isFirstDay={isFirstDay}
                       isLastDay={isLastDay}
+                      isSelected={event.id === selectedEventId}
                       renderEvent={renderEvent}
                     />
                   )
@@ -188,6 +193,7 @@ function MonthWeekRowInner<T extends EventCalendarItem = EventCalendarItem>({
                               view='month'
                               isFirstDay={isSameDay(day, new Date(event.start))}
                               isLastDay={isSameDay(day, new Date(event.end))}
+                              isSelected={event.id === selectedEventId}
                               renderEvent={renderEvent}
                             />
                           ))}
@@ -215,6 +221,8 @@ interface MonthViewProps<T extends EventCalendarItem = EventCalendarItem> {
   onEventSelect: (event: T) => void
   onSlotClick?: (startTime: Date) => void
   renderEvent?: RenderEvent<T>
+  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
+  selectedEventId?: string | null
   /** Fires when a user scroll settles on a new month — with the stream's top-left day. */
   onDateChange?: (date: Date) => void
   /** Fires with the rendered (visible + overscan) week window — consumers fetch this. */
@@ -238,6 +246,7 @@ export function MonthView<T extends EventCalendarItem = EventCalendarItem>({
   onEventSelect,
   onSlotClick,
   renderEvent,
+  selectedEventId,
   onDateChange,
   onVisibleRangeChange,
   isNonWorkingDay,
@@ -430,7 +439,7 @@ export function MonthView<T extends EventCalendarItem = EventCalendarItem>({
               style={{ top: track.top, height: track.height }}>
               <div
                 className={cn(
-                  'bg-background/75 sticky top-2 ml-3 rounded-2xl px-5 py-3 text-3xl font-semibold shadow-lg backdrop-blur-md',
+                  ' sticky top-2 ml-3 text-2xl  ',
                   // Appear instantly while scrolling; only the exit fades.
                   scrollLabelVisible ? 'opacity-100' : 'opacity-0 transition-opacity duration-500'
                 )}>
@@ -449,6 +458,7 @@ export function MonthView<T extends EventCalendarItem = EventCalendarItem>({
               onEventSelect={onEventSelect}
               onSlotClick={onSlotClick}
               renderEvent={renderEvent}
+              selectedEventId={selectedEventId}
               isNonWorkingDay={isNonWorkingDay}
             />
           ))}

--- a/packages/ui/src/components/event-calendar/resource-day-view.tsx
+++ b/packages/ui/src/components/event-calendar/resource-day-view.tsx
@@ -10,6 +10,7 @@ import { BackgroundEventsLayer } from './background-events'
 import { EndHour, StartHour, WeekCellsHeight } from './constants'
 import { CurrentTimeLine } from './current-time-line'
 import { DraggableEvent } from './draggable-event'
+import { DropPreview } from './drop-preview'
 import { DroppableCell } from './droppable-cell'
 import { EventItem } from './event-item'
 import { useCurrentTimeIndicator } from './hooks/use-current-time-indicator'
@@ -27,6 +28,8 @@ interface ResourceDayViewProps<T extends EventCalendarItem = EventCalendarItem> 
   onSlotClick?: (startTime: Date, resourceId: string) => void
   onEventResize?: (event: T, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
+  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
+  selectedEventId?: string | null
 }
 
 /**
@@ -43,6 +46,7 @@ export function ResourceDayView<T extends EventCalendarItem = EventCalendarItem>
   onSlotClick,
   onEventResize,
   renderEvent,
+  selectedEventId,
 }: ResourceDayViewProps<T>) {
   const hours = useMemo(() => {
     const dayStart = startOfDay(currentDate)
@@ -126,6 +130,7 @@ export function ResourceDayView<T extends EventCalendarItem = EventCalendarItem>
                     event={event}
                     view='resource'
                     allDayLane
+                    isSelected={event.id === selectedEventId}
                     renderEvent={renderEvent}>
                     <div>{event.title}</div>
                   </EventItem>
@@ -176,10 +181,13 @@ export function ResourceDayView<T extends EventCalendarItem = EventCalendarItem>
                       height={positioned.height}
                       onResize={onEventResize}
                       renderEvent={renderEvent}
+                      isSelected={positioned.event.id === selectedEventId}
                     />
                   </div>
                 </div>
               ))}
+
+              <DropPreview day={currentDate} resourceId={resource.id} />
 
               {currentTimeVisible && <CurrentTimeLine position={currentTimePosition} />}
 

--- a/packages/ui/src/components/event-calendar/utils.ts
+++ b/packages/ui/src/components/event-calendar/utils.ts
@@ -23,10 +23,20 @@ export function eventColorVar(color?: string): CSSProperties {
 // Tint tuned to a Notion-Calendar level (was 6%/18% — nearly invisible in light mode).
 export const eventTintBgClass =
   'bg-[color-mix(in_oklch,var(--ec-color)_14%,transparent)] dark:bg-[color-mix(in_oklch,var(--ec-color)_28%,transparent)]'
+// Emphasized fill for the dragged/selected chip — a much stronger color-mix so it
+// reads as visibly "darker" than a resting chip (a brightness filter can't do this
+// on an ~86%-transparent tint). Used INSTEAD of `eventTintBgClass`, never alongside
+// it, so there's no competing `background-color` utility.
+export const eventTintBgStrongClass =
+  'bg-[color-mix(in_oklch,var(--ec-color)_36%,transparent)] dark:bg-[color-mix(in_oklch,var(--ec-color)_52%,transparent)]'
 export const eventTintTextClass =
   'text-[color-mix(in_oklch,var(--ec-color)_70%,black)] dark:text-[color-mix(in_oklch,var(--ec-color)_55%,white)]'
 export const eventSolidBgClass = 'bg-[var(--ec-color)]'
 export const eventBorderAccentClass = 'border-[var(--ec-color)]'
+// Active-selection affordance: an inset ring in the event's own color (no layout shift,
+// follows the chip's radius). Distinct from the dragged chip's darker FILL so "selected"
+// and "dragging" read differently.
+export const eventSelectedRingClass = 'ring-2 ring-inset ring-[var(--ec-color)]'
 
 /**
  * Get CSS classes for border radius based on event position in multi-day events

--- a/packages/ui/src/components/event-calendar/week-day-column.tsx
+++ b/packages/ui/src/components/event-calendar/week-day-column.tsx
@@ -10,6 +10,7 @@ import { BackgroundEventsLayer } from './background-events'
 import { StartHour, WeekCellsHeight } from './constants'
 import { CurrentTimeLine } from './current-time-line'
 import { DraggableEvent } from './draggable-event'
+import { DropPreview } from './drop-preview'
 import { DroppableCell } from './droppable-cell'
 import { positionEventsForDay } from './position-events'
 import type { BackgroundEvent, EventCalendarItem, RenderEvent } from './types'
@@ -33,6 +34,8 @@ interface WeekDayColumnProps<T extends EventCalendarItem = EventCalendarItem> {
   onSlotClick?: (startTime: Date) => void
   onEventResize?: (event: T, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
+  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
+  selectedEventId?: string | null
   /** Current-time line position (% of the hour grid) — shared math, rendered only when `isToday(day)`. */
   currentTimePosition: number
 }
@@ -63,6 +66,7 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
   onSlotClick,
   onEventResize,
   renderEvent,
+  selectedEventId,
   currentTimePosition,
 }: WeekDayColumnProps<T>) {
   const day = dayAt(index)
@@ -123,10 +127,13 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
               height={p.height}
               onResize={onEventResize}
               renderEvent={renderEvent}
+              isSelected={p.event.id === selectedEventId}
             />
           </div>
         </div>
       ))}
+
+      <DropPreview day={day} />
 
       {isToday(day) && <CurrentTimeLine position={currentTimePosition} />}
 

--- a/packages/ui/src/components/event-calendar/week-view.tsx
+++ b/packages/ui/src/components/event-calendar/week-view.tsx
@@ -21,6 +21,7 @@ import {
   EndHour,
   EventGap,
   EventHeight,
+  GridHeaderHeight,
   StartHour,
   StreamEndYear,
   StreamStartYear,
@@ -33,8 +34,8 @@ import type { BackgroundEvent, EventCalendarItem, RenderEvent } from './types'
 import { getAllEventsForDay, isMultiDayEvent } from './utils'
 import { WeekDayColumn } from './week-day-column'
 
-/** Height (px) of the sticky day-of-week / date label row. */
-const HeaderLabelHeight = 36
+/** Height (px) of the sticky day-of-week / date label row — Notion's `--grid-header-height`. */
+const HeaderLabelHeight = GridHeaderHeight
 
 /** Minimum height (px) of the always-visible all-day lane, even with zero events — no pop-in. */
 const AllDayLaneMinHeight = 32
@@ -55,6 +56,8 @@ interface WeekViewProps<T extends EventCalendarItem = EventCalendarItem> {
   onSlotClick?: (startTime: Date) => void
   onEventResize?: (event: T, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
+  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
+  selectedEventId?: string | null
   /** Fires when a user scroll settles on a new leftmost day. */
   onDateChange?: (date: Date) => void
   /** Fires with the rendered (visible + overscan) day window — consumers fetch this. */
@@ -86,6 +89,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
   onSlotClick,
   onEventResize,
   renderEvent,
+  selectedEventId,
   onDateChange,
   onVisibleRangeChange,
 }: WeekViewProps<T>) {
@@ -284,34 +288,49 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
                 style={{ height: HeaderLabelHeight }}>
                 <span className='max-[479px]:sr-only'>{format(new Date(), 'O')}</span>
               </div>
-              <div
-                className='bg-muted/50 border-border/70 relative border-t'
-                style={{ height: laneHeight }}>
-                <span className='text-muted-foreground/70 absolute inset-x-0 bottom-1 px-2 text-right text-[10px] sm:px-4 sm:text-xs'>
+              <div className='bg-muted/50 relative' style={{ height: laneHeight }}>
+                <span className='text-muted-foreground/70 absolute inset-0 flex items-center justify-end px-2 text-[10px] sm:px-3'>
                   All day
                 </span>
               </div>
             </div>
 
+            {/* Full-width hairline between the date-label row and the all-day lane — runs
+                continuously across the gutter corner and every day column. */}
+            <div
+              className='bg-border/70 absolute inset-x-0 h-px'
+              style={{ top: HeaderLabelHeight }}
+            />
+
             {virtualItems.map((v) => {
               const day = dayAt(v.index)
               const x = gutterWidth + v.start
+              const today = isToday(day)
               return (
                 <div
                   key={`label-${v.key}`}
-                  className='data-today:text-foreground text-muted-foreground/70 absolute flex items-center justify-center text-sm data-today:font-medium'
+                  className='text-muted-foreground/80 absolute flex items-center justify-center gap-1.5 text-sm'
                   style={{
                     top: 0,
                     left: 0,
                     width: dayWidth,
                     height: HeaderLabelHeight,
                     transform: `translateX(${x}px)`,
-                  }}
-                  data-today={isToday(day) || undefined}>
-                  <span className='sm:hidden' aria-hidden='true'>
-                    {format(day, 'E')[0]} {format(day, 'd')}
+                  }}>
+                  <span className='uppercase max-sm:hidden'>{format(day, 'EEE')}</span>
+                  <span className='uppercase sm:hidden' aria-hidden='true'>
+                    {format(day, 'E')[0]}
                   </span>
-                  <span className='max-sm:hidden'>{format(day, 'EEE dd')}</span>
+                  {/* Today's date sits in a filled badge (Notion look); other days stay plain. */}
+                  <span
+                    className={cn(
+                      'flex h-6 min-w-6 items-center justify-center rounded-full px-1 tabular-nums',
+                      today
+                        ? 'bg-primary text-primary-foreground font-semibold'
+                        : 'text-foreground font-medium'
+                    )}>
+                    {format(day, 'd')}
+                  </span>
                 </div>
               )
             })}
@@ -350,6 +369,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
                         allDayLane
                         isFirstDay={isFirstDay}
                         isLastDay={isLastDay}
+                        isSelected={event.id === selectedEventId}
                         renderEvent={renderEvent}>
                         <div
                           className={cn('truncate', !isFirstDay && 'invisible')}
@@ -393,6 +413,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
               onSlotClick={onSlotClick}
               onEventResize={onEventResize}
               renderEvent={renderEvent}
+              selectedEventId={selectedEventId}
               currentTimePosition={currentTimePosition}
             />
           ))}


### PR DESCRIPTION
## Summary

Polish pass on the shared `@auxx/ui` event-calendar.

### Selection ring
- New `selectedEventId` prop threaded through every view (month/week/day/resource/agenda) — draws an in-color ring on the event whose detail/drawer is open.
- Wired from the **schedule** page/calendar (open visit/meeting/task) and the **dispatch** board (active visit).

### Notion-style tick grid
- Hour-row height now derives from a 5-minute tick via `--grid-tick-*` CSS vars, so every timed cell and event position scales off one knob (`constants.ts`, `event-calendar.tsx`, week/day views, hour-gutter).

### Drag polish
- New `drop-preview.tsx` overlay; refinements to `current-time-line`, `draggable-event`, `calendar-dnd-context`, and `use-current-time-indicator`.

The schedule/dispatch edits pass the new `selectedEventId`, so they ship with this PR.

## Test plan
- [ ] Open an event on schedule + dispatch → selection ring shows on the right chip
- [ ] Week/day timed grid renders at correct heights; drag/resize positions land on the tick grid
- [ ] Drag an event → drop-preview overlay tracks the target slot