### PR TITLE
feat(dispatch): render sequences from TipTap JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,196 +1,406 @@
 # Repository Guidelines
 
-This monorepo uses pnpm workspaces and Turborepo to manage multiple TypeScript apps and packages. Follow these concise guidelines to keep contributions consistent and easy to review.
+## Important Rules
 
-## Project Structure & Module Organization
+- Do not lie to me, that is being dishonest.
+- Do not tell me I'm right when I'm not right.
+- If my idea is inferior to your idea, let me know.
 
-- apps/: Next.js and Node services (e.g., `apps/web`, `apps/admin`, `apps/kb`, `apps/docs`, `apps/api`, `apps/websockets`, `apps/worker`).
-- packages/: Shared code (e.g., `packages/db` Prisma schema + client, `packages/lib`, `packages/ui`, `packages/config`, `packages/eslint-config`, `packages/typescript-config`).
-- infra-cdk/, infra/: Infrastructure definitions and scripts.
-- scripts/: Utility scripts (env, setup, migrations). docs/: Additional project docs.
-- Env files: `.env.example` → copy to `.env` per app/service as needed.
-- Zod 4 is used which deprecated nativeEnum. now its just z.enum
+## Project Overview
 
-## Build, Test, and Development Commands
+Auxx.ai is an open-source AI-powered email support ticket answer service for Shopify businesses. The platform integrates email services (Gmail and Outlook) with Shopify to provide automated customer support solutions.
 
-- Install: `pnpm i` (Node 22; see `.nvmrc`).
-- Develop (all): `pnpm dev` (Turbo parallel dev).
-- Build (all): `pnpm build`; Start (all): `pnpm start`.
-- Lint/Format: `pnpm lint`, `pnpm lint:fix`, `pnpm format`.
-- Test (workspace): `pnpm test`, `pnpm test:run`, `pnpm test:coverage`.
-- Filter per app: `pnpm -F web dev`, `pnpm -F api build`, `pnpm -F worker start`.
-- Docker (optional): `pnpm docker:dev`, `pnpm docker:stop`. S3/CDN dev setup: `pnpm setup:dev`.
+## Tech Stack
 
-## Coding Style & Naming Conventions
+- **Framework**: Next.js v16.1 with React Server Components and app router
+- **API**: tRPC v11 with React Query
+- **Database**: PostgreSQL with Drizzle ORM v0.44, pgvector
+- **Auth**: Better-auth v1.3 (Google, GitHub, Email/Password, Passkey, 2FA)
+- **Frontend**: TailwindCSS v4, shadcn component library
+- **Forms**: react-hook-form v7.54
+- **State**: Zustand
+- **Caching**: Redis
+- **Linting**: Biome (2-space indent, 100-char line width, single quotes). Prefer `pnpm lint:fix` to auto-fix lint issues after making changes.
+- **Build**: Turborepo, pnpm
+- **Infra**: AWS (SST), Docker
 
-- Language: TypeScript across apps/packages. Paths under `src/`.
-- Formatting: Prettier enforced (2 spaces, single quotes, no semicolons). Run `pnpm format`.
-- Linting: ESLint via shared configs in `packages/eslint-config` (+ Next.js rules where relevant).
-- Filenames: kebab-case for files/dirs; React component identifiers use PascalCase.
-- Create reusable and modular components
-- Break large components into smaller ones for better maintainability
-- File naming: use kebab-case for files (e.g., `user-profile.tsx`)
-- At the top of each file, comment the file-path/file-name.file_type
+## Monorepo Structure
+
+### Apps
+
+| App             | Port | Purpose                   |
+| --------------- | ---- | ------------------------- |
+| `apps/web`      | 3000 | Main Next.js application  |
+| `apps/api`      | 3007 | Express REST API          |
+| `apps/worker`   | 3005 | Job/queue worker (BullMQ) |
+| `apps/lambda`   | 3008 | AWS Lambda handlers       |
+| `apps/build`    | 3006 | Build-time utilities      |
+| `apps/homepage` | 3001 | Marketing site            |
+| `apps/kb`       | 3002 | Knowledge base            |
+| `apps/docs`     | 3004 | Documentation             |
+
+### Key Packages
+
+| Package             | Purpose                                     |
+| ------------------- | ------------------------------------------- |
+| `@auxx/database`    | Drizzle schema, models, migrations          |
+| `@auxx/lib`         | Shared business logic (~70 feature modules) |
+| `@auxx/ui`          | Shadcn component library                    |
+| `@auxx/types`       | Shared TypeScript types                     |
+| `@auxx/services`    | Business service layer                      |
+| `@auxx/config`      | Configuration management                    |
+| `@auxx/credentials` | Credential/secret management                |
+| `@auxx/redis`       | Redis client wrapper                        |
+| `@auxx/email`       | Email service (Mailgun, SES, SMTP)          |
+| `@auxx/billing`     | Stripe integration                          |
+| `@auxx/sdk`         | Public SDK                                  |
+| `@auxx/seed`        | Database seeding (CLI + domain seeders)      |
+
+### Package Dependency Rules
+
+**CRITICAL**: Only import from packages listed as dependencies in the importing package's `package.json`. Node.js resolves packages relative to the **importing file**, not the app entry point. A dynamic `import('@auxx/foo')` inside `@auxx/lib` will fail if `@auxx/lib/package.json` doesn't list `@auxx/foo` — even if the calling app has it.
+
+**Dependency tiers** (higher tiers can import lower, never the reverse):
+
+```
+Tier 0 (leaf):  config, logger, deployment, typescript-config
+Tier 1 (infra): database, redis, credentials, utils, types
+Tier 2 (core):  services, email, billing, workflow-nodes
+Tier 3 (biz):   lib  (imports tier 0–2, NEVER seed)
+Tier 4 (seed):  seed (imports lib + database, NEVER imported by lib)
+Tier 5 (apps):  web, worker, api, lambda, build (can import anything)
+```
+
+**Key constraint**: `@auxx/seed` ↔ `@auxx/lib` is a **one-way dependency** (`seed → lib`). Code in `@auxx/lib` must NEVER import from `@auxx/seed`. If lib code needs seed functionality, either:
+1. Move the logic into lib itself, or
+2. Define an interface/stub in lib and implement it in the app layer (worker/web) where both are available
+
+### Key Paths
+
+| What                    | Where                              |
+| ----------------------- | ---------------------------------- |
+| Next.js app routes      | `apps/web/src/app/`                |
+| tRPC routers            | `apps/web/src/server/api/routers/` |
+| tRPC root router        | `apps/web/src/server/api/root.ts`  |
+| tRPC setup & middleware | `apps/web/src/server/api/trpc.ts`  |
+| Auth config             | `apps/web/src/auth/server.ts`      |
+| DB schema files         | `packages/database/src/db/schema/` |
+| DB models               | `packages/database/src/db/models/` |
+| Shared lib modules      | `packages/lib/src/`                |
+| UI components           | `packages/ui/src/components/`      |
+| Infrastructure (SST)    | `infra/`                           |
+| CI/CD workflows         | `.github/workflows/`               |
+| Environment template    | `.env.example`                     |
+
+---
+
+# Coding Standards
+
+## General
+
+- Use TypeScript for all code.
+- Implement responsive designs for all components.
+- This is an early-stage startup. Prioritize simple, readable code with minimal abstraction. Strive for elegant, minimal solutions. No premature optimization. No backward compatibility unless specifically requested.
+- Add JSDoc to exported public APIs. Prefer self-documenting code over inline comments.
+- At the top of each file, comment the file-path/file-name.
+
+## Client vs Server Imports
+
+**CRITICAL**: Never import from `@auxx/lib/<module>` in client-side code. Barrel exports pull in server-only dependencies (bullmq, sharp, etc.) and will break the build.
+
+```typescript
+// WRONG — pulls in server-only deps:
+import { something } from '@auxx/lib/custom-fields'
+
+// CORRECT — client-safe export:
+import { something } from '@auxx/lib/custom-fields/client'
+```
+
+If a constant/type doesn't exist in the `/client` export yet, add it there first, then import from `/client`. See `packages/lib/package.json` exports field for all available subpaths.
+
+## Import Subpaths
+
+Before writing an import, check the target package's `package.json` `exports` field to confirm the subpath exists. Do not guess import paths — e.g. `@auxx/lib/permissions/types` won't work if only `@auxx/lib/permissions` is exported. When in doubt, check what existing code in the same file or router imports.
+
+## Component Architecture
+
+- File naming: kebab-case (e.g., `user-profile.tsx`)
+- Component naming: PascalCase (e.g., `UserProfile`)
 - Add `'use client'` directive for any components using client-side hooks or state
-- Comment every function, interface, type, and global variable
+- Split components when: file exceeds 800 lines, UI is reused, or it has a clear single responsibility
 
-## Testing Guidelines
+## API & Data Handling
 
-- Runner: Vitest with a workspace config (`vitest.workspace.ts`).
-- Web app uses JSDOM and Testing Library; libs/packages use Node environment.
-- Naming: `*.test.ts(x)` or `*.spec.ts(x)` under `src/` or `__tests__/`.
-- Coverage: thresholds enforced in configs (e.g., web ≥70%, lib/workflow-nodes ≥75%). Use `pnpm test:coverage`.
+### tRPC Procedure Types
 
-## Commit & Pull Request Guidelines
+| Procedure             | Use for                                                                  |
+| --------------------- | ------------------------------------------------------------------------ |
+| `publicProcedure`     | Unauthenticated routes                                                   |
+| `protectedProcedure`  | Authenticated routes (verifies session + organization)                   |
+| `adminProcedure`      | Admin/owner only (checks via `OrganizationMemberModel.isAdminOrOwner()`) |
+| `superAdminProcedure` | Super admin only (checks `isSuperAdmin` flag)                            |
 
-- Commits: follow Conventional Commits (`feat:`, `fix:`, `refactor:`, optional scopes).
-- Before PR: `pnpm lint && pnpm test:run && pnpm build` must pass; include migration notes for `packages/db/prisma` changes.
-- PRs: clear description, linked issues, screenshots/GIFs for UI, and notes for env/infra impacts.
+### tRPC Context
 
-## Security & Configuration Tips
+```typescript
+ctx.db        // Drizzle database instance
+ctx.session   // Better-auth session (user, defaultOrganizationId, isSuperAdmin)
+ctx.headers   // Request headers
+```
 
-- Do not commit secrets. Use `.env` (see `.env.example`) and `scripts/fetch-env.ts` for environment sync.
-- AWS/S3/CDN: see `.aws.md` and `scripts/setup-*.js`. Keep keys in your local env/SSM, not VCS.
+### Conventions
 
-## Utility Methods
+- Access DB in protected procedures with `ctx.db.<tableName>` (singular form)
+- Import tRPC client: `import { api } from '~/trpc/react'`
+- Mutation naming — use the action name, not suffixed with "Mutation":
+  ```typescript
+  // Do:
+  const sendReply = api.ticketAttachment.sendTicketReply.useMutation()
+  // Don't:
+  const sendReplyMutation = api.ticketAttachment.sendTicketReply.useMutation()
+  ```
 
-**IMPORTANT**: Before creating any utility functions, check `packages/lib/src/utils` for existing helpers:
+## Error Handling
 
-- **date.ts** - Date formatting and relative time
-- **email.ts** - Email parsing, validation, and formatting
-- **file.ts** - File operations and path utilities
-- **generateId.ts** - Unique ID generation
-- **strings.ts** - String manipulation (titleize, pluralize, whitespace)
-- **contact.ts** - Name, phone, and address formatting
+### AuxxError Classes (`@auxx/lib/errors`)
+
+Use the appropriate error class. All extend `AuxxError`:
+
+| Class                      | Status | Use for            |
+| -------------------------- | ------ | ------------------ |
+| `BadRequestError`          | 400    | Invalid input      |
+| `UnauthorizedError`        | 401    | Not authenticated  |
+| `ForbiddenError`           | 403    | Not authorized     |
+| `NotFoundError`            | 404    | Resource not found |
+| `ConflictError`            | 409    | Duplicate/conflict |
+| `UnprocessableEntityError` | 422    | Validation failure |
+| `RateLimitError`           | 429    | Too many requests  |
+
+### Result Pattern (`@auxx/lib/result`)
+
+Database models return `TypedResult<V, E>` instead of throwing:
+
+```typescript
+const result = await model.findById(id)
+if (result.ok) {
+  const value = result.value
+} else {
+  const error = result.error // Error instance
+}
+
+// Creating results:
+Result.ok(value)
+Result.error(new NotFoundError('Not found'))
+Result.nil() // Ok with undefined value
+```
+
+## Org Cache (read-path first)
+
+Before adding a new DB query for org-scoped data, check `@auxx/lib/cache`. Most hot read paths are already cached per-org and hydrated by providers — re-querying defeats invalidation and wastes a roundtrip.
+
+```typescript
+import {
+  getCachedResource, getCachedResources, getCachedResourceFields,
+  getCachedCustomFields, getCachedFieldMap, getCachedEntityDefId,
+  getCachedMembers, isOrgMember, getCachedGroups,
+  getCachedAgents, getCachedAgentById, getCachedDefaultModel,
+  getOrgCache, // for keys without a helper
+} from '@auxx/lib/cache'
+```
+
+Cached keys (`OrgCacheDataMap`): `entityDefs`, `entityDefSlugs`, `systemUser`, `channelProviders`, `members`, `memberRoleMap`, `features`, `subscription`, `orgProfile`, `resources`, `customFields`, `groups`, `agents`, `inboxes`, `channels`, `overages`, `orgSettings`, `installedApps`, `workflowApps`, `aiProviderConfigs`, `aiCredentials`, `aiDefaultModels`. For anything in this list, prefer `getOrgCache().get(orgId, '<key>')` over a fresh query. Only hit the DB when the data isn't cached or you need a write-after-read consistency guarantee.
+
+## Database Models
+
+Models extend `BaseModel` with typed CRUD operations and org-scoped queries:
+
+```typescript
+export class ApiKeyModel extends BaseModel<typeof ApiKey, CreateInput, Entity, UpdateInput> {
+  get table() { return ApiKey }
+
+  async listActiveByUser(userId: string): Promise<TypedResult<ApiKeyEntity[], Error>> {
+    // Uses this.db, this.scopeFilter, Result.ok/error
+  }
+}
+```
+
+## Database Schema Changes
+
+- **Never write raw SQL migration files.** Always modify the Drizzle schema files in `packages/database/src/db/schema/`.
+- When planning tasks that involve schema changes, show the TypeScript schema file changes, not SQL.
+- After modifying schema files, generate the migration from the `packages/database` folder: `pnpm db:generate --name <descriptive_name>`. From root, use `pnpm db:generate -- --name <descriptive_name>`.
+- Apply the migration: `pnpm db:migrate`
+
+## Module Exports
+
+In `index.ts` files, use explicit named exports:
+
+```typescript
+// Do:
+export { X, Y } from './xy'
+// Don't:
+export * from './xy'
+```
+
+## Zustand Stores
+
+Always use selectors to avoid unnecessary re-renders:
+
+```typescript
+// CORRECT:
+const markDirty = useWorkflowStore((state) => state.markDirty)
+
+// WRONG — causes re-renders on every state change:
+const { markDirty } = useWorkflowStore()
+```
 
 ## UI Components
 
-### **confirmations**: For delete confirmations use, the
+**Before building a settings page, detail page, dialog, or tree list, read
+`docs/ui-design-guide.md`.** It documents the shared layout/form/dialog/tree
+primitives (`MainPage`, `NavStack`, `SettingsPage`/`SettingsSection`, `ListCard`
+placeholders, `FieldPanel`/`FieldPanelRow`/`FieldInputAdapter`, `DialogNav`/
+`DialogNavPages`, `TreeRow`/`TreeRowButton`) with real usage examples — this is
+what keeps AI-generated UI consistent instead of each screen reinventing its
+own card/dialog/form shape.
+
+- Import shadcn components from `'@auxx/ui/components/<component>'`
+- Every `<SelectItem>` must have a `value` prop
+
+### Toast (errors only)
+
+```typescript
+import { toastError } from '@auxx/ui/components/toast'
+
+// No success toasts. Only error:
+toastError({ title: 'Error sending reply', description: error.message })
+```
+
+### Delete Confirmations
 
 ```typescript
 import { useConfirm } from '~/hooks/use-confirm'
+
 const [confirm, ConfirmDialog] = useConfirm()
 const confirmed = await confirm({
-  title: 'TEXT?',
-  description: 'TEXT',
+  title: 'Delete item?',
+  description: 'This action cannot be undone.',
   confirmText: 'Remove',
   cancelText: 'Cancel',
   destructive: true,
 })
-
-if (confirmed) {
-  // do the deleting code
-}
+if (confirmed) { /* delete */ }
 ```
 
-### **Buttons**: For disabling buttons while loading do this:
+### Buttons
 
 ```typescript
-<Button
-  variant="outline"
-  loading={isPending}
-  loadingText="Connecting...">
+// Loading state:
+<Button variant="outline" loading={isPending} loadingText="Connecting...">
   Connect
 </Button>
-```
 
-### **Buttons**: Using icons in buttons. Do NOT add any className to the <Icon />.
-
-```typescript
-<Button
-  variant="outline">
-  <Icon /> // <!-- No h-4 w-4 added. Its handled by Button.
+// Icons — do NOT add className to the icon, Button handles sizing:
+<Button variant="outline">
+  <Icon />
 </Button>
 ```
 
-Abstract patterns
+## Design Patterns
 
-```typescript
-export interface Provider<I, O> {
-  /** Unique id like "local" or "s3" */
-  id: string
+For provider/manager patterns (AI providers, storage, etc.), follow the existing implementations:
 
-  /** Optional warm-up step (e.g., clients, keys) */
-  init?(config?: unknown): Promise<void> | void
+- **AI providers**: `packages/lib/src/ai/providers/provider-manager.ts`
+- **File storage**: `packages/lib/src/files/storage/storage-manager.ts`
 
-  /** Do the thing */
-  execute(input: I): Promise<O> | O
-}
-```
-
-Use of dynamic loaders:
-
-```typescript
-export const loaders = {
-  local: async () => (await import('./local')).default, // => class LocalProvider
-  s3: async () => (await import('./s3')).default, // => class S3Provider
-} as const
-
-export type ProviderId = keyof typeof loaders
-```
-
-Manager pattern:
-
-```typescript
-import { loaders, type ProviderId } from '../providers/manifest'
-import type { Provider } from './types'
-import type { LocalInput, LocalOutput } from '../providers/local'
-import type { S3Input, S3Output } from '../providers/s3'
-
-export type ManagerOptions = {
-  config?: Partial<Record<ProviderId, unknown>>
-}
-
-export class ProviderManager {
-  private cache = new Map<ProviderId, Provider<any, any>>()
-  constructor(private opts: ManagerOptions = {}) {}
-
-  private async get(id: ProviderId): Promise<Provider<any, any>> {
-    let instance = this.cache.get(id)
-    if (instance) return instance
-
-    const Cls = await loaders[id]()
-    instance = new Cls()
-    if (typeof instance.init === 'function') {
-      await instance.init(this.opts.config?.[id])
-    }
-    this.cache.set(id, instance)
-    return instance
-  }
-
-  // ---- Overloads keep types nice but code simple ----
-  async execute(id: 'local', input: LocalInput): Promise<LocalOutput>
-  async execute(id: 's3', input: S3Input): Promise<S3Output>
-  async execute(id: ProviderId, input: any): Promise<any> {
-    const provider = await this.get(id)
-    return provider.execute(input)
-  }
-}
-```
-
-## Railway CLI (production)
-
-The project is linked to Railway via `railway link`. The `.railway` config file is gitignored.
-
-**Workspace:** Auxx.Ai's Projects | **Project:** Auxx Ai | **Environment:** production
-
-**Services:** web, api, worker, build, lambda-server, homepage, docs, Postgres, pgvector, Redis
-
-```bash
-# List all projects
-railway list
-
-# Show all services and their deployment status
-railway service status -a --json
-
-# View variables for a specific service
-railway variables -s <service-name> --json
-
-# View logs for a specific service
-railway service logs -s <service-name>
-
-# Redeploy a service
-railway service redeploy -s <service-name>
-```
+Pattern: Feature modules use a Manager class that lazily loads and caches provider instances, with a `Provider` interface defining `id`, optional `init()`, and `execute()`.
 
 ---
+
+# Development Workflow
+
+## Documentation
+
+For code generation, setup, configuration, or library/API questions, consult the relevant official documentation before making assumptions.
+
+---
+
+# Development Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Run tests
+pnpm test
+
+# Lint (Biome) — full repo, errors only (CI uses this on pushes to main)
+pnpm lint
+
+# Lint changed files only vs main branch — errors only (CI uses this on PRs)
+pnpm lint:changed
+
+# Lint + auto-fix (writes changes, includes import sorting)
+pnpm lint:fix
+
+# Format only (writes changes)
+pnpm format
+
+# Generate DB migration (after schema changes)
+pnpm db:generate --name <descriptive_name>
+
+# Apply DB migrations
+pnpm db:migrate
+
+# Run standalone scripts (uses dotenv-cli to load .env with multiline values)
+npx dotenv -- npx tsx path/to/script.ts
+```
+
+### Type Checking (`tsc`)
+
+Every package/app has a scoped `typecheck` script (`tsc --noEmit` run from that
+package's own directory against its own `tsconfig.json`, via `composite: true`
+project references). Run it **per package**, never as a bare `tsc`/`tsc -b`
+from the repo root — there is no root `tsconfig.json`, and a whole-monorepo
+invocation walks every package's sources in one process.
+
+```bash
+# Scope to one package (fast, low memory — most packages finish in seconds)
+pnpm --filter @auxx/utils typecheck
+pnpm --filter @auxx/database typecheck
+
+# apps/web and packages/lib are large enough to hit V8's default ~4GB
+# old-space heap limit even when scoped to just that package. Bump it:
+cd apps/web && NODE_OPTIONS="--max-old-space-size=8192" pnpm exec tsc --noEmit
+cd packages/lib && NODE_OPTIONS="--max-old-space-size=8192" pnpm exec tsc --noEmit
+```
+
+The OOM was never about total errors or physical memory — it's Node/V8's
+default heap ceiling, hit while checking apps/web's ~3.5k files (or lib's
+~2.6k) in a single process. Scoping to a package keeps most invocations well
+under the limit; for web/lib, raising `--max-old-space-size` is enough (~6GB
+peak observed for web).
+
+### Rules
+
+- **Do NOT run a whole-repo `tsc`.** Scope it per-package as shown above.
+- **Do NOT stop or restart the dev server.**
+
+---
+
+# Viewing Logs (dev)
+
+`@auxx/logger` prints to the console AND ships structured logs to a local **OpenObserve** instance that `pnpm dev` starts automatically (dev-only). Use it to search/review log history instead of scrolling the terminal.
+
+- **UI**: http://localhost:5080 → _Logs_ → stream `auxx`
+- **Login**: `root@auxx.dev` / `Complexpass#123` (local dev only — not a secret)
+- Every entry has `level`, `scope`, `app` (`@auxx/web` / `@auxx/worker` / …), `message`, plus any `.with({...})` fields. Filter with SQL, e.g. `level='error'`, `scope='billing'`, `app='@auxx/worker'`, or full-text `match_all('stripe')`.
+- Querying the API directly (Basic auth): `POST http://localhost:5080/api/default/_search?type=logs` with a SQL body.
+
+Full details (how it works, turning it off): `docs/log-history.md`.
+
+---
+
+# Ops Reference (Railway, AWS)
+
+For Railway (production) and AWS (dev) commands — log tailing, service status, RDS, ECS — read `docs/ops-reference.md`. Pull it in when the user asks about deploys, prod logs, or infrastructure debugging.

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
@@ -53,6 +53,10 @@ export function useBoardMutations(range: DateRange) {
         startTime: vars.startTime,
         endTime: vars.endTime,
       }
+      const existing = utils.dispatch.getBoard
+        .getData(range)
+        ?.visits.find((v) => v.id === vars.visitId)
+      if (existing?.status === 'canceled') patch.status = 'scheduled'
       if (vars.assigneeUserId !== undefined) patch.assigneeUserId = vars.assigneeUserId
       return { previous: patchVisit(vars.visitId, patch) }
     },

--- a/apps/web/src/components/sequences/hooks/use-sequence-step-autosave.ts
+++ b/apps/web/src/components/sequences/hooks/use-sequence-step-autosave.ts
@@ -12,7 +12,6 @@ const AUTOSAVE_DELAY_MS = 750
 export interface SequenceUpdateStepFields {
   subject?: string | null
   bodyJson?: Record<string, unknown> | null
-  bodyHtml?: string | null
   delayDays?: number
   delayHours?: number
   attachmentIds?: string[]

--- a/apps/web/src/components/sequences/ui/detail/sequence-body-editor.tsx
+++ b/apps/web/src/components/sequences/ui/detail/sequence-body-editor.tsx
@@ -3,7 +3,7 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { cn } from '@auxx/ui/lib/utils'
-import { generateHTML, type JSONContent } from '@tiptap/core'
+import type { JSONContent } from '@tiptap/core'
 import Color from '@tiptap/extension-color'
 import FontFamily from '@tiptap/extension-font-family'
 import Link from '@tiptap/extension-link'
@@ -37,12 +37,10 @@ import { Tooltip } from '~/components/global/tooltip'
 interface SequenceBodyEditorProps {
   /** Persisted TipTap JSON body (preferred). */
   bodyJson: Record<string, unknown> | null
-  /** Persisted HTML body — seed fallback when no JSON exists yet. */
-  bodyHtml: string | null
   /** Null for manual sequences — offers Visit fields only on visit-subject sequences. */
   subjectKind?: 'visit' | 'work_order' | 'invoice' | null
-  /** Fires with the stripped JSON + generated HTML on every doc change. */
-  onChange: (bodyJson: JSONContent, bodyHtml: string) => void
+  /** Fires with the stripped canonical JSON on every doc change. */
+  onChange: (bodyJson: JSONContent) => void
   /** Fires when focus leaves the editor — flush pending autosave. */
   onBlur?: () => void
   placeholder?: string
@@ -76,7 +74,6 @@ export function SequenceBodyEditor(props: SequenceBodyEditorProps) {
 
 function SequenceBodyEditorInner({
   bodyJson,
-  bodyHtml,
   subjectKind,
   onChange,
   onBlur,
@@ -133,17 +130,14 @@ function SequenceBodyEditorInner({
     ]
   )
 
-  // For the HTML projection — `generateHTML` from the STRIPPED json instead of
-  // `editor.getHTML()`, which would serialize an open chip's markup (+ ZWSP
-  // seed) into the saved step HTML.
-  const extensionsRef = useRef(extensions)
-  extensionsRef.current = extensions
-
   const editor = useEditor(
     {
       extensions,
-      // Seed-once: JSON is canonical; fall back to the HTML projection, then empty.
-      content: (bodyJson as JSONContent | null) ?? bodyHtml ?? '',
+      // Sequence bodies remain TipTap JSON all the way to send-time rendering.
+      content: (bodyJson as JSONContent | null) ?? {
+        type: 'doc',
+        content: [{ type: 'paragraph' }],
+      },
       immediatelyRender: false,
       shouldRerenderOnTransaction: false,
       editorProps: {
@@ -155,7 +149,7 @@ function SequenceBodyEditorInner({
       onUpdate: ({ editor, transaction }) => {
         if (!transaction.docChanged) return
         const json = stripOpenChips(editor.getJSON())
-        onChange(json, generateHTML(json, extensionsRef.current))
+        onChange(json)
       },
     },
     []

--- a/apps/web/src/components/sequences/ui/detail/sequence-step-card.tsx
+++ b/apps/web/src/components/sequences/ui/detail/sequence-step-card.tsx
@@ -110,10 +110,9 @@ export function SequenceStepCard({
 
         <SequenceBodyEditor
           bodyJson={step.bodyJson as Record<string, unknown> | null}
-          bodyHtml={step.bodyHtml}
           subjectKind={subjectKind}
-          onChange={(bodyJson, bodyHtml) =>
-            autosave.schedule({ bodyJson: bodyJson as Record<string, unknown>, bodyHtml })
+          onChange={(bodyJson) =>
+            autosave.schedule({ bodyJson: bodyJson as Record<string, unknown> })
           }
           onBlur={autosave.flush}
         />

--- a/apps/web/src/server/api/routers/sequence.ts
+++ b/apps/web/src/server/api/routers/sequence.ts
@@ -69,7 +69,6 @@ const updateSequenceFieldsSchema = z.object({
 const updateStepFieldsSchema = z.object({
   subject: z.string().nullable().optional(),
   bodyJson: z.record(z.string(), z.unknown()).nullable().optional(),
-  bodyHtml: z.string().nullable().optional(),
   delayDays: z.number().int().min(0).optional(),
   delayHours: z.number().int().min(0).optional(),
   attachmentIds: z.array(z.string()).optional(),

--- a/apps/worker/scripts/verify-dispatch-m2.ts
+++ b/apps/worker/scripts/verify-dispatch-m2.ts
@@ -321,6 +321,28 @@ async function main() {
       (await woStatus(organizationId, woB.instance.id)) === 'new'
     )
 
+    const rescheduledStart = new Date(start1.getTime() + 24 * 60 * 60 * 1000)
+    const rescheduledEnd = new Date(rescheduledStart.getTime() + 60 * 60 * 1000)
+    const rescheduled = await scheduleVisit({
+      organizationId,
+      userId,
+      visitId: visitB0.id,
+      startTime: rescheduledStart,
+      endTime: rescheduledEnd,
+      assigneeUserId: userId,
+    })
+    check(
+      'rescheduling a canceled visit restores scheduled status and the new time',
+      rescheduled.status === 'scheduled' &&
+        rescheduled.startTime?.getTime() === rescheduledStart.getTime() &&
+        rescheduled.endTime?.getTime() === rescheduledEnd.getTime(),
+      rescheduled
+    )
+    check(
+      'rescheduling a canceled visit restores work_order_status scheduled',
+      (await woStatus(organizationId, woB.instance.id)) === 'scheduled'
+    )
+
     const unscheduled = await unscheduleVisit({ organizationId, userId, visitId: visitB0.id })
     check(
       'unscheduleVisit clears startTime/endTime',

--- a/packages/database/src/db/schema/sequence.ts
+++ b/packages/database/src/db/schema/sequence.ts
@@ -177,9 +177,9 @@ export const SequenceStep = pgTable(
     channel: text().default('email').notNull(),
     /** Used when this step opens the thread (step 1). */
     subject: text(),
-    /** TipTap document JSON — carries the `{{token}}` placeholder spans. */
+    /** Canonical TipTap document JSON — placeholder nodes resolve structurally at send time. */
     bodyJson: jsonb().$type<Record<string, unknown>>(),
-    /** Rendered HTML (placeholders resolved against the recipient at send time). */
+    /** @deprecated Legacy editor projection. Sequence publication and sends never read this column. */
     bodyHtml: text(),
     attachmentIds: jsonb().$type<string[]>().default([]),
     createdAt: timestamp({ precision: 3 }).defaultNow().notNull(),

--- a/packages/lib/src/dispatch/visit-mutations.ts
+++ b/packages/lib/src/dispatch/visit-mutations.ts
@@ -90,10 +90,11 @@ export async function afterVisitWrite(
 }
 
 /**
- * Schedule (or reschedule) a visit — the single time/assignee writer. Rolls the work order
- * up to `scheduled`; the forward-only guard in `lifecycle.ts` makes rescheduling an
- * already-scheduled-or-later work order a no-op there, so this is safe to call on every
- * drag/drop and popover save alike.
+ * Schedule (or reschedule) a visit — the single time/assignee writer. Rescheduling a canceled
+ * visit explicitly revives it to `scheduled`; it never revives a `done` or in-progress visit.
+ * Rolls the work order up to `scheduled`; the forward-only guard in `lifecycle.ts` makes
+ * rescheduling an already-scheduled-or-later work order a no-op there, so this is safe to call
+ * on every drag/drop and popover save alike.
  *
  * `timeWriteKind` (plan 20 §4.2, default `'confirmed'` — fails toward protecting times):
  * `'confirmed'` stamps `timeConfirmedAt` and, when the span is positive, syncs
@@ -113,7 +114,13 @@ export async function scheduleVisit(input: ScheduleVisitInput): Promise<WorkOrde
       eq(schema.WorkOrderVisit.id, visitId),
       eq(schema.WorkOrderVisit.organizationId, organizationId)
     ),
-    columns: { recurrenceRuleId: true, startTime: true, endTime: true, dispatchedAt: true },
+    columns: {
+      recurrenceRuleId: true,
+      startTime: true,
+      endTime: true,
+      dispatchedAt: true,
+      status: true,
+    },
   })
   if (!existing) throw new NotFoundError('Visit not found')
 
@@ -125,6 +132,7 @@ export async function scheduleVisit(input: ScheduleVisitInput): Promise<WorkOrde
   if (input.assigneeUserId !== undefined) set.assigneeUserId = input.assigneeUserId
   if (timezone !== undefined) set.timezone = timezone
   if (existing.recurrenceRuleId) set.isDetached = true
+  if (existing.status === 'canceled') set.status = 'scheduled'
 
   const kind = input.timeWriteKind ?? 'confirmed'
   if (kind === 'confirmed') {
@@ -173,9 +181,10 @@ export async function scheduleVisit(input: ScheduleVisitInput): Promise<WorkOrde
   }
 
   // Client-notification hooks (plan 19 §4.3/§4.2): enrollment is one-off only — recurring-born
-  // visits are the hourly sweep's job (never through this function). Re-anchor fires on ANY
-  // startTime change, one-off or a detached recurring occurrence, both routed through here.
-  if (!existing.recurrenceRuleId && !existing.startTime) {
+  // visits are the hourly sweep's job (never through this function). A canceled one-off's active
+  // runs were exited at cancellation, so explicitly rescheduling it starts fresh reminders.
+  // Re-anchor fires on every other startTime change, one-off or a detached recurring occurrence.
+  if (!existing.recurrenceRuleId && (!existing.startTime || existing.status === 'canceled')) {
     try {
       await enrollVisitScheduledSequences(organizationId, visitId)
     } catch (error) {

--- a/packages/lib/src/placeholders/document-resolver.test.ts
+++ b/packages/lib/src/placeholders/document-resolver.test.ts
@@ -1,0 +1,117 @@
+// packages/lib/src/placeholders/document-resolver.test.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { describe, expect, it, vi } from 'vitest'
+import type { TiptapDoc } from '../tiptap'
+
+/** Deterministic resolver dependencies so document behavior is tested without a database. */
+const resolver = vi.hoisted(() => ({
+  resolveFieldTokens: vi.fn(),
+  formatFieldValueForText: vi.fn(),
+}))
+
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({ get: vi.fn() }),
+  getUserCache: () => ({ get: vi.fn() }),
+}))
+vi.mock('./resolver', () => resolver)
+
+import { resolvePlaceholdersInDocument } from './document-resolver'
+
+describe('resolvePlaceholdersInDocument', () => {
+  it('batches one field read while applying each structural occurrence independently', async () => {
+    resolver.resolveFieldTokens.mockResolvedValue(
+      new Map([
+        [
+          'visit:startTime',
+          {
+            value: { type: 'date', value: '2026-07-14T16:30:00.000Z' },
+            fieldType: FieldType.TIME,
+            fieldOptions: { timeFormat: '12h' },
+          },
+        ],
+      ])
+    )
+    resolver.formatFieldValueForText.mockReturnValueOnce('9:30 AM').mockReturnValueOnce('09:30')
+
+    const document: TiptapDoc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'placeholder', attrs: { id: 'visit:startTime' } },
+            { type: 'text', text: ' / ' },
+            {
+              type: 'placeholder',
+              attrs: {
+                id: 'visit:startTime',
+                format: { v: 1, t: 'TIME', o: { timeFormat: '24h' } },
+              },
+              marks: [{ type: 'bold' }],
+            },
+          ],
+        },
+      ],
+    }
+
+    const resolved = await resolvePlaceholdersInDocument(document, {
+      db: {} as never,
+      organizationId: 'org_123',
+      timezone: 'America/Los_Angeles',
+      recordIdsByRoot: new Map([['visit', 'visit:visit_123' as never]]),
+    })
+
+    expect(resolver.resolveFieldTokens).toHaveBeenCalledTimes(1)
+    expect(resolver.resolveFieldTokens.mock.calls[0]?.[0]).toEqual([
+      {
+        id: 'visit:startTime',
+        parsed: expect.objectContaining({ kind: 'field' }),
+      },
+    ])
+    expect(resolver.formatFieldValueForText).toHaveBeenLastCalledWith(
+      expect.anything(),
+      FieldType.TIME,
+      expect.objectContaining({
+        timeFormat: '24h',
+        timeZone: 'America/Los_Angeles',
+      })
+    )
+    expect(resolved.content?.[0]?.content).toEqual([
+      { type: 'text', text: '9:30 AM' },
+      { type: 'text', text: ' / ' },
+      { type: 'text', text: '09:30', marks: [{ type: 'bold' }] },
+    ])
+    expect(document.content?.[0]?.content?.[0]?.type).toBe('placeholder')
+  })
+
+  it('uses structural fallbacks when a field is empty', async () => {
+    resolver.resolveFieldTokens.mockResolvedValue(new Map([['visit:assignee', null]]))
+
+    const resolved = await resolvePlaceholdersInDocument(
+      {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'placeholder',
+                attrs: {
+                  id: 'visit:assignee',
+                  fallback: { v: 1, t: 'TEXT', d: 'our team' },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      { db: {} as never, organizationId: 'org_123', recordIdsByRoot: new Map() }
+    )
+
+    expect(resolved.content?.[0]?.content?.[0]).toEqual({
+      type: 'text',
+      text: 'our team',
+    })
+  })
+})

--- a/packages/lib/src/placeholders/document-resolver.ts
+++ b/packages/lib/src/placeholders/document-resolver.ts
@@ -1,0 +1,175 @@
+// packages/lib/src/placeholders/document-resolver.ts
+
+import { getOrgCache, getUserCache } from '../cache'
+import type { TiptapDoc, TiptapNode } from '../tiptap'
+import { decodeFallback, type FallbackPayload, renderFallbackPayload } from './fallback-codec'
+import {
+  decodePlaceholderFormat,
+  getPlaceholderFormatOptions,
+  type PlaceholderFormatPayload,
+} from './format-codec'
+import { type ParsedPlaceholder, tryParsePlaceholderId } from './path-parser'
+import {
+  formatFieldValueForText,
+  type PlaceholderResolutionContext,
+  resolveFieldTokens,
+} from './resolver'
+
+/** Resolve a persisted TipTap document to a concrete document ready for email rendering. */
+export async function resolvePlaceholdersInDocument(
+  document: TiptapDoc,
+  ctx: PlaceholderResolutionContext
+): Promise<TiptapDoc> {
+  const ids = new Set<string>()
+  let needsOrg = false
+  let needsUser = false
+
+  walk(document, (node) => {
+    if (node.type !== 'placeholder') return
+    const id = node.attrs?.id
+    if (typeof id !== 'string' || !id) throw new Error('Placeholder node is missing attrs.id')
+    const parsed = tryParsePlaceholderId(id)
+    if (!parsed) throw new Error(`Unresolvable placeholder token: ${id}`)
+    ids.add(id)
+    if (parsed.kind === 'org') needsOrg = true
+    if (parsed.kind === 'user') needsUser = true
+  })
+
+  const fieldTokens: {
+    id: string
+    parsed: Extract<ParsedPlaceholder, { kind: 'field' }>
+  }[] = []
+  for (const id of ids) {
+    const parsed = tryParsePlaceholderId(id)!
+    if (parsed.kind === 'field') fieldTokens.push({ id, parsed })
+  }
+
+  const [fieldValues, orgProfile, userProfile] = await Promise.all([
+    resolveFieldTokens(fieldTokens, ctx),
+    needsOrg ? getOrgCache().get(ctx.organizationId, 'orgProfile') : Promise.resolve(null),
+    needsUser && ctx.senderUserId
+      ? getUserCache().get(ctx.senderUserId, 'userProfile')
+      : Promise.resolve(null),
+  ])
+  const now = ctx.now ?? new Date()
+
+  const rebuild = (node: TiptapNode): TiptapNode => {
+    if (node.type === 'placeholder') {
+      const id = node.attrs?.id as string
+      return {
+        type: 'text',
+        text: resolvePlaceholderNodeText(node, id, fieldValues, orgProfile, userProfile, now, ctx),
+        ...(node.marks ? { marks: node.marks.map((mark) => ({ ...mark })) } : {}),
+      }
+    }
+    return {
+      ...node,
+      ...(node.attrs ? { attrs: { ...node.attrs } } : {}),
+      ...(node.marks ? { marks: node.marks.map((mark) => ({ ...mark })) } : {}),
+      ...(node.content ? { content: node.content.map(rebuild) } : {}),
+    }
+  }
+
+  return rebuild(document) as TiptapDoc
+}
+
+/** Walk all nodes in a document without mutating persisted JSON. */
+function walk(node: TiptapNode, visit: (node: TiptapNode) => void): void {
+  visit(node)
+  for (const child of node.content ?? []) walk(child, visit)
+}
+
+/** Resolve one structural placeholder occurrence, including its own fallback and format. */
+function resolvePlaceholderNodeText(
+  node: TiptapNode,
+  id: string,
+  fieldValues: Awaited<ReturnType<typeof resolveFieldTokens>>,
+  orgProfile: {
+    name: string | null
+    handle: string | null
+    website: string | null
+  } | null,
+  userProfile: {
+    id: string
+    name: string | null
+    email: string | null
+    firstName: string | null
+    lastName: string | null
+  } | null,
+  now: Date,
+  ctx: PlaceholderResolutionContext
+): string {
+  const parsed = tryParsePlaceholderId(id)
+  if (!parsed) throw new Error(`Unresolvable placeholder token: ${id}`)
+  if (parsed.kind === 'date') return formatDate(parsed.slug, now)
+
+  const fallback = decodePayload<FallbackPayload>(node.attrs?.fallback, decodeFallback)
+  const format = decodePayload<PlaceholderFormatPayload>(
+    node.attrs?.format,
+    decodePlaceholderFormat
+  )
+  let value = ''
+
+  if (parsed.kind === 'org') {
+    if (!orgProfile) throw new Error(`Organization profile not found for org: ${id}`)
+    value = orgValue(orgProfile, parsed.slug) ?? ''
+  } else if (parsed.kind === 'user') {
+    value = userProfile ? (userValue(userProfile, parsed.slug) ?? '') : ''
+  } else {
+    const resolved = fieldValues.get(id)
+    if (resolved) {
+      value = formatFieldValueForText(resolved.value, resolved.fieldType, {
+        ...resolved.fieldOptions,
+        ...getPlaceholderFormatOptions(format, resolved.fieldType),
+        ...(ctx.timezone ? { timeZone: ctx.timezone } : {}),
+      })
+    }
+  }
+
+  return value || (fallback ? renderFallbackPayload(fallback) : '')
+}
+
+/** Decode persisted node payloads defensively, using the same codecs as HTML. */
+function decodePayload<T>(
+  value: unknown,
+  decode: (raw: string | null | undefined) => T | null
+): T | null {
+  if (!value || typeof value !== 'object') return null
+  return decode(JSON.stringify(value))
+}
+
+function orgValue(
+  value: { name: string | null; handle: string | null; website: string | null },
+  slug: 'name' | 'handle' | 'website'
+): string | null {
+  return value[slug]
+}
+
+function userValue(
+  value: {
+    id: string
+    name: string | null
+    email: string | null
+    firstName: string | null
+    lastName: string | null
+  },
+  slug: 'id' | 'email' | 'name' | 'firstName' | 'lastName'
+): string | null {
+  return value[slug]
+}
+
+function formatDate(slug: 'today' | 'now' | 'tomorrow' | 'yesterday', now: Date): string {
+  const day = 24 * 60 * 60 * 1000
+  if (slug === 'now') return now.toLocaleString()
+  const date =
+    slug === 'tomorrow'
+      ? new Date(now.getTime() + day)
+      : slug === 'yesterday'
+        ? new Date(now.getTime() - day)
+        : now
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}

--- a/packages/lib/src/placeholders/index.ts
+++ b/packages/lib/src/placeholders/index.ts
@@ -4,6 +4,7 @@ export {
   type BuildContextInput,
   buildPlaceholderContextForThread,
 } from './context'
+export { resolvePlaceholdersInDocument } from './document-resolver'
 export {
   decodeFallback,
   encodeFallback,
@@ -19,6 +20,9 @@ export {
   tryParsePlaceholderId,
 } from './path-parser'
 export {
+  formatFieldValueForText,
   type PlaceholderResolutionContext,
+  type ResolvedFieldToken,
+  resolveFieldTokens,
   resolvePlaceholdersInHtml,
 } from './resolver'

--- a/packages/lib/src/placeholders/resolver.ts
+++ b/packages/lib/src/placeholders/resolver.ts
@@ -48,7 +48,8 @@ export interface PlaceholderResolutionContext {
 }
 
 /** Typed field metadata retained until each placeholder span is rendered. */
-interface ResolvedFieldToken {
+/** Typed field metadata retained until a placeholder occurrence is rendered. */
+export interface ResolvedFieldToken {
   value: TypedFieldValue | TypedFieldValue[]
   fieldType: FieldType
   fieldOptions?: FieldOptions
@@ -235,7 +236,12 @@ function userColumn(
   }
 }
 
-async function resolveFieldTokens(
+/**
+ * Batch-resolve field-backed placeholder ids without committing to an output
+ * representation. Both the legacy HTML adapter and structural document
+ * resolver use this so field reads and display metadata stay identical.
+ */
+export async function resolveFieldTokens(
   tokens: { id: string; parsed: Extract<ParsedPlaceholder, { kind: 'field' }> }[],
   ctx: PlaceholderResolutionContext
 ): Promise<Map<string, ResolvedFieldToken | null>> {
@@ -328,7 +334,7 @@ function formatDateOnly(d: Date): string {
  *   converter returns the raw id/object for frontend hydration, which is
  *   useless in an email).
  */
-function formatFieldValueForText(
+export function formatFieldValueForText(
   value: TypedFieldValue | TypedFieldValue[],
   fieldType: FieldType,
   options?: FieldOptions

--- a/packages/lib/src/sequences/publish.ts
+++ b/packages/lib/src/sequences/publish.ts
@@ -13,6 +13,7 @@ import { type Database, schema } from '@auxx/database'
 import { and, asc, eq } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { BadRequestError, ConflictError, NotFoundError } from '../errors'
+import type { TiptapDoc } from '../tiptap'
 import type { SequenceEntity, SequenceStepEntity } from './types'
 
 interface GraphNode {
@@ -110,7 +111,7 @@ export function buildSequenceGraph(
       stepId: step.id,
       stepIndex,
       subject: step.subject ?? null,
-      bodyHtml: step.bodyHtml ?? '',
+      bodyJson: step.bodyJson as unknown as TiptapDoc,
       attachmentIds: step.attachmentIds ?? [],
       integrationId: sequence.integrationId,
       signatureId: sequence.signatureEntityInstanceId ?? null,
@@ -165,6 +166,11 @@ export async function publishSequence(
   })
   if (steps.length === 0) {
     return err(new BadRequestError('Sequence must have at least one step to publish'))
+  }
+  if (steps.some((step) => !step.bodyJson)) {
+    return err(
+      new BadRequestError('Every sequence step needs a TipTap email body before publishing')
+    )
   }
 
   const firstStep = steps[0]!

--- a/packages/lib/src/sequences/seed-templates.ts
+++ b/packages/lib/src/sequences/seed-templates.ts
@@ -18,7 +18,8 @@
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
-import { encodeFallback, type FallbackPayload } from '../placeholders/fallback-codec'
+import type { FallbackPayload } from '../placeholders/fallback-codec'
+import type { TiptapDoc, TiptapNode } from '../tiptap'
 import { SystemUserService } from '../users/system-user-service'
 import { createSequence } from './crud'
 import { buildSequenceGraph } from './publish'
@@ -33,26 +34,43 @@ import type {
 
 const logger = createScopedLogger('sequences-seed-templates')
 
-/** `<entityDefId>:<fieldKey>` placeholder span — mirrors `snippets/system-snippets.ts`'s
- * private `placeholderSpan`/`fieldToken` helpers (not exported there, so duplicated here; both
- * builders independently produce the exact HTML `resolvePlaceholdersInHtml` expects). */
-function placeholderSpan(
+/** Build a canonical structural placeholder atom for a seeded sequence body. */
+function placeholder(
   entityDefId: string,
   fieldKey: string,
   fallback?: FallbackPayload
-): string {
-  const id = `${entityDefId}:${fieldKey}`
-  const dataFallback = fallback ? ` data-fallback="${encodeFallback(fallback)}"` : ''
-  return `<span data-type="placeholder" data-id="${id}"${dataFallback}>{{${id}}}</span>`
+): TiptapNode {
+  return {
+    type: 'placeholder',
+    attrs: {
+      id: `${entityDefId}:${fieldKey}`,
+      ...(fallback ? { fallback } : {}),
+    },
+  }
 }
 
-const CLOSING = '<p>Let us know if you have any questions.</p>'
+/** Build one paragraph without serializing any intermediary HTML. */
+function paragraph(...content: Array<string | TiptapNode>): TiptapNode {
+  return {
+    type: 'paragraph',
+    content: content.map((part) =>
+      typeof part === 'string' ? { type: 'text', text: part } : part
+    ),
+  }
+}
+
+/** Build the persisted JSON sequence email document. */
+function sequenceBody(...content: TiptapNode[]): TiptapDoc {
+  return { type: 'doc', content }
+}
+
+const CLOSING = paragraph('Let us know if you have any questions.')
 const FIRST_NAME_FALLBACK: FallbackPayload = { v: 1, t: 'TEXT', d: 'there' }
 const TITLE_FALLBACK: FallbackPayload = { v: 1, t: 'TEXT', d: 'your service' }
 
 interface SeedStep {
   subject: string
-  bodyHtml: (entityDefs: Record<string, string>) => string
+  bodyJson: (entityDefs: Record<string, string>) => TiptapDoc
   timingMode: 'relative' | 'anchor'
   delayDays?: number
   anchorOffsetDays?: number
@@ -97,32 +115,60 @@ export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
         subject: 'Your visit is booked',
         timingMode: 'relative',
         delayDays: 0,
-        bodyHtml: (defs) =>
-          `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>We've got you down for ${placeholderSpan('visit', 'date')} from ` +
-          `${placeholderSpan('visit', 'startTime')} to ${placeholderSpan('visit', 'endTime')} for ` +
-          `${placeholderSpan(defs.work_order!, 'title', TITLE_FALLBACK)} ` +
-          `(${placeholderSpan(defs.work_order!, 'number')}).</p>${CLOSING}`,
+        bodyJson: (defs) =>
+          sequenceBody(
+            paragraph('Hi ', placeholder(defs.contact!, 'firstName', FIRST_NAME_FALLBACK), ','),
+            paragraph(
+              "We've got you down for ",
+              placeholder('visit', 'date'),
+              ' from ',
+              placeholder('visit', 'startTime'),
+              ' to ',
+              placeholder('visit', 'endTime'),
+              ' for ',
+              placeholder(defs.work_order!, 'title', TITLE_FALLBACK),
+              ' (',
+              placeholder(defs.work_order!, 'number'),
+              ').'
+            ),
+            CLOSING
+          ),
       },
       {
         subject: 'Reminder: your visit is coming up',
         timingMode: 'anchor',
         anchorOffsetDays: -2,
         anchorTimeOfDay: '09:00',
-        bodyHtml: (defs) =>
-          `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Just a reminder — we'll see you on ${placeholderSpan('visit', 'date')} at ` +
-          `${placeholderSpan('visit', 'startTime')}.</p>${CLOSING}`,
+        bodyJson: (defs) =>
+          sequenceBody(
+            paragraph('Hi ', placeholder(defs.contact!, 'firstName', FIRST_NAME_FALLBACK), ','),
+            paragraph(
+              "Just a reminder — we'll see you on ",
+              placeholder('visit', 'date'),
+              ' at ',
+              placeholder('visit', 'startTime'),
+              '.'
+            ),
+            CLOSING
+          ),
       },
       {
         subject: "We'll see you today",
         timingMode: 'anchor',
         anchorOffsetDays: 0,
         anchorTimeOfDay: '07:30',
-        bodyHtml: (defs) =>
-          `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Today's the day! We'll be there at ${placeholderSpan('visit', 'startTime')}. ` +
-          `${placeholderSpan('visit', 'assignee')} will be your technician.</p>${CLOSING}`,
+        bodyJson: (defs) =>
+          sequenceBody(
+            paragraph('Hi ', placeholder(defs.contact!, 'firstName', FIRST_NAME_FALLBACK), ','),
+            paragraph(
+              "Today's the day! We'll be there at ",
+              placeholder('visit', 'startTime'),
+              '. ',
+              placeholder('visit', 'assignee'),
+              ' will be your technician.'
+            ),
+            CLOSING
+          ),
       },
     ],
   },
@@ -140,10 +186,18 @@ export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
         subject: "We're on our way",
         timingMode: 'relative',
         delayDays: 0,
-        bodyHtml: (defs) =>
-          `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Just a heads up — ${placeholderSpan('visit', 'assignee')} is on the way and should arrive ` +
-          `around ${placeholderSpan('visit', 'startTime')}.</p>${CLOSING}`,
+        bodyJson: (defs) =>
+          sequenceBody(
+            paragraph('Hi ', placeholder(defs.contact!, 'firstName', FIRST_NAME_FALLBACK), ','),
+            paragraph(
+              'Just a heads up — ',
+              placeholder('visit', 'assignee'),
+              ' is on the way and should arrive around ',
+              placeholder('visit', 'startTime'),
+              '.'
+            ),
+            CLOSING
+          ),
       },
     ],
   },
@@ -161,21 +215,33 @@ export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
         subject: 'Thank you!',
         timingMode: 'relative',
         delayDays: 0,
-        bodyHtml: (defs) =>
-          `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Thanks for choosing us for ` +
-          `${placeholderSpan(defs.work_order!, 'title', TITLE_FALLBACK)} ` +
-          `(${placeholderSpan(defs.work_order!, 'number')}). We hope everything went well.</p>${CLOSING}`,
+        bodyJson: (defs) =>
+          sequenceBody(
+            paragraph('Hi ', placeholder(defs.contact!, 'firstName', FIRST_NAME_FALLBACK), ','),
+            paragraph(
+              'Thanks for choosing us for ',
+              placeholder(defs.work_order!, 'title', TITLE_FALLBACK),
+              ' (',
+              placeholder(defs.work_order!, 'number'),
+              '). We hope everything went well.'
+            ),
+            CLOSING
+          ),
       },
       {
         subject: 'How did everything go?',
         timingMode: 'relative',
         delayDays: 10,
-        bodyHtml: (defs) =>
-          `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>It's been a little while since we completed ` +
-          `${placeholderSpan(defs.work_order!, 'title', TITLE_FALLBACK)}. We'd love to hear how ` +
-          `everything's holding up — and if you have a minute, a review would mean a lot.</p>${CLOSING}`,
+        bodyJson: (defs) =>
+          sequenceBody(
+            paragraph('Hi ', placeholder(defs.contact!, 'firstName', FIRST_NAME_FALLBACK), ','),
+            paragraph(
+              "It's been a little while since we completed ",
+              placeholder(defs.work_order!, 'title', TITLE_FALLBACK),
+              ". We'd love to hear how everything's holding up — and if you have a minute, a review would mean a lot."
+            ),
+            CLOSING
+          ),
       },
     ],
   },
@@ -194,34 +260,64 @@ export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
         timingMode: 'anchor',
         anchorOffsetDays: -2,
         anchorTimeOfDay: '09:00',
-        bodyHtml: (defs) =>
-          `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Just a reminder that invoice ${placeholderSpan(defs.invoice!, 'number')} for ` +
-          `${placeholderSpan(defs.invoice!, 'total')} is due ` +
-          `${placeholderSpan(defs.invoice!, 'dueDate', { v: 1, t: 'DATE', d: 'soon' })}.</p>${CLOSING}`,
+        bodyJson: (defs) =>
+          sequenceBody(
+            paragraph('Hi ', placeholder(defs.contact!, 'firstName', FIRST_NAME_FALLBACK), ','),
+            paragraph(
+              'Just a reminder that invoice ',
+              placeholder(defs.invoice!, 'number'),
+              ' for ',
+              placeholder(defs.invoice!, 'total'),
+              ' is due ',
+              placeholder(defs.invoice!, 'dueDate', {
+                v: 1,
+                t: 'DATE',
+                d: 'soon',
+              }),
+              '.'
+            ),
+            CLOSING
+          ),
       },
       {
         subject: 'Your invoice is overdue',
         timingMode: 'anchor',
         anchorOffsetDays: 3,
         anchorTimeOfDay: '09:00',
-        bodyHtml: (defs) =>
-          `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Invoice ${placeholderSpan(defs.invoice!, 'number')} for ` +
-          `${placeholderSpan(defs.invoice!, 'total')} was due ` +
-          `${placeholderSpan(defs.invoice!, 'dueDate', { v: 1, t: 'DATE', d: 'recently' })} and is ` +
-          `now overdue. Please let us know if you have any questions about payment.</p>`,
+        bodyJson: (defs) =>
+          sequenceBody(
+            paragraph('Hi ', placeholder(defs.contact!, 'firstName', FIRST_NAME_FALLBACK), ','),
+            paragraph(
+              'Invoice ',
+              placeholder(defs.invoice!, 'number'),
+              ' for ',
+              placeholder(defs.invoice!, 'total'),
+              ' was due ',
+              placeholder(defs.invoice!, 'dueDate', {
+                v: 1,
+                t: 'DATE',
+                d: 'recently',
+              }),
+              ' and is now overdue. Please let us know if you have any questions about payment.'
+            )
+          ),
       },
       {
         subject: 'Invoice still outstanding',
         timingMode: 'anchor',
         anchorOffsetDays: 10,
         anchorTimeOfDay: '09:00',
-        bodyHtml: (defs) =>
-          `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Invoice ${placeholderSpan(defs.invoice!, 'number')} for ` +
-          `${placeholderSpan(defs.invoice!, 'total')} is still outstanding. Please reach out if ` +
-          `there's anything we can help with.</p>`,
+        bodyJson: (defs) =>
+          sequenceBody(
+            paragraph('Hi ', placeholder(defs.contact!, 'firstName', FIRST_NAME_FALLBACK), ','),
+            paragraph(
+              'Invoice ',
+              placeholder(defs.invoice!, 'number'),
+              ' for ',
+              placeholder(defs.invoice!, 'total'),
+              " is still outstanding. Please reach out if there's anything we can help with."
+            )
+          ),
       },
     ],
   },
@@ -239,10 +335,16 @@ export const SEQUENCE_SEED_TEMPLATES: SeedTemplate[] = [
         subject: 'Thanks — see you next time',
         timingMode: 'relative',
         delayDays: 0,
-        bodyHtml: (defs) =>
-          `<p>Hi ${placeholderSpan(defs.contact!, 'firstName', FIRST_NAME_FALLBACK)},</p>` +
-          `<p>Thank you for having us out on ${placeholderSpan('visit', 'date')}. We hope everything went well — see ` +
-          `you next time!</p>${CLOSING}`,
+        bodyJson: (defs) =>
+          sequenceBody(
+            paragraph('Hi ', placeholder(defs.contact!, 'firstName', FIRST_NAME_FALLBACK), ','),
+            paragraph(
+              'Thank you for having us out on ',
+              placeholder('visit', 'date'),
+              '. We hope everything went well — see you next time!'
+            ),
+            CLOSING
+          ),
       },
     ],
   },
@@ -253,7 +355,10 @@ async function resolveOrgEntityDefs(
   organizationId: string
 ): Promise<Record<string, string>> {
   const defs = await db
-    .select({ entityType: schema.EntityDefinition.entityType, id: schema.EntityDefinition.id })
+    .select({
+      entityType: schema.EntityDefinition.entityType,
+      id: schema.EntityDefinition.id,
+    })
     .from(schema.EntityDefinition)
     .where(eq(schema.EntityDefinition.organizationId, organizationId))
   const map: Record<string, string> = {}
@@ -353,7 +458,7 @@ export async function seedClientNotificationSequences(
         sequenceId: sequence.id,
         organizationId,
         subject: step.subject,
-        bodyHtml: step.bodyHtml(entityDefs),
+        bodyJson: step.bodyJson(entityDefs) as unknown as Record<string, unknown>,
         delayDays: step.timingMode === 'relative' ? (step.delayDays ?? 0) : 0,
         delayHours: 0,
         timingMode: step.timingMode,

--- a/packages/lib/src/sequences/steps.ts
+++ b/packages/lib/src/sequences/steps.ts
@@ -17,6 +17,9 @@ import type {
   UpdateStepFields,
 } from './types'
 
+/** Empty, valid TipTap body for a newly-created sequence step. */
+const EMPTY_SEQUENCE_BODY = { type: 'doc', content: [{ type: 'paragraph' }] }
+
 /** Mark the parent sequence dirty after a step edit, but only if it's been published. */
 async function markDirtyIfPublished(db: Database, sequenceId: string): Promise<void> {
   const sequence = await db.query.Sequence.findFirst({
@@ -54,8 +57,7 @@ export async function createStep(
       delayDays: fields.delayDays ?? 0,
       delayHours: fields.delayHours ?? 0,
       subject: fields.subject ?? null,
-      bodyJson: fields.bodyJson ?? null,
-      bodyHtml: fields.bodyHtml ?? null,
+      bodyJson: fields.bodyJson ?? EMPTY_SEQUENCE_BODY,
       attachmentIds: fields.attachmentIds ?? [],
       timingMode: fields.timingMode ?? 'relative',
       anchorOffsetDays: fields.anchorOffsetDays ?? 0,

--- a/packages/lib/src/sequences/types.ts
+++ b/packages/lib/src/sequences/types.ts
@@ -95,7 +95,6 @@ export interface CreateStepInput {
   delayHours?: number
   subject?: string | null
   bodyJson?: Record<string, unknown> | null
-  bodyHtml?: string | null
   attachmentIds?: string[]
   /** `'relative'` = existing delayDays/delayHours semantics; `'anchor'` = signed offset from
    * the sequence's subject date. Defaults to `'relative'` at the schema level. */
@@ -116,7 +115,6 @@ export interface UpdateStepFields {
   delayHours?: number
   subject?: string | null
   bodyJson?: Record<string, unknown> | null
-  bodyHtml?: string | null
   attachmentIds?: string[]
   timingMode?: 'relative' | 'anchor'
   anchorOffsetDays?: number

--- a/packages/lib/src/tiptap/index.ts
+++ b/packages/lib/src/tiptap/index.ts
@@ -13,5 +13,9 @@ export { collectVariableIds } from './collect-variable-ids'
 export { isNonEmptyDoc, trimTrailingEmptyParagraphs } from './doc-shape'
 export { docToText } from './doc-to-text'
 export { docToHtml, htmlToDoc, stripHtml } from './html'
+export {
+  appendSequenceUnsubscribeFooter,
+  sequenceEmailDocumentToHtml,
+} from './sequence-email-document-to-html'
 export { type TextToDocOptions, textToDoc } from './text-to-doc'
 export type { TiptapDoc, TiptapMark, TiptapNode } from './types'

--- a/packages/lib/src/tiptap/sequence-email-document-to-html.test.ts
+++ b/packages/lib/src/tiptap/sequence-email-document-to-html.test.ts
@@ -1,0 +1,71 @@
+// packages/lib/src/tiptap/sequence-email-document-to-html.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { sequenceEmailDocumentToHtml } from './sequence-email-document-to-html'
+
+describe('sequenceEmailDocumentToHtml', () => {
+  it('renders concrete rich text with escaped content', () => {
+    expect(
+      sequenceEmailDocumentToHtml({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            attrs: { textAlign: 'center' },
+            content: [
+              {
+                type: 'text',
+                text: '<Jordan & Co>',
+                marks: [{ type: 'bold' }],
+              },
+              { type: 'hardBreak' },
+              {
+                type: 'text',
+                text: 'Open details',
+                marks: [
+                  {
+                    type: 'link',
+                    attrs: { href: 'https://example.com/details?a=1&b=2' },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    ).toBe(
+      '<p style="text-align:center"><strong>&lt;Jordan &amp; Co&gt;</strong><br><a href="https://example.com/details?a=1&amp;b=2" target="_blank" rel="noopener noreferrer">Open details</a></p>'
+    )
+  })
+
+  it('fails closed for unresolved placeholders and unsafe links', () => {
+    expect(() =>
+      sequenceEmailDocumentToHtml({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'placeholder', attrs: { id: 'visit:date' } }],
+          },
+        ],
+      })
+    ).toThrow('Unresolved placeholder')
+    expect(() =>
+      sequenceEmailDocumentToHtml({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Nope',
+                marks: [{ type: 'link', attrs: { href: 'javascript:alert(1)' } }],
+              },
+            ],
+          },
+        ],
+      })
+    ).toThrow('Unsafe email link')
+  })
+})

--- a/packages/lib/src/tiptap/sequence-email-document-to-html.ts
+++ b/packages/lib/src/tiptap/sequence-email-document-to-html.ts
@@ -1,0 +1,144 @@
+// packages/lib/src/tiptap/sequence-email-document-to-html.ts
+
+import type { TiptapDoc, TiptapMark, TiptapNode } from './types'
+
+/** Render a concrete sequence email document to safe outbound HTML. */
+export function sequenceEmailDocumentToHtml(document: TiptapDoc): string {
+  return (document.content ?? []).map(renderBlock).join('')
+}
+
+/** Add the sequence-owned unsubscribe footer before the document reaches the HTML boundary. */
+export function appendSequenceUnsubscribeFooter(document: TiptapDoc, url: string): TiptapDoc {
+  return {
+    ...document,
+    content: [
+      ...(document.content ?? []),
+      {
+        type: 'paragraph',
+        attrs: { textAlign: 'left' },
+        content: [
+          {
+            type: 'text',
+            text: 'Unsubscribe',
+            marks: [{ type: 'link', attrs: { href: url } }],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+function renderBlock(node: TiptapNode): string {
+  const content = renderInline(node.content)
+  const attrs = blockStyle(node)
+  switch (node.type) {
+    case 'paragraph':
+      return `<p${attrs}>${content}</p>`
+    case 'heading': {
+      const level = Number(node.attrs?.level)
+      if (!Number.isInteger(level) || level < 1 || level > 3)
+        throw new Error('Unsupported heading level')
+      return `<h${level}${attrs}>${content}</h${level}>`
+    }
+    case 'bulletList':
+      return `<ul${attrs}>${(node.content ?? []).map(renderListItem).join('')}</ul>`
+    case 'orderedList':
+      return `<ol${attrs}>${(node.content ?? []).map(renderListItem).join('')}</ol>`
+    case 'blockquote':
+      return `<blockquote${attrs}>${(node.content ?? []).map(renderBlock).join('')}</blockquote>`
+    case 'codeBlock':
+      return `<pre${attrs}><code>${content}</code></pre>`
+    case 'horizontalRule':
+      return '<hr>'
+    default:
+      throw new Error(`Unsupported sequence email node: ${node.type ?? 'unknown'}`)
+  }
+}
+
+function renderListItem(node: TiptapNode): string {
+  if (node.type !== 'listItem') throw new Error(`Unsupported list child: ${node.type ?? 'unknown'}`)
+  return `<li${blockStyle(node)}>${(node.content ?? []).map(renderBlock).join('')}</li>`
+}
+
+function renderInline(nodes: TiptapNode[] | undefined): string {
+  return (nodes ?? [])
+    .map((node) => {
+      if (node.type === 'text') return applyMarks(escapeHtml(node.text ?? ''), node.marks ?? [])
+      if (node.type === 'hardBreak') return '<br>'
+      if (node.type === 'placeholder')
+        throw new Error('Unresolved placeholder reached sequence email renderer')
+      throw new Error(`Unsupported sequence email inline node: ${node.type ?? 'unknown'}`)
+    })
+    .join('')
+}
+
+function applyMarks(html: string, marks: TiptapMark[]): string {
+  return marks.reduce((value, mark) => {
+    switch (mark.type) {
+      case 'bold':
+        return `<strong>${value}</strong>`
+      case 'italic':
+        return `<em>${value}</em>`
+      case 'underline':
+        return `<u>${value}</u>`
+      case 'strike':
+        return `<s>${value}</s>`
+      case 'code':
+        return `<code>${value}</code>`
+      case 'link': {
+        const href = mark.attrs?.href
+        if (typeof href !== 'string' || !isSafeHref(href)) throw new Error('Unsafe email link')
+        return `<a href="${escapeAttribute(href)}" target="_blank" rel="noopener noreferrer">${value}</a>`
+      }
+      case 'textStyle': {
+        const style = textStyle(mark.attrs)
+        return style ? `<span style="${style}">${value}</span>` : value
+      }
+      default:
+        throw new Error(`Unsupported sequence email mark: ${mark.type}`)
+    }
+  }, html)
+}
+
+function blockStyle(node: TiptapNode): string {
+  const styles: string[] = []
+  const align = node.attrs?.textAlign
+  if (align === 'center' || align === 'right' || align === 'justify')
+    styles.push(`text-align:${align}`)
+  const indent = node.attrs?.indent
+  if (typeof indent === 'number' && Number.isInteger(indent) && indent > 0 && indent <= 8)
+    styles.push(`margin-left:${indent * 2}em`)
+  return styles.length ? ` style="${styles.join(';')}"` : ''
+}
+
+function textStyle(attrs: Record<string, unknown> | undefined): string {
+  if (!attrs) return ''
+  const styles: string[] = []
+  if (typeof attrs.color === 'string' && /^#[0-9a-f]{3,8}$/i.test(attrs.color))
+    styles.push(`color:${attrs.color}`)
+  if (typeof attrs.fontFamily === 'string' && /^[a-z0-9 ,'-]{1,80}$/i.test(attrs.fontFamily))
+    styles.push(`font-family:${attrs.fontFamily}`)
+  if (typeof attrs.fontSize === 'string' && /^\d{1,2}(px|pt|em|rem|%)$/.test(attrs.fontSize))
+    styles.push(`font-size:${attrs.fontSize}`)
+  return styles.join(';')
+}
+
+function isSafeHref(href: string): boolean {
+  try {
+    const url = new URL(href, 'https://auxx.invalid')
+    return url.protocol === 'https:' || url.protocol === 'http:' || url.protocol === 'mailto:'
+  } catch {
+    return false
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[char]!
+  )
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value)
+}

--- a/packages/lib/src/workflow-engine/nodes/sequence-send-email/sequence-send-email-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/sequence-send-email/sequence-send-email-processor.ts
@@ -13,8 +13,10 @@ import { and, eq, isNull } from 'drizzle-orm'
 import { getOrgCache } from '../../../cache'
 import { MessageSenderService } from '../../../messages/message-sender.service'
 import type { SendMessageInput } from '../../../messages/types/message-sending.types'
-import type { PlaceholderResolutionContext } from '../../../placeholders'
-import { resolvePlaceholdersInHtml } from '../../../placeholders'
+import {
+  type PlaceholderResolutionContext,
+  resolvePlaceholdersInDocument,
+} from '../../../placeholders'
 import { ProviderRegistryService } from '../../../providers/provider-registry-service'
 import { buildSequenceUnsubscribeUrl, exitSequenceRun } from '../../../sequences/runtime'
 import {
@@ -24,6 +26,11 @@ import {
   type SubjectContext,
 } from '../../../sequences/subject'
 import { recordSignal, toSignalRecordKey } from '../../../signals'
+import {
+  appendSequenceUnsubscribeFooter,
+  sequenceEmailDocumentToHtml,
+  type TiptapNode,
+} from '../../../tiptap'
 import { SystemUserService } from '../../../users/system-user-service'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
@@ -67,6 +74,19 @@ function isTerminalSendFailure(errorMessage: string | null | undefined): boolean
   return false
 }
 
+/** Check structural placeholder atoms for a rendered Visit schedule field. */
+function containsVisitSchedulePlaceholder(node: TiptapNode): boolean {
+  if (
+    node.type === 'placeholder' &&
+    (node.attrs?.id === 'visit:date' ||
+      node.attrs?.id === 'visit:startTime' ||
+      node.attrs?.id === 'visit:endTime')
+  ) {
+    return true
+  }
+  return (node.content ?? []).some((child) => containsVisitSchedulePlaceholder(child))
+}
+
 export class SequenceSendEmailProcessor extends BaseNodeProcessor {
   readonly type = 'sequence-send-email'
 
@@ -79,7 +99,7 @@ export class SequenceSendEmailProcessor extends BaseNodeProcessor {
     if (typeof config.stepIndex !== 'number' || config.stepIndex < 1) {
       errors.push('stepIndex must be a positive number')
     }
-    if (!config.bodyHtml) errors.push('bodyHtml is required')
+    if (!config.bodyJson || config.bodyJson.type !== 'doc') errors.push('bodyJson is required')
     if (!config.integrationId) errors.push('integrationId is required')
     if (config.stepIndex === 1 && !config.subject) {
       errors.push('subject is required for step 1')
@@ -244,11 +264,11 @@ export class SequenceSendEmailProcessor extends BaseNodeProcessor {
 
     try {
       // ── (4) generic placeholder resolution with subject record context ──────
+      const entityDefs = await getOrgCache().get(organizationId, 'entityDefs')
       const includesVisitScheduleField =
         subjectKind === 'visit' &&
         visitRow?.startTime != null &&
-        /data-id="visit:(date|startTime|endTime)"/.test(config.bodyHtml)
-      const entityDefs = await getOrgCache().get(organizationId, 'entityDefs')
+        containsVisitSchedulePlaceholder(config.bodyJson)
       const recordIdsByRoot = new Map<string, RecordId>()
       if (entityDefs.contact && contactRecordId) {
         recordIdsByRoot.set(entityDefs.contact, contactRecordId)
@@ -268,13 +288,14 @@ export class SequenceSendEmailProcessor extends BaseNodeProcessor {
         recordIdsByRoot,
         timezone: sequence.deliveryTimezone ?? 'UTC',
       }
-      let resolvedHtml = await resolvePlaceholdersInHtml(config.bodyHtml, placeholderCtx)
+      let resolvedDocument = await resolvePlaceholdersInDocument(config.bodyJson, placeholderCtx)
 
       // ── (5) unsubscribe footer — only when the sequence wants one ─────────
       if (sequence.includeUnsubscribeFooter) {
         const unsubscribeUrl = buildSequenceUnsubscribeUrl(run.unsubscribeToken)
-        resolvedHtml += `<p style="color:#8a8a8a;font-size:12px;margin-top:24px;"><a href="${unsubscribeUrl}" target="_blank" rel="noopener noreferrer" style="color:#8a8a8a;">Unsubscribe</a></p>`
+        resolvedDocument = appendSequenceUnsubscribeFooter(resolvedDocument, unsubscribeUrl)
       }
+      const resolvedHtml = sequenceEmailDocumentToHtml(resolvedDocument)
 
       // ── Subject: step 1 opens the thread; steps 2..N reply into it ─────────
       const subject = await this.resolveSubject(config, run, database)

--- a/packages/lib/src/workflow-engine/nodes/sequence-send-email/types.ts
+++ b/packages/lib/src/workflow-engine/nodes/sequence-send-email/types.ts
@@ -4,6 +4,8 @@
 // node palette. `publishSequence` (Phase 2) is the sole writer of a compiled
 // step node's `data`; nothing in the UI authors this shape directly.
 
+import type { TiptapDoc } from '../../../tiptap'
+
 /** A compiled sequence step's node config — written by `publishSequence`. */
 export interface SequenceSendEmailNodeConfig {
   sequenceId: string
@@ -12,8 +14,8 @@ export interface SequenceSendEmailNodeConfig {
   stepIndex: number
   /** Used only when this step opens the thread (step 1 / no `threadId` yet). */
   subject?: string | null
-  /** Rendered HTML — carries the `{{token}}` placeholder spans, resolved at send time. */
-  bodyHtml: string
+  /** Immutable TipTap snapshot — placeholder nodes resolve structurally at send time. */
+  bodyJson: TiptapDoc
   attachmentIds: string[]
   /** Pinned sending mailbox (`Sequence.integrationId`). */
   integrationId: string


### PR DESCRIPTION
## Summary
- make sequence bodies JSON-only from editor persistence through published send-node snapshots
- resolve placeholder nodes structurally and render concrete, safe email HTML only at send time
- convert seeded client-notification templates to TipTap JSON and retain Visit/actor resolution
- include dispatch visit mutation and verification updates plus refreshed repository guidance

## Validation
- pnpm --filter @auxx/lib test:run src/placeholders/document-resolver.test.ts src/tiptap/sequence-email-document-to-html.test.ts src/field-values/resolvers/system-table-resolver.test.ts src/field-values/resolvers/visit-virtual-fields.test.ts
- focused @auxx/lib and @auxx/web typecheck output for touched files
- git diff --check