### PR TITLE
feat: add sequence Visit placeholder formatting

### DIFF
--- a/apps/web/src/app/(protected)/app/workflows/_components/analytics/workflow-analytics.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/_components/analytics/workflow-analytics.tsx
@@ -21,6 +21,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { keepPreviousData } from '@tanstack/react-query'
 import { format, startOfMonth, startOfQuarter, startOfYear, subMonths, subWeeks } from 'date-fns'
 import { Activity, CalendarIcon, CheckCircle, Clock, Zap } from 'lucide-react'
+import { useState } from 'react'
 import { CartesianGrid, Line, LineChart, XAxis, YAxis } from 'recharts'
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
@@ -226,6 +227,7 @@ function WorkflowAnalyticsOptions() {
   const dateRange = useAnalyticsStore((state) => state.dateRange)
   const handleTimeFrameChange = useAnalyticsStore((state) => state.handleTimeFrameChange)
   const setDateRange = useAnalyticsStore((state) => state.setDateRange)
+  const [draftDateRange, setDraftDateRange] = useState<CalendarDateRange>(dateRange)
 
   return (
     <div className='flex items-center p-1 bg-primary-150 border-b border-primary-300 rounded-t-lg'>
@@ -258,8 +260,9 @@ function WorkflowAnalyticsOptions() {
             <PopoverContent className='w-auto p-0' align='start'>
               <Calendar
                 mode='range'
-                selected={dateRange}
+                selected={draftDateRange}
                 onSelect={(range: CalendarDateRange) => {
+                  setDraftDateRange(range)
                   if (range.from && range.to) {
                     setDateRange({ from: range.from, to: range.to })
                   }

--- a/apps/web/src/components/editor/inline-picker/nodes/placeholder-badge.tsx
+++ b/apps/web/src/components/editor/inline-picker/nodes/placeholder-badge.tsx
@@ -6,6 +6,9 @@ import {
   type FallbackPayload,
   type FallbackSupportedType,
   isFallbackSupportedType,
+  isPlaceholderFormatType,
+  normalizePlaceholderFormat,
+  type PlaceholderFormatPayload,
   tryParsePlaceholderId,
 } from '@auxx/lib/placeholders/client'
 import { mapBaseTypeToFieldType } from '@auxx/lib/workflow-engine/client'
@@ -59,9 +62,14 @@ export function PlaceholderBadge({
     usePlaceholderLabel(id)
 
   const fallback = (attrs.fallback as FallbackPayload | null) ?? null
+  const format = (attrs.format as PlaceholderFormatPayload | null) ?? null
 
   const onFallbackChange = (payload: FallbackPayload | null) => {
     updateAttributes({ fallback: payload })
+  }
+
+  const onFormatChange = (payload: PlaceholderFormatPayload | null) => {
+    updateAttributes({ format: payload ? normalizePlaceholderFormat(payload) : null })
   }
 
   const onChangeVariable = (newId: string) => {
@@ -69,7 +77,13 @@ export function PlaceholderBadge({
     // clear it (payload shape is type-specific and won't round-trip).
     const current = (attrs.fallback as FallbackPayload | null) ?? null
     const preserve = current && fieldTypeFromNewId(newId) === current.t
-    updateAttributes({ id: newId, fallback: preserve ? current : null })
+    const currentFormat = (attrs.format as PlaceholderFormatPayload | null) ?? null
+    const preserveFormat = currentFormat && fieldTypeFromNewId(newId) === currentFormat.t
+    updateAttributes({
+      id: newId,
+      fallback: preserve ? current : null,
+      format: preserveFormat ? currentFormat : null,
+    })
   }
 
   const handleOpenChange = (next: boolean) => {
@@ -111,8 +125,11 @@ export function PlaceholderBadge({
           fieldType={fieldType}
           fallbackSupported={fallbackSupported}
           fallback={fallback}
+          format={format}
+          formattingSupported={fieldType !== null && isPlaceholderFormatType(fieldType)}
           onChangeVariable={onChangeVariable}
           onFallbackChange={onFallbackChange}
+          onFormatChange={onFormatChange}
           onDelete={deleteNode}
           onClose={() => setOpen(false)}
         />

--- a/apps/web/src/components/editor/inline-picker/nodes/placeholder-node.ts
+++ b/apps/web/src/components/editor/inline-picker/nodes/placeholder-node.ts
@@ -1,6 +1,11 @@
 // apps/web/src/components/editor/inline-picker/nodes/placeholder-node.ts
 
-import { decodeFallback, encodeFallback } from '@auxx/lib/placeholders/client'
+import {
+  decodeFallback,
+  decodePlaceholderFormat,
+  encodeFallback,
+  encodePlaceholderFormat,
+} from '@auxx/lib/placeholders/client'
 import { createInlineNode } from '../core/inline-node'
 import type { InlineNodeBadgeProps, InlineNodeConfig } from '../types'
 
@@ -37,6 +42,12 @@ const placeholderNodeConfig: InlineNodeConfig = {
       dataAttr: 'data-fallback',
       serialize: encodeFallback,
       parse: decodeFallback,
+    },
+    format: {
+      default: null,
+      dataAttr: 'data-format',
+      serialize: encodePlaceholderFormat,
+      parse: decodePlaceholderFormat,
     },
   },
 }

--- a/apps/web/src/components/editor/placeholders/placeholder-formatting-editor.tsx
+++ b/apps/web/src/components/editor/placeholders/placeholder-formatting-editor.tsx
@@ -1,0 +1,58 @@
+// apps/web/src/components/editor/placeholders/placeholder-formatting-editor.tsx
+
+'use client'
+
+import type { FieldOptions } from '@auxx/lib/field-values/client'
+import type { PlaceholderFormatType } from '@auxx/lib/placeholders/client'
+import {
+  BooleanFormattingEditor,
+  CurrencyFormattingEditor,
+  DateFormattingEditor,
+  DateTimeFormattingEditor,
+  NumberFormattingEditor,
+  PhoneFormattingEditor,
+  TimeFormattingEditor,
+  UrlFormattingEditor,
+} from '~/components/custom-fields/ui/formatting-editors'
+
+/** Props for the shared per-placeholder display-formatting editor. */
+interface PlaceholderFormattingEditorProps {
+  /** Field type selecting one of the existing display-option editors. */
+  fieldType: PlaceholderFormatType
+  /** Effective field options plus any persisted per-placeholder override. */
+  options: Partial<FieldOptions>
+  /** Persist the display-option override for this placeholder occurrence. */
+  onChange: (options: Partial<FieldOptions>) => void
+}
+
+/**
+ * Reuses the field-formatting controls for a placeholder occurrence.
+ *
+ * This component deliberately owns no persistence or formatting logic: the
+ * badge popover stores the returned partial `FieldOptions` payload, and the
+ * server merges it with `FieldValueService` result metadata at render time.
+ */
+export function PlaceholderFormattingEditor({
+  fieldType,
+  options,
+  onChange,
+}: PlaceholderFormattingEditorProps) {
+  switch (fieldType) {
+    case 'NUMBER':
+      return <NumberFormattingEditor options={options} onChange={onChange} />
+    case 'CURRENCY':
+      return <CurrencyFormattingEditor options={options} onChange={onChange} />
+    case 'DATE':
+      return <DateFormattingEditor options={options} onChange={onChange} />
+    case 'DATETIME':
+      return <DateTimeFormattingEditor options={options} onChange={onChange} />
+    case 'TIME':
+      return <TimeFormattingEditor options={options} onChange={onChange} />
+    case 'CHECKBOX':
+      return <BooleanFormattingEditor options={options} onChange={onChange} />
+    case 'PHONE_INTL':
+      return <PhoneFormattingEditor options={options} onChange={onChange} />
+    case 'URL':
+      return <UrlFormattingEditor options={options} onChange={onChange} />
+  }
+}

--- a/apps/web/src/components/editor/placeholders/placeholder-picker-content.tsx
+++ b/apps/web/src/components/editor/placeholders/placeholder-picker-content.tsx
@@ -2,7 +2,6 @@
 
 'use client'
 
-import { SEQUENCE_VISIT_PLACEHOLDER_TOKENS } from '@auxx/lib/sequences/client'
 import type { FieldReference } from '@auxx/types/field'
 import { fieldRefToKey } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
@@ -96,6 +95,8 @@ interface PlaceholderPickerContentProps {
    * inline-picker hook's `closePicker`.
    */
   onClose?: () => void
+  /** Number of parent navigation entries to ignore before resolving a picker root. */
+  navigationOffset?: number
   /**
    * Extra roots appended after the standard list — opt-in only, so every other consumer (mail
    * composer, tickets, snippets) keeps today's fixed root list. The sequence step editor passes
@@ -135,9 +136,10 @@ function PlaceholderPickerBody({
   onClose,
   backLabel = 'Back',
   extraRoots,
+  navigationOffset = 0,
 }: PlaceholderPickerContentProps) {
-  const { current } = useCommandNavigation<PlaceholderNavItem>()
-  const rootId = current?.id ?? null
+  const { current, stack } = useCommandNavigation<PlaceholderNavItem>()
+  const rootId = stack.length <= navigationOffset ? null : (current?.id ?? null)
 
   if (rootId === 'date') {
     return <DateListContent onSelect={onSelect} />
@@ -145,10 +147,6 @@ function PlaceholderPickerBody({
 
   if (rootId === 'organization') {
     return <OrganizationListContent onSelect={onSelect} />
-  }
-
-  if (rootId === 'visit') {
-    return <VisitTokenListContent onSelect={onSelect} />
   }
 
   if (rootId !== null) {
@@ -326,54 +324,6 @@ function OrganizationListContent({ onSelect }: { onSelect: (id: string) => void 
             <CommandItem key={o.slug} value={o.label} onSelect={() => onSelect(`org:${o.slug}`)}>
               <Braces className='size-4 text-muted-foreground' />
               <span>{o.label}</span>
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
-    </Command>
-  )
-}
-
-/**
- * Visit tokens (client-notifications plan §4.5) — pre-resolved by plain code in the send node
- * (`WorkOrderVisit` isn't an `EntityInstance`, so these can't ride `FieldPickerContent`'s
- * entity-backed field picker). Inserted as literal `{{visit:*}}` text, not a placeholder chip —
- * see `SequenceBodyEditor`'s `onSelect`.
- */
-function VisitTokenListContent({ onSelect }: { onSelect: (id: string) => void }) {
-  const { pop } = useCommandNavigation<PlaceholderNavItem>()
-  const [search, setSearch] = useState('')
-  const q = search.toLowerCase().trim()
-  const filtered = q
-    ? SEQUENCE_VISIT_PLACEHOLDER_TOKENS.filter((t) => t.label.toLowerCase().includes(q))
-    : SEQUENCE_VISIT_PLACEHOLDER_TOKENS
-
-  return (
-    <Command
-      shouldFilter={false}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          e.stopPropagation()
-          pop()
-        } else if ((e.key === 'Backspace' || e.key === 'ArrowLeft') && !search) {
-          e.preventDefault()
-          pop()
-        }
-      }}>
-      <CommandBreadcrumb rootLabel='Placeholder' />
-      <CommandInput
-        placeholder='Search visit fields...'
-        value={search}
-        onValueChange={setSearch}
-        autoFocus
-      />
-      <CommandList>
-        <CommandEmpty>No fields found.</CommandEmpty>
-        <CommandGroup heading='Visit'>
-          {filtered.map((t) => (
-            <CommandItem key={t.id} value={t.label} onSelect={() => onSelect(t.id)}>
-              <Braces className='size-4 text-muted-foreground' />
-              <span>{t.label}</span>
             </CommandItem>
           ))}
         </CommandGroup>

--- a/apps/web/src/components/editor/placeholders/placeholder-popover.tsx
+++ b/apps/web/src/components/editor/placeholders/placeholder-popover.tsx
@@ -2,14 +2,26 @@
 
 'use client'
 
-import type { FallbackPayload, FallbackSupportedType } from '@auxx/lib/placeholders/client'
+import type { FieldOptions } from '@auxx/lib/field-values/client'
+import type {
+  FallbackPayload,
+  FallbackSupportedType,
+  PlaceholderFormatPayload,
+  PlaceholderFormatType,
+} from '@auxx/lib/placeholders/client'
+import { normalizePlaceholderFormat } from '@auxx/lib/placeholders/client'
 import type { ResourceField } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
+import {
+  CommandNavigation,
+  type NavigationItem,
+  useCommandNavigation,
+} from '@auxx/ui/components/command'
 import { Separator } from '@auxx/ui/components/separator'
-import { ArrowRightLeft, Trash2 } from 'lucide-react'
-import { useState } from 'react'
+import { ArrowRightLeft, Settings2, Trash2 } from 'lucide-react'
 import { FieldInputRow } from '~/components/custom-fields/ui/field-input-row'
 import { FieldPanel } from '~/components/global/forms/field-panel'
+import { PlaceholderFormattingEditor } from './placeholder-formatting-editor'
 import { PlaceholderPickerContent } from './placeholder-picker-content'
 
 interface PlaceholderPopoverProps {
@@ -23,20 +35,30 @@ interface PlaceholderPopoverProps {
   fallbackSupported: boolean
   /** Decoded payload stored on the node, or `null` if unset. */
   fallback: FallbackPayload | null
+  /** Persisted display-format override for this placeholder occurrence. */
+  format: PlaceholderFormatPayload | null
+  /** Whether the terminal field has an existing shared formatting editor. */
+  formattingSupported: boolean
   /** Swap the placeholder id + clear (or preserve) fallback. */
   onChangeVariable: (newId: string) => void
   /** Patch `fallback` attr on the node. `null` unsets it. */
   onFallbackChange: (payload: FallbackPayload | null) => void
+  /** Patch the per-placeholder display-format payload. */
+  onFormatChange: (payload: PlaceholderFormatPayload | null) => void
   /** Remove the node. */
   onDelete: () => void
   /** Close the popover after an action. */
   onClose: () => void
 }
 
+/** Routes within the placeholder popover's shared command-navigation stack. */
+type PlaceholderPopoverNavItem = NavigationItem
+
 /**
- * Popover content anchored on a placeholder badge. Two modes:
+ * Popover content anchored on a placeholder badge. Three command-navigation routes:
  * - `edit`: breadcrumb + typed fallback input + footer (change / delete)
  * - `picker`: renders the shared placeholder picker with a back affordance
+ * - `formatting`: renders the shared field-options editor for this occurrence
  */
 export function PlaceholderPopover({
   breadcrumb,
@@ -44,25 +66,65 @@ export function PlaceholderPopover({
   fieldType,
   fallbackSupported,
   fallback,
+  format,
+  formattingSupported,
   onChangeVariable,
   onFallbackChange,
+  onFormatChange,
   onDelete,
   onClose,
 }: PlaceholderPopoverProps) {
-  const [mode, setMode] = useState<'edit' | 'picker'>('edit')
+  return (
+    <CommandNavigation<PlaceholderPopoverNavItem>>
+      <PlaceholderPopoverContent
+        breadcrumb={breadcrumb}
+        field={field}
+        fieldType={fieldType}
+        fallbackSupported={fallbackSupported}
+        fallback={fallback}
+        format={format}
+        formattingSupported={formattingSupported}
+        onChangeVariable={onChangeVariable}
+        onFallbackChange={onFallbackChange}
+        onFormatChange={onFormatChange}
+        onDelete={onDelete}
+        onClose={onClose}
+      />
+    </CommandNavigation>
+  )
+}
 
-  if (mode === 'picker') {
+/** Render the placeholder popover for the current shared navigation route. */
+function PlaceholderPopoverContent({
+  breadcrumb,
+  field,
+  fieldType,
+  fallbackSupported,
+  fallback,
+  format,
+  formattingSupported,
+  onChangeVariable,
+  onFallbackChange,
+  onFormatChange,
+  onDelete,
+  onClose,
+}: PlaceholderPopoverProps) {
+  const { current, isAtRoot, pop, push, reset } = useCommandNavigation<PlaceholderPopoverNavItem>()
+  const route = current?.id
+
+  if (route === 'picker' || (!isAtRoot && route !== 'formatting')) {
     // Match the width of the inline-picker popover (InlinePickerPopover uses
     // width={288}). The badge's host PopoverContent is `w-auto`, so without
     // an explicit width here the picker collapses to fit content.
     return (
       <div className='w-72'>
         <PlaceholderPickerContent
-          onBack={() => setMode('edit')}
-          backLabel='Fallback'
+          onBack={pop}
+          backLabel='Placeholder'
+          navigationOffset={1}
           onSelect={(newId) => {
             onChangeVariable(newId)
-            setMode('edit')
+            reset()
           }}
         />
       </div>
@@ -70,6 +132,34 @@ export function PlaceholderPopover({
   }
 
   const currentValue = fallback && fallback.t === fieldType ? extractValue(fallback) : null
+  const formattingType =
+    formattingSupported && fieldType ? (fieldType as PlaceholderFormatType) : null
+  const formattingOptions = {
+    ...field?.options,
+    ...(format?.t === formattingType ? format.o : {}),
+  }
+
+  if (route === 'formatting' && formattingType) {
+    return (
+      <div className='w-80 p-2'>
+        <Button variant='ghost' size='sm' onClick={pop} className='mb-2'>
+          Back
+        </Button>
+        <PlaceholderFormattingEditor
+          fieldType={formattingType}
+          options={formattingOptions as Partial<FieldOptions>}
+          onChange={(options) => {
+            onFormatChange(normalizePlaceholderFormat({ v: 1, t: formattingType, o: options }))
+          }}
+        />
+        {format && (
+          <Button variant='ghost' size='xs' onClick={() => onFormatChange(null)} className='mt-2'>
+            Use field default
+          </Button>
+        )}
+      </div>
+    )
+  }
 
   return (
     <div className='flex flex-col gap-2 p-2 w-[320px]'>
@@ -99,22 +189,34 @@ export function PlaceholderPopover({
         <Button
           variant='ghost'
           size='sm'
-          onClick={() => setMode('picker')}
+          onClick={() => push({ id: 'picker', label: 'Placeholder' })}
           className='h-7 gap-1 text-xs'>
           <ArrowRightLeft className='size-3' />
           Change variable
         </Button>
-        <Button
-          variant='ghost'
-          size='icon-sm'
-          onClick={() => {
-            onDelete()
-            onClose()
-          }}
-          className='h-7 w-7 text-muted-foreground hover:text-destructive'
-          aria-label='Remove placeholder'>
-          <Trash2 className='size-3' />
-        </Button>
+        <div className='flex items-center gap-1'>
+          {formattingType && (
+            <Button
+              variant='ghost'
+              size='icon-sm'
+              onClick={() => push({ id: 'formatting', label: 'Formatting' })}
+              className='h-7 w-7 text-muted-foreground'
+              aria-label='Format placeholder'>
+              <Settings2 className='size-3' />
+            </Button>
+          )}
+          <Button
+            variant='ghost'
+            size='icon-sm'
+            onClick={() => {
+              onDelete()
+              onClose()
+            }}
+            className='h-7 w-7 text-muted-foreground hover:text-destructive'
+            aria-label='Remove placeholder'>
+            <Trash2 className='size-3' />
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/components/sequences/ui/detail/sequence-body-editor.tsx
+++ b/apps/web/src/components/sequences/ui/detail/sequence-body-editor.tsx
@@ -39,8 +39,7 @@ interface SequenceBodyEditorProps {
   bodyJson: Record<string, unknown> | null
   /** Persisted HTML body — seed fallback when no JSON exists yet. */
   bodyHtml: string | null
-  /** Null for manual sequences — offers the visit-token placeholder root only on visit-subject
-   * sequences (client-notifications plan §4.5/§4.7). */
+  /** Null for manual sequences — offers Visit fields only on visit-subject sequences. */
   subjectKind?: 'visit' | 'work_order' | 'invoice' | null
   /** Fires with the stripped JSON + generated HTML on every doc change. */
   onChange: (bodyJson: JSONContent, bodyHtml: string) => void
@@ -235,13 +234,6 @@ function SequenceBodyEditorInner({
             extraRoots={extraRoots}
             onSelect={(id) => {
               runWithChipRange((editor, range) => {
-                // Visit tokens (§4.5) are pre-resolved by plain code in the send node, not the
-                // entity placeholder resolver — insert literal `{{visit:*}}` text, not a chip
-                // (a chip would render as an unresolvable "Unknown placeholder" badge).
-                if (id.startsWith('visit:')) {
-                  editor.chain().focus().deleteRange(range).insertContent(`{{${id}}} `).run()
-                  return
-                }
                 editor
                   .chain()
                   .focus()

--- a/apps/web/src/components/sequences/ui/detail/sequence-step-card.tsx
+++ b/apps/web/src/components/sequences/ui/detail/sequence-step-card.tsx
@@ -22,7 +22,7 @@ interface SequenceStepCardProps {
   totalSteps: number
   /** Step 1's subject — steps 2+ thread under it ("Re: …"). */
   step1Subject: string | null
-  /** Null for manual sequences — gates the visit-token placeholder root (§4.5/§4.7). */
+  /** Null for manual sequences — gates the Visit placeholder root (§4.5/§4.7). */
   subjectKind: 'visit' | 'work_order' | 'invoice' | null
   onMoveUp?: () => void
   onMoveDown?: () => void

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -117,6 +117,7 @@ export const ModelTypeValues = [
   'article',
   'kb',
   'work_order',
+  'visit',
   'service_request',
   'quote',
   'line_item',
@@ -156,6 +157,7 @@ export const ModelTypes = {
   ARTICLE: 'article',
   KB: 'kb',
   WORK_ORDER: 'work_order',
+  VISIT: 'visit',
   SERVICE_REQUEST: 'service_request',
   QUOTE: 'quote',
   LINE_ITEM: 'line_item',
@@ -353,6 +355,15 @@ export const ModelTypeMeta: Record<
     // its fullscreen button and `getRecordLink` starts returning
     // `/app/work-orders/[id]` URLs. `service_request` stays drawer-only.
     hasDetailPage: true,
+  },
+  visit: {
+    label: 'Visit',
+    plural: 'Visits',
+    icon: 'calendar',
+    color: 'sky',
+    apiSlug: 'visits',
+    dbTable: 'WorkOrderVisit',
+    hasDetailPage: false,
   },
   service_request: {
     label: 'Service Request',

--- a/packages/lib/src/field-values/field-value-queries.ts
+++ b/packages/lib/src/field-values/field-value-queries.ts
@@ -625,14 +625,14 @@ async function fetchVirtualFieldResults(
     if (!recordId) continue
 
     for (const entry of virtualFields) {
-      const value = fieldMap.get(entry.fieldKey)
-      if (value) {
+      const virtualValue = fieldMap.get(entry.fieldKey)
+      if (virtualValue) {
         results.push({
           recordId,
           fieldRef: entry.fieldRef,
-          value,
+          value: virtualValue.value,
           fieldType: entry.fieldType,
-          fieldOptions: entry.fieldOptions,
+          fieldOptions: { ...entry.fieldOptions, ...virtualValue.fieldOptions },
         })
       }
     }
@@ -853,8 +853,8 @@ async function fetchTerminalFieldValues(
     for (const [entityId, fieldMap] of virtualValues) {
       const rid = instanceToRecordId.get(entityId)
       if (!rid) continue
-      const val = fieldMap.get(cachedField.key)
-      if (val) resultMap.set(rid, val)
+      const virtualValue = fieldMap.get(cachedField.key)
+      if (virtualValue) resultMap.set(rid, virtualValue.value)
     }
     return resultMap
   }

--- a/packages/lib/src/field-values/resolvers/index.ts
+++ b/packages/lib/src/field-values/resolvers/index.ts
@@ -8,3 +8,4 @@ export {
 } from './system-table-resolver'
 export { resolveThreadVirtualFields } from './thread-virtual-fields'
 export { isVirtualField, resolveVirtualFields } from './virtual-field-registry'
+export { resolveVisitVirtualFields } from './visit-virtual-fields'

--- a/packages/lib/src/field-values/resolvers/system-table-resolver.test.ts
+++ b/packages/lib/src/field-values/resolvers/system-table-resolver.test.ts
@@ -1,0 +1,116 @@
+// packages/lib/src/field-values/resolvers/system-table-resolver.test.ts
+
+import { FieldType } from '@auxx/database/enums'
+import type { ResourceFieldId } from '@auxx/types/field'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FieldValueContext } from '../field-value-helpers'
+import type { SystemFieldDescriptor } from './system-table-resolver'
+
+/** Replace the org cache with deterministic actor records for resolver tests. */
+const { getCachedMembersByUserIds } = vi.hoisted(() => ({
+  getCachedMembersByUserIds: vi.fn(),
+}))
+
+vi.mock('../../cache', () => ({ getCachedMembersByUserIds }))
+vi.mock('@auxx/database', () => ({
+  schema: {
+    WorkOrderVisit: { id: {}, organizationId: {}, assigneeUserId: {} },
+    Thread: { id: {}, organizationId: {}, assigneeUserId: {} },
+  },
+}))
+
+import { resolveSystemTableFields } from './system-table-resolver'
+
+/** Build the minimal query-chain double used by the system-table resolver. */
+function createDatabase(rows: unknown[]) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: async () => rows,
+      }),
+    }),
+  }
+}
+
+/** Build a field-value context with the supplied system-table rows. */
+function createContext(rows: unknown[]): FieldValueContext {
+  return {
+    db: createDatabase(rows) as unknown as FieldValueContext['db'],
+    organizationId: 'org_123',
+    fieldCache: new Map(),
+    batchRelationshipValidationCache: new Map(),
+    validator: {} as FieldValueContext['validator'],
+    bypassFieldGuards: new Set(),
+  }
+}
+
+/** Build an ACTOR descriptor backed by a system-table user-id column. */
+function actorField(entityType: string): SystemFieldDescriptor {
+  return {
+    fieldKey: 'assignee',
+    fieldId: 'assignee-field',
+    fieldRef: `${entityType}:assignee` as ResourceFieldId,
+    fieldType: FieldType.ACTOR,
+    fieldOptions: { actor: { target: 'user', multiple: false } },
+    dbColumn: 'assigneeUserId',
+  }
+}
+
+describe('resolveSystemTableFields actor hydration', () => {
+  beforeEach(() => {
+    getCachedMembersByUserIds.mockReset()
+  })
+
+  it('uses the cached member name for a Visit actor field', async () => {
+    getCachedMembersByUserIds.mockResolvedValue([
+      { userId: 'user_123', user: { name: 'Jordan Lee' } },
+    ])
+
+    const results = await resolveSystemTableFields(
+      createContext([{ id: 'visit_123', assignee: 'user_123' }]),
+      'visit',
+      ['visit_123'],
+      [actorField('visit')]
+    )
+
+    expect(results[0]?.value).toMatchObject({
+      type: 'actor',
+      actorId: 'user:user_123',
+      displayName: 'Jordan Lee',
+    })
+    expect(getCachedMembersByUserIds).toHaveBeenCalledWith('org_123', ['user_123'])
+  })
+
+  it('leaves a deleted or missing actor unnamed so the placeholder fallback can apply', async () => {
+    getCachedMembersByUserIds.mockResolvedValue([])
+
+    const results = await resolveSystemTableFields(
+      createContext([{ id: 'visit_123', assignee: 'user_deleted' }]),
+      'visit',
+      ['visit_123'],
+      [actorField('visit')]
+    )
+
+    expect(results[0]?.value).toMatchObject({ type: 'actor', actorId: 'user:user_deleted' })
+    expect(results[0]?.value).not.toHaveProperty('displayName')
+  })
+
+  it('hydrates actor fields for every system resource, not only Visit', async () => {
+    getCachedMembersByUserIds.mockResolvedValue([
+      { userId: 'user_456', user: { name: 'Morgan Yu' } },
+    ])
+
+    const results = await resolveSystemTableFields(
+      createContext([{ id: 'thread_123', assignee: 'user_456' }]),
+      'thread',
+      ['thread_123'],
+      [actorField('thread')]
+    )
+
+    expect(results[0]?.value).toMatchObject({
+      type: 'actor',
+      actorId: 'user:user_456',
+      displayName: 'Morgan Yu',
+    })
+  })
+})

--- a/packages/lib/src/field-values/resolvers/system-table-resolver.ts
+++ b/packages/lib/src/field-values/resolvers/system-table-resolver.ts
@@ -7,6 +7,7 @@ import { toActorId } from '@auxx/types/actor'
 import { parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
 import { and, eq, inArray } from 'drizzle-orm'
+import { getCachedMembersByUserIds } from '../../cache'
 import type { FieldOptions } from '../../custom-fields/field-options'
 import { RESOURCE_DISPLAY_CONFIG } from '../../resources/registry/display-config'
 import { RESOURCE_TABLE_MAP, type TableId } from '../../resources/registry/field-registry'
@@ -66,8 +67,9 @@ export async function resolveSystemTableFields(
   if (Object.keys(selectedColumns).length === 0) return []
 
   const rows = await querySystemTable(ctx, entityDefId, table, entityIds, selectedColumns)
-
-  return mapRowsToResults(rows, fields, entityDefId)
+  const results = mapRowsToResults(rows, fields, entityDefId)
+  await hydrateActorDisplayNames(ctx, results)
+  return results
 }
 
 /**
@@ -163,7 +165,9 @@ export async function resolveEntityInstanceFields(
     .from(table)
     .where(and(inArray(table.id, entityIds), eq(table.organizationId, ctx.organizationId)))
 
-  return mapRowsToResults(rows, fields, entityDefId)
+  const results = mapRowsToResults(rows, fields, entityDefId)
+  await hydrateActorDisplayNames(ctx, results)
+  return results
 }
 
 /**
@@ -292,4 +296,45 @@ function resolveActorValue(
     id,
     actorId: toActorId(actorTarget, id),
   } as TypedFieldValue
+}
+
+/**
+ * Hydrate names for actor values emitted from system-table columns.
+ *
+ * Values retain their actor discriminator so group/agent hydration can be
+ * added here without changing the resolver's public result shape. Unknown or
+ * deleted actors intentionally keep no display name, allowing the generic
+ * placeholder fallback path to render its configured value.
+ */
+async function hydrateActorDisplayNames(
+  ctx: FieldValueContext,
+  results: TypedFieldValueResult[]
+): Promise<void> {
+  const userIds = new Set<string>()
+  for (const result of results) {
+    const values =
+      result.value === null ? [] : Array.isArray(result.value) ? result.value : [result.value]
+    for (const value of values) {
+      if (value.type === 'actor' && value.actorType === 'user') userIds.add(value.id)
+    }
+  }
+  if (userIds.size === 0) return
+
+  const users = await getCachedMembersByUserIds(ctx.organizationId, [...userIds])
+
+  const displayNameById = new Map<string, string>()
+  for (const user of users) {
+    const displayName = user.user?.name?.trim()
+    if (displayName) displayNameById.set(user.userId, displayName)
+  }
+
+  for (const result of results) {
+    const values =
+      result.value === null ? [] : Array.isArray(result.value) ? result.value : [result.value]
+    for (const value of values) {
+      if (value.type !== 'actor' || value.actorType !== 'user') continue
+      const displayName = displayNameById.get(value.id)
+      if (displayName) value.displayName = displayName
+    }
+  }
 }

--- a/packages/lib/src/field-values/resolvers/virtual-field-registry.ts
+++ b/packages/lib/src/field-values/resolvers/virtual-field-registry.ts
@@ -1,8 +1,19 @@
 // packages/lib/src/field-values/resolvers/virtual-field-registry.ts
 
 import type { TypedFieldValue } from '@auxx/types'
+import type { FieldOptions } from '../../custom-fields/field-options'
 import type { FieldValueContext } from '../field-value-helpers'
 import { resolveThreadVirtualFields } from './thread-virtual-fields'
+import { resolveVisitVirtualFields } from './visit-virtual-fields'
+
+/** A virtual value plus per-record options needed to display it correctly. */
+export interface VirtualFieldValue {
+  value: TypedFieldValue
+  fieldOptions?: FieldOptions
+}
+
+/** Virtual values grouped by record id and field key. */
+export type VirtualFieldMap = Map<string, Map<string, VirtualFieldValue>>
 
 /**
  * Fields with dbColumn: undefined that have custom cross-table resolvers.
@@ -10,6 +21,7 @@ import { resolveThreadVirtualFields } from './thread-virtual-fields'
  */
 const VIRTUAL_FIELD_KEYS: Record<string, Set<string>> = {
   thread: new Set(['from', 'to', 'body', 'hasAttachments', 'hasDraft', 'sent']),
+  visit: new Set(['date', 'startTime', 'endTime']),
 }
 
 /** Check using field KEY (not UUID). */
@@ -24,13 +36,26 @@ export async function resolveVirtualFields(
   entityIds: string[],
   fieldKeys: string[],
   fieldIdMap: Map<string, string>
-): Promise<Map<string, Map<string, TypedFieldValue>>> {
+): Promise<VirtualFieldMap> {
   if (entityIds.length === 0 || fieldKeys.length === 0) return new Map()
 
   switch (entityDefId) {
     case 'thread':
-      return resolveThreadVirtualFields(ctx, entityIds, fieldKeys, fieldIdMap)
+      return toVirtualFieldMap(
+        await resolveThreadVirtualFields(ctx, entityIds, fieldKeys, fieldIdMap)
+      )
+    case 'visit':
+      return resolveVisitVirtualFields(ctx, entityIds, fieldKeys, fieldIdMap)
     default:
       return new Map()
   }
+}
+
+/** Wrap legacy virtual values that do not require per-record display options. */
+function toVirtualFieldMap(values: Map<string, Map<string, TypedFieldValue>>): VirtualFieldMap {
+  const result: VirtualFieldMap = new Map()
+  for (const [entityId, fieldMap] of values) {
+    result.set(entityId, new Map([...fieldMap].map(([key, value]) => [key, { value }])))
+  }
+  return result
 }

--- a/packages/lib/src/field-values/resolvers/visit-virtual-fields.test.ts
+++ b/packages/lib/src/field-values/resolvers/visit-virtual-fields.test.ts
@@ -1,0 +1,80 @@
+// packages/lib/src/field-values/resolvers/visit-virtual-fields.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { FieldValueContext } from '../field-value-helpers'
+import { resolveVisitVirtualFields } from './visit-virtual-fields'
+
+/** Build the minimal query-chain double needed by the Visit virtual resolver. */
+function createDatabase(rows: unknown[]) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: async () => rows,
+      }),
+    }),
+  }
+}
+
+/** Build the field-value context needed by the Visit virtual resolver. */
+function createContext(rows: unknown[]): FieldValueContext {
+  return {
+    db: createDatabase(rows) as unknown as FieldValueContext['db'],
+    organizationId: 'org_123',
+    fieldCache: new Map(),
+    batchRelationshipValidationCache: new Map(),
+    validator: {} as FieldValueContext['validator'],
+    bypassFieldGuards: new Set(),
+  }
+}
+
+describe('resolveVisitVirtualFields', () => {
+  it('returns raw typed timestamps without presentation metadata', async () => {
+    const startTime = new Date('2026-07-14T16:30:00.000Z')
+    const endTime = new Date('2026-07-14T17:30:00.000Z')
+    const values = await resolveVisitVirtualFields(
+      createContext([{ id: 'visit_123', startTime, endTime }]),
+      ['visit_123'],
+      ['date', 'startTime', 'endTime'],
+      new Map([
+        ['date', 'date-field'],
+        ['startTime', 'start-field'],
+        ['endTime', 'end-field'],
+      ])
+    )
+
+    const fields = values.get('visit_123')
+    expect(fields?.get('date')).toMatchObject({
+      value: { type: 'date', value: startTime.toISOString() },
+    })
+    expect(fields?.get('startTime')).toMatchObject({
+      value: { type: 'date', value: startTime.toISOString() },
+    })
+    expect(fields?.get('endTime')).toMatchObject({
+      value: { type: 'date', value: endTime.toISOString() },
+    })
+    expect(fields?.get('date')?.fieldOptions).toBeUndefined()
+    expect(fields?.get('startTime')?.fieldOptions).toBeUndefined()
+    expect(fields?.get('endTime')?.fieldOptions).toBeUndefined()
+  })
+
+  it('omits absent Visit times', async () => {
+    const startTime = new Date('2026-07-14T16:30:00.000Z')
+    const values = await resolveVisitVirtualFields(
+      createContext([{ id: 'visit_123', startTime, endTime: null }]),
+      ['visit_123'],
+      ['date', 'startTime', 'endTime'],
+      new Map()
+    )
+
+    const fields = values.get('visit_123')
+    expect(fields?.get('date')?.value).toMatchObject({
+      type: 'date',
+      value: startTime.toISOString(),
+    })
+    expect(fields?.get('startTime')?.value).toMatchObject({
+      type: 'date',
+      value: startTime.toISOString(),
+    })
+    expect(fields?.has('endTime')).toBe(false)
+  })
+})

--- a/packages/lib/src/field-values/resolvers/visit-virtual-fields.ts
+++ b/packages/lib/src/field-values/resolvers/visit-virtual-fields.ts
@@ -1,0 +1,79 @@
+// packages/lib/src/field-values/resolvers/visit-virtual-fields.ts
+
+import { schema } from '@auxx/database'
+import type { TypedFieldValue } from '@auxx/types'
+import { and, eq, inArray } from 'drizzle-orm'
+import type { FieldValueContext } from '../field-value-helpers'
+import type { VirtualFieldMap } from './virtual-field-registry'
+
+/** Build the shared typed-value metadata for a virtual Visit field. */
+function buildBase(entityId: string, fieldKey: string, fieldIdMap: Map<string, string>) {
+  const now = new Date().toISOString()
+  return {
+    id: `virtual_${entityId}_${fieldKey}`,
+    entityId,
+    fieldId: fieldIdMap.get(fieldKey) ?? fieldKey,
+    sortKey: '0',
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+/** Store a resolved virtual field value. */
+function setFieldValue(
+  result: VirtualFieldMap,
+  entityId: string,
+  fieldKey: string,
+  value: TypedFieldValue
+) {
+  const fieldMap = result.get(entityId) ?? new Map()
+  fieldMap.set(fieldKey, { value })
+  result.set(entityId, fieldMap)
+}
+
+/**
+ * Resolve Visit presentation fields from one organization-scoped query.
+ *
+ * `startTime` and `endTime` stay absolute ISO values. Callers apply their
+ * own presentation timezone only when they render the resolved value.
+ */
+export async function resolveVisitVirtualFields(
+  ctx: FieldValueContext,
+  entityIds: string[],
+  fieldKeys: string[],
+  fieldIdMap: Map<string, string>
+): Promise<VirtualFieldMap> {
+  if (entityIds.length === 0 || fieldKeys.length === 0) return new Map()
+
+  const rows = await ctx.db
+    .select({
+      id: schema.WorkOrderVisit.id,
+      startTime: schema.WorkOrderVisit.startTime,
+      endTime: schema.WorkOrderVisit.endTime,
+    })
+    .from(schema.WorkOrderVisit)
+    .where(
+      and(
+        inArray(schema.WorkOrderVisit.id, entityIds),
+        eq(schema.WorkOrderVisit.organizationId, ctx.organizationId)
+      )
+    )
+
+  const requested = new Set(fieldKeys)
+  const result: VirtualFieldMap = new Map()
+  for (const row of rows) {
+    for (const fieldKey of ['date', 'startTime', 'endTime'] as const) {
+      if (!requested.has(fieldKey)) continue
+      const value = fieldKey === 'endTime' ? row.endTime : row.startTime
+      if (!value) continue
+
+      setFieldValue(result, row.id, fieldKey, {
+        ...buildBase(row.id, fieldKey, fieldIdMap),
+        type: 'date',
+        value: value.toISOString(),
+      } as TypedFieldValue)
+    }
+  }
+
+  return result
+}

--- a/packages/lib/src/placeholders/client.ts
+++ b/packages/lib/src/placeholders/client.ts
@@ -14,6 +14,16 @@ export {
   renderFallbackPayload,
 } from './fallback-codec'
 export {
+  decodePlaceholderFormat,
+  encodePlaceholderFormat,
+  getPlaceholderFormatOptions,
+  isPlaceholderFormatType,
+  normalizePlaceholderFormat,
+  PLACEHOLDER_FORMAT_TYPES,
+  type PlaceholderFormatPayload,
+  type PlaceholderFormatType,
+} from './format-codec'
+export {
   type DateSlug,
   type OrgSlug,
   type ParsedPlaceholder,

--- a/packages/lib/src/placeholders/format-codec.test.ts
+++ b/packages/lib/src/placeholders/format-codec.test.ts
@@ -1,0 +1,48 @@
+// packages/lib/src/placeholders/format-codec.test.ts
+
+import { describe, expect, it } from 'vitest'
+import {
+  decodePlaceholderFormat,
+  encodePlaceholderFormat,
+  getPlaceholderFormatOptions,
+  normalizePlaceholderFormat,
+} from './format-codec'
+
+describe('placeholder format codec', () => {
+  it('round-trips standard field options for a matching field type', () => {
+    const encoded = encodePlaceholderFormat({
+      v: 1,
+      t: 'TIME',
+      o: { timeFormat: '24h' },
+    })
+    const payload = decodePlaceholderFormat(encoded)
+
+    expect(payload).toEqual({ v: 1, t: 'TIME', o: { timeFormat: '24h' } })
+    expect(getPlaceholderFormatOptions(payload, 'TIME')).toEqual({ timeFormat: '24h' })
+    expect(getPlaceholderFormatOptions(payload, 'DATE')).toBeUndefined()
+  })
+
+  it('does not allow a placeholder to override resolver-owned timezone metadata', () => {
+    const payload = decodePlaceholderFormat(
+      JSON.stringify({
+        v: 1,
+        t: 'TIME',
+        o: { timeFormat: '24h', timeZone: 'Pacific/Honolulu' },
+      })
+    )
+
+    expect(payload).toEqual({ v: 1, t: 'TIME', o: { timeFormat: '24h' } })
+    expect(
+      normalizePlaceholderFormat({
+        v: 1,
+        t: 'TIME',
+        o: { timeFormat: '24h', timeZone: 'Pacific/Honolulu' },
+      })
+    ).toEqual({ v: 1, t: 'TIME', o: { timeFormat: '24h' } })
+  })
+
+  it('rejects malformed and unsupported formatting payloads', () => {
+    expect(decodePlaceholderFormat('{')).toBeNull()
+    expect(decodePlaceholderFormat(JSON.stringify({ v: 1, t: 'ACTOR', o: {} }))).toBeNull()
+  })
+})

--- a/packages/lib/src/placeholders/format-codec.ts
+++ b/packages/lib/src/placeholders/format-codec.ts
@@ -1,0 +1,183 @@
+// packages/lib/src/placeholders/format-codec.ts
+
+import type { FieldOptions } from '../custom-fields/field-options'
+
+/** Field types whose standard display options can be overridden per placeholder occurrence. */
+export const PLACEHOLDER_FORMAT_TYPES = [
+  'NUMBER',
+  'CURRENCY',
+  'DATE',
+  'DATETIME',
+  'TIME',
+  'CHECKBOX',
+  'PHONE_INTL',
+  'URL',
+] as const
+
+/** A field type supported by the shared placeholder formatting editor. */
+export type PlaceholderFormatType = (typeof PLACEHOLDER_FORMAT_TYPES)[number]
+
+/** A versioned, per-placeholder override of the normal field display options. */
+export interface PlaceholderFormatPayload {
+  v: 1
+  t: PlaceholderFormatType
+  o: Partial<FieldOptions>
+}
+
+/** Check whether a field type can use the shared placeholder formatting editor. */
+export function isPlaceholderFormatType(value: string): value is PlaceholderFormatType {
+  return (PLACEHOLDER_FORMAT_TYPES as readonly string[]).includes(value)
+}
+
+/** Serialize a display override for the placeholder node's `data-format` attribute. */
+export function encodePlaceholderFormat(payload: PlaceholderFormatPayload): string {
+  const normalized = normalizePlaceholderFormat(payload)
+  return normalized ? JSON.stringify(normalized) : ''
+}
+
+/**
+ * Parse and normalize a placeholder display override.
+ *
+ * Only formatting keys produced by the shared editors are accepted. In
+ * particular, `timeZone` is deliberately excluded: Visit resolution owns that
+ * context-sensitive option so sequence delivery timezone remains authoritative.
+ */
+export function decodePlaceholderFormat(
+  raw: string | null | undefined
+): PlaceholderFormatPayload | null {
+  if (!raw) return null
+
+  try {
+    const parsed = JSON.parse(raw) as { v?: unknown; t?: unknown; o?: unknown }
+    if (parsed.v !== 1 || typeof parsed.t !== 'string' || !isPlaceholderFormatType(parsed.t)) {
+      return null
+    }
+    return normalizePlaceholderFormat(parsed)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Normalize a format payload before it is retained in editor JSON or HTML.
+ *
+ * This makes the node state and rendered span obey the same allow-list, so a
+ * runtime-only option such as a resolver-provided timezone cannot be saved by
+ * a caller that updates node attributes directly.
+ */
+export function normalizePlaceholderFormat(payload: {
+  v?: unknown
+  t?: unknown
+  o?: unknown
+}): PlaceholderFormatPayload | null {
+  if (payload.v !== 1 || typeof payload.t !== 'string' || !isPlaceholderFormatType(payload.t)) {
+    return null
+  }
+  const options = normalizeOptions(payload.t, payload.o)
+  return options ? { v: 1, t: payload.t, o: options } : null
+}
+
+/** Return the override when it applies to the resolved field type. */
+export function getPlaceholderFormatOptions(
+  payload: PlaceholderFormatPayload | null,
+  fieldType: string
+): Partial<FieldOptions> | undefined {
+  return payload?.t === fieldType ? payload.o : undefined
+}
+
+/** Normalize only the field options supported by the matching display editor. */
+function normalizeOptions(
+  fieldType: PlaceholderFormatType,
+  input: unknown
+): Partial<FieldOptions> | null {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return null
+  const value = input as Record<string, unknown>
+
+  switch (fieldType) {
+    case 'NUMBER':
+      return pickNumberOptions(value)
+    case 'CURRENCY':
+      return { ...pickNumberOptions(value), ...pickCurrencyOptions(value) }
+    case 'DATE':
+    case 'DATETIME':
+    case 'TIME':
+      return pickDateOptions(value, fieldType)
+    case 'CHECKBOX':
+      return pickCheckboxOptions(value)
+    case 'PHONE_INTL':
+      return pickPhoneOptions(value)
+    case 'URL':
+      return pickUrlOptions(value)
+  }
+}
+
+/** Select valid number display options. */
+function pickNumberOptions(value: Record<string, unknown>): Partial<FieldOptions> {
+  const options: Partial<FieldOptions> = {}
+  if (typeof value.decimals === 'number' && Number.isInteger(value.decimals)) {
+    options.decimals = value.decimals
+  }
+  if (typeof value.useGrouping === 'boolean') options.useGrouping = value.useGrouping
+  if (isOneOf(value.displayAs, ['number', 'percentage', 'compact', 'bytes'])) {
+    options.displayAs = value.displayAs
+  }
+  if (typeof value.prefix === 'string') options.prefix = value.prefix
+  if (typeof value.suffix === 'string') options.suffix = value.suffix
+  return options
+}
+
+/** Select valid currency-specific display options. */
+function pickCurrencyOptions(value: Record<string, unknown>): Partial<FieldOptions> {
+  const options: Partial<FieldOptions> = {}
+  if (typeof value.currencyCode === 'string') options.currencyCode = value.currencyCode
+  if (isOneOf(value.currencyDisplay, ['symbol', 'code', 'name', 'compact'])) {
+    options.currencyDisplay = value.currencyDisplay
+  }
+  return options
+}
+
+/** Select valid date and time display options without permitting timezone overrides. */
+function pickDateOptions(
+  value: Record<string, unknown>,
+  fieldType: 'DATE' | 'DATETIME' | 'TIME'
+): Partial<FieldOptions> {
+  const options: Partial<FieldOptions> = {}
+  if (
+    fieldType !== 'TIME' &&
+    isOneOf(value.format, ['short', 'medium', 'long', 'relative', 'iso'])
+  ) {
+    options.format = value.format
+  }
+  if (fieldType !== 'DATE' && isOneOf(value.timeFormat, ['12h', '24h'])) {
+    options.timeFormat = value.timeFormat
+  }
+  return options
+}
+
+/** Select valid checkbox display options. */
+function pickCheckboxOptions(value: Record<string, unknown>): Partial<FieldOptions> {
+  const options: Partial<FieldOptions> = {}
+  if (isOneOf(value.checkboxStyle, ['icon', 'text', 'icon-text'])) {
+    options.checkboxStyle = value.checkboxStyle
+  }
+  if (typeof value.trueLabel === 'string') options.trueLabel = value.trueLabel
+  if (typeof value.falseLabel === 'string') options.falseLabel = value.falseLabel
+  return options
+}
+
+/** Select a valid phone display option. */
+function pickPhoneOptions(value: Record<string, unknown>): Partial<FieldOptions> {
+  return isOneOf(value.phoneFormat, ['raw', 'national', 'international'])
+    ? { phoneFormat: value.phoneFormat }
+    : {}
+}
+
+/** Select a valid URL display option. */
+function pickUrlOptions(value: Record<string, unknown>): Partial<FieldOptions> {
+  return isOneOf(value.urlDisplay, ['link', 'image']) ? { urlDisplay: value.urlDisplay } : {}
+}
+
+/** Narrow an unknown value to one literal from an allowed list. */
+function isOneOf<const T extends string>(value: unknown, allowed: readonly T[]): value is T {
+  return typeof value === 'string' && (allowed as readonly string[]).includes(value)
+}

--- a/packages/lib/src/placeholders/resolver.ts
+++ b/packages/lib/src/placeholders/resolver.ts
@@ -11,6 +11,7 @@ import type { FieldOptions } from '../custom-fields/field-options'
 import { FieldValueService } from '../field-values/field-value-service'
 import { formatToDisplayValue } from '../field-values/formatter'
 import { decodeFallback, renderFallbackPayload } from './fallback-codec'
+import { decodePlaceholderFormat, getPlaceholderFormatOptions } from './format-codec'
 import {
   type OrgSlug,
   type ParsedPlaceholder,
@@ -36,12 +37,21 @@ export interface PlaceholderResolutionContext {
   senderUserId?: string
   /** Optional "now" override — defaults to `new Date()`. Useful in tests. */
   now?: Date
+  /** Optional timezone for presentation-only fields such as Visit date and times. */
+  timezone?: string
   /**
    * Root id → RecordId map. Populated by `buildPlaceholderContextForThread`
    * (or any other context builder). Slug-rooted entries use the slug
    * literal; cuid-rooted entries use `EntityDefinition.id`.
    */
   recordIdsByRoot: Map<string, RecordId>
+}
+
+/** Typed field metadata retained until each placeholder span is rendered. */
+interface ResolvedFieldToken {
+  value: TypedFieldValue | TypedFieldValue[]
+  fieldType: FieldType
+  fieldOptions?: FieldOptions
 }
 
 /**
@@ -152,6 +162,7 @@ export async function resolvePlaceholdersInHtml(
 
     const raw = extractAttr(fullMatch, 'data-fallback')
     const fallback = decodeFallback(raw)
+    const format = decodePlaceholderFormat(extractAttr(fullMatch, 'data-format'))
 
     if (parsed.kind === 'org') {
       if (!orgProfile) throw new Error(`Organization profile not found for org: ${id}`)
@@ -173,10 +184,16 @@ export async function resolvePlaceholdersInHtml(
     }
 
     const resolved = fieldValues.get(id)
-    if (resolved === null || resolved === '' || resolved === undefined) {
+    if (resolved === null || resolved === undefined) {
       return fallback ? escapeHtml(renderFallbackPayload(fallback)) : ''
     }
-    return escapeHtml(resolved)
+    const value = formatFieldValueForText(resolved.value, resolved.fieldType, {
+      ...resolved.fieldOptions,
+      ...getPlaceholderFormatOptions(format, resolved.fieldType),
+      ...(ctx.timezone ? { timeZone: ctx.timezone } : {}),
+    })
+    if (value === '') return fallback ? escapeHtml(renderFallbackPayload(fallback)) : ''
+    return escapeHtml(value)
   })
 }
 
@@ -221,7 +238,7 @@ function userColumn(
 async function resolveFieldTokens(
   tokens: { id: string; parsed: Extract<ParsedPlaceholder, { kind: 'field' }> }[],
   ctx: PlaceholderResolutionContext
-): Promise<Map<string, string | null>> {
+): Promise<Map<string, ResolvedFieldToken | null>> {
   if (tokens.length === 0) return new Map()
 
   // Group by starting record id so we can batch per-record.
@@ -240,7 +257,7 @@ async function resolveFieldTokens(
   }
 
   const service = new FieldValueService(ctx.organizationId, ctx.senderUserId, ctx.db)
-  const result = new Map<string, string | null>()
+  const result = new Map<string, ResolvedFieldToken | null>()
 
   for (const [recordId, entries] of byRecordId) {
     const fieldRefs = entries.map((e) => e.fieldRef)
@@ -249,9 +266,9 @@ async function resolveFieldTokens(
       fieldReferences: fieldRefs,
     })
 
-    // Index batch results by fieldRefKey for lookup. Carry `fieldType` /
-    // `fieldOptions` alongside the value so we can format currency, dates,
-    // options, etc. the same way the UI does (not a raw `String()`).
+    // Index batch results by fieldRefKey for lookup. Typed metadata remains
+    // intact until Pass 2 because duplicate spans may apply distinct display
+    // overrides to the same field reference.
     const byKey = new Map<string, (typeof batch.values)[number]>()
     for (const v of batch.values) {
       byKey.set(fieldRefToKey(v.fieldRef), v)
@@ -261,12 +278,16 @@ async function resolveFieldTokens(
       const key = fieldRefToKey(fieldRef)
       const entry = byKey.get(key)
       const raw = entry?.value
-      // Null/undefined → let Pass 2 apply the fallback (or hard-fail).
+      // Null/undefined → let Pass 2 apply the span's fallback (or empty value).
       result.set(
         id,
         raw === undefined || raw === null
           ? null
-          : formatFieldValueForText(raw, entry!.fieldType, entry!.fieldOptions)
+          : {
+              value: raw,
+              fieldType: entry!.fieldType,
+              fieldOptions: entry!.fieldOptions,
+            }
       )
     }
   }
@@ -325,7 +346,7 @@ function formatSingleForText(
 ): string {
   // Human-readable name for links/people — never the raw id.
   if (v.type === 'relationship') return v.displayName ?? v.recordId
-  if (v.type === 'actor') return v.displayName ?? v.actorId
+  if (v.type === 'actor') return v.displayName ?? ''
 
   // Money is integer cents (money-engine convention); the shared converter
   // would multiply by 100 and be off by 100×.

--- a/packages/lib/src/resources/registry/display-config.ts
+++ b/packages/lib/src/resources/registry/display-config.ts
@@ -227,4 +227,13 @@ export const RESOURCE_DISPLAY_CONFIG: Record<TableId, SystemResourceDisplayConfi
     defaultSortDirection: 'desc',
     orgScopingStrategy: 'direct',
   },
+
+  visit: {
+    identifierField: 'id',
+    primaryDisplayFieldId: 'id',
+    searchFields: ['id'],
+    defaultSortField: 'startTime',
+    defaultSortDirection: 'desc',
+    orgScopingStrategy: 'direct',
+  },
 }

--- a/packages/lib/src/resources/registry/field-registry.ts
+++ b/packages/lib/src/resources/registry/field-registry.ts
@@ -28,6 +28,7 @@ import { THREAD_FIELDS } from './resources/thread-fields'
 import { TICKET_FIELDS } from './resources/ticket-fields'
 import { USER_FIELDS } from './resources/user-fields'
 import { VENDOR_PART_FIELDS } from './resources/vendor-part-fields'
+import { VISIT_FIELDS } from './resources/visit-fields'
 import { WORK_ORDER_FIELDS } from './resources/work-order-fields'
 
 /** Types excluded from RESOURCE_TABLE_REGISTRY: 'entity' (generic marker) + all EntityDefinition types */
@@ -117,6 +118,7 @@ export const RESOURCE_FIELD_REGISTRY: ResourceFieldRegistry = {
   article: ARTICLE_FIELDS,
   kb: KB_FIELDS,
   work_order: WORK_ORDER_FIELDS,
+  visit: VISIT_FIELDS,
   service_request: SERVICE_REQUEST_FIELDS,
   quote: QUOTE_FIELDS,
   line_item: LINE_ITEM_FIELDS,

--- a/packages/lib/src/resources/registry/resources/visit-fields.ts
+++ b/packages/lib/src/resources/registry/resources/visit-fields.ts
@@ -1,0 +1,101 @@
+// packages/lib/src/resources/registry/resources/visit-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import type { ResourceField } from '../field-types'
+
+/** Read-only presentation fields for a dispatch visit's schedule and assignee. */
+export const VISIT_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    dbColumn: 'id',
+    nullable: false,
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique visit identifier',
+  },
+  date: {
+    id: toFieldId('date'),
+    key: 'date',
+    label: 'Visit date',
+    type: BaseType.DATE,
+    fieldType: FieldType.DATE,
+    nullable: true,
+    options: { format: 'medium', includeTime: false },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+      computed: true,
+    },
+    description: 'Date of the scheduled visit in the placeholder timezone',
+  },
+  startTime: {
+    id: toFieldId('startTime'),
+    key: 'startTime',
+    label: 'Start time',
+    type: BaseType.TIME,
+    fieldType: FieldType.TIME,
+    nullable: true,
+    options: { format: 'time-only', timeFormat: '12h' },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+      computed: true,
+    },
+    description: 'Scheduled start time in the placeholder timezone',
+  },
+  endTime: {
+    id: toFieldId('endTime'),
+    key: 'endTime',
+    label: 'End time',
+    type: BaseType.TIME,
+    fieldType: FieldType.TIME,
+    nullable: true,
+    options: { format: 'time-only', timeFormat: '12h' },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+      computed: true,
+    },
+    description: 'Scheduled end time in the placeholder timezone',
+  },
+  assignee: {
+    id: toFieldId('assignee'),
+    key: 'assignee',
+    label: 'Assignee',
+    type: BaseType.ACTOR,
+    fieldType: FieldType.ACTOR,
+    dbColumn: 'assigneeUserId',
+    nullable: true,
+    dynamicOptionsKey: 'teamMembers',
+    options: { actor: { target: 'user', multiple: false } },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Team member assigned to the visit',
+  },
+}

--- a/packages/lib/src/sequences/client.ts
+++ b/packages/lib/src/sequences/client.ts
@@ -102,17 +102,3 @@ export const SEQUENCE_ANCHOR_LABELS: Record<'visit' | 'invoice', string> = {
   visit: 'the visit time',
   invoice: 'the due date',
 }
-
-/**
- * Visit tokens pre-resolved by plain code in the send node (§4.5 — `WorkOrderVisit` isn't an
- * `EntityInstance`, so these can't ride the entity placeholder resolver). Inserted as literal
- * `{{visit:*}}` text in the step body, not an entity-backed placeholder chip. Offered in the
- * step editor's placeholder picker only on visit-subject sequences.
- */
-export const SEQUENCE_VISIT_PLACEHOLDER_TOKENS: { id: string; label: string }[] = [
-  { id: 'visit:date', label: 'Visit date' },
-  { id: 'visit:startTime', label: 'Start time' },
-  { id: 'visit:endTime', label: 'End time' },
-  { id: 'visit:timeWindow', label: 'Time window' },
-  { id: 'visit:assigneeFirstName', label: "Technician's first name" },
-]

--- a/packages/lib/src/sequences/index.ts
+++ b/packages/lib/src/sequences/index.ts
@@ -20,7 +20,6 @@ export {
   SEQUENCE_ENROLL_MAX_RECIPIENTS,
   SEQUENCE_TRIGGER_LABELS,
   SEQUENCE_TRIGGER_TYPES,
-  SEQUENCE_VISIT_PLACEHOLDER_TOKENS,
 } from './client'
 export type { UpdateSequenceInput } from './crud'
 // CRUD

--- a/packages/lib/src/sequences/seed-templates.ts
+++ b/packages/lib/src/sequences/seed-templates.ts
@@ -79,10 +79,8 @@ interface SeedTemplate {
  * `'there'` fallback, one factual sentence, a closing "any questions" line, no hard-coded
  * sign-off — the composer/send-node appends the sender's signature separately). Entity
  * placeholders (`contact:firstName`, `work_order:number`/`title`, `invoice:number`/`total`/
- * `dueDate`) are per-org `EntityDefinition`-id-keyed spans (§4.5); visit tokens
- * (`{{visit:date}}`, `{{visit:timeWindow}}`, `{{visit:assigneeFirstName}}`) are plain literal
- * text — the send node's visit-token pre-resolution pass substitutes them directly, no span
- * wrapping needed.
+ * `dueDate`) are per-org `EntityDefinition`-id-keyed spans (§4.5). Visit fields are normal
+ * system-resource spans keyed by their stable `visit` root.
  */
 export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
   {
@@ -101,7 +99,8 @@ export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
         delayDays: 0,
         bodyHtml: (defs) =>
           `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>We've got you down for {{visit:date}} at {{visit:timeWindow}} for ` +
+          `<p>We've got you down for ${placeholderSpan('visit', 'date')} from ` +
+          `${placeholderSpan('visit', 'startTime')} to ${placeholderSpan('visit', 'endTime')} for ` +
           `${placeholderSpan(defs.work_order!, 'title', TITLE_FALLBACK)} ` +
           `(${placeholderSpan(defs.work_order!, 'number')}).</p>${CLOSING}`,
       },
@@ -112,7 +111,8 @@ export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
         anchorTimeOfDay: '09:00',
         bodyHtml: (defs) =>
           `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Just a reminder — we'll see you on {{visit:date}} at {{visit:timeWindow}}.</p>${CLOSING}`,
+          `<p>Just a reminder — we'll see you on ${placeholderSpan('visit', 'date')} at ` +
+          `${placeholderSpan('visit', 'startTime')}.</p>${CLOSING}`,
       },
       {
         subject: "We'll see you today",
@@ -121,8 +121,8 @@ export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
         anchorTimeOfDay: '07:30',
         bodyHtml: (defs) =>
           `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Today's the day! We'll be there at {{visit:timeWindow}}. {{visit:assigneeFirstName}} ` +
-          `will be your technician.</p>${CLOSING}`,
+          `<p>Today's the day! We'll be there at ${placeholderSpan('visit', 'startTime')}. ` +
+          `${placeholderSpan('visit', 'assignee')} will be your technician.</p>${CLOSING}`,
       },
     ],
   },
@@ -142,8 +142,8 @@ export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
         delayDays: 0,
         bodyHtml: (defs) =>
           `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Just a heads up — {{visit:assigneeFirstName}} is on the way and should arrive ` +
-          `around {{visit:timeWindow}}.</p>${CLOSING}`,
+          `<p>Just a heads up — ${placeholderSpan('visit', 'assignee')} is on the way and should arrive ` +
+          `around ${placeholderSpan('visit', 'startTime')}.</p>${CLOSING}`,
       },
     ],
   },
@@ -241,7 +241,7 @@ export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
         delayDays: 0,
         bodyHtml: (defs) =>
           `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Thank you for having us out on {{visit:date}}. We hope everything went well — see ` +
+          `<p>Thank you for having us out on ${placeholderSpan('visit', 'date')}. We hope everything went well — see ` +
           `you next time!</p>${CLOSING}`,
       },
     ],

--- a/packages/lib/src/sequences/subject.ts
+++ b/packages/lib/src/sequences/subject.ts
@@ -159,9 +159,10 @@ export async function evaluateSubjectGuards(
 export interface SubjectContext {
   contactRecordId?: RecordId
   workOrderInstanceId?: string
-  /** Only populated for a visit subject — the token pre-resolution pass (§4.5) needs the row;
-   * `recurrenceRuleId`/`occurrenceDate` feed the signal metadata (§4.10's future dedup key). */
+  /** Only populated for a visit subject; `recurrenceRuleId`/`occurrenceDate` feed the signal
+   * metadata (§4.10's future dedup key). */
   visit?: {
+    id: string
     startTime: Date | null
     endTime: Date | null
     assigneeUserId: string | null
@@ -215,6 +216,7 @@ export async function resolveSubjectContext(
         eq(schema.WorkOrderVisit.organizationId, organizationId)
       ),
       columns: {
+        id: true,
         workOrderId: true,
         startTime: true,
         endTime: true,
@@ -226,6 +228,7 @@ export async function resolveSubjectContext(
     workOrderInstanceId = row?.workOrderId
     if (row)
       visit = {
+        id: row.id,
         startTime: row.startTime,
         endTime: row.endTime,
         assigneeUserId: row.assigneeUserId,

--- a/packages/lib/src/workflow-engine/nodes/sequence-send-email/sequence-send-email-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/sequence-send-email/sequence-send-email-processor.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/workflow-engine/nodes/sequence-send-email/sequence-send-email-processor.ts
 // Server-registered node processor for a compiled sequence's per-step send
-// (Sequences plan §3.2/§3.3; client-notifications plan §4.4 adds the subject guards, visit
-// tokens, conditional footer, and `EntitySignal` write below) — wraps `MessageSenderService`.
+// (Sequences plan §3.2/§3.3; client-notifications plan §4.4 adds the subject guards,
+// conditional footer, and `EntitySignal` write below) — wraps `MessageSenderService`.
 // NOT added to the user node palette; only `publishSequence` ever writes a node with this
 // `type`.
 
@@ -9,8 +9,6 @@ import { type Database, database as defaultDb, schema } from '@auxx/database'
 import { IdentifierType, SendStatus } from '@auxx/database/enums'
 import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId, toRecordId } from '@auxx/types/resource'
-import { format } from 'date-fns'
-import { toZonedTime } from 'date-fns-tz'
 import { and, eq, isNull } from 'drizzle-orm'
 import { getOrgCache } from '../../../cache'
 import { MessageSenderService } from '../../../messages/message-sender.service'
@@ -67,39 +65,6 @@ function isTerminalSendFailure(errorMessage: string | null | undefined): boolean
     return true // INVALID_RECIPIENTS
   }
   return false
-}
-
-/** Visit tokens (§4.5) — pre-resolved by plain code before the entity placeholder pass, since
- * `WorkOrderVisit` is a plain table (not an `EntityInstance`) and can't ride
- * `resolvePlaceholdersInHtml`. An unscheduled visit (`startTime` null — shouldn't reach here,
- * the subject guard already exits on that) degrades every time token to `''`, never
- * "undefined". */
-function buildVisitTokenMap(
-  visit: { startTime: Date | null; endTime: Date | null },
-  timezone: string,
-  assigneeFirstName: string
-): Record<string, string> {
-  if (!visit.startTime) {
-    return {
-      '{{visit:date}}': '',
-      '{{visit:startTime}}': '',
-      '{{visit:endTime}}': '',
-      '{{visit:timeWindow}}': '',
-      '{{visit:assigneeFirstName}}': assigneeFirstName,
-    }
-  }
-  const zonedStart = toZonedTime(visit.startTime, timezone)
-  const dateStr = format(zonedStart, 'MMMM d, yyyy')
-  const startStr = format(zonedStart, 'h:mm a')
-  const endStr = visit.endTime ? format(toZonedTime(visit.endTime, timezone), 'h:mm a') : ''
-  const timeWindow = endStr ? `${startStr} – ${endStr}` : startStr
-  return {
-    '{{visit:date}}': dateStr,
-    '{{visit:startTime}}': startStr,
-    '{{visit:endTime}}': endStr,
-    '{{visit:timeWindow}}': timeWindow,
-    '{{visit:assigneeFirstName}}': assigneeFirstName,
-  }
 }
 
 export class SequenceSendEmailProcessor extends BaseNodeProcessor {
@@ -278,27 +243,11 @@ export class SequenceSendEmailProcessor extends BaseNodeProcessor {
     }
 
     try {
-      // ── (4) visit-token pre-resolution (§4.5), THEN entity placeholder pass ──
-      let bodyHtml = config.bodyHtml
-      let timeBearingTokenSubstituted = false
-      if (subjectKind === 'visit' && visitRow) {
-        let assigneeFirstName = ''
-        if (visitRow.assigneeUserId) {
-          const assignee = await database.query.User.findFirst({
-            where: eq(schema.User.id, visitRow.assigneeUserId),
-            columns: { firstName: true, name: true },
-          })
-          assigneeFirstName = assignee?.firstName || assignee?.name?.split(' ')[0] || ''
-        }
-        const timezone = sequence.deliveryTimezone ?? 'UTC'
-        const hasTimeToken = /\{\{visit:(date|startTime|timeWindow)\}\}/.test(bodyHtml)
-        const tokens = buildVisitTokenMap(visitRow, timezone, assigneeFirstName)
-        for (const [token, value] of Object.entries(tokens)) {
-          bodyHtml = bodyHtml.split(token).join(value)
-        }
-        timeBearingTokenSubstituted = hasTimeToken && visitRow.startTime !== null
-      }
-
+      // ── (4) generic placeholder resolution with subject record context ──────
+      const includesVisitScheduleField =
+        subjectKind === 'visit' &&
+        visitRow?.startTime != null &&
+        /data-id="visit:(date|startTime|endTime)"/.test(config.bodyHtml)
       const entityDefs = await getOrgCache().get(organizationId, 'entityDefs')
       const recordIdsByRoot = new Map<string, RecordId>()
       if (entityDefs.contact && contactRecordId) {
@@ -310,12 +259,16 @@ export class SequenceSendEmailProcessor extends BaseNodeProcessor {
       if (workOrderInstanceId && entityDefs.work_order) {
         recordIdsByRoot.set(entityDefs.work_order, toRecordId('work_order', workOrderInstanceId))
       }
+      if (subjectKind === 'visit' && visitRow) {
+        recordIdsByRoot.set('visit', toRecordId('visit', visitRow.id))
+      }
       const placeholderCtx: PlaceholderResolutionContext = {
         db: database,
         organizationId,
         recordIdsByRoot,
+        timezone: sequence.deliveryTimezone ?? 'UTC',
       }
-      let resolvedHtml = await resolvePlaceholdersInHtml(bodyHtml, placeholderCtx)
+      let resolvedHtml = await resolvePlaceholdersInHtml(config.bodyHtml, placeholderCtx)
 
       // ── (5) unsubscribe footer — only when the sequence wants one ─────────
       if (sequence.includeUnsubscribeFooter) {
@@ -427,7 +380,7 @@ export class SequenceSendEmailProcessor extends BaseNodeProcessor {
       })
 
       // ── (7) the sent reminder IS the promise — stamp timeConfirmedAt if unset ───
-      if (subjectKind === 'visit' && run.subjectId && timeBearingTokenSubstituted) {
+      if (subjectKind === 'visit' && run.subjectId && includesVisitScheduleField) {
         await database
           .update(schema.WorkOrderVisit)
           .set({ timeConfirmedAt: new Date() })


### PR DESCRIPTION
## Summary
- add Visit as a system resource with virtual date, time, and assignee placeholder fields
- add per-placeholder formatting controls and preserve formatting through the editor and sequence flow
- resolve placeholder values through typed field values with delivery timezone applied only at display time

## Verification
- pnpm --filter @auxx/lib exec vitest run --config vitest.config.ts src/placeholders/format-codec.test.ts src/field-values/resolvers/visit-virtual-fields.test.ts src/field-values/resolvers/system-table-resolver.test.ts