### PR TITLE
fix(dispatch,ui): calendar padding polish + worker profile field adapters

### DIFF
--- a/apps/web/src/components/dispatch/ui/board/board-toolbar.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-toolbar.tsx
@@ -5,7 +5,7 @@
 import { Button } from '@auxx/ui/components/button'
 import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
 import { Separator } from '@auxx/ui/components/separator'
-import { addDays, format, startOfWeek } from 'date-fns'
+import { startOfWeek } from 'date-fns'
 import {
   CalendarDays,
   CalendarRange,
@@ -16,10 +16,9 @@ import {
   PanelLeft,
 } from 'lucide-react'
 import { Tooltip } from '~/components/global/tooltip'
-import { DateTimePicker } from '~/components/pickers/date-time-picker'
 import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
 import type { BoardViewMode } from './types'
-import { goToNextDate, goToPreviousDate, viewedMonthStart, type WeekStartIndex } from './utils'
+import { goToNextDate, goToPreviousDate, type WeekStartIndex } from './utils'
 
 export type BoardMode = 'calendar' | 'map'
 
@@ -36,24 +35,6 @@ interface BoardToolbarProps {
   weekStartsOn: WeekStartIndex
   boardMode: BoardMode
   onBoardModeChange: (mode: BoardMode) => void
-}
-
-/** View-shaped date label: month → "August 2026", week → short from–to, day → full date. */
-function dateLabel(view: BoardViewMode, date: Date, weekStartsOn: WeekStartIndex): string {
-  if (view === 'month') return format(viewedMonthStart(date, weekStartsOn), 'MMMM yyyy')
-  if (view === 'week') {
-    // Anchor model (13-week-view-horizontal-stream.md): `date` is the leftmost visible day of
-    // the stream, not necessarily a `weekStartsOn`-aligned week start — the displayed "week" is
-    // just the 7 days from the anchor.
-    const start = date
-    const end = addDays(date, 6)
-    if (start.getFullYear() !== end.getFullYear())
-      return `${format(start, 'MMM d, yyyy')} – ${format(end, 'MMM d, yyyy')}`
-    if (start.getMonth() !== end.getMonth())
-      return `${format(start, 'MMM d')} – ${format(end, 'MMM d, yyyy')}`
-    return `${format(start, 'MMM d')} – ${format(end, 'd, yyyy')}`
-  }
-  return format(date, 'PPP')
 }
 
 /**
@@ -137,16 +118,6 @@ export function BoardToolbar({
           aria-label='Next'>
           <ChevronRight />
         </Button>
-        <DateTimePicker
-          value={date}
-          onChange={(value) => value && onDateChange(value)}
-          mode='date'
-          notClearable>
-          {/* Fixed width — the label re-formats per view/day and must not shift its neighbors. */}
-          <Button variant='ghost' size='sm' className='w-44 justify-center truncate'>
-            {dateLabel(effectiveView, date, weekStartsOn)}
-          </Button>
-        </DateTimePicker>
       </div>
 
       <Separator orientation='vertical' className='h-6' />

--- a/apps/web/src/components/dispatch/ui/worker-profile-page.tsx
+++ b/apps/web/src/components/dispatch/ui/worker-profile-page.tsx
@@ -1,17 +1,15 @@
 // apps/web/src/components/dispatch/ui/worker-profile-page.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import type { SelectOptionColor } from '@auxx/lib/custom-fields/client'
 import { Button } from '@auxx/ui/components/button'
 import { DialogFooter } from '@auxx/ui/components/dialog'
 import { KbdSubmit } from '@auxx/ui/components/kbd'
-import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
 import { Trash2 } from 'lucide-react'
-import {
-  type AddressStruct,
-  AddressStructFields,
-} from '~/components/fields/inputs/address-struct-input-field'
+import type { AddressStruct } from '~/components/fields/inputs/address-struct-input-field'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
 import { ColorTagPicker } from '~/components/tags/ui/color-tag-picker'
@@ -148,10 +146,10 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
           showIcon
           description='Used for routing on the live map (M3).'>
           <div className='py-2'>
-            <AddressStructFields
+            <FieldInputAdapter
+              fieldType={FieldType.ADDRESS_STRUCT}
               value={draft.homeBase}
-              onChange={(homeBase) => patch({ homeBase })}
-              className='flex flex-col gap-2'
+              onChange={(homeBase) => patch({ homeBase: homeBase as AddressStruct })}
               disabled={isSaving}
             />
           </div>
@@ -162,9 +160,11 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
           type={BaseType.BOOLEAN}
           showIcon
           description='Inactive workers are hidden from the board.'>
-          <Switch
-            checked={draft.isActive}
-            onCheckedChange={(isActive) => patch({ isActive })}
+          <FieldInputAdapter
+            fieldType={FieldType.CHECKBOX}
+            fieldOptions={{ variant: 'switch' }}
+            value={draft.isActive}
+            onChange={(isActive) => patch({ isActive: isActive as boolean })}
             disabled={isSaving}
           />
         </FieldPanelRow>
@@ -174,9 +174,13 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
           type={BaseType.BOOLEAN}
           showIcon
           description='Route begins at the business address.'>
-          <Switch
-            checked={draft.routeStartAtHome}
-            onCheckedChange={(routeStartAtHome) => patch({ routeStartAtHome })}
+          <FieldInputAdapter
+            fieldType={FieldType.CHECKBOX}
+            fieldOptions={{ variant: 'switch' }}
+            value={draft.routeStartAtHome}
+            onChange={(routeStartAtHome) =>
+              patch({ routeStartAtHome: routeStartAtHome as boolean })
+            }
             disabled={isSaving}
           />
         </FieldPanelRow>
@@ -186,9 +190,11 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
           type={BaseType.BOOLEAN}
           showIcon
           description='Route ends at the business address.'>
-          <Switch
-            checked={draft.routeEndAtHome}
-            onCheckedChange={(routeEndAtHome) => patch({ routeEndAtHome })}
+          <FieldInputAdapter
+            fieldType={FieldType.CHECKBOX}
+            fieldOptions={{ variant: 'switch' }}
+            value={draft.routeEndAtHome}
+            onChange={(routeEndAtHome) => patch({ routeEndAtHome: routeEndAtHome as boolean })}
             disabled={isSaving}
           />
         </FieldPanelRow>

--- a/apps/web/src/components/pickers/date-time-picker/views/calendar-view.tsx
+++ b/apps/web/src/components/pickers/date-time-picker/views/calendar-view.tsx
@@ -31,7 +31,6 @@ const CalendarView: React.FC<CalendarViewProps> = ({
       maxDate={maxDate}
       showOutsideDays={true}
       captionLayout='dropdown'
-      className='p-2'
     />
   )
 }

--- a/packages/ui/src/components/calendar/calendar.tsx
+++ b/packages/ui/src/components/calendar/calendar.tsx
@@ -184,12 +184,13 @@ export function Calendar(props: CalendarProps) {
         data-slot='calendar'
         // Reserve a definite width so the calendar renders correctly inside width-fitting
         // containers (e.g. `w-auto` popovers), where the fluid `w-full`/`aspect-square` day
-        // cells would otherwise collapse to zero. Each month claims ≥13rem plus gaps/padding;
-        // `min-width` still lets the grid grow to fill wider fixed-width containers.
+        // cells would otherwise collapse to zero. Each month claims ≥14rem (grid + its own
+        // `px-2`) plus inter-month gaps; `min-width` still lets the grid grow to fill wider
+        // fixed-width containers.
         style={{
-          minWidth: `calc(${numberOfMonths} * 13rem + ${numberOfMonths - 1} * 1rem + 1.5rem)`,
+          minWidth: `calc(${numberOfMonths} * 14rem + ${numberOfMonths - 1} * 1rem)`,
         }}
-        className={cn('@container relative select-none p-3', className)}>
+        className={cn('@container relative select-none', className)}>
         {!hideNavigation && captionLayout === 'label' && (
           <div
             data-slot='nav'

--- a/packages/ui/src/components/calendar/month-grid.tsx
+++ b/packages/ui/src/components/calendar/month-grid.tsx
@@ -44,7 +44,7 @@ export function MonthGrid({
       role='grid'
       aria-label={format(month, 'MMMM yyyy')}
       onKeyDown={onKeyDown}
-      className='w-full outline-none'>
+      className='w-full px-2 outline-none'>
       <div data-slot='weekdays' role='row' className='grid grid-cols-7'>
         {weekdays.map((day) => (
           <div

--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -234,7 +234,7 @@ export function DateRangePicker({
             variant={triggerVariant}
             size='sm'
             className={cn('justify-start text-left font-normal', triggerClassName)}>
-            <CalendarIcon className='mr-2 h-4 w-4' />
+            <CalendarIcon />
             {displayLabel}
           </Button>
         )}

--- a/packages/ui/src/components/event-calendar/event-calendar.tsx
+++ b/packages/ui/src/components/event-calendar/event-calendar.tsx
@@ -352,7 +352,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
 
   return (
     <div
-      className={cn('flex min-w-0 flex-col rounded-lg border', className)}
+      className={cn('flex min-w-0 flex-col', className)}
       style={
         {
           '--event-height': `${EventHeight}px`,

--- a/packages/ui/src/components/mini-month-calendar.tsx
+++ b/packages/ui/src/components/mini-month-calendar.tsx
@@ -105,12 +105,13 @@ function MiniMonthCalendar({
       onMonthChange={handleMonthChange}
       weekStartsOn={weekStartsOn}
       showOutsideDays
+      captionLayout='dropdown'
       // Always render 6 rows so paging between 5- and 6-week months doesn't shift the
       // sidebar's height (and the board content below it).
       fixedWeeks
       renderDay={renderDay}
       modifiers={modifiers}
-      className={cn('p-2 [&_[data-slot=day][data-visible-range]]:bg-accent/50', className)}
+      className={cn('[&_[data-slot=day][data-visible-range]]:bg-accent/50', className)}
     />
   )
 }


### PR DESCRIPTION
## Summary
- Move calendar internal padding from the outer `Calendar` wrapper to per-month `MonthGrid`s so multi-month calendars pad each month correctly instead of only the outer edge; adjusted `min-width` calc to match.
- Drop now-redundant `p-2` overrides in `calendar-view.tsx` and `mini-month-calendar.tsx`, remove the double-bordered look in `event-calendar.tsx`, and normalize the trigger icon size in `date-range-picker.tsx`.
- Migrate `WorkerProfilePage`'s ad-hoc `Switch`/`AddressStructFields` inputs onto the shared `FieldInputAdapter` (per the Settings v2 field-type pattern).
- Remove an abandoned "jump to date" button from the dispatch board toolbar along with its now-unused `dateLabel()` helper and imports (was left half-removed, failing lint).

## Test plan
- [x] `pnpm exec biome check` on all changed files — clean
- [ ] Manually verify calendar popovers (date-time-picker, date-range-picker, mini-month-calendar) render with correct padding in the browser
- [ ] Manually verify worker profile page switches/address field still save correctly
- [ ] Confirm dispatch board toolbar still navigates dates correctly via Today/prev/next (date-jump button intentionally removed)