### PR TITLE
fix(dispatch): improve visit detail and line drafts

### DIFF
--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-card.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-card.tsx
@@ -19,6 +19,7 @@ import { VISIT_STATUS_FORWARD_ORDER, VISIT_STATUS_LABELS, type VisitStatus } fro
 import { getVisitDayContext, isExecutionReady } from '../board/utils'
 import { type ExistingVisitForOverlap, SchedulePopover } from '../schedule-popover'
 import type { JobVisit, UseJobVisitsResult } from './use-job-visits'
+import { VisitDateBlock } from './visit-date-block'
 
 export interface VisitCardProps {
   visit: JobVisit | undefined
@@ -106,19 +107,7 @@ export function VisitCard({
   return (
     <div className='group/tree-row space-y-2.5 rounded-2xl border bg-primary-100/50 py-2.5 px-3'>
       <div className='flex items-center gap-3'>
-        {/* Calendar date block — month + day (04 mock), icon when unscheduled. */}
-        <div className='flex size-11 shrink-0 flex-col items-center justify-center rounded-lg border bg-background'>
-          {start ? (
-            <>
-              <span className='text-[10px] font-semibold uppercase leading-none text-muted-foreground'>
-                {format(start, 'MMM')}
-              </span>
-              <span className='text-base font-semibold leading-tight'>{format(start, 'd')}</span>
-            </>
-          ) : (
-            <CalendarClock className='size-5 text-muted-foreground' />
-          )}
-        </div>
+        <VisitDateBlock startTime={visit.startTime} />
 
         <div className='min-w-0 flex-1'>
           <div className='flex items-center gap-2 text-sm font-medium'>

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-date-block.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-date-block.tsx
@@ -1,0 +1,28 @@
+// apps/web/src/components/dispatch/ui/job-schedule/visit-date-block.tsx
+'use client'
+
+import { format } from 'date-fns'
+import { CalendarClock } from 'lucide-react'
+
+/**
+ * Calendar-style visit date tile shared by the work-order Schedule card and
+ * the drilled visit detail. An unscheduled visit falls back to its clock icon.
+ */
+export function VisitDateBlock({ startTime }: { startTime: Date | string | null | undefined }) {
+  const start = startTime ? new Date(startTime) : null
+
+  return (
+    <div className='flex size-11 shrink-0 flex-col items-center justify-center rounded-lg border bg-background'>
+      {start ? (
+        <>
+          <span className='text-[10px] font-semibold uppercase leading-none text-muted-foreground'>
+            {format(start, 'MMM')}
+          </span>
+          <span className='text-base font-semibold leading-tight'>{format(start, 'd')}</span>
+        </>
+      ) : (
+        <CalendarClock className='size-5 text-muted-foreground' />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
@@ -1,31 +1,35 @@
 // apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import { toActorId } from '@auxx/types/actor'
 import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { Input } from '@auxx/ui/components/input'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { toastError } from '@auxx/ui/components/toast'
 import { format } from 'date-fns'
 import { CalendarClock, ReceiptText, Send, User, XCircle } from 'lucide-react'
 import { useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { getInitials } from '~/components/groups/utils/group-utils'
 import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
 import { TuckedLabel } from '~/components/money/ui/tucked-label'
 import type { RecordDrillContext } from '~/components/records/record-drill-panels'
 import { useActors } from '~/components/resources/hooks/use-actor'
+import { BaseType } from '~/components/workflow/types'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { VISIT_STATUS_LABELS, type VisitStatus } from '../board/types'
 import { SchedulePopover } from '../schedule-popover'
 import {
-  formatVisitWindow,
+  isPastVisit,
   resolveVisitDurationMinutes,
   VISIT_STATUS_BADGE_VARIANT,
 } from './job-schedule-utils'
 import { useJobVisits } from './use-job-visits'
+import { VisitDateBlock } from './visit-date-block'
 import { VisitProofOfWork } from './visit-proof-of-work'
 
 /**
@@ -41,7 +45,7 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
   const [confirm, ConfirmDialog] = useConfirm()
   // Plan 20 §4.1a — explicit duration write. Never touches the schedule; draft state so a
   // blur/Enter commits and an Escape reverts without re-render churn on every keystroke.
-  const [durationDraft, setDurationDraft] = useState<string | null>(null)
+  const [durationDraft, setDurationDraft] = useState<number | undefined | null>(null)
   const setVisitDuration = api.dispatch.setVisitDuration.useMutation({
     onError: (error) => toastError({ title: 'Error saving duration', description: error.message }),
     onSuccess: refresh,
@@ -60,12 +64,15 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
 
   const canCancel = visit.status !== 'canceled' && visit.status !== 'done'
   const resolvedDurationMinutes = resolveVisitDurationMinutes(visit)
+  const isHistory = isPastVisit(visit)
+  const start = visit.startTime ? new Date(visit.startTime) : null
+  const end = visit.endTime ? new Date(visit.endTime) : null
+  const isProvisionalTime = Boolean(start) && visit.timeConfirmedAt == null
 
   const commitDuration = () => {
     if (durationDraft === null) return
-    const trimmed = durationDraft.trim()
     setDurationDraft(null)
-    const nextValue = trimmed === '' ? null : Number.parseInt(trimmed, 10)
+    const nextValue = durationDraft ?? null
     if (nextValue !== null && (Number.isNaN(nextValue) || nextValue < 1 || nextValue > 1440)) return
     if (nextValue === (visit.durationMinutes ?? null)) return
     setVisitDuration.mutate({ visitId: visit.id, durationMinutes: nextValue })
@@ -86,29 +93,44 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
   return (
     <ScrollArea className='h-full' scrollbarClassName='w-1.5 z-20' noFade>
       <div className='flex flex-col gap-4 p-4'>
-        <div className='flex items-center justify-between gap-2'>
-          <div className='flex flex-col gap-1'>
-            <span className='text-sm font-medium'>{formatVisitWindow(visit)}</span>
-            <Badge
-              variant={VISIT_STATUS_BADGE_VARIANT[visit.status] ?? 'default'}
-              size='sm'
-              className='w-fit'>
-              {VISIT_STATUS_LABELS[visit.status as VisitStatus] ?? visit.status}
-            </Badge>
-          </div>
-          {assignee ? (
-            <div className='flex items-center gap-2'>
-              <Avatar className='size-7'>
-                <AvatarImage src={assignee.avatarUrl ?? undefined} />
-                <AvatarFallback className='text-xs'>{getInitials(assignee.name)}</AvatarFallback>
-              </Avatar>
-              <span className='text-sm'>{assignee.name}</span>
+        <div className='flex items-center gap-3'>
+          <VisitDateBlock startTime={visit.startTime} />
+          <div className='min-w-0 flex-1'>
+            <div className='flex items-center gap-2 text-sm font-medium'>
+              <span className='truncate'>
+                {start ? `Visit · ${format(start, 'EEE, MMM d')}` : 'Not scheduled yet'}
+              </span>
+              <Badge variant={VISIT_STATUS_BADGE_VARIANT[visit.status] ?? 'default'} size='sm'>
+                {VISIT_STATUS_LABELS[visit.status as VisitStatus] ?? visit.status}
+              </Badge>
             </div>
-          ) : (
-            <span className='flex items-center gap-1.5 text-sm text-muted-foreground'>
-              <User className='size-4' /> Unassigned
-            </span>
-          )}
+            <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+              {start && (
+                <span
+                  title={
+                    isProvisionalTime ? 'Estimated from route plan — not confirmed' : undefined
+                  }>
+                  {isProvisionalTime && '~'}
+                  {end ? `${format(start, 'p')} – ${format(end, 'p')}` : format(start, 'p')}
+                </span>
+              )}
+              {assignee ? (
+                <span className='flex min-w-0 items-center gap-1.5'>
+                  <Avatar className='size-4 shrink-0'>
+                    <AvatarImage src={assignee.avatarUrl ?? undefined} />
+                    <AvatarFallback className='text-[9px]'>
+                      {getInitials(assignee.name)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className='truncate'>{assignee.name}</span>
+                </span>
+              ) : (
+                <span className='flex items-center gap-1'>
+                  <User className='size-3.5' /> Unassigned
+                </span>
+              )}
+            </div>
+          </div>
         </div>
 
         {visit.dispatchedAt && (
@@ -135,47 +157,52 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
               onScheduled={refresh}
               onUnscheduled={refresh}
             />
-            <Button
-              variant='outline'
-              size='sm'
-              onClick={() => mutations.dispatchVisit.mutate({ visitId: visit.id })}
-              loading={mutations.dispatchVisit.isPending}
-              disabled={!visit.assigneeUserId || !visit.startTime}>
-              <Send /> {visit.dispatchedAt ? 'Re-dispatch' : 'Dispatch'}
-            </Button>
-            {canCancel && (
-              <Button variant='ghost' size='sm' onClick={handleCancel}>
-                <XCircle /> Cancel visit
-              </Button>
+            {!isHistory && (
+              <>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={() => mutations.dispatchVisit.mutate({ visitId: visit.id })}
+                  loading={mutations.dispatchVisit.isPending}
+                  disabled={!visit.assigneeUserId || !visit.startTime}>
+                  <Send /> {visit.dispatchedAt ? 'Re-dispatch' : 'Dispatch'}
+                </Button>
+                {canCancel && (
+                  <Button variant='ghost' size='sm' onClick={handleCancel}>
+                    <XCircle /> Cancel visit
+                  </Button>
+                )}
+              </>
             )}
           </div>
         )}
 
-        {/* Intended on-site duration (plan 20 §4.1a) — explicit value when set, else an empty
-            input showing the resolved fallback (span, then 60) as a placeholder. Never touches
-            the schedule; planner writes (apply-times, slot-in) only ever consume this. */}
-        <div className='flex items-center justify-between gap-2 text-sm'>
-          <span className='text-muted-foreground'>Duration</span>
-          <div className='flex items-center gap-1.5'>
-            <Input
-              type='number'
-              min={1}
-              max={1440}
-              inputMode='numeric'
-              placeholder={`${resolvedDurationMinutes} (default)`}
-              value={durationDraft ?? (visit.durationMinutes != null ? visit.durationMinutes : '')}
-              onChange={(e) => setDurationDraft(e.target.value)}
-              onBlur={commitDuration}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') e.currentTarget.blur()
-                if (e.key === 'Escape') setDurationDraft(null)
+        {/* Intended on-site duration (plan 20 §4.1a). An explicit value overrides the resolved
+            fallback (scheduled span, then 60 minutes), without changing the schedule itself. */}
+        <FieldPanel className='p-0'>
+          <FieldPanelRow title='Duration' type={BaseType.NUMBER} showIcon>
+            <div
+              onBlur={(event) => {
+                if (!event.currentTarget.contains(event.relatedTarget)) commitDuration()
               }}
-              disabled={!canEdit || setVisitDuration.isPending}
-              className='h-7 w-20 text-right'
-            />
-            <span className='text-xs text-muted-foreground'>min</span>
-          </div>
-        </div>
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.currentTarget.querySelector<HTMLInputElement>('input')?.blur()
+                }
+                if (event.key === 'Escape') setDurationDraft(null)
+              }}>
+              <FieldInputAdapter
+                fieldType={FieldType.NUMBER}
+                value={
+                  durationDraft === null ? (visit.durationMinutes ?? undefined) : durationDraft
+                }
+                onChange={(value) => setDurationDraft(value as number | undefined)}
+                placeholder={`${resolvedDurationMinutes} min (default)`}
+                disabled={!canEdit || setVisitDuration.isPending}
+              />
+            </div>
+          </FieldPanelRow>
+        </FieldPanel>
 
         {/* Per-visit proof of work — the worker's captured QC checklist (notes + photos),
             read-only dispatcher-side. Authoring stays on the worker surface's Notes tab. */}

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
@@ -204,7 +204,7 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
             Automatic invoicing is turned off for your organization.
           </div>
         )}
-        <div className='me-4'>
+        <div className='me-3'>
           {/* Block d — invoices */}
           <BlockLabel>Invoices</BlockLabel>
           <div className='bg-primary-100 border rounded-xl mb-4'>

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -35,6 +35,9 @@
 //   flight keep mutating local draft state; once it resolves, anything that
 //   changed since the snapshot was sent is flushed via `saveMultipleAsync`
 //   against the real record. An untouched draft simply vanishes on unmount.
+//   An editable builder initially seeds three of these drafts as local loading
+//   placeholders. If persisted rows arrive, they replace only those initial
+//   drafts; they still follow the same no-save-until-edited rule.
 // - Reorder: dnd-kit sortable rows (grip handle) → `api.money.reorderLines`.
 //   Draft rows aren't part of the sortable set — they pin after the real rows.
 // - Delete: real rows → `api.record.delete` + `api.money.recomputeTotals`
@@ -106,6 +109,7 @@ export interface LineBuilderProps {
 
 const LINE_ITEM_SLUG = 'line-items'
 const PAGE_SIZE = 100
+const INITIAL_DRAFT_COUNT = 3
 /** Stable sort ref — `useRecordList` keys its cache off this object. */
 const LINE_SORT = [{ id: 'sortOrder', desc: false }]
 
@@ -175,6 +179,11 @@ export function LineBuilder({
   const [lastAddedDraftId, setLastAddedDraftId] = useState<string | null>(null)
   const draftsRef = useRef<DraftLine[]>([])
   draftsRef.current = drafts
+  // An editable document starts with a small working set of local-only rows.
+  // Track just these initial rows so persisted records can replace them without
+  // hiding drafts the user explicitly added later.
+  const seededInitialDraftsRef = useRef(false)
+  const initialDraftIdsRef = useRef<Set<string>>(new Set())
   /** Rows container — the keydown listener {@link useLineNav} attaches to. */
   const rowsContainerRef = useRef<HTMLDivElement>(null)
   // Last focused line cell (row/col + caret). Committing a draft fires a
@@ -294,6 +303,44 @@ export function LineBuilder({
   const displayIdsRef = useRef<string[]>([])
   displayIdsRef.current = displayRecords.map((r) => r.id)
 
+  // Seed local loading placeholders immediately. Persisted rows replace these
+  // exact drafts below; manually added drafts are never part of this set.
+  useEffect(() => {
+    if (
+      !entityDefinitionId ||
+      readOnly ||
+      seededInitialDraftsRef.current ||
+      displayRecords.length > 0 ||
+      draftsRef.current.length > 0
+    ) {
+      return
+    }
+
+    seededInitialDraftsRef.current = true
+    const initialDrafts = Array.from({ length: INITIAL_DRAFT_COUNT }, () =>
+      freshDraft(generateId())
+    )
+    initialDraftIdsRef.current = new Set(initialDrafts.map((draft) => draft.draftId))
+    setDrafts(initialDrafts)
+    setLastAddedDraftId(initialDrafts[0].draftId)
+  }, [entityDefinitionId, readOnly, displayRecords.length])
+
+  // When persisted lines arrive, hide/remove the initial loading placeholders
+  // in the same render. A draft becomes non-placeholder before its first
+  // `record.create`, so a user edit is never discarded by this cleanup.
+  const visibleDrafts = useMemo(() => {
+    if (displayRecords.length === 0) return drafts
+    return drafts.filter((draft) => !initialDraftIdsRef.current.has(draft.draftId))
+  }, [displayRecords.length, drafts])
+
+  useEffect(() => {
+    if (displayRecords.length === 0 || initialDraftIdsRef.current.size === 0) return
+    const initialDraftIds = initialDraftIdsRef.current
+    initialDraftIdsRef.current = new Set()
+    setDrafts((current) => current.filter((draft) => !initialDraftIds.has(draft.draftId)))
+    setLastAddedDraftId((current) => (current && initialDraftIds.has(current) ? null : current))
+  }, [displayRecords.length])
+
   const lineRecordIds = useMemo(
     () =>
       entityDefinitionId ? displayRecords.map((r) => toRecordId(entityDefinitionId, r.id)) : [],
@@ -352,6 +399,7 @@ export function LineBuilder({
   /** Draft delete (trash icon) — local splice, no network. */
   const deleteDraft = useCallback((draftId: string) => {
     creatingDraftIdsRef.current.delete(draftId)
+    initialDraftIdsRef.current.delete(draftId)
     setDrafts((prev) => prev.filter((d) => d.draftId !== draftId))
   }, [])
 
@@ -374,6 +422,9 @@ export function LineBuilder({
    */
   const createDraft = useCallback(
     async (draftId: string, overrides: Partial<DraftLine> = {}) => {
+      // The first real edit promotes an initial loading placeholder to a normal
+      // draft, so an arriving persisted list cannot remove the user's work.
+      initialDraftIdsRef.current.delete(draftId)
       if (creatingDraftIdsRef.current.has(draftId)) {
         setDrafts((prev) => prev.map((d) => (d.draftId === draftId ? { ...d, ...overrides } : d)))
         return
@@ -722,7 +773,7 @@ export function LineBuilder({
   // Enter / ArrowDown / Tab past the last row calls `addLine` to spawn a draft.
   useLineNav({
     containerRef: rowsContainerRef,
-    rowCount: displayRecords.length + drafts.length,
+    rowCount: displayRecords.length + visibleDrafts.length,
     colCount: 3,
     onAddRow: addLine,
     readOnly,
@@ -756,7 +807,7 @@ export function LineBuilder({
   if (!entityDefinitionId) return null
 
   const isEmpty =
-    !isLoading && !isLoadingRecords && displayRecords.length === 0 && drafts.length === 0
+    !isLoading && !isLoadingRecords && displayRecords.length === 0 && visibleDrafts.length === 0
 
   return (
     <div
@@ -839,7 +890,7 @@ export function LineBuilder({
           {/* Phantom draft rows — pinned after the real rows, never drag-sortable.
               They continue the nav index space (real count + draft index). */}
           {!readOnly &&
-            drafts.map((draft, i) => (
+            visibleDrafts.map((draft, i) => (
               <DraftLineRow
                 key={draft.draftId}
                 draft={draft}

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -348,7 +348,11 @@ function LineNameCellView({
         onSelectGroup={onSelectGroup}
         onFreeText={onFreeText}
         onCloseFocus={() => inputRef.current?.focus()}>
-        <div className='flex min-w-0 flex-1 items-center gap-1.5'>
+        <div
+          className='flex min-w-0 flex-1 items-center gap-1.5'
+          onClick={() => {
+            if (!focused) setFocused(true)
+          }}>
           {focused ? (
             <input
               ref={inputRef}
@@ -380,7 +384,7 @@ function LineNameCellView({
               data-cell-focusable
               onFocus={() => setFocused(true)}
               onClick={() => setFocused(true)}
-              className='flex h-7 min-w-0 items-center rounded-sm px-1 text-left text-sm outline-none'>
+              className='flex h-7 min-w-0 flex-1 items-center rounded-sm px-1 text-left text-sm outline-none'>
               <span className={cn('min-w-0 truncate', !name && 'text-muted-foreground/50')}>
                 {name || 'Add item'}
               </span>


### PR DESCRIPTION
## Summary
- share the visit date tile with drilled visit details and keep historical visits free of scheduling actions
- render three local line-item drafts as loading placeholders that are replaced by persisted lines
- make the full line-description cell focusable
- use the shared field-panel number input for visit duration

## Validation
- pnpm exec biome check on touched files
- scoped web typecheck attempted (blocked by unrelated existing errors)