### PR TITLE
feat(dispatch): split repeat-row pill into short label + detail line

### DIFF
--- a/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
@@ -209,7 +209,10 @@ export function VisitPopoverContent({
       />
 
       <EventRepeatSection
-        summary={editor.recurrenceSummary ?? undefined}
+        label={editor.repeatLabel}
+        detail={
+          editor.repeatMode === 'custom' ? (editor.recurrenceSummary ?? undefined) : undefined
+        }
         disabled={!canEdit || !workOrderRecordId}
         renderEditor={() => <RepeatEditor editor={editor} />}
         onOpenChange={(open) => {

--- a/apps/web/src/components/dispatch/ui/recurrence/recurrence-utils.ts
+++ b/apps/web/src/components/dispatch/ui/recurrence/recurrence-utils.ts
@@ -34,6 +34,23 @@ export function classifyRecurrencePreset(pattern: RecurrencePattern | null): Rec
   return 'custom'
 }
 
+/** Short cadence label for the collapsed Repeat row's pill — the long human-readable example
+ * (`describeRecurrence`) renders below the row instead of stretching the trigger. */
+export function recurrencePresetLabel(preset: RecurrencePreset): string {
+  switch (preset) {
+    case 'none':
+      return 'Does not repeat'
+    case 'weekly':
+      return 'Weekly'
+    case 'biweekly':
+      return 'Every 2 weeks'
+    case 'monthly':
+      return 'Monthly'
+    case 'custom':
+      return 'Custom'
+  }
+}
+
 /** Preset → pattern, derived from the currently picked start date (06 §6 preset semantics). */
 export function buildPresetPattern(
   preset: 'weekly' | 'biweekly' | 'monthly',

--- a/apps/web/src/components/dispatch/ui/schedule-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/schedule-popover.tsx
@@ -205,7 +205,10 @@ export function SchedulePopoverContent({
       <AssigneeRow value={assigneeUserId} onChange={handleAssigneeChange} />
       {workOrderRecordId && (
         <EventRepeatSection
-          summary={editor.recurrenceSummary ?? undefined}
+          label={editor.repeatLabel}
+          detail={
+            editor.repeatMode === 'custom' ? (editor.recurrenceSummary ?? undefined) : undefined
+          }
           renderEditor={() => <RepeatEditor editor={editor} />}
           onOpenChange={(open) => {
             if (!open && !isDraft) commitRecurrence()

--- a/apps/web/src/components/dispatch/ui/shared/use-recurrence-editor.ts
+++ b/apps/web/src/components/dispatch/ui/shared/use-recurrence-editor.ts
@@ -17,6 +17,7 @@ import {
   classifyRecurrencePreset as classifyPreset,
   defaultCustomPattern,
   type RecurrencePreset,
+  recurrencePresetLabel,
   scalarSetting,
 } from '../recurrence/recurrence-utils'
 
@@ -169,6 +170,9 @@ export function useRecurrenceEditor({
   return {
     hasExistingRule,
     repeatMode,
+    // Short label for the collapsed Repeat row's pill ("Weekly", "Custom", …); the full
+    // `recurrenceSummary` renders below the row so a long custom cadence never stretches the pill.
+    repeatLabel: recurrencePresetLabel(repeatMode),
     customPattern,
     setCustomPattern,
     ends,

--- a/packages/ui/src/components/event-calendar/event-popover/event-popover-sections.tsx
+++ b/packages/ui/src/components/event-calendar/event-popover/event-popover-sections.tsx
@@ -354,7 +354,12 @@ function TimeDrillPage({ start, end, commitTime, use24Hour }: TimeDrillPageProps
 // ---------------------------------------------------------------------------
 
 interface EventRepeatSectionProps {
-  summary?: string
+  /** Short cadence label shown in the trailing pill (e.g. "Weekly", "Custom") — kept concise so
+   * the pill never stretches the row. Full detail goes in `detail`. */
+  label?: string
+  /** The concrete cadence example (e.g. "Every 2 weeks on Mon, Wed until Dec 31"), rendered below
+   * the row rather than in the pill so a long custom summary doesn't blow out the trigger. */
+  detail?: string
   /** Content for the drill page; `close` pops back to the previous level (repeat edits bypass
    * the scope chooser by design — decision #3). */
   renderEditor: (close: () => void) => React.ReactNode
@@ -366,10 +371,12 @@ interface EventRepeatSectionProps {
   placeholder?: string
 }
 
-/** Single-row `PanelCard`: Repeat row, trailing `PanelRowValue` with the current summary, drills
- * into a consumer-injected recurrence editor page. */
+/** Single-row `PanelCard`: Repeat row, trailing `PanelRowValue` with the short cadence label,
+ * drills into a consumer-injected recurrence editor page. The full cadence example (`detail`)
+ * renders below the row so a long custom summary stays out of the pill. */
 export function EventRepeatSection({
-  summary,
+  label,
+  detail,
   renderEditor,
   onOpenChange,
   disabled,
@@ -387,20 +394,21 @@ export function EventRepeatSection({
   }, [isOpen, onOpenChange])
 
   return (
-    <PanelCard>
+    <PanelCard className={detail ? 'space-y-2' : undefined}>
       <PanelCardRow
         icon={<RefreshCcw />}
         title='Repeat'
         trailing={
           disabled ? (
-            <span className='text-muted-foreground text-sm'>{summary ?? placeholder}</span>
+            <span className='text-muted-foreground text-sm'>{label ?? placeholder}</span>
           ) : (
             <PanelRowValue onClick={() => push({ id: 'repeat', label: 'Repeat' })}>
-              {summary ?? placeholder}
+              {label ?? placeholder}
             </PanelRowValue>
           )
         }
       />
+      {detail && <p className='pl-7.5 text-muted-foreground text-xs'>{detail}</p>}
       {/* Portalled from HERE (the consumer's live subtree) so the editor re-renders with fresh
           consumer state on every edit — a frame-captured `render()` closure would freeze it. */}
       <EventDrillPage id='repeat'>{renderEditor(pop)}</EventDrillPage>


### PR DESCRIPTION
## Summary
- The Repeat row's trailing pill in schedule/visit popovers used the full recurrence summary (e.g. "Every 2 weeks on Mon, Wed until Dec 31"), which could stretch the row.
- Now shows a short cadence label in the pill (`Weekly`, `Custom`, ...) via a new `recurrencePresetLabel` helper, and renders the full cadence example below the row as `detail`.
- Applies to both `schedule-popover.tsx` and `visit-popover.tsx` via the shared `EventRepeatSection` primitive in `@auxx/ui`.

## Test plan
- [ ] Open a dispatch schedule/visit popover, confirm the Repeat row shows a short pill label
- [ ] Set a custom recurrence with a long cadence, confirm the full description renders below the row instead of stretching the pill
- [ ] Confirm disabled state still shows the label correctly