### PR TITLE
Fix dispatch calendar scrolling and dock interactions

### DIFF
--- a/apps/web/src/components/dispatch/stores/use-resolved-days.ts
+++ b/apps/web/src/components/dispatch/stores/use-resolved-days.ts
@@ -1,7 +1,7 @@
 // apps/web/src/components/dispatch/stores/use-resolved-days.ts
 'use client'
 
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo } from 'react'
 import { api } from '~/trpc/react'
 import { chunkRange, type DateRange, subtractRanges } from '../utils/date-ranges'
 import {
@@ -14,6 +14,31 @@ import {
 /** `availability.resolve` hard-caps at 366 days; keep requests comfortably below that limit. */
 const MAX_FETCH_DAYS = 180
 
+// Requests are shared across hook instances (board shading, popover hints, etc.). Treat pending
+// ranges as covered while calculating gaps so a fast-moving calendar window cannot launch several
+// mostly-overlapping resolves before the first response has had a chance to enter the store.
+const pendingRangesBySubject = new Map<string, Map<string, DateRange>>()
+
+function pendingRanges(key: string): DateRange[] {
+  return Array.from(pendingRangesBySubject.get(key)?.values() ?? [])
+}
+
+function reservePendingRange(key: string, range: DateRange): string | null {
+  const tag = `${range.from}:${range.to}`
+  const subjectRanges = pendingRangesBySubject.get(key) ?? new Map<string, DateRange>()
+  if (subjectRanges.has(tag)) return null
+  subjectRanges.set(tag, range)
+  pendingRangesBySubject.set(key, subjectRanges)
+  return tag
+}
+
+function releasePendingRange(key: string, tag: string): void {
+  const subjectRanges = pendingRangesBySubject.get(key)
+  if (!subjectRanges) return
+  subjectRanges.delete(tag)
+  if (subjectRanges.size === 0) pendingRangesBySubject.delete(key)
+}
+
 /** A subject paired with its stable cache key. */
 interface ResolvedDaysSubject {
   key: string
@@ -23,11 +48,6 @@ interface ResolvedDaysSubject {
 /** Creates a cache-addressable subject entry. */
 function toResolvedDaysSubject(subject: AvailabilitySubject): ResolvedDaysSubject {
   return { key: availabilitySubjectKey(subject), subject }
-}
-
-/** Returns a stable signature so equivalent subject arrays do not restart the fetch effect. */
-function subjectSignature(subjects: ResolvedDaysSubject[]): string {
-  return subjects.map(({ key }) => key).join(',')
 }
 
 /**
@@ -42,27 +62,25 @@ export function useResolvedDaysForSubjects(
   const utils = api.useUtils()
   const cacheSubjects = useAvailabilityCacheStore((state) => state.subjects)
   const ingestResolved = useAvailabilityCacheStore((state) => state.ingestResolved)
-  const inFlight = useRef(new Set<string>())
   const range = useMemo<DateRange>(() => ({ from: fromIso, to: toIso }), [fromIso, toIso])
   const entries = useMemo(() => subjects.map(toResolvedDaysSubject), [subjects])
-  const signature = subjectSignature(entries)
 
   useEffect(() => {
     for (const { key, subject } of entries) {
       const loaded = cacheSubjects[key]?.loadedRanges ?? []
-      const gaps = subtractRanges(range, loaded).flatMap((gap) => chunkRange(gap, MAX_FETCH_DAYS))
+      const covered = [...loaded, ...pendingRanges(key)]
+      const gaps = subtractRanges(range, covered).flatMap((gap) => chunkRange(gap, MAX_FETCH_DAYS))
       for (const gap of gaps) {
-        const tag = `${key}:${gap.from}:${gap.to}`
-        if (inFlight.current.has(tag)) continue
-        inFlight.current.add(tag)
+        const tag = reservePendingRange(key, gap)
+        if (!tag) continue
         utils.availability.resolve
           .fetch({ subject, from: gap.from, to: gap.to })
           .then((days) => ingestResolved(key, gap, days))
           .catch(() => {})
-          .finally(() => inFlight.current.delete(tag))
+          .finally(() => releasePendingRange(key, tag))
       }
     }
-  }, [cacheSubjects, entries, ingestResolved, range, signature, utils])
+  }, [cacheSubjects, entries, ingestResolved, range, utils])
 
   return useMemo(
     () =>

--- a/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
@@ -10,7 +10,7 @@ import {
   EventPopover,
   type RenderEventContext,
 } from '@auxx/ui/components/event-calendar'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
 import type { ExistingVisitForOverlap } from '../schedule-popover'
 import type { useBoardMutations } from './hooks/use-board-mutations'
@@ -71,6 +71,13 @@ export function BoardCalendarGrid({
   isDockOpen,
 }: BoardCalendarGridProps) {
   const setEventDockOpen = useDispatchSidebarStore((s) => s.setEventDockOpen)
+  // Docking transfers the currently controlled popover into the panel. Radix may report the
+  // floating layer closing during that same commit; ignore that close so it cannot clear the
+  // selected event and make the dock briefly reopen on its empty guide state.
+  const dockingEventIdRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (isDockOpen) dockingEventIdRef.current = null
+  }, [isDockOpen])
 
   const renderEvent = useCallback(
     (event: DispatchVisitEvent, ctx: RenderEventContext) => {
@@ -95,7 +102,10 @@ export function BoardCalendarGrid({
       return (
         <EventPopover
           open={isOpen}
-          onOpenChange={(open) => onActiveVisitChange(open ? event.id : null)}
+          onOpenChange={(open) => {
+            if (!open && dockingEventIdRef.current === event.id) return
+            onActiveVisitChange(open ? event.id : null)
+          }}
           series={{
             isMember: Boolean(event.recurrenceRuleId),
             labels: { this: 'This visit', following: 'This and following', all: 'All visits' },
@@ -108,7 +118,11 @@ export function BoardCalendarGrid({
             existingVisits={existingVisits}
             onClose={() => onActiveVisitChange(null)}
             onOpenRecord={onOpenRecord}
-            onDock={() => setEventDockOpen(true)}
+            onDock={() => {
+              dockingEventIdRef.current = event.id
+              onActiveVisitChange(event.id)
+              setEventDockOpen(true)
+            }}
           />
         </EventPopover>
       )

--- a/apps/web/src/components/dispatch/ui/board/event-dock-guide.tsx
+++ b/apps/web/src/components/dispatch/ui/board/event-dock-guide.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { useDockChrome } from '@auxx/ui/components/dock-panel'
 import {
   GuideColumn,
   GuideColumns,
@@ -10,7 +11,30 @@ import {
   GuideShortcut,
   GuideShortcuts,
 } from '@auxx/ui/components/guide'
-import { ArrowLeftRight, PanelRightOpen } from 'lucide-react'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
+import { ArrowLeftRight, PanelRightOpen, X } from 'lucide-react'
+
+function DockControl({
+  label,
+  onClick,
+  children,
+}: {
+  label: string
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <SimpleTooltip content={label}>
+      <button
+        type='button'
+        aria-label={label}
+        onClick={onClick}
+        className='shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground [&_svg]:size-4'>
+        {children}
+      </button>
+    </SimpleTooltip>
+  )
+}
 
 /**
  * Empty state for the docked event panel (plan 21 §"Empty-state guide") — shown when
@@ -19,32 +43,57 @@ import { ArrowLeftRight, PanelRightOpen } from 'lucide-react'
  * is the surface), replicating `GuideDialog`'s `p-6` body padding.
  */
 export function EventDockGuide() {
+  const dock = useDockChrome()
+
   return (
-    <div className='p-4'>
-      <GuideColumns cols={1}>
-        <GuideColumn title='Shortcuts'>
-          <GuideShortcuts>
-            <GuideShortcut keys={['click']} label='Open event details' />
-            <GuideShortcut keys={['drag']} label='Reschedule' />
-            <GuideShortcut keys={['drag edge']} label='Resize' />
-            <GuideShortcut keys={['esc']} label='Close' />
-          </GuideShortcuts>
-        </GuideColumn>
-        <GuideColumn title='This panel'>
-          <GuideConcepts>
-            <GuideConcept
-              glyph={<PanelRightOpen className='size-3.5 text-muted-foreground' />}
-              term='Pop out'>
-              Undock back into a floating popover anchored to the event.
-            </GuideConcept>
-            <GuideConcept
-              glyph={<ArrowLeftRight className='size-3.5 text-muted-foreground' />}
-              term='Flip side'>
-              Move the dock to the other side of the calendar.
-            </GuideConcept>
-          </GuideConcepts>
-        </GuideColumn>
-      </GuideColumns>
+    <div>
+      {dock && (
+        <div className='sticky top-0 z-10 flex items-center justify-end gap-0.5 border-b border-border/50 bg-background px-3 py-2'>
+          {dock.onFlipSide && (
+            <DockControl
+              label='Flip side'
+              onClick={() => dock.onFlipSide?.(dock.side === 'left' ? 'right' : 'left')}>
+              <ArrowLeftRight />
+            </DockControl>
+          )}
+          {dock.onPopOut && (
+            <DockControl label='Pop out' onClick={dock.onPopOut}>
+              <PanelRightOpen />
+            </DockControl>
+          )}
+          {dock.onClose && (
+            <DockControl label='Close' onClick={dock.onClose}>
+              <X />
+            </DockControl>
+          )}
+        </div>
+      )}
+      <div className='p-4'>
+        <GuideColumns cols={1}>
+          <GuideColumn title='Shortcuts'>
+            <GuideShortcuts>
+              <GuideShortcut keys={['click']} label='Open event details' />
+              <GuideShortcut keys={['drag']} label='Reschedule' />
+              <GuideShortcut keys={['drag edge']} label='Resize' />
+              <GuideShortcut keys={['esc']} label='Close' />
+            </GuideShortcuts>
+          </GuideColumn>
+          <GuideColumn title='This panel'>
+            <GuideConcepts>
+              <GuideConcept
+                glyph={<PanelRightOpen className='size-3.5 text-muted-foreground' />}
+                term='Pop out'>
+                Undock back into a floating popover anchored to the event.
+              </GuideConcept>
+              <GuideConcept
+                glyph={<ArrowLeftRight className='size-3.5 text-muted-foreground' />}
+                term='Flip side'>
+                Move the dock to the other side of the calendar.
+              </GuideConcept>
+            </GuideConcepts>
+          </GuideColumn>
+        </GuideColumns>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/dispatch/ui/board/event-dock-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/board/event-dock-panel.tsx
@@ -44,18 +44,21 @@ export function EventDockPanel({
   const setEventDockOpen = useDispatchSidebarStore((s) => s.setEventDockOpen)
   const setEventDockSide = useDispatchSidebarStore((s) => s.setEventDockSide)
 
-  // Esc clears the selection (→ guide state) while docked with an event selected. A plain
+  // Esc clears the selection (→ guide state) while docked with an event selected, then closes
+  // the empty guide on the next press. A plain
   // window listener rather than fighting existing dialog/popover Esc handling — nothing else
   // owns Esc here since the floating `EventPopover`/its `Popover` primitive isn't mounted in
   // dock mode (board-calendar-grid.tsx renders a plain click target instead).
   useEffect(() => {
-    if (!dock.open || !event) return
+    if (!dock.open) return
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onActiveVisitChange(null)
+      if (e.key !== 'Escape') return
+      if (event) onActiveVisitChange(null)
+      else setEventDockOpen(false)
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [dock.open, event, onActiveVisitChange])
+  }, [dock.open, event, onActiveVisitChange, setEventDockOpen])
 
   return (
     <DockPanel

--- a/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
@@ -28,6 +28,7 @@ import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import type { ExistingVisitForOverlap } from '../schedule-popover'
 import { AssigneeRow } from '../shared/assignee-row'
+import { InlineEventTimePicker } from '../shared/inline-event-time-picker'
 import { RepeatEditor } from '../shared/repeat-editor'
 import { useRecurrenceEditor } from '../shared/use-recurrence-editor'
 import { useScheduleHints } from '../shared/use-schedule-hints'
@@ -208,6 +209,7 @@ export function VisitPopoverContent({
           end={event.end}
           disabled={!canEdit}
           warnings={hints}
+          renderTimeEditor={(props) => <InlineEventTimePicker {...props} />}
           onChange={
             canEdit
               ? ({ start, end }, scope) => {

--- a/apps/web/src/components/dispatch/ui/schedule-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/schedule-popover.tsx
@@ -17,6 +17,7 @@ import { type ReactNode, useState } from 'react'
 import type { RecordId } from '~/components/resources'
 import { api } from '~/trpc/react'
 import { AssigneeRow } from './shared/assignee-row'
+import { InlineEventTimePicker } from './shared/inline-event-time-picker'
 import { RepeatEditor } from './shared/repeat-editor'
 import { useRecurrenceEditor } from './shared/use-recurrence-editor'
 import { useScheduleHints } from './shared/use-schedule-hints'
@@ -192,6 +193,7 @@ export function SchedulePopoverContent({
         start={startTime}
         end={endTime}
         warnings={hints}
+        renderTimeEditor={(props) => <InlineEventTimePicker {...props} />}
         onChange={handleDateTimeChange}
         onDateToggle={
           isDraft

--- a/apps/web/src/components/dispatch/ui/shared/inline-event-time-picker.tsx
+++ b/apps/web/src/components/dispatch/ui/shared/inline-event-time-picker.tsx
@@ -1,0 +1,47 @@
+// apps/web/src/components/dispatch/ui/shared/inline-event-time-picker.tsx
+
+'use client'
+
+import type { EventTimeEditorProps } from '@auxx/ui/components/event-calendar'
+import { cn } from '@auxx/ui/lib/utils'
+import { useState } from 'react'
+import { DateTimePickerContent } from '~/components/pickers/date-time-picker'
+
+/** Dispatch's inline start/end editor backed by the shared scrolling time picker. */
+export function InlineEventTimePicker({ start, end, use24Hour, onCommit }: EventTimeEditorProps) {
+  const [active, setActive] = useState<'start' | 'end'>('start')
+  const value = active === 'start' ? start : end
+
+  return (
+    <div className='space-y-2'>
+      <div className='grid grid-cols-2 rounded-lg bg-muted p-1'>
+        {(['start', 'end'] as const).map((which) => (
+          <button
+            key={which}
+            type='button'
+            className={cn(
+              'rounded-md px-2 py-1.5 text-sm capitalize transition-colors',
+              active === which
+                ? 'bg-background font-medium text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+            onClick={() => setActive(which)}>
+            {which}
+          </button>
+        ))}
+      </div>
+      <DateTimePickerContent
+        value={value}
+        mode='time'
+        hideNowButton
+        use24HourTime={use24Hour}
+        className='w-full min-w-0'
+        onChange={(next) => {
+          if (!next) return
+          onCommit(active, next.getHours(), next.getMinutes())
+          if (active === 'start') setActive('end')
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -4,7 +4,7 @@
 
 // The document-agnostic line-items builder (money MQ1 build spec §H.1, 01-ui.md #1).
 // Lines render as plain `group/tree-row` grid rows under a matching grid header
-// (Description / Qty / Unit cost / Total / actions): one shared
+// (Description / Qty / Unit cost / Total): one shared
 // `grid-template-columns` keeps the number columns aligned across the header and
 // every row. Line counts are small, so plain rows replace the virtualized
 // `DynamicView` embed this used to be. Row/cell markup lives in `line-rows.tsx`;
@@ -82,7 +82,6 @@ import {
   DraftLineRow,
   freshDraft,
   LINE_COLS,
-  LINE_COLS_READONLY,
   LineRow,
   relKeyForDocumentType,
 } from './line-rows'
@@ -825,7 +824,7 @@ export function LineBuilder({
             The grip lives in the gutter now, so Description starts flush (pl-2). */}
         <div
           className='sticky top-0 z-10 grid rounded-t-lg border-primary-200/50 border-b bg-primary-50 px-1 py-2 text-muted-foreground text-sm dark:border-[#1e2227] dark:bg-background'
-          style={{ gridTemplateColumns: readOnly ? LINE_COLS_READONLY : LINE_COLS }}>
+          style={{ gridTemplateColumns: LINE_COLS }}>
           <div className='flex items-center gap-1 pl-2'>
             Description
             {!readOnly && (
@@ -844,7 +843,6 @@ export function LineBuilder({
           <div className='px-2 text-right'>Qty</div>
           <div className='px-2 text-right'>Unit cost</div>
           <div className='px-2 text-right'>Total</div>
-          {!readOnly && <div />}
         </div>
 
         {/* Rows container — the keydown listener for spreadsheet nav lives here, so

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -50,16 +50,9 @@ import { formatCurrency, titleCase } from './shared'
  * Shared `grid-template-columns` for the header row and every line row (the
  * mapping-columns.ts idiom) — one template is what keeps the qty / unit cost /
  * total columns aligned. Columns: description (fills) │ qty │ unit cost │
- * total │ actions.
+ * total.
  */
-export const LINE_COLS = 'minmax(10rem, 1fr) 3rem 5.5rem 6.5rem 3.75rem'
-
-/**
- * Read-only column template — the trailing actions column is dropped (no
- * hover actions when read-only), so `Total` lands flush right and the freed
- * width is absorbed by the `1fr` description column.
- */
-export const LINE_COLS_READONLY = 'minmax(10rem, 1fr) 3rem 5.5rem 6.5rem'
+export const LINE_COLS = 'minmax(10rem, 1fr) 3rem 5.5rem 6.5rem'
 
 // Module-level (stable-reference) attribute lists — `useSystemValues` memoizes
 // on the array identity, so these must never be inline literals.
@@ -118,26 +111,22 @@ export function relKeyForDocumentType(documentType: 'quote' | 'work_order' | 'in
  * `TreeRowButton`s (grip, pick, description, taxable, delete) still fade in on
  * row hover. Owns the shared column template + the `data-line-row`/`col` tags
  * that {@link useLineNav} focus-hops between. Name/qty/price are the three
- * navigable cells (cols 0–2); total + actions ride outside the nav order.
+ * navigable cells (cols 0–2); total rides outside the nav order.
  */
 function LineGridRow({
   rowIndex,
-  readOnly,
   grip,
   name,
   qty,
   price,
   total,
-  actions,
 }: {
   rowIndex: number
-  readOnly: boolean
   grip: ReactNode
   name: ReactNode
   qty: ReactNode
   price: ReactNode
   total: ReactNode
-  actions?: ReactNode
 }) {
   return (
     <div className='group/tree-row relative text-sm'>
@@ -149,7 +138,7 @@ function LineGridRow({
 
       <div
         className='relative grid min-h-9 items-stretch px-1 text-muted-foreground'
-        style={{ gridTemplateColumns: readOnly ? LINE_COLS_READONLY : LINE_COLS }}>
+        style={{ gridTemplateColumns: LINE_COLS }}>
         {/* Col 0 — name input (the grip sits in the gutter, not this column). */}
         <div data-line-row={rowIndex} data-line-col={0} className='flex min-w-0 items-center'>
           {name}
@@ -162,7 +151,6 @@ function LineGridRow({
           {price}
         </div>
         <div className='flex items-center'>{total}</div>
-        {!readOnly && <div className='flex items-center justify-end'>{actions}</div>}
       </div>
     </div>
   )
@@ -244,6 +232,7 @@ function LineNameCellView({
   onSelectGroup,
   onFreeText,
   onCommitDescription,
+  actions,
 }: {
   name: string
   description: string | null
@@ -256,6 +245,7 @@ function LineNameCellView({
   onSelectGroup: (pick: CatalogGroupPick) => void
   onFreeText: (text: string) => void
   onCommitDescription: (value: string | null) => void
+  actions?: ReactNode
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
   const [pickerOpen, setPickerOpen] = useState(false)
@@ -414,6 +404,7 @@ function LineNameCellView({
             onClick={() => setDescriptionDraft(description ?? '')}>
             <AlignLeft />
           </TreeRowButton>
+          {actions}
         </>
       )}
     </div>
@@ -426,11 +417,13 @@ function LineNameCell({
   readOnly,
   currencyCode,
   onSelectGroup,
+  actions,
 }: {
   recordId: RecordId
   readOnly: boolean
   currencyCode: string
   onSelectGroup: (pick: CatalogGroupPick) => void
+  actions?: ReactNode
 }) {
   const { values } = useSystemValues(recordId, NAME_ATTRS, { autoFetch: true })
   const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue()
@@ -469,6 +462,7 @@ function LineNameCell({
       onCommitDescription={(value) =>
         saveFieldValue(recordId, 'line_item_description', value, FieldType.TEXT)
       }
+      actions={actions}
     />
   )
 }
@@ -600,10 +594,8 @@ function LineTotalCell({ recordId, currencyCode }: { recordId: RecordId; currenc
 }
 
 /**
- * Trailing actions cell — taxable toggle (persistent when exempt, so the
- * exemption reads at rest) then delete. Description editing lives in the primary
- * cell ({@link LineNameCellView}); this column holds the two remaining actions
- * for both real rows and drafts.
+ * Inline actions rendered beside the description button in the primary cell:
+ * taxable toggle (persistent when exempt, so the exemption reads at rest), then delete.
  */
 function LineActionsCellView({
   taxable,
@@ -617,17 +609,19 @@ function LineActionsCellView({
   deleteLine: (lineId: string) => void
 }) {
   return (
-    <div className='flex w-full items-center justify-end gap-0.5 pr-1'>
+    <div className='flex items-center gap-0.5'>
       <TreeRowButton
         persistent={!taxable}
         tooltipText={taxable ? 'Taxable — click to exempt' : 'Tax exempt — click to tax'}
         className={cn(!taxable && 'text-muted-foreground/50')}
+        onMouseDown={(e) => e.preventDefault()}
         onClick={() => onToggleTaxable(!taxable)}>
         {taxable ? <CircleCheck /> : <CircleX />}
       </TreeRowButton>
       <TreeRowButton
         variant='destructive'
         tooltipText='Delete line'
+        onMouseDown={(e) => e.preventDefault()}
         onClick={() => deleteLine(rowId)}>
         <Trash2 />
       </TreeRowButton>
@@ -697,7 +691,6 @@ export function LineRow({
       className={cn(isDragging && 'relative z-10 opacity-80')}>
       <LineGridRow
         rowIndex={rowIndex}
-        readOnly={readOnly}
         grip={readOnly ? null : <GripSlot attributes={attributes} listeners={listeners} />}
         name={
           <LineNameCell
@@ -705,6 +698,11 @@ export function LineRow({
             readOnly={readOnly}
             currencyCode={currencyCode}
             onSelectGroup={(pick) => onSelectGroup(recordId, pick)}
+            actions={
+              readOnly ? undefined : (
+                <LineActionsCell recordId={recordId} rowId={record.id} deleteLine={deleteLine} />
+              )
+            }
           />
         }
         qty={
@@ -726,11 +724,6 @@ export function LineRow({
           />
         }
         total={<LineTotalCell recordId={recordId} currencyCode={currencyCode} />}
-        actions={
-          readOnly ? undefined : (
-            <LineActionsCell recordId={recordId} rowId={record.id} deleteLine={deleteLine} />
-          )
-        }
       />
     </div>
   )
@@ -764,7 +757,6 @@ export function DraftLineRow({
   return (
     <LineGridRow
       rowIndex={rowIndex}
-      readOnly={false}
       grip={null}
       name={
         <LineNameCellView
@@ -787,6 +779,14 @@ export function DraftLineRow({
           onSelectGroup={(pick) => onSelectGroup(draft.draftId, pick)}
           onFreeText={(text) => void createDraft(draft.draftId, { name: text })}
           onCommitDescription={(value) => void createDraft(draft.draftId, { description: value })}
+          actions={
+            <LineActionsCellView
+              taxable={draft.taxable}
+              rowId={draft.draftId}
+              onToggleTaxable={(next) => void createDraft(draft.draftId, { taxable: next })}
+              deleteLine={deleteDraft}
+            />
+          }
         />
       }
       qty={
@@ -815,14 +815,6 @@ export function DraftLineRow({
           qty={draft.qty}
           unitPrice={draft.unitPriceCents}
           currencyCode={currencyCode}
-        />
-      }
-      actions={
-        <LineActionsCellView
-          taxable={draft.taxable}
-          rowId={draft.draftId}
-          onToggleTaxable={(next) => void createDraft(draft.draftId, { taxable: next })}
-          deleteLine={deleteDraft}
         />
       }
     />

--- a/apps/web/src/components/pickers/date-time-picker/date-time-picker-content.tsx
+++ b/apps/web/src/components/pickers/date-time-picker/date-time-picker-content.tsx
@@ -49,6 +49,7 @@ export function DateTimePickerContent({
   maxDate,
   disabledDates,
   minuteFilter,
+  use24HourTime = false,
   className,
 }: DateTimePickerContentProps) {
   // Current view state
@@ -96,13 +97,13 @@ export function DateTimePickerContent({
   /** Handle hour selection */
   const handleSelectHour = useCallback(
     (hourStr: string) => {
-      const hour12 = parseInt(hourStr, 10)
+      const selectedHour = parseInt(hourStr, 10)
       const currentPeriod = selectedDate ? getPeriod(selectedDate) : Period.AM
-      const hour24 = to24Hour(hour12, currentPeriod)
+      const hour24 = use24HourTime ? selectedHour : to24Hour(selectedHour, currentPeriod)
       const currentMinutes = selectedDate?.getMinutes() ?? 0
       setSelectedDate(createDateWithTime(selectedDate, hour24, currentMinutes))
     },
-    [selectedDate]
+    [selectedDate, use24HourTime]
   )
 
   /** Handle minute selection */
@@ -203,6 +204,7 @@ export function DateTimePickerContent({
         <TimeView
           selectedTime={selectedDate}
           minuteFilter={minuteFilter}
+          use24HourTime={use24HourTime}
           onSelectHour={handleSelectHour}
           onSelectMinute={handleSelectMinute}
           onSelectPeriod={handleSelectPeriod}

--- a/apps/web/src/components/pickers/date-time-picker/types.ts
+++ b/apps/web/src/components/pickers/date-time-picker/types.ts
@@ -205,6 +205,8 @@ export interface DateTimePickerContentProps {
   disabledDates?: (date: Date) => boolean
   /** Filter function for minutes */
   minuteFilter?: (minutes: string[]) => string[]
+  /** Render hours in 24-hour format and hide the AM/PM column. */
+  use24HourTime?: boolean
 
   // Styling
   /** Additional className */

--- a/packages/ui/src/components/dock-panel.tsx
+++ b/packages/ui/src/components/dock-panel.tsx
@@ -29,8 +29,7 @@ export function useDockChrome(): DockChrome | null {
 }
 
 interface DockPanelProps {
-  /** Whether the panel is open. Closed animates width 0 <-> `width` and takes no layout
-   * space once the tween finishes. */
+  /** Whether the panel is open. Closed takes no layout space. */
   open: boolean
   /** Which side the panel docks to. Render `DockPanel` where a LEFT dock should sit in the
    * flex row (e.g. between a module sidebar and the grid) — `side='left'` keeps that DOM
@@ -54,7 +53,7 @@ const DEFAULT_WIDTH = '20rem'
 /**
  * Notion-Calendar-style dock shell: a flex column that pushes its siblings on desktop, or a
  * bottom sheet on narrow viewports. Content-agnostic — it only owns placement, the width
- * tween, chrome (flip-side / pop-out / close), and the `DockPanelFrame` content cross-fade.
+ * handoff, chrome (flip-side / pop-out / close), and the `DockPanelFrame` content cross-fade.
  * See `plans/dispatch/21-dockable-event-panel.md` for the full design.
  */
 function DockPanel({
@@ -68,13 +67,18 @@ function DockPanel({
   children,
 }: DockPanelProps) {
   const isMobile = useIsMobile()
-
-  // Keep children mounted through the 280ms close tween, then unmount — otherwise the
-  // collapsed column keeps its full content alive at width 0: still in the a11y tree, still
-  // tab-focusable, and (for data-heavy consumers) still running queries in duplicate next to
-  // the floating popover. `inert` covers the closing window itself.
+  // Keep the desktop frame mounted for its compositor-only exit animation. The outer column
+  // reserves/releases its final width once per transition; only this fixed-width inner frame moves.
   const [rendered, setRendered] = React.useState(open)
   if (open && !rendered) setRendered(true)
+
+  React.useEffect(() => {
+    if (open || !rendered) return
+    // Animation events can be suppressed by the browser or test environment. This fallback keeps
+    // the closed panel from remaining mounted/inert indefinitely.
+    const timeout = window.setTimeout(() => setRendered(false), 320)
+    return () => window.clearTimeout(timeout)
+  }, [open, rendered])
 
   if (isMobile) {
     return (
@@ -99,24 +103,25 @@ function DockPanel({
     <div
       className={cn(
         'flex h-full shrink-0 flex-col overflow-hidden',
-        'transition-[width] duration-[280ms] ease-[var(--auxx-dock-ease)]',
         side === 'right' && 'order-[999]'
       )}
-      style={{ width: open ? width : '0px' }}
+      style={{ width: rendered ? width : '0px' }}
       aria-hidden={!open}
-      inert={!open}
-      onTransitionEnd={(e) => {
-        if (e.target === e.currentTarget && e.propertyName === 'width' && !open) {
-          setRendered(false)
-        }
-      }}>
-      {/* Fixed-width inner wrapper so text doesn't reflow mid-tween, and so the border
-       * (grid-facing edge) is clipped away entirely by the outer `overflow-hidden` once
-       * collapsed to 0 width — the column then truly takes no space at rest. */}
+      inert={!open}>
+      {/* Reserve the final width in one layout pass, then animate only this fixed-width frame's
+       * transform. Unlike the old width tween, this never remeasures the calendar per frame. */}
       {rendered && (
         <div
-          className={cn('flex h-full flex-col', side === 'left' ? 'border-r' : 'border-l')}
-          style={{ width }}>
+          className={cn(
+            'auxx-dock-panel-frame flex h-full flex-col',
+            side === 'left' ? 'border-r' : 'border-l'
+          )}
+          style={{ width }}
+          data-side={side}
+          data-state={open ? 'open' : 'closed'}
+          onAnimationEnd={(event) => {
+            if (event.target === event.currentTarget && !open) setRendered(false)
+          }}>
           {/* No header of our own — the content renders one and folds these controls into it
            * via `useDockChrome()`, so the dock chrome and the event title never duplicate. */}
           <DockChromeContext.Provider value={{ side, onClose, onPopOut, onFlipSide }}>

--- a/packages/ui/src/components/event-calendar/event-popover/event-popover-sections.tsx
+++ b/packages/ui/src/components/event-calendar/event-popover/event-popover-sections.tsx
@@ -17,6 +17,7 @@ import * as React from 'react'
 import { AutosizeTextarea } from '../../autosize-textarea'
 import { Avatar, AvatarFallback, AvatarImage } from '../../avatar'
 import { Calendar } from '../../calendar'
+import { AnimatedCollapsibleContent } from '../../collapsible'
 import { useCommandNavigation } from '../../command'
 import { useDockChrome } from '../../dock-panel'
 import { PanelCard, PanelCardRow, PanelRowValue, PanelSectionLabel } from '../../panel-card'
@@ -289,11 +290,19 @@ interface EventDateTimeSectionProps {
    * icon and its title is re-tinted amber, with the hints in a hover tooltip — swapped in place,
    * so a late-arriving async result never shifts layout (replaces the old `EventPopoverHints`). */
   warnings?: string[]
+  /** App-level time editor injected here so this UI package does not depend on app code. */
+  renderTimeEditor?: (props: EventTimeEditorProps) => React.ReactNode
 }
 
-/** Labeled "Date & Time" `PanelCard divided`: Date row (drills into a `Calendar` page, pops on
- * select), Time row (drills into `TimeDrillPage`'s start/end `TimeInput`s + duration hint),
- * optional All-day row. All `onChange` commits route through `useSeriesScope().gate`. */
+export interface EventTimeEditorProps {
+  start: Date
+  end: Date
+  use24Hour?: boolean
+  onCommit: (which: 'start' | 'end', hours: number, minutes: number) => void
+}
+
+/** Labeled "Date & Time" card with mutually exclusive date/time editors that animate open
+ * directly below their row. All `onChange` commits route through `useSeriesScope().gate`. */
 export function EventDateTimeSection({
   start,
   end,
@@ -304,10 +313,18 @@ export function EventDateTimeSection({
   disabled,
   defaultStartHour = 9,
   warnings,
+  renderTimeEditor,
 }: EventDateTimeSectionProps) {
   const { gate } = useSeriesScope()
-  const { push, pop } = useCommandNavigation<EventDrillItem>()
   const readOnly = disabled || !onChange
+  const [openEditor, setOpenEditor] = React.useState<'date' | 'time' | null>(null)
+  const [localTime, setLocalTime] = React.useState<{ start: Date; end: Date } | null>(() =>
+    start && end ? { start, end } : null
+  )
+
+  React.useEffect(() => {
+    if (openEditor !== 'time' && start && end) setLocalTime({ start, end })
+  }, [end, openEditor, start])
 
   const handleDateSelect = (date: Date) => {
     let newStart: Date
@@ -320,16 +337,15 @@ export function EventDateTimeSection({
       newStart = withTimeOfDay(date, defaultStartHour, 0)
       newEnd = addMinutes(newStart, 60)
     }
-    pop()
+    setOpenEditor(null)
     gate((scope) => onChange?.({ start: newStart, end: newEnd }, scope))
   }
 
   /**
    * Commits a start/end change from a given base (rather than closing over the section's own
-   * `start`/`end` props) — the Time drill page edits repeatedly without popping, and in draft
-   * mode a commit may not round-trip into new props at all, so the page composes successive
-   * edits off its own local `{ start, end }` (see `TimeDrillPage`). Returning the resolved
-   * pair lets the page adopt it immediately.
+   * `start`/`end` props). The inline editor can commit repeatedly, and in draft mode a commit may
+   * not round-trip into new props, so it composes successive edits off local state. Returning the
+   * resolved pair lets the editor adopt it immediately.
    */
   const commitTime = (
     base: { start: Date; end: Date },
@@ -345,6 +361,18 @@ export function EventDateTimeSection({
     if (newEnd <= newStart) newEnd = addMinutes(newStart, prevDuration)
     gate((scope) => onChange?.({ start: newStart, end: newEnd }, scope))
     return { start: newStart, end: newEnd }
+  }
+
+  const handleTimeCommit = (which: 'start' | 'end', hours: number, minutes: number) => {
+    if (!localTime) return
+    const next = commitTime(localTime, which, hours, minutes)
+    setLocalTime(next)
+  }
+
+  const toggleEditor = (editor: 'date' | 'time') => {
+    const next = openEditor === editor ? null : editor
+    if (next === 'time' && start && end) setLocalTime({ start, end })
+    setOpenEditor(next)
   }
 
   return (
@@ -368,13 +396,19 @@ export function EventDateTimeSection({
               {!readOnly && (
                 <PanelRowValue
                   aria-label='Change date'
-                  onClick={() => push({ id: 'date', label: 'Date' })}>
+                  aria-expanded={openEditor === 'date'}
+                  onClick={() => toggleEditor('date')}>
                   {null}
                 </PanelRowValue>
               )}
             </div>
           }
         />
+        <AnimatedCollapsibleContent open={openEditor === 'date'}>
+          <div className='pb-1'>
+            <Calendar mode='single' selected={start ?? undefined} onSelect={handleDateSelect} />
+          </div>
+        </AnimatedCollapsibleContent>
         <PanelCardRow
           icon={<Clock8 />}
           title='Time'
@@ -387,12 +421,32 @@ export function EventDateTimeSection({
             !readOnly && start && end ? (
               <PanelRowValue
                 aria-label='Change time'
-                onClick={() => push({ id: 'time', label: 'Time' })}>
+                aria-expanded={openEditor === 'time'}
+                onClick={() => toggleEditor('time')}>
                 {null}
               </PanelRowValue>
             ) : null
           }
         />
+        <AnimatedCollapsibleContent open={openEditor === 'time'}>
+          {localTime && (
+            <div className='pb-1'>
+              {renderTimeEditor ? (
+                renderTimeEditor({
+                  ...localTime,
+                  use24Hour,
+                  onCommit: handleTimeCommit,
+                })
+              ) : (
+                <InlineTimeEditor
+                  {...localTime}
+                  use24Hour={use24Hour}
+                  onCommit={handleTimeCommit}
+                />
+              )}
+            </div>
+          )}
+        </AnimatedCollapsibleContent>
         {allDay && (
           <PanelCardRow
             title='All day'
@@ -406,75 +460,31 @@ export function EventDateTimeSection({
           />
         )}
       </PanelCard>
-      <EventDrillPage id='date'>
-        <PanelCard>
-          <Calendar mode='single' selected={start ?? undefined} onSelect={handleDateSelect} />
-        </PanelCard>
-      </EventDrillPage>
-      {start && end && (
-        <EventDrillPage id='time'>
-          <TimeDrillPage start={start} end={end} commitTime={commitTime} use24Hour={use24Hour} />
-        </EventDrillPage>
-      )}
     </div>
   )
 }
 
-interface TimeDrillPageProps {
-  start: Date
-  end: Date
-  commitTime: (
-    base: { start: Date; end: Date },
-    which: 'start' | 'end',
-    hours: number,
-    minutes: number
-  ) => { start: Date; end: Date }
-  use24Hour?: boolean
-}
-
-/**
- * Content for the Time drill page — start/end `TimeInput`s + a duration hint. Owns local
- * `{ start, end }` state seeded from props at mount: each commit calls `commitTime` with the
- * current local pair and adopts the returned one, so successive edits compose correctly even
- * when a commit doesn't round-trip into new props (draft staging, series-scope chooser pending).
- */
-function TimeDrillPage({ start, end, commitTime, use24Hour }: TimeDrillPageProps) {
-  const [local, setLocal] = React.useState({ start, end })
-
-  const handleCommit = (which: 'start' | 'end', hours: number, minutes: number) => {
-    // `commitTime` is NOT pure — it calls `gate()`, which for a series member does a
-    // `setPendingCommit()` on `SeriesScopeProvider`. Running it here (the TimeInput commit
-    // handler) keeps that side effect in an event handler. Doing it inside a `setLocal`
-    // updater instead ran it during render → "Cannot update a component while rendering a
-    // different component", which can make React drop the render and leave the panel stale.
-    const next = commitTime(local, which, hours, minutes)
-    setLocal(next)
-  }
-
+function InlineTimeEditor({ start, end, onCommit, use24Hour }: EventTimeEditorProps) {
   return (
-    <PanelCard className='space-y-3'>
+    <div className='space-y-3'>
       <div className='flex items-center gap-2'>
         <div className='flex-1 space-y-1'>
           <div className='text-muted-foreground text-xs'>Start</div>
           <TimeInput
-            value={local.start}
-            onCommit={(h, m) => handleCommit('start', h, m)}
+            value={start}
+            onCommit={(h, m) => onCommit('start', h, m)}
             use24Hour={use24Hour}
           />
         </div>
         <div className='flex-1 space-y-1'>
           <div className='text-muted-foreground text-xs'>End</div>
-          <TimeInput
-            value={local.end}
-            onCommit={(h, m) => handleCommit('end', h, m)}
-            use24Hour={use24Hour}
-          />
+          <TimeInput value={end} onCommit={(h, m) => onCommit('end', h, m)} use24Hour={use24Hour} />
         </div>
       </div>
       <div className='text-muted-foreground text-xs'>
-        {formatDuration(differenceInMinutes(local.end, local.start))}
+        {formatDuration(differenceInMinutes(end, start))}
       </div>
-    </PanelCard>
+    </div>
   )
 }
 

--- a/packages/ui/src/components/event-calendar/index.ts
+++ b/packages/ui/src/components/event-calendar/index.ts
@@ -32,6 +32,7 @@ export {
   EventPeopleSection,
   EventPopoverFooter,
   EventRepeatSection,
+  type EventTimeEditorProps,
   type EventTitleAction,
   EventTitleSection,
 } from './event-popover/event-popover-sections'

--- a/packages/ui/src/components/event-calendar/month-view.tsx
+++ b/packages/ui/src/components/event-calendar/month-view.tsx
@@ -317,10 +317,13 @@ export function MonthView<T extends EventCalendarItem = EventCalendarItem>({
 
   // Rows are fixed-height, so the target offset is exact math — scrolling directly
   // (instead of virtualizer.scrollToIndex) sidesteps its measurement-cache staleness.
+  const lastRowHeightRef = useRef(rowHeight)
   useLayoutEffect(() => {
-    if (lastEmittedDateRef.current === currentDateRef.current.getTime()) return
+    const rowHeightChanged = lastRowHeightRef.current !== rowHeight
+    if (!rowHeightChanged && lastEmittedDateRef.current === currentDateRef.current.getTime()) return
     const el = scrollRef.current
     if (!el) return
+    lastRowHeightRef.current = rowHeight
     programmaticScrollRef.current = true
     el.scrollTo({ top: targetIndex * rowHeight })
     const timeout = setTimeout(() => {

--- a/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
@@ -199,13 +199,19 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
   // Set when a scroll-settle emits onDateChange — that date echoing back as the
   // `currentDate` prop must NOT re-scroll (the user is already looking at it).
   const lastEmittedDateRef = useRef<number | null>(null)
+  const lastDayWidthRef = useRef(dayWidth)
+  const lastScrollLeftRef = useRef(0)
 
   useLayoutEffect(() => {
-    if (lastEmittedDateRef.current === currentDateRef.current.getTime()) return
+    const dayWidthChanged = lastDayWidthRef.current !== dayWidth
+    if (!dayWidthChanged && lastEmittedDateRef.current === currentDateRef.current.getTime()) return
     const el = scrollRef.current
     if (!el) return
+    lastDayWidthRef.current = dayWidth
     programmaticScrollRef.current = true
-    el.scrollTo({ left: targetIndex * dayWidth })
+    const targetOffset = targetIndex * dayWidth
+    el.scrollTo({ left: targetOffset })
+    lastScrollLeftRef.current = targetOffset
     const timeout = setTimeout(() => {
       programmaticScrollRef.current = false
     }, 300)
@@ -218,7 +224,6 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
   // and skips when unchanged, so a pure vertical (time-axis) scroll never yanks
   // sideways. Snapping is GUARDED by snapEnabled: when a day is wider than the
   // viewport we skip the snap-scroll but still emit the (rounded) leftmost day.
-  const lastScrollLeftRef = useRef(0)
   const settleTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const handleScroll = useCallback(() => {
     clearTimeout(settleTimeoutRef.current)

--- a/packages/ui/src/components/event-calendar/week-view.tsx
+++ b/packages/ui/src/components/event-calendar/week-view.tsx
@@ -173,13 +173,19 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
   // Set when a scroll-settle emits onDateChange — that date echoing back as the
   // `currentDate` prop must NOT re-scroll (the user is already looking at it).
   const lastEmittedDateRef = useRef<number | null>(null)
+  const lastDayWidthRef = useRef(dayWidth)
+  const lastScrollLeftRef = useRef(0)
 
   useLayoutEffect(() => {
-    if (lastEmittedDateRef.current === currentDateRef.current.getTime()) return
+    const dayWidthChanged = lastDayWidthRef.current !== dayWidth
+    if (!dayWidthChanged && lastEmittedDateRef.current === currentDateRef.current.getTime()) return
     const el = scrollRef.current
     if (!el) return
+    lastDayWidthRef.current = dayWidth
     programmaticScrollRef.current = true
-    el.scrollTo({ left: targetIndex * dayWidth })
+    const targetOffset = targetIndex * dayWidth
+    el.scrollTo({ left: targetOffset })
+    lastScrollLeftRef.current = targetOffset
     const timeout = setTimeout(() => {
       programmaticScrollRef.current = false
     }, 300)
@@ -191,7 +197,6 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
   // This container scrolls BOTH axes — the settle handler compares scrollLeft against
   // its value from before this scroll gesture and skips snapping when it's unchanged,
   // otherwise a pure vertical (time-axis) scroll would yank the view sideways.
-  const lastScrollLeftRef = useRef(0)
   const settleTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const handleScroll = useCallback(() => {
     clearTimeout(settleTimeoutRef.current)

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -90,14 +90,59 @@
   }
 }
 
-/*
-  Dock panel primitive (`@auxx/ui/components/dock-panel`) — shared easing token for the
-  width tween (open/close/flip) and the content-swap frame animation below. Values lifted
-  from `packages/chat` (`--auxx-chat-shell-ease`) per plans/dispatch/21-dockable-event-panel.md
-  — replicated here, not imported, since chat is a separate Preact bundle.
-*/
+/* The dock reserves its final flex width once, then moves only the fixed-width inner frame on the
+   compositor. This uses chat's 280ms shell curve without animating layout beside the calendar. */
 :root {
   --auxx-dock-ease: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.auxx-dock-panel-frame {
+  will-change: transform;
+  backface-visibility: hidden;
+}
+.auxx-dock-panel-frame[data-state='open'][data-side='left'] {
+  animation: auxx-dock-panel-in-left 280ms var(--auxx-dock-ease) both;
+}
+.auxx-dock-panel-frame[data-state='open'][data-side='right'] {
+  animation: auxx-dock-panel-in-right 280ms var(--auxx-dock-ease) both;
+}
+.auxx-dock-panel-frame[data-state='closed'][data-side='left'] {
+  animation: auxx-dock-panel-out-left 280ms var(--auxx-dock-ease) both;
+}
+.auxx-dock-panel-frame[data-state='closed'][data-side='right'] {
+  animation: auxx-dock-panel-out-right 280ms var(--auxx-dock-ease) both;
+}
+@keyframes auxx-dock-panel-in-left {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+@keyframes auxx-dock-panel-in-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+@keyframes auxx-dock-panel-out-left {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+@keyframes auxx-dock-panel-out-right {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
 }
 
 /* 1) Define keyframes */
@@ -211,9 +256,8 @@
   inset: 0;
   flex: none;
 }
-/* The dock opens once (the column's width tween); switching the selected event only swaps the
-   body, so a slide-in would read as a second "opening". A quick cross-fade keeps it a content
-   swap. First mount has no exiting layer, so nothing animates when the panel first opens. */
+/* Docking itself is an instant layout handoff; switching the selected event only swaps the body.
+   A quick cross-fade keeps that change a content swap rather than a second opening. */
 .auxx-dock-frame--entering {
   animation: auxx-dock-frame-fade-in 140ms ease-out both;
 }
@@ -1039,6 +1083,9 @@ body.dnd-dragging * {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .auxx-dock-panel-frame {
+    animation-duration: 1ms !important;
+  }
   .candy-stripes {
     animation: none;
   }


### PR DESCRIPTION
## Summary

- coalesce in-flight availability ranges and stabilize virtual calendar anchoring during resize and overscroll
- preserve event state through popover-to-dock handoff, use compositor-based dock animations, and restore empty-dock controls
- animate inline Date and Time editors and reuse the shared scrolling time picker for dispatch start/end selection
- move line-item tax and delete actions into the description cell and remove the dedicated actions column

## Verification

- pnpm exec biome check on all 18 changed files
- git diff --check
- @auxx/ui typecheck attempted; remains blocked by the existing unrelated repository error set, with no changed-file error reported
- authenticated browser gesture and animation pass remains owed because available local credentials were rejected