### PR TITLE
feat(ui,dispatch): event-calendar resize + dock/popover polish

### DIFF
--- a/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
@@ -34,7 +34,7 @@ interface BoardCalendarGridProps {
   activeVisitId: string | null
   onActiveVisitChange: (visitId: string | null) => void
   onRangeChange: (from: Date, to: Date) => void
-  onEventResize: (event: DispatchVisitEvent, newEnd: Date) => void
+  onEventResize: (event: DispatchVisitEvent, newStart: Date, newEnd: Date) => void
   onOpenRecord: (recordId: RecordId, drill?: { panel?: string; item?: string }) => void
   isNonWorkingDay?: (date: Date) => boolean
   /** Plan 21 (dockable event panel) — sticky mode: while the event dock is open, every event

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -224,10 +224,10 @@ export function DispatchBoard() {
   )
 
   const handleEventResize = useCallback(
-    (event: DispatchVisitEvent, newEnd: Date) => {
+    (event: DispatchVisitEvent, newStart: Date, newEnd: Date) => {
       mutations.scheduleVisit.mutate({
         visitId: event.id,
-        startTime: event.start,
+        startTime: newStart,
         endTime: newEnd,
         assigneeUserId: event.assigneeUserId,
       })

--- a/apps/web/src/components/dispatch/ui/board/event-dock-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/board/event-dock-panel.tsx
@@ -62,7 +62,6 @@ export function EventDockPanel({
       open={dock.open}
       side={dock.side}
       contentKey={event?.id ?? 'empty'}
-      header={<span className='truncate font-medium text-sm'>{event?.title ?? 'Event'}</span>}
       onClose={() => {
         setEventDockOpen(false)
         onActiveVisitChange(null)
@@ -85,7 +84,12 @@ export function EventDockPanel({
             canEdit={canEdit}
             mutations={mutations}
             existingVisits={existingVisits}
-            onClose={() => onActiveVisitChange(null)}
+            // In dock mode `onClose` is only fired by the record-opening link handlers to
+            // dismiss the *floating* popover before the drawer opens. The dock is sticky
+            // (plan 21 decision #3) — keep the event selected so opening a work order/contact
+            // doesn't clear `activeVisitId` and drop the panel back to the guide. Real
+            // dismissal goes through `DockPanel`'s own `onClose` (X / Esc).
+            onClose={() => {}}
             onOpenRecord={onOpenRecord}
           />
         </EventPopoverBody>

--- a/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
@@ -6,16 +6,23 @@ import { getInstanceId, type RecordId, toRecordId } from '@auxx/lib/resources/cl
 import { Button } from '@auxx/ui/components/button'
 import {
   EventDateTimeSection,
-  EventPopoverHints,
   EventRepeatSection,
+  type EventTitleAction,
   EventTitleSection,
 } from '@auxx/ui/components/event-calendar'
 import { PanelCard, PanelCardRow } from '@auxx/ui/components/panel-card'
 import { toastError } from '@auxx/ui/components/toast'
 import { useIsMobile } from '@auxx/ui/hooks/use-mobile'
 import { differenceInMinutes } from 'date-fns'
-import { ArrowUpRight, CircleDot, Contact, PanelRight, Send, TriangleAlert } from 'lucide-react'
-import { Tooltip } from '~/components/global/tooltip'
+import {
+  ArrowUpRight,
+  CalendarX2,
+  CircleDot,
+  Contact,
+  PanelRight,
+  Send,
+  TriangleAlert,
+} from 'lucide-react'
 import { useResource } from '~/components/resources'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -135,176 +142,183 @@ export function VisitPopoverContent({
     if (contactId) onOpenRecord(contactId, {})
   }
 
+  /** The single "event actions" toolbar above the title. Dock is desktop-only (plan 21 decision
+   * #5 — no docked column on mobile) and omitted from the dock panel's own render (no `onDock`);
+   * once docked, `EventTitleSection` appends the dock chrome (flip / pop-out / close) itself. */
+  const titleActions: EventTitleAction[] = [
+    ...(onDock && !isMobile
+      ? [{ icon: <PanelRight />, label: 'Dock panel', onClick: onDock }]
+      : []),
+    {
+      icon: <ArrowUpRight />,
+      label: 'Open work order',
+      onClick: openWorkOrder,
+      href: `/app/work-orders/${event.workOrderId}`,
+    },
+    ...(canEdit
+      ? [
+          {
+            icon: <CalendarX2 />,
+            label: 'Remove from calendar',
+            destructive: true,
+            onClick: () => {
+              mutations.unscheduleVisit.mutate({ visitId: event.id })
+              onClose()
+            },
+          },
+        ]
+      : []),
+  ]
+
   return (
     <>
-      {/* Desktop-only (plan 21 decision #5) — the docked column doesn't exist on mobile. */}
-      {onDock && !isMobile && (
-        <div className='flex justify-end'>
-          <Tooltip content='Dock panel'>
-            <Button variant='ghost' size='icon-xs' aria-label='Dock panel' onClick={onDock}>
-              <PanelRight />
-            </Button>
-          </Tooltip>
-        </div>
-      )}
-
-      <EventTitleSection
-        title={event.title}
-        editable={false}
-        onTitleClick={openWorkOrder}
-        titleHref={`/app/work-orders/${event.workOrderId}`}
-        action={{
-          icon: <ArrowUpRight />,
-          label: 'Open work order',
-          onClick: openWorkOrder,
-          href: `/app/work-orders/${event.workOrderId}`,
-        }}
-        subtitle={
-          <>
-            <div>{VISIT_STATUS_LABELS[event.status]}</div>
-            {isOverdue && (
-              <div className='flex items-center gap-1 text-amber-600 dark:text-amber-500'>
-                <TriangleAlert className='size-3' /> Overdue — not completed
-              </div>
-            )}
-          </>
-        }
-        links={
-          contactDisplayName
-            ? [
-                {
-                  icon: <Contact />,
-                  label: contactDisplayName,
-                  href: contactId ? `/app/contacts/${getInstanceId(contactId)}` : undefined,
-                  onClick: contactId ? openContact : undefined,
-                },
-              ]
-            : undefined
-        }
-      />
-
-      <EventDateTimeSection
-        start={event.start}
-        end={event.end}
-        disabled={!canEdit}
-        onChange={
-          canEdit
-            ? ({ start, end }, scope) => {
-                if (scope === 'this') {
-                  mutations.scheduleVisit.mutate({
-                    visitId: event.id,
-                    startTime: start,
-                    endTime: end,
-                    assigneeUserId: event.assigneeUserId,
-                  })
-                } else {
-                  mutations.applyToSeries.mutate({
-                    visitId: event.id,
-                    scope,
-                    changes: {
-                      startMinute: start.getHours() * 60 + start.getMinutes(),
-                      durationMinutes: differenceInMinutes(end, start),
-                    },
-                  })
-                }
-              }
-            : undefined
-        }
-        onDateToggle={
-          canEdit
-            ? (enabled) => {
-                if (!enabled) mutations.unscheduleVisit.mutate({ visitId: event.id })
-              }
-            : undefined
-        }
-      />
-
-      <EventPopoverHints hints={hints} />
-
-      <AssigneeRow
-        value={event.assigneeUserId}
-        disabled={!canEdit}
-        onChange={(userId, scope) => {
-          if (scope === 'this') {
-            mutations.scheduleVisit.mutate({
-              visitId: event.id,
-              startTime: event.start,
-              endTime: event.end,
-              assigneeUserId: userId,
-            })
-          } else {
-            mutations.applyToSeries.mutate({
-              visitId: event.id,
-              scope,
-              changes: { assigneeUserId: userId },
-            })
+      <div className='space-y-2'>
+        <EventTitleSection
+          title={event.title}
+          editable={false}
+          onTitleClick={openWorkOrder}
+          titleHref={`/app/work-orders/${event.workOrderId}`}
+          actions={titleActions}
+          subtitle={
+            <>
+              <div>{VISIT_STATUS_LABELS[event.status]}</div>
+              {isOverdue && (
+                <div className='flex items-center gap-1 text-amber-600 dark:text-amber-500'>
+                  <TriangleAlert className='size-3' /> Overdue — not completed
+                </div>
+              )}
+            </>
           }
-        }}
-      />
+          links={
+            contactDisplayName
+              ? [
+                  {
+                    icon: <Contact />,
+                    label: contactDisplayName,
+                    href: contactId ? `/app/contacts/${getInstanceId(contactId)}` : undefined,
+                    onClick: contactId ? openContact : undefined,
+                  },
+                ]
+              : undefined
+          }
+        />
 
-      <EventRepeatSection
-        label={editor.repeatLabel}
-        detail={
-          editor.repeatMode === 'custom' ? (editor.recurrenceSummary ?? undefined) : undefined
-        }
-        disabled={!canEdit || !workOrderRecordId}
-        renderEditor={() => <RepeatEditor editor={editor} />}
-        onOpenChange={(open) => {
-          if (!open) commitRecurrence()
-        }}
-      />
+        <EventDateTimeSection
+          start={event.start}
+          end={event.end}
+          disabled={!canEdit}
+          warnings={hints}
+          onChange={
+            canEdit
+              ? ({ start, end }, scope) => {
+                  if (scope === 'this') {
+                    mutations.scheduleVisit.mutate({
+                      visitId: event.id,
+                      startTime: start,
+                      endTime: end,
+                      assigneeUserId: event.assigneeUserId,
+                    })
+                  } else {
+                    mutations.applyToSeries.mutate({
+                      visitId: event.id,
+                      scope,
+                      changes: {
+                        startMinute: start.getHours() * 60 + start.getMinutes(),
+                        durationMinutes: differenceInMinutes(end, start),
+                      },
+                    })
+                  }
+                }
+              : undefined
+          }
+        />
 
-      {canEdit && (
-        <PanelCard divided>
-          <PanelCardRow
-            icon={<CircleDot />}
-            title='Status'
-            description={VISIT_STATUS_LABELS[event.status]}
-            trailing={
-              <div className='flex flex-col items-end gap-1.5'>
-                {next && isExecutionReady(dayContext) && (
-                  <Button
-                    size='sm'
-                    variant='outline'
-                    onClick={() =>
-                      mutations.setVisitStatus.mutate({ visitId: event.id, status: next })
-                    }
-                    loading={mutations.setVisitStatus.isPending}>
-                    Advance to {VISIT_STATUS_LABELS[next]}
-                  </Button>
-                )}
-                {canCancel && (
-                  <Button
-                    size='sm'
-                    variant='ghost'
-                    onClick={() =>
-                      mutations.setVisitStatus.mutate({ visitId: event.id, status: 'canceled' })
-                    }
-                    loading={mutations.setVisitStatus.isPending}>
-                    Cancel visit
-                  </Button>
-                )}
-              </div>
+        <AssigneeRow
+          value={event.assigneeUserId}
+          disabled={!canEdit}
+          onChange={(userId, scope) => {
+            if (scope === 'this') {
+              mutations.scheduleVisit.mutate({
+                visitId: event.id,
+                startTime: event.start,
+                endTime: event.end,
+                assigneeUserId: userId,
+              })
+            } else {
+              mutations.applyToSeries.mutate({
+                visitId: event.id,
+                scope,
+                changes: { assigneeUserId: userId },
+              })
             }
-          />
-          <PanelCardRow
-            icon={<Send />}
-            title='Dispatch'
-            description={event.dispatchedAt ? 'Re-dispatch notifies the assignee again' : undefined}
-            trailing={
-              <Button
-                size='sm'
-                variant='outline'
-                onClick={handleDispatch}
-                loading={mutations.dispatchVisit.isPending}
-                disabled={!event.assigneeUserId}>
-                {event.dispatchedAt ? 'Re-dispatch' : 'Dispatch'}
-              </Button>
-            }
-          />
-        </PanelCard>
-      )}
+          }}
+        />
 
+        <EventRepeatSection
+          label={editor.repeatLabel}
+          detail={
+            editor.repeatMode === 'custom' ? (editor.recurrenceSummary ?? undefined) : undefined
+          }
+          disabled={!canEdit || !workOrderRecordId}
+          renderEditor={() => <RepeatEditor editor={editor} />}
+          onOpenChange={(open) => {
+            if (!open) commitRecurrence()
+          }}
+        />
+
+        {canEdit && (
+          <PanelCard divided>
+            <PanelCardRow
+              icon={<CircleDot />}
+              title='Status'
+              description={VISIT_STATUS_LABELS[event.status]}
+              trailing={
+                <div className='flex flex-col items-end gap-1.5'>
+                  {next && isExecutionReady(dayContext) && (
+                    <Button
+                      size='sm'
+                      variant='outline'
+                      onClick={() =>
+                        mutations.setVisitStatus.mutate({ visitId: event.id, status: next })
+                      }
+                      loading={mutations.setVisitStatus.isPending}>
+                      Advance to {VISIT_STATUS_LABELS[next]}
+                    </Button>
+                  )}
+                  {canCancel && (
+                    <Button
+                      size='sm'
+                      variant='ghost'
+                      onClick={() =>
+                        mutations.setVisitStatus.mutate({ visitId: event.id, status: 'canceled' })
+                      }
+                      loading={mutations.setVisitStatus.isPending}>
+                      Cancel visit
+                    </Button>
+                  )}
+                </div>
+              }
+            />
+            <PanelCardRow
+              icon={<Send />}
+              title='Dispatch'
+              description={
+                event.dispatchedAt ? 'Re-dispatch notifies the assignee again' : undefined
+              }
+              trailing={
+                <Button
+                  size='sm'
+                  variant='outline'
+                  onClick={handleDispatch}
+                  loading={mutations.dispatchVisit.isPending}
+                  disabled={!event.assigneeUserId}>
+                  {event.dispatchedAt ? 'Re-dispatch' : 'Dispatch'}
+                </Button>
+              }
+            />
+          </PanelCard>
+        )}
+      </div>
       <ConfirmDialog />
     </>
   )

--- a/apps/web/src/components/dispatch/ui/schedule-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/schedule-popover.tsx
@@ -7,7 +7,6 @@ import {
   EventDateTimeSection,
   EventPopoverBody,
   EventPopoverFooter,
-  EventPopoverHints,
   EventRepeatSection,
   type SeriesScope,
 } from '@auxx/ui/components/event-calendar'
@@ -192,6 +191,7 @@ export function SchedulePopoverContent({
       <EventDateTimeSection
         start={startTime}
         end={endTime}
+        warnings={hints}
         onChange={handleDateTimeChange}
         onDateToggle={
           isDraft
@@ -201,7 +201,6 @@ export function SchedulePopoverContent({
               }
         }
       />
-      <EventPopoverHints hints={hints} />
       <AssigneeRow value={assigneeUserId} onChange={handleAssigneeChange} />
       {workOrderRecordId && (
         <EventRepeatSection

--- a/packages/ui/src/components/dock-panel.tsx
+++ b/packages/ui/src/components/dock-panel.tsx
@@ -1,15 +1,32 @@
 // packages/ui/src/components/dock-panel.tsx
 'use client'
 
-import { Button } from '@auxx/ui/components/button'
 import { Sheet, SheetContent, SheetTitle } from '@auxx/ui/components/sheet'
 import { useIsMobile } from '@auxx/ui/hooks/use-mobile'
 import { cn } from '@auxx/ui/lib/utils'
-import { ArrowLeftRight, PanelRightOpen, X } from 'lucide-react'
 import * as React from 'react'
 
 /** Which edge of the parent flex row the panel docks to. */
 type DockSide = 'left' | 'right'
+
+interface DockChrome {
+  side: DockSide
+  onClose?: () => void
+  onPopOut?: () => void
+  onFlipSide?: (side: DockSide) => void
+}
+
+const DockChromeContext = React.createContext<DockChrome | null>(null)
+
+/**
+ * The enclosing dock's chrome controls (flip-side / pop-out / close), or `null` when the content
+ * isn't docked. Consumed by a content-provided header (e.g. `EventTitleSection`) so it can fold
+ * the controls into its own actions row — the dock renders no separate header of its own. Only
+ * present in the desktop docked column; the mobile sheet uses its own built-in close button.
+ */
+export function useDockChrome(): DockChrome | null {
+  return React.useContext(DockChromeContext)
+}
 
 interface DockPanelProps {
   /** Whether the panel is open. Closed animates width 0 <-> `width` and takes no layout
@@ -21,16 +38,14 @@ interface DockPanelProps {
   side: DockSide
   /** Fixed width while open. Not resizable in v1. */
   width?: string
-  /** X button in the header. */
+  /** Close the dock. Surfaced to the content via `useDockChrome()`. */
   onClose: () => void
-  /** Undock -> float. Omit to hide the pop-out button. */
+  /** Undock -> float. Omit to hide the pop-out control. Surfaced via `useDockChrome()`. */
   onPopOut?: () => void
-  /** Flip side (left <-> right). Omit to hide the flip-side button. */
+  /** Flip side (left <-> right). Omit to hide the flip-side control. Surfaced via `useDockChrome()`. */
   onFlipSide?: (side: DockSide) => void
-  /** Key that changes per selected entity — drives the slide/cross-fade content swap. */
+  /** Key that changes per selected entity — drives the cross-fade content swap. */
   contentKey: string
-  /** Title row content, to the left of the control cluster. */
-  header?: React.ReactNode
   children: React.ReactNode
 }
 
@@ -50,7 +65,6 @@ function DockPanel({
   onPopOut,
   onFlipSide,
   contentKey,
-  header,
   children,
 }: DockPanelProps) {
   const isMobile = useIsMobile()
@@ -70,11 +84,11 @@ function DockPanel({
           if (!next) onClose()
         }}>
         <SheetContent side='bottom' className='flex h-[70vh] flex-col gap-0 p-0'>
+          {/* The content provides its own visible header (e.g. `EventTitleSection`); this keeps
+           * the dialog accessible without a duplicate title row. Flip-side / pop-out are
+           * meaningless in a sheet, and the sheet's built-in close button covers dismissal — so
+           * no `DockChrome` is provided on mobile. */}
           <SheetTitle className='sr-only'>Panel</SheetTitle>
-          {/* Flip-side / pop-out are meaningless in a sheet — omit both handlers so
-           * `DockPanelHeader` only renders the title row. The sheet's own built-in close
-           * button (top-right, from `SheetContent`) covers dismissal. */}
-          <DockPanelHeader header={header} side={side} />
           <div className='min-h-0 flex-1 overflow-y-auto'>{children}</div>
         </SheetContent>
       </Sheet>
@@ -103,55 +117,13 @@ function DockPanel({
         <div
           className={cn('flex h-full flex-col', side === 'left' ? 'border-r' : 'border-l')}
           style={{ width }}>
-          <DockPanelHeader
-            header={header}
-            side={side}
-            onFlipSide={onFlipSide}
-            onPopOut={onPopOut}
-            onClose={onClose}
-          />
-          <DockPanelFrame contentKey={contentKey}>{children}</DockPanelFrame>
+          {/* No header of our own — the content renders one and folds these controls into it
+           * via `useDockChrome()`, so the dock chrome and the event title never duplicate. */}
+          <DockChromeContext.Provider value={{ side, onClose, onPopOut, onFlipSide }}>
+            <DockPanelFrame contentKey={contentKey}>{children}</DockPanelFrame>
+          </DockChromeContext.Provider>
         </div>
       )}
-    </div>
-  )
-}
-
-interface DockPanelHeaderProps {
-  header?: React.ReactNode
-  side: DockSide
-  onFlipSide?: (side: DockSide) => void
-  onPopOut?: () => void
-  onClose?: () => void
-}
-
-/** Header row: `header` content on the left, control cluster on the right. Each control
- * only renders when its handler is provided. */
-function DockPanelHeader({ header, side, onFlipSide, onPopOut, onClose }: DockPanelHeaderProps) {
-  return (
-    <div className='flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2'>
-      <div className='flex min-w-0 flex-1 items-center gap-2'>{header}</div>
-      <div className='flex shrink-0 items-center gap-0.5'>
-        {onFlipSide && (
-          <Button
-            variant='ghost'
-            size='icon'
-            aria-label='Flip side'
-            onClick={() => onFlipSide(side === 'left' ? 'right' : 'left')}>
-            <ArrowLeftRight />
-          </Button>
-        )}
-        {onPopOut && (
-          <Button variant='ghost' size='icon' aria-label='Pop out' onClick={onPopOut}>
-            <PanelRightOpen />
-          </Button>
-        )}
-        {onClose && (
-          <Button variant='ghost' size='icon' aria-label='Close' onClick={onClose}>
-            <X />
-          </Button>
-        )}
-      </div>
     </div>
   )
 }

--- a/packages/ui/src/components/event-calendar/day-resource-group.tsx
+++ b/packages/ui/src/components/event-calendar/day-resource-group.tsx
@@ -33,7 +33,7 @@ interface DayResourceGroupProps<T extends EventCalendarItem = EventCalendarItem>
   backgroundEvents: BackgroundEvent[]
   onEventSelect: (event: T) => void
   onSlotClick?: (startTime: Date, resourceId: string) => void
-  onEventResize?: (event: T, newEnd: Date) => void
+  onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
   /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
   selectedEventId?: string | null

--- a/packages/ui/src/components/event-calendar/day-view.tsx
+++ b/packages/ui/src/components/event-calendar/day-view.tsx
@@ -25,7 +25,7 @@ interface DayViewProps<T extends EventCalendarItem = EventCalendarItem> {
   backgroundEvents?: BackgroundEvent[]
   onEventSelect: (event: T) => void
   onSlotClick?: (startTime: Date) => void
-  onEventResize?: (event: T, newEnd: Date) => void
+  onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
   /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
   selectedEventId?: string | null

--- a/packages/ui/src/components/event-calendar/draggable-event.tsx
+++ b/packages/ui/src/components/event-calendar/draggable-event.tsx
@@ -25,8 +25,8 @@ interface DraggableEventProps<T extends EventCalendarItem = EventCalendarItem> {
   /** Active selection — the event whose detail/popover is open. Draws the in-color ring. */
   isSelected?: boolean
   renderEvent?: RenderEvent<T>
-  /** Enables the bottom-edge resize handle — only meaningful in week/day/resource. */
-  onResize?: (event: T, newEnd: Date) => void
+  /** Enables the top/bottom-edge resize handles — only meaningful in week/day/resource. */
+  onResize?: (event: T, newStart: Date, newEnd: Date) => void
 }
 
 export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>({
@@ -66,7 +66,7 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
 
   const canResize =
     onResize !== undefined && (view === 'week' || view === 'day' || view === 'resource')
-  const { isResizing, previewHeight, resizeHandleProps } = useEventResize({
+  const { isResizing, previewHeight, previewOffsetY, getResizeHandleProps } = useEventResize({
     event,
     cellHeight: WeekCellsHeight,
     onResize,
@@ -96,10 +96,16 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
 
   const effectiveHeight = isResizing && previewHeight !== null ? previewHeight : height
 
+  // During a resize the dnd transform is null (resize stops propagation, so no move-drag),
+  // so the top-edge preview translate lives in the else branch alongside the height.
   const style =
     transform && !isDragSource
       ? { transform: CSS.Translate.toString(transform), height: effectiveHeight || 'auto' }
-      : { height: effectiveHeight || 'auto' }
+      : {
+          height: effectiveHeight || 'auto',
+          transform:
+            isResizing && previewOffsetY !== 0 ? `translateY(${previewOffsetY}px)` : undefined,
+        }
 
   return (
     <div
@@ -126,14 +132,18 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
         renderEvent={renderEvent}
       />
       {canResize && (
-        <div
-          {...resizeHandleProps}
-          className={cn(
-            'absolute inset-x-0 bottom-0 flex h-2 cursor-ns-resize touch-none items-end justify-center opacity-0 transition-opacity group-hover/event:opacity-100',
-            isResizing && 'opacity-100'
-          )}>
-          <span className='mb-0.5 h-1 w-6 rounded-full bg-current opacity-40' />
-        </div>
+        <>
+          {/* Invisible top drag zone — resizes the start time. */}
+          <div
+            {...getResizeHandleProps('top')}
+            className='absolute inset-x-0 top-0 h-2 cursor-ns-resize touch-none'
+          />
+          {/* Invisible bottom drag zone — resizes the end time. */}
+          <div
+            {...getResizeHandleProps('bottom')}
+            className='absolute inset-x-0 bottom-0 h-2 cursor-ns-resize touch-none'
+          />
+        </>
       )}
     </div>
   )

--- a/packages/ui/src/components/event-calendar/event-calendar.tsx
+++ b/packages/ui/src/components/event-calendar/event-calendar.tsx
@@ -76,7 +76,7 @@ export interface EventCalendarProps<T extends EventCalendarItem = EventCalendarI
   onSlotClick?: (startTime: Date, resourceId?: string) => void
   /** The calendar never mutates — every write (move or resize) round-trips through these. */
   onEventDrop?: (event: T, newStart: Date, newEnd: Date, resourceId?: string) => void
-  onEventResize?: (event: T, newEnd: Date) => void
+  onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   /** Hide the built-in date-nav/view-switcher header when the consumer brings their own toolbar chrome. */
   hideToolbar?: boolean
   /** Month view only — cells where this returns true get a muted background (closed days). */

--- a/packages/ui/src/components/event-calendar/event-popover/event-popover-sections.tsx
+++ b/packages/ui/src/components/event-calendar/event-popover/event-popover-sections.tsx
@@ -2,15 +2,26 @@
 
 'use client'
 
+import { cn } from '@auxx/ui/lib/utils'
 import { addMinutes, differenceInMinutes, format } from 'date-fns'
-import { AlertTriangle, CalendarDays, Clock8, RefreshCcw, User } from 'lucide-react'
+import {
+  ArrowLeftRight,
+  CalendarDays,
+  Clock8,
+  PanelRightOpen,
+  RefreshCcw,
+  User,
+  X,
+} from 'lucide-react'
 import * as React from 'react'
 import { AutosizeTextarea } from '../../autosize-textarea'
 import { Avatar, AvatarFallback, AvatarImage } from '../../avatar'
 import { Calendar } from '../../calendar'
 import { useCommandNavigation } from '../../command'
+import { useDockChrome } from '../../dock-panel'
 import { PanelCard, PanelCardRow, PanelRowValue, PanelSectionLabel } from '../../panel-card'
 import { Switch } from '../../switch'
+import { SimpleTooltip } from '../../tooltip'
 import { EventDrillPage } from './event-popover'
 import { formatTimeOfDay } from './parse-time'
 import { useSeriesScope } from './series-scope-chooser'
@@ -64,12 +75,37 @@ interface EventTitleLink {
   onClick?: () => void
 }
 
-interface EventTitleAction {
+export interface EventTitleAction {
   icon: React.ReactNode
-  /** Accessible label for the icon button (e.g. "Open work order"). */
+  /** Accessible label, also shown as the button's tooltip (e.g. "Open work order"). */
   label: string
   href?: string
   onClick?: () => void
+  /** Red hover styling for destructive actions (e.g. delete). */
+  destructive?: boolean
+}
+
+/** One icon button in the `EventTitleSection` actions toolbar — ghost square with a tooltip,
+ * anchor when `href` is set (modified-click → new tab), plain button otherwise. */
+function EventTitleActionButton({ action }: { action: EventTitleAction }) {
+  const className = cn(
+    'shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground [&_svg]:size-4',
+    action.destructive && 'hover:bg-destructive/10 hover:text-destructive'
+  )
+  const inner = action.href ? (
+    <a
+      href={action.href}
+      onClick={(e) => handleAnchorClick(e, action.onClick)}
+      aria-label={action.label}
+      className={className}>
+      {action.icon}
+    </a>
+  ) : (
+    <button type='button' onClick={action.onClick} aria-label={action.label} className={className}>
+      {action.icon}
+    </button>
+  )
+  return <SimpleTooltip content={action.label}>{inner}</SimpleTooltip>
 }
 
 interface EventTitleSectionProps {
@@ -80,27 +116,52 @@ interface EventTitleSectionProps {
    * modified clicks fall back to `titleHref`'s native anchor behavior (new tab). */
   onTitleClick?: () => void
   titleHref?: string
-  /** Trailing icon button in the title row's top-right — the "open record" affordance. */
-  action?: EventTitleAction
+  /** Toolbar of icon actions rendered above the title (open, dock, copy, delete, …) — the single
+   * "event actions" location. Right-aligned; renders nothing when empty. */
+  actions?: EventTitleAction[]
   subtitle?: React.ReactNode
   links?: EventTitleLink[]
 }
 
-/** Top `PanelCard`: borderless autosize title (Notion autosave — commits on blur/Enter),
- * optional subtitle node, optional bordered-top linked-record rows (decision #6). The title can
- * double as a record link (`onTitleClick`/`titleHref`) with a trailing `action` icon button. */
+/** Top `PanelCard`: an optional right-aligned actions toolbar, a borderless autosize title
+ * (Notion autosave — commits on blur/Enter), optional subtitle node, and optional bordered-top
+ * linked-record rows (decision #6). The title can double as a record link
+ * (`onTitleClick`/`titleHref`). */
 export function EventTitleSection({
   title,
   editable = false,
   onCommit,
   onTitleClick,
   titleHref,
-  action,
+  actions,
   subtitle,
   links,
 }: EventTitleSectionProps) {
   const [draft, setDraft] = React.useState(title)
   const skipCommitRef = React.useRef(false)
+
+  // When rendered inside a `DockPanel`, fold the dock's chrome controls (flip-side / pop-out /
+  // close) into this same toolbar so the dock needs no separate header — the event title IS the
+  // header. `useDockChrome()` is null in the floating popover, so nothing is added there.
+  const dock = useDockChrome()
+  const dockActions: EventTitleAction[] = dock
+    ? [
+        ...(dock.onFlipSide
+          ? [
+              {
+                icon: <ArrowLeftRight />,
+                label: 'Flip side',
+                onClick: () => dock.onFlipSide?.(dock.side === 'left' ? 'right' : 'left'),
+              },
+            ]
+          : []),
+        ...(dock.onPopOut
+          ? [{ icon: <PanelRightOpen />, label: 'Pop out', onClick: dock.onPopOut }]
+          : []),
+        ...(dock.onClose ? [{ icon: <X />, label: 'Close', onClick: dock.onClose }] : []),
+      ]
+    : []
+  const allActions = [...(actions ?? []), ...dockActions]
 
   React.useEffect(() => {
     setDraft(title)
@@ -157,28 +218,25 @@ export function EventTitleSection({
   )
 
   return (
-    <PanelCard className={links?.length ? 'space-y-3' : undefined}>
-      <div className='flex items-start justify-between gap-2'>
-        {titleNode}
-        {action &&
-          (action.href ? (
-            <a
-              href={action.href}
-              onClick={(e) => handleAnchorClick(e, action.onClick)}
-              aria-label={action.label}
-              className='shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground [&_svg]:size-4'>
-              {action.icon}
-            </a>
-          ) : (
-            <button
-              type='button'
-              onClick={action.onClick}
-              aria-label={action.label}
-              className='shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground [&_svg]:size-4'>
-              {action.icon}
-            </button>
+    <PanelCard
+      data-slot='event-title'
+      data-docked={dock ? '' : undefined}
+      className={cn(
+        links?.length && 'space-y-3',
+        // Docked: flatten the card into a sticky panel header (no floating-card chrome), full-bleed
+        // over `PanelShell`'s p-2 and pinned to the scroll viewport top so the merged dock chrome
+        // (close / pop-out) never scrolls away. `data-slot`/`data-docked` let consumers restyle.
+        dock &&
+          'sticky top-0 z-10 -mx-2 -mt-2 rounded-none border-0 border-b border-border/50 bg-background px-3 py-2'
+      )}>
+      {allActions.length > 0 && (
+        <div className='-mt-1 -mr-1 flex items-center justify-end gap-0.5'>
+          {allActions.map((action) => (
+            <EventTitleActionButton key={action.label} action={action} />
           ))}
-      </div>
+        </div>
+      )}
+      <div className='flex items-start gap-2'>{titleNode}</div>
       {subtitle && <div className='text-muted-foreground text-sm'>{subtitle}</div>}
       {links?.map((link) => {
         const content = (
@@ -219,11 +277,18 @@ interface EventDateTimeSectionProps {
   start: Date | null
   end: Date | null
   onChange?: (change: { start: Date; end: Date }, scope: SeriesScope) => void
+  /** When set, a trailing toggle on the Date row reflects `start != null`; flipping it off is the
+   * "unschedule" affordance. Omit to hide the toggle (e.g. the board popover, which unschedules
+   * via a title action instead). */
   onDateToggle?: (value: boolean) => void
   allDay?: { value: boolean; onChange: (value: boolean) => void }
   use24Hour?: boolean
   disabled?: boolean
   defaultStartHour?: number
+  /** Availability/overlap hints. When present, the Date row's icon becomes a circular warning
+   * icon and its title is re-tinted amber, with the hints in a hover tooltip — swapped in place,
+   * so a late-arriving async result never shifts layout (replaces the old `EventPopoverHints`). */
+  warnings?: string[]
 }
 
 /** Labeled "Date & Time" `PanelCard divided`: Date row (drills into a `Calendar` page, pops on
@@ -238,6 +303,7 @@ export function EventDateTimeSection({
   use24Hour,
   disabled,
   defaultStartHour = 9,
+  warnings,
 }: EventDateTimeSectionProps) {
   const { gate } = useSeriesScope()
   const { push, pop } = useCommandNavigation<EventDrillItem>()
@@ -288,6 +354,7 @@ export function EventDateTimeSection({
         <PanelCardRow
           icon={<CalendarDays />}
           title='Date'
+          warnings={warnings}
           description={start ? format(start, 'PPP') : 'No date'}
           trailing={
             <div className='flex items-center gap-2'>
@@ -375,7 +442,13 @@ function TimeDrillPage({ start, end, commitTime, use24Hour }: TimeDrillPageProps
   const [local, setLocal] = React.useState({ start, end })
 
   const handleCommit = (which: 'start' | 'end', hours: number, minutes: number) => {
-    setLocal((prev) => commitTime(prev, which, hours, minutes))
+    // `commitTime` is NOT pure — it calls `gate()`, which for a series member does a
+    // `setPendingCommit()` on `SeriesScopeProvider`. Running it here (the TimeInput commit
+    // handler) keeps that side effect in an event handler. Doing it inside a `setLocal`
+    // updater instead ran it during render → "Cannot update a component while rendering a
+    // different component", which can make React drop the render and leave the panel stale.
+    const next = commitTime(local, which, hours, minutes)
+    setLocal(next)
   }
 
   return (
@@ -522,31 +595,6 @@ export function EventPeopleSection({
       />
       <EventDrillPage id='people'>{renderPicker(pop)}</EventDrillPage>
     </PanelCard>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// EventPopoverHints
-// ---------------------------------------------------------------------------
-
-interface EventPopoverHintsProps {
-  hints: string[]
-}
-
-/** Amber availability/overlap hints block rendered under the Date & Time card. `null` when
- * `hints` is empty. */
-export function EventPopoverHints({ hints }: EventPopoverHintsProps) {
-  if (hints.length === 0) return null
-
-  return (
-    <div className='space-y-1 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400'>
-      {hints.map((hint) => (
-        <div key={hint} className='flex items-center gap-1.5'>
-          <AlertTriangle className='size-3 shrink-0' />
-          {hint}
-        </div>
-      ))}
-    </div>
   )
 }
 

--- a/packages/ui/src/components/event-calendar/hooks/use-event-resize.ts
+++ b/packages/ui/src/components/event-calendar/hooks/use-event-resize.ts
@@ -8,34 +8,46 @@ import { useCallback, useRef, useState } from 'react'
 import { MinEventDurationMinutes, SnapMinutes } from '../constants'
 import type { EventCalendarItem } from '../types'
 
+/** Which edge of the chip the active resize gesture is dragging. */
+export type ResizeEdge = 'top' | 'bottom'
+
 interface UseEventResizeOptions<T extends EventCalendarItem> {
   event: T
   /** Pixels per hour (`WeekCellsHeight`) — used to translate pointer delta into minutes. */
   cellHeight: number
-  onResize?: (event: T, newEnd: Date) => void
+  onResize?: (event: T, newStart: Date, newEnd: Date) => void
+}
+
+interface ResizeHandleProps {
+  onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
+  onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void
+  onPointerUp: (e: React.PointerEvent<HTMLDivElement>) => void
+  onPointerCancel: (e: React.PointerEvent<HTMLDivElement>) => void
 }
 
 export interface UseEventResizeResult {
   isResizing: boolean
-  /** Live preview height (px) while dragging the handle — falls back to the chip's own height when idle. */
+  /** Live preview height (px) while dragging a handle — falls back to the chip's own height when idle. */
   previewHeight: number | null
-  resizeHandleProps: {
-    onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
-    onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void
-    onPointerUp: (e: React.PointerEvent<HTMLDivElement>) => void
-    onPointerCancel: (e: React.PointerEvent<HTMLDivElement>) => void
-  }
+  /**
+   * Live preview vertical offset (px) while dragging the TOP handle — the chip's top edge moves
+   * up/down (negative = up) so the bottom edge stays visually fixed. Always 0 for the bottom handle.
+   */
+  previewOffsetY: number
+  /** Returns the pointer handlers for one edge; the handler captures that edge on pointerdown. */
+  getResizeHandleProps: (edge: ResizeEdge) => ResizeHandleProps
 }
 
 /**
- * Bottom-edge resize handle for week/day/resource event chips.
+ * Two-edge resize handles for week/day/resource event chips: the top handle drags the start
+ * time, the bottom handle drags the end time — in both cases the OPPOSITE edge stays visually
+ * fixed.
  *
- * Deliberately NOT routed through dnd-kit — resize needs its own vertical-only
- * drag rooted at the chip's bottom edge, and layering a second dnd-kit
- * draggable on top of `DraggableEvent`'s existing move-drag is more fragile
- * than a plain pointer-capture handler scoped to the handle element. The
- * handle calls `e.stopPropagation()` on pointerdown so it never bubbles into
- * the parent chip's drag-move listeners.
+ * Deliberately NOT routed through dnd-kit — resize needs its own vertical-only drag rooted at a
+ * chip edge, and layering a second dnd-kit draggable on top of `DraggableEvent`'s existing
+ * move-drag is more fragile than a plain pointer-capture handler scoped to the handle element.
+ * The handle calls `e.stopPropagation()` on pointerdown so it never bubbles into the parent
+ * chip's drag-move listeners.
  */
 export function useEventResize<T extends EventCalendarItem>({
   event,
@@ -44,21 +56,23 @@ export function useEventResize<T extends EventCalendarItem>({
 }: UseEventResizeOptions<T>): UseEventResizeResult {
   const [isResizing, setIsResizing] = useState(false)
   const [previewHeight, setPreviewHeight] = useState<number | null>(null)
-  const startRef = useRef<{ pointerY: number; startHeight: number } | null>(null)
+  const [previewOffsetY, setPreviewOffsetY] = useState(0)
+  const startRef = useRef<{ pointerY: number; startHeight: number; edge: ResizeEdge } | null>(null)
 
   const pixelsPerMinute = cellHeight / 60
   const minHeight = MinEventDurationMinutes * pixelsPerMinute
 
   const handlePointerDown = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
+    (edge: ResizeEdge, e: React.PointerEvent<HTMLDivElement>) => {
       e.stopPropagation()
       e.preventDefault()
       e.currentTarget.setPointerCapture(e.pointerId)
       const duration = differenceInMinutes(new Date(event.end), new Date(event.start))
       const startHeight = duration * pixelsPerMinute
-      startRef.current = { pointerY: e.clientY, startHeight }
+      startRef.current = { pointerY: e.clientY, startHeight, edge }
       setIsResizing(true)
       setPreviewHeight(startHeight)
+      setPreviewOffsetY(0)
     },
     [event.start, event.end, pixelsPerMinute]
   )
@@ -67,9 +81,17 @@ export function useEventResize<T extends EventCalendarItem>({
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (!startRef.current) return
       e.stopPropagation()
-      const deltaY = e.clientY - startRef.current.pointerY
-      const rawHeight = startRef.current.startHeight + deltaY
-      setPreviewHeight(Math.max(minHeight, rawHeight))
+      const { pointerY, startHeight, edge } = startRef.current
+      const deltaY = e.clientY - pointerY
+      if (edge === 'bottom') {
+        setPreviewHeight(Math.max(minHeight, startHeight + deltaY))
+        setPreviewOffsetY(0)
+      } else {
+        // Top edge: growing the chip means its top moves up (negative offset), bottom stays put.
+        const nextHeight = Math.max(minHeight, startHeight - deltaY)
+        setPreviewHeight(nextHeight)
+        setPreviewOffsetY(startHeight - nextHeight)
+      }
     },
     [minHeight]
   )
@@ -78,19 +100,36 @@ export function useEventResize<T extends EventCalendarItem>({
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (!startRef.current) return
       e.stopPropagation()
-      const deltaY = e.clientY - startRef.current.pointerY
+      const { pointerY, edge } = startRef.current
+      const deltaY = e.clientY - pointerY
       const deltaMinutes = deltaY / pixelsPerMinute
-      const duration = differenceInMinutes(new Date(event.end), new Date(event.start))
-
-      let newDuration = Math.round((duration + deltaMinutes) / SnapMinutes) * SnapMinutes
-      newDuration = Math.max(MinEventDurationMinutes, newDuration)
+      const start = new Date(event.start)
+      const end = new Date(event.end)
+      const duration = differenceInMinutes(end, start)
 
       startRef.current = null
       setIsResizing(false)
       setPreviewHeight(null)
+      setPreviewOffsetY(0)
 
-      if (newDuration !== duration) {
-        onResize?.(event, addMinutes(new Date(event.start), newDuration))
+      if (edge === 'bottom') {
+        const newDuration = Math.max(
+          MinEventDurationMinutes,
+          Math.round((duration + deltaMinutes) / SnapMinutes) * SnapMinutes
+        )
+        if (newDuration !== duration) {
+          onResize?.(event, start, addMinutes(start, newDuration))
+        }
+      } else {
+        const snappedDelta = Math.round(deltaMinutes / SnapMinutes) * SnapMinutes
+        // Clamp so the remaining duration never drops below the minimum: newStart can be no
+        // later than `end - MinEventDurationMinutes`.
+        const maxStart = addMinutes(end, -MinEventDurationMinutes)
+        let newStart = addMinutes(start, snappedDelta)
+        if (newStart > maxStart) newStart = maxStart
+        if (newStart.getTime() !== start.getTime()) {
+          onResize?.(event, newStart, end)
+        }
       }
     },
     [event, pixelsPerMinute, onResize]
@@ -102,16 +141,23 @@ export function useEventResize<T extends EventCalendarItem>({
     startRef.current = null
     setIsResizing(false)
     setPreviewHeight(null)
+    setPreviewOffsetY(0)
   }, [])
+
+  const getResizeHandleProps = useCallback(
+    (edge: ResizeEdge): ResizeHandleProps => ({
+      onPointerDown: (e) => handlePointerDown(edge, e),
+      onPointerMove: handlePointerMove,
+      onPointerUp: finishResize,
+      onPointerCancel: cancelResize,
+    }),
+    [handlePointerDown, handlePointerMove, finishResize, cancelResize]
+  )
 
   return {
     isResizing,
     previewHeight,
-    resizeHandleProps: {
-      onPointerDown: handlePointerDown,
-      onPointerMove: handlePointerMove,
-      onPointerUp: finishResize,
-      onPointerCancel: cancelResize,
-    },
+    previewOffsetY,
+    getResizeHandleProps,
   }
 }

--- a/packages/ui/src/components/event-calendar/index.ts
+++ b/packages/ui/src/components/event-calendar/index.ts
@@ -31,8 +31,8 @@ export {
   EventDateTimeSection,
   EventPeopleSection,
   EventPopoverFooter,
-  EventPopoverHints,
   EventRepeatSection,
+  type EventTitleAction,
   EventTitleSection,
 } from './event-popover/event-popover-sections'
 export { formatTimeOfDay, parseTimeInput } from './event-popover/parse-time'

--- a/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
@@ -63,7 +63,7 @@ interface ResourceTimelineViewProps<T extends EventCalendarItem = EventCalendarI
   desiredDays?: number
   onEventSelect: (event: T) => void
   onSlotClick?: (startTime: Date, resourceId: string) => void
-  onEventResize?: (event: T, newEnd: Date) => void
+  onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
   /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
   selectedEventId?: string | null

--- a/packages/ui/src/components/event-calendar/week-day-column.tsx
+++ b/packages/ui/src/components/event-calendar/week-day-column.tsx
@@ -32,7 +32,7 @@ interface WeekDayColumnProps<T extends EventCalendarItem = EventCalendarItem> {
   backgroundEvents: BackgroundEvent[]
   onEventSelect: (event: T) => void
   onSlotClick?: (startTime: Date) => void
-  onEventResize?: (event: T, newEnd: Date) => void
+  onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
   /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
   selectedEventId?: string | null

--- a/packages/ui/src/components/event-calendar/week-view.tsx
+++ b/packages/ui/src/components/event-calendar/week-view.tsx
@@ -54,7 +54,7 @@ interface WeekViewProps<T extends EventCalendarItem = EventCalendarItem> {
   backgroundEvents?: BackgroundEvent[]
   onEventSelect: (event: T) => void
   onSlotClick?: (startTime: Date) => void
-  onEventResize?: (event: T, newEnd: Date) => void
+  onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
   /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
   selectedEventId?: string | null

--- a/packages/ui/src/components/panel-card.tsx
+++ b/packages/ui/src/components/panel-card.tsx
@@ -3,8 +3,50 @@
 'use client'
 
 import { cn } from '@auxx/ui/lib/utils'
-import { ChevronsUpDown } from 'lucide-react'
+import { AlertTriangle, ChevronsUpDown } from 'lucide-react'
 import type * as React from 'react'
+import { SimpleTooltip } from './tooltip'
+
+type WarningType = 'warning' | 'error'
+
+const warningTone = (type: WarningType) =>
+  type === 'error'
+    ? {
+        icon: 'bg-red-500/15 text-red-600 dark:text-red-400',
+        title: 'text-red-600 dark:text-red-400',
+      }
+    : {
+        icon: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+        title: 'text-amber-600 dark:text-amber-500',
+      }
+
+/**
+ * Circular warning/error icon that replaces a `PanelCardRow`'s leading icon when the row carries
+ * `warnings`. The messages surface in a hover tooltip. Rendering inline (rather than a floating
+ * corner badge) keeps the row height stable — a late-arriving async hint only swaps the icon and
+ * re-tints the title, so it never reflows the panel.
+ */
+function PanelWarningIcon({ messages, type }: { messages: string[]; type: WarningType }) {
+  return (
+    <SimpleTooltip
+      variant={type === 'error' ? 'destructive' : 'default'}
+      contentComponent={
+        <ul className='max-w-2xs space-y-0.5'>
+          {messages.map((message) => (
+            <li key={message}>{message}</li>
+          ))}
+        </ul>
+      }>
+      <span
+        className={cn(
+          'mt-0.5 flex size-4.5 shrink-0 items-center justify-center rounded-full [&_svg]:size-3',
+          warningTone(type).icon
+        )}>
+        <AlertTriangle />
+      </span>
+    </SimpleTooltip>
+  )
+}
 
 interface PanelShellProps {
   /** Adds the popover-less chrome (`rounded-3xl shadow-xl ring-1 ring-border bg-popover`).
@@ -28,23 +70,22 @@ function PanelShell({ standalone, className, children }: PanelShellProps) {
   )
 }
 
-interface PanelCardProps {
-  className?: string
+interface PanelCardProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Adds a top border + top padding to every row after the first, so rows never need to
    * track their own "am I first" flag. */
   divided?: boolean
-  children: React.ReactNode
 }
 
 /** A single rounded card grouping one or more `PanelCardRow`s. */
-function PanelCard({ className, divided, children }: PanelCardProps) {
+function PanelCard({ className, divided, children, ...props }: PanelCardProps) {
   return (
     <div
       className={cn(
-        'relative rounded-2xl border border-border/50 bg-muted/40 p-4',
+        'relative rounded-2xl border border-border/50 bg-muted/40 p-2',
         divided && 'space-y-3 [&>*+*]:border-t [&>*+*]:border-border/50 [&>*+*]:pt-3',
         className
-      )}>
+      )}
+      {...props}>
       {children}
     </div>
   )
@@ -57,6 +98,10 @@ interface PanelCardRowProps {
   trailing?: React.ReactNode
   className?: string
   onClick?: () => void
+  /** When non-empty, the row's leading icon is replaced by a circular warning icon and the title
+   * is re-tinted; the messages surface in a hover tooltip. Swaps in place — no layout shift. */
+  warnings?: string[]
+  warningType?: WarningType
 }
 
 /**
@@ -71,8 +116,11 @@ function PanelCardRow({
   trailing,
   className,
   onClick,
+  warnings,
+  warningType = 'warning',
 }: PanelCardRowProps) {
   const interactive = Boolean(onClick)
+  const hasWarning = Boolean(warnings && warnings.length > 0)
 
   return (
     <div
@@ -95,9 +143,15 @@ function PanelCardRow({
           'cursor-pointer rounded-lg focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring/50',
         className
       )}>
-      {icon && <span className='mt-0.5 shrink-0 text-foreground/50 [&_svg]:size-4.5'>{icon}</span>}
+      {hasWarning ? (
+        <PanelWarningIcon messages={warnings!} type={warningType} />
+      ) : (
+        icon && <span className='mt-0.5 shrink-0 text-foreground/50 [&_svg]:size-4.5'>{icon}</span>
+      )}
       <div className='min-w-0 flex-1'>
-        <div className='text-sm font-medium'>{title}</div>
+        <div className={cn('text-sm font-medium', hasWarning && warningTone(warningType).title)}>
+          {title}
+        </div>
         {description && <div className='text-muted-foreground text-xs'>{description}</div>}
       </div>
       {trailing && <div className='ml-auto shrink-0'>{trailing}</div>}

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -211,37 +211,14 @@
   inset: 0;
   flex: none;
 }
+/* The dock opens once (the column's width tween); switching the selected event only swaps the
+   body, so a slide-in would read as a second "opening". A quick cross-fade keeps it a content
+   swap. First mount has no exiting layer, so nothing animates when the panel first opens. */
 .auxx-dock-frame--entering {
-  animation: auxx-dock-frame-slide-in-right 280ms var(--auxx-dock-ease) both;
+  animation: auxx-dock-frame-fade-in 140ms ease-out both;
 }
 .auxx-dock-frame--exiting {
-  animation: auxx-dock-frame-slide-out-left 280ms var(--auxx-dock-ease) both;
-}
-@keyframes auxx-dock-frame-slide-in-right {
-  from {
-    transform: translateX(100%);
-  }
-  to {
-    transform: translateX(0);
-  }
-}
-@keyframes auxx-dock-frame-slide-out-left {
-  from {
-    transform: translateX(0);
-    opacity: 1;
-  }
-  to {
-    transform: translateX(-30%);
-    opacity: 0;
-  }
-}
-@media (prefers-reduced-motion: reduce) {
-  .auxx-dock-frame--entering {
-    animation: auxx-dock-frame-fade-in 120ms ease-out both;
-  }
-  .auxx-dock-frame--exiting {
-    animation: auxx-dock-frame-fade-out 120ms ease-out both;
-  }
+  animation: auxx-dock-frame-fade-out 140ms ease-out both;
 }
 @keyframes auxx-dock-frame-fade-in {
   from {


### PR DESCRIPTION
Pure-UI follow-up to the dockable event panel (plan 21, #1175). No schema, no backend — safe to review/merge independently.

## Changes
- **Two-edge resize** — `use-event-resize` now returns `newStart` **and** `newEnd`; `board-calendar-grid` + `dispatch-board` thread the new start through `scheduleVisit` (previously start was pinned).
- **Dock animation** — event swap cross-fades instead of sliding, so switching the selected event reads as a content swap rather than a second "open" (`global.css`, `dock-panel`).
- **Sticky dock** — `event-dock-panel` `onClose` is a no-op in dock mode so opening a work order/contact keeps the event selected (plan 21 decision #3).
- **Popover** — `EventPopoverHints` folded into `EventDateTimeSection` `warnings`; new `EventTitleAction`; `visit-popover` / `schedule-popover` updated to match.
- Layout polish in `panel-card`.

## Notes
Files are disjoint from the client-notifications/sequences/signals branch, which carries all migrations.