### PR TITLE
feat: improve sequence settings drawer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,10 +356,35 @@ pnpm db:migrate
 npx dotenv -- npx tsx path/to/script.ts
 ```
 
+### Type Checking (`tsc`)
+
+Every package/app has a scoped `typecheck` script (`tsc --noEmit` run from that
+package's own directory against its own `tsconfig.json`, via `composite: true`
+project references). Run it **per package**, never as a bare `tsc`/`tsc -b`
+from the repo root — there is no root `tsconfig.json`, and a whole-monorepo
+invocation walks every package's sources in one process.
+
+```bash
+# Scope to one package (fast, low memory — most packages finish in seconds)
+pnpm --filter @auxx/utils typecheck
+pnpm --filter @auxx/database typecheck
+
+# apps/web and packages/lib are large enough to hit V8's default ~4GB
+# old-space heap limit even when scoped to just that package. Bump it:
+cd apps/web && NODE_OPTIONS="--max-old-space-size=8192" pnpm exec tsc --noEmit
+cd packages/lib && NODE_OPTIONS="--max-old-space-size=8192" pnpm exec tsc --noEmit
+```
+
+The OOM was never about total errors or physical memory — it's Node/V8's
+default heap ceiling, hit while checking apps/web's ~3.5k files (or lib's
+~2.6k) in a single process. Scoping to a package keeps most invocations well
+under the limit; for web/lib, raising `--max-old-space-size` is enough (~6GB
+peak observed for web).
+
 ### Rules
 
-- **Do NOT run `tsc` type checking.** Too many errors — it will run out of memory.
-- **Do NOT stop the dev server.**
+- **Do NOT run a whole-repo `tsc`.** Scope it per-package as shown above.
+- **Do NOT stop or restart the dev server.**
 
 ---
 

--- a/apps/web/src/components/dispatch/ui/board/types.ts
+++ b/apps/web/src/components/dispatch/ui/board/types.ts
@@ -73,5 +73,10 @@ export interface BoardResourceInput {
  */
 export interface BacklogItem {
   visit: { id: string; workOrderId: string; status: string }
-  workOrder: { number: string | null; displayName: string | null } | undefined
+  /** `addressText` is map-mode-only (`getRoutePlannerBoard`'s `PlannerWorkOrder`) — calendar
+   * mode's `getBoard` never fetches it, so it stays `undefined` there. `null` (explicitly fetched
+   * but empty) is the "missing service address" signal the backlog row flags. */
+  workOrder:
+    | { number: string | null; displayName: string | null; addressText?: string | null }
+    | undefined
 }

--- a/apps/web/src/components/dispatch/ui/sidebar/backlog-group.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/backlog-group.tsx
@@ -10,9 +10,10 @@ import {
 } from '@auxx/ui/components/sidebar'
 import { cn } from '@auxx/ui/lib/utils'
 import { useDraggable, useDroppable } from '@dnd-kit/core'
-import { GripVertical } from 'lucide-react'
+import { AlertTriangle, GripVertical } from 'lucide-react'
 import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
 import { SidebarItem } from '~/components/global/sidebar/sidebar-item'
+import { Tooltip } from '~/components/global/tooltip'
 import type { BacklogItem } from '../board/types'
 import { isVisitStatus } from '../board/utils'
 import { STATUS_ACCENT_CLASS } from '../board/visit-chip-content'
@@ -167,9 +168,18 @@ function BacklogRow({ item, dragType, canEdit, onSelectVisit }: BacklogRowProps)
           />
         }
         end={
-          canEdit ? (
-            <GripVertical className='text-muted-foreground size-3 shrink-0 opacity-0 group-hover/item:opacity-100' />
-          ) : undefined
+          <>
+            {/* Map-mode only: `addressText === null` = fetched-but-empty (calendar mode leaves it
+                `undefined`, so this stays silent there). Always visible, left of the hover grip. */}
+            {workOrder?.addressText === null && (
+              <Tooltip content='No service address'>
+                <AlertTriangle className='mr-1 size-3.5 shrink-0 text-amber-500' />
+              </Tooltip>
+            )}
+            {canEdit && (
+              <GripVertical className='text-muted-foreground size-3 shrink-0 opacity-0 group-hover/item:opacity-100' />
+            )}
+          </>
         }
       />
     </SidebarMenuItem>

--- a/apps/web/src/components/dispatch/ui/sidebar/routes-group.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/routes-group.tsx
@@ -27,7 +27,7 @@ import { useDndContext, useDroppable } from '@dnd-kit/core'
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { format } from 'date-fns'
-import { MoreVertical, Route as RouteIcon, Timer, X } from 'lucide-react'
+import { AlertTriangle, MoreVertical, Route as RouteIcon, Timer, X } from 'lucide-react'
 import { useState } from 'react'
 import { SidebarGroupHeader } from '~/components/global/sidebar/sidebar-group-header'
 import { Tooltip } from '~/components/global/tooltip'
@@ -432,6 +432,11 @@ function StopRow({
             <span className='truncate group-data-[collapsible=icon]:hidden'>
               {workOrder?.number ?? 'Work order'}
             </span>
+            {workOrder?.addressText === null && (
+              <Tooltip content='No service address'>
+                <AlertTriangle className='ml-1 size-3.5 shrink-0 text-amber-500 group-data-[collapsible=icon]:hidden' />
+              </Tooltip>
+            )}
           </div>
 
           <div className='flex shrink-0 items-center group-data-[collapsible=icon]:hidden'>

--- a/apps/web/src/components/pickers/channel-picker.tsx
+++ b/apps/web/src/components/pickers/channel-picker.tsx
@@ -5,12 +5,13 @@ import type { SelectOption } from '@auxx/types/custom-field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
-import { ChevronsUpDown, Star } from 'lucide-react'
+import { Star } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useDefaultChannelId } from '~/components/channels/hooks/use-default-channel'
 import { useEmailChannels } from '~/components/channels/store/channel-store'
 import { Tooltip } from '~/components/global/tooltip'
+import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import { useSettings } from '~/hooks/use-settings'
 import { MultiSelectPicker } from './multi-select-picker'
 
@@ -18,11 +19,19 @@ interface ChannelPickerProps {
   value: string
   onChange: (value: string) => void
   disabled?: boolean
+  /** Styling for the shared picker trigger. */
+  triggerProps?: PickerTriggerOptions
   /** className forwarded to PopoverContent (e.g. for z-index override) */
   className?: string
 }
 
-export function ChannelPicker({ value, onChange, disabled, className }: ChannelPickerProps) {
+export function ChannelPicker({
+  value,
+  onChange,
+  disabled,
+  triggerProps,
+  className,
+}: ChannelPickerProps) {
   const router = useRouter()
   const allChannels = useEmailChannels()
   // Example integrations are seeded placeholders — they can't actually send.
@@ -71,25 +80,21 @@ export function ChannelPicker({ value, onChange, disabled, className }: ChannelP
         if (disabled) return
         setOpen(next)
       }}>
-      <PopoverTrigger asChild disabled={disabled}>
-        <div className='inline-block'>
-          <Badge
-            variant='user'
-            className={disabled ? 'cursor-not-allowed opacity-70' : ''}
-            role='combobox'
-            aria-expanded={open}
-            aria-label='Select channel'
-            onClick={(e) => {
-              if (disabled) return
-              e.preventDefault()
-              setOpen(!open)
-            }}>
-            {displayName}
-            <ChevronsUpDown
-              className={`ml-1 h-3 w-3 opacity-50 transition-transform ${open ? 'rotate-180' : ''}`}
-            />
-          </Badge>
-        </div>
+      <PopoverTrigger asChild>
+        <PickerTrigger
+          open={open}
+          disabled={disabled}
+          variant={triggerProps?.variant ?? 'transparent'}
+          size={triggerProps?.size}
+          hasValue={!!selected}
+          placeholder='Select channel'
+          icon={triggerProps?.icon}
+          iconPosition={triggerProps?.iconPosition}
+          hideIcon={triggerProps?.hideIcon}
+          asCombobox
+          className={triggerProps?.className}>
+          <Badge variant='user'>{displayName}</Badge>
+        </PickerTrigger>
       </PopoverTrigger>
       <PopoverContent className={cn('w-auto min-w-[240px] p-0', className)}>
         <MultiSelectPicker

--- a/apps/web/src/components/sequences/ui/detail/sequence-detail-view.tsx
+++ b/apps/web/src/components/sequences/ui/detail/sequence-detail-view.tsx
@@ -5,6 +5,7 @@ import { SEQUENCE_TRIGGER_LABELS, type SequenceTriggerType } from '@auxx/lib/seq
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import {
+  type DockedPanelConfig,
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
@@ -16,10 +17,12 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/ta
 import { toastError } from '@auxx/ui/components/toast'
 import { Mails, Pause, Pencil, Play, Send, Settings, UsersRound } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import { LoadingSpinner } from '~/components/global/loading-content'
 import { Tooltip } from '~/components/global/tooltip'
+import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
 import { SequenceRecipients } from './sequence-recipients'
 import { SequenceSettingsDrawer } from './sequence-settings-drawer'
@@ -54,6 +57,11 @@ function Shell({ title, children }: { title: string; children: React.ReactNode }
 export function SequenceDetailView({ sequenceId }: SequenceDetailViewProps) {
   const [tab, setTab] = useQueryState('tab', { defaultValue: 'editor' })
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const isDocked = useEffectiveDockState()
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+  const minWidth = useDockStore((state) => state.minWidth)
+  const maxWidth = useDockStore((state) => state.maxWidth)
   const utils = api.useUtils()
 
   const { data, isLoading } = api.sequence.get.useQuery({ id: sequenceId })
@@ -68,6 +76,22 @@ export function SequenceDetailView({ sequenceId }: SequenceDetailViewProps) {
     onError: (error) =>
       toastError({ title: 'Failed to update sequence', description: error.message }),
   })
+
+  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
+    const sequence = data?.sequence
+    if (!isDocked || !settingsOpen || !sequence) return []
+
+    return [
+      {
+        key: 'sequence-settings',
+        content: <SequenceSettingsDrawer sequence={sequence} open onOpenChange={setSettingsOpen} />,
+        width: dockedWidth,
+        onWidthChange: setDockedWidth,
+        minWidth,
+        maxWidth,
+      },
+    ]
+  }, [data?.sequence, isDocked, settingsOpen, dockedWidth, setDockedWidth, minWidth, maxWidth])
 
   if (isLoading && !data) {
     return (
@@ -166,7 +190,7 @@ export function SequenceDetailView({ sequenceId }: SequenceDetailViewProps) {
         </MainPageBreadcrumb>
       </MainPageHeader>
 
-      <MainPageContent>
+      <MainPageContent dockedPanels={dockedPanels}>
         <div className='flex h-full flex-1 flex-col min-h-0'>
           <SequenceStatsStrip sequenceId={sequenceId} />
 
@@ -201,7 +225,7 @@ export function SequenceDetailView({ sequenceId }: SequenceDetailViewProps) {
         </div>
       </MainPageContent>
 
-      {settingsOpen && (
+      {!isDocked && settingsOpen && (
         <SequenceSettingsDrawer
           sequence={sequence}
           open={settingsOpen}

--- a/apps/web/src/components/sequences/ui/detail/sequence-settings-drawer.tsx
+++ b/apps/web/src/components/sequences/ui/detail/sequence-settings-drawer.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/sequences/ui/detail/sequence-settings-drawer.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { getFieldOperators } from '@auxx/lib/resources/client'
 import {
@@ -10,39 +11,13 @@ import {
 } from '@auxx/lib/sequences/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { Drawer, DrawerContent, DrawerHeader } from '@auxx/ui/components/drawer'
-import { Input } from '@auxx/ui/components/input'
+import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
+import { DrawerHeader } from '@auxx/ui/components/drawer'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
-import { Switch } from '@auxx/ui/components/switch'
 import { toastError } from '@auxx/ui/components/toast'
-import { TreeRow } from '@auxx/ui/components/tree-row'
-import {
-  Building2,
-  CalendarClock,
-  Clock,
-  Filter,
-  Globe,
-  ListFilter,
-  Mail,
-  MailX,
-  PenLine,
-  Plus,
-  Power,
-  Reply,
-  Send,
-  Settings,
-  Trash2,
-  TriangleAlert,
-  Zap,
-} from 'lucide-react'
+import { formatTimeOfDay, parseTimeOfDay } from '@auxx/utils/date'
+import { CalendarClock, ListFilter, Plus, Reply, Send, Settings, Trash2, Zap } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import {
@@ -52,14 +27,18 @@ import {
   type ConditionSystemConfig,
   useConditionActions,
 } from '~/components/conditions'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { DockToggleButton } from '~/components/global/dock-toggle-button'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { ChannelPicker } from '~/components/pickers/channel-picker'
 import { TimeZonePicker } from '~/components/pickers/timezone-picker'
 import { useResourceFields } from '~/components/resources/hooks/use-resource-fields'
 import { useResourceStore } from '~/components/resources/store/resource-store'
-import { useSignature } from '~/components/signatures/hooks/use-signature'
 import { SignaturePicker } from '~/components/signatures/ui/signature-picker'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useDebouncedCallback } from '~/hooks/use-debounced-value'
+import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockStore } from '~/stores/dock-store'
 import { api, type RouterOutputs } from '~/trpc/react'
 
 type Sequence = RouterOutputs['sequence']['get']['sequence']
@@ -85,9 +64,9 @@ function filterEntityTypeForSubject(subjectKind: string | null): 'work_order' | 
 }
 
 /**
- * Right-side settings drawer: Sending (mailbox + signature), Delivery window
- * (start/end time, timezone, business days), Status (pause/enable), and the
- * Danger zone (delete). Every edit saves immediately via `sequence.update`,
+ * Dockable sequence settings drawer: Sending (mailbox + signature), Delivery window
+ * (start/end time, timezone, business days), and behavior controls. Header
+ * actions handle deletion. Every edit saves immediately via `sequence.update`,
  * optimistically patched into the `sequence.get` cache (no invalidate — the
  * server row reconciles on success, rollback on error).
  */
@@ -99,6 +78,11 @@ export function SequenceSettingsDrawer({
   const router = useRouter()
   const utils = api.useUtils()
   const [confirm, ConfirmDialog] = useConfirm()
+  const isDocked = useEffectiveDockState()
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+  const minWidth = useDockStore((state) => state.minWidth)
+  const maxWidth = useDockStore((state) => state.maxWidth)
 
   const update = api.sequence.update.useMutation({
     onMutate: async ({ fields }) => {
@@ -116,7 +100,10 @@ export function SequenceSettingsDrawer({
       ),
     onError: (error, _variables, context) => {
       if (context?.previous) utils.sequence.get.setData({ id: sequence.id }, context.previous)
-      toastError({ title: 'Failed to update sequence', description: error.message })
+      toastError({
+        title: 'Failed to update sequence',
+        description: error.message,
+      })
     },
   })
   const save = (fields: UpdateFields) => update.mutate({ id: sequence.id, fields })
@@ -128,7 +115,10 @@ export function SequenceSettingsDrawer({
       router.push('/app/workflows?t=sequences')
     },
     onError: (error) =>
-      toastError({ title: 'Failed to delete sequence', description: error.message }),
+      toastError({
+        title: 'Failed to delete sequence',
+        description: error.message,
+      }),
   })
 
   const handleDelete = async () => {
@@ -143,10 +133,6 @@ export function SequenceSettingsDrawer({
     if (confirmed) deleteSequence.mutate({ id: sequence.id })
   }
 
-  const { signature } = useSignature(sequence.signatureEntityInstanceId)
-
-  const isEnabled = sequence.status === 'enabled'
-  const canEnable = !!sequence.publishedAt && !!sequence.integrationId
   const isSeededTrigger = !!sequence.templateKey
   const isEventTriggered = sequence.triggerType !== 'manual'
 
@@ -205,269 +191,234 @@ export function SequenceSettingsDrawer({
   )
 
   return (
-    <Drawer direction='right' open={open} onOpenChange={onOpenChange} defaultWidth={440}>
-      <DrawerContent>
-        <ConfirmDialog />
-        <DrawerHeader
-          icon={<Settings className='size-5 text-muted-foreground' />}
-          title='Sequence settings'
-          onClose={() => onOpenChange(false)}
-        />
+    <DockableDrawer
+      open={open}
+      onOpenChange={onOpenChange}
+      isDocked={isDocked}
+      width={dockedWidth}
+      onWidthChange={setDockedWidth}
+      minWidth={minWidth}
+      maxWidth={maxWidth}
+      title='Sequence settings'>
+      <ConfirmDialog />
+      <DrawerHeader
+        icon={<Settings className='size-5 text-muted-foreground' />}
+        title='Sequence settings'
+        actions={
+          <>
+            {!isSeededTrigger && (
+              <Button
+                variant='destructive-hover'
+                size='icon-xs'
+                loading={deleteSequence.isPending}
+                loadingText='Deleting…'
+                aria-label='Delete sequence'
+                onClick={() => void handleDelete()}>
+                <Trash2 />
+              </Button>
+            )}
+            <DockToggleButton />
+          </>
+        }
+        onClose={() => onOpenChange(false)}
+      />
 
-        <ScrollArea className='flex-1' scrollbarClassName='w-1.5'>
-          <Section
-            title='Trigger'
-            icon={<Zap className='size-4' />}
-            description='When this sequence automatically enrolls a subject. Manual sequences only enroll from the Recipients tab.'
-            initialOpen
-            collapsible={false}>
-            <TreeRow
-              icon={<Zap className='size-4 text-muted-foreground' />}
-              title='Event'
-              secondary={
-                isSeededTrigger ? (
+      <ScrollArea className='flex-1' scrollbarClassName='w-1.5'>
+        <Section
+          title='Trigger'
+          icon={<Zap className='size-4' />}
+          description='When this sequence automatically enrolls a subject. Manual sequences only enroll from the Recipients tab.'
+          initialOpen
+          collapsible={false}>
+          <FieldPanel className='p-0'>
+            <FieldPanelRow title='Event'>
+              {isSeededTrigger ? (
+                <div className='flex h-8 items-center'>
                   <Badge variant='outline' size='sm'>
                     {SEQUENCE_TRIGGER_LABELS[sequence.triggerType as SequenceTriggerType] ??
                       sequence.triggerType}
                   </Badge>
-                ) : (
-                  <Select
-                    value={sequence.triggerType}
-                    onValueChange={(v) => save({ triggerType: v as SequenceTriggerType })}>
-                    <SelectTrigger size='xs' className='w-44'>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {SEQUENCE_TRIGGER_TYPES.map((t) => (
-                        <SelectItem key={t} value={t}>
-                          {SEQUENCE_TRIGGER_LABELS[t]}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )
-              }
-            />
-            {isSeededTrigger && (
-              <div className='ps-9 pb-1 text-xs text-muted-foreground'>
-                Built-in template — the trigger can't be changed.
-              </div>
-            )}
-          </Section>
-
-          <Section
-            title='Sending'
-            icon={<Send className='size-4' />}
-            initialOpen
-            collapsible={false}>
-            <div className='flex flex-col'>
-              <TreeRow
-                icon={<Mail className='size-4 text-muted-foreground' />}
-                title='Mailbox'
-                description='All steps send from this connected email account.'
-                secondaryFill
-                secondary={
-                  <ChannelPicker
-                    value={sequence.integrationId ?? ''}
-                    onChange={(integrationId) => save({ integrationId })}
-                  />
-                }
-              />
-              {!sequence.integrationId && (
-                <div className='ps-9 pb-1 text-xs text-amber-600'>
-                  Choose a mailbox — publishing requires one.
                 </div>
+              ) : (
+                <FieldInputAdapter
+                  fieldType={FieldType.SINGLE_SELECT}
+                  fieldOptions={{
+                    options: SEQUENCE_TRIGGER_TYPES.map((triggerType) => ({
+                      value: triggerType,
+                      label: SEQUENCE_TRIGGER_LABELS[triggerType],
+                    })),
+                  }}
+                  triggerProps={{
+                    variant: 'transparent',
+                    className: 'w-full ps-0 pe-1',
+                  }}
+                  value={[sequence.triggerType]}
+                  onChange={(value) => {
+                    const triggerType = (value as string[])[0] as SequenceTriggerType | undefined
+                    if (triggerType) save({ triggerType })
+                  }}
+                />
               )}
-              <TreeRow
-                icon={<PenLine className='size-4 text-muted-foreground' />}
-                title='Signature'
-                description='Appended to every step. Optional.'
-                secondaryFill
-                secondary={
-                  <SignaturePicker
-                    selected={sequence.signatureEntityInstanceId}
-                    onChange={(signatureId) => save({ signatureEntityInstanceId: signatureId })}>
-                    <Button variant='outline' size='xs'>
-                      {signature?.name ?? 'No signature'}
-                    </Button>
-                  </SignaturePicker>
-                }
-              />
+            </FieldPanelRow>
+          </FieldPanel>
+          {isSeededTrigger && (
+            <div className='pt-1 text-xs text-muted-foreground'>
+              Built-in template — the trigger can't be changed.
             </div>
-          </Section>
-
-          <Section
-            title='Delivery window'
-            icon={<CalendarClock className='size-4' />}
-            description='Emails only send inside this window; out-of-window sends wait for the next opening.'
-            initialOpen
-            collapsible={false}>
-            <div className='flex flex-col'>
-              <TreeRow
-                icon={<Clock className='size-4 text-muted-foreground' />}
-                title='Start time'
-                secondary={
-                  <Input
-                    type='time'
-                    className='h-7 w-28'
-                    defaultValue={sequence.deliveryStartTime ?? ''}
-                    onBlur={(e) => save({ deliveryStartTime: e.target.value || null })}
-                  />
-                }
-              />
-              <TreeRow
-                icon={<Clock className='size-4 text-muted-foreground' />}
-                title='End time'
-                secondary={
-                  <Input
-                    type='time'
-                    className='h-7 w-28'
-                    defaultValue={sequence.deliveryEndTime ?? ''}
-                    onBlur={(e) => save({ deliveryEndTime: e.target.value || null })}
-                  />
-                }
-              />
-              <TreeRow
-                icon={<Globe className='size-4 text-muted-foreground' />}
-                title='Timezone'
-                secondary={
-                  <TimeZonePicker
-                    selected={sequence.deliveryTimezone ?? undefined}
-                    onChange={(tz) => save({ deliveryTimezone: tz || null })}
-                    triggerProps={{ size: 'xs' }}
-                  />
-                }
-              />
-              <TreeRow
-                icon={<Building2 className='size-4 text-muted-foreground' />}
-                title='Business days only'
-                description='Skip Saturday and Sunday.'
-                secondary={
-                  <Switch
-                    checked={sequence.deliveryBusinessDaysOnly}
-                    onCheckedChange={(checked) => save({ deliveryBusinessDaysOnly: checked })}
-                  />
-                }
-              />
-            </div>
-          </Section>
-
-          <Section
-            title='Behavior'
-            icon={<Reply className='size-4' />}
-            initialOpen
-            collapsible={false}>
-            <div className='flex flex-col'>
-              <TreeRow
-                icon={<Reply className='size-4 text-muted-foreground' />}
-                title='Exit when the recipient replies'
-                secondary={
-                  <Switch
-                    checked={sequence.exitOnReply}
-                    onCheckedChange={(checked) => save({ exitOnReply: checked })}
-                  />
-                }
-              />
-              <TreeRow
-                icon={<MailX className='size-4 text-muted-foreground' />}
-                title='Respect unsubscribe / suppression list'
-                secondary={
-                  <Switch
-                    checked={sequence.respectSuppression}
-                    onCheckedChange={(checked) => save({ respectSuppression: checked })}
-                  />
-                }
-              />
-              <TreeRow
-                icon={<Filter className='size-4 text-muted-foreground' />}
-                title='Include unsubscribe footer'
-                secondary={
-                  <Switch
-                    checked={sequence.includeUnsubscribeFooter}
-                    onCheckedChange={(checked) => save({ includeUnsubscribeFooter: checked })}
-                  />
-                }
-              />
-            </div>
-          </Section>
-
-          {isEventTriggered && (
-            <ConditionProvider
-              conditions={EMPTY_CONDITIONS}
-              groups={filterGroups}
-              config={filterConditionConfig}
-              onConditionsChange={() => {}}
-              onGroupsChange={handleFilterGroupsChange}
-              getAvailableFields={() => filterFieldDefinitions}
-              getFieldDefinition={(id) => filterFieldDefinitions.find((f) => f.id === id)}>
-              <Section
-                title='Enrollment filter'
-                icon={<ListFilter className='size-4' />}
-                description='Only enroll subjects that match these conditions. Evaluated once, at enrollment — leave empty to enroll everything.'
-                initialOpen
-                collapsible={false}
-                actions={<AddFilterGroupButton />}>
-                <ConditionContainer
-                  emptyStateText='No conditions — every match enrolls'
-                  showAddButton={false}
-                  showGrouping
-                />
-              </Section>
-            </ConditionProvider>
           )}
+        </Section>
 
-          <Section
-            title='Status'
-            icon={<Power className='size-4' />}
-            initialOpen
-            collapsible={false}>
-            <TreeRow
-              icon={<Power className='size-4 text-muted-foreground' />}
-              title={isEnabled ? 'Enabled' : 'Paused'}
-              description='Pausing blocks new enrollments; in-flight runs finish on their own.'
-              secondary={
-                <Switch
-                  checked={isEnabled}
-                  onCheckedChange={(checked) => save({ status: checked ? 'enabled' : 'disabled' })}
-                  disabled={!isEnabled && !canEnable}
+        <Section title='Sending' icon={<Send className='size-4' />} initialOpen collapsible={false}>
+          <FieldPanel className='p-0'>
+            <FieldPanelRow
+              title='Mailbox'
+              description='All steps send from this connected email account.'>
+              <div className='flex h-8 items-center'>
+                <ChannelPicker
+                  value={sequence.integrationId ?? ''}
+                  onChange={(integrationId) => save({ integrationId })}
+                  triggerProps={{ variant: 'transparent', className: 'w-full ps-0 pe-1' }}
                 />
-              }
-            />
-            {!canEnable && (
-              <div className='ps-9 text-xs text-muted-foreground'>
-                {!sequence.publishedAt
-                  ? 'Publish the sequence before enabling it.'
-                  : 'Choose a sending mailbox before enabling it.'}
+              </div>
+            </FieldPanelRow>
+            {!sequence.integrationId && (
+              <div className='px-2 pb-1 text-xs text-amber-600'>
+                Choose a mailbox — publishing requires one.
               </div>
             )}
-          </Section>
+            <FieldPanelRow title='Signature' description='Appended to every step. Optional.'>
+              <SignaturePicker
+                selected={sequence.signatureEntityInstanceId}
+                onChange={(signatureId) => save({ signatureEntityInstanceId: signatureId })}
+                triggerProps={{ variant: 'transparent', className: 'w-full ps-0 pe-1' }}
+              />
+            </FieldPanelRow>
+          </FieldPanel>
+        </Section>
 
-          <Section
-            title='Danger zone'
-            icon={<TriangleAlert className='size-4' />}
-            initialOpen
-            collapsible={false}>
-            <TreeRow
-              icon={<Trash2 className='size-4 text-bad-500' />}
-              title='Delete sequence'
-              description='Removes the sequence, its steps, and its run history.'
-              secondary={
-                <Button
-                  variant='destructive-hover'
-                  size='xs'
-                  loading={deleteSequence.isPending}
-                  loadingText='Deleting…'
-                  onClick={() => void handleDelete()}>
-                  Delete
-                </Button>
-              }
-            />
-          </Section>
+        <Section
+          title='Delivery window'
+          icon={<CalendarClock className='size-4' />}
+          description='Emails only send inside this window; out-of-window sends wait for the next opening.'
+          initialOpen
+          collapsible={false}>
+          <FieldPanel className='p-0'>
+            <FieldPanelRow title='Start time'>
+              <FieldInputAdapter
+                fieldType={FieldType.TIME}
+                triggerProps={{
+                  variant: 'transparent',
+                  className: 'w-full ps-0 pe-1',
+                }}
+                value={parseTimeOfDay(sequence.deliveryStartTime)?.toISOString()}
+                onChange={(value) =>
+                  save({
+                    deliveryStartTime:
+                      typeof value === 'string' ? formatTimeOfDay(new Date(value)) : null,
+                  })
+                }
+              />
+            </FieldPanelRow>
+            <FieldPanelRow title='End time'>
+              <FieldInputAdapter
+                fieldType={FieldType.TIME}
+                triggerProps={{
+                  variant: 'transparent',
+                  className: 'w-full ps-0 pe-1',
+                }}
+                value={parseTimeOfDay(sequence.deliveryEndTime)?.toISOString()}
+                onChange={(value) =>
+                  save({
+                    deliveryEndTime:
+                      typeof value === 'string' ? formatTimeOfDay(new Date(value)) : null,
+                  })
+                }
+              />
+            </FieldPanelRow>
+            <FieldPanelRow title='Timezone'>
+              <TimeZonePicker
+                selected={sequence.deliveryTimezone ?? undefined}
+                onChange={(timezone) => save({ deliveryTimezone: timezone || null })}
+                triggerProps={{
+                  variant: 'transparent',
+                  className: 'w-full ps-0 pe-1',
+                }}
+              />
+            </FieldPanelRow>
+            <FieldPanelRow title='Business days only' description='Skip Saturday and Sunday.'>
+              <FieldInputAdapter
+                fieldType={FieldType.CHECKBOX}
+                fieldOptions={{ variant: 'switch' }}
+                value={sequence.deliveryBusinessDaysOnly}
+                onChange={(value) => save({ deliveryBusinessDaysOnly: value as boolean })}
+              />
+            </FieldPanelRow>
+          </FieldPanel>
+        </Section>
 
-          <div className='h-8' />
-        </ScrollArea>
-      </DrawerContent>
-    </Drawer>
+        <Section
+          title='Behavior'
+          icon={<Reply className='size-4' />}
+          initialOpen
+          collapsible={false}>
+          <FieldPanel className='p-0'>
+            <FieldPanelRow
+              title='Exit when the recipient replies'
+              description='Stop the sequence after an inbound reply.'>
+              <FieldInputAdapter
+                fieldType={FieldType.CHECKBOX}
+                fieldOptions={{ variant: 'switch' }}
+                value={sequence.exitOnReply}
+                onChange={(value) => save({ exitOnReply: value as boolean })}
+              />
+            </FieldPanelRow>
+            <FieldPanelRow title='Respect unsubscribe / suppression list'>
+              <FieldInputAdapter
+                fieldType={FieldType.CHECKBOX}
+                fieldOptions={{ variant: 'switch' }}
+                value={sequence.respectSuppression}
+                onChange={(value) => save({ respectSuppression: value as boolean })}
+              />
+            </FieldPanelRow>
+            <FieldPanelRow title='Include unsubscribe footer'>
+              <FieldInputAdapter
+                fieldType={FieldType.CHECKBOX}
+                fieldOptions={{ variant: 'switch' }}
+                value={sequence.includeUnsubscribeFooter}
+                onChange={(value) => save({ includeUnsubscribeFooter: value as boolean })}
+              />
+            </FieldPanelRow>
+          </FieldPanel>
+        </Section>
+
+        {isEventTriggered && (
+          <ConditionProvider
+            conditions={EMPTY_CONDITIONS}
+            groups={filterGroups}
+            config={filterConditionConfig}
+            onConditionsChange={() => {}}
+            onGroupsChange={handleFilterGroupsChange}
+            getAvailableFields={() => filterFieldDefinitions}
+            getFieldDefinition={(id) => filterFieldDefinitions.find((f) => f.id === id)}>
+            <Section
+              title='Enrollment filter'
+              icon={<ListFilter className='size-4' />}
+              description='Only enroll subjects that match these conditions. Evaluated once, at enrollment — leave empty to enroll everything.'
+              initialOpen
+              collapsible={false}
+              actions={<AddFilterGroupButton />}>
+              <ConditionContainer
+                emptyStateText='No conditions — every match enrolls'
+                showAddButton={false}
+                showGrouping
+              />
+            </Section>
+          </ConditionProvider>
+        )}
+
+        <div className='h-8' />
+      </ScrollArea>
+    </DockableDrawer>
   )
 }
 

--- a/apps/web/src/components/signatures/ui/signature-picker.tsx
+++ b/apps/web/src/components/signatures/ui/signature-picker.tsx
@@ -2,11 +2,11 @@
 'use client'
 
 import type { SelectOption } from '@auxx/types/custom-field'
-import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
 import { type ComponentProps, useCallback, useMemo, useState } from 'react'
 import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
+import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import { type SignatureItem, useSignatures } from '../hooks'
 import { SignatureDialog } from './signature-dialog'
 
@@ -19,6 +19,8 @@ interface SignaturePickerProps
   onChange?: (signatureId: string | null) => void
   className?: string
   signatures?: SignatureItem[]
+  /** Styling for the shared picker trigger. */
+  triggerProps?: PickerTriggerOptions
   children?: React.ReactNode
   disabled?: boolean
 }
@@ -34,6 +36,7 @@ export function SignaturePicker({
   onChange,
   className,
   signatures: externalSignatures,
+  triggerProps,
   children,
   disabled = false,
   ...popoverContentProps
@@ -49,6 +52,7 @@ export function SignaturePicker({
   // Fetch signatures if not provided
   const { signatures: fetchedSignatures } = useSignatures()
   const signatures = externalSignatures ?? fetchedSignatures
+  const selectedSignature = signatures.find((signature) => signature.id === selected)
 
   // Convert signatures to SelectOption format
   const options: SelectOption[] = useMemo(() => {
@@ -85,10 +89,32 @@ export function SignaturePicker({
     [onChange, setIsOpen]
   )
 
+  /** Clears the optional signature selection without opening the picker. */
+  const handleClear = useCallback(() => onChange?.(null), [onChange])
+
+  const trigger = children ?? (
+    <PickerTrigger
+      open={isOpen}
+      disabled={disabled}
+      variant={triggerProps?.variant ?? 'transparent'}
+      size={triggerProps?.size}
+      hasValue={!!selectedSignature}
+      placeholder='No signature'
+      showClear={triggerProps?.showClear ?? true}
+      onClear={handleClear}
+      icon={triggerProps?.icon}
+      iconPosition={triggerProps?.iconPosition}
+      hideIcon={triggerProps?.hideIcon}
+      asCombobox
+      className={triggerProps?.className}>
+      <span className='truncate'>{selectedSignature?.name}</span>
+    </PickerTrigger>
+  )
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild disabled={disabled}>
-        {children ?? <Button variant='outline'>Select Signature</Button>}
+        {trigger}
       </PopoverTrigger>
       <PopoverContent className={cn('w-[250px] p-0', className)} {...popoverContentProps}>
         <MultiSelectPicker

--- a/packages/utils/src/__tests__/date.test.ts
+++ b/packages/utils/src/__tests__/date.test.ts
@@ -1,7 +1,7 @@
 // packages/utils/src/__tests__/date.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { formatRelativeTime } from '../date'
+import { formatRelativeTime, formatTimeOfDay, parseTimeOfDay } from '../date'
 
 const secondsAgo = (n: number) => new Date(Date.now() - n * 1000)
 const secondsAhead = (n: number) => new Date(Date.now() + n * 1000)
@@ -37,5 +37,24 @@ describe('formatRelativeTime', () => {
   it('accepts strings and epoch numbers', () => {
     expect(formatRelativeTime(secondsAgo(3600).toISOString())).toBe('1 hour ago')
     expect(formatRelativeTime(secondsAgo(3600).getTime())).toBe('1 hour ago')
+  })
+})
+
+describe('time-of-day utilities', () => {
+  it('parses an HH:MM time onto the provided local date', () => {
+    const baseDate = new Date(2025, 0, 1, 0, 0, 0, 0)
+    const result = parseTimeOfDay('14:30', baseDate)
+
+    expect(result).toEqual(new Date(2025, 0, 1, 14, 30, 0, 0))
+  })
+
+  it('rejects invalid time-of-day values', () => {
+    expect(parseTimeOfDay('24:00')).toBeUndefined()
+    expect(parseTimeOfDay('9:30')).toBeUndefined()
+    expect(parseTimeOfDay(null)).toBeUndefined()
+  })
+
+  it('formats a local date as HH:MM', () => {
+    expect(formatTimeOfDay(new Date(2025, 0, 1, 9, 5))).toBe('09:05')
   })
 })

--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -1,3 +1,32 @@
+import { format } from 'date-fns'
+
+/**
+ * Parses a local 24-hour `HH:MM` value onto a date used only as the time picker’s display anchor.
+ * Invalid values return `undefined`.
+ */
+export function parseTimeOfDay(
+  value: string | null | undefined,
+  baseDate: Date = new Date()
+): Date | undefined {
+  if (!value) return undefined
+
+  const match = /^(\d{2}):(\d{2})$/.exec(value)
+  if (!match) return undefined
+
+  const hours = Number(match[1])
+  const minutes = Number(match[2])
+  if (hours > 23 || minutes > 59) return undefined
+
+  const date = new Date(baseDate)
+  date.setHours(hours, minutes, 0, 0)
+  return date
+}
+
+/** Formats a date’s local clock time as a 24-hour `HH:MM` value. */
+export function formatTimeOfDay(date: Date): string {
+  return format(date, 'HH:mm')
+}
+
 /**
  * Returns a relative time string (e.g., "3 hours ago", "in 2 days").
  * Past dates read "<n> <unit> ago", future dates "in <n> <unit>". In `short`

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -45,10 +45,12 @@ export {
   formatInTimezone,
   formatRelativeTime,
   formatRelativeTimeWithTimezone,
+  formatTimeOfDay,
   getCurrentTimeInTimezone,
   getEndOfWeek,
   getStartOfWeek,
   isSameWeek,
+  parseTimeOfDay,
 } from './date'
 
 // Email utilities


### PR DESCRIPTION
## Summary
- standardize sequence settings fields and shared picker triggers
- make the sequence settings drawer dockable and protect seeded templates from deletion
- improve dispatch missing-address visibility and document scoped type checking

## Validation
- biome checks run via the commit hook
- targeted Biome lint passed
- full web typecheck remains blocked by existing repository-wide TypeScript errors