### PR TITLE
feat(money): products & services catalog editor rewrite

### DIFF
--- a/apps/web/src/components/money/hooks/use-catalog-groups.ts
+++ b/apps/web/src/components/money/hooks/use-catalog-groups.ts
@@ -82,6 +82,8 @@ interface UseCatalogGroupsResult {
   refresh: () => void
   /** Append a freshly created group into the `listAll` cache — skips a refetch. */
   appendRecord: (item: AllRecordsItem) => void
+  /** Remove a deleted group from the `listAll` cache — skips a refetch. */
+  removeRecord: (id: string) => void
 }
 
 /**
@@ -90,7 +92,7 @@ interface UseCatalogGroupsResult {
  * system. Same "small dataset, no pagination" shape as `useCatalogItems`.
  */
 export function useCatalogGroups(): UseCatalogGroupsResult {
-  const { records, entityDefinitionId, fields, isLoading, refresh, appendRecord } =
+  const { records, entityDefinitionId, fields, isLoading, refresh, appendRecord, removeRecord } =
     useAllRecords<CatalogGroupRecord>({
       apiSlug: 'catalog-groups',
       includeArchived: false,
@@ -101,5 +103,14 @@ export function useCatalogGroups(): UseCatalogGroupsResult {
     return { groups: list, groupMap: new Map(list.map((group) => [group.id, group])) }
   }, [records])
 
-  return { groups, groupMap, entityDefinitionId, fields, isLoading, refresh, appendRecord }
+  return {
+    groups,
+    groupMap,
+    entityDefinitionId,
+    fields,
+    isLoading,
+    refresh,
+    appendRecord,
+    removeRecord,
+  }
 }

--- a/apps/web/src/components/money/hooks/use-catalog-items.ts
+++ b/apps/web/src/components/money/hooks/use-catalog-items.ts
@@ -73,6 +73,8 @@ interface UseCatalogItemsResult {
   refresh: () => void
   /** Append a freshly created item into the `listAll` cache — skips a refetch. */
   appendRecord: (item: AllRecordsItem) => void
+  /** Remove a deleted item from the `listAll` cache — skips a refetch. */
+  removeRecord: (id: string) => void
 }
 
 /**
@@ -82,7 +84,7 @@ interface UseCatalogItemsResult {
  * only consumer, so this lives under `money/hooks` rather than `resources`.
  */
 export function useCatalogItems(): UseCatalogItemsResult {
-  const { records, entityDefinitionId, fields, isLoading, refresh, appendRecord } =
+  const { records, entityDefinitionId, fields, isLoading, refresh, appendRecord, removeRecord } =
     useAllRecords<CatalogItemRecord>({
       apiSlug: 'catalog-items',
       includeArchived: false,
@@ -93,5 +95,14 @@ export function useCatalogItems(): UseCatalogItemsResult {
     return { items: list, itemMap: new Map(list.map((item) => [item.id, item])) }
   }, [records])
 
-  return { items, itemMap, entityDefinitionId, fields, isLoading, refresh, appendRecord }
+  return {
+    items,
+    itemMap,
+    entityDefinitionId,
+    fields,
+    isLoading,
+    refresh,
+    appendRecord,
+    removeRecord,
+  }
 }

--- a/apps/web/src/components/money/hooks/use-seed-catalog-record.ts
+++ b/apps/web/src/components/money/hooks/use-seed-catalog-record.ts
@@ -1,0 +1,70 @@
+// apps/web/src/components/money/hooks/use-seed-catalog-record.ts
+
+import type { FieldType } from '@auxx/database/types'
+import { formatToTypedInput } from '@auxx/lib/field-values/client'
+import type { RecordId } from '@auxx/lib/resources/client'
+import { useCallback } from 'react'
+import type {
+  CreatedRecordInstance,
+  SeedFieldValue,
+} from '~/components/resources/hooks/use-seed-created-record'
+import {
+  buildFieldValueKey,
+  type FieldReference,
+  useFieldValueStore,
+} from '~/components/resources/store/field-value-store'
+import { type RecordMeta, useRecordStore } from '~/components/resources/store/record-store'
+import { useResourceStore } from '~/components/resources/store/resource-store'
+
+/**
+ * Seed the record + field-value caches from a `record.create` result for the
+ * catalog settings surfaces (products, groups) — same store-write shape as
+ * `useSeedCreatedRecord` (`resources/hooks/use-seed-created-record.ts`), minus
+ * the record-store LIST-cache push (`appendCreatedRecord(listKey)`): these
+ * lists come from `useAllRecords`'s `listAll` query cache, which is pushed
+ * separately via `appendRecord` from `useCatalogItems`/`useCatalogGroups`, so
+ * there's no `listKey` to thread through here. Nulls are included in `values`
+ * so nothing flashes as blank/undefined before the diff-flush lands.
+ */
+export function useSeedCatalogRecord() {
+  const seedCatalogRecord = useCallback(
+    (params: {
+      entityDefinitionId: string
+      recordId: RecordId
+      instance: CreatedRecordInstance
+      values: SeedFieldValue[]
+    }) => {
+      const { entityDefinitionId, recordId, instance, values } = params
+
+      const meta: RecordMeta = {
+        id: instance.id,
+        recordId,
+        displayName: instance.displayName ?? undefined,
+        secondaryInfo: instance.secondaryDisplayValue ?? undefined,
+        avatarUrl: instance.avatarUrl ?? undefined,
+        createdAt:
+          instance.createdAt instanceof Date
+            ? instance.createdAt.toISOString()
+            : instance.createdAt,
+        updatedAt:
+          instance.updatedAt instanceof Date
+            ? instance.updatedAt.toISOString()
+            : instance.updatedAt,
+      }
+      useRecordStore.getState().setRecords(entityDefinitionId, [meta])
+
+      const systemAttributeMap = useResourceStore.getState().systemAttributeMap
+      const entries = values.map(({ fieldId, value, fieldType }) => {
+        const resourceFieldId = (systemAttributeMap[fieldId] ?? fieldId) as FieldReference
+        return {
+          key: buildFieldValueKey(recordId, resourceFieldId),
+          value: formatToTypedInput(value, fieldType as FieldType),
+        }
+      })
+      useFieldValueStore.getState().setValues(entries)
+    },
+    []
+  )
+
+  return { seedCatalogRecord }
+}

--- a/apps/web/src/components/money/ui/document-actions-cluster.tsx
+++ b/apps/web/src/components/money/ui/document-actions-cluster.tsx
@@ -17,8 +17,9 @@ import { Tooltip } from '~/components/global/tooltip'
 
 export interface DocumentActionsClusterProps {
   /**
-   * Primary inline segment — the Send/Resend button. Omit to render only the
-   * chevron menu (e.g. a terminal status where the document can no longer be sent).
+   * Primary inline segment — the Send/Resend button. Omit to render the menu as a
+   * standalone labeled "Actions" button (e.g. a terminal status where the document
+   * can no longer be sent).
    */
   send?: {
     label: string
@@ -58,14 +59,14 @@ export function DocumentActionsCluster({
           (send.disabledReason ? (
             <Tooltip allowInteraction contentComponent={send.disabledReason}>
               <span className='inline-flex'>
-                <Button size='sm' variant='outline' className='border-r-0' disabled>
+                <Button size='xs' variant='outline' className='border-r-0' disabled>
                   {send.label}
                 </Button>
               </span>
             </Tooltip>
           ) : (
             <Button
-              size='sm'
+              size='xs'
               variant='outline'
               className='border-r-0'
               loading={send.isPending}
@@ -78,7 +79,12 @@ export function DocumentActionsCluster({
         {send && <ButtonGroupSeparator />}
 
         <DropdownMenuTrigger asChild>
-          <Button size='sm' variant='outline' className='px-1.5' aria-label={menuLabel}>
+          <Button
+            size='xs'
+            variant='outline'
+            className={send ? 'px-1.5' : undefined}
+            aria-label={menuLabel}>
+            {!send && 'Actions'}
             <ChevronDown />
           </Button>
         </DropdownMenuTrigger>

--- a/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
+++ b/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
@@ -40,6 +40,8 @@ const QUOTE_STATUS_ATTRS = ['quote_status', 'quote_valid_until'] as const
 const EXPIRABLE_STATUSES = new Set(['draft', 'sent'])
 /** Statuses where a quote can still be (re)sent (money MQ2 build spec §E.2). */
 const SENDABLE_STATUSES = new Set(['draft', 'sent'])
+/** Post-draft statuses that can be returned to draft for editing (mirrors invoice SENT_STATUSES). */
+const REVERTIBLE_STATUSES = new Set(['sent', 'approved', 'declined', 'canceled'])
 
 export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
   const router = useRouter()
@@ -92,10 +94,13 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
     }
   }
 
-  const handleEditSent = async () => {
+  const handleReturnToDraft = async () => {
     const confirmed = await confirm({
       title: 'Edit this quote?',
-      description: 'This quote was sent — editing returns it to draft.',
+      description:
+        status === 'sent'
+          ? 'This quote was sent — editing returns it to draft.'
+          : `This quote is ${status} — editing returns it to draft.`,
       confirmText: 'Edit',
       cancelText: 'Cancel',
     })
@@ -172,10 +177,10 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
             </DropdownMenuItem>
           )}
 
-          {status === 'sent' && (
+          {REVERTIBLE_STATUSES.has(status) && (
             <>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleEditSent}>
+              <DropdownMenuItem onClick={handleReturnToDraft}>
                 <Undo2 /> Return to draft
               </DropdownMenuItem>
             </>
@@ -183,10 +188,12 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
         </DocumentActionsCluster>
       </DocumentSectionActions>
 
-      {status === 'sent' && (
+      {REVERTIBLE_STATUSES.has(status) && (
         <div className='mx-4 mt-3 flex items-center gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm'>
           <span className='text-amber-700 dark:text-amber-400'>
-            This quote was sent — use “Return to draft” to edit it.
+            {status === 'sent'
+              ? 'This quote was sent — use “Return to draft” to edit it.'
+              : `This quote is ${status} — use “Return to draft” to edit it.`}
           </span>
         </div>
       )}

--- a/apps/web/src/components/money/ui/settings/catalog-draft-types.ts
+++ b/apps/web/src/components/money/ui/settings/catalog-draft-types.ts
@@ -1,0 +1,26 @@
+// apps/web/src/components/money/ui/settings/catalog-draft-types.ts
+
+/**
+ * The minimal "is there a phantom draft, and what's its display name" handle
+ * the products-services-page owner keeps for each tab (products/groups).
+ * The full draft field set (description, category, price, entries, …) lives
+ * entirely inside the editor component instance (`ProductDraftEditorForm` /
+ * `GroupDraftEditorForm`, keyed by `draftId`) — the page only needs enough to
+ * render the phantom row in the list and to know whether the currently
+ * selected id is a draft or a real record.
+ */
+export interface CatalogDraftHandle {
+  draftId: string
+  name: string
+  /**
+   * Set once the draft's first `record.create` resolves. The draft is KEPT
+   * alive after creation (with selection swapped to this id) so the draft
+   * editor form stays mounted — remounting onto the store-bound form
+   * mid-typing would replace the input's text with the create snapshot and
+   * cancel the pending debounced name commit (`useDebouncedCallback` clears
+   * its timer on unmount). The list hides the phantom row once this is set
+   * (the real row arrived via `appendRecord`); the draft is finally dropped
+   * when the user navigates to another row/tab.
+   */
+  recordId?: string
+}

--- a/apps/web/src/components/money/ui/settings/group-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/group-editor.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
+import type { RecordId } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import {
   Command,
@@ -12,6 +13,7 @@ import {
   CommandList,
 } from '@auxx/ui/components/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { toastError } from '@auxx/ui/components/toast'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import {
@@ -33,7 +35,7 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { CircleCheck, CircleDashed, CircleX, GripVertical, Pencil, Plus, X } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import {
@@ -45,24 +47,65 @@ import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-v
 import { BaseType } from '~/components/workflow/types'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
 import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
 import { type CatalogGroup, useCatalogGroups } from '../../hooks/use-catalog-groups'
 import { type CatalogItem, useCatalogItems } from '../../hooks/use-catalog-items'
+import { useSeedCatalogRecord } from '../../hooks/use-seed-catalog-record'
+import type { CatalogDraftHandle } from './catalog-draft-types'
 import { formatMoney } from './format-money'
 import type { TaxRate } from './tax-rate-types'
 
 interface GroupEditorProps {
   selectedId: string | null
   currency: string
+  /** Phantom draft for the Product groups tab, owned by `products-services-page.tsx`. */
+  draft: CatalogDraftHandle | null
+  /** List phantom-row preview sync — fired per debounced name commit. */
+  onDraftNameChange: (name: string) => void
+  /** First create resolved — swap `selectedId` to the real record id. The page
+   *  KEEPS the draft (stamped with `recordId`) so this form stays mounted;
+   *  see `CatalogDraftHandle.recordId` for why a remount here loses text. */
+  onDraftCommitted: (recordId: string) => void
 }
+
+/** `FocusableInputWrapper` (field-input-adapter.tsx) autofocuses once `open` is
+ *  truthy — a stable no-op keeps the effect from refiring every render. */
+function noop() {}
 
 /**
  * Right column of the Product groups tab: a `FieldPanel` form for the
  * selected group (name/description/tax rate/discount/active, autosaved via
- * `useSaveFieldValue` — mirrors `product-editor.tsx`), plus an entries
- * section below (drag-reorder, qty/description/taxable overrides).
+ * `useSaveFieldValue`), plus an entries section below (drag-reorder,
+ * qty/description/taxable overrides). Renders `GroupDraftEditorForm` instead
+ * while `selectedId` is a phantom draft (money 15-settings-phantom-editors.md
+ * phase 2).
  */
-export function GroupEditor({ selectedId, currency }: GroupEditorProps) {
+export function GroupEditor({
+  selectedId,
+  currency,
+  draft,
+  onDraftNameChange,
+  onDraftCommitted,
+}: GroupEditorProps) {
   const { groupMap } = useCatalogGroups()
+
+  // The draft form also stays active while `selectedId` is the draft's
+  // committed recordId — swapping to the store-bound form would remount the
+  // inputs mid-typing (replaced text + cancelled debounce timer).
+  const draftActive =
+    !!draft && (selectedId === draft.draftId || (!!draft.recordId && selectedId === draft.recordId))
+
+  if (draft && draftActive) {
+    return (
+      <GroupDraftEditorForm
+        key={draft.draftId}
+        currency={currency}
+        onDraftNameChange={onDraftNameChange}
+        onDraftCommitted={onDraftCommitted}
+      />
+    )
+  }
+
   const group = selectedId ? groupMap.get(selectedId) : undefined
 
   if (!group) {
@@ -85,7 +128,6 @@ function GroupEditorForm({ group, currency }: { group: CatalogGroup; currency: s
 
   const [name, setName] = useState(group.name)
   const [description, setDescription] = useState(group.description ?? '')
-  const [discountDraft, setDiscountDraft] = useState<string | null>(null)
 
   const commitName = useDebouncedCallback((value: string) => {
     saveFieldValue(group.recordId, 'catalog_group_name', value, FieldType.TEXT)
@@ -105,40 +147,11 @@ function GroupEditorForm({ group, currency }: { group: CatalogGroup; currency: s
     )
   }
 
-  // Amount discounts are stored as integer cents (CURRENCY convention); percent
-  // discounts as plain percentages — the input always shows/accepts the display
-  // unit. Mirrors the totals-footer.tsx conversion idiom.
-  const discountDisplayValue =
-    group.discountValue === null
-      ? ''
-      : String(group.discountType === 'amount' ? group.discountValue / 100 : group.discountValue)
-
   const writeDiscount = (type: 'percent' | 'amount' | null, value: number | null) => {
     void saveMultipleAsync(group.recordId, [
       { fieldId: 'catalog_group_discount_type', value: type, fieldType: FieldType.SINGLE_SELECT },
       { fieldId: 'catalog_group_discount_value', value, fieldType: FieldType.NUMBER },
     ])
-  }
-
-  const commitDiscountValue = () => {
-    if (discountDraft === null) return
-    const trimmed = discountDraft.trim()
-    setDiscountDraft(null)
-    const parsed = trimmed === '' ? null : Number(trimmed)
-    if (parsed !== null && Number.isNaN(parsed)) return
-    const type = parsed === null ? null : (group.discountType ?? 'percent')
-    writeDiscount(type, parsed !== null && type === 'amount' ? Math.round(parsed * 100) : parsed)
-  }
-
-  // Type toggle keeps the number the user SEES stable: 10% becomes $10 (1000¢).
-  const toggleDiscountType = (type: 'percent' | 'amount') => {
-    if (group.discountValue === null) {
-      writeDiscount(type, null)
-      return
-    }
-    const displayed =
-      group.discountType === 'amount' ? group.discountValue / 100 : group.discountValue
-    writeDiscount(type, type === 'amount' ? Math.round(displayed * 100) : displayed)
   }
 
   return (
@@ -193,36 +206,11 @@ function GroupEditorForm({ group, currency }: { group: CatalogGroup; currency: s
         </FieldPanelRow>
 
         <FieldPanelRow title='Discount' type={BaseType.NUMBER} showIcon>
-          <div className='flex items-center gap-1.5'>
-            <div className='flex overflow-hidden rounded-md border border-primary-200/60 dark:border-[#2c313a]'>
-              {(['percent', 'amount'] as const).map((type) => (
-                <button
-                  key={type}
-                  type='button'
-                  onClick={() => toggleDiscountType(type)}
-                  className={cn(
-                    'px-2 py-1 text-xs leading-none',
-                    (group.discountType ?? 'percent') === type
-                      ? 'bg-primary-150 text-foreground dark:bg-primary-100'
-                      : 'text-muted-foreground hover:bg-primary-100/60'
-                  )}>
-                  {type === 'percent' ? '%' : '$'}
-                </button>
-              ))}
-            </div>
-            <input
-              value={discountDraft ?? discountDisplayValue}
-              onChange={(e) => setDiscountDraft(e.target.value)}
-              onBlur={commitDiscountValue}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') e.currentTarget.blur()
-                if (e.key === 'Escape') setDiscountDraft(null)
-              }}
-              inputMode='decimal'
-              placeholder='0'
-              className='w-20 rounded-md border border-primary-200/60 bg-transparent px-2 py-1 text-sm tabular-nums outline-none hover:bg-primary-100/60 focus:bg-primary-100/80 dark:border-[#2c313a]'
-            />
-          </div>
+          <DiscountEditor
+            discountType={group.discountType}
+            discountValue={group.discountValue}
+            onChange={writeDiscount}
+          />
         </FieldPanelRow>
 
         <FieldPanelRow title='Active' type={BaseType.BOOLEAN} showIcon>
@@ -243,6 +231,374 @@ function GroupEditorForm({ group, currency }: { group: CatalogGroup; currency: s
         items={items}
         currency={currency}
         onChange={commitEntries}
+      />
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Draft (phantom) editor — same layout, local state instead of the store.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Local, not-yet-persisted field set for a fresh catalog group. Mirrors
+ *  `CatalogGroup` minus `id`/`recordId` — those only exist once created. */
+interface GroupDraftValues {
+  name: string
+  description: string | null
+  entries: CatalogGroupEntry[]
+  taxRateId: string | null
+  discountType: 'percent' | 'amount' | null
+  discountValue: number | null
+  active: boolean
+}
+
+function freshGroupDraftValues(): GroupDraftValues {
+  // `active` mirrors the `catalog_group` registry default
+  // (packages/lib/src/resources/registry/resources/catalog-group-fields.ts).
+  return {
+    name: '',
+    description: null,
+    entries: [],
+    taxRateId: null,
+    discountType: null,
+    discountValue: null,
+    active: true,
+  }
+}
+
+/** Draft key → wire descriptor. Drives the create seed, the post-create
+ *  diff-flush, and live commit routing once the record exists. */
+const GROUP_DRAFT_FIELDS: {
+  [K in keyof GroupDraftValues]: { fieldId: string; fieldType: FieldType }
+} = {
+  name: { fieldId: 'catalog_group_name', fieldType: FieldType.TEXT },
+  description: { fieldId: 'catalog_group_description', fieldType: FieldType.TEXT },
+  entries: { fieldId: 'catalog_group_entries', fieldType: FieldType.JSON },
+  taxRateId: { fieldId: 'catalog_group_tax_rate_id', fieldType: FieldType.TEXT },
+  discountType: { fieldId: 'catalog_group_discount_type', fieldType: FieldType.SINGLE_SELECT },
+  discountValue: { fieldId: 'catalog_group_discount_value', fieldType: FieldType.NUMBER },
+  active: { fieldId: 'catalog_group_active', fieldType: FieldType.CHECKBOX },
+}
+const GROUP_DRAFT_KEYS = Object.keys(GROUP_DRAFT_FIELDS) as (keyof GroupDraftValues)[]
+
+/** Entries go over the wire in the `{ entries: [...] }` envelope (the generic
+ *  save path splits bare top-level arrays into one row per element). */
+function groupWireValue(key: keyof GroupDraftValues, values: GroupDraftValues): unknown {
+  return key === 'entries' ? serializeCatalogGroupEntries(values.entries) : values[key]
+}
+
+/**
+ * Draft-mode `GroupEditorForm`: identical field layout (+ entries section),
+ * bound to local state instead of the field-value store. `name` is required
+ * server-side (`catalog_group_name`) and empty/whitespace is treated as
+ * absent by `assertRequiredFieldsPresent` — so, like `ProductDraftEditorForm`,
+ * creation is GATED on `name` being non-empty rather than firing on the very
+ * first commit of any field (entries/discount/tax-rate edits made before a
+ * name exists just merge into local state, zero network — this is what keeps
+ * the "no placeholder name ever persists" decision true).
+ */
+function GroupDraftEditorForm({
+  currency,
+  onDraftNameChange,
+  onDraftCommitted,
+}: {
+  currency: string
+  onDraftNameChange: (name: string) => void
+  onDraftCommitted: (recordId: string) => void
+}) {
+  const { itemMap, items } = useCatalogItems()
+  const { entityDefinitionId, appendRecord } = useCatalogGroups()
+  const { getSetting } = useSettings({ scope: 'DOCUMENTS' })
+  const taxRates = (getSetting('documents.taxRates') as TaxRate[] | null) ?? []
+  const taxOptions = useMemo(
+    () => taxRates.map((rate) => ({ label: `${rate.name} (${rate.rate}%)`, value: rate.id })),
+    [taxRates]
+  )
+
+  const { saveMultipleAsync } = useSaveFieldValue({})
+  const { seedCatalogRecord } = useSeedCatalogRecord()
+  const createRecord = api.record.create.useMutation()
+
+  const valuesRef = useRef<GroupDraftValues>(freshGroupDraftValues())
+  const [values, setValues] = useState<GroupDraftValues>(valuesRef.current)
+  // Synchronous guard (not state-derived) so two commits landing before a
+  // re-render can never race two `record.create` calls for the same draft.
+  const creatingRef = useRef(false)
+  // Set once the create resolves. This form stays mounted afterwards (the
+  // page keeps the draft alive, see onDraftCommitted) and every later commit
+  // routes straight through saveMultipleAsync against this id — so text typed
+  // during and after the create round trip is never replaced by a remount.
+  const recordIdRef = useRef<RecordId | null>(null)
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+
+  const createNow = useCallback(
+    async (snapshot: GroupDraftValues) => {
+      if (!entityDefinitionId) return
+      const createValues: Record<string, unknown> = {
+        catalog_group_name: snapshot.name,
+        catalog_group_active: snapshot.active,
+        catalog_group_entries: serializeCatalogGroupEntries(snapshot.entries),
+      }
+      if (snapshot.description) createValues.catalog_group_description = snapshot.description
+      if (snapshot.taxRateId) createValues.catalog_group_tax_rate_id = snapshot.taxRateId
+      if (snapshot.discountType) {
+        createValues.catalog_group_discount_type = snapshot.discountType
+        createValues.catalog_group_discount_value = snapshot.discountValue
+      }
+
+      try {
+        const result = await createRecord.mutateAsync({ entityDefinitionId, values: createValues })
+
+        // Flip the commit target FIRST — a keystroke landing while we seed
+        // below must route to the real record, not the buffered-create path.
+        recordIdRef.current = result.recordId
+
+        seedCatalogRecord({
+          entityDefinitionId,
+          recordId: result.recordId,
+          instance: result.instance,
+          values: GROUP_DRAFT_KEYS.map((key) => ({
+            fieldId: GROUP_DRAFT_FIELDS[key].fieldId,
+            value: groupWireValue(key, snapshot),
+            fieldType: GROUP_DRAFT_FIELDS[key].fieldType,
+          })),
+        })
+
+        appendRecord({
+          ...result.instance,
+          recordId: result.recordId,
+          fieldValues: {
+            catalog_group_name: snapshot.name,
+            catalog_group_description: snapshot.description,
+            catalog_group_entries: serializeCatalogGroupEntries(snapshot.entries),
+            catalog_group_tax_rate_id: snapshot.taxRateId,
+            catalog_group_discount_type: snapshot.discountType,
+            catalog_group_discount_value: snapshot.discountValue,
+            catalog_group_active: snapshot.active,
+            ...result.values,
+          },
+        })
+
+        // Diff whatever landed locally while the create was in flight, and
+        // flush just the changed fields against the now-real record. (A commit
+        // arriving after the recordIdRef flip above may already have saved
+        // itself directly — re-flushing the same value here is harmless, the
+        // store's per-key mutationVersion guard settles it.)
+        const latest = valuesRef.current
+        const changed = GROUP_DRAFT_KEYS.filter((key) => latest[key] !== snapshot[key]).map(
+          (key) => ({
+            fieldId: GROUP_DRAFT_FIELDS[key].fieldId,
+            value: groupWireValue(key, latest),
+            fieldType: GROUP_DRAFT_FIELDS[key].fieldType,
+          })
+        )
+        if (changed.length > 0) await saveMultipleAsync(result.recordId, changed)
+
+        onDraftCommitted(result.instance.id)
+      } catch (error) {
+        creatingRef.current = false
+        toastError({
+          title: 'Error creating group',
+          description: error instanceof Error ? error.message : 'Could not create the group',
+        })
+      }
+    },
+    [
+      entityDefinitionId,
+      createRecord,
+      seedCatalogRecord,
+      appendRecord,
+      saveMultipleAsync,
+      onDraftCommitted,
+    ]
+  )
+
+  const commitDraft = useCallback(
+    (patch: Partial<GroupDraftValues>) => {
+      const merged = { ...valuesRef.current, ...patch }
+      valuesRef.current = merged
+      setValues(merged)
+
+      // Already created (form stayed mounted through the swap): plain
+      // optimistic field saves, exactly like the store-bound form.
+      const recordId = recordIdRef.current
+      if (recordId) {
+        const changes = (Object.keys(patch) as (keyof GroupDraftValues)[]).map((key) => ({
+          fieldId: GROUP_DRAFT_FIELDS[key].fieldId,
+          value: groupWireValue(key, merged),
+          fieldType: GROUP_DRAFT_FIELDS[key].fieldType,
+        }))
+        if (changes.length > 0) void saveMultipleAsync(recordId, changes)
+        return
+      }
+
+      if (patch.name !== undefined) onDraftNameChange(patch.name)
+      if (creatingRef.current) return // create in-flight — merged above, diff-flush picks it up
+      if (!merged.name.trim() || !entityDefinitionId) return // buffering: name required to create
+
+      creatingRef.current = true
+      void createNow(merged)
+    },
+    [createNow, entityDefinitionId, onDraftNameChange, saveMultipleAsync]
+  )
+
+  const commitName = useDebouncedCallback((value: string) => {
+    commitDraft({ name: value })
+  }, 500)
+  const commitDescription = useDebouncedCallback((value: string) => {
+    commitDraft({ description: value || null })
+  }, 500)
+
+  return (
+    <div className='flex flex-col gap-3 p-3'>
+      <FieldPanel
+        orientation='horizontal'
+        breakpoint='md'
+        resizeId='catalog-group-form'
+        defaultLabelWidth={140}
+        className='p-0'>
+        <FieldPanelRow title='Name' type={BaseType.STRING} showIcon isRequired>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={name}
+            open
+            onOpenChange={noop}
+            onChange={(value) => {
+              setName(value as string)
+              commitName(value as string)
+            }}
+            placeholder='Group name'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Description' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            fieldOptions={{ multiline: true }}
+            value={description}
+            onChange={(value) => {
+              setDescription(value as string)
+              commitDescription(value as string)
+            }}
+            placeholder='Admin-facing note'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Tax rate' type={BaseType.ENUM} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.SINGLE_SELECT}
+            fieldOptions={{ options: taxOptions }}
+            value={values.taxRateId ? [values.taxRateId] : []}
+            triggerProps={{ showClear: true, className: 'w-full' }}
+            onChange={(value) => commitDraft({ taxRateId: (value as string[])[0] ?? null })}
+            placeholder='No tax'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Discount' type={BaseType.NUMBER} showIcon>
+          <DiscountEditor
+            discountType={values.discountType}
+            discountValue={values.discountValue}
+            onChange={(type, value) => commitDraft({ discountType: type, discountValue: value })}
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Active' type={BaseType.BOOLEAN} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.CHECKBOX}
+            fieldOptions={{ variant: 'switch' }}
+            value={values.active}
+            onChange={(value) => commitDraft({ active: value as boolean })}
+          />
+        </FieldPanelRow>
+      </FieldPanel>
+
+      <EntriesSection
+        entries={values.entries}
+        itemMap={itemMap}
+        items={items}
+        currency={currency}
+        onChange={(next) => commitDraft({ entries: next })}
+      />
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Discount widget — type toggle (%/$) + amount input, shared by the real and
+// draft forms (only the commit target differs).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function DiscountEditor({
+  discountType,
+  discountValue,
+  onChange,
+}: {
+  discountType: 'percent' | 'amount' | null
+  discountValue: number | null
+  onChange: (type: 'percent' | 'amount' | null, value: number | null) => void
+}) {
+  const [discountDraft, setDiscountDraft] = useState<string | null>(null)
+
+  // Amount discounts are stored as integer cents (CURRENCY convention); percent
+  // discounts as plain percentages — the input always shows/accepts the display
+  // unit. Mirrors the totals-footer.tsx conversion idiom.
+  const discountDisplayValue =
+    discountValue === null
+      ? ''
+      : String(discountType === 'amount' ? discountValue / 100 : discountValue)
+
+  const commitDiscountValue = () => {
+    if (discountDraft === null) return
+    const trimmed = discountDraft.trim()
+    setDiscountDraft(null)
+    const parsed = trimmed === '' ? null : Number(trimmed)
+    if (parsed !== null && Number.isNaN(parsed)) return
+    const type = parsed === null ? null : (discountType ?? 'percent')
+    onChange(type, parsed !== null && type === 'amount' ? Math.round(parsed * 100) : parsed)
+  }
+
+  // Type toggle keeps the number the user SEES stable: 10% becomes $10 (1000¢).
+  const toggleDiscountType = (type: 'percent' | 'amount') => {
+    if (discountValue === null) {
+      onChange(type, null)
+      return
+    }
+    const displayed = discountType === 'amount' ? discountValue / 100 : discountValue
+    onChange(type, type === 'amount' ? Math.round(displayed * 100) : displayed)
+  }
+
+  return (
+    <div className='flex items-center gap-1.5'>
+      <div className='flex overflow-hidden rounded-md border border-primary-200/60 dark:border-[#2c313a]'>
+        {(['percent', 'amount'] as const).map((type) => (
+          <button
+            key={type}
+            type='button'
+            onClick={() => toggleDiscountType(type)}
+            className={cn(
+              'px-2 py-1 text-xs leading-none',
+              (discountType ?? 'percent') === type
+                ? 'bg-primary-150 text-foreground dark:bg-primary-100'
+                : 'text-muted-foreground hover:bg-primary-100/60'
+            )}>
+            {type === 'percent' ? '%' : '$'}
+          </button>
+        ))}
+      </div>
+      <input
+        value={discountDraft ?? discountDisplayValue}
+        onChange={(e) => setDiscountDraft(e.target.value)}
+        onBlur={commitDiscountValue}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') e.currentTarget.blur()
+          if (e.key === 'Escape') setDiscountDraft(null)
+        }}
+        inputMode='decimal'
+        placeholder='0'
+        className='w-20 rounded-md border border-primary-200/60 bg-transparent px-2 py-1 text-sm tabular-nums outline-none hover:bg-primary-100/60 focus:bg-primary-100/80 dark:border-[#2c313a]'
       />
     </div>
   )

--- a/apps/web/src/components/money/ui/settings/groups-list.tsx
+++ b/apps/web/src/components/money/ui/settings/groups-list.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/money/ui/settings/groups-list.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { InputSearch } from '@auxx/ui/components/input-search'
@@ -10,40 +11,43 @@ import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { Boxes, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
+import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
 import { type CatalogGroup, useCatalogGroups } from '../../hooks/use-catalog-groups'
 import { useCatalogItems } from '../../hooks/use-catalog-items'
+import type { CatalogDraftHandle } from './catalog-draft-types'
 import { formatMoney } from './format-money'
 import type { TaxRate } from './tax-rate-types'
 
 interface GroupsListProps {
   selectedId: string | null
-  onSelect: (id: string) => void
+  onSelect: (id: string | null) => void
   currency: string
+  /** Phantom draft, owned by `products-services-page.tsx`. */
+  draft: CatalogDraftHandle | null
+  /** "Add group" — creates a fresh draft, or re-selects the existing one. */
+  onAddDraft: () => void
 }
 
 /**
  * Left column of the Product groups tab: search + "Add group" above a flat
  * `TreeRow` list (products-list.tsx master–detail recipe). Rows show a Boxes
  * icon · name · "N items · computed total" + discount/tax badges when set ·
- * a trailing active `Switch`.
+ * a trailing active `Switch`. A phantom draft (if any) renders as a final,
+ * action-less row.
  */
-export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) {
-  const { groups, entityDefinitionId, isLoading, refresh, appendRecord } = useCatalogGroups()
+export function GroupsList({ selectedId, onSelect, currency, draft, onAddDraft }: GroupsListProps) {
+  const { groups, entityDefinitionId, isLoading, removeRecord } = useCatalogGroups()
   const { itemMap } = useCatalogItems()
   const { getSetting } = useSettings({ scope: 'DOCUMENTS' })
   const taxRates = (getSetting('documents.taxRates') as TaxRate[] | null) ?? []
   const [search, setSearch] = useState('')
   const [confirm, ConfirmDialog] = useConfirm()
 
-  const updateRecord = api.record.update.useMutation()
-  const createRecord = api.record.create.useMutation({
-    onError: (error) => toastError({ title: 'Error creating group', description: error.message }),
-  })
+  const { saveFieldValue } = useSaveFieldValue({})
   const deleteRecord = api.record.delete.useMutation({
-    onSuccess: () => refresh(),
     onError: (error) => toastError({ title: 'Error deleting group', description: error.message }),
   })
 
@@ -54,14 +58,17 @@ export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) 
       confirmText: 'Delete',
       destructive: true,
     })
-    if (confirmed) deleteRecord.mutate({ recordId: group.recordId })
+    if (!confirmed) return
+    deleteRecord.mutate(
+      { recordId: group.recordId },
+      {
+        onSuccess: () => {
+          removeRecord(group.id)
+          if (selectedId === group.id) onSelect(null)
+        },
+      }
+    )
   }
-
-  // Optimistic overlay for the active toggle — `record.update` bypasses the
-  // granular field-value store, so reflect the flip locally and invalidate
-  // `listAll` in the background rather than waiting on a full refetch.
-  const [activeOverride, setActiveOverride] = useState<Record<string, boolean>>({})
-  const effectiveActive = (group: CatalogGroup) => activeOverride[group.id] ?? group.active
 
   function computeTotal(group: CatalogGroup): number | null {
     let total = 0
@@ -100,32 +107,7 @@ export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) 
   }
 
   function handleToggleActive(group: CatalogGroup) {
-    const next = !effectiveActive(group)
-    setActiveOverride((prev) => ({ ...prev, [group.id]: next }))
-    updateRecord.mutate(
-      { recordId: group.recordId, values: { catalog_group_active: next } },
-      {
-        onSuccess: () => refresh(),
-        onError: (error) => {
-          setActiveOverride((prev) => ({ ...prev, [group.id]: !next }))
-          toastError({ title: 'Error updating group', description: error.message })
-        },
-      }
-    )
-  }
-
-  async function handleAdd() {
-    if (!entityDefinitionId) return
-    const result = await createRecord.mutateAsync({
-      entityDefinitionId,
-      values: { catalog_group_name: 'New group' },
-    })
-    appendRecord({
-      ...result.instance,
-      recordId: result.recordId,
-      fieldValues: { catalog_group_name: 'New group', ...result.values },
-    })
-    onSelect(result.instance.id)
+    saveFieldValue(group.recordId, 'catalog_group_active', !group.active, FieldType.CHECKBOX)
   }
 
   const filtered = search
@@ -140,13 +122,7 @@ export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) 
           onChange={(e) => setSearch(e.target.value)}
           placeholder='Search product groups...'
         />
-        <Button
-          variant='outline'
-          size='sm'
-          onClick={handleAdd}
-          loading={createRecord.isPending}
-          loadingText='Adding...'
-          disabled={!entityDefinitionId}>
+        <Button variant='outline' size='sm' onClick={onAddDraft} disabled={!entityDefinitionId}>
           <Plus />
           Add group
         </Button>
@@ -154,7 +130,7 @@ export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) 
 
       {isLoading ? (
         <div className='p-4 text-center text-sm text-muted-foreground'>Loading…</div>
-      ) : filtered.length === 0 ? (
+      ) : filtered.length === 0 && !draft ? (
         <div className='p-4 text-center text-sm text-muted-foreground'>
           {search ? 'No matches' : 'No product groups yet — add your first one.'}
         </div>
@@ -171,7 +147,7 @@ export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) 
                 rowClassName={cn(
                   'bg-primary-100/50 hover:bg-primary-100',
                   selectedId === group.id && 'bg-primary-100 ring-1 ring-primary-200',
-                  !effectiveActive(group) && 'opacity-60'
+                  !group.active && 'opacity-60'
                 )}
                 secondary={
                   <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
@@ -191,15 +167,30 @@ export function GroupsList({ selectedId, onSelect, currency }: GroupsListProps) 
                     </TreeRowButton>
                     <Switch
                       size='xs'
-                      checked={effectiveActive(group)}
+                      checked={group.active}
                       onCheckedChange={() => handleToggleActive(group)}
-                      disabled={updateRecord.isPending}
                     />
                   </div>
                 }
               />
             )
           })}
+          {draft && !draft.recordId && (
+            <TreeRow
+              key={draft.draftId}
+              icon={<Boxes className='size-4 text-muted-foreground' />}
+              title={
+                <span className={cn('text-sm', !draft.name && 'text-muted-foreground italic')}>
+                  {draft.name || 'Untitled group'}
+                </span>
+              }
+              onToggleOpen={() => onSelect(draft.draftId)}
+              rowClassName={cn(
+                'bg-primary-100/50 hover:bg-primary-100',
+                selectedId === draft.draftId && 'bg-primary-100 ring-1 ring-primary-200'
+              )}
+            />
+          )}
         </div>
       )}
       <ConfirmDialog />

--- a/apps/web/src/components/money/ui/settings/product-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/product-editor.tsx
@@ -2,26 +2,69 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
-import { useState } from 'react'
+import type { RecordId } from '@auxx/lib/resources/client'
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useRef, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useResourceFields } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { BaseType } from '~/components/workflow/types'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
+import { api } from '~/trpc/react'
 import { type CatalogItem, useCatalogItems } from '../../hooks/use-catalog-items'
+import { useSeedCatalogRecord } from '../../hooks/use-seed-catalog-record'
+import type { CatalogDraftHandle } from './catalog-draft-types'
 
 interface ProductEditorProps {
   selectedId: string | null
+  /** Phantom draft for the Products tab, owned by `products-services-page.tsx`. */
+  draft: CatalogDraftHandle | null
+  /** List phantom-row preview sync — fired per debounced name commit. */
+  onDraftNameChange: (name: string) => void
+  /** First create resolved — swap `selectedId` to the real record id. The page
+   *  KEEPS the draft (stamped with `recordId`) so this form stays mounted;
+   *  see `CatalogDraftHandle.recordId` for why a remount here loses text. */
+  onDraftCommitted: (recordId: string) => void
 }
+
+/** `FocusableInputWrapper` (field-input-adapter.tsx) autofocuses once `open` is
+ *  truthy — a stable no-op keeps the effect from refiring every render. */
+function noop() {}
 
 /**
  * Right column of the Products & Services tab: a `FieldPanel` form for the
  * selected catalog item. Autosaves per field via `useSaveFieldValue` (same
  * optimistic path as record detail views) — no submit button, no dialog.
+ * Renders `ProductDraftEditorForm` instead while `selectedId` is a phantom
+ * draft (money 15-settings-phantom-editors.md phase 2).
  */
-export function ProductEditor({ selectedId }: ProductEditorProps) {
-  const { itemMap } = useCatalogItems()
+export function ProductEditor({
+  selectedId,
+  draft,
+  onDraftNameChange,
+  onDraftCommitted,
+}: ProductEditorProps) {
+  const { itemMap, entityDefinitionId, appendRecord } = useCatalogItems()
+
+  // The draft form also stays active while `selectedId` is the draft's
+  // committed recordId — swapping to the store-bound form would remount the
+  // inputs mid-typing (replaced text + cancelled debounce timer).
+  const draftActive =
+    !!draft && (selectedId === draft.draftId || (!!draft.recordId && selectedId === draft.recordId))
+
+  if (draft && draftActive) {
+    return (
+      <ProductDraftEditorForm
+        key={draft.draftId}
+        entityDefinitionId={entityDefinitionId}
+        appendRecord={appendRecord}
+        onDraftNameChange={onDraftNameChange}
+        onDraftCommitted={onDraftCommitted}
+      />
+    )
+  }
+
   const item = selectedId ? itemMap.get(selectedId) : undefined
 
   if (!item) {
@@ -135,6 +178,306 @@ function ProductEditorForm({ item }: { item: CatalogItem }) {
               onChange={(value) =>
                 saveFieldValue(item.recordId, 'catalog_item_part', value, FieldType.RELATIONSHIP)
               }
+              placeholder='Link a part'
+            />
+          </FieldPanelRow>
+        )}
+      </FieldPanel>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Draft (phantom) editor — same layout, local state instead of the store.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Local, not-yet-persisted field set for a fresh catalog item. Mirrors
+ *  `CatalogItem` minus `id`/`recordId` — those only exist once created. */
+interface ProductDraftValues {
+  name: string
+  description: string | null
+  category: string
+  defaultUnitPriceCents: number | null
+  taxable: boolean
+  active: boolean
+  partRecordId: RecordId | null
+}
+
+function freshProductDraftValues(): ProductDraftValues {
+  // Category/taxable/active mirror the `catalog_item` registry defaults
+  // (packages/lib/src/resources/registry/resources/catalog-item-fields.ts)
+  // so the phantom form renders identically to a freshly created row.
+  return {
+    name: '',
+    description: null,
+    category: 'service',
+    defaultUnitPriceCents: null,
+    taxable: true,
+    active: true,
+    partRecordId: null,
+  }
+}
+
+/** Draft key → wire descriptor. Drives the create seed, the post-create
+ *  diff-flush, and live commit routing once the record exists. */
+const PRODUCT_DRAFT_FIELDS: {
+  [K in keyof ProductDraftValues]: { fieldId: string; fieldType: FieldType }
+} = {
+  name: { fieldId: 'catalog_item_name', fieldType: FieldType.TEXT },
+  description: { fieldId: 'catalog_item_description', fieldType: FieldType.TEXT },
+  category: { fieldId: 'catalog_item_category', fieldType: FieldType.SINGLE_SELECT },
+  defaultUnitPriceCents: {
+    fieldId: 'catalog_item_default_unit_price',
+    fieldType: FieldType.CURRENCY,
+  },
+  taxable: { fieldId: 'catalog_item_taxable', fieldType: FieldType.CHECKBOX },
+  active: { fieldId: 'catalog_item_active', fieldType: FieldType.CHECKBOX },
+  partRecordId: { fieldId: 'catalog_item_part', fieldType: FieldType.RELATIONSHIP },
+}
+const PRODUCT_DRAFT_KEYS = Object.keys(PRODUCT_DRAFT_FIELDS) as (keyof ProductDraftValues)[]
+
+/**
+ * Draft-mode `ProductEditorForm`: identical field layout, bound to local
+ * state instead of the field-value store. `name` is required server-side
+ * (`catalog_item_name`, `capabilities.required: true`) and an empty/whitespace
+ * value is treated as absent by `assertRequiredFieldsPresent` — so unlike the
+ * line-builder's `line_item_name` (not required), creation here is GATED on
+ * `name` being non-empty rather than firing on the very first commit of any
+ * field. Edits to other fields while name is still empty just merge into
+ * local state (zero network) — this is what keeps the "no placeholder name
+ * ever persists" decision true even though the server can't accept a blank
+ * name. Once name has a value, whichever commit lands (the name commit
+ * itself, or a later one) fires the ONE `record.create` with everything
+ * accumulated so far.
+ */
+function ProductDraftEditorForm({
+  entityDefinitionId,
+  appendRecord,
+  onDraftNameChange,
+  onDraftCommitted,
+}: {
+  entityDefinitionId: string | null
+  appendRecord: ReturnType<typeof useCatalogItems>['appendRecord']
+  onDraftNameChange: (name: string) => void
+  onDraftCommitted: (recordId: string) => void
+}) {
+  const { fields } = useResourceFields('catalog-items')
+  const categoryField = fields.find((f) => f.key === 'category')
+  const partField = fields.find((f) => f.key === 'part')
+
+  const { saveMultipleAsync } = useSaveFieldValue({})
+  const { seedCatalogRecord } = useSeedCatalogRecord()
+  const createRecord = api.record.create.useMutation()
+
+  const valuesRef = useRef<ProductDraftValues>(freshProductDraftValues())
+  const [values, setValues] = useState<ProductDraftValues>(valuesRef.current)
+  // Synchronous guard (not state-derived) so two commits landing before a
+  // re-render can never race two `record.create` calls for the same draft.
+  const creatingRef = useRef(false)
+  // Set once the create resolves. This form stays mounted afterwards (the
+  // page keeps the draft alive, see onDraftCommitted) and every later commit
+  // routes straight through saveMultipleAsync against this id — so text typed
+  // during and after the create round trip is never replaced by a remount.
+  const recordIdRef = useRef<RecordId | null>(null)
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+
+  const createNow = useCallback(
+    async (snapshot: ProductDraftValues) => {
+      if (!entityDefinitionId) return
+      const createValues: Record<string, unknown> = {
+        catalog_item_name: snapshot.name,
+        catalog_item_category: snapshot.category,
+        catalog_item_taxable: snapshot.taxable,
+        catalog_item_active: snapshot.active,
+      }
+      if (snapshot.description) createValues.catalog_item_description = snapshot.description
+      if (snapshot.defaultUnitPriceCents !== null) {
+        createValues.catalog_item_default_unit_price = snapshot.defaultUnitPriceCents
+      }
+      if (snapshot.partRecordId) createValues.catalog_item_part = snapshot.partRecordId
+
+      try {
+        const result = await createRecord.mutateAsync({ entityDefinitionId, values: createValues })
+
+        // Flip the commit target FIRST — a keystroke landing while we seed
+        // below must route to the real record, not the buffered-create path.
+        recordIdRef.current = result.recordId
+
+        seedCatalogRecord({
+          entityDefinitionId,
+          recordId: result.recordId,
+          instance: result.instance,
+          values: PRODUCT_DRAFT_KEYS.map((key) => ({
+            fieldId: PRODUCT_DRAFT_FIELDS[key].fieldId,
+            value: snapshot[key],
+            fieldType: PRODUCT_DRAFT_FIELDS[key].fieldType,
+          })),
+        })
+
+        appendRecord({
+          ...result.instance,
+          recordId: result.recordId,
+          fieldValues: {
+            catalog_item_name: snapshot.name,
+            catalog_item_description: snapshot.description,
+            catalog_item_category: snapshot.category,
+            catalog_item_default_unit_price: snapshot.defaultUnitPriceCents,
+            catalog_item_taxable: snapshot.taxable,
+            catalog_item_active: snapshot.active,
+            catalog_item_part: snapshot.partRecordId,
+            ...result.values,
+          },
+        })
+
+        // Diff whatever landed locally while the create was in flight, and
+        // flush just the changed fields against the now-real record. (A commit
+        // arriving after the recordIdRef flip above may already have saved
+        // itself directly — re-flushing the same value here is harmless, the
+        // store's per-key mutationVersion guard settles it.)
+        const latest = valuesRef.current
+        const changed = PRODUCT_DRAFT_KEYS.filter((key) => latest[key] !== snapshot[key]).map(
+          (key) => ({
+            fieldId: PRODUCT_DRAFT_FIELDS[key].fieldId,
+            value: latest[key],
+            fieldType: PRODUCT_DRAFT_FIELDS[key].fieldType,
+          })
+        )
+        if (changed.length > 0) await saveMultipleAsync(result.recordId, changed)
+
+        onDraftCommitted(result.instance.id)
+      } catch (error) {
+        creatingRef.current = false
+        toastError({
+          title: 'Error creating item',
+          description: error instanceof Error ? error.message : 'Could not create the item',
+        })
+      }
+    },
+    [
+      entityDefinitionId,
+      createRecord,
+      seedCatalogRecord,
+      appendRecord,
+      saveMultipleAsync,
+      onDraftCommitted,
+    ]
+  )
+
+  const commitDraft = useCallback(
+    (patch: Partial<ProductDraftValues>) => {
+      const merged = { ...valuesRef.current, ...patch }
+      valuesRef.current = merged
+      setValues(merged)
+
+      // Already created (form stayed mounted through the swap): plain
+      // optimistic field saves, exactly like the store-bound form.
+      const recordId = recordIdRef.current
+      if (recordId) {
+        const changes = (Object.keys(patch) as (keyof ProductDraftValues)[]).map((key) => ({
+          fieldId: PRODUCT_DRAFT_FIELDS[key].fieldId,
+          value: merged[key],
+          fieldType: PRODUCT_DRAFT_FIELDS[key].fieldType,
+        }))
+        if (changes.length > 0) void saveMultipleAsync(recordId, changes)
+        return
+      }
+
+      if (patch.name !== undefined) onDraftNameChange(patch.name)
+      if (creatingRef.current) return // create in-flight — merged above, diff-flush picks it up
+      if (!merged.name.trim() || !entityDefinitionId) return // buffering: name required to create
+
+      creatingRef.current = true
+      void createNow(merged)
+    },
+    [createNow, entityDefinitionId, onDraftNameChange, saveMultipleAsync]
+  )
+
+  const commitName = useDebouncedCallback((value: string) => {
+    commitDraft({ name: value })
+  }, 500)
+  const commitDescription = useDebouncedCallback((value: string) => {
+    commitDraft({ description: value || null })
+  }, 500)
+
+  return (
+    <div className='p-3'>
+      <FieldPanel
+        orientation='horizontal'
+        breakpoint='md'
+        resizeId='catalog-item-form'
+        defaultLabelWidth={160}
+        className='p-0'>
+        <FieldPanelRow title='Name' type={BaseType.STRING} showIcon isRequired>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={name}
+            open
+            onOpenChange={noop}
+            onChange={(value) => {
+              setName(value as string)
+              commitName(value as string)
+            }}
+            placeholder='Item name'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Description' type={BaseType.STRING} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            fieldOptions={{ multiline: true }}
+            value={description}
+            onChange={(value) => {
+              setDescription(value as string)
+              commitDescription(value as string)
+            }}
+            placeholder='Enter a description'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Category' type={BaseType.ENUM} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.SINGLE_SELECT}
+            fieldOptions={categoryField?.options}
+            value={values.category}
+            triggerProps={{ className: 'w-full ps-0 pe-1' }}
+            onChange={(value) => commitDraft({ category: value as string })}
+            placeholder='Select category'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Default Unit Price' type={BaseType.CURRENCY} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.CURRENCY}
+            value={values.defaultUnitPriceCents}
+            onChange={(value) => commitDraft({ defaultUnitPriceCents: value as number | null })}
+            placeholder='0.00'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Taxable' type={BaseType.BOOLEAN} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.CHECKBOX}
+            fieldOptions={{ variant: 'switch' }}
+            value={values.taxable}
+            onChange={(value) => commitDraft({ taxable: value as boolean })}
+          />
+        </FieldPanelRow>
+
+        {values.category === 'material' && partField && (
+          <FieldPanelRow title='Part' type={BaseType.RELATION} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.RELATIONSHIP}
+              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              fieldOptions={{
+                relationship: partField.relationship ?? partField.options?.relationship,
+              }}
+              value={values.partRecordId ? [values.partRecordId] : []}
+              onChange={(value) => {
+                const ids = value as RecordId[]
+                commitDraft({ partRecordId: ids[0] ?? null })
+              }}
               placeholder='Link a part'
             />
           </FieldPanelRow>

--- a/apps/web/src/components/money/ui/settings/products-list.tsx
+++ b/apps/web/src/components/money/ui/settings/products-list.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/money/ui/settings/products-list.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import { getOptionColor, type SelectOptionColor } from '@auxx/lib/custom-fields/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
@@ -12,15 +13,21 @@ import { cn } from '@auxx/ui/lib/utils'
 import { Package, Plus, Trash2, Wrench } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useResourceFields } from '~/components/resources'
+import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { type CatalogItem, useCatalogItems } from '../../hooks/use-catalog-items'
+import type { CatalogDraftHandle } from './catalog-draft-types'
 import { formatMoney } from './format-money'
 
 interface ProductsListProps {
   selectedId: string | null
-  onSelect: (id: string) => void
+  onSelect: (id: string | null) => void
   currency: string
+  /** Phantom draft, owned by `products-services-page.tsx`. */
+  draft: CatalogDraftHandle | null
+  /** "Add item" — creates a fresh draft, or re-selects the existing one. */
+  onAddDraft: () => void
 }
 
 /** Category → row icon. Falls back to the generic `service` icon for org-added options. */
@@ -36,9 +43,16 @@ function CategoryIcon({ category }: { category: string }) {
  * Left column of the Products & Services tab: search + "Add item" above a
  * flat `TreeRow` list (mcp-server-tools-tab master–detail recipe). Rows show
  * category icon · name · price + category badge · a trailing active `Switch`.
+ * A phantom draft (if any) renders as a final, action-less row.
  */
-export function ProductsList({ selectedId, onSelect, currency }: ProductsListProps) {
-  const { items, entityDefinitionId, isLoading, refresh, appendRecord } = useCatalogItems()
+export function ProductsList({
+  selectedId,
+  onSelect,
+  currency,
+  draft,
+  onAddDraft,
+}: ProductsListProps) {
+  const { items, entityDefinitionId, isLoading, removeRecord } = useCatalogItems()
   const { fields: catalogFields } = useResourceFields('catalog-items')
   const categoryOptions = useMemo(
     () => catalogFields.find((f) => f.key === 'category')?.options?.options ?? [],
@@ -47,12 +61,8 @@ export function ProductsList({ selectedId, onSelect, currency }: ProductsListPro
   const [search, setSearch] = useState('')
   const [confirm, ConfirmDialog] = useConfirm()
 
-  const updateRecord = api.record.update.useMutation()
-  const createRecord = api.record.create.useMutation({
-    onError: (error) => toastError({ title: 'Error creating item', description: error.message }),
-  })
+  const { saveFieldValue } = useSaveFieldValue({})
   const deleteRecord = api.record.delete.useMutation({
-    onSuccess: () => refresh(),
     onError: (error) => toastError({ title: 'Error deleting item', description: error.message }),
   })
 
@@ -63,14 +73,17 @@ export function ProductsList({ selectedId, onSelect, currency }: ProductsListPro
       confirmText: 'Delete',
       destructive: true,
     })
-    if (confirmed) deleteRecord.mutate({ recordId: item.recordId })
+    if (!confirmed) return
+    deleteRecord.mutate(
+      { recordId: item.recordId },
+      {
+        onSuccess: () => {
+          removeRecord(item.id)
+          if (selectedId === item.id) onSelect(null)
+        },
+      }
+    )
   }
-
-  // Optimistic overlay for the active toggle — `record.update` bypasses the
-  // granular field-value store, so reflect the flip locally and invalidate
-  // `listAll` in the background rather than waiting on a full refetch.
-  const [activeOverride, setActiveOverride] = useState<Record<string, boolean>>({})
-  const effectiveActive = (item: CatalogItem) => activeOverride[item.id] ?? item.active
 
   function categoryBadge(category: string) {
     const option = categoryOptions.find((o) => o.value === category)
@@ -83,32 +96,7 @@ export function ProductsList({ selectedId, onSelect, currency }: ProductsListPro
   }
 
   function handleToggleActive(item: CatalogItem) {
-    const next = !effectiveActive(item)
-    setActiveOverride((prev) => ({ ...prev, [item.id]: next }))
-    updateRecord.mutate(
-      { recordId: item.recordId, values: { catalog_item_active: next } },
-      {
-        onSuccess: () => refresh(),
-        onError: (error) => {
-          setActiveOverride((prev) => ({ ...prev, [item.id]: !next }))
-          toastError({ title: 'Error updating item', description: error.message })
-        },
-      }
-    )
-  }
-
-  async function handleAdd() {
-    if (!entityDefinitionId) return
-    const result = await createRecord.mutateAsync({
-      entityDefinitionId,
-      values: { catalog_item_name: 'New item' },
-    })
-    appendRecord({
-      ...result.instance,
-      recordId: result.recordId,
-      fieldValues: { catalog_item_name: 'New item', ...result.values },
-    })
-    onSelect(result.instance.id)
+    saveFieldValue(item.recordId, 'catalog_item_active', !item.active, FieldType.CHECKBOX)
   }
 
   const filtered = search
@@ -123,13 +111,7 @@ export function ProductsList({ selectedId, onSelect, currency }: ProductsListPro
           onChange={(e) => setSearch(e.target.value)}
           placeholder='Search products & services...'
         />
-        <Button
-          variant='outline'
-          size='sm'
-          onClick={handleAdd}
-          loading={createRecord.isPending}
-          loadingText='Adding...'
-          disabled={!entityDefinitionId}>
+        <Button variant='outline' size='sm' onClick={onAddDraft} disabled={!entityDefinitionId}>
           <Plus />
           Add item
         </Button>
@@ -137,7 +119,7 @@ export function ProductsList({ selectedId, onSelect, currency }: ProductsListPro
 
       {isLoading ? (
         <div className='p-4 text-center text-sm text-muted-foreground'>Loading…</div>
-      ) : filtered.length === 0 ? (
+      ) : filtered.length === 0 && !draft ? (
         <div className='p-4 text-center text-sm text-muted-foreground'>
           {search ? 'No matches' : 'No products or services yet — add your first item.'}
         </div>
@@ -152,7 +134,7 @@ export function ProductsList({ selectedId, onSelect, currency }: ProductsListPro
               rowClassName={cn(
                 'bg-primary-100/50 hover:bg-primary-100',
                 selectedId === item.id && 'bg-primary-100 ring-1 ring-primary-200',
-                !effectiveActive(item) && 'opacity-60'
+                !item.active && 'opacity-60'
               )}
               secondary={
                 <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
@@ -170,14 +152,29 @@ export function ProductsList({ selectedId, onSelect, currency }: ProductsListPro
                   </TreeRowButton>
                   <Switch
                     size='xs'
-                    checked={effectiveActive(item)}
+                    checked={item.active}
                     onCheckedChange={() => handleToggleActive(item)}
-                    disabled={updateRecord.isPending}
                   />
                 </div>
               }
             />
           ))}
+          {draft && !draft.recordId && (
+            <TreeRow
+              key={draft.draftId}
+              icon={<CategoryIcon category='service' />}
+              title={
+                <span className={cn('text-sm', !draft.name && 'text-muted-foreground italic')}>
+                  {draft.name || 'Untitled item'}
+                </span>
+              }
+              onToggleOpen={() => onSelect(draft.draftId)}
+              rowClassName={cn(
+                'bg-primary-100/50 hover:bg-primary-100',
+                selectedId === draft.draftId && 'bg-primary-100 ring-1 ring-primary-200'
+              )}
+            />
+          )}
         </div>
       )}
       <ConfirmDialog />

--- a/apps/web/src/components/money/ui/settings/products-services-page.tsx
+++ b/apps/web/src/components/money/ui/settings/products-services-page.tsx
@@ -14,6 +14,7 @@ import { useMedia } from '~/hooks/use-media'
 import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import type { CatalogDraftHandle } from './catalog-draft-types'
 import { GroupEditor } from './group-editor'
 import { GroupsList } from './groups-list'
 import { ProductEditor } from './product-editor'
@@ -48,6 +49,74 @@ export function ProductsServicesPage() {
   const [selectedProductId, setSelectedProductId] = useState<string | null>(null)
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null)
   const [selectedTaxRateId, setSelectedTaxRateId] = useState<string | null>(null)
+
+  // Phantom drafts (money 15-settings-phantom-editors.md phase 2) — one per
+  // tab. The full draft field set lives inside the editor component instance
+  // (keyed by `draftId`); this page only tracks enough to render the list's
+  // phantom row and to know whether the current selection is a draft. An
+  // untouched draft is dropped silently on: selecting another row, adding a
+  // new draft, or switching tabs — never on a mere re-render.
+  const [productDraft, setProductDraft] = useState<CatalogDraftHandle | null>(null)
+  const [groupDraft, setGroupDraft] = useState<CatalogDraftHandle | null>(null)
+
+  function handleSelectProduct(id: string | null) {
+    // Selecting anything other than the draft itself (or its committed record,
+    // which keeps the draft form mounted — see CatalogDraftHandle.recordId)
+    // drops the draft.
+    if (productDraft && id !== productDraft.draftId && id !== productDraft.recordId) {
+      setProductDraft(null)
+    }
+    setSelectedProductId(id)
+  }
+  function handleSelectGroup(id: string | null) {
+    if (groupDraft && id !== groupDraft.draftId && id !== groupDraft.recordId) {
+      setGroupDraft(null)
+    }
+    setSelectedGroupId(id)
+  }
+  function handleAddProductDraft() {
+    if (productDraft && !productDraft.recordId) {
+      setSelectedProductId(productDraft.draftId) // uncommitted one exists — just re-select it
+      return
+    }
+    const draftId = generateId('draft')
+    setProductDraft({ draftId, name: '' })
+    setSelectedProductId(draftId)
+  }
+  function handleAddGroupDraft() {
+    if (groupDraft && !groupDraft.recordId) {
+      setSelectedGroupId(groupDraft.draftId)
+      return
+    }
+    const draftId = generateId('draft')
+    setGroupDraft({ draftId, name: '' })
+    setSelectedGroupId(draftId)
+  }
+  function handleProductDraftNameChange(name: string) {
+    setProductDraft((prev) => (prev ? { ...prev, name } : prev))
+  }
+  function handleGroupDraftNameChange(name: string) {
+    setGroupDraft((prev) => (prev ? { ...prev, name } : prev))
+  }
+  // First create resolved: swap selection to the real id but KEEP the draft —
+  // the draft editor form must stay mounted so mid-typing text and the pending
+  // debounced name commit survive (a remount would replace the input's text
+  // with the create snapshot and cancel the debounce timer).
+  function handleProductDraftCommitted(recordId: string) {
+    setProductDraft((prev) => (prev ? { ...prev, recordId } : prev))
+    setSelectedProductId(recordId)
+  }
+  function handleGroupDraftCommitted(recordId: string) {
+    setGroupDraft((prev) => (prev ? { ...prev, recordId } : prev))
+    setSelectedGroupId(recordId)
+  }
+  function handleTabChange(next: string) {
+    setTab(next)
+    // Untouched drafts don't survive a tab switch — the other tab's list no
+    // longer renders the phantom row, so hanging onto it would be confusing.
+    if (productDraft) setProductDraft(null)
+    if (groupDraft) setGroupDraft(null)
+  }
 
   // `useSettings({ scope })` FILTERS reads to that scope (use-settings.tsx:44-54) — currency
   // stayed GENERAL while taxRates moved to DOCUMENTS (money MQ2 §A.3), so two hook instances
@@ -126,9 +195,20 @@ export function ProductsServicesPage() {
 
   const editorContent =
     activeTab === 'products' ? (
-      <ProductEditor selectedId={selectedProductId} />
+      <ProductEditor
+        selectedId={selectedProductId}
+        draft={productDraft}
+        onDraftNameChange={handleProductDraftNameChange}
+        onDraftCommitted={handleProductDraftCommitted}
+      />
     ) : activeTab === 'groups' ? (
-      <GroupEditor selectedId={selectedGroupId} currency={currency} />
+      <GroupEditor
+        selectedId={selectedGroupId}
+        currency={currency}
+        draft={groupDraft}
+        onDraftNameChange={handleGroupDraftNameChange}
+        onDraftCommitted={handleGroupDraftCommitted}
+      />
     ) : (
       <TaxRateEditor
         taxRate={selectedTaxRate}
@@ -142,26 +222,25 @@ export function ProductsServicesPage() {
       description='Manage the catalog and tax rates used on quotes and invoices.'
       breadcrumbs={breadcrumbs}
       subHeader={
-        <ResponsiveTabs
-          value={activeTab}
-          onValueChange={(value) => setTab(value)}
-          size='sm'
-          items={TABS}
-        />
+        <ResponsiveTabs value={activeTab} onValueChange={handleTabChange} size='sm' items={TABS} />
       }>
       <div className='grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
         <div className='min-w-0'>
           {activeTab === 'products' ? (
             <ProductsList
               selectedId={selectedProductId}
-              onSelect={setSelectedProductId}
+              onSelect={handleSelectProduct}
               currency={currency}
+              draft={productDraft}
+              onAddDraft={handleAddProductDraft}
             />
           ) : activeTab === 'groups' ? (
             <GroupsList
               selectedId={selectedGroupId}
-              onSelect={setSelectedGroupId}
+              onSelect={handleSelectGroup}
               currency={currency}
+              draft={groupDraft}
+              onAddDraft={handleAddGroupDraft}
             />
           ) : (
             <TaxRatesList
@@ -184,6 +263,8 @@ export function ProductsServicesPage() {
             setSelectedProductId(null)
             setSelectedGroupId(null)
             setSelectedTaxRateId(null)
+            setProductDraft(null)
+            setGroupDraft(null)
           }
         }}
         isDocked={false}

--- a/apps/web/src/components/resources/hooks/use-all-records.ts
+++ b/apps/web/src/components/resources/hooks/use-all-records.ts
@@ -68,6 +68,12 @@ interface UseAllRecordsResult<T = RecordMeta> {
    * hasn't been populated yet (falls back to the next natural fetch).
    */
   appendRecord: (item: AllRecordsItem) => void
+  /**
+   * Remove a deleted item from the `listAll` cache, the record store, and its
+   * field-value store keys — the delete counterpart of `appendRecord`. Skips
+   * the `refresh()` round-trip so the row disappears instantly.
+   */
+  removeRecord: (id: string) => void
 }
 
 /**
@@ -139,6 +145,24 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
 
   const resolvedEntityDefId = data?.entityDefinitionId ?? null
 
+  // Remove a deleted item from the listAll cache directly instead of
+  // refetching — the delete counterpart of appendRecord above. Also drops the
+  // row from the record store and clears its field-value store keys so a
+  // stale row can't reappear via the compose step.
+  const removeRecord = useCallback(
+    (id: string) => {
+      utils.record.listAll.setData(
+        { entityDefinitionId, apiSlug, fieldIds, includeArchived },
+        (old) => (old ? { ...old, items: old.items.filter((item) => item.id !== id) } : old)
+      )
+      if (resolvedEntityDefId) {
+        useRecordStore.getState().removeRecord(resolvedEntityDefId, id)
+        useFieldValueStore.getState().invalidateResource(toRecordId(resolvedEntityDefId, id))
+      }
+    },
+    [utils, entityDefinitionId, apiSlug, fieldIds, includeArchived, resolvedEntityDefId]
+  )
+
   // Resolve fieldKey → fieldId (UUID) using data.fields from API response
   // System fields use systemAttribute as key (e.g., 'inbox_name') but save uses UUID
   // Custom fields already use UUID as key, so resolution is a no-op for them
@@ -149,19 +173,27 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
     [data?.fields]
   )
 
-  // Build field value keys for all records (stable reference)
+  // Build field value keys for all records (stable reference). Union the
+  // payload's own keys with the entity's known field keys (`data.fields`) —
+  // a freshly created record has no payload entry for fields that only got
+  // a value via a later store write (createEntity only writes fields it was
+  // given or that have a configured defaultValue), so subscribing to payload
+  // keys alone means the compose step below never re-runs when that field
+  // gets its first store value.
   const fieldValueKeys = useMemo(() => {
     if (!data?.items || !resolvedEntityDefId) return []
+    const knownFieldKeys = data.fields ? Object.keys(data.fields) : []
     const keys: FieldValueKey[] = []
     for (const item of data.items) {
       const recordId = toRecordId(resolvedEntityDefId, item.id)
-      for (const fieldKey of Object.keys(item.fieldValues)) {
+      const unionKeys = new Set([...Object.keys(item.fieldValues), ...knownFieldKeys])
+      for (const fieldKey of unionKeys) {
         const resolvedFieldId = resolveFieldId(fieldKey)
         keys.push(buildFieldValueKey(recordId, resolvedFieldId))
       }
     }
     return keys
-  }, [data?.items, resolvedEntityDefId, resolveFieldId])
+  }, [data?.items, data?.fields, resolvedEntityDefId, resolveFieldId])
 
   // Stable string key for selector memoization
   const keysKey = fieldValueKeys.join(',')
@@ -210,7 +242,12 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
     )
   )
 
-  // Populate both stores when data arrives
+  // Populate both stores when data arrives. The field-value store is
+  // authoritative once a key exists — this effect only fills GAPS (first
+  // load, a newly appended record) rather than re-seeding every key on every
+  // `data` identity change, which would stomp a since-confirmed optimistic
+  // edit that this stale payload doesn't know about yet. `refresh()` below is
+  // the explicit reconcile path that clears keys before refetching.
   useEffect(() => {
     if (!data?.items || !data.entityDefinitionId) return
 
@@ -221,8 +258,10 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
     // since requestRecord checks: records[entityDefId]?.has(id)
     setRecords(entityDefId, data.items)
 
-    // Populate field value store (expects Array<{ key, value }> format)
-    // Use resolveFieldId to ensure keys match what save operations use
+    // Populate field value store (expects Array<{ key, value }> format).
+    // Use resolveFieldId to ensure keys match what save operations use, and
+    // skip any key the store already has a value for (store wins).
+    const currentValues = useFieldValueStore.getState().values
     const fieldValueEntries: Array<{ key: FieldValueKey; value: StoredFieldValue }> = []
 
     for (const item of data.items) {
@@ -232,6 +271,7 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
         // Resolve systemAttribute → UUID (custom fields already use UUID, so no-op)
         const resolvedFieldId = resolveFieldId(fieldKey)
         const key = buildFieldValueKey(recordId, resolvedFieldId)
+        if (key in currentValues) continue
         fieldValueEntries.push({ key, value: value as StoredFieldValue })
       }
     }
@@ -241,17 +281,38 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
     }
   }, [data, setRecords, setFieldValues, resolveFieldId])
 
+  // Explicit reconcile path: invalidate the field-value store for the
+  // currently-listed records BEFORE refetching, so the populate effect above
+  // (which only fills gaps) re-seeds those keys fresh once the new `data`
+  // lands. Realtime keeps mounted rows fresh in between; this is for callers
+  // that need a hard resync (e.g. after a raw `record.update` that bypasses
+  // the field-value store).
+  const refresh = useCallback(() => {
+    if (resolvedEntityDefId && data?.items) {
+      const currentRecordIds = data.items.map((item) => toRecordId(resolvedEntityDefId, item.id))
+      useFieldValueStore.getState().invalidateResources(currentRecordIds)
+    }
+    return refetch()
+  }, [resolvedEntityDefId, data?.items, refetch])
+
   // Compose records from base data + store field values (reactive to optimistic updates)
   const records = useMemo(() => {
     if (!data?.items || !resolvedEntityDefId) return []
+
+    const knownFieldKeys = data.fields ? Object.keys(data.fields) : []
 
     return data.items.map((item) => {
       const recordId = toRecordId(resolvedEntityDefId, item.id)
       const storeMeta = storeMetas[item.id]
 
-      // Build field values by reading from store (includes optimistic updates)
+      // Build field values from the union of the payload's keys and the
+      // entity's known field keys — a fresh record has no payload entry for
+      // a field it only got a value for via a later store write (see
+      // fieldValueKeys above for why). Keys absent from both store and
+      // payload compose to `undefined`; consumers already `?? null` those.
       const composedFieldValues: Record<string, unknown> = {}
-      for (const fieldKey of Object.keys(item.fieldValues)) {
+      const unionKeys = new Set([...Object.keys(item.fieldValues), ...knownFieldKeys])
+      for (const fieldKey of unionKeys) {
         const resolvedFieldId = resolveFieldId(fieldKey)
         const storeKey = buildFieldValueKey(recordId, resolvedFieldId)
         // Prefer store value (may have optimistic update), fallback to API data
@@ -292,7 +353,8 @@ export function useAllRecords<T extends RecordMeta = RecordMeta>(
     fields: data?.fields ?? {},
     isLoading: shouldFetch && isLoading,
     error: error ?? null,
-    refresh: refetch,
+    refresh,
     appendRecord,
+    removeRecord,
   }
 }


### PR DESCRIPTION
Reworks the product/group settings editors with instant optimistic delete via a new `useAllRecords.removeRecord` (the delete counterpart of `appendRecord`), plus a gap-filling field-value store populate that no longer stomps confirmed optimistic edits.

## Changes
- `removeRecord` on `useAllRecords` — drops a deleted row from the `listAll` cache, record store, and field-value store keys with no `refresh()` round-trip.
- Field-value populate now unions payload keys with known entity field keys and only fills gaps (store wins), so freshly created records re-compose correctly.
- New `catalog-draft-types` + `use-seed-catalog-record` hook; product/group editors and lists rebuilt on the new delete path.

## Files
money settings editors/lists, catalog hooks, quote line-items + document actions cluster, and `resources/hooks/use-all-records.ts` (only the money catalog consumes the new methods).