### PR TITLE
feat(dispatch): delete quality-check templates

### DIFF
--- a/apps/web/src/components/dispatch/ui/quality-check-tree-row.tsx
+++ b/apps/web/src/components/dispatch/ui/quality-check-tree-row.tsx
@@ -4,11 +4,11 @@
 
 import { Badge } from '@auxx/ui/components/badge'
 import { Switch } from '@auxx/ui/components/switch'
-import { TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { GripVertical } from 'lucide-react'
+import { GripVertical, Trash2 } from 'lucide-react'
 import type { RouterOutputs } from '~/trpc/react'
 
 export type QcItemTemplateRow = RouterOutputs['dispatch']['listQcTemplates'][number]
@@ -18,20 +18,23 @@ interface QualityCheckTreeRowProps {
   isSelected: boolean
   onSelect: () => void
   onToggleActive: () => void
+  onDelete: () => void
   isPending: boolean
 }
 
 /**
  * One QC template row in the settings tree list (08-worker-surface.md §5), styled to match the
  * Products & Services lists — draggable via dnd-kit `useSortable` (the drag handle doubles as the
- * row's leading icon); selecting it opens the FieldPanel editor. Active/inactive is a trailing
- * `Switch` (templates are deactivate-not-delete, so there is no destructive action).
+ * row's leading icon); selecting it opens the FieldPanel editor. Trailing actions mirror
+ * products-list.tsx: a destructive delete button (already-materialized visit checklists keep
+ * their snapshot rows) and the active/inactive `Switch`.
  */
 export function QualityCheckTreeRow({
   template,
   isSelected,
   onSelect,
   onToggleActive,
+  onDelete,
   isPending,
 }: QualityCheckTreeRowProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -71,12 +74,17 @@ export function QualityCheckTreeRow({
           ) : undefined
         }
         actions={
-          <Switch
-            size='xs'
-            checked={template.isActive}
-            onCheckedChange={onToggleActive}
-            disabled={isPending}
-          />
+          <div className='flex items-center gap-1'>
+            <TreeRowButton tooltipText='Delete check' variant='destructive' onClick={onDelete}>
+              <Trash2 />
+            </TreeRowButton>
+            <Switch
+              size='xs'
+              checked={template.isActive}
+              onCheckedChange={onToggleActive}
+              disabled={isPending}
+            />
+          </div>
         }
       />
     </div>

--- a/apps/web/src/components/dispatch/ui/quality-checks-page.tsx
+++ b/apps/web/src/components/dispatch/ui/quality-checks-page.tsx
@@ -7,6 +7,9 @@ import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
 import { toastError } from '@auxx/ui/components/toast'
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { generateId } from '@auxx/utils'
 import {
   closestCenter,
   DndContext,
@@ -24,7 +27,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { Lock, Plus } from 'lucide-react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import type { QcItemTemplateRow } from '~/components/dispatch/ui/quality-check-tree-row'
 import { QualityCheckTreeRow } from '~/components/dispatch/ui/quality-check-tree-row'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
@@ -32,6 +35,7 @@ import { EmptyState } from '~/components/global/empty-state'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import SettingsPage from '~/components/global/settings-page'
 import { BaseType } from '~/components/workflow/types'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
 import { useMedia } from '~/hooks/use-media'
 import { useUser } from '~/hooks/use-user'
@@ -41,12 +45,43 @@ import { api } from '~/trpc/react'
 const BREADCRUMBS = [{ title: 'Dispatch Settings' }, { title: 'Quality Checks' }]
 
 /**
+ * A phantom QC template (plans/dispatch/15-settings-phantom-editors.md Phase 3): exists only in
+ * local state until its first committed edit. Only one draft can exist at a time — clicking
+ * "Add check" again, selecting a different row, or navigating away while it's untouched drops it
+ * silently (nothing was ever persisted).
+ */
+interface QcDraft {
+  draftId: string
+  title: string
+  description: string
+  isRequired: boolean
+  /**
+   * Set once the draft's first `createQcTemplate` resolves. The draft is KEPT alive after
+   * creation (with selection swapped to this id) so the draft editor stays mounted — remounting
+   * onto the template-bound editor mid-typing would replace the input's text with the create
+   * snapshot and cancel the pending debounced title/description commit (`useDebouncedCallback`
+   * clears its timer on unmount; the trap `CatalogDraftHandle.recordId` documents). The list
+   * hides the phantom row once this is set (the real row arrived via the cache append); the
+   * draft is finally dropped when the user navigates to another row.
+   */
+  recordId?: string
+}
+
+function freshQcDraft(draftId: string): QcDraft {
+  return { draftId, title: '', description: '', isRequired: false }
+}
+
+/**
  * Dispatch Quality Checks settings page (plans/dispatch/08-worker-surface.md §5): the
  * admin-managed catalog of QC item templates a worker's per-visit checklist is materialized from.
  * Master-detail mirroring the Products & Services page — a sortable `TreeRow` list on the left
- * (active/inactive is a trailing `Switch`; templates are deactivate-not-delete) and a per-field
- * autosaving `FieldPanel` editor on the right (a `DockableDrawer` below `lg`). Create/toggle/edit
- * all update the cached list optimistically, reconciling from the server only on error.
+ * (trailing delete button + active `Switch`; deleting a template never touches already-
+ * materialized visit checklists) and a per-field autosaving `FieldPanel` editor on the right (a
+ * `DockableDrawer` below `lg`). Create/toggle/edit/delete all update the cached list
+ * optimistically or on success, reconciling from the server only on error.
+ *
+ * "Add check" is phantom-until-first-edit: it renders a local draft row + editor instantly (no
+ * network) and only fires `createQcTemplate` on the draft's first real commit.
  */
 export function QualityChecksPage() {
   useUser({ requireRoles: ['ADMIN', 'OWNER'] })
@@ -62,7 +97,22 @@ export function QualityChecksPage() {
   const [orderOverride, setOrderOverride] = useState<QcItemTemplateRow[] | null>(null)
   const orderedTemplates = orderOverride ?? templates
 
+  // Phantom draft state. `draftRef` mirrors `draft` so `commitDraft`'s post-await continuation
+  // always reads the live value instead of a stale closure (the line-builder recipe,
+  // line-builder.tsx:154-156). `creatingDraftIdRef` is the synchronous double-create guard:
+  // commits that land while that draft's first create is still in flight merge into local state
+  // instead of firing a second create. `createdIdRef` mirrors the CURRENT draft's `recordId` —
+  // flipped synchronously (before any state lands) so a commit racing the create's success
+  // callback routes straight to `patchTemplate` instead of buffering (product-editor.tsx's
+  // `recordIdRef` recipe; reset whenever the draft handle is dropped or replaced).
+  const [draft, setDraft] = useState<QcDraft | null>(null)
+  const draftRef = useRef<QcDraft | null>(null)
+  draftRef.current = draft
+  const creatingDraftIdRef = useRef<string | null>(null)
+  const createdIdRef = useRef<string | null>(null)
+
   const isDesktop = useMedia('(min-width: 1024px)')
+  const [confirm, ConfirmDialog] = useConfirm()
 
   const invalidate = () => utils.dispatch.listQcTemplates.invalidate()
 
@@ -89,6 +139,10 @@ export function QualityChecksPage() {
     },
   })
 
+  const deleteTemplate = api.dispatch.deleteQcTemplate.useMutation({
+    onError: (error) => toastError({ title: 'Error deleting check', description: error.message }),
+  })
+
   const reorderTemplates = api.dispatch.reorderQcTemplates.useMutation({
     onSettled: () => {
       setOrderOverride(null)
@@ -99,6 +153,7 @@ export function QualityChecksPage() {
   })
 
   const selected = orderedTemplates.find((t) => t.id === selectedId) ?? null
+  const isDraftSelected = draft !== null && selectedId === draft.draftId
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 3 } }),
@@ -112,6 +167,8 @@ export function QualityChecksPage() {
     const newIndex = orderedTemplates.findIndex((t) => t.id === over.id)
     if (oldIndex === -1 || newIndex === -1) return
 
+    // The draft (if any) never enters `orderedTemplates` — it's local state rendered as a
+    // trailing row outside the sortable list — so it can never appear in this payload.
     const reordered = arrayMove(orderedTemplates, oldIndex, newIndex)
     setOrderOverride(reordered)
     reorderTemplates.mutate(reordered.map((t, i) => ({ id: t.id, sortOrder: i })))
@@ -126,14 +183,156 @@ export function QualityChecksPage() {
     patchTemplate(template.id, { isActive: !template.isActive })
   }
 
-  const mobileDrawerOpen = !isDesktop && !!selected
+  /** Confirm + delete a template — cache removal, no refetch (products-list.tsx recipe).
+   * Already-materialized visit checklists keep their snapshot rows (templateId FK is set-null). */
+  const handleDelete = async (template: QcItemTemplateRow) => {
+    const confirmed = await confirm({
+      title: 'Delete check?',
+      description: `“${template.title}” will be removed from the catalog. Checklists on existing visits are unaffected.`,
+      confirmText: 'Delete',
+      destructive: true,
+    })
+    if (!confirmed) return
+    deleteTemplate.mutate(
+      { templateId: template.id },
+      {
+        onSuccess: () => {
+          utils.dispatch.listQcTemplates.setData(undefined, (old) =>
+            old?.filter((t) => t.id !== template.id)
+          )
+          setOrderOverride((prev) => (prev ? prev.filter((t) => t.id !== template.id) : prev))
+          if (selectedId === template.id) setSelectedId(null)
+          // The deleted row may be a just-committed draft's record — drop the stale handle.
+          if (draftRef.current?.recordId === template.id) dropDraft()
+        },
+      }
+    )
+  }
 
-  const editorContent = selected ? (
-    // Keyed by id so switching selection remounts the editor with fresh field state.
-    <TemplateEditor key={selected.id} template={selected} onPatch={patchTemplate} />
-  ) : (
-    <div className='p-4 text-sm text-muted-foreground'>Select a check to edit.</div>
-  )
+  /** Drop the draft handle + reset the commit-routing ref (called when selection leaves it). */
+  const dropDraft = () => {
+    setDraft(null)
+    createdIdRef.current = null
+  }
+
+  const selectRow = (id: string) => {
+    // Selecting anything other than the draft itself (or its committed record, which keeps the
+    // draft editor mounted — see QcDraft.recordId) drops the draft. A committed draft is already
+    // a real template, so dropping the handle loses nothing.
+    const current = draftRef.current
+    if (current && id !== current.draftId && id !== current.recordId) dropDraft()
+    setSelectedId(id)
+  }
+
+  const handleAdd = () => {
+    const current = draftRef.current
+    if (current && !current.recordId) {
+      // An uncommitted draft already exists — just re-select it (products-services-page recipe).
+      setSelectedId(current.draftId)
+      return
+    }
+    dropDraft()
+    const draftId = generateId('draft')
+    setDraft(freshQcDraft(draftId))
+    setSelectedId(draftId)
+  }
+
+  /**
+   * Draft commit path. Three phases (product-editor.tsx's `commitDraft` recipe):
+   * 1. Already created (`createdIdRef` set — the editor stayed mounted through the swap): merge
+   *    into draft state and route straight through the normal optimistic `patchTemplate` path.
+   * 2. Create in flight: merge into draft state only — the diff-flush below picks it up.
+   * 3. First commit: fire the ONE `createQcTemplate` call with everything accumulated so far.
+   *    `title` is required server-side — an empty title falls back to `'New check'` (a later
+   *    title edit renames it through phase 1). On success the hook-level `onSuccess` has already
+   *    appended the row + swapped selection; here we flip `createdIdRef` FIRST (so racing
+   *    commits route to phase 1), diff-flush edits typed during the round trip, and stamp
+   *    `recordId` onto the draft — KEEPING it alive so the editor never remounts mid-typing.
+   *    On error: clear the guard and keep the draft (nothing was created); the mutation's
+   *    hook-level `onError` already toasts.
+   */
+  const commitDraft = (patch: Partial<Pick<QcDraft, 'title' | 'description' | 'isRequired'>>) => {
+    const current = draftRef.current
+    if (!current) return
+
+    const createdId = createdIdRef.current
+    if (createdId) {
+      setDraft((prev) => (prev ? { ...prev, ...patch } : prev))
+      const changes: Partial<QcItemTemplateRow> = {}
+      if (patch.title !== undefined) changes.title = patch.title
+      if (patch.description !== undefined) changes.description = patch.description || null
+      if (patch.isRequired !== undefined) changes.isRequired = patch.isRequired
+      if (Object.keys(changes).length > 0) patchTemplate(createdId, changes)
+      return
+    }
+
+    if (creatingDraftIdRef.current === current.draftId) {
+      setDraft((prev) => (prev ? { ...prev, ...patch } : prev))
+      return
+    }
+
+    const snapshot: QcDraft = { ...current, ...patch }
+    creatingDraftIdRef.current = current.draftId
+    setDraft(snapshot)
+
+    createTemplate.mutate(
+      {
+        title: snapshot.title.trim() || 'New check',
+        description: snapshot.description || null,
+        isRequired: snapshot.isRequired,
+      },
+      {
+        onSuccess: (row) => {
+          creatingDraftIdRef.current = null
+          const latest = draftRef.current
+          // Draft dropped/replaced during the round trip — the row was still created and
+          // appended (hook-level onSuccess); nothing to route or flush.
+          if (latest?.draftId !== snapshot.draftId) return
+
+          // Flip the commit target FIRST — a commit landing while we flush below must route
+          // through patchTemplate, not the buffered-create path.
+          createdIdRef.current = row.id
+
+          const changed: Partial<QcItemTemplateRow> = {}
+          if (latest.title !== snapshot.title) changed.title = latest.title
+          if (latest.description !== snapshot.description) {
+            changed.description = latest.description || null
+          }
+          if (latest.isRequired !== snapshot.isRequired) changed.isRequired = latest.isRequired
+          if (Object.keys(changed).length > 0) patchTemplate(row.id, changed)
+
+          // Keep the draft alive, stamped — the list hides the phantom row (the real cached
+          // row took its place) and the editor stays on the draft branch, unmounted only when
+          // selection genuinely leaves.
+          setDraft((prev) =>
+            prev?.draftId === snapshot.draftId ? { ...prev, recordId: row.id } : prev
+          )
+        },
+        onError: () => {
+          if (creatingDraftIdRef.current === snapshot.draftId) creatingDraftIdRef.current = null
+        },
+      }
+    )
+  }
+
+  // The draft editor also stays active while `selectedId` is the draft's committed recordId —
+  // swapping to the template-bound editor would remount the inputs mid-typing (replaced text +
+  // cancelled debounce timer).
+  const draftActive =
+    draft !== null &&
+    (selectedId === draft.draftId || (!!draft.recordId && selectedId === draft.recordId))
+
+  const mobileDrawerOpen = !isDesktop && (!!selected || draftActive)
+
+  const editorContent =
+    draftActive && draft ? (
+      <TemplateEditor key={draft.draftId} draft={draft} onCommitDraft={commitDraft} />
+    ) : selected ? (
+      // Keyed by id so switching selection remounts the editor with fresh field state.
+      <TemplateEditor key={selected.id} template={selected} onPatch={patchTemplate} />
+    ) : (
+      <div className='p-4 text-sm text-muted-foreground'>Select a check to edit.</div>
+    )
 
   if (!hasAccess(FeatureKey.dispatch)) {
     return (
@@ -160,44 +359,64 @@ export function QualityChecksPage() {
         <div className='min-w-0'>
           <div className='flex flex-col gap-3 p-3'>
             <div className='flex items-center justify-end'>
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={() => createTemplate.mutate({ title: 'New check' })}
-                loading={createTemplate.isPending}
-                loadingText='Adding...'>
+              <Button variant='outline' size='sm' onClick={handleAdd}>
                 <Plus />
                 Add check
               </Button>
             </div>
 
-            {orderedTemplates.length === 0 ? (
+            {orderedTemplates.length === 0 && !draft ? (
               <div className='p-4 text-center text-sm text-muted-foreground'>
                 No checks yet — add one to start building the visit checklist.
               </div>
             ) : (
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
-                modifiers={[restrictToVerticalAxis]}>
-                <SortableContext
-                  items={orderedTemplates.map((t) => t.id)}
-                  strategy={verticalListSortingStrategy}>
-                  <div className='flex flex-col gap-0.5'>
-                    {orderedTemplates.map((template) => (
-                      <QualityCheckTreeRow
-                        key={template.id}
-                        template={template}
-                        isSelected={selectedId === template.id}
-                        onSelect={() => setSelectedId(template.id)}
-                        onToggleActive={() => handleToggleActive(template)}
-                        isPending={updateTemplate.isPending}
-                      />
-                    ))}
-                  </div>
-                </SortableContext>
-              </DndContext>
+              <div className='flex flex-col gap-0.5'>
+                {orderedTemplates.length > 0 && (
+                  <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleDragEnd}
+                    modifiers={[restrictToVerticalAxis]}>
+                    <SortableContext
+                      items={orderedTemplates.map((t) => t.id)}
+                      strategy={verticalListSortingStrategy}>
+                      {orderedTemplates.map((template) => (
+                        <QualityCheckTreeRow
+                          key={template.id}
+                          template={template}
+                          isSelected={selectedId === template.id}
+                          onSelect={() => selectRow(template.id)}
+                          onToggleActive={() => handleToggleActive(template)}
+                          onDelete={() => handleDelete(template)}
+                          isPending={updateTemplate.isPending}
+                        />
+                      ))}
+                    </SortableContext>
+                  </DndContext>
+                )}
+
+                {draft && !draft.recordId && (
+                  // Minimal inline draft row — not draggable (rendered outside the
+                  // SortableContext above, so it can never enter a reorder payload), no
+                  // Switch/Required badge (nothing to toggle until the row is real). Hidden
+                  // once the draft committed — the real row is in the cache by then.
+                  <TreeRow
+                    icon={<span className='size-4' />}
+                    isOpen={isDraftSelected}
+                    onToggleOpen={() => setSelectedId(draft.draftId)}
+                    rowClassName={cn(
+                      'bg-primary-100/50 hover:bg-primary-100',
+                      isDraftSelected && 'bg-primary-100 ring-1 ring-primary-200'
+                    )}
+                    title={
+                      <span
+                        className={cn('text-sm', !draft.title && 'text-muted-foreground italic')}>
+                        {draft.title || 'Untitled check'}
+                      </span>
+                    }
+                  />
+                )}
+              </div>
             )}
           </div>
         </div>
@@ -207,7 +426,10 @@ export function QualityChecksPage() {
       <DockableDrawer
         open={mobileDrawerOpen}
         onOpenChange={(open) => {
-          if (!open) setSelectedId(null)
+          if (!open) {
+            dropDraft()
+            setSelectedId(null)
+          }
         }}
         isDocked={false}
         width={380}
@@ -217,33 +439,52 @@ export function QualityChecksPage() {
         title='Edit check'>
         {editorContent}
       </DockableDrawer>
+
+      <ConfirmDialog />
     </SettingsPage>
   )
 }
 
-/**
- * The selected template's FieldPanel editor — remounted per template (see the `key` above), so
- * text fields can seed local state once and autosave on change (debounced), mirroring
- * `product-editor.tsx`. Active lives on the list row, not here.
- */
-function TemplateEditor({
-  template,
-  onPatch,
-}: {
-  template: QcItemTemplateRow
-  onPatch: (id: string, patch: Partial<QcItemTemplateRow>) => void
-}) {
-  const [title, setTitle] = useState(template.title)
-  const [description, setDescription] = useState(template.description ?? '')
+type TemplateEditorProps =
+  | {
+      template: QcItemTemplateRow
+      onPatch: (id: string, patch: Partial<QcItemTemplateRow>) => void
+      draft?: undefined
+      onCommitDraft?: undefined
+    }
+  | {
+      draft: QcDraft
+      onCommitDraft: (patch: Partial<Pick<QcDraft, 'title' | 'description' | 'isRequired'>>) => void
+      template?: undefined
+      onPatch?: undefined
+    }
 
-  const commitTitle = useDebouncedCallback(
-    (value: string) => onPatch(template.id, { title: value }),
-    500
+/**
+ * The selected template's (or draft's) FieldPanel editor — remounted per template/draft (see the
+ * `key` above), so text fields can seed local state once and autosave on change (debounced),
+ * mirroring `product-editor.tsx`. Active lives on the list row, not here. In draft mode, commits
+ * route through `onCommitDraft` instead of `onPatch`, and the title input autofocuses on mount.
+ */
+function TemplateEditor(props: TemplateEditorProps) {
+  const [title, setTitle] = useState(props.draft ? props.draft.title : props.template.title)
+  const [description, setDescription] = useState(
+    props.draft ? props.draft.description : (props.template.description ?? '')
   )
-  const commitDescription = useDebouncedCallback(
-    (value: string) => onPatch(template.id, { description: value || null }),
-    500
-  )
+  const isRequired = props.draft ? props.draft.isRequired : props.template.isRequired
+
+  const commitTitle = useDebouncedCallback((value: string) => {
+    if (props.draft) props.onCommitDraft({ title: value })
+    else props.onPatch(props.template.id, { title: value })
+  }, 500)
+  const commitDescription = useDebouncedCallback((value: string) => {
+    if (props.draft) props.onCommitDraft({ description: value })
+    else props.onPatch(props.template.id, { description: value || null })
+  }, 500)
+
+  const commitRequired = (value: boolean) => {
+    if (props.draft) props.onCommitDraft({ isRequired: value })
+    else props.onPatch(props.template.id, { isRequired: value })
+  }
 
   return (
     <div className='p-3'>
@@ -257,6 +498,7 @@ function TemplateEditor({
           <FieldInputAdapter
             fieldType={FieldType.TEXT}
             value={title}
+            open={props.draft ? true : undefined}
             onChange={(value) => {
               setTitle(value as string)
               commitTitle(value as string)
@@ -282,8 +524,8 @@ function TemplateEditor({
           <FieldInputAdapter
             fieldType={FieldType.CHECKBOX}
             fieldOptions={{ variant: 'switch' }}
-            value={template.isRequired}
-            onChange={(value) => onPatch(template.id, { isRequired: Boolean(value) })}
+            value={isRequired}
+            onChange={(value) => commitRequired(Boolean(value))}
           />
         </FieldPanelRow>
       </FieldPanel>

--- a/apps/web/src/server/api/routers/dispatch.ts
+++ b/apps/web/src/server/api/routers/dispatch.ts
@@ -12,6 +12,7 @@ import {
   convertRequestToWorkOrder,
   createQcItemTemplate,
   createWorkOrderFromTicket,
+  deleteQcItemTemplate,
   dispatchVisit,
   endEngagement,
   getBoard,
@@ -373,8 +374,9 @@ export const dispatchRouter = createTRPCRouter({
       })
     }),
 
-  // 08-worker-surface.md §5 — the quality-checklist template catalog. Admin-managed
-  // (deactivate-not-delete, no delete procedure); org-scoped only, no assignee guard.
+  // 08-worker-surface.md §5 — the quality-checklist template catalog. Admin-managed;
+  // org-scoped only, no assignee guard. Deleting a template never touches already-materialized
+  // visit snapshots (their templateId FK is set-null on delete).
   listQcTemplates: dispatchAdminProcedure.query(async ({ ctx }) => {
     return listQcItemTemplates(ctx.session.organizationId)
   }),
@@ -401,6 +403,12 @@ export const dispatchRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       return updateQcItemTemplate(ctx.session.organizationId, input)
+    }),
+  deleteQcTemplate: dispatchAdminProcedure
+    .input(z.object({ templateId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await deleteQcItemTemplate(ctx.session.organizationId, input.templateId)
+      return { success: true }
     }),
   reorderQcTemplates: dispatchAdminProcedure
     .input(z.array(z.object({ id: z.string(), sortOrder: z.number().int() })))

--- a/packages/lib/src/dispatch/index.ts
+++ b/packages/lib/src/dispatch/index.ts
@@ -48,6 +48,7 @@ export {
   addMyAdhocQcItem,
   addMyQcItemPhoto,
   createQcItemTemplate,
+  deleteQcItemTemplate,
   listMyVisitQcItems,
   listQcItemTemplates,
   removeMyQcItemPhoto,

--- a/packages/lib/src/dispatch/qc.ts
+++ b/packages/lib/src/dispatch/qc.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/dispatch/qc.ts
 //
 // The quality-checklist feature (08-worker-surface.md §5) — an admin-managed template catalog
-// (deactivate-not-delete) lazily materialized once per visit into worker-editable snapshot rows.
+// lazily materialized once per visit into worker-editable snapshot rows.
 // `title`/`isRequired` on `VisitQcItem` are SNAPSHOT columns: once copied from a template they
 // never change, even if the source template is edited or deactivated afterward — only visits
 // materialized after the edit see the new values. Every worker-scoped fn below guards through
@@ -71,8 +71,8 @@ export interface UpdateQcItemTemplateInput {
 }
 
 /**
- * Update a template's fields — includes deactivate/reactivate via `isActive` (deactivate-not-
- * delete; v1 has no delete fn). Never rewrites already-materialized `VisitQcItem` snapshots.
+ * Update a template's fields — includes deactivate/reactivate via `isActive`. Never rewrites
+ * already-materialized `VisitQcItem` snapshots.
  *
  * @throws {NotFoundError} when the template doesn't exist in this org.
  */
@@ -93,6 +93,30 @@ export async function updateQcItemTemplate(
     .returning()
   if (!updated) throw new NotFoundError('Quality check template not found')
   return updated
+}
+
+/**
+ * Hard-delete a template from the catalog. Already-materialized `VisitQcItem` snapshots survive
+ * — their `templateId` FK is `onDelete: 'set null'`, turning them into template-less rows (the
+ * same shape as a worker's ad-hoc items), and `title`/`isRequired` were copied at
+ * materialization time anyway.
+ *
+ * @throws {NotFoundError} when the template doesn't exist in this org.
+ */
+export async function deleteQcItemTemplate(
+  organizationId: string,
+  templateId: string
+): Promise<void> {
+  const [deleted] = await database
+    .delete(schema.QcItemTemplate)
+    .where(
+      and(
+        eq(schema.QcItemTemplate.id, templateId),
+        eq(schema.QcItemTemplate.organizationId, organizationId)
+      )
+    )
+    .returning({ id: schema.QcItemTemplate.id })
+  if (!deleted) throw new NotFoundError('Quality check template not found')
 }
 
 /** One row's new position for {@link reorderQcItemTemplates}. */


### PR DESCRIPTION
Adds hard-delete for QC templates (previously deactivate-only).

## Changes
- New `deleteQcTemplate` procedure backed by `deleteQcItemTemplate` in `@auxx/lib/dispatch`.
- Deleting a template leaves already-materialized visit snapshots untouched — their `templateId` FK is set-null on delete.
- Delete action wired into the quality-checks page tree rows.

## Files
`quality-check-tree-row.tsx`, `quality-checks-page.tsx`, `server/api/routers/dispatch.ts`, `packages/lib/src/dispatch/{qc,index}.ts`.