### PR TITLE
feat(money,dispatch,records): tucked-label billing headers + open full page

### DIFF
--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-payments-block.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-payments-block.tsx
@@ -8,17 +8,20 @@
 // affected invoice's own `listPayments` so an open invoice drawer stays fresh. `renderRowSuffix`
 // adds a small invoice chip per row (§B slot) so a mixed-invoice ledger stays legible.
 //
+// Layout mirrors the invoices block (block 4): a plain `TuckedLabel` header with no action, a
+// `px-2` list, and the "record" affordance as a `TreeRow` at the bottom (matching "Create
+// invoice") rather than a header button.
+//
 // §C: candidates = invoices with `invoice_status !== 'void'` and `invoice_balance > 0`, handed
 // down by the billing tab (it already aggregates per-invoice values for the summary strip).
-// Exactly one → the dialog opens directly against it; multiple → a small `DropdownMenu`
-// chooser lists each ("<number> — <balance> due"); zero → no action, and — when there are no
-// invoices at all — a custom `EmptySection` explaining that, instead of `PaymentsList`'s own
+// Exactly one → the Record-payment row opens the dialog against it; multiple → that row becomes
+// a `DropdownMenu` chooser ("<number> — <balance> due"); zero → the row is hidden. When there
+// are no invoices at all, a custom `EmptySection` explains that, instead of `PaymentsList`'s own
 // "no payments recorded" copy (which reads wrong when there's nothing to attach a payment to).
 
 import type { RecordId } from '@auxx/types/resource'
 import { getInstanceId } from '@auxx/types/resource'
 import { Badge } from '@auxx/ui/components/badge'
-import { Button } from '@auxx/ui/components/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,6 +30,7 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { EmptySection } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
 import { CreditCard, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
@@ -34,6 +38,7 @@ import { useAdminGate } from '~/components/global/admin-gate'
 import { RecordPaymentDialog } from '~/components/money/ui/invoice/record-payment-dialog'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
 import { PaymentsList } from '~/components/money/ui/payments/payments-list'
+import { TuckedLabel } from '~/components/money/ui/tucked-label'
 import { useRecord } from '~/components/resources'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -123,57 +128,90 @@ export function WorkOrderBillingPaymentsBlock({
 
   const openDirect = (candidate: PaymentCandidate) => setTarget(candidate)
 
+  const hasPayments = (payments?.length ?? 0) > 0
+
   return (
-    <div className='flex flex-col gap-1'>
-      <div className='flex items-center justify-between px-4 pt-1 pb-1'>
-        <span className='text-xs font-medium text-muted-foreground'>Payments</span>
-        {candidates.length === 1 && (
-          <Button variant='ghost' size='xs' onClick={() => openDirect(candidates[0]!)}>
-            <Plus />
-            Record payment
-          </Button>
-        )}
-        {candidates.length > 1 && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant='ghost' size='xs'>
-                <Plus />
-                Record payment
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align='end'>
-              {candidates.map((candidate) => (
-                <DropdownMenuItem key={candidate.recordId} onClick={() => openDirect(candidate)}>
-                  {candidate.displayName} — {formatCurrency(candidate.balance, currencyCode)} due
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+    <div className='flex flex-col'>
+      {/* Header + content mirror the invoices block: a plain tucked label (no action) and a
+          `px-2` list whose "create" affordance is a TreeRow at the bottom (§B / block 4 parity). */}
+      <TuckedLabel className='mx-4 mt-2'>Payments</TuckedLabel>
+
+      <div className={`px-2 ${TREE_SECONDARY_NOTRUNCATE}`}>
+        {!hasInvoices ? (
+          <EmptySection
+            icon={<CreditCard className='size-5' />}
+            title='No invoices yet'
+            description='Create an invoice above before recording a payment.'
+          />
+        ) : (
+          <>
+            {(hasPayments || isLoading) && (
+              <PaymentsList
+                payments={payments}
+                isLoading={isLoading}
+                currencyCode={currencyCode}
+                isAdmin={isAdmin}
+                onDelete={handleDelete}
+                onRefund={handleRefund}
+                deletePending={deletePayment.isPending}
+                refundPending={refundTransaction.isPending}
+                renderRowSuffix={(payment) => {
+                  const invoiceRecordId = invoiceByTransactionId.get(payment.id)
+                  return invoiceRecordId ? (
+                    <PaymentInvoiceChip invoiceRecordId={invoiceRecordId} />
+                  ) : null
+                }}
+              />
+            )}
+
+            {candidates.length === 1 && (
+              <TreeRow
+                icon={hasPayments ? <Plus className='size-4' /> : <CreditCard className='size-4' />}
+                title={<span className='text-muted-foreground text-sm'>Record payment</span>}
+                onToggleOpen={() => openDirect(candidates[0]!)}
+              />
+            )}
+
+            {candidates.length > 1 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <div>
+                    <TreeRow
+                      rowClassName='cursor-pointer'
+                      icon={
+                        hasPayments ? (
+                          <Plus className='size-4' />
+                        ) : (
+                          <CreditCard className='size-4' />
+                        )
+                      }
+                      title={<span className='text-muted-foreground text-sm'>Record payment</span>}
+                    />
+                  </div>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='start'>
+                  {candidates.map((candidate) => (
+                    <DropdownMenuItem
+                      key={candidate.recordId}
+                      onClick={() => openDirect(candidate)}>
+                      {candidate.displayName} — {formatCurrency(candidate.balance, currencyCode)}{' '}
+                      due
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+
+            {!isLoading && !hasPayments && candidates.length === 0 && (
+              <EmptySection
+                icon={<CreditCard className='size-5' />}
+                title='No payments recorded'
+                description='Payments appear here once an invoice has a balance due.'
+              />
+            )}
+          </>
         )}
       </div>
-
-      {!hasInvoices ? (
-        <EmptySection
-          icon={<CreditCard className='size-5' />}
-          title='No invoices yet'
-          description='Create an invoice above before recording a payment.'
-        />
-      ) : (
-        <PaymentsList
-          payments={payments}
-          isLoading={isLoading}
-          currencyCode={currencyCode}
-          isAdmin={isAdmin}
-          onDelete={handleDelete}
-          onRefund={handleRefund}
-          deletePending={deletePayment.isPending}
-          refundPending={refundTransaction.isPending}
-          renderRowSuffix={(payment) => {
-            const invoiceRecordId = invoiceByTransactionId.get(payment.id)
-            return invoiceRecordId ? <PaymentInvoiceChip invoiceRecordId={invoiceRecordId} /> : null
-          }}
-        />
-      )}
 
       {target && (
         <RecordPaymentDialog

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
@@ -17,6 +17,7 @@ import type { DetailViewTabProps } from '~/components/detail-view'
 import type { InvoiceBillingValues } from '~/components/money/hooks/use-work-order-invoices'
 import { useWorkOrderInvoices } from '~/components/money/hooks/use-work-order-invoices'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { TuckedLabel } from '~/components/money/ui/tucked-label'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
@@ -28,9 +29,9 @@ import { WorkOrderBillingPaymentsBlock } from './work-order-billing-payments-blo
 /** Timings whose invoice drafts are generated automatically (vs `as_needed`, manual). */
 const AUTOMATED_TIMINGS = new Set(['per_visit_completed', 'on_completion', 'custom_schedule'])
 
-/** Quiet sub-block label — same style as the line-items tab's "Billed each visit" row. */
+/** Quiet sub-block header — the Attio-style tucked label the block below stacks into. */
 function BlockLabel({ children }: { children: React.ReactNode }) {
-  return <div className='px-4 pt-3 pb-1 text-xs font-medium text-muted-foreground'>{children}</div>
+  return <TuckedLabel className=' mt-2'>{children}</TuckedLabel>
 }
 
 export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
@@ -106,7 +107,7 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
           isSection ? 'max-h-[70vh] overflow-auto' : 'min-h-0 flex-1'
         )}>
         {/* Block a — summary strip */}
-        <div className='flex items-stretch gap-6 px-4 pt-2 pb-3'>
+        <div className='flex items-stretch gap-6  pt-2 pb-3'>
           <SummaryCell label='Invoiced' value={formatCurrency(invoicedTotal, currencyCode)} />
           <SummaryCell label='Paid' value={formatCurrency(paidTotal, currencyCode)} />
           <SummaryCell label='Balance due' value={formatCurrency(balanceTotal, currencyCode)} />
@@ -124,31 +125,32 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
         {/* Block c — invoicing schedule */}
         <BillingScheduleRow workOrderRecordId={recordId} invoiceTiming={invoiceTiming} />
         {showOrgDisabledWarning && (
-          <div className='flex items-center gap-1.5 px-4 pt-1 pb-2 text-xs text-amber-700 dark:text-amber-400'>
+          <div className='flex items-center gap-1.5  pt-1 pb-2 text-xs text-amber-700 dark:text-amber-400'>
             <CalendarClock className='size-3.5 shrink-0' />
             Automatic invoicing is turned off for your organization.
           </div>
         )}
+        <div className='me-4'>
+          {/* Block d — invoices */}
+          <BlockLabel>Invoices</BlockLabel>
+          <div className='bg-primary-100 border rounded-xl mb-4'>
+            <WorkOrderBillingInvoicesBlock
+              workOrderRecordId={recordId}
+              invoiceRecordIds={invoiceRecordIds}
+              isLoading={invoicesLoading}
+              currencyCode={currencyCode}
+              onInvoiceValues={handleInvoiceValues}
+            />
+          </div>
 
-        {/* Block d — invoices */}
-        <BlockLabel>Invoices</BlockLabel>
-        <div className='px-2'>
-          <WorkOrderBillingInvoicesBlock
+          {/* Block e — payments */}
+          <WorkOrderBillingPaymentsBlock
             workOrderRecordId={recordId}
-            invoiceRecordIds={invoiceRecordIds}
-            isLoading={invoicesLoading}
+            hasInvoices={invoiceRecordIds.length > 0}
+            candidates={candidates}
             currencyCode={currencyCode}
-            onInvoiceValues={handleInvoiceValues}
           />
         </div>
-
-        {/* Block e — payments */}
-        <WorkOrderBillingPaymentsBlock
-          workOrderRecordId={recordId}
-          hasInvoices={invoiceRecordIds.length > 0}
-          candidates={candidates}
-          currencyCode={currencyCode}
-        />
       </div>
     </div>
   )

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
@@ -4,6 +4,7 @@
 import { cn } from '@auxx/ui/lib/utils'
 import type { DetailViewTabProps } from '~/components/detail-view'
 import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
+import { TuckedLabel } from '~/components/money/ui/tucked-label'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 
 /**
@@ -24,12 +25,8 @@ export function WorkOrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewT
   const isSection = variant === 'section'
 
   return (
-    <div className={cn('flex flex-col', isSection ? '' : 'h-full min-h-0')}>
-      {jobType === 'recurring' && (
-        <div className='px-4 pt-1 pb-1 text-xs font-medium text-muted-foreground'>
-          Billed each visit
-        </div>
-      )}
+    <div className={cn('flex flex-col ', isSection ? ' pe-3' : 'h-full min-h-0')}>
+      {jobType === 'recurring' && <TuckedLabel className='ms-4'>Billed each visit</TuckedLabel>}
       <div
         className={cn(
           'flex flex-col',

--- a/apps/web/src/components/drawers/cards/related-record-row.tsx
+++ b/apps/web/src/components/drawers/cards/related-record-row.tsx
@@ -27,6 +27,7 @@ export function RelatedRecordRow({
   recordId,
   statusAttr,
   href: hrefOverride,
+  rowClassName,
 }: {
   recordId: RecordId
   statusAttr: string
@@ -36,6 +37,8 @@ export function RelatedRecordRow({
    * records-view drawer convention.
    */
   href?: string
+  /** Extra classes for the row (passed through to `TreeRow`), e.g. a hover tint. */
+  rowClassName?: string
 }) {
   const router = useRouter()
   const { record } = useRecord({ recordId, enabled: true })
@@ -60,6 +63,7 @@ export function RelatedRecordRow({
 
   return (
     <TreeRow
+      rowClassName={rowClassName}
       onDrill={handleOpen}
       icon={
         <RecordIcon

--- a/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
+++ b/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
@@ -79,11 +79,17 @@ export function WorkOrderInvoicesCard({ recordId }: DrawerTabProps) {
   return (
     <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
       {invoiceRecordIds.map((id) => (
-        <RelatedRecordRow key={id} recordId={id} statusAttr='invoice_status' />
+        <RelatedRecordRow
+          key={id}
+          recordId={id}
+          statusAttr='invoice_status'
+          rowClassName='hover:bg-primary-100'
+        />
       ))}
 
       {/* Always available — the gather dialog owns the "no uninvoiced lines" empty state. */}
       <TreeRow
+        rowClassName='hover:bg-primary-100'
         icon={
           invoiceRecordIds.length > 0 ? <Plus className='size-4' /> : <Receipt className='size-4' />
         }

--- a/apps/web/src/components/money/ui/invoice/invoice-lines-card.tsx
+++ b/apps/web/src/components/money/ui/invoice/invoice-lines-card.tsx
@@ -154,15 +154,7 @@ export function InvoiceLinesCard({ recordId }: DrawerTabProps) {
         </DocumentActionsCluster>
       </DocumentSectionActions>
 
-      {SENT_STATUSES.has(status) && (
-        <div className='mx-3 mt-2 mb-3 flex items-center gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm'>
-          <span className='text-amber-700 dark:text-amber-400'>
-            This invoice was sent — use “Return to draft” to edit it.
-          </span>
-        </div>
-      )}
-
-      <div className='min-h-0 flex-1'>
+      <div className='min-h-0 flex-1 pe-3'>
         <LineBuilder documentRecordId={recordId} documentType='invoice' readOnly={readOnly} />
       </div>
 

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -100,6 +100,8 @@ export interface LineBuilderProps {
    * set (`visitId` empty). The two sets never overlap — that split is enforced in `filters` below.
    */
   visitId?: string
+  /** Extra classes merged onto the builder's scroll-container root. */
+  className?: string
 }
 
 const LINE_ITEM_SLUG = 'line-items'
@@ -145,6 +147,7 @@ export function LineBuilder({
   documentType,
   readOnly = false,
   visitId,
+  className,
 }: LineBuilderProps) {
   const docRecordId = documentRecordId as RecordId
   const { resource } = useResource(LINE_ITEM_SLUG)
@@ -761,7 +764,8 @@ export function LineBuilder({
         'flex min-h-0 flex-1 flex-col overflow-y-auto rounded-lg',
         // Left gutter so the drag grip can sit outside the framed box (grips
         // absolutely position into this space at `-left-4`).
-        !readOnly && 'pl-4'
+        !readOnly && 'pl-4',
+        className
       )}>
       {/* Header + rows share one bordered box, so the grid reads as a single
           framed table. Totals sit outside the frame, below. */}

--- a/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
+++ b/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
@@ -198,11 +198,7 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
         </div>
       )}
 
-      <div
-        className={cn(
-          'flex flex-col pb-4 pt-3',
-          isSection ? 'max-h-[60vh] overflow-auto' : 'min-h-0 flex-1'
-        )}>
+      <div className={cn(isSection ? 'max-h-[60vh] overflow-auto pe-3' : 'min-h-0 flex-1')}>
         <LineBuilder documentRecordId={recordId} documentType='quote' readOnly={readOnly} />
       </div>
 

--- a/apps/web/src/components/money/ui/tucked-label.tsx
+++ b/apps/web/src/components/money/ui/tucked-label.tsx
@@ -1,0 +1,41 @@
+// apps/web/src/components/money/ui/tucked-label.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import type * as React from 'react'
+
+interface TuckedLabelProps {
+  /** Leading icon (optional) — sized to 12px to match the label text. */
+  icon?: React.ReactNode
+  /** The label content (e.g. "Line items", or "Invoices · 3"). */
+  children: React.ReactNode
+  /** Right-aligned trailing slot — a count, badge, or small action button. */
+  trailing?: React.ReactNode
+  className?: string
+}
+
+/**
+ * TuckedLabel — an Attio-style header "tab" that the following content tucks into.
+ *
+ * Rounded top corners, a tinted background, muted text, and a `-mb-3` (12px)
+ * bottom margin so the sibling content card rendered immediately after it
+ * overlaps the label's lower edge — the two then read as one stacked unit.
+ *
+ * It does NOT wrap the content. Render it as the sibling directly BEFORE the
+ * block it heads (LineBuilder, invoices list, payments list), and give that
+ * block a solid background so it paints over the tucked region.
+ */
+export function TuckedLabel({ icon, children, trailing, className }: TuckedLabelProps) {
+  return (
+    <div
+      className={cn(
+        '-mb-3 flex items-center gap-1.5 rounded-t-xl px-3 pt-2 pb-5',
+        'bg-primary-200/80 text-muted-foreground text-xs font-medium dark:bg-white/[0.03]',
+        className
+      )}>
+      {icon && <span className='flex items-center [&_svg]:size-3'>{icon}</span>}
+      <span className='min-w-0 truncate'>{children}</span>
+      {trailing && <span className='ml-auto flex shrink-0 items-center'>{trailing}</span>}
+    </div>
+  )
+}

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -21,7 +21,17 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { useQueryClient } from '@tanstack/react-query'
-import { Archive, Combine, Database, FileText, Play, Plus, SquarePen, Trash2 } from 'lucide-react'
+import {
+  Archive,
+  Combine,
+  Database,
+  Expand,
+  FileText,
+  Play,
+  Plus,
+  SquarePen,
+  Trash2,
+} from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
 import { useCallback, useMemo, useRef, useState } from 'react'
@@ -42,7 +52,13 @@ import { useCommandPaletteStore } from '~/components/kbar/store'
 import { KopilotContext } from '~/components/kopilot/context'
 import { MergeDialog } from '~/components/merge'
 import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
-import { type RecordMeta, toRecordId, useResource } from '~/components/resources'
+import {
+  getRecordLink,
+  type RecordMeta,
+  resourceHasDetailPage,
+  toRecordId,
+  useResource,
+} from '~/components/resources'
 import { useRunAiBulkGenerate } from '~/components/resources/hooks/run-ai-bulk-generate'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useActorStore } from '~/components/resources/store/actor-store'
@@ -253,6 +269,16 @@ export function RecordsView({ slug, basePath, embedded }: RecordsViewProps) {
             <SquarePen />
             Edit
           </DropdownMenuItem>
+          {resource && resourceHasDetailPage(resource) && (
+            <DropdownMenuItem
+              onClick={() => {
+                const href = getRecordLink(toRecordId(entityDefinitionId, row.id), resource)
+                if (href) router.push(href)
+              }}>
+              <Expand />
+              Open full page
+            </DropdownMenuItem>
+          )}
           <FavoriteToggleMenuItem
             targetType='ENTITY_INSTANCE'
             targetIds={{
@@ -275,6 +301,8 @@ export function RecordsView({ slug, basePath, embedded }: RecordsViewProps) {
     [
       entityDefinitionId,
       primaryResourceFieldId,
+      resource,
+      router,
       handleOpenDrawer,
       handleOpenEditDialog,
       handleArchive,

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -101,7 +101,7 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     mainTabs: [
       // fullBleed: the line-items table spans edge-to-edge (cancels the Section's
       // px-3), matching the quote drawer/sidebar cards' `fullBleed` treatment.
-      { value: 'line-items', label: 'Line items', icon: 'receipt-text', fullBleed: true },
+      { value: 'line-items', label: 'Line items', icon: 'receipt-text', fullBleed: false },
       { value: 'timeline', label: 'Timeline', icon: 'clock' },
       { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
     ],

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -140,7 +140,7 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     },
     tabCards: {
       overview: [
-        { value: 'lines', label: 'Line items', fullBleed: true },
+        { value: 'lines', label: 'Line items', fullBleed: false },
         { value: 'payments', label: 'Payments' },
       ],
     },


### PR DESCRIPTION
## Summary
- Restyle the work-order billing/payments and line-items sub-block headers with a shared `TuckedLabel` component (rounded, tinted tab that the following content card tucks into), matching the existing invoices-block treatment.
- Payments block: "Record payment" moves from a header button to a `TreeRow` at the bottom of the list (single-invoice direct action, multi-invoice dropdown chooser), for parity with the invoices block's "Create invoice" row.
- Add an "Open full page" row action to the records grid dropdown for resources that have a detail page.
- Turn off `fullBleed` for the invoice/quote line-items tabs/cards now that `LineBuilder` accepts a `className` for its own padding.

## Test plan
- [ ] Open a work order's Billing tab: verify Invoices and Payments sections render with the new tucked-label headers and the record-payment row (single invoice, multiple invoices, and zero-invoice empty state).
- [ ] Open a work order's Line items tab (recurring job type) and confirm the "Billed each visit" tucked label renders correctly.
- [ ] Open an invoice drawer/detail page and confirm line items render without the old `fullBleed` edge-to-edge table and the sent-invoice banner behavior is unchanged (dropdown "Return to draft" action still works).
- [ ] Open a quote drawer/detail page and confirm line items still render correctly.
- [ ] From the records grid, right-click/open the row menu on a resource with a detail page and confirm "Open full page" navigates correctly.