### PR TITLE
feat(money,records,drawers): quote↔job linkage + root-level record editor

### DIFF
--- a/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
+++ b/apps/web/src/app/(protected)/app/_components/app-layout-wrapper.tsx
@@ -13,6 +13,7 @@ import { GlobalCreateRoot } from '~/components/global-create/global-create-root'
 import { CommandPalette } from '~/components/kbar'
 import { SimpleLayout } from '~/components/layouts/simple-layout'
 import { FloatingComposeRoot } from '~/components/mail/email-editor/floating-compose-root'
+import { GlobalRecordEditorRoot } from '~/components/records/global-record-editor-root'
 import { SignatureDialogRoot } from '~/components/signatures/ui/signature-dialog-root'
 import { SnippetDialogRoot } from '~/components/snippets/snippet-dialog-root'
 import { SubscriptionEnded } from '~/components/subscriptions/subscription-ended'
@@ -88,6 +89,7 @@ export function AppLayoutWrapper({ children, user }: AppLayoutWrapperProps) {
               <FloatingComposeRoot />
               <FloatingTaskRoot />
               <GlobalCreateRoot />
+              <GlobalRecordEditorRoot />
               <SignatureDialogRoot />
               <SnippetDialogRoot />
               <CommandPalette />

--- a/apps/web/src/components/drawers/cards/quote-jobs-card.tsx
+++ b/apps/web/src/components/drawers/cards/quote-jobs-card.tsx
@@ -1,0 +1,36 @@
+// apps/web/src/components/drawers/cards/quote-jobs-card.tsx
+'use client'
+
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+import {
+  EmptyRow,
+  RelatedRecordRow,
+  RowSkeleton,
+  TREE_SECONDARY_NOTRUNCATE,
+} from './related-record-row'
+
+/**
+ * QuoteJobsCard — the work order(s) this quote was converted into (dispatch v5
+ * build spec 01: the public accept page auto-converts, so the resulting job must
+ * be visible from the quote). Resolves via the `quote_work_orders` inverse of
+ * `work_order_quote` — the WorkOrderInvoicesCard read pattern.
+ */
+export function QuoteJobsCard({ recordId }: DrawerTabProps) {
+  const { values, isLoading } = useSystemValues(recordId, ['quote_work_orders'], {
+    autoFetch: true,
+  })
+  const workOrderRecordIds = extractRelationshipRecordIds(values.quote_work_orders)
+
+  if (isLoading) return <RowSkeleton />
+  if (workOrderRecordIds.length === 0) return <EmptyRow label='Not converted to a job yet' />
+
+  return (
+    <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
+      {workOrderRecordIds.map((id) => (
+        <RelatedRecordRow key={id} recordId={id} statusAttr='work_order_status' />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/drawers/cards/work-order-origin-card.tsx
+++ b/apps/web/src/components/drawers/cards/work-order-origin-card.tsx
@@ -31,22 +31,33 @@ const REQUEST_ATTRS = [
  * spec §F.2, 04-ui.md §6: "source request incl. preferred/alternate dates +
  * arrival window — the dispatcher's scheduling hint, always visible next to the
  * sections; plus source ticket link"). Uniform TreeRow blocks (see
- * related-record-row.tsx); resolved via `work_order_request`.
+ * related-record-row.tsx); resolved via `work_order_request` +
+ * `work_order_quote` (the quote-convert origin, money MQ1 §F.4).
  */
 export function WorkOrderOriginCard({ recordId }: DrawerTabProps) {
   const { values: workOrderValues, isLoading: workOrderLoading } = useSystemValues(
     recordId,
-    ['work_order_request'],
+    ['work_order_request', 'work_order_quote'],
     { autoFetch: true }
   )
 
-  const requestRecordIds = extractRelationshipRecordIds(workOrderValues.work_order_request)
-  const requestRecordId = requestRecordIds[0]
+  const requestRecordId = extractRelationshipRecordIds(workOrderValues.work_order_request)[0]
+  const quoteRecordId = extractRelationshipRecordIds(workOrderValues.work_order_quote)[0]
 
   if (workOrderLoading) return <RowSkeleton />
-  if (!requestRecordId) return <EmptyRow label='Not converted from a service request' />
+  if (!requestRecordId && !quoteRecordId)
+    return <EmptyRow label='Not converted from a service request or quote' />
 
-  return <RequestDetails requestRecordId={requestRecordId} />
+  return (
+    <div className='space-y-0.5'>
+      {requestRecordId && <RequestDetails requestRecordId={requestRecordId} />}
+      {quoteRecordId && (
+        <div className={TREE_SECONDARY_NOTRUNCATE}>
+          <RelatedRecordRow recordId={quoteRecordId} statusAttr='quote_status' />
+        </div>
+      )}
+    </div>
+  )
 }
 
 /** Inner component — only rendered when requestRecordId is resolved. */

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -108,6 +108,7 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     import('./cards/quote-customer-card').then((m) => ({ default: m.QuoteCustomerCard })),
   'quote:origin': () =>
     import('./cards/quote-origin-card').then((m) => ({ default: m.QuoteOriginCard })),
+  'quote:jobs': () => import('./cards/quote-jobs-card').then((m) => ({ default: m.QuoteJobsCard })),
   // Drawer-only line-items block (the invoice:lines pattern) — the detail page
   // renders its own Line-items section via DETAIL_VIEW_TAB_COMPONENTS instead.
   'quote:lines': () =>

--- a/apps/web/src/components/fields/field-input.tsx
+++ b/apps/web/src/components/fields/field-input.tsx
@@ -89,6 +89,12 @@ export function FieldInput({ children }: FieldInputProps) {
         sideOffset={-28}
         alignOffset={-5}
         onPointerDownOutside={handleOutsideEvent}
+        // Close (and save) when focus leaves for a layer outside this popover's
+        // Radix branch — e.g. the root-level record editor opened from a related
+        // record's hover card. Nested layers (inline-create dialog, a select /
+        // date sub-popover) register as branches, so Radix skips them here and
+        // the field stays open behind them.
+        onFocusOutside={handleOutsideEvent}
         onEscapeKeyDown={handleEscapeKey}
         onKeyDown={handleKeyDown}>
         <div className='flex flex-col'>{InputComponent}</div>

--- a/apps/web/src/components/money/ui/public-document/public-document-shell.tsx
+++ b/apps/web/src/components/money/ui/public-document/public-document-shell.tsx
@@ -19,11 +19,14 @@ interface PublicDocumentShellProps {
 
 export function PublicDocumentShell({ children }: PublicDocumentShellProps) {
   return (
+    // Own scroll viewport (`h-screen overflow-y-auto`) — the root layout pins `<body>` to
+    // `overflow-hidden` for the app shell, so a public document taller than the viewport would
+    // otherwise clip below the fold with no way to scroll. Same pattern as `EmbedShell`.
     // Solid deep-navy base behind ColorfulBg: its mountains-night image mask fades out toward
     // the bottom, and unlike the one-viewport login page a document can grow taller than the
     // image — without this the below-the-fold area falls through to the white body background
     // and the translucent white/NN text becomes unreadable.
-    <div className='relative overflow-hidden bg-[#050e24]'>
+    <div className='relative h-screen overflow-y-auto overflow-x-hidden bg-[#050e24]'>
       <ColorfulBg>
         <div className='absolute pointer-events-none inset-0 bg-gradient-to-br from-primary/20 to-secondary/20 blur-lg opacity-50' />
         <div className='flex min-h-screen flex-col'>

--- a/apps/web/src/components/money/ui/public-quote/public-quote-actions.tsx
+++ b/apps/web/src/components/money/ui/public-quote/public-quote-actions.tsx
@@ -27,19 +27,23 @@ export function QuoteAcceptForm({
       action={`/quote/${token}/accept`}
       onSubmit={() => setIsPending(true)}
       className='space-y-3'>
-      <label
-        htmlFor='quote-accept-name'
-        className='block text-white/50 text-xs uppercase tracking-wide'>
-        Type your full name to accept
-      </label>
-      <Input
-        id='quote-accept-name'
-        name='name'
-        variant='translucent'
-        size='lg'
-        placeholder='Full name'
-        required={requireSignature}
-      />
+      {requireSignature ? (
+        <>
+          <label
+            htmlFor='quote-accept-name'
+            className='block text-white/50 text-xs uppercase tracking-wide'>
+            Type your full name to accept
+          </label>
+          <Input
+            id='quote-accept-name'
+            name='name'
+            variant='translucent'
+            size='lg'
+            placeholder='Full name'
+            required
+          />
+        </>
+      ) : null}
       <Button
         type='submit'
         variant='translucent'

--- a/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
+++ b/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
@@ -13,6 +13,7 @@
 // (QuoteLinesOverviewCard below — records-view/dashboards open quotes in a drawer
 // regardless of `hasDetailPage`).
 
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
 import { parseRecordId } from '@auxx/lib/resources/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
@@ -34,7 +35,7 @@ import { useSaveSystemValues, useSystemValues } from '~/components/resources/hoo
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 
-const QUOTE_STATUS_ATTRS = ['quote_status', 'quote_valid_until'] as const
+const QUOTE_STATUS_ATTRS = ['quote_status', 'quote_valid_until', 'quote_work_orders'] as const
 
 /** Statuses where the quote can still expire — approved/declined/canceled are terminal. */
 const EXPIRABLE_STATUSES = new Set(['draft', 'sent'])
@@ -52,6 +53,9 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
 
   const status = (values.quote_status as string | undefined) ?? 'draft'
   const validUntil = values.quote_valid_until as string | null | undefined
+  // Job this quote was already converted into (the public accept page
+  // auto-converts) — swaps "Convert to job" for "View job" below.
+  const convertedWorkOrderRecordId = extractRelationshipRecordIds(values.quote_work_orders)[0]
 
   const isExpired = useMemo(() => {
     if (!validUntil || !EXPIRABLE_STATUSES.has(status)) return false
@@ -171,9 +175,20 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
             </>
           )}
 
-          {status === 'approved' && (
+          {status === 'approved' && !convertedWorkOrderRecordId && (
             <DropdownMenuItem onClick={handleConvert}>
               <SquareArrowOutUpRight /> Convert to job
+            </DropdownMenuItem>
+          )}
+
+          {convertedWorkOrderRecordId && (
+            <DropdownMenuItem
+              onClick={() =>
+                router.push(
+                  `/app/work-orders/${parseRecordId(convertedWorkOrderRecordId).entityInstanceId}`
+                )
+              }>
+              <SquareArrowOutUpRight /> View job
             </DropdownMenuItem>
           )}
 
@@ -187,7 +202,7 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
           )}
         </DocumentActionsCluster>
       </DocumentSectionActions>
-
+      {/* 
       {REVERTIBLE_STATUSES.has(status) && (
         <div className='mx-4 mt-3 flex items-center gap-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm'>
           <span className='text-amber-700 dark:text-amber-400'>
@@ -196,9 +211,9 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
               : `This quote is ${status} — use “Return to draft” to edit it.`}
           </span>
         </div>
-      )}
+      )} */}
 
-      <div className={cn(isSection ? 'max-h-[60vh] overflow-auto pe-3' : 'min-h-0 flex-1')}>
+      <div className={cn(isSection ? 'max-h-[60vh] overflow-auto ps-3 pe-3' : 'min-h-0 flex-1')}>
         <LineBuilder documentRecordId={recordId} documentType='quote' readOnly={readOnly} />
       </div>
 

--- a/apps/web/src/components/records/global-record-editor-root.tsx
+++ b/apps/web/src/components/records/global-record-editor-root.tsx
@@ -1,0 +1,34 @@
+// apps/web/src/components/records/global-record-editor-root.tsx
+
+'use client'
+
+import { RecordEditorDialog } from './record-editor-dialog'
+import { useRecordEditorStore } from './record-editor-store'
+
+/**
+ * Root-level renderer for the global "edit an existing record" dialog.
+ * Mount once at the app layout level (alongside `GlobalCreateRoot`) so any
+ * surface — relationship badges, hover cards, pickers — can open a record
+ * editor without rendering the dialog inside its own (popover) subtree.
+ *
+ * See {@link useRecordEditorStore} for why root-level rendering matters.
+ */
+export function GlobalRecordEditorRoot() {
+  const open = useRecordEditorStore((s) => s.open)
+  const entityDefinitionId = useRecordEditorStore((s) => s.entityDefinitionId)
+  const recordId = useRecordEditorStore((s) => s.recordId)
+  const close = useRecordEditorStore((s) => s.close)
+
+  if (!open || !entityDefinitionId || !recordId) return null
+
+  return (
+    <RecordEditorDialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) close()
+      }}
+      entityDefinitionId={entityDefinitionId}
+      recordId={recordId}
+    />
+  )
+}

--- a/apps/web/src/components/records/record-editor-store.ts
+++ b/apps/web/src/components/records/record-editor-store.ts
@@ -1,0 +1,43 @@
+// apps/web/src/components/records/record-editor-store.ts
+
+'use client'
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import { create } from 'zustand'
+
+interface RecordEditorStoreState {
+  open: boolean
+  entityDefinitionId: string | null
+  recordId: RecordId | null
+
+  /** Open the edit dialog for an existing record. */
+  openEditor: (args: { entityDefinitionId: string; recordId: RecordId }) => void
+  close: () => void
+}
+
+/**
+ * Global store for the "edit an existing record" dialog.
+ *
+ * The dialog is rendered once at the app root ({@link GlobalRecordEditorRoot})
+ * rather than inline wherever the edit is triggered. Triggers are usually deep
+ * inside a relationship picker / hover card, and Radix registers a locally
+ * rendered dialog as a *branch* of that enclosing popover — so opening it never
+ * dismisses the popover and it sits open behind the dialog. Rendering at the
+ * root keeps the dialog out of every popover's branch, so the popover's own
+ * `onFocusOutside` fires when the modal takes focus and it closes normally.
+ *
+ * Mirrors the create-side {@link useCreateEntityStore}.
+ */
+export const useRecordEditorStore = create<RecordEditorStoreState>((set) => ({
+  open: false,
+  entityDefinitionId: null,
+  recordId: null,
+
+  openEditor: ({ entityDefinitionId, recordId }) => {
+    set({ open: true, entityDefinitionId, recordId })
+  },
+
+  close: () => {
+    set({ open: false, entityDefinitionId: null, recordId: null })
+  },
+}))

--- a/apps/web/src/components/resources/ui/record-hover-card.tsx
+++ b/apps/web/src/components/resources/ui/record-hover-card.tsx
@@ -16,7 +16,7 @@ import { Maximize2, PanelRight, Pencil, Star } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
 import { useFavoriteToggle } from '~/components/favorites/hooks/use-favorite-toggle'
-import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
+import { useRecordEditorStore } from '~/components/records/record-editor-store'
 import { useRecord } from '~/components/resources/hooks/use-record'
 import { useResource } from '~/components/resources/hooks/use-resource'
 import { useResourceStore } from '~/components/resources/store/resource-store'
@@ -64,51 +64,60 @@ export function RecordHoverCard({
   className,
   onOpenInDrawer,
 }: RecordHoverCardProps) {
-  // Edit-dialog state lives here (not in the body) so the dialog survives the
-  // hover card closing — `HoverCardContent` unmounts on mouse-leave, which would
-  // otherwise tear down a dialog rendered inside it the moment it opens.
-  const [isEditOpen, setIsEditOpen] = useState(false)
+  // The hover card is controlled so we can force it shut the instant an overlay
+  // (edit dialog / drawer) opens from inside it. Otherwise the modal disables
+  // outside pointer events, the card never gets its pointer-leave, and it stays
+  // mounted — visible through the dialog's transparent (blur-only) overlay.
+  const [isHoverOpen, setIsHoverOpen] = useState(false)
+
+  // The edit dialog is opened at the app root (`GlobalRecordEditorRoot`), NOT
+  // rendered here — see `useRecordEditorStore`. Rendering it inline makes it a
+  // Radix "branch" of any enclosing picker, so the picker can't dismiss and sits
+  // open behind the dialog. Rooted, the modal grabs focus from outside the
+  // picker's branch and the picker's own `onFocusOutside` closes it.
+  const openEditor = useRecordEditorStore((s) => s.openEditor)
+
+  // Opening an overlay from the hover card: close the card first (Radix hover
+  // cards don't self-dismiss on outside focus), then open the overlay.
+  const openOverlay = (open: () => void) => {
+    setIsHoverOpen(false)
+    open()
+  }
 
   if (!recordId) return <>{children}</>
 
   const entityDefinitionId = getDefinitionId(recordId)
 
   return (
-    <>
-      <HoverCard openDelay={openDelay} closeDelay={closeDelay}>
-        {/* Wrap in a stable inline-flex span so the trigger's pointer listeners
-            attach to a host element we own — avoids asChild merging into a
-            re-rendering Link/anchor inside a virtualized cell, which can drop
-            pointerenter events. */}
-        <HoverCardTrigger asChild>
-          <span data-slot='record-hover-trigger' className='inline-flex max-w-full'>
-            {children}
-          </span>
-        </HoverCardTrigger>
-        <HoverCardContent
-          side={side}
-          align={align}
-          sideOffset={sideOffset}
-          collisionPadding={8}
-          className={cn('w-80 p-3', className)}
-          onClick={(e) => e.stopPropagation()}>
-          <RecordHoverCardBody
-            recordId={recordId}
-            fields={fields}
-            onOpenInDrawer={onOpenInDrawer}
-            onEdit={() => setIsEditOpen(true)}
-          />
-        </HoverCardContent>
-      </HoverCard>
-      {isEditOpen && (
-        <RecordEditorDialog
-          open={isEditOpen}
-          onOpenChange={setIsEditOpen}
-          entityDefinitionId={entityDefinitionId}
+    <HoverCard
+      open={isHoverOpen}
+      onOpenChange={setIsHoverOpen}
+      openDelay={openDelay}
+      closeDelay={closeDelay}>
+      {/* Wrap in a stable inline-flex span so the trigger's pointer listeners
+          attach to a host element we own — avoids asChild merging into a
+          re-rendering Link/anchor inside a virtualized cell, which can drop
+          pointerenter events. */}
+      <HoverCardTrigger asChild>
+        <span data-slot='record-hover-trigger' className='inline-flex max-w-full'>
+          {children}
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+        collisionPadding={8}
+        className={cn('w-80 p-3', className)}
+        onClick={(e) => e.stopPropagation()}>
+        <RecordHoverCardBody
           recordId={recordId}
+          fields={fields}
+          onOpenInDrawer={onOpenInDrawer && ((id) => openOverlay(() => onOpenInDrawer(id)))}
+          onEdit={() => openOverlay(() => openEditor({ entityDefinitionId, recordId }))}
         />
-      )}
-    </>
+      </HoverCardContent>
+    </HoverCard>
   )
 }
 

--- a/packages/lib/src/money/convert-quote.ts
+++ b/packages/lib/src/money/convert-quote.ts
@@ -65,6 +65,40 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
     )
   }
 
+  // One-job-per-quote guard: the quote stays `approved` after conversion (there is
+  // no `converted` quote status), so without this a second convert — e.g. the admin
+  // clicking "Convert to job" after the public accept page already auto-converted —
+  // would silently duplicate the job. Canceled jobs don't count: a canceled
+  // conversion can be redone.
+  const existingJobs = await handler.listFiltered({
+    entityDefinitionId: 'work_order',
+    filters: [
+      {
+        id: 'converted-job-guard',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'converted-job-guard-quote',
+            fieldId: 'work_order:quote',
+            operator: 'is',
+            value: quoteRecordId,
+          },
+          {
+            id: 'converted-job-guard-status',
+            fieldId: 'work_order:status',
+            operator: 'not in',
+            value: ['canceled'],
+          },
+        ],
+      },
+    ],
+    limit: 1,
+    mode: 'oneshot',
+  })
+  if (existingJobs.ids.length > 0) {
+    throw new BadRequestError('This quote has already been converted to a job')
+  }
+
   // ─── Step 2: read quote fields + the request's serviceAddress when linked ──
   const titleTyped = cf.quote_title ? firstTyped(quoteValues.get(cf.quote_title.id)) : undefined
   const contactTyped = cf.quote_contact

--- a/packages/lib/src/money/payments/connect.ts
+++ b/packages/lib/src/money/payments/connect.ts
@@ -36,7 +36,9 @@ export const stripeConnectHandler: HostedProvisionHandler = {
           stripe_dashboard: { type: 'full' },
           requirement_collection: 'stripe',
         },
-        capabilities: { card_payments: { requested: true } },
+        // Stripe requires `transfers` alongside `card_payments` — accounts can't request one
+        // without the other.
+        capabilities: { card_payments: { requested: true }, transfers: { requested: true } },
         metadata: { organizationId: ctx.organizationId },
       })
       stripeAccountId = account.id

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -117,6 +117,7 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     sidebarCards: [
       { value: 'customer', label: 'Customer' },
       { value: 'origin', label: 'Origin' },
+      { value: 'jobs', label: 'Jobs' },
     ],
   },
 

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -123,6 +123,7 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
         { value: 'lines', label: 'Line items', fullBleed: true },
         { value: 'customer', label: 'Customer' },
         { value: 'origin', label: 'Origin' },
+        { value: 'jobs', label: 'Jobs' },
       ],
     },
   },


### PR DESCRIPTION
## Summary

- **Root-level record editor** — new `record-editor-store` + `GlobalRecordEditorRoot` mounted at the app layout (beside `GlobalCreateRoot`). Hover-card/picker edits now open the editor at the app root instead of rendering it inline. Rendering inline made the dialog a Radix *branch* of the enclosing popover, so the popover never dismissed and sat open behind the dialog. `field-input` now also closes on `onFocusOutside` so the field saves when the rooted editor grabs focus.
- **Quote↔job linkage** — new `QuoteJobsCard` (Jobs tab on the quote drawer + detail view) resolving `quote_work_orders`. One-job-per-quote guard added in `convertQuoteToWorkOrder`: the public accept page auto-converts, so this blocks a duplicate admin "Convert to job" (canceled jobs don't count). "View job" replaces "Convert to job" once converted. Work-order origin card now also resolves the quote-convert origin.
- **Public quote / document polish** — signature name field only renders when `requireSignature`; `PublicDocumentShell` gets its own scroll viewport (`h-screen overflow-y-auto`) so tall documents don't clip below the fold.
- **Stripe Connect** — request `transfers` capability alongside `card_payments` (Stripe requires both together).

## Notes

- `quote-line-items-tab.tsx` comments out (rather than removes) the revertible-status warning banner — flagged as a minor code smell but left as-is.

## Test plan

- [ ] Open a record hover card, click edit → editor opens at root, hover card dismisses, no dialog stuck behind picker
- [ ] Accept a quote on the public page → job auto-created; admin "Convert to job" now shows "View job" and a second convert is blocked
- [ ] Public quote with signature off → no name field; tall public document scrolls
- [ ] Stripe Connect onboarding requests card_payments + transfers