### PR TITLE
feat(money): work-order billing section (invoices + payments on the job view)

### DIFF
--- a/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
+++ b/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
@@ -69,6 +69,10 @@ export const DETAIL_VIEW_TAB_COMPONENTS: Record<
     import('../dispatch/ui/job-schedule/work-order-line-items-tab').then((m) => ({
       default: m.WorkOrderLineItemsTab,
     })),
+  'work_order:billing': () =>
+    import('../dispatch/ui/job-schedule/work-order-billing-tab').then((m) => ({
+      default: m.WorkOrderBillingTab,
+    })),
 }
 
 /**

--- a/apps/web/src/components/detail-view/utils.ts
+++ b/apps/web/src/components/detail-view/utils.ts
@@ -5,6 +5,7 @@ import {
   Calendar,
   CalendarClock,
   Clock,
+  CreditCard,
   History,
   HouseIcon,
   Layers,
@@ -39,6 +40,8 @@ const ICON_MAP: Record<string, LucideIcon> = {
   calendar: Calendar,
   'calendar-clock': CalendarClock,
   history: History,
+  // work_order Billing section anchor (money plan 10 §E).
+  'credit-card': CreditCard,
 }
 
 /**

--- a/apps/web/src/components/dispatch/ui/board/visit-chip-content.tsx
+++ b/apps/web/src/components/dispatch/ui/board/visit-chip-content.tsx
@@ -38,8 +38,8 @@ export function VisitChipContent({ event, isOverlapping }: VisitChipContentProps
       className={cn(
         'relative flex h-full w-full items-stretch gap-1.5 overflow-hidden rounded-[inherit]',
         done && 'opacity-60',
-        canceled && 'opacity-50',
-        isOverlapping && 'ring-2 ring-inset ring-amber-500'
+        canceled && 'opacity-50'
+        // isOverlapping && 'ring-2 ring-inset ring-amber-500'
       )}>
       <span
         className={cn('w-1 shrink-0 rounded-full', STATUS_ACCENT_CLASS[event.status])}

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-invoices-block.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-invoices-block.tsx
@@ -1,0 +1,163 @@
+// apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-invoices-block.tsx
+'use client'
+
+// Billing tab §D block 4 (plans/dispatch/money/10-work-order-billing-tab.md) — one TreeRow per
+// invoice (number/status/issued date/total/balance) + the drawer's "Create invoice" TreeRow
+// pattern, copied verbatim from `WorkOrderInvoicesCard` (work-order-related-cards.tsx). Extends
+// `RelatedRecordRow`'s composition (record icon + displayName + status Badge) with the money
+// columns the plan calls for, since `RelatedRecordRow` itself is deliberately bare. Each row
+// reports its own resolved values up to the billing tab via `onInvoiceValues` — the summary
+// strip and the §C record-payment candidate list are built from that map (no batch field-value
+// hook exists yet; see `use-work-order-invoices.ts`).
+
+import { getDefinitionId, getInstanceId, type RecordId } from '@auxx/types/resource'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { format } from 'date-fns'
+import { ExternalLink, Plus, Receipt } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import { RowSkeleton } from '~/components/drawers/cards/related-record-row'
+import type { InvoiceBillingValues } from '~/components/money/hooks/use-work-order-invoices'
+import { GatherInvoiceDialog } from '~/components/money/ui/invoice/gather-invoice-dialog'
+import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { useRecord, useResource } from '~/components/resources'
+import { useSystemField } from '~/components/resources/hooks/use-field'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { RecordIcon } from '~/components/resources/ui/record-icon'
+
+const INVOICE_ATTRS = [
+  'invoice_status',
+  'invoice_total',
+  'invoice_amount_paid',
+  'invoice_balance',
+  'invoice_issued_at',
+] as const
+
+export interface WorkOrderBillingInvoicesBlockProps {
+  workOrderRecordId: RecordId
+  invoiceRecordIds: RecordId[]
+  isLoading: boolean
+  currencyCode: string
+  onInvoiceValues: (invoiceRecordId: RecordId, values: InvoiceBillingValues) => void
+}
+
+/** Invoices block — registered rows + "Create invoice" (billing tab §D block 4). */
+export function WorkOrderBillingInvoicesBlock({
+  workOrderRecordId,
+  invoiceRecordIds,
+  isLoading,
+  currencyCode,
+  onInvoiceValues,
+}: WorkOrderBillingInvoicesBlockProps) {
+  const [gatherOpen, setGatherOpen] = useState(false)
+
+  return (
+    <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
+      {isLoading ? (
+        <RowSkeleton />
+      ) : (
+        invoiceRecordIds.map((id) => (
+          <InvoiceBillingRow
+            key={id}
+            recordId={id}
+            currencyCode={currencyCode}
+            onValues={onInvoiceValues}
+          />
+        ))
+      )}
+
+      {/* Always available — the gather dialog owns the "no uninvoiced lines" empty state. */}
+      <TreeRow
+        icon={
+          invoiceRecordIds.length > 0 ? <Plus className='size-4' /> : <Receipt className='size-4' />
+        }
+        title={<span className='text-sm text-muted-foreground'>Create invoice</span>}
+        onToggleOpen={() => setGatherOpen(true)}
+      />
+
+      <GatherInvoiceDialog
+        open={gatherOpen}
+        onOpenChange={setGatherOpen}
+        workOrderRecordId={workOrderRecordId}
+      />
+    </div>
+  )
+}
+
+/** One invoice row: number + status badge + issued date + total + balance, opens the drawer. */
+function InvoiceBillingRow({
+  recordId,
+  currencyCode,
+  onValues,
+}: {
+  recordId: RecordId
+  currencyCode: string
+  onValues: (recordId: RecordId, values: InvoiceBillingValues) => void
+}) {
+  const router = useRouter()
+  const { record } = useRecord({ recordId, enabled: true })
+  const { resource } = useResource(getDefinitionId(recordId))
+  const { values, isLoading } = useSystemValues(recordId, [...INVOICE_ATTRS], { autoFetch: true })
+  const statusField = useSystemField('invoice_status')
+
+  const status = values.invoice_status as string | undefined
+  const total = (values.invoice_total as number | null | undefined) ?? 0
+  const amountPaid = (values.invoice_amount_paid as number | null | undefined) ?? 0
+  const balance = (values.invoice_balance as number | null | undefined) ?? 0
+  const issuedAt = values.invoice_issued_at as string | undefined
+  const displayName = record?.displayName ?? 'Untitled'
+  const statusOption = statusField?.options?.options?.find((o) => o.value === status)
+
+  // Report this row's resolved values up once loaded — feeds the summary strip's sums and the
+  // §C record-payment candidate list (both live on the parent billing tab).
+  const reportValues = useCallback(() => {
+    onValues(recordId, { recordId, status, total, amountPaid, balance, issuedAt, displayName })
+  }, [recordId, status, total, amountPaid, balance, issuedAt, displayName, onValues])
+
+  useEffect(() => {
+    if (isLoading) return
+    reportValues()
+  }, [isLoading, reportValues])
+
+  const href = `/app/invoices?id=${getInstanceId(recordId)}`
+
+  return (
+    <TreeRow
+      icon={
+        <RecordIcon
+          avatarUrl={record?.avatarUrl}
+          iconId={resource?.icon || 'receipt-text'}
+          color={resource?.color || 'gray'}
+          size='xs'
+        />
+      }
+      title={<span className='truncate text-sm'>{displayName}</span>}
+      secondary={
+        status ? (
+          <Badge variant={(statusOption?.color as Variant) ?? 'secondary'} size='xs'>
+            {statusOption?.label ?? status}
+          </Badge>
+        ) : undefined
+      }
+      onToggleOpen={() => router.push(href)}
+      actions={
+        <div className='flex items-center gap-3 text-xs text-muted-foreground'>
+          {issuedAt && (
+            <span className='tabular-nums'>{format(new Date(issuedAt), 'MMM d, yyyy')}</span>
+          )}
+          <span className='w-16 shrink-0 text-right tabular-nums'>
+            {formatCurrency(total, currencyCode)}
+          </span>
+          <span
+            className={`w-16 shrink-0 text-right tabular-nums ${balance > 0 ? 'font-medium text-foreground' : ''}`}>
+            {formatCurrency(balance, currencyCode)}
+          </span>
+          <TreeRowButton persistent tooltipText='Open' onClick={() => router.push(href)}>
+            <ExternalLink />
+          </TreeRowButton>
+        </div>
+      }
+    />
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-payments-block.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-payments-block.tsx
@@ -1,0 +1,209 @@
+// apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-payments-block.tsx
+'use client'
+
+// Billing tab §D block 5 + §C record-payment invoice preselect
+// (plans/dispatch/money/10-work-order-billing-tab.md). Thin wrapper around the shared
+// `PaymentsList` (§B) — same query/mutation/confirm shape as `invoice-payments-card.tsx`, just
+// cross-invoice (`listPaymentsForWorkOrder`) and invalidating both the WO-scoped query and the
+// affected invoice's own `listPayments` so an open invoice drawer stays fresh. `renderRowSuffix`
+// adds a small invoice chip per row (§B slot) so a mixed-invoice ledger stays legible.
+//
+// §C: candidates = invoices with `invoice_status !== 'void'` and `invoice_balance > 0`, handed
+// down by the billing tab (it already aggregates per-invoice values for the summary strip).
+// Exactly one → the dialog opens directly against it; multiple → a small `DropdownMenu`
+// chooser lists each ("<number> — <balance> due"); zero → no action, and — when there are no
+// invoices at all — a custom `EmptySection` explaining that, instead of `PaymentsList`'s own
+// "no payments recorded" copy (which reads wrong when there's nothing to attach a payment to).
+
+import type { RecordId } from '@auxx/types/resource'
+import { getInstanceId } from '@auxx/types/resource'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { EmptySection } from '@auxx/ui/components/section'
+import { toastError } from '@auxx/ui/components/toast'
+import { CreditCard, Plus } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useMemo, useState } from 'react'
+import { useAdminGate } from '~/components/global/admin-gate'
+import { RecordPaymentDialog } from '~/components/money/ui/invoice/record-payment-dialog'
+import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { PaymentsList } from '~/components/money/ui/payments/payments-list'
+import { useRecord } from '~/components/resources'
+import { useConfirm } from '~/hooks/use-confirm'
+import { api } from '~/trpc/react'
+
+export interface PaymentCandidate {
+  recordId: RecordId
+  balance: number
+  displayName: string
+}
+
+export interface WorkOrderBillingPaymentsBlockProps {
+  workOrderRecordId: RecordId
+  hasInvoices: boolean
+  candidates: PaymentCandidate[]
+  currencyCode: string
+}
+
+export function WorkOrderBillingPaymentsBlock({
+  workOrderRecordId,
+  hasInvoices,
+  candidates,
+  currencyCode,
+}: WorkOrderBillingPaymentsBlockProps) {
+  const { allowed: isAdmin } = useAdminGate()
+  const [confirm, ConfirmDialog] = useConfirm()
+  const [target, setTarget] = useState<PaymentCandidate | null>(null)
+
+  const utils = api.useUtils()
+  const { data: payments, isLoading } = api.money.listPaymentsForWorkOrder.useQuery({
+    workOrderRecordId,
+  })
+
+  const invalidateBoth = (invoiceRecordId: RecordId) => {
+    void utils.money.listPaymentsForWorkOrder.invalidate({ workOrderRecordId })
+    void utils.money.listPayments.invalidate({ invoiceRecordId })
+  }
+
+  // `PaymentsList`'s `renderRowSuffix` callback is typed against the bare `listPayments` row
+  // shape (no `invoiceRecordId`) — look the invoice up by transaction id from our own
+  // `listPaymentsForWorkOrder` data instead of widening that shared type.
+  const invoiceByTransactionId = useMemo(() => {
+    const map = new Map<string, RecordId>()
+    for (const payment of payments ?? []) map.set(payment.id, payment.invoiceRecordId)
+    return map
+  }, [payments])
+
+  const deletePayment = api.money.deletePayment.useMutation({
+    onError: (error) => toastError({ title: 'Error deleting payment', description: error.message }),
+  })
+
+  const refundTransaction = api.money.refundTransaction.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Error refunding payment', description: error.message }),
+  })
+
+  const handleDelete = async (transactionId: string) => {
+    const payment = payments?.find((p) => p.id === transactionId)
+    const confirmed = await confirm({
+      title: 'Delete this payment?',
+      description: 'Invoice balance will be recalculated.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+    deletePayment.mutate(
+      { transactionId },
+      { onSuccess: () => payment && invalidateBoth(payment.invoiceRecordId) }
+    )
+  }
+
+  const handleRefund = async (transactionId: string) => {
+    const payment = payments?.find((p) => p.id === transactionId)
+    const confirmed = await confirm({
+      title: 'Refund this payment in full?',
+      description: 'The platform fee is refunded too.',
+      confirmText: 'Refund',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+    refundTransaction.mutate(
+      { transactionId },
+      { onSuccess: () => payment && invalidateBoth(payment.invoiceRecordId) }
+    )
+  }
+
+  const openDirect = (candidate: PaymentCandidate) => setTarget(candidate)
+
+  return (
+    <div className='flex flex-col gap-1'>
+      <div className='flex items-center justify-between px-4 pt-1 pb-1'>
+        <span className='text-xs font-medium text-muted-foreground'>Payments</span>
+        {candidates.length === 1 && (
+          <Button variant='ghost' size='xs' onClick={() => openDirect(candidates[0]!)}>
+            <Plus />
+            Record payment
+          </Button>
+        )}
+        {candidates.length > 1 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant='ghost' size='xs'>
+                <Plus />
+                Record payment
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+              {candidates.map((candidate) => (
+                <DropdownMenuItem key={candidate.recordId} onClick={() => openDirect(candidate)}>
+                  {candidate.displayName} — {formatCurrency(candidate.balance, currencyCode)} due
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+
+      {!hasInvoices ? (
+        <EmptySection
+          icon={<CreditCard className='size-5' />}
+          title='No invoices yet'
+          description='Create an invoice above before recording a payment.'
+        />
+      ) : (
+        <PaymentsList
+          payments={payments}
+          isLoading={isLoading}
+          currencyCode={currencyCode}
+          isAdmin={isAdmin}
+          onDelete={handleDelete}
+          onRefund={handleRefund}
+          deletePending={deletePayment.isPending}
+          refundPending={refundTransaction.isPending}
+          renderRowSuffix={(payment) => {
+            const invoiceRecordId = invoiceByTransactionId.get(payment.id)
+            return invoiceRecordId ? <PaymentInvoiceChip invoiceRecordId={invoiceRecordId} /> : null
+          }}
+        />
+      )}
+
+      {target && (
+        <RecordPaymentDialog
+          open={!!target}
+          onOpenChange={(open) => !open && setTarget(null)}
+          invoiceRecordId={target.recordId}
+          balance={target.balance}
+          currencyCode={currencyCode}
+          onRecorded={() => invalidateBoth(target.recordId)}
+        />
+      )}
+
+      <ConfirmDialog />
+    </div>
+  )
+}
+
+/** Small invoice chip in a payment row's trailing slot — click opens that invoice's drawer. */
+function PaymentInvoiceChip({ invoiceRecordId }: { invoiceRecordId: RecordId }) {
+  const router = useRouter()
+  const { record } = useRecord({ recordId: invoiceRecordId, enabled: true })
+
+  return (
+    <button
+      type='button'
+      className='shrink-0 cursor-pointer'
+      onClick={() => router.push(`/app/invoices?id=${getInstanceId(invoiceRecordId)}`)}>
+      <Badge variant='secondary' size='xs' className='hover:bg-primary-150'>
+        {record?.displayName ?? '—'}
+      </Badge>
+    </button>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
@@ -1,0 +1,166 @@
+// apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
+'use client'
+
+// WorkOrderBillingTab — registered as `work_order:billing`
+// (plans/dispatch/money/10-work-order-billing-tab.md §D/§E). The job view's money surface:
+// summary strip, the ready-to-invoice callout (locked decision 4), the invoicing schedule
+// (`BillingScheduleRow`, moved here from the line-items section), the invoices block, and the
+// shared payments block (§B/§C). Follows `WorkOrderLineItemsTab`'s `variant` handling — bounded
+// `max-h` + `overflow-auto` in `section` mode, full-height flex in `tab` mode. The wrapping
+// `<Section>` (`DetailViewSections`) owns the "Billing" heading — this component renders content
+// only.
+
+import { cn } from '@auxx/ui/lib/utils'
+import { CalendarClock, TriangleAlert } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import type { DetailViewTabProps } from '~/components/detail-view'
+import type { InvoiceBillingValues } from '~/components/money/hooks/use-work-order-invoices'
+import { useWorkOrderInvoices } from '~/components/money/hooks/use-work-order-invoices'
+import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSettings } from '~/hooks/use-settings'
+import { api } from '~/trpc/react'
+import { BillingScheduleRow } from './billing-schedule-row'
+import { WorkOrderBillingInvoicesBlock } from './work-order-billing-invoices-block'
+import type { PaymentCandidate } from './work-order-billing-payments-block'
+import { WorkOrderBillingPaymentsBlock } from './work-order-billing-payments-block'
+
+/** Timings whose invoice drafts are generated automatically (vs `as_needed`, manual). */
+const AUTOMATED_TIMINGS = new Set(['per_visit_completed', 'on_completion', 'custom_schedule'])
+
+/** Quiet sub-block label — same style as the line-items tab's "Billed each visit" row. */
+function BlockLabel({ children }: { children: React.ReactNode }) {
+  return <div className='px-4 pt-3 pb-1 text-xs font-medium text-muted-foreground'>{children}</div>
+}
+
+export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
+  const isSection = variant === 'section'
+  const { getSetting } = useSettings({})
+  const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
+  const autoEnabled = (getSetting('documents.invoice.autoEnabled') as boolean | null) ?? true
+
+  // Same fallback the line-items tab used — `per_visit_completed` is the field's static
+  // default, and defaulting to `as_needed` here would flash the ready-to-invoice callout on
+  // automated jobs while the value loads.
+  const { values } = useSystemValues(recordId, ['work_order_invoice_timing'], { autoFetch: true })
+  const invoiceTiming =
+    (values.work_order_invoice_timing as string | undefined) ?? 'per_visit_completed'
+
+  const { invoiceRecordIds, isLoading: invoicesLoading } = useWorkOrderInvoices(recordId)
+
+  const { data: uninvoicedLines } = api.money.listUninvoicedLines.useQuery({
+    workOrderRecordId: recordId,
+  })
+  const { data: visits } = api.dispatch.listVisits.useQuery({ workOrderRecordId: recordId })
+
+  // Per-invoice values map, fed by each `InvoiceBillingRow` as its own read resolves (billing
+  // tab build spec §D.1 — no batch field-value hook exists yet).
+  const [invoiceValuesById, setInvoiceValuesById] = useState<Record<string, InvoiceBillingValues>>(
+    {}
+  )
+  const handleInvoiceValues = useCallback(
+    (invoiceRecordId: string, invoiceValues: InvoiceBillingValues) => {
+      setInvoiceValuesById((prev) => ({ ...prev, [invoiceRecordId]: invoiceValues }))
+    },
+    []
+  )
+
+  const knownInvoiceValues = useMemo(
+    () =>
+      invoiceRecordIds
+        .map((id) => invoiceValuesById[id])
+        .filter((v): v is InvoiceBillingValues => !!v),
+    [invoiceRecordIds, invoiceValuesById]
+  )
+  const nonVoidValues = useMemo(
+    () => knownInvoiceValues.filter((v) => v.status !== 'void'),
+    [knownInvoiceValues]
+  )
+
+  const invoicedTotal = nonVoidValues.reduce((sum, v) => sum + v.total, 0)
+  const paidTotal = nonVoidValues.reduce((sum, v) => sum + v.amountPaid, 0)
+  const balanceTotal = nonVoidValues.reduce((sum, v) => sum + v.balance, 0)
+  const uninvoicedTotal = (uninvoicedLines ?? []).reduce((sum, line) => sum + line.lineTotal, 0)
+
+  // §C candidates — invoices with a positive balance that aren't void.
+  const candidates: PaymentCandidate[] = useMemo(
+    () =>
+      nonVoidValues
+        .filter((v) => v.balance > 0)
+        .map((v) => ({ recordId: v.recordId, balance: v.balance, displayName: v.displayName })),
+    [nonVoidValues]
+  )
+
+  const anyDoneVisit = (visits ?? []).some((v) => v.status === 'done')
+  const hasUninvoicedLines = (uninvoicedLines ?? []).length > 0
+  const effectiveManual = invoiceTiming === 'as_needed' || autoEnabled === false
+  const showReadyToInvoiceCallout = anyDoneVisit && hasUninvoicedLines && effectiveManual
+
+  const showOrgDisabledWarning = autoEnabled === false && AUTOMATED_TIMINGS.has(invoiceTiming)
+
+  return (
+    <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
+      <div
+        className={cn(
+          'flex flex-col',
+          isSection ? 'max-h-[70vh] overflow-auto' : 'min-h-0 flex-1'
+        )}>
+        {/* Block a — summary strip */}
+        <div className='flex items-stretch gap-6 px-4 pt-2 pb-3'>
+          <SummaryCell label='Invoiced' value={formatCurrency(invoicedTotal, currencyCode)} />
+          <SummaryCell label='Paid' value={formatCurrency(paidTotal, currencyCode)} />
+          <SummaryCell label='Balance due' value={formatCurrency(balanceTotal, currencyCode)} />
+          <SummaryCell label='Uninvoiced' value={formatCurrency(uninvoicedTotal, currencyCode)} />
+        </div>
+
+        {/* Block b — ready-to-invoice callout (locked decision 4) */}
+        {showReadyToInvoiceCallout && (
+          <div className='mx-4 mb-2 flex items-center gap-1.5 rounded-md bg-amber-500/10 px-3 py-2 text-amber-700 text-xs dark:text-amber-400'>
+            <TriangleAlert className='size-3.5 shrink-0' />
+            This job has completed work that hasn't been invoiced.
+          </div>
+        )}
+
+        {/* Block c — invoicing schedule */}
+        <BillingScheduleRow workOrderRecordId={recordId} invoiceTiming={invoiceTiming} />
+        {showOrgDisabledWarning && (
+          <div className='flex items-center gap-1.5 px-4 pt-1 pb-2 text-xs text-amber-700 dark:text-amber-400'>
+            <CalendarClock className='size-3.5 shrink-0' />
+            Automatic invoicing is turned off for your organization.
+          </div>
+        )}
+
+        {/* Block d — invoices */}
+        <BlockLabel>Invoices</BlockLabel>
+        <div className='px-2'>
+          <WorkOrderBillingInvoicesBlock
+            workOrderRecordId={recordId}
+            invoiceRecordIds={invoiceRecordIds}
+            isLoading={invoicesLoading}
+            currencyCode={currencyCode}
+            onInvoiceValues={handleInvoiceValues}
+          />
+        </div>
+
+        {/* Block e — payments */}
+        <WorkOrderBillingPaymentsBlock
+          workOrderRecordId={recordId}
+          hasInvoices={invoiceRecordIds.length > 0}
+          candidates={candidates}
+          currencyCode={currencyCode}
+        />
+      </div>
+    </div>
+  )
+}
+
+function SummaryCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className='flex flex-col gap-0.5'>
+      <span className='text-xs text-muted-foreground'>{label}</span>
+      <span className='font-medium text-sm tabular-nums'>{value}</span>
+    </div>
+  )
+}
+
+export default WorkOrderBillingTab

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
@@ -5,7 +5,6 @@ import { cn } from '@auxx/ui/lib/utils'
 import type { DetailViewTabProps } from '~/components/detail-view'
 import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
-import { BillingScheduleRow } from './billing-schedule-row'
 
 /**
  * WorkOrderLineItemsTab — registered as `work_order:line-items` (dispatch M2
@@ -15,23 +14,17 @@ import { BillingScheduleRow } from './billing-schedule-row'
  * `hasBilling` is quote/invoice-only) — this is the job's per-cycle line set
  * ("what every visit bills", 04-ui.md §6 Line items section / money 01-ui
  * #13): the header reads "Billed each visit" when the job is recurring
- * (`work_order_job_type`). The Billing row (money MI2 build spec §K.1) sits
- * above it — the reserved slot for how/when invoice drafts get generated.
+ * (`work_order_job_type`). The billing schedule row (money MI2 build spec
+ * §K.1) moved to the `billing` section — see `work-order-billing-tab.tsx`
+ * (money plan 10 §D block 3).
  */
 export function WorkOrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
-  const { values } = useSystemValues(
-    recordId,
-    ['work_order_job_type', 'work_order_invoice_timing'],
-    { autoFetch: true }
-  )
+  const { values } = useSystemValues(recordId, ['work_order_job_type'], { autoFetch: true })
   const jobType = (values.work_order_job_type as string | undefined) ?? 'one_off'
-  const invoiceTiming =
-    (values.work_order_invoice_timing as string | undefined) ?? 'per_visit_completed'
   const isSection = variant === 'section'
 
   return (
     <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
-      <BillingScheduleRow workOrderRecordId={recordId} invoiceTiming={invoiceTiming} />
       {jobType === 'recurring' && (
         <div className='px-4 pt-1 pb-1 text-xs font-medium text-muted-foreground'>
           Billed each visit

--- a/apps/web/src/components/money/hooks/use-work-order-invoices.ts
+++ b/apps/web/src/components/money/hooks/use-work-order-invoices.ts
@@ -1,0 +1,39 @@
+// apps/web/src/components/money/hooks/use-work-order-invoices.ts
+
+// Work-order billing tab build spec §D.1/§D.4 (plans/dispatch/money/10-work-order-billing-tab.md)
+// — resolves a job's linked invoices via the `work_order_invoices` inverse relationship, the
+// same read `WorkOrderInvoicesCard` (work-order-related-cards.tsx) already uses. Shared by the
+// billing tab's summary strip, invoices block, and record-payment candidate list so all three
+// read one relationship fetch instead of three.
+
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import type { RecordId } from '@auxx/types/resource'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+
+/**
+ * Per-invoice money/status snapshot reported up by each invoice row (`InvoiceBillingRow`) once
+ * its own `useSystemValues` read resolves — the "per-invoice child row feeds a parent-held map"
+ * shape called for in the build spec (no batch field-value hook exists yet, see §D.1).
+ */
+export interface InvoiceBillingValues {
+  recordId: RecordId
+  status: string | undefined
+  total: number
+  amountPaid: number
+  balance: number
+  issuedAt: string | undefined
+  /** `EntityInstance.displayName` — the invoice number (e.g. "INV-0001"). */
+  displayName: string
+}
+
+/** Resolve a work order's linked invoice recordIds via `work_order_invoices`. */
+export function useWorkOrderInvoices(recordId: RecordId): {
+  invoiceRecordIds: RecordId[]
+  isLoading: boolean
+} {
+  const { values, isLoading } = useSystemValues(recordId, ['work_order_invoices'], {
+    autoFetch: true,
+  })
+
+  return { invoiceRecordIds: extractRelationshipRecordIds(values.work_order_invoices), isLoading }
+}

--- a/apps/web/src/components/money/ui/invoice/invoice-payments-card.tsx
+++ b/apps/web/src/components/money/ui/invoice/invoice-payments-card.tsx
@@ -2,56 +2,23 @@
 'use client'
 
 // Invoice drawer's "Payments" tab card — registered as 'invoice:payments' (money MI1 build
-// spec §J.1; money MP1 build spec §K adds the provider-aware per-row action). Lists the
-// `PaymentTransaction` ledger rows (`money.listPayments` — reads the ledger, not the
-// `payment` entity mirrors, so Stripe rows show with zero data-fetch change), admin-gated
-// delete (manual rows, decision 8) / refund (Stripe rows), and the "Record payment" footer
-// action (§J.3).
+// spec §J.1; money MP1 build spec §K adds the provider-aware per-row action). Thin wrapper:
+// owns the queries/mutations/confirms and the "Record payment" footer action, and renders the
+// shared `PaymentsList` (money plan 10 §B) for the row markup.
 
-import { Badge, type Variant as BadgeVariant } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { EmptySection } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
-import { format } from 'date-fns'
-import { CreditCard, Plus, RotateCcw, Trash2 } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { useState } from 'react'
 import { DrawerCardActions } from '~/components/drawers/drawer-card-actions'
 import type { DrawerTabProps } from '~/components/drawers/drawer-tab-registry'
 import { useAdminGate } from '~/components/global/admin-gate'
-import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { PaymentsList } from '~/components/money/ui/payments/payments-list'
 import { useSystemValues } from '~/components/resources/hooks'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
-import { paymentMethodLabel } from './payment-method-options'
 import { RecordPaymentDialog } from './record-payment-dialog'
-
-/** Non-actionable Stripe rows render a status chip instead of an action — a refund-in-progress,
- * an already-refunded charge, or a disputed one. A refunded CHARGE row deliberately keeps
- * `status: 'succeeded'` (the refund row does the subtracting in the ledger math), so
- * refunded-ness is derived from the linked refund row's status, not the charge's own. */
-function stripeStatusChip(
-  payment: { kind: string; status: string },
-  linkedRefundStatus?: string
-): {
-  label: string
-  variant: BadgeVariant
-} {
-  if (payment.kind === 'refund') {
-    if (payment.status === 'succeeded') return { label: 'Refunded', variant: 'gray' }
-    if (payment.status === 'pending') return { label: 'Refund pending', variant: 'amber' }
-    return { label: 'Refund failed', variant: 'red' }
-  }
-  if (linkedRefundStatus) {
-    return linkedRefundStatus === 'succeeded'
-      ? { label: 'Refunded', variant: 'gray' }
-      : { label: 'Refund pending', variant: 'amber' }
-  }
-  if (payment.status === 'refunded') return { label: 'Refunded', variant: 'gray' }
-  if (payment.status === 'disputed') return { label: 'Disputed', variant: 'red' }
-  if (payment.status === 'pending') return { label: 'Processing', variant: 'amber' }
-  return { label: payment.status, variant: 'gray' }
-}
 
 const INVOICE_ATTRS = ['invoice_status', 'invoice_balance'] as const
 
@@ -111,20 +78,6 @@ export function InvoicePaymentsCard({ recordId }: DrawerTabProps) {
 
   const canRecordPayment = status !== 'void' && balance > 0
 
-  // Charge id → its open/succeeded refund's status. A charge with a linked refund is no longer
-  // refundable (the server would reject it) — it renders a chip instead of the Refund action.
-  const refundStatusByCharge = new Map<string, string>()
-  for (const p of payments ?? []) {
-    if (
-      p.kind === 'refund' &&
-      p.refundedTransactionId &&
-      p.status !== 'failed' &&
-      p.status !== 'canceled'
-    ) {
-      refundStatusByCharge.set(p.refundedTransactionId, p.status)
-    }
-  }
-
   return (
     <div className='flex flex-col gap-2'>
       {canRecordPayment && (
@@ -136,66 +89,16 @@ export function InvoicePaymentsCard({ recordId }: DrawerTabProps) {
         </DrawerCardActions>
       )}
 
-      {isLoading ? (
-        <EmptySection loading />
-      ) : !payments?.length ? (
-        <EmptySection
-          icon={<CreditCard className='size-5' />}
-          title='No payments recorded'
-          description='Record a payment to get started.'
-        />
-      ) : (
-        <div className='flex flex-col divide-y divide-primary-200/50 dark:divide-[#1e2227]'>
-          {payments.map((payment) => (
-            <div key={payment.id} className='group flex items-center gap-2 py-1.5 text-sm'>
-              <span className='w-24 shrink-0 tabular-nums text-muted-foreground'>
-                {format(new Date(payment.date), 'MMM d, yyyy')}
-              </span>
-              <span className='w-28 shrink-0 truncate text-muted-foreground'>
-                {paymentMethodLabel(payment.method ?? 'other')}
-              </span>
-              <span className='min-w-0 flex-1 truncate text-muted-foreground text-xs'>
-                {payment.reference ?? ''}
-              </span>
-              <span className='shrink-0 tabular-nums'>
-                {formatCurrency(payment.amount, currencyCode)}
-              </span>
-              {payment.provider === 'manual'
-                ? isAdmin && (
-                    <Button
-                      variant='ghost'
-                      size='icon-sm'
-                      className='shrink-0 text-destructive/70 opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100'
-                      loading={deletePayment.isPending}
-                      onClick={() => handleDelete(payment.id)}>
-                      <Trash2 />
-                    </Button>
-                  )
-                : payment.kind === 'charge' &&
-                    payment.status === 'succeeded' &&
-                    !refundStatusByCharge.has(payment.id)
-                  ? isAdmin && (
-                      <Button
-                        variant='ghost'
-                        size='icon-sm'
-                        className='shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100'
-                        loading={refundTransaction.isPending}
-                        onClick={() => handleRefund(payment.id)}>
-                        <RotateCcw />
-                      </Button>
-                    )
-                  : (() => {
-                      const chip = stripeStatusChip(payment, refundStatusByCharge.get(payment.id))
-                      return (
-                        <Badge variant={chip.variant} size='sm' className='shrink-0'>
-                          {chip.label}
-                        </Badge>
-                      )
-                    })()}
-            </div>
-          ))}
-        </div>
-      )}
+      <PaymentsList
+        payments={payments}
+        isLoading={isLoading}
+        currencyCode={currencyCode}
+        isAdmin={isAdmin}
+        onDelete={handleDelete}
+        onRefund={handleRefund}
+        deletePending={deletePayment.isPending}
+        refundPending={refundTransaction.isPending}
+      />
 
       <RecordPaymentDialog
         open={dialogOpen}

--- a/apps/web/src/components/money/ui/payments/payments-list.tsx
+++ b/apps/web/src/components/money/ui/payments/payments-list.tsx
@@ -1,0 +1,156 @@
+// apps/web/src/components/money/ui/payments/payments-list.tsx
+'use client'
+
+// Shared presentational payments list — the row markup (date / method / reference / amount),
+// the `stripeStatusChip` helper, and the `refundStatusByCharge` derivation, extracted verbatim
+// from the invoice drawer's payments card (money MP1 build spec §K) so the work-order billing
+// section (money plan 10 §B) can reuse it. Admin-gated delete (manual rows) / refund (Stripe
+// rows) behavior is unchanged; callers own their own queries/mutations.
+
+import { Badge, type Variant as BadgeVariant } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { EmptySection } from '@auxx/ui/components/section'
+import { format } from 'date-fns'
+import { CreditCard, RotateCcw, Trash2 } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import type { RouterOutputs } from '~/trpc/react'
+import { paymentMethodLabel } from '../invoice/payment-method-options'
+
+type PaymentRow = RouterOutputs['money']['listPayments'][number]
+
+/** Non-actionable Stripe rows render a status chip instead of an action — a refund-in-progress,
+ * an already-refunded charge, or a disputed one. A refunded CHARGE row deliberately keeps
+ * `status: 'succeeded'` (the refund row does the subtracting in the ledger math), so
+ * refunded-ness is derived from the linked refund row's status, not the charge's own. */
+function stripeStatusChip(
+  payment: { kind: string; status: string },
+  linkedRefundStatus?: string
+): {
+  label: string
+  variant: BadgeVariant
+} {
+  if (payment.kind === 'refund') {
+    if (payment.status === 'succeeded') return { label: 'Refunded', variant: 'gray' }
+    if (payment.status === 'pending') return { label: 'Refund pending', variant: 'amber' }
+    return { label: 'Refund failed', variant: 'red' }
+  }
+  if (linkedRefundStatus) {
+    return linkedRefundStatus === 'succeeded'
+      ? { label: 'Refunded', variant: 'gray' }
+      : { label: 'Refund pending', variant: 'amber' }
+  }
+  if (payment.status === 'refunded') return { label: 'Refunded', variant: 'gray' }
+  if (payment.status === 'disputed') return { label: 'Disputed', variant: 'red' }
+  if (payment.status === 'pending') return { label: 'Processing', variant: 'amber' }
+  return { label: payment.status, variant: 'gray' }
+}
+
+export interface PaymentsListProps {
+  payments: PaymentRow[] | undefined
+  isLoading: boolean
+  currencyCode: string
+  isAdmin: boolean
+  onDelete: (transactionId: string) => void
+  onRefund: (transactionId: string) => void
+  deletePending: boolean
+  refundPending: boolean
+  /** Optional slot rendered at the end of each row, after the action button/chip — e.g. the
+   * work-order billing section's invoice chip/link. */
+  renderRowSuffix?: (payment: PaymentRow) => ReactNode
+}
+
+/** Presentational payments ledger list — rows, loading + empty states, and the admin-gated
+ * delete (manual) / refund (Stripe) actions. Shared by the invoice drawer's payments card and
+ * the work-order billing section's payments block. */
+export function PaymentsList({
+  payments,
+  isLoading,
+  currencyCode,
+  isAdmin,
+  onDelete,
+  onRefund,
+  deletePending,
+  refundPending,
+  renderRowSuffix,
+}: PaymentsListProps) {
+  // Charge id → its open/succeeded refund's status. A charge with a linked refund is no longer
+  // refundable (the server would reject it) — it renders a chip instead of the Refund action.
+  const refundStatusByCharge = new Map<string, string>()
+  for (const p of payments ?? []) {
+    if (
+      p.kind === 'refund' &&
+      p.refundedTransactionId &&
+      p.status !== 'failed' &&
+      p.status !== 'canceled'
+    ) {
+      refundStatusByCharge.set(p.refundedTransactionId, p.status)
+    }
+  }
+
+  if (isLoading) return <EmptySection loading />
+
+  if (!payments?.length) {
+    return (
+      <EmptySection
+        icon={<CreditCard className='size-5' />}
+        title='No payments recorded'
+        description='Record a payment to get started.'
+      />
+    )
+  }
+
+  return (
+    <div className='flex flex-col divide-y divide-primary-200/50 dark:divide-[#1e2227]'>
+      {payments.map((payment) => (
+        <div key={payment.id} className='group flex items-center gap-2 py-1.5 text-sm'>
+          <span className='w-24 shrink-0 tabular-nums text-muted-foreground'>
+            {format(new Date(payment.date), 'MMM d, yyyy')}
+          </span>
+          <span className='w-28 shrink-0 truncate text-muted-foreground'>
+            {paymentMethodLabel(payment.method ?? 'other')}
+          </span>
+          <span className='min-w-0 flex-1 truncate text-muted-foreground text-xs'>
+            {payment.reference ?? ''}
+          </span>
+          <span className='shrink-0 tabular-nums'>
+            {formatCurrency(payment.amount, currencyCode)}
+          </span>
+          {payment.provider === 'manual'
+            ? isAdmin && (
+                <Button
+                  variant='ghost'
+                  size='icon-sm'
+                  className='shrink-0 text-destructive/70 opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100'
+                  loading={deletePending}
+                  onClick={() => onDelete(payment.id)}>
+                  <Trash2 />
+                </Button>
+              )
+            : payment.kind === 'charge' &&
+                payment.status === 'succeeded' &&
+                !refundStatusByCharge.has(payment.id)
+              ? isAdmin && (
+                  <Button
+                    variant='ghost'
+                    size='icon-sm'
+                    className='shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100'
+                    loading={refundPending}
+                    onClick={() => onRefund(payment.id)}>
+                    <RotateCcw />
+                  </Button>
+                )
+              : (() => {
+                  const chip = stripeStatusChip(payment, refundStatusByCharge.get(payment.id))
+                  return (
+                    <Badge variant={chip.variant} size='sm' className='shrink-0'>
+                      {chip.label}
+                    </Badge>
+                  )
+                })()}
+          {renderRowSuffix?.(payment)}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/server/api/routers/money.ts
+++ b/apps/web/src/server/api/routers/money.ts
@@ -1,5 +1,6 @@
 // apps/web/src/server/api/routers/money.ts
 
+import type { PaymentTransactionEntity } from '@auxx/database'
 import { database, schema } from '@auxx/database'
 import { renderPreviewQuotePdf } from '@auxx/lib/documents'
 import { NotFoundError } from '@auxx/lib/errors'
@@ -18,6 +19,7 @@ import {
   getInvoiceSchedule,
   getPaymentAccount,
   listUninvoicedLines,
+  listWorkOrderPayments,
   markInvoiceSent,
   markQuoteSent,
   prepareDocumentEmail,
@@ -38,7 +40,7 @@ import {
 } from '@auxx/lib/recurrence'
 import { getOrganizationSetting } from '@auxx/lib/settings'
 import type { RecordId } from '@auxx/types/resource'
-import { parseRecordId, recordIdSchema } from '@auxx/types/resource'
+import { parseRecordId, recordIdSchema, toRecordId } from '@auxx/types/resource'
 import { and, asc, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { adminProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
@@ -65,6 +67,29 @@ const moneyAdminProcedure = adminProcedure.use(async ({ ctx, next }) => {
   )
   return next()
 })
+
+/**
+ * Shape a `PaymentTransaction` ledger row for the payments list UI (money MI1 build spec
+ * §E.2 row shape) — shared by `listPayments` (per-invoice, invoice-drawer) and
+ * `listPaymentsForWorkOrder` (cross-invoice, job page) so the row shape can't drift between
+ * the two call sites.
+ */
+function mapPaymentRow(row: PaymentTransactionEntity) {
+  return {
+    id: row.id,
+    amount: row.amount,
+    kind: row.kind,
+    status: row.status,
+    date: (row.metadata as { date?: string } | null)?.date ?? row.createdAt.toISOString(),
+    method: row.method,
+    reference: row.reference,
+    note: row.note,
+    provider: row.provider,
+    createdByUserId: row.createdByUserId,
+    stripeRefundId: row.stripeRefundId,
+    refundedTransactionId: row.refundedTransactionId,
+  }
+}
 
 export const moneyRouter = createTRPCRouter({
   createQuoteFromRequest: moneyProcedure
@@ -388,19 +413,29 @@ export const moneyRouter = createTRPCRouter({
         orderBy: asc(schema.PaymentTransaction.createdAt),
       })
 
+      return rows.map(mapPaymentRow)
+    }),
+
+  /**
+   * Cross-invoice payments read for the job page's billing section (money work-order billing
+   * tab build spec §A) — every ledger row across ALL of a work order's invoices, `createdAt`
+   * asc. Row shape = `listPayments`'s exact mapper plus `invoiceRecordId` so the client can
+   * label rows by invoice and invalidate that invoice's `listPayments` query on record/delete/
+   * refund. `listPayments` itself is untouched — the invoice drawer keeps its exact query key.
+   */
+  listPaymentsForWorkOrder: moneyProcedure
+    .input(z.object({ workOrderRecordId: recordIdSchema }))
+    .query(async ({ ctx, input }) => {
+      const { entityInstanceId: workOrderInstanceId } = parseRecordId(input.workOrderRecordId)
+      const rows = await listWorkOrderPayments({
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.user.id,
+        workOrderInstanceId,
+      })
+
       return rows.map((row) => ({
-        id: row.id,
-        amount: row.amount,
-        kind: row.kind,
-        status: row.status,
-        date: (row.metadata as { date?: string } | null)?.date ?? row.createdAt.toISOString(),
-        method: row.method,
-        reference: row.reference,
-        note: row.note,
-        provider: row.provider,
-        createdByUserId: row.createdByUserId,
-        stripeRefundId: row.stripeRefundId,
-        refundedTransactionId: row.refundedTransactionId,
+        ...mapPaymentRow(row),
+        invoiceRecordId: toRecordId('invoice', row.invoiceInstanceId),
       }))
     }),
 

--- a/packages/lib/src/money/index.ts
+++ b/packages/lib/src/money/index.ts
@@ -33,6 +33,7 @@ export {
 export {
   deleteManualPayment,
   hasSucceededCharges,
+  listWorkOrderPayments,
   recordManualPayment,
   syncInvoicePaymentState,
   syncTransaction,
@@ -94,6 +95,7 @@ export type {
   InvoiceScheduleQueryInput,
   LineForTotals,
   ListUninvoicedLinesInput,
+  ListWorkOrderPaymentsInput,
   MoneyMutationInput,
   PaymentMethod,
   QuoteLifecycleInput,

--- a/packages/lib/src/money/payments/ledger.ts
+++ b/packages/lib/src/money/payments/ledger.ts
@@ -4,15 +4,17 @@ import type { PaymentTransactionEntity } from '@auxx/database'
 import { database, schema } from '@auxx/database'
 import type { TypedFieldValue } from '@auxx/types'
 import { extractValue } from '@auxx/types'
-import { toRecordId } from '@auxx/types/resource'
-import { and, eq, inArray } from 'drizzle-orm'
+import { parseRecordId, toRecordId } from '@auxx/types/resource'
+import { and, asc, eq, inArray } from 'drizzle-orm'
 import { getOrgCache } from '../../cache'
 import { BadRequestError, ForbiddenError, NotFoundError } from '../../errors'
 import { FieldValueService } from '../../field-values/field-value-service'
+import { extractRelationshipRecordIds } from '../../field-values/relationship-field'
 import { UnifiedCrudHandler } from '../../resources/crud'
 import { getOrganizationSetting } from '../../settings/settings-service'
 import type {
   DeleteManualPaymentInput,
+  ListWorkOrderPaymentsInput,
   RecordManualPaymentInput,
   SyncInvoicePaymentStateInput,
 } from '../types'
@@ -73,6 +75,45 @@ export async function hasSucceededCharges(
     columns: { id: true },
   })
   return !!row
+}
+
+/**
+ * List every ledger row across ALL invoices linked to a work order, ordered `createdAt` asc
+ * (money §A build spec, plans/dispatch/money/10-work-order-billing-tab.md §A) — the
+ * cross-invoice read backing the job page's billing section (`listPayments` stays
+ * per-invoice, invoice-drawer-only, and is left untouched). Resolves the WO's invoices via the
+ * `work_order_invoices` inverse relationship — the same `getFieldValues` +
+ * `extractRelationshipRecordIds` mechanism the client's `WorkOrderInvoicesCard` reads
+ * (`work-order-related-cards.tsx`), not a new FieldValue query shape. Returns `[]` without
+ * touching the ledger table when the work order has no invoices yet.
+ */
+export async function listWorkOrderPayments(
+  input: ListWorkOrderPaymentsInput
+): Promise<PaymentTransactionEntity[]> {
+  const { organizationId, userId, workOrderInstanceId } = input
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  const workOrderRecordId = toRecordId('work_order', workOrderInstanceId)
+
+  const woCf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['work_order_invoices'] as const)
+  if (!woCf.work_order_invoices) return []
+
+  const values = await handler.getFieldValues(workOrderRecordId, [woCf.work_order_invoices.id])
+  const invoiceRecordIds = extractRelationshipRecordIds(values.get(woCf.work_order_invoices.id))
+  if (invoiceRecordIds.length === 0) return []
+
+  const invoiceInstanceIds = invoiceRecordIds.map(
+    (recordId) => parseRecordId(recordId).entityInstanceId
+  )
+
+  return database.query.PaymentTransaction.findMany({
+    where: and(
+      eq(schema.PaymentTransaction.organizationId, organizationId),
+      inArray(schema.PaymentTransaction.invoiceInstanceId, invoiceInstanceIds)
+    ),
+    orderBy: asc(schema.PaymentTransaction.createdAt),
+  })
 }
 
 /**

--- a/packages/lib/src/money/types.ts
+++ b/packages/lib/src/money/types.ts
@@ -106,6 +106,13 @@ export interface DeleteManualPaymentInput extends MoneyMutationInput {
   transactionId: string
 }
 
+/** Input for `listWorkOrderPayments` — the job page's cross-invoice payments read (money
+ * work-order billing tab build spec §A). */
+export interface ListWorkOrderPaymentsInput extends MoneyMutationInput {
+  /** EntityInstance id of the work order (not the RecordId). */
+  workOrderInstanceId: string
+}
+
 /** Input for `syncInvoicePaymentState` — the ledger → invoice mirror projection (§E.4). */
 export interface SyncInvoicePaymentStateInput extends MoneyMutationInput {
   /** EntityInstance id of the invoice (not the RecordId). */

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -130,6 +130,7 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
       { value: 'schedule', label: 'Schedule', icon: 'calendar' },
       { value: 'history', label: 'History', icon: 'history' },
       { value: 'line-items', label: 'Line items', icon: 'receipt-text' },
+      { value: 'billing', label: 'Billing', icon: 'credit-card' },
       { value: 'timeline', label: 'Timeline', icon: 'clock' },
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],


### PR DESCRIPTION
## Summary

The work-order full-screen view had zero money surface — invoices lived only in the drawer's bare card, payments only on the invoice drawer, and the per-job invoicing config was buried at the top of the line-items section. This adds a **Billing** scroll-spy section owning the job's whole financial story.

### What's in it

- **Summary strip** — invoiced / paid / balance due / uninvoiced, summed from per-invoice field values (void excluded) + `listUninvoicedLines`; totals update via realtime field-value frames, no polling.
- **Ready-to-invoice callout** — amber nudge when a job with completed visits has unbilled lines and invoicing is effectively manual (`as_needed` timing, or the org `documents.invoice.autoEnabled` switch off). Derived client-side, no new state.
- **Invoicing schedule** — `BillingScheduleRow` moves here from the line-items section (single home), plus a quiet warning when org-level automation is off while the job has an automated timing.
- **Invoices block** — TreeRow per invoice (status badge, issued date, total, balance; opens the invoice drawer) + the drawer's Create-invoice gather row pattern.
- **Payments block** — new `money.listPaymentsForWorkOrder` (cross-invoice ledger read resolving the `work_order_invoices` relationship in lib) rendered by `PaymentsList`, extracted **verbatim** from the invoice drawer's payments card (the drawer card is now a thin wrapper with identical query keys/behavior). Each row carries an invoice chip; delete/refund invalidate both the WO-scoped and per-invoice queries.
- **Record payment from the job page** — one open invoice goes straight to the existing `RecordPaymentDialog`; multiple get a DropdownMenu chooser ("INV-000x — $y due"); zero invoices shows an empty state pointing at Create invoice (payments require an invoice — ledger FK).

### Wiring

`billing` mainTab after line-items (`detail-view-config.ts`), `work_order:billing` registry entry, `credit-card` added to the detail-view icon map.

> **Note for local testing:** restart the web dev server after pulling — the mainTab entry rides in the rebuilt `@auxx/lib` dist.

Plan: `plans/dispatch/money/10-work-order-billing-tab.md` (local)

## Test plan

- [ ] Billing section renders in the scroll-spy nav; `?tab=billing` deep-links
- [ ] Summary figures reconcile (void excluded; uninvoiced matches the gather dialog)
- [ ] Record payment: single-invoice direct, multi-invoice chooser, zero-invoice empty state
- [ ] Delete/refund from the job page recalculate the strip; member sees neither (admin gate)
- [ ] Create invoice via gather; new invoice appears without reload
- [ ] Ready-to-invoice callout shows/clears per the predicate; automated-and-on jobs never show it
- [ ] Invoice drawer payments card regression (post-extraction, should be byte-identical)
- [ ] Line-items section no longer shows the billing schedule row