### PR TITLE
refactor(dispatch,money): payments block wiring + TreeRow rows

### DIFF
--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-payments-block.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-payments-block.tsx
@@ -8,16 +8,15 @@
 // affected invoice's own `listPayments` so an open invoice drawer stays fresh. `renderRowSuffix`
 // adds a small invoice chip per row (§B slot) so a mixed-invoice ledger stays legible.
 //
-// Layout mirrors the invoices block (block 4): a plain `TuckedLabel` header with no action, a
-// `px-2` list, and the "record" affordance as a `TreeRow` at the bottom (matching "Create
-// invoice") rather than a header button.
+// Layout mirrors `WorkOrderBillingInvoicesBlock` exactly: the label + bordered container live in
+// the parent tab, this component renders only rows + the "record" affordance as a `TreeRow` at
+// the bottom (matching "Create invoice"). `PaymentsList` owns the loading/empty state — no
+// second empty-state branch here.
 //
 // §C: candidates = invoices with `invoice_status !== 'void'` and `invoice_balance > 0`, handed
 // down by the billing tab (it already aggregates per-invoice values for the summary strip).
 // Exactly one → the Record-payment row opens the dialog against it; multiple → that row becomes
-// a `DropdownMenu` chooser ("<number> — <balance> due"); zero → the row is hidden. When there
-// are no invoices at all, a custom `EmptySection` explains that, instead of `PaymentsList`'s own
-// "no payments recorded" copy (which reads wrong when there's nothing to attach a payment to).
+// a `DropdownMenu` chooser ("<number> — <balance> due"); zero → the row is hidden.
 
 import type { RecordId } from '@auxx/types/resource'
 import { getInstanceId } from '@auxx/types/resource'
@@ -28,9 +27,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
-import { EmptySection } from '@auxx/ui/components/section'
 import { toastError } from '@auxx/ui/components/toast'
-import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRow } from '@auxx/ui/components/tree-row'
 import { CreditCard, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
@@ -38,7 +36,6 @@ import { useAdminGate } from '~/components/global/admin-gate'
 import { RecordPaymentDialog } from '~/components/money/ui/invoice/record-payment-dialog'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
 import { PaymentsList } from '~/components/money/ui/payments/payments-list'
-import { TuckedLabel } from '~/components/money/ui/tucked-label'
 import { useRecord } from '~/components/resources'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -51,14 +48,13 @@ export interface PaymentCandidate {
 
 export interface WorkOrderBillingPaymentsBlockProps {
   workOrderRecordId: RecordId
-  hasInvoices: boolean
   candidates: PaymentCandidate[]
   currencyCode: string
 }
 
+/** Payments block — the shared ledger list + "Record payment" (billing tab §D block 5). */
 export function WorkOrderBillingPaymentsBlock({
   workOrderRecordId,
-  hasInvoices,
   candidates,
   currencyCode,
 }: WorkOrderBillingPaymentsBlockProps) {
@@ -70,6 +66,7 @@ export function WorkOrderBillingPaymentsBlock({
   const { data: payments, isLoading } = api.money.listPaymentsForWorkOrder.useQuery({
     workOrderRecordId,
   })
+  const hasPayments = (payments?.length ?? 0) > 0
 
   const invalidateBoth = (invoiceRecordId: RecordId | null) => {
     void utils.money.listPaymentsForWorkOrder.invalidate({ workOrderRecordId })
@@ -127,92 +124,31 @@ export function WorkOrderBillingPaymentsBlock({
     )
   }
 
-  const openDirect = (candidate: PaymentCandidate) => setTarget(candidate)
-
-  const hasPayments = (payments?.length ?? 0) > 0
-
   return (
-    <div className='flex flex-col'>
-      {/* Header + content mirror the invoices block: a plain tucked label (no action) and a
-          `px-2` list whose "create" affordance is a TreeRow at the bottom (§B / block 4 parity). */}
-      <TuckedLabel className='mx-4 mt-2'>Payments</TuckedLabel>
+    <div>
+      <PaymentsList
+        payments={payments}
+        isLoading={isLoading}
+        currencyCode={currencyCode}
+        isAdmin={isAdmin}
+        onDelete={handleDelete}
+        onRefund={handleRefund}
+        deletePending={deletePayment.isPending}
+        refundPending={refundTransaction.isPending}
+        renderRowSuffix={(payment) => {
+          const invoiceRecordId = invoiceByTransactionId.get(payment.id)
+          return invoiceRecordId ? <PaymentInvoiceChip invoiceRecordId={invoiceRecordId} /> : null
+        }}
+      />
 
-      <div className={`px-2 ${TREE_SECONDARY_NOTRUNCATE}`}>
-        {!hasInvoices ? (
-          <EmptySection
-            icon={<CreditCard className='size-5' />}
-            title='No invoices yet'
-            description='Create an invoice above before recording a payment.'
-          />
-        ) : (
-          <>
-            {(hasPayments || isLoading) && (
-              <PaymentsList
-                payments={payments}
-                isLoading={isLoading}
-                currencyCode={currencyCode}
-                isAdmin={isAdmin}
-                onDelete={handleDelete}
-                onRefund={handleRefund}
-                deletePending={deletePayment.isPending}
-                refundPending={refundTransaction.isPending}
-                renderRowSuffix={(payment) => {
-                  const invoiceRecordId = invoiceByTransactionId.get(payment.id)
-                  return invoiceRecordId ? (
-                    <PaymentInvoiceChip invoiceRecordId={invoiceRecordId} />
-                  ) : null
-                }}
-              />
-            )}
-
-            {candidates.length === 1 && (
-              <TreeRow
-                icon={hasPayments ? <Plus className='size-4' /> : <CreditCard className='size-4' />}
-                title={<span className='text-muted-foreground text-sm'>Record payment</span>}
-                onToggleOpen={() => openDirect(candidates[0]!)}
-              />
-            )}
-
-            {candidates.length > 1 && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <div>
-                    <TreeRow
-                      rowClassName='cursor-pointer'
-                      icon={
-                        hasPayments ? (
-                          <Plus className='size-4' />
-                        ) : (
-                          <CreditCard className='size-4' />
-                        )
-                      }
-                      title={<span className='text-muted-foreground text-sm'>Record payment</span>}
-                    />
-                  </div>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align='start'>
-                  {candidates.map((candidate) => (
-                    <DropdownMenuItem
-                      key={candidate.recordId}
-                      onClick={() => openDirect(candidate)}>
-                      {candidate.displayName} — {formatCurrency(candidate.balance, currencyCode)}{' '}
-                      due
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-
-            {!isLoading && !hasPayments && candidates.length === 0 && (
-              <EmptySection
-                icon={<CreditCard className='size-5' />}
-                title='No payments recorded'
-                description='Payments appear here once an invoice has a balance due.'
-              />
-            )}
-          </>
-        )}
-      </div>
+      {candidates.length > 0 && (
+        <RecordPaymentRow
+          candidates={candidates}
+          hasPayments={hasPayments}
+          currencyCode={currencyCode}
+          onSelect={setTarget}
+        />
+      )}
 
       {target && (
         <RecordPaymentDialog
@@ -227,6 +163,44 @@ export function WorkOrderBillingPaymentsBlock({
 
       <ConfirmDialog />
     </div>
+  )
+}
+
+/** "Record payment" affordance — a single TreeRow when there's one open invoice to bill, a
+ * dropdown-backed TreeRow when there are several. Shares its icon/title so both stay in sync. */
+function RecordPaymentRow({
+  candidates,
+  hasPayments,
+  currencyCode,
+  onSelect,
+}: {
+  candidates: PaymentCandidate[]
+  hasPayments: boolean
+  currencyCode: string
+  onSelect: (candidate: PaymentCandidate) => void
+}) {
+  const icon = hasPayments ? <Plus className='size-4' /> : <CreditCard className='size-4' />
+  const title = <span className='text-muted-foreground text-sm'>Record payment</span>
+
+  if (candidates.length === 1) {
+    return <TreeRow icon={icon} title={title} onToggleOpen={() => onSelect(candidates[0]!)} />
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <div>
+          <TreeRow rowClassName='cursor-pointer' icon={icon} title={title} />
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='start'>
+        {candidates.map((candidate) => (
+          <DropdownMenuItem key={candidate.recordId} onClick={() => onSelect(candidate)}>
+            {candidate.displayName} — {formatCurrency(candidate.balance, currencyCode)} due
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
@@ -218,12 +218,14 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
           </div>
 
           {/* Block e — payments */}
-          <WorkOrderBillingPaymentsBlock
-            workOrderRecordId={recordId}
-            hasInvoices={invoiceRecordIds.length > 0}
-            candidates={candidates}
-            currencyCode={currencyCode}
-          />
+          <BlockLabel>Payments</BlockLabel>
+          <div className='bg-primary-100 border rounded-xl'>
+            <WorkOrderBillingPaymentsBlock
+              workOrderRecordId={recordId}
+              candidates={candidates}
+              currencyCode={currencyCode}
+            />
+          </div>
         </div>
       </div>
       <ConfirmDialog />

--- a/apps/web/src/components/money/ui/payments/payments-list.tsx
+++ b/apps/web/src/components/money/ui/payments/payments-list.tsx
@@ -8,8 +8,8 @@
 // rows) behavior is unchanged; callers own their own queries/mutations.
 
 import { Badge, type Variant as BadgeVariant } from '@auxx/ui/components/badge'
-import { Button } from '@auxx/ui/components/button'
 import { EmptySection } from '@auxx/ui/components/section'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
 import { format } from 'date-fns'
 import { CreditCard, RotateCcw, Trash2 } from 'lucide-react'
 import type { ReactNode } from 'react'
@@ -101,44 +101,29 @@ export function PaymentsList({
   }
 
   return (
-    <div className='flex flex-col divide-y divide-primary-200/50 dark:divide-[#1e2227]'>
-      {payments.map((payment) => (
-        <div key={payment.id} className='group flex items-center gap-2 py-1.5 text-sm'>
-          <span className='w-24 shrink-0 tabular-nums text-muted-foreground'>
-            {format(new Date(payment.date), 'MMM d, yyyy')}
-          </span>
-          <span className='w-28 shrink-0 truncate text-muted-foreground'>
-            {paymentMethodLabel(payment.method ?? 'other')}
-          </span>
-          <span className='min-w-0 flex-1 truncate text-muted-foreground text-xs'>
-            {payment.reference ?? ''}
-          </span>
-          <span className='shrink-0 tabular-nums'>
-            {formatCurrency(payment.amount, currencyCode)}
-          </span>
-          {payment.provider === 'manual'
+    <div className='flex flex-col'>
+      {payments.map((payment) => {
+        const action =
+          payment.provider === 'manual'
             ? isAdmin && (
-                <Button
-                  variant='ghost'
-                  size='icon-sm'
-                  className='shrink-0 text-destructive/70 opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100'
-                  loading={deletePending}
+                <TreeRowButton
+                  variant='destructive'
+                  tooltipText='Delete payment'
+                  disabled={deletePending}
                   onClick={() => onDelete(payment.id)}>
                   <Trash2 />
-                </Button>
+                </TreeRowButton>
               )
             : payment.kind === 'charge' &&
                 payment.status === 'succeeded' &&
                 !refundStatusByCharge.has(payment.id)
               ? isAdmin && (
-                  <Button
-                    variant='ghost'
-                    size='icon-sm'
-                    className='shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100'
-                    loading={refundPending}
+                  <TreeRowButton
+                    tooltipText='Refund payment'
+                    disabled={refundPending}
                     onClick={() => onRefund(payment.id)}>
                     <RotateCcw />
-                  </Button>
+                  </TreeRowButton>
                 )
               : (() => {
                   const chip = stripeStatusChip(payment, refundStatusByCharge.get(payment.id))
@@ -147,10 +132,35 @@ export function PaymentsList({
                       {chip.label}
                     </Badge>
                   )
-                })()}
-          {renderRowSuffix?.(payment)}
-        </div>
-      ))}
+                })()
+
+        return (
+          <TreeRow
+            key={payment.id}
+            icon={<CreditCard className='size-4' />}
+            title={
+              <span className='truncate text-sm'>
+                {paymentMethodLabel(payment.method ?? 'other')}
+              </span>
+            }
+            secondary={
+              <span className='tabular-nums'>{format(new Date(payment.date), 'MMM d, yyyy')}</span>
+            }
+            actions={
+              <div className='flex items-center gap-3 text-xs text-muted-foreground'>
+                {payment.reference && (
+                  <span className='max-w-32 truncate'>{payment.reference}</span>
+                )}
+                <span className='shrink-0 text-foreground text-sm tabular-nums'>
+                  {formatCurrency(payment.amount, currencyCode)}
+                </span>
+                {renderRowSuffix?.(payment)}
+                {action}
+              </div>
+            }
+          />
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Work-order billing payments block now mirrors the invoices block's structure: the parent tab owns the label + bordered wrapper, and the three overlapping empty-state branches (plus the duplicated single/multi-candidate "Record payment" row markup) collapse into one.
- `PaymentsList` renders real `TreeRow`/`TreeRowButton` rows instead of hand-rolled divs, so the leading icon, hover background, and action-button styling stay automatically in sync with the invoice rows instead of being hand-copied classes.

## Test plan
- [x] Verified in browser: work order Billing tab — Invoices and Payments blocks now share identical wrapper/label styling, payment rows show a leading icon, hover state matches the invoice rows, and the delete/refund action sits last in the actions cluster (after the invoice chip).
- [ ] `pnpm lint:changed`