### PR TITLE
feat(dispatch): route-times auto-sync setting (plan 20 phase 3)

### DIFF
--- a/apps/web/src/app/(protected)/app/dispatch/settings/general/page.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/settings/general/page.tsx
@@ -1,0 +1,9 @@
+// apps/web/src/app/(protected)/app/dispatch/settings/general/page.tsx
+
+import { DispatchGeneralSettingsPage } from '~/components/dispatch/ui/dispatch-general-settings-page'
+
+function DispatchGeneralSettings() {
+  return <DispatchGeneralSettingsPage />
+}
+
+export default DispatchGeneralSettings

--- a/apps/web/src/app/(protected)/app/dispatch/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/settings/layout.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   Hash,
   Receipt,
+  SlidersHorizontal,
   Tags,
   Users,
 } from 'lucide-react'
@@ -24,6 +25,12 @@ const DISPATCH_SETTINGS: SidebarProps[] = [
     label: 'Settings',
     type: 'header',
     items: [
+      {
+        id: 'dispatch-settings-general',
+        label: 'General',
+        slug: 'general',
+        icon: <SlidersHorizontal />,
+      },
       {
         id: 'dispatch-settings-workers',
         label: 'Workers',

--- a/apps/web/src/app/(protected)/app/dispatch/settings/page.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/settings/page.tsx
@@ -2,9 +2,10 @@
 
 import { redirect } from 'next/navigation'
 
-/** No dedicated overview yet — Products & Services is the only settings page in MQ1. */
+/** `SidebarSecondary` always links to `${baseUrl}/${slug}` (no empty-slug support), so the
+ * index route just redirects to the General settings page. */
 function DispatchSettings() {
-  redirect('/app/dispatch/settings/products')
+  redirect('/app/dispatch/settings/general')
 }
 
 export default DispatchSettings

--- a/apps/web/src/components/dispatch/ui/board/event-dock-guide.tsx
+++ b/apps/web/src/components/dispatch/ui/board/event-dock-guide.tsx
@@ -20,8 +20,8 @@ import { ArrowLeftRight, PanelRightOpen } from 'lucide-react'
  */
 export function EventDockGuide() {
   return (
-    <div className='p-6'>
-      <GuideColumns cols={2}>
+    <div className='p-4'>
+      <GuideColumns cols={1}>
         <GuideColumn title='Shortcuts'>
           <GuideShortcuts>
             <GuideShortcut keys={['click']} label='Open event details' />

--- a/apps/web/src/components/dispatch/ui/dispatch-general-settings-page.tsx
+++ b/apps/web/src/components/dispatch/ui/dispatch-general-settings-page.tsx
@@ -1,0 +1,109 @@
+// apps/web/src/components/dispatch/ui/dispatch-general-settings-page.tsx
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import type { SettingValue } from '@auxx/lib/settings/client'
+import { Lock, Route as RouteIcon } from 'lucide-react'
+import { EmptyState } from '~/components/global/empty-state'
+import { FieldPanel } from '~/components/global/forms/field-panel'
+import { FormSaveBar } from '~/components/global/forms/form-save-bar'
+import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
+import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
+import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+import { useSettings } from '~/hooks/use-settings'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+
+const BREADCRUMBS = [{ title: 'Dispatch Settings' }, { title: 'General' }]
+
+/**
+ * Dispatch General settings page (plan 20 §5) — currently just the route auto-sync switch;
+ * follows `invoicing-page.tsx`'s exact recipe (admin-gated, feature-gated, `useDirtyDraft` +
+ * `FormSaveBar` over a scalar `DRAFT_KEYS` slice of the `'GENERAL'` scope).
+ */
+export function DispatchGeneralSettingsPage() {
+  useUser({ requireRoles: ['ADMIN', 'OWNER'] })
+  const { hasAccess } = useFeatureFlags()
+
+  if (!hasAccess(FeatureKey.dispatch)) {
+    return (
+      <SettingsPage
+        title='General'
+        description='General dispatch and route planner behavior.'
+        breadcrumbs={BREADCRUMBS}>
+        <EmptyState
+          icon={Lock}
+          title='Dispatch Not Available'
+          description='Upgrade your plan to use quoting and dispatch.'
+          button={<div className='h-12' />}
+        />
+      </SettingsPage>
+    )
+  }
+
+  return <DispatchGeneralSettingsBody />
+}
+
+/** Scalar catalog keys this page's draft owns — `useSettings({scope:'GENERAL'})` returns every
+ * `'GENERAL'`-scope setting across the whole app, so the draft/save must stay scoped to exactly
+ * these keys or a save here would clobber unrelated GENERAL settings. */
+const DRAFT_KEYS = ['dispatch.routes.autoApplyTimes'] as const
+
+function DispatchGeneralSettingsBody() {
+  const { getSetting, batchUpdateOrganizationSettings, isBatchUpdatingOrgSettings } = useSettings({
+    scope: 'GENERAL',
+  })
+
+  // Rebuilt each render; `useDirtyDraft` compares by value so a fresh identity never reseeds.
+  const server: Record<string, SettingValue> = {}
+  for (const key of DRAFT_KEYS) server[key] = getSetting(key)
+
+  const { draft, patch, dirty, save, discard } = useDirtyDraft(server, {
+    isSaving: isBatchUpdatingOrgSettings,
+    onSave: (next) => {
+      const changed = DRAFT_KEYS.filter((key) => next[key] !== server[key]).map((key) => ({
+        key,
+        value: next[key],
+      }))
+      if (changed.length > 0) batchUpdateOrganizationSettings(changed)
+    },
+  })
+
+  const controlled = (key: (typeof DRAFT_KEYS)[number]) => ({
+    value: draft[key],
+    onChange: (value: unknown) => patch({ [key]: value as SettingValue }),
+  })
+
+  return (
+    <SettingsPage
+      title='General'
+      description='General dispatch and route planner behavior.'
+      breadcrumbs={BREADCRUMBS}>
+      <div className='flex flex-col gap-8 p-3 sm:p-6'>
+        <SettingsSection
+          icon={RouteIcon}
+          title='Routes'
+          description='How the route planner keeps stop times in sync with route order.'>
+          <FieldPanel
+            className='mt-1 p-0'
+            resizeId='dispatch-general-settings'
+            defaultLabelWidth={260}>
+            <SettingsFieldRow
+              settingKey='dispatch.routes.autoApplyTimes'
+              title='Auto-apply times on reorder'
+              description='Reordering a route automatically re-chains provisional stop times. Confirmed (promised) times stay fixed — reordering around them surfaces a conflict instead of moving them.'
+              {...controlled('dispatch.routes.autoApplyTimes')}
+            />
+          </FieldPanel>
+        </SettingsSection>
+
+        <FormSaveBar
+          dirty={dirty}
+          isSaving={isBatchUpdatingOrgSettings}
+          onSave={save}
+          onDiscard={discard}
+        />
+      </div>
+    </SettingsPage>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/route-planner/hooks/use-route-planner-mutations.ts
+++ b/apps/web/src/components/dispatch/ui/route-planner/hooks/use-route-planner-mutations.ts
@@ -273,7 +273,7 @@ export function useRoutePlannerMutations(window: PlannerDayWindow) {
     void queryClient.invalidateQueries({ queryKey: geometryQueryKeyPrefix })
   }
 
-  const setRouteOrder = api.dispatch.setRouteOrder.useMutation({
+  const setRouteOrderMutation = api.dispatch.setRouteOrder.useMutation({
     onMutate: async (vars) => {
       await utils.dispatch.getRoutePlannerBoard.cancel(boardKey)
       return {
@@ -286,6 +286,18 @@ export function useRoutePlannerMutations(window: PlannerDayWindow) {
     },
     onSettled: settle,
   })
+  // `dateKey` (plan 20 §5 — server needs it to scope the auto-sync anchored chain to the right
+  // planned day) always equals this hook's own `window.dateKey` — every caller already
+  // constructs its `setRouteOrder.mutate` vars from a `PlannerDayWindow` in scope, so it's
+  // threaded here once instead of at each of the ~6 call sites (drag-end, pin-popover, Suggest
+  // route). Same source `applyRouteTimes` already uses (`date.dateKey` in apply-times-dialog.tsx).
+  type SetRouteOrderVars = Parameters<typeof setRouteOrderMutation.mutate>[0]
+  type SetRouteOrderOptions = Parameters<typeof setRouteOrderMutation.mutate>[1]
+  const setRouteOrder = {
+    ...setRouteOrderMutation,
+    mutate: (vars: Omit<SetRouteOrderVars, 'dateKey'>, options?: SetRouteOrderOptions) =>
+      setRouteOrderMutation.mutate({ ...vars, dateKey: window.dateKey }, options),
+  }
 
   const applyRouteTimes = api.dispatch.applyRouteTimes.useMutation({
     onMutate: async () => {

--- a/apps/web/src/components/dispatch/ui/sidebar/routes-group.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/routes-group.tsx
@@ -31,6 +31,7 @@ import { MoreVertical, Route as RouteIcon, Timer, X } from 'lucide-react'
 import { useState } from 'react'
 import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
 import { Tooltip } from '~/components/global/tooltip'
+import { useSettings } from '~/hooks/use-settings'
 import { ApplyTimesDialog } from '../route-planner/apply-times-dialog'
 import {
   dayStartAnchor,
@@ -96,6 +97,11 @@ export function RoutesGroup({
 
   const workOrderById = new Map(board.workOrders.map((w) => [w.id, w]))
 
+  // Read once here (not per-worker) — plan 20 §5's tooltip copy for the drift badge depends on
+  // whether auto-sync is on org-wide; every `WorkerStopSection` shares the same read.
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const autoApplyTimes = !!getSetting('dispatch.routes.autoApplyTimes')
+
   return (
     <SidebarGroup>
       <SidebarGroupHeader
@@ -117,6 +123,7 @@ export function RoutesGroup({
               geometry={geometryByWorker[worker.userId]}
               workOrderById={workOrderById}
               canEdit={canEdit}
+              autoApplyTimes={autoApplyTimes}
               open={groupOpen[`routes:${worker.userId}`] ?? true}
               onOpenChange={(o) => onWorkerOpenChange(worker.userId, o)}
               onSelectVisit={onSelectVisit}
@@ -135,6 +142,10 @@ interface WorkerStopSectionProps {
   geometry: RouteGeometry | undefined
   workOrderById: Map<string, PlannerWorkOrder>
   canEdit: boolean
+  /** `dispatch.routes.autoApplyTimes` org setting (plan 20 §5) — changes the drift badge's
+   * tooltip copy when 'drifted': with auto-sync on, drift only ever means a confirmed-stop
+   * conflict, not a stale unapplied reorder. */
+  autoApplyTimes: boolean
   open: boolean
   onOpenChange: (open: boolean) => void
   onSelectVisit?: (sel: { workOrderId: string; visitId: string }) => void
@@ -147,6 +158,7 @@ function WorkerStopSection({
   geometry,
   workOrderById,
   canEdit,
+  autoApplyTimes,
   open,
   onOpenChange,
   onSelectVisit,
@@ -237,7 +249,9 @@ function WorkerStopSection({
                 <Tooltip
                   content={
                     drift === 'drifted'
-                      ? "Times don't match route order — reapply"
+                      ? autoApplyTimes
+                        ? 'Order conflicts with confirmed times — auto-sync keeps promised times fixed; reapply to override'
+                        : "Times don't match route order — reapply"
                       : 'Times not applied yet'
                   }>
                   <span

--- a/apps/web/src/server/api/routers/dispatch.ts
+++ b/apps/web/src/server/api/routers/dispatch.ts
@@ -286,6 +286,7 @@ export const dispatchRouter = createTRPCRouter({
         assigneeUserId: z.string(),
         from: z.date(),
         to: z.date(),
+        dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
         visitIds: z.array(z.string()),
       })
     )
@@ -295,6 +296,7 @@ export const dispatchRouter = createTRPCRouter({
         userId: ctx.session.user.id,
         assigneeUserId: input.assigneeUserId,
         window: { from: input.from, to: input.to },
+        dateKey: input.dateKey,
         visitIds: input.visitIds,
         excludeSocketId: excludeSocketId(ctx),
       })

--- a/apps/worker/scripts/verify-dispatch-route-planner.ts
+++ b/apps/worker/scripts/verify-dispatch-route-planner.ts
@@ -61,6 +61,7 @@ import {
   type SuggestStopInput,
   scheduleVisit,
   setRouteOrder,
+  setVisitDuration,
   suggestRouteOrder,
   upsertDispatchWorker,
 } from '@auxx/lib/dispatch'
@@ -507,6 +508,7 @@ async function main() {
       userId,
       assigneeUserId: userId,
       window: { from: win2.from, to: win2.to },
+      dateKey: win2.dateKey,
       visitIds: [vC.id, vA.id, vB.id],
     })
 
@@ -568,11 +570,12 @@ async function main() {
       await setVisitCoords(vI.id, I.lat, I.lng)
 
       const firstDeparture = atHour(win3.from, 8)
-      const stops = [
-        { visitId: vG.id, durationMinutes: 20 },
-        { visitId: vH.id, durationMinutes: 15 },
-        { visitId: vI.id, durationMinutes: 25 },
-      ]
+      // plan 20 §4.1a: `applyRouteTimes` reads durations server-side from the visit's own
+      // `durationMinutes` column (not client input) — seed them explicitly here so the
+      // independent oracle below can compute exact expected spans.
+      await setVisitDuration({ organizationId, userId, visitId: vG.id, durationMinutes: 20 })
+      await setVisitDuration({ organizationId, userId, visitId: vH.id, durationMinutes: 15 })
+      await setVisitDuration({ organizationId, userId, visitId: vI.id, durationMinutes: 25 })
 
       await applyRouteTimes({
         organizationId,
@@ -580,7 +583,7 @@ async function main() {
         assigneeUserId: userId,
         dateKey: win3.dateKey,
         firstDeparture,
-        stops,
+        visitIds: [vG.id, vH.id, vI.id],
       })
 
       // Independent oracle (contract item 12): depot is null for this org (no

--- a/apps/worker/scripts/verify-dispatch-times-sync.ts
+++ b/apps/worker/scripts/verify-dispatch-times-sync.ts
@@ -1,14 +1,19 @@
 // apps/worker/scripts/verify-dispatch-times-sync.ts
 /**
- * Dispatch plan 20 "Route Times ↔ Route Order Sync" Phase 2 backend verification
- * (plans/dispatch/20-route-times-sync.md §4.5). Exercises the REAL write paths added this
- * slice: `resolveVisitDurationMinutes` (`@auxx/lib/dispatch`, pure), `scheduleVisit`'s
+ * Dispatch plan 20 "Route Times ↔ Route Order Sync" Phase 2 + Phase 3 backend verification
+ * (plans/dispatch/20-route-times-sync.md §4.5, §5). Exercises the REAL write paths added these
+ * slices: `resolveVisitDurationMinutes` (`@auxx/lib/dispatch`, pure), `scheduleVisit`'s
  * `timeWriteKind` classification (`packages/lib/src/dispatch/visit-mutations.ts`),
  * `unscheduleVisit` (clears `timeConfirmedAt`, keeps `durationMinutes`), the new
  * `setVisitDuration` mutation, `applyRouteTimes`' anchored-chain rework
  * (`packages/lib/src/dispatch/route-planner/apply-times.ts` — confirmed stops are fixed
- * anchors, provisional stops chain around them), and the recurring materializer persisting
- * `durationMinutes` while leaving `timeConfirmedAt` null.
+ * anchors, provisional stops chain around them), the recurring materializer persisting
+ * `durationMinutes` while leaving `timeConfirmedAt` null, and (§5, section 7) `setRouteOrder`'s
+ * (`packages/lib/src/dispatch/route-planner/route-order.ts`) auto-sync call into
+ * `autoApplyRouteTimes` gated on the `dispatch.routes.autoApplyTimes` org setting (GENERAL
+ * scope, default off) — flipped via `updateOrganizationSetting` + `onCacheEvent`
+ * (`'org.settings.changed'`, the only way `getOrganizationSetting`'s org-cache read sees a
+ * same-process write) and always restored in `finally`.
  *
  * Work orders are created via `UnifiedCrudHandler.create` (the M1 number + visit auto-create
  * hooks), prefixed "[TS-verify]", and deleted at the end — `WorkOrderVisit.workOrderId`
@@ -39,6 +44,8 @@
  */
 
 import { database } from '@auxx/database'
+import { resolveAvailability } from '@auxx/lib/availability'
+import { onCacheEvent } from '@auxx/lib/cache'
 import {
   applyRouteTimes,
   assignVisit,
@@ -47,12 +54,18 @@ import {
   resolveVisitDurationMinutes,
   scheduleVisit,
   setRecurrenceRule,
+  setRouteOrder,
   setVisitDuration,
   unscheduleVisit,
   upsertDispatchWorker,
 } from '@auxx/lib/dispatch'
 import { NotFoundError } from '@auxx/lib/errors'
 import { UnifiedCrudHandler } from '@auxx/lib/resources'
+import {
+  getOrganizationSetting,
+  type SettingValue,
+  updateOrganizationSetting,
+} from '@auxx/lib/settings'
 
 // Force-unset before any lib import/call reads them (both read at call time — see file header)
 // — a MapTiler TEST key has since been added to the root `.env` for other features, but section
@@ -74,14 +87,16 @@ function check(name: string, ok: boolean, detail?: unknown) {
 
 // ── Date/window helpers (verify-dispatch-route-planner.ts precedent) ──
 
-function dayWindow(daysFromNow: number): { from: Date; dateKey: string } {
+function dayWindow(daysFromNow: number): { from: Date; to: Date; dateKey: string } {
   const base = new Date()
   base.setUTCDate(base.getUTCDate() + daysFromNow)
   base.setUTCHours(0, 0, 0, 0)
+  const from = new Date(base)
+  const to = new Date(base.getTime() + 24 * 60 * 60 * 1000 - 1)
   const y = base.getUTCFullYear()
   const m = String(base.getUTCMonth() + 1).padStart(2, '0')
   const d = String(base.getUTCDate()).padStart(2, '0')
-  return { from: base, dateKey: `${y}-${m}-${d}` }
+  return { from, to, dateKey: `${y}-${m}-${d}` }
 }
 function atHour(day: Date, hour: number, minute = 0): Date {
   return new Date(day.getTime() + hour * 60 * 60 * 1000 + minute * 60 * 1000)
@@ -138,6 +153,16 @@ async function setVisitCoords(visitId: string, lat: number, lng: number): Promis
   )
 }
 
+/** Raw status fixture write (section 7d) — bypasses `setVisitStatus`'s roll-up/invoice-draft
+ * side effects, same rationale as `setVisitRouteOrder`/`setVisitCoords` above. Exact literals
+ * per `VISIT_STATUS_VALUES` (`packages/lib/src/dispatch/types.ts`): `'done'` / `'canceled'`. */
+async function setVisitStatusRaw(visitId: string, status: 'done' | 'canceled'): Promise<void> {
+  await database.$client.query('UPDATE "WorkOrderVisit" SET "status" = $1 WHERE id = $2', [
+    status,
+    visitId,
+  ])
+}
+
 async function residueCount(): Promise<number> {
   const res = await database.$client.query(
     `SELECT count(*)::int AS n FROM "FieldValue" fv WHERE fv."valueText" ILIKE '%[TS-verify]%'`
@@ -161,6 +186,11 @@ async function main() {
   const handler = new UnifiedCrudHandler(organizationId, userId)
   const createdRecordIds: string[] = []
   const workerIds: string[] = []
+
+  // Section 7 (auto-sync) flips `dispatch.routes.autoApplyTimes` — declared outside the `try`
+  // so the `finally` cleanup below can always restore it, even if a check throws mid-section.
+  let originalAutoApplyTimes: SettingValue = false
+  let autoApplyTimesChanged = false
 
   try {
     // ══════════════════════════════════════════════════════════════════════
@@ -598,6 +628,352 @@ async function main() {
       '6: every materialized row leaves timeConfirmedAt null (nobody promised it)',
       materialized.every((r) => r.timeConfirmedAt === null)
     )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 7. Auto-sync (plan 20 §5) — setRouteOrder -> autoApplyRouteTimes, gated on the
+    //    `dispatch.routes.autoApplyTimes` org setting (GENERAL scope, default off)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('7: auto-sync (setRouteOrder -> autoApplyRouteTimes)')
+
+    originalAutoApplyTimes = await getOrganizationSetting({
+      organizationId,
+      key: 'dispatch.routes.autoApplyTimes',
+    })
+
+    async function setAutoApplyTimes(value: boolean): Promise<void> {
+      await updateOrganizationSetting({
+        organizationId,
+        key: 'dispatch.routes.autoApplyTimes',
+        value,
+      })
+      await onCacheEvent('org.settings.changed', {
+        orgId: organizationId,
+        broadcastUserKeys: true,
+      })
+    }
+
+    // ── Shared 4-stop fixture for 7a (OFF)/7b (ON rechain+duration+seed)/7c (mid-route anchor).
+    const win7 = dayWindow(260)
+    const coords7: Array<[number, number]> = [
+      [40.0, -105.0],
+      [40.05, -104.9],
+      [40.1, -104.8],
+      [40.15, -104.7],
+    ]
+    const visits7: string[] = []
+    for (let i = 0; i < 4; i++) {
+      const wo = await handler.create('work_order', {
+        work_order_title: `[TS-verify] auto-sync stop ${i}`,
+      })
+      createdRecordIds.push(wo.recordId)
+      const v = await getVisit(wo.instance.id)
+      await assignVisit({ organizationId, userId, visitId: v.id, assigneeUserId: userId })
+      await setVisitCoords(v.id, coords7[i]![0], coords7[i]![1])
+      await setVisitRouteOrder(v.id, i)
+      // Baseline provisional times, as if a previous apply already ran — 1hr spacing from 09:00.
+      await scheduleVisit({
+        organizationId,
+        userId,
+        visitId: v.id,
+        startTime: atHour(win7.from, 9 + i),
+        endTime: atHour(win7.from, 9 + i, 45),
+        timeWriteKind: 'provisional',
+      })
+      visits7.push(v.id)
+    }
+    const [w0, w1, w2, w3] = visits7 as [string, string, string, string]
+
+    // ── 7a: setting OFF (default) — setRouteOrder writes routeOrder ONLY; every stop's
+    // startTime/endTime/timeConfirmedAt stays byte-unchanged.
+    await setAutoApplyTimes(false)
+    autoApplyTimesChanged = true
+    const before7a = await Promise.all(visits7.map((id) => getVisitById(id)))
+    await setRouteOrder({
+      organizationId,
+      userId,
+      assigneeUserId: userId,
+      window: { from: win7.from, to: win7.to },
+      dateKey: win7.dateKey,
+      visitIds: [w3, w1, w0, w2],
+    })
+    const after7a = await Promise.all(visits7.map((id) => getVisitById(id)))
+    check(
+      '7a OFF: routeOrder updated to the new order (w3=0, w1=1, w0=2, w2=3)',
+      after7a[3]!.routeOrder === 0 &&
+        after7a[1]!.routeOrder === 1 &&
+        after7a[0]!.routeOrder === 2 &&
+        after7a[2]!.routeOrder === 3,
+      after7a.map((r) => r.routeOrder)
+    )
+    check(
+      "7a OFF: every stop's startTime/endTime/timeConfirmedAt byte-unchanged",
+      before7a.every((b, i) => {
+        const a = after7a[i]!
+        return (
+          a.startTime?.getTime() === b.startTime?.getTime() &&
+          a.endTime?.getTime() === b.endTime?.getTime() &&
+          a.timeConfirmedAt?.getTime() === b.timeConfirmedAt?.getTime()
+        )
+      }),
+      { before: before7a, after: after7a }
+    )
+
+    // ── 7b: setting ON — provisional stops re-chained in the NEW order; explicit duration
+    // respected; re-chained stops STAY provisional; day-start SEED preserved from the previous
+    // min(startTime) (the new first stop's leg is the documented depot-less zero-second leg —
+    // no business address configured in dev, see file header / section 5 precedent).
+    await setAutoApplyTimes(true)
+    await setVisitDuration({ organizationId, userId, visitId: w1, durationMinutes: 90 })
+    const minStartBefore7b = Math.min(
+      ...(await Promise.all(visits7.map((id) => getVisitById(id)))).map((r) =>
+        (r.startTime as Date).getTime()
+      )
+    )
+    await setRouteOrder({
+      organizationId,
+      userId,
+      assigneeUserId: userId,
+      window: { from: win7.from, to: win7.to },
+      dateKey: win7.dateKey,
+      visitIds: [w2, w0, w3, w1],
+    })
+    const [rb2, rb0, rb3, rb1] = await Promise.all([w2, w0, w3, w1].map((id) => getVisitById(id)))
+    check(
+      '7b ON: chain is monotonic in the NEW order (start_i >= end_{i-1})',
+      rb0.startTime! >= rb2.endTime! &&
+        rb3.startTime! >= rb0.endTime! &&
+        rb1.startTime! >= rb3.endTime!,
+      { rb2, rb0, rb3, rb1 }
+    )
+    check(
+      '7b ON: re-chained stops STAY provisional (timeConfirmedAt still null)',
+      [rb2, rb0, rb3, rb1].every((r) => r.timeConfirmedAt === null)
+    )
+    check(
+      '7b ON: explicit durationMinutes (90) respected on the re-chained stop',
+      spanMinutes(rb1) === 90,
+      spanMinutes(rb1)
+    )
+    check(
+      '7b ON seed: earliest re-chained stop (new first, w2) starts at the previously chosen ' +
+        'day start (min(startTime) before reorder, zero-second first leg in dev)',
+      rb2.startTime?.getTime() === minStartBefore7b,
+      { expected: new Date(minStartBefore7b), actual: rb2.startTime }
+    )
+
+    // ── 7c: confirmed anchor MID-ROUTE — held byte-exact; the stop immediately after it in the
+    // new order departs from the anchor's endTime; its neighbors stay provisional.
+    await scheduleVisit({
+      organizationId,
+      userId,
+      visitId: w0,
+      startTime: atHour(win7.from, 13),
+      endTime: atHour(win7.from, 14),
+    }) // default kind = confirmed (anchor)
+    const anchor7c = await getVisitById(w0)
+    await setRouteOrder({
+      organizationId,
+      userId,
+      assigneeUserId: userId,
+      window: { from: win7.from, to: win7.to },
+      dateKey: win7.dateKey,
+      visitIds: [w2, w0, w1, w3],
+    })
+    const [rc2, rc0, rc1, rc3] = await Promise.all([w2, w0, w1, w3].map((id) => getVisitById(id)))
+    check(
+      '7c: confirmed anchor (w0) mid-route held byte-exact by the auto-sync reorder',
+      rc0.startTime?.getTime() === anchor7c.startTime?.getTime() &&
+        rc0.endTime?.getTime() === anchor7c.endTime?.getTime() &&
+        rc0.timeConfirmedAt?.getTime() === anchor7c.timeConfirmedAt?.getTime(),
+      { before: anchor7c, after: rc0 }
+    )
+    check(
+      "7c: following stop (w1) departs at/after the anchor's endTime",
+      rc1.startTime! >= rc0.endTime!,
+      { anchorEnd: rc0.endTime, followingStart: rc1.startTime }
+    )
+    check(
+      "7c: the anchor's neighbors stay provisional",
+      rc2.timeConfirmedAt === null && rc1.timeConfirmedAt === null && rc3.timeConfirmedAt === null
+    )
+    check(
+      '7c: chain continues monotonically past the anchor (w3 after w1)',
+      rc3.startTime! >= rc1.endTime!
+    )
+
+    // ── 7d: done/canceled stops in the route are EXCLUDED from auto-sync — routeOrder still
+    // moves for them (setRouteOrder itself doesn't filter by status), but their times are
+    // untouched by the ON reorder; the remaining ACTIVE stops re-chain normally.
+    const win7d = dayWindow(261)
+    const coords7d: Array<[number, number]> = [
+      [41.0, -106.0],
+      [41.05, -105.9],
+      [41.1, -105.8],
+    ]
+    const visits7d: string[] = []
+    for (let i = 0; i < 3; i++) {
+      const wo = await handler.create('work_order', {
+        work_order_title: `[TS-verify] auto-sync done/canceled ${i}`,
+      })
+      createdRecordIds.push(wo.recordId)
+      const v = await getVisit(wo.instance.id)
+      await assignVisit({ organizationId, userId, visitId: v.id, assigneeUserId: userId })
+      await setVisitCoords(v.id, coords7d[i]![0], coords7d[i]![1])
+      await setVisitRouteOrder(v.id, i)
+      await scheduleVisit({
+        organizationId,
+        userId,
+        visitId: v.id,
+        startTime: atHour(win7d.from, 9 + i),
+        endTime: atHour(win7d.from, 9 + i, 45),
+        timeWriteKind: 'provisional',
+      })
+      visits7d.push(v.id)
+    }
+    const [wd0, wd1, wd2] = visits7d as [string, string, string]
+    await setVisitStatusRaw(wd1, 'done')
+    const before7dDone = await getVisitById(wd1)
+
+    await setRouteOrder({
+      organizationId,
+      userId,
+      assigneeUserId: userId,
+      window: { from: win7d.from, to: win7d.to },
+      dateKey: win7d.dateKey,
+      visitIds: [wd2, wd1, wd0],
+    })
+    const [rd2, rd1, rd0] = await Promise.all([wd2, wd1, wd0].map((id) => getVisitById(id)))
+    check(
+      '7d: done stop (wd1) STILL gets its routeOrder written (index 1 in the new order)',
+      rd1.routeOrder === 1,
+      rd1.routeOrder
+    )
+    check(
+      '7d: done stop (wd1) times untouched by the ON auto-sync (excluded as inactive)',
+      rd1.startTime?.getTime() === before7dDone.startTime?.getTime() &&
+        rd1.endTime?.getTime() === before7dDone.endTime?.getTime(),
+      { before: before7dDone, after: rd1 }
+    )
+    check(
+      '7d: the two ACTIVE stops (wd2 then wd0) re-chain normally (monotonic, skipping wd1)',
+      rd0.startTime! >= rd2.endTime!,
+      { rd2, rd0 }
+    )
+
+    // ── 7e: ALL active stops confirmed (anchors) -> autoApplyRouteTimes no-ops entirely (no
+    // time writes at all); only routeOrder moves.
+    const win7e = dayWindow(262)
+    const coords7e: Array<[number, number]> = [
+      [42.0, -107.0],
+      [42.05, -106.9],
+    ]
+    const visits7e: string[] = []
+    for (let i = 0; i < 2; i++) {
+      const wo = await handler.create('work_order', {
+        work_order_title: `[TS-verify] auto-sync all-confirmed ${i}`,
+      })
+      createdRecordIds.push(wo.recordId)
+      const v = await getVisit(wo.instance.id)
+      await assignVisit({ organizationId, userId, visitId: v.id, assigneeUserId: userId })
+      await setVisitCoords(v.id, coords7e[i]![0], coords7e[i]![1])
+      await setVisitRouteOrder(v.id, i)
+      await scheduleVisit({
+        organizationId,
+        userId,
+        visitId: v.id,
+        startTime: atHour(win7e.from, 9 + i),
+        endTime: atHour(win7e.from, 10 + i),
+      }) // default kind = confirmed (anchor)
+      visits7e.push(v.id)
+    }
+    const [we0, we1] = visits7e as [string, string]
+    const before7e = await Promise.all(visits7e.map((id) => getVisitById(id)))
+    const before7eById = new Map(before7e.map((r) => [r.id, r]))
+
+    await setRouteOrder({
+      organizationId,
+      userId,
+      assigneeUserId: userId,
+      window: { from: win7e.from, to: win7e.to },
+      dateKey: win7e.dateKey,
+      visitIds: [we1, we0],
+    })
+    const after7e = await Promise.all([we1, we0].map((id) => getVisitById(id)))
+    check(
+      '7e: routeOrder swapped (we1=0, we0=1)',
+      after7e[0]!.routeOrder === 0 && after7e[1]!.routeOrder === 1,
+      after7e.map((r) => r.routeOrder)
+    )
+    check(
+      '7e: all-confirmed route -> NO time writes at all (byte-unchanged for both stops)',
+      after7e.every((a) => {
+        const b = before7eById.get(a.id)!
+        return (
+          a.startTime?.getTime() === b.startTime?.getTime() &&
+          a.endTime?.getTime() === b.endTime?.getTime() &&
+          a.timeConfirmedAt?.getTime() === b.timeConfirmedAt?.getTime()
+        )
+      }),
+      { before: before7e, after: after7e }
+    )
+
+    // ── 7g: fresh route (no times at all) — chain starts at the availability day-start seed,
+    // the same `resolveAvailability` computation `autoApplyRouteTimes` uses internally.
+    const win7g = dayWindow(263)
+    const coords7g: Array<[number, number]> = [
+      [43.0, -108.0],
+      [43.05, -107.9],
+      [43.1, -107.8],
+    ]
+    const visits7g: string[] = []
+    for (let i = 0; i < 3; i++) {
+      const wo = await handler.create('work_order', {
+        work_order_title: `[TS-verify] auto-sync fresh-route seed ${i}`,
+      })
+      createdRecordIds.push(wo.recordId)
+      const v = await getVisit(wo.instance.id)
+      await assignVisit({ organizationId, userId, visitId: v.id, assigneeUserId: userId })
+      await setVisitCoords(v.id, coords7g[i]![0], coords7g[i]![1])
+      await setVisitRouteOrder(v.id, i)
+      visits7g.push(v.id) // no scheduleVisit — times stay null (fresh, unapplied route)
+    }
+    const [wg0, wg1, wg2] = visits7g as [string, string, string]
+
+    const availDays7g = await resolveAvailability(
+      { type: 'worker', organizationId, userId },
+      { from: win7g.dateKey, to: win7g.dateKey }
+    )
+    const startMinutes7g = availDays7g[0]?.ranges[0]?.start ?? 8 * 60
+    const expectedSeed7g = new Date(win7g.from.getTime() + startMinutes7g * 60_000)
+
+    await setRouteOrder({
+      organizationId,
+      userId,
+      assigneeUserId: userId,
+      window: { from: win7g.from, to: win7g.to },
+      dateKey: win7g.dateKey,
+      visitIds: [wg2, wg0, wg1],
+    })
+    const [rg2, rg0, rg1] = await Promise.all([wg2, wg0, wg1].map((id) => getVisitById(id)))
+    check(
+      '7g: fresh route seed — first stop (wg2) starts at the availability day-start seed',
+      rg2.startTime?.getTime() === expectedSeed7g.getTime(),
+      { expected: expectedSeed7g, actual: rg2.startTime }
+    )
+    check(
+      '7g: fresh route -> written stops stay provisional',
+      rg2.timeConfirmedAt === null && rg0.timeConfirmedAt === null && rg1.timeConfirmedAt === null
+    )
+    check(
+      '7g: fresh route chain is monotonic',
+      rg0.startTime! >= rg2.endTime! && rg1.startTime! >= rg0.endTime!
+    )
+
+    // ── 7h: setting is org-scoped — restore it now that every ON-dependent case is done; a
+    // subsequent reorder on the same org must go back to routeOrder-only (7a already proved
+    // this at OFF; the `finally` block below is the safety-net restore if anything above threw).
+    await setAutoApplyTimes(originalAutoApplyTimes as boolean)
+    autoApplyTimesChanged = false
   } finally {
     // ── Cleanup ──
     console.log(`Cleanup: deleting ${createdRecordIds.length} verify work orders`)
@@ -614,6 +990,27 @@ async function main() {
       } catch (err) {
         console.log(
           `  cleanup failed for worker ${workerId}:`,
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+    // Safety-net restore for section 7's `dispatch.routes.autoApplyTimes` flip — 7h already
+    // restores it inline on the happy path; this only fires if something threw before reaching
+    // 7h (or 7h's own restore threw).
+    if (autoApplyTimesChanged) {
+      try {
+        await updateOrganizationSetting({
+          organizationId,
+          key: 'dispatch.routes.autoApplyTimes',
+          value: originalAutoApplyTimes,
+        })
+        await onCacheEvent('org.settings.changed', {
+          orgId: organizationId,
+          broadcastUserKeys: true,
+        })
+      } catch (err) {
+        console.log(
+          '  cleanup failed restoring dispatch.routes.autoApplyTimes:',
           err instanceof Error ? err.message : err
         )
       }

--- a/packages/lib/src/dispatch/index.ts
+++ b/packages/lib/src/dispatch/index.ts
@@ -68,8 +68,11 @@ export {
   setRecurrenceRule,
   sweepRecurringVisits,
 } from './recurring'
-export type { ApplyRouteTimesInput } from './route-planner/apply-times'
-export { applyRouteTimes } from './route-planner/apply-times'
+export type {
+  ApplyRouteTimesInput,
+  AutoApplyRouteTimesInput,
+} from './route-planner/apply-times'
+export { applyRouteTimes, autoApplyRouteTimes } from './route-planner/apply-times'
 export type { BackfillGeocodeResult } from './route-planner/backfill'
 export { backfillGeocodeVisits } from './route-planner/backfill'
 export { resolveOrgDepot, resolveRouteStart } from './route-planner/depot'

--- a/packages/lib/src/dispatch/route-planner/apply-times.ts
+++ b/packages/lib/src/dispatch/route-planner/apply-times.ts
@@ -1,27 +1,29 @@
 // packages/lib/src/dispatch/route-planner/apply-times.ts
 //
 // "Apply times to schedule" (plans/dispatch/09-route-planner.md §E/§F, build contract item 12;
-// anchored-chain rework plans/dispatch/20-route-times-sync.md §4.4) — the only path that writes
-// `startTime`/`endTime` from the planner. Walks the dispatcher-confirmed stop order as a
-// sequence of segments split at CONFIRMED stops (anchors, plan 20 §4.2): an anchor's own write
-// is skipped (its time is a promise, not planner math) and its `endTime` becomes the next
-// segment's departure; provisional stops between anchors get chained off the same Directions
-// leg durations the map preview draws from (cache-shared), written through the existing
-// single-visit `scheduleVisit` with `timeWriteKind: 'provisional'` — mirror/roll-up/broadcast
-// fire exactly like a manual reschedule. `routeOrder` is left untouched (already correct from
-// `setRouteOrder`); only the time fields move. Conflicts (computed arrival at an anchor later
-// than its confirmed `startTime`) are NOT errored here — Phase 2 only reports them, client-side,
-// in the apply-times dialog preview (§4.4).
+// anchored-chain rework plans/dispatch/20-route-times-sync.md §4.4; auto-sync §5) — the only
+// path that writes `startTime`/`endTime` from the planner. Walks the dispatcher-confirmed stop
+// order as a sequence of segments split at CONFIRMED stops (anchors, plan 20 §4.2): an anchor's
+// own write is skipped (its time is a promise, not planner math) and its `endTime` becomes the
+// next segment's departure; provisional stops between anchors get chained off the same
+// Directions leg durations the map preview draws from (cache-shared), written through the
+// existing single-visit `scheduleVisit` with `timeWriteKind: 'provisional'` — mirror/roll-up/
+// broadcast fire exactly like a manual reschedule. `routeOrder` is left untouched (already
+// correct from `setRouteOrder`); only the time fields move. Conflicts (computed arrival at an
+// anchor later than its confirmed `startTime`) are NOT errored here — Phase 2 only reports
+// them, client-side, in the apply-times dialog preview (§4.4); auto-sync (§5) applies them
+// as-computed too, the drift badge is the affordance.
 
 import { database, schema } from '@auxx/database'
 import { and, eq, inArray } from 'drizzle-orm'
+import { resolveAvailability } from '../../availability'
 import { NotFoundError } from '../../errors'
 import { resolveVisitDurationMinutes } from '../types'
 import { scheduleVisit } from '../visit-mutations'
 import { listDispatchWorkers } from '../workers'
 import { resolveRouteStart } from './depot'
 import { getRouteLegs } from './directions'
-import type { RouteStop } from './types'
+import type { PlannerDayWindow, RouteStop } from './types'
 
 /** Input for {@link applyRouteTimes}. */
 export interface ApplyRouteTimesInput {
@@ -38,37 +40,47 @@ export interface ApplyRouteTimesInput {
   excludeSocketId?: string
 }
 
-/**
- * Walk the ordered stops as anchor-delimited segments (plan 20 §4.4): a stop is an ANCHOR when
- * it already has a confirmed time (`timeConfirmedAt !== null` with both `startTime`/`endTime`
- * set) — its write is skipped entirely and its `endTime` becomes the next segment's departure.
- * Provisional stops chain off the same Directions leg durations the map preview uses (contract
- * item 12): `arrival_i = departure_{i-1} + legSeconds_i`, `startTime_i = arrival_i`,
- * `endTime_i = startTime_i + durationMinutes_i` (read via {@link resolveVisitDurationMinutes}),
- * `departure_i = endTime_i` — `departure_0 = firstDeparture`. Writes through `scheduleVisit`
- * per row, in order, with `timeWriteKind: 'provisional'` (each write's mirror/roll-up/broadcast
- * still fires the same as a manual reschedule).
- */
-export async function applyRouteTimes(input: ApplyRouteTimesInput): Promise<void> {
-  const {
-    organizationId,
-    userId,
-    assigneeUserId,
-    dateKey,
-    firstDeparture,
-    visitIds,
-    excludeSocketId,
-  } = input
-  if (visitIds.length === 0) return
+/** Input for {@link autoApplyRouteTimes}. */
+export interface AutoApplyRouteTimesInput {
+  organizationId: string
+  userId: string
+  assigneeUserId: string
+  /** `yyyy-MM-dd` label of the planned day, client-resolved — the Directions cache-key day. */
+  dateKey: string
+  /** The planned day's client-resolved bounds ({@link PlannerDayWindow}) — `from` is the local
+   * day start, the base for the availability first-departure seed. */
+  window: Pick<PlannerDayWindow, 'from' | 'to'>
+  /** Ordered visit ids (the just-written `routeOrder`) — done/canceled stops are filtered
+   * out here, unlike {@link applyRouteTimes} whose dialog caller pre-filters. */
+  visitIds: string[]
+  excludeSocketId?: string
+}
 
-  const worker = (await listDispatchWorkers(organizationId)).find(
-    (w) => w.userId === assigneeUserId
-  )
-  if (!worker) throw new NotFoundError('Dispatch worker not found')
+/** The visit columns the chain reads — shared by both apply entry points. */
+interface ChainVisitRow {
+  id: string
+  status: string
+  latitude: number | null
+  longitude: number | null
+  startTime: Date | null
+  endTime: Date | null
+  timeConfirmedAt: Date | null
+  durationMinutes: number | null
+}
 
-  const visitRows = await database
+/** An anchor (plan 20 §4.4): a confirmed time with both bounds set. */
+function isAnchorRow(row: ChainVisitRow): boolean {
+  return row.timeConfirmedAt !== null && row.startTime !== null && row.endTime !== null
+}
+
+async function loadVisitRows(
+  organizationId: string,
+  visitIds: string[]
+): Promise<Map<string, ChainVisitRow>> {
+  const rows = await database
     .select({
       id: schema.WorkOrderVisit.id,
+      status: schema.WorkOrderVisit.status,
       latitude: schema.WorkOrderVisit.latitude,
       longitude: schema.WorkOrderVisit.longitude,
       startTime: schema.WorkOrderVisit.startTime,
@@ -83,15 +95,33 @@ export async function applyRouteTimes(input: ApplyRouteTimesInput): Promise<void
         inArray(schema.WorkOrderVisit.id, visitIds)
       )
     )
-  const rowsByVisitId = new Map(visitRows.map((r) => [r.id, r]))
+  return new Map(rows.map((r) => [r.id, r]))
+}
+
+/**
+ * Fetch the Directions leg seconds for the ordered stop list, keyed by `toVisitId` — the same
+ * `getRouteLegs` call (and cache) the map preview draws from. Ungeocoded stops are dropped from
+ * the waypoint list fed to Directions — no leg can be drawn to/from a point with no coordinates;
+ * they fall back to a zero-second leg in the chain (no travel-time signal available for them).
+ */
+async function loadLegSeconds(params: {
+  organizationId: string
+  assigneeUserId: string
+  dateKey: string
+  visitIds: string[]
+  rowsByVisitId: Map<string, ChainVisitRow>
+}): Promise<Map<string, number>> {
+  const { organizationId, assigneeUserId, dateKey, visitIds, rowsByVisitId } = params
+
+  const worker = (await listDispatchWorkers(organizationId)).find(
+    (w) => w.userId === assigneeUserId
+  )
+  if (!worker) throw new NotFoundError('Dispatch worker not found')
 
   const homePoint = await resolveRouteStart(organizationId, worker)
   const depotStart = worker.routeStartAtHome ? homePoint : null
   const depotEnd = worker.routeEndAtHome ? homePoint : null
 
-  // Preserve the given (dispatcher-confirmed) order; drop ungeocoded stops from the waypoint
-  // list fed to Directions — no leg can be drawn to/from a point with no coordinates. Those
-  // stops fall back to a zero-second leg below (no travel-time signal available for them).
   const geoStops: RouteStop[] = []
   for (const visitId of visitIds) {
     const row = rowsByVisitId.get(visitId)
@@ -108,15 +138,43 @@ export async function applyRouteTimes(input: ApplyRouteTimesInput): Promise<void
     depotEnd,
     geoStops
   )
-  const legSecondsByVisitId = new Map(geometry.legs.map((leg) => [leg.toVisitId, leg.seconds]))
+  return new Map(geometry.legs.map((leg) => [leg.toVisitId, leg.seconds]))
+}
+
+/**
+ * The anchored chain core (plan 20 §4.4, contract item 12), shared by both entry points:
+ * anchors are skipped (their `endTime` becomes the next segment's departure); provisional
+ * stops get `arrival_i = departure_{i-1} + legSeconds_i`, `startTime_i = arrival_i`,
+ * `endTime_i = startTime_i + durationMinutes_i` (read via {@link resolveVisitDurationMinutes}),
+ * `departure_i = endTime_i` — `departure_0 = firstDeparture`. Writes through `scheduleVisit`
+ * per row, in order, with `timeWriteKind: 'provisional'` (each write's mirror/roll-up/broadcast
+ * still fires the same as a manual reschedule).
+ */
+async function runAnchoredChain(params: {
+  organizationId: string
+  userId: string
+  firstDeparture: Date
+  visitIds: string[]
+  rowsByVisitId: Map<string, ChainVisitRow>
+  legSecondsByVisitId: Map<string, number>
+  excludeSocketId?: string
+}): Promise<void> {
+  const {
+    organizationId,
+    userId,
+    firstDeparture,
+    visitIds,
+    rowsByVisitId,
+    legSecondsByVisitId,
+    excludeSocketId,
+  } = params
 
   let departure = firstDeparture
   for (const visitId of visitIds) {
     const row = rowsByVisitId.get(visitId)
     if (!row) continue
 
-    const isAnchor = row.timeConfirmedAt !== null && row.startTime !== null && row.endTime !== null
-    if (isAnchor) {
+    if (isAnchorRow(row)) {
       // Confirmed stops are fixed (§4.4): skip the write, chain off its existing endTime. A
       // conflict (the chain's arrival here would have landed after this promised start) is not
       // detectable retroactively once we've skipped ahead — the dialog preview computes and
@@ -142,4 +200,108 @@ export async function applyRouteTimes(input: ApplyRouteTimesInput): Promise<void
 
     departure = endTime
   }
+}
+
+/**
+ * Walk the ordered stops as anchor-delimited segments (plan 20 §4.4) from the given
+ * dispatcher-chosen `firstDeparture` — see {@link runAnchoredChain} for the segment math.
+ * Callers (the apply-times dialog) pass a pre-filtered active stop list.
+ */
+export async function applyRouteTimes(input: ApplyRouteTimesInput): Promise<void> {
+  const {
+    organizationId,
+    userId,
+    assigneeUserId,
+    dateKey,
+    firstDeparture,
+    visitIds,
+    excludeSocketId,
+  } = input
+  if (visitIds.length === 0) return
+
+  const rowsByVisitId = await loadVisitRows(organizationId, visitIds)
+  const legSecondsByVisitId = await loadLegSeconds({
+    organizationId,
+    assigneeUserId,
+    dateKey,
+    visitIds,
+    rowsByVisitId,
+  })
+  await runAnchoredChain({
+    organizationId,
+    userId,
+    firstDeparture,
+    visitIds,
+    rowsByVisitId,
+    legSecondsByVisitId,
+    excludeSocketId,
+  })
+}
+
+/**
+ * Auto-sync entry point (plan 20 §5, `dispatch.routes.autoApplyTimes` setting) — re-chains a
+ * route's provisional times right after a `setRouteOrder` write, no dialog. Filters the ordered
+ * list to active stops (status not `done`/`canceled` — the dialog's client-side filter, done
+ * server-side here) and no-ops when none remain or every remaining stop is a confirmed anchor
+ * (§4.4 — nothing to write). First-departure seed per §3.2: if any active stop already has a
+ * `startTime`, the previously chosen day start is preserved (`min(startTime)` minus the new
+ * first stop's leg seconds); otherwise the worker's availability day-start for `dateKey`
+ * (`resolveAvailability`, org-hours fallback) on top of `window.from`, falling back to 08:00 —
+ * the apply-times dialog's exact seed. Conflicts at anchors are applied as-computed, same as
+ * the dialog path; the drift badge is the affordance.
+ */
+export async function autoApplyRouteTimes(input: AutoApplyRouteTimesInput): Promise<void> {
+  const { organizationId, userId, assigneeUserId, dateKey, window, visitIds, excludeSocketId } =
+    input
+  if (visitIds.length === 0) return
+
+  const rowsByVisitId = await loadVisitRows(organizationId, visitIds)
+  const activeVisitIds = visitIds.filter((visitId) => {
+    const row = rowsByVisitId.get(visitId)
+    return row !== undefined && row.status !== 'done' && row.status !== 'canceled'
+  })
+  if (activeVisitIds.length === 0) return
+
+  const activeRows = activeVisitIds.map((visitId) => rowsByVisitId.get(visitId) as ChainVisitRow)
+  if (activeRows.every(isAnchorRow)) return
+
+  // Legs are fetched ONCE — the seed's first-stop leg and the chain reuse the same map.
+  const legSecondsByVisitId = await loadLegSeconds({
+    organizationId,
+    assigneeUserId,
+    dateKey,
+    visitIds: activeVisitIds,
+    rowsByVisitId,
+  })
+
+  const timedStartsMs = activeRows
+    .filter((row) => row.startTime !== null)
+    .map((row) => (row.startTime as Date).getTime())
+
+  let firstDeparture: Date
+  if (timedStartsMs.length > 0) {
+    // §3.2 — keep the day start the dispatcher previously chose: earliest scheduled start
+    // minus the (new) first stop's leg.
+    const firstLegSeconds = legSecondsByVisitId.get(activeVisitIds[0] as string) ?? 0
+    firstDeparture = new Date(Math.min(...timedStartsMs) - firstLegSeconds * 1000)
+  } else {
+    // Fresh, unapplied route — worker availability day-start (minutes since local midnight,
+    // resolved for the planned day) stamped onto the client-resolved local day start.
+    const days = await resolveAvailability(
+      { type: 'worker', organizationId, userId: assigneeUserId },
+      { from: dateKey, to: dateKey }
+    )
+    const startMinutes = days[0]?.ranges[0]?.start ?? 8 * 60
+    firstDeparture = new Date(window.from.getTime() + startMinutes * 60_000)
+  }
+
+  await runAnchoredChain({
+    organizationId,
+    userId,
+    firstDeparture,
+    visitIds: activeVisitIds,
+    rowsByVisitId,
+    legSecondsByVisitId,
+    excludeSocketId,
+  })
 }

--- a/packages/lib/src/dispatch/route-planner/route-order.ts
+++ b/packages/lib/src/dispatch/route-planner/route-order.ts
@@ -5,9 +5,13 @@
 // ordering (design doc §B: a worker's day rarely exceeds ~15-20 stops).
 
 import { database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
 import { and, eq, gte, isNotNull, lte, notInArray } from 'drizzle-orm'
 import { afterVisitWrite } from '../visit-mutations'
+import { autoApplyRouteTimes } from './apply-times'
 import type { PlannerDayWindow } from './types'
+
+const logger = createScopedLogger('dispatch:route-planner:route-order')
 
 /** Input for {@link setRouteOrder}. */
 export interface SetRouteOrderInput {
@@ -16,6 +20,9 @@ export interface SetRouteOrderInput {
   assigneeUserId: string
   /** The planned day, client-resolved ({@link PlannerDayWindow}). */
   window: Pick<PlannerDayWindow, 'from' | 'to'>
+  /** `yyyy-MM-dd` label of the planned day, client-resolved — the Directions cache-key day
+   * (same as `ApplyRouteTimesInput.dateKey`). */
+  dateKey: string
   /** Ordered visit ids — index in the array becomes the new `routeOrder`. */
   visitIds: string[]
   excludeSocketId?: string
@@ -30,7 +37,8 @@ export interface SetRouteOrderInput {
  * since it isn't a mirrored field — `afterVisitWrite` is called without a `trigger`).
  */
 export async function setRouteOrder(input: SetRouteOrderInput): Promise<void> {
-  const { organizationId, userId, assigneeUserId, window, visitIds, excludeSocketId } = input
+  const { organizationId, userId, assigneeUserId, window, dateKey, visitIds, excludeSocketId } =
+    input
   const { from, to } = window
 
   const nullOutConditions = [
@@ -67,5 +75,37 @@ export async function setRouteOrder(input: SetRouteOrderInput): Promise<void> {
 
   for (const row of [...nulledRows, ...reorderedRows]) {
     await afterVisitWrite(row, { userId, excludeSocketId })
+  }
+
+  // Auto-sync (plan 20 §5): with `dispatch.routes.autoApplyTimes` on, re-chain the route's
+  // provisional times in the same request. The `routeOrder` writes above are already committed
+  // — a failure here (settings read included) must never fail the reorder, so the whole block
+  // is caught-and-logged.
+  if (visitIds.length > 0) {
+    try {
+      const { getOrganizationSetting } = await import('../../settings/settings-service')
+      const autoApplyTimes = await getOrganizationSetting({
+        organizationId,
+        key: 'dispatch.routes.autoApplyTimes',
+      })
+      if (autoApplyTimes) {
+        await autoApplyRouteTimes({
+          organizationId,
+          userId,
+          assigneeUserId,
+          dateKey,
+          window,
+          visitIds,
+          excludeSocketId,
+        })
+      }
+    } catch (error) {
+      logger.error('Auto-apply route times failed after reorder', {
+        organizationId,
+        assigneeUserId,
+        dateKey,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
   }
 }

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -318,6 +318,18 @@ export const SETTINGS_CATALOG = {
     defaultValue: false,
     description: 'Display times in 24-hour format instead of AM/PM',
   },
+  // Dispatch auto-sync (plans/dispatch/20-route-times-sync.md §5) — GENERAL like the other
+  // org-wide operational switches; Phase 3 is schema-free, no new scope.
+  'dispatch.routes.autoApplyTimes': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'CHECKBOX',
+    options: { variant: 'switch' },
+    defaultValue: false,
+    description:
+      'When on, reordering a route automatically re-chains scheduled times for provisional ' +
+      'stops (confirmed times hold as anchors)',
+  },
 
   // ── DOCUMENTS (quote/invoice PDF + email settings, money MQ2 build spec §A) ──────────────
   // `documents.taxRates` moved here from GENERAL (money MQ1 §G.1 shipped it under GENERAL —


### PR DESCRIPTION
## Summary
Phase 3 of `plans/dispatch/20-route-times-sync.md` (Phases 1+2 shipped in #1174). Adds the org-level `dispatch.routes.autoApplyTimes` setting: when on, reordering a route automatically re-chains scheduled times for provisional stops, while confirmed times hold as anchors. Anchor conflicts are applied-as-computed (the drift badge is the affordance). Schema-free — no new scope, no migration.

- New Dispatch Settings -> General page (toggle lives here)
- `applyRouteTimes` / `route-order.ts` — anchor-aware re-chaining
- `dispatch` router — `dateKey` added to the relevant mutation input
- `verify-dispatch-times-sync.ts` extended (72/72 x3 per the plan doc)

## Test plan
- [ ] Browser pass for all three phases (plan doc notes this is still owed — needs web dev-server restart after lib rebuild)
- [ ] `pnpm lint:changed`
- [ ] Confirm migration 0287 (Phases 1+2) status on prod before/alongside this lands