### PR TITLE
fix(dispatch): improve event popover date/time layout and catalog picker scroll

### DIFF
--- a/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
+++ b/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
@@ -306,7 +306,11 @@ export function CatalogPicker({
             onValueChange={setQuery}
             placeholder='Search products & services…'
           />
-          <CommandList>
+          <CommandList
+            scrollAreaClassName='max-h-none'
+            scrollAreaStyle={{
+              height: 'min(300px, calc(var(--radix-popover-content-available-height) - 78px))',
+            }}>
             {!(itemsLoading || groupsLoading) && !hasAnyMatch && !query.trim() && (
               <CommandEmpty>No products or services yet</CommandEmpty>
             )}

--- a/packages/ui/src/components/event-calendar/event-popover/event-popover-sections.tsx
+++ b/packages/ui/src/components/event-calendar/event-popover/event-popover-sections.tsx
@@ -378,86 +378,92 @@ export function EventDateTimeSection({
   return (
     <div className='space-y-2'>
       <PanelSectionLabel>Date & Time</PanelSectionLabel>
-      <PanelCard divided>
-        <PanelCardRow
-          icon={<CalendarDays />}
-          title='Date'
-          warnings={warnings}
-          description={start ? format(start, 'PPP') : 'No date'}
-          trailing={
-            <div className='flex items-center gap-2'>
-              {onDateToggle && (
-                <Switch
-                  checked={start != null}
-                  onCheckedChange={onDateToggle}
-                  disabled={disabled}
-                />
-              )}
-              {!readOnly && (
-                <PanelRowValue
-                  aria-label='Change date'
-                  aria-expanded={openEditor === 'date'}
-                  onClick={() => toggleEditor('date')}>
-                  {null}
-                </PanelRowValue>
-              )}
-            </div>
-          }
-        />
-        <AnimatedCollapsibleContent open={openEditor === 'date'}>
-          <div className='pb-1'>
-            <Calendar mode='single' selected={start ?? undefined} onSelect={handleDateSelect} />
-          </div>
-        </AnimatedCollapsibleContent>
-        <PanelCardRow
-          icon={<Clock8 />}
-          title='Time'
-          description={
-            start && end
-              ? `${formatTimeOfDay(start, use24Hour)} – ${formatTimeOfDay(end, use24Hour)}`
-              : 'No time'
-          }
-          trailing={
-            !readOnly && start && end ? (
-              <PanelRowValue
-                aria-label='Change time'
-                aria-expanded={openEditor === 'time'}
-                onClick={() => toggleEditor('time')}>
-                {null}
-              </PanelRowValue>
-            ) : null
-          }
-        />
-        <AnimatedCollapsibleContent open={openEditor === 'time'}>
-          {localTime && (
-            <div className='pb-1'>
-              {renderTimeEditor ? (
-                renderTimeEditor({
-                  ...localTime,
-                  use24Hour,
-                  onCommit: handleTimeCommit,
-                })
-              ) : (
-                <InlineTimeEditor
-                  {...localTime}
-                  use24Hour={use24Hour}
-                  onCommit={handleTimeCommit}
-                />
-              )}
-            </div>
-          )}
-        </AnimatedCollapsibleContent>
-        {allDay && (
+      <PanelCard>
+        <div>
           <PanelCardRow
-            title='All day'
+            icon={<CalendarDays />}
+            title='Date'
+            warnings={warnings}
+            description={start ? format(start, 'PPP') : 'No date'}
             trailing={
-              <Switch
-                checked={allDay.value}
-                onCheckedChange={allDay.onChange}
-                disabled={disabled}
-              />
+              <div className='flex items-center gap-2'>
+                {onDateToggle && (
+                  <Switch
+                    checked={start != null}
+                    onCheckedChange={onDateToggle}
+                    disabled={disabled}
+                  />
+                )}
+                {!readOnly && (
+                  <PanelRowValue
+                    aria-label='Change date'
+                    aria-expanded={openEditor === 'date'}
+                    onClick={() => toggleEditor('date')}>
+                    {null}
+                  </PanelRowValue>
+                )}
+              </div>
             }
           />
+          <AnimatedCollapsibleContent open={openEditor === 'date'}>
+            <div className='pt-3 pb-1'>
+              <Calendar mode='single' selected={start ?? undefined} onSelect={handleDateSelect} />
+            </div>
+          </AnimatedCollapsibleContent>
+        </div>
+        <div className='mt-3 border-t border-border/50 pt-3'>
+          <PanelCardRow
+            icon={<Clock8 />}
+            title='Time'
+            description={
+              start && end
+                ? `${formatTimeOfDay(start, use24Hour)} – ${formatTimeOfDay(end, use24Hour)}`
+                : 'No time'
+            }
+            trailing={
+              !readOnly && start && end ? (
+                <PanelRowValue
+                  aria-label='Change time'
+                  aria-expanded={openEditor === 'time'}
+                  onClick={() => toggleEditor('time')}>
+                  {null}
+                </PanelRowValue>
+              ) : null
+            }
+          />
+          <AnimatedCollapsibleContent open={openEditor === 'time'}>
+            {localTime && (
+              <div className='pt-3 pb-1'>
+                {renderTimeEditor ? (
+                  renderTimeEditor({
+                    ...localTime,
+                    use24Hour,
+                    onCommit: handleTimeCommit,
+                  })
+                ) : (
+                  <InlineTimeEditor
+                    {...localTime}
+                    use24Hour={use24Hour}
+                    onCommit={handleTimeCommit}
+                  />
+                )}
+              </div>
+            )}
+          </AnimatedCollapsibleContent>
+        </div>
+        {allDay && (
+          <div className='mt-3 border-t border-border/50 pt-3'>
+            <PanelCardRow
+              title='All day'
+              trailing={
+                <Switch
+                  checked={allDay.value}
+                  onCheckedChange={allDay.onChange}
+                  disabled={disabled}
+                />
+              }
+            />
+          </div>
         )}
       </PanelCard>
     </div>

--- a/packages/ui/src/components/event-calendar/event-popover/event-popover.tsx
+++ b/packages/ui/src/components/event-calendar/event-popover/event-popover.tsx
@@ -197,6 +197,7 @@ export function EventPopover({
       <PopoverContent
         side={side}
         align={align}
+        updatePositionStrategy='always'
         onOpenAutoFocus={(e) => e.preventDefault()}
         className='w-80 rounded-3xl p-0 shadow-xl'>
         <EventPopoverBody series={series} header={header}>


### PR DESCRIPTION
## Summary
- Split the event popover's Date/Time/All-day rows into visually separated, bordered sections with consistent spacing instead of a single divided card.
- Set `updatePositionStrategy='always'` on the event popover so it repositions as its content (e.g. expanding date/time editors) changes size.
- Cap the catalog picker's `CommandList` scroll area to the available popover height (`min(300px, calc(var(--radix-popover-content-available-height) - 78px))`) instead of the fixed `max-h-[300px]` default, so it doesn't overflow the popover.

## Test plan
- [ ] Open the dispatch calendar, click an event to open the popover, expand the date and time editors, and confirm layout/spacing looks correct and the popover repositions without overflowing the viewport.
- [ ] Open the money line-builder catalog picker near the bottom of the viewport and confirm the list scrolls within the popover bounds instead of overflowing.