### PR TITLE
feat(settings): unify money + dispatch settings UI polish

### DIFF
--- a/apps/web/src/components/detail-view/detail-view-sections.tsx
+++ b/apps/web/src/components/detail-view/detail-view-sections.tsx
@@ -215,7 +215,10 @@ export function DetailViewSections({
               const Icon = getIconComponent(tab.icon)
               return (
                 <div key={tab.value} ref={assignRef(tab.value)}>
-                  <ChromedSection label={tab.label} icon={<Icon className='size-4' />}>
+                  <ChromedSection
+                    label={tab.label}
+                    icon={<Icon className='size-4' />}
+                    fullBleed={tab.fullBleed}>
                     <LazySectionTabComponent
                       entityType={entityType}
                       tabValue={tab.value}
@@ -275,10 +278,13 @@ export function DetailViewSections({
 function ChromedSection({
   label,
   icon,
+  fullBleed = false,
   children,
 }: {
   label: string
   icon: React.ReactNode
+  /** Cancel the Section's horizontal inset so the body spans edge-to-edge (e.g. a line-items table). */
+  fullBleed?: boolean
   children: React.ReactNode
 }) {
   const [titleSlot, setTitleSlot] = React.useState<HTMLElement | null>(null)
@@ -298,7 +304,10 @@ function ChromedSection({
         icon={icon}
         actions={<span ref={setActionsSlot} className='flex items-center gap-1.5 empty:hidden' />}
         collapsible={false}
-        initialOpen>
+        initialOpen
+        className={
+          fullBleed ? '[&>[data-slot=section]>[data-slot=section-content]]:-mx-3' : undefined
+        }>
         {children}
       </Section>
     </SectionChromeContext.Provider>

--- a/apps/web/src/components/dispatch/ui/quality-check-tree-row.tsx
+++ b/apps/web/src/components/dispatch/ui/quality-check-tree-row.tsx
@@ -3,11 +3,12 @@
 'use client'
 
 import { Badge } from '@auxx/ui/components/badge'
-import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { Switch } from '@auxx/ui/components/switch'
+import { TreeRow } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { GripVertical, Power, PowerOff } from 'lucide-react'
+import { GripVertical } from 'lucide-react'
 import type { RouterOutputs } from '~/trpc/react'
 
 export type QcItemTemplateRow = RouterOutputs['dispatch']['listQcTemplates'][number]
@@ -21,10 +22,10 @@ interface QualityCheckTreeRowProps {
 }
 
 /**
- * One QC template row in the settings tree list (08-worker-surface.md §5) — draggable via
- * dnd-kit `useSortable` (the drag handle doubles as the row's leading icon); selecting it opens
- * the FieldPanel editor. The only row-level action is deactivate/reactivate — templates are
- * never deleted, so there is no destructive `TreeRowButton` here.
+ * One QC template row in the settings tree list (08-worker-surface.md §5), styled to match the
+ * Products & Services lists — draggable via dnd-kit `useSortable` (the drag handle doubles as the
+ * row's leading icon); selecting it opens the FieldPanel editor. Active/inactive is a trailing
+ * `Switch` (templates are deactivate-not-delete, so there is no destructive action).
  */
 export function QualityCheckTreeRow({
   template,
@@ -55,29 +56,27 @@ export function QualityCheckTreeRow({
         isOpen={isSelected}
         onToggleOpen={onSelect}
         rowClassName={cn(
-          isSelected ? 'bg-primary-100 hover:bg-primary-150' : 'bg-primary-50 hover:bg-primary-100',
+          'bg-primary-100/50 hover:bg-primary-100',
+          isSelected && 'bg-primary-100 ring-1 ring-primary-200',
           !template.isActive && 'opacity-60'
         )}
         title={<span className='text-sm'>{template.title}</span>}
-        actions={
-          <div className='flex items-center gap-1.5'>
-            {template.isRequired && (
-              <Badge variant='secondary' size='sm'>
+        secondary={
+          template.isRequired ? (
+            <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+              <Badge variant='secondary' size='xs'>
                 Required
               </Badge>
-            )}
-            {!template.isActive && (
-              <Badge variant='outline' size='sm'>
-                Inactive
-              </Badge>
-            )}
-            <TreeRowButton
-              tooltipText={template.isActive ? 'Deactivate' : 'Reactivate'}
-              disabled={isPending}
-              onClick={onToggleActive}>
-              {template.isActive ? <PowerOff /> : <Power />}
-            </TreeRowButton>
-          </div>
+            </span>
+          ) : undefined
+        }
+        actions={
+          <Switch
+            size='xs'
+            checked={template.isActive}
+            onCheckedChange={onToggleActive}
+            disabled={isPending}
+          />
         }
       />
     </div>

--- a/apps/web/src/components/dispatch/ui/quality-checks-page.tsx
+++ b/apps/web/src/components/dispatch/ui/quality-checks-page.tsx
@@ -5,7 +5,7 @@
 import { FieldType } from '@auxx/database/enums'
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
-import { EmptySection, Section } from '@auxx/ui/components/section'
+import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
 import { toastError } from '@auxx/ui/components/toast'
 import {
   closestCenter,
@@ -23,45 +23,30 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { ClipboardCheck, Lock, Plus, Settings2 } from 'lucide-react'
+import { Lock, Plus } from 'lucide-react'
 import { useState } from 'react'
 import type { QcItemTemplateRow } from '~/components/dispatch/ui/quality-check-tree-row'
 import { QualityCheckTreeRow } from '~/components/dispatch/ui/quality-check-tree-row'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { EmptyState } from '~/components/global/empty-state'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
-import { FormSaveBar } from '~/components/global/forms/form-save-bar'
-import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
 import SettingsPage from '~/components/global/settings-page'
+import { BaseType } from '~/components/workflow/types'
+import { useDebouncedCallback } from '~/hooks/use-debounced-value'
+import { useMedia } from '~/hooks/use-media'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 
 const BREADCRUMBS = [{ title: 'Dispatch Settings' }, { title: 'Quality Checks' }]
 
-interface TemplateDraft {
-  title: string
-  description: string
-  isRequired: boolean
-  isActive: boolean
-}
-
-function draftFromTemplate(template: QcItemTemplateRow | null): TemplateDraft {
-  return {
-    title: template?.title ?? '',
-    description: template?.description ?? '',
-    isRequired: template?.isRequired ?? false,
-    isActive: template?.isActive ?? true,
-  }
-}
-
 /**
  * Dispatch Quality Checks settings page (plans/dispatch/08-worker-surface.md §5): the
- * admin-managed catalog of QC item templates a worker's per-visit checklist is materialized
- * from (deactivate-not-delete — there is no delete affordance). Master-detail, mirroring
- * `RecordRuleActionsPage`'s shell: a sortable `TreeRow` list of templates, and a shared
- * `FieldPanel` editor below for the selected one, saved via the shared dirty-draft +
- * `FormSaveBar` (10-settings-forms-unification.md).
+ * admin-managed catalog of QC item templates a worker's per-visit checklist is materialized from.
+ * Master-detail mirroring the Products & Services page — a sortable `TreeRow` list on the left
+ * (active/inactive is a trailing `Switch`; templates are deactivate-not-delete) and a per-field
+ * autosaving `FieldPanel` editor on the right (a `DockableDrawer` below `lg`). Create/toggle/edit
+ * all update the cached list optimistically, reconciling from the server only on error.
  */
 export function QualityChecksPage() {
   useUser({ requireRoles: ['ADMIN', 'OWNER'] })
@@ -77,19 +62,31 @@ export function QualityChecksPage() {
   const [orderOverride, setOrderOverride] = useState<QcItemTemplateRow[] | null>(null)
   const orderedTemplates = orderOverride ?? templates
 
+  const isDesktop = useMedia('(min-width: 1024px)')
+
   const invalidate = () => utils.dispatch.listQcTemplates.invalidate()
+
+  /** Optimistically merge a partial patch into the cached list (used by the toggle + editor). */
+  const patchCached = (id: string, patch: Partial<QcItemTemplateRow>) => {
+    utils.dispatch.listQcTemplates.setData(undefined, (old) =>
+      old?.map((t) => (t.id === id ? { ...t, ...patch } : t))
+    )
+  }
 
   const createTemplate = api.dispatch.createQcTemplate.useMutation({
     onSuccess: (row) => {
+      utils.dispatch.listQcTemplates.setData(undefined, (old) => [...(old ?? []), row])
       setSelectedId(row.id)
-      invalidate()
     },
     onError: (error) => toastError({ title: 'Error adding check', description: error.message }),
   })
 
   const updateTemplate = api.dispatch.updateQcTemplate.useMutation({
-    onSuccess: () => invalidate(),
-    onError: (error) => toastError({ title: 'Error saving check', description: error.message }),
+    // Optimistic patch already applied; only reconcile from the server if the write failed.
+    onError: (error) => {
+      invalidate()
+      toastError({ title: 'Error saving check', description: error.message })
+    },
   })
 
   const reorderTemplates = api.dispatch.reorderQcTemplates.useMutation({
@@ -120,9 +117,23 @@ export function QualityChecksPage() {
     reorderTemplates.mutate(reordered.map((t, i) => ({ id: t.id, sortOrder: i })))
   }
 
-  const handleToggleActive = (template: QcItemTemplateRow) => {
-    updateTemplate.mutate({ templateId: template.id, isActive: !template.isActive })
+  const patchTemplate = (id: string, patch: Partial<QcItemTemplateRow>) => {
+    patchCached(id, patch)
+    updateTemplate.mutate({ templateId: id, ...patch })
   }
+
+  const handleToggleActive = (template: QcItemTemplateRow) => {
+    patchTemplate(template.id, { isActive: !template.isActive })
+  }
+
+  const mobileDrawerOpen = !isDesktop && !!selected
+
+  const editorContent = selected ? (
+    // Keyed by id so switching selection remounts the editor with fresh field state.
+    <TemplateEditor key={selected.id} template={selected} onPatch={patchTemplate} />
+  ) : (
+    <div className='p-4 text-sm text-muted-foreground'>Select a check to edit.</div>
+  )
 
   if (!hasAccess(FeatureKey.dispatch)) {
     return (
@@ -145,145 +156,137 @@ export function QualityChecksPage() {
       title='Quality Checks'
       description='Manage the quality-check checklist workers complete on every visit.'
       breadcrumbs={BREADCRUMBS}>
-      <div className='flex flex-col'>
-        <Section
-          title='Checks'
-          icon={<ClipboardCheck className='size-4' />}
-          collapsible={false}
-          actions={
-            <Button
-              variant='ghost'
-              size='xs'
-              onClick={() => createTemplate.mutate({ title: 'New check' })}
-              loading={createTemplate.isPending}
-              loadingText='Adding...'>
-              <Plus />
-              Add check
-            </Button>
-          }>
-          {orderedTemplates.length === 0 ? (
-            <EmptySection
-              icon={<ClipboardCheck className='size-5' />}
-              title='No checks yet'
-              description='Add a check to start building the visit checklist.'
-            />
-          ) : (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-              modifiers={[restrictToVerticalAxis]}>
-              <SortableContext
-                items={orderedTemplates.map((t) => t.id)}
-                strategy={verticalListSortingStrategy}>
-                <div className='flex flex-col gap-0.5'>
-                  {orderedTemplates.map((template) => (
-                    <QualityCheckTreeRow
-                      key={template.id}
-                      template={template}
-                      isSelected={selectedId === template.id}
-                      onSelect={() => setSelectedId(template.id)}
-                      onToggleActive={() => handleToggleActive(template)}
-                      isPending={updateTemplate.isPending}
-                    />
-                  ))}
-                </div>
-              </SortableContext>
-            </DndContext>
-          )}
-        </Section>
+      <div className='grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
+        <div className='min-w-0'>
+          <div className='flex flex-col gap-3 p-3'>
+            <div className='flex items-center justify-end'>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => createTemplate.mutate({ title: 'New check' })}
+                loading={createTemplate.isPending}
+                loadingText='Adding...'>
+                <Plus />
+                Add check
+              </Button>
+            </div>
 
-        <Section
-          title={selected ? `Configure · ${selected.title || 'Untitled'}` : 'Configure'}
-          icon={<Settings2 className='size-4' />}
-          collapsible={false}>
-          {!selected ? (
-            <EmptySection
-              icon={<Settings2 className='size-5' />}
-              title='No check selected'
-              description='Select a check to configure it.'
-            />
-          ) : (
-            // Keyed by id so switching selection remounts the editor with a fresh draft — a
-            // dirty draft from check A must never be saveable onto check B.
-            <TemplateEditor
-              key={selected.id}
-              template={selected}
-              isSaving={updateTemplate.isPending}
-              onSave={(next) =>
-                updateTemplate.mutate({
-                  templateId: selected.id,
-                  title: next.title,
-                  description: next.description || null,
-                  isRequired: next.isRequired,
-                  isActive: next.isActive,
-                })
-              }
-            />
-          )}
-        </Section>
+            {orderedTemplates.length === 0 ? (
+              <div className='p-4 text-center text-sm text-muted-foreground'>
+                No checks yet — add one to start building the visit checklist.
+              </div>
+            ) : (
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+                modifiers={[restrictToVerticalAxis]}>
+                <SortableContext
+                  items={orderedTemplates.map((t) => t.id)}
+                  strategy={verticalListSortingStrategy}>
+                  <div className='flex flex-col gap-0.5'>
+                    {orderedTemplates.map((template) => (
+                      <QualityCheckTreeRow
+                        key={template.id}
+                        template={template}
+                        isSelected={selectedId === template.id}
+                        onSelect={() => setSelectedId(template.id)}
+                        onToggleActive={() => handleToggleActive(template)}
+                        isPending={updateTemplate.isPending}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            )}
+          </div>
+        </div>
+        <div className='hidden border-l lg:block'>{editorContent}</div>
       </div>
+
+      <DockableDrawer
+        open={mobileDrawerOpen}
+        onOpenChange={(open) => {
+          if (!open) setSelectedId(null)
+        }}
+        isDocked={false}
+        width={380}
+        onWidthChange={() => {}}
+        minWidth={320}
+        maxWidth={480}
+        title='Edit check'>
+        {editorContent}
+      </DockableDrawer>
     </SettingsPage>
   )
 }
 
-/** The selected template's FieldPanel editor — remounted per template (see the `key` above). */
+/**
+ * The selected template's FieldPanel editor — remounted per template (see the `key` above), so
+ * text fields can seed local state once and autosave on change (debounced), mirroring
+ * `product-editor.tsx`. Active lives on the list row, not here.
+ */
 function TemplateEditor({
   template,
-  isSaving,
-  onSave,
+  onPatch,
 }: {
   template: QcItemTemplateRow
-  isSaving: boolean
-  onSave: (draft: TemplateDraft) => void
+  onPatch: (id: string, patch: Partial<QcItemTemplateRow>) => void
 }) {
-  const server = draftFromTemplate(template)
-  const { draft, patch, dirty, save, discard } = useDirtyDraft(server, { isSaving, onSave })
+  const [title, setTitle] = useState(template.title)
+  const [description, setDescription] = useState(template.description ?? '')
+
+  const commitTitle = useDebouncedCallback(
+    (value: string) => onPatch(template.id, { title: value }),
+    500
+  )
+  const commitDescription = useDebouncedCallback(
+    (value: string) => onPatch(template.id, { description: value || null }),
+    500
+  )
 
   return (
-    <div className='flex flex-col gap-3'>
-      <FieldPanel className='p-0' breakpoint='md' resizeId='qc-template'>
-        <FieldPanelRow title='Title' isRequired>
+    <div className='p-3'>
+      <FieldPanel
+        orientation='horizontal'
+        breakpoint='md'
+        resizeId='qc-template-form'
+        defaultLabelWidth={140}
+        className='p-0'>
+        <FieldPanelRow title='Title' type={BaseType.STRING} showIcon isRequired>
           <FieldInputAdapter
             fieldType={FieldType.TEXT}
-            value={draft.title}
-            onChange={(v) => patch({ title: String(v ?? '') })}
+            value={title}
+            onChange={(value) => {
+              setTitle(value as string)
+              commitTitle(value as string)
+            }}
             placeholder='Check title'
           />
         </FieldPanelRow>
-        <FieldPanelRow title='Description'>
+
+        <FieldPanelRow title='Description' type={BaseType.STRING} showIcon>
           <FieldInputAdapter
             fieldType={FieldType.TEXT}
             fieldOptions={{ multiline: true }}
-            value={draft.description}
-            onChange={(v) => patch({ description: String(v ?? '') })}
+            value={description}
+            onChange={(value) => {
+              setDescription(value as string)
+              commitDescription(value as string)
+            }}
             placeholder='Optional detail shown to the worker on the visit'
           />
         </FieldPanelRow>
-        <FieldPanelRow title='Required'>
+
+        <FieldPanelRow title='Required' type={BaseType.BOOLEAN} showIcon>
           <FieldInputAdapter
             fieldType={FieldType.CHECKBOX}
             fieldOptions={{ variant: 'switch' }}
-            value={draft.isRequired}
-            onChange={(v) => patch({ isRequired: Boolean(v) })}
-          />
-        </FieldPanelRow>
-        <FieldPanelRow title='Active'>
-          <FieldInputAdapter
-            fieldType={FieldType.CHECKBOX}
-            fieldOptions={{ variant: 'switch' }}
-            value={draft.isActive}
-            onChange={(v) => patch({ isActive: Boolean(v) })}
+            value={template.isRequired}
+            onChange={(value) => onPatch(template.id, { isRequired: Boolean(value) })}
           />
         </FieldPanelRow>
       </FieldPanel>
-      <FormSaveBar
-        dirty={dirty}
-        isSaving={isSaving}
-        onSave={save}
-        onDiscard={discard}
-        saveDisabled={!draft.title.trim()}
-      />
     </div>
   )
 }

--- a/apps/web/src/components/money/ui/settings/group-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/group-editor.tsx
@@ -12,13 +12,6 @@ import {
   CommandList,
 } from '@auxx/ui/components/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import {
@@ -83,6 +76,10 @@ function GroupEditorForm({ group, currency }: { group: CatalogGroup; currency: s
   const { itemMap, items } = useCatalogItems()
   const { getSetting } = useSettings({ scope: 'DOCUMENTS' })
   const taxRates = (getSetting('documents.taxRates') as TaxRate[] | null) ?? []
+  const taxOptions = useMemo(
+    () => taxRates.map((rate) => ({ label: `${rate.name} (${rate.rate}%)`, value: rate.id })),
+    [taxRates]
+  )
 
   const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue({})
 
@@ -144,8 +141,6 @@ function GroupEditorForm({ group, currency }: { group: CatalogGroup; currency: s
     writeDiscount(type, type === 'amount' ? Math.round(displayed * 100) : displayed)
   }
 
-  const selectedTaxId = group.taxRateId ?? '__none__'
-
   return (
     <div className='flex flex-col gap-3 p-3'>
       <FieldPanel
@@ -179,29 +174,22 @@ function GroupEditorForm({ group, currency }: { group: CatalogGroup; currency: s
           />
         </FieldPanelRow>
 
-        <FieldPanelRow title='Tax rate' type={BaseType.STRING} showIcon>
-          <Select
-            value={selectedTaxId}
-            onValueChange={(id) =>
+        <FieldPanelRow title='Tax rate' type={BaseType.ENUM} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.SINGLE_SELECT}
+            fieldOptions={{ options: taxOptions }}
+            value={group.taxRateId ? [group.taxRateId] : []}
+            triggerProps={{ showClear: true, className: 'w-full' }}
+            onChange={(value) =>
               saveFieldValue(
                 group.recordId,
                 'catalog_group_tax_rate_id',
-                id === '__none__' ? null : id,
+                (value as string[])[0] ?? null,
                 FieldType.TEXT
               )
-            }>
-            <SelectTrigger className='w-full'>
-              <SelectValue placeholder='No tax' />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value='__none__'>No tax</SelectItem>
-              {taxRates.map((rate) => (
-                <SelectItem key={rate.id} value={rate.id}>
-                  {rate.name} ({rate.rate}%)
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            }
+            placeholder='No tax'
+          />
         </FieldPanelRow>
 
         <FieldPanelRow title='Discount' type={BaseType.NUMBER} showIcon>

--- a/apps/web/src/components/money/ui/settings/groups-list.tsx
+++ b/apps/web/src/components/money/ui/settings/groups-list.tsx
@@ -6,10 +6,11 @@ import { Button } from '@auxx/ui/components/button'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
-import { TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { Boxes, Plus } from 'lucide-react'
+import { Boxes, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
 import { type CatalogGroup, useCatalogGroups } from '../../hooks/use-catalog-groups'
@@ -35,11 +36,26 @@ export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) 
   const { getSetting } = useSettings({ scope: 'DOCUMENTS' })
   const taxRates = (getSetting('documents.taxRates') as TaxRate[] | null) ?? []
   const [search, setSearch] = useState('')
+  const [confirm, ConfirmDialog] = useConfirm()
 
   const updateRecord = api.record.update.useMutation()
   const createRecord = api.record.create.useMutation({
     onError: (error) => toastError({ title: 'Error creating group', description: error.message }),
   })
+  const deleteRecord = api.record.delete.useMutation({
+    onSuccess: () => refresh(),
+    onError: (error) => toastError({ title: 'Error deleting group', description: error.message }),
+  })
+
+  async function handleDelete(group: CatalogGroup) {
+    const confirmed = await confirm({
+      title: 'Delete group?',
+      description: `“${group.name}” will be removed. Its items stay in the catalog.`,
+      confirmText: 'Delete',
+      destructive: true,
+    })
+    if (confirmed) deleteRecord.mutate({ recordId: group.recordId })
+  }
 
   // Optimistic overlay for the active toggle — `record.update` bypasses the
   // granular field-value store, so reflect the flip locally and invalidate
@@ -166,18 +182,27 @@ export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) 
                   </span>
                 }
                 actions={
-                  <Switch
-                    size='xs'
-                    checked={effectiveActive(group)}
-                    onCheckedChange={() => handleToggleActive(group)}
-                    disabled={updateRecord.isPending}
-                  />
+                  <div className='flex items-center gap-1'>
+                    <TreeRowButton
+                      tooltipText='Delete group'
+                      variant='destructive'
+                      onClick={() => handleDelete(group)}>
+                      <Trash2 />
+                    </TreeRowButton>
+                    <Switch
+                      size='xs'
+                      checked={effectiveActive(group)}
+                      onCheckedChange={() => handleToggleActive(group)}
+                      disabled={updateRecord.isPending}
+                    />
+                  </div>
                 }
               />
             )
           })}
         </div>
       )}
+      <ConfirmDialog />
     </div>
   )
 }

--- a/apps/web/src/components/money/ui/settings/product-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/product-editor.tsx
@@ -2,14 +2,11 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
-import type { RecordId } from '@auxx/lib/resources/client'
 import { useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
-import { RecordPicker } from '~/components/pickers/record-picker'
-import { useRecord, useResourceFields, useResourceProperty } from '~/components/resources'
+import { useResourceFields } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
-import { PickerTrigger } from '~/components/ui/picker-trigger'
 import { BaseType } from '~/components/workflow/types'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
 import { type CatalogItem, useCatalogItems } from '../../hooks/use-catalog-items'
@@ -39,11 +36,7 @@ export function ProductEditor({ selectedId }: ProductEditorProps) {
 function ProductEditorForm({ item }: { item: CatalogItem }) {
   const { fields } = useResourceFields('catalog-items')
   const categoryField = fields.find((f) => f.key === 'category')
-  const partDefId = useResourceProperty('part', 'id')
-  const { record: partRecord } = useRecord({
-    recordId: item.partRecordId ?? undefined,
-    enabled: !!item.partRecordId,
-  })
+  const partField = fields.find((f) => f.key === 'part')
 
   const { saveFieldValue } = useSaveFieldValue({})
 
@@ -130,20 +123,20 @@ function ProductEditorForm({ item }: { item: CatalogItem }) {
           />
         </FieldPanelRow>
 
-        {item.category === 'material' && (
+        {item.category === 'material' && partField && (
           <FieldPanelRow title='Part' type={BaseType.RELATION} showIcon>
-            <RecordPicker
-              entityDefinitionId={partDefId ?? undefined}
+            <FieldInputAdapter
+              fieldType={FieldType.RELATIONSHIP}
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              fieldOptions={{
+                relationship: partField.relationship ?? partField.options?.relationship,
+              }}
               value={item.partRecordId ? [item.partRecordId] : []}
-              onChange={(ids: RecordId[]) =>
-                saveFieldValue(item.recordId, 'catalog_item_part', ids, FieldType.RELATIONSHIP)
+              onChange={(value) =>
+                saveFieldValue(item.recordId, 'catalog_item_part', value, FieldType.RELATIONSHIP)
               }
-              multi={false}
-              emptyLabel='Link a part'>
-              <PickerTrigger hasValue={!!item.partRecordId} placeholder='Link a part'>
-                {partRecord?.displayName ?? 'Select a part'}
-              </PickerTrigger>
-            </RecordPicker>
+              placeholder='Link a part'
+            />
           </FieldPanelRow>
         )}
       </FieldPanel>

--- a/apps/web/src/components/money/ui/settings/products-list.tsx
+++ b/apps/web/src/components/money/ui/settings/products-list.tsx
@@ -7,11 +7,12 @@ import { Button } from '@auxx/ui/components/button'
 import { InputSearch } from '@auxx/ui/components/input-search'
 import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
-import { TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { Package, Plus, Wrench } from 'lucide-react'
+import { Package, Plus, Trash2, Wrench } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useResourceFields } from '~/components/resources'
+import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { type CatalogItem, useCatalogItems } from '../../hooks/use-catalog-items'
 import { formatMoney } from './format-money'
@@ -44,11 +45,26 @@ export function ProductsList({ selectedId, onSelect, currency }: ProductsListPro
     [catalogFields]
   )
   const [search, setSearch] = useState('')
+  const [confirm, ConfirmDialog] = useConfirm()
 
   const updateRecord = api.record.update.useMutation()
   const createRecord = api.record.create.useMutation({
     onError: (error) => toastError({ title: 'Error creating item', description: error.message }),
   })
+  const deleteRecord = api.record.delete.useMutation({
+    onSuccess: () => refresh(),
+    onError: (error) => toastError({ title: 'Error deleting item', description: error.message }),
+  })
+
+  async function handleDelete(item: CatalogItem) {
+    const confirmed = await confirm({
+      title: 'Delete item?',
+      description: `“${item.name}” will be removed from the catalog. Existing document lines are unaffected.`,
+      confirmText: 'Delete',
+      destructive: true,
+    })
+    if (confirmed) deleteRecord.mutate({ recordId: item.recordId })
+  }
 
   // Optimistic overlay for the active toggle — `record.update` bypasses the
   // granular field-value store, so reflect the flip locally and invalidate
@@ -145,17 +161,26 @@ export function ProductsList({ selectedId, onSelect, currency }: ProductsListPro
                 </span>
               }
               actions={
-                <Switch
-                  size='xs'
-                  checked={effectiveActive(item)}
-                  onCheckedChange={() => handleToggleActive(item)}
-                  disabled={updateRecord.isPending}
-                />
+                <div className='flex items-center gap-1'>
+                  <TreeRowButton
+                    tooltipText='Delete item'
+                    variant='destructive'
+                    onClick={() => handleDelete(item)}>
+                    <Trash2 />
+                  </TreeRowButton>
+                  <Switch
+                    size='xs'
+                    checked={effectiveActive(item)}
+                    onCheckedChange={() => handleToggleActive(item)}
+                    disabled={updateRecord.isPending}
+                  />
+                </div>
               }
             />
           ))}
         </div>
       )}
+      <ConfirmDialog />
     </div>
   )
 }

--- a/apps/web/src/components/money/ui/settings/products-services-page.tsx
+++ b/apps/web/src/components/money/ui/settings/products-services-page.tsx
@@ -104,6 +104,17 @@ export function ProductsServicesPage() {
     commitTaxRates(taxRates.map((r) => ({ ...r, isDefault: r.id === id })))
   }
 
+  function handleDeleteTaxRate(id: string) {
+    const removed = taxRates.find((r) => r.id === id)
+    const next = taxRates.filter((r) => r.id !== id)
+    // Deleting the default promotes the first remaining rate — one is always default.
+    if (removed?.isDefault && next.length > 0 && !next.some((r) => r.isDefault)) {
+      next[0] = { ...next[0], isDefault: true }
+    }
+    commitTaxRates(next)
+    if (selectedTaxRateId === id) setSelectedTaxRateId(null)
+  }
+
   const selectedTaxRate = taxRates.find((r) => r.id === selectedTaxRateId) ?? null
   const selectedId =
     activeTab === 'products'
@@ -122,7 +133,6 @@ export function ProductsServicesPage() {
       <TaxRateEditor
         taxRate={selectedTaxRate}
         onUpdate={(patch) => selectedTaxRate && handleUpdateTaxRate(selectedTaxRate.id, patch)}
-        onSetDefault={() => selectedTaxRate && handleSetDefaultTaxRate(selectedTaxRate.id)}
       />
     )
 
@@ -159,6 +169,8 @@ export function ProductsServicesPage() {
               selectedId={selectedTaxRateId}
               onSelect={setSelectedTaxRateId}
               onAdd={handleAddTaxRate}
+              onSetDefault={handleSetDefaultTaxRate}
+              onDelete={handleDeleteTaxRate}
             />
           )}
         </div>

--- a/apps/web/src/components/money/ui/settings/tax-rate-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/tax-rate-editor.tsx
@@ -12,37 +12,29 @@ import type { TaxRate } from './tax-rate-types'
 interface TaxRateEditorProps {
   taxRate: TaxRate | null
   onUpdate: (patch: Partial<TaxRate>) => void
-  onSetDefault: () => void
 }
 
 /**
- * Right column of the Tax rates tab: name / rate / is-default for the
- * selected rate. Every edit rewrites the whole `documents.taxRates` array
- * atomically (see `products-services-page.tsx`) — text fields are debounced
- * locally so typing doesn't fire a setting write per keystroke.
+ * Right column of the Tax rates tab: name / rate for the selected rate. Every
+ * edit rewrites the whole `documents.taxRates` array atomically (see
+ * `products-services-page.tsx`) — text fields are debounced locally so typing
+ * doesn't fire a setting write per keystroke. The default rate is toggled from
+ * the list row, not here.
  */
-export function TaxRateEditor({ taxRate, onUpdate, onSetDefault }: TaxRateEditorProps) {
+export function TaxRateEditor({ taxRate, onUpdate }: TaxRateEditorProps) {
   if (!taxRate) {
     return <div className='p-4 text-sm text-muted-foreground'>Select a tax rate to edit.</div>
   }
 
-  return (
-    <TaxRateEditorForm
-      key={taxRate.id}
-      taxRate={taxRate}
-      onUpdate={onUpdate}
-      onSetDefault={onSetDefault}
-    />
-  )
+  return <TaxRateEditorForm key={taxRate.id} taxRate={taxRate} onUpdate={onUpdate} />
 }
 
 interface TaxRateEditorFormProps {
   taxRate: TaxRate
   onUpdate: (patch: Partial<TaxRate>) => void
-  onSetDefault: () => void
 }
 
-function TaxRateEditorForm({ taxRate, onUpdate, onSetDefault }: TaxRateEditorFormProps) {
+function TaxRateEditorForm({ taxRate, onUpdate }: TaxRateEditorFormProps) {
   const [name, setName] = useState(taxRate.name)
   const [rate, setRate] = useState(taxRate.rate)
 
@@ -84,23 +76,6 @@ function TaxRateEditorForm({ taxRate, onUpdate, onSetDefault }: TaxRateEditorFor
               commitRate(next)
             }}
             placeholder='0'
-          />
-        </FieldPanelRow>
-
-        <FieldPanelRow
-          title='Default'
-          description='Preselected on new quotes and invoices'
-          type={BaseType.BOOLEAN}
-          showIcon>
-          <FieldInputAdapter
-            fieldType={FieldType.CHECKBOX}
-            fieldOptions={{ variant: 'switch' }}
-            value={!!taxRate.isDefault}
-            onChange={(value) => {
-              // Set-only toggle: turning it on makes this the default; it can't be unset here.
-              if (value) onSetDefault()
-            }}
-            disabled={taxRate.isDefault}
           />
         </FieldPanelRow>
       </FieldPanel>

--- a/apps/web/src/components/money/ui/settings/tax-rates-list.tsx
+++ b/apps/web/src/components/money/ui/settings/tax-rates-list.tsx
@@ -3,9 +3,10 @@
 
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
-import { Percent, Plus } from 'lucide-react'
+import { Percent, Plus, Trash2 } from 'lucide-react'
+import { useConfirm } from '~/hooks/use-confirm'
 import type { TaxRate } from './tax-rate-types'
 
 interface TaxRatesListProps {
@@ -13,14 +14,37 @@ interface TaxRatesListProps {
   selectedId: string | null
   onSelect: (id: string) => void
   onAdd: () => void
+  onSetDefault: (id: string) => void
+  onDelete: (id: string) => void
 }
 
 /**
  * Left column of the Tax rates tab: flat `TreeRow` list backed by the
  * `documents.taxRates` org setting (no entity, no dialogs — see the Products
  * & Services tab / mcp-server-tools-tab for the shared master–detail recipe).
+ * The default rate is a toggle badge on each row (set-only — one rate is always
+ * the default), not an editor field.
  */
-export function TaxRatesList({ taxRates, selectedId, onSelect, onAdd }: TaxRatesListProps) {
+export function TaxRatesList({
+  taxRates,
+  selectedId,
+  onSelect,
+  onAdd,
+  onSetDefault,
+  onDelete,
+}: TaxRatesListProps) {
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  async function handleDelete(rate: TaxRate) {
+    const confirmed = await confirm({
+      title: 'Delete tax rate?',
+      description: `“${rate.name}” will be removed. Existing documents keep their applied tax.`,
+      confirmText: 'Delete',
+      destructive: true,
+    })
+    if (confirmed) onDelete(rate.id)
+  }
+
   return (
     <div className='flex flex-col gap-3 p-3'>
       <div className='flex items-center justify-end'>
@@ -47,19 +71,39 @@ export function TaxRatesList({ taxRates, selectedId, onSelect, onAdd }: TaxRates
                 selectedId === rate.id && 'bg-primary-100 ring-1 ring-primary-200'
               )}
               secondary={
-                <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+                <span className='flex items-center gap-1.5 text-xs text-muted-foreground p-[3px]'>
                   {rate.rate}%
-                  {rate.isDefault && (
-                    <Badge variant='outline' size='xs'>
+                  {rate.isDefault ? (
+                    <Badge variant='magenta' size='xs'>
                       Default
+                    </Badge>
+                  ) : (
+                    <Badge
+                      variant='outline'
+                      size='xs'
+                      className='text-muted-foreground hover:text-primary-700'
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onSetDefault(rate.id)
+                      }}>
+                      Set default
                     </Badge>
                   )}
                 </span>
+              }
+              actions={
+                <TreeRowButton
+                  tooltipText='Delete rate'
+                  variant='destructive'
+                  onClick={() => handleDelete(rate)}>
+                  <Trash2 />
+                </TreeRowButton>
               }
             />
           ))}
         </div>
       )}
+      <ConfirmDialog />
     </div>
   )
 }

--- a/packages/lib/src/resources/registry/detail-view-config-types.ts
+++ b/packages/lib/src/resources/registry/detail-view-config-types.ts
@@ -13,6 +13,13 @@ export interface MainTabDefinition {
   label: string
   /** Icon name (e.g., 'ticket', 'clock') */
   icon: string
+  /**
+   * Cancel the wrapping `<Section>`'s horizontal inset so the content (e.g. a
+   * line-items table) spans edge-to-edge — the `sections` layout twin of the
+   * drawer card's `fullBleed` (drawer-config-types.ts). Applies `-mx-3` to the
+   * section body via `ChromedSection`.
+   */
+  fullBleed?: boolean
 }
 
 /**

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -99,7 +99,9 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     // DetailViewSections' <Section> wrapper is always non-collapsible.
     layout: 'sections',
     mainTabs: [
-      { value: 'line-items', label: 'Line items', icon: 'receipt-text' },
+      // fullBleed: the line-items table spans edge-to-edge (cancels the Section's
+      // px-3), matching the quote drawer/sidebar cards' `fullBleed` treatment.
+      { value: 'line-items', label: 'Line items', icon: 'receipt-text', fullBleed: true },
       { value: 'timeline', label: 'Timeline', icon: 'clock' },
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],


### PR DESCRIPTION
## Summary
UI polish pass unifying the money settings and dispatch quality-checks pages onto the shared master–detail recipe.

### Money settings
- **Delete affordances** on products, groups, and tax-rate list rows (confirm-gated; existing document lines / catalog items stay intact).
- **Tax rate default** moved to a set-only badge on the list row (one rate is always default) and dropped from the editor.
- **Group tax rate** now uses `FieldInputAdapter` single-select; **product part link** uses the `FieldInputAdapter` relationship picker.

### Dispatch quality checks
- Rewritten as master–detail matching Products & Services:
  - trailing `Switch` for active/inactive (deactivate-not-delete),
  - per-field autosaving `FieldPanel` editor (debounced),
  - optimistic cached list updates, reconciling from the server only on error,
  - `DockableDrawer` for the editor below `lg`.

### Detail view
- New `fullBleed` main-tab option so a section body (e.g. the quote line-items table) spans edge-to-edge, mirroring the drawer card's `fullBleed`.

## Test plan
- [ ] Products/Services/Groups/Tax rates: create, edit, toggle active, set default, delete
- [ ] Quality checks: create, reorder, toggle active, edit title/description (autosave), mobile drawer
- [ ] Quote detail: line-items tab renders edge-to-edge