### PR TITLE
perf(availability): batch resolve across subjects in one query set

### DIFF
--- a/apps/web/src/components/dispatch/stores/use-resolved-days.ts
+++ b/apps/web/src/components/dispatch/stores/use-resolved-days.ts
@@ -66,6 +66,10 @@ export function useResolvedDaysForSubjects(
   const entries = useMemo(() => subjects.map(toResolvedDaysSubject), [subjects])
 
   useEffect(() => {
+    // Compute uncovered gaps per subject, then group subjects that share the same gap so ONE
+    // batched resolve covers all of them (on a date change every subject has the same gap, so
+    // this normally collapses to a single request). Pending bookkeeping stays per subject.
+    const groups = new Map<string, { gap: DateRange; targets: ResolvedDaysSubject[] }>()
     for (const { key, subject } of entries) {
       const loaded = cacheSubjects[key]?.loadedRanges ?? []
       const covered = [...loaded, ...pendingRanges(key)]
@@ -73,12 +77,21 @@ export function useResolvedDaysForSubjects(
       for (const gap of gaps) {
         const tag = reservePendingRange(key, gap)
         if (!tag) continue
-        utils.availability.resolve
-          .fetch({ subject, from: gap.from, to: gap.to })
-          .then((days) => ingestResolved(key, gap, days))
-          .catch(() => {})
-          .finally(() => releasePendingRange(key, tag))
+        const group = groups.get(tag) ?? { gap, targets: [] }
+        group.targets.push({ key, subject })
+        groups.set(tag, group)
       }
+    }
+    for (const [tag, { gap, targets }] of groups) {
+      utils.availability.resolve
+        .fetch({ subjects: targets.map((t) => t.subject), from: gap.from, to: gap.to })
+        .then((daysBySubject) => {
+          targets.forEach(({ key }, i) => ingestResolved(key, gap, daysBySubject[i] ?? []))
+        })
+        .catch(() => {})
+        .finally(() => {
+          for (const { key } of targets) releasePendingRange(key, tag)
+        })
     }
   }, [cacheSubjects, entries, ingestResolved, range, utils])
 

--- a/apps/web/src/server/api/routers/availability.ts
+++ b/apps/web/src/server/api/routers/availability.ts
@@ -5,7 +5,7 @@ import {
   deleteException,
   getWeeklyHours,
   listExceptions,
-  resolveAvailability,
+  resolveAvailabilityForSubjects,
   saveWeeklyHours,
   updateException,
 } from '@auxx/lib/availability'
@@ -129,10 +129,20 @@ export const availabilityRouter = createTRPCRouter({
       return deleteException(subject, input.ids)
     }),
 
+  /**
+   * Batched resolve — one call covers many subjects for the same range (board shading asks for
+   * org + every visible worker per navigation). Result is index-aligned with `subjects`.
+   */
   resolve: protectedProcedure
-    .input(z.object({ subject: subjectInputSchema, from: isoDate, to: isoDate }))
+    .input(
+      z.object({
+        subjects: z.array(subjectInputSchema).min(1).max(100),
+        from: isoDate,
+        to: isoDate,
+      })
+    )
     .query(async ({ ctx, input }) => {
-      const subject = buildSubject(ctx.session.organizationId, input.subject)
-      return resolveAvailability(subject, { from: input.from, to: input.to })
+      const subjects = input.subjects.map((s) => buildSubject(ctx.session.organizationId, s))
+      return resolveAvailabilityForSubjects(subjects, { from: input.from, to: input.to })
     }),
 })

--- a/apps/worker/scripts/verify-availability.ts
+++ b/apps/worker/scripts/verify-availability.ts
@@ -26,6 +26,7 @@ import {
   getWeeklyHours,
   listExceptions,
   resolveAvailability,
+  resolveAvailabilityForSubjects,
   saveWeeklyHours,
   type TimeRange,
   type WeeklyHours,
@@ -483,6 +484,45 @@ async function main() {
       !!wed10d && rangesEqual(wed10d.ranges, [{ start: 600, end: 840 }]),
       wed10d
     )
+
+    // ── 10e: batched resolve parity ──────────────────────────────────────────
+    // Exercises `resolveAvailabilityForSubjects` against the richest state from step 10:
+    // org weekly + org closed-exception + worker special-hours exception + worker weekly.
+    console.log('10e: resolveAvailabilityForSubjects parity')
+    const [batchOrg, batchWorker] = await resolveAvailabilityForSubjects(
+      [orgSubject, workerSubject],
+      window
+    )
+    const soloOrg = await resolveAvailability(orgSubject, window)
+    const soloWorker = await resolveAvailability(workerSubject, window)
+    check(
+      '10e: batch [org, worker] matches individual org resolve',
+      JSON.stringify(batchOrg) === JSON.stringify(soloOrg),
+      { batchOrg, soloOrg }
+    )
+    check(
+      '10e: batch [org, worker] matches individual worker resolve',
+      JSON.stringify(batchWorker) === JSON.stringify(soloWorker),
+      { batchWorker, soloWorker }
+    )
+    const [orgOnly] = await resolveAvailabilityForSubjects([orgSubject], window)
+    check(
+      '10e: org-only batch matches individual org resolve',
+      JSON.stringify(orgOnly) === JSON.stringify(soloOrg),
+      orgOnly
+    )
+    check(
+      '10e: empty batch returns []',
+      (await resolveAvailabilityForSubjects([], window)).length === 0
+    )
+    const mixedOrgRejected = await resolveAvailabilityForSubjects(
+      [orgSubject, { type: 'organization', organizationId: 'someone-elses-org' }],
+      window
+    ).then(
+      () => false,
+      (err) => err instanceof BadRequestError
+    )
+    check('10e: mixed-organization batch throws BadRequestError', mixedOrgRejected)
 
     // ── 11: getWeeklyHours null ───────────────────────────────────────────────
     console.log('11: getWeeklyHours null for a subject with zero weekly rows')

--- a/packages/lib/src/availability/index.ts
+++ b/packages/lib/src/availability/index.ts
@@ -5,7 +5,7 @@
 // Functional + Drizzle, no model classes (money/dispatch are the direct siblings).
 
 export { addException, deleteException, listExceptions, updateException } from './exceptions'
-export { resolveAvailability } from './resolve'
+export { resolveAvailability, resolveAvailabilityForSubjects } from './resolve'
 export type {
   AddExceptionInput,
   AvailabilitySubject,

--- a/packages/lib/src/availability/resolve.ts
+++ b/packages/lib/src/availability/resolve.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/availability/resolve.ts
 //
-// Resolve a subject's effective schedule for a date range (05-availability.md §A.2, and
+// Resolve subjects' effective schedules for a date range (05-availability.md §A.2, and
 // 01-data-model.md §4.1's precedence rule). Precedence, per date:
 //   1. the subject's own exception rows for that date
 //   2. org-level exception rows for that date (org exceptions apply to every subject)
@@ -8,86 +8,178 @@
 //   4. the org's weekly rows for that weekday — fallback ONLY when the subject has ZERO
 //      weekly rows overall (not per-day; e.g. an inheriting worker)
 //
-// All rows for the window are fetched once up front and resolved in memory.
+// Batched (plans/dispatch/25-availability-resolve-batching.md): all subjects share one
+// organization, so the org rows (needed both when the org is itself a subject and as every
+// worker/widget's fallback) are fetched ONCE, and all non-org subjects' rows come back in one
+// `inArray` query per kind — a constant 4 queries regardless of subject count.
 
 import { database, schema } from '@auxx/database'
-import { and, eq, gte, lte } from 'drizzle-orm'
+import { and, eq, gte, inArray, lte, or, type SQL } from 'drizzle-orm'
+import { BadRequestError } from '../errors'
 import { dayOfWeekFromDate, enumerateDates } from './dates'
 import { groupExceptionRowsByDate } from './exceptions'
 import { subjectConditions } from './subject'
 import type { AvailabilitySubject, ResolvedDay } from './types'
 import { groupWeeklyRowsByDay } from './weekly-hours'
 
-/** Effective ranges for every date in `[range.from, range.to]` (inclusive, capped at 366 days). */
-export async function resolveAvailability(
-  subject: AvailabilitySubject,
-  range: { from: string; to: string }
-): Promise<ResolvedDay[]> {
-  const dates = enumerateDates(range.from, range.to)
+type OperatingHoursRow = typeof schema.OperatingHours.$inferSelect
 
-  const orgSubject: AvailabilitySubject = {
-    type: 'organization',
-    organizationId: subject.organizationId,
+/** Grouping key matching a fetched row back to its subject. */
+function subjectKey(subject: AvailabilitySubject): string {
+  switch (subject.type) {
+    case 'organization':
+      return 'org'
+    case 'worker':
+      return `w:${subject.userId}`
+    case 'widget':
+      return `wg:${subject.widgetId}`
   }
-  const needsOrgFallback = subject.type !== 'organization'
+}
 
-  const [subjectExceptionRows, subjectWeeklyRows, orgExceptionRows, orgWeeklyRows] =
+function rowKey(row: OperatingHoursRow): string {
+  if (row.subjectType === 'worker') return `w:${row.userId}`
+  if (row.subjectType === 'widget') return `wg:${row.widgetId}`
+  return 'org'
+}
+
+function groupByKey(rows: OperatingHoursRow[]): Map<string, OperatingHoursRow[]> {
+  const byKey = new Map<string, OperatingHoursRow[]>()
+  for (const row of rows) {
+    const key = rowKey(row)
+    const list = byKey.get(key)
+    if (list) list.push(row)
+    else byKey.set(key, [row])
+  }
+  return byKey
+}
+
+/**
+ * Effective ranges for every date in `[range.from, range.to]` (inclusive, capped at 366 days)
+ * for EACH subject — the result array is index-aligned with `subjects`. All subjects must
+ * belong to the same organization.
+ */
+export async function resolveAvailabilityForSubjects(
+  subjects: AvailabilitySubject[],
+  range: { from: string; to: string }
+): Promise<ResolvedDay[][]> {
+  if (subjects.length === 0) return []
+  const organizationId = subjects[0]!.organizationId
+  if (subjects.some((s) => s.organizationId !== organizationId)) {
+    throw new BadRequestError('All subjects in a batch must belong to the same organization')
+  }
+
+  const dates = enumerateDates(range.from, range.to)
+  const orgSubject: AvailabilitySubject = { type: 'organization', organizationId }
+
+  const workerIds = [...new Set(subjects.flatMap((s) => (s.type === 'worker' ? [s.userId] : [])))]
+  const widgetIds = [...new Set(subjects.flatMap((s) => (s.type === 'widget' ? [s.widgetId] : [])))]
+
+  const nonOrgPredicates: SQL[] = []
+  if (workerIds.length > 0) {
+    nonOrgPredicates.push(
+      and(
+        eq(schema.OperatingHours.subjectType, 'worker'),
+        inArray(schema.OperatingHours.userId, workerIds)
+      )!
+    )
+  }
+  if (widgetIds.length > 0) {
+    nonOrgPredicates.push(
+      and(
+        eq(schema.OperatingHours.subjectType, 'widget'),
+        inArray(schema.OperatingHours.widgetId, widgetIds)
+      )!
+    )
+  }
+  const nonOrgConditions =
+    nonOrgPredicates.length > 0
+      ? and(eq(schema.OperatingHours.organizationId, organizationId), or(...nonOrgPredicates))!
+      : null
+
+  const dateBounds = and(
+    gte(schema.OperatingHours.date, range.from),
+    lte(schema.OperatingHours.date, range.to)
+  )!
+
+  const [orgExceptionRows, orgWeeklyRows, nonOrgExceptionRows, nonOrgWeeklyRows] =
     await Promise.all([
       database.query.OperatingHours.findMany({
         where: and(
-          subjectConditions(subject),
+          subjectConditions(orgSubject),
           eq(schema.OperatingHours.kind, 'exception'),
-          gte(schema.OperatingHours.date, range.from),
-          lte(schema.OperatingHours.date, range.to)
+          dateBounds
         ),
       }),
       database.query.OperatingHours.findMany({
-        where: and(subjectConditions(subject), eq(schema.OperatingHours.kind, 'weekly')),
+        where: and(subjectConditions(orgSubject), eq(schema.OperatingHours.kind, 'weekly')),
       }),
-      needsOrgFallback
+      nonOrgConditions
         ? database.query.OperatingHours.findMany({
-            where: and(
-              subjectConditions(orgSubject),
-              eq(schema.OperatingHours.kind, 'exception'),
-              gte(schema.OperatingHours.date, range.from),
-              lte(schema.OperatingHours.date, range.to)
-            ),
+            where: and(nonOrgConditions, eq(schema.OperatingHours.kind, 'exception'), dateBounds),
           })
         : Promise.resolve([]),
-      needsOrgFallback
+      nonOrgConditions
         ? database.query.OperatingHours.findMany({
-            where: and(subjectConditions(orgSubject), eq(schema.OperatingHours.kind, 'weekly')),
+            where: and(nonOrgConditions, eq(schema.OperatingHours.kind, 'weekly')),
           })
         : Promise.resolve([]),
     ])
 
-  const subjectExceptionsByDate = groupExceptionRowsByDate(subjectExceptionRows)
+  const nonOrgExceptionsByKey = groupByKey(nonOrgExceptionRows)
+  const nonOrgWeeklyByKey = groupByKey(nonOrgWeeklyRows)
+
   const orgExceptionsByDate = groupExceptionRowsByDate(orgExceptionRows)
-  const subjectWeeklyByDay = groupWeeklyRowsByDay(subjectWeeklyRows)
   const orgWeeklyByDay = groupWeeklyRowsByDay(orgWeeklyRows)
-  const subjectHasWeekly = subjectWeeklyRows.length > 0
-  const subjectTimezone = subjectWeeklyRows[0]?.timezone ?? 'UTC'
   const orgTimezone = orgWeeklyRows[0]?.timezone ?? 'UTC'
 
-  return dates.map((date): ResolvedDay => {
-    const subjectException = subjectExceptionsByDate.get(date)
-    if (subjectException) {
-      return { date, ranges: subjectException.ranges, timezone: subjectException.timezone }
-    }
+  return subjects.map((subject): ResolvedDay[] => {
+    const isOrg = subject.type === 'organization'
+    const key = subjectKey(subject)
+    const subjectExceptionRows = isOrg ? orgExceptionRows : (nonOrgExceptionsByKey.get(key) ?? [])
+    const subjectWeeklyRows = isOrg ? orgWeeklyRows : (nonOrgWeeklyByKey.get(key) ?? [])
 
-    const orgException = orgExceptionsByDate.get(date)
-    if (orgException) {
-      return { date, ranges: orgException.ranges, timezone: orgException.timezone }
-    }
+    const subjectExceptionsByDate = isOrg
+      ? orgExceptionsByDate
+      : groupExceptionRowsByDate(subjectExceptionRows)
+    const subjectWeeklyByDay = isOrg ? orgWeeklyByDay : groupWeeklyRowsByDay(subjectWeeklyRows)
+    const subjectHasWeekly = subjectWeeklyRows.length > 0
+    const subjectTimezone = subjectWeeklyRows[0]?.timezone ?? 'UTC'
 
-    const dayOfWeek = dayOfWeekFromDate(date)
+    // The org fallback applies to non-org subjects only — an org subject's own rows ARE the
+    // org rows, and its misses resolve to closed (empty ranges), never back onto itself.
+    const fallbackExceptionsByDate = isOrg ? undefined : orgExceptionsByDate
+    const fallbackWeeklyByDay = isOrg ? undefined : orgWeeklyByDay
+    const fallbackTimezone = isOrg ? 'UTC' : orgTimezone
 
-    if (subjectHasWeekly) {
-      const day = subjectWeeklyByDay.get(dayOfWeek)
-      return { date, ranges: day?.ranges ?? [], timezone: day?.timezone ?? subjectTimezone }
-    }
+    return dates.map((date): ResolvedDay => {
+      const subjectException = subjectExceptionsByDate.get(date)
+      if (subjectException) {
+        return { date, ranges: subjectException.ranges, timezone: subjectException.timezone }
+      }
 
-    const orgDay = orgWeeklyByDay.get(dayOfWeek)
-    return { date, ranges: orgDay?.ranges ?? [], timezone: orgDay?.timezone ?? orgTimezone }
+      const orgException = fallbackExceptionsByDate?.get(date)
+      if (orgException) {
+        return { date, ranges: orgException.ranges, timezone: orgException.timezone }
+      }
+
+      const dayOfWeek = dayOfWeekFromDate(date)
+
+      if (subjectHasWeekly) {
+        const day = subjectWeeklyByDay.get(dayOfWeek)
+        return { date, ranges: day?.ranges ?? [], timezone: day?.timezone ?? subjectTimezone }
+      }
+
+      const orgDay = fallbackWeeklyByDay?.get(dayOfWeek)
+      return { date, ranges: orgDay?.ranges ?? [], timezone: orgDay?.timezone ?? fallbackTimezone }
+    })
   })
+}
+
+/** Effective ranges for a single subject — thin wrapper over the batched resolver. */
+export async function resolveAvailability(
+  subject: AvailabilitySubject,
+  range: { from: string; to: string }
+): Promise<ResolvedDay[]> {
+  const [days] = await resolveAvailabilityForSubjects([subject], range)
+  return days ?? []
 }

--- a/packages/lib/src/dispatch/route-planner/planner-board.ts
+++ b/packages/lib/src/dispatch/route-planner/planner-board.ts
@@ -9,7 +9,7 @@
 
 import { database, schema } from '@auxx/database'
 import { and, eq, gte, inArray, isNull, lte } from 'drizzle-orm'
-import { resolveAvailability } from '../../availability'
+import { resolveAvailabilityForSubjects } from '../../availability'
 import { getOrgCache } from '../../cache'
 import { extractFieldValueScalar } from '../../field-values'
 import { formatAddress } from '../address'
@@ -186,13 +186,11 @@ export async function getRoutePlannerBoard(
           eq(schema.WorkOrderVisit.status, 'scheduled')
         )
       ),
-    Promise.all(
-      filteredWorkers.map((w) =>
-        resolveAvailability(
-          { type: 'worker', organizationId, userId: w.userId },
-          { from: dateKey, to: dateKey }
-        )
-      )
+    // One batched resolve for ALL workers (index-aligned with `filteredWorkers`) — constant
+    // 4 OperatingHours queries instead of 4 per worker.
+    resolveAvailabilityForSubjects(
+      filteredWorkers.map((w) => ({ type: 'worker' as const, organizationId, userId: w.userId })),
+      { from: dateKey, to: dateKey }
     ),
     resolveOrgDepot(organizationId),
   ])


### PR DESCRIPTION
## What

Adds `resolveAvailabilityForSubjects` — resolves many **same-org** subjects for a date range in a **constant 4** `OperatingHours` queries, regardless of subject count:

- org rows (needed both when the org is a subject and as every worker/widget fallback) are fetched **once**
- all non-org subjects' rows come back via one `inArray` query per kind

`resolveAvailability` is now a thin single-subject wrapper over it, so existing callers are unchanged in behavior.

## Callers switched to batched resolve

- **Planner board** (`planner-board.ts`) — one resolve for all filtered workers instead of `Promise.all` of one-per-worker (was 4 queries × N workers).
- **`use-resolved-days` hook** — groups subjects sharing the same uncovered gap into one batched `availability.resolve` request (on a date change every subject shares the gap → collapses to a single request). Pending bookkeeping stays per-subject.
- **tRPC `availability.resolve`** — input is now `subjects[]` (min 1, max 100), result index-aligned with input; enforces same-organization batches.

## Tests

`verify-availability.ts` step 10e adds batched-vs-individual parity checks against the richest fixture state (org weekly + org closed-exception + worker special-hours + worker weekly), plus empty-batch and mixed-org-rejection cases.

Plan: `plans/dispatch/25-availability-resolve-batching.md`