### PR TITLE
feat(money): unit pricing + part markup + optional quote lines (plans 13/17/18)

### DIFF
--- a/apps/web/src/app/(public)/quote/[token]/accept/route.ts
+++ b/apps/web/src/app/(public)/quote/[token]/accept/route.ts
@@ -20,9 +20,18 @@ export async function POST(
   const { token } = await params
   const formData = await request.formData()
   const name = formData.get('name')
+  // The page always renders every optional line's checkbox (money plan 18 §4), so this route
+  // always provides the array — an empty array on an all-unchecked submit correctly means
+  // "deselect every optional line" (standard HTML form semantics), never "leave defaults
+  // untouched" (that's `undefined`, which this route never sends). Zero-optional quotes send
+  // an empty array too; `acceptQuoteByToken` no-ops when the quote has no optional lines.
+  const selectedLineIds = formData.getAll('selectedLineIds').map(String)
 
   try {
-    await acceptQuoteByToken(token, { name: typeof name === 'string' ? name : undefined })
+    await acceptQuoteByToken(token, {
+      name: typeof name === 'string' ? name : undefined,
+      selectedLineIds,
+    })
     const redirectUrl = new URL(`/quote/${token}`, request.url)
     redirectUrl.searchParams.set('state', 'accepted')
     return NextResponse.redirect(redirectUrl, { status: 303 })

--- a/apps/web/src/components/money/hooks/use-catalog-items.ts
+++ b/apps/web/src/components/money/hooks/use-catalog-items.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/money/hooks/use-catalog-items.ts
 
+import type { LineItemUnit } from '@auxx/lib/money/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 import { useMemo } from 'react'
 import {
@@ -16,9 +17,12 @@ export interface CatalogItemRecord extends RecordMeta {
     catalog_item_description?: string | null
     catalog_item_category?: string | string[]
     catalog_item_default_unit_price?: number | null
+    catalog_item_default_unit?: string | string[] | null
     catalog_item_taxable?: boolean
     catalog_item_active?: boolean
     catalog_item_part?: RecordId | RecordId[] | null
+    catalog_item_cost?: number | null
+    catalog_item_markup?: number | null
   }
 }
 
@@ -31,9 +35,15 @@ export interface CatalogItem {
   category: string
   /** Stored in cents, matching the CURRENCY field-value convention. */
   defaultUnitPriceCents: number | null
+  /** Fixed unit list (money plan 13 §1) — `null` means unitized pricing is off. */
+  defaultUnit: LineItemUnit | null
   taxable: boolean
   active: boolean
   partRecordId: RecordId | null
+  /** Synced from the linked part's cost by the pricing engine — read-only (money plan 17). */
+  cost: number | null
+  /** Markup rate as a percentage of cost — `null` pauses auto-pricing (money plan 17). */
+  markup: number | null
 }
 
 /**
@@ -54,9 +64,14 @@ function toCatalogItem(record: CatalogItemRecord): CatalogItem {
     description: record.fieldValues.catalog_item_description ?? null,
     category: scalarValue(record.fieldValues.catalog_item_category) ?? 'service',
     defaultUnitPriceCents: record.fieldValues.catalog_item_default_unit_price ?? null,
+    defaultUnit:
+      (scalarValue(record.fieldValues.catalog_item_default_unit) as LineItemUnit | undefined) ??
+      null,
     taxable: record.fieldValues.catalog_item_taxable ?? true,
     active: record.fieldValues.catalog_item_active ?? true,
     partRecordId: scalarValue(record.fieldValues.catalog_item_part) ?? null,
+    cost: record.fieldValues.catalog_item_cost ?? null,
+    markup: record.fieldValues.catalog_item_markup ?? null,
   }
 }
 

--- a/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
+++ b/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
@@ -14,6 +14,7 @@
 // everything with field values in one call" hook fits better than the
 // paginated `useRecordList` used for large lists.
 
+import type { LineItemUnit } from '@auxx/lib/money/client'
 import { toRecordId } from '@auxx/lib/resources/client'
 import type { RecordId } from '@auxx/types/resource'
 import {
@@ -43,6 +44,8 @@ export interface CatalogItemPick {
   category: string | null
   taxable: boolean
   unitPrice: number | null
+  /** Copied exactly, including `null` (money plan 13 §5) — never re-derived. */
+  defaultUnit: LineItemUnit | null
 }
 
 /** One resolved line payload inside a picked group's explode (plans/dispatch/money/09-product-groups.md). */
@@ -52,6 +55,8 @@ export interface CatalogGroupPickLine {
   category: string | null
   taxable: boolean
   unitPrice: number | null
+  /** The resolved catalog item's current unit, snapshotted at explosion time (money plan 13 §5). */
+  unit: LineItemUnit | null
   qty: number
   /** EntityInstance id of the `catalog_item` (NOT the branded RecordId). */
   catalogItemId: string
@@ -77,6 +82,7 @@ interface CatalogItemFieldValues {
   catalog_item_description?: string | null
   catalog_item_category?: unknown
   catalog_item_default_unit_price?: number | null
+  catalog_item_default_unit?: LineItemUnit | LineItemUnit[] | null
   catalog_item_taxable?: boolean
   catalog_item_active?: boolean
   catalog_item_part?: unknown
@@ -148,6 +154,8 @@ function resolveGroup(
       category: firstOf<string>(item.fieldValues.catalog_item_category),
       taxable: entry.taxable ?? item.fieldValues.catalog_item_taxable !== false,
       unitPrice: item.fieldValues.catalog_item_default_unit_price ?? null,
+      // Same snapshot boundary as price — no entry-level override exists for unit.
+      unit: firstOf<LineItemUnit>(item.fieldValues.catalog_item_default_unit),
       qty: entry.qty,
       catalogItemId: entry.catalogItemId,
     })
@@ -268,6 +276,7 @@ export function CatalogPicker({
       category: firstOf<string>(row.fieldValues.catalog_item_category),
       taxable: row.fieldValues.catalog_item_taxable !== false,
       unitPrice: row.fieldValues.catalog_item_default_unit_price ?? null,
+      defaultUnit: firstOf<LineItemUnit>(row.fieldValues.catalog_item_default_unit),
     })
     onOpenChange(false)
   }

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -4,14 +4,14 @@
 
 // The document-agnostic line-items builder (money MQ1 build spec §H.1, 01-ui.md #1).
 // Lines render as plain `group/tree-row` grid rows under a matching grid header
-// (Description / Qty / Unit cost / Total): one shared
+// (Description / Qty / Rate / Total): one shared
 // `grid-template-columns` keeps the number columns aligned across the header and
 // every row. Line counts are small, so plain rows replace the virtualized
 // `DynamicView` embed this used to be. Row/cell markup lives in `line-rows.tsx`;
 // this file owns state, data fetching, and mutations.
 //
 // Keyboard: the rows sit in a container wired to `useLineNav` — spreadsheet-style
-// focus movement across name → qty → unit cost, where Enter / ArrowDown / Tab
+// focus movement across name → qty → rate, where Enter / ArrowDown / Tab
 // past the last row spawns a fresh draft (`addLine`). The name cell is free-text;
 // `/` on an empty cell opens the catalog picker.
 //
@@ -70,6 +70,7 @@ import {
   toRecordId,
   useRecordList,
   useResource,
+  useResourceFields,
 } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSeedCreatedRecord } from '~/components/resources/hooks/use-seed-created-record'
@@ -78,6 +79,7 @@ import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
 import type { CatalogGroupPick, CatalogGroupPickLine } from './catalog-picker'
 import {
+  type CategoryOption,
   type DraftLine,
   DraftLineRow,
   freshDraft,
@@ -155,6 +157,17 @@ export function LineBuilder({
   const docRecordId = documentRecordId as RecordId
   const { resource } = useResource(LINE_ITEM_SLUG)
   const entityDefinitionId = resource?.id
+  // Category options come from the field definition (not a hardcoded list) so
+  // org-added categories appear in the badge dropdown with their own colors.
+  const { fields: lineItemFields } = useResourceFields(LINE_ITEM_SLUG)
+  const categoryOptions = useMemo<CategoryOption[]>(() => {
+    const field = lineItemFields.find((f) => f.key === 'category')
+    return (field?.options?.options ?? []).map((o) => ({
+      value: o.value,
+      label: o.label,
+      color: o.color,
+    }))
+  }, [lineItemFields])
   const { getSetting } = useSettings({})
   const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
 
@@ -443,7 +456,10 @@ export function LineBuilder({
       const relKey = relKeyForDocumentType(documentType)
       const values: Record<string, unknown> = {
         line_item_qty: snapshot.qty,
+        line_item_unit: snapshot.unit,
         line_item_taxable: snapshot.taxable,
+        line_item_optional: snapshot.optional,
+        line_item_optional_selected: snapshot.optionalSelected,
         line_item_sort_order: displayIdsRef.current.length + draftIndex,
         [relKey]: documentRecordId,
       }
@@ -478,6 +494,11 @@ export function LineBuilder({
             },
             { fieldId: 'line_item_qty', value: snapshot.qty, fieldType: FieldType.NUMBER },
             {
+              fieldId: 'line_item_unit',
+              value: snapshot.unit,
+              fieldType: FieldType.SINGLE_SELECT,
+            },
+            {
               fieldId: 'line_item_unit_price',
               value: snapshot.unitPriceCents,
               fieldType: FieldType.CURRENCY,
@@ -485,6 +506,16 @@ export function LineBuilder({
             {
               fieldId: 'line_item_taxable',
               value: snapshot.taxable,
+              fieldType: FieldType.CHECKBOX,
+            },
+            {
+              fieldId: 'line_item_optional',
+              value: snapshot.optional,
+              fieldType: FieldType.CHECKBOX,
+            },
+            {
+              fieldId: 'line_item_optional_selected',
+              value: snapshot.optionalSelected,
               fieldType: FieldType.CHECKBOX,
             },
           ],
@@ -529,11 +560,32 @@ export function LineBuilder({
             fieldType: FieldType.NUMBER,
           })
         }
+        if (latest.unit !== snapshot.unit) {
+          changed.push({
+            fieldId: 'line_item_unit',
+            value: latest.unit,
+            fieldType: FieldType.SINGLE_SELECT,
+          })
+        }
         if (latest.unitPriceCents !== snapshot.unitPriceCents) {
           changed.push({
             fieldId: 'line_item_unit_price',
             value: latest.unitPriceCents,
             fieldType: FieldType.CURRENCY,
+          })
+        }
+        if (latest.optional !== snapshot.optional) {
+          changed.push({
+            fieldId: 'line_item_optional',
+            value: latest.optional,
+            fieldType: FieldType.CHECKBOX,
+          })
+        }
+        if (latest.optionalSelected !== snapshot.optionalSelected) {
+          changed.push({
+            fieldId: 'line_item_optional_selected',
+            value: latest.optionalSelected,
+            fieldType: FieldType.CHECKBOX,
           })
         }
         if (latest.catalogItemRecordId !== snapshot.catalogItemRecordId) {
@@ -592,7 +644,12 @@ export function LineBuilder({
                 line_item_category: line.category,
                 line_item_taxable: line.taxable,
                 line_item_unit_price: line.unitPrice,
+                line_item_unit: line.unit,
                 line_item_qty: line.qty,
+                // Catalog/group-exploded lines start required (money plan 18 §3);
+                // the user marks them optional afterwards.
+                line_item_optional: false,
+                line_item_optional_selected: true,
                 line_item_catalog_item: toRecordId('catalog_item', line.catalogItemId),
                 line_item_sort_order: baseOrder + index,
                 [relKey]: documentRecordId,
@@ -685,7 +742,9 @@ export function LineBuilder({
       const [first, ...rest] = pick.lines
 
       // Step 1: entry #1 fills the CURRENT line — the handlePick shape (catalog-picker.tsx)
-      // plus qty, which the single-item pick leaves untouched.
+      // plus qty, which the single-item pick leaves untouched. Resets optional/optionalSelected
+      // to required (money plan 18 §3) — same "pick overwrites the line's identity" precedent
+      // as taxable already follows.
       void saveMultipleAsync(recordId, [
         { fieldId: 'line_item_name', value: first.name, fieldType: FieldType.TEXT },
         { fieldId: 'line_item_description', value: first.description, fieldType: FieldType.TEXT },
@@ -696,7 +755,10 @@ export function LineBuilder({
         },
         { fieldId: 'line_item_taxable', value: first.taxable, fieldType: FieldType.CHECKBOX },
         { fieldId: 'line_item_unit_price', value: first.unitPrice, fieldType: FieldType.CURRENCY },
+        { fieldId: 'line_item_unit', value: first.unit, fieldType: FieldType.SINGLE_SELECT },
         { fieldId: 'line_item_qty', value: first.qty, fieldType: FieldType.NUMBER },
+        { fieldId: 'line_item_optional', value: false, fieldType: FieldType.CHECKBOX },
+        { fieldId: 'line_item_optional_selected', value: true, fieldType: FieldType.CHECKBOX },
         {
           fieldId: 'line_item_catalog_item',
           value: toRecordId('catalog_item', first.catalogItemId),
@@ -720,15 +782,19 @@ export function LineBuilder({
 
       const [first, ...rest] = pick.lines
 
-      // Step 1: entry #1's values become THIS draft's create.
+      // Step 1: entry #1's values become THIS draft's create. Catalog/group-exploded
+      // lines start required (money plan 18 §3).
       void createDraft(draftId, {
         name: first.name,
         description: first.description,
         category: first.category,
         taxable: first.taxable,
         unitPriceCents: first.unitPrice,
+        unit: first.unit,
         qty: first.qty,
         catalogItemRecordId: toRecordId('catalog_item', first.catalogItemId),
+        optional: false,
+        optionalSelected: true,
       })
 
       // Real records + every current draft occupy a sort-order slot ahead of `rest`.
@@ -768,7 +834,7 @@ export function LineBuilder({
     [entityDefinitionId, docRecordId, reorderMutate, refresh]
   )
 
-  // Spreadsheet keyboard nav across the rows container (name → qty → unit cost);
+  // Spreadsheet keyboard nav across the rows container (name → qty → rate);
   // Enter / ArrowDown / Tab past the last row calls `addLine` to spawn a draft.
   useLineNav({
     containerRef: rowsContainerRef,
@@ -844,7 +910,7 @@ export function LineBuilder({
             )}
           </div>
           <div className='px-2 text-right'>Qty</div>
-          <div className='px-2 text-right'>Unit cost</div>
+          <div className='px-2 text-right'>Rate</div>
           <div className='px-2 text-right'>Total</div>
         </div>
 
@@ -878,8 +944,10 @@ export function LineBuilder({
                     record={record}
                     rowIndex={index}
                     entityDefinitionId={entityDefinitionId}
+                    categoryOptions={categoryOptions}
                     readOnly={readOnly}
                     currencyCode={currencyCode}
+                    documentType={documentType}
                     deleteLine={deleteLine}
                     onSelectGroup={handleGroupPick}
                   />
@@ -897,7 +965,9 @@ export function LineBuilder({
                 draft={draft}
                 rowIndex={displayRecords.length + i}
                 autoFocus={draft.draftId === lastAddedDraftId}
+                categoryOptions={categoryOptions}
                 currencyCode={currencyCode}
+                documentType={documentType}
                 deleteDraft={deleteDraft}
                 createDraft={createDraft}
                 onSelectGroup={handleGroupPickDraft}
@@ -912,6 +982,7 @@ export function LineBuilder({
         readOnly={readOnly}
         currencyCode={currencyCode}
         lineRecordIds={lineRecordIds}
+        draftLines={visibleDrafts}
       />
     </div>
   )

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -15,15 +15,29 @@
 // (not the tree `GridTreeRow` — we only kept its `TreeRowButton` hover-action
 // primitive). Each navigable cell carries `data-line-row`/`data-line-col` so a
 // single container-level keydown listener can move focus spreadsheet-style
-// across name → qty → unit cost, adding a fresh draft when nav lands past the
+// across name → qty → rate, adding a fresh draft when nav lands past the
 // last row. The name cell is a free-text `<input>`: type any product name, or
 // press `/` on an empty cell (or click the trailing pick icon) to open the
 // catalog picker and drop in a pre-existing product.
 
 import { FieldType } from '@auxx/database/enums'
-import { computeLineTotal } from '@auxx/lib/money/client'
+import {
+  computeLineTotal,
+  formatLineItemUnit,
+  LINE_ITEM_UNIT_OPTIONS,
+  type LineItemUnit,
+  parseQuantityWithUnit,
+} from '@auxx/lib/money/client'
 import { AutosizeTextarea } from '@auxx/ui/components/autosize-textarea'
-import { Badge } from '@auxx/ui/components/badge'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { Checkbox } from '@auxx/ui/components/checkbox'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { SimpleTooltip, TooltipExplanation } from '@auxx/ui/components/tooltip'
 import { TreeRowButton } from '@auxx/ui/components/tree-row'
 import { cn } from '@auxx/ui/lib/utils'
@@ -32,10 +46,14 @@ import { CSS } from '@dnd-kit/utilities'
 import {
   AlignLeft,
   Check,
+  ChevronsUpDown,
   CircleCheck,
   CircleX,
+  Ellipsis,
   GripVertical,
   PackageSearch,
+  Plus,
+  Tag,
   Trash2,
   X,
 } from 'lucide-react'
@@ -48,24 +66,70 @@ import { formatCurrency, titleCase } from './shared'
 
 /**
  * Shared `grid-template-columns` for the header row and every line row (the
- * mapping-columns.ts idiom) — one template is what keeps the qty / unit cost /
- * total columns aligned. Columns: description (fills) │ qty │ unit cost │
- * total.
+ * mapping-columns.ts idiom) — one template is what keeps the qty / rate /
+ * total columns aligned. Columns: description (fills) │ qty (widened for a
+ * smart `2.375 cy` quantity+unit cell, money plan 13 §5) │ rate │ total.
  */
-export const LINE_COLS = 'minmax(10rem, 1fr) 3rem 5.5rem 6.5rem'
+export const LINE_COLS = 'minmax(10rem, 1fr) 7rem 5.5rem 6.5rem'
 
 // Module-level (stable-reference) attribute lists — `useSystemValues` memoizes
 // on the array identity, so these must never be inline literals.
 const NAME_ATTRS = ['line_item_name', 'line_item_description', 'line_item_category']
-const QTY_ATTRS = ['line_item_qty']
+const QTY_ATTRS = ['line_item_qty', 'line_item_unit']
 const PRICE_ATTRS = ['line_item_unit_price']
 const TOTAL_ATTRS = ['line_item_qty', 'line_item_unit_price']
 const TAXABLE_ATTRS = ['line_item_taxable']
+// Optional/optionalSelected (money plan 18 §3) — quotes only; `LineRow` gates the
+// fetch on `documentType === 'quote'` so non-quote surfaces never subscribe.
+const OPTIONAL_ATTRS = ['line_item_optional', 'line_item_optional_selected']
+
+/**
+ * One selectable line category — the builder receives these from the
+ * `line_item.category` field definition (via `useResourceFields` in
+ * line-builder.tsx), so org-added categories show up alongside the seeded
+ * service/material/labor set with their own labels and colors.
+ */
+export interface CategoryOption {
+  value: string
+  label: string
+  color?: string
+}
+
+// Field-option colors are tailwind color names, which the Badge color variants
+// mirror — anything unrecognized falls back to the neutral gray badge.
+const BADGE_COLOR_VARIANTS = new Set([
+  'red',
+  'orange',
+  'amber',
+  'yellow',
+  'lime',
+  'green',
+  'emerald',
+  'teal',
+  'cyan',
+  'sky',
+  'blue',
+  'indigo',
+  'violet',
+  'purple',
+  'fuchsia',
+  'magenta',
+  'pink',
+  'rose',
+  'zinc',
+  'gray',
+])
+
+function badgeVariantForColor(color: string | undefined): Variant {
+  return color && BADGE_COLOR_VARIANTS.has(color) ? (color as Variant) : 'gray'
+}
 
 /**
  * A phantom line row that exists only in local state until its first real
  * commit — no `EntityInstance` behind it yet. `unitPriceCents` mirrors the
  * CURRENCY storage convention (integer cents), matching `line_item_unit_price`.
+ * `unit`/`optional`/`optionalSelected` mirror `line_item_unit`/`line_item_optional`/
+ * `line_item_optional_selected` (money plans 13 §5, 18 §3).
  */
 export interface DraftLine {
   draftId: string
@@ -74,7 +138,12 @@ export interface DraftLine {
   category: string | null
   taxable: boolean
   qty: number
+  unit: LineItemUnit | null
   unitPriceCents: number | null
+  /** Customer-selectable upsell (quotes only) — always `false` outside quote builders. */
+  optional: boolean
+  /** Pre-check state; meaningful only when `optional` is true. */
+  optionalSelected: boolean
   catalogItemRecordId: RecordId | null
   creating: boolean
 }
@@ -87,7 +156,10 @@ export function freshDraft(draftId: string): DraftLine {
     category: null,
     taxable: true,
     qty: 1,
+    unit: 'each',
     unitPriceCents: null,
+    optional: false,
+    optionalSelected: true,
     catalogItemRecordId: null,
     creating: false,
   }
@@ -107,29 +179,36 @@ export function relKeyForDocumentType(documentType: 'quote' | 'work_order' | 'in
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * One line's grid row — a `group/tree-row` so the hover-revealed
- * `TreeRowButton`s (grip, pick, description, taxable, delete) still fade in on
- * row hover. Owns the shared column template + the `data-line-row`/`col` tags
- * that {@link useLineNav} focus-hops between. Name/qty/price are the three
- * navigable cells (cols 0–2); total rides outside the nav order.
+ * One line's grid row — a `group/tree-row` so hover/focus-within-revealed
+ * chrome (grip, `⋯` row menu) fades in on row hover. Owns the shared column
+ * template + the `data-line-row`/`col` tags that {@link useLineNav} focus-hops
+ * between. Name/qty/price are the three navigable cells (cols 0–2); total
+ * rides outside the nav order. `menu` is the row-level `⋯` actions dropdown
+ * ({@link LineRowMenu}), absolutely pinned to the name/qty column seam — the
+ * col-0 wrapper is `relative` so the pin anchors to the column, not the row.
  */
 function LineGridRow({
   rowIndex,
   grip,
   name,
+  menu,
   qty,
   price,
   total,
+  optional = false,
 }: {
   rowIndex: number
   grip: ReactNode
   name: ReactNode
+  menu?: ReactNode
   qty: ReactNode
   price: ReactNode
   total: ReactNode
+  /** Muted/indented treatment for a deselectable quote line (money plan 18 §3). */
+  optional?: boolean
 }) {
   return (
-    <div className='group/tree-row relative text-sm'>
+    <div className={cn('group/tree-row relative text-sm', optional && 'opacity-75')}>
       {/* Drag grip — lives in the left gutter, OUTSIDE the framed grid. */}
       {grip}
 
@@ -137,11 +216,19 @@ function LineGridRow({
       <div className='absolute inset-0 rounded-md transition-colors group-hover/tree-row:bg-background' />
 
       <div
-        className='relative grid min-h-9 items-stretch px-1 text-muted-foreground'
+        className={cn(
+          'relative grid min-h-9 items-stretch px-1 text-muted-foreground',
+          optional && 'pl-3'
+        )}
         style={{ gridTemplateColumns: LINE_COLS }}>
-        {/* Col 0 — name input (the grip sits in the gutter, not this column). */}
-        <div data-line-row={rowIndex} data-line-col={0} className='flex min-w-0 items-center'>
+        {/* Col 0 — name input (the grip sits in the gutter, not this column).
+            `relative` anchors the `⋯` row menu to the column's right edge. */}
+        <div
+          data-line-row={rowIndex}
+          data-line-col={0}
+          className='relative flex min-w-0 items-center'>
           {name}
+          {menu}
         </div>
 
         <div data-line-row={rowIndex} data-line-col={1} className='flex items-center'>
@@ -183,30 +270,135 @@ function GripSlot({
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Compact category badge — a single-letter pill (S/M) colored per category
- * (service → blue, material → orange), with the full category label revealed
- * on hover. Unknown/org-added categories fall back to a neutral badge showing
- * the title-cased value. Renders nothing when there is no category.
+ * Compact category badge — a single-letter pill (S/M/L…) whose letter and
+ * color derive from the field definition's option list, with the full label in
+ * a tooltip. Editable rows make the badge a dropdown trigger for switching
+ * category (or clearing it); an uncategorized editable line shows a
+ * hover-revealed ghost `+` badge in the same slot so category can be set
+ * without hunting through menus. Values no longer in the option list (an org
+ * removed the option) fall back to a neutral badge with the title-cased value.
  */
-function CategoryBadge({ category }: { category: string | null }) {
-  if (!category) return null
+function CategoryBadge({
+  category,
+  options,
+  readOnly,
+  onCommitCategory,
+}: {
+  category: string | null
+  options: CategoryOption[]
+  readOnly: boolean
+  onCommitCategory: (value: string | null) => void
+}) {
+  const option = options.find((o) => o.value === category) ?? null
+  const label = option?.label ?? (category ? titleCase(category) : null)
+  const letter = label ? label.charAt(0).toUpperCase() : null
 
-  const known: Record<string, { letter: string; variant: 'blue' | 'orange' }> = {
-    service: { letter: 'S', variant: 'blue' },
-    material: { letter: 'M', variant: 'orange' },
+  if (readOnly) {
+    if (!category) return null
+    return (
+      <SimpleTooltip content={label ?? undefined}>
+        <Badge
+          size='xs'
+          variant={badgeVariantForColor(option?.color)}
+          className='shrink-0 font-medium leading-tight'>
+          {letter}
+        </Badge>
+      </SimpleTooltip>
+    )
   }
-  const match = known[category]
-  const label = titleCase(category)
 
   return (
-    <SimpleTooltip content={label}>
-      <Badge
-        size='xs'
-        variant={match?.variant ?? 'gray'}
-        className='shrink-0 font-medium leading-tight'>
-        {match?.letter ?? label}
+    <DropdownMenu>
+      <SimpleTooltip content={label ?? 'Set category'} allowInteraction>
+        <DropdownMenuTrigger asChild>
+          <Badge
+            asChild
+            size='xs'
+            variant={category ? badgeVariantForColor(option?.color) : 'gray'}
+            className={cn(
+              'shrink-0 cursor-pointer font-medium leading-tight',
+              // Ghost `+` for an uncategorized line — only materializes on row
+              // hover/focus (and stays while its own menu is open).
+              !category &&
+                'opacity-0 transition-opacity data-[state=open]:opacity-100 group-focus-within/tree-row:opacity-100 group-hover/tree-row:opacity-100'
+            )}>
+            {/* stopPropagation: the surrounding name-cell wrapper click focuses
+                the name input — a badge click must only open this menu. */}
+            <button type='button' tabIndex={-1} onClick={(e) => e.stopPropagation()}>
+              {category ? letter : <Plus className='size-3' />}
+            </button>
+          </Badge>
+        </DropdownMenuTrigger>
+      </SimpleTooltip>
+      <DropdownMenuContent align='start'>
+        {options.map((o) => (
+          <DropdownMenuItem key={o.value} onSelect={() => onCommitCategory(o.value)}>
+            {o.label}
+            {o.value === category && <Check className='ml-auto size-3.5' />}
+          </DropdownMenuItem>
+        ))}
+        {category && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => onCommitCategory(null)}>No category</DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/** Rest-state marker for a tax-exempt line — a struck-through `T`, tooltip-explained. */
+function TaxExemptBadge({ taxable }: { taxable: boolean }) {
+  if (taxable) return null
+  return (
+    <SimpleTooltip content='Tax exempt'>
+      <Badge size='xs' variant='gray' className='shrink-0 font-medium leading-tight line-through'>
+        T
       </Badge>
     </SimpleTooltip>
+  )
+}
+
+/**
+ * "Optional" state tag for a deselectable quote line (money plan 18 §3) — an `O`
+ * badge (full word in the tooltip, matching the single-letter category badges)
+ * plus an inline pre-check checkbox bound to `optionalSelected`; the checkbox's
+ * tooltip carries the "Recommended" meaning a text label used to. `readOnly`
+ * disables the checkbox instead of hiding it, so a read-only builder still
+ * shows the customer's current selection.
+ */
+function OptionalLineTag({
+  optionalSelected,
+  readOnly,
+  onToggleSelected,
+}: {
+  optionalSelected: boolean
+  readOnly: boolean
+  onToggleSelected: (next: boolean) => void
+}) {
+  return (
+    <span className='flex shrink-0 items-center gap-1.5'>
+      <SimpleTooltip content='Optional — the customer chooses whether to include this line'>
+        <Badge size='xs' variant='sky' className='shrink-0 font-medium leading-tight'>
+          O
+        </Badge>
+      </SimpleTooltip>
+      <SimpleTooltip
+        content={
+          optionalSelected ? 'Recommended — pre-checked for the customer' : 'Not pre-checked'
+        }>
+        {/* Stops row-level click-through (e.g. a future row-click drill) from firing. */}
+        <span className='flex items-center' onClick={(e) => e.stopPropagation()}>
+          <Checkbox
+            checked={optionalSelected}
+            disabled={readOnly}
+            onCheckedChange={(checked) => onToggleSelected(checked === true)}
+            className='size-3.5'
+          />
+        </span>
+      </SimpleTooltip>
+    </span>
   )
 }
 
@@ -215,37 +407,53 @@ function CategoryBadge({ category }: { category: string | null }) {
  * item. Type any product name (an ad-hoc line, no catalog rel); press `/` on an
  * empty cell (or click the trailing pick icon) to open the catalog picker and
  * drop in a pre-existing product, which overwrites name/price/category/taxable
- * and keeps the catalog relationship. The category badge sits inline; a trailing
- * description-edit affordance swaps the input for an autosize textarea in place —
- * the line never grows a permanent second row. Purely presentational: values +
- * commit callbacks are props, so both the store-bound real cell and the
- * local-state draft cell render the exact same markup.
+ * and keeps the catalog relationship. State reads as badges at rest (category —
+ * clickable to change it — tax-exempt, optional); a trailing description-edit
+ * affordance swaps the input for an autosize textarea in place — the line never
+ * grows a permanent second row. While focused, only the two editing actions
+ * (pick, description) render inline; the line-level actions live in the row's
+ * `⋯` menu ({@link LineRowMenu}). Purely presentational: values + commit
+ * callbacks are props, so both the store-bound real cell and the local-state
+ * draft cell render the exact same markup.
  */
 function LineNameCellView({
   name,
   description,
   category,
+  categoryOptions,
+  taxable,
   readOnly,
   currencyCode,
   autoFocus = false,
+  showOptionalControls,
+  optional,
+  optionalSelected,
+  onToggleOptionalSelected,
   onPickCatalogItem,
   onSelectGroup,
   onFreeText,
   onCommitDescription,
-  actions,
+  onCommitCategory,
 }: {
   name: string
   description: string | null
   category: string | null
+  categoryOptions: CategoryOption[]
+  taxable: boolean
   readOnly: boolean
   currencyCode: string
   /** Focus the name input on mount — set for a freshly added draft row. */
   autoFocus?: boolean
+  /** Quotes only (money plan 18 §3) — work-order/invoice builders pass `false`. */
+  showOptionalControls: boolean
+  optional: boolean
+  optionalSelected: boolean
+  onToggleOptionalSelected: (next: boolean) => void
   onPickCatalogItem: (pick: CatalogItemPick) => void
   onSelectGroup: (pick: CatalogGroupPick) => void
   onFreeText: (text: string) => void
   onCommitDescription: (value: string | null) => void
-  actions?: ReactNode
+  onCommitCategory: (value: string | null) => void
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
   const [pickerOpen, setPickerOpen] = useState(false)
@@ -277,9 +485,11 @@ function LineNameCellView({
   // Description edit mode — replaces the input with an autosize textarea in the
   // same slot (single line at rest, grows while typing) + confirm/cancel. The
   // grid nav hook leaves textareas fully native, so Enter confirms here.
+  // `pr-5` clears the `⋯` row menu pinned at the column seam (focus-within
+  // keeps it visible while typing), so it never overlaps the cancel button.
   if (editing) {
     return (
-      <div className='flex min-w-0 flex-1 items-center gap-1 py-1'>
+      <div className='flex min-w-0 flex-1 items-center gap-1 py-1 pr-5'>
         <AutosizeTextarea
           value={descriptionDraft ?? ''}
           onChange={(e) => setDescriptionDraft(e.target.value)}
@@ -317,7 +527,20 @@ function LineNameCellView({
           className={cn('min-w-0 truncate px-1 text-sm', !name && 'text-muted-foreground italic')}>
           {name || 'Untitled line'}
         </span>
-        <CategoryBadge category={category} />
+        <CategoryBadge
+          category={category}
+          options={categoryOptions}
+          readOnly
+          onCommitCategory={onCommitCategory}
+        />
+        <TaxExemptBadge taxable={taxable} />
+        {showOptionalControls && optional && (
+          <OptionalLineTag
+            optionalSelected={optionalSelected}
+            readOnly
+            onToggleSelected={onToggleOptionalSelected}
+          />
+        )}
         {description && <TooltipExplanation text={description} />}
       </div>
     )
@@ -326,7 +549,11 @@ function LineNameCellView({
   const value = nameDraft ?? name
 
   return (
-    <div className='flex min-w-0 flex-1 items-center gap-1.5 py-1'>
+    // `pr-5` while focused clears the `⋯` row menu pinned at the column seam
+    // (focus-within keeps it visible), so it never overlaps the trailing
+    // description button. At rest the content flows edge to edge — the menu
+    // only materializes on hover, over what is normally dead space.
+    <div className={cn('flex min-w-0 flex-1 items-center gap-1.5 py-1', focused && 'pr-5')}>
       {/* CatalogPicker stays mounted across the text↔input swap so its popover
           anchor never detaches; only its inner trigger changes shape. */}
       <CatalogPicker
@@ -380,13 +607,33 @@ function LineNameCellView({
               </span>
             </button>
           )}
-          {/* Category badge sits next to the label; hidden while editing the name. */}
-          {!focused && <CategoryBadge category={category} />}
+          {/* State badges (category, tax-exempt, Optional tag) sit next to the
+              label; hidden while editing. */}
+          {!focused && (
+            <>
+              <CategoryBadge
+                category={category}
+                options={categoryOptions}
+                readOnly={false}
+                onCommitCategory={onCommitCategory}
+              />
+              <TaxExemptBadge taxable={taxable} />
+              {showOptionalControls && optional && (
+                <OptionalLineTag
+                  optionalSelected={optionalSelected}
+                  readOnly={false}
+                  onToggleSelected={onToggleOptionalSelected}
+                />
+              )}
+            </>
+          )}
         </div>
       </CatalogPicker>
 
-      {/* Actions only while focused. `onMouseDown` preventDefault keeps the input
-          from blur-collapsing before the click handler runs. */}
+      {/* Editing actions only while focused — line-level actions (optional,
+          taxable, delete) live in the row's `⋯` menu instead. `onMouseDown`
+          preventDefault keeps the input from blur-collapsing before the click
+          handler runs. */}
       {focused && (
         <>
           <TreeRowButton
@@ -404,7 +651,6 @@ function LineNameCellView({
             onClick={() => setDescriptionDraft(description ?? '')}>
             <AlignLeft />
           </TreeRowButton>
-          {actions}
         </>
       )}
     </div>
@@ -414,16 +660,26 @@ function LineNameCellView({
 /** Store-bound wrapper around {@link LineNameCellView} for real (persisted) line rows. */
 function LineNameCell({
   recordId,
+  categoryOptions,
+  taxable,
   readOnly,
   currencyCode,
+  showOptionalControls,
+  optional,
+  optionalSelected,
+  onToggleOptionalSelected,
   onSelectGroup,
-  actions,
 }: {
   recordId: RecordId
+  categoryOptions: CategoryOption[]
+  taxable: boolean
   readOnly: boolean
   currencyCode: string
+  showOptionalControls: boolean
+  optional: boolean
+  optionalSelected: boolean
+  onToggleOptionalSelected: (next: boolean) => void
   onSelectGroup: (pick: CatalogGroupPick) => void
-  actions?: ReactNode
 }) {
   const { values } = useSystemValues(recordId, NAME_ATTRS, { autoFetch: true })
   const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue()
@@ -434,13 +690,18 @@ function LineNameCell({
 
   const handlePick = (pick: CatalogItemPick) => {
     // COPY the catalog defaults onto the line (snapshot — catalog price changes
-    // never rewrite documents) + keep the provenance relationship.
+    // never rewrite documents) + keep the provenance relationship. A catalog/group
+    // pick always resets the line to required (money plan 18 §3) — the same
+    // "this pick overwrites the line's identity" precedent taxable already follows.
     void saveMultipleAsync(recordId, [
       { fieldId: 'line_item_name', value: pick.name, fieldType: FieldType.TEXT },
       { fieldId: 'line_item_description', value: pick.description, fieldType: FieldType.TEXT },
       { fieldId: 'line_item_category', value: pick.category, fieldType: FieldType.SINGLE_SELECT },
       { fieldId: 'line_item_taxable', value: pick.taxable, fieldType: FieldType.CHECKBOX },
       { fieldId: 'line_item_unit_price', value: pick.unitPrice, fieldType: FieldType.CURRENCY },
+      { fieldId: 'line_item_unit', value: pick.defaultUnit, fieldType: FieldType.SINGLE_SELECT },
+      { fieldId: 'line_item_optional', value: false, fieldType: FieldType.CHECKBOX },
+      { fieldId: 'line_item_optional_selected', value: true, fieldType: FieldType.CHECKBOX },
       {
         fieldId: 'line_item_catalog_item',
         value: pick.recordId,
@@ -454,15 +715,23 @@ function LineNameCell({
       name={name}
       description={description}
       category={category}
+      categoryOptions={categoryOptions}
+      taxable={taxable}
       readOnly={readOnly}
       currencyCode={currencyCode}
+      showOptionalControls={showOptionalControls}
+      optional={optional}
+      optionalSelected={optionalSelected}
+      onToggleOptionalSelected={onToggleOptionalSelected}
       onPickCatalogItem={handlePick}
       onSelectGroup={onSelectGroup}
       onFreeText={(text) => saveFieldValue(recordId, 'line_item_name', text, FieldType.TEXT)}
       onCommitDescription={(value) =>
         saveFieldValue(recordId, 'line_item_description', value, FieldType.TEXT)
       }
-      actions={actions}
+      onCommitCategory={(value) =>
+        saveFieldValue(recordId, 'line_item_category', value, FieldType.SINGLE_SELECT)
+      }
     />
   )
 }
@@ -470,29 +739,23 @@ function LineNameCell({
 /**
  * Chromeless inline number editor view — quiet at rest, editable on click (the
  * cell-treatment lock in 01-ui #1). Commits on blur/Enter, no-ops if the value
- * didn't actually change.
+ * didn't actually change. Handles the rate (`line_item_unit_price`) column only —
+ * quantity moved to the smart {@link QuantityCellView} (money plan 13 §5).
  */
-function InlineNumberCellView({
+function PriceCellView({
   value,
-  attr,
   readOnly,
   currencyCode,
   onCommit,
 }: {
   value: number | null
-  attr: 'line_item_qty' | 'line_item_unit_price'
   readOnly: boolean
   currencyCode: string
   onCommit: (next: number | null) => void
 }) {
   const [draft, setDraft] = useState<string | null>(null)
 
-  const display =
-    attr === 'line_item_unit_price'
-      ? formatCurrency(value ?? null, currencyCode)
-      : value !== null && value !== undefined
-        ? String(value)
-        : ''
+  const display = formatCurrency(value ?? null, currencyCode)
 
   const commit = () => {
     if (draft === null) return
@@ -500,11 +763,8 @@ function InlineNumberCellView({
     const parsed = trimmed === '' ? null : Number(trimmed)
     setDraft(null)
     if (parsed !== null && Number.isNaN(parsed)) return
-    // Qty is non-nullable — an emptied qty keeps its previous value.
-    if (attr === 'line_item_qty' && parsed === null) return
-    // Prices are typed in dollars but stored as integer cents (CURRENCY convention).
-    const next =
-      parsed !== null && attr === 'line_item_unit_price' ? Math.round(parsed * 100) : parsed
+    // Typed in dollars but stored as integer cents (CURRENCY convention).
+    const next = parsed !== null ? Math.round(parsed * 100) : parsed
     if (next === (value ?? null)) return
     onCommit(next)
   }
@@ -517,13 +777,7 @@ function InlineNumberCellView({
     <input
       value={draft ?? display}
       onChange={(e) => setDraft(e.target.value)}
-      onFocus={() =>
-        setDraft(
-          value !== null && value !== undefined
-            ? String(attr === 'line_item_unit_price' ? value / 100 : value)
-            : ''
-        )
-      }
+      onFocus={() => setDraft(value !== null && value !== undefined ? String(value / 100) : '')}
       onBlur={commit}
       onKeyDown={(e) => {
         if (e.key === 'Escape') setDraft(null)
@@ -534,33 +788,175 @@ function InlineNumberCellView({
   )
 }
 
-/** Store-bound wrapper around {@link InlineNumberCellView} for real line rows. */
-function InlineNumberCell({
+/** Store-bound wrapper around {@link PriceCellView} for real line rows. */
+function PriceCell({
   recordId,
-  attr,
-  fieldType,
   readOnly,
   currencyCode,
 }: {
   recordId: RecordId
-  attr: 'line_item_qty' | 'line_item_unit_price'
-  fieldType: FieldType
   readOnly: boolean
   currencyCode: string
 }) {
-  const attrs = attr === 'line_item_qty' ? QTY_ATTRS : PRICE_ATTRS
-  const { values } = useSystemValues(recordId, attrs, { autoFetch: true })
+  const { values } = useSystemValues(recordId, PRICE_ATTRS, { autoFetch: true })
   const { saveFieldValue } = useSaveFieldValue()
 
-  const raw = (values[attr] as number | null | undefined) ?? null
+  const raw = (values.line_item_unit_price as number | null | undefined) ?? null
 
   return (
-    <InlineNumberCellView
+    <PriceCellView
       value={raw}
-      attr={attr}
       readOnly={readOnly}
       currencyCode={currencyCode}
-      onCommit={(next) => saveFieldValue(recordId, attr, next, fieldType)}
+      onCommit={(next) =>
+        saveFieldValue(recordId, 'line_item_unit_price', next, FieldType.CURRENCY)
+      }
+    />
+  )
+}
+
+/** Formats a quantity without trailing zeros, up to 3 decimal places (`2.375`, `5`, `12`). */
+function formatQtyNumber(qty: number): string {
+  return String(Number(qty.toFixed(3)))
+}
+
+/** `12 hr`, `5 sf`, or bare `5` when the line has no unit — money plan 13 §5's compact form. */
+function formatQtyDisplay(qty: number, unit: LineItemUnit | null): string {
+  const suffix = formatLineItemUnit(unit, 'compact')
+  return suffix ? `${formatQtyNumber(qty)} ${suffix}` : formatQtyNumber(qty)
+}
+
+/**
+ * Smart quantity cell (money plan 13 §5) — rests as compact text (`12 hr`, `5 sf`, bare `5`
+ * when unitless). On focus it becomes a raw text input holding the exact compact string;
+ * the input is NEVER rewritten while focused (no caret jumps) — only `parseQuantityWithUnit`
+ * on blur/Enter/Tab can change what's committed. A recognized parse saves quantity + unit
+ * TOGETHER (`onCommit`) so realtime observers never see a half-updated pair; an unrecognized
+ * parse restores the last committed display and flashes a brief destructive tint, persisting
+ * nothing. A hover/click-revealed dropdown trigger (mouse/touch only — not in the Tab order,
+ * the ONLY way to clear a unit) offers "No unit" + every fixed unit; picking one preserves
+ * quantity. Unit-only changes never touch `computeDocumentTotals` — that reads qty/rate only.
+ */
+function QuantityCellView({
+  quantity,
+  unit,
+  readOnly,
+  onCommit,
+}: {
+  quantity: number
+  unit: LineItemUnit | null
+  readOnly: boolean
+  onCommit: (next: { quantity: number; unit: LineItemUnit | null }) => void
+}) {
+  const [draft, setDraft] = useState<string | null>(null)
+  const [invalid, setInvalid] = useState(false)
+  const invalidTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const display = formatQtyDisplay(quantity, unit)
+
+  const flashInvalid = () => {
+    setInvalid(true)
+    if (invalidTimeoutRef.current) clearTimeout(invalidTimeoutRef.current)
+    invalidTimeoutRef.current = setTimeout(() => setInvalid(false), 1200)
+  }
+
+  const commit = () => {
+    if (draft === null) return
+    const raw = draft
+    setDraft(null)
+    const parsed = parseQuantityWithUnit(raw, { quantity, unit })
+    if (!parsed.ok) {
+      flashInvalid()
+      return
+    }
+    const nextQuantity = parsed.quantity ?? quantity
+    const nextUnit = parsed.unit
+    if (nextQuantity === quantity && nextUnit === unit) return
+    onCommit({ quantity: nextQuantity, unit: nextUnit })
+  }
+
+  const pickUnitOnly = (nextUnit: LineItemUnit | null) => {
+    if (nextUnit === unit) return
+    onCommit({ quantity, unit: nextUnit })
+  }
+
+  if (readOnly) {
+    return <div className='w-full px-2 text-right text-sm tabular-nums'>{display}</div>
+  }
+
+  return (
+    <div className='group/qty relative flex h-full w-full items-center'>
+      <input
+        value={draft ?? display}
+        onChange={(e) => setDraft(e.target.value)}
+        onFocus={() => setDraft(display)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') setDraft(null)
+        }}
+        inputMode='text'
+        className={cn(
+          'h-full w-full rounded-sm border-none bg-transparent py-1 pr-5 pl-2 text-right text-sm tabular-nums outline-none transition-colors',
+          invalid && 'bg-destructive/10 ring-1 ring-destructive/60'
+        )}
+      />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type='button'
+            tabIndex={-1}
+            onMouseDown={(e) => e.preventDefault()}
+            className='-translate-y-1/2 absolute top-1/2 right-0.5 rounded-sm p-0.5 text-muted-foreground opacity-0 outline-none hover:bg-primary-100 focus:opacity-100 group-hover/qty:opacity-100'>
+            <ChevronsUpDown className='size-3' />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='end' className='max-h-64 overflow-y-auto'>
+          <DropdownMenuItem onSelect={() => pickUnitOnly(null)}>No unit</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          {LINE_ITEM_UNIT_OPTIONS.map((option) => (
+            <DropdownMenuItem key={option.value} onSelect={() => pickUnitOnly(option.value)}>
+              {option.label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}
+
+/** Store-bound wrapper around {@link QuantityCellView} for real line rows. */
+function QuantityCell({ recordId, readOnly }: { recordId: RecordId; readOnly: boolean }) {
+  const { values } = useSystemValues(recordId, QTY_ATTRS, { autoFetch: true })
+  const { saveMultipleAsync } = useSaveFieldValue()
+
+  const qty = (values.line_item_qty as number | null | undefined) ?? 1
+  const unit = (values.line_item_unit as LineItemUnit | null | undefined) ?? null
+
+  return (
+    <QuantityCellView
+      quantity={qty}
+      unit={unit}
+      readOnly={readOnly}
+      onCommit={(next) => {
+        // Only the fields that actually changed — a combined save so realtime
+        // observers never see qty/unit half-updated relative to each other.
+        const changed: Array<{ fieldId: string; value: unknown; fieldType: FieldType }> = []
+        if (next.quantity !== qty) {
+          changed.push({
+            fieldId: 'line_item_qty',
+            value: next.quantity,
+            fieldType: FieldType.NUMBER,
+          })
+        }
+        if (next.unit !== unit) {
+          changed.push({
+            fieldId: 'line_item_unit',
+            value: next.unit,
+            fieldType: FieldType.SINGLE_SELECT,
+          })
+        }
+        if (changed.length > 0) void saveMultipleAsync(recordId, changed)
+      }}
     />
   )
 }
@@ -594,65 +990,58 @@ function LineTotalCell({ recordId, currencyCode }: { recordId: RecordId; currenc
 }
 
 /**
- * Inline actions rendered beside the description button in the primary cell:
- * taxable toggle (persistent when exempt, so the exemption reads at rest), then delete.
+ * Row-level `⋯` actions menu, pinned to the name/qty column seam — the one
+ * spot with reliably dead space in a narrow drawer (name text is left-aligned,
+ * qty is right-aligned). Revealed on row hover or focus-within (and while its
+ * own menu is open), mouse/touch only (`tabIndex={-1}`, mirroring the qty
+ * unit-dropdown precedent). Holds the line-level actions: optional toggle
+ * (quotes only), taxable toggle, delete. The drag grip stays drag-only.
  */
-function LineActionsCellView({
+function LineRowMenu({
   taxable,
+  optional,
+  showOptionalToggle,
   rowId,
   onToggleTaxable,
+  onToggleOptional,
   deleteLine,
 }: {
   taxable: boolean
+  optional: boolean
+  showOptionalToggle: boolean
   rowId: string
   onToggleTaxable: (next: boolean) => void
+  onToggleOptional: (next: boolean) => void
   deleteLine: (lineId: string) => void
 }) {
   return (
-    <div className='flex items-center gap-0.5'>
-      <TreeRowButton
-        persistent={!taxable}
-        tooltipText={taxable ? 'Taxable — click to exempt' : 'Tax exempt — click to tax'}
-        className={cn(!taxable && 'text-muted-foreground/50')}
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => onToggleTaxable(!taxable)}>
-        {taxable ? <CircleCheck /> : <CircleX />}
-      </TreeRowButton>
-      <TreeRowButton
-        variant='destructive'
-        tooltipText='Delete line'
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => deleteLine(rowId)}>
-        <Trash2 />
-      </TreeRowButton>
-    </div>
-  )
-}
-
-/** Store-bound wrapper around {@link LineActionsCellView} for real line rows. */
-function LineActionsCell({
-  recordId,
-  rowId,
-  deleteLine,
-}: {
-  recordId: RecordId
-  rowId: string
-  deleteLine: (lineId: string) => void
-}) {
-  const { values } = useSystemValues(recordId, TAXABLE_ATTRS, { autoFetch: true })
-  const { saveFieldValue } = useSaveFieldValue()
-
-  const taxable = (values.line_item_taxable as boolean | undefined) !== false
-
-  return (
-    <LineActionsCellView
-      taxable={taxable}
-      rowId={rowId}
-      onToggleTaxable={(next) =>
-        saveFieldValue(recordId, 'line_item_taxable', next, FieldType.CHECKBOX)
-      }
-      deleteLine={deleteLine}
-    />
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type='button'
+          tabIndex={-1}
+          className='-right-2.5 -translate-y-1/2 absolute top-1/2 z-10 flex h-5 w-5 items-center justify-center rounded-md border bg-background text-muted-foreground opacity-0 shadow-sm transition-opacity data-[state=open]:opacity-100 group-focus-within/tree-row:opacity-100 group-hover/tree-row:opacity-100'>
+          <Ellipsis className='size-3.5' />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='end'>
+        {showOptionalToggle && (
+          <DropdownMenuItem onSelect={() => onToggleOptional(!optional)}>
+            <Tag />
+            {optional ? 'Make required' : 'Mark as optional'}
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem onSelect={() => onToggleTaxable(!taxable)}>
+          {taxable ? <CircleX /> : <CircleCheck />}
+          {taxable ? 'Mark tax exempt' : 'Mark taxable'}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant='destructive' onSelect={() => deleteLine(rowId)}>
+          <Trash2 />
+          Delete line
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 
@@ -665,24 +1054,47 @@ export function LineRow({
   record,
   rowIndex,
   entityDefinitionId,
+  categoryOptions,
   readOnly,
   currencyCode,
+  documentType,
   deleteLine,
   onSelectGroup,
 }: {
   record: RecordMeta
   rowIndex: number
   entityDefinitionId: string
+  categoryOptions: CategoryOption[]
   readOnly: boolean
   currencyCode: string
+  documentType: 'quote' | 'work_order' | 'invoice'
   deleteLine: (lineId: string) => void
   onSelectGroup: (recordId: RecordId, pick: CatalogGroupPick) => void
 }) {
   const recordId = toRecordId(entityDefinitionId, record.id)
+  const isQuote = documentType === 'quote'
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: record.id,
     disabled: readOnly,
   })
+
+  // Optional/optionalSelected (money plan 18 §3) — read once here so the row's
+  // muted/indented treatment and both cells that expose it (name badge/checkbox,
+  // actions toggle) stay in agreement. Gated on `isQuote`: work-order/invoice
+  // builders never fetch or show any of it.
+  const { values: optionalValues } = useSystemValues(recordId, OPTIONAL_ATTRS, {
+    autoFetch: isQuote,
+    enabled: isQuote,
+  })
+  const { saveFieldValue } = useSaveFieldValue()
+  const optional = isQuote && (optionalValues.line_item_optional as boolean | undefined) === true
+  const optionalSelected =
+    !isQuote || (optionalValues.line_item_optional_selected as boolean | undefined) !== false
+
+  // Taxable is read here (not in a cell) because two surfaces show it: the
+  // name cell's rest badge and the `⋯` row menu's toggle.
+  const { values: taxableValues } = useSystemValues(recordId, TAXABLE_ATTRS, { autoFetch: true })
+  const taxable = (taxableValues.line_item_taxable as boolean | undefined) !== false
 
   return (
     <div
@@ -691,38 +1103,43 @@ export function LineRow({
       className={cn(isDragging && 'relative z-10 opacity-80')}>
       <LineGridRow
         rowIndex={rowIndex}
+        optional={optional}
         grip={readOnly ? null : <GripSlot attributes={attributes} listeners={listeners} />}
         name={
           <LineNameCell
             recordId={recordId}
+            categoryOptions={categoryOptions}
+            taxable={taxable}
             readOnly={readOnly}
             currencyCode={currencyCode}
-            onSelectGroup={(pick) => onSelectGroup(recordId, pick)}
-            actions={
-              readOnly ? undefined : (
-                <LineActionsCell recordId={recordId} rowId={record.id} deleteLine={deleteLine} />
-              )
+            showOptionalControls={isQuote}
+            optional={optional}
+            optionalSelected={optionalSelected}
+            onToggleOptionalSelected={(next) =>
+              saveFieldValue(recordId, 'line_item_optional_selected', next, FieldType.CHECKBOX)
             }
+            onSelectGroup={(pick) => onSelectGroup(recordId, pick)}
           />
         }
-        qty={
-          <InlineNumberCell
-            recordId={recordId}
-            attr='line_item_qty'
-            fieldType={FieldType.NUMBER}
-            readOnly={readOnly}
-            currencyCode={currencyCode}
-          />
+        menu={
+          readOnly ? null : (
+            <LineRowMenu
+              taxable={taxable}
+              optional={optional}
+              showOptionalToggle={isQuote}
+              rowId={record.id}
+              onToggleTaxable={(next) =>
+                saveFieldValue(recordId, 'line_item_taxable', next, FieldType.CHECKBOX)
+              }
+              onToggleOptional={(next) =>
+                saveFieldValue(recordId, 'line_item_optional', next, FieldType.CHECKBOX)
+              }
+              deleteLine={deleteLine}
+            />
+          )
         }
-        price={
-          <InlineNumberCell
-            recordId={recordId}
-            attr='line_item_unit_price'
-            fieldType={FieldType.CURRENCY}
-            readOnly={readOnly}
-            currencyCode={currencyCode}
-          />
-        }
+        qty={<QuantityCell recordId={recordId} readOnly={readOnly} />}
+        price={<PriceCell recordId={recordId} readOnly={readOnly} currencyCode={currencyCode} />}
         total={<LineTotalCell recordId={recordId} currencyCode={currencyCode} />}
       />
     </div>
@@ -740,7 +1157,9 @@ export function DraftLineRow({
   draft,
   rowIndex,
   autoFocus,
+  categoryOptions,
   currencyCode,
+  documentType,
   deleteDraft,
   createDraft,
   onSelectGroup,
@@ -749,23 +1168,36 @@ export function DraftLineRow({
   rowIndex: number
   /** Focus the name input on mount — set for the just-added draft. */
   autoFocus: boolean
+  categoryOptions: CategoryOption[]
   currencyCode: string
+  documentType: 'quote' | 'work_order' | 'invoice'
   deleteDraft: (draftId: string) => void
   createDraft: (draftId: string, overrides?: Partial<DraftLine>) => Promise<void>
   onSelectGroup: (draftId: string, pick: CatalogGroupPick) => void
 }) {
+  const isQuote = documentType === 'quote'
+
   return (
     <LineGridRow
       rowIndex={rowIndex}
+      optional={isQuote && draft.optional}
       grip={null}
       name={
         <LineNameCellView
           name={draft.name}
           description={draft.description}
           category={draft.category}
+          categoryOptions={categoryOptions}
+          taxable={draft.taxable}
           readOnly={false}
           currencyCode={currencyCode}
           autoFocus={autoFocus}
+          showOptionalControls={isQuote}
+          optional={draft.optional}
+          optionalSelected={draft.optionalSelected}
+          onToggleOptionalSelected={(next) =>
+            void createDraft(draft.draftId, { optionalSelected: next })
+          }
           onPickCatalogItem={(pick) =>
             void createDraft(draft.draftId, {
               name: pick.name,
@@ -773,38 +1205,42 @@ export function DraftLineRow({
               category: pick.category,
               taxable: pick.taxable,
               unitPriceCents: pick.unitPrice,
+              unit: pick.defaultUnit,
               catalogItemRecordId: pick.recordId,
+              optional: false,
+              optionalSelected: true,
             })
           }
           onSelectGroup={(pick) => onSelectGroup(draft.draftId, pick)}
           onFreeText={(text) => void createDraft(draft.draftId, { name: text })}
           onCommitDescription={(value) => void createDraft(draft.draftId, { description: value })}
-          actions={
-            <LineActionsCellView
-              taxable={draft.taxable}
-              rowId={draft.draftId}
-              onToggleTaxable={(next) => void createDraft(draft.draftId, { taxable: next })}
-              deleteLine={deleteDraft}
-            />
-          }
+          onCommitCategory={(value) => void createDraft(draft.draftId, { category: value })}
+        />
+      }
+      menu={
+        <LineRowMenu
+          taxable={draft.taxable}
+          optional={draft.optional}
+          showOptionalToggle={isQuote}
+          rowId={draft.draftId}
+          onToggleTaxable={(next) => void createDraft(draft.draftId, { taxable: next })}
+          onToggleOptional={(next) => void createDraft(draft.draftId, { optional: next })}
+          deleteLine={deleteDraft}
         />
       }
       qty={
-        <InlineNumberCellView
-          value={draft.qty}
-          attr='line_item_qty'
+        <QuantityCellView
+          quantity={draft.qty}
+          unit={draft.unit}
           readOnly={false}
-          currencyCode={currencyCode}
-          onCommit={(next) => {
-            if (next === null) return
-            void createDraft(draft.draftId, { qty: next })
-          }}
+          onCommit={(next) =>
+            void createDraft(draft.draftId, { qty: next.quantity, unit: next.unit })
+          }
         />
       }
       price={
-        <InlineNumberCellView
+        <PriceCellView
           value={draft.unitPriceCents}
-          attr='line_item_unit_price'
           readOnly={false}
           currencyCode={currencyCode}
           onCommit={(next) => void createDraft(draft.draftId, { unitPriceCents: next })}

--- a/apps/web/src/components/money/ui/line-builder/totals-footer.tsx
+++ b/apps/web/src/components/money/ui/line-builder/totals-footer.tsx
@@ -38,6 +38,7 @@ import {
 } from '~/components/resources/store/field-value-store'
 import { useResourceStore } from '~/components/resources/store/resource-store'
 import { useSettings } from '~/hooks/use-settings'
+import type { DraftLine } from './line-rows'
 import { formatCurrency } from './shared'
 
 /** Org tax rate preset (`documents.taxRates` setting, §G.1). */
@@ -71,36 +72,44 @@ const INVOICE_BILLING_ATTRS = [
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Subscribe to every line's qty/unitPrice/taxable and shape them as
- * `LineForTotals[]`. Queues its own store fetches — virtualized rows outside
- * the viewport never mount their cells, so the footer can't rely on cell
- * subscriptions alone.
+ * Subscribe to every REAL line's qty/unitPrice/taxable/optional/optionalSelected and shape
+ * them as `LineForTotals[]`, then append local phantom draft lines' equivalent values
+ * (`draftLines` — pure client state, no store fetch needed) so the optimistic footer counts
+ * in-progress rows too. Queues its own store fetches — virtualized rows outside the viewport
+ * never mount their cells, so the footer can't rely on cell subscriptions alone.
  */
-function useLinesForTotals(lineRecordIds: RecordId[]): LineForTotals[] {
+function useLinesForTotals(lineRecordIds: RecordId[], draftLines: DraftLine[]): LineForTotals[] {
   const systemAttributeMap = useResourceStore((s) => s.systemAttributeMap)
   const qtyRef = systemAttributeMap.line_item_qty
   const priceRef = systemAttributeMap.line_item_unit_price
   const taxableRef = systemAttributeMap.line_item_taxable
+  const optionalRef = systemAttributeMap.line_item_optional
+  const optionalSelectedRef = systemAttributeMap.line_item_optional_selected
 
   useEffect(() => {
-    if (!qtyRef || !priceRef || !taxableRef || lineRecordIds.length === 0) return
+    if (!qtyRef || !priceRef || !taxableRef || !optionalRef || !optionalSelectedRef) return
+    if (lineRecordIds.length === 0) return
     fieldValueFetchQueue.queueFetchBatch(
       lineRecordIds.flatMap((recordId) => [
         { recordId, fieldRef: qtyRef },
         { recordId, fieldRef: priceRef },
         { recordId, fieldRef: taxableRef },
+        { recordId, fieldRef: optionalRef },
+        { recordId, fieldRef: optionalSelectedRef },
       ])
     )
-  }, [lineRecordIds, qtyRef, priceRef, taxableRef])
+  }, [lineRecordIds, qtyRef, priceRef, taxableRef, optionalRef, optionalSelectedRef])
 
   const keys = useMemo(() => {
-    if (!qtyRef || !priceRef || !taxableRef) return []
+    if (!qtyRef || !priceRef || !taxableRef || !optionalRef || !optionalSelectedRef) return []
     return lineRecordIds.map((recordId) => ({
       qty: buildFieldValueKey(recordId, qtyRef),
       price: buildFieldValueKey(recordId, priceRef),
       taxable: buildFieldValueKey(recordId, taxableRef),
+      optional: buildFieldValueKey(recordId, optionalRef),
+      optionalSelected: buildFieldValueKey(recordId, optionalSelectedRef),
     }))
-  }, [lineRecordIds, qtyRef, priceRef, taxableRef])
+  }, [lineRecordIds, qtyRef, priceRef, taxableRef, optionalRef, optionalSelectedRef])
   const keysKey = keys.map((k) => k.qty).join(',')
 
   const storeValues = useFieldValueStore(
@@ -113,6 +122,8 @@ function useLinesForTotals(lineRecordIds: RecordId[]): LineForTotals[] {
             result[k.qty] = state.values[k.qty]
             result[k.price] = state.values[k.price]
             result[k.taxable] = state.values[k.taxable]
+            result[k.optional] = state.values[k.optional]
+            result[k.optionalSelected] = state.values[k.optionalSelected]
           }
           return result
         },
@@ -121,7 +132,7 @@ function useLinesForTotals(lineRecordIds: RecordId[]): LineForTotals[] {
     )
   )
 
-  return useMemo(
+  const realLines = useMemo(
     () =>
       keys.map((k) => {
         // formatToRawValue returns arrays for array-stored values — collapse to
@@ -135,10 +146,26 @@ function useLinesForTotals(lineRecordIds: RecordId[]): LineForTotals[] {
         const unitPrice =
           (scalar(storeValues[k.price], FieldType.CURRENCY) as number | null | undefined) ?? null
         const taxable = scalar(storeValues[k.taxable], FieldType.CHECKBOX) !== false
-        return { lineTotal: computeLineTotal(qty, unitPrice), taxable }
+        const optional = scalar(storeValues[k.optional], FieldType.CHECKBOX) === true
+        const optionalSelected =
+          scalar(storeValues[k.optionalSelected], FieldType.CHECKBOX) !== false
+        return { lineTotal: computeLineTotal(qty, unitPrice), taxable, optional, optionalSelected }
       }),
     [keys, storeValues]
   )
+
+  const draftLinesForTotals = useMemo(
+    () =>
+      draftLines.map((draft) => ({
+        lineTotal: computeLineTotal(draft.qty, draft.unitPriceCents),
+        taxable: draft.taxable,
+        optional: draft.optional,
+        optionalSelected: draft.optionalSelected,
+      })),
+    [draftLines]
+  )
+
+  return useMemo(() => [...realLines, ...draftLinesForTotals], [realLines, draftLinesForTotals])
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -151,12 +178,15 @@ export function TotalsFooter({
   readOnly,
   currencyCode,
   lineRecordIds,
+  draftLines,
 }: {
   documentRecordId: RecordId
   documentType: 'quote' | 'work_order' | 'invoice'
   readOnly: boolean
   currencyCode: string
   lineRecordIds: RecordId[]
+  /** Local phantom draft lines not yet persisted — counted optimistically (money plan 18 §3). */
+  draftLines: DraftLine[]
 }) {
   const isQuote = documentType === 'quote'
   const isInvoice = documentType === 'invoice'
@@ -164,7 +194,7 @@ export function TotalsFooter({
   // systemAttribute prefix (money MI1 build spec §J.2) — work_order (M2 job view) has none.
   const hasBilling = isQuote || isInvoice
   const prefix = isInvoice ? 'invoice' : 'quote'
-  const lines = useLinesForTotals(lineRecordIds)
+  const lines = useLinesForTotals(lineRecordIds, draftLines)
   const { saveMultipleAsync } = useSaveFieldValue()
   const { getSetting } = useSettings({})
   const [discountDraft, setDiscountDraft] = useState<string | null>(null)

--- a/apps/web/src/components/money/ui/line-builder/use-line-nav.ts
+++ b/apps/web/src/components/money/ui/line-builder/use-line-nav.ts
@@ -6,7 +6,7 @@ type UseLineNavOptions = {
   containerRef: React.RefObject<HTMLDivElement | null>
   /** Total navigable rows (real records + phantom drafts). */
   rowCount: number
-  /** Navigable columns per row: 0 = name, 1 = qty, 2 = unit cost. */
+  /** Navigable columns per row: 0 = name, 1 = qty, 2 = rate. */
   colCount: number
   /** Push a fresh phantom draft row. Called when nav lands past the last row. */
   onAddRow: () => void

--- a/apps/web/src/components/money/ui/public-document/public-document-line-items.tsx
+++ b/apps/web/src/components/money/ui/public-document/public-document-line-items.tsx
@@ -1,8 +1,11 @@
 // apps/web/src/components/money/ui/public-document/public-document-line-items.tsx
 
 // Shared line-items table for public documents (quote acceptance, invoice pay) — translucent
-// dark styling, horizontally scrollable on mobile inside its own overflow container.
+// dark styling, horizontally scrollable on mobile inside its own overflow container. Stays
+// server/read-only for INVOICES; the quote page uses its own client selection wrapper
+// (`public-quote/quote-lines-with-selection.tsx`, money plan 18 §4) instead of this component.
 
+import { formatLineItemUnit, type LineItemUnit } from '@auxx/lib/money/client'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
 
 /** One rendered line — decoupled from `@auxx/lib/money`'s payload types on purpose so this
@@ -10,6 +13,8 @@ import { formatCurrency } from '~/components/money/ui/line-builder/shared'
 export interface PublicDocumentLine {
   name: string
   qty: number
+  /** Money plan 13 §1/§6 — `null`/absent renders exactly as an unitless line does today. */
+  unit?: LineItemUnit | null
   unitPrice: number | null
   lineTotal: number | null
 }
@@ -17,6 +22,12 @@ export interface PublicDocumentLine {
 interface PublicDocumentLineItemsProps {
   lines: PublicDocumentLine[]
   currency: string
+}
+
+/** Formats a quantity without trailing zeros, up to 3 decimal places (`2.375`, `5`, `12`) —
+ * mirrors the line-builder's compact quantity cell (money plan 13 §7 decimal rule). */
+function formatQty(qty: number): string {
+  return String(Number(qty.toFixed(3)))
 }
 
 export function PublicDocumentLineItems({ lines, currency }: PublicDocumentLineItemsProps) {
@@ -32,18 +43,25 @@ export function PublicDocumentLineItems({ lines, currency }: PublicDocumentLineI
           </tr>
         </thead>
         <tbody>
-          {lines.map((line, i) => (
-            <tr key={i} className='border-white/10 border-b text-white/80 last:border-0'>
-              <td className='py-2 pr-2'>{line.name}</td>
-              <td className='py-2 text-right tabular-nums'>{line.qty}</td>
-              <td className='py-2 text-right tabular-nums'>
-                {formatCurrency(line.unitPrice, currency)}
-              </td>
-              <td className='py-2 text-right tabular-nums'>
-                {formatCurrency(line.lineTotal, currency)}
-              </td>
-            </tr>
-          ))}
+          {lines.map((line, i) => {
+            const unitSuffix = formatLineItemUnit(line.unit, 'document')
+            return (
+              <tr key={i} className='border-white/10 border-b text-white/80 last:border-0'>
+                <td className='py-2 pr-2'>{line.name}</td>
+                <td className='py-2 text-right tabular-nums'>
+                  {unitSuffix ? `${formatQty(line.qty)} ${unitSuffix}` : formatQty(line.qty)}
+                </td>
+                <td className='py-2 text-right tabular-nums'>
+                  {unitSuffix && line.unitPrice !== null
+                    ? `${formatCurrency(line.unitPrice, currency)}/${unitSuffix}`
+                    : formatCurrency(line.unitPrice, currency)}
+                </td>
+                <td className='py-2 text-right tabular-nums'>
+                  {formatCurrency(line.lineTotal, currency)}
+                </td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/apps/web/src/components/money/ui/public-quote/public-quote-actions.tsx
+++ b/apps/web/src/components/money/ui/public-quote/public-quote-actions.tsx
@@ -23,6 +23,7 @@ export function QuoteAcceptForm({
 
   return (
     <form
+      id='accept-form'
       method='post'
       action={`/quote/${token}/accept`}
       onSubmit={() => setIsPending(true)}

--- a/apps/web/src/components/money/ui/public-quote/public-quote-document.tsx
+++ b/apps/web/src/components/money/ui/public-quote/public-quote-document.tsx
@@ -17,9 +17,7 @@ import {
   PublicDocumentContact,
   PublicDocumentHeader,
 } from '~/components/money/ui/public-document/public-document-header'
-import { PublicDocumentLineItems } from '~/components/money/ui/public-document/public-document-line-items'
 import { PublicDocumentShell } from '~/components/money/ui/public-document/public-document-shell'
-import { PublicDocumentTotals } from '~/components/money/ui/public-document/public-document-totals'
 import { ProcessingPoller } from '~/components/money/ui/public-invoice/processing-poller'
 import {
   QuoteAcceptForm,
@@ -27,6 +25,7 @@ import {
   QuoteDepositForm,
   QuoteRequestUpdateForm,
 } from '~/components/money/ui/public-quote/public-quote-actions'
+import { QuoteLinesWithSelection } from '~/components/money/ui/public-quote/quote-lines-with-selection'
 
 interface PublicQuoteDocumentProps {
   token: string
@@ -47,12 +46,10 @@ export function PublicQuoteDocument({ token, payload, state, message }: PublicQu
     terms,
     contact,
     lines,
-    subtotal,
-    discountAmount,
+    discountType,
+    discountValue,
     taxName,
     taxRate,
-    taxTotal,
-    total,
     currency,
     business,
     branding,
@@ -97,16 +94,14 @@ export function PublicQuoteDocument({ token, payload, state, message }: PublicQu
 
         <PublicDocumentContact label='Prepared for' name={contact.name} email={contact.email} />
 
-        <PublicDocumentLineItems lines={lines} currency={currency} />
-
-        <PublicDocumentTotals
+        <QuoteLinesWithSelection
+          lines={lines}
           currency={currency}
-          subtotal={subtotal}
-          discountAmount={discountAmount}
+          discountType={discountType}
+          discountValue={discountValue}
           taxName={taxName}
           taxRate={taxRate}
-          taxTotal={taxTotal}
-          total={total}
+          readOnly={!showAcceptDecline}
         />
 
         {terms ? (

--- a/apps/web/src/components/money/ui/public-quote/quote-lines-with-selection.tsx
+++ b/apps/web/src/components/money/ui/public-quote/quote-lines-with-selection.tsx
@@ -1,0 +1,177 @@
+// apps/web/src/components/money/ui/public-quote/quote-lines-with-selection.tsx
+'use client'
+
+// Client wrapper for the public quote page's line-items table + totals (money plan 18 §4).
+// Required lines render exactly like the shared read-only `PublicDocumentLineItems`; optional
+// lines get a real, unstyled `<input type="checkbox">` — NOT the shadcn `Checkbox` (that one
+// wraps a Radix `button`, which can't carry `form`/`name`/`value` for native submission, see
+// `@auxx/ui/components/checkbox`) — bound via `form="accept-form"` to the Accept form so a
+// no-JS submit still carries selections (progressive enhancement, amendment 2). Toggling only
+// updates local React state and recomputes the displayed totals with `computeDocumentTotals`
+// from `@auxx/lib/money/client` — the same isomorphic function the line-builder footer uses —
+// never a network call; nothing persists until the Accept POST (decision 3).
+
+import {
+  computeDocumentTotals,
+  type DiscountType,
+  formatLineItemUnit,
+  type LineItemUnit,
+} from '@auxx/lib/money/client'
+import { cn } from '@auxx/ui/lib/utils'
+import { useMemo, useState } from 'react'
+import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+import { PublicDocumentTotals } from '~/components/money/ui/public-document/public-document-totals'
+
+/** One quote line as the public page needs it — decoupled from `@auxx/lib/money`'s payload
+ * types on purpose so this client component never statically imports a server-only module. */
+export interface QuoteSelectionLine {
+  lineInstanceId: string
+  name: string
+  qty: number
+  unit?: LineItemUnit | null
+  unitPrice: number | null
+  lineTotal: number | null
+  taxable: boolean
+  optional: boolean
+  /** Seller's pre-accept default (checked = "included unless removed", money plan 18 decision 2). */
+  optionalSelected: boolean
+}
+
+interface QuoteLinesWithSelectionProps {
+  lines: QuoteSelectionLine[]
+  currency: string
+  discountType: DiscountType | null
+  discountValue: number | null
+  taxName: string | null
+  taxRate: number | null
+  /** Disables the checkboxes once the quote is no longer awaiting a decision (approved,
+   * declined, expired, or still being revised) — selections are locked at accept (decision 3),
+   * so there's nothing left to toggle and no accept form in the DOM to submit into anyway. */
+  readOnly?: boolean
+}
+
+/** Formats a quantity without trailing zeros, up to 3 decimal places (`2.375`, `5`, `12`) —
+ * mirrors the line-builder's compact quantity cell (money plan 13 §7 decimal rule). */
+function formatQty(qty: number): string {
+  return String(Number(qty.toFixed(3)))
+}
+
+export function QuoteLinesWithSelection({
+  lines,
+  currency,
+  discountType,
+  discountValue,
+  taxName,
+  taxRate,
+  readOnly = false,
+}: QuoteLinesWithSelectionProps) {
+  // Page-local selection state, seeded from each optional line's seller default. Keyed by line
+  // instance id — untouched (required) lines never enter this map.
+  const [selected, setSelected] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(
+      lines
+        .filter((line) => line.optional)
+        .map((line) => [line.lineInstanceId, line.optionalSelected])
+    )
+  )
+
+  const isChecked = (line: QuoteSelectionLine): boolean =>
+    line.optional ? (selected[line.lineInstanceId] ?? line.optionalSelected) : true
+
+  const toggle = (lineInstanceId: string) => {
+    setSelected((prev) => ({ ...prev, [lineInstanceId]: !prev[lineInstanceId] }))
+  }
+
+  const totals = useMemo(() => {
+    const linesForTotals = lines.map((line) => ({
+      lineTotal: line.lineTotal,
+      taxable: line.taxable,
+      optional: line.optional,
+      optionalSelected: line.optional
+        ? (selected[line.lineInstanceId] ?? line.optionalSelected)
+        : undefined,
+    }))
+    return computeDocumentTotals(linesForTotals, { discountType, discountValue, taxRate })
+  }, [lines, selected, discountType, discountValue, taxRate])
+
+  return (
+    <>
+      <div className='mt-6 overflow-x-auto'>
+        <table className='w-full text-sm'>
+          <thead>
+            <tr className='border-white/10 border-b text-left text-white/50'>
+              <th className='py-2 font-medium'>Description</th>
+              <th className='py-2 text-right font-medium'>Qty</th>
+              <th className='py-2 text-right font-medium'>Unit price</th>
+              <th className='py-2 text-right font-medium'>Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lines.map((line) => {
+              const unitSuffix = formatLineItemUnit(line.unit, 'document')
+              const checked = isChecked(line)
+              return (
+                <tr
+                  key={line.lineInstanceId}
+                  className={cn(
+                    'border-white/10 border-b last:border-0',
+                    line.optional ? 'text-white/60' : 'text-white/80'
+                  )}>
+                  <td className='py-2 pr-2'>
+                    <div className='flex items-start gap-2'>
+                      {line.optional ? (
+                        <input
+                          type='checkbox'
+                          name='selectedLineIds'
+                          value={line.lineInstanceId}
+                          form='accept-form'
+                          checked={checked}
+                          disabled={readOnly}
+                          onChange={() => toggle(line.lineInstanceId)}
+                          aria-label={`Include ${line.name}`}
+                          className='mt-0.5 h-4 w-4 shrink-0 rounded-sm border border-white/30 bg-transparent accent-white disabled:opacity-50'
+                        />
+                      ) : null}
+                      <div>
+                        <span>{line.name}</span>
+                        {line.optional ? (
+                          <span className='ml-2 inline-flex items-center gap-1 align-middle text-[10px] text-white/40 uppercase tracking-wide'>
+                            <span className='rounded-full border border-white/20 px-1.5 py-0.5'>
+                              Optional
+                            </span>
+                            {line.optionalSelected ? '(recommended)' : '(add-on)'}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                  </td>
+                  <td className='py-2 text-right tabular-nums'>
+                    {unitSuffix ? `${formatQty(line.qty)} ${unitSuffix}` : formatQty(line.qty)}
+                  </td>
+                  <td className='py-2 text-right tabular-nums'>
+                    {unitSuffix && line.unitPrice !== null
+                      ? `${formatCurrency(line.unitPrice, currency)}/${unitSuffix}`
+                      : formatCurrency(line.unitPrice, currency)}
+                  </td>
+                  <td className='py-2 text-right tabular-nums'>
+                    {formatCurrency(line.lineTotal, currency)}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <PublicDocumentTotals
+        currency={currency}
+        subtotal={totals.subtotal}
+        discountAmount={totals.discountAmount}
+        taxName={taxName}
+        taxRate={taxRate}
+        taxTotal={totals.taxTotal}
+        total={totals.total}
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/money/ui/settings/product-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/product-editor.tsx
@@ -2,7 +2,9 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
+import { formatLineItemUnit, type LineItemUnit } from '@auxx/lib/money/client'
 import type { RecordId } from '@auxx/lib/resources/client'
+import { Badge } from '@auxx/ui/components/badge'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useRef, useState } from 'react'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
@@ -15,6 +17,31 @@ import { api } from '~/trpc/react'
 import { type CatalogItem, useCatalogItems } from '../../hooks/use-catalog-items'
 import { useSeedCatalogRecord } from '../../hooks/use-seed-catalog-record'
 import type { CatalogDraftHandle } from './catalog-draft-types'
+import { formatMoney } from './format-money'
+
+/**
+ * Category default unit (money plan 13 §4): applied on a category change ONLY while the
+ * current unit is `null` — never overwrites a non-null unit choice.
+ */
+const CATEGORY_DEFAULT_UNIT: Record<string, LineItemUnit | null> = {
+  labor: 'hour',
+  material: 'each',
+  service: null,
+}
+
+function categoryDefaultUnit(category: string): LineItemUnit | null {
+  return CATEGORY_DEFAULT_UNIT[category] ?? null
+}
+
+/** `Default rate` row label — shows unit context once one is selected (money plan 13 §4). */
+function defaultRateTitle(unit: LineItemUnit | null): string {
+  return unit ? `Default rate / ${formatLineItemUnit(unit, 'compact')}` : 'Default rate'
+}
+
+/** Effective margin on a hand-set, part-linked, non-auto price (money plan 17 §4), as a percent. */
+function effectiveMarginPct(priceCents: number, costCents: number): number {
+  return Math.round(((priceCents - costCents) / priceCents) * 100)
+}
 
 interface ProductEditorProps {
   selectedId: string | null
@@ -80,8 +107,9 @@ function ProductEditorForm({ item }: { item: CatalogItem }) {
   const { fields } = useResourceFields('catalog-items')
   const categoryField = fields.find((f) => f.key === 'category')
   const partField = fields.find((f) => f.key === 'part')
+  const defaultUnitField = fields.find((f) => f.key === 'defaultUnit')
 
-  const { saveFieldValue } = useSaveFieldValue({})
+  const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue({})
 
   const [name, setName] = useState(item.name)
   const [description, setDescription] = useState(item.description ?? '')
@@ -92,6 +120,38 @@ function ProductEditorForm({ item }: { item: CatalogItem }) {
   const commitDescription = useDebouncedCallback((value: string) => {
     saveFieldValue(item.recordId, 'catalog_item_description', value || null, FieldType.TEXT)
   }, 500)
+
+  const commitCategory = useCallback(
+    (category: string) => {
+      // Category default only applies while the unit is unset — never overwrite a chosen unit.
+      const nextUnit = item.defaultUnit === null ? categoryDefaultUnit(category) : item.defaultUnit
+      if (nextUnit !== item.defaultUnit) {
+        void saveMultipleAsync(item.recordId, [
+          { fieldId: 'catalog_item_category', value: category, fieldType: FieldType.SINGLE_SELECT },
+          {
+            fieldId: 'catalog_item_default_unit',
+            value: nextUnit,
+            fieldType: FieldType.SINGLE_SELECT,
+          },
+        ])
+      } else {
+        saveFieldValue(item.recordId, 'catalog_item_category', category, FieldType.SINGLE_SELECT)
+      }
+    },
+    [item.recordId, item.defaultUnit, saveFieldValue, saveMultipleAsync]
+  )
+
+  const hasPart = !!item.partRecordId
+  const showAutoRate = hasPart && item.markup !== null
+  const showMargin =
+    hasPart &&
+    item.markup === null &&
+    item.cost !== null &&
+    item.defaultUnitPriceCents !== null &&
+    item.defaultUnitPriceCents > 0
+  const marginPct = showMargin
+    ? effectiveMarginPct(item.defaultUnitPriceCents as number, item.cost as number)
+    : null
 
   return (
     <div className='p-3'>
@@ -132,27 +192,106 @@ function ProductEditorForm({ item }: { item: CatalogItem }) {
             fieldOptions={categoryField?.options}
             value={item.category}
             triggerProps={{ className: 'w-full ps-0 pe-1' }}
-            onChange={(value) =>
-              saveFieldValue(item.recordId, 'catalog_item_category', value, FieldType.SINGLE_SELECT)
-            }
+            onChange={(value) => commitCategory(value as string)}
             placeholder='Select category'
           />
         </FieldPanelRow>
 
-        <FieldPanelRow title='Default Unit Price' type={BaseType.CURRENCY} showIcon>
+        {item.category === 'material' && partField && (
+          <FieldPanelRow title='Part' type={BaseType.RELATION} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.RELATIONSHIP}
+              triggerProps={{ className: 'w-full ps-0 pe-1', showClear: true }}
+              fieldOptions={{
+                relationship: partField.relationship ?? partField.options?.relationship,
+              }}
+              value={item.partRecordId ? [item.partRecordId] : []}
+              onChange={(value) =>
+                saveFieldValue(item.recordId, 'catalog_item_part', value, FieldType.RELATIONSHIP)
+              }
+              placeholder='Link a part'
+            />
+          </FieldPanelRow>
+        )}
+
+        {hasPart && (
+          <FieldPanelRow
+            title='Cost'
+            type={BaseType.CURRENCY}
+            showIcon
+            description="Synced from the linked part's cost.">
+            <div className='px-2 py-1.5 text-sm tabular-nums'>{formatMoney(item.cost, 'USD')}</div>
+          </FieldPanelRow>
+        )}
+
+        {hasPart && (
+          <FieldPanelRow title='Markup %' type={BaseType.NUMBER} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.NUMBER}
+              value={item.markup}
+              onChange={(value) =>
+                saveFieldValue(
+                  item.recordId,
+                  'catalog_item_markup',
+                  (value as number | undefined) ?? null,
+                  FieldType.NUMBER
+                )
+              }
+              placeholder='Empty pauses auto-pricing'
+            />
+          </FieldPanelRow>
+        )}
+
+        <FieldPanelRow title='Default unit' type={BaseType.ENUM} showIcon>
           <FieldInputAdapter
-            fieldType={FieldType.CURRENCY}
-            value={item.defaultUnitPriceCents}
+            fieldType={FieldType.SINGLE_SELECT}
+            fieldOptions={defaultUnitField?.options}
+            value={item.defaultUnit ? [item.defaultUnit] : []}
+            triggerProps={{ className: 'w-full ps-0 pe-1', showClear: true }}
             onChange={(value) =>
               saveFieldValue(
                 item.recordId,
-                'catalog_item_default_unit_price',
-                value,
-                FieldType.CURRENCY
+                'catalog_item_default_unit',
+                (value as string[])[0] ?? null,
+                FieldType.SINGLE_SELECT
               )
             }
-            placeholder='0.00'
+            placeholder='No unit'
           />
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title={defaultRateTitle(item.defaultUnit)}
+          type={BaseType.CURRENCY}
+          showIcon
+          description={
+            showAutoRate ? 'Auto-priced from cost + markup — edit to override.' : undefined
+          }>
+          <div className='flex flex-1 items-center gap-2'>
+            <FieldInputAdapter
+              fieldType={FieldType.CURRENCY}
+              value={item.defaultUnitPriceCents}
+              onChange={(value) =>
+                saveFieldValue(
+                  item.recordId,
+                  'catalog_item_default_unit_price',
+                  value,
+                  FieldType.CURRENCY
+                )
+              }
+              placeholder='0.00'
+            />
+            {showAutoRate && (
+              <Badge variant='blue' size='sm' className='shrink-0'>
+                Auto
+              </Badge>
+            )}
+            {showMargin && (
+              <span className='shrink-0 whitespace-nowrap text-xs text-muted-foreground'>
+                Margin {marginPct}%
+              </span>
+            )}
+          </div>
         </FieldPanelRow>
 
         <FieldPanelRow title='Taxable' type={BaseType.BOOLEAN} showIcon>
@@ -165,23 +304,6 @@ function ProductEditorForm({ item }: { item: CatalogItem }) {
             }
           />
         </FieldPanelRow>
-
-        {item.category === 'material' && partField && (
-          <FieldPanelRow title='Part' type={BaseType.RELATION} showIcon>
-            <FieldInputAdapter
-              fieldType={FieldType.RELATIONSHIP}
-              triggerProps={{ className: 'w-full ps-0 pe-1' }}
-              fieldOptions={{
-                relationship: partField.relationship ?? partField.options?.relationship,
-              }}
-              value={item.partRecordId ? [item.partRecordId] : []}
-              onChange={(value) =>
-                saveFieldValue(item.recordId, 'catalog_item_part', value, FieldType.RELATIONSHIP)
-              }
-              placeholder='Link a part'
-            />
-          </FieldPanelRow>
-        )}
       </FieldPanel>
     </div>
   )
@@ -198,9 +320,14 @@ interface ProductDraftValues {
   description: string | null
   category: string
   defaultUnitPriceCents: number | null
+  defaultUnit: LineItemUnit | null
   taxable: boolean
   active: boolean
   partRecordId: RecordId | null
+  /** Markup rate as a percentage of cost — `null` pauses auto-pricing (money plan 17). Only
+   *  meaningful once a part is linked; `cost` itself has no client-writable counterpart here —
+   *  the pricing engine only syncs it against a real, persisted record. */
+  markup: number | null
 }
 
 function freshProductDraftValues(): ProductDraftValues {
@@ -212,9 +339,11 @@ function freshProductDraftValues(): ProductDraftValues {
     description: null,
     category: 'service',
     defaultUnitPriceCents: null,
+    defaultUnit: null,
     taxable: true,
     active: true,
     partRecordId: null,
+    markup: null,
   }
 }
 
@@ -230,9 +359,11 @@ const PRODUCT_DRAFT_FIELDS: {
     fieldId: 'catalog_item_default_unit_price',
     fieldType: FieldType.CURRENCY,
   },
+  defaultUnit: { fieldId: 'catalog_item_default_unit', fieldType: FieldType.SINGLE_SELECT },
   taxable: { fieldId: 'catalog_item_taxable', fieldType: FieldType.CHECKBOX },
   active: { fieldId: 'catalog_item_active', fieldType: FieldType.CHECKBOX },
   partRecordId: { fieldId: 'catalog_item_part', fieldType: FieldType.RELATIONSHIP },
+  markup: { fieldId: 'catalog_item_markup', fieldType: FieldType.NUMBER },
 }
 const PRODUCT_DRAFT_KEYS = Object.keys(PRODUCT_DRAFT_FIELDS) as (keyof ProductDraftValues)[]
 
@@ -264,6 +395,7 @@ function ProductDraftEditorForm({
   const { fields } = useResourceFields('catalog-items')
   const categoryField = fields.find((f) => f.key === 'category')
   const partField = fields.find((f) => f.key === 'part')
+  const defaultUnitField = fields.find((f) => f.key === 'defaultUnit')
 
   const { saveMultipleAsync } = useSaveFieldValue({})
   const { seedCatalogRecord } = useSeedCatalogRecord()
@@ -296,7 +428,11 @@ function ProductDraftEditorForm({
       if (snapshot.defaultUnitPriceCents !== null) {
         createValues.catalog_item_default_unit_price = snapshot.defaultUnitPriceCents
       }
+      if (snapshot.defaultUnit !== null) {
+        createValues.catalog_item_default_unit = snapshot.defaultUnit
+      }
       if (snapshot.partRecordId) createValues.catalog_item_part = snapshot.partRecordId
+      if (snapshot.markup !== null) createValues.catalog_item_markup = snapshot.markup
 
       try {
         const result = await createRecord.mutateAsync({ entityDefinitionId, values: createValues })
@@ -324,9 +460,11 @@ function ProductDraftEditorForm({
             catalog_item_description: snapshot.description,
             catalog_item_category: snapshot.category,
             catalog_item_default_unit_price: snapshot.defaultUnitPriceCents,
+            catalog_item_default_unit: snapshot.defaultUnit,
             catalog_item_taxable: snapshot.taxable,
             catalog_item_active: snapshot.active,
             catalog_item_part: snapshot.partRecordId,
+            catalog_item_markup: snapshot.markup,
             ...result.values,
           },
         })
@@ -394,6 +532,9 @@ function ProductDraftEditorForm({
     [createNow, entityDefinitionId, onDraftNameChange, saveMultipleAsync]
   )
 
+  const draftHasPart = !!values.partRecordId
+  const draftShowAutoRate = draftHasPart && values.markup !== null
+
   const commitName = useDebouncedCallback((value: string) => {
     commitDraft({ name: value })
   }, 500)
@@ -442,26 +583,16 @@ function ProductDraftEditorForm({
             fieldOptions={categoryField?.options}
             value={values.category}
             triggerProps={{ className: 'w-full ps-0 pe-1' }}
-            onChange={(value) => commitDraft({ category: value as string })}
+            onChange={(value) => {
+              const category = value as string
+              // Category default only applies while the unit is unset (money plan 13 §4).
+              const nextUnit =
+                values.defaultUnit === null ? categoryDefaultUnit(category) : values.defaultUnit
+              commitDraft(
+                nextUnit !== values.defaultUnit ? { category, defaultUnit: nextUnit } : { category }
+              )
+            }}
             placeholder='Select category'
-          />
-        </FieldPanelRow>
-
-        <FieldPanelRow title='Default Unit Price' type={BaseType.CURRENCY} showIcon>
-          <FieldInputAdapter
-            fieldType={FieldType.CURRENCY}
-            value={values.defaultUnitPriceCents}
-            onChange={(value) => commitDraft({ defaultUnitPriceCents: value as number | null })}
-            placeholder='0.00'
-          />
-        </FieldPanelRow>
-
-        <FieldPanelRow title='Taxable' type={BaseType.BOOLEAN} showIcon>
-          <FieldInputAdapter
-            fieldType={FieldType.CHECKBOX}
-            fieldOptions={{ variant: 'switch' }}
-            value={values.taxable}
-            onChange={(value) => commitDraft({ taxable: value as boolean })}
           />
         </FieldPanelRow>
 
@@ -469,7 +600,7 @@ function ProductDraftEditorForm({
           <FieldPanelRow title='Part' type={BaseType.RELATION} showIcon>
             <FieldInputAdapter
               fieldType={FieldType.RELATIONSHIP}
-              triggerProps={{ className: 'w-full ps-0 pe-1' }}
+              triggerProps={{ className: 'w-full ps-0 pe-1', showClear: true }}
               fieldOptions={{
                 relationship: partField.relationship ?? partField.options?.relationship,
               }}
@@ -482,6 +613,72 @@ function ProductDraftEditorForm({
             />
           </FieldPanelRow>
         )}
+
+        {draftHasPart && (
+          <FieldPanelRow
+            title='Cost'
+            type={BaseType.CURRENCY}
+            showIcon
+            description="Synced from the linked part's cost once the item is created.">
+            <div className='px-2 py-1.5 text-sm tabular-nums'>{formatMoney(null, 'USD')}</div>
+          </FieldPanelRow>
+        )}
+
+        {draftHasPart && (
+          <FieldPanelRow title='Markup %' type={BaseType.NUMBER} showIcon>
+            <FieldInputAdapter
+              fieldType={FieldType.NUMBER}
+              value={values.markup}
+              onChange={(value) => commitDraft({ markup: (value as number | undefined) ?? null })}
+              placeholder='Empty pauses auto-pricing'
+            />
+          </FieldPanelRow>
+        )}
+
+        <FieldPanelRow title='Default unit' type={BaseType.ENUM} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.SINGLE_SELECT}
+            fieldOptions={defaultUnitField?.options}
+            value={values.defaultUnit ? [values.defaultUnit] : []}
+            triggerProps={{ className: 'w-full ps-0 pe-1', showClear: true }}
+            onChange={(value) => {
+              const ids = value as string[]
+              commitDraft({ defaultUnit: (ids[0] as LineItemUnit | undefined) ?? null })
+            }}
+            placeholder='No unit'
+          />
+        </FieldPanelRow>
+
+        <FieldPanelRow
+          title={defaultRateTitle(values.defaultUnit)}
+          type={BaseType.CURRENCY}
+          showIcon
+          description={
+            draftShowAutoRate ? 'Auto-priced from cost + markup — edit to override.' : undefined
+          }>
+          <div className='flex flex-1 items-center gap-2'>
+            <FieldInputAdapter
+              fieldType={FieldType.CURRENCY}
+              value={values.defaultUnitPriceCents}
+              onChange={(value) => commitDraft({ defaultUnitPriceCents: value as number | null })}
+              placeholder='0.00'
+            />
+            {draftShowAutoRate && (
+              <Badge variant='blue' size='sm' className='shrink-0'>
+                Auto
+              </Badge>
+            )}
+          </div>
+        </FieldPanelRow>
+
+        <FieldPanelRow title='Taxable' type={BaseType.BOOLEAN} showIcon>
+          <FieldInputAdapter
+            fieldType={FieldType.CHECKBOX}
+            fieldOptions={{ variant: 'switch' }}
+            value={values.taxable}
+            onChange={(value) => commitDraft({ taxable: value as boolean })}
+          />
+        </FieldPanelRow>
       </FieldPanel>
     </div>
   )

--- a/apps/worker/scripts/run-entity-migration-044.ts
+++ b/apps/worker/scripts/run-entity-migration-044.ts
@@ -1,0 +1,33 @@
+// apps/worker/scripts/run-entity-migration-044.ts
+/**
+ * One-off runner for entity migration 044 (unit/markup/optional fields for money plans 13/17/18
+ * — plans/dispatch/money/13-unit-based-pricing.md §3, 17-part-markup-pricing.md §5,
+ * 18-optional-line-items.md §1/§10) across all orgs.
+ * Runs ONLY 044 — deliberately not runAllEntityMigrations, so pending migrations from parallel
+ * work stay untouched. Idempotent — safe to re-run to confirm alreadyUpToDate.
+ *
+ * Run (from repo root) under the worker runtime so the @auxx/lib import chain
+ * resolves its native ESM deps:
+ *   node --conditions source --env-file .env --import tsx/esm \
+ *     apps/worker/scripts/run-entity-migration-044.ts
+ */
+
+import { database } from '@auxx/database'
+import {
+  ALL_ENTITY_MIGRATIONS,
+  runEntityMigrationForAllOrgs,
+} from '@auxx/lib/seed/entity-migrations'
+
+async function main() {
+  const migration = ALL_ENTITY_MIGRATIONS.find((m) => m.id === '044-line-pricing-fields')
+  if (!migration) throw new Error('Migration 044 not found in registry')
+
+  await runEntityMigrationForAllOrgs(database, migration)
+  console.log('done')
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/worker/scripts/verify-money-line-pricing.ts
+++ b/apps/worker/scripts/verify-money-line-pricing.ts
@@ -1,0 +1,990 @@
+// apps/worker/scripts/verify-money-line-pricing.ts
+/**
+ * Money 13 + 17 + 18 (unit-based pricing / part-markup catalog pricing / optional line items)
+ * integration verification (plans/dispatch/money/13-unit-based-pricing.md §8,
+ * 17-part-markup-pricing.md §7, 18-optional-line-items.md §9 — Automated sections only, browser
+ * passes are out of scope for this script). Exercises the real write paths — `markQuoteSent`/
+ * `approveQuote`/`convertQuoteToWorkOrder` (money/quote-lifecycle.ts, money/convert-quote.ts),
+ * `createInvoiceFromWorkOrder` (money/gather.ts, the "gather" mutation), `acceptQuoteByToken`
+ * (money/quote-acceptance.ts, the public-token accept path a real POST would hit), and the BOM
+ * cost-recalc → catalog-pricing sync chain (field-hooks/post/bom-cost-triggers.ts →
+ * bom/cost-calculator.ts → money/catalog-pricing.ts), all driven end to end against the live dev
+ * DB instead of the mocked 273 vitest tests.
+ *
+ * SAFETY: the dev `.env` is LIVE email + a LIVE worker draining queues. `acceptQuoteByToken`/
+ * `declineQuoteByToken`/`requestQuoteUpdateByToken`'s only side-notification path is
+ * `notifyQuoteCreator` (quote-acceptance.ts) → `NotificationService.sendNotification`
+ * (notifications/notification-service.ts) — that call is DB-insert + realtime-publish ONLY (an
+ * explicit `// Future enhancement: Add email/push notification delivery here` comment in that
+ * file confirms no email/queue path exists today). So calling `acceptQuoteByToken` directly here
+ * is safe: there is nothing to neutralize, unlike the Stripe-charge/refund calls the sibling
+ * money scripts (`verify-money-deposit-allocations.ts`) avoid. This script never calls anything
+ * Stripe-shaped (no checkout/charge creation) and never touches the email-sending
+ * `prepareDocumentEmail`/`sendPaymentReceipt` paths either.
+ *
+ * Org settings this script depends on (`documents.quote.acceptancePageEnabled`,
+ * `documents.quote.autoConvertOnAccept`) are read first; a direct DB check confirmed dev org
+ * `u45w22ft66ymiaa19ohs7m9f` (Marki Corp) has zero `OrganizationSetting` override rows for either
+ * key, so both are at their shipped defaults (`true`/`true`) — no override is needed. The script
+ * still defends against dev-DB drift: if either is ever found `false`, it flips it on and restores
+ * the exact original value (byte-exact) in `finally`.
+ *
+ * Creates records prefixed "[LP-verify]" and deletes/reverts everything in a try/finally.
+ * Cleanup order (mirrors `verify-money-deposit-allocations.ts`'s precedent): invoices FIRST
+ * (cascades `InvoiceLineAllocation` rows away, freeing the restrict FK on the gathered source
+ * line) BEFORE line items BEFORE work orders BEFORE quotes BEFORE catalog items BEFORE vendor
+ * parts BEFORE parts BEFORE the vendor company BEFORE the shared contact.
+ *
+ * Run (from repo root) under the worker runtime:
+ *   cd apps/worker && npx dotenv -- node --conditions source --import tsx/esm \
+ *     scripts/verify-money-line-pricing.ts
+ */
+
+import { database } from '@auxx/database'
+import { getOrgCache } from '@auxx/lib/cache'
+import { AuxxError } from '@auxx/lib/errors'
+import {
+  acceptQuoteByToken,
+  approveQuote,
+  convertQuoteToWorkOrder,
+  createInvoiceFromWorkOrder,
+  ensureQuotePublicToken,
+  markQuoteSent,
+} from '@auxx/lib/money'
+import { UnifiedCrudHandler } from '@auxx/lib/resources'
+import { ALL_ENTITY_MIGRATIONS } from '@auxx/lib/seed/entity-migrations'
+import { getOrganizationSetting, updateOrganizationSetting } from '@auxx/lib/settings'
+
+/** Build a RecordId string without pulling in `@auxx/types` (not a worker dependency). */
+function toRecordId(entityDefinitionId: string, entityInstanceId: string) {
+  return `${entityDefinitionId}:${entityInstanceId}` as never
+}
+
+let pass = 0
+let fail = 0
+function check(name: string, ok: boolean, detail?: unknown) {
+  if (ok) {
+    pass++
+    console.log(`  ✅ ${name}`)
+  } else {
+    fail++
+    console.log(`  ❌ ${name}`, detail ?? '')
+  }
+}
+
+/** Run `fn`, expecting it to throw. Returns the caught error (or `undefined` if it didn't). */
+async function expectThrow(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+    return undefined
+  } catch (err) {
+    return err ?? new Error('threw a falsy value')
+  }
+}
+
+async function entityDefId(organizationId: string, entityType: string) {
+  const def = await database.query.EntityDefinition.findFirst({
+    columns: { id: true },
+    where: (t, { and, eq }) =>
+      and(eq(t.organizationId, organizationId), eq(t.entityType, entityType)),
+  })
+  return def?.id ?? null
+}
+
+async function fieldId(organizationId: string, entityType: string, systemAttribute: string) {
+  const defId = await entityDefId(organizationId, entityType)
+  if (!defId) return null
+  const field = await database.query.CustomField.findFirst({
+    columns: { id: true },
+    where: (t, { and, eq }) =>
+      and(eq(t.entityDefinitionId, defId), eq(t.systemAttribute, systemAttribute)),
+  })
+  return field?.id ?? null
+}
+
+/** Read one `FieldValue` row by (entityType, instanceId, systemAttribute). `null` when unset. */
+async function fieldValueByAttr(
+  organizationId: string,
+  entityType: string,
+  instanceId: string,
+  systemAttribute: string
+) {
+  const fid = await fieldId(organizationId, entityType, systemAttribute)
+  if (!fid) return null
+  const fv = await database.query.FieldValue.findFirst({
+    where: (t, { and, eq }) => and(eq(t.entityId, instanceId), eq(t.fieldId, fid)),
+  })
+  return fv ?? null
+}
+
+/** `line_item` instance ids matching one relationship filter (`line_item:quote is X`, etc). */
+async function lineIdsWhere(handler: UnifiedCrudHandler, filterFieldId: string, value: unknown) {
+  const { ids } = await handler.listFiltered({
+    entityDefinitionId: 'line_item',
+    filters: [
+      {
+        id: 'f',
+        logicalOperator: 'AND',
+        conditions: [{ id: 'c', fieldId: filterFieldId, operator: 'is', value }],
+      },
+    ],
+    limit: 200,
+    mode: 'oneshot',
+  })
+  return ids
+}
+
+/** `work_order` instance ids linked to a given quote (mirrors convert-quote.ts's own guard query). */
+async function workOrderIdsForQuote(handler: UnifiedCrudHandler, quoteRecordId: unknown) {
+  const { ids } = await handler.listFiltered({
+    entityDefinitionId: 'work_order',
+    filters: [
+      {
+        id: 'f',
+        logicalOperator: 'AND',
+        conditions: [
+          { id: 'c', fieldId: 'work_order:quote', operator: 'is', value: quoteRecordId },
+        ],
+      },
+    ],
+    limit: 10,
+    mode: 'oneshot',
+  })
+  return ids
+}
+
+async function main() {
+  const user = await database.query.User.findFirst({
+    columns: { id: true },
+    where: (t, { eq }) => eq(t.email, 'm4rkuskk@gmail.com'),
+  })
+  if (!user) throw new Error('Dev user not found')
+  const organizationId = 'u45w22ft66ymiaa19ohs7m9f' // Marki Corp (primary dev org)
+  const userId = user.id
+  console.log(`Org ${organizationId}, user ${userId}`)
+
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+
+  const createdContactIds: string[] = []
+  const createdCompanyIds: string[] = []
+  const createdPartIds: string[] = []
+  const createdVendorPartIds: string[] = []
+  const createdCatalogItemIds: string[] = []
+  const createdQuoteIds: string[] = []
+  const createdLineIds: string[] = []
+  const createdWorkOrderIds: string[] = []
+  const createdInvoiceIds: string[] = []
+
+  // ── Defensive org-settings guard (byte-exact restore) ────────────────────────
+  let acceptancePageOverridden = false
+  let originalAcceptancePageEnabled: unknown = null
+  let autoConvertOverridden = false
+  let originalAutoConvertOnAccept: unknown = null
+
+  try {
+    originalAcceptancePageEnabled = await getOrganizationSetting({
+      organizationId,
+      key: 'documents.quote.acceptancePageEnabled',
+    })
+    if (originalAcceptancePageEnabled === false) {
+      await updateOrganizationSetting({
+        organizationId,
+        key: 'documents.quote.acceptancePageEnabled',
+        value: true,
+      })
+      await getOrgCache().invalidateAndRecompute(organizationId, ['orgSettings'])
+      acceptancePageOverridden = true
+    }
+    originalAutoConvertOnAccept = await getOrganizationSetting({
+      organizationId,
+      key: 'documents.quote.autoConvertOnAccept',
+    })
+    if (originalAutoConvertOnAccept === false) {
+      await updateOrganizationSetting({
+        organizationId,
+        key: 'documents.quote.autoConvertOnAccept',
+        value: true,
+      })
+      await getOrgCache().invalidateAndRecompute(organizationId, ['orgSettings'])
+      autoConvertOverridden = true
+    }
+
+    const contact = await handler.create('contact', {
+      first_name: '[LP-verify]',
+      last_name: 'Test Customer',
+      primary_email: 'lp-verify@example.com',
+    })
+    createdContactIds.push(contact.instance.id)
+    const contactRecordId = toRecordId('contact', contact.instance.id)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // A. Units snapshot chain (13 §8)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('A: units snapshot chain')
+
+    const catA = await handler.create('catalog_item', {
+      catalog_item_name: '[LP-verify] Hourly Labor',
+      catalog_item_default_unit: 'hour',
+      catalog_item_default_unit_price: 5000,
+    })
+    createdCatalogItemIds.push(catA.instance.id)
+
+    const quoteUnits = await handler.create('quote', {
+      quote_title: '[LP-verify] Units chain quote',
+      quote_contact: contactRecordId,
+    })
+    createdQuoteIds.push(quoteUnits.instance.id)
+
+    // A.1 — simulate the server-side catalog pick: create the line with the catalog item's unit.
+    const lineUnits = await handler.create('line_item', {
+      line_item_name: '[LP-verify] Hourly Labor line',
+      line_item_qty: 1,
+      line_item_unit_price: 5000,
+      line_item_taxable: false,
+      line_item_unit: 'hour',
+      line_item_catalog_item: toRecordId('catalog_item', catA.instance.id),
+      line_item_quote: quoteUnits.recordId,
+    })
+    createdLineIds.push(lineUnits.instance.id)
+
+    const lineUnitsInitial = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      lineUnits.instance.id,
+      'line_item_unit'
+    )
+    check('A1: picked line has unit "hour"', lineUnitsInitial?.optionId === 'hour')
+
+    // A.2 — edit the line's unit; catalog item's own default is untouched (snapshot independence).
+    await handler.update(toRecordId('line_item', lineUnits.instance.id), { line_item_unit: 'day' })
+    const lineUnitsAfterEdit = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      lineUnits.instance.id,
+      'line_item_unit'
+    )
+    check('A2: line unit edited to "day"', lineUnitsAfterEdit?.optionId === 'day')
+    const catAUnitAfterEdit = await fieldValueByAttr(
+      organizationId,
+      'catalog_item',
+      catA.instance.id,
+      'catalog_item_default_unit'
+    )
+    check(
+      'A2: catalog item defaultUnit still "hour" (snapshot independence)',
+      catAUnitAfterEdit?.optionId === 'hour'
+    )
+
+    // A.3 — convert to work order: copied line carries the CURRENT unit ("day").
+    await markQuoteSent({ organizationId, userId, quoteInstanceId: quoteUnits.instance.id })
+    await approveQuote({ organizationId, userId, quoteInstanceId: quoteUnits.instance.id })
+    const woUnits = await convertQuoteToWorkOrder({
+      organizationId,
+      userId,
+      quoteInstanceId: quoteUnits.instance.id,
+    })
+    createdWorkOrderIds.push(woUnits.instance.id)
+
+    const woUnitsLineIds = await lineIdsWhere(handler, 'line_item:workOrder', woUnits.recordId)
+    createdLineIds.push(...woUnitsLineIds)
+    check(
+      'A3: exactly one copied line on the work order',
+      woUnitsLineIds.length === 1,
+      woUnitsLineIds
+    )
+    const woLineId = woUnitsLineIds[0]!
+    const woLineUnit = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      woLineId,
+      'line_item_unit'
+    )
+    check('A3: converted job line has unit "day"', woLineUnit?.optionId === 'day')
+
+    // A.4 — gather the work-order line onto an invoice: invoice copy carries "day" too.
+    const invoiceUnits = await createInvoiceFromWorkOrder({
+      organizationId,
+      userId,
+      workOrderInstanceId: woUnits.instance.id,
+      lineInstanceIds: [woLineId],
+    })
+    createdInvoiceIds.push(invoiceUnits.instanceId)
+
+    const invoiceUnitsLineIds = await lineIdsWhere(
+      handler,
+      'line_item:invoice',
+      invoiceUnits.recordId
+    )
+    createdLineIds.push(...invoiceUnitsLineIds)
+    check(
+      'A4: exactly one gathered line on the invoice',
+      invoiceUnitsLineIds.length === 1,
+      invoiceUnitsLineIds
+    )
+    const invoiceLineId = invoiceUnitsLineIds[0]!
+    const invoiceLineUnit = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      invoiceLineId,
+      'line_item_unit'
+    )
+    check('A4: gathered invoice line has unit "day"', invoiceLineUnit?.optionId === 'day')
+
+    // A.5 — editing the invoice copy's unit does not mutate the work-order source line.
+    await handler.update(toRecordId('line_item', invoiceLineId), { line_item_unit: 'hour' })
+    const woLineUnitAfterInvoiceEdit = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      woLineId,
+      'line_item_unit'
+    )
+    check(
+      'A5: editing invoice copy unit leaves work-order line unchanged ("day")',
+      woLineUnitAfterInvoiceEdit?.optionId === 'day'
+    )
+
+    // A.6 — a line with a null unit stays null through the same chain (legacy shape).
+    const quoteNull = await handler.create('quote', {
+      quote_title: '[LP-verify] Null-unit chain quote',
+      quote_contact: contactRecordId,
+    })
+    createdQuoteIds.push(quoteNull.instance.id)
+    const lineNull = await handler.create('line_item', {
+      line_item_name: '[LP-verify] Legacy no-unit line',
+      line_item_qty: 1,
+      line_item_unit_price: 1000,
+      line_item_taxable: false,
+      line_item_quote: quoteNull.recordId,
+    })
+    createdLineIds.push(lineNull.instance.id)
+    const lineNullUnit = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      lineNull.instance.id,
+      'line_item_unit'
+    )
+    check('A6: legacy line has no unit set', lineNullUnit === null, lineNullUnit)
+
+    await markQuoteSent({ organizationId, userId, quoteInstanceId: quoteNull.instance.id })
+    await approveQuote({ organizationId, userId, quoteInstanceId: quoteNull.instance.id })
+    const woNull = await convertQuoteToWorkOrder({
+      organizationId,
+      userId,
+      quoteInstanceId: quoteNull.instance.id,
+    })
+    createdWorkOrderIds.push(woNull.instance.id)
+    const woNullLineIds = await lineIdsWhere(handler, 'line_item:workOrder', woNull.recordId)
+    createdLineIds.push(...woNullLineIds)
+    const woNullLineUnit = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      woNullLineIds[0]!,
+      'line_item_unit'
+    )
+    check('A6: converted job line still has no unit', woNullLineUnit === null, woNullLineUnit)
+
+    const invoiceNull = await createInvoiceFromWorkOrder({
+      organizationId,
+      userId,
+      workOrderInstanceId: woNull.instance.id,
+      lineInstanceIds: [woNullLineIds[0]!],
+    })
+    createdInvoiceIds.push(invoiceNull.instanceId)
+    const invoiceNullLineIds = await lineIdsWhere(
+      handler,
+      'line_item:invoice',
+      invoiceNull.recordId
+    )
+    createdLineIds.push(...invoiceNullLineIds)
+    const invoiceNullLineUnit = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      invoiceNullLineIds[0]!,
+      'line_item_unit'
+    )
+    check(
+      'A6: gathered invoice line still has no unit',
+      invoiceNullLineUnit === null,
+      invoiceNullLineUnit
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // B. Optional-lines acceptance (18 §9)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('B: optional-lines acceptance')
+
+    const REQUIRED_AMOUNT = 10000
+    const OPTION_A_AMOUNT = 5000
+    const OPTION_B_AMOUNT = 3000
+
+    async function seedOptionalQuote(
+      title: string,
+      opts: { includeOptions: boolean; aSelected?: boolean; bSelected?: boolean }
+    ) {
+      const quote = await handler.create('quote', {
+        quote_title: title,
+        quote_contact: contactRecordId,
+      })
+      createdQuoteIds.push(quote.instance.id)
+
+      const required = await handler.create('line_item', {
+        line_item_name: '[LP-verify] Required line',
+        line_item_qty: 1,
+        line_item_unit_price: REQUIRED_AMOUNT,
+        line_item_taxable: false,
+        line_item_quote: quote.recordId,
+      })
+      createdLineIds.push(required.instance.id)
+
+      let optionA: Awaited<ReturnType<typeof handler.create>> | undefined
+      let optionB: Awaited<ReturnType<typeof handler.create>> | undefined
+      if (opts.includeOptions) {
+        optionA = await handler.create('line_item', {
+          line_item_name: '[LP-verify] Optional A (pre-checked)',
+          line_item_qty: 1,
+          line_item_unit_price: OPTION_A_AMOUNT,
+          line_item_taxable: false,
+          line_item_optional: true,
+          line_item_optional_selected: opts.aSelected ?? true,
+          line_item_quote: quote.recordId,
+        })
+        createdLineIds.push(optionA.instance.id)
+
+        optionB = await handler.create('line_item', {
+          line_item_name: '[LP-verify] Optional B (unchecked)',
+          line_item_qty: 1,
+          line_item_unit_price: OPTION_B_AMOUNT,
+          line_item_taxable: false,
+          line_item_optional: true,
+          line_item_optional_selected: opts.bSelected ?? false,
+          line_item_quote: quote.recordId,
+        })
+        createdLineIds.push(optionB.instance.id)
+      }
+
+      await markQuoteSent({ organizationId, userId, quoteInstanceId: quote.instance.id })
+      const token = await ensureQuotePublicToken(organizationId, quote.instance.id)
+      return { quote, required, optionA, optionB, token }
+    }
+
+    // ── B.1/B.2/B.4: pre-checked A, unchecked B; accept selecting [B] (A absent = deselected) ──
+    const b1 = await seedOptionalQuote('[LP-verify] Optional-lines quote (B1/B2/B4)', {
+      includeOptions: true,
+      aSelected: true,
+      bSelected: false,
+    })
+
+    const b1TotalBeforeAccept = await fieldValueByAttr(
+      organizationId,
+      'quote',
+      b1.quote.instance.id,
+      'quote_total'
+    )
+    check(
+      'B1: stored quote_total = required + A, excludes B (10000 + 5000 = 15000)',
+      b1TotalBeforeAccept?.valueNumber === 15000,
+      b1TotalBeforeAccept?.valueNumber
+    )
+
+    const b1Result = await acceptQuoteByToken(b1.token, {
+      selectedLineIds: [b1.optionB!.instance.id],
+      name: 'Verify Customer',
+    })
+    check(
+      'B2: acceptQuoteByToken succeeds, not idempotent, converts',
+      b1Result.alreadyAccepted === false && b1Result.converted === true,
+      b1Result
+    )
+
+    const b1OptionAFlag = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      b1.optionA!.instance.id,
+      'line_item_optional_selected'
+    )
+    const b1OptionBFlag = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      b1.optionB!.instance.id,
+      'line_item_optional_selected'
+    )
+    check(
+      'B2: flags written — A -> false (absent from selection), B -> true (selected)',
+      b1OptionAFlag?.valueBoolean === false && b1OptionBFlag?.valueBoolean === true,
+      { a: b1OptionAFlag?.valueBoolean, b: b1OptionBFlag?.valueBoolean }
+    )
+
+    const b1TotalAfterAccept = await fieldValueByAttr(
+      organizationId,
+      'quote',
+      b1.quote.instance.id,
+      'quote_total'
+    )
+    check(
+      'B2: totals recomputed to required + B (10000 + 3000 = 13000)',
+      b1TotalAfterAccept?.valueNumber === 13000,
+      b1TotalAfterAccept?.valueNumber
+    )
+
+    const b1Status = await fieldValueByAttr(
+      organizationId,
+      'quote',
+      b1.quote.instance.id,
+      'quote_status'
+    )
+    check('B2: quote approved', b1Status?.optionId === 'approved', b1Status?.optionId)
+
+    const b1WorkOrderIds = await workOrderIdsForQuote(handler, b1.quote.recordId)
+    check(
+      'B2: auto-convert produced exactly one work order',
+      b1WorkOrderIds.length === 1,
+      b1WorkOrderIds
+    )
+    const b1WorkOrderId = b1WorkOrderIds[0]!
+    createdWorkOrderIds.push(b1WorkOrderId)
+    const b1WoLineIds = await lineIdsWhere(
+      handler,
+      'line_item:workOrder',
+      toRecordId('work_order', b1WorkOrderId)
+    )
+    createdLineIds.push(...b1WoLineIds)
+    check(
+      'B2: converted work order has exactly 2 lines (required + B only)',
+      b1WoLineIds.length === 2,
+      b1WoLineIds
+    )
+    let b1WoTotal = 0
+    let b1WoCopiesCarryOptionalFlag = false
+    for (const id of b1WoLineIds) {
+      const priceFv = await fieldValueByAttr(
+        organizationId,
+        'line_item',
+        id,
+        'line_item_unit_price'
+      )
+      b1WoTotal += priceFv?.valueNumber ?? 0
+      const optFv = await fieldValueByAttr(organizationId, 'line_item', id, 'line_item_optional')
+      if (optFv?.valueBoolean === true) b1WoCopiesCarryOptionalFlag = true
+    }
+    check('B2: converted job total = required + B (13000)', b1WoTotal === 13000, b1WoTotal)
+    check('B2: converted job copies carry NO optional flag', !b1WoCopiesCarryOptionalFlag)
+
+    // ── B.3: unknown id, then required-line id, both rejected; quote stays unapproved ──
+    const b3 = await seedOptionalQuote('[LP-verify] Bad-selection quote (B3)', {
+      includeOptions: true,
+      aSelected: true,
+      bSelected: false,
+    })
+    const b3UnknownErr = await expectThrow(() =>
+      acceptQuoteByToken(b3.token, {
+        selectedLineIds: ['nonexistent-line-id-xyz'],
+        name: 'Verify Customer',
+      })
+    )
+    check(
+      'B3: unknown line id -> BadRequestError',
+      b3UnknownErr instanceof AuxxError &&
+        /is not a selectable option/.test((b3UnknownErr as Error).message),
+      b3UnknownErr
+    )
+    const b3RequiredErr = await expectThrow(() =>
+      acceptQuoteByToken(b3.token, {
+        selectedLineIds: [b3.required.instance.id],
+        name: 'Verify Customer',
+      })
+    )
+    check(
+      'B3: required-line id -> BadRequestError',
+      b3RequiredErr instanceof AuxxError &&
+        /is not a selectable option/.test((b3RequiredErr as Error).message),
+      b3RequiredErr
+    )
+    const b3Status = await fieldValueByAttr(
+      organizationId,
+      'quote',
+      b3.quote.instance.id,
+      'quote_status'
+    )
+    check(
+      'B3: quote stays unapproved ("sent") after both rejections',
+      b3Status?.optionId === 'sent'
+    )
+
+    // ── B.4: re-submit acceptance on the now-approved b1 quote with a DIFFERENT selection ──
+    const b1Resubmit = await acceptQuoteByToken(b1.token, {
+      selectedLineIds: [b1.optionA!.instance.id],
+      name: 'Verify Customer',
+    })
+    check(
+      'B4: re-submit on an approved quote is an idempotent early return',
+      b1Resubmit.alreadyAccepted === true && b1Resubmit.converted === false,
+      b1Resubmit
+    )
+    const b1OptionAFlagAfterResubmit = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      b1.optionA!.instance.id,
+      'line_item_optional_selected'
+    )
+    const b1OptionBFlagAfterResubmit = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      b1.optionB!.instance.id,
+      'line_item_optional_selected'
+    )
+    check(
+      'B4: selections unchanged by the idempotent re-submit',
+      b1OptionAFlagAfterResubmit?.valueBoolean === false &&
+        b1OptionBFlagAfterResubmit?.valueBoolean === true,
+      { a: b1OptionAFlagAfterResubmit?.valueBoolean, b: b1OptionBFlagAfterResubmit?.valueBoolean }
+    )
+
+    // ── B.5: empty selectedLineIds on a fresh quote deselects every optional line ──
+    const b5 = await seedOptionalQuote('[LP-verify] Empty-selection quote (B5)', {
+      includeOptions: true,
+      aSelected: true,
+      bSelected: true,
+    })
+    const b5Result = await acceptQuoteByToken(b5.token, {
+      selectedLineIds: [],
+      name: 'Verify Customer',
+    })
+    check(
+      'B5: empty selection accepts and converts',
+      b5Result.alreadyAccepted === false && b5Result.converted === true,
+      b5Result
+    )
+    const b5OptionAFlag = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      b5.optionA!.instance.id,
+      'line_item_optional_selected'
+    )
+    const b5OptionBFlag = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      b5.optionB!.instance.id,
+      'line_item_optional_selected'
+    )
+    check(
+      'B5: every optional line deselected',
+      b5OptionAFlag?.valueBoolean === false && b5OptionBFlag?.valueBoolean === false,
+      { a: b5OptionAFlag?.valueBoolean, b: b5OptionBFlag?.valueBoolean }
+    )
+    const b5Total = await fieldValueByAttr(
+      organizationId,
+      'quote',
+      b5.quote.instance.id,
+      'quote_total'
+    )
+    check('B5: total = required only (10000)', b5Total?.valueNumber === 10000, b5Total?.valueNumber)
+    const b5WorkOrderIds = await workOrderIdsForQuote(handler, b5.quote.recordId)
+    check('B5: converted', b5WorkOrderIds.length === 1, b5WorkOrderIds)
+    const b5WorkOrderId = b5WorkOrderIds[0]!
+    createdWorkOrderIds.push(b5WorkOrderId)
+    const b5WoLineIds = await lineIdsWhere(
+      handler,
+      'line_item:workOrder',
+      toRecordId('work_order', b5WorkOrderId)
+    )
+    createdLineIds.push(...b5WoLineIds)
+    check('B5: converted job has only the required line', b5WoLineIds.length === 1, b5WoLineIds)
+
+    // ── B.6: zero-optional quote + undefined selectedLineIds accepts exactly as before ──
+    const b6 = await seedOptionalQuote('[LP-verify] Zero-optional quote (B6)', {
+      includeOptions: false,
+    })
+    const b6TotalBefore = await fieldValueByAttr(
+      organizationId,
+      'quote',
+      b6.quote.instance.id,
+      'quote_total'
+    )
+    check('B6: total = required only before accept (10000)', b6TotalBefore?.valueNumber === 10000)
+    const b6Result = await acceptQuoteByToken(b6.token, { name: 'Verify Customer' })
+    check(
+      'B6: zero-optional quote accepts and converts with undefined selectedLineIds',
+      b6Result.alreadyAccepted === false && b6Result.converted === true,
+      b6Result
+    )
+    const b6TotalAfter = await fieldValueByAttr(
+      organizationId,
+      'quote',
+      b6.quote.instance.id,
+      'quote_total'
+    )
+    check(
+      'B6: totals untouched by accept (still 10000, no selection write)',
+      b6TotalAfter?.valueNumber === 10000,
+      b6TotalAfter?.valueNumber
+    )
+    const b6WorkOrderIds = await workOrderIdsForQuote(handler, b6.quote.recordId)
+    if (b6WorkOrderIds[0]) createdWorkOrderIds.push(b6WorkOrderIds[0])
+    const b6WoLineIds = b6WorkOrderIds[0]
+      ? await lineIdsWhere(
+          handler,
+          'line_item:workOrder',
+          toRecordId('work_order', b6WorkOrderIds[0])
+        )
+      : []
+    createdLineIds.push(...b6WoLineIds)
+    check('B6: converted job has only the required line', b6WoLineIds.length === 1, b6WoLineIds)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // C. Part-cost → catalog pricing (17 §7)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('C: part-cost -> catalog pricing sync')
+
+    const vendorCompany = await handler.create('company', {
+      company_name: '[LP-verify] Vendor Co',
+    })
+    createdCompanyIds.push(vendorCompany.instance.id)
+
+    const part = await handler.create('part', {
+      part_title: '[LP-verify] Widget',
+      part_sku: `LP-VERIFY-PART-${Date.now()}`,
+    })
+    createdPartIds.push(part.instance.id)
+
+    const catMarkup = await handler.create('catalog_item', {
+      catalog_item_name: '[LP-verify] Catalog item WITH markup',
+      catalog_item_part: toRecordId('part', part.instance.id),
+      catalog_item_markup: 50,
+    })
+    createdCatalogItemIds.push(catMarkup.instance.id)
+
+    const catNoMarkup = await handler.create('catalog_item', {
+      catalog_item_name: '[LP-verify] Catalog item WITHOUT markup',
+      catalog_item_part: toRecordId('part', part.instance.id),
+    })
+    createdCatalogItemIds.push(catNoMarkup.instance.id)
+
+    // "Existing quote line picked from that item earlier" — an already-priced line snapshot
+    // that must be untouched by any later repricing (decision 5).
+    const quotePriceCheck = await handler.create('quote', {
+      quote_title: '[LP-verify] Price-check quote',
+      quote_contact: contactRecordId,
+    })
+    createdQuoteIds.push(quotePriceCheck.instance.id)
+    const linePriceCheck = await handler.create('line_item', {
+      line_item_name: '[LP-verify] Picked-earlier line',
+      line_item_qty: 1,
+      line_item_unit_price: 4242,
+      line_item_taxable: false,
+      line_item_catalog_item: toRecordId('catalog_item', catMarkup.instance.id),
+      line_item_quote: quotePriceCheck.recordId,
+    })
+    createdLineIds.push(linePriceCheck.instance.id)
+
+    const vendorPart = await handler.create('vendor_part', {
+      vendor_part_part: toRecordId('part', part.instance.id),
+      vendor_part_contact: toRecordId('company', vendorCompany.instance.id),
+      vendor_part_vendor_sku: `LP-VERIFY-VP-${Date.now()}`,
+      vendor_part_unit_price: 1000,
+      vendor_part_is_preferred: true,
+    })
+    createdVendorPartIds.push(vendorPart.instance.id)
+
+    // C.1 — trigger the real recalc by CHANGING the vendor price (a genuine "changed" event —
+    // the synchronous `mfg-vendor-part-unit-price` field-system-rule fires
+    // `recalculatePartCost` -> `recalculateAffectedParts` -> `syncCatalogItemPricing`, all
+    // awaited inline by the time `handler.update` resolves).
+    await handler.update(toRecordId('vendor_part', vendorPart.instance.id), {
+      vendor_part_unit_price: 2000,
+    })
+
+    const partCost = await fieldValueByAttr(organizationId, 'part', part.instance.id, 'part_cost')
+    check(
+      'C1: part_cost recalculated to landed cost (2000)',
+      partCost?.valueNumber === 2000,
+      partCost?.valueNumber
+    )
+
+    const catMarkupCost = await fieldValueByAttr(
+      organizationId,
+      'catalog_item',
+      catMarkup.instance.id,
+      'catalog_item_cost'
+    )
+    const catNoMarkupCost = await fieldValueByAttr(
+      organizationId,
+      'catalog_item',
+      catNoMarkup.instance.id,
+      'catalog_item_cost'
+    )
+    check(
+      'C1: BOTH catalog items cost-synced to 2000',
+      catMarkupCost?.valueNumber === 2000 && catNoMarkupCost?.valueNumber === 2000,
+      { markup: catMarkupCost?.valueNumber, noMarkup: catNoMarkupCost?.valueNumber }
+    )
+
+    const catMarkupPrice = await fieldValueByAttr(
+      organizationId,
+      'catalog_item',
+      catMarkup.instance.id,
+      'catalog_item_default_unit_price'
+    )
+    check(
+      'C1: ONLY the markup item price recomputes — round(2000 * 1.5) = 3000',
+      catMarkupPrice?.valueNumber === 3000,
+      catMarkupPrice?.valueNumber
+    )
+    const catNoMarkupPrice = await fieldValueByAttr(
+      organizationId,
+      'catalog_item',
+      catNoMarkup.instance.id,
+      'catalog_item_default_unit_price'
+    )
+    check(
+      'C1: no-markup item price untouched (still unset)',
+      catNoMarkupPrice === null,
+      catNoMarkupPrice
+    )
+
+    // C.2 — the pre-existing quote line's own unit_price is untouched by the repricing.
+    const linePriceCheckAfter = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      linePriceCheck.instance.id,
+      'line_item_unit_price'
+    )
+    check(
+      'C2: existing quote line untouched by repricing (still 4242)',
+      linePriceCheckAfter?.valueNumber === 4242,
+      linePriceCheckAfter?.valueNumber
+    )
+
+    // C.3 — migration idempotency spot-check.
+    const migration044 = ALL_ENTITY_MIGRATIONS.find((m) => m.id === '044-line-pricing-fields')
+    if (!migration044) throw new Error('Migration 044 not found in registry')
+    const migrationRun1 = await migration044.up(database, organizationId)
+    check(
+      'C3: migration 044 re-run #1 is alreadyUpToDate',
+      migrationRun1.alreadyUpToDate === true,
+      migrationRun1
+    )
+    const migrationRun2 = await migration044.up(database, organizationId)
+    check(
+      'C3: migration 044 re-run #2 is alreadyUpToDate',
+      migrationRun2.alreadyUpToDate === true,
+      migrationRun2
+    )
+  } finally {
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+    console.log(
+      `Cleanup: ${createdInvoiceIds.length} invoices, ${createdLineIds.length} lines, ` +
+        `${createdWorkOrderIds.length} work orders, ${createdQuoteIds.length} quotes, ` +
+        `${createdCatalogItemIds.length} catalog items, ${createdVendorPartIds.length} vendor parts, ` +
+        `${createdPartIds.length} parts, ${createdCompanyIds.length} companies, ` +
+        `${createdContactIds.length} contacts`
+    )
+    // Invoices BEFORE lines: `InvoiceLineAllocation.sourceLineItemId` is a restrict FK, freed
+    // only once the owning invoice cascades its allocation rows away (deposit-allocations
+    // script's precedent).
+    for (const id of [...new Set(createdInvoiceIds)]) {
+      try {
+        await handler.delete(toRecordId('invoice', id))
+      } catch (err) {
+        console.log(`  cleanup failed for invoice:${id}:`, err instanceof Error ? err.message : err)
+      }
+    }
+    for (const id of [...new Set(createdLineIds)]) {
+      try {
+        await handler.delete(toRecordId('line_item', id))
+      } catch (err) {
+        console.log(
+          `  cleanup failed for line_item:${id}:`,
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+    for (const id of [...new Set(createdWorkOrderIds)]) {
+      try {
+        await handler.delete(toRecordId('work_order', id))
+      } catch (err) {
+        console.log(
+          `  cleanup failed for work_order:${id}:`,
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+    for (const id of [...new Set(createdQuoteIds)]) {
+      try {
+        await handler.delete(toRecordId('quote', id))
+      } catch (err) {
+        console.log(`  cleanup failed for quote:${id}:`, err instanceof Error ? err.message : err)
+      }
+    }
+    for (const id of [...new Set(createdCatalogItemIds)]) {
+      try {
+        await handler.delete(toRecordId('catalog_item', id))
+      } catch (err) {
+        console.log(
+          `  cleanup failed for catalog_item:${id}:`,
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+    for (const id of [...new Set(createdVendorPartIds)]) {
+      try {
+        await handler.delete(toRecordId('vendor_part', id))
+      } catch (err) {
+        console.log(
+          `  cleanup failed for vendor_part:${id}:`,
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+    for (const id of [...new Set(createdPartIds)]) {
+      try {
+        await handler.delete(toRecordId('part', id))
+      } catch (err) {
+        console.log(`  cleanup failed for part:${id}:`, err instanceof Error ? err.message : err)
+      }
+    }
+    for (const id of [...new Set(createdCompanyIds)]) {
+      try {
+        await handler.delete(toRecordId('company', id))
+      } catch (err) {
+        console.log(`  cleanup failed for company:${id}:`, err instanceof Error ? err.message : err)
+      }
+    }
+    for (const id of [...new Set(createdContactIds)]) {
+      try {
+        await handler.delete(toRecordId('contact', id))
+      } catch (err) {
+        console.log(`  cleanup failed for contact:${id}:`, err instanceof Error ? err.message : err)
+      }
+    }
+
+    // Restore any org settings this script changed, byte-exact.
+    if (acceptancePageOverridden) {
+      await updateOrganizationSetting({
+        organizationId,
+        key: 'documents.quote.acceptancePageEnabled',
+        value: (originalAcceptancePageEnabled ?? true) as boolean,
+      }).catch(() => {})
+      await getOrgCache()
+        .invalidateAndRecompute(organizationId, ['orgSettings'])
+        .catch(() => {})
+    }
+    if (autoConvertOverridden) {
+      await updateOrganizationSetting({
+        organizationId,
+        key: 'documents.quote.autoConvertOnAccept',
+        value: (originalAutoConvertOnAccept ?? true) as boolean,
+      }).catch(() => {})
+      await getOrgCache()
+        .invalidateAndRecompute(organizationId, ['orgSettings'])
+        .catch(() => {})
+    }
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`)
+  process.exit(fail > 0 ? 1 : 0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/lib/src/bom/cost-calculator.ts
+++ b/packages/lib/src/bom/cost-calculator.ts
@@ -563,6 +563,10 @@ export async function recalculateAllPartCosts(orgId: string): Promise<string[]> 
     changedParts: changedIds.length,
   })
 
+  if (changedIds.length > 0) {
+    await syncCatalogPricingSafely(orgId, changedIds)
+  }
+
   return changedIds
 }
 
@@ -614,7 +618,29 @@ export async function recalculateAffectedParts(
     changedParts: changedIds.length,
   })
 
+  if (changedIds.length > 0) {
+    await syncCatalogPricingSafely(orgId, changedIds)
+  }
+
   return changedIds
+}
+
+/**
+ * Ripple changed part costs into linked catalog items (plan 17 §2) — lazy `import()`
+ * so this bom module doesn't gain a static edge onto `money/` (no existing lazy-import
+ * convention in this file otherwise; new for this call site). Swallows its own errors:
+ * a catalog-pricing bug must never fail the part-cost recalc that triggered it.
+ */
+async function syncCatalogPricingSafely(orgId: string, changedPartIds: string[]): Promise<void> {
+  try {
+    const { syncCatalogItemPricing } = await import('../money/catalog-pricing')
+    await syncCatalogItemPricing(orgId, changedPartIds)
+  } catch (error) {
+    logger.error('Failed to sync catalog item pricing after part cost recalc', {
+      orgId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
 }
 
 // ─── Exported helpers for BomService ─────────────────────────────────

--- a/packages/lib/src/documents/payload.ts
+++ b/packages/lib/src/documents/payload.ts
@@ -15,20 +15,32 @@ import { getInvoiceDepositApplied } from '../money/payments/allocation-reads'
 import { buildPayUrl, ensureInvoicePublicToken, isPaymentsConnected } from '../money/public-token'
 import { computeDocumentTotals } from '../money/totals'
 import type { DiscountType } from '../money/types'
+import type { LineItemUnit } from '../money/units'
 import { UnifiedCrudHandler } from '../resources/crud'
 import type { ResolvedDocumentSettings } from './resolve-settings'
 import { resolveDocumentSettings } from './resolve-settings'
 
 /** One rendered line on the quote PDF's line-item table. */
 export interface QuotePdfLineItem {
+  /** `line_item` EntityInstance id — the public quote page's optional-line checkbox `value`
+   * (money plan 18 §4/amendment 1). Not present on any other document-payload line before
+   * this. */
+  lineInstanceId: string
   name: string
   description: string | null
   qty: number
+  /** Immutable-at-copy-time display snapshot (money plan 13 §1/§6). `null` = unitless. */
+  unit: LineItemUnit | null
   /** Integer cents. `null` = not yet priced (money MQ1 convention). */
   unitPrice: number | null
   /** Integer cents. */
   lineTotal: number | null
   taxable: boolean
+  /** Customer-selectable upsell line (quotes only, money plan 18). `false` on invoice lines —
+   * optionality never survives conversion (decision 6). */
+  optional: boolean
+  /** Current selection state — meaningful only when `optional` is true. */
+  optionalSelected: boolean
 }
 
 /** Billing-party display fields — no street address on `contact` today (city/region/country only). */
@@ -268,9 +280,12 @@ async function loadPdfLines(
       'line_item_name',
       'line_item_description',
       'line_item_qty',
+      'line_item_unit',
       'line_item_unit_price',
       'line_item_line_total',
       'line_item_taxable',
+      'line_item_optional',
+      'line_item_optional_selected',
     ] as const)
 
   const { ids: lineInstanceIds } = await handler.listFiltered({
@@ -285,9 +300,12 @@ async function loadPdfLines(
     lineCf.line_item_name,
     lineCf.line_item_description,
     lineCf.line_item_qty,
+    lineCf.line_item_unit,
     lineCf.line_item_unit_price,
     lineCf.line_item_line_total,
     lineCf.line_item_taxable,
+    lineCf.line_item_optional,
+    lineCf.line_item_optional_selected,
   ]
     .filter(Boolean)
     .map((f) => f!.id)
@@ -301,17 +319,26 @@ async function loadPdfLines(
     const nameTyped = getLine(lineCf.line_item_name)
     const descriptionTyped = getLine(lineCf.line_item_description)
     const qtyTyped = getLine(lineCf.line_item_qty)
+    const unitTyped = getLine(lineCf.line_item_unit)
     const unitPriceTyped = getLine(lineCf.line_item_unit_price)
     const lineTotalTyped = getLine(lineCf.line_item_line_total)
     const taxableTyped = getLine(lineCf.line_item_taxable)
+    const optionalTyped = getLine(lineCf.line_item_optional)
+    const optionalSelectedTyped = getLine(lineCf.line_item_optional_selected)
 
     lines.push({
+      lineInstanceId,
       name: nameTyped ? (extractValue(nameTyped) as string) : '',
       description: descriptionTyped ? (extractValue(descriptionTyped) as string) : null,
       qty: qtyTyped ? (extractValue(qtyTyped) as number) : 0,
+      unit: unitTyped ? (extractValue(unitTyped) as LineItemUnit) : null,
       unitPrice: unitPriceTyped ? (extractValue(unitPriceTyped) as number) : null,
       lineTotal: lineTotalTyped ? (extractValue(lineTotalTyped) as number) : null,
       taxable: taxableTyped ? (extractValue(taxableTyped) as boolean) : true,
+      optional: optionalTyped ? (extractValue(optionalTyped) as boolean) : false,
+      optionalSelected: optionalSelectedTyped
+        ? (extractValue(optionalSelectedTyped) as boolean)
+        : true,
     })
   }
 
@@ -419,9 +446,16 @@ export async function buildQuotePdfPayload(params: {
     },
   ])
 
-  // ─── Totals (pure function — same math the totals-engine hook writes) ──────
+  // ─── Totals (pure function — same math the totals-engine hook writes). Pass the
+  // optional/optionalSelected flags so a deselected upsell line is excluded from the
+  // recomputed payload total exactly like the stored `quote_total` mirror (decision 4). ──────
   const totals = computeDocumentTotals(
-    lines.map((l) => ({ lineTotal: l.lineTotal, taxable: l.taxable })),
+    lines.map((l) => ({
+      lineTotal: l.lineTotal,
+      taxable: l.taxable,
+      optional: l.optional,
+      optionalSelected: l.optionalSelected,
+    })),
     { discountType, discountValue, taxRate }
   )
 
@@ -664,28 +698,40 @@ export const SAMPLE_QUOTE_PDF_PAYLOAD: QuotePdfPayload = {
   },
   lines: [
     {
+      lineInstanceId: 'sample-line-1',
       name: 'Site inspection',
       description: 'On-site assessment and measurements',
       qty: 1,
+      unit: null,
       unitPrice: 15000,
       lineTotal: 15000,
       taxable: true,
+      optional: false,
+      optionalSelected: true,
     },
     {
+      lineInstanceId: 'sample-line-2',
       name: 'Materials',
       description: 'Parts and supplies per estimate',
       qty: 4,
+      unit: 'each',
       unitPrice: 5000,
       lineTotal: 20000,
       taxable: true,
+      optional: false,
+      optionalSelected: true,
     },
     {
+      lineInstanceId: 'sample-line-3',
       name: 'Labor',
       description: 'Installation and cleanup',
       qty: 3,
+      unit: 'hour',
       unitPrice: 8000,
       lineTotal: 24000,
       taxable: false,
+      optional: false,
+      optionalSelected: true,
     },
   ],
   subtotal: 59000,

--- a/packages/lib/src/documents/pdf/parts.tsx
+++ b/packages/lib/src/documents/pdf/parts.tsx
@@ -5,6 +5,7 @@
 import { formatCurrency } from '@auxx/utils/currency'
 import { Image, Text, View } from '@react-pdf/renderer'
 import { format } from 'date-fns'
+import { formatLineItemUnit, type LineItemUnit } from '../../money/units'
 import type { DocumentBusinessSettings } from '../resolve-settings'
 import type { createDocumentStyles } from './theme'
 
@@ -132,8 +133,44 @@ export interface DocumentLineRow {
   name: string
   description?: string | null
   qty: number
+  /** Money plan 13 §1/§6 — `null`/absent renders exactly as an unitless line does today. */
+  unit?: LineItemUnit | null
   unitPrice: number | null
   lineTotal: number | null
+  /** Small muted label under the line name — quote-pdf.tsx uses it to tag a pre-checked
+   * optional line as "Optional · included" in the main list (money plan 18 §7). Absent on
+   * every other row (invoice lines, deselected add-ons rendered in their own block). */
+  tag?: string | null
+}
+
+/** Formats a quantity without trailing zeros, up to 3 decimal places (`2.375`, `5`, `12`) —
+ * mirrors the line-builder's compact quantity cell (money plan 13 §7 decimal rule). */
+function formatDocQty(qty: number): string {
+  return String(Number(qty.toFixed(3)))
+}
+
+/**
+ * `12 hr` or bare `12` when the line has no unit — the document-label qty cell (money plan
+ * 13 §6/§9's explicit multiplication form, split across the Qty/Unit price/Amount columns).
+ */
+function formatDocQtyCell(qty: number, unit: LineItemUnit | null | undefined): string {
+  const suffix = formatLineItemUnit(unit, 'document')
+  return suffix ? `${formatDocQty(qty)} ${suffix}` : formatDocQty(qty)
+}
+
+/**
+ * `$85.00/hr` when priced and unitized, plain `$85.00` when unitized but the existing
+ * unpriced/em-dash state stays untouched — a `null` rate never renders `$0/unit` (money plan
+ * 13 §6).
+ */
+function formatDocUnitPriceCell(
+  unitPrice: number | null,
+  unit: LineItemUnit | null | undefined,
+  currencyCode: string
+): string {
+  const formatted = formatCurrency(unitPrice, { currencyCode })
+  const suffix = formatLineItemUnit(unit, 'document')
+  return suffix && unitPrice !== null ? `${formatted}/${suffix}` : formatted
 }
 
 /**
@@ -163,14 +200,15 @@ export function LineItemsTable(props: {
         <View key={i} style={styles.tableRow}>
           <View style={styles.colDescription}>
             <Text style={styles.lineName}>{line.name}</Text>
+            {line.tag ? <Text style={styles.lineTag}>{line.tag}</Text> : null}
             {showDescriptions && line.description ? (
               <Text style={styles.lineDescription}>{line.description}</Text>
             ) : null}
           </View>
-          {full ? <Text style={styles.colQty}>{line.qty}</Text> : null}
+          {full ? <Text style={styles.colQty}>{formatDocQtyCell(line.qty, line.unit)}</Text> : null}
           {full ? (
             <Text style={styles.colUnitPrice}>
-              {formatCurrency(line.unitPrice, { currencyCode })}
+              {formatDocUnitPriceCell(line.unitPrice, line.unit, currencyCode)}
             </Text>
           ) : null}
           <Text style={styles.colAmount}>{formatCurrency(line.lineTotal, { currencyCode })}</Text>

--- a/packages/lib/src/documents/pdf/quote-pdf.tsx
+++ b/packages/lib/src/documents/pdf/quote-pdf.tsx
@@ -8,6 +8,7 @@ import {
   BillingPartyBlock,
   DocumentFooter,
   DocumentHeader,
+  type DocumentLineRow,
   LineItemsTable,
   TotalsBlock,
 } from './parts'
@@ -17,12 +18,39 @@ import { createDocumentStyles, pageSizeFor } from './theme'
  * The quote PDF document template (money MQ2 build spec §B.2). Composes the
  * document-agnostic `parts.tsx` building blocks — MI1's `invoice-pdf.tsx` reuses the same
  * parts with an `invoice` settings bucket instead of `quote`.
+ *
+ * Optional line items (money plan 18 §7): pre-checked (`optional && optionalSelected`) lines
+ * stay in the main list, tagged "Optional · included"; deselected options move to a visually
+ * separated "Optional add-ons" block with prices but excluded from every total (they already
+ * are — `payload.subtotal`/`total` were computed with the exclusion applied, decision 4). The
+ * note that add-ons can be picked on the online quote page renders unconditionally: whether
+ * `documents.quote.acceptancePageEnabled` is on isn't part of `QuotePdfPayload` today (only the
+ * public quote-page's own payload carries it) and this wave intentionally doesn't plumb a new
+ * setting through the PDF payload just for this note.
  */
 export function QuotePdf(props: { payload: QuotePdfPayload; logoBytes?: Buffer | null }) {
   const { payload, logoBytes } = props
   const { settings } = payload
   const styles = createDocumentStyles(settings)
   const currencyCode = settings.currency
+
+  const mainLines: DocumentLineRow[] = []
+  const addOnLines: DocumentLineRow[] = []
+  for (const line of payload.lines) {
+    const row: DocumentLineRow = {
+      name: line.name,
+      description: line.description,
+      qty: line.qty,
+      unit: line.unit,
+      unitPrice: line.unitPrice,
+      lineTotal: line.lineTotal,
+    }
+    if (line.optional && !line.optionalSelected) {
+      addOnLines.push(row)
+    } else {
+      mainLines.push(line.optional ? { ...row, tag: 'Optional · included' } : row)
+    }
+  }
 
   return (
     <Document title={`${payload.number} — ${payload.title}`}>
@@ -47,11 +75,28 @@ export function QuotePdf(props: { payload: QuotePdfPayload; logoBytes?: Buffer |
 
         <LineItemsTable
           styles={styles}
-          lines={payload.lines}
+          lines={mainLines}
           lineDisplay={settings.quote.lineDisplay}
           showDescriptions={settings.quote.showDescriptions}
           currencyCode={currencyCode}
         />
+
+        {addOnLines.length > 0 ? (
+          <View style={{ marginTop: 16 }}>
+            <Text style={[styles.label, { marginBottom: 6 }]}>Optional add-ons</Text>
+            <LineItemsTable
+              styles={styles}
+              lines={addOnLines}
+              lineDisplay={settings.quote.lineDisplay}
+              showDescriptions={settings.quote.showDescriptions}
+              currencyCode={currencyCode}
+            />
+            <Text style={[styles.value, { marginTop: 6, fontSize: 8, color: '#6b7280' }]}>
+              These add-ons aren&apos;t included in the total above — they can be added on the
+              online quote page.
+            </Text>
+          </View>
+        ) : null}
 
         <TotalsBlock
           styles={styles}

--- a/packages/lib/src/documents/pdf/theme.ts
+++ b/packages/lib/src/documents/pdf/theme.ts
@@ -71,6 +71,14 @@ export function createDocumentStyles(settings: ResolvedDocumentSettings) {
     colAmount: { flex: 1, paddingHorizontal: 4, textAlign: 'right' },
     lineName: { fontSize: 9 },
     lineDescription: { fontSize: 8, color: '#6b7280', marginTop: 2 },
+    /** Money plan 18 §7 — the "Optional · included" tag under a pre-checked optional line. */
+    lineTag: {
+      fontSize: 7,
+      color: '#6b7280',
+      marginTop: 1,
+      textTransform: 'uppercase',
+      letterSpacing: 0.3,
+    },
     totalsBlock: { marginTop: 16, alignSelf: 'flex-end', width: 220 },
     totalsRow: { flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 3 },
     totalsRowFinal: {

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -17,6 +17,11 @@ import {
   syncContactAfterWorkOrderDelete,
 } from '../money/billing-hooks'
 import {
+  pauseMarkupOnPriceEdit,
+  recomputePriceOnMarkupChange,
+  syncCatalogCostOnPartChange,
+} from '../money/catalog-pricing'
+import {
   recomputeOnInvoiceBillingChange,
   recomputeOnLineChange,
   recomputeOnQuoteBillingChange,
@@ -138,6 +143,19 @@ export function registerAllHooks(): void {
     enrollInvoiceReminderOnSent,
     reanchorInvoiceOnDueDateChange,
     syncBillingOnInvoiceChange,
+  ])
+
+  // Part cost sync + markup pricing (money plan 17 §3) — the three interactive
+  // triggers: linking/unlinking a part syncs (or clears) `cost`; setting a markup
+  // recomputes `price`; hand-editing `price` clears markup (the pause switch). All
+  // writes go through the hook-free writer in `catalog-pricing.ts`, so these can never
+  // recurse into each other. The bulk-recalc ripple (vendor price / BOM composition
+  // changes) chains in separately at the end of `recalculateAllPartCosts` /
+  // `recalculateAffectedParts` (`bom/cost-calculator.ts`), not through this door.
+  registerEntityFieldChangeHooks('catalog-items', [
+    syncCatalogCostOnPartChange,
+    recomputePriceOnMarkupChange,
+    pauseMarkupOnPriceEdit,
   ])
 
   // ---------------------------------------------------------------------------

--- a/packages/lib/src/money/__tests__/quote-acceptance.test.ts
+++ b/packages/lib/src/money/__tests__/quote-acceptance.test.ts
@@ -1,0 +1,36 @@
+// packages/lib/src/money/__tests__/quote-acceptance.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { BadRequestError } from '../../errors'
+import { validateSelectedLineIds } from '../quote-acceptance'
+
+describe('validateSelectedLineIds (money plan 18 §5 step 2)', () => {
+  it('returns a selection set when every submitted id is one of the optional lines', () => {
+    const result = validateSelectedLineIds(['opt-1', 'opt-2', 'opt-3'], ['opt-1', 'opt-3'])
+    expect(result).toEqual(new Set(['opt-1', 'opt-3']))
+  })
+
+  it('treats an empty submission as deselecting every optional line (not an error)', () => {
+    const result = validateSelectedLineIds(['opt-1', 'opt-2'], [])
+    expect(result.size).toBe(0)
+  })
+
+  it("rejects an id that is not one of the quote's optional lines (unknown id)", () => {
+    expect(() => validateSelectedLineIds(['opt-1', 'opt-2'], ['not-a-real-line'])).toThrow(
+      BadRequestError
+    )
+  })
+
+  it('rejects an id belonging to a required (non-optional) line rather than silently ignoring it', () => {
+    // required-line-9 is a real line instance id, but it's not in the optional-lines list —
+    // the caller must reject it, not drop it, per plan 18 §5 step 2.
+    expect(() => validateSelectedLineIds(['opt-1'], ['opt-1', 'required-line-9'])).toThrow(
+      /required-line-9/
+    )
+  })
+
+  it('is order-independent and de-duplicates the returned set', () => {
+    const result = validateSelectedLineIds(['opt-1', 'opt-2'], ['opt-2', 'opt-1', 'opt-2'])
+    expect(result).toEqual(new Set(['opt-1', 'opt-2']))
+  })
+})

--- a/packages/lib/src/money/__tests__/units.test.ts
+++ b/packages/lib/src/money/__tests__/units.test.ts
@@ -1,0 +1,352 @@
+// packages/lib/src/money/__tests__/units.test.ts
+
+import { describe, expect, it } from 'vitest'
+import {
+  formatLineItemUnit,
+  LINE_ITEM_UNIT_OPTIONS,
+  type LineItemUnit,
+  parseQuantityWithUnit,
+} from '../units'
+
+/** money plan 13 §1 canonical table — stored value, compact label, document label. */
+const CANONICAL_UNITS: Array<[LineItemUnit, string, string]> = [
+  ['each', 'ea', 'ea'],
+  ['minute', 'min', 'min'],
+  ['hour', 'hr', 'hr'],
+  ['day', 'day', 'day'],
+  ['week', 'wk', 'wk'],
+  ['linear_foot', 'lf', 'lf'],
+  ['square_foot', 'sf', 'sq ft'],
+  ['cubic_foot', 'cf', 'cu ft'],
+  ['cubic_yard', 'cy', 'cu yd'],
+  ['gallon', 'gal', 'gal'],
+  ['pound', 'lb', 'lb'],
+  ['mile', 'mi', 'mi'],
+  ['ton', 'ton', 'ton'],
+  ['acre', 'ac', 'ac'],
+]
+
+/** money plan 13 §1 minimum-alias table — every alias must resolve to its stored unit. */
+const MINIMUM_ALIASES: Array<[string, LineItemUnit]> = [
+  ['ea', 'each'],
+  ['each', 'each'],
+  ['item', 'each'],
+  ['piece', 'each'],
+  ['pc', 'each'],
+  ['min', 'minute'],
+  ['mins', 'minute'],
+  ['minute', 'minute'],
+  ['minutes', 'minute'],
+  ['h', 'hour'],
+  ['hr', 'hour'],
+  ['hrs', 'hour'],
+  ['hour', 'hour'],
+  ['hours', 'hour'],
+  ['d', 'day'],
+  ['day', 'day'],
+  ['days', 'day'],
+  ['wk', 'week'],
+  ['wks', 'week'],
+  ['week', 'week'],
+  ['weeks', 'week'],
+  ['lf', 'linear_foot'],
+  ['lft', 'linear_foot'],
+  ['ft', 'linear_foot'],
+  ['foot', 'linear_foot'],
+  ['feet', 'linear_foot'],
+  ['linear foot', 'linear_foot'],
+  ['linear feet', 'linear_foot'],
+  ['sf', 'square_foot'],
+  ['sqft', 'square_foot'],
+  ['sq ft', 'square_foot'],
+  ['square foot', 'square_foot'],
+  ['square feet', 'square_foot'],
+  ['cf', 'cubic_foot'],
+  ['cuft', 'cubic_foot'],
+  ['cu ft', 'cubic_foot'],
+  ['cubic foot', 'cubic_foot'],
+  ['cubic feet', 'cubic_foot'],
+  ['cy', 'cubic_yard'],
+  ['cuyd', 'cubic_yard'],
+  ['cu yd', 'cubic_yard'],
+  ['cubic yard', 'cubic_yard'],
+  ['cubic yards', 'cubic_yard'],
+  ['gal', 'gallon'],
+  ['gals', 'gallon'],
+  ['gallon', 'gallon'],
+  ['gallons', 'gallon'],
+  ['lb', 'pound'],
+  ['lbs', 'pound'],
+  ['pound', 'pound'],
+  ['pounds', 'pound'],
+  ['mi', 'mile'],
+  ['mile', 'mile'],
+  ['miles', 'mile'],
+  ['t', 'ton'],
+  ['ton', 'ton'],
+  ['tons', 'ton'],
+  ['ac', 'acre'],
+  ['acre', 'acre'],
+  ['acres', 'acre'],
+]
+
+describe('LINE_ITEM_UNIT_OPTIONS', () => {
+  it('has one option per canonical unit, in table order, with no color', () => {
+    expect(LINE_ITEM_UNIT_OPTIONS).toHaveLength(CANONICAL_UNITS.length)
+    CANONICAL_UNITS.forEach(([value], index) => {
+      expect(LINE_ITEM_UNIT_OPTIONS[index]).toEqual({
+        label: expect.any(String),
+        value,
+      })
+    })
+  })
+})
+
+describe('formatLineItemUnit', () => {
+  it.each(CANONICAL_UNITS)('formats %s compact as %s and document as %s', (unit, compact, doc) => {
+    expect(formatLineItemUnit(unit, 'compact')).toBe(compact)
+    expect(formatLineItemUnit(unit, 'document')).toBe(doc)
+  })
+
+  it('formats null/undefined as an empty string in both modes', () => {
+    expect(formatLineItemUnit(null, 'compact')).toBe('')
+    expect(formatLineItemUnit(undefined, 'compact')).toBe('')
+    expect(formatLineItemUnit(null, 'document')).toBe('')
+    expect(formatLineItemUnit(undefined, 'document')).toBe('')
+  })
+})
+
+describe('parseQuantityWithUnit — number-only', () => {
+  it('parses a bare integer and preserves the current unit', () => {
+    expect(parseQuantityWithUnit('5', { quantity: 1, unit: 'hour' })).toEqual({
+      ok: true,
+      quantity: 5,
+      unit: 'hour',
+    })
+  })
+
+  it('preserves a null current unit', () => {
+    expect(parseQuantityWithUnit('5', { quantity: 1, unit: null })).toEqual({
+      ok: true,
+      quantity: 5,
+      unit: null,
+    })
+  })
+
+  it('parses a decimal quantity', () => {
+    expect(parseQuantityWithUnit('1.5', { quantity: null, unit: 'hour' })).toEqual({
+      ok: true,
+      quantity: 1.5,
+      unit: 'hour',
+    })
+  })
+
+  it('parses a leading-dot decimal quantity', () => {
+    expect(parseQuantityWithUnit('.5', { quantity: null, unit: 'hour' })).toEqual({
+      ok: true,
+      quantity: 0.5,
+      unit: 'hour',
+    })
+  })
+
+  it('parses a simple fraction', () => {
+    expect(parseQuantityWithUnit('3/4', { quantity: null, unit: 'cubic_yard' })).toEqual({
+      ok: true,
+      quantity: 0.75,
+      unit: 'cubic_yard',
+    })
+  })
+
+  it('parses a mixed fraction', () => {
+    expect(parseQuantityWithUnit('1 1/2', { quantity: null, unit: 'hour' })).toEqual({
+      ok: true,
+      quantity: 1.5,
+      unit: 'hour',
+    })
+  })
+})
+
+describe('parseQuantityWithUnit — unit-only', () => {
+  it('sets the unit and preserves the current quantity', () => {
+    expect(parseQuantityWithUnit('hr', { quantity: 12, unit: null })).toEqual({
+      ok: true,
+      quantity: 12,
+      unit: 'hour',
+    })
+  })
+
+  it('preserves a null current quantity', () => {
+    expect(parseQuantityWithUnit('hr', { quantity: null, unit: null })).toEqual({
+      ok: true,
+      quantity: null,
+      unit: 'hour',
+    })
+  })
+
+  it('is case-insensitive and whitespace tolerant', () => {
+    expect(parseQuantityWithUnit(' SQ FT ', { quantity: 5, unit: null })).toEqual({
+      ok: true,
+      quantity: 5,
+      unit: 'square_foot',
+    })
+  })
+})
+
+describe('parseQuantityWithUnit — quantity + unit', () => {
+  it.each([
+    ['5sf', 5, 'square_foot'],
+    ['5 SF', 5, 'square_foot'],
+    ['5 sq ft', 5, 'square_foot'],
+    ['2.375cy', 2.375, 'cubic_yard'],
+    ['1.5hr', 1.5, 'hour'],
+    ['1 1/2hr', 1.5, 'hour'],
+    ['3/4 cy', 0.75, 'cubic_yard'],
+    ['12 hr', 12, 'hour'],
+    ['140lf', 140, 'linear_foot'],
+    ['8.5 cy', 8.5, 'cubic_yard'],
+  ] as const)('parses %s as quantity %s, unit %s', (input, quantity, unit) => {
+    expect(parseQuantityWithUnit(input, { quantity: null, unit: null })).toEqual({
+      ok: true,
+      quantity,
+      unit,
+    })
+  })
+
+  it.each(
+    MINIMUM_ALIASES
+  )('resolves alias "%s" to %s when suffixed to a quantity', (alias, unit) => {
+    expect(parseQuantityWithUnit(`3${alias}`, { quantity: null, unit: null })).toEqual({
+      ok: true,
+      quantity: 3,
+      unit,
+    })
+    expect(parseQuantityWithUnit(`3 ${alias}`, { quantity: null, unit: null })).toEqual({
+      ok: true,
+      quantity: 3,
+      unit,
+    })
+    expect(
+      parseQuantityWithUnit(`3 ${alias.toUpperCase()}`, { quantity: null, unit: null })
+    ).toEqual({
+      ok: true,
+      quantity: 3,
+      unit,
+    })
+  })
+
+  it.each(
+    MINIMUM_ALIASES
+  )('resolves alias "%s" unit-only to %s, preserving quantity', (alias, unit) => {
+    expect(parseQuantityWithUnit(alias, { quantity: 7, unit: null })).toEqual({
+      ok: true,
+      quantity: 7,
+      unit,
+    })
+  })
+
+  it('tolerates ordinary punctuation in multi-word aliases', () => {
+    expect(parseQuantityWithUnit('5 sq.ft.', { quantity: null, unit: null })).toEqual({
+      ok: true,
+      quantity: 5,
+      unit: 'square_foot',
+    })
+    expect(parseQuantityWithUnit('5 cu-yd', { quantity: null, unit: null })).toEqual({
+      ok: true,
+      quantity: 5,
+      unit: 'cubic_yard',
+    })
+  })
+})
+
+describe('parseQuantityWithUnit — determinism and longest-alias-wins', () => {
+  it('does not let a shorter overlapping alias win over the full suffix', () => {
+    expect(parseQuantityWithUnit('5 sq ft', { quantity: null, unit: null })).toEqual({
+      ok: true,
+      quantity: 5,
+      unit: 'square_foot',
+    })
+    expect(parseQuantityWithUnit('5 sq ft', { quantity: null, unit: null })).not.toEqual(
+      expect.objectContaining({ unit: 'linear_foot' })
+    )
+  })
+
+  it('distinguishes ft (linear_foot) from sqft (square_foot) with no space', () => {
+    expect(parseQuantityWithUnit('5ft', { quantity: null, unit: null })).toEqual({
+      ok: true,
+      quantity: 5,
+      unit: 'linear_foot',
+    })
+    expect(parseQuantityWithUnit('5sqft', { quantity: null, unit: null })).toEqual({
+      ok: true,
+      quantity: 5,
+      unit: 'square_foot',
+    })
+  })
+
+  it('a recognized suffix always replaces the current unit', () => {
+    expect(parseQuantityWithUnit('5 day', { quantity: null, unit: 'hour' })).toEqual({
+      ok: true,
+      quantity: 5,
+      unit: 'day',
+    })
+  })
+
+  it('parsing never converts units — changing the unit leaves quantity untouched', () => {
+    const committed = parseQuantityWithUnit('5', { quantity: null, unit: null })
+    expect(committed).toEqual({ ok: true, quantity: 5, unit: null })
+    if (!committed.ok) throw new Error('expected ok result')
+
+    const reUnit = parseQuantityWithUnit('day', {
+      quantity: committed.quantity,
+      unit: committed.unit,
+    })
+    expect(reUnit).toEqual({ ok: true, quantity: 5, unit: 'day' })
+  })
+})
+
+describe('parseQuantityWithUnit — invalid input', () => {
+  it('rejects empty input', () => {
+    const result = parseQuantityWithUnit('', { quantity: 1, unit: 'hour' })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects whitespace-only input', () => {
+    const result = parseQuantityWithUnit('   ', { quantity: 1, unit: 'hour' })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a zero-denominator simple fraction', () => {
+    const result = parseQuantityWithUnit('3/0 cy', { quantity: null, unit: null })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a zero-denominator mixed fraction', () => {
+    const result = parseQuantityWithUnit('1 1/0 hr', { quantity: null, unit: null })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects an unknown unit suffix rather than keeping the numeric prefix', () => {
+    const result = parseQuantityWithUnit('5xyz', { quantity: 1, unit: 'hour' })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects unit-only text that matches no alias', () => {
+    const result = parseQuantityWithUnit('xyz', { quantity: 1, unit: 'hour' })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a malformed number with a stray extra decimal point', () => {
+    const result = parseQuantityWithUnit('5.5.5hr', { quantity: null, unit: null })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects trailing garbage after a valid unit', () => {
+    const result = parseQuantityWithUnit('5 sf extra', { quantity: null, unit: null })
+    expect(result.ok).toBe(false)
+  })
+
+  it('does not persist either field on an invalid parse (returns error only)', () => {
+    const result = parseQuantityWithUnit('5xyz', { quantity: 1, unit: 'hour' })
+    expect(result).toEqual({ ok: false, error: expect.any(String) })
+  })
+})

--- a/packages/lib/src/money/catalog-pricing.test.ts
+++ b/packages/lib/src/money/catalog-pricing.test.ts
@@ -1,0 +1,390 @@
+// packages/lib/src/money/catalog-pricing.test.ts
+// Plan 17 §2/§3 — part cost sync + markup pricing. Mirrors the harness style of
+// `field-hooks/post/bom-cost-triggers.test.ts`: mock `@auxx/database` with a sequential
+// result queue (queries run in a deterministic order per call) and the cache/field-value/
+// realtime seams, then assert on the hook-free writer's calls rather than on drizzle
+// column identity (drizzle column refs can read as `undefined` under vitest).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  queryQueue: [] as unknown[][],
+  setValueWithType: vi.fn(async (_ctx: unknown, _params: unknown) => [] as unknown[]),
+  createFieldValueContext: vi.fn((organizationId: string) => ({ organizationId })),
+  getRealtimeService: vi.fn(() => ({})),
+  publishFieldValueUpdates: vi.fn(async (_svc: unknown, _orgId: string, _entries: unknown[]) => {}),
+  bySystemAttributes: vi.fn(),
+  bySystemAttribute: vi.fn(),
+  requireCachedEntityDefId: vi.fn(async () => 'catalog_item_def'),
+}))
+
+function nextRows(): unknown[] {
+  return h.queryQueue.shift() ?? []
+}
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(nextRows()),
+      }),
+    }),
+  },
+  schema: {
+    FieldValue: {
+      entityId: 'entityId',
+      fieldId: 'fieldId',
+      relatedEntityId: 'relatedEntityId',
+      organizationId: 'organizationId',
+      valueNumber: 'valueNumber',
+    },
+  },
+}))
+
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: h.bySystemAttributes,
+      bySystemAttribute: h.bySystemAttribute,
+    }),
+  }),
+  requireCachedEntityDefId: h.requireCachedEntityDefId,
+}))
+
+vi.mock('../field-values/field-value-helpers', () => ({
+  createFieldValueContext: h.createFieldValueContext,
+}))
+
+vi.mock('../field-values/field-value-mutations', () => ({
+  setValueWithType: h.setValueWithType,
+}))
+
+vi.mock('../realtime', () => ({
+  getRealtimeService: h.getRealtimeService,
+  publishFieldValueUpdates: h.publishFieldValueUpdates,
+}))
+
+import type { EntityFieldChangeEvent } from '../field-hooks/types'
+import {
+  computeMarkupPrice,
+  pauseMarkupOnPriceEdit,
+  recomputePriceOnMarkupChange,
+  shouldPauseMarkup,
+  syncCatalogCostOnPartChange,
+  syncCatalogItemPricing,
+} from './catalog-pricing'
+
+const ALL_CATALOG_FIELDS = {
+  catalog_item_part: { id: 'f_part', type: 'RELATIONSHIP' },
+  catalog_item_cost: { id: 'f_cost', type: 'CURRENCY' },
+  catalog_item_markup: { id: 'f_markup', type: 'NUMBER' },
+  catalog_item_default_unit_price: { id: 'f_price', type: 'CURRENCY' },
+}
+
+function buildEvent(overrides: Record<string, unknown>): EntityFieldChangeEvent {
+  return {
+    recordId: 'catalog_item:cat1',
+    entityDefinitionId: 'catalog_item_def',
+    entityType: null,
+    entitySlug: 'catalog-items',
+    field: { id: 'f_part', type: 'RELATIONSHIP', systemAttribute: 'catalog_item_part' },
+    oldValue: null,
+    newValue: null,
+    oldDisplay: null,
+    newDisplay: null,
+    organizationId: 'org_1',
+    userId: 'user_1',
+    ...overrides,
+  } as unknown as EntityFieldChangeEvent
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.queryQueue = []
+  h.bySystemAttributes.mockResolvedValue(ALL_CATALOG_FIELDS)
+  h.bySystemAttribute.mockResolvedValue({ id: 'f_partcost', type: 'CURRENCY' })
+})
+
+// ─── Pure math ───────────────────────────────────────────────────────
+
+describe('computeMarkupPrice', () => {
+  it('applies a 50% markup and rounds to a whole cent', () => {
+    expect(computeMarkupPrice(320, 50)).toBe(480)
+  })
+
+  it('returns cost unchanged at 0% markup', () => {
+    expect(computeMarkupPrice(1000, 0)).toBe(1000)
+  })
+
+  it('doubles cost at 100% markup', () => {
+    expect(computeMarkupPrice(500, 100)).toBe(1000)
+  })
+
+  it('rounds fractional cents (round-half-up)', () => {
+    // 333 * 1.15 = 382.95 → 383
+    expect(computeMarkupPrice(333, 15)).toBe(383)
+  })
+})
+
+describe('shouldPauseMarkup', () => {
+  it('does not pause when the new price matches the computed auto price', () => {
+    expect(shouldPauseMarkup(computeMarkupPrice(500, 50), 500, 50)).toBe(false)
+  })
+
+  it('pauses when the new price differs from the computed auto price', () => {
+    expect(shouldPauseMarkup(999, 500, 50)).toBe(true)
+  })
+
+  it('pauses when there is no cost basis to compare against', () => {
+    expect(shouldPauseMarkup(750, null, 50)).toBe(true)
+  })
+
+  it('pauses when the price was cleared entirely', () => {
+    expect(shouldPauseMarkup(null, 500, 50)).toBe(true)
+  })
+})
+
+// ─── Sync engine (§2) ────────────────────────────────────────────────
+
+describe('syncCatalogItemPricing', () => {
+  it('returns immediately for an empty changedPartIds array (no cache/DB calls)', async () => {
+    await syncCatalogItemPricing('org_1', [])
+    expect(h.bySystemAttributes).not.toHaveBeenCalled()
+  })
+
+  it('logs and returns when the pricing fields are not migrated yet', async () => {
+    h.bySystemAttributes.mockResolvedValue({
+      catalog_item_part: null,
+      catalog_item_cost: null,
+      catalog_item_markup: null,
+      catalog_item_default_unit_price: null,
+    })
+    await syncCatalogItemPricing('org_1', ['part1'])
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('runs exactly ONE query and writes nothing when no catalog item is linked', async () => {
+    h.queryQueue = [[]] // linkRows query → nothing linked
+    await syncCatalogItemPricing('org_1', ['part1'])
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.requireCachedEntityDefId).not.toHaveBeenCalled()
+  })
+
+  it('updates cost on both linked items but price ONLY on the one with a markup set', async () => {
+    h.queryQueue = [
+      // linkRows: two catalog items both backed by part1
+      [
+        { catalogInstanceId: 'cat1', partInstanceId: 'part1' },
+        { catalogInstanceId: 'cat2', partInstanceId: 'part1' },
+      ],
+      // part costs: part1's new landed cost is 500
+      [{ entityId: 'part1', valueNumber: 500 }],
+      // current values: cat1 has no markup, cat2 has markup=50 and a stale price
+      [
+        { entityId: 'cat1', fieldId: 'f_cost', valueNumber: 300 },
+        { entityId: 'cat2', fieldId: 'f_cost', valueNumber: 300 },
+        { entityId: 'cat2', fieldId: 'f_markup', valueNumber: 50 },
+        { entityId: 'cat2', fieldId: 'f_price', valueNumber: 450 },
+      ],
+    ]
+
+    await syncCatalogItemPricing('org_1', ['part1'])
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(3) // cat1 cost, cat2 cost, cat2 price
+    const calls = h.setValueWithType.mock.calls.map(
+      (call) => call[1] as { recordId: string; fieldId: string; value: unknown }
+    )
+
+    const cat1Cost = calls.find(
+      (c) => c.recordId === 'catalog_item_def:cat1' && c.fieldId === 'f_cost'
+    )
+    expect(cat1Cost?.value).toEqual({ type: 'number', value: 500 })
+
+    const cat2Cost = calls.find(
+      (c) => c.recordId === 'catalog_item_def:cat2' && c.fieldId === 'f_cost'
+    )
+    expect(cat2Cost?.value).toEqual({ type: 'number', value: 500 })
+
+    const cat2Price = calls.find(
+      (c) => c.recordId === 'catalog_item_def:cat2' && c.fieldId === 'f_price'
+    )
+    expect(cat2Price?.value).toEqual({ type: 'number', value: computeMarkupPrice(500, 50) })
+
+    const cat1Price = calls.find(
+      (c) => c.recordId === 'catalog_item_def:cat1' && c.fieldId === 'f_price'
+    )
+    expect(cat1Price).toBeUndefined()
+
+    expect(h.publishFieldValueUpdates).toHaveBeenCalledTimes(1)
+    const entries = h.publishFieldValueUpdates.mock.calls[0]?.[2] as unknown[]
+    expect(entries).toHaveLength(3)
+  })
+
+  it('skips a write when the new value equals the current value', async () => {
+    h.queryQueue = [
+      [{ catalogInstanceId: 'cat1', partInstanceId: 'part1' }],
+      [{ entityId: 'part1', valueNumber: 500 }],
+      [{ entityId: 'cat1', fieldId: 'f_cost', valueNumber: 500 }], // already in sync
+    ]
+    await syncCatalogItemPricing('org_1', ['part1'])
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.publishFieldValueUpdates).not.toHaveBeenCalled()
+  })
+})
+
+// ─── Interactive triggers (§3) ────────────────────────────────────────
+
+describe('syncCatalogCostOnPartChange', () => {
+  it('ignores field changes other than catalog_item_part', async () => {
+    const event = buildEvent({
+      field: { id: 'f_other', type: 'TEXT', systemAttribute: 'catalog_item_name' },
+    })
+    await syncCatalogCostOnPartChange(event)
+    expect(h.bySystemAttributes).not.toHaveBeenCalled()
+  })
+
+  it('part set: writes cost, and recomputes price when markup is already set', async () => {
+    h.queryQueue = [
+      [], // current cost on the catalog item (none yet)
+      [{ valueNumber: 500 }], // the linked part's current part_cost
+      [{ valueNumber: 50 }], // current markup on the catalog item
+      [{ valueNumber: 200 }], // current (stale) price
+    ]
+    const event = buildEvent({
+      newValue: [{ type: 'relationship', recordId: 'part:part1' }],
+    })
+    await syncCatalogCostOnPartChange(event)
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(2)
+    const values = h.setValueWithType.mock.calls.map((c) => (c[1] as { value: unknown }).value)
+    expect(values).toContainEqual({ type: 'number', value: 500 })
+    expect(values).toContainEqual({ type: 'number', value: computeMarkupPrice(500, 50) })
+  })
+
+  it('part cleared: clears cost, keeps markup untouched', async () => {
+    h.queryQueue = [[{ valueNumber: 500 }]] // existing cost present
+    const event = buildEvent({ newValue: null })
+    await syncCatalogCostOnPartChange(event)
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    const write = h.setValueWithType.mock.calls[0]?.[1] as { fieldId: string; value: unknown }
+    expect(write.fieldId).toBe('f_cost')
+    expect(write.value).toBeNull()
+  })
+
+  it('part cleared with no existing cost: no-op', async () => {
+    h.queryQueue = [[]] // no current cost
+    const event = buildEvent({ newValue: null })
+    await syncCatalogCostOnPartChange(event)
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+})
+
+describe('recomputePriceOnMarkupChange', () => {
+  it('ignores field changes other than catalog_item_markup', async () => {
+    const event = buildEvent({
+      field: { id: 'f_other', type: 'TEXT', systemAttribute: 'catalog_item_name' },
+    })
+    await recomputePriceOnMarkupChange(event)
+    expect(h.bySystemAttributes).not.toHaveBeenCalled()
+  })
+
+  it('markup cleared: no-op (that IS the pause)', async () => {
+    const event = buildEvent({
+      field: { id: 'f_markup', type: 'NUMBER', systemAttribute: 'catalog_item_markup' },
+      newValue: null,
+    })
+    await recomputePriceOnMarkupChange(event)
+    expect(h.bySystemAttributes).not.toHaveBeenCalled()
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('markup set but no cost yet: no-op (inert without a linked part)', async () => {
+    h.queryQueue = [[]] // no current cost
+    const event = buildEvent({
+      field: { id: 'f_markup', type: 'NUMBER', systemAttribute: 'catalog_item_markup' },
+      newValue: { type: 'number', value: 50 },
+    })
+    await recomputePriceOnMarkupChange(event)
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('markup set with a cost basis: recomputes and writes price', async () => {
+    h.queryQueue = [
+      [{ valueNumber: 500 }], // current cost
+      [{ valueNumber: 200 }], // current (stale) price
+    ]
+    const event = buildEvent({
+      field: { id: 'f_markup', type: 'NUMBER', systemAttribute: 'catalog_item_markup' },
+      newValue: { type: 'number', value: 50 },
+    })
+    await recomputePriceOnMarkupChange(event)
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    const write = h.setValueWithType.mock.calls[0]?.[1] as { fieldId: string; value: unknown }
+    expect(write.fieldId).toBe('f_price')
+    expect(write.value).toEqual({ type: 'number', value: computeMarkupPrice(500, 50) })
+  })
+})
+
+describe('pauseMarkupOnPriceEdit', () => {
+  it('ignores field changes other than catalog_item_default_unit_price', async () => {
+    const event = buildEvent({
+      field: { id: 'f_other', type: 'TEXT', systemAttribute: 'catalog_item_name' },
+    })
+    await pauseMarkupOnPriceEdit(event)
+    expect(h.bySystemAttributes).not.toHaveBeenCalled()
+  })
+
+  it('already paused (markup null): no-op', async () => {
+    h.queryQueue = [[]] // no current markup
+    const event = buildEvent({
+      field: {
+        id: 'f_price',
+        type: 'CURRENCY',
+        systemAttribute: 'catalog_item_default_unit_price',
+      },
+      newValue: { type: 'number', value: 999 },
+    })
+    await pauseMarkupOnPriceEdit(event)
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('retyping the exact auto price: no pause', async () => {
+    h.queryQueue = [
+      [{ valueNumber: 50 }], // current markup
+      [{ valueNumber: 500 }], // current cost
+    ]
+    const event = buildEvent({
+      field: {
+        id: 'f_price',
+        type: 'CURRENCY',
+        systemAttribute: 'catalog_item_default_unit_price',
+      },
+      newValue: { type: 'number', value: computeMarkupPrice(500, 50) },
+    })
+    await pauseMarkupOnPriceEdit(event)
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('editing to a different price: pauses by clearing markup', async () => {
+    h.queryQueue = [
+      [{ valueNumber: 50 }], // current markup
+      [{ valueNumber: 500 }], // current cost
+    ]
+    const event = buildEvent({
+      field: {
+        id: 'f_price',
+        type: 'CURRENCY',
+        systemAttribute: 'catalog_item_default_unit_price',
+      },
+      newValue: { type: 'number', value: 999 },
+    })
+    await pauseMarkupOnPriceEdit(event)
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    const write = h.setValueWithType.mock.calls[0]?.[1] as { fieldId: string; value: unknown }
+    expect(write.fieldId).toBe('f_markup')
+    expect(write.value).toBeNull()
+  })
+})

--- a/packages/lib/src/money/catalog-pricing.ts
+++ b/packages/lib/src/money/catalog-pricing.ts
@@ -1,0 +1,474 @@
+// packages/lib/src/money/catalog-pricing.ts
+//
+// Part cost sync + markup pricing engine for catalog items (plan 17). A part-linked
+// catalog item always mirrors its part's `part_cost` into `catalog_item_cost`; when a
+// markup percentage is set it also drives `catalog_item_default_unit_price` — but the
+// price stays hand-editable, and editing it clears the markup (the pause switch). All
+// writes here go through hook-free `setValueWithType`, exactly like `persistCosts` in
+// `bom/cost-calculator.ts` (see plan 17 §2's "why not a record rule" finding): the
+// price-edit-clears-markup hook below (§3) treats ANY normal-path
+// `catalog_item_default_unit_price` write as a genuine user edit, which only holds if
+// the sync engine's own writes never fire hooks.
+
+import { database, schema } from '@auxx/database'
+import type { FieldType } from '@auxx/database/types'
+import { createScopedLogger } from '@auxx/logger'
+import type { TypedFieldValue } from '@auxx/types'
+import { buildFieldValueKey, type FieldId, type FieldValueKey } from '@auxx/types/field'
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getOrgCache, requireCachedEntityDefId } from '../cache'
+import type { EntityFieldChangeHandler } from '../field-hooks/types'
+import { createFieldValueContext } from '../field-values/field-value-helpers'
+import { setValueWithType } from '../field-values/field-value-mutations'
+import { getRealtimeService, publishFieldValueUpdates } from '../realtime'
+
+const logger = createScopedLogger('money:catalog-pricing')
+
+// ─── Pure math ───────────────────────────────────────────────────────
+
+/**
+ * Auto-price formula (plan 17 decision 2): `price = round(cost * (1 + markup/100))`,
+ * in whole integer cents (the platform CURRENCY storage convention).
+ */
+export function computeMarkupPrice(cost: number, markup: number): number {
+  return Math.round(cost * (1 + markup / 100))
+}
+
+/**
+ * Guard for the price-edit-clears-markup hook (plan 17 §3, row 3): a user edit to
+ * `defaultUnitPrice` pauses auto-pricing UNLESS the new value is exactly what the
+ * formula would have produced anyway (a no-op retype of the auto price). No cost basis
+ * (`cost == null`) means there's nothing to compare against, so any edit pauses.
+ */
+export function shouldPauseMarkup(
+  newPrice: number | null,
+  cost: number | null,
+  markup: number
+): boolean {
+  if (cost == null) return true
+  return newPrice !== computeMarkupPrice(cost, markup)
+}
+
+// ─── Shared field resolution + hook-free writer ─────────────────────
+
+interface CatalogPricingFields {
+  part: { id: string; type: FieldType }
+  cost: { id: string; type: FieldType }
+  markup: { id: string; type: FieldType } | null
+  price: { id: string; type: FieldType } | null
+}
+
+/**
+ * Resolve the four catalog-item pricing fields via the org cache. Returns `null`
+ * (after logging) when the org hasn't run migration 044 yet — `part`/`cost` are the
+ * load-bearing pair; `markup`/`price` are optional so the sync still runs cost-only.
+ */
+async function resolveCatalogPricingFields(
+  organizationId: string
+): Promise<CatalogPricingFields | null> {
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes([
+      'catalog_item_part',
+      'catalog_item_cost',
+      'catalog_item_markup',
+      'catalog_item_default_unit_price',
+    ] as const)
+
+  if (!cf.catalog_item_part || !cf.catalog_item_cost) {
+    logger.warn('catalog_item pricing fields not found — org not migrated (044)', {
+      organizationId,
+    })
+    return null
+  }
+
+  // Cast at the one resolution point — `CustomFieldEntity.type` is drizzle-inferred from
+  // the DB enum (currently wider than `FieldType` by a legacy `PHONE` literal), so every
+  // downstream `setValueWithType` call needs the narrower published type.
+  return {
+    part: { id: cf.catalog_item_part.id, type: cf.catalog_item_part.type as FieldType },
+    cost: { id: cf.catalog_item_cost.id, type: cf.catalog_item_cost.type as FieldType },
+    markup: cf.catalog_item_markup
+      ? { id: cf.catalog_item_markup.id, type: cf.catalog_item_markup.type as FieldType }
+      : null,
+    price: cf.catalog_item_default_unit_price
+      ? {
+          id: cf.catalog_item_default_unit_price.id,
+          type: cf.catalog_item_default_unit_price.type as FieldType,
+        }
+      : null,
+  }
+}
+
+interface CatalogFieldWrite {
+  recordId: RecordId
+  fieldId: string
+  fieldType: FieldType
+  /** `null` clears the field (e.g. cost on an unlinked item). */
+  value: number | null
+}
+
+const BATCH_SIZE = 20
+
+/**
+ * THE hook-free writer for every catalog pricing write in this module — the sync
+ * engine's batch pass and all three interactive hooks funnel through this. Writes via
+ * `setValueWithType` (no field-change hooks, no recursion by construction) and
+ * publishes realtime `fieldValues:updated` entries so an open settings editor updates
+ * live, mirroring `persistCosts` (`bom/cost-calculator.ts`) batching + publish pattern.
+ */
+async function writeCatalogNumberValues(
+  organizationId: string,
+  writes: CatalogFieldWrite[]
+): Promise<void> {
+  if (writes.length === 0) return
+
+  const ctx = createFieldValueContext(organizationId)
+  const entries: Array<{ key: FieldValueKey; value: { type: 'number'; value: number } | null }> = []
+
+  for (let i = 0; i < writes.length; i += BATCH_SIZE) {
+    const batch = writes.slice(i, i + BATCH_SIZE)
+    const results = await Promise.allSettled(
+      batch.map(async (write) => {
+        await setValueWithType(ctx, {
+          recordId: write.recordId,
+          fieldId: write.fieldId,
+          fieldType: write.fieldType,
+          value: write.value == null ? null : { type: 'number', value: write.value },
+        })
+        return write
+      })
+    )
+
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        const write = result.value
+        entries.push({
+          key: buildFieldValueKey(write.recordId, write.fieldId as FieldId),
+          value: write.value == null ? null : { type: 'number', value: write.value },
+        })
+      } else {
+        logger.error('Failed to write catalog pricing field', {
+          error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        })
+      }
+    }
+  }
+
+  if (entries.length > 0) {
+    await publishFieldValueUpdates(getRealtimeService(), organizationId, entries).catch(() => {})
+  }
+}
+
+/** Read a single numeric FieldValue by raw entity instance id (no def-typed RecordId needed). */
+async function readNumberByEntityInstance(
+  organizationId: string,
+  entityInstanceId: string,
+  fieldId: string
+): Promise<number | null> {
+  const rows = await database
+    .select({ valueNumber: schema.FieldValue.valueNumber })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.entityId, entityInstanceId),
+        eq(schema.FieldValue.fieldId, fieldId),
+        eq(schema.FieldValue.organizationId, organizationId)
+      )
+    )
+  return rows[0]?.valueNumber ?? null
+}
+
+/** Read a single numeric FieldValue for a catalog item's own record. */
+async function readCurrentNumber(
+  organizationId: string,
+  recordId: RecordId,
+  fieldId: string
+): Promise<number | null> {
+  const { entityInstanceId } = parseRecordId(recordId)
+  return readNumberByEntityInstance(organizationId, entityInstanceId, fieldId)
+}
+
+// ─── Event value extraction (door 1 hooks) ──────────────────────────
+
+/** `EntityFieldChangeEvent.oldValue`/`newValue` is array-wrapped for RELATIONSHIP fields. */
+function firstTyped(value: unknown): TypedFieldValue | undefined {
+  if (value == null) return undefined
+  return Array.isArray(value)
+    ? (value[0] as TypedFieldValue | undefined)
+    : (value as TypedFieldValue)
+}
+
+function relationshipEntityInstanceId(value: unknown): string | null {
+  const typed = firstTyped(value)
+  if (!typed || typed.type !== 'relationship') return null
+  return parseRecordId(typed.recordId).entityInstanceId
+}
+
+function numericValue(value: unknown): number | null {
+  const typed = firstTyped(value)
+  if (!typed || typed.type !== 'number') return null
+  return typed.value
+}
+
+// ─── Sync engine (plan 17 §2) ────────────────────────────────────────
+
+/**
+ * Ripple changed part costs into every catalog item backed by those parts (plan 17
+ * §2). Called from the end of both `recalculateAllPartCosts` and
+ * `recalculateAffectedParts` (`bom/cost-calculator.ts`) with their `changedPartIds`.
+ *
+ * One cheap query for the common case (no catalog items linked to any changed part),
+ * then a batch cost sync + conditional markup-driven price recompute, hook-free.
+ */
+export async function syncCatalogItemPricing(
+  organizationId: string,
+  changedPartIds: string[]
+): Promise<void> {
+  if (changedPartIds.length === 0) return
+
+  const fields = await resolveCatalogPricingFields(organizationId)
+  if (!fields) return
+
+  // ── Step 2: ONE query — catalog items currently linked to a changed part ──
+  const linkRows = await database
+    .select({
+      catalogInstanceId: schema.FieldValue.entityId,
+      partInstanceId: schema.FieldValue.relatedEntityId,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.fieldId, fields.part.id),
+        eq(schema.FieldValue.organizationId, organizationId),
+        inArray(schema.FieldValue.relatedEntityId, changedPartIds)
+      )
+    )
+
+  if (linkRows.length === 0) return
+
+  // ── Step 3a: current part_cost for every referenced part ──
+  const partIds = [
+    ...new Set(linkRows.map((row) => row.partInstanceId).filter((id): id is string => id != null)),
+  ]
+
+  const partCostField = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttribute('part_cost')
+
+  const partCosts = new Map<string, number>()
+  if (partCostField && partIds.length > 0) {
+    const rows = await database
+      .select({ entityId: schema.FieldValue.entityId, valueNumber: schema.FieldValue.valueNumber })
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.fieldId, partCostField.id),
+          eq(schema.FieldValue.organizationId, organizationId),
+          inArray(schema.FieldValue.entityId, partIds)
+        )
+      )
+    for (const row of rows) {
+      if (row.valueNumber != null) partCosts.set(row.entityId, row.valueNumber)
+    }
+  }
+
+  // ── Step 3b: each affected item's current cost/markup/price ──
+  const catalogIds = linkRows.map((row) => row.catalogInstanceId)
+  const currentFieldIds = [fields.cost.id, fields.markup?.id, fields.price?.id].filter(
+    (id): id is string => id != null
+  )
+
+  const current = new Map<
+    string,
+    { cost: number | null; markup: number | null; price: number | null }
+  >()
+  if (currentFieldIds.length > 0) {
+    const rows = await database
+      .select({
+        entityId: schema.FieldValue.entityId,
+        fieldId: schema.FieldValue.fieldId,
+        valueNumber: schema.FieldValue.valueNumber,
+      })
+      .from(schema.FieldValue)
+      .where(
+        and(
+          inArray(schema.FieldValue.fieldId, currentFieldIds),
+          eq(schema.FieldValue.organizationId, organizationId),
+          inArray(schema.FieldValue.entityId, catalogIds)
+        )
+      )
+    for (const row of rows) {
+      const entry = current.get(row.entityId) ?? { cost: null, markup: null, price: null }
+      if (row.fieldId === fields.cost.id) entry.cost = row.valueNumber
+      else if (fields.markup && row.fieldId === fields.markup.id) entry.markup = row.valueNumber
+      else if (fields.price && row.fieldId === fields.price.id) entry.price = row.valueNumber
+      current.set(row.entityId, entry)
+    }
+  }
+
+  // ── Step 4: write cost always, price only where markup is set ──
+  const catalogDefId = await requireCachedEntityDefId(organizationId, 'catalog_item')
+  const writes: CatalogFieldWrite[] = []
+
+  for (const { catalogInstanceId, partInstanceId } of linkRows) {
+    if (!partInstanceId) continue
+    const newCost = partCosts.get(partInstanceId)
+    if (newCost == null) continue
+
+    const existing = current.get(catalogInstanceId) ?? { cost: null, markup: null, price: null }
+    const recordId = toRecordId(catalogDefId, catalogInstanceId) as RecordId
+
+    if (existing.cost !== newCost) {
+      writes.push({
+        recordId,
+        fieldId: fields.cost.id,
+        fieldType: fields.cost.type,
+        value: newCost,
+      })
+    }
+
+    if (fields.price && existing.markup != null) {
+      const newPrice = computeMarkupPrice(newCost, existing.markup)
+      if (existing.price !== newPrice) {
+        writes.push({
+          recordId,
+          fieldId: fields.price.id,
+          fieldType: fields.price.type,
+          value: newPrice,
+        })
+      }
+    }
+  }
+
+  await writeCatalogNumberValues(organizationId, writes)
+
+  logger.info('Synced catalog item pricing from part cost change', {
+    organizationId,
+    changedParts: changedPartIds.length,
+    affectedItems: linkRows.length,
+    writes: writes.length,
+  })
+}
+
+// ─── Interactive triggers (plan 17 §3 — door 1, real field-change hooks) ────
+
+/**
+ * `catalog_item_part` changed (plan 17 §3 row 1). Set → pull the new part's
+ * `part_cost`, write `cost`, and recompute `price` when a markup is already set.
+ * Cleared → clear `cost` only; KEEP `markup` (inert without a cost, resumes on
+ * re-link). Registered under the `catalog-items` apiSlug.
+ */
+export const syncCatalogCostOnPartChange: EntityFieldChangeHandler = async (event) => {
+  if (event.field.systemAttribute !== 'catalog_item_part') return
+
+  const { organizationId, recordId } = event
+  const fields = await resolveCatalogPricingFields(organizationId)
+  if (!fields) return
+
+  const partInstanceId = relationshipEntityInstanceId(event.newValue)
+  const currentCost = await readCurrentNumber(organizationId, recordId, fields.cost.id)
+
+  if (!partInstanceId) {
+    if (currentCost == null) return
+    await writeCatalogNumberValues(organizationId, [
+      { recordId, fieldId: fields.cost.id, fieldType: fields.cost.type, value: null },
+    ])
+    return
+  }
+
+  const partCostField = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttribute('part_cost')
+  if (!partCostField) return
+
+  const newCost = await readNumberByEntityInstance(organizationId, partInstanceId, partCostField.id)
+  if (newCost == null) {
+    // Newly linked part has no calculated cost yet — a stale cost from a previously linked
+    // part must not masquerade as synced from this one. Clear it; the next BOM recalc
+    // repopulates via `syncCatalogItemPricing`.
+    if (currentCost != null) {
+      await writeCatalogNumberValues(organizationId, [
+        { recordId, fieldId: fields.cost.id, fieldType: fields.cost.type, value: null },
+      ])
+    }
+    return
+  }
+
+  const writes: CatalogFieldWrite[] = []
+  if (currentCost !== newCost) {
+    writes.push({ recordId, fieldId: fields.cost.id, fieldType: fields.cost.type, value: newCost })
+  }
+
+  if (fields.markup && fields.price) {
+    const markup = await readCurrentNumber(organizationId, recordId, fields.markup.id)
+    if (markup != null) {
+      const newPrice = computeMarkupPrice(newCost, markup)
+      const currentPrice = await readCurrentNumber(organizationId, recordId, fields.price.id)
+      if (currentPrice !== newPrice) {
+        writes.push({
+          recordId,
+          fieldId: fields.price.id,
+          fieldType: fields.price.type,
+          value: newPrice,
+        })
+      }
+    }
+  }
+
+  await writeCatalogNumberValues(organizationId, writes)
+}
+
+/**
+ * `catalog_item_markup` changed (plan 17 §3 row 2). Non-null + `cost` non-null →
+ * recompute `price`. Cleared → nothing (that IS the pause). Registered under the
+ * `catalog-items` apiSlug.
+ */
+export const recomputePriceOnMarkupChange: EntityFieldChangeHandler = async (event) => {
+  if (event.field.systemAttribute !== 'catalog_item_markup') return
+
+  const newMarkup = numericValue(event.newValue)
+  if (newMarkup == null) return
+
+  const { organizationId, recordId } = event
+  const fields = await resolveCatalogPricingFields(organizationId)
+  if (!fields?.price) return
+
+  const cost = await readCurrentNumber(organizationId, recordId, fields.cost.id)
+  if (cost == null) return
+
+  const newPrice = computeMarkupPrice(cost, newMarkup)
+  const currentPrice = await readCurrentNumber(organizationId, recordId, fields.price.id)
+  if (currentPrice === newPrice) return
+
+  await writeCatalogNumberValues(organizationId, [
+    { recordId, fieldId: fields.price.id, fieldType: fields.price.type, value: newPrice },
+  ])
+}
+
+/**
+ * `catalog_item_default_unit_price` changed (plan 17 §3 row 3). If `markup` is
+ * non-null and the new price doesn't match the computed auto price, clear `markup`
+ * (pause). Retyping the exact auto price is a no-op, not a surprise pause. Registered
+ * under the `catalog-items` apiSlug.
+ */
+export const pauseMarkupOnPriceEdit: EntityFieldChangeHandler = async (event) => {
+  if (event.field.systemAttribute !== 'catalog_item_default_unit_price') return
+
+  const { organizationId, recordId } = event
+  const fields = await resolveCatalogPricingFields(organizationId)
+  if (!fields?.markup) return
+
+  const markup = await readCurrentNumber(organizationId, recordId, fields.markup.id)
+  if (markup == null) return
+
+  const cost = await readCurrentNumber(organizationId, recordId, fields.cost.id)
+  const newPrice = numericValue(event.newValue)
+
+  if (shouldPauseMarkup(newPrice, cost, markup)) {
+    await writeCatalogNumberValues(organizationId, [
+      { recordId, fieldId: fields.markup.id, fieldType: fields.markup.type, value: null },
+    ])
+  }
+}

--- a/packages/lib/src/money/client.ts
+++ b/packages/lib/src/money/client.ts
@@ -19,6 +19,15 @@ export type {
   WorkOrderBillingBasis,
   WorkOrderInvoiceTiming,
 } from './types'
+export {
+  formatLineItemUnit,
+  LINE_ITEM_UNIT_OPTIONS,
+  type LineItemQuantityState,
+  type LineItemUnit,
+  type LineItemUnitDisplayMode,
+  type ParseLineItemQuantityResult,
+  parseQuantityWithUnit,
+} from './units'
 
 /**
  * Valid invoice timings for each billing basis (work-order invoice flow plan §1.2) — the single

--- a/packages/lib/src/money/convert-quote.ts
+++ b/packages/lib/src/money/convert-quote.ts
@@ -187,6 +187,7 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
       'line_item_name',
       'line_item_description',
       'line_item_qty',
+      'line_item_unit',
       'line_item_unit_price',
       'line_item_line_total',
       'line_item_taxable',
@@ -194,6 +195,8 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
       'line_item_discount',
       'line_item_sort_order',
       'line_item_catalog_item',
+      'line_item_optional',
+      'line_item_optional_selected',
     ] as const)
 
   const { ids: lineInstanceIds } = await handler.listFiltered({
@@ -221,6 +224,7 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
     lineCf.line_item_name,
     lineCf.line_item_description,
     lineCf.line_item_qty,
+    lineCf.line_item_unit,
     lineCf.line_item_unit_price,
     lineCf.line_item_line_total,
     lineCf.line_item_taxable,
@@ -228,6 +232,8 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
     lineCf.line_item_discount,
     lineCf.line_item_sort_order,
     lineCf.line_item_catalog_item,
+    lineCf.line_item_optional,
+    lineCf.line_item_optional_selected,
   ]
     .filter(Boolean)
     .map((f) => f!.id)
@@ -240,6 +246,7 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
     const nameTyped = get(lineCf.line_item_name)
     const descriptionTyped = get(lineCf.line_item_description)
     const qtyTyped = get(lineCf.line_item_qty)
+    const unitTyped = get(lineCf.line_item_unit)
     const unitPriceTyped = get(lineCf.line_item_unit_price)
     const lineTotalTyped = get(lineCf.line_item_line_total)
     const taxableTyped = get(lineCf.line_item_taxable)
@@ -247,11 +254,23 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
     const discountTyped = get(lineCf.line_item_discount)
     const sortOrderTyped = get(lineCf.line_item_sort_order)
     const catalogItemTyped = get(lineCf.line_item_catalog_item)
+    const optionalTyped = get(lineCf.line_item_optional)
+    const optionalSelectedTyped = get(lineCf.line_item_optional_selected)
 
+    // Deselected option (plan 18 §6, decision 5) — stays on the quote only, never becomes work.
+    const optional = optionalTyped ? (extractValue(optionalTyped) as boolean) : false
+    const optionalSelected = optionalSelectedTyped
+      ? (extractValue(optionalSelectedTyped) as boolean)
+      : true
+    if (optional && !optionalSelected) continue
+
+    // Surviving copies are plain required lines (decision 6) — `line_item_optional`/
+    // `line_item_optional_selected` are read above only to decide the skip, never written here.
     const copyValues: Record<string, unknown> = {
       line_item_name: nameTyped ? extractValue(nameTyped) : undefined,
       line_item_description: descriptionTyped ? extractValue(descriptionTyped) : undefined,
       line_item_qty: qtyTyped ? extractValue(qtyTyped) : 1,
+      line_item_unit: unitTyped ? extractValue(unitTyped) : undefined,
       line_item_unit_price: unitPriceTyped ? extractValue(unitPriceTyped) : undefined,
       line_item_line_total: lineTotalTyped ? extractValue(lineTotalTyped) : undefined,
       line_item_taxable: taxableTyped ? extractValue(taxableTyped) : true,

--- a/packages/lib/src/money/gather.ts
+++ b/packages/lib/src/money/gather.ts
@@ -28,6 +28,7 @@ import type {
   ListUninvoicedLinesInput,
   UninvoicedLine,
 } from './types'
+import type { LineItemUnit } from './units'
 
 /** Unwrap a `getFieldValues()` map entry — takes the first value if array-returned. */
 function firstTyped(
@@ -41,6 +42,7 @@ const LINE_ROW_ATTRS = [
   'line_item_name',
   'line_item_description',
   'line_item_qty',
+  'line_item_unit',
   'line_item_unit_price',
   'line_item_line_total',
   'line_item_taxable',
@@ -56,6 +58,7 @@ export const LINE_COPY_ATTRS = [
   'line_item_name',
   'line_item_description',
   'line_item_qty',
+  'line_item_unit',
   'line_item_unit_price',
   'line_item_line_total',
   'line_item_taxable',
@@ -108,6 +111,7 @@ export async function listUninvoicedLines(
     name: string
     description: string | undefined
     qty: number
+    unit: LineItemUnit | null
     unitPrice: number | null
     lineTotal: number | null
     taxable: boolean
@@ -130,6 +134,7 @@ export async function listUninvoicedLines(
       name: (values.get('line_item_name') as string | undefined) ?? '',
       description: values.get('line_item_description') as string | undefined,
       qty: (values.get('line_item_qty') as number | undefined) ?? 1,
+      unit: (values.get('line_item_unit') as LineItemUnit | undefined) ?? null,
       unitPrice: (values.get('line_item_unit_price') as number | undefined) ?? null,
       lineTotal: (values.get('line_item_line_total') as number | undefined) ?? null,
       taxable: (values.get('line_item_taxable') as boolean | undefined) ?? true,
@@ -150,6 +155,7 @@ export async function listUninvoicedLines(
       name: row.name,
       description: row.description,
       qty: row.qty,
+      unit: row.unit,
       unitPrice: row.unitPrice,
       lineTotal: row.lineTotal,
       taxable: row.taxable,
@@ -344,6 +350,7 @@ export async function copyLineOntoInvoice(input: {
   const nameTyped = get(lineCf.line_item_name)
   const descriptionTyped = get(lineCf.line_item_description)
   const qtyTyped = get(lineCf.line_item_qty)
+  const unitTyped = get(lineCf.line_item_unit)
   const unitPriceTyped = get(lineCf.line_item_unit_price)
   const lineTotalTyped = get(lineCf.line_item_line_total)
   const taxableTyped = get(lineCf.line_item_taxable)
@@ -352,11 +359,13 @@ export async function copyLineOntoInvoice(input: {
   const sortOrderTyped = get(lineCf.line_item_sort_order)
   const catalogItemTyped = get(lineCf.line_item_catalog_item)
 
-  // No `line_item_work_order`, no `line_item_quote` on copies (§B.3 invariant).
+  // No `line_item_work_order`, no `line_item_quote` on copies (§B.3 invariant). Units flow to
+  // invoices (plan 13 §6); optionality does not — invoice/work-order lines never carry it.
   const copyValues: Record<string, unknown> = {
     line_item_name: nameTyped ? extractValue(nameTyped) : undefined,
     line_item_description: descriptionTyped ? extractValue(descriptionTyped) : undefined,
     line_item_qty: qtyTyped ? extractValue(qtyTyped) : 1,
+    line_item_unit: unitTyped ? extractValue(unitTyped) : undefined,
     line_item_unit_price: unitPriceTyped ? extractValue(unitPriceTyped) : undefined,
     line_item_line_total: lineTotalTyped ? extractValue(lineTotalTyped) : undefined,
     line_item_taxable: taxableTyped ? extractValue(taxableTyped) : true,

--- a/packages/lib/src/money/index.ts
+++ b/packages/lib/src/money/index.ts
@@ -45,6 +45,14 @@ export {
   syncWorkOrderBillingProjection,
 } from './billing-projection'
 export { getContactBillingOverview, getWorkOrderBillingState } from './billing-state'
+export {
+  computeMarkupPrice,
+  pauseMarkupOnPriceEdit,
+  recomputePriceOnMarkupChange,
+  shouldPauseMarkup,
+  syncCatalogCostOnPartChange,
+  syncCatalogItemPricing,
+} from './catalog-pricing'
 export { convertQuoteToWorkOrder } from './convert-quote'
 export { createInvoiceFromWorkOrder, deleteInvoiceLine, listUninvoicedLines } from './gather'
 export { deleteInvoice, markInvoiceSent, voidInvoice } from './invoice-lifecycle'
@@ -197,3 +205,12 @@ export type {
   WorkOrderBillingState,
   WorkOrderInvoiceTiming,
 } from './types'
+export {
+  formatLineItemUnit,
+  LINE_ITEM_UNIT_OPTIONS,
+  type LineItemQuantityState,
+  type LineItemUnit,
+  type LineItemUnitDisplayMode,
+  type ParseLineItemQuantityResult,
+  parseQuantityWithUnit,
+} from './units'

--- a/packages/lib/src/money/quote-acceptance.ts
+++ b/packages/lib/src/money/quote-acceptance.ts
@@ -3,14 +3,17 @@
 import { database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { toRecordId } from '@auxx/types/resource'
-import { getOrgCache } from '../cache'
+import { getOrgCache, requireCachedEntityDefId } from '../cache'
 import { BadRequestError, NotFoundError } from '../errors'
 import { FieldValueService } from '../field-values/field-value-service'
 import { NotificationService } from '../notifications/notification-service'
+import { UnifiedCrudHandler } from '../resources/crud'
+import { batchReadSystemValues } from './billing-projection'
 import { convertQuoteToWorkOrder } from './convert-quote'
 import { approveQuote, declineQuote } from './quote-lifecycle'
 import type { PublicQuotePayload } from './quote-public-token'
 import { getPublicQuotePayload, resolveQuoteByPublicToken } from './quote-public-token'
+import { recomputeTotals } from './totals-hooks'
 
 const logger = createScopedLogger('money:quote-acceptance')
 
@@ -88,6 +91,21 @@ async function notifyQuoteCreator(params: {
 export interface AcceptQuoteByTokenInput {
   /** Typed-signature name — required when `documents.quote.requireSignature` is on. */
   name?: string
+  /**
+   * Public accept-page optional-line selection (plan 18 §5) — the instance ids of every
+   * optional line the customer left checked. Standard HTML checkbox-form semantics: an
+   * unchecked box simply isn't in the submitted set, so a submitted-but-absent optional line
+   * id is treated as deselected.
+   *
+   * `undefined` (the field omitted entirely) means "no selection was submitted" — the
+   * internal/legacy accept path (no public form, or the quote's `acceptancePageEnabled` is
+   * off) takes the seller's pre-checked `optionalSelected` defaults as-is and this input is
+   * never touched.
+   *
+   * `[]` is an EXPLICIT submission that deselects every optional line (an all-unchecked
+   * public form) — it is honored as a real selection, not treated the same as `undefined`.
+   */
+  selectedLineIds?: string[]
 }
 
 /** Result of {@link acceptQuoteByToken}. */
@@ -99,11 +117,137 @@ export interface AcceptQuoteByTokenResult {
 }
 
 /**
+ * Validate a public accept-page selection against a quote's actual optional-line ids (plan 18
+ * §5 step 2). Pure and DB-free so it's unit-testable without a live quote. Every id in
+ * `selectedLineIds` must appear in `optionalLineInstanceIds` — an id that's simply unknown OR
+ * belongs to one of the quote's *required* lines is rejected, never silently ignored (decision:
+ * the plan explicitly calls for a throw, not a drop).
+ *
+ * @throws {BadRequestError} on the first id that isn't one of the quote's optional lines.
+ */
+export function validateSelectedLineIds(
+  optionalLineInstanceIds: readonly string[],
+  selectedLineIds: readonly string[]
+): Set<string> {
+  const optionalSet = new Set(optionalLineInstanceIds)
+  for (const id of selectedLineIds) {
+    if (!optionalSet.has(id)) {
+      throw new BadRequestError(`"${id}" is not a selectable option on this quote`)
+    }
+  }
+  return new Set(selectedLineIds)
+}
+
+/**
+ * Write the public accept-page's optional-line selection onto the quote and recompute its
+ * totals once (plan 18 §5 steps 1–3, amendment 3). Called AFTER the status/expiry/signature
+ * guards and BEFORE `approveQuote` — a second POST against an already-`approved` quote never
+ * reaches here (the idempotent early return in {@link acceptQuoteByToken} sits above it).
+ *
+ * Zero-optional quotes (no `line_item_optional` lines at all) are a total no-op — today's exact
+ * path, `selectedLineIds` or not. See {@link AcceptQuoteByTokenInput.selectedLineIds} for the
+ * `undefined` vs `[]` distinction that governs everything past that point.
+ */
+async function applyOptionalLineSelections(params: {
+  organizationId: string
+  userId: string
+  quoteInstanceId: string
+  selectedLineIds: string[] | undefined
+}): Promise<void> {
+  const { organizationId, userId, quoteInstanceId, selectedLineIds } = params
+  const quoteRecordId = toRecordId('quote', quoteInstanceId)
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+
+  const { ids: optionalLineInstanceIds } = await handler.listFiltered({
+    entityDefinitionId: 'line_item',
+    filters: [
+      {
+        id: 'quote-optional-lines',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'quote-optional-lines-quote',
+            fieldId: 'line_item:quote',
+            operator: 'is',
+            value: quoteRecordId,
+          },
+          {
+            id: 'quote-optional-lines-optional',
+            fieldId: 'line_item:optional',
+            operator: 'is',
+            value: true,
+          },
+        ],
+      },
+    ],
+    limit: 1000,
+    mode: 'oneshot',
+  })
+
+  // Zero-optional quote: skip entirely, no matter what the caller submitted.
+  if (optionalLineInstanceIds.length === 0) return
+  // No selection submitted (internal/legacy accept, or acceptancePageEnabled off): the
+  // seller's pre-checked defaults ARE the selection — leave them untouched.
+  if (selectedLineIds === undefined) return
+
+  const selectedSet = validateSelectedLineIds(optionalLineInstanceIds, selectedLineIds)
+
+  const cf = await getOrgCache()
+    .from(organizationId, 'customFields')
+    .bySystemAttributes(['line_item_optional_selected'] as const)
+  const optionalSelectedField = cf.line_item_optional_selected
+  if (!optionalSelectedField) return // pre-migration org — field doesn't exist, nothing to write
+
+  const fieldValueService = new FieldValueService(organizationId, userId)
+  const currentById = await batchReadSystemValues({
+    service: fieldValueService,
+    organizationId,
+    entityType: 'line_item',
+    entityInstanceIds: optionalLineInstanceIds,
+    attributes: ['line_item_optional_selected'] as const,
+  })
+
+  // Def-UUID-form RecordId — `toRecordId('line_item', id)` would stamp the literal string
+  // "line_item" into FieldValue.entityDefinitionId (a known trap: the write looks successful
+  // but the row is orphaned from every query that resolves the real def UUID first).
+  const lineItemDefId = await requireCachedEntityDefId(organizationId, 'line_item')
+
+  for (const lineInstanceId of optionalLineInstanceIds) {
+    const nextSelected = selectedSet.has(lineInstanceId)
+    const currentSelected =
+      (currentById.get(lineInstanceId)?.get('line_item_optional_selected') as
+        | boolean
+        | undefined) ?? true
+    if (currentSelected === nextSelected) continue // stored value already matches — skip the write
+
+    // Hook-free write path (amendment 3) — `setValueWithType` bypasses the field-change hooks
+    // that `setValuesForEntity` fires, so this doesn't trigger N redundant per-line recomputes;
+    // the one explicit `recomputeTotals` call below is the single deterministic recompute.
+    await fieldValueService.setValueWithType({
+      recordId: toRecordId(lineItemDefId, lineInstanceId),
+      fieldId: optionalSelectedField.id,
+      fieldType: optionalSelectedField.type,
+      value: { type: 'boolean', value: nextSelected },
+    })
+  }
+
+  await recomputeTotals({
+    organizationId,
+    userId,
+    documentType: 'quote',
+    documentInstanceId: quoteInstanceId,
+  })
+}
+
+/**
  * Accept a quote from the public `/quote/{token}` page (v5 build spec 01). Flips
  * `quote_status` via `approveQuote` (mirrors the linked service request), stamps
  * `quote_accepted_by_name`/`quote_accepted_at` as acceptance evidence, notifies the quote's
  * creator, then auto-converts to a work order when `documents.quote.autoConvertOnAccept` is on
  * (default). Deposit collection is deferred — no payment/checkout step here.
+ *
+ * Optional-line selections (plan 18 §5), when submitted, are written and priced into totals
+ * BEFORE `approveQuote` — see {@link applyOptionalLineSelections}.
  */
 export async function acceptQuoteByToken(
   token: string,
@@ -126,6 +270,13 @@ export async function acceptQuoteByToken(
   if (payload.requireSignature && !name) {
     throw new BadRequestError('Please type your full name to accept')
   }
+
+  await applyOptionalLineSelections({
+    organizationId,
+    userId: systemUserId,
+    quoteInstanceId,
+    selectedLineIds: input.selectedLineIds,
+  })
 
   await approveQuote({ organizationId, userId: systemUserId, quoteInstanceId })
 

--- a/packages/lib/src/money/totals-hooks.ts
+++ b/packages/lib/src/money/totals-hooks.ts
@@ -38,6 +38,8 @@ const LINE_TRIGGER_ATTRS = new Set<SystemAttribute>([
   'line_item_unit_price',
   'line_item_taxable',
   'line_item_discount',
+  'line_item_optional', // selection toggles a line's contribution, not its own total (plan 18 §2)
+  'line_item_optional_selected',
   'line_item_quote',
   'line_item_work_order',
   'line_item_invoice', // attach/detach recomputes the invoice (money MI1 build spec §G.1)
@@ -114,6 +116,8 @@ async function recomputeQuoteTotals(params: {
       'quote_tax_rate',
       'line_item_line_total',
       'line_item_taxable',
+      'line_item_optional',
+      'line_item_optional_selected',
     ] as const)
 
   const billingFieldIds = [cf.quote_discount_type, cf.quote_discount_value, cf.quote_tax_rate]
@@ -161,17 +165,29 @@ async function recomputeQuoteTotals(params: {
   if (cf.line_item_line_total && cf.line_item_taxable) {
     const lineTotalFieldId = cf.line_item_line_total.id
     const taxableFieldId = cf.line_item_taxable.id
+    const optionalFieldId = cf.line_item_optional?.id
+    const optionalSelectedFieldId = cf.line_item_optional_selected?.id
     for (const lineInstanceId of lineInstanceIds) {
       const lineRecordId = toRecordId('line_item', lineInstanceId)
-      const lineValues = await handler.getFieldValues(lineRecordId, [
-        lineTotalFieldId,
-        taxableFieldId,
-      ])
+      const fieldIds = [lineTotalFieldId, taxableFieldId, optionalFieldId, optionalSelectedFieldId]
+        .filter(Boolean)
+        .map((id) => id!)
+      const lineValues = await handler.getFieldValues(lineRecordId, fieldIds)
       const lineTotalTyped = firstTyped(lineValues.get(lineTotalFieldId))
       const taxableTyped = firstTyped(lineValues.get(taxableFieldId))
+      const optionalTyped = optionalFieldId
+        ? firstTyped(lineValues.get(optionalFieldId))
+        : undefined
+      const optionalSelectedTyped = optionalSelectedFieldId
+        ? firstTyped(lineValues.get(optionalSelectedFieldId))
+        : undefined
       lines.push({
         lineTotal: lineTotalTyped ? (extractValue(lineTotalTyped) as number) : null,
         taxable: taxableTyped ? (extractValue(taxableTyped) as boolean) : true,
+        optional: optionalTyped ? (extractValue(optionalTyped) as boolean) : undefined,
+        optionalSelected: optionalSelectedTyped
+          ? (extractValue(optionalSelectedTyped) as boolean)
+          : undefined,
       })
     }
   }
@@ -217,6 +233,8 @@ async function recomputeInvoiceTotals(params: {
       'invoice_tax_rate',
       'line_item_line_total',
       'line_item_taxable',
+      'line_item_optional',
+      'line_item_optional_selected',
     ] as const)
 
   const billingFieldIds = [cf.invoice_discount_type, cf.invoice_discount_value, cf.invoice_tax_rate]
@@ -270,17 +288,29 @@ async function recomputeInvoiceTotals(params: {
   if (cf.line_item_line_total && cf.line_item_taxable) {
     const lineTotalFieldId = cf.line_item_line_total.id
     const taxableFieldId = cf.line_item_taxable.id
+    const optionalFieldId = cf.line_item_optional?.id
+    const optionalSelectedFieldId = cf.line_item_optional_selected?.id
     for (const lineInstanceId of lineInstanceIds) {
       const lineRecordId = toRecordId('line_item', lineInstanceId)
-      const lineValues = await handler.getFieldValues(lineRecordId, [
-        lineTotalFieldId,
-        taxableFieldId,
-      ])
+      const fieldIds = [lineTotalFieldId, taxableFieldId, optionalFieldId, optionalSelectedFieldId]
+        .filter(Boolean)
+        .map((id) => id!)
+      const lineValues = await handler.getFieldValues(lineRecordId, fieldIds)
       const lineTotalTyped = firstTyped(lineValues.get(lineTotalFieldId))
       const taxableTyped = firstTyped(lineValues.get(taxableFieldId))
+      const optionalTyped = optionalFieldId
+        ? firstTyped(lineValues.get(optionalFieldId))
+        : undefined
+      const optionalSelectedTyped = optionalSelectedFieldId
+        ? firstTyped(lineValues.get(optionalSelectedFieldId))
+        : undefined
       lines.push({
         lineTotal: lineTotalTyped ? (extractValue(lineTotalTyped) as number) : null,
         taxable: taxableTyped ? (extractValue(taxableTyped) as boolean) : true,
+        optional: optionalTyped ? (extractValue(optionalTyped) as boolean) : undefined,
+        optionalSelected: optionalSelectedTyped
+          ? (extractValue(optionalSelectedTyped) as boolean)
+          : undefined,
       })
     }
   }

--- a/packages/lib/src/money/totals.test.ts
+++ b/packages/lib/src/money/totals.test.ts
@@ -144,3 +144,105 @@ describe('computeDocumentTotals', () => {
     expect(result.discountAmount).toBe(0)
   })
 })
+
+describe('computeDocumentTotals — optional lines (money plan 18)', () => {
+  it('excludes a deselected optional line from subtotal, taxable subtotal, and discount base', () => {
+    const lines: LineForTotals[] = [
+      { lineTotal: 5000, taxable: true },
+      { lineTotal: 2000, taxable: true, optional: true, optionalSelected: false },
+    ]
+    const result = computeDocumentTotals(lines, { taxRate: 10 })
+    expect(result.subtotal).toBe(5000)
+    expect(result.taxTotal).toBe(500)
+    expect(result.total).toBe(5500)
+  })
+
+  it('includes a selected optional line normally', () => {
+    const lines: LineForTotals[] = [
+      { lineTotal: 5000, taxable: true },
+      { lineTotal: 2000, taxable: true, optional: true, optionalSelected: true },
+    ]
+    const result = computeDocumentTotals(lines, {})
+    expect(result.subtotal).toBe(7000)
+    expect(result.total).toBe(7000)
+  })
+
+  it('produces byte-for-byte identical output when optional/optionalSelected are absent vs explicitly undefined', () => {
+    const withoutFlags: LineForTotals[] = [
+      { lineTotal: 10_000, taxable: true },
+      { lineTotal: 10_000, taxable: false },
+    ]
+    const withUndefinedFlags: LineForTotals[] = [
+      { lineTotal: 10_000, taxable: true, optional: undefined, optionalSelected: undefined },
+      { lineTotal: 10_000, taxable: false, optional: undefined, optionalSelected: undefined },
+    ]
+    const billing = { discountType: 'percent' as const, discountValue: 50, taxRate: 10 }
+    expect(computeDocumentTotals(withUndefinedFlags, billing)).toEqual(
+      computeDocumentTotals(withoutFlags, billing)
+    )
+  })
+
+  it('matches every pre-existing (required-only) case exactly when optional is unset', () => {
+    // Re-run a sample of the pre-optional-lines cases above through the same assertions —
+    // proves the new exclusion filter is a strict no-op for documents with no optional flags.
+    const flat: LineForTotals[] = [
+      { lineTotal: 10_000, taxable: true },
+      { lineTotal: 10_000, taxable: false },
+    ]
+    expect(
+      computeDocumentTotals(flat, { discountType: 'percent', discountValue: 50, taxRate: 10 })
+    ).toEqual({ subtotal: 20_000, discountAmount: 10_000, taxTotal: 500, total: 10_500 })
+
+    const single: LineForTotals[] = [{ lineTotal: 3333, taxable: true }]
+    expect(computeDocumentTotals(single, { taxRate: 7.25 })).toEqual({
+      subtotal: 3333,
+      discountAmount: 0,
+      taxTotal: 242,
+      total: 3575,
+    })
+  })
+
+  it('returns all-zero totals when every line is an optional deselected line', () => {
+    const lines: LineForTotals[] = [
+      { lineTotal: 5000, taxable: true, optional: true, optionalSelected: false },
+      { lineTotal: 2000, taxable: false, optional: true, optionalSelected: false },
+    ]
+    expect(computeDocumentTotals(lines, { taxRate: 10 })).toEqual({
+      subtotal: 0,
+      discountAmount: 0,
+      taxTotal: 0,
+      total: 0,
+    })
+  })
+
+  it('pro-rates discount + tax across a mixed selection (required, selected option, deselected option)', () => {
+    // required 10000 (taxable) + selected option 5000 (taxable) = subtotal 15000; the
+    // deselected 8000 (taxable) option is excluded entirely, including from taxableSubtotal.
+    // 20% discount -> discountAmount 3000. taxBase = 15000 * (1 - 3000/15000) = 12000.
+    // taxTotal = 12000 * 10% = 1200. total = 15000 - 3000 + 1200 = 13200.
+    const lines: LineForTotals[] = [
+      { lineTotal: 10_000, taxable: true },
+      { lineTotal: 5000, taxable: true, optional: true, optionalSelected: true },
+      { lineTotal: 8000, taxable: true, optional: true, optionalSelected: false },
+    ]
+    const result = computeDocumentTotals(lines, {
+      discountType: 'percent',
+      discountValue: 20,
+      taxRate: 10,
+    })
+    expect(result.subtotal).toBe(15_000)
+    expect(result.discountAmount).toBe(3000)
+    expect(result.taxTotal).toBe(1200)
+    expect(result.total).toBe(13_200)
+  })
+
+  it('contributes normally for optional:true/optionalSelected:true and the nonsensical optional:false/optionalSelected:false combo', () => {
+    const lines: LineForTotals[] = [
+      { lineTotal: 5000, taxable: true, optional: true, optionalSelected: true },
+      { lineTotal: 3000, taxable: true, optional: false, optionalSelected: false },
+    ]
+    const result = computeDocumentTotals(lines, {})
+    expect(result.subtotal).toBe(8000)
+    expect(result.total).toBe(8000)
+  })
+})

--- a/packages/lib/src/money/totals.ts
+++ b/packages/lib/src/money/totals.ts
@@ -54,16 +54,28 @@ function computeDiscountAmount(
  *   `taxableSubtotal * (1 - discountAmount / subtotal)`
  * - `taxTotal` = `taxBase * taxRate / 100`
  * - `total` = `subtotal - discountAmount + taxTotal`
+ *
+ * Deselected options (money plan 18 §2) — a line with `optional: true` and
+ * `optionalSelected: false` contributes nothing to `subtotal`, `taxableSubtotal`, or (by
+ * extension) the discount/tax base. Absent/undefined flags are equivalent to a required line
+ * and keep today's behavior byte-for-byte.
  */
 export function computeDocumentTotals(
   lines: LineForTotals[],
   billing: DocumentBillingInputs
 ): DocumentTotals {
+  const isExcluded = (line: LineForTotals): boolean =>
+    line.optional === true && line.optionalSelected === false
+
   const subtotal = roundCents(
-    lines.reduce((sum, line) => (line.lineTotal === null ? sum : sum + line.lineTotal), 0)
+    lines.reduce(
+      (sum, line) => (line.lineTotal === null || isExcluded(line) ? sum : sum + line.lineTotal),
+      0
+    )
   )
   const taxableSubtotal = lines.reduce(
-    (sum, line) => (line.lineTotal === null || !line.taxable ? sum : sum + line.lineTotal),
+    (sum, line) =>
+      line.lineTotal === null || !line.taxable || isExcluded(line) ? sum : sum + line.lineTotal,
     0
   )
 

--- a/packages/lib/src/money/types.ts
+++ b/packages/lib/src/money/types.ts
@@ -2,6 +2,7 @@
 
 import type { RecordId } from '@auxx/types/resource'
 import type { RecurrencePattern } from '../recurrence'
+import type { LineItemUnit } from './units'
 
 /** Percent-of-subtotal vs flat-amount discount (mirrors `QUOTE_DISCOUNT_TYPE_OPTIONS`). */
 export type DiscountType = 'percent' | 'amount'
@@ -14,6 +15,10 @@ export interface LineForTotals {
   /** `qty * unitPrice` in integer cents, already computed (roundCents). `null` when `unitPrice` is null. */
   lineTotal: number | null
   taxable: boolean
+  /** Customer-selectable upsell line (quotes only, plan 18). Absent/`false` = a required line. */
+  optional?: boolean
+  /** Current selection state — meaningful only when `optional` is true. */
+  optionalSelected?: boolean
 }
 
 /** Document-level billing inputs (the quote's own fields) driving discount + tax math. */
@@ -132,6 +137,8 @@ export interface UninvoicedLine {
   name: string
   description?: string
   qty: number
+  /** `null` for a unitless line — preserve today's `qty × unitPrice` rendering (plan 13 §6). */
+  unit: LineItemUnit | null
   unitPrice: number | null
   lineTotal: number | null
   taxable: boolean

--- a/packages/lib/src/money/units.ts
+++ b/packages/lib/src/money/units.ts
@@ -1,0 +1,260 @@
+// packages/lib/src/money/units.ts
+
+/**
+ * Canonical line-item units of measure (money plan 13 §1) — the single source of truth for
+ * catalog default units, line-item units, the smart quantity editor's parser, and every
+ * customer-facing document renderer. Client-safe: zero server-only imports. Do not duplicate
+ * this list or its alias parsing anywhere else (settings selectors, PDFs, document payloads);
+ * import from here.
+ *
+ * Units are a fixed product list (README decision #10) — organizations cannot add custom units
+ * in v1. A unit is descriptive pricing context only: parsing and re-labelling never convert
+ * quantity or price (decision #6).
+ */
+interface LineItemUnitDefinition {
+  /** Stable stored value — persisted on catalog items and line items. */
+  readonly value: string
+  /** Label shown in settings selectors and registry SINGLE_SELECT option lists. */
+  readonly label: string
+  /** Abbreviation shown in the compact line-builder quantity cell, e.g. `12 hr`. */
+  readonly compact: string
+  /** Abbreviation shown on customer-facing quotes/invoices, e.g. `12 hr × $85.00/hr`. */
+  readonly document: string
+  /**
+   * Minimum recognized input aliases for the smart quantity parser, lowercase and free of
+   * punctuation (see `normalizeAliasKey`). Includes the compact abbreviation itself.
+   */
+  readonly aliases: readonly string[]
+}
+
+/**
+ * The 14 canonical units (money plan 13 §1). `ft` is an alias of `linear_foot`, not a separate
+ * stored unit — it prices the same length, just written differently.
+ */
+const LINE_ITEM_UNITS = [
+  {
+    value: 'each',
+    label: 'Each',
+    compact: 'ea',
+    document: 'ea',
+    aliases: ['ea', 'each', 'item', 'piece', 'pc'],
+  },
+  {
+    value: 'minute',
+    label: 'Minute',
+    compact: 'min',
+    document: 'min',
+    aliases: ['min', 'mins', 'minute', 'minutes'],
+  },
+  {
+    value: 'hour',
+    label: 'Hour',
+    compact: 'hr',
+    document: 'hr',
+    aliases: ['h', 'hr', 'hrs', 'hour', 'hours'],
+  },
+  { value: 'day', label: 'Day', compact: 'day', document: 'day', aliases: ['d', 'day', 'days'] },
+  {
+    value: 'week',
+    label: 'Week',
+    compact: 'wk',
+    document: 'wk',
+    aliases: ['wk', 'wks', 'week', 'weeks'],
+  },
+  {
+    value: 'linear_foot',
+    label: 'Linear foot',
+    compact: 'lf',
+    document: 'lf',
+    aliases: ['lf', 'lft', 'ft', 'foot', 'feet', 'linear foot', 'linear feet'],
+  },
+  {
+    value: 'square_foot',
+    label: 'Square foot',
+    compact: 'sf',
+    document: 'sq ft',
+    aliases: ['sf', 'sqft', 'sq ft', 'square foot', 'square feet'],
+  },
+  {
+    value: 'cubic_foot',
+    label: 'Cubic foot',
+    compact: 'cf',
+    document: 'cu ft',
+    aliases: ['cf', 'cuft', 'cu ft', 'cubic foot', 'cubic feet'],
+  },
+  {
+    value: 'cubic_yard',
+    label: 'Cubic yard',
+    compact: 'cy',
+    document: 'cu yd',
+    aliases: ['cy', 'cuyd', 'cu yd', 'cubic yard', 'cubic yards'],
+  },
+  {
+    value: 'gallon',
+    label: 'Gallon',
+    compact: 'gal',
+    document: 'gal',
+    aliases: ['gal', 'gals', 'gallon', 'gallons'],
+  },
+  {
+    value: 'pound',
+    label: 'Pound',
+    compact: 'lb',
+    document: 'lb',
+    aliases: ['lb', 'lbs', 'pound', 'pounds'],
+  },
+  { value: 'mile', label: 'Mile', compact: 'mi', document: 'mi', aliases: ['mi', 'mile', 'miles'] },
+  { value: 'ton', label: 'Ton', compact: 'ton', document: 'ton', aliases: ['t', 'ton', 'tons'] },
+  { value: 'acre', label: 'Acre', compact: 'ac', document: 'ac', aliases: ['ac', 'acre', 'acres'] },
+] as const satisfies readonly LineItemUnitDefinition[]
+
+/** Stable stored unit value, derived from the canonical list — never maintained separately. */
+export type LineItemUnit = (typeof LINE_ITEM_UNITS)[number]['value']
+
+/** Display mode for `formatLineItemUnit` — compact editor cell vs customer-facing document. */
+export type LineItemUnitDisplayMode = 'compact' | 'document'
+
+/**
+ * Options for registry SINGLE_SELECT field definitions (e.g. `LINE_ITEM_FIELDS.unit`,
+ * `CATALOG_ITEM_FIELDS.defaultUnit`) and plain settings selectors. Mirrors the minimal shape
+ * `CATALOG_CATEGORY_OPTIONS` uses — units don't need a `color`.
+ */
+export const LINE_ITEM_UNIT_OPTIONS: ReadonlyArray<{ label: string; value: LineItemUnit }> =
+  LINE_ITEM_UNITS.map(({ label, value }) => ({ label, value }))
+
+const UNIT_BY_VALUE: ReadonlyMap<LineItemUnit, LineItemUnitDefinition> = new Map(
+  LINE_ITEM_UNITS.map((unit) => [unit.value, unit])
+)
+
+/**
+ * Normalizes free-typed unit text for alias lookup: lowercase, periods/commas stripped, and
+ * runs of whitespace/hyphens collapsed to a single space. Tolerant of `sq.ft.`, `sq-ft`, `SQ FT`
+ * all resolving the same way, without treating arbitrary punctuation as matchable content.
+ */
+function normalizeAliasKey(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[.,]/g, '')
+    .replace(/[\s-]+/g, ' ')
+    .trim()
+}
+
+const UNIT_ALIAS_MAP: ReadonlyMap<string, LineItemUnit> = new Map(
+  LINE_ITEM_UNITS.flatMap((unit) =>
+    unit.aliases.map((alias) => [normalizeAliasKey(alias), unit.value] as const)
+  )
+)
+
+/**
+ * Resolves free-typed unit text to a canonical unit. Matches only the complete normalized text
+ * against the alias table — never an arbitrary trailing substring — so `sq ft` and `ft` can
+ * never be confused with each other regardless of match order.
+ */
+function lookupUnitAlias(text: string): LineItemUnit | null {
+  const key = normalizeAliasKey(text)
+  return key.length > 0 ? (UNIT_ALIAS_MAP.get(key) ?? null) : null
+}
+
+/**
+ * Formats a unit for display. Returns `''` for `null`/`undefined` (unitless lines render with no
+ * suffix at all).
+ */
+export function formatLineItemUnit(
+  unit: LineItemUnit | null | undefined,
+  mode: LineItemUnitDisplayMode
+): string {
+  if (!unit) return ''
+  const definition = UNIT_BY_VALUE.get(unit)
+  if (!definition) return ''
+  return mode === 'compact' ? definition.compact : definition.document
+}
+
+/** Current committed quantity/unit state the smart quantity parser preserves fields against. */
+export interface LineItemQuantityState {
+  quantity: number | null
+  unit: LineItemUnit | null
+}
+
+/** Result of `parseQuantityWithUnit` — a plain discriminated union, not `TypedResult`.
+ *
+ * This is UI input validation running on every Enter/Tab/blur, not a domain/DB operation, so an
+ * error is a plain display string rather than an `Error` instance — see money plan 13 §2.
+ */
+export type ParseLineItemQuantityResult =
+  | { ok: true; quantity: number | null; unit: LineItemUnit | null }
+  | { ok: false; error: string }
+
+/**
+ * Extracts a leading numeric token from `text` (mixed fraction, simple fraction, decimal, or
+ * integer — tried in that order so `1 1/2` is not mistaken for the integer `1`). Returns
+ * `[value, remainder]`, or `null` if no numeric token starts the string.
+ */
+function extractLeadingNumber(text: string): [number, string] | null {
+  const match = text.match(/^(\d+\s+\d+\/\d+|\d+\/\d+|\d+\.\d+|\.\d+|\d+)/)
+  if (!match) return null
+
+  const token = match[1]
+  const remainder = text.slice(token.length).trim()
+
+  const mixed = token.match(/^(\d+)\s+(\d+)\/(\d+)$/)
+  if (mixed) {
+    const denominator = Number(mixed[3])
+    if (denominator === 0) return null
+    return [Number(mixed[1]) + Number(mixed[2]) / denominator, remainder]
+  }
+
+  const fraction = token.match(/^(\d+)\/(\d+)$/)
+  if (fraction) {
+    const denominator = Number(fraction[2])
+    if (denominator === 0) return null
+    return [Number(fraction[1]) / denominator, remainder]
+  }
+
+  const value = Number(token)
+  return Number.isFinite(value) ? [value, remainder] : null
+}
+
+/**
+ * Parses the smart quantity editor's free-typed input (money plan 13 §2). Accepted forms:
+ * a bare number (preserves `current.unit`, including `null`); a bare recognized unit alias
+ * (preserves `current.quantity`, including `null`); or a number immediately followed by a
+ * recognized unit suffix, with optional whitespace and simple/mixed fractions
+ * (`5`, `5sf`, `5 sq ft`, `1.5hr`, `1 1/2hr`, `3/4 cy`, `hr`).
+ *
+ * Deterministic and side-effect free: never converts units, never guesses at an unknown suffix
+ * by discarding it and keeping only the numeric prefix, and treats a zero denominator, malformed
+ * number, unknown suffix, or leftover text as fully invalid. Empty input is invalid — clearing a
+ * unit is a job for the fixed-unit selector's `No unit` option, not this parser.
+ */
+export function parseQuantityWithUnit(
+  input: string,
+  current: LineItemQuantityState
+): ParseLineItemQuantityResult {
+  const collapsed = input.trim().replace(/\s+/g, ' ')
+  if (collapsed.length === 0) {
+    return { ok: false, error: 'Enter a quantity, a unit, or both.' }
+  }
+
+  const leading = extractLeadingNumber(collapsed)
+
+  if (!leading) {
+    // Unit-only form, e.g. `hr`.
+    const unit = lookupUnitAlias(collapsed)
+    if (!unit) {
+      return { ok: false, error: `Unrecognized unit "${collapsed}".` }
+    }
+    return { ok: true, quantity: current.quantity, unit }
+  }
+
+  const [quantity, suffix] = leading
+  if (suffix.length === 0) {
+    // Number-only form, e.g. `5`.
+    return { ok: true, quantity, unit: current.unit }
+  }
+
+  const unit = lookupUnitAlias(suffix)
+  if (!unit) {
+    return { ok: false, error: `Unrecognized unit "${suffix}".` }
+  }
+  return { ok: true, quantity, unit }
+}

--- a/packages/lib/src/resources/registry/resources/catalog-item-fields.ts
+++ b/packages/lib/src/resources/registry/resources/catalog-item-fields.ts
@@ -2,6 +2,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { LINE_ITEM_UNIT_OPTIONS } from '../../../money/units'
 import { BaseType } from '../../types'
 import { CREATED_BY_FIELD } from '../common-fields'
 import type { ResourceField } from '../field-types'
@@ -13,6 +14,7 @@ import type { ResourceField } from '../field-types'
 export const CATALOG_CATEGORY_OPTIONS = [
   { label: 'Service', value: 'service', color: 'blue' },
   { label: 'Material', value: 'material', color: 'orange' },
+  { label: 'Labor', value: 'labor', color: 'green' },
 ] as const
 
 /**
@@ -133,6 +135,27 @@ export const CATALOG_ITEM_FIELDS: Record<string, ResourceField> = {
     placeholder: 'Enter default price',
   },
 
+  defaultUnit: {
+    id: toFieldId('defaultUnit'),
+    key: 'defaultUnit',
+    label: 'Default Unit',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'catalog_item_default_unit',
+    systemSortOrder: 'a5',
+    nullable: true,
+    options: { options: [...LINE_ITEM_UNIT_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select unit',
+  },
+
   taxable: {
     id: toFieldId('taxable'),
     key: 'taxable',
@@ -141,7 +164,7 @@ export const CATALOG_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.CHECKBOX,
     isSystem: true,
     systemAttribute: 'catalog_item_taxable',
-    systemSortOrder: 'a5',
+    systemSortOrder: 'a6',
     nullable: false,
     capabilities: {
       filterable: true,
@@ -162,7 +185,7 @@ export const CATALOG_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.CHECKBOX,
     isSystem: true,
     systemAttribute: 'catalog_item_active',
-    systemSortOrder: 'a6',
+    systemSortOrder: 'a7',
     nullable: false,
     capabilities: {
       filterable: true,
@@ -183,7 +206,7 @@ export const CATALOG_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RELATIONSHIP,
     isSystem: true,
     systemAttribute: 'catalog_item_part',
-    systemSortOrder: 'a7',
+    systemSortOrder: 'a8',
     nullable: true,
     capabilities: {
       filterable: true,
@@ -206,6 +229,53 @@ export const CATALOG_ITEM_FIELDS: Record<string, ResourceField> = {
     description: 'Inventory part backing this catalog entry (material items)',
   },
 
+  cost: {
+    id: toFieldId('cost'),
+    key: 'cost',
+    label: 'Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'catalog_item_cost',
+    systemSortOrder: 'a9',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false, // the pricing sync engine is the only writer
+      updatable: false,
+      configurable: false,
+    },
+    description: "Synced from the linked part's calculated cost",
+  },
+
+  markup: {
+    id: toFieldId('markup'),
+    key: 'markup',
+    label: 'Markup (%)',
+    type: BaseType.NUMBER,
+    fieldType: FieldType.NUMBER,
+    isSystem: true,
+    systemAttribute: 'catalog_item_markup',
+    systemSortOrder: 'aA',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Markup percentage',
+    description: 'Markup rate as a percentage of cost — null pauses auto-pricing',
+  },
+
   lineItems: {
     id: toFieldId('lineItems'),
     key: 'lineItems',
@@ -214,7 +284,7 @@ export const CATALOG_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RELATIONSHIP,
     isSystem: true,
     systemAttribute: 'catalog_item_line_items',
-    systemSortOrder: 'a8',
+    systemSortOrder: 'aB',
     showInPanel: false,
     capabilities: {
       filterable: true,

--- a/packages/lib/src/resources/registry/resources/line-item-fields.ts
+++ b/packages/lib/src/resources/registry/resources/line-item-fields.ts
@@ -2,6 +2,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { LINE_ITEM_UNIT_OPTIONS } from '../../../money/units'
 import { BaseType } from '../../types'
 import { CREATED_BY_FIELD } from '../common-fields'
 import type { ResourceField } from '../field-types'
@@ -101,6 +102,29 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     defaultValue: 1,
   },
 
+  unit: {
+    id: toFieldId('unit'),
+    key: 'unit',
+    label: 'Unit',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'line_item_unit',
+    systemSortOrder: 'a4',
+    nullable: true,
+    options: { options: [...LINE_ITEM_UNIT_OPTIONS] },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select unit',
+    description:
+      'Immutable-at-copy-time display snapshot; the current editable line may subsequently change it',
+  },
+
   unitPrice: {
     id: toFieldId('unitPrice'),
     key: 'unitPrice',
@@ -109,7 +133,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.CURRENCY,
     isSystem: true,
     systemAttribute: 'line_item_unit_price',
-    systemSortOrder: 'a4',
+    systemSortOrder: 'a5',
     nullable: true,
     options: {
       currencyCode: 'USD',
@@ -134,7 +158,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.CURRENCY,
     isSystem: true,
     systemAttribute: 'line_item_line_total',
-    systemSortOrder: 'a5',
+    systemSortOrder: 'a6',
     nullable: true,
     options: {
       currencyCode: 'USD',
@@ -160,7 +184,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.CHECKBOX,
     isSystem: true,
     systemAttribute: 'line_item_taxable',
-    systemSortOrder: 'a6',
+    systemSortOrder: 'a7',
     nullable: false,
     capabilities: {
       filterable: true,
@@ -172,6 +196,50 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     defaultValue: true,
   },
 
+  optional: {
+    id: toFieldId('optional'),
+    key: 'optional',
+    label: 'Optional',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'line_item_optional',
+    systemSortOrder: 'a8',
+    showInPanel: false, // builder-only UI
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    defaultValue: false,
+    description: 'True for quote line items the customer can opt in/out of',
+  },
+
+  optionalSelected: {
+    id: toFieldId('optionalSelected'),
+    key: 'optionalSelected',
+    label: 'Optional Selected',
+    type: BaseType.BOOLEAN,
+    fieldType: FieldType.CHECKBOX,
+    isSystem: true,
+    systemAttribute: 'line_item_optional_selected',
+    systemSortOrder: 'a9',
+    showInPanel: false, // builder-only UI
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    defaultValue: true,
+    description: 'Meaningful only when optional is true; required lines ignore this',
+  },
+
   category: {
     id: toFieldId('category'),
     key: 'category',
@@ -180,7 +248,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.SINGLE_SELECT,
     isSystem: true,
     systemAttribute: 'line_item_category',
-    systemSortOrder: 'a7',
+    systemSortOrder: 'aA',
     nullable: true,
     options: { options: [...CATALOG_CATEGORY_OPTIONS] },
     capabilities: {
@@ -201,7 +269,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.NUMBER,
     isSystem: true,
     systemAttribute: 'line_item_discount',
-    systemSortOrder: 'a8',
+    systemSortOrder: 'aB',
     showInPanel: false, // line-level discount is a later UI unlock (README); field ships now
     nullable: true,
     capabilities: {
@@ -221,7 +289,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.NUMBER,
     isSystem: true,
     systemAttribute: 'line_item_sort_order',
-    systemSortOrder: 'a9',
+    systemSortOrder: 'aC',
     showInPanel: false,
     nullable: true,
     capabilities: {
@@ -242,7 +310,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.TEXT,
     isSystem: true,
     systemAttribute: 'line_item_visit_id',
-    systemSortOrder: 'aA',
+    systemSortOrder: 'aD',
     showInPanel: false,
     nullable: true,
     capabilities: {
@@ -263,7 +331,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RELATIONSHIP,
     isSystem: true,
     systemAttribute: 'line_item_catalog_item',
-    systemSortOrder: 'aB',
+    systemSortOrder: 'aE',
     nullable: true,
     capabilities: {
       filterable: true,
@@ -294,7 +362,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RELATIONSHIP,
     isSystem: true,
     systemAttribute: 'line_item_quote',
-    systemSortOrder: 'aC',
+    systemSortOrder: 'aF',
     nullable: true,
     capabilities: {
       filterable: true,
@@ -325,7 +393,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RELATIONSHIP,
     isSystem: true,
     systemAttribute: 'line_item_work_order',
-    systemSortOrder: 'aD',
+    systemSortOrder: 'b0',
     nullable: true,
     capabilities: {
       filterable: true,
@@ -356,7 +424,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.RELATIONSHIP,
     isSystem: true,
     systemAttribute: 'line_item_invoice',
-    systemSortOrder: 'aE',
+    systemSortOrder: 'b1',
     nullable: true,
     capabilities: {
       filterable: true,
@@ -387,7 +455,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.DATETIME,
     isSystem: true,
     systemAttribute: 'created_at',
-    systemSortOrder: 'b0',
+    systemSortOrder: 'b2',
     dbColumn: 'createdAt',
     nullable: false,
     capabilities: {
@@ -408,7 +476,7 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     fieldType: FieldType.DATETIME,
     isSystem: true,
     systemAttribute: 'updated_at',
-    systemSortOrder: 'b1',
+    systemSortOrder: 'b3',
     dbColumn: 'updatedAt',
     nullable: false,
     capabilities: {

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -46,6 +46,7 @@ import { migration040CatalogGroup } from './migrations/040-catalog-group'
 import { migration041QuoteAcceptanceFields } from './migrations/041-quote-acceptance-fields'
 import { migration042QuoteDepositFields } from './migrations/042-quote-deposit-fields'
 import { migration043WorkOrderBillingAllocations } from './migrations/043-work-order-billing-allocations'
+import { migration044LinePricingFields } from './migrations/044-line-pricing-fields'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -97,6 +98,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration041QuoteAcceptanceFields,
   migration042QuoteDepositFields,
   migration043WorkOrderBillingAllocations,
+  migration044LinePricingFields,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/044-line-pricing-fields.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/044-line-pricing-fields.ts
@@ -1,0 +1,217 @@
+// packages/lib/src/seed/entity-migrations/migrations/044-line-pricing-fields.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { RecordId } from '@auxx/types/resource'
+import { toRecordId } from '@auxx/types/resource'
+import { and, eq, inArray } from 'drizzle-orm'
+import { createFieldValueContext } from '../../../field-values/field-value-helpers'
+import { setValueWithType } from '../../../field-values/field-value-mutations'
+import { CATALOG_ITEM_FIELDS } from '../../../resources/registry/resources/catalog-item-fields'
+import { LINE_ITEM_FIELDS } from '../../../resources/registry/resources/line-item-fields'
+import { ensureCustomFields, fieldKey, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:044')
+
+/** Matches `CATALOG_CATEGORY_OPTIONS`' new entry (catalog-item-fields.ts) — kept in sync by hand. */
+const LABOR_CATEGORY_OPTION = { label: 'Labor', value: 'labor', color: 'green' } as const
+
+/**
+ * Migration 044: registry fields for money plans 13 (unit-based pricing), 17 (part markup
+ * pricing), and 18 (optional line items) — one shared migration (18 §8) since all three land
+ * together.
+ *
+ * Fresh orgs get every field and the `labor` category option for free via the registries
+ * (`LINE_ITEM_FIELDS`/`CATALOG_ITEM_FIELDS`/`CATALOG_CATEGORY_OPTIONS`) through the normal
+ * `EntitySeeder` path — this migration only backfills orgs that installed `line_item`/
+ * `catalog_item` (032/035) before these fields existed:
+ *
+ * 1. `line_item`: adds `unit`, `optional`, `optionalSelected`.
+ * 2. `catalog_item`: adds `defaultUnit`, `cost`, `markup`.
+ * 3. Both existing category fields (`catalog_item_category`, `line_item_category`) get the
+ *    `labor` option merged in — org-added options are preserved (037's recipe: `ensureCustomFields`
+ *    never touches an existing field's options).
+ * 4. Cost backfill (plan 17 §5): part-linked catalog items get `cost` populated directly from
+ *    the linked part's current `part_cost`, so the feature is visible without waiting for the
+ *    next BOM recalc. No `markup` backfill and therefore no price writes — existing prices are
+ *    all hand-set by definition.
+ */
+export const migration044LinePricingFields: EntityMigration = {
+  id: '044-line-pricing-fields',
+  description: 'Add unit/markup/optional fields (money 13/17/18), labor category, cost backfill',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+    let changed = false
+
+    const lineItemDef = existing.entityDefs.get('line_item')
+    const catalogItemDef = existing.entityDefs.get('catalog_item')
+    const partDef = existing.entityDefs.get('part')
+
+    if (lineItemDef) {
+      await ensureCustomFields(
+        db,
+        organizationId,
+        'line_item',
+        lineItemDef.id,
+        {
+          unit: LINE_ITEM_FIELDS.unit!,
+          optional: LINE_ITEM_FIELDS.optional!,
+          optionalSelected: LINE_ITEM_FIELDS.optionalSelected!,
+        },
+        existing,
+        state
+      )
+    }
+
+    let catalogFieldMap: Awaited<ReturnType<typeof ensureCustomFields>> | undefined
+    if (catalogItemDef) {
+      catalogFieldMap = await ensureCustomFields(
+        db,
+        organizationId,
+        'catalog_item',
+        catalogItemDef.id,
+        {
+          defaultUnit: CATALOG_ITEM_FIELDS.defaultUnit!,
+          cost: CATALOG_ITEM_FIELDS.cost!,
+          markup: CATALOG_ITEM_FIELDS.markup!,
+        },
+        existing,
+        state
+      )
+    }
+
+    // Category options: merge `labor` into both category fields without discarding any
+    // org-extended options already present.
+    for (const [def, systemAttribute] of [
+      [catalogItemDef, 'catalog_item_category'],
+      [lineItemDef, 'line_item_category'],
+    ] as const) {
+      if (!def) continue
+      const field = existing.fields.get(fieldKey(def.id, systemAttribute))
+      if (!field) continue
+
+      const currentOptions =
+        (field.options as { options?: Array<{ value: string }> })?.options ?? []
+      const hasLabor = currentOptions.some((o) => o.value === 'labor')
+      if (hasLabor) continue
+
+      await db
+        .update(schema.CustomField)
+        .set({
+          options: {
+            ...(field.options as Record<string, unknown>),
+            options: [...currentOptions, LABOR_CATEGORY_OPTION],
+          },
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.CustomField.id, field.id))
+
+      changed = true
+      logger.info('Migration 044 added labor category option', {
+        organizationId,
+        systemAttribute,
+      })
+    }
+
+    // Cost backfill (plan 17 §5): part-linked catalog items get `cost` populated directly.
+    if (catalogItemDef && partDef && catalogFieldMap) {
+      const catalogPartField = existing.fields.get(fieldKey(catalogItemDef.id, 'catalog_item_part'))
+      const catalogCostField = catalogFieldMap.get('catalog_item:cost')
+      const partCostField = existing.fields.get(fieldKey(partDef.id, 'part_cost'))
+
+      if (catalogPartField && catalogCostField && partCostField) {
+        const linkRows = await db
+          .select({
+            catalogItemId: schema.FieldValue.entityId,
+            partId: schema.FieldValue.relatedEntityId,
+          })
+          .from(schema.FieldValue)
+          .where(
+            and(
+              eq(schema.FieldValue.organizationId, organizationId),
+              eq(schema.FieldValue.fieldId, catalogPartField.id)
+            )
+          )
+
+        const partIdByCatalogItemId = new Map(
+          linkRows
+            .filter((r): r is { catalogItemId: string; partId: string } => r.partId != null)
+            .map((r) => [r.catalogItemId, r.partId])
+        )
+
+        if (partIdByCatalogItemId.size > 0) {
+          const partIds = [...new Set(partIdByCatalogItemId.values())]
+          const catalogItemIds = [...partIdByCatalogItemId.keys()]
+
+          const [partCostRows, catalogCostRows] = await Promise.all([
+            db
+              .select({ entityId: schema.FieldValue.entityId, cost: schema.FieldValue.valueNumber })
+              .from(schema.FieldValue)
+              .where(
+                and(
+                  eq(schema.FieldValue.organizationId, organizationId),
+                  eq(schema.FieldValue.fieldId, partCostField.id),
+                  inArray(schema.FieldValue.entityId, partIds)
+                )
+              ),
+            db
+              .select({ entityId: schema.FieldValue.entityId, cost: schema.FieldValue.valueNumber })
+              .from(schema.FieldValue)
+              .where(
+                and(
+                  eq(schema.FieldValue.organizationId, organizationId),
+                  eq(schema.FieldValue.fieldId, catalogCostField.id),
+                  inArray(schema.FieldValue.entityId, catalogItemIds)
+                )
+              ),
+          ])
+
+          const partCostById = new Map(
+            partCostRows.filter((r) => r.cost != null).map((r) => [r.entityId, r.cost as number])
+          )
+          const catalogCostById = new Map(
+            catalogCostRows.filter((r) => r.cost != null).map((r) => [r.entityId, r.cost as number])
+          )
+
+          const ctx = createFieldValueContext(organizationId, undefined, db)
+          let backfilled = 0
+
+          for (const [catalogItemId, partId] of partIdByCatalogItemId.entries()) {
+            const partCost = partCostById.get(partId)
+            if (partCost == null) continue
+
+            const currentCost = catalogCostById.get(catalogItemId)
+            if (currentCost != null && currentCost === partCost) continue
+
+            const recordId = toRecordId(catalogItemDef.id, catalogItemId) as RecordId
+            await setValueWithType(ctx, {
+              recordId,
+              fieldId: catalogCostField.id,
+              fieldType: catalogCostField._fieldDef.fieldType!,
+              value: { type: 'number', value: partCost },
+            })
+            backfilled++
+          }
+
+          if (backfilled > 0) {
+            changed = true
+            logger.info('Migration 044 backfilled catalog item cost', {
+              organizationId,
+              backfilled,
+            })
+          }
+        }
+      }
+    }
+
+    const alreadyUpToDate = state.fieldsCreated === 0 && !changed
+    if (!alreadyUpToDate) {
+      logger.info('Migration 044 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -90,6 +90,16 @@ export const SYSTEM_ATTRIBUTES = [
   'tag_is_public',
   'tag_scope',
 
+  // ─── KB fields ──────────────────────────────────────────────────
+  'kb_name',
+  'kb_slug',
+  'kb_description',
+  'kb_publish_status',
+  'kb_visibility',
+  'kb_articles',
+  'kb_published_at',
+  'kb_last_published_at',
+
   // ─── Article fields ─────────────────────────────────────────────
   'article_title',
   'article_slug',
@@ -111,6 +121,7 @@ export const SYSTEM_ATTRIBUTES = [
   // ─── Part fields ────────────────────────────────────────────────
   'part_title',
   'part_description',
+  'part_image',
   'part_sku',
   'category',
   'part_unit_price',
@@ -174,9 +185,11 @@ export const SYSTEM_ATTRIBUTES = [
   'company_logo',
   'company_website',
   'company_domain',
+  'company_x_follower_count',
   'company_industry',
   'company_size',
   'company_annual_revenue',
+  'company_funding_raised',
   'company_founded',
   'company_headquarters',
   'company_notes',
@@ -268,16 +281,26 @@ export const SYSTEM_ATTRIBUTES = [
   'quote_total',
   'quote_notes',
   'quote_terms',
+  'quote_pdf_asset',
   'quote_line_items', // inverse of line_item_quote
   'quote_work_orders', // inverse of work_order_quote
+  'quote_public_token',
+  'quote_accepted_by_name',
+  'quote_accepted_at',
+  'quote_decline_reason',
+  'quote_deposit_type',
+  'quote_deposit_value',
 
   // ─── Line Item fields ──────────────────────────────────────────
   'line_item_name',
   'line_item_description',
   'line_item_qty',
+  'line_item_unit',
   'line_item_unit_price',
   'line_item_line_total',
   'line_item_taxable',
+  'line_item_optional',
+  'line_item_optional_selected',
   'line_item_category',
   'line_item_discount',
   'line_item_sort_order',
@@ -292,9 +315,12 @@ export const SYSTEM_ATTRIBUTES = [
   'catalog_item_description',
   'catalog_item_category',
   'catalog_item_default_unit_price',
+  'catalog_item_default_unit',
   'catalog_item_taxable',
   'catalog_item_active',
   'catalog_item_part',
+  'catalog_item_cost',
+  'catalog_item_markup',
   'catalog_item_line_items', // inverse of line_item_catalog_item
 
   // ─── Catalog Group fields ───────────────────────────────────────


### PR DESCRIPTION
## Summary

One wave, three features sharing the line-item surfaces (built per plan 18 §10's combined order — building sequentially would re-walk each surface three times):

### 13 — Unit-based pricing
- Canonical 14-unit module (`money/units.ts`): stored values, settings/compact/document labels, alias table, smart quantity parser (`5sf`, `2.375cy`, `1 1/2hr`, `3/4 cy`, unit-only `day`) — 169 table-driven tests
- Line builder gets a compact smart quantity cell (Description / Qty / Rate / Total) with a unit dropdown incl. "No unit"; qty+unit save atomically
- Catalog items get a default unit; Labor category added (labor→hr, material→ea, service→none, defaults never overwrite a chosen unit)
- Units snapshot across every copy boundary (quote→job, gather→invoice, group explosion) and render as `12 hr × $85.00/hr` on PDFs and public pages; unitless lines unchanged

### 17 — Part cost sync + markup pricing
- `catalog_item_cost` (read-only) syncs from the linked part's BOM landed cost — chained into both part-cost recalcs, hook-free writes + realtime so open editors update live
- `catalog_item_markup` (%) auto-computes the default rate; hand-editing the rate clears markup (pause), retyping the exact auto price is a no-op
- Editor: part-gated Cost/Markup rows, Auto badge, effective-margin hint; re-linking to a cost-less part clears the stale cost

### 18 — Optional line items (customer-selectable upsells)
- `line_item_optional` / `line_item_optional_selected` pair, quotes only; deselected options contribute nothing to subtotal/taxable/discount base anywhere (stored mirrors, optimistic footer, payload, PDF)
- Quote builder: Optional toggle + "Recommended" pre-check (muted row + badge); other builders unaffected
- Public quote page: real `<input type=checkbox form="accept-form">` per option (no-JS accepts carry selections), live total recompute client-side, nothing persists until accept
- Accept: validates ids (unknown/required → 400), writes selections hook-free, ONE deterministic totals recompute before approval; approved re-submits can never rewrite locked selections
- Conversion copies only selected lines, as plain required lines; declined options stay on the quote; PDF renders deselected options in an "Optional add-ons" block

### Shared infra
- **Entity migration 044** (idempotent, applied dev 26/26 ×2): six fields, labor option merged preserving org-extended options, part-linked cost backfill — no Drizzle change
- Registers 18 pre-existing missing `SYSTEM_ATTRIBUTES` literals (types-only; lib tsc baseline −18)

## Verification
- NEW `apps/worker/scripts/verify-money-line-pricing.ts` — **41/41 ×2** against dev DB (units snapshot chain ×9, acceptance matrix ×19 incl. rejection/idempotency/deselect-all/zero-optional paths, pricing ripple ×6); zero residue after both runs
- 273 money + 4 BOM vitest green; biome clean; `@auxx/types` tsc clean; no new lib/web tsc errors in touched files (pre-existing baseline documented)
- Browser: product editor pass done (row order, part X-clear, cost/markup). Owed post-merge: smart-qty-cell gestures, public-page accept flow, PDF visual, live cost ripple
- Prod owes: entity migration 044 (runner script included)

Plans: `plans/dispatch/money/{13-unit-based-pricing,17-part-markup-pricing,18-optional-line-items}.md`