### PR TITLE
perf(dispatch): reduce board query traffic

### DIFF
--- a/apps/web/src/components/availability/ui/availability-settings-page.tsx
+++ b/apps/web/src/components/availability/ui/availability-settings-page.tsx
@@ -25,6 +25,7 @@ import { SettingsFieldRow } from '~/components/settings/settings-field-row'
 import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 
 const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6] as const
@@ -86,18 +87,26 @@ export function AvailabilitySettingsPage() {
   const { getSetting } = useSettings({ scope: 'GENERAL' })
 
   const utils = api.useUtils()
-  const weeklyQuery = api.availability.getWeeklyHours.useQuery({
-    subject: { type: 'organization' },
-  })
+  const weeklyQuery = api.availability.getWeeklyHours.useQuery(
+    {
+      subject: { type: 'organization' },
+    },
+    { staleTime: ORG_STATIC_STALE_TIME }
+  )
 
   const saveWeeklyHours = api.availability.saveWeeklyHours.useMutation({
     onSuccess: () => {
-      utils.availability.getWeeklyHours.invalidate({ subject: { type: 'organization' } })
+      utils.availability.getWeeklyHours.invalidate({
+        subject: { type: 'organization' },
+      })
       // Org hours drive every column (workers inherit the org default) — drop the whole board cache.
       useAvailabilityCacheStore.getState().invalidateAll()
     },
     onError: (error) =>
-      toastError({ title: 'Error saving weekly hours', description: error.message }),
+      toastError({
+        title: 'Error saving weekly hours',
+        description: error.message,
+      }),
   })
 
   // Rebuilt each render; `useDirtyDraft` reseeds by value, so a background refetch never wipes edits.
@@ -105,7 +114,10 @@ export function AvailabilitySettingsPage() {
   const { draft, patch, setDraft, dirty, save, discard } = useDirtyDraft(server, {
     isSaving: saveWeeklyHours.isPending,
     onSave: (next) =>
-      saveWeeklyHours.mutate({ subject: { type: 'organization' }, weekly: toWeeklyHours(next) }),
+      saveWeeklyHours.mutate({
+        subject: { type: 'organization' },
+        weekly: toWeeklyHours(next),
+      }),
   })
 
   const weekStart = (scalarSetting(getSetting('organization.weekStart')) ?? 'monday') as
@@ -155,7 +167,10 @@ export function AvailabilitySettingsPage() {
                 <TimeZonePicker
                   selected={draft.timezone}
                   onChange={(timezone) => patch({ timezone })}
-                  triggerProps={{ variant: 'transparent', className: 'w-full ps-0 pe-1' }}
+                  triggerProps={{
+                    variant: 'transparent',
+                    className: 'w-full ps-0 pe-1',
+                  }}
                 />
               </FieldPanelRow>
             )}

--- a/apps/web/src/components/dispatch/stores/use-resolved-days.ts
+++ b/apps/web/src/components/dispatch/stores/use-resolved-days.ts
@@ -1,0 +1,94 @@
+// apps/web/src/components/dispatch/stores/use-resolved-days.ts
+'use client'
+
+import { useEffect, useMemo, useRef } from 'react'
+import { api } from '~/trpc/react'
+import { chunkRange, type DateRange, subtractRanges } from '../utils/date-ranges'
+import {
+  type AvailabilitySubject,
+  availabilitySubjectKey,
+  type ResolvedDay,
+  useAvailabilityCacheStore,
+} from './availability-cache-store'
+
+/** `availability.resolve` hard-caps at 366 days; keep requests comfortably below that limit. */
+const MAX_FETCH_DAYS = 180
+
+/** A subject paired with its stable cache key. */
+interface ResolvedDaysSubject {
+  key: string
+  subject: AvailabilitySubject
+}
+
+/** Creates a cache-addressable subject entry. */
+function toResolvedDaysSubject(subject: AvailabilitySubject): ResolvedDaysSubject {
+  return { key: availabilitySubjectKey(subject), subject }
+}
+
+/** Returns a stable signature so equivalent subject arrays do not restart the fetch effect. */
+function subjectSignature(subjects: ResolvedDaysSubject[]): string {
+  return subjects.map(({ key }) => key).join(',')
+}
+
+/**
+ * Reads resolved availability days from the shared store and fetches only uncovered gaps for the
+ * supplied subjects/range. This is the single client-side path for availability.resolve consumers.
+ */
+export function useResolvedDaysForSubjects(
+  subjects: AvailabilitySubject[],
+  fromIso: string,
+  toIso: string
+): Record<string, ResolvedDay[]> {
+  const utils = api.useUtils()
+  const cacheSubjects = useAvailabilityCacheStore((state) => state.subjects)
+  const ingestResolved = useAvailabilityCacheStore((state) => state.ingestResolved)
+  const inFlight = useRef(new Set<string>())
+  const range = useMemo<DateRange>(() => ({ from: fromIso, to: toIso }), [fromIso, toIso])
+  const entries = useMemo(() => subjects.map(toResolvedDaysSubject), [subjects])
+  const signature = subjectSignature(entries)
+
+  useEffect(() => {
+    for (const { key, subject } of entries) {
+      const loaded = cacheSubjects[key]?.loadedRanges ?? []
+      const gaps = subtractRanges(range, loaded).flatMap((gap) => chunkRange(gap, MAX_FETCH_DAYS))
+      for (const gap of gaps) {
+        const tag = `${key}:${gap.from}:${gap.to}`
+        if (inFlight.current.has(tag)) continue
+        inFlight.current.add(tag)
+        utils.availability.resolve
+          .fetch({ subject, from: gap.from, to: gap.to })
+          .then((days) => ingestResolved(key, gap, days))
+          .catch(() => {})
+          .finally(() => inFlight.current.delete(tag))
+      }
+    }
+  }, [cacheSubjects, entries, ingestResolved, range, signature, utils])
+
+  return useMemo(
+    () =>
+      Object.fromEntries(
+        entries.map(({ key }) => [
+          key,
+          Object.values(cacheSubjects[key]?.days ?? {}).filter(
+            (day) => day.date >= fromIso && day.date <= toIso
+          ),
+        ])
+      ),
+    [cacheSubjects, entries, fromIso, toIso]
+  )
+}
+
+/**
+ * Convenience wrapper for a single subject. Pass `null` while the subject is unknown to avoid a
+ * placeholder request; it returns no days until a real subject is supplied.
+ */
+export function useResolvedDays(
+  subject: AvailabilitySubject | null,
+  fromIso: string | undefined,
+  toIso: string | undefined
+): ResolvedDay[] {
+  const subjects = useMemo(() => (subject ? [subject] : []), [subject])
+  const resolved = useResolvedDaysForSubjects(subjects, fromIso ?? '', toIso ?? '')
+  const key = subject ? availabilitySubjectKey(subject) : ''
+  return resolved[key] ?? []
+}

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -59,7 +59,7 @@ export function DispatchBoard() {
 
   const data = useBoardData()
   const mutations = useBoardMutations(data.range)
-  useBoardRealtime(data.range)
+  useBoardRealtime()
 
   // Route planner data (09-route-planner.md §A) lives here, not inside `RoutePlannerView`
   // itself — the sidebar's Tags group needs the same distinct-tags list and selection the map

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-availability-shading.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-availability-shading.ts
@@ -12,14 +12,16 @@ import {
   subMonths,
   subWeeks,
 } from 'date-fns'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 import {
   type AvailabilitySubject,
   availabilitySubjectKey,
   useAvailabilityCacheStore,
 } from '../../../stores/availability-cache-store'
-import { chunkRange, type DateRange as IsoRange, subtractRanges } from '../../../utils/date-ranges'
+import { useResolvedDaysForSubjects } from '../../../stores/use-resolved-days'
+import type { DateRange as IsoRange } from '../../../utils/date-ranges'
 import type { BoardViewMode } from '../types'
 import { UNASSIGNED_RESOURCE_ID } from '../types'
 import { offHoursBackgroundEvents } from '../utils'
@@ -27,9 +29,6 @@ import type { DateRange } from './use-board-data'
 
 const ORG_KEY = availabilitySubjectKey({ type: 'organization' })
 const workerKey = (userId: string) => availabilitySubjectKey({ type: 'worker', userId })
-/** `availability.resolve` hard-caps at 366 days; chunk well under it. */
-const MAX_FETCH_DAYS = 180
-
 /**
  * Availability shading (07 §D.2 · 12-availability-cache.md), redesigned onto a client cache: instead
  * of re-querying `availability.resolve` for each visible window, we over-fetch a 3-month window,
@@ -47,15 +46,19 @@ export function useAvailabilityShading({
   view: BoardViewMode
   range: DateRange
   workerUserIds: string[]
-}): { backgroundEvents: BackgroundEvent[]; isNonWorkingDay: (date: Date) => boolean } {
-  const utils = api.useUtils()
+}): {
+  backgroundEvents: BackgroundEvent[]
+  isNonWorkingDay: (date: Date) => boolean
+} {
   const subjects = useAvailabilityCacheStore((s) => s.subjects)
-  const ingestResolved = useAvailabilityCacheStore((s) => s.ingestResolved)
   const setWeeklyWorkingDays = useAvailabilityCacheStore((s) => s.setWeeklyWorkingDays)
 
   // Instant baseline — the org's weekly working-days (persisted; drives `isNonWorkingDay` before any
   // resolve returns). Cached by React Query; we mirror it into the store on every result.
-  const orgWeekly = api.availability.getWeeklyHours.useQuery({ subject: { type: 'organization' } })
+  const orgWeekly = api.availability.getWeeklyHours.useQuery(
+    { subject: { type: 'organization' } },
+    { staleTime: ORG_STATIC_STALE_TIME }
+  )
   useEffect(() => {
     if (orgWeekly.data === undefined) return
     setWeeklyWorkingDays(
@@ -79,30 +82,20 @@ export function useAvailabilityShading({
     ]
     if (view === 'day' || view === 'timeline') {
       for (const userId of workerUserIds) {
-        list.push({ key: workerKey(userId), subject: { type: 'worker', userId } })
+        list.push({
+          key: workerKey(userId),
+          subject: { type: 'worker', userId },
+        })
       }
     }
     return list
   }, [view, workerUserIds])
 
-  // Gap-only fetch: for each subject, resolve only the parts of `fetchWindow` not already loaded.
-  const inFlight = useRef(new Set<string>())
-  useEffect(() => {
-    for (const { key, subject } of subjectList) {
-      const loaded = subjects[key]?.loadedRanges ?? []
-      const gaps = subtractRanges(fetchWindow, loaded).flatMap((g) => chunkRange(g, MAX_FETCH_DAYS))
-      for (const gap of gaps) {
-        const tag = `${key}:${gap.from}:${gap.to}`
-        if (inFlight.current.has(tag)) continue
-        inFlight.current.add(tag)
-        utils.availability.resolve
-          .fetch({ subject, from: gap.from, to: gap.to })
-          .then((days) => ingestResolved(key, gap, days))
-          .catch(() => {})
-          .finally(() => inFlight.current.delete(tag))
-      }
-    }
-  }, [subjectList, fetchWindow, subjects, utils, ingestResolved])
+  useResolvedDaysForSubjects(
+    subjectList.map(({ subject }) => subject),
+    fetchWindow.from,
+    fetchWindow.to
+  )
 
   // Shading reads from the cache for the VISIBLE range (the calendar filters bands per day anyway).
   const fromIso = format(range.from, 'yyyy-MM-dd')

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
@@ -6,6 +6,7 @@ import { getOptionColorHex } from '@auxx/lib/custom-fields/client'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useMemo } from 'react'
 import { useCalendarRange } from '~/components/calendar/core/use-calendar-range'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 import { useHiddenWorkerIds } from '../../../stores/dispatch-sidebar-store'
 import {
@@ -55,7 +56,7 @@ export function useBoardData() {
 
   const boardQuery = api.dispatch.getBoard.useQuery(
     { from: range.from, to: range.to },
-    { placeholderData: (prev) => prev }
+    { placeholderData: (prev) => prev, staleTime: ORG_STATIC_STALE_TIME }
   )
 
   const allWorkers: BoardWorker[] = boardQuery.data?.workers ?? []
@@ -112,14 +113,24 @@ export function useBoardData() {
   }, [allEvents, view, visibleWorkerUserIds, showUnassigned])
 
   const backlogEvents = useMemo(
-    () => backlog.map((v) => ({ visit: v, workOrder: workOrderById.get(v.workOrderId) })),
+    () =>
+      backlog.map((v) => ({
+        visit: v,
+        workOrder: workOrderById.get(v.workOrderId),
+      })),
     [backlog, workOrderById]
   )
 
   const resources: BoardResourceInput[] = useMemo(
     () => [
       ...(showUnassigned
-        ? [{ id: UNASSIGNED_RESOURCE_ID, label: 'Unassigned', color: UNASSIGNED_COLOR }]
+        ? [
+            {
+              id: UNASSIGNED_RESOURCE_ID,
+              label: 'Unassigned',
+              color: UNASSIGNED_COLOR,
+            },
+          ]
         : []),
       ...workers.map((w) => ({
         id: w.userId,

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
@@ -41,7 +41,7 @@ export function useBoardMutations(range: DateRange) {
   )
 
   const settle = useCallback(() => {
-    void utils.dispatch.getBoard.invalidate(range)
+    void utils.dispatch.getBoard.invalidate()
     // v3 sidebar plan §1.4 — keep the mini-calendar's day-marker dots fresh alongside the board.
     void utils.dispatch.getVisitDayMarkers.invalidate()
   }, [range, utils])
@@ -49,13 +49,19 @@ export function useBoardMutations(range: DateRange) {
   const scheduleVisit = api.dispatch.scheduleVisit.useMutation({
     onMutate: async (vars) => {
       await utils.dispatch.getBoard.cancel(range)
-      const patch: Partial<BoardVisit> = { startTime: vars.startTime, endTime: vars.endTime }
+      const patch: Partial<BoardVisit> = {
+        startTime: vars.startTime,
+        endTime: vars.endTime,
+      }
       if (vars.assigneeUserId !== undefined) patch.assigneeUserId = vars.assigneeUserId
       return { previous: patchVisit(vars.visitId, patch) }
     },
     onError: (error, _vars, ctx) => {
       rollback(ctx?.previous)
-      toastError({ title: 'Error scheduling visit', description: error.message })
+      toastError({
+        title: 'Error scheduling visit',
+        description: error.message,
+      })
     },
     onSettled: settle,
   })
@@ -63,11 +69,16 @@ export function useBoardMutations(range: DateRange) {
   const unscheduleVisit = api.dispatch.unscheduleVisit.useMutation({
     onMutate: async (vars) => {
       await utils.dispatch.getBoard.cancel(range)
-      return { previous: patchVisit(vars.visitId, { startTime: null, endTime: null }) }
+      return {
+        previous: patchVisit(vars.visitId, { startTime: null, endTime: null }),
+      }
     },
     onError: (error, _vars, ctx) => {
       rollback(ctx?.previous)
-      toastError({ title: 'Error unscheduling visit', description: error.message })
+      toastError({
+        title: 'Error unscheduling visit',
+        description: error.message,
+      })
     },
     onSettled: settle,
   })
@@ -79,7 +90,10 @@ export function useBoardMutations(range: DateRange) {
     },
     onError: (error, _vars, ctx) => {
       rollback(ctx?.previous)
-      toastError({ title: 'Error updating visit status', description: error.message })
+      toastError({
+        title: 'Error updating visit status',
+        description: error.message,
+      })
     },
     onSettled: settle,
   })
@@ -87,11 +101,16 @@ export function useBoardMutations(range: DateRange) {
   const dispatchVisit = api.dispatch.dispatchVisit.useMutation({
     onMutate: async (vars) => {
       await utils.dispatch.getBoard.cancel(range)
-      return { previous: patchVisit(vars.visitId, { dispatchedAt: new Date() }) }
+      return {
+        previous: patchVisit(vars.visitId, { dispatchedAt: new Date() }),
+      }
     },
     onError: (error, _vars, ctx) => {
       rollback(ctx?.previous)
-      toastError({ title: 'Error dispatching visit', description: error.message })
+      toastError({
+        title: 'Error dispatching visit',
+        description: error.message,
+      })
     },
     onSettled: settle,
   })
@@ -101,7 +120,10 @@ export function useBoardMutations(range: DateRange) {
   // repaints every affected chip once the write lands.
   const applyToSeries = api.dispatch.applyToSeries.useMutation({
     onError: (error) => {
-      toastError({ title: 'Error updating series', description: error.message })
+      toastError({
+        title: 'Error updating series',
+        description: error.message,
+      })
     },
     onSettled: settle,
   })

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-realtime.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-realtime.ts
@@ -5,26 +5,25 @@
 import { useCallback } from 'react'
 import { useOrgChannel } from '~/realtime/hooks'
 import { api } from '~/trpc/react'
-import type { DateRange } from './use-board-data'
 
 /**
  * Live board updates (07 §D.5, the `use-eval-cases-realtime.ts` recipe): any
- * `dispatch:visit-changed` broadcast for the org invalidates `dispatch.getBoard` for the
- * current range. The acting client's own writes are excluded server-side via the
+ * `dispatch:visit-changed` broadcast for the org invalidates every cached `dispatch.getBoard`
+ * range. The acting client's own writes are excluded server-side via the
  * `x-realtime-socket-id` header (attached globally by the tRPC client link), so this never
  * double-patches the tab that made the change — only other tabs/users refetch.
  */
-export function useBoardRealtime(range: DateRange) {
+export function useBoardRealtime() {
   const utils = api.useUtils()
 
   const onEvent = useCallback(
     (event: string) => {
       if (event !== 'dispatch:visit-changed') return
-      void utils.dispatch.getBoard.invalidate(range)
+      void utils.dispatch.getBoard.invalidate()
       // v3 sidebar plan §1.4 — the mini-calendar's day-marker dots follow the same broadcast.
       void utils.dispatch.getVisitDayMarkers.invalidate()
     },
-    [range, utils]
+    [utils]
   )
 
   useOrgChannel({ onEvent })

--- a/apps/web/src/components/dispatch/ui/job-schedule/recurring-engagement-card.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/recurring-engagement-card.tsx
@@ -12,6 +12,7 @@ import { DetailSectionActions, DetailSectionTitleExtra } from '~/components/deta
 import type { RecordId } from '~/components/resources'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useSettings } from '~/hooks/use-settings'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 import { scalarSetting } from '../recurrence/recurrence-utils'
 import { type ExistingVisitForOverlap, SchedulePopover } from '../schedule-popover'
@@ -61,7 +62,10 @@ export function RecurringEngagementCard({
     | 'sunday'
     | 'saturday'
 
-  const ruleQuery = api.dispatch.getRecurrence.useQuery({ workOrderRecordId: recordId })
+  const ruleQuery = api.dispatch.getRecurrence.useQuery(
+    { workOrderRecordId: recordId },
+    { staleTime: ORG_STATIC_STALE_TIME }
+  )
 
   const summary = useMemo(() => {
     if (!ruleQuery.data) return null
@@ -71,23 +75,34 @@ export function RecurringEngagementCard({
   }, [ruleQuery.data, weekStart])
 
   const invalidate = () => {
-    void utils.dispatch.getRecurrence.invalidate({ workOrderRecordId: recordId })
+    void utils.dispatch.getRecurrence.invalidate({
+      workOrderRecordId: recordId,
+    })
     onRefresh()
   }
 
   const pauseEngagement = api.dispatch.pauseEngagement.useMutation({
     onError: (error) =>
-      toastError({ title: 'Error pausing engagement', description: error.message }),
+      toastError({
+        title: 'Error pausing engagement',
+        description: error.message,
+      }),
     onSuccess: invalidate,
   })
   const resumeEngagement = api.dispatch.resumeEngagement.useMutation({
     onError: (error) =>
-      toastError({ title: 'Error resuming engagement', description: error.message }),
+      toastError({
+        title: 'Error resuming engagement',
+        description: error.message,
+      }),
     onSuccess: invalidate,
   })
   const endEngagement = api.dispatch.endEngagement.useMutation({
     onError: (error) =>
-      toastError({ title: 'Error ending engagement', description: error.message }),
+      toastError({
+        title: 'Error ending engagement',
+        description: error.message,
+      }),
     onSuccess: invalidate,
   })
 

--- a/apps/web/src/components/dispatch/ui/route-planner/pin-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/route-planner/pin-popover.tsx
@@ -19,6 +19,7 @@ import { useMemo, useState } from 'react'
 import { getInitials } from '~/components/groups/utils/group-utils'
 import { ActorPickerContent } from '~/components/pickers/actor-picker/actor-picker-content'
 import { useActors, useAvailableActors } from '~/components/resources/hooks/use-actor'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 import { stopsForWorker, useRoutePlannerMutations } from './hooks/use-route-planner-mutations'
 import type { PlannerBoard, PlannerDayWindow, PlannerVisit } from './types'
@@ -47,7 +48,11 @@ export function PinPopoverContent({ visit, board, onClose }: PinPopoverContentPr
 
   const dayWindow = useMemo((): PlannerDayWindow => {
     const anchor = visit.startTime ? new Date(visit.startTime) : new Date()
-    return { from: startOfDay(anchor), to: endOfDay(anchor), dateKey: format(anchor, 'yyyy-MM-dd') }
+    return {
+      from: startOfDay(anchor),
+      to: endOfDay(anchor),
+      dateKey: format(anchor, 'yyyy-MM-dd'),
+    }
   }, [visit.startTime])
 
   const { setRouteOrder, assignVisit } = useRoutePlannerMutations(dayWindow)
@@ -57,7 +62,9 @@ export function PinPopoverContent({ visit, board, onClose }: PinPopoverContentPr
   const stops = assigneeUserId ? stopsForWorker(board, assigneeUserId) : []
   const currentIndex = stops.findIndex((v) => v.id === visit.id)
 
-  const workersQuery = api.dispatch.listWorkers.useQuery()
+  const workersQuery = api.dispatch.listWorkers.useQuery(undefined, {
+    staleTime: ORG_STATIC_STALE_TIME,
+  })
   const activeWorkers = useMemo(
     () => (workersQuery.data ?? []).filter((w) => w.isActive),
     [workersQuery.data]
@@ -84,7 +91,11 @@ export function PinPopoverContent({ visit, board, onClose }: PinPopoverContentPr
       { assigneeUserId, from: dayWindow.from, to: dayWindow.to, visitIds },
       {
         onSuccess: onClose,
-        onError: (error) => toastError({ title: 'Error moving stop', description: error.message }),
+        onError: (error) =>
+          toastError({
+            title: 'Error moving stop',
+            description: error.message,
+          }),
       }
     )
   }
@@ -97,7 +108,10 @@ export function PinPopoverContent({ visit, board, onClose }: PinPopoverContentPr
       {
         onSuccess: onClose,
         onError: (error) =>
-          toastError({ title: 'Error removing stop from route', description: error.message }),
+          toastError({
+            title: 'Error removing stop from route',
+            description: error.message,
+          }),
       }
     )
   }
@@ -121,7 +135,10 @@ export function PinPopoverContent({ visit, board, onClose }: PinPopoverContentPr
           onClose()
         },
         onError: (error) =>
-          toastError({ title: 'Error reassigning visit', description: error.message }),
+          toastError({
+            title: 'Error reassigning visit',
+            description: error.message,
+          }),
       }
     )
   }

--- a/apps/web/src/components/dispatch/ui/shared/use-recurrence-editor.ts
+++ b/apps/web/src/components/dispatch/ui/shared/use-recurrence-editor.ts
@@ -11,6 +11,7 @@ import { differenceInMinutes, format } from 'date-fns'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { RecordId } from '~/components/resources'
 import { useSettings } from '~/hooks/use-settings'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 import {
   buildPresetPattern,
@@ -62,7 +63,7 @@ export function useRecurrenceEditor({
 
   const recurrenceQuery = api.dispatch.getRecurrence.useQuery(
     { workOrderRecordId: workOrderRecordId as RecordId },
-    { enabled: Boolean(workOrderRecordId) }
+    { enabled: Boolean(workOrderRecordId), staleTime: ORG_STATIC_STALE_TIME }
   )
   const hasExistingRule = Boolean(recurrenceQuery.data)
 

--- a/apps/web/src/components/dispatch/ui/shared/use-schedule-hints.ts
+++ b/apps/web/src/components/dispatch/ui/shared/use-schedule-hints.ts
@@ -2,7 +2,7 @@
 
 import { format } from 'date-fns'
 import { useMemo } from 'react'
-import { api } from '~/trpc/react'
+import { useResolvedDays } from '../../stores/use-resolved-days'
 import type { ExistingVisitForOverlap } from '../schedule-popover'
 
 export interface UseScheduleHintsParams {
@@ -27,18 +27,15 @@ export function useScheduleHints({
   existingVisits,
 }: UseScheduleHintsParams): string[] {
   const dayIso = startTime ? format(startTime, 'yyyy-MM-dd') : undefined
-  const availabilityQuery = api.availability.resolve.useQuery(
-    {
-      subject: { type: 'worker', userId: assigneeUserId ?? '' },
-      from: dayIso ?? '',
-      to: dayIso ?? '',
-    },
-    { enabled: Boolean(assigneeUserId && dayIso) }
+  const resolvedDays = useResolvedDays(
+    assigneeUserId && dayIso ? { type: 'worker', userId: assigneeUserId } : null,
+    dayIso,
+    dayIso
   )
 
   return useMemo(() => {
     const list: string[] = []
-    const resolvedDay = availabilityQuery.data?.[0]
+    const resolvedDay = resolvedDays[0]
     if (resolvedDay) {
       if (resolvedDay.ranges.length === 0) {
         list.push('Off that day')
@@ -61,5 +58,5 @@ export function useScheduleHints({
       }
     }
     return list
-  }, [availabilityQuery.data, startTime, endTime, assigneeUserId, existingVisits, visitId])
+  }, [resolvedDays, startTime, endTime, assigneeUserId, existingVisits, visitId])
 }

--- a/apps/web/src/components/dispatch/ui/shared/use-worker-actor-excludes.ts
+++ b/apps/web/src/components/dispatch/ui/shared/use-worker-actor-excludes.ts
@@ -3,6 +3,7 @@
 import { type ActorId, getActorRawId } from '@auxx/types/actor'
 import { useMemo } from 'react'
 import { useAvailableActors } from '~/components/resources/hooks/use-actor'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 
 /**
@@ -11,7 +12,9 @@ import { api } from '~/trpc/react'
  * Assignee row, so every other `user` actor is excluded from `ActorPickerContent`.
  */
 export function useWorkerActorExcludes(): ActorId[] {
-  const workersQuery = api.dispatch.listWorkers.useQuery()
+  const workersQuery = api.dispatch.listWorkers.useQuery(undefined, {
+    staleTime: ORG_STATIC_STALE_TIME,
+  })
   const activeWorkers = useMemo(
     () => (workersQuery.data ?? []).filter((w) => w.isActive),
     [workersQuery.data]

--- a/apps/web/src/components/dispatch/ui/sidebar/hooks/use-mini-calendar-density.ts
+++ b/apps/web/src/components/dispatch/ui/sidebar/hooks/use-mini-calendar-density.ts
@@ -4,6 +4,7 @@
 
 import { endOfMonth, endOfWeek, format, startOfMonth, startOfWeek } from 'date-fns'
 import { useMemo } from 'react'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 import type { WeekStartIndex } from '../../board/utils'
 import { isWorkerHidden } from '../../board/utils'
@@ -30,7 +31,10 @@ export function useMiniCalendarDensity(
     return new Date(inclusiveEnd.getTime() + 24 * 60 * 60 * 1000) // exclusive end for the query
   }, [displayMonth, weekStartsOn])
 
-  const query = api.dispatch.getVisitDayMarkers.useQuery({ from, to })
+  const query = api.dispatch.getVisitDayMarkers.useQuery(
+    { from, to },
+    { staleTime: ORG_STATIC_STALE_TIME }
+  )
 
   const density = useMemo(() => {
     const map: Record<string, number> = {}

--- a/apps/web/src/components/dispatch/ui/worker-hours-page.tsx
+++ b/apps/web/src/components/dispatch/ui/worker-hours-page.tsx
@@ -16,6 +16,7 @@ import {
 } from '~/components/availability/ui/weekly-hours-editor'
 import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
 import { useConfirm } from '~/hooks/use-confirm'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 import {
   availabilitySubjectKey,
@@ -84,8 +85,14 @@ export function WorkerHoursPage({ userId, weekStartsOn, use24HourTime }: WorkerH
   const [confirm, ConfirmDialog] = useConfirm()
 
   const subject = { type: 'worker' as const, userId }
-  const workerQuery = api.availability.getWeeklyHours.useQuery({ subject })
-  const orgQuery = api.availability.getWeeklyHours.useQuery({ subject: { type: 'organization' } })
+  const workerQuery = api.availability.getWeeklyHours.useQuery(
+    { subject },
+    { staleTime: ORG_STATIC_STALE_TIME }
+  )
+  const orgQuery = api.availability.getWeeklyHours.useQuery(
+    { subject: { type: 'organization' } },
+    { staleTime: ORG_STATIC_STALE_TIME }
+  )
 
   const orgDraft = buildDraftFromResponse(orgQuery.data ?? null, detectTimezone())
   const loading = !workerQuery.isSuccess || !orgQuery.isSuccess
@@ -113,7 +120,10 @@ export function WorkerHoursPage({ userId, weekStartsOn, use24HourTime }: WorkerH
         // Replace-all with zero rows == delete the worker's override.
         saveWeeklyHours.mutate({
           subject,
-          weekly: { timezone: next.weekly?.timezone ?? orgDraft.timezone, days: [] },
+          weekly: {
+            timezone: next.weekly?.timezone ?? orgDraft.timezone,
+            days: [],
+          },
         })
         return
       }

--- a/apps/web/src/components/dispatch/ui/workers-settings-page.tsx
+++ b/apps/web/src/components/dispatch/ui/workers-settings-page.tsx
@@ -9,6 +9,7 @@ import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 import { AddWorkerDialog } from './add-worker-dialog'
 import { type DispatchWorkerRow, WorkerCard } from './worker-card'
@@ -40,6 +41,7 @@ export function WorkersSettingsPage() {
 
   const { data: workers, isLoading } = api.dispatch.listWorkers.useQuery(undefined, {
     enabled: dispatchEnabled,
+    staleTime: ORG_STATIC_STALE_TIME,
   })
 
   const [addOpen, setAddOpen] = useState(false)

--- a/apps/web/src/hooks/use-settings.tsx
+++ b/apps/web/src/hooks/use-settings.tsx
@@ -110,14 +110,8 @@ export function useSettings({ scope }: UseSettingsOptions) {
     if (updateOrgSettingMutation.isSuccess) {
       // Invalidate queries to refresh the data
       utils.setting.getAllUserSettings.invalidate({ scope })
-      utils.setting.getOrganizationSettingsWithMetadata.invalidate({ scope })
     }
-  }, [
-    updateOrgSettingMutation.isSuccess,
-    utils.setting.getAllUserSettings,
-    utils.setting.getOrganizationSettingsWithMetadata,
-    scope,
-  ])
+  }, [updateOrgSettingMutation.isSuccess, utils.setting.getAllUserSettings, scope])
 
   // Effect to handle errors for org setting updates
   useEffect(() => {
@@ -137,18 +131,12 @@ export function useSettings({ scope }: UseSettingsOptions) {
     if (batchUpdateOrgSettingsMutation.isSuccess) {
       // Invalidate queries to refresh the data
       utils.setting.getAllUserSettings.invalidate({ scope })
-      utils.setting.getOrganizationSettingsWithMetadata.invalidate({ scope })
       toastSuccess({
         title: 'Settings updated',
         description: 'Organization settings have been updated successfully',
       })
     }
-  }, [
-    batchUpdateOrgSettingsMutation.isSuccess,
-    utils.setting.getAllUserSettings,
-    utils.setting.getOrganizationSettingsWithMetadata,
-    scope,
-  ])
+  }, [batchUpdateOrgSettingsMutation.isSuccess, utils.setting.getAllUserSettings, scope])
 
   // Effect to handle errors for batch updates
   useEffect(() => {
@@ -159,10 +147,6 @@ export function useSettings({ scope }: UseSettingsOptions) {
       })
     }
   }, [batchUpdateOrgSettingsMutation.isError, batchUpdateOrgSettingsMutation.error])
-
-  // Get organization settings with metadata (for admins)
-  const { data: orgSettingsWithMetadata } =
-    api.setting.getOrganizationSettingsWithMetadata.useQuery({ scope })
 
   // Helper function to get a specific setting
   const getSetting = useCallback(
@@ -234,7 +218,6 @@ export function useSettings({ scope }: UseSettingsOptions) {
     // Data
     settings,
     settingsCatalog,
-    orgSettingsWithMetadata,
     isLoading: false, // Settings are always available from dehydrated state
 
     // Actions


### PR DESCRIPTION
## Summary
- remove the unused organization-settings metadata query from useSettings
- cache static dispatch and availability reads for five minutes while retaining mutation and realtime invalidation
- route schedule hints through the shared gap-fetching availability cache and invalidate all cached board ranges on visit changes

## Validation
- pnpm --filter @auxx/web typecheck
- pnpm exec biome check --diagnostic-level=error (changed files)