### PR TITLE
feat(dispatch): sidebar routes group on shared item primitives + worker drop targets

### DIFF
--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -6,7 +6,7 @@ import { weekStartToIndex } from '@auxx/lib/availability/client'
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { isRecordId } from '@auxx/lib/resources/client'
 import { CalendarDndProvider } from '@auxx/ui/components/event-calendar'
-import { MainPageContent } from '@auxx/ui/components/main-page'
+import { type DockedPanelConfig, MainPageContent } from '@auxx/ui/components/main-page'
 import type { DragEndEvent } from '@dnd-kit/core'
 import { addMinutes } from 'date-fns'
 import { Lock } from 'lucide-react'
@@ -16,9 +16,11 @@ import { renderAppDragGhost } from '~/components/global/app-drag-overlay'
 import { EmptyState } from '~/components/global/empty-state'
 import { RecordDrawer } from '~/components/records/record-drawer'
 import { toRecordId, useResource } from '~/components/resources'
+import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { useDockStore } from '~/stores/dock-store'
 import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
 import { useRoutePlannerData } from '../route-planner/hooks/use-route-planner-data'
 import { PlannerDndProvider } from '../route-planner/planner-dnd-provider'
@@ -120,6 +122,44 @@ export function DispatchBoard() {
     },
     [workOrderResource, setRecordParam]
   )
+  const handleDrawerOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) setRecordParam(null)
+    },
+    [setRecordParam]
+  )
+
+  // Dock-aware drawer placement (records-view.tsx's recipe): user's dock preference on →
+  // the drawer renders as a resizable `MainPageContent` docked panel; off (or mobile) →
+  // the overlay `RecordDrawer` at the bottom of this component.
+  const isDocked = useEffectiveDockState()
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+  const dockMinWidth = useDockStore((state) => state.minWidth)
+  const dockMaxWidth = useDockStore((state) => state.maxWidth)
+  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
+    if (!isDocked || !drawerRecordId) return []
+    return [
+      {
+        key: 'record-detail',
+        content: (
+          <RecordDrawer open onOpenChange={handleDrawerOpenChange} recordId={drawerRecordId} />
+        ),
+        width: dockedWidth,
+        onWidthChange: setDockedWidth,
+        minWidth: dockMinWidth,
+        maxWidth: dockMaxWidth,
+      },
+    ]
+  }, [
+    isDocked,
+    drawerRecordId,
+    handleDrawerOpenChange,
+    dockedWidth,
+    setDockedWidth,
+    dockMinWidth,
+    dockMaxWidth,
+  ])
 
   const existingVisits: ExistingVisitForOverlap[] = useMemo(
     () =>
@@ -227,7 +267,7 @@ export function DispatchBoard() {
   }
 
   return (
-    <MainPageContent>
+    <MainPageContent dockedPanels={dockedPanels}>
       <div className='flex h-full flex-col overflow-hidden'>
         <BoardToolbar
           date={data.date}
@@ -312,13 +352,13 @@ export function DispatchBoard() {
           </CalendarDndProvider>
         )}
       </div>
-      <RecordDrawer
-        open={!!drawerRecordId}
-        onOpenChange={(nextOpen) => {
-          if (!nextOpen) setRecordParam(null)
-        }}
-        recordId={drawerRecordId ?? undefined}
-      />
+      {!isDocked && (
+        <RecordDrawer
+          open={!!drawerRecordId}
+          onOpenChange={handleDrawerOpenChange}
+          recordId={drawerRecordId ?? undefined}
+        />
+      )}
     </MainPageContent>
   )
 }

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
@@ -32,7 +32,7 @@ export function WorkOrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewT
       )}
       <div
         className={cn(
-          'flex flex-col px-4 pb-4',
+          'flex flex-col',
           isSection ? 'max-h-[60vh] overflow-auto' : 'min-h-0 flex-1'
         )}>
         <LineBuilder documentRecordId={recordId} documentType='work_order' />

--- a/apps/web/src/components/dispatch/ui/route-planner/hooks/use-route-planner-mutations.ts
+++ b/apps/web/src/components/dispatch/ui/route-planner/hooks/use-route-planner-mutations.ts
@@ -11,6 +11,7 @@ import { differenceInMinutes } from 'date-fns'
 import { useCallback } from 'react'
 import { createDateWithTime } from '~/components/pickers/date-time-picker/utils'
 import { api } from '~/trpc/react'
+import type { BacklogItem } from '../../board/types'
 import type {
   PlannerBoard,
   PlannerDayWindow,
@@ -26,11 +27,12 @@ import type {
 //   data: { type: 'planner-backlog', visitId, item } })` — `item` (the full `BacklogItem`) rides
 //   along only for the shared drag-ghost overlay (`AppDragOverlay`/`renderAppDragGhost`) to read;
 //   this handler still only needs `visitId`.
-// - Stop row draggable (stop-list-panel.tsx), inside a worker's `SortableContext`:
+// - Stop row draggable (sidebar routes-group.tsx), inside a worker's `SortableContext`:
 //   `useSortable({ id: visitId })` combined with `data: { type: 'planner-stop', visitId,
-//   assigneeUserId } }` passed to the same `useSortable` call (dnd-kit merges `data` from
-//   `useSortable`'s options onto the draggable/droppable it registers).
-// - Worker section droppable (stop-list-panel.tsx) — catches drops on the section body itself
+//   assigneeUserId, item } }` passed to the same `useSortable` call (dnd-kit merges `data` from
+//   `useSortable`'s options onto the draggable/droppable it registers). Like the backlog row,
+//   `item` exists only for the shared drag-ghost overlay.
+// - Worker section droppable (routes-group.tsx) — catches drops on the section body itself
 //   (an empty list, or past the last row), not just a specific stop row:
 //   `useDroppable({ id: \`planner-worker-list-${assigneeUserId}\`, data: { type:
 //   'planner-worker-list', assigneeUserId } })`.
@@ -43,10 +45,13 @@ export interface PlannerStopDragData {
   type: 'planner-stop'
   visitId: string
   assigneeUserId: string
+  /** Ghost payload for `renderAppDragGhost` only — never read by the drag-end handler. */
+  item?: BacklogItem
 }
 export interface PlannerWorkerListDropData {
   type: 'planner-worker-list'
-  assigneeUserId: string
+  /** `null` = the sidebar Workers group's synthetic "Unassigned" row (workers-group.tsx). */
+  assigneeUserId: string | null
 }
 export type PlannerDragData = PlannerBacklogDragData | PlannerStopDragData
 export type PlannerDropData = PlannerStopDragData | PlannerWorkerListDropData
@@ -329,6 +334,15 @@ export function useRoutePlannerDragEnd({
       if (!activeData || !overData) return
 
       const targetAssigneeUserId = overData.assigneeUserId
+      if (targetAssigneeUserId === null) {
+        // The Workers group's "Unassigned" row: a stop drops back to unassigned (no
+        // `setRouteOrder` follow-up — the router input requires a real assignee); a backlog
+        // item is already unassigned, so there's nothing to do.
+        if (activeData.type === 'planner-stop') {
+          mutations.assignVisit.mutate({ visitId: activeData.visitId, assigneeUserId: null })
+        }
+        return
+      }
       const targetStops = stopsForWorker(board, targetAssigneeUserId)
       const targetIds = targetStops.map((v) => v.id)
       let dropIndex =

--- a/apps/web/src/components/dispatch/ui/route-planner/planner-dnd-provider.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/planner-dnd-provider.tsx
@@ -3,10 +3,10 @@
 'use client'
 
 import {
-  closestCenter,
   DndContext,
   KeyboardSensor,
   PointerSensor,
+  pointerWithin,
   TouchSensor,
   useSensor,
   useSensors,
@@ -44,7 +44,10 @@ export function PlannerDndProvider({
   const handleDragEnd = useRoutePlannerDragEnd({ board, window, geometryByWorker })
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+    // `pointerWithin` (files-management.tsx / dashboard.tsx's choice) over `closestCenter`:
+    // the sidebar nests row droppables inside section droppables, and center-distance picks
+    // the section only in narrow bands — pointer containment resolves innermost-first.
+    <DndContext sensors={sensors} collisionDetection={pointerWithin} onDragEnd={handleDragEnd}>
       {children}
       <AppDragOverlay />
     </DndContext>

--- a/apps/web/src/components/dispatch/ui/sidebar/dispatch-sidebar.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/dispatch-sidebar.tsx
@@ -43,9 +43,9 @@ interface DispatchSidebarProps {
   plannerGeometryByWorker?: Record<string, RouteGeometry | undefined>
   /** Distinct `work_order.tags` across the planner's visible day (map mode only). */
   tags?: string[]
-  /** Backlog row click (v4 Phase 4) — reports the clicked row's work-order instance id so the
-   * board shell can open a `RecordDrawer`. Sidebar rows only; the map pin popover and board
-   * visit popover keep navigating to the job page. */
+  /** Backlog/routes row click (v4 Phase 4) — reports the clicked row's work-order instance id
+   * so the board shell can open a `RecordDrawer`. Sidebar rows only; the map pin popover and
+   * board visit popover keep navigating to the job page. */
   onSelectWorkOrder?: (workOrderId: string) => void
 }
 
@@ -144,6 +144,7 @@ export function DispatchSidebar({
         onToggleWorker={toggleWorkerHidden}
         open={isGroupOpen('workers')}
         onOpenChange={(o) => setGroupOpen('workers', o)}
+        mode={mode}
       />
       {mode === 'map' && (
         <TagsGroup
@@ -169,10 +170,12 @@ export function DispatchSidebar({
           filters={plannerFilters}
           geometryByWorker={plannerGeometryByWorker ?? {}}
           date={plannerWindow}
+          canEdit={canEdit}
           open={isGroupOpen('routes')}
           onOpenChange={(o) => setGroupOpen('routes', o)}
           groupOpen={groupOpen}
           onWorkerOpenChange={(userId, o) => setGroupOpen(`routes:${userId}`, o)}
+          onSelectWorkOrder={onSelectWorkOrder}
         />
       )}
     </ModuleSidebar>

--- a/apps/web/src/components/dispatch/ui/sidebar/routes-group.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/routes-group.tsx
@@ -2,20 +2,34 @@
 
 'use client'
 
-import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { getOptionColor, type SelectOptionColor } from '@auxx/lib/custom-fields/client'
 import { Button } from '@auxx/ui/components/button'
 import { CollapsibleChevron } from '@auxx/ui/components/collapsible'
-import { SidebarGroup, SidebarGroupCollapse } from '@auxx/ui/components/sidebar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import {
+  SidebarGroup,
+  SidebarGroupCollapse,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+} from '@auxx/ui/components/sidebar'
 import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
-import { useDroppable } from '@dnd-kit/core'
+import { useDndContext, useDroppable } from '@dnd-kit/core'
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { format } from 'date-fns'
-import { GripVertical, Route as RouteIcon, Timer } from 'lucide-react'
+import { MoreVertical, Route as RouteIcon, Timer, X } from 'lucide-react'
 import { useState } from 'react'
 import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
-import { getInitials } from '~/components/groups/utils/group-utils'
 import { ApplyTimesDialog } from '../route-planner/apply-times-dialog'
 import {
   dayStartAnchor,
@@ -40,32 +54,37 @@ interface RoutesGroupProps {
   filters: PlannerFilters
   geometryByWorker: Record<string, RouteGeometry | undefined>
   date: PlannerDayWindow
+  canEdit: boolean
   open: boolean
   onOpenChange: (open: boolean) => void
   /** Per-worker sub-section open state, keyed `routes:<userId>` in the same store map as the
    * group itself (`groupOpen`) — persisted so a dispatcher's per-worker collapse choices stick. */
   groupOpen: Record<string, boolean>
   onWorkerOpenChange: (userId: string, open: boolean) => void
+  /** Stop row click — reports the row's work-order instance id so the board shell can open a
+   * `RecordDrawer` (same wiring as the Backlog group's rows). */
+  onSelectWorkOrder?: (workOrderId: string) => void
 }
 
 /**
- * Sidebar Routes group (v3 sidebar plan §1.2, map mode only) — ported nearly verbatim from the
- * deleted `route-planner/stop-list-panel.tsx`'s `WorkerStopSection`/`StopRow`: same
- * `useDroppable`/`SortableContext` wiring (`useRoutePlannerDragEnd` still owns cross-list
- * drops), same Suggest (`suggestRouteOrder` → `setRouteOrder`) and Apply-times
- * (`ApplyTimesDialog`) actions — only the visual shell changes (sidebar one-line rows instead of
- * a drawer's cards) and per-worker collapse now persists via the sidebar store instead of local
- * `useState`.
+ * Sidebar Routes group (v3 sidebar plan §1.2, map mode only) — one folder-style row per worker
+ * (color dot + name + stop count + hover 3-dot menu with Suggest route / Apply times, patterned
+ * on `entity-folder.tsx`) collapsing into `SidebarMenuSub` stop rows. Stop rows are whole-row
+ * draggable `useSortable`s (`useRoutePlannerDragEnd` still owns reorders and cross-list drops;
+ * the shared `AppDragOverlay` renders the cursor ghost), click through to the record drawer via
+ * `onSelectWorkOrder`, and carry a hover X that unassigns the visit back to the backlog.
  */
 export function RoutesGroup({
   board,
   filters,
   geometryByWorker,
   date,
+  canEdit,
   open,
   onOpenChange,
   groupOpen,
   onWorkerOpenChange,
+  onSelectWorkOrder,
 }: RoutesGroupProps) {
   const visibleWorkers =
     filters.workerIds === null
@@ -85,7 +104,7 @@ export function RoutesGroup({
         hideEditOption
       />
       <SidebarGroupCollapse open={open}>
-        <div className='flex flex-col gap-1.5 px-0.5'>
+        <SidebarMenu>
           {visibleWorkers.map((worker) => (
             <WorkerStopSection
               key={worker.id}
@@ -94,11 +113,13 @@ export function RoutesGroup({
               date={date}
               geometry={geometryByWorker[worker.userId]}
               workOrderById={workOrderById}
+              canEdit={canEdit}
               open={groupOpen[`routes:${worker.userId}`] ?? true}
               onOpenChange={(o) => onWorkerOpenChange(worker.userId, o)}
+              onSelectWorkOrder={onSelectWorkOrder}
             />
           ))}
-        </div>
+        </SidebarMenu>
       </SidebarGroupCollapse>
     </SidebarGroup>
   )
@@ -110,8 +131,10 @@ interface WorkerStopSectionProps {
   date: PlannerDayWindow
   geometry: RouteGeometry | undefined
   workOrderById: Map<string, PlannerWorkOrder>
+  canEdit: boolean
   open: boolean
   onOpenChange: (open: boolean) => void
+  onSelectWorkOrder?: (workOrderId: string) => void
 }
 
 function WorkerStopSection({
@@ -120,12 +143,19 @@ function WorkerStopSection({
   date,
   geometry,
   workOrderById,
+  canEdit,
   open,
   onOpenChange,
+  onSelectWorkOrder,
 }: WorkerStopSectionProps) {
   const [applyOpen, setApplyOpen] = useState(false)
-  const { setRouteOrder } = useRoutePlannerMutations(date)
-  const { setNodeRef: setDroppableRef } = useDroppable({
+  const [menuOpen, setMenuOpen] = useState(false)
+  const { setRouteOrder, assignVisit } = useRoutePlannerMutations(date)
+  const { active } = useDndContext()
+  const isCompatibleDrag =
+    active?.data.current?.type === 'planner-backlog' ||
+    active?.data.current?.type === 'planner-stop'
+  const { setNodeRef: setDroppableRef, isOver } = useDroppable({
     id: `planner-worker-list-${worker.userId}`,
     data: { type: 'planner-worker-list', assigneeUserId: worker.userId },
   })
@@ -133,6 +163,7 @@ function WorkerStopSection({
   const stops = stopsForWorker(board, worker.userId)
   const activeStops = stops.filter((v) => v.status !== 'done')
   const dayStart = dayStartAnchor(date, worker, '08:00')
+  const workerName = worker.name ?? worker.email ?? 'Worker'
 
   const handleSuggest = () => {
     const movable = stops.filter((v) => v.status !== 'done')
@@ -158,38 +189,94 @@ function WorkerStopSection({
   }
 
   return (
-    <div className='rounded-md border'>
-      <div className='flex items-center gap-1 p-1.5'>
-        <button
-          type='button'
-          className='flex flex-1 items-center gap-1.5 text-left'
+    // The whole section (header row + stop list) is ONE drop target — a drag can land on the
+    // worker even while their stop list is collapsed. Inset ring/outline (entity-folder.tsx's
+    // recipe): the sidebar clips overflow, so non-inset variants get cut off at the edges.
+    <SidebarMenuItem
+      ref={setDroppableRef}
+      className={cn(
+        'rounded-md transition-colors duration-150 ease-in-out',
+        isCompatibleDrag && 'outline-dashed outline-1 outline-primary/30 [outline-offset:-1px]',
+        isCompatibleDrag &&
+          isOver &&
+          'bg-primary/20 outline-primary/80 ring-2 ring-inset ring-primary/60'
+      )}>
+      <SidebarMenuButton asChild className='h-7 py-0 pe-[3px]' tooltip={workerName}>
+        <div
+          className='group/item relative flex h-7 w-full cursor-pointer items-center justify-between'
           onClick={() => onOpenChange(!open)}>
-          <CollapsibleChevron open={open} />
-          <Avatar className='size-5'>
-            <AvatarImage src={worker.image ?? undefined} />
-            <AvatarFallback className='text-[9px]'>
-              {getInitials(worker.name ?? worker.email ?? 'Worker')}
-            </AvatarFallback>
-          </Avatar>
-          <span className='truncate text-xs font-medium'>{worker.name ?? worker.email}</span>
-          <span className='text-muted-foreground text-xs'>({stops.length})</span>
-        </button>
-        <Button variant='ghost' size='icon-xs' title='Suggest route' onClick={handleSuggest}>
-          <RouteIcon />
-        </Button>
-        <Button
-          variant='ghost'
-          size='icon-xs'
-          title='Apply times'
-          onClick={() => setApplyOpen(true)}>
-          <Timer />
-        </Button>
-      </div>
+          <div className='flex min-w-0 grow items-center'>
+            <div
+              className={cn(
+                'mr-2 size-2 shrink-0 rounded-full',
+                getOptionColor((worker.color ?? 'gray') as SelectOptionColor).swatch
+              )}
+            />
+            <span className='truncate group-data-[collapsible=icon]:hidden'>{workerName}</span>
+            <span className='ml-1 inline-flex shrink-0 items-center text-muted-foreground group-data-[collapsible=icon]:hidden'>
+              <CollapsibleChevron open={open} />
+            </span>
+          </div>
+
+          <div className='flex shrink-0 items-center group-data-[collapsible=icon]:hidden'>
+            {!menuOpen && (
+              <>
+                <span className='pointer-events-none text-xs text-muted-foreground sm:hidden'>
+                  {stops.length}
+                </span>
+                <div className='pointer-events-none absolute right-[11px] top-1/2 hidden -translate-y-1/2 text-right text-xs sm:flex sm:group-hover/item:opacity-0'>
+                  {stops.length}
+                </div>
+              </>
+            )}
+            {canEdit && (
+              <div
+                onClick={(e) => {
+                  e.stopPropagation()
+                  e.preventDefault()
+                }}>
+                <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant='ghost'
+                      size='icon'
+                      className={cn(
+                        'size-6 shrink-0 rounded-md opacity-100 sm:opacity-0 hover:bg-primary/10 hover:text-foreground/50 focus-visible:ring-primary/10 hover:bg-primary-200/50',
+                        {
+                          'bg-primary-200 opacity-100': menuOpen,
+                          'sm:group-hover/item:opacity-100': !menuOpen,
+                        }
+                      )}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        e.preventDefault()
+                        setMenuOpen(!menuOpen)
+                      }}>
+                      <MoreVertical className='size-3.5' />
+                      <span className='sr-only'>Route options</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent className='w-50' align='start'>
+                    <DropdownMenuItem onClick={handleSuggest}>
+                      <RouteIcon />
+                      Suggest route
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => setApplyOpen(true)}>
+                      <Timer />
+                      Apply times
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            )}
+          </div>
+        </div>
+      </SidebarMenuButton>
 
       <SidebarGroupCollapse open={open}>
-        <div ref={setDroppableRef} className='space-y-1 border-t p-1.5'>
+        <SidebarMenuSub className='me-0 pe-0'>
           {stops.length === 0 ? (
-            <div className='text-muted-foreground px-1 py-1 text-xs'>No stops today.</div>
+            <li className='px-1 py-1 text-xs text-muted-foreground'>No stops today.</li>
           ) : (
             <SortableContext items={stops.map((v) => v.id)} strategy={verticalListSortingStrategy}>
               {stops.map((visit, index) => (
@@ -200,11 +287,14 @@ function WorkerStopSection({
                   assigneeUserId={worker.userId}
                   workOrder={workOrderById.get(visit.workOrderId)}
                   eta={estimateArrivalForVisit(dayStart, geometry, visit.id)}
+                  canEdit={canEdit}
+                  onSelectWorkOrder={onSelectWorkOrder}
+                  onRemove={() => assignVisit.mutate({ visitId: visit.id, assigneeUserId: null })}
                 />
               ))}
             </SortableContext>
           )}
-        </div>
+        </SidebarMenuSub>
       </SidebarGroupCollapse>
 
       <ApplyTimesDialog
@@ -215,7 +305,7 @@ function WorkerStopSection({
         geometry={geometry}
         date={date}
       />
-    </div>
+    </SidebarMenuItem>
   )
 }
 
@@ -225,38 +315,102 @@ interface StopRowProps {
   assigneeUserId: string
   workOrder: PlannerWorkOrder | undefined
   eta: Date | null
+  canEdit: boolean
+  onSelectWorkOrder?: (workOrderId: string) => void
+  onRemove: () => void
 }
 
-function StopRow({ visit, index, assigneeUserId, workOrder, eta }: StopRowProps) {
+function StopRow({
+  visit,
+  index,
+  assigneeUserId,
+  workOrder,
+  eta,
+  canEdit,
+  onSelectWorkOrder,
+  onRemove,
+}: StopRowProps) {
   const isDone = visit.status === 'done'
+  const draggable = canEdit && !isDone
+  // `item` rides along in the sortable's data (BacklogRow's exact recipe) so the shared
+  // `AppDragOverlay`/`renderAppDragGhost` can render the cursor ghost without a cross-context
+  // store lookup — the drag-end handler itself only reads `visitId`/`assigneeUserId`.
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: visit.id,
-    data: { type: 'planner-stop', visitId: visit.id, assigneeUserId },
-    disabled: isDone,
+    data: {
+      type: 'planner-stop',
+      visitId: visit.id,
+      assigneeUserId,
+      item: {
+        visit,
+        workOrder: workOrder
+          ? { number: workOrder.number, displayName: workOrder.displayName }
+          : undefined,
+      },
+    },
+    disabled: !draggable,
   })
 
-  const style = { transform: CSS.Transform.toString(transform), transition }
-
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={cn(
-        'hover:bg-sidebar-accent flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs',
-        isDone && 'opacity-50',
-        isDragging && 'opacity-40'
-      )}>
-      {!isDone && (
+    <SidebarMenuSubItem>
+      {/* `asChild` + div root (entity-folder.tsx's recipe): the row hosts a nested remove
+          <Button>, so its own root must not be a <button>. */}
+      <SidebarMenuSubButton asChild className='h-7 py-0 pe-[3px]'>
         <div
-          {...attributes}
-          {...listeners}
-          className='cursor-grab touch-none active:cursor-grabbing'>
-          <GripVertical className='text-muted-foreground size-3' />
+          ref={setNodeRef}
+          {...(draggable ? { ...attributes, ...listeners } : {})}
+          style={{ transform: CSS.Transform.toString(transform), transition }}
+          onClick={onSelectWorkOrder ? () => onSelectWorkOrder(visit.workOrderId) : undefined}
+          className={cn(
+            'group/item relative flex h-7 w-full items-center justify-between',
+            onSelectWorkOrder && 'cursor-pointer',
+            draggable && 'cursor-grab touch-none active:cursor-grabbing',
+            isDone && 'opacity-50',
+            isDragging && 'opacity-40'
+          )}>
+          <div className='flex min-w-0 grow items-center'>
+            <span className='mr-2 shrink-0 text-xs text-muted-foreground tabular-nums'>
+              {index + 1}.
+            </span>
+            <span className='truncate group-data-[collapsible=icon]:hidden'>
+              {workOrder?.number ?? 'Work order'}
+            </span>
+          </div>
+
+          <div className='flex shrink-0 items-center group-data-[collapsible=icon]:hidden'>
+            {eta && (
+              <>
+                <span className='pointer-events-none text-xs text-muted-foreground sm:hidden'>
+                  {format(eta, 'p')}
+                </span>
+                <span
+                  className={cn(
+                    'pointer-events-none absolute right-[11px] top-1/2 hidden -translate-y-1/2 text-xs text-muted-foreground sm:flex',
+                    draggable && 'sm:group-hover/item:opacity-0'
+                  )}>
+                  {format(eta, 'p')}
+                </span>
+              </>
+            )}
+            {draggable && (
+              <Button
+                variant='ghost'
+                size='icon'
+                title='Remove from route'
+                className='size-6 shrink-0 rounded-md opacity-100 sm:opacity-0 sm:group-hover/item:opacity-100 hover:bg-primary/10 hover:text-foreground/50 focus-visible:ring-primary/10 hover:bg-primary-200/50'
+                onClick={(e) => {
+                  e.stopPropagation()
+                  e.preventDefault()
+                  onRemove()
+                }}
+                onPointerDown={(e) => e.stopPropagation()}>
+                <X className='size-3.5' />
+                <span className='sr-only'>Remove from route</span>
+              </Button>
+            )}
+          </div>
         </div>
-      )}
-      <span className='text-muted-foreground shrink-0 tabular-nums'>{index + 1}.</span>
-      <span className='min-w-0 flex-1 truncate'>{workOrder?.number ?? 'Work order'}</span>
-      {eta && <span className='text-muted-foreground shrink-0'>· {format(eta, 'p')}</span>}
-    </div>
+      </SidebarMenuSubButton>
+    </SidebarMenuSubItem>
   )
 }

--- a/apps/web/src/components/dispatch/ui/sidebar/workers-group.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/workers-group.tsx
@@ -4,6 +4,8 @@
 
 import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
 import { SidebarGroup, SidebarGroupCollapse, SidebarMenu } from '@auxx/ui/components/sidebar'
+import { cn } from '@auxx/ui/lib/utils'
+import { useDndContext, useDroppable } from '@dnd-kit/core'
 import { UserPlus } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { SourceToggleRow } from '~/components/calendar/ui/source-toggle-group'
@@ -22,6 +24,62 @@ interface WorkersGroupProps {
   onToggleWorker: (workerId: string) => void
   open: boolean
   onOpenChange: (open: boolean) => void
+  /** 'map' mode enables droppable worker rows for backlog/stop assignments; 'calendar' disables
+   * (calendar mode routes drops via handleForeignDragEnd which doesn't target worker rows). */
+  mode?: 'map' | 'calendar'
+}
+
+/**
+ * Wrapper component to make a SourceToggleRow representing a worker droppable for backlog
+ * items and route stops. For the synthetic "Unassigned" row, passes `null` as assigneeUserId
+ * instead of the resource id.
+ */
+function DroppableWorkerRow({
+  id,
+  userId,
+  label,
+  color,
+  visible,
+  onToggle,
+  mode,
+}: {
+  id: string
+  userId: string
+  label: string
+  color: string
+  visible: boolean
+  onToggle: () => void
+  mode?: 'map' | 'calendar'
+}) {
+  const { active } = useDndContext()
+  const isCompatibleDrag =
+    active?.data.current?.type === 'planner-backlog' ||
+    active?.data.current?.type === 'planner-stop'
+  const isUnassigned = userId === UNASSIGNED_RESOURCE_ID
+  const { setNodeRef, isOver } = useDroppable({
+    id: `worker-row-${userId}`,
+    data: {
+      type: 'planner-worker-list',
+      assigneeUserId: isUnassigned ? null : userId,
+    },
+    disabled: mode !== 'map' || !isCompatibleDrag,
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        'rounded-md transition-colors duration-150 ease-in-out',
+        // Inset variants (entity-folder.tsx's recipe) — the sidebar clips overflow, so a
+        // non-inset ring/outline gets cut off at the group edges.
+        isCompatibleDrag && 'outline-dashed outline-1 outline-primary/30 [outline-offset:-1px]',
+        isCompatibleDrag &&
+          isOver &&
+          'bg-primary/20 outline-primary/80 ring-2 ring-inset ring-primary/60'
+      )}>
+      <SourceToggleRow id={id} label={label} color={color} visible={visible} onToggle={onToggle} />
+    </div>
+  )
 }
 
 /**
@@ -32,6 +90,9 @@ interface WorkersGroupProps {
  * semantics: toggling writes the store's `hiddenWorkerIds` (inverse set — see `board/utils.ts`'s
  * `selectedWorkerIdsFromHidden` adapter for how consumers read it back as `Set<string> | null`).
  * The header's `additionalOptions` opens `AddWorkerDialog` ("New worker").
+ *
+ * In map mode, worker rows become droppable targets for backlog items and route stops; in
+ * calendar mode, drops are handled by handleForeignDragEnd which doesn't target worker rows.
  */
 export function WorkersGroup({
   workers,
@@ -40,6 +101,7 @@ export function WorkersGroup({
   onToggleWorker,
   open,
   onOpenChange,
+  mode = 'map',
 }: WorkersGroupProps) {
   const hidden = useMemo(() => new Set(hiddenWorkerIds), [hiddenWorkerIds])
   const [addOpen, setAddOpen] = useState(false)
@@ -69,21 +131,25 @@ export function WorkersGroup({
       <SidebarGroupCollapse open={open}>
         <SidebarMenu>
           {workers.map((worker) => (
-            <SourceToggleRow
+            <DroppableWorkerRow
               key={worker.id}
               id={worker.id}
+              userId={worker.userId}
               label={worker.user?.name ?? worker.user?.email ?? 'Worker'}
               color={colorByUserId.get(worker.userId) ?? DEFAULT_WORKER_COLOR}
               visible={!hidden.has(worker.userId)}
               onToggle={() => onToggleWorker(worker.userId)}
+              mode={mode}
             />
           ))}
-          <SourceToggleRow
+          <DroppableWorkerRow
             id={UNASSIGNED_RESOURCE_ID}
+            userId={UNASSIGNED_RESOURCE_ID}
             label='Unassigned'
             color={UNASSIGNED_COLOR}
             visible={!hidden.has(UNASSIGNED_RESOURCE_ID)}
             onToggle={() => onToggleWorker(UNASSIGNED_RESOURCE_ID)}
+            mode={mode}
           />
         </SidebarMenu>
       </SidebarGroupCollapse>

--- a/apps/web/src/components/global/app-drag-overlay.tsx
+++ b/apps/web/src/components/global/app-drag-overlay.tsx
@@ -36,6 +36,7 @@ export function renderAppDragGhost(active: Active): ReactNode {
       return data.favoriteId ? <FavoriteDragOverlay favoriteId={data.favoriteId} /> : null
     case 'backlog-visit':
     case 'planner-backlog':
+    case 'planner-stop':
       return data.item ? <BacklogRowGhost item={data.item} /> : null
     default:
       return null


### PR DESCRIPTION
## What

### Routes group → shared sidebar item primitives
- Worker rows are now folder-style sidebar items (`entity-folder.tsx` pattern): worker **option-color dot** (`getOptionColor(worker.color)`), name, chevron, stop count that hides on hover, and a hover **3-dot menu** with *Suggest route* / *Apply times* (replacing the two inline icon buttons).
- Stop rows render as `SidebarMenuSub` subitems: **whole-row drag** (grip removed), **click opens the work-order record drawer**, and a hover **X** that unassigns the visit back to the backlog (`assignVisit(null)`). Done stops stay non-draggable and have no X.

### Drag & drop
- `renderAppDragGhost` now handles `planner-stop`, so stops dragged out of a route render the shared cursor ghost (case was missed in #1159); stop rows carry the `item` payload for it.
- **Workers group rows (map mode) are drop targets**: dropping a backlog item slot-in schedules onto that worker, dropping a stop reassigns — reusing the existing `planner-worker-list` drop handling. Drop-over styling copied from the mail sidebar (`shared-inbox-group.tsx`), switched to **inset** ring/outline so the sidebar's overflow clipping doesn't cut it off.
- Each routes section (header + stop list) is **one droppable** on the `SidebarMenuItem`, so it highlights as a unit and accepts drops while collapsed.
- Dropping on the synthetic **Unassigned** row unassigns a stop and skips the `setRouteOrder` follow-up (router input requires a real assignee — previously this would 400).
- Planner `DndContext` switches `closestCenter` → **`pointerWithin`** (same as `files-management.tsx` / `dashboard.tsx`): nested section/row targets resolve under the pointer instead of in narrow center-distance bands. Known tradeoff (same as files): keyboard-driven drags get no collisions.

### Record drawer docking
- `dispatch-board.tsx` now follows records-view's `dockedPanels` recipe: with the dock preference on, the `?record=` drawer renders as a resizable `MainPageContent` docked panel; otherwise the overlay drawer, as before.

### Misc
- Work-order line-items tab: stray padding removed.

## Verified
- Browser-checked in map mode: routes group rendering (dot/count/menu/stop rows), stop click → docked work-order drawer, docked panel resizing mount.
- Drag flows (ghost, worker-row drops, Unassigned drop, hover states) exercised by hand — see checklist below if re-verifying:
  - drag backlog item over worker rows → dashed outlines, hovered row fills, uncut borders
  - drag stop across workers → section highlight + reassign
  - drop stop on Unassigned → back to backlog, no error toast