### PR TITLE
feat(dispatch): unify drag ghosts on shared AppDragOverlay

### DIFF
--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -10,6 +10,7 @@ import type { DragEndEvent } from '@dnd-kit/core'
 import { addMinutes } from 'date-fns'
 import { Lock } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { renderAppDragGhost } from '~/components/global/app-drag-overlay'
 import { EmptyState } from '~/components/global/empty-state'
 import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
@@ -250,7 +251,8 @@ export function DispatchBoard() {
           <CalendarDndProvider<DispatchVisitEvent>
             onEventDrop={canEdit ? handleEventDrop : undefined}
             onDragEnd={canEdit ? handleForeignDragEnd : undefined}
-            renderEvent={renderDragGhost}>
+            renderEvent={renderDragGhost}
+            renderForeignOverlay={renderAppDragGhost}>
             <div className='flex flex-1 overflow-hidden'>
               <DispatchSidebar
                 mode='calendar'

--- a/apps/web/src/components/dispatch/ui/route-planner/apply-times-dialog.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/apply-times-dialog.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
@@ -11,10 +12,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@auxx/ui/components/dialog'
-import { Input } from '@auxx/ui/components/input'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { format } from 'date-fns'
 import { useEffect, useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { createDateWithTime } from '~/components/pickers/date-time-picker/utils'
 import { useRoutePlannerMutations, visitDurationMinutes } from './hooks/use-route-planner-mutations'
@@ -76,6 +78,14 @@ function parseClockValue(clock: string): [number, number] {
   return [Number.isFinite(h) ? (h as number) : 8, Number.isFinite(m) ? (m as number) : 0]
 }
 
+/** Default first-departure: the worker's availability start (`HH:MM`, falling back to 08:00),
+ * stamped onto the planner day. `FieldType.TIME` stores a full Date (ISO string), so the day
+ * portion has to come from `date.from`. */
+function seedFirstDeparture(dayFrom: Date, availabilityStart: string | null | undefined): Date {
+  const [hours, minutes] = parseClockValue(availabilityStart ?? '08:00')
+  return createDateWithTime(dayFrom, hours, minutes)
+}
+
 /**
  * "Apply times to schedule" (design doc §E/§F, decision #1/#9; seam contract's
  * `ApplyTimesDialog`) — the only planner surface that writes `startTime`/`endTime`. Single-page
@@ -90,25 +100,20 @@ export function ApplyTimesDialog({
   date,
 }: ApplyTimesDialogProps) {
   const { applyRouteTimes } = useRoutePlannerMutations(date)
-  const [firstDepartureClock, setFirstDepartureClock] = useState(
-    worker.availabilityStart ?? '08:00'
+  const [firstDeparture, setFirstDeparture] = useState(() =>
+    seedFirstDeparture(date.from, worker.availabilityStart)
   )
 
   // Re-seed the default first-departure every time the dialog opens (worker availability may
   // have changed since the last open).
   useEffect(() => {
-    if (open) setFirstDepartureClock(worker.availabilityStart ?? '08:00')
-  }, [open, worker.availabilityStart])
+    if (open) setFirstDeparture(seedFirstDeparture(date.from, worker.availabilityStart))
+  }, [open, worker.availabilityStart, date.from])
 
   const activeStops = useMemo(
     () => stops.filter((v) => v.status !== 'done' && v.status !== 'canceled'),
     [stops]
   )
-
-  const firstDeparture = useMemo(() => {
-    const [hours, minutes] = parseClockValue(firstDepartureClock)
-    return createDateWithTime(date.from, hours, minutes)
-  }, [firstDepartureClock, date.from])
 
   const preview = useMemo(
     () => buildPreview(firstDeparture, activeStops, geometry),
@@ -137,7 +142,7 @@ export function ApplyTimesDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className='sm:max-w-[480px]' position='tc'>
+      <DialogContent position='tc'>
         <DialogHeader>
           <DialogTitle>Apply times to schedule</DialogTitle>
           <DialogDescription>
@@ -146,45 +151,58 @@ export function ApplyTimesDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <FieldPanel className='p-0' breakpoint='md'>
-          <FieldPanelRow title='First departure' description='Defaults to worker availability'>
-            <Input
-              type='time'
-              value={firstDepartureClock}
-              onChange={(e) => setFirstDepartureClock(e.target.value)}
-              className='w-32'
-            />
-          </FieldPanelRow>
-        </FieldPanel>
+        <div className='space-y-4'>
+          <FieldPanel className='p-0' breakpoint='md'>
+            <FieldPanelRow title='First departure' description='Defaults to worker availability'>
+              <FieldInputAdapter
+                fieldType={FieldType.TIME}
+                value={firstDeparture.toISOString()}
+                onChange={(val) => {
+                  if (val) setFirstDeparture(new Date(val as string))
+                }}
+                disabled={applyRouteTimes.isPending}
+              />
+            </FieldPanelRow>
+          </FieldPanel>
 
-        <div className='max-h-72 space-y-1 overflow-y-auto rounded-md border p-2'>
-          {preview.length === 0 ? (
-            <p className='text-muted-foreground px-1 py-2 text-xs'>No active stops to apply.</p>
-          ) : (
-            preview.map((row, index) => (
-              <div key={row.visit.id} className='flex items-center gap-2 text-xs'>
-                <span className='text-muted-foreground w-5 shrink-0'>{index + 1}.</span>
-                <span className='min-w-0 flex-1 truncate'>Stop {index + 1}</span>
-                <span className='shrink-0'>
-                  {format(row.startTime, 'p')}–{format(row.endTime, 'p')}
-                </span>
-                {row.isDefaultDuration && (
-                  <span className='text-muted-foreground shrink-0'>(1h default)</span>
-                )}
-              </div>
-            ))
-          )}
+          <div className='max-h-72 space-y-2 overflow-y-auto rounded-2xl border py-2 px-3'>
+            {preview.length === 0 ? (
+              <p className='text-muted-foreground px-1 py-2 text-xs'>No active stops to apply.</p>
+            ) : (
+              preview.map((row, index) => (
+                <div key={row.visit.id} className='flex items-center gap-2 text-xs'>
+                  <span className='text-muted-foreground w-5 shrink-0'>{index + 1}.</span>
+                  <span className='min-w-0 flex-1 truncate'>Stop {index + 1}</span>
+                  <span className='shrink-0'>
+                    {format(row.startTime, 'p')}–{format(row.endTime, 'p')}
+                  </span>
+                  {row.isDefaultDuration && (
+                    <span className='text-muted-foreground shrink-0'>(1h default)</span>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
         </div>
 
         <DialogFooter>
-          <Button variant='ghost' onClick={() => onOpenChange(false)}>
-            Cancel
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={applyRouteTimes.isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
           </Button>
           <Button
             onClick={handleConfirm}
+            variant='outline'
+            size='sm'
             loading={applyRouteTimes.isPending}
-            disabled={activeStops.length === 0}>
-            Confirm
+            loadingText='Applying...'
+            disabled={activeStops.length === 0}
+            data-dialog-submit>
+            Confirm <KbdSubmit variant='outline' size='sm' />
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/components/dispatch/ui/route-planner/hooks/use-route-planner-mutations.ts
+++ b/apps/web/src/components/dispatch/ui/route-planner/hooks/use-route-planner-mutations.ts
@@ -22,8 +22,10 @@ import type {
 // ── Drag data shapes (this module's seam contribution — 2A's route-planner-view.tsx only
 // mounts a DndContext and forwards `onDragEnd`; it never builds these payloads) ──────────────
 //
-// - Backlog row draggable (backlog-pane.tsx): `useDraggable({ id: \`planner-backlog-${visitId}\`,
-//   data: { type: 'planner-backlog', visitId } })`.
+// - Backlog row draggable (backlog-group.tsx): `useDraggable({ id: \`sidebar-backlog-${visitId}\`,
+//   data: { type: 'planner-backlog', visitId, item } })` — `item` (the full `BacklogItem`) rides
+//   along only for the shared drag-ghost overlay (`AppDragOverlay`/`renderAppDragGhost`) to read;
+//   this handler still only needs `visitId`.
 // - Stop row draggable (stop-list-panel.tsx), inside a worker's `SortableContext`:
 //   `useSortable({ id: visitId })` combined with `data: { type: 'planner-stop', visitId,
 //   assigneeUserId } }` passed to the same `useSortable` call (dnd-kit merges `data` from

--- a/apps/web/src/components/dispatch/ui/route-planner/planner-dnd-provider.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/planner-dnd-provider.tsx
@@ -11,6 +11,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
+import { AppDragOverlay } from '~/components/global/app-drag-overlay'
 import { useRoutePlannerDragEnd } from './hooks/use-route-planner-mutations'
 import type { PlannerBoard, PlannerDayWindow, RouteGeometry } from './types'
 
@@ -35,7 +36,7 @@ export function PlannerDndProvider({
   children,
 }: PlannerDndProviderProps) {
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
     useSensor(KeyboardSensor)
   )
@@ -45,6 +46,7 @@ export function PlannerDndProvider({
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       {children}
+      <AppDragOverlay />
     </DndContext>
   )
 }

--- a/apps/web/src/components/dispatch/ui/route-planner/planner-map.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/planner-map.tsx
@@ -296,7 +296,7 @@ export function PlannerMap({ board, filters, geometryByWorker, window }: Planner
               style={{ left: anchorPoint.x, top: anchorPoint.y }}
             />
           </PopoverAnchor>
-          <PopoverContent side='top' align='center' className='w-72'>
+          <PopoverContent side='top' align='center' className='w-72 p-0'>
             <PinPopoverContent visit={selectedVisit} board={board} onClose={closePopover} />
           </PopoverContent>
         </Popover>

--- a/apps/web/src/components/dispatch/ui/sidebar/backlog-group.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/backlog-group.tsx
@@ -124,9 +124,14 @@ interface BacklogRowProps {
 
 function BacklogRow({ item, dragType, canEdit }: BacklogRowProps) {
   const { visit, workOrder } = item
+  // `item` rides along in the draggable's data (not just `visitId`) so the shared
+  // `AppDragOverlay`/`renderAppDragGhost` (apps/web/src/components/global/app-drag-overlay.tsx)
+  // can render `BacklogRowGhost` without a cross-context store lookup — the ghost is rendered by
+  // a different `DndContext`'s overlay (dispatch calendar/map mode), so it can't reach back into
+  // whatever board-data hook produced this row.
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `sidebar-backlog-${visit.id}`,
-    data: { type: dragType, visitId: visit.id },
+    data: { type: dragType, visitId: visit.id, item },
     disabled: !canEdit,
   })
   const status = isVisitStatus(visit.status) ? visit.status : 'scheduled'
@@ -137,7 +142,7 @@ function BacklogRow({ item, dragType, canEdit }: BacklogRowProps) {
         ref={setNodeRef}
         {...(canEdit ? { ...attributes, ...listeners } : {})}
         id={`sidebar-backlog-${visit.id}`}
-        name={`${workOrder?.number ? `${workOrder.number} · ` : ''}${workOrder?.displayName ?? 'Work order'}`}
+        name={backlogRowLabel(item)}
         className={cn(
           canEdit && 'cursor-grab touch-none active:cursor-grabbing',
           isDragging && 'opacity-40'
@@ -155,5 +160,33 @@ function BacklogRow({ item, dragType, canEdit }: BacklogRowProps) {
         }
       />
     </SidebarMenuItem>
+  )
+}
+
+/** WO number + title, shared by the live row and its drag ghost. */
+function backlogRowLabel(item: BacklogItem): string {
+  const { workOrder } = item
+  return `${workOrder?.number ? `${workOrder.number} · ` : ''}${workOrder?.displayName ?? 'Work order'}`
+}
+
+/**
+ * Presentational copy of the backlog row (status dot + WO number + title), rendered as the
+ * cursor-following drag ghost by `renderAppDragGhost`/`AppDragOverlay`
+ * (apps/web/src/components/global/app-drag-overlay.tsx) — a floating box rather than a
+ * `SidebarItem`, since the ghost is portaled outside any `Sidebar`/`SidebarProvider` tree
+ * (plans/dispatch/16-dnd-unification.md Phase 2). The live row keeps its `opacity-40`
+ * `isDragging` treatment and never applies a transform — this is the only thing that moves.
+ */
+export function BacklogRowGhost({ item }: { item: BacklogItem }) {
+  const status = isVisitStatus(item.visit.status) ? item.visit.status : 'scheduled'
+
+  return (
+    <div className='inline-flex max-w-xs items-center gap-2 rounded-md border bg-popover px-2 py-1 text-sm shadow-md'>
+      <span
+        className={cn('size-1.5 shrink-0 rounded-full', STATUS_ACCENT_CLASS[status])}
+        aria-hidden
+      />
+      <span className='truncate'>{backlogRowLabel(item)}</span>
+    </div>
   )
 }

--- a/apps/web/src/components/global/app-drag-overlay.tsx
+++ b/apps/web/src/components/global/app-drag-overlay.tsx
@@ -1,0 +1,78 @@
+// apps/web/src/components/global/app-drag-overlay.tsx
+
+'use client'
+
+import { type Active, DragOverlay, useDndContext } from '@dnd-kit/core'
+import { snapCenterToCursor } from '@dnd-kit/modifiers'
+import type { ReactNode } from 'react'
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { BacklogRowGhost } from '~/components/dispatch/ui/sidebar/backlog-group'
+import { FavoriteDragOverlay } from '~/components/favorites/ui/favorite-drag-overlay'
+import MailThreadItemDragOverlay from '~/components/mail/mail-thread-item-drag-overlay'
+
+/**
+ * Type-switched ghost renderer shared by every `DndContext` on the page (plans/dispatch/
+ * 16-dnd-unification.md Phase 2). Pure function so it can be threaded through
+ * `CalendarDndProvider`'s `renderForeignOverlay` slot (dispatch calendar mode already owns its
+ * own `DragOverlay` and can't mount a second `AppDragOverlay` inside the same context) as well as
+ * called directly by `AppDragOverlay` below for contexts that don't need a foreign-item slot.
+ */
+export function renderAppDragGhost(active: Active): ReactNode {
+  const data = active.data.current as
+    | {
+        type?: string
+        draggedThreadIds?: string[]
+        favoriteId?: string
+        item?: Parameters<typeof BacklogRowGhost>[0]['item']
+      }
+    | undefined
+  if (!data) return null
+
+  switch (data.type) {
+    case 'thread':
+      return <MailThreadItemDragOverlay items={data.draggedThreadIds ?? []} isDragging />
+    case 'favorite':
+      return data.favoriteId ? <FavoriteDragOverlay favoriteId={data.favoriteId} /> : null
+    case 'backlog-visit':
+    case 'planner-backlog':
+      return data.item ? <BacklogRowGhost item={data.item} /> : null
+    default:
+      return null
+  }
+}
+
+/**
+ * Portaled `DragOverlay` — the cursor-following ghost for whichever item is being dragged.
+ * Extracted from `dashboard.tsx`'s inline block so every `DndContext` on `/app/dispatch` (the
+ * app-level Dashboard context, and map mode's `PlannerDndProvider`) renders an identical ghost.
+ * Calendar mode can't mount a second instance inside its own context (a `DragOverlay` only shows
+ * drags from its own `DndContext`) — it threads `renderAppDragGhost` through
+ * `CalendarDndProvider`'s `renderForeignOverlay` slot instead.
+ *
+ * Reads the active drag straight from dnd-kit's own context (`useDndContext`) rather than taking
+ * a prop, so mounting it is a single `<AppDragOverlay />` inside the owning `DndContext` — no
+ * wiring required.
+ */
+export function AppDragOverlay() {
+  const { active } = useDndContext()
+  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    setPortalContainer(document.body)
+  }, [])
+
+  if (!portalContainer) return null
+
+  return createPortal(
+    <DragOverlay
+      dropAnimation={null}
+      adjustScale={false}
+      modifiers={[snapCenterToCursor]}
+      style={{ width: 'auto' }}
+      className='w-auto'>
+      {active ? renderAppDragGhost(active) : null}
+    </DragOverlay>,
+    portalContainer
+  )
+}

--- a/apps/web/src/components/global/dashboard.tsx
+++ b/apps/web/src/components/global/dashboard.tsx
@@ -7,7 +7,6 @@ import {
   type Active,
   DndContext,
   type DragEndEvent,
-  DragOverlay,
   type DragStartEvent,
   PointerSensor,
   pointerWithin,
@@ -15,19 +14,16 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
-import { snapCenterToCursor } from '@dnd-kit/modifiers'
 import { usePathname, useRouter } from 'next/navigation'
 import React, { useCallback, useState } from 'react'
-import { createPortal } from 'react-dom'
 import { DndStateProvider } from '~/app/context/dnd-state-context'
 import { OverageBanner } from '~/components/banner/overage-banner'
 import { DemoBanner } from '~/components/demo/demo-banner'
 import { useFavoriteDragEnd } from '~/components/favorites/hooks/use-favorite-drag-end'
-import { FavoriteDragOverlay } from '~/components/favorites/ui/favorite-drag-overlay'
+import { AppDragOverlay } from '~/components/global/app-drag-overlay'
 import AppSidebar from '~/components/global/sidebar'
 import { KopilotDock } from '~/components/kopilot/ui/kopilot-dock'
 import { KopilotRuntime } from '~/components/kopilot/ui/kopilot-runtime'
-import MailThreadItemDragOverlay from '~/components/mail/mail-thread-item-drag-overlay'
 import { useThreadMutation } from '~/components/threads/hooks'
 import { useOverages } from '~/hooks/use-overages'
 import {
@@ -52,13 +48,7 @@ export const Dashboard = ({
   const overages = useOverages(organizationId)
 
   const [activeDragId, setActiveDragId] = useState<string | null>(null)
-  const [activeDragData, setActiveDragData] = useState<Record<string, any> | null>(null)
   const [activeDndItem, setActiveDndItem] = useState<Active | null>(null)
-  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null)
-
-  React.useEffect(() => {
-    setPortalContainer(document.body)
-  }, [])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -67,7 +57,6 @@ export const Dashboard = ({
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
     setActiveDragId(event.active.id as string)
-    setActiveDragData(event.active.data.current ?? {})
     setActiveDndItem(event.active)
   }, [])
 
@@ -92,7 +81,6 @@ export const Dashboard = ({
     (event: DragEndEvent) => {
       const { active, over } = event
       setActiveDragId(null)
-      setActiveDragData(null)
       setActiveDndItem(null)
 
       if (!over || active.id === over.id) return
@@ -145,25 +133,7 @@ export const Dashboard = ({
             <KopilotRuntime />
           </div>
         </DndStateProvider>
-        {portalContainer &&
-          createPortal(
-            <DragOverlay
-              dropAnimation={null}
-              adjustScale={false}
-              modifiers={[snapCenterToCursor]}
-              style={{ width: 'auto' }}
-              className='w-auto'>
-              {activeDndItem?.data.current?.type === 'thread' ? (
-                <MailThreadItemDragOverlay
-                  items={activeDragData?.draggedThreadIds ?? []}
-                  isDragging
-                />
-              ) : activeDndItem?.data.current?.type === 'favorite' ? (
-                <FavoriteDragOverlay favoriteId={activeDndItem.data.current.favoriteId} />
-              ) : null}
-            </DragOverlay>,
-            portalContainer
-          )}
+        <AppDragOverlay />
       </DndContext>
     </SidebarProvider>
   )

--- a/apps/web/src/components/money/ui/invoice/record-payment-dialog.tsx
+++ b/apps/web/src/components/money/ui/invoice/record-payment-dialog.tsx
@@ -93,7 +93,7 @@ export function RecordPaymentDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className='sm:max-w-[440px]' position='tc'>
+      <DialogContent position='tc'>
         <DialogHeader>
           <DialogTitle>Record payment</DialogTitle>
           <DialogDescription>Log a cash, check, card, or bank payment.</DialogDescription>

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -72,6 +72,7 @@ import {
   DraftLineRow,
   freshDraft,
   LINE_COLS,
+  LINE_COLS_READONLY,
   LineRow,
   relKeyForDocumentType,
 } from './line-rows'
@@ -683,12 +684,12 @@ export function LineBuilder({
           The Description label offsets past the row px-1 + grip slot + title/button padding. */}
       <div
         className='sticky top-0 z-10 grid border-primary-200/50 border-b bg-primary-50 px-1 pb-1 text-muted-foreground text-xs dark:border-[#1e2227] dark:bg-background'
-        style={{ gridTemplateColumns: LINE_COLS }}>
+        style={{ gridTemplateColumns: readOnly ? LINE_COLS_READONLY : LINE_COLS }}>
         <div className={readOnly ? 'pl-2' : 'pl-9'}>Description</div>
         <div className='px-2 text-right'>Qty</div>
         <div className='px-2 text-right'>Unit cost</div>
         <div className='px-2 text-right'>Total</div>
-        <div />
+        {!readOnly && <div />}
       </div>
 
       {isEmpty && readOnly ? (

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -34,6 +34,13 @@ import { formatCurrency, titleCase } from './shared'
  */
 export const LINE_COLS = 'minmax(10rem, 1fr) 4rem 6.5rem 6.5rem 5.5rem'
 
+/**
+ * Read-only column template — the trailing actions column is dropped (no
+ * hover actions when read-only), so `Total` lands flush right and the freed
+ * width is absorbed by the `1fr` description column.
+ */
+export const LINE_COLS_READONLY = 'minmax(10rem, 1fr) 4rem 6.5rem 6.5rem'
+
 // Module-level (stable-reference) attribute lists — `useSystemValues` memoizes
 // on the array identity, so these must never be inline literals.
 const NAME_ATTRS = ['line_item_name', 'line_item_description', 'line_item_category']
@@ -494,7 +501,7 @@ export function LineRow({
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(isDragging && 'relative z-10 opacity-80')}>
       <GridTreeRow
-        columns={LINE_COLS}
+        columns={readOnly ? LINE_COLS_READONLY : LINE_COLS}
         icon={
           readOnly ? undefined : (
             <span
@@ -534,17 +541,19 @@ export function LineRow({
             currencyCode={currencyCode}
           />,
           <LineTotalCell key='total' recordId={recordId} currencyCode={currencyCode} />,
-          readOnly ? (
-            <span key='actions' />
-          ) : (
-            <LineActionsCell
-              key='actions'
-              recordId={recordId}
-              rowId={record.id}
-              toggleDescription={toggleDescription}
-              deleteLine={deleteLine}
-            />
-          ),
+          // Read-only rows drop the actions column entirely (LINE_COLS_READONLY),
+          // so `Total` sits flush right and description absorbs the freed width.
+          ...(readOnly
+            ? []
+            : [
+                <LineActionsCell
+                  key='actions'
+                  recordId={recordId}
+                  rowId={record.id}
+                  toggleDescription={toggleDescription}
+                  deleteLine={deleteLine}
+                />,
+              ]),
         ]}
       />
     </div>

--- a/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
+++ b/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
@@ -3,18 +3,19 @@
 'use client'
 
 import {
+  type Active,
   DndContext,
   type DragEndEvent,
   type DragOverEvent,
   DragOverlay,
   type DragStartEvent,
-  MouseSensor,
   PointerSensor,
   TouchSensor,
   type UniqueIdentifier,
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
+import { snapCenterToCursor } from '@dnd-kit/modifiers'
 import { addMinutes, differenceInMinutes } from 'date-fns'
 import { createContext, type ReactNode, useContext, useId, useState } from 'react'
 
@@ -70,6 +71,13 @@ interface CalendarDndProviderProps<T extends EventCalendarItem = EventCalendarIt
    */
   onDragEnd?: (event: DragEndEvent) => void
   renderEvent?: RenderEvent<T>
+  /**
+   * Overlay slot for a dragged item that isn't a calendar event (dispatch's sidebar Backlog
+   * rows, composed in via `onDragEnd`'s escape hatch) — rendered inside this provider's own
+   * `DragOverlay` when the active drag has no `data.current.event`. `null`/omitted keeps today's
+   * behavior (no ghost for foreign items).
+   */
+  renderForeignOverlay?: (active: Active) => ReactNode
 }
 
 export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarItem>({
@@ -77,6 +85,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
   onEventDrop,
   onDragEnd,
   renderEvent,
+  renderForeignOverlay,
 }: CalendarDndProviderProps<T>) {
   const [activeEvent, setActiveEvent] = useState<T | null>(null)
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null)
@@ -84,11 +93,11 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
   const [currentTime, setCurrentTime] = useState<Date | null>(null)
   const [currentResourceId, setCurrentResourceId] = useState<string | null>(null)
   const [eventHeight, setEventHeight] = useState<number | null>(null)
+  const [foreignActive, setForeignActive] = useState<Active | null>(null)
 
   const sensors = useSensors(
-    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } })
   )
 
   const dndContextId = useId()
@@ -107,8 +116,12 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
     const data = active.data.current as
       | { event?: T; view?: DraggableView; height?: number }
       | undefined
-    if (!data?.event) return
+    if (!data?.event) {
+      setForeignActive(active)
+      return
+    }
 
+    setForeignActive(null)
     setActiveEvent(data.event)
     setActiveId(active.id)
     setActiveView(data.view ?? null)
@@ -160,6 +173,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
     setCurrentTime(null)
     setCurrentResourceId(null)
     setEventHeight(null)
+    setForeignActive(null)
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -223,9 +237,14 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
 
         {/* The floating copy that follows the pointer — kept translucent (origin stays solid
             in place) and darkened so it reads as "the thing being moved", with the drop
-            outline showing through underneath. */}
-        <DragOverlay adjustScale={false} dropAnimation={null}>
-          {activeEvent && activeView && (
+            outline showing through underneath. A foreign item (no `data.current.event` — e.g.
+            dispatch's sidebar Backlog rows) has no fixed size/position to preserve, so its ghost
+            gets `snapCenterToCursor`; the calendar-event ghost keeps its own positioning. */}
+        <DragOverlay
+          adjustScale={false}
+          dropAnimation={null}
+          modifiers={foreignActive ? [snapCenterToCursor] : []}>
+          {activeEvent && activeView ? (
             <div
               className='opacity-80'
               style={{ width: '100%', height: eventHeight ? `${eventHeight}px` : 'auto' }}>
@@ -238,6 +257,8 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
                 renderEvent={renderEvent}
               />
             </div>
+          ) : (
+            foreignActive && renderForeignOverlay?.(foreignActive)
           )}
         </DragOverlay>
       </CalendarDndContext.Provider>


### PR DESCRIPTION
## Summary

Unifies drag-ghost rendering across the app so every `DndContext` on a page produces an identical cursor-following ghost (plans/dispatch/16-dnd-unification.md Phase 2).

- **New `global/app-drag-overlay.tsx`** — extracts dashboard's inline `DragOverlay` into a shared `AppDragOverlay` (reads the active drag from dnd-kit context, mount with a single `<AppDragOverlay />`) plus a pure `renderAppDragGhost` type-switch (thread / favorite / backlog).
- **Calendar mode** — `CalendarDndProvider` gains a `renderForeignOverlay` slot; dispatch board threads `renderAppDragGhost` through it since the calendar owns its own `DragOverlay`. Foreign items get `snapCenterToCursor`; calendar-event ghosts keep their own sizing/position.
- **Map mode** — `PlannerDndProvider` mounts `AppDragOverlay` directly.
- **Backlog rows** carry the full `BacklogItem` in draggable data and expose a presentational `BacklogRowGhost` (portaled outside the Sidebar tree).
- **Sensors** normalized to Pointer distance-8 / Touch delay-200 across contexts.

### Money UI polish (bundled)
- `LINE_COLS_READONLY` drops the trailing actions column so read-only totals sit flush right, description absorbs the freed width.
- `apply-times-dialog` moves onto `FieldInputAdapter` (`FieldType.TIME`) + `Kbd`/`KbdSubmit` footer; drops fixed dialog max-widths on it and `record-payment-dialog`.

## Test plan
- [ ] Drag a backlog row in dispatch calendar, map, and board modes — ghost renders identically in all three.
- [ ] Drag a mail thread and a favorite from the app sidebar — ghosts unchanged.
- [ ] Apply-times dialog: TIME input seeds from worker availability, esc/enter shortcuts work.
- [ ] Read-only line builder: totals flush right, no actions column.