### PR TITLE
feat: gate sequences behind feature flag

### DIFF
--- a/apps/web/src/app/(protected)/app/dispatch/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/settings/layout.tsx
@@ -85,6 +85,7 @@ const DISPATCH_SETTINGS: SidebarProps[] = [
         label: 'Client notifications',
         slug: 'client-notifications',
         icon: <Bell />,
+        featureKey: 'sequences',
       },
     ],
   },

--- a/apps/web/src/app/(protected)/app/workflows/page.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/page.tsx
@@ -37,6 +37,9 @@ import { WorkflowsStatsCards } from './_components/stats/workflows-stats-cards'
  */
 function WorkflowsPageContent() {
   const [tab, setTab] = useQueryState('t', { defaultValue: 'workflows' })
+  const { hasAccess } = useFeatureFlags()
+  const sequencesEnabled = hasAccess(FeatureKey.sequences)
+  const activeTab = sequencesEnabled && tab === 'sequences' ? 'sequences' : 'workflows'
 
   return (
     <MainPage>
@@ -51,36 +54,40 @@ function WorkflowsPageContent() {
             void setTab('workflows')
           }}
         />
-        <CommandAction
-          label='Go to Sequences'
-          icon='send'
-          keywords='sequences tab view cadence email outreach'
-          priority={1}
-          perform={() => {
-            useCommandPaletteStore.getState().close()
-            void setTab('sequences')
-          }}
-        />
+        {sequencesEnabled && (
+          <CommandAction
+            label='Go to Sequences'
+            icon='send'
+            keywords='sequences tab view cadence email outreach'
+            priority={1}
+            perform={() => {
+              useCommandPaletteStore.getState().close()
+              void setTab('sequences')
+            }}
+          />
+        )}
       </CommandContext>
 
       <MainPageHeader
-        action={tab === 'sequences' ? <CreateSequenceButton /> : <CreateWorkflowButton />}>
+        action={activeTab === 'sequences' ? <CreateSequenceButton /> : <CreateWorkflowButton />}>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Automation' href='/app/workflows' last />
         </MainPageBreadcrumb>
       </MainPageHeader>
 
       <MainPageContent>
-        <Tabs value={tab} onValueChange={setTab} className='flex-1 h-full flex flex-col'>
+        <Tabs value={activeTab} onValueChange={setTab} className='flex-1 h-full flex flex-col'>
           <TabsList className='border-b w-full justify-start rounded-b-none bg-primary-150'>
             <TabsTrigger value='workflows' variant='outline'>
               <Workflow />
               Workflows
             </TabsTrigger>
-            <TabsTrigger value='sequences' variant='outline'>
-              <SendHorizonal />
-              Sequences
-            </TabsTrigger>
+            {sequencesEnabled && (
+              <TabsTrigger value='sequences' variant='outline'>
+                <SendHorizonal />
+                Sequences
+              </TabsTrigger>
+            )}
           </TabsList>
 
           <TabsContent value='workflows' className='flex flex-col flex-1 min-h-0'>
@@ -98,9 +105,11 @@ function WorkflowsPageContent() {
             </ListSelectionProvider>
           </TabsContent>
 
-          <TabsContent value='sequences' className='flex flex-col flex-1 min-h-0'>
-            <SequencesList />
-          </TabsContent>
+          {sequencesEnabled && (
+            <TabsContent value='sequences' className='flex flex-col flex-1 min-h-0'>
+              <SequencesList />
+            </TabsContent>
+          )}
         </Tabs>
       </MainPageContent>
     </MainPage>

--- a/apps/web/src/app/(protected)/app/workflows/sequences/[sequenceId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/sequences/[sequenceId]/page.tsx
@@ -1,11 +1,18 @@
 // apps/web/src/app/(protected)/app/workflows/sequences/[sequenceId]/page.tsx
 'use client'
 
+import { FeatureKey } from '@auxx/lib/permissions/client'
 import { useParams } from 'next/navigation'
+import { EmptyState } from '~/components/global/empty-state'
 import { SequenceDetailView } from '~/components/sequences/ui/detail/sequence-detail-view'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
 /** Thin route wrapper — all logic lives in the client detail view. */
 export default function SequenceDetailPage() {
   const params = useParams<{ sequenceId: string }>()
+
+  const { hasAccess } = useFeatureFlags()
+  if (!hasAccess(FeatureKey.sequences)) return <EmptyState title='Page not found' />
+
   return <SequenceDetailView sequenceId={params?.sequenceId ?? ''} />
 }

--- a/apps/web/src/components/detail-view/components/detail-view-actions.tsx
+++ b/apps/web/src/components/detail-view/components/detail-view-actions.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/detail-view/components/detail-view-actions.tsx
 'use client'
 
+import { FeatureKey } from '@auxx/lib/permissions/client'
 import { parseRecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
 import { Archive, Ban, Merge, Send, Trash2, Users, Zap } from 'lucide-react'
@@ -8,6 +9,7 @@ import { useState } from 'react'
 import { MergeDialog } from '~/components/merge'
 import { AddToSequenceDialog } from '~/components/sequences/ui/add-to-sequence-dialog'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import type { DetailViewActionsProps } from '../types'
 import { AppRecordActions } from './app-record-actions'
 
@@ -21,6 +23,8 @@ export function DetailViewActions({
   record,
   config,
 }: DetailViewActionsProps) {
+  const { hasAccess } = useFeatureFlags()
+  const sequencesEnabled = hasAccess(FeatureKey.sequences)
   const [confirm, ConfirmDialog] = useConfirm()
   const [isGroupDialogOpen, setIsGroupDialogOpen] = useState(false)
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false)
@@ -103,7 +107,7 @@ export function DetailViewActions({
           </Button>
         )}
 
-        {actions.enableAddToSequence && (
+        {actions.enableAddToSequence && sequencesEnabled && (
           <Button variant='outline' size='sm' onClick={() => setAddToSequenceDialogOpen(true)}>
             <Send /> Add to sequence
           </Button>
@@ -141,7 +145,7 @@ export function DetailViewActions({
         />
       )}
 
-      {addToSequenceDialogOpen && recordId && (
+      {sequencesEnabled && addToSequenceDialogOpen && recordId && (
         <AddToSequenceDialog
           open={addToSequenceDialogOpen}
           onOpenChange={setAddToSequenceDialogOpen}

--- a/apps/web/src/components/dispatch/ui/client-notifications-settings-page.tsx
+++ b/apps/web/src/components/dispatch/ui/client-notifications-settings-page.tsx
@@ -62,7 +62,7 @@ export function ClientNotificationsSettingsPage() {
   useUser({ requireRoles: ['ADMIN', 'OWNER'] })
   const { hasAccess } = useFeatureFlags()
 
-  if (!hasAccess(FeatureKey.dispatch)) {
+  if (!hasAccess(FeatureKey.dispatch) || !hasAccess(FeatureKey.sequences)) {
     return (
       <SettingsPage
         title='Client notifications'

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -4,6 +4,7 @@
 import type { FieldType } from '@auxx/database/types'
 import { isAiEligible } from '@auxx/lib/custom-fields/client'
 import { converters } from '@auxx/lib/field-values/client'
+import { FeatureKey } from '@auxx/lib/permissions/client'
 import type { RecordId, ResourceField } from '@auxx/lib/resources/client'
 import type { ActorId } from '@auxx/types/actor'
 import type { AiOptions } from '@auxx/types/custom-field'
@@ -69,6 +70,7 @@ import { AddToSequenceDialog } from '~/components/sequences/ui/add-to-sequence-d
 import { MassWorkflowTriggerDialog } from '~/components/workflow/mass-workflow-trigger-dialog'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useEntityInstanceOperations } from '~/hooks/use-entity-instance-operations'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useDockStore } from '~/stores/dock-store'
 import { RecordDrawer } from './record-drawer'
 import { searchConditionsToGroup, useRecordsSearchStore } from './records-search-store'
@@ -102,6 +104,8 @@ interface RecordsViewProps {
 export function RecordsView({ slug, basePath, embedded }: RecordsViewProps) {
   const resolvedBasePath = basePath ?? `/app/custom/${slug}`
   const router = useRouter()
+  const { hasAccess } = useFeatureFlags()
+  const sequencesEnabled = hasAccess(FeatureKey.sequences)
 
   // Cross-client saved-view refresh (e.g. Kopilot create/update/set-default).
   useTableViewRealtime()
@@ -338,7 +342,7 @@ export function RecordsView({ slug, basePath, embedded }: RecordsViewProps) {
         },
       },
       // Sequences plan §17 — contacts are the only enrollable recipient type.
-      ...(isContactResource
+      ...(isContactResource && sequencesEnabled
         ? [
             {
               label: 'Add to sequence',
@@ -373,7 +377,7 @@ export function RecordsView({ slug, basePath, embedded }: RecordsViewProps) {
         action: (rows: EntityRow[]) => handleBulkDelete(rows),
       },
     ],
-    [handleBulkArchive, handleBulkDelete, isContactResource]
+    [handleBulkArchive, handleBulkDelete, isContactResource, sequencesEnabled]
   )
 
   const { saveBulkMultipleFields } = useSaveFieldValue()
@@ -990,7 +994,7 @@ export function RecordsView({ slug, basePath, embedded }: RecordsViewProps) {
       )}
 
       {/* Add to Sequence Dialog (contact views only; dialog enforces the 50-recipient cap) */}
-      {isAddToSequenceDialogOpen && (
+      {sequencesEnabled && isAddToSequenceDialogOpen && (
         <AddToSequenceDialog
           open={isAddToSequenceDialogOpen}
           onOpenChange={setIsAddToSequenceDialogOpen}

--- a/apps/web/src/components/sequences/ui/add-to-sequence-dialog.tsx
+++ b/apps/web/src/components/sequences/ui/add-to-sequence-dialog.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/sequences/ui/add-to-sequence-dialog.tsx
 'use client'
 
+import { FeatureKey } from '@auxx/lib/permissions/client'
 import { SEQUENCE_ENROLL_MAX_RECIPIENTS } from '@auxx/lib/sequences/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
@@ -18,6 +19,7 @@ import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import { CircleAlert, SendHorizonal, TriangleAlert } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 
 interface AddToSequenceDialogProps {
@@ -74,6 +76,8 @@ export function AddToSequenceDialog({
   onOpenChange,
   recipientEntityInstanceIds,
 }: AddToSequenceDialogProps) {
+  const { hasAccess } = useFeatureFlags()
+  const sequencesEnabled = hasAccess(FeatureKey.sequences)
   const [selectedSequenceId, setSelectedSequenceId] = useState<string | null>(null)
   const [results, setResults] = useState<
     { recipientId: string; status: 'enrolled' | 'skipped'; reason?: string }[] | null
@@ -81,7 +85,9 @@ export function AddToSequenceDialog({
 
   const overCap = recipientEntityInstanceIds.length > SEQUENCE_ENROLL_MAX_RECIPIENTS
 
-  const sequences = api.sequence.list.useQuery(undefined, { enabled: open && !overCap })
+  const sequences = api.sequence.list.useQuery(undefined, {
+    enabled: sequencesEnabled && open && !overCap,
+  })
   const eligible = (sequences.data ?? []).filter((s) => s.status === 'enabled' && s.publishedAt)
 
   const enroll = api.sequence.enroll.useMutation({
@@ -105,6 +111,8 @@ export function AddToSequenceDialog({
       setResults(null)
     }
   }, [open])
+
+  if (!sequencesEnabled) return null
 
   const handleEnroll = () => {
     if (!selectedSequenceId) return

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -119,7 +119,13 @@ export const SIDEBAR_MENU: SidebarProps[] = [
     featureKey: 'workflows',
   },
   { id: 'tasks', label: 'Tasks', slug: 'tasks', icon: <CheckSquare /> },
-  { id: 'schedule', label: 'Schedule', slug: 'schedule', icon: <CalendarClock /> },
+  {
+    id: 'schedule',
+    label: 'Schedule',
+    slug: 'schedule',
+    icon: <CalendarClock />,
+    featureKey: 'dispatch',
+  },
   {
     id: 'dispatch',
     label: 'Dispatch',

--- a/apps/web/src/server/api/routers/sequence.ts
+++ b/apps/web/src/server/api/routers/sequence.ts
@@ -11,6 +11,7 @@ import { ResourcePermission } from '@auxx/database/enums'
 import { getOrgCache } from '@auxx/lib/cache'
 import { conditionGroupsSchema } from '@auxx/lib/conditions'
 import { AuxxError } from '@auxx/lib/errors'
+import { FeatureKey, FeaturePermissionService } from '@auxx/lib/permissions'
 import {
   checkSequenceAccess,
   createSequence,
@@ -38,6 +39,15 @@ import { and, asc, eq, inArray } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
+
+/** Protected procedure that requires the organization to have Sequences enabled. */
+const sequenceProcedure = protectedProcedure.use(async ({ ctx, next }) => {
+  await new FeaturePermissionService().requireAccess(
+    ctx.session.organizationId,
+    FeatureKey.sequences
+  )
+  return next()
+})
 
 // ── Shared zod shapes ─────────────────────────────────────────────────────────
 
@@ -173,7 +183,7 @@ async function filterViewableSequences(
 
 export const sequenceRouter = createTRPCRouter({
   /** Sequences the current user can view, newest first, with run counts per status. */
-  list: protectedProcedure.query(async ({ ctx }) => {
+  list: sequenceProcedure.query(async ({ ctx }) => {
     const all = unwrap(await listSequences(ctx.db, { organizationId: ctx.session.organizationId }))
     const visible = await filterViewableSequences(ctx, all)
     if (visible.length === 0) return []
@@ -210,7 +220,7 @@ export const sequenceRouter = createTRPCRouter({
   }),
 
   /** A sequence + its ordered steps in one payload. */
-  get: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
+  get: sequenceProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
     await requireSequenceAccess(ctx, input.id, ResourcePermission.view)
 
     const sequence = unwrap(
@@ -238,7 +248,7 @@ export const sequenceRouter = createTRPCRouter({
    * `triggerType` (plan §4.7 — defaults to `'manual'` at the schema level when
    * omitted) drives `subjectKind`, derived here so the two columns never desync.
    */
-  create: protectedProcedure
+  create: sequenceProcedure
     .input(z.object({ name: z.string().min(1), triggerType: triggerTypeSchema.optional() }))
     .mutation(async ({ ctx, input }) => {
       // integrationId stays null while drafting — the settings drawer sets the
@@ -261,7 +271,7 @@ export const sequenceRouter = createTRPCRouter({
    * value) and is locked once a sequence carries a `templateKey` — a seeded sequence's trigger
    * identity must stay stable (plan §4.7).
    */
-  update: protectedProcedure
+  update: sequenceProcedure
     .input(z.object({ id: z.string(), fields: updateSequenceFieldsSchema }))
     .mutation(async ({ ctx, input }) => {
       await requireSequenceAccess(ctx, input.id, ResourcePermission.edit)
@@ -317,24 +327,22 @@ export const sequenceRouter = createTRPCRouter({
     }),
 
   /** Delete a sequence (and its hidden workflow) — admin grant required, no active runs. */
-  delete: protectedProcedure
-    .input(z.object({ id: z.string() }))
-    .mutation(async ({ ctx, input }) => {
-      await requireSequenceAccess(ctx, input.id, ResourcePermission.admin)
-      unwrap(
-        await deleteSequence(ctx.db, {
-          sequenceId: input.id,
-          organizationId: ctx.session.organizationId,
-        })
-      )
-      return { success: true }
-    }),
+  delete: sequenceProcedure.input(z.object({ id: z.string() })).mutation(async ({ ctx, input }) => {
+    await requireSequenceAccess(ctx, input.id, ResourcePermission.admin)
+    unwrap(
+      await deleteSequence(ctx.db, {
+        sequenceId: input.id,
+        organizationId: ctx.session.organizationId,
+      })
+    )
+    return { success: true }
+  }),
 
   /**
    * Add an empty step. The domain layer appends at the end; when `afterStepId`
    * is given the new step is immediately reordered to sit right after it.
    */
-  createStep: protectedProcedure
+  createStep: sequenceProcedure
     .input(z.object({ sequenceId: z.string(), afterStepId: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       await requireSequenceAccess(ctx, input.sequenceId, ResourcePermission.edit)
@@ -374,7 +382,7 @@ export const sequenceRouter = createTRPCRouter({
     }),
 
   /** Patch a step's content/delays. */
-  updateStep: protectedProcedure
+  updateStep: sequenceProcedure
     .input(z.object({ stepId: z.string(), fields: updateStepFieldsSchema }))
     .mutation(async ({ ctx, input }) => {
       const sequenceId = await getStepSequenceId(ctx, input.stepId)
@@ -390,7 +398,7 @@ export const sequenceRouter = createTRPCRouter({
     }),
 
   /** Remove a step. */
-  deleteStep: protectedProcedure
+  deleteStep: sequenceProcedure
     .input(z.object({ stepId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const sequenceId = await getStepSequenceId(ctx, input.stepId)
@@ -406,7 +414,7 @@ export const sequenceRouter = createTRPCRouter({
     }),
 
   /** Move a step between two neighbors (fractional sortOrder). */
-  reorderStep: protectedProcedure
+  reorderStep: sequenceProcedure
     .input(
       z.object({
         stepId: z.string(),
@@ -430,7 +438,7 @@ export const sequenceRouter = createTRPCRouter({
     }),
 
   /** Validate + compile the step list into the hidden workflow graph. */
-  publish: protectedProcedure
+  publish: sequenceProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       await requireSequenceAccess(ctx, input.id, ResourcePermission.edit)
@@ -444,7 +452,7 @@ export const sequenceRouter = createTRPCRouter({
     }),
 
   /** Enroll up to 50 contacts — returns per-recipient enrolled/skipped outcomes. */
-  enroll: protectedProcedure
+  enroll: sequenceProcedure
     .input(
       z.object({
         sequenceId: z.string(),
@@ -465,7 +473,7 @@ export const sequenceRouter = createTRPCRouter({
     }),
 
   /** Runs (enrollments) for the Recipients tab, optionally filtered by status. */
-  listRuns: protectedProcedure
+  listRuns: sequenceProcedure
     .input(z.object({ sequenceId: z.string(), status: runStatusSchema.optional() }))
     .query(async ({ ctx, input }) => {
       await requireSequenceAccess(ctx, input.sequenceId, ResourcePermission.view)
@@ -480,7 +488,7 @@ export const sequenceRouter = createTRPCRouter({
     }),
 
   /** Manually remove a recipient from a sequence (exit reason 'manual'). */
-  exitRun: protectedProcedure
+  exitRun: sequenceProcedure
     .input(z.object({ sequenceRunId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const run = await ctx.db.query.SequenceRun.findFirst({
@@ -503,7 +511,7 @@ export const sequenceRouter = createTRPCRouter({
     }),
 
   /** Header stats: enrolled/active/completed/exited/failed, per-step sent, reply/bounce rates. */
-  stats: protectedProcedure
+  stats: sequenceProcedure
     .input(z.object({ sequenceId: z.string() }))
     .query(async ({ ctx, input }) => {
       await requireSequenceAccess(ctx, input.sequenceId, ResourcePermission.view)
@@ -523,7 +531,7 @@ export const sequenceRouter = createTRPCRouter({
    * ResourceAccess check — every member with dispatch settings access already sees the whole
    * template set). Ordered per §4.6's documented table, not `createdAt`.
    */
-  listTemplates: protectedProcedure.query(async ({ ctx }) => {
+  listTemplates: sequenceProcedure.query(async ({ ctx }) => {
     const all = unwrap(await listSequences(ctx.db, { organizationId: ctx.session.organizationId }))
     const templated = all.filter((s): s is SequenceEntity & { templateKey: string } =>
       Boolean(s.templateKey)

--- a/packages/lib/src/permissions/types.ts
+++ b/packages/lib/src/permissions/types.ts
@@ -48,6 +48,7 @@ export enum FeatureKey {
   mailPermissions = 'mailPermissions',
   dashboards = 'dashboards',
   dispatch = 'dispatch',
+  sequences = 'sequences',
 
   // ── Static limits (count of things, not time-based) ──
   teammates = 'teammates',
@@ -199,6 +200,13 @@ export const FEATURE_REGISTRY: FeatureMetadata[] = [
     label: 'Dispatch',
     description: 'Field-service work orders, scheduling, and dispatching.',
     group: 'Dispatch',
+  },
+  {
+    key: FeatureKey.sequences,
+    type: 'boolean',
+    label: 'Sequences',
+    description: 'Automated outbound email sequences and contact enrollment.',
+    group: 'Automation',
   },
 
   // ── Static limits ──

--- a/packages/lib/src/resources/registry/resources/work-order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/work-order-fields.ts
@@ -205,7 +205,7 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
       filterable: true,
       sortable: true,
       creatable: true,
-      updatable: true,
+      updatable: false,
       configurable: false,
     },
     placeholder: 'Select job type',


### PR DESCRIPTION
## Summary
- Add a typed sequences feature flag and enforce it across the Sequence tRPC router.
- Hide Sequence navigation, editor, enrollment actions, and Dispatch client-notification templates when disabled.
- Gate the Schedule menu with the existing Dispatch flag.
- Include the existing work-order job-type immutability change.

## Validation
- Focused Biome check on changed files; pre-existing warnings remain.
- Lib typecheck is blocked by existing unrelated repository errors.