### PR TITLE
feat(records,money,ui): record-editor registry + line-builder keyboard nav + shared TreeRowList

### DIFF
--- a/apps/web/src/app/(protected)/app/parts/page.tsx
+++ b/apps/web/src/app/(protected)/app/parts/page.tsx
@@ -2,57 +2,8 @@
 
 'use client'
 
-import type { RecordId } from '@auxx/types/resource'
-import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useCallback, useState } from 'react'
-import { PartFormDialog } from '~/components/manufacturing/parts/part-form-dialog'
 import { RecordsView } from '~/components/records'
-import { useRecordInvalidation, useResourceProperty } from '~/components/resources'
-import { api } from '~/trpc/react'
 
 export default function PartsPage() {
-  const [isCreateOpen, setIsCreateOpen] = useQueryState('create', parseAsBoolean.withDefault(false))
-  const [editingRecordId, setEditingRecordId] = useState<RecordId | null>(null)
-  const partDefId = useResourceProperty('part', 'id')
-  const { onRecordCreated } = useRecordInvalidation()
-  const utils = api.useUtils()
-
-  const handleDialogOpenChange = useCallback(
-    (open: boolean) => {
-      setIsCreateOpen(open || null)
-      if (!open) setEditingRecordId(null)
-    },
-    [setIsCreateOpen]
-  )
-
-  const handleEditRecord = useCallback((recordId: RecordId) => {
-    setEditingRecordId(recordId)
-  }, [])
-
-  const handleSuccess = useCallback(() => {
-    handleDialogOpenChange(false)
-    if (partDefId) {
-      onRecordCreated(partDefId)
-      utils.record.listFiltered.invalidate()
-    }
-  }, [handleDialogOpenChange, partDefId, onRecordCreated, utils.record.listFiltered])
-
-  return (
-    <>
-      <RecordsView
-        slug='parts'
-        basePath='/app/parts'
-        embedded
-        renderCreateDialog={false}
-        onEditRecord={handleEditRecord}
-      />
-
-      <PartFormDialog
-        open={isCreateOpen || !!editingRecordId}
-        onOpenChange={handleDialogOpenChange}
-        recordId={editingRecordId ?? undefined}
-        onSuccess={handleSuccess}
-      />
-    </>
-  )
+  return <RecordsView slug='parts' basePath='/app/parts' embedded />
 }

--- a/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-runs-panel.tsx
@@ -5,13 +5,13 @@ import { Alert } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { ButtonGroup, ButtonGroupSeparator } from '@auxx/ui/components/button-group'
-import { AnimatedCollapsibleContent } from '@auxx/ui/components/collapsible'
 import { DrawerHeader } from '@auxx/ui/components/drawer'
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { LastUpdated } from '@auxx/ui/components/last-updated'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { EmptySection, Section } from '@auxx/ui/components/section'
 import { TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { cn } from '@auxx/ui/lib/utils'
 import { pluralize } from '@auxx/utils/strings'
 import { ArchiveX, History, Plus, RefreshCw, SkipForward, Trash2, XCircle } from 'lucide-react'
@@ -398,43 +398,6 @@ function buildMockData(scenario: Exclude<typeof MOCK_SCENARIO, 'off'>): {
 const VISIBLE_RUN_LIMIT = 7
 
 /**
- * The run history list: the latest {@link VISIBLE_RUN_LIMIT} runs, then a
- * "Show more" tree row that reveals the remainder in an animated collapse. The
- * extra runs are siblings of the toggle row (not its children) so they keep the
- * flat-list indentation.
- */
-function RunHistoryList({ rows, sourceLabel }: { rows: ConnectorRun[]; sourceLabel: string }) {
-  const [showAll, setShowAll] = useState(false)
-  const visible = rows.slice(0, VISIBLE_RUN_LIMIT)
-  const hidden = rows.slice(VISIBLE_RUN_LIMIT)
-
-  return (
-    <div className='@container/runs flex flex-col ps-2 pe-4'>
-      {visible.map((run) => (
-        <RunRow key={run.id} run={run} sourceLabel={sourceLabel} />
-      ))}
-      {hidden.length > 0 && (
-        <>
-          <AnimatedCollapsibleContent open={showAll} className='flex flex-col'>
-            {hidden.map((run) => (
-              <RunRow key={run.id} run={run} sourceLabel={sourceLabel} />
-            ))}
-          </AnimatedCollapsibleContent>
-          <TreeRow
-            icon={<History className='size-4' />}
-            title={showAll ? 'Show less' : `Show ${hidden.length} more`}
-            rowClassName='hover:bg-primary-100'
-            expandable
-            isOpen={showAll}
-            onToggleOpen={() => setShowAll((v) => !v)}
-          />
-        </>
-      )}
-    </div>
-  )
-}
-
-/**
  * Docked Runs panel: live sync status (polls `getStatus` every 4s while syncing,
  * matching the Knowledge-Sources cadence) + the `DataConnectorRun` history with
  * per-run created/updated/skipped/archived/deleted/failed counts, relationship
@@ -558,7 +521,14 @@ export function ConnectorRunsPanel({
               />
             </div>
           ) : (
-            <RunHistoryList rows={rows} sourceLabel={sourceLabel} />
+            <TreeRowList
+              items={rows}
+              getKey={(run) => run.id}
+              visibleLimit={VISIBLE_RUN_LIMIT}
+              showMoreIcon={<History className='size-4' />}
+              className='@container/runs ps-2 pe-4'
+              renderRow={(run) => <RunRow run={run} sourceLabel={sourceLabel} />}
+            />
           )}
         </Section>
       </ScrollArea>

--- a/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
@@ -3,7 +3,8 @@
 
 import { EmptySection } from '@auxx/ui/components/section'
 import { TREE_SECONDARY_NOTRUNCATE } from '@auxx/ui/components/tree-row'
-import { ArrowRight, History } from 'lucide-react'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
+import { History } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import type { DetailViewTabProps } from '~/components/detail-view'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
@@ -22,7 +23,7 @@ const PREVIEW_LIMIT = 3
  * the recurrence row (recurring jobs — `RecurringEngagementCard`, which also
  * portals the engagement badge + Pause/Edit into the Section header), the
  * "Next visit" card, and the remaining upcoming visits as `ScheduleVisitRow`s
- * with a "View all →" drill. History stays its own section
+ * with an inline "Show more" expand. History stays its own section
  * (`VisitHistorySection`).
  */
 export function JobScheduleSection({ recordId }: DetailViewTabProps) {
@@ -42,7 +43,6 @@ export function JobScheduleSection({ recordId }: DetailViewTabProps) {
   // The primary visit already renders as the card — preview only the visits after it.
   const laterUpcoming = upcoming.slice(1)
 
-  const openList = () => void setPanel('visits')
   const openItem = (visitId: string) => {
     void setPanel('visits')
     void setItem(visitId)
@@ -75,26 +75,23 @@ export function JobScheduleSection({ recordId }: DetailViewTabProps) {
       />
 
       {laterUpcoming.length > 0 && (
-        <div>
-          <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
-            {laterUpcoming.slice(0, PREVIEW_LIMIT).map((visit) => (
-              <ScheduleVisitRow
-                key={visit.id}
-                visit={visit}
-                canEdit={canEdit}
-                mutations={mutations}
-                existingVisits={existingVisits}
-                workOrderRecordId={recordId}
-                onRefresh={refresh}
-                onOpen={() => openItem(visit.id)}
-              />
-            ))}
-          </div>
-
-          {laterUpcoming.length > PREVIEW_LIMIT && (
-            <ViewAllRow label={`View all ${upcoming.length} upcoming visits`} onClick={openList} />
+        <TreeRowList
+          items={laterUpcoming}
+          getKey={(visit) => visit.id}
+          visibleLimit={PREVIEW_LIMIT}
+          className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}
+          renderRow={(visit) => (
+            <ScheduleVisitRow
+              visit={visit}
+              canEdit={canEdit}
+              mutations={mutations}
+              existingVisits={existingVisits}
+              workOrderRecordId={recordId}
+              onRefresh={refresh}
+              onOpen={() => openItem(visit.id)}
+            />
           )}
-        </div>
+        />
       )}
     </div>
   )
@@ -102,9 +99,8 @@ export function JobScheduleSection({ recordId }: DetailViewTabProps) {
 
 /**
  * Registered as `work_order:history` — standalone visit History section: the
- * same `ScheduleVisitRow`s capped at PREVIEW_LIMIT, plus a "View all →"
- * link that pushes the `?panel=visits` drill (the shared nuqs params
- * `DetailViewSections` reads). The section heading comes from the surrounding
+ * same `ScheduleVisitRow`s capped at PREVIEW_LIMIT, with the rest revealed by an
+ * inline "Show more" expand. The section heading comes from the surrounding
  * `<Section>` — no block header here.
  */
 export function VisitHistorySection({ recordId }: DetailViewTabProps) {
@@ -114,7 +110,6 @@ export function VisitHistorySection({ recordId }: DetailViewTabProps) {
 
   const { history } = splitJobVisits(visits)
 
-  const openList = () => void setPanel('visits')
   const openItem = (visitId: string) => {
     void setPanel('visits')
     void setItem(visitId)
@@ -133,39 +128,23 @@ export function VisitHistorySection({ recordId }: DetailViewTabProps) {
   }
 
   return (
-    <div>
-      <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
-        {history.slice(0, PREVIEW_LIMIT).map((visit) => (
-          <ScheduleVisitRow
-            key={visit.id}
-            visit={visit}
-            canEdit={canEdit}
-            mutations={mutations}
-            existingVisits={existingVisits}
-            workOrderRecordId={recordId}
-            onRefresh={refresh}
-            onOpen={() => openItem(visit.id)}
-          />
-        ))}
-      </div>
-
-      {history.length > PREVIEW_LIMIT && (
-        <ViewAllRow label={`View all ${history.length} past visits`} onClick={openList} />
+    <TreeRowList
+      items={history}
+      getKey={(visit) => visit.id}
+      visibleLimit={PREVIEW_LIMIT}
+      className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}
+      renderRow={(visit) => (
+        <ScheduleVisitRow
+          visit={visit}
+          canEdit={canEdit}
+          mutations={mutations}
+          existingVisits={existingVisits}
+          workOrderRecordId={recordId}
+          onRefresh={refresh}
+          onOpen={() => openItem(visit.id)}
+        />
       )}
-    </div>
-  )
-}
-
-/** The 04 mock's "View all N … →" text link under the visit rows. */
-function ViewAllRow({ label, onClick }: { label: string; onClick: () => void }) {
-  return (
-    <button
-      type='button'
-      onClick={onClick}
-      className='mt-1 flex items-center gap-1 px-1 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground'>
-      {label}
-      <ArrowRight className='size-3.5' />
-    </button>
+    />
   )
 }
 

--- a/apps/web/src/components/dispatch/ui/job-schedule/schedule-visit-row.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/schedule-visit-row.tsx
@@ -72,6 +72,7 @@ export function ScheduleVisitRow({
     <>
       <TreeRow
         depth={depth}
+        rowClassName='hover:bg-primary-100'
         icon={<CalendarClock className='size-4' />}
         title={<span className='truncate text-sm'>{formatVisitWindow(visit)}</span>}
         secondary={

--- a/apps/web/src/components/dispatch/ui/job-schedule/visits-list-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visits-list-panel.tsx
@@ -3,9 +3,11 @@
 
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { TREE_SECONDARY_NOTRUNCATE } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import type { RecordDrillContext } from '~/components/records/record-drill-panels'
 import { splitJobVisits } from './job-schedule-utils'
 import { ScheduleVisitRow } from './schedule-visit-row'
+import type { JobVisit } from './use-job-visits'
 import { useJobVisits } from './use-job-visits'
 
 /**
@@ -16,14 +18,34 @@ import { useJobVisits } from './use-job-visits'
 export function VisitsListPanel({ recordId, setItemId }: RecordDrillContext) {
   const { visits, isLoading, canEdit, mutations, existingVisits, refresh } = useJobVisits(recordId)
   const { upcoming, history } = splitJobVisits(visits)
+  const loading = isLoading && visits.length === 0
+
+  const renderRow = (visit: JobVisit) => (
+    <ScheduleVisitRow
+      visit={visit}
+      canEdit={canEdit}
+      mutations={mutations}
+      existingVisits={existingVisits}
+      workOrderRecordId={recordId}
+      onRefresh={refresh}
+      onOpen={() => setItemId(visit.id)}
+    />
+  )
 
   return (
     <ScrollArea className='h-full' scrollbarClassName='w-1.5 z-20' noFade>
       <div className='flex flex-col gap-4 p-3'>
-        {isLoading && visits.length === 0 && (
-          <div className='p-6 text-sm text-muted-foreground'>Loading visits...</div>
+        {loading && (
+          <TreeRowList
+            items={[]}
+            loading
+            skeletonCount={5}
+            getKey={(v) => v.id}
+            renderRow={renderRow}
+            className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}
+          />
         )}
-        {!isLoading && visits.length === 0 && (
+        {!loading && visits.length === 0 && (
           <div className='p-6 text-center text-sm text-muted-foreground'>No visits yet.</div>
         )}
 
@@ -32,20 +54,12 @@ export function VisitsListPanel({ recordId, setItemId }: RecordDrillContext) {
             <div className='px-1 pb-1 text-xs font-medium uppercase text-muted-foreground'>
               Upcoming
             </div>
-            <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
-              {upcoming.map((visit) => (
-                <ScheduleVisitRow
-                  key={visit.id}
-                  visit={visit}
-                  canEdit={canEdit}
-                  mutations={mutations}
-                  existingVisits={existingVisits}
-                  workOrderRecordId={recordId}
-                  onRefresh={refresh}
-                  onOpen={() => setItemId(visit.id)}
-                />
-              ))}
-            </div>
+            <TreeRowList
+              items={upcoming}
+              getKey={(v) => v.id}
+              renderRow={renderRow}
+              className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}
+            />
           </div>
         )}
 
@@ -54,20 +68,12 @@ export function VisitsListPanel({ recordId, setItemId }: RecordDrillContext) {
             <div className='px-1 pb-1 text-xs font-medium uppercase text-muted-foreground'>
               History
             </div>
-            <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
-              {history.map((visit) => (
-                <ScheduleVisitRow
-                  key={visit.id}
-                  visit={visit}
-                  canEdit={canEdit}
-                  mutations={mutations}
-                  existingVisits={existingVisits}
-                  workOrderRecordId={recordId}
-                  onRefresh={refresh}
-                  onOpen={() => setItemId(visit.id)}
-                />
-              ))}
-            </div>
+            <TreeRowList
+              items={history}
+              getKey={(v) => v.id}
+              renderRow={renderRow}
+              className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}
+            />
           </div>
         )}
       </div>

--- a/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
+++ b/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
@@ -10,6 +10,7 @@
 
 import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
 import { TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { Plus, Receipt } from 'lucide-react'
 import { useState } from 'react'
 import { ScheduleVisitRow } from '~/components/dispatch/ui/job-schedule/schedule-visit-row'
@@ -29,18 +30,25 @@ import {
 // Schedule block (visits + per-visit Reschedule/Cancel)
 // ─────────────────────────────────────────────────────────────────────────────
 
+/** How many visits render before the inline "Show more" row collapses the rest. */
+const VISIT_PREVIEW_LIMIT = 5
+
 export function WorkOrderScheduleCard({ recordId }: DrawerTabProps) {
   const drill = useRecordDrill()
   const { visits, isLoading, canEdit, mutations, existingVisits, refresh } = useJobVisits(recordId)
 
-  if (isLoading && visits.length === 0) return <RowSkeleton />
-  if (!visits.length) return <EmptyRow label='No visits yet' />
+  const loading = isLoading && visits.length === 0
+  if (!loading && !visits.length) return <EmptyRow label='No visits yet' />
 
   return (
-    <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
-      {visits.map((visit) => (
+    <TreeRowList
+      items={visits}
+      loading={loading}
+      getKey={(visit) => visit.id}
+      visibleLimit={VISIT_PREVIEW_LIMIT}
+      className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}
+      renderRow={(visit) => (
         <ScheduleVisitRow
-          key={visit.id}
           visit={visit}
           canEdit={canEdit}
           mutations={mutations}
@@ -49,8 +57,8 @@ export function WorkOrderScheduleCard({ recordId }: DrawerTabProps) {
           onRefresh={refresh}
           onOpen={() => drill.open('visits', visit.id)}
         />
-      ))}
-    </div>
+      )}
+    />
   )
 }
 

--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -13,9 +13,9 @@ import {
   type SelectOption,
 } from '@auxx/types/custom-field'
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-instance-dialog'
 import { ActorPicker } from '~/components/pickers/actor-picker/actor-picker'
 import { ParticipantPicker } from '~/components/pickers/participant-picker'
+import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
 import type { PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import {
@@ -258,7 +258,7 @@ export function FieldInputAdapter({
             shouldPreventDismiss={shouldPreventDismiss}
           />
           {createDialogOpen && createEntityDefinitionId && (
-            <EntityInstanceDialog
+            <RecordEditorDialog
               open={createDialogOpen}
               onOpenChange={setCreateDialogOpen}
               entityDefinitionId={createEntityDefinitionId}

--- a/apps/web/src/components/fields/inputs/relationship-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/relationship-input-field.tsx
@@ -15,8 +15,8 @@ import {
 import { toResourceFieldId } from '@auxx/types/field'
 import { isSingleRelationship } from '@auxx/utils'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-instance-dialog'
 import { RecordPickerContent } from '~/components/pickers/record-picker'
+import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import { getRelationshipStoreState, toRecordId, useResource } from '~/components/resources'
 import { api } from '~/trpc/react'
 import { useFieldNavigationOptional } from '../field-navigation-context'
@@ -244,9 +244,9 @@ export function RelationshipInputField() {
         pinnedSelectedIds={createdRecordIds}
       />
 
-      {/* Inline Create Dialog */}
+      {/* Inline Create Dialog — resolves the custom editor per entity type (e.g. Parts). */}
       {canInlineCreate && relatedResource && (
-        <EntityInstanceDialog
+        <RecordEditorDialog
           open={isCreateDialogOpen}
           onOpenChange={setIsCreateDialogOpen}
           entityDefinitionId={relatedEntityDefinitionId!}

--- a/apps/web/src/components/global-create/global-create-root.tsx
+++ b/apps/web/src/components/global-create/global-create-root.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import { useHotkeySequence } from '@tanstack/react-hotkeys'
-import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-instance-dialog'
+import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import { useResources } from '~/components/resources/hooks/use-resources'
 import { useRecordStore } from '~/components/resources/store/record-store'
 import { api } from '~/trpc/react'
@@ -21,7 +21,8 @@ const upper = (combo: [string, string]): [string, string] => [
  * Mount once at the app layout level so entities can be created from anywhere.
  *
  * Handles four fixed system-entity shortcuts (contacts, tickets, parts, companies)
- * and hosts a single EntityInstanceDialog driven by useCreateEntityStore.
+ * and hosts a single RecordEditorDialog driven by useCreateEntityStore, which
+ * resolves the right editor per entity type (e.g. the custom Parts dialog).
  */
 export function GlobalCreateRoot() {
   const open = useCreateEntityStore((s) => s.open)
@@ -52,7 +53,7 @@ export function GlobalCreateRoot() {
   if (!open || !entityDefinitionId) return null
 
   return (
-    <EntityInstanceDialog
+    <RecordEditorDialog
       open={open}
       onOpenChange={(isOpen) => {
         if (!isOpen) closeDialog()

--- a/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
+++ b/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
@@ -25,7 +25,7 @@ import {
   CommandList,
   CommandSeparator,
 } from '@auxx/ui/components/command'
-import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
 import { Boxes, Package, Plus, Settings2 } from 'lucide-react'
 import Link from 'next/link'
@@ -180,6 +180,9 @@ export interface CatalogPickerProps {
   onSelectGroup: (group: CatalogGroupPick) => void
   /** User typed text with no catalog match — add as an ad-hoc line, no catalog rel. */
   onFreeText: (text: string) => void
+  /** Return focus to the name input once the picker closes (pick / Escape / outside). */
+  onCloseFocus?: () => void
+  /** The name cell — used as the popover anchor, so it stays fully typable. */
   children: ReactNode
 }
 
@@ -198,6 +201,7 @@ export function CatalogPicker({
   onSelectCatalogItem,
   onSelectGroup,
   onFreeText,
+  onCloseFocus,
   children,
 }: CatalogPickerProps) {
   const [query, setQuery] = useState(initialQuery)
@@ -286,8 +290,16 @@ export function CatalogPicker({
         onOpenChange(next)
         if (next) setQuery(initialQuery)
       }}>
-      <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent align='start' className='w-[320px] p-0'>
+      <PopoverAnchor asChild>{children}</PopoverAnchor>
+      <PopoverContent
+        align='start'
+        className='w-[320px] p-0'
+        onCloseAutoFocus={(e) => {
+          // Radix would refocus the anchor's first focusable; we manage focus
+          // ourselves so it lands back on the name input the caret came from.
+          e.preventDefault()
+          onCloseFocus?.()
+        }}>
         <Command shouldFilter={false}>
           <CommandInput
             value={query}

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -3,12 +3,17 @@
 'use client'
 
 // The document-agnostic line-items builder (money MQ1 build spec §H.1, 01-ui.md #1).
-// Lines render as `GridTreeRow`s under a plain grid header (Description / Qty /
-// Unit cost / Total / actions) — the data-connectors mapping-editor idiom
-// (mapping-row.tsx): one shared `grid-template-columns` keeps the number columns
-// aligned across the header and every row. Line counts are small, so plain rows
-// replace the virtualized `DynamicView` embed this used to be. Row/cell markup
-// lives in `line-rows.tsx` — this file owns state, data fetching, and mutations.
+// Lines render as plain `group/tree-row` grid rows under a matching grid header
+// (Description / Qty / Unit cost / Total / actions): one shared
+// `grid-template-columns` keeps the number columns aligned across the header and
+// every row. Line counts are small, so plain rows replace the virtualized
+// `DynamicView` embed this used to be. Row/cell markup lives in `line-rows.tsx`;
+// this file owns state, data fetching, and mutations.
+//
+// Keyboard: the rows sit in a container wired to `useLineNav` — spreadsheet-style
+// focus movement across name → qty → unit cost, where Enter / ArrowDown / Tab
+// past the last row spawns a fresh draft (`addLine`). The name cell is free-text;
+// `/` on an empty cell opens the catalog picker.
 //
 // Data flow:
 // - Line cell reads: `useSystemValues` (field-value store, autoFetch).
@@ -20,7 +25,7 @@
 //   same function the server hook uses, so the optimistic footer and the
 //   stored mirrors can never disagree.
 // - Add: pushes a purely-local "phantom draft" row (`DraftLine`, line-rows.tsx)
-//   — no mutation, no round-trip — with the catalog picker already open. The
+//   — no mutation, no round-trip — with its name cell auto-focused. The
 //   record is only created on the draft's first real commit (catalog pick,
 //   free-text name, description, qty/price blur, taxable toggle, or a
 //   catalog-group pick), carrying every value accumulated on the draft in one
@@ -39,7 +44,10 @@
 import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { Button } from '@auxx/ui/components/button'
+import { EmptySection } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
+import { cn } from '@auxx/ui/lib/utils'
 import { generateId } from '@auxx/utils'
 import {
   closestCenter,
@@ -52,8 +60,7 @@ import {
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { Plus, ReceiptText } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { EmptyState } from '~/components/global/empty-state'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import {
   type RecordId,
   type RecordMeta,
@@ -77,6 +84,7 @@ import {
   relKeyForDocumentType,
 } from './line-rows'
 import { TotalsFooter } from './totals-footer'
+import { useLineNav } from './use-line-nav'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Props / shared types
@@ -159,8 +167,30 @@ export function LineBuilder({
 
   const [orderOverride, setOrderOverride] = useState<string[] | null>(null)
   const [drafts, setDrafts] = useState<DraftLine[]>([])
+  // Id of the most recently added draft — its name cell auto-focuses on mount so
+  // a keyboard-driven or button-driven "add row" lands the caret ready to type.
+  const [lastAddedDraftId, setLastAddedDraftId] = useState<string | null>(null)
   const draftsRef = useRef<DraftLine[]>([])
   draftsRef.current = drafts
+  /** Rows container — the keydown listener {@link useLineNav} attaches to. */
+  const rowsContainerRef = useRef<HTMLDivElement>(null)
+  // Last focused line cell (row/col + caret). Committing a draft fires a
+  // `record.create` whose completion swaps `DraftLineRow` → `LineRow`, replacing
+  // the row's input elements and dropping focus to `<body>`. We snapshot the
+  // focused cell here and restore it after that swap so keyboard flow survives
+  // materialization (otherwise the next Tab escapes the grid entirely).
+  const focusedCellRef = useRef<{ row: number; col: number; caret: number | null } | null>(null)
+
+  const rememberFocusedCell = useCallback(() => {
+    const el = document.activeElement as HTMLInputElement | HTMLTextAreaElement | null
+    const cell = el?.closest?.('[data-line-row][data-line-col]') as HTMLElement | null
+    if (!cell || !rowsContainerRef.current?.contains(cell)) return
+    focusedCellRef.current = {
+      row: Number(cell.dataset.lineRow),
+      col: Number(cell.dataset.lineCol),
+      caret: typeof el?.selectionStart === 'number' ? el.selectionStart : null,
+    }
+  }, [])
   // Ref-guarded (not state-derived) so a synchronous double-commit can never
   // race two `record.create` calls for the same draft before React re-renders.
   const creatingDraftIdsRef = useRef<Set<string>>(new Set())
@@ -322,9 +352,14 @@ export function LineBuilder({
     setDrafts((prev) => prev.filter((d) => d.draftId !== draftId))
   }, [])
 
-  /** "+ Add line item" — pushes a purely-local phantom draft. No mutation. */
+  /**
+   * "+ Add line item" (and keyboard nav past the last row) — pushes a
+   * purely-local phantom draft and marks it as the one to auto-focus. No mutation.
+   */
   const addLine = useCallback(() => {
-    setDrafts((prev) => [...prev, freshDraft(generateId())])
+    const draft = freshDraft(generateId())
+    setLastAddedDraftId(draft.draftId)
+    setDrafts((prev) => [...prev, draft])
   }, [])
 
   /**
@@ -680,73 +715,140 @@ export function LineBuilder({
     [entityDefinitionId, docRecordId, reorderMutate, refresh]
   )
 
+  // Spreadsheet keyboard nav across the rows container (name → qty → unit cost);
+  // Enter / ArrowDown / Tab past the last row calls `addLine` to spawn a draft.
+  useLineNav({
+    containerRef: rowsContainerRef,
+    rowCount: displayRecords.length + drafts.length,
+    colCount: 3,
+    onAddRow: addLine,
+    readOnly,
+  })
+
+  // Restore focus after a draft→real swap: when materialization detaches the
+  // focused input, the browser parks focus on `<body>`. Only then (never when the
+  // user intentionally clicked elsewhere) do we re-focus the same cell index.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on any row-set change (records/drafts)
+  useLayoutEffect(() => {
+    const target = focusedCellRef.current
+    if (!target || document.activeElement !== document.body) return
+    const sel = `[data-line-row="${target.row}"][data-line-col="${target.col}"]`
+    // The name cell rests as a `[data-cell-focusable]` text button (no <input>
+    // until focused), so match that too — otherwise focus is lost after a
+    // draft→real swap on the name column.
+    const input = rowsContainerRef.current?.querySelector(
+      `${sel} input, ${sel} textarea, ${sel} [data-cell-focusable]`
+    ) as HTMLElement | null
+    if (!input) return
+    input.focus()
+    if (target.caret != null && 'setSelectionRange' in input) {
+      try {
+        ;(input as HTMLInputElement).setSelectionRange(target.caret, target.caret)
+      } catch {
+        // Non-text inputs reject setSelectionRange — focus alone is enough.
+      }
+    }
+  }, [records, drafts])
+
   if (!entityDefinitionId) return null
 
   const isEmpty =
     !isLoading && !isLoadingRecords && displayRecords.length === 0 && drafts.length === 0
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col overflow-y-auto rounded-lg'>
-      {/* Header — same grid template as the rows, so the labels sit over their columns.
-          The Description label offsets past the row px-1 + grip slot + title/button padding. */}
-      <div
-        className='sticky top-0 z-10 grid border-primary-200/50 border-b bg-primary-50 px-1 pb-1 text-muted-foreground text-xs dark:border-[#1e2227] dark:bg-background'
-        style={{ gridTemplateColumns: readOnly ? LINE_COLS_READONLY : LINE_COLS }}>
-        <div className={readOnly ? 'pl-2' : 'pl-9'}>Description</div>
-        <div className='px-2 text-right'>Qty</div>
-        <div className='px-2 text-right'>Unit cost</div>
-        <div className='px-2 text-right'>Total</div>
-        {!readOnly && <div />}
-      </div>
+    <div
+      className={cn(
+        'flex min-h-0 flex-1 flex-col overflow-y-auto rounded-lg',
+        // Left gutter so the drag grip can sit outside the framed box (grips
+        // absolutely position into this space at `-left-4`).
+        !readOnly && 'pl-4'
+      )}>
+      {/* Header + rows share one bordered box, so the grid reads as a single
+          framed table. Totals sit outside the frame, below. */}
+      <div className='rounded-lg border border-primary-200/50 dark:border-[#1e2227]'>
+        {/* Header — same grid template as the rows, so the labels sit over their columns.
+            The grip lives in the gutter now, so Description starts flush (pl-2). */}
+        <div
+          className='sticky top-0 z-10 grid rounded-t-lg border-primary-200/50 border-b bg-primary-50 px-1 py-2 text-muted-foreground text-sm dark:border-[#1e2227] dark:bg-background'
+          style={{ gridTemplateColumns: readOnly ? LINE_COLS_READONLY : LINE_COLS }}>
+          <div className='flex items-center gap-1 pl-2'>
+            Description
+            {!readOnly && (
+              <SimpleTooltip content='Add line item' side='right'>
+                <Button
+                  variant='ghost'
+                  size='icon-xs'
+                  className='ml-1 size-5 rounded-md bg-primary-100 hover:bg-primary-200 dark:bg-background'
+                  onClick={addLine}
+                  aria-label='Add line item'>
+                  <Plus className='size-3' />
+                </Button>
+              </SimpleTooltip>
+            )}
+          </div>
+          <div className='px-2 text-right'>Qty</div>
+          <div className='px-2 text-right'>Unit cost</div>
+          <div className='px-2 text-right'>Total</div>
+          {!readOnly && <div />}
+        </div>
 
-      {isEmpty && readOnly ? (
-        <EmptyState icon={ReceiptText} title='No line items' />
-      ) : (
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
-          modifiers={[restrictToVerticalAxis]}>
-          <SortableContext
-            items={displayIdsRef.current}
-            strategy={verticalListSortingStrategy}
-            disabled={readOnly}>
-            {displayRecords.map((record) => (
-              <LineRow
-                key={record.id}
-                record={record}
-                entityDefinitionId={entityDefinitionId}
-                readOnly={readOnly}
+        {/* Rows container — the keydown listener for spreadsheet nav lives here, so
+            real rows and phantom drafts share one continuous focus index space.
+            The capture handlers keep `focusedCellRef` fresh for post-swap restore. */}
+        <div
+          ref={rowsContainerRef}
+          onFocusCapture={rememberFocusedCell}
+          onKeyUpCapture={rememberFocusedCell}
+          onPointerUpCapture={rememberFocusedCell}>
+          {isEmpty && readOnly ? (
+            <EmptySection
+              className='border-transparent ring-0'
+              icon={<ReceiptText className='size-5' />}
+              title='No line items'
+            />
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+              modifiers={[restrictToVerticalAxis]}>
+              <SortableContext
+                items={displayIdsRef.current}
+                strategy={verticalListSortingStrategy}
+                disabled={readOnly}>
+                {displayRecords.map((record, index) => (
+                  <LineRow
+                    key={record.id}
+                    record={record}
+                    rowIndex={index}
+                    entityDefinitionId={entityDefinitionId}
+                    readOnly={readOnly}
+                    currencyCode={currencyCode}
+                    deleteLine={deleteLine}
+                    onSelectGroup={handleGroupPick}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
+          )}
+
+          {/* Phantom draft rows — pinned after the real rows, never drag-sortable.
+              They continue the nav index space (real count + draft index). */}
+          {!readOnly &&
+            drafts.map((draft, i) => (
+              <DraftLineRow
+                key={draft.draftId}
+                draft={draft}
+                rowIndex={displayRecords.length + i}
+                autoFocus={draft.draftId === lastAddedDraftId}
                 currencyCode={currencyCode}
-                deleteLine={deleteLine}
-                onSelectGroup={handleGroupPick}
+                deleteDraft={deleteDraft}
+                createDraft={createDraft}
+                onSelectGroup={handleGroupPickDraft}
               />
             ))}
-          </SortableContext>
-        </DndContext>
-      )}
-
-      {/* Phantom draft rows — pinned after the real rows, never drag-sortable. */}
-      {!readOnly &&
-        drafts.map((draft) => (
-          <DraftLineRow
-            key={draft.draftId}
-            draft={draft}
-            currencyCode={currencyCode}
-            deleteDraft={deleteDraft}
-            createDraft={createDraft}
-            onSelectGroup={handleGroupPickDraft}
-          />
-        ))}
-
-      {!readOnly && (
-        <div className='border-primary-200/50 border-b px-1 py-0.5 dark:border-[#1e2227]'>
-          <Button variant='ghost' size='sm' className='text-muted-foreground' onClick={addLine}>
-            <Plus />
-            Add line item
-          </Button>
         </div>
-      )}
+      </div>
 
       <TotalsFooter
         documentRecordId={docRecordId}

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -10,19 +10,36 @@
 // draft lines — see line-builder.tsx's file-header comment for the draft
 // lifecycle). `LineBuilder` itself (state, mutations, data fetching) stays in
 // line-builder.tsx.
+//
+// Keyboard model (use-line-nav.ts): rows are a plain `group/tree-row grid`
+// (not the tree `GridTreeRow` — we only kept its `TreeRowButton` hover-action
+// primitive). Each navigable cell carries `data-line-row`/`data-line-col` so a
+// single container-level keydown listener can move focus spreadsheet-style
+// across name → qty → unit cost, adding a fresh draft when nav lands past the
+// last row. The name cell is a free-text `<input>`: type any product name, or
+// press `/` on an empty cell (or click the trailing pick icon) to open the
+// catalog picker and drop in a pre-existing product.
 
 import { FieldType } from '@auxx/database/enums'
 import { computeLineTotal } from '@auxx/lib/money/client'
 import { AutosizeTextarea } from '@auxx/ui/components/autosize-textarea'
 import { Badge } from '@auxx/ui/components/badge'
-import { Button } from '@auxx/ui/components/button'
 import { SimpleTooltip, TooltipExplanation } from '@auxx/ui/components/tooltip'
-import { GridTreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { AlignLeft, Check, CircleCheck, CircleX, GripVertical, Trash2, X } from 'lucide-react'
-import { useState } from 'react'
+import {
+  AlignLeft,
+  Check,
+  CircleCheck,
+  CircleX,
+  GripVertical,
+  PackageSearch,
+  Trash2,
+  X,
+} from 'lucide-react'
+import { type ReactNode, useRef, useState } from 'react'
 import { type RecordId, type RecordMeta, toRecordId } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
@@ -93,6 +110,87 @@ export function relKeyForDocumentType(documentType: 'quote' | 'work_order' | 'in
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// The plain grid row shell (replaces GridTreeRow)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * One line's grid row — a `group/tree-row` so the hover-revealed
+ * `TreeRowButton`s (grip, pick, description, taxable, delete) still fade in on
+ * row hover. Owns the shared column template + the `data-line-row`/`col` tags
+ * that {@link useLineNav} focus-hops between. Name/qty/price are the three
+ * navigable cells (cols 0–2); total + actions ride outside the nav order.
+ */
+function LineGridRow({
+  rowIndex,
+  readOnly,
+  grip,
+  name,
+  qty,
+  price,
+  total,
+  actions,
+}: {
+  rowIndex: number
+  readOnly: boolean
+  grip: ReactNode
+  name: ReactNode
+  qty: ReactNode
+  price: ReactNode
+  total: ReactNode
+  actions?: ReactNode
+}) {
+  return (
+    <div className='group/tree-row relative text-sm'>
+      {/* Drag grip — lives in the left gutter, OUTSIDE the framed grid. */}
+      {grip}
+
+      {/* Hover background — a standalone layer behind the grid columns. */}
+      <div className='absolute inset-0 rounded-md transition-colors group-hover/tree-row:bg-background' />
+
+      <div
+        className='relative grid min-h-9 items-stretch px-1 text-muted-foreground'
+        style={{ gridTemplateColumns: readOnly ? LINE_COLS_READONLY : LINE_COLS }}>
+        {/* Col 0 — name input (the grip sits in the gutter, not this column). */}
+        <div data-line-row={rowIndex} data-line-col={0} className='flex min-w-0 items-center'>
+          {name}
+        </div>
+
+        <div data-line-row={rowIndex} data-line-col={1} className='flex items-center'>
+          {qty}
+        </div>
+        <div data-line-row={rowIndex} data-line-col={2} className='flex items-center'>
+          {price}
+        </div>
+        <div className='flex items-center'>{total}</div>
+        {!readOnly && <div className='flex items-center justify-end'>{actions}</div>}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Drag grip pinned into the left gutter (the `-left-4` offset lands it outside
+ * the bordered frame, mirroring the KB table row handle). Revealed only on row
+ * hover; draft rows render no grip at all (they aren't sortable).
+ */
+function GripSlot({
+  attributes,
+  listeners,
+}: {
+  attributes?: Record<string, unknown>
+  listeners?: Record<string, unknown>
+}) {
+  return (
+    <span
+      {...attributes}
+      {...listeners}
+      className='-left-4 absolute top-0 bottom-0 flex w-4 cursor-grab items-center justify-center text-muted-foreground opacity-0 transition-opacity group-hover/tree-row:opacity-100'>
+      <GripVertical className='size-3.5' />
+    </span>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Presentational cells — shared by real (store-bound) rows and draft rows
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -125,14 +223,15 @@ function CategoryBadge({ category }: { category: string | null }) {
 }
 
 /**
- * Primary line cell — a single-line row that owns everything about the item:
- * the catalog picker (transparent full-width button, doubling as free-text
- * rename), the category badge, a description help-tooltip (when set), and the
- * trailing description-edit affordance. Editing the description swaps the picker
- * in place for an autosize textarea with confirm/cancel — the line never grows a
- * permanent second row. Purely presentational: values + commit callbacks are
- * props, so both the store-bound real cell and the local-state draft cell render
- * the exact same markup.
+ * Primary line cell — a free-text name `<input>` that owns everything about the
+ * item. Type any product name (an ad-hoc line, no catalog rel); press `/` on an
+ * empty cell (or click the trailing pick icon) to open the catalog picker and
+ * drop in a pre-existing product, which overwrites name/price/category/taxable
+ * and keeps the catalog relationship. The category badge sits inline; a trailing
+ * description-edit affordance swaps the input for an autosize textarea in place —
+ * the line never grows a permanent second row. Purely presentational: values +
+ * commit callbacks are props, so both the store-bound real cell and the
+ * local-state draft cell render the exact same markup.
  */
 function LineNameCellView({
   name,
@@ -140,7 +239,7 @@ function LineNameCellView({
   category,
   readOnly,
   currencyCode,
-  initialPickerOpen = false,
+  autoFocus = false,
   onPickCatalogItem,
   onSelectGroup,
   onFreeText,
@@ -151,17 +250,33 @@ function LineNameCellView({
   category: string | null
   readOnly: boolean
   currencyCode: string
-  /** Fresh drafts mount with the catalog picker already open. */
-  initialPickerOpen?: boolean
+  /** Focus the name input on mount — set for a freshly added draft row. */
+  autoFocus?: boolean
   onPickCatalogItem: (pick: CatalogItemPick) => void
   onSelectGroup: (pick: CatalogGroupPick) => void
   onFreeText: (text: string) => void
   onCommitDescription: (value: string | null) => void
 }) {
-  const [pickerOpen, setPickerOpen] = useState(initialPickerOpen)
-  // `null` = not editing; any string (incl. '') = the in-progress description.
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  // `null` = not typing; any string (incl. '') = the in-progress name edit.
+  const [nameDraft, setNameDraft] = useState<string | null>(null)
+  // `null` = not editing description; any string (incl. '') = in-progress text.
   const [descriptionDraft, setDescriptionDraft] = useState<string | null>(null)
   const editing = descriptionDraft !== null
+  // At rest the name is a plain text label (+ category badge); on focus it swaps
+  // to the free-text input and reveals the pick/description actions. A freshly
+  // added draft (`autoFocus`) opens straight into the input.
+  const [focused, setFocused] = useState(autoFocus)
+
+  const commitName = () => {
+    if (nameDraft === null) return
+    const trimmed = nameDraft.trim()
+    setNameDraft(null)
+    // Only commit a non-empty change: an emptied cell keeps its previous name
+    // (mirrors the qty cell) and never spawns an empty-named draft record.
+    if (trimmed && trimmed !== name) onFreeText(trimmed)
+  }
 
   const confirmDescription = () => {
     if (descriptionDraft === null) return
@@ -169,8 +284,9 @@ function LineNameCellView({
     setDescriptionDraft(null)
   }
 
-  // Description edit mode — replaces the picker with an autosize textarea in the
-  // same slot (single line at rest, grows while typing) + confirm/cancel.
+  // Description edit mode — replaces the input with an autosize textarea in the
+  // same slot (single line at rest, grows while typing) + confirm/cancel. The
+  // grid nav hook leaves textareas fully native, so Enter confirms here.
   if (editing) {
     return (
       <div className='flex min-w-0 flex-1 items-center gap-1 py-1'>
@@ -204,52 +320,97 @@ function LineNameCellView({
     )
   }
 
+  if (readOnly) {
+    return (
+      <div className='flex min-w-0 flex-1 items-center gap-1.5 py-1'>
+        <span
+          className={cn('min-w-0 truncate px-1 text-sm', !name && 'text-muted-foreground italic')}>
+          {name || 'Untitled line'}
+        </span>
+        <CategoryBadge category={category} />
+        {description && <TooltipExplanation text={description} />}
+      </div>
+    )
+  }
+
+  const value = nameDraft ?? name
+
   return (
     <div className='flex min-w-0 flex-1 items-center gap-1.5 py-1'>
-      {readOnly ? (
+      {/* CatalogPicker stays mounted across the text↔input swap so its popover
+          anchor never detaches; only its inner trigger changes shape. */}
+      <CatalogPicker
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        initialQuery={value}
+        currencyCode={currencyCode}
+        onSelectCatalogItem={onPickCatalogItem}
+        onSelectGroup={onSelectGroup}
+        onFreeText={onFreeText}
+        onCloseFocus={() => inputRef.current?.focus()}>
+        <div className='flex min-w-0 flex-1 items-center gap-1.5'>
+          {focused ? (
+            <input
+              ref={inputRef}
+              data-cell-focusable
+              autoFocus
+              value={value}
+              onChange={(e) => setNameDraft(e.target.value)}
+              onFocus={() => setNameDraft(name)}
+              onBlur={() => {
+                commitName()
+                // Collapse back to text, unless the picker took focus (its own
+                // input blurs us) — then stay in edit mode behind the popover.
+                if (!pickerOpen) setFocused(false)
+              }}
+              onKeyDown={(e) => {
+                // `/` on an empty cell opens the picker; typed anywhere else it's a
+                // literal slash (e.g. "1/2 inch pipe").
+                if (e.key === '/' && value === '') {
+                  e.preventDefault()
+                  setPickerOpen(true)
+                }
+              }}
+              placeholder='Add item or press /'
+              className='h-7 min-w-0 flex-1 rounded-sm border-none bg-transparent px-1 text-sm outline-none placeholder:text-muted-foreground/50'
+            />
+          ) : (
+            <button
+              type='button'
+              data-cell-focusable
+              onFocus={() => setFocused(true)}
+              onClick={() => setFocused(true)}
+              className='flex h-7 min-w-0 items-center rounded-sm px-1 text-left text-sm outline-none'>
+              <span className={cn('min-w-0 truncate', !name && 'text-muted-foreground/50')}>
+                {name || 'Add item'}
+              </span>
+            </button>
+          )}
+          {/* Category badge sits next to the label; hidden while editing the name. */}
+          {!focused && <CategoryBadge category={category} />}
+        </div>
+      </CatalogPicker>
+
+      {/* Actions only while focused. `onMouseDown` preventDefault keeps the input
+          from blur-collapsing before the click handler runs. */}
+      {focused && (
         <>
-          <span
-            className={cn(
-              'min-w-0 truncate px-1 text-sm',
-              !name && 'text-muted-foreground italic'
-            )}>
-            {name || 'Untitled line'}
-          </span>
-          <CategoryBadge category={category} />
+          <TreeRowButton
+            persistent
+            className='ml-auto'
+            tooltipText='Pick product'
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => setPickerOpen(true)}>
+            <PackageSearch />
+          </TreeRowButton>
+          <TreeRowButton
+            persistent
+            tooltipText={description || 'Add description'}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => setDescriptionDraft(description ?? '')}>
+            <AlignLeft />
+          </TreeRowButton>
         </>
-      ) : (
-        <CatalogPicker
-          open={pickerOpen}
-          onOpenChange={setPickerOpen}
-          initialQuery={name}
-          currencyCode={currencyCode}
-          onSelectCatalogItem={onPickCatalogItem}
-          onSelectGroup={onSelectGroup}
-          onFreeText={onFreeText}>
-          <Button
-            variant='transparent'
-            className={cn(
-              'h-7 min-w-0 flex-1 justify-start gap-1.5 rounded-sm px-1 text-sm hover:bg-primary/5',
-              !name && 'text-muted-foreground'
-            )}>
-            <span className='truncate'>{name || 'Add item…'}</span>
-            <CategoryBadge category={category} />
-          </Button>
-        </CatalogPicker>
-      )}
-
-      {/* Read-only rows surface the description via the help-tooltip; editable rows
-          drop it — the description-edit button below carries the text as its own
-          tooltip instead. */}
-      {readOnly && description && <TooltipExplanation text={description} />}
-
-      {!readOnly && (
-        <TreeRowButton
-          className='ml-auto'
-          tooltipText={description || 'Add description'}
-          onClick={() => setDescriptionDraft(description ?? '')}>
-          <AlignLeft />
-        </TreeRowButton>
       )}
     </div>
   )
@@ -367,14 +528,10 @@ function InlineNumberCellView({
       }
       onBlur={commit}
       onKeyDown={(e) => {
-        if (e.key === 'Enter') e.currentTarget.blur()
         if (e.key === 'Escape') setDraft(null)
       }}
       inputMode='decimal'
-      className={cn(
-        'h-full w-full rounded-sm border-none bg-transparent px-2 text-right text-sm tabular-nums outline-none',
-        'hover:bg-primary/5 focus:bg-primary/10'
-      )}
+      className='h-full w-full rounded-sm border-none bg-transparent px-2 text-right text-sm tabular-nums outline-none'
     />
   )
 }
@@ -505,9 +662,10 @@ function LineActionsCell({
 // Rows
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** One sortable line row — a GridTreeRow whose leading icon is the drag grip. */
+/** One sortable line row — a grid row whose leading slot is the drag grip. */
 export function LineRow({
   record,
+  rowIndex,
   entityDefinitionId,
   readOnly,
   currencyCode,
@@ -515,6 +673,7 @@ export function LineRow({
   onSelectGroup,
 }: {
   record: RecordMeta
+  rowIndex: number
   entityDefinitionId: string
   readOnly: boolean
   currencyCode: string
@@ -532,19 +691,11 @@ export function LineRow({
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(isDragging && 'relative z-10 opacity-80')}>
-      <GridTreeRow
-        columns={readOnly ? LINE_COLS_READONLY : LINE_COLS}
-        icon={
-          readOnly ? undefined : (
-            <span
-              {...attributes}
-              {...listeners}
-              className='flex cursor-grab items-center justify-center opacity-0 transition-opacity group-hover/tree-row:opacity-100'>
-              <GripVertical className='size-3.5' />
-            </span>
-          )
-        }
-        title={
+      <LineGridRow
+        rowIndex={rowIndex}
+        readOnly={readOnly}
+        grip={readOnly ? null : <GripSlot attributes={attributes} listeners={listeners} />}
+        name={
           <LineNameCell
             recordId={recordId}
             readOnly={readOnly}
@@ -552,78 +703,73 @@ export function LineRow({
             onSelectGroup={(pick) => onSelectGroup(recordId, pick)}
           />
         }
-        cells={[
+        qty={
           <InlineNumberCell
-            key='qty'
             recordId={recordId}
             attr='line_item_qty'
             fieldType={FieldType.NUMBER}
             readOnly={readOnly}
             currencyCode={currencyCode}
-          />,
+          />
+        }
+        price={
           <InlineNumberCell
-            key='price'
             recordId={recordId}
             attr='line_item_unit_price'
             fieldType={FieldType.CURRENCY}
             readOnly={readOnly}
             currencyCode={currencyCode}
-          />,
-          <LineTotalCell key='total' recordId={recordId} currencyCode={currencyCode} />,
-          // Read-only rows drop the actions column entirely (LINE_COLS_READONLY),
-          // so `Total` sits flush right and description absorbs the freed width.
-          ...(readOnly
-            ? []
-            : [
-                <LineActionsCell
-                  key='actions'
-                  recordId={recordId}
-                  rowId={record.id}
-                  deleteLine={deleteLine}
-                />,
-              ]),
-        ]}
+          />
+        }
+        total={<LineTotalCell recordId={recordId} currencyCode={currencyCode} />}
+        actions={
+          readOnly ? undefined : (
+            <LineActionsCell recordId={recordId} rowId={record.id} deleteLine={deleteLine} />
+          )
+        }
       />
     </div>
   )
 }
 
 /**
- * A phantom draft line row — same `GridTreeRow` layout as {@link LineRow}, wired
- * to local draft state instead of the field-value store. Not drag-sortable
- * (empty, disabled icon slot in place of the grip, so columns stay aligned).
- * Every commit callback routes through `createDraft`, which fires the record's
- * first `record.create` on the draft's first real edit.
+ * A phantom draft line row — same grid layout as {@link LineRow}, wired to local
+ * draft state instead of the field-value store. Not drag-sortable (empty,
+ * disabled grip slot in place of the handle, so columns stay aligned). Every
+ * commit callback routes through `createDraft`, which fires the record's first
+ * `record.create` on the draft's first real edit.
  */
 export function DraftLineRow({
   draft,
+  rowIndex,
+  autoFocus,
   currencyCode,
   deleteDraft,
   createDraft,
   onSelectGroup,
 }: {
   draft: DraftLine
+  rowIndex: number
+  /** Focus the name input on mount — set for the just-added draft. */
+  autoFocus: boolean
   currencyCode: string
   deleteDraft: (draftId: string) => void
   createDraft: (draftId: string, overrides?: Partial<DraftLine>) => Promise<void>
   onSelectGroup: (draftId: string, pick: CatalogGroupPick) => void
 }) {
   return (
-    <GridTreeRow
-      columns={LINE_COLS}
-      icon={
-        <span className='flex items-center justify-center opacity-0'>
-          <GripVertical className='size-3.5' />
-        </span>
-      }
-      title={
+    <LineGridRow
+      rowIndex={rowIndex}
+      readOnly={false}
+      grip={null}
+      name={
         <LineNameCellView
           name={draft.name}
           description={draft.description}
           category={draft.category}
           readOnly={false}
           currencyCode={currencyCode}
-          initialPickerOpen
+          autoFocus={autoFocus}
           onPickCatalogItem={(pick) =>
             void createDraft(draft.draftId, {
               name: pick.name,
@@ -639,9 +785,8 @@ export function DraftLineRow({
           onCommitDescription={(value) => void createDraft(draft.draftId, { description: value })}
         />
       }
-      cells={[
+      qty={
         <InlineNumberCellView
-          key='qty'
           value={draft.qty}
           attr='line_item_qty'
           readOnly={false}
@@ -650,29 +795,32 @@ export function DraftLineRow({
             if (next === null) return
             void createDraft(draft.draftId, { qty: next })
           }}
-        />,
+        />
+      }
+      price={
         <InlineNumberCellView
-          key='price'
           value={draft.unitPriceCents}
           attr='line_item_unit_price'
           readOnly={false}
           currencyCode={currencyCode}
           onCommit={(next) => void createDraft(draft.draftId, { unitPriceCents: next })}
-        />,
+        />
+      }
+      total={
         <LineTotalCellView
-          key='total'
           qty={draft.qty}
           unitPrice={draft.unitPriceCents}
           currencyCode={currencyCode}
-        />,
+        />
+      }
+      actions={
         <LineActionsCellView
-          key='actions'
           taxable={draft.taxable}
           rowId={draft.draftId}
           onToggleTaxable={(next) => void createDraft(draft.draftId, { taxable: next })}
           deleteLine={deleteDraft}
-        />,
-      ]}
+        />
+      }
     />
   )
 }

--- a/apps/web/src/components/money/ui/line-builder/use-line-nav.ts
+++ b/apps/web/src/components/money/ui/line-builder/use-line-nav.ts
@@ -1,0 +1,178 @@
+// apps/web/src/components/money/ui/line-builder/use-line-nav.ts
+
+import { useEffect, useRef } from 'react'
+
+type UseLineNavOptions = {
+  containerRef: React.RefObject<HTMLDivElement | null>
+  /** Total navigable rows (real records + phantom drafts). */
+  rowCount: number
+  /** Navigable columns per row: 0 = name, 1 = qty, 2 = unit cost. */
+  colCount: number
+  /** Push a fresh phantom draft row. Called when nav lands past the last row. */
+  onAddRow: () => void
+  readOnly: boolean
+}
+
+/**
+ * Spreadsheet-like keyboard navigation for the line-items grid — the
+ * `use-key-value-navigation` idiom (data-connectors HTTP editor) ported to the
+ * line builder. A single capture-phase `keydown` listener on the rows container
+ * moves focus between cells tagged `data-line-row` / `data-line-col`:
+ *
+ * - Arrows cross cells only when the caret sits at the input's text boundary,
+ *   so left/right editing inside a cell still works.
+ * - Tab / Shift-Tab walk the grid; forward past the last cell adds a row.
+ * - Enter commits (the focus move blurs the input) and drops into the next row's
+ *   name cell — adding a fresh draft when already on the last row, so "keep
+ *   adding items" is a pure-keyboard rhythm.
+ *
+ * Bails out while focus is inside a Radix popper (the catalog `/` picker), so the
+ * picker's own arrow/enter keys are never hijacked.
+ */
+export function useLineNav({
+  containerRef,
+  rowCount,
+  colCount,
+  onAddRow,
+  readOnly,
+}: UseLineNavOptions) {
+  const rowCountRef = useRef(rowCount)
+  const onAddRowRef = useRef(onAddRow)
+  rowCountRef.current = rowCount
+  onAddRowRef.current = onAddRow
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || readOnly) return
+
+    function getActiveCell(): { row: number; col: number } | null {
+      const active = document.activeElement
+      if (!active || !container!.contains(active)) return null
+      const cell = active.closest('[data-line-row][data-line-col]') as HTMLElement | null
+      if (!cell) return null
+      const row = Number.parseInt(cell.dataset.lineRow!, 10)
+      const col = Number.parseInt(cell.dataset.lineCol!, 10)
+      if (Number.isNaN(row) || Number.isNaN(col)) return null
+      return { row, col }
+    }
+
+    function focusCell(row: number, col: number) {
+      const target = container!.querySelector(
+        `[data-line-row="${row}"][data-line-col="${col}"]`
+      ) as HTMLElement | null
+      if (!target) return
+      // `[data-cell-focusable]` covers the name cell's at-rest text button (which
+      // swaps to an <input> on focus); qty/unit-cost cells match on `input`.
+      const focusable = target.querySelector(
+        'input, textarea, [data-cell-focusable]'
+      ) as HTMLElement | null
+      if (focusable) {
+        focusable.focus()
+        focusable.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+      }
+    }
+
+    function focusCellAfterAdd(row: number, col: number) {
+      requestAnimationFrame(() => focusCell(row, col))
+    }
+
+    /** True while focus is inside the catalog `/` picker (a Radix popper portal). */
+    function isInsidePopper(): boolean {
+      const active = document.activeElement
+      if (!active) return false
+      return !!active.closest('[data-radix-popper-content-wrapper]')
+    }
+
+    /** Plain <input>/<textarea> caret-at-edge test (no contenteditable here). */
+    function isCaretAtBoundary(direction: 'start' | 'end'): boolean {
+      const el = document.activeElement
+      if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+        if (direction === 'start') return el.selectionStart === 0 && el.selectionEnd === 0
+        const end = el.value.length
+        return el.selectionStart === end && el.selectionEnd === end
+      }
+      return true
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (isInsidePopper()) return
+      // The description sub-editor is a <textarea> — leave all its keys native
+      // (Enter confirms, arrows move the caret), never grid-navigate from it.
+      if (document.activeElement instanceof HTMLTextAreaElement) return
+
+      const pos = getActiveCell()
+      if (!pos) return
+
+      const { row, col } = pos
+      const totalRows = rowCountRef.current
+      const totalCols = colCount
+
+      switch (e.key) {
+        case 'Enter': {
+          e.preventDefault()
+          if (row < totalRows - 1) {
+            focusCell(row + 1, 0)
+          } else {
+            onAddRowRef.current()
+            focusCellAfterAdd(row + 1, 0)
+          }
+          break
+        }
+
+        case 'ArrowDown': {
+          e.preventDefault()
+          if (row < totalRows - 1) {
+            focusCell(row + 1, col)
+          } else {
+            onAddRowRef.current()
+            focusCellAfterAdd(row + 1, col)
+          }
+          break
+        }
+
+        case 'ArrowUp': {
+          if (row > 0) {
+            e.preventDefault()
+            focusCell(row - 1, col)
+          }
+          break
+        }
+
+        case 'ArrowLeft': {
+          if (col > 0 && isCaretAtBoundary('start')) {
+            e.preventDefault()
+            focusCell(row, col - 1)
+          }
+          break
+        }
+
+        case 'ArrowRight': {
+          if (col < totalCols - 1 && isCaretAtBoundary('end')) {
+            e.preventDefault()
+            focusCell(row, col + 1)
+          }
+          break
+        }
+
+        case 'Tab': {
+          e.preventDefault()
+          if (e.shiftKey) {
+            if (col > 0) focusCell(row, col - 1)
+            else if (row > 0) focusCell(row - 1, totalCols - 1)
+          } else if (col < totalCols - 1) {
+            focusCell(row, col + 1)
+          } else if (row < totalRows - 1) {
+            focusCell(row + 1, 0)
+          } else {
+            onAddRowRef.current()
+            focusCellAfterAdd(row + 1, 0)
+          }
+          break
+        }
+      }
+    }
+
+    container.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () => container.removeEventListener('keydown', handleKeyDown, { capture: true })
+  }, [containerRef, colCount, readOnly])
+}

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -27,7 +27,6 @@ import {
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import * as React from 'react'
-import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-instance-dialog'
 import { BaseEntityDrawer } from '~/components/drawers/base-entity-drawer'
 import { getHeaderActions } from '~/components/drawers/drawer-action-registry'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
@@ -37,6 +36,7 @@ import { CommandContext, RecordCommandActions } from '~/components/kbar/contextu
 import { KopilotContext } from '~/components/kopilot/context'
 import { KopilotSuggestion } from '~/components/kopilot/suggestions'
 import { MergeDialog } from '~/components/merge'
+import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import { resourceHasDetailPage, useRecord, useResource } from '~/components/resources'
 import { useFieldValue } from '~/components/resources/hooks/use-field-values'
 import { AvatarUploadIcon } from '~/components/resources/ui/avatar-upload-icon'
@@ -458,9 +458,9 @@ export const RecordDrawer = React.memo(function RecordDrawer({
         }
       />
 
-      {/* Edit Dialog */}
+      {/* Edit Dialog — resolves the custom editor per entity type (e.g. Parts). */}
       {editDialogOpen && entityDefinitionId && (
-        <EntityInstanceDialog
+        <RecordEditorDialog
           open={editDialogOpen}
           onOpenChange={setEditDialogOpen}
           entityDefinitionId={entityDefinitionId}

--- a/apps/web/src/components/records/record-editor-dialog.tsx
+++ b/apps/web/src/components/records/record-editor-dialog.tsx
@@ -1,0 +1,62 @@
+// apps/web/src/components/records/record-editor-dialog.tsx
+'use client'
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-instance-dialog'
+import { PartFormDialog } from '~/components/manufacturing/parts/part-form-dialog'
+import { useResource } from '~/components/resources/hooks/use-resource'
+
+/**
+ * Normalized props every record editor (generic or custom) accepts, so callers
+ * never care which concrete dialog resolves for a given entity type.
+ */
+export interface RecordEditorDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Entity definition ID of the record being created/edited. */
+  entityDefinitionId: string
+  /** RecordId for edit mode; undefined for create. */
+  recordId?: RecordId
+  /** Called after a successful save. */
+  onSaved?: (instanceId?: string) => void
+  /** Preset field values for CREATE mode. Custom editors may ignore this. */
+  presetValues?: Record<string, unknown>
+}
+
+/**
+ * Registry of entity types whose editor is a bespoke dialog rather than the
+ * generic {@link EntityInstanceDialog}. Keyed by `resource.entityType` (the
+ * stable system enum, e.g. `'part'`). Anything not listed falls through to the
+ * generic form. Adapters normalize each dialog's props onto
+ * {@link RecordEditorDialogProps}.
+ */
+const CUSTOM_EDITORS: Record<string, React.ComponentType<RecordEditorDialogProps>> = {
+  part: PartEditorAdapter,
+}
+
+/** Adapts {@link PartFormDialog} (uses `onSuccess`, no def id / presets) to the shared shape. */
+function PartEditorAdapter({ open, onOpenChange, recordId, onSaved }: RecordEditorDialogProps) {
+  return (
+    <PartFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      recordId={recordId}
+      onSuccess={() => onSaved?.()}
+    />
+  )
+}
+
+/**
+ * Single entry point for opening a record's create/edit dialog from anywhere.
+ * Resolves the entity type from the resource store and renders that type's
+ * custom editor when one is registered, otherwise the generic form. Use this
+ * instead of reaching for `EntityInstanceDialog` directly so custom editors
+ * (e.g. Parts) can't be bypassed.
+ */
+export function RecordEditorDialog(props: RecordEditorDialogProps) {
+  const { resource } = useResource(props.entityDefinitionId)
+  const Custom = resource?.entityType ? CUSTOM_EDITORS[resource.entityType] : undefined
+
+  if (Custom) return <Custom {...props} />
+  return <EntityInstanceDialog {...props} />
+}

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -26,7 +26,6 @@ import { useRouter } from 'next/navigation'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { BulkUpdateEntityInstanceDialog } from '~/components/custom-fields/ui/bulk-update-entity-instance-dialog'
-import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-instance-dialog'
 import type { CellSelectionConfig } from '~/components/dynamic-table'
 import { PrimaryFieldCell } from '~/components/dynamic-table'
 import {
@@ -42,6 +41,7 @@ import { CommandAction, CommandContext } from '~/components/kbar/contextual'
 import { useCommandPaletteStore } from '~/components/kbar/store'
 import { KopilotContext } from '~/components/kopilot/context'
 import { MergeDialog } from '~/components/merge'
+import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import { type RecordMeta, toRecordId, useResource } from '~/components/resources'
 import { useRunAiBulkGenerate } from '~/components/resources/hooks/run-ai-bulk-generate'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
@@ -74,12 +74,6 @@ interface RecordsViewProps {
   basePath?: string
   /** When true, RecordsView renders without its own MainPage wrapper (parent provides it) */
   embedded?: boolean
-  /** When false, suppresses the built-in EntityInstanceDialog. Default: true.
-   *  Use this when the parent renders its own create/edit dialog listening to ?create=true. */
-  renderCreateDialog?: boolean
-  /** Called when the user triggers an edit on a record (e.g. primary field edit button).
-   *  Only relevant when renderCreateDialog is false — lets the parent open its own edit dialog. */
-  onEditRecord?: (recordId: RecordId) => void
 }
 
 /**
@@ -87,13 +81,7 @@ interface RecordsViewProps {
  * Composes DynamicResourceView with the records-specific primary cell,
  * bulk-action set, paste/fill/AI cell selection config, and dialogs.
  */
-export function RecordsView({
-  slug,
-  basePath,
-  embedded,
-  renderCreateDialog,
-  onEditRecord,
-}: RecordsViewProps) {
+export function RecordsView({ slug, basePath, embedded }: RecordsViewProps) {
   const resolvedBasePath = basePath ?? `/app/custom/${slug}`
   const router = useRouter()
 
@@ -124,15 +112,10 @@ export function RecordsView({
   const isCreateDialogOpen = isCreateDialogOpenInternal || createParam
   const setIsCreateDialogOpen = useCallback(
     (open: boolean) => {
-      if (renderCreateDialog === false) {
-        // Parent handles the dialog — communicate via URL param only
-        setCreateParam(open || null)
-      } else {
-        setIsCreateDialogOpenInternal(open)
-        if (!open && createParam) setCreateParam(null)
-      }
+      setIsCreateDialogOpenInternal(open)
+      if (!open && createParam) setCreateParam(null)
     },
-    [createParam, setCreateParam, renderCreateDialog]
+    [createParam, setCreateParam]
   )
 
   // Local state
@@ -209,15 +192,11 @@ export function RecordsView({
 
   const handleOpenEditDialog = useCallback(
     (row: EntityRow) => {
-      if (onEditRecord && entityDefinitionId) {
-        onEditRecord(toRecordId(entityDefinitionId, row.id))
-      } else {
-        setEditingInstance(row)
-      }
+      setEditingInstance(row)
       setCreatePresetValues(undefined)
       setIsCreateDialogOpen(true)
     },
-    [setIsCreateDialogOpen, onEditRecord, entityDefinitionId]
+    [setIsCreateDialogOpen]
   )
 
   const handleDrawerOpenChange = useCallback(
@@ -908,9 +887,9 @@ export function RecordsView({
         </MainPage>
       )}
 
-      {/* Create/Edit Dialog */}
-      {renderCreateDialog !== false && entityDefinitionId && isCreateDialogOpen && (
-        <EntityInstanceDialog
+      {/* Create/Edit Dialog — resolves the custom editor per entity type (e.g. Parts). */}
+      {entityDefinitionId && isCreateDialogOpen && (
+        <RecordEditorDialog
           open={isCreateDialogOpen}
           onOpenChange={handleDialogOpenChange}
           entityDefinitionId={entityDefinitionId}

--- a/apps/web/src/components/resources/ui/record-hover-card.tsx
+++ b/apps/web/src/components/resources/ui/record-hover-card.tsx
@@ -12,10 +12,11 @@ import { Button } from '@auxx/ui/components/button'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@auxx/ui/components/hover-card'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
-import { Maximize2, PanelRight, Star } from 'lucide-react'
+import { Maximize2, PanelRight, Pencil, Star } from 'lucide-react'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useFavoriteToggle } from '~/components/favorites/hooks/use-favorite-toggle'
+import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import { useRecord } from '~/components/resources/hooks/use-record'
 import { useResource } from '~/components/resources/hooks/use-resource'
 import { useResourceStore } from '~/components/resources/store/resource-store'
@@ -63,29 +64,51 @@ export function RecordHoverCard({
   className,
   onOpenInDrawer,
 }: RecordHoverCardProps) {
+  // Edit-dialog state lives here (not in the body) so the dialog survives the
+  // hover card closing — `HoverCardContent` unmounts on mouse-leave, which would
+  // otherwise tear down a dialog rendered inside it the moment it opens.
+  const [isEditOpen, setIsEditOpen] = useState(false)
+
   if (!recordId) return <>{children}</>
 
+  const entityDefinitionId = getDefinitionId(recordId)
+
   return (
-    <HoverCard openDelay={openDelay} closeDelay={closeDelay}>
-      {/* Wrap in a stable inline-flex span so the trigger's pointer listeners
-          attach to a host element we own — avoids asChild merging into a
-          re-rendering Link/anchor inside a virtualized cell, which can drop
-          pointerenter events. */}
-      <HoverCardTrigger asChild>
-        <span data-slot='record-hover-trigger' className='inline-flex max-w-full'>
-          {children}
-        </span>
-      </HoverCardTrigger>
-      <HoverCardContent
-        side={side}
-        align={align}
-        sideOffset={sideOffset}
-        collisionPadding={8}
-        className={cn('w-80 p-3', className)}
-        onClick={(e) => e.stopPropagation()}>
-        <RecordHoverCardBody recordId={recordId} fields={fields} onOpenInDrawer={onOpenInDrawer} />
-      </HoverCardContent>
-    </HoverCard>
+    <>
+      <HoverCard openDelay={openDelay} closeDelay={closeDelay}>
+        {/* Wrap in a stable inline-flex span so the trigger's pointer listeners
+            attach to a host element we own — avoids asChild merging into a
+            re-rendering Link/anchor inside a virtualized cell, which can drop
+            pointerenter events. */}
+        <HoverCardTrigger asChild>
+          <span data-slot='record-hover-trigger' className='inline-flex max-w-full'>
+            {children}
+          </span>
+        </HoverCardTrigger>
+        <HoverCardContent
+          side={side}
+          align={align}
+          sideOffset={sideOffset}
+          collisionPadding={8}
+          className={cn('w-80 p-3', className)}
+          onClick={(e) => e.stopPropagation()}>
+          <RecordHoverCardBody
+            recordId={recordId}
+            fields={fields}
+            onOpenInDrawer={onOpenInDrawer}
+            onEdit={() => setIsEditOpen(true)}
+          />
+        </HoverCardContent>
+      </HoverCard>
+      {isEditOpen && (
+        <RecordEditorDialog
+          open={isEditOpen}
+          onOpenChange={setIsEditOpen}
+          entityDefinitionId={entityDefinitionId}
+          recordId={recordId}
+        />
+      )}
+    </>
   )
 }
 
@@ -93,9 +116,11 @@ interface BodyProps {
   recordId: RecordId
   fields?: FieldReference[]
   onOpenInDrawer?: (recordId: RecordId) => void
+  /** Opens the record's edit dialog (owned by the parent so it outlives the card). */
+  onEdit?: () => void
 }
 
-function RecordHoverCardBody({ recordId, fields, onOpenInDrawer }: BodyProps) {
+function RecordHoverCardBody({ recordId, fields, onOpenInDrawer, onEdit }: BodyProps) {
   const entityDefinitionId = getDefinitionId(recordId)
   const { record, isLoading: isLoadingRecord, isNotFound } = useRecord({ recordId })
   const { resource, isLoading: isLoadingResource } = useResource(entityDefinitionId)
@@ -145,7 +170,7 @@ function RecordHoverCardBody({ recordId, fields, onOpenInDrawer }: BodyProps) {
 
   const displayName = (record?.displayName as string | undefined) ?? 'Untitled'
 
-  const hasFooter = !!onOpenInDrawer || !!href
+  const hasFooter = !!onOpenInDrawer
   const showDivider = resolvedFields.length > 0 || hasFooter
 
   return (
@@ -160,9 +185,37 @@ function RecordHoverCardBody({ recordId, fields, onOpenInDrawer }: BodyProps) {
           inverse
         />
         <div className='min-w-0 flex-1'>
-          <div className='flex items-center gap-1.5'>
-            <h4 className=' truncate text-sm font-semibold leading-snug'>{displayName}</h4>
+          <div className='flex items-center gap-0.5'>
+            <h4 className='min-w-0 flex-1 truncate text-sm font-semibold leading-snug'>
+              {displayName}
+            </h4>
             <FavoriteStarButton recordId={recordId} />
+            {onEdit && (
+              <Button
+                variant='ghost'
+                size='icon-xs'
+                className='shrink-0'
+                title='Edit'
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  onEdit()
+                }}>
+                <Pencil />
+              </Button>
+            )}
+            {href && (
+              <Button
+                asChild
+                variant='ghost'
+                size='icon-xs'
+                className='shrink-0'
+                title='Open full page'>
+                <Link href={href} onClick={(e) => e.stopPropagation()}>
+                  <Maximize2 />
+                </Link>
+              </Button>
+            )}
           </div>
           {secondaryDisplay && (
             <p className='truncate text-xs text-muted-foreground'>{secondaryDisplay}</p>
@@ -180,33 +233,24 @@ function RecordHoverCardBody({ recordId, fields, onOpenInDrawer }: BodyProps) {
       )}
 
       {/* Footer */}
-      {hasFooter && (
+      {hasFooter && onOpenInDrawer && (
         <div
           className={cn(
             'flex items-center justify-end gap-1',
             // Only render the divider once — fields section already has its own.
             !resolvedFields.length && showDivider && 'border-t'
           )}>
-          {onOpenInDrawer && (
-            <Button
-              variant='ghost'
-              size='icon-xs'
-              title='Open in drawer'
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                onOpenInDrawer(recordId)
-              }}>
-              <PanelRight />
-            </Button>
-          )}
-          {href && (
-            <Button asChild variant='ghost' size='icon-xs' title='Open full page'>
-              <Link href={href} onClick={(e) => e.stopPropagation()}>
-                <Maximize2 />
-              </Link>
-            </Button>
-          )}
+          <Button
+            variant='ghost'
+            size='icon-xs'
+            title='Open in drawer'
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onOpenInDrawer(recordId)
+            }}>
+            <PanelRight />
+          </Button>
         </div>
       )}
     </>

--- a/apps/web/src/server/api/trpc.ts
+++ b/apps/web/src/server/api/trpc.ts
@@ -9,7 +9,7 @@
 
 import { database as db } from '@auxx/database'
 import { getOrgCache } from '@auxx/lib/cache'
-import { AuxxError } from '@auxx/lib/errors'
+import { AuxxError, AuxxErrorCodes } from '@auxx/lib/errors'
 import { isAdminOrOwner } from '@auxx/lib/members'
 import { FeatureKey } from '@auxx/lib/permissions'
 import { RedisRateLimiter } from '@auxx/lib/utils/rate-limiter/redis-rate-limiter'
@@ -201,6 +201,25 @@ const HTTP_TO_TRPC: Record<number, TRPC_ERROR_CODE_KEY> = {
   429: 'TOO_MANY_REQUESTS',
 }
 
+const AUXX_ERROR_NAMES = new Set<string>(Object.values(AuxxErrorCodes))
+
+/**
+ * Detects AuxxError instances by duck-typing rather than `instanceof` alone.
+ *
+ * `@auxx/lib` is transpiled by Next (see `transpilePackages`), so the `AuxxError`
+ * class bound here and the copy inside `@auxx/lib/dist/*.mjs` — which service code
+ * actually throws — are different module instances. `instanceof` fails across that
+ * boundary, so a thrown `BadRequestError` would otherwise fall through as an
+ * `INTERNAL_SERVER_ERROR` and get its message masked. Matching on the `name` +
+ * numeric `statusCode` shape keeps the correct code and message regardless of which
+ * copy produced the error.
+ */
+const isAuxxError = (error: unknown): error is AuxxError =>
+  error instanceof AuxxError ||
+  (error instanceof Error &&
+    typeof (error as AuxxError).statusCode === 'number' &&
+    AUXX_ERROR_NAMES.has(error.name))
+
 /**
  * Middleware that catches AuxxError instances thrown by service-layer code
  * and re-throws them as proper TRPCErrors with the correct error code.
@@ -209,7 +228,7 @@ const auxxErrorMiddleware = t.middleware(async ({ next }) => {
   try {
     return await next()
   } catch (error) {
-    if (error instanceof AuxxError) {
+    if (isAuxxError(error)) {
       throw new TRPCError({
         code: HTTP_TO_TRPC[error.statusCode] ?? 'INTERNAL_SERVER_ERROR',
         message: error.message,

--- a/packages/ui/src/components/tree-row-list.tsx
+++ b/packages/ui/src/components/tree-row-list.tsx
@@ -1,0 +1,98 @@
+// packages/ui/src/components/tree-row-list.tsx
+'use client'
+
+import { AnimatedCollapsibleContent } from '@auxx/ui/components/collapsible'
+import { TreeRow, TreeRowSkeleton } from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { Fragment, type ReactNode, useState } from 'react'
+
+export interface TreeRowListProps<T> {
+  /** The rows' backing data, in render order. */
+  items: T[]
+  /** Renders one row — typically a {@link TreeRow} or a wrapper around it. */
+  renderRow: (item: T, index: number) => ReactNode
+  /** Stable React key per item. */
+  getKey: (item: T, index: number) => string
+  /**
+   * Cap the always-visible rows; anything past it collapses behind an inline
+   * "Show N more" toggle row that expands in place. Omit (or 0) to show all.
+   */
+  visibleLimit?: number
+  /** Render `skeletonCount` placeholder rows instead of the items. */
+  loading?: boolean
+  /** Placeholder-row count while `loading`. */
+  skeletonCount?: number
+  /** Leading icon for the "Show N more" / "Show less" toggle row. */
+  showMoreIcon?: ReactNode
+  /** Override the collapsed label (default: `Show {n} more`). */
+  showMoreLabel?: (hiddenCount: number) => string
+  /** Class for the outer container (rows are stacked with `flex flex-col`). */
+  className?: string
+}
+
+/**
+ * TreeRowList — the shared "list of {@link TreeRow}s with an inline show-more
+ * collapse and loading placeholders" primitive. The first {@link
+ * TreeRowListProps.visibleLimit} rows always render; the remainder are siblings
+ * inside an animated collapse (so they keep the flat-list indentation) behind a
+ * "Show N more" toggle. Row rendering is caller-owned via `renderRow`, so this
+ * stays row-type-agnostic (connector runs, work-order visits, …); groups/headers
+ * are the caller's job — render one list per group.
+ */
+export function TreeRowList<T>({
+  items,
+  renderRow,
+  getKey,
+  visibleLimit,
+  loading = false,
+  skeletonCount = 3,
+  showMoreIcon,
+  showMoreLabel,
+  className,
+}: TreeRowListProps<T>) {
+  const [showAll, setShowAll] = useState(false)
+
+  if (loading) {
+    return (
+      <div className={cn('flex flex-col', className)}>
+        {Array.from({ length: skeletonCount }).map((_, i) => (
+          <TreeRowSkeleton key={i} />
+        ))}
+      </div>
+    )
+  }
+
+  const limit = visibleLimit && visibleLimit > 0 ? visibleLimit : items.length
+  const visible = items.slice(0, limit)
+  const hidden = items.slice(limit)
+
+  return (
+    <div className={cn('flex flex-col', className)}>
+      {visible.map((item, i) => (
+        <Fragment key={getKey(item, i)}>{renderRow(item, i)}</Fragment>
+      ))}
+
+      {hidden.length > 0 && (
+        <>
+          <AnimatedCollapsibleContent open={showAll} className='flex flex-col'>
+            {hidden.map((item, i) => (
+              <Fragment key={getKey(item, limit + i)}>{renderRow(item, limit + i)}</Fragment>
+            ))}
+          </AnimatedCollapsibleContent>
+          <TreeRow
+            icon={showMoreIcon}
+            title={
+              showAll
+                ? 'Show less'
+                : (showMoreLabel?.(hidden.length) ?? `Show ${hidden.length} more`)
+            }
+            rowClassName='hover:bg-primary-100'
+            expandable
+            isOpen={showAll}
+            onToggleOpen={() => setShowAll((v) => !v)}
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/ui/src/components/tree-row.tsx
+++ b/packages/ui/src/components/tree-row.tsx
@@ -1,6 +1,7 @@
 // packages/ui/src/components/tree-row.tsx
 'use client'
 
+import { Skeleton } from '@auxx/ui/components/skeleton'
 import { SimpleTooltip, TooltipExplanation } from '@auxx/ui/components/tooltip'
 import { cn } from '@auxx/ui/lib/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
@@ -340,6 +341,22 @@ export function TreeRow({
       line={line}>
       {children}
     </BaseTreeRow>
+  )
+}
+
+/**
+ * Placeholder row matching {@link TreeRow}'s height and indent — a skeleton icon
+ * box plus a text-line skeleton. Used by {@link TreeRowList} while its data loads
+ * so the list reserves the same vertical rhythm as the real rows.
+ */
+export function TreeRowSkeleton({ depth = 0 }: { depth?: number }) {
+  return (
+    <div style={{ paddingLeft: `${depth * INDENT_REM}rem` }}>
+      <div className='flex items-center gap-2 px-1 py-1.5'>
+        <Skeleton className='size-4 shrink-0 rounded' />
+        <Skeleton className='h-4 w-40 max-w-full' />
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

Four related refactors landed together:

- **Record-editor registry** — New `RecordEditorDialog` is now the single entry point for opening a record's create/edit dialog. It resolves a bespoke editor per entity type (`part` → `PartFormDialog`) and otherwise falls through to the generic `EntityInstanceDialog`. Global-create, record-drawer, and relationship inline-create all route through it, so a custom editor can't be silently bypassed.
- **Line-builder keyboard nav** — `useLineNav` adds spreadsheet-style navigation to the money line-items grid: arrows cross cells at text boundaries, Tab/Shift-Tab walk the grid, Enter commits and drops into the next row (adding a fresh draft on the last row). It bails out inside the catalog `/` picker popper so the picker's own keys aren't hijacked. `line-rows` / `line-builder` refactored to drive it.
- **Shared `TreeRowList` primitive** — Extracted the "list of `TreeRow`s with inline show-more collapse + loading placeholders" pattern into `@auxx/ui`. Row rendering stays caller-owned so it's row-type-agnostic; adopted in connector-runs, work-order related cards, and dispatch visits / job-schedule panels.
- **tRPC AuxxError fix** — `auxxErrorMiddleware` now duck-types `AuxxError` (name + numeric `statusCode`) in addition to `instanceof`. Because Next transpiles `@auxx/lib`, service code throws from a different class instance than the one bound in `trpc.ts`; `instanceof` failed across that boundary and errors like `BadRequestError` were masking as `INTERNAL_SERVER_ERROR`. Now they keep their correct code and message.

## Test plan

- [ ] Create/edit a Part from global-create, record drawer, and a relationship field — the custom Parts dialog opens in all three
- [ ] Create/edit a non-Part record — generic dialog still opens
- [ ] Line builder: navigate the grid with arrows/Tab/Enter; confirm the catalog picker keys still work while open
- [ ] Show-more toggles work in connector runs, work-order cards, and dispatch visit/job-schedule panels
- [ ] Trigger a service-layer validation error through tRPC and confirm the original message/status surfaces (not a generic 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)