### PR TITLE
feat(dispatch,ui): dockable event panel (Notion-Calendar-style side dock)

### DIFF
--- a/apps/web/src/components/dispatch/stores/dispatch-sidebar-store.ts
+++ b/apps/web/src/components/dispatch/stores/dispatch-sidebar-store.ts
@@ -12,6 +12,11 @@ interface DispatchSidebarExtra {
   /** `null` = every tag visible (map mode only). */
   selectedTags: string[] | null
   setSelectedTags: (tags: string[] | null) => void
+  /** Dockable event panel (plan 21) — on/off + which side of the calendar it's pinned to.
+   * Default off, right (opposite the always-left `DispatchSidebar`). */
+  eventDock: { open: boolean; side: 'left' | 'right' }
+  setEventDockOpen: (open: boolean) => void
+  setEventDockSide: (side: 'left' | 'right') => void
 }
 
 /**
@@ -35,6 +40,9 @@ export const useDispatchSidebarStore = createCalendarSidebarStore<DispatchSideba
   (set) => ({
     selectedTags: null,
     setSelectedTags: (tags) => set({ selectedTags: tags }),
+    eventDock: { open: false, side: 'right' },
+    setEventDockOpen: (open) => set((state) => ({ eventDock: { ...state.eventDock, open } })),
+    setEventDockSide: (side) => set((state) => ({ eventDock: { ...state.eventDock, side } })),
   })
 )
 

--- a/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
@@ -11,6 +11,7 @@ import {
   type RenderEventContext,
 } from '@auxx/ui/components/event-calendar'
 import { useCallback, useMemo } from 'react'
+import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
 import type { ExistingVisitForOverlap } from '../schedule-popover'
 import type { useBoardMutations } from './hooks/use-board-mutations'
 import type { BoardResourceInput, BoardViewMode, DispatchVisitEvent } from './types'
@@ -36,6 +37,10 @@ interface BoardCalendarGridProps {
   onEventResize: (event: DispatchVisitEvent, newEnd: Date) => void
   onOpenRecord: (recordId: RecordId, drill?: { panel?: string; item?: string }) => void
   isNonWorkingDay?: (date: Date) => boolean
+  /** Plan 21 (dockable event panel) — sticky mode: while the event dock is open, every event
+   * click routes to the panel instead of opening the floating `EventPopover`, so this suppresses
+   * that popover entirely and renders a plain click target for the chip. */
+  isDockOpen?: boolean
 }
 
 /**
@@ -63,9 +68,29 @@ export function BoardCalendarGrid({
   onEventResize,
   onOpenRecord,
   isNonWorkingDay,
+  isDockOpen,
 }: BoardCalendarGridProps) {
+  const setEventDockOpen = useDispatchSidebarStore((s) => s.setEventDockOpen)
+
   const renderEvent = useCallback(
     (event: DispatchVisitEvent, ctx: RenderEventContext) => {
+      const chip =
+        ctx.view === 'month' ? (
+          <VisitChipMonthContent event={event} />
+        ) : (
+          <VisitChipContent event={event} isOverlapping={overlappingIds.has(event.id)} />
+        )
+
+      // Sticky mode (plan 21 decision #3): docked, so route the click straight into the
+      // panel — no floating popover, and no per-event popover state to manage here.
+      if (isDockOpen) {
+        return (
+          <div className='h-full w-full' onClick={() => onActiveVisitChange(event.id)}>
+            {chip}
+          </div>
+        )
+      }
+
       const isOpen = activeVisitId === event.id
       return (
         <EventPopover
@@ -75,15 +100,7 @@ export function BoardCalendarGrid({
             isMember: Boolean(event.recurrenceRuleId),
             labels: { this: 'This visit', following: 'This and following', all: 'All visits' },
           }}
-          anchor={
-            <div className='h-full w-full'>
-              {ctx.view === 'month' ? (
-                <VisitChipMonthContent event={event} />
-              ) : (
-                <VisitChipContent event={event} isOverlapping={overlappingIds.has(event.id)} />
-              )}
-            </div>
-          }>
+          anchor={<div className='h-full w-full'>{chip}</div>}>
           <VisitPopoverContent
             event={event}
             canEdit={canEdit}
@@ -91,6 +108,7 @@ export function BoardCalendarGrid({
             existingVisits={existingVisits}
             onClose={() => onActiveVisitChange(null)}
             onOpenRecord={onOpenRecord}
+            onDock={() => setEventDockOpen(true)}
           />
         </EventPopover>
       )
@@ -103,6 +121,8 @@ export function BoardCalendarGrid({
       mutations,
       existingVisits,
       onOpenRecord,
+      isDockOpen,
+      setEventDockOpen,
     ]
   )
 

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -29,6 +29,7 @@ import type { ExistingVisitForOverlap } from '../schedule-popover'
 import { DispatchSidebar } from '../sidebar/dispatch-sidebar'
 import { BoardCalendarGrid } from './board-calendar-grid'
 import { BoardToolbar } from './board-toolbar'
+import { EventDockPanel } from './event-dock-panel'
 import { useAvailabilityShading } from './hooks/use-availability-shading'
 import { useBoardData } from './hooks/use-board-data'
 import { useBoardMutations } from './hooks/use-board-mutations'
@@ -104,6 +105,16 @@ export function DispatchBoard() {
   const overlappingIds = useMemo(() => computeOverlappingVisitIds(data.events), [data.events])
 
   const [activeVisitId, setActiveVisitId] = useState<string | null>(null)
+
+  // Dockable event panel (plan 21) — a board-scoped push column, separate from the page-level
+  // `useDockStore`/`DockedPanelConfig` dock further below that drives the record drawer; this
+  // one only ever knows about the calendar's selected event. `isEventDockOpen` alone (not the
+  // side) is all `BoardCalendarGrid` needs to suppress the floating popover.
+  const isEventDockOpen = useDispatchSidebarStore((s) => s.eventDock.open)
+  const selectedEvent = useMemo(
+    () => data.events.find((e) => e.id === activeVisitId) ?? null,
+    [data.events, activeVisitId]
+  )
 
   // Record-peek drawer (v4 Phase 4, decision #8; deep-drill wiring per v4/02 Phase 3):
   // `?record=<defId>:<instanceId>&panel=visits&item=<visitId>` — a full RecordId in the URL
@@ -350,6 +361,17 @@ export function DispatchBoard() {
                 backlogEvents={data.backlogEvents}
                 onSelectVisit={handleSelectVisit}
               />
+              {/* Sits between sidebar and grid in DOM so a left dock reads as a second left
+               * column next to the grid (plan 21); `DockPanel` orders itself after the grid
+               * when `side='right'`. */}
+              <EventDockPanel
+                event={selectedEvent}
+                onActiveVisitChange={setActiveVisitId}
+                canEdit={canEdit}
+                mutations={mutations}
+                existingVisits={existingVisits}
+                onOpenRecord={handleOpenRecord}
+              />
               <BoardCalendarGrid
                 date={data.date}
                 onDateChange={data.setDate}
@@ -368,6 +390,7 @@ export function DispatchBoard() {
                 onEventResize={handleEventResize}
                 onOpenRecord={handleOpenRecord}
                 isNonWorkingDay={isNonWorkingDay}
+                isDockOpen={isEventDockOpen}
               />
             </div>
           </CalendarDndProvider>

--- a/apps/web/src/components/dispatch/ui/board/event-dock-guide.tsx
+++ b/apps/web/src/components/dispatch/ui/board/event-dock-guide.tsx
@@ -1,0 +1,50 @@
+// apps/web/src/components/dispatch/ui/board/event-dock-guide.tsx
+
+'use client'
+
+import {
+  GuideColumn,
+  GuideColumns,
+  GuideConcept,
+  GuideConcepts,
+  GuideShortcut,
+  GuideShortcuts,
+} from '@auxx/ui/components/guide'
+import { ArrowLeftRight, PanelRightOpen } from 'lucide-react'
+
+/**
+ * Empty state for the docked event panel (plan 21 §"Empty-state guide") — shown when
+ * `activeVisitId` is `null` while docked. Built straight from the container-agnostic
+ * `@auxx/ui/components/guide` content primitives (no `GuideDialog` wrapper; the panel itself
+ * is the surface), replicating `GuideDialog`'s `p-6` body padding.
+ */
+export function EventDockGuide() {
+  return (
+    <div className='p-6'>
+      <GuideColumns cols={2}>
+        <GuideColumn title='Shortcuts'>
+          <GuideShortcuts>
+            <GuideShortcut keys={['click']} label='Open event details' />
+            <GuideShortcut keys={['drag']} label='Reschedule' />
+            <GuideShortcut keys={['drag edge']} label='Resize' />
+            <GuideShortcut keys={['esc']} label='Close' />
+          </GuideShortcuts>
+        </GuideColumn>
+        <GuideColumn title='This panel'>
+          <GuideConcepts>
+            <GuideConcept
+              glyph={<PanelRightOpen className='size-3.5 text-muted-foreground' />}
+              term='Pop out'>
+              Undock back into a floating popover anchored to the event.
+            </GuideConcept>
+            <GuideConcept
+              glyph={<ArrowLeftRight className='size-3.5 text-muted-foreground' />}
+              term='Flip side'>
+              Move the dock to the other side of the calendar.
+            </GuideConcept>
+          </GuideConcepts>
+        </GuideColumn>
+      </GuideColumns>
+    </div>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/board/event-dock-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/board/event-dock-panel.tsx
@@ -1,0 +1,99 @@
+// apps/web/src/components/dispatch/ui/board/event-dock-panel.tsx
+
+'use client'
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import { DockPanel } from '@auxx/ui/components/dock-panel'
+import { EventPopoverBody } from '@auxx/ui/components/event-calendar'
+import { useEffect } from 'react'
+import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
+import type { ExistingVisitForOverlap } from '../schedule-popover'
+import { EventDockGuide } from './event-dock-guide'
+import type { useBoardMutations } from './hooks/use-board-mutations'
+import type { DispatchVisitEvent } from './types'
+import { VisitPopoverContent } from './visit-popover'
+
+interface EventDockPanelProps {
+  /** The selected event (`data.events` looked up by `activeVisitId`), or `null` when nothing
+   * is selected — renders `EventDockGuide` in that case. */
+  event: DispatchVisitEvent | null
+  onActiveVisitChange: (visitId: string | null) => void
+  canEdit: boolean
+  mutations: ReturnType<typeof useBoardMutations>
+  existingVisits: ExistingVisitForOverlap[]
+  onOpenRecord: (recordId: RecordId, drill?: { panel?: string; item?: string }) => void
+}
+
+/**
+ * Dispatch's consumer of the general `@auxx/ui` `DockPanel` primitive (plan 21, "Dispatch
+ * wiring"). Once docked (decision #3, sticky mode) every event click swaps this panel's body
+ * instead of opening the floating `EventPopover` — `board-calendar-grid.tsx` suppresses that
+ * popover via `isDockOpen`. Body reuses `VisitPopoverContent` verbatim inside `EventPopoverBody`
+ * (`fill` mode), which provides the series-scope gate + `CommandNavigation` drill stack its
+ * sections require. Empty selection ('empty' `contentKey`) shows `EventDockGuide`.
+ */
+export function EventDockPanel({
+  event,
+  onActiveVisitChange,
+  canEdit,
+  mutations,
+  existingVisits,
+  onOpenRecord,
+}: EventDockPanelProps) {
+  const dock = useDispatchSidebarStore((s) => s.eventDock)
+  const setEventDockOpen = useDispatchSidebarStore((s) => s.setEventDockOpen)
+  const setEventDockSide = useDispatchSidebarStore((s) => s.setEventDockSide)
+
+  // Esc clears the selection (→ guide state) while docked with an event selected. A plain
+  // window listener rather than fighting existing dialog/popover Esc handling — nothing else
+  // owns Esc here since the floating `EventPopover`/its `Popover` primitive isn't mounted in
+  // dock mode (board-calendar-grid.tsx renders a plain click target instead).
+  useEffect(() => {
+    if (!dock.open || !event) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onActiveVisitChange(null)
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [dock.open, event, onActiveVisitChange])
+
+  return (
+    <DockPanel
+      open={dock.open}
+      side={dock.side}
+      contentKey={event?.id ?? 'empty'}
+      header={<span className='truncate font-medium text-sm'>{event?.title ?? 'Event'}</span>}
+      onClose={() => {
+        setEventDockOpen(false)
+        onActiveVisitChange(null)
+      }}
+      onPopOut={() => setEventDockOpen(false)}
+      onFlipSide={setEventDockSide}>
+      {event ? (
+        /* `VisitPopoverContent`'s sections need the full `EventPopoverBody` wrapper — the
+         * series-scope gate (`useSeriesScope`) AND the `CommandNavigation` drill stack
+         * (`useCommandNavigation` in `EventDateTimeSection` et al.) both throw without it.
+         * `fill` stretches it to the column instead of the popover's 40rem max-height cap. */
+        <EventPopoverBody
+          fill
+          series={{
+            isMember: Boolean(event.recurrenceRuleId),
+            labels: { this: 'This visit', following: 'This and following', all: 'All visits' },
+          }}>
+          <VisitPopoverContent
+            event={event}
+            canEdit={canEdit}
+            mutations={mutations}
+            existingVisits={existingVisits}
+            onClose={() => onActiveVisitChange(null)}
+            onOpenRecord={onOpenRecord}
+          />
+        </EventPopoverBody>
+      ) : (
+        <div className='min-h-0 flex-1 overflow-y-auto'>
+          <EventDockGuide />
+        </div>
+      )}
+    </DockPanel>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
@@ -12,8 +12,10 @@ import {
 } from '@auxx/ui/components/event-calendar'
 import { PanelCard, PanelCardRow } from '@auxx/ui/components/panel-card'
 import { toastError } from '@auxx/ui/components/toast'
+import { useIsMobile } from '@auxx/ui/hooks/use-mobile'
 import { differenceInMinutes } from 'date-fns'
-import { ArrowUpRight, CircleDot, Contact, Send, TriangleAlert } from 'lucide-react'
+import { ArrowUpRight, CircleDot, Contact, PanelRight, Send, TriangleAlert } from 'lucide-react'
+import { Tooltip } from '~/components/global/tooltip'
 import { useResource } from '~/components/resources'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -36,6 +38,11 @@ interface VisitPopoverContentProps {
   /** Opens a record in the board's docked/overlay `RecordDrawer` (nuqs `?record=`). An optional
    * `drill` lands the drawer pre-drilled onto a panel item (e.g. the clicked visit). */
   onOpenRecord: (recordId: RecordId, drill?: { panel?: string; item?: string }) => void
+  /** Renders the dock-panel toggle (plan 21) in the floating-popover-only usage. Pass this ONLY
+   * from `board-calendar-grid.tsx`'s floating `EventPopover` call site — the docked panel's own
+   * `event-dock-panel.tsx` renders this same content without it, so the button never shows up
+   * inside the dock (it would be redundant there). */
+  onDock?: () => void
 }
 
 /**
@@ -53,9 +60,11 @@ export function VisitPopoverContent({
   existingVisits,
   onClose,
   onOpenRecord,
+  onDock,
 }: VisitPopoverContentProps) {
   const utils = api.useUtils()
   const [confirm, ConfirmDialog] = useConfirm()
+  const isMobile = useIsMobile()
 
   const dayContext = getVisitDayContext(event.start, event.end)
   const isOverdue = dayContext === 'past' && event.status !== 'done' && event.status !== 'canceled'
@@ -128,6 +137,17 @@ export function VisitPopoverContent({
 
   return (
     <>
+      {/* Desktop-only (plan 21 decision #5) — the docked column doesn't exist on mobile. */}
+      {onDock && !isMobile && (
+        <div className='flex justify-end'>
+          <Tooltip content='Dock panel'>
+            <Button variant='ghost' size='icon-xs' aria-label='Dock panel' onClick={onDock}>
+              <PanelRight />
+            </Button>
+          </Tooltip>
+        </div>
+      )}
+
       <EventTitleSection
         title={event.title}
         editable={false}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,6 +22,7 @@
     "./components/kb/theme": "./src/components/kb/theme/index.ts",
     "./components/kb/utils": "./src/components/kb/utils/index.ts",
     "./components/menu-styles": "./src/components/menu-styles.ts",
+    "./components/dock-panel": "./src/components/dock-panel.tsx",
     "./components/event-calendar": "./src/components/event-calendar/index.ts",
     "./components/calendar": "./src/components/calendar/index.ts",
     "./components/*": "./src/components/*.tsx",

--- a/packages/ui/src/components/dock-panel.tsx
+++ b/packages/ui/src/components/dock-panel.tsx
@@ -1,0 +1,223 @@
+// packages/ui/src/components/dock-panel.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Sheet, SheetContent, SheetTitle } from '@auxx/ui/components/sheet'
+import { useIsMobile } from '@auxx/ui/hooks/use-mobile'
+import { cn } from '@auxx/ui/lib/utils'
+import { ArrowLeftRight, PanelRightOpen, X } from 'lucide-react'
+import * as React from 'react'
+
+/** Which edge of the parent flex row the panel docks to. */
+type DockSide = 'left' | 'right'
+
+interface DockPanelProps {
+  /** Whether the panel is open. Closed animates width 0 <-> `width` and takes no layout
+   * space once the tween finishes. */
+  open: boolean
+  /** Which side the panel docks to. Render `DockPanel` where a LEFT dock should sit in the
+   * flex row (e.g. between a module sidebar and the grid) — `side='left'` keeps that DOM
+   * position, `side='right'` jumps after the other siblings via CSS `order`. */
+  side: DockSide
+  /** Fixed width while open. Not resizable in v1. */
+  width?: string
+  /** X button in the header. */
+  onClose: () => void
+  /** Undock -> float. Omit to hide the pop-out button. */
+  onPopOut?: () => void
+  /** Flip side (left <-> right). Omit to hide the flip-side button. */
+  onFlipSide?: (side: DockSide) => void
+  /** Key that changes per selected entity — drives the slide/cross-fade content swap. */
+  contentKey: string
+  /** Title row content, to the left of the control cluster. */
+  header?: React.ReactNode
+  children: React.ReactNode
+}
+
+const DEFAULT_WIDTH = '20rem'
+
+/**
+ * Notion-Calendar-style dock shell: a flex column that pushes its siblings on desktop, or a
+ * bottom sheet on narrow viewports. Content-agnostic — it only owns placement, the width
+ * tween, chrome (flip-side / pop-out / close), and the `DockPanelFrame` content cross-fade.
+ * See `plans/dispatch/21-dockable-event-panel.md` for the full design.
+ */
+function DockPanel({
+  open,
+  side,
+  width = DEFAULT_WIDTH,
+  onClose,
+  onPopOut,
+  onFlipSide,
+  contentKey,
+  header,
+  children,
+}: DockPanelProps) {
+  const isMobile = useIsMobile()
+
+  // Keep children mounted through the 280ms close tween, then unmount — otherwise the
+  // collapsed column keeps its full content alive at width 0: still in the a11y tree, still
+  // tab-focusable, and (for data-heavy consumers) still running queries in duplicate next to
+  // the floating popover. `inert` covers the closing window itself.
+  const [rendered, setRendered] = React.useState(open)
+  if (open && !rendered) setRendered(true)
+
+  if (isMobile) {
+    return (
+      <Sheet
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) onClose()
+        }}>
+        <SheetContent side='bottom' className='flex h-[70vh] flex-col gap-0 p-0'>
+          <SheetTitle className='sr-only'>Panel</SheetTitle>
+          {/* Flip-side / pop-out are meaningless in a sheet — omit both handlers so
+           * `DockPanelHeader` only renders the title row. The sheet's own built-in close
+           * button (top-right, from `SheetContent`) covers dismissal. */}
+          <DockPanelHeader header={header} side={side} />
+          <div className='min-h-0 flex-1 overflow-y-auto'>{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex h-full shrink-0 flex-col overflow-hidden',
+        'transition-[width] duration-[280ms] ease-[var(--auxx-dock-ease)]',
+        side === 'right' && 'order-[999]'
+      )}
+      style={{ width: open ? width : '0px' }}
+      aria-hidden={!open}
+      inert={!open}
+      onTransitionEnd={(e) => {
+        if (e.target === e.currentTarget && e.propertyName === 'width' && !open) {
+          setRendered(false)
+        }
+      }}>
+      {/* Fixed-width inner wrapper so text doesn't reflow mid-tween, and so the border
+       * (grid-facing edge) is clipped away entirely by the outer `overflow-hidden` once
+       * collapsed to 0 width — the column then truly takes no space at rest. */}
+      {rendered && (
+        <div
+          className={cn('flex h-full flex-col', side === 'left' ? 'border-r' : 'border-l')}
+          style={{ width }}>
+          <DockPanelHeader
+            header={header}
+            side={side}
+            onFlipSide={onFlipSide}
+            onPopOut={onPopOut}
+            onClose={onClose}
+          />
+          <DockPanelFrame contentKey={contentKey}>{children}</DockPanelFrame>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface DockPanelHeaderProps {
+  header?: React.ReactNode
+  side: DockSide
+  onFlipSide?: (side: DockSide) => void
+  onPopOut?: () => void
+  onClose?: () => void
+}
+
+/** Header row: `header` content on the left, control cluster on the right. Each control
+ * only renders when its handler is provided. */
+function DockPanelHeader({ header, side, onFlipSide, onPopOut, onClose }: DockPanelHeaderProps) {
+  return (
+    <div className='flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2'>
+      <div className='flex min-w-0 flex-1 items-center gap-2'>{header}</div>
+      <div className='flex shrink-0 items-center gap-0.5'>
+        {onFlipSide && (
+          <Button
+            variant='ghost'
+            size='icon'
+            aria-label='Flip side'
+            onClick={() => onFlipSide(side === 'left' ? 'right' : 'left')}>
+            <ArrowLeftRight />
+          </Button>
+        )}
+        {onPopOut && (
+          <Button variant='ghost' size='icon' aria-label='Pop out' onClick={onPopOut}>
+            <PanelRightOpen />
+          </Button>
+        )}
+        {onClose && (
+          <Button variant='ghost' size='icon' aria-label='Close' onClick={onClose}>
+            <X />
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface DockPanelFrameProps {
+  contentKey: string
+  children: React.ReactNode
+}
+
+interface ExitingLayer {
+  key: string
+  children: React.ReactNode
+}
+
+/**
+ * Content-swap layer for `DockPanel`'s body — a React port of `packages/chat`'s
+ * `FrameTransition` (Preact; see `chat/src/components/frame-transition.tsx`, not imported
+ * since chat is a separate bundle). On `contentKey` change, the previous render is frozen as
+ * an absolutely-positioned "exiting" layer while the new render slides in from the right —
+ * the panel shell (header + controls) never remounts, so scroll position and focus survive.
+ *
+ * The key change is detected *during render* (not in an effect) so both layers commit in the
+ * same paint — otherwise there'd be a one-frame flash where the new content appears without
+ * its slide-in animation.
+ */
+function DockPanelFrame({ contentKey, children }: DockPanelFrameProps) {
+  const lastKeyRef = React.useRef(contentKey)
+  const lastChildrenRef = React.useRef(children)
+  const [exiting, setExiting] = React.useState<ExitingLayer | null>(null)
+
+  if (lastKeyRef.current !== contentKey && (!exiting || exiting.key !== lastKeyRef.current)) {
+    setExiting({ key: lastKeyRef.current, children: lastChildrenRef.current })
+  }
+
+  React.useLayoutEffect(() => {
+    lastKeyRef.current = contentKey
+    lastChildrenRef.current = children
+  })
+
+  const handleExitEnd = (event: React.AnimationEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget) return
+    setExiting(null)
+  }
+
+  return (
+    <div
+      className={cn(
+        'auxx-dock-frame-transition',
+        exiting && 'auxx-dock-frame-transition--animating'
+      )}>
+      {exiting && (
+        <div
+          key={exiting.key}
+          className='auxx-dock-frame-layer auxx-dock-frame--exiting'
+          onAnimationEnd={handleExitEnd}>
+          {exiting.children}
+        </div>
+      )}
+      <div
+        key={contentKey}
+        className={cn('auxx-dock-frame-layer', exiting && 'auxx-dock-frame--entering')}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export { DockPanel, DockPanelFrame }
+export type { DockPanelProps, DockSide }

--- a/packages/ui/src/components/event-calendar/event-popover/event-popover.tsx
+++ b/packages/ui/src/components/event-calendar/event-popover/event-popover.tsx
@@ -24,11 +24,15 @@ interface EventPopoverBodyProps {
   header?: EventPopoverHeaderConfig
   children: React.ReactNode
   className?: string
+  /** Stretch to fill a height-bounded flex-column parent (e.g. `DockPanel`) instead of
+   * sizing to content under the floating popover's `max-h-[min(85vh,40rem)]` cap. */
+  fill?: boolean
 }
 
 interface EventPopoverBodyChromeProps {
   header?: EventPopoverHeaderConfig
   className?: string
+  fill?: boolean
   children: React.ReactNode
 }
 
@@ -65,12 +69,18 @@ export function EventDrillPage({ id, children }: { id: string; children: React.R
  * Tailwind's `space-y-*` selectors already exclude `[hidden]` elements, so this doesn't add a
  * phantom gap above the drilled page.
  */
-function EventPopoverBodyChrome({ header, className, children }: EventPopoverBodyChromeProps) {
+function EventPopoverBodyChrome({
+  header,
+  className,
+  fill,
+  children,
+}: EventPopoverBodyChromeProps) {
   const { current, isAtRoot, pop } = useCommandNavigation<EventDrillItem>()
   const [drillOutlet, setDrillOutlet] = React.useState<HTMLElement | null>(null)
 
   return (
     <div
+      className={fill ? 'flex min-h-0 flex-1 flex-col' : undefined}
       onKeyDown={(e) => {
         if (e.key === 'Escape' && !isAtRoot) {
           e.preventDefault()
@@ -111,7 +121,9 @@ function EventPopoverBodyChrome({ header, className, children }: EventPopoverBod
       ) : (
         <CommandBreadcrumb rootLabel={header?.label ?? 'Back'} />
       )}
-      <ScrollArea viewportClassName='max-h-[min(85vh,40rem)]'>
+      <ScrollArea
+        className={fill ? 'min-h-0 flex-1' : undefined}
+        viewportClassName={fill ? 'h-full' : 'max-h-[min(85vh,40rem)]'}>
         <PanelShell className={className}>
           <DrillOutletContext.Provider value={drillOutlet}>
             <div hidden={!isAtRoot}>{children}</div>
@@ -133,11 +145,17 @@ function EventPopoverBodyChrome({ header, className, children }: EventPopoverBod
  * `CommandNavigation` stack so sections drill in place (date/time/repeat/people pickers) instead
  * of nesting their own popovers.
  */
-export function EventPopoverBody({ series, header, children, className }: EventPopoverBodyProps) {
+export function EventPopoverBody({
+  series,
+  header,
+  children,
+  className,
+  fill,
+}: EventPopoverBodyProps) {
   return (
     <SeriesScopeProvider series={series}>
       <CommandNavigation<EventDrillItem>>
-        <EventPopoverBodyChrome header={header} className={className}>
+        <EventPopoverBodyChrome header={header} className={className} fill={fill}>
           {children}
         </EventPopoverBodyChrome>
       </CommandNavigation>

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -90,6 +90,16 @@
   }
 }
 
+/*
+  Dock panel primitive (`@auxx/ui/components/dock-panel`) — shared easing token for the
+  width tween (open/close/flip) and the content-swap frame animation below. Values lifted
+  from `packages/chat` (`--auxx-chat-shell-ease`) per plans/dispatch/21-dockable-event-panel.md
+  — replicated here, not imported, since chat is a separate Preact bundle.
+*/
+:root {
+  --auxx-dock-ease: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
 /* 1) Define keyframes */
 @keyframes accordion-down {
   from {
@@ -168,6 +178,85 @@
   }
   40% {
     opacity: 1;
+  }
+}
+
+/*
+  Dock panel content-swap frame (`DockPanelFrame` in dock-panel.tsx). Two layers stack
+  absolutely; `overflow: hidden` only applies while a swap is in flight so a portaled
+  popover/menu inside the panel body isn't clipped at rest. iOS-style parallax: the entering
+  layer slides in the full width while the exiting layer drifts 30% off with a fade. Values
+  and structure ported from `packages/chat`'s `auxx-chat-frame-*` transition (Preact) — see
+  plans/dispatch/21-dockable-event-panel.md "Animation specs".
+*/
+.auxx-dock-frame-transition {
+  position: relative;
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: visible;
+}
+.auxx-dock-frame-transition--animating {
+  overflow: hidden;
+}
+.auxx-dock-frame-layer {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1 1 0;
+}
+.auxx-dock-frame-transition--animating .auxx-dock-frame-layer {
+  position: absolute;
+  inset: 0;
+  flex: none;
+}
+.auxx-dock-frame--entering {
+  animation: auxx-dock-frame-slide-in-right 280ms var(--auxx-dock-ease) both;
+}
+.auxx-dock-frame--exiting {
+  animation: auxx-dock-frame-slide-out-left 280ms var(--auxx-dock-ease) both;
+}
+@keyframes auxx-dock-frame-slide-in-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+@keyframes auxx-dock-frame-slide-out-left {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(-30%);
+    opacity: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .auxx-dock-frame--entering {
+    animation: auxx-dock-frame-fade-in 120ms ease-out both;
+  }
+  .auxx-dock-frame--exiting {
+    animation: auxx-dock-frame-fade-out 120ms ease-out both;
+  }
+}
+@keyframes auxx-dock-frame-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes auxx-dock-frame-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

Notion-Calendar-style dock for the dispatch board's event popover (plan 21). A dock button in the floating `EventPopover` pins the event details as a persistent, full-height column inside the board's calendar flex row. While docked it's **sticky mode**: every event click swaps the panel's content in place — no floating popover. Deselect (Esc / close) shows a shortcuts/concepts guide. Dock state (`open` + `side`) persists in the dispatch sidebar store across reloads and calendar↔map switches.

## The reusable primitive — `@auxx/ui` `DockPanel`

- Push-layout flex column (grid reflows, like `DispatchSidebar`), 280ms width tween on `cubic-bezier(0.32, 0.72, 0, 1)` (`--auxx-dock-ease`).
- `DockPanelFrame` content swap ported from `packages/chat`'s `FrameTransition` (replicated in React, not imported): render-phase key-change detection so both layers commit in one paint, slide-in + 30% parallax fade-out, reduced-motion fade fallback. The shell never remounts on content change.
- Header chrome: flip side / pop out / close (each renders only when its handler is passed).
- `< md` renders a bottom `Sheet` instead of a column.
- Children unmount after the close tween (`inert` + `aria-hidden` while closing) — a collapsed panel leaves no focusable duplicate content in the a11y tree.

## Dispatch wiring

- `eventDock: { open, side }` + setters in `dispatch-sidebar-store` (persisted).
- `EventDockPanel` renders `VisitPopoverContent` through `EventPopoverBody` — its sections require the series-scope gate and `CommandNavigation` drill stack, so the content can't render bare. `EventPopoverBody` gains a `fill` prop to stretch to the column instead of the floating 40rem max-height cap.
- `BoardCalendarGrid` gets `isDockOpen` to suppress the floating popover; clicks route through the existing `activeVisitId` selection.
- Desktop-only `PanelRight` dock button in the floating popover header; pop-out keeps the selection so the floating popover reopens anchored to the chip.
- Left dock sits between the module sidebar and the grid (DOM position); right dock via CSS `order`.

## Verification

Browser-verified end-to-end on the board: dock button → panel, content swap between events, Esc → guide, flip L/R, pop out → floating popover reopens with selection kept, re-dock, persistence across full reload, no console errors. Lint clean.

Owed (follow-ups, noted in plans/dispatch/STATUS.md): mobile bottom-sheet pass, `canEdit=false` parity eyeball, drag-while-docked gesture pass.