### PR TITLE
fix(records): canonicalize RecordId prefixes across record/field-value/relationship caches

### DIFF
--- a/apps/web/src/components/dynamic-table/components/custom-field-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/custom-field-cell.tsx
@@ -11,7 +11,7 @@ import { memo, useMemo } from 'react'
 import { AiCellOverlay } from '~/components/fields/ai-overlay/ai-cell-overlay'
 import { ConnectorLockBadge } from '~/components/fields/connector-lock-badge'
 import { useField } from '~/components/resources/hooks/use-field'
-import { useFieldManagedState, useFieldValue } from '~/components/resources/hooks/use-field-values'
+import { useFieldCellState } from '~/components/resources/hooks/use-field-values'
 import { decodeColumnId } from '../utils/column-id'
 import { ExpandableCell } from './expandable-cell'
 import { FormattedCell } from './formatted-cell'
@@ -46,9 +46,12 @@ export const CustomFieldCell = memo(function CustomFieldCell({
     return { fieldRef: decoded.resourceFieldId as FieldReference, isPath: false }
   }, [columnId])
 
-  // Direct store subscription using FieldReference
+  // Combined cell state: value, loading, AI, and managed markers through ONE
+  // canonical key + ONE store subscription (hardening plan Part 6).
   // autoFetch ensures isLoading=true on first render (queues synchronously)
-  const { value, isLoading } = useFieldValue(recordId, fieldRef, { autoFetch: true })
+  const { value, isLoading, managedConnectorId } = useFieldCellState(recordId, fieldRef, {
+    autoFetch: true,
+  })
 
   // Get target field metadata (last element for paths)
   const targetResourceFieldId = useMemo(() => {
@@ -64,10 +67,6 @@ export const CustomFieldCell = memo(function CustomFieldCell({
 
   // Use effectiveFieldType for rendering (handles CALC fields automatically)
   const fieldType = field?.effectiveFieldType
-
-  // Contributing data-connector marker (per-cell, still editable). Called
-  // unconditionally to satisfy hook rules; resolves nothing for path columns.
-  const managedConnectorId = useFieldManagedState(recordId, (field?.id ?? '') as FieldId)
 
   if (isLoading && value === undefined) {
     return (

--- a/apps/web/src/components/merge/use-merge-preview.ts
+++ b/apps/web/src/components/merge/use-merge-preview.ts
@@ -10,14 +10,18 @@ import {
   buildFieldValueKey,
   useFieldValueStore,
 } from '~/components/resources/store/field-value-store'
+import {
+  useNormalizedRecordId,
+  useNormalizedRecordIds,
+} from '~/components/resources/utils/normalize-record-id'
 
 /**
  * Hook to preview merge results by computing merged field values
  * from target and source entities.
  */
 export function useMergePreview({
-  targetRecordId,
-  sourceRecordIds,
+  targetRecordId: rawTargetRecordId,
+  sourceRecordIds: rawSourceRecordIds,
   fields,
 }: {
   targetRecordId: RecordId
@@ -30,6 +34,11 @@ export function useMergePreview({
     isSystem?: boolean
   }>
 }) {
+  // Canonicalize prefixes — the store is keyed by EntityDefinition-UUID
+  // RecordIds, and this hook builds keys directly (not via the base hooks).
+  const targetRecordId = useNormalizedRecordId(rawTargetRecordId)
+  const sourceRecordIds = useNormalizedRecordIds(rawSourceRecordIds)
+
   const storeValues = useFieldValueStore((state) => state.values)
 
   return useMemo(() => {

--- a/apps/web/src/components/resources/hooks/index.ts
+++ b/apps/web/src/components/resources/hooks/index.ts
@@ -26,7 +26,7 @@ export {
   useSystemField,
 } from './use-field'
 // Field value hooks (extracted from store)
-export { useFieldValue, useFieldValues } from './use-field-values'
+export { useFieldCellState, useFieldValue, useFieldValues } from './use-field-values'
 export { useIsRecordLoading, useIsRecordPending, useRecord } from './use-record'
 export { useRecordBatchFetcher } from './use-record-batch-fetcher'
 // Record hydration hook

--- a/apps/web/src/components/resources/hooks/use-field-value-syncer.ts
+++ b/apps/web/src/components/resources/hooks/use-field-value-syncer.ts
@@ -6,11 +6,18 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { decodeColumnId } from '~/components/dynamic-table/utils/column-id'
 import { fieldValueFetchQueue } from '~/components/resources/store/field-value-fetch-queue'
 import {
-  buildFieldValueKey,
   type FieldReference,
   type StoredFieldValue,
   useFieldValueStore,
 } from '~/components/resources/store/field-value-store'
+import {
+  buildCanonicalFieldValueKey,
+  canonicalizeFieldRef,
+} from '~/components/resources/utils/canonicalize-field-ref'
+import {
+  useNormalizedRecordIds,
+  usePrefixEpoch,
+} from '~/components/resources/utils/normalize-record-id'
 
 interface UseFieldValueSyncerOptions {
   /** RecordIds for the entities being displayed */
@@ -60,24 +67,34 @@ interface SyncerResult {
  */
 export function useFieldValueSyncer(options: UseFieldValueSyncerOptions): SyncerResult {
   const {
-    recordIds,
+    recordIds: rawRecordIds,
     columnVisibility,
     resourceFieldIds,
     enabled = true,
     debounceMs = 150,
   } = options
 
+  // Canonicalize prefixes once — store keys and the fetch queue must only ever
+  // see canonical-definition RecordIds.
+  const recordIds = useNormalizedRecordIds(rawRecordIds)
+  const prefixEpoch = usePrefixEpoch()
+
   const pendingRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Convert columnIds to FieldReferences, filtering by visibility
+  // Persisted-ref ingress boundary: saved views store column ids whose
+  // definition segments may be alias-form (entityType/apiSlug) or drill-down
+  // paths — canonicalize each column ONCE here instead of per cell.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: prefixEpoch invalidates store-derived normalization
   const visibleFieldRefs = useMemo((): FieldReference[] => {
     return resourceFieldIds
       .filter((columnId) => columnVisibility[columnId] !== false)
       .map((columnId) => {
         const decoded = decodeColumnId(columnId)
-        return decoded.type === 'path' ? decoded.fieldPath : decoded.resourceFieldId
+        return canonicalizeFieldRef(
+          decoded.type === 'path' ? decoded.fieldPath : decoded.resourceFieldId
+        )
       })
-  }, [resourceFieldIds, columnVisibility])
+  }, [resourceFieldIds, columnVisibility, prefixEpoch])
 
   // Debounced queue trigger - delegates to shared fetch queue
   useEffect(() => {
@@ -101,10 +118,12 @@ export function useFieldValueSyncer(options: UseFieldValueSyncerOptions): Syncer
     }
   }, [enabled, visibleFieldRefs, recordIds, debounceMs])
 
-  // Get value accessor - reads directly from store via getState (stable function)
+  // Get value accessor - reads directly from store via getState (stable
+  // function). Defensive: external selection/copy callers can pass alias
+  // forms, so canonicalize both key halves here too.
   const getValue = useCallback(
     (recordId: RecordId, fieldRef: FieldReference): StoredFieldValue | undefined => {
-      const key = buildFieldValueKey(recordId, fieldRef)
+      const { key } = buildCanonicalFieldValueKey(recordId, fieldRef)
       return useFieldValueStore.getState().values[key]
     },
     []
@@ -112,7 +131,7 @@ export function useFieldValueSyncer(options: UseFieldValueSyncerOptions): Syncer
 
   // Loading state accessor
   const isValueLoading = useCallback((recordId: RecordId, fieldRef: FieldReference): boolean => {
-    const key = buildFieldValueKey(recordId, fieldRef)
+    const { key } = buildCanonicalFieldValueKey(recordId, fieldRef)
     return useFieldValueStore.getState().isKeyLoading(key)
   }, [])
 

--- a/apps/web/src/components/resources/hooks/use-field-values.ts
+++ b/apps/web/src/components/resources/hooks/use-field-values.ts
@@ -1,22 +1,23 @@
 // apps/web/src/components/resources/hooks/use-field-values.ts
 
-import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
+import type { RecordId } from '@auxx/lib/resources/client'
 import {
   type FieldId,
   type FieldReference,
+  type FieldValueKey,
   fieldRefToKey,
-  toResourceFieldId,
 } from '@auxx/types/field'
-import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { fieldValueFetchQueue } from '../store/field-value-fetch-queue'
 import {
   type AiCellState,
-  buildFieldValueKey,
   type CustomFieldValueState,
   type StoredFieldValue,
   useFieldValueStore,
 } from '../store/field-value-store'
+import { buildCanonicalFieldValueKey } from '../utils/canonicalize-field-ref'
+import { usePrefixEpoch } from '../utils/normalize-record-id'
 
 /**
  * Options for useFieldValue hook.
@@ -24,6 +25,31 @@ import {
 interface UseFieldValueOptions {
   /** When true, automatically fetch the value if not in store */
   autoFetch?: boolean
+}
+
+/**
+ * Memoize the canonical field-value key for a (recordId, fieldRef) pair.
+ * Both halves are canonicalized (RecordId prefix AND fieldRef definition
+ * segments) so subscriber keys always agree with queue/request keys.
+ * Recomputes only when inputs or prefix mappings change — no resource-store
+ * subscription, so field-metadata updates never fan out here.
+ */
+function useCanonicalKey(
+  rawRecordId: RecordId,
+  fieldRef: FieldReference | undefined
+): { recordId: RecordId; fieldRef: FieldReference | undefined; key: FieldValueKey | null } {
+  const epoch = usePrefixEpoch()
+  const refKey = fieldRef ? fieldRefToKey(fieldRef) : ''
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refKey stands in for fieldRef; epoch invalidates store-derived results
+  return useMemo(() => {
+    if (!fieldRef) return { recordId: rawRecordId, fieldRef, key: null }
+    return buildCanonicalFieldValueKey(rawRecordId, fieldRef)
+  }, [rawRecordId, refKey, epoch])
+}
+
+const EMPTY_VALUE_STATE: { value: StoredFieldValue | undefined; isLoading: boolean } = {
+  value: undefined,
+  isLoading: false,
 }
 
 /**
@@ -48,26 +74,17 @@ interface UseFieldValueOptions {
  * const { value, isLoading } = useFieldValue(recordId, 'order:totalPrice', { autoFetch: true })
  */
 export function useFieldValue(
-  recordId: RecordId,
+  rawRecordId: RecordId,
   fieldRef: FieldReference | undefined,
   options: UseFieldValueOptions = {}
 ): { value: StoredFieldValue | undefined; isLoading: boolean } {
   const { autoFetch = false } = options
-  const key = fieldRef ? buildFieldValueKey(recordId, fieldRef) : ('' as any)
+  const { recordId, fieldRef: canonicalRef, key } = useCanonicalKey(rawRecordId, fieldRef)
 
-  // Subscribe to value
-  const value = useFieldValueStore(
-    useCallback(
-      (state: CustomFieldValueState) => (fieldRef ? state.values[key] : undefined),
-      [key, fieldRef]
-    )
-  )
-
-  // Subscribe to loading state
-  const isLoading = useFieldValueStore(
-    useCallback(
-      (state: CustomFieldValueState) => (fieldRef ? key in state.fetchingKeys : false),
-      [key, fieldRef]
+  // Single shallow subscription for value + loading state
+  const state = useFieldValueStore(
+    useShallow((s: CustomFieldValueState) =>
+      key ? { value: s.values[key], isLoading: key in s.fetchingKeys } : EMPTY_VALUE_STATE
     )
   )
 
@@ -77,13 +94,13 @@ export function useFieldValue(
   // Queue fetch in useLayoutEffect - runs synchronously before paint
   // This prevents the flicker where the component renders with isLoading=false
   useLayoutEffect(() => {
-    if (!autoFetch || !fieldRef) return
-    if (value !== undefined) return
+    if (!autoFetch || !key || !canonicalRef) return
+    if (state.value !== undefined) return
     if (requestedRef.current.has(key)) return
 
     requestedRef.current.add(key)
-    fieldValueFetchQueue.queueFetch(recordId, fieldRef)
-  }, [autoFetch, fieldRef, value, key, recordId])
+    fieldValueFetchQueue.queueFetch(recordId, canonicalRef)
+  }, [autoFetch, state.value, key, recordId, canonicalRef])
 
   // Clear requested set when key changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: key triggers clearing the requested set
@@ -91,7 +108,7 @@ export function useFieldValue(
     requestedRef.current.clear()
   }, [key])
 
-  return { value, isLoading }
+  return state
 }
 
 /**
@@ -105,7 +122,8 @@ interface UseFieldValuesOptions {
 /**
  * Get multiple values for a single resource by FieldReferences.
  * Uses stable selector with useShallow for memoization to prevent infinite loops.
- * Returns Record keyed by fieldRefKey (use fieldRefToKey for consistent keys).
+ * Returns Record keyed by the INPUT fieldRefKey (use fieldRefToKey for
+ * consistent keys) — store lookups use canonical keys internally.
  *
  * @example
  * // Passive subscription (no auto-fetch)
@@ -116,59 +134,115 @@ interface UseFieldValuesOptions {
  * const { values, isLoading } = useFieldValues(recordId, fieldRefs, { autoFetch: true })
  */
 export function useFieldValues(
-  recordId: RecordId,
+  rawRecordId: RecordId,
   fieldRefs: FieldReference[],
   options: UseFieldValuesOptions = {}
 ): { values: Record<string, StoredFieldValue | undefined>; isLoading: boolean } {
   const { autoFetch = false } = options
+  const epoch = usePrefixEpoch()
   const refsKey = fieldRefs.map(fieldRefToKey).join(',')
+
+  // Canonicalize once per (recordId, refs, prefix-map) combination
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refsKey stands in for fieldRefs; epoch invalidates store-derived results
+  const canonical = useMemo(() => {
+    return fieldRefs.map((fieldRef) => {
+      const { recordId, fieldRef: ref, key } = buildCanonicalFieldValueKey(rawRecordId, fieldRef)
+      return { recordId, fieldRef: ref, key, resultKey: fieldRefToKey(fieldRef) }
+    })
+  }, [rawRecordId, refsKey, epoch])
 
   // Subscribe to values
   const values = useFieldValueStore(
-    useShallow(
-      // biome-ignore lint/correctness/useExhaustiveDependencies: fieldRefs is derived from refsKey, using refsKey as stable string dependency
-      useCallback(
-        (state: CustomFieldValueState) => {
-          const result: Record<string, StoredFieldValue | undefined> = {}
-          for (const fieldRef of fieldRefs) {
-            const storeKey = buildFieldValueKey(recordId, fieldRef)
-            result[fieldRefToKey(fieldRef)] = state.values[storeKey]
-          }
-          return result
-        },
-        [recordId, refsKey]
-      )
-    )
+    useShallow((state: CustomFieldValueState) => {
+      const result: Record<string, StoredFieldValue | undefined> = {}
+      for (const entry of canonical) {
+        result[entry.resultKey] = state.values[entry.key]
+      }
+      return result
+    })
   )
 
   // Subscribe to loading state
-  const isLoading = useFieldValueStore(
-    useCallback(
-      (state: CustomFieldValueState) => {
-        for (const fieldRef of fieldRefs) {
-          if (state.isKeyFetching(buildFieldValueKey(recordId, fieldRef))) return true
-        }
-        return false
-      },
-      [recordId, fieldRefs]
-    )
-  )
+  const isLoading = useFieldValueStore((state: CustomFieldValueState) => {
+    for (const entry of canonical) {
+      if (entry.key in state.fetchingKeys) return true
+    }
+    return false
+  })
 
   // Auto-fetch: queue once per unique (recordId + fieldRefs) combination
   const queuedKeyRef = useRef<string>('')
 
   useLayoutEffect(() => {
-    if (!autoFetch || fieldRefs.length === 0) return
+    if (!autoFetch || canonical.length === 0) return
 
-    const requestKey = `${recordId}:${refsKey}`
+    const requestKey = `${rawRecordId}:${refsKey}:${epoch}`
     if (queuedKeyRef.current === requestKey) return
     queuedKeyRef.current = requestKey
 
     // Use batch queue - handles deduplication internally
-    fieldValueFetchQueue.queueFetchBatch(fieldRefs.map((fieldRef) => ({ recordId, fieldRef })))
-  }, [autoFetch, recordId, refsKey, fieldRefs])
+    fieldValueFetchQueue.queueFetchBatch(
+      canonical.map((entry) => ({ recordId: entry.recordId, fieldRef: entry.fieldRef }))
+    )
+  }, [autoFetch, rawRecordId, refsKey, epoch, canonical])
 
   return { values, isLoading }
+}
+
+/** State bundle returned by {@link useFieldCellState}. */
+export interface FieldCellState {
+  value: StoredFieldValue | undefined
+  isLoading: boolean
+  aiState: AiCellState | undefined
+  /** Contributing data-connector id when the cell is connector-synced. */
+  managedConnectorId: string | undefined
+}
+
+const EMPTY_CELL_STATE: FieldCellState = {
+  value: undefined,
+  isLoading: false,
+  aiState: undefined,
+  managedConnectorId: undefined,
+}
+
+/**
+ * Combined cell-state selector for high-volume field rendering (table cells).
+ * Builds the canonical key ONCE and selects value, loading, AI, and managed
+ * state through a single shallow store subscription — instead of the three
+ * subscriptions + repeated normalization the individual hooks would add up to.
+ */
+export function useFieldCellState(
+  rawRecordId: RecordId,
+  fieldRef: FieldReference | undefined,
+  options: UseFieldValueOptions = {}
+): FieldCellState {
+  const { autoFetch = false } = options
+  const { recordId, fieldRef: canonicalRef, key } = useCanonicalKey(rawRecordId, fieldRef)
+
+  const state = useFieldValueStore(
+    useShallow((s: CustomFieldValueState): FieldCellState => {
+      if (!key) return EMPTY_CELL_STATE
+      return {
+        value: s.values[key],
+        isLoading: key in s.fetchingKeys,
+        aiState: s.aiStates[key],
+        managedConnectorId: s.managedStates[key],
+      }
+    })
+  )
+
+  const requestedRef = useRef<Set<string>>(new Set())
+
+  useLayoutEffect(() => {
+    if (!autoFetch || !key || !canonicalRef) return
+    if (state.value !== undefined) return
+    if (requestedRef.current.has(key)) return
+
+    requestedRef.current.add(key)
+    fieldValueFetchQueue.queueFetch(recordId, canonicalRef)
+  }, [autoFetch, state.value, key, recordId, canonicalRef])
+
+  return state
 }
 
 /**
@@ -178,11 +252,9 @@ export function useFieldValues(
  * buildFieldValueKey → useFieldValueStore` chain that every AI overlay
  * mount point would otherwise re-implement.
  */
-export function useFieldAiState(recordId: RecordId, fieldId: FieldId): AiCellState | undefined {
-  const { entityDefinitionId } = parseRecordId(recordId)
-  const resourceFieldId = toResourceFieldId(entityDefinitionId, fieldId)
-  const key = buildFieldValueKey(recordId, resourceFieldId)
-  return useFieldValueStore((s) => s.aiStates[key])
+export function useFieldAiState(rawRecordId: RecordId, fieldId: FieldId): AiCellState | undefined {
+  const key = useAttributeKey(rawRecordId, fieldId)
+  return useFieldValueStore((s) => (key ? s.aiStates[key] : undefined))
 }
 
 /**
@@ -191,9 +263,18 @@ export function useFieldAiState(recordId: RecordId, fieldId: FieldId): AiCellSta
  * contributing connector, else `undefined`. Mirrors `useFieldAiState` — the cell
  * stays editable; this only drives the "Synced by <connector>" badge.
  */
-export function useFieldManagedState(recordId: RecordId, fieldId: FieldId): string | undefined {
-  const { entityDefinitionId } = parseRecordId(recordId)
-  const resourceFieldId = toResourceFieldId(entityDefinitionId, fieldId)
-  const key = buildFieldValueKey(recordId, resourceFieldId)
-  return useFieldValueStore((s) => s.managedStates[key])
+export function useFieldManagedState(rawRecordId: RecordId, fieldId: FieldId): string | undefined {
+  const key = useAttributeKey(rawRecordId, fieldId)
+  return useFieldValueStore((s) => (key ? s.managedStates[key] : undefined))
+}
+
+/** Canonical key for a (record, plain-FieldId) pair — shared by the marker hooks. */
+function useAttributeKey(rawRecordId: RecordId, fieldId: FieldId): FieldValueKey | null {
+  const epoch = usePrefixEpoch()
+  // biome-ignore lint/correctness/useExhaustiveDependencies: epoch invalidates store-derived results
+  return useMemo(() => {
+    if (!fieldId) return null
+    const { key } = buildCanonicalFieldValueKey(rawRecordId, fieldId as unknown as FieldReference)
+    return key
+  }, [rawRecordId, fieldId, epoch])
 }

--- a/apps/web/src/components/resources/hooks/use-field.ts
+++ b/apps/web/src/components/resources/hooks/use-field.ts
@@ -3,6 +3,7 @@
 import type { FieldType } from '@auxx/database/types'
 import { getEffectiveFieldType } from '@auxx/lib/custom-fields/client'
 import type { Resource, ResourceField } from '@auxx/lib/resources/client'
+import { resolveStaticPrefix } from '@auxx/lib/resources/client'
 import type { SelectOption } from '@auxx/types/custom-field'
 import { type ResourceFieldId, toFieldId, toResourceFieldId } from '@auxx/types/field'
 import { useMemo } from 'react'
@@ -279,7 +280,13 @@ export function useFieldByKey(
     const sysRfId = state.systemAttributeMap[key]
     if (sysRfId) return sysRfId
     if (!entityDefinitionId) return undefined
-    return toResourceFieldId(entityDefinitionId, toFieldId(key))
+    // Canonicalize the def prefix — fieldMap is keyed by the canonical
+    // definition id only (unlike resourceMap), so an alias arg would miss.
+    const canonicalDefId =
+      resolveStaticPrefix(entityDefinitionId) ??
+      state.definitionIdByPrefix.get(entityDefinitionId) ??
+      entityDefinitionId
+    return toResourceFieldId(canonicalDefId, toFieldId(key))
   })
 
   return useField(resourceFieldId)

--- a/apps/web/src/components/resources/hooks/use-record-batch-fetcher.ts
+++ b/apps/web/src/components/resources/hooks/use-record-batch-fetcher.ts
@@ -7,7 +7,7 @@ import { hydrateMultipleRecords } from '~/components/resources/store/hydrate-fie
 import { api } from '~/trpc/react'
 import { getRecordStoreState, type RecordMeta, useRecordStore } from '../store/record-store'
 import { useResourceStore } from '../store/resource-store'
-import { getNormalizedRecordId } from '../utils/normalize-record-id'
+import { getNormalizedRecordId, usePrefixEpoch } from '../utils/normalize-record-id'
 
 const BATCH_DELAY = 50
 const EMPTY_ITEMS: RecordId[] = []
@@ -28,7 +28,14 @@ export function useRecordBatchFetcher() {
   // Subscribe to pending count (triggers re-render when items are added)
   const pendingCount = useRecordStore((s) => s.pendingFetchIds.size)
 
+  // The per-id gate lives in startBatch(): statically-canonical ids (legacy
+  // system types, definition UUIDs) flush immediately — even with no seed —
+  // while unresolved dynamic aliases stay pending. The prefix epoch retriggers
+  // the drain when mappings arrive (seed → hydration, org switch, new defs).
+  const prefixEpoch = usePrefixEpoch()
+
   // Schedule batch processing when pending items exist
+  // biome-ignore lint/correctness/useExhaustiveDependencies: prefixEpoch retriggers the drain when mappings change
   useEffect(() => {
     if (pendingCount === 0 || currentBatch.length > 0) return
 
@@ -40,7 +47,7 @@ export function useRecordBatchFetcher() {
     }, BATCH_DELAY)
 
     return () => clearTimeout(timer)
-  }, [pendingCount, currentBatch.length])
+  }, [prefixEpoch, pendingCount, currentBatch.length])
 
   // Stable query input
   const queryItems = useMemo<RecordId[]>(() => {
@@ -60,6 +67,14 @@ export function useRecordBatchFetcher() {
   // Handle successful fetch
   useEffect(() => {
     if (!data || currentBatch.length === 0) return
+
+    // Org-switch guard: clearAll() empties loadingIds, so a response that
+    // resolves after clearResourceCaches() must not write the previous org's
+    // records into the fresh store.
+    if (!currentBatch.some((id) => getRecordStoreState().loadingIds.has(id))) {
+      setCurrentBatch([])
+      return
+    }
 
     // Group results by entityDefinitionId for store update
     const byEntityDefinitionId = new Map<string, RecordMeta[]>()

--- a/apps/web/src/components/resources/hooks/use-record-list.ts
+++ b/apps/web/src/components/resources/hooks/use-record-list.ts
@@ -12,12 +12,13 @@ import {
   type RecordMeta,
   useRecordStore,
 } from '../store/record-store'
+import { useNormalizedDefinitionId } from '../utils/normalize-record-id'
 
 /** Stable empty array for default return */
 const EMPTY_IDS: string[] = []
 
 interface UseRecordListOptions {
-  /** Entity definition ID (e.g., 'contact', 'ticket', 'entity_abc') */
+  /** EntityDefinition UUID. Alias forms (entityType/apiSlug) are normalized internally. */
   entityDefinitionId: string
   /** Filter conditions - pass undefined or stable reference, NOT [] */
   filters?: ConditionGroup[]
@@ -70,12 +71,16 @@ interface UseRecordListResult<T = RecordMeta> {
  * IMPORTANT: Do NOT pass [] or {} as defaults - use undefined instead.
  */
 export function useRecordList<T extends RecordMeta = RecordMeta>({
-  entityDefinitionId,
+  entityDefinitionId: rawEntityDefinitionId,
   filters,
   sorting,
   limit = 50,
   enabled = true,
 }: UseRecordListOptions): UseRecordListResult<T> {
+  // Canonicalize the definition prefix once — listKey, requestRecord, and all
+  // records[...] reads below key by the EntityDefinition UUID.
+  const entityDefinitionId = useNormalizedDefinitionId(rawEntityDefinitionId)
+
   // Use stable empty defaults to prevent infinite loops
   const stableFilters = filters ?? EMPTY_FILTERS
   const stableSorting = sorting ?? EMPTY_SORTING

--- a/apps/web/src/components/resources/hooks/use-records.ts
+++ b/apps/web/src/components/resources/hooks/use-records.ts
@@ -3,6 +3,7 @@
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import { useEffect, useMemo } from 'react'
 import { type RecordMeta, useRecordStore } from '../store/record-store'
+import { useNormalizedRecordIds } from '../utils/normalize-record-id'
 
 /**
  * Options for the useRecords hook.
@@ -41,12 +42,16 @@ const EMPTY_NOT_FOUND: RecordId[] = []
  * Hook for fetching multiple specific records by RecordId array.
  * Leverages the batch fetcher system for efficient fetching with automatic deduplication.
  *
+ * Input RecordIds are normalized to the canonical EntityDefinition-UUID prefix,
+ * and all returned keys (`recordsByKey`, `notFoundIds`) use the normalized form.
+ *
  * @example
- * // Basic usage
+ * // Basic usage (prefer canonical entityDefinitionId prefixes; alias forms
+ * // like toRecordId('contact', id) are normalized internally)
  * const { records, isLoading } = useRecords({
  *   recordIds: [
- *     toRecordId('contact', 'abc123'),
- *     toRecordId('ticket', 'xyz789'),
+ *     toRecordId(contactResource.id, 'abc123'),
+ *     toRecordId(ticketResource.id, 'xyz789'),
  *   ]
  * })
  *
@@ -63,9 +68,13 @@ const EMPTY_NOT_FOUND: RecordId[] = []
  * })
  */
 export function useRecords<T extends RecordMeta = RecordMeta>({
-  recordIds,
+  recordIds: rawRecordIds,
   enabled = true,
 }: UseRecordsOptions): UseRecordsResult<T> {
+  // Canonicalize prefixes once at the top — all subscriptions, requests, and
+  // returned keys below use the normalized ids.
+  const recordIds = useNormalizedRecordIds(rawRecordIds)
+
   // Create stable key for dependencies
   const recordIdsKey = useMemo(() => recordIds.join(','), [recordIds])
 

--- a/apps/web/src/components/resources/hooks/use-relationship-sync.ts
+++ b/apps/web/src/components/resources/hooks/use-relationship-sync.ts
@@ -17,6 +17,7 @@ import {
   type StoredFieldValue,
   useFieldValueStore,
 } from '~/components/resources/store/field-value-store'
+import { getNormalizedRecordId } from '~/components/resources/utils/normalize-record-id'
 
 /**
  * Info needed to sync inverse relationships.
@@ -61,8 +62,15 @@ export function useRelationshipSync() {
    */
   const syncInverseCache = useCallback(
     (input: SyncInput) => {
-      const { sourceRecordId, oldRelatedRecordIds, newRelatedRecordIds, inverseInfo } = input
+      const { inverseInfo } = input
       const { inverseResourceFieldId, sourceResourceFieldId, inverseRelationshipType } = inverseInfo
+
+      // Canonicalize all record prefixes — stored relationship values can carry
+      // alias-prefixed recordIds (e.g. minted by workflow relation inputs), and
+      // inverse-side keys must hit the canonical field-value slots.
+      const sourceRecordId = getNormalizedRecordId(input.sourceRecordId)
+      const oldRelatedRecordIds = input.oldRelatedRecordIds.map(getNormalizedRecordId)
+      const newRelatedRecordIds = input.newRelatedRecordIds.map(getNormalizedRecordId)
 
       // Parse source ResourceFieldId for entity definition ID
       const { entityDefinitionId: sourceEntityDefinitionId } =
@@ -218,14 +226,15 @@ function normalizeToArray(value: StoredFieldValue): RelationshipFieldValue[] {
 }
 
 /**
- * Extract the related RecordId from a relationship value.
- * Returns the recordId directly from the value.
+ * Extract the related RecordId from a relationship value, canonicalized to the
+ * EntityDefinition-UUID prefix so comparisons against normalized ids match
+ * even when the stored value carries an alias-form prefix.
  */
 function extractRelatedRecordId(value: unknown): RecordId | null {
   if (!value || typeof value !== 'object') return null
   const rel = value as RelationshipFieldValue
   if (!rel.recordId) return null
-  return rel.recordId
+  return getNormalizedRecordId(rel.recordId)
 }
 
 /**

--- a/apps/web/src/components/resources/hooks/use-seed-created-record.ts
+++ b/apps/web/src/components/resources/hooks/use-seed-created-record.ts
@@ -11,6 +11,7 @@ import {
 } from '~/components/resources/store/field-value-store'
 import { type RecordMeta, useRecordStore } from '~/components/resources/store/record-store'
 import { useResourceStore } from '~/components/resources/store/resource-store'
+import { getNormalizedRecordId } from '~/components/resources/utils/normalize-record-id'
 
 /** Minimal instance shape needed to seed a `RecordMeta` — the fields carried by
  *  `CreateEntityResult.instance` (`@auxx/lib` `unified-handler-mutations.ts`). */
@@ -48,7 +49,9 @@ export function useSeedCreatedRecord() {
       instance: CreatedRecordInstance
       values: SeedFieldValue[]
     }) => {
-      const { entityDefinitionId, recordId, listKey, instance, values } = params
+      const { entityDefinitionId, listKey, instance, values } = params
+      // Guard: canonicalize the prefix so seeded keys match subscriber keys.
+      const recordId = getNormalizedRecordId(params.recordId)
 
       const meta: RecordMeta = {
         id: instance.id,

--- a/apps/web/src/components/resources/providers/resource-provider.tsx
+++ b/apps/web/src/components/resources/providers/resource-provider.tsx
@@ -18,6 +18,7 @@ import { initComputedFieldSync } from '../store/computed-field-registry'
 import { fieldValueFetchQueue } from '../store/field-value-fetch-queue'
 import { useFieldValueStore } from '../store/field-value-store'
 import { getResourceStoreState } from '../store/resource-store'
+import { usePrefixEpoch } from '../utils/normalize-record-id'
 
 /**
  * Component that handles batch fetching of records.
@@ -129,18 +130,22 @@ export function ResourceProvider({ children }: { children: React.ReactNode }) {
   // === RELATIONSHIP ITEMS BATCHING ===
   const [relationshipBatch, setRelationshipBatch] = useState<RecordId[]>([])
   const relationshipPendingSize = useRelationshipStore((s) => s.pendingIds.size)
+  // Retrigger the drain when prefix mappings change — unresolved alias ids
+  // stay pending until their mapping arrives (seed failure, org switch).
+  const prefixEpoch = usePrefixEpoch()
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: prefixEpoch retriggers the drain when mappings change
   useEffect(() => {
     if (relationshipPendingSize === 0 || relationshipBatch.length > 0) return
     const timeout = setTimeout(() => {
-      const state = getRelationshipStoreState()
-      const recordIds = state.getItemsToFetch().slice(0, MAX_RELATIONSHIP_BATCH)
+      // startBatch canonicalizes + dedupes and drains only resolvable ids, so
+      // loading, requested keys, and dataMap slots are always canonical.
+      const recordIds = getRelationshipStoreState().startBatch(MAX_RELATIONSHIP_BATCH)
       if (recordIds.length === 0) return
-      state.markLoading(recordIds)
       setRelationshipBatch(recordIds)
     }, BATCH_DELAY)
     return () => clearTimeout(timeout)
-  }, [relationshipPendingSize, relationshipBatch.length])
+  }, [relationshipPendingSize, relationshipBatch.length, prefixEpoch])
 
   const { data: relationshipData, error: relationshipError } = api.record.getByIds.useQuery(
     { items: relationshipBatch },
@@ -149,8 +154,15 @@ export function ResourceProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!relationshipData || relationshipBatch.length === 0) return
+    const state = getRelationshipStoreState()
+    // Org-switch guard: reset() empties loadingIds, so a response resolving
+    // after clearResourceCaches() must not publish into the new org's store.
+    if (!relationshipBatch.some((id) => state.loadingIds.has(id))) {
+      setRelationshipBatch([])
+      return
+    }
     // Pass requested keys so missing items (deleted entities) get marked as not found
-    getRelationshipStoreState().addHydratedItems(relationshipData, relationshipBatch)
+    state.addHydratedItems(relationshipData, relationshipBatch)
     setRelationshipBatch([])
   }, [relationshipData, relationshipBatch])
 
@@ -174,6 +186,9 @@ export function ResourceProvider({ children }: { children: React.ReactNode }) {
  * Call on logout or organization switch.
  */
 export function clearResourceCaches() {
+  // Reset singleton queues FIRST: cancels pending timers and bumps the
+  // generation so in-flight batches can't write into the cleared stores.
+  fieldValueFetchQueue.reset()
   getResourceStoreState().reset()
   getRelationshipStoreState().reset()
   getRecordStoreState().clearAll()

--- a/apps/web/src/components/resources/store/field-value-fetch-queue.test.ts
+++ b/apps/web/src/components/resources/store/field-value-fetch-queue.test.ts
@@ -1,0 +1,237 @@
+// apps/web/src/components/resources/store/field-value-fetch-queue.test.ts
+// Hardening-plan Parts 0/4/7/8: O(1) Map dedupe, both-halves re-keying,
+// org-reset generation guard, no timer polling, linear batch growth.
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import type { FieldReference } from '@auxx/types/field'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fieldValueFetchQueue } from './field-value-fetch-queue'
+import { useFieldValueStore } from './field-value-store'
+import { getResourceStoreState } from './resource-store'
+
+const WORK_ORDER_DEF = 'cmworkorderdef12345678'
+
+const workOrderResource = {
+  id: WORK_ORDER_DEF,
+  type: 'custom',
+  apiSlug: 'work_orders',
+  entityType: 'work_order',
+  entityDefinitionId: WORK_ORDER_DEF,
+  organizationId: 'org_1',
+  label: 'Work Order',
+  plural: 'Work Orders',
+  icon: 'wrench',
+  color: 'blue',
+  isVisible: true,
+  fields: [],
+  display: {
+    primaryDisplayField: null,
+    secondaryDisplayField: null,
+    avatarField: null,
+    defaultSortField: 'updatedAt',
+    defaultSortDirection: 'desc',
+    orgScopingStrategy: 'direct',
+  },
+} as any
+
+type FetchCall = { recordIds: RecordId[]; fieldReferences: FieldReference[] }
+
+function makeFetchFn(calls: FetchCall[]) {
+  return vi.fn(async (params: FetchCall) => {
+    calls.push(params)
+    return {
+      values: params.recordIds.flatMap((recordId) =>
+        params.fieldReferences.map((fieldRef) => ({
+          recordId,
+          fieldRef,
+          value: `v:${recordId}`,
+        }))
+      ),
+    }
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  fieldValueFetchQueue.reset()
+  fieldValueFetchQueue.setDebounceMs(0)
+  getResourceStoreState().reset()
+  useFieldValueStore.getState().clearAll()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('enqueue dedupe', () => {
+  it('produces exactly one entry per FieldValueKey (alias + canonical collapse)', async () => {
+    getResourceStoreState().setResources([workOrderResource])
+    const calls: FetchCall[] = []
+    fieldValueFetchQueue.setFetchFn(makeFetchFn(calls))
+
+    // Same cell requested via alias record, canonical record, alias fieldRef —
+    // all must map to ONE canonical key and ONE request combination.
+    fieldValueFetchQueue.queueFetchBatch([
+      { recordId: 'work_order:r1', fieldRef: 'work_order:f1' as FieldReference },
+      { recordId: `${WORK_ORDER_DEF}:r1`, fieldRef: `${WORK_ORDER_DEF}:f1` as FieldReference },
+      { recordId: 'work_orders:r1', fieldRef: `${WORK_ORDER_DEF}:f1` as FieldReference },
+    ])
+
+    await vi.runAllTimersAsync()
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.recordIds).toEqual([`${WORK_ORDER_DEF}:r1`])
+    expect(calls[0]!.fieldReferences).toEqual([`${WORK_ORDER_DEF}:f1`])
+    expect(useFieldValueStore.getState().values[`${WORK_ORDER_DEF}:r1:${WORK_ORDER_DEF}:f1`]).toBe(
+      `v:${WORK_ORDER_DEF}:r1`
+    )
+  })
+})
+
+describe('pre-hydration re-keying', () => {
+  it('rekeys BOTH RecordId and fieldRef halves when the mapping arrives', async () => {
+    const calls: FetchCall[] = []
+    fieldValueFetchQueue.setFetchFn(makeFetchFn(calls))
+
+    // No mapping yet — entry queues under the alias key and must NOT flush.
+    fieldValueFetchQueue.queueFetch('work_order:r1', 'work_order:f1' as FieldReference)
+    await vi.runAllTimersAsync()
+    expect(calls).toHaveLength(0)
+    // Alias fetching marker present pre-hydration (skeleton stays up)
+    expect(useFieldValueStore.getState().isKeyFetching('work_order:r1:work_order:f1')).toBe(true)
+
+    // Mapping arrives → prefix-map subscription schedules the flush.
+    getResourceStoreState().setResources([workOrderResource])
+    await vi.runAllTimersAsync()
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.recordIds).toEqual([`${WORK_ORDER_DEF}:r1`])
+    expect(calls[0]!.fieldReferences).toEqual([`${WORK_ORDER_DEF}:f1`])
+    // Stale alias marker swapped for the canonical one, value landed canonical
+    const state = useFieldValueStore.getState()
+    expect(state.isKeyFetching('work_order:r1:work_order:f1')).toBe(false)
+    expect(state.values[`${WORK_ORDER_DEF}:r1:${WORK_ORDER_DEF}:f1`]).toBe(`v:${WORK_ORDER_DEF}:r1`)
+  })
+
+  it('leaves no recurring timer when resources never hydrate (no polling)', async () => {
+    const calls: FetchCall[] = []
+    fieldValueFetchQueue.setFetchFn(makeFetchFn(calls))
+    fieldValueFetchQueue.queueFetch('work_order:r1', 'work_order:f1' as FieldReference)
+
+    await vi.runAllTimersAsync()
+    expect(calls).toHaveLength(0)
+    // runAllTimersAsync would loop forever on a self-rescheduling timer; the
+    // stronger assertion is that no timer remains at all:
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('flushes statically-canonical ids immediately even with no seed', async () => {
+    const calls: FetchCall[] = []
+    fieldValueFetchQueue.setFetchFn(makeFetchFn(calls))
+    fieldValueFetchQueue.queueFetch('thread:t1', 'thread:subject' as FieldReference)
+
+    await vi.runAllTimersAsync()
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.recordIds).toEqual(['thread:t1'])
+  })
+})
+
+describe('org reset / generation guard', () => {
+  it('reset cancels pending work', async () => {
+    const calls: FetchCall[] = []
+    fieldValueFetchQueue.setFetchFn(makeFetchFn(calls))
+    fieldValueFetchQueue.queueFetch('thread:t1', 'thread:subject' as FieldReference)
+
+    fieldValueFetchQueue.reset()
+    await vi.runAllTimersAsync()
+    expect(calls).toHaveLength(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('discards an old-generation response after reset (no writes into new stores)', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    fieldValueFetchQueue.setFetchFn(async (params) => {
+      await gate
+      return {
+        values: params.recordIds.map((recordId) => ({
+          recordId,
+          fieldRef: params.fieldReferences[0]!,
+          value: 'stale-org-value',
+        })),
+      }
+    })
+
+    fieldValueFetchQueue.queueFetch('thread:t1', 'thread:subject' as FieldReference)
+    await vi.advanceTimersByTimeAsync(1) // start the flush; fetch is in flight
+
+    // Org switch mid-flight
+    fieldValueFetchQueue.reset()
+    useFieldValueStore.getState().clearAll()
+
+    release()
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+
+    const state = useFieldValueStore.getState()
+    expect(Object.keys(state.values)).toHaveLength(0)
+    expect(Object.keys(state.fetchingKeys)).toHaveLength(0)
+    expect(Object.keys(state.loadingBatches)).toHaveLength(0)
+  })
+})
+
+describe('batch scaling (Part 0 benchmark, operation-shape assertions)', () => {
+  it('10k combinations enqueue via Map dedupe and produce one canonical request set', async () => {
+    getResourceStoreState().setResources([workOrderResource])
+    const calls: FetchCall[] = []
+    fieldValueFetchQueue.setFetchFn(makeFetchFn(calls))
+
+    const RECORDS = 1000
+    const FIELDS = 10
+    const requests: Array<{ recordId: RecordId; fieldRef: FieldReference }> = []
+    for (let r = 0; r < RECORDS; r++) {
+      for (let f = 0; f < FIELDS; f++) {
+        requests.push({
+          recordId: `work_order:r${r}`,
+          fieldRef: `${WORK_ORDER_DEF}:f${f}` as FieldReference,
+        })
+      }
+    }
+
+    const start = performance.now()
+    const queued = fieldValueFetchQueue.queueFetchBatch(requests)
+    const enqueueMs = performance.now() - start
+    // eslint-disable-next-line no-console
+    console.log(`[benchmark] enqueue ${RECORDS * FIELDS} combinations: ${enqueueMs.toFixed(1)}ms`)
+
+    expect(queued).toHaveLength(RECORDS * FIELDS)
+    // Every key canonical, no alias slots
+    expect(queued.every((k) => k.startsWith(`${WORK_ORDER_DEF}:`))).toBe(true)
+
+    await vi.runAllTimersAsync()
+    // 1000 records / BATCH_SIZE(100) = 10 chunks, all sharing the field set
+    expect(calls).toHaveLength(10)
+    expect(calls[0]!.fieldReferences).toHaveLength(FIELDS)
+    const requestedRecords = new Set(calls.flatMap((c) => c.recordIds))
+    expect(requestedRecords.size).toBe(RECORDS)
+  })
+
+  it('duplicate-heavy alias/canonical mix collapses to unique combinations', () => {
+    getResourceStoreState().setResources([workOrderResource])
+    fieldValueFetchQueue.setFetchFn(makeFetchFn([]))
+
+    const requests: Array<{ recordId: RecordId; fieldRef: FieldReference }> = []
+    for (let r = 0; r < 200; r++) {
+      for (const prefix of ['work_order', 'work_orders', WORK_ORDER_DEF]) {
+        requests.push({
+          recordId: `${prefix}:r${r}`,
+          fieldRef: 'work_order:f1' as FieldReference,
+        })
+      }
+    }
+    const queued = fieldValueFetchQueue.queueFetchBatch(requests)
+    expect(queued).toHaveLength(200) // 600 inputs → 200 unique canonical keys
+  })
+})

--- a/apps/web/src/components/resources/store/field-value-fetch-queue.ts
+++ b/apps/web/src/components/resources/store/field-value-fetch-queue.ts
@@ -2,8 +2,10 @@
 
 import type { AiStatus, AiValueMetadata } from '@auxx/lib/realtime/client'
 import type { RecordId } from '@auxx/lib/resources/client'
-import { isResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
+import { fieldRefToKey, isResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
 import { generateId } from '@auxx/utils/generateId'
+import { buildCanonicalFieldValueKey, canonicalizeFieldRef } from '../utils/canonicalize-field-ref'
+import { getNormalizedRecordId, tryNormalizeRecordId } from '../utils/normalize-record-id'
 import { ensureCalcValue } from './calc-value-computer'
 import { computedFieldRegistry } from './computed-field-registry'
 import {
@@ -14,6 +16,7 @@ import {
   type StoredFieldValue,
   useFieldValueStore,
 } from './field-value-store'
+import { useResourceStore } from './resource-store'
 
 const BATCH_SIZE = 100
 const DEFAULT_DEBOUNCE_MS = 50
@@ -45,18 +48,42 @@ interface QueueEntry {
 /**
  * Singleton fetch queue that batches and deduplicates field value requests.
  * Used by both useFieldValueSyncer (table views) and useFieldValue with autoFetch (single record views).
+ *
+ * Invariants (hardening plan Parts 4/7):
+ * - `pendingByKey` gives O(1) dedupe — no linear scans on enqueue.
+ * - Keys are canonical in BOTH halves (RecordId prefix + fieldRef definition
+ *   segments) whenever the prefix map can resolve them.
+ * - flush() drains per-id: resolvable entries fetch, unresolved entries stay
+ *   pending until the prefix map changes (no timer polling).
+ * - reset() + generation guard: an org switch discards in-flight results so
+ *   they can never write into the next org's stores.
  */
 class FieldValueFetchQueue {
-  private pending: QueueEntry[] = []
+  private pendingByKey = new Map<FieldValueKey, QueueEntry>()
   private timeoutId: ReturnType<typeof setTimeout> | null = null
   private fetchFn: FetchFn | null = null
   private debounceMs = DEFAULT_DEBOUNCE_MS
+  private generation = 0
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      // Re-attempt a flush when prefix mappings change — this is the ONLY
+      // wake-up source for entries that were unresolvable at enqueue time.
+      useResourceStore.subscribe(
+        (s) => s.definitionIdByPrefix,
+        () => {
+          if (this.pendingByKey.size > 0) this.scheduleFlush()
+        }
+      )
+    }
+  }
 
   /**
    * Set the fetch function (called once when tRPC client is available).
    */
   setFetchFn(fn: FetchFn) {
     this.fetchFn = fn
+    if (this.pendingByKey.size > 0) this.scheduleFlush()
   }
 
   /**
@@ -67,17 +94,31 @@ class FieldValueFetchQueue {
   }
 
   /**
+   * Cancel pending work and invalidate in-flight requests. Called from
+   * `clearResourceCaches()` on logout/org switch, BEFORE stores are cleared.
+   */
+  reset() {
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId)
+      this.timeoutId = null
+    }
+    this.pendingByKey.clear()
+    this.generation++
+  }
+
+  /**
    * Queue a fetch request. Will be batched and deduplicated automatically.
    * Returns true if the request was queued, false if already loading/cached.
    * For computed fields (CALC, NAME), queues source fields instead since values are computed client-side.
    */
-  queueFetch(recordId: RecordId, fieldRef: FieldReference): boolean {
-    // Normalize fieldRef to ResourceFieldId first so computed field check uses consistent format.
-    // The registry keys are ResourceFieldId (e.g. "contact:abc123"), but callers may pass plain FieldId.
-    const normalizedRef =
-      typeof fieldRef === 'string' && !isResourceFieldId(fieldRef)
-        ? normalizeFieldRef(recordId, fieldRef)
-        : fieldRef
+  queueFetch(rawRecordId: RecordId, rawFieldRef: FieldReference): boolean {
+    // Canonicalize BOTH halves (no-op for unresolvable prefixes pre-hydration;
+    // the flush drain re-keys those before they ever hit the network).
+    const {
+      recordId,
+      fieldRef: normalizedRef,
+      key,
+    } = buildCanonicalFieldValueKey(rawRecordId, rawFieldRef)
 
     // Check if this is a computed field (CALC, NAME) — decompose into source fields
     if (
@@ -104,20 +145,17 @@ class FieldValueFetchQueue {
       }
     }
 
-    const key = buildFieldValueKey(recordId, normalizedRef)
     const store = useFieldValueStore.getState()
 
-    // Skip if already in store or already being fetched
+    // Skip if already in store, already being fetched, or already pending
     if (key in store.values || store.isKeyFetching(key)) {
       return false
     }
-
-    // Skip if already in pending queue
-    if (this.pending.some((e) => e.key === key)) {
+    if (this.pendingByKey.has(key)) {
       return false
     }
 
-    this.pending.push({ recordId, fieldRef: normalizedRef, key })
+    this.pendingByKey.set(key, { recordId, fieldRef: normalizedRef, key })
 
     // Mark as fetching immediately - this triggers skeleton in cells
     store.markFetching([key])
@@ -129,6 +167,8 @@ class FieldValueFetchQueue {
   /**
    * Queue multiple fetch requests at once (more efficient than individual calls).
    * Decomposes computed fields (CALC, NAME) into their source field fetches.
+   * Normalizes each unique RecordId and fieldRef ONCE per batch — cost scales
+   * with unique inputs, not record×field combinations.
    */
   queueFetchBatch(
     requests: Array<{ recordId: RecordId; fieldRef: FieldReference }>
@@ -136,12 +176,35 @@ class FieldValueFetchQueue {
     const store = useFieldValueStore.getState()
     const queued: FieldValueKey[] = []
 
-    for (const { recordId, fieldRef } of requests) {
-      // Normalize fieldRef to ResourceFieldId for consistent registry lookups
-      const normalizedRef =
-        typeof fieldRef === 'string' && !isResourceFieldId(fieldRef)
-          ? normalizeFieldRef(recordId, fieldRef)
-          : fieldRef
+    // Per-batch normalization caches
+    const recordIdCache = new Map<RecordId, RecordId>()
+    const refCache = new Map<string, { ref: FieldReference; refKey: string }>()
+
+    const normalizeRecordIdCached = (raw: RecordId): RecordId => {
+      let normalized = recordIdCache.get(raw)
+      if (normalized === undefined) {
+        normalized = getNormalizedRecordId(raw)
+        recordIdCache.set(raw, normalized)
+      }
+      return normalized
+    }
+
+    for (const { recordId: rawRecordId, fieldRef: rawFieldRef } of requests) {
+      const recordId = normalizeRecordIdCached(rawRecordId)
+
+      // Canonicalize the ref once per unique (recordId-independent) reference.
+      // Plain FieldIds depend on the record prefix, so key those by record too.
+      const rawRefKey =
+        typeof rawFieldRef === 'string' && !isResourceFieldId(rawFieldRef)
+          ? `${recordId}|${rawFieldRef}`
+          : fieldRefToKey(rawFieldRef)
+      let cached = refCache.get(rawRefKey)
+      if (!cached) {
+        const ref = canonicalizeFieldRef(normalizeFieldRef(recordId, rawFieldRef))
+        cached = { ref, refKey: fieldRefToKey(ref) }
+        refCache.set(rawRefKey, cached)
+      }
+      const normalizedRef = cached.ref
 
       // Decompose computed fields (CALC, NAME) into source fields
       if (
@@ -152,11 +215,15 @@ class FieldValueFetchQueue {
         if (config) {
           let queuedForCalc = false
           for (const sourceFieldId of Object.values(config.sourceFields)) {
-            const sourceKey = buildFieldValueKey(recordId, sourceFieldId)
+            const sourceRef = normalizeFieldRef(recordId, sourceFieldId)
+            const sourceKey = `${recordId}:${fieldRefToKey(sourceRef)}` as FieldValueKey
             if (sourceKey in store.values || store.isKeyFetching(sourceKey)) continue
-            if (this.pending.some((e) => e.key === sourceKey)) continue
-            const sourceNormalized = normalizeFieldRef(recordId, sourceFieldId)
-            this.pending.push({ recordId, fieldRef: sourceNormalized, key: sourceKey })
+            if (this.pendingByKey.has(sourceKey)) continue
+            this.pendingByKey.set(sourceKey, {
+              recordId,
+              fieldRef: sourceRef,
+              key: sourceKey,
+            })
             queued.push(sourceKey)
             queuedForCalc = true
           }
@@ -169,13 +236,13 @@ class FieldValueFetchQueue {
         }
       }
 
-      const key = buildFieldValueKey(recordId, normalizedRef)
+      const key = `${recordId}:${cached.refKey}` as FieldValueKey
 
-      // Skip if already in store or already being fetched
+      // Skip if already in store, already being fetched, or already pending
       if (key in store.values || store.isKeyFetching(key)) continue
-      if (this.pending.some((e) => e.key === key)) continue
+      if (this.pendingByKey.has(key)) continue
 
-      this.pending.push({ recordId, fieldRef: normalizedRef, key })
+      this.pendingByKey.set(key, { recordId, fieldRef: normalizedRef, key })
       queued.push(key)
     }
 
@@ -200,7 +267,8 @@ class FieldValueFetchQueue {
   }
 
   /**
-   * Schedule a flush of the pending queue.
+   * Schedule a flush of the pending queue. Only ever one timer; wake-up
+   * sources are: new entries, the prefix map changing, and setFetchFn.
    */
   private scheduleFlush() {
     if (this.timeoutId) {
@@ -208,32 +276,78 @@ class FieldValueFetchQueue {
     }
 
     this.timeoutId = setTimeout(() => {
+      this.timeoutId = null
       this.flush()
     }, this.debounceMs)
   }
 
   /**
-   * Flush the pending queue - executes the batch fetch.
+   * Flush the pending queue - executes the batch fetch for every entry whose
+   * RecordId prefix is resolvable. Unresolved entries stay pending (released
+   * by the prefix-map subscription). Entries queued before their mapping
+   * existed are re-keyed here — BOTH halves — in one pass.
    */
   private async flush() {
-    if (!this.fetchFn || this.pending.length === 0) return
+    if (!this.fetchFn || this.pendingByKey.size === 0) return
 
-    // Take current pending and clear
-    const toFetch = [...this.pending]
-    this.pending = []
-    this.timeoutId = null
+    const generation = this.generation
+    const store = useFieldValueStore.getState()
 
-    const keys = toFetch.map((e) => e.key)
+    // Drain resolvable entries, re-keying pre-hydration aliases. Duplicates
+    // introduced by re-keying collapse into the toFetch map.
+    const toFetch = new Map<FieldValueKey, QueueEntry>()
+    const staleKeys: FieldValueKey[] = []
+    const rekeyedKeys: FieldValueKey[] = []
+
+    for (const [key, entry] of this.pendingByKey) {
+      const canonicalRecordId = tryNormalizeRecordId(entry.recordId)
+      if (!canonicalRecordId) continue // unresolved — stays pending
+
+      this.pendingByKey.delete(key)
+
+      let next = entry
+      if (canonicalRecordId !== entry.recordId) {
+        // The prefix map learned this alias after enqueue — rewrite the
+        // RecordId half AND the fieldRef definition segments.
+        const fieldRef = canonicalizeFieldRef(normalizeFieldRef(canonicalRecordId, entry.fieldRef))
+        const newKey = `${canonicalRecordId}:${fieldRefToKey(fieldRef)}` as FieldValueKey
+        staleKeys.push(key)
+        if (!(newKey in store.values)) rekeyedKeys.push(newKey)
+        next = { recordId: canonicalRecordId, fieldRef, key: newKey }
+      }
+
+      // Merge duplicates; skip keys that already have a value in store
+      // (arrived via realtime/hydration while queued) — clear their marker.
+      if (next.key in store.values) {
+        if (next === entry) staleKeys.push(key)
+        continue
+      }
+      if (!toFetch.has(next.key)) toFetch.set(next.key, next)
+    }
+
+    // Swap stale alias markers for canonical ones in ONE store update.
+    if (staleKeys.length > 0 || rekeyedKeys.length > 0) {
+      store.replaceFetching(staleKeys, rekeyedKeys)
+    }
+
+    if (toFetch.size === 0) return
+
+    const entriesToFetch = [...toFetch.values()]
+    const keys = entriesToFetch.map((e) => e.key)
     const batchId = generateId('batch')
 
     // Mark as loading
     useFieldValueStore.getState().startLoading(batchId, keys)
 
-    // Group by unique recordIds and fieldRefs
-    const recordIds = [...new Set(toFetch.map((e) => e.recordId))]
-    const fieldRefs = [...new Set(toFetch.map((e) => JSON.stringify(e.fieldRef)))].map(
-      (s) => JSON.parse(s) as FieldReference
-    )
+    // Group by unique recordIds and fieldRefs (stable keys, no JSON round-trip)
+    const recordIds = [...new Set(entriesToFetch.map((e) => e.recordId))]
+    const fieldRefsByKey = new Map<string, FieldReference>()
+    for (const entry of entriesToFetch) {
+      // entry.fieldRef is always normalized at enqueue — key it directly
+      const refKey = fieldRefToKey(entry.fieldRef)
+      if (!fieldRefsByKey.has(refKey)) fieldRefsByKey.set(refKey, entry.fieldRef)
+    }
+    const fieldRefs = [...fieldRefsByKey.values()]
 
     try {
       // Chunk recordIds to avoid API limits
@@ -247,6 +361,10 @@ class FieldValueFetchQueue {
           })
         )
       )
+
+      // Org switched while in flight — discard entirely; the new org's stores
+      // must never receive this generation's values or markers.
+      if (generation !== this.generation) return
 
       // Build entries map from results
       const entriesMap = new Map<FieldValueKey, StoredFieldValue>()
@@ -274,7 +392,8 @@ class FieldValueFetchQueue {
         }
       }
 
-      // Compute all requested combinations
+      // Compute all requested combinations (server evaluates the cross
+      // product, so null-backfill must cover it too)
       const allRequestedCombinations = new Set<FieldValueKey>()
       for (const recordId of recordIds) {
         for (const fieldRef of fieldRefs) {
@@ -312,7 +431,9 @@ class FieldValueFetchQueue {
     } catch (error) {
       console.error('[FieldValueFetchQueue] Fetch failed:', error)
     } finally {
-      useFieldValueStore.getState().finishLoading(batchId)
+      if (generation === this.generation) {
+        useFieldValueStore.getState().finishLoading(batchId)
+      }
     }
   }
 

--- a/apps/web/src/components/resources/store/field-value-store.ts
+++ b/apps/web/src/components/resources/store/field-value-store.ts
@@ -1,19 +1,13 @@
 // apps/web/src/stores/custom-field-value-store.ts
 
 import type { AiStatus, AiValueMetadata } from '@auxx/lib/realtime/client'
-import { parseRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import { type RecordId, toRecordId } from '@auxx/lib/resources/client'
 import {
-  buildFieldValueKey,
-  type FieldPath,
   type FieldReference,
   type FieldValueKey,
   fieldRefToKey,
-  isFieldPath,
-  isResourceFieldId,
   keyToFieldRef,
-  normalizeFieldRef,
   type ResourceFieldId,
-  toResourceFieldId,
 } from '@auxx/types/field'
 import type { TypedFieldValue } from '@auxx/types/field-value'
 import { create } from 'zustand'
@@ -164,6 +158,16 @@ interface CustomFieldValueState {
 
   /** Mark keys as being fetched (called when queued, cleared when values arrive) */
   markFetching: (keys: FieldValueKey[]) => void
+
+  /** Remove fetching markers without writing values (stale keys after re-normalization) */
+  clearFetching: (keys: FieldValueKey[]) => void
+
+  /**
+   * Atomically swap fetching markers: remove stale (alias) keys and add their
+   * canonical replacements in ONE store update, so subscribers never observe
+   * the intermediate no-marker state during flush re-keying.
+   */
+  replaceFetching: (staleKeys: FieldValueKey[], newKeys: FieldValueKey[]) => void
 
   // ─────────────────────────────────────────────────────────────────
   // INVALIDATION (crucial for correctness)
@@ -479,6 +483,30 @@ export const useFieldValueStore = create<CustomFieldValueState>()(
       set((state) => {
         const newFetchingKeys = { ...state.fetchingKeys }
         for (const key of keys) {
+          newFetchingKeys[key] = true
+        }
+        return { fetchingKeys: newFetchingKeys }
+      })
+    },
+
+    clearFetching: (keys) => {
+      set((state) => {
+        const newFetchingKeys = { ...state.fetchingKeys }
+        for (const key of keys) {
+          delete newFetchingKeys[key]
+        }
+        return { fetchingKeys: newFetchingKeys }
+      })
+    },
+
+    replaceFetching: (staleKeys, newKeys) => {
+      if (staleKeys.length === 0 && newKeys.length === 0) return
+      set((state) => {
+        const newFetchingKeys = { ...state.fetchingKeys }
+        for (const key of staleKeys) {
+          delete newFetchingKeys[key]
+        }
+        for (const key of newKeys) {
           newFetchingKeys[key] = true
         }
         return { fetchingKeys: newFetchingKeys }

--- a/apps/web/src/components/resources/store/hydrate-field-values.ts
+++ b/apps/web/src/components/resources/store/hydrate-field-values.ts
@@ -10,6 +10,7 @@ import {
   type ResourceField,
 } from '@auxx/lib/resources/client'
 import { parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
+import { getNormalizedRecordId } from '../utils/normalize-record-id'
 import { buildFieldValueKey, type StoredFieldValue, useFieldValueStore } from './field-value-store'
 
 /**
@@ -41,7 +42,13 @@ interface HydrationOptions {
  *
  * This is a pure function that can be called from any context (not a hook).
  */
-export function hydrateFieldValues({ resource, recordId, recordData }: HydrationOptions): void {
+export function hydrateFieldValues({
+  resource,
+  recordId: rawRecordId,
+  recordData,
+}: HydrationOptions): void {
+  // Guard: canonicalize the prefix so hydrated keys match subscriber keys.
+  const recordId = getNormalizedRecordId(rawRecordId)
   const entries: Array<{ key: string; value: StoredFieldValue }> = []
 
   // Process all fields (system + custom)
@@ -135,7 +142,10 @@ export function hydrateMultipleRecords(
       })
 
       if (typedValue !== null) {
-        const storeKey = buildFieldValueKey(record.recordId, field.resourceFieldId ?? field.id)
+        const storeKey = buildFieldValueKey(
+          getNormalizedRecordId(record.recordId),
+          field.resourceFieldId ?? field.id
+        )
         allEntries.push({ key: storeKey, value: typedValue as StoredFieldValue })
       }
     }

--- a/apps/web/src/components/resources/store/record-store-batching.test.ts
+++ b/apps/web/src/components/resources/store/record-store-batching.test.ts
@@ -1,0 +1,112 @@
+// apps/web/src/components/resources/store/record-store-batching.test.ts
+// Hardening-plan Part 8: startBatch is the single canonicalizing drain —
+// alias+canonical dedupe, per-id gating, canonical loading keys.
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getRecordStoreState } from './record-store'
+import { getRelationshipStoreState, useRelationshipStore } from './relationship-store'
+import { getResourceStoreState } from './resource-store'
+
+const WORK_ORDER_DEF = 'cmworkorderdef12345678'
+
+const workOrderResource = {
+  id: WORK_ORDER_DEF,
+  type: 'custom',
+  apiSlug: 'work_orders',
+  entityType: 'work_order',
+  entityDefinitionId: WORK_ORDER_DEF,
+  organizationId: 'org_1',
+  label: 'Work Order',
+  plural: 'Work Orders',
+  icon: 'wrench',
+  color: 'blue',
+  isVisible: true,
+  fields: [],
+  display: {
+    primaryDisplayField: null,
+    secondaryDisplayField: null,
+    avatarField: null,
+    defaultSortField: 'updatedAt',
+    defaultSortDirection: 'desc',
+    orgScopingStrategy: 'direct',
+  },
+} as any
+
+beforeEach(() => {
+  getResourceStoreState().reset()
+  getRecordStoreState().clearAll()
+  getRelationshipStoreState().reset()
+})
+
+describe('recordStore.startBatch', () => {
+  it('collapses alias + canonical duplicates into one request slot', () => {
+    const store = getRecordStoreState()
+
+    // Pre-hydration: the alias can't normalize at entry, so both forms of the
+    // same record occupy separate pending slots — the classic double-queue.
+    store.requestRecord('work_order:x')
+    store.requestRecord(`${WORK_ORDER_DEF}:x`)
+    expect(getRecordStoreState().pendingFetchIds.size).toBe(2)
+
+    // Hydration arrives; the drain must collapse both into ONE canonical id.
+    getResourceStoreState().setResources([workOrderResource])
+    const batch = getRecordStoreState().startBatch()
+    expect(batch).toEqual([`${WORK_ORDER_DEF}:x`])
+    expect(getRecordStoreState().pendingFetchIds.size).toBe(0)
+    expect(getRecordStoreState().loadingIds.has(`${WORK_ORDER_DEF}:x`)).toBe(true)
+  })
+
+  it('flushes statically-canonical ids while unresolved aliases stay pending', () => {
+    const store = getRecordStoreState()
+    store.requestRecord('thread:t1') // legacy — statically canonical
+    store.requestRecord('work_order:w1') // dynamic alias — no mapping yet
+
+    const batch = getRecordStoreState().startBatch()
+    expect(batch).toEqual(['thread:t1'])
+    expect(getRecordStoreState().pendingFetchIds.has('work_order:w1')).toBe(true)
+
+    // Mapping arrives — the pending alias releases exactly once
+    getResourceStoreState().setResources([workOrderResource])
+    const second = getRecordStoreState().startBatch()
+    expect(second).toEqual([`${WORK_ORDER_DEF}:w1`])
+    expect(getRecordStoreState().pendingFetchIds.size).toBe(0)
+    expect(getRecordStoreState().startBatch()).toEqual([])
+  })
+
+  it('duplicates do not reduce effective batch size (dedupe before slice)', () => {
+    const store = getRecordStoreState()
+    // Pre-hydration: 60 unique records, each queued in both alias and
+    // canonical form → 120 queued entries. After hydration the batch must
+    // still contain all 60 unique ids (slicing before dedupe would drop 10).
+    for (let i = 0; i < 60; i++) {
+      store.requestRecord(`work_order:r${i}`)
+      store.requestRecord(`${WORK_ORDER_DEF}:r${i}`)
+    }
+    expect(getRecordStoreState().pendingFetchIds.size).toBe(120)
+    getResourceStoreState().setResources([workOrderResource])
+    const batch = getRecordStoreState().startBatch()
+    expect(batch).toHaveLength(60)
+    expect(new Set(batch).size).toBe(60)
+    expect(batch.every((id) => id.startsWith(`${WORK_ORDER_DEF}:`))).toBe(true)
+  })
+})
+
+describe('relationshipStore.startBatch', () => {
+  it('alias + canonical share one hydration slot; unresolved ids stay pending', () => {
+    const wrapper = getRelationshipStoreState()
+    wrapper.requestHydration(['thread:t1', 'work_order:w1'])
+    // pre-hydration: work_order alias queued as-is
+    let batch = getRelationshipStoreState().startBatch(100)
+    expect(batch).toEqual(['thread:t1'])
+    expect(useRelationshipStore.getState().pendingIds.has('work_order:w1')).toBe(true)
+    expect(useRelationshipStore.getState().loadingIds.has('thread:t1')).toBe(true)
+
+    getResourceStoreState().setResources([workOrderResource])
+    // Also queue the canonical form — must collapse with the pending alias
+    getRelationshipStoreState().requestHydration([`${WORK_ORDER_DEF}:w1`])
+    batch = getRelationshipStoreState().startBatch(100)
+    expect(batch).toEqual([`${WORK_ORDER_DEF}:w1`])
+    expect(useRelationshipStore.getState().pendingIds.size).toBe(0)
+    expect(useRelationshipStore.getState().loadingIds.has(`${WORK_ORDER_DEF}:w1`)).toBe(true)
+  })
+})

--- a/apps/web/src/components/resources/store/record-store.ts
+++ b/apps/web/src/components/resources/store/record-store.ts
@@ -11,6 +11,11 @@ import {
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
+import {
+  getNormalizedDefinitionId,
+  getNormalizedRecordId,
+  tryNormalizeRecordId,
+} from '../utils/normalize-record-id'
 
 // ─────────────────────────────────────────────────────────────────
 // BATCHING CONSTANTS
@@ -217,8 +222,14 @@ export const useRecordStore = create<RecordStoreState>()(
 
       // ─── RECORD ACTIONS ────────────────────────────────────────────
       // With immer: direct mutations, structural sharing preserved
+      //
+      // Every action canonicalizes its definition prefix / RecordId at entry
+      // (UUID | entityType | apiSlug → EntityDefinition UUID) so alias-form
+      // callers can never create or miss a cache slot. No-op before a
+      // translation source exists — the batch flush gate covers that window.
 
-      setRecords: (entityDefinitionId, records) => {
+      setRecords: (rawEntityDefinitionId, records) => {
+        const entityDefinitionId = getNormalizedDefinitionId(rawEntityDefinitionId)
         set((state) => {
           if (!state.records[entityDefinitionId]) {
             state.records[entityDefinitionId] = new Map()
@@ -231,7 +242,8 @@ export const useRecordStore = create<RecordStoreState>()(
         })
       },
 
-      updateRecord: (entityDefinitionId, id, updates) => {
+      updateRecord: (rawEntityDefinitionId, id, updates) => {
+        const entityDefinitionId = getNormalizedDefinitionId(rawEntityDefinitionId)
         set((state) => {
           const record = state.records[entityDefinitionId]?.get(id)
           if (record) {
@@ -241,7 +253,8 @@ export const useRecordStore = create<RecordStoreState>()(
         })
       },
 
-      removeRecord: (entityDefinitionId, id) => {
+      removeRecord: (rawEntityDefinitionId, id) => {
+        const entityDefinitionId = getNormalizedDefinitionId(rawEntityDefinitionId)
         const recordId = toRecordId(entityDefinitionId, id)
         set((state) => {
           // Remove from records
@@ -293,7 +306,11 @@ export const useRecordStore = create<RecordStoreState>()(
 
       // ─── BATCHED RECORD FETCHING (unified across resource types) ───
 
-      requestRecord: (recordId) => {
+      requestRecord: (rawRecordId) => {
+        // Canonicalize BEFORE the dedupe checks so post-hydration callers
+        // dedupe against the canonical slot. Pre-hydration this is a no-op;
+        // the flush gate + startBatch normalization cover that window.
+        const recordId = getNormalizedRecordId(rawRecordId)
         const state = get()
         const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
 
@@ -326,12 +343,36 @@ export const useRecordStore = create<RecordStoreState>()(
         const pending = get().pendingFetchIds
         if (pending.size === 0) return []
 
-        const recordIds = Array.from(pending).slice(0, MAX_BATCH_SIZE)
+        // Single authority for draining canonicalizable records (per-id gate):
+        // normalize each queued id ONCE, select up to MAX_BATCH_SIZE unique
+        // canonical ids (dedupe BEFORE capacity so `work_order:X` + `<uuid>:X`
+        // never consume two slots), drain every queued form that maps to a
+        // selected id, and leave unresolved prefixes pending — they release
+        // when the prefix map changes.
+        const canonicalByQueued = new Map<RecordId, RecordId | null>()
+        for (const queuedId of pending) {
+          canonicalByQueued.set(queuedId, tryNormalizeRecordId(queuedId))
+        }
+
+        const recordIds: RecordId[] = []
+        const selected = new Set<RecordId>()
+        for (const canonicalId of canonicalByQueued.values()) {
+          if (!canonicalId || selected.has(canonicalId)) continue
+          if (recordIds.length >= MAX_BATCH_SIZE) break
+          selected.add(canonicalId)
+          recordIds.push(canonicalId)
+        }
+        if (recordIds.length === 0) return []
 
         set((state) => {
-          // Move from pending to loading
+          // Drain every queued alias/canonical form of a selected id; move
+          // only canonical ids into loadingIds and the request.
+          for (const [queuedId, canonicalId] of canonicalByQueued) {
+            if (canonicalId && selected.has(canonicalId)) {
+              state.pendingFetchIds.delete(queuedId)
+            }
+          }
           for (const recordId of recordIds) {
-            state.pendingFetchIds.delete(recordId)
             state.loadingIds.add(recordId)
           }
         })
@@ -360,26 +401,30 @@ export const useRecordStore = create<RecordStoreState>()(
 
       // ─── HELPERS ───────────────────────────────────────────────────
 
-      hasRecord: (recordId) => {
-        const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+      hasRecord: (rawRecordId) => {
+        const { entityDefinitionId, entityInstanceId } = parseRecordId(
+          getNormalizedRecordId(rawRecordId)
+        )
         return get().records[entityDefinitionId]?.has(entityInstanceId) ?? false
       },
 
-      isLoading: (recordId) => {
+      isLoading: (rawRecordId) => {
+        const recordId = getNormalizedRecordId(rawRecordId)
         return get().loadingIds.has(recordId) || get().pendingFetchIds.has(recordId)
       },
 
-      isNotFound: (recordId) => {
-        return get().notFoundIds.has(recordId)
+      isNotFound: (rawRecordId) => {
+        return get().notFoundIds.has(getNormalizedRecordId(rawRecordId))
       },
 
-      hasLoadedOnce: (recordId) => {
-        return get().attemptedIds.has(recordId)
+      hasLoadedOnce: (rawRecordId) => {
+        return get().attemptedIds.has(getNormalizedRecordId(rawRecordId))
       },
 
       // ─── INVALIDATION ──────────────────────────────────────────────
 
-      invalidateRecord: (entityDefinitionId, id) => {
+      invalidateRecord: (rawEntityDefinitionId, id) => {
+        const entityDefinitionId = getNormalizedDefinitionId(rawEntityDefinitionId)
         const recordId = toRecordId(entityDefinitionId, id)
         set((state) => {
           state.records[entityDefinitionId]?.delete(id)
@@ -388,7 +433,8 @@ export const useRecordStore = create<RecordStoreState>()(
         })
       },
 
-      invalidateLists: (entityDefinitionId) => {
+      invalidateLists: (rawEntityDefinitionId) => {
+        const entityDefinitionId = getNormalizedDefinitionId(rawEntityDefinitionId)
         set((state) => {
           const prefix = `${entityDefinitionId}:`
           for (const key of Object.keys(state.lists)) {
@@ -405,7 +451,8 @@ export const useRecordStore = create<RecordStoreState>()(
         })
       },
 
-      invalidateResourceType: (entityDefinitionId) => {
+      invalidateResourceType: (rawEntityDefinitionId) => {
+        const entityDefinitionId = getNormalizedDefinitionId(rawEntityDefinitionId)
         set((state) => {
           delete state.records[entityDefinitionId]
           const prefix = `${entityDefinitionId}:` as const

--- a/apps/web/src/components/resources/store/relationship-store.ts
+++ b/apps/web/src/components/resources/store/relationship-store.ts
@@ -4,6 +4,11 @@ import type { RecordPickerItem } from '@auxx/lib/resources/client'
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
 import { useMemo } from 'react'
 import { createHydrationStore, type HydrationStore } from '~/stores'
+import {
+  getNormalizedRecordId,
+  tryNormalizeRecordId,
+  useNormalizedRecordIds,
+} from '../utils/normalize-record-id'
 
 /**
  * Zustand store for relationship field hydration
@@ -19,8 +24,12 @@ export const useRelationshipStore = createHydrationStore<RecordPickerItem>({
 export interface RelationshipStoreState extends HydrationStore<RecordPickerItem> {
   /** Request hydration for RecordId[] */
   requestHydration: (recordIds: RecordId[]) => void
-  /** Get items pending fetch as RecordId[] */
-  getItemsToFetch: () => RecordId[]
+  /**
+   * Drain up to `max` canonicalizable pending ids into loadingIds and return
+   * the canonical batch. Alias + canonical duplicates collapse into one slot;
+   * unresolved prefixes stay pending until the prefix map changes.
+   */
+  startBatch: (max: number) => RecordId[]
   /** Add hydrated items. Pass requestedKeys to mark missing items as not found. */
   addHydratedItems: (items: Record<RecordId, RecordPickerItem>, requestedKeys?: RecordId[]) => void
 }
@@ -34,10 +43,38 @@ export function getRelationshipStoreState(): RelationshipStoreState {
   return {
     ...state,
     requestHydration: (recordIds: RecordId[]) => {
-      state.request(recordIds)
+      // Canonicalize — dataMap is keyed by the requested RecordId verbatim
+      // (server echoes the caller's prefix), so alias requests would create
+      // slots no post-hydration reader watches. Pre-hydration aliases queue
+      // as-is and are canonicalized at drain time in startBatch().
+      state.request(recordIds.map(getNormalizedRecordId))
     },
-    getItemsToFetch: () => {
-      return state.getKeysToFetch() as RecordId[]
+    startBatch: (max: number) => {
+      // Mirror the record-store drain: normalize each queued id once, select
+      // unique canonical ids up to `max`, drain every queued form mapping to
+      // a selected id, leave unresolved ids pending.
+      const canonicalByQueued = new Map<string, RecordId | null>()
+      for (const queuedId of state.pendingIds) {
+        canonicalByQueued.set(queuedId, tryNormalizeRecordId(queuedId as RecordId))
+      }
+
+      const recordIds: RecordId[] = []
+      const selected = new Set<RecordId>()
+      for (const canonicalId of canonicalByQueued.values()) {
+        if (!canonicalId || selected.has(canonicalId)) continue
+        if (recordIds.length >= max) break
+        selected.add(canonicalId)
+        recordIds.push(canonicalId)
+      }
+      if (recordIds.length === 0) return []
+
+      const drained: string[] = []
+      for (const [queuedId, canonicalId] of canonicalByQueued) {
+        if (canonicalId && selected.has(canonicalId)) drained.push(queuedId)
+      }
+      state.drainToLoading(drained, recordIds)
+
+      return recordIds
     },
     addHydratedItems: (items, requestedKeys) => {
       state.addItems(items, requestedKeys)
@@ -49,7 +86,10 @@ export function getRelationshipStoreState(): RelationshipStoreState {
  * Selector hook for getting hydrated items by RecordId
  * Returns: RecordPickerItem (found), null (not found/deleted), or undefined (not loaded)
  */
-export function useHydratedItems(recordIds: RecordId[]): (RecordPickerItem | null | undefined)[] {
+export function useHydratedItems(
+  rawRecordIds: RecordId[]
+): (RecordPickerItem | null | undefined)[] {
+  const recordIds = useNormalizedRecordIds(rawRecordIds)
   const dataMap = useRelationshipStore((state) => state.dataMap)
   return useMemo(() => recordIds.map((id) => dataMap[id]), [recordIds, dataMap])
 }
@@ -57,7 +97,8 @@ export function useHydratedItems(recordIds: RecordId[]): (RecordPickerItem | nul
 /**
  * Selector hook for checking if any RecordIds are loading
  */
-export function useIsLoadingRelationships(recordIds: RecordId[]): boolean {
+export function useIsLoadingRelationships(rawRecordIds: RecordId[]): boolean {
+  const recordIds = useNormalizedRecordIds(rawRecordIds)
   return useRelationshipStore((state) =>
     recordIds.some((id) => state.loadingIds.has(id) || state.pendingIds.has(id))
   )

--- a/apps/web/src/components/resources/store/resource-store.ts
+++ b/apps/web/src/components/resources/store/resource-store.ts
@@ -45,6 +45,19 @@ interface ResourceStoreState {
   /** Map for O(1) lookups by id or apiSlug */
   resourceMap: Map<string, Resource>
 
+  /**
+   * Authoritative prefix → canonical entityDefinitionId map (the dynamic tier
+   * of RecordId normalization; the static tier lives in
+   * `@auxx/lib/resources/static-prefixes`). Contains identity entries for
+   * canonical ids plus alias entries for `id`, `entityType`, and `apiSlug`.
+   * Seeded from the dehydrated-state payload before React hydrates, replaced
+   * by the full projection when `resource.list` lands. `setResources`
+   * preserves the map REFERENCE when mappings are unchanged, so normalization
+   * hooks can subscribe to the reference without field-metadata fan-out.
+   * Cleared on reset (org switch/logout) — never re-seeded there.
+   */
+  definitionIdByPrefix: Map<string, string>
+
   /** Server-confirmed field definitions by ResourceFieldId */
   serverFieldMap: Record<ResourceFieldId, ResourceField>
 
@@ -358,6 +371,58 @@ function buildEffectiveFieldMap(
 }
 
 /**
+ * Seed the prefix→UUID map from the dehydrated-state payload. The
+ * `beforeInteractive` script in the protected layout guarantees
+ * `window.AUXX_DEHYDRATED_STATE` exists before any client module runs.
+ */
+function seedPrefixMap(): Map<string, string> {
+  if (typeof window === 'undefined') return new Map()
+  const seed = window.AUXX_DEHYDRATED_STATE?.resourceIdMap
+  return seed ? new Map(Object.entries(seed)) : new Map()
+}
+
+/**
+ * Build the complete prefix → canonical entityDefinitionId projection from a
+ * resource list: identity entry for the canonical id, plus alias entries for
+ * `id`, `entityType`, and `apiSlug`.
+ */
+function buildPrefixMap(resources: Resource[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const resource of resources) {
+    const canonicalId = resource.entityDefinitionId || resource.id
+    map.set(canonicalId, canonicalId)
+    map.set(resource.id, canonicalId)
+    if (resource.entityType) map.set(resource.entityType, canonicalId)
+    if (resource.apiSlug) map.set(resource.apiSlug, canonicalId)
+  }
+  return map
+}
+
+/** Key/value equality for prefix maps (reference-stability check). */
+function prefixMapsEqual(a: Map<string, string>, b: Map<string, string>): boolean {
+  if (a.size !== b.size) return false
+  for (const [key, value] of a) {
+    if (b.get(key) !== value) return false
+  }
+  return true
+}
+
+/**
+ * Return a prefix map extended with one resource's entries — reuses the input
+ * reference when nothing changed (mid-session single-resource confirmations).
+ */
+function withResourcePrefixes(map: Map<string, string>, resource: Resource): Map<string, string> {
+  const canonicalId = resource.entityDefinitionId || resource.id
+  const prefixes = [canonicalId, resource.id, resource.entityType, resource.apiSlug]
+  if (prefixes.every((p) => !p || map.get(p) === canonicalId)) return map
+  const next = new Map(map)
+  for (const prefix of prefixes) {
+    if (prefix) next.set(prefix, canonicalId)
+  }
+  return next
+}
+
+/**
  * Initial state
  */
 const initialState = {
@@ -367,6 +432,7 @@ const initialState = {
   hasLoadedOnce: false,
   lastFetchTimestamp: 0,
   resourceMap: new Map<string, Resource>(),
+  definitionIdByPrefix: seedPrefixMap(),
   serverFieldMap: {} as Record<ResourceFieldId, ResourceField>,
   fieldMap: {} as Record<ResourceFieldId, ResourceField>,
   systemAttributeMap: {} as Record<string, ResourceFieldId>,
@@ -408,6 +474,14 @@ export const useResourceStore = create<ResourceStoreState>()(
           resourceMap.set(r.entityDefinitionId, r)
         }
       })
+
+      // Rebuild the authoritative prefix index, preserving the reference when
+      // mappings are unchanged so RecordId-normalization subscribers don't
+      // re-run on field-metadata-only updates.
+      const nextPrefixMap = buildPrefixMap(resources)
+      const definitionIdByPrefix = prefixMapsEqual(state.definitionIdByPrefix, nextPrefixMap)
+        ? state.definitionIdByPrefix
+        : nextPrefixMap
 
       // Filter custom resources
       const customResources = resources.filter(isCustomResource)
@@ -528,6 +602,7 @@ export const useResourceStore = create<ResourceStoreState>()(
         resources,
         customResources,
         resourceMap,
+        definitionIdByPrefix,
         serverFieldMap,
         fieldMap,
         systemAttributeMap,
@@ -1054,6 +1129,9 @@ export const useResourceStore = create<ResourceStoreState>()(
             resourceMap: newResourceMap,
             resources: newResources,
             customResources: newCustomResources,
+            // A slug/type rename adds a new alias entry (old aliases stay
+            // resolvable until the next full `setResources` rebuild).
+            definitionIdByPrefix: withResourcePrefixes(state.definitionIdByPrefix, serverResource),
           }
         }
 
@@ -1157,6 +1235,7 @@ export const useResourceStore = create<ResourceStoreState>()(
           resourceMap: newResourceMap,
           resources: newResources,
           customResources: newCustomResources,
+          definitionIdByPrefix: withResourcePrefixes(state.definitionIdByPrefix, serverResource),
         }
       })
     },
@@ -1336,6 +1415,7 @@ export const useResourceStore = create<ResourceStoreState>()(
           customResources: newCustomResources,
           serverFieldMap: newServerFieldMap,
           fieldMap,
+          definitionIdByPrefix: withResourcePrefixes(state.definitionIdByPrefix, resource),
         }
       })
     },
@@ -1372,6 +1452,10 @@ export const useResourceStore = create<ResourceStoreState>()(
       set({
         ...initialState,
         resourceMap: new Map<string, Resource>(),
+        // Never re-seed from the dehydrated payload here — after an org switch
+        // the seed belongs to the previous org; unresolved prefixes stay
+        // pending until the new org's `resource.list` lands.
+        definitionIdByPrefix: new Map<string, string>(),
         serverFieldMap: {} as Record<ResourceFieldId, ResourceField>,
         fieldMap: {} as Record<ResourceFieldId, ResourceField>,
         systemAttributeMap: {} as Record<string, ResourceFieldId>,

--- a/apps/web/src/components/resources/utils/canonicalize-field-ref.test.ts
+++ b/apps/web/src/components/resources/utils/canonicalize-field-ref.test.ts
@@ -1,0 +1,118 @@
+// apps/web/src/components/resources/utils/canonicalize-field-ref.test.ts
+// Hardening-plan Part 7 + system-field-id resolution: BOTH key halves become
+// canonical — def prefix (entityType/apiSlug → def id) AND field id
+// (static key / systemAttribute → CustomField row id).
+
+import type { FieldPath, FieldReference } from '@auxx/types/field'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getResourceStoreState } from '../store/resource-store'
+import { buildCanonicalFieldValueKey, canonicalizeFieldRef } from './canonicalize-field-ref'
+
+const WORK_ORDER_DEF = 'cmworkorderdef12345678'
+const STATUS_ROW_ID = 'cfstatus1'
+
+const statusField = {
+  id: STATUS_ROW_ID,
+  key: 'status',
+  label: 'Status',
+  type: 'string',
+  fieldType: 'SINGLE_SELECT',
+  systemAttribute: 'work_order_status',
+  capabilities: {},
+} as any
+
+const workOrderResource = {
+  id: WORK_ORDER_DEF,
+  type: 'custom',
+  apiSlug: 'work_orders',
+  entityType: 'work_order',
+  entityDefinitionId: WORK_ORDER_DEF,
+  organizationId: 'org_1',
+  label: 'Work Order',
+  plural: 'Work Orders',
+  icon: 'wrench',
+  color: 'blue',
+  isVisible: true,
+  fields: [statusField],
+  display: {
+    primaryDisplayField: null,
+    secondaryDisplayField: null,
+    avatarField: null,
+    defaultSortField: 'updatedAt',
+    defaultSortDirection: 'desc',
+    orgScopingStrategy: 'direct',
+  },
+} as any
+
+beforeEach(() => {
+  getResourceStoreState().reset()
+  getResourceStoreState().setResources([workOrderResource])
+})
+
+describe('canonicalizeFieldRef', () => {
+  it('canonicalizes the definition half (entityType/apiSlug → def id)', () => {
+    expect(canonicalizeFieldRef(`work_order:${STATUS_ROW_ID}` as FieldReference)).toBe(
+      `${WORK_ORDER_DEF}:${STATUS_ROW_ID}`
+    )
+    expect(canonicalizeFieldRef(`work_orders:${STATUS_ROW_ID}` as FieldReference)).toBe(
+      `${WORK_ORDER_DEF}:${STATUS_ROW_ID}`
+    )
+  })
+
+  it('canonicalizes the field half: static key form → row-id form', () => {
+    expect(canonicalizeFieldRef('work_order:status' as FieldReference)).toBe(
+      `${WORK_ORDER_DEF}:${STATUS_ROW_ID}`
+    )
+    expect(canonicalizeFieldRef(`${WORK_ORDER_DEF}:status` as FieldReference)).toBe(
+      `${WORK_ORDER_DEF}:${STATUS_ROW_ID}`
+    )
+  })
+
+  it('leaves canonical refs untouched (same string identity)', () => {
+    const canonical = `${WORK_ORDER_DEF}:${STATUS_ROW_ID}` as FieldReference
+    expect(canonicalizeFieldRef(canonical)).toBe(canonical)
+  })
+
+  it('preserves late-bound @app: encoding while fixing the def half', () => {
+    expect(canonicalizeFieldRef('work_orders:@app:shopify:ext_id' as FieldReference)).toBe(
+      `${WORK_ORDER_DEF}:@app:shopify:ext_id`
+    )
+  })
+
+  it('canonicalizes every segment of a drill-down FieldPath', () => {
+    const path = ['work_order:cfrel1', 'work_order:status'] as FieldPath
+    expect(canonicalizeFieldRef(path)).toEqual([
+      `${WORK_ORDER_DEF}:cfrel1`,
+      `${WORK_ORDER_DEF}:${STATUS_ROW_ID}`,
+    ])
+  })
+
+  it('is a no-op for unknown prefixes (pre-hydration)', () => {
+    getResourceStoreState().reset()
+    expect(canonicalizeFieldRef('work_order:status' as FieldReference)).toBe('work_order:status')
+  })
+})
+
+describe('buildCanonicalFieldValueKey', () => {
+  it('resolves bare systemAttribute field ids (e.g. work_order_status)', () => {
+    const { key } = buildCanonicalFieldValueKey(
+      'work_order:r1',
+      'work_order_status' as FieldReference
+    )
+    expect(key).toBe(`${WORK_ORDER_DEF}:r1:${WORK_ORDER_DEF}:${STATUS_ROW_ID}`)
+  })
+
+  it('all alias spellings of the same cell land on ONE key', () => {
+    const spellings: Array<[string, FieldReference]> = [
+      ['work_order:r1', 'work_order:status' as FieldReference],
+      ['work_orders:r1', `${WORK_ORDER_DEF}:${STATUS_ROW_ID}` as FieldReference],
+      [`${WORK_ORDER_DEF}:r1`, 'status' as FieldReference],
+      [`${WORK_ORDER_DEF}:r1`, 'work_order_status' as FieldReference],
+    ]
+    const keys = new Set(
+      spellings.map(([rid, ref]) => buildCanonicalFieldValueKey(rid as never, ref).key)
+    )
+    expect(keys.size).toBe(1)
+    expect([...keys][0]).toBe(`${WORK_ORDER_DEF}:r1:${WORK_ORDER_DEF}:${STATUS_ROW_ID}`)
+  })
+})

--- a/apps/web/src/components/resources/utils/canonicalize-field-ref.ts
+++ b/apps/web/src/components/resources/utils/canonicalize-field-ref.ts
@@ -1,0 +1,106 @@
+// apps/web/src/components/resources/utils/canonicalize-field-ref.ts
+
+'use client'
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import {
+  type FieldPath,
+  type FieldReference,
+  type FieldValueKey,
+  fieldRefToKey,
+  isFieldPath,
+  normalizeFieldRef,
+  type ResourceFieldId,
+} from '@auxx/types/field'
+import { useResourceStore } from '../store/resource-store'
+import { getNormalizedDefinitionId, getNormalizedRecordId } from './normalize-record-id'
+
+/**
+ * Canonicalize a single ResourceFieldId — BOTH halves:
+ *
+ * 1. Definition half: alias prefix (entityType/apiSlug) → canonical def id.
+ *    Splits on the FIRST colon only, so app-field encoding
+ *    (`<def>:@app:<slug>:<key>`) passes through with its tail intact.
+ * 2. Field half: static-key / systemAttribute forms → the row-id form the
+ *    server, realtime, and save paths key by. `work_order:name` and
+ *    `line_item_name` must land in the same value slot as
+ *    `<defId>:<customFieldRowId>` — otherwise key-form subscribers miss
+ *    optimistic updates.
+ *
+ * Unknown segments are left untouched (pre-hydration no-op).
+ */
+function canonicalizeSegment(segment: ResourceFieldId): ResourceFieldId {
+  const colonIndex = segment.indexOf(':')
+  if (colonIndex === -1) return segment
+  const defSegment = segment.slice(0, colonIndex)
+  const fieldHalf = segment.slice(colonIndex + 1)
+  const canonicalDef = getNormalizedDefinitionId(defSegment)
+  const candidate =
+    canonicalDef === defSegment ? segment : (`${canonicalDef}:${fieldHalf}` as ResourceFieldId)
+
+  // Late-bound app refs keep their encoding — getFieldByRef resolves those.
+  if (fieldHalf.startsWith('@app:')) return candidate
+
+  const state = useResourceStore.getState()
+  // fieldMap registers static-key aliases (`<def>:<key>`) pointing at the
+  // effective field object, whose resourceFieldId is the canonical row-id ref.
+  const field = state.fieldMap[candidate]
+  if (field?.resourceFieldId && field.resourceFieldId !== candidate) {
+    return field.resourceFieldId
+  }
+  if (!field) {
+    // Bare systemAttribute as the field half (e.g. `line_item_name`) —
+    // globally unique; only adopt it when it belongs to this definition.
+    const attrRfId = state.systemAttributeMap[fieldHalf]
+    if (attrRfId?.startsWith(`${canonicalDef}:`)) return attrRfId
+  }
+  return candidate
+}
+
+/**
+ * Canonicalize every definition segment of a FieldReference where a mapping
+ * exists — the direct-ref segment, or ALL segments of a drill-down FieldPath
+ * (`Ticket → Contact → Name` references other definitions per segment).
+ * Plain FieldIds pass through (no definition half to rewrite). Unknown
+ * prefixes are left untouched.
+ */
+export function canonicalizeFieldRef(fieldRef: FieldReference): FieldReference {
+  if (isFieldPath(fieldRef)) {
+    let changed = false
+    const segments = fieldRef.map((segment) => {
+      const next = canonicalizeSegment(segment)
+      if (next !== segment) changed = true
+      return next
+    })
+    return changed ? (segments as FieldPath) : fieldRef
+  }
+  if (typeof fieldRef === 'string' && fieldRef.includes(':')) {
+    return canonicalizeSegment(fieldRef as ResourceFieldId)
+  }
+  return fieldRef
+}
+
+/** Result of {@link buildCanonicalFieldValueKey}. */
+export interface CanonicalFieldValueKey {
+  /** Canonical RecordId (prefix = entityDefinitionId). */
+  recordId: RecordId
+  /** Canonical FieldReference (plain FieldIds resolved against the record's def). */
+  fieldRef: FieldReference
+  /** Store key: `${recordId}:${fieldRefKey}` with both halves canonical. */
+  key: FieldValueKey
+}
+
+/**
+ * Canonicalize BOTH halves of a field-value key — the single helper behind
+ * queue keys, subscriber keys, and request building, so they can never
+ * disagree on prefix form (plan Part 7).
+ */
+export function buildCanonicalFieldValueKey(
+  rawRecordId: RecordId,
+  rawFieldRef: FieldReference
+): CanonicalFieldValueKey {
+  const recordId = getNormalizedRecordId(rawRecordId)
+  const fieldRef = canonicalizeFieldRef(normalizeFieldRef(recordId, rawFieldRef))
+  const key = `${recordId}:${fieldRefToKey(fieldRef)}` as FieldValueKey
+  return { recordId, fieldRef, key }
+}

--- a/apps/web/src/components/resources/utils/index.ts
+++ b/apps/web/src/components/resources/utils/index.ts
@@ -1,5 +1,11 @@
 // apps/web/src/components/resources/utils/index.ts
 
+export {
+  // Both key halves canonical — queue/subscriber/request key builder
+  buildCanonicalFieldValueKey,
+  // Canonicalize FieldReference definition segments (incl. FieldPath drill-downs)
+  canonicalizeFieldRef,
+} from './canonicalize-field-ref'
 export type { GetRecordLinkOptions } from './get-record-link'
 export {
   // Pure function (requires resource object)
@@ -10,12 +16,22 @@ export {
   useRecordLink,
 } from './get-record-link'
 export {
+  // Resolvability check for a bare definition prefix
+  canNormalizeDefinitionId,
+  // Resolvability check without normalizing
+  canNormalizeRecordId,
+  // Imperative prefix canonicalization (static tier + dynamic map)
+  getNormalizedDefinitionId,
   // Imperative (reads store state — use from callbacks/non-hook contexts)
   getNormalizedRecordId,
-  // Pure function (requires resource object)
-  normalizeRecordId,
-  // Hook (resolves resource from the store)
+  // Canonicalize-or-null for drain/flush loops (single parse)
+  tryNormalizeRecordId,
+  // Hook variant for a bare definition prefix
+  useNormalizedDefinitionId,
+  // Hook (recomputes when prefix mappings change)
   useNormalizedRecordId,
   // Plural hook
   useNormalizedRecordIds,
+  // Reactivity primitive: bumps exactly when prefix mappings change
+  usePrefixEpoch,
 } from './normalize-record-id'

--- a/apps/web/src/components/resources/utils/normalize-record-id.test.ts
+++ b/apps/web/src/components/resources/utils/normalize-record-id.test.ts
@@ -1,0 +1,153 @@
+// apps/web/src/components/resources/utils/normalize-record-id.test.ts
+// Hardening-plan Part 8: prefix index + resolver — seed resolution, static
+// tier, hydration replace + hook recompute, reference stability, reset.
+
+import type { CustomResource, Resource } from '@auxx/lib/resources/client'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getResourceStoreState, useResourceStore } from '../store/resource-store'
+import {
+  canNormalizeRecordId,
+  getNormalizedDefinitionId,
+  getNormalizedRecordId,
+  tryNormalizeRecordId,
+  useNormalizedRecordId,
+} from './normalize-record-id'
+
+const WORK_ORDER_DEF = 'cmworkorderdef12345678'
+const CUSTOM_DEF = 'cmcustomdef12345678901'
+
+function makeResource(overrides: Partial<CustomResource>): Resource {
+  return {
+    id: CUSTOM_DEF,
+    type: 'custom',
+    apiSlug: 'gadgets',
+    entityDefinitionId: CUSTOM_DEF,
+    organizationId: 'org_1',
+    label: 'Gadget',
+    plural: 'Gadgets',
+    icon: 'box',
+    color: 'blue',
+    isVisible: true,
+    fields: [],
+    display: {
+      primaryDisplayField: null,
+      secondaryDisplayField: null,
+      avatarField: null,
+      defaultSortField: 'updatedAt',
+      defaultSortDirection: 'desc',
+      orgScopingStrategy: 'direct',
+    },
+    ...overrides,
+  } as Resource
+}
+
+const workOrderResource = makeResource({
+  id: WORK_ORDER_DEF,
+  entityDefinitionId: WORK_ORDER_DEF,
+  entityType: 'work_order',
+  apiSlug: 'work_orders',
+  label: 'Work Order',
+  plural: 'Work Orders',
+})
+
+const customResource = makeResource({})
+
+beforeEach(() => {
+  getResourceStoreState().reset()
+})
+
+describe('static tier resolution (no seed, no hydration)', () => {
+  it('legacy system names resolve to themselves', () => {
+    expect(getNormalizedRecordId('thread:abc')).toBe('thread:abc')
+    expect(canNormalizeRecordId('thread:abc')).toBe(true)
+    expect(tryNormalizeRecordId('thread:abc')).toBe('thread:abc')
+  })
+
+  it('legacy apiSlugs resolve to the system name', () => {
+    expect(getNormalizedRecordId('threads:abc')).toBe('thread:abc')
+    expect(tryNormalizeRecordId('threads:abc')).toBe('thread:abc')
+  })
+
+  it('long-form definition ids are processable before hydration', () => {
+    const id = `${WORK_ORDER_DEF}:inst1` as const
+    expect(getNormalizedRecordId(id)).toBe(id)
+    expect(canNormalizeRecordId(id)).toBe(true)
+    expect(tryNormalizeRecordId(id)).toBe(id)
+  })
+
+  it('def-backed entityTypes are unresolved until a mapping exists', () => {
+    expect(canNormalizeRecordId('work_order:abc')).toBe(false)
+    expect(tryNormalizeRecordId('work_order:abc')).toBeNull()
+    // getNormalizedRecordId is a no-op (never throws / never guesses)
+    expect(getNormalizedRecordId('work_order:abc')).toBe('work_order:abc')
+  })
+})
+
+describe('dynamic tier (hydrated prefix map)', () => {
+  beforeEach(() => {
+    getResourceStoreState().setResources([workOrderResource, customResource])
+  })
+
+  it('resolves entityType, apiSlug, and identity forms to the canonical id', () => {
+    expect(getNormalizedRecordId('work_order:x')).toBe(`${WORK_ORDER_DEF}:x`)
+    expect(getNormalizedRecordId('work_orders:x')).toBe(`${WORK_ORDER_DEF}:x`)
+    expect(getNormalizedRecordId(`${WORK_ORDER_DEF}:x`)).toBe(`${WORK_ORDER_DEF}:x`)
+    expect(getNormalizedDefinitionId('gadgets')).toBe(CUSTOM_DEF)
+  })
+
+  it('partial mapping does not claim an unrelated alias is resolvable', () => {
+    expect(canNormalizeRecordId('contact:abc')).toBe(false)
+  })
+
+  it('reset clears the mapping (org switch) — aliases become unresolved again', () => {
+    getResourceStoreState().reset()
+    expect(canNormalizeRecordId('work_order:x')).toBe(false)
+    // static tier is unaffected by reset
+    expect(canNormalizeRecordId('thread:x')).toBe(true)
+  })
+})
+
+describe('setResources prefix-map reference stability', () => {
+  it('reuses the map reference when mappings are unchanged', () => {
+    getResourceStoreState().setResources([workOrderResource])
+    const first = useResourceStore.getState().definitionIdByPrefix
+    // Same resources again (e.g. field-only refetch)
+    getResourceStoreState().setResources([workOrderResource])
+    expect(useResourceStore.getState().definitionIdByPrefix).toBe(first)
+  })
+
+  it('replaces the reference when a mapping is added', () => {
+    getResourceStoreState().setResources([workOrderResource])
+    const first = useResourceStore.getState().definitionIdByPrefix
+    getResourceStoreState().setResources([workOrderResource, customResource])
+    const second = useResourceStore.getState().definitionIdByPrefix
+    expect(second).not.toBe(first)
+    expect(second.get('gadgets')).toBe(CUSTOM_DEF)
+  })
+})
+
+describe('useNormalizedRecordId', () => {
+  it('recomputes when hydration adds the mapping (no sticky memo)', () => {
+    const { result } = renderHook(() => useNormalizedRecordId('work_order:x'))
+    expect(result.current).toBe('work_order:x')
+
+    act(() => {
+      getResourceStoreState().setResources([workOrderResource])
+    })
+    expect(result.current).toBe(`${WORK_ORDER_DEF}:x`)
+  })
+
+  it('field-only updates (unchanged mappings) keep the same result identity', () => {
+    act(() => {
+      getResourceStoreState().setResources([workOrderResource])
+    })
+    const { result, rerender } = renderHook(() => useNormalizedRecordId('work_order:x'))
+    const first = result.current
+    act(() => {
+      getResourceStoreState().setResources([workOrderResource])
+    })
+    rerender()
+    expect(result.current).toBe(first)
+  })
+})

--- a/apps/web/src/components/resources/utils/normalize-record-id.ts
+++ b/apps/web/src/components/resources/utils/normalize-record-id.ts
@@ -2,60 +2,169 @@
 
 'use client'
 
-import { parseRecordId, type RecordId, type Resource, toRecordId } from '@auxx/lib/resources/client'
-import { useMemo } from 'react'
+import {
+  isStaticCanonicalDefinitionId,
+  parseRecordId,
+  type RecordId,
+  resolveStaticPrefix,
+  toRecordId,
+} from '@auxx/lib/resources/client'
+import { useMemo, useSyncExternalStore } from 'react'
 import { useResourceStore } from '../store/resource-store'
 
 /**
- * Normalize a RecordId so the definition prefix is always the real
- * `entityDefinitionId` (the EntityDefinition row id), never the entityType
- * string or apiSlug.
+ * RecordId prefix canonicalization — two tiers:
  *
- * Callers can produce RecordIds in a few shapes — e.g. `toRecordId('ticket', id)`
- * yields `"ticket:<instanceId>"`, while server writes/reads key by the actual
- * EntityDefinition id. Field-value store keys include the prefix verbatim, so
- * a mismatch here causes subscriptions to miss optimistic updates.
+ * 1. Static tier (`@auxx/lib/resources/static-prefixes`): legacy system types
+ *    (thread, message, …) and their apiSlugs resolve at build time — no seed,
+ *    no store, no hydration.
+ * 2. Dynamic tier (`resourceStore.definitionIdByPrefix`): def-backed
+ *    entityTypes (`contact`, `work_order`, …), apiSlugs, and custom defs
+ *    resolve to their EntityDefinition UUID via the org-specific map (seeded
+ *    from dehydrated state, replaced on `resource.list` hydration).
+ *
+ * Field-value store keys embed the prefix verbatim, so a mismatch here causes
+ * subscriptions to miss optimistic updates.
  */
-export function normalizeRecordId(recordId: RecordId, resource: Resource): RecordId {
-  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
-  if (!entityInstanceId) return recordId
-  if (resource.entityDefinitionId === entityDefinitionId) return recordId
-  return toRecordId(resource.entityDefinitionId, entityInstanceId)
+
+// ─────────────────────────────────────────────────────────────────
+// PREFIX EPOCH — reactivity primitive for normalization consumers
+// ─────────────────────────────────────────────────────────────────
+
+let prefixEpoch = 0
+const epochListeners = new Set<() => void>()
+
+if (typeof window !== 'undefined') {
+  // Bumps ONLY when prefix mappings actually change (setResources preserves
+  // the map reference when mappings are identical), so field-metadata updates
+  // never fan out to normalization consumers.
+  useResourceStore.subscribe(
+    (s) => s.definitionIdByPrefix,
+    () => {
+      prefixEpoch++
+      for (const listener of epochListeners) listener()
+    }
+  )
+}
+
+function subscribeToPrefixEpoch(listener: () => void): () => void {
+  epochListeners.add(listener)
+  return () => epochListeners.delete(listener)
 }
 
 /**
- * Hook variant of {@link normalizeRecordId} that resolves the resource from the
- * resource store. Falls back to the input when the resource is unknown.
- *
- * Subscribes only to `hasLoadedOnce` (a single-flip boolean) rather than the
- * whole `resourceMap`, then reads the map imperatively. This keeps
- * subscription fan-out minimal on pages with hundreds of badges — zustand
- * skips notifications when `hasLoadedOnce` stays `true`, so mid-session
- * `setResources` calls (optimistic resource updates, new fields arriving, …)
- * do not re-render every consumer.
+ * Subscribe to the prefix-map epoch: a counter that increments exactly when
+ * prefix mappings change. Memoize normalization results against it instead of
+ * subscribing to the resource store — resource updates that don't change
+ * mappings cost consumers nothing.
  */
+export function usePrefixEpoch(): number {
+  return useSyncExternalStore(
+    subscribeToPrefixEpoch,
+    () => prefixEpoch,
+    () => 0
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────
+// IMPERATIVE RESOLVERS
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Canonicalize a definition prefix (UUID | entityType | apiSlug) → canonical
+ * entityDefinitionId. Static tier first, then the org-dynamic map. Returns
+ * the input unchanged when neither tier knows it.
+ */
+export function getNormalizedDefinitionId(prefix: string): string {
+  const staticCanonical = resolveStaticPrefix(prefix)
+  if (staticCanonical) return staticCanonical
+  return useResourceStore.getState().definitionIdByPrefix.get(prefix) ?? prefix
+}
+
+/**
+ * True when the prefix is resolvable RIGHT NOW: statically canonical (legacy
+ * system name or long-form definition id), statically aliased, or present in
+ * the dynamic map. Known org-dynamic aliases return false until their mapping
+ * is available — fetch gates hold those ids back.
+ */
+export function canNormalizeDefinitionId(prefix: string): boolean {
+  if (resolveStaticPrefix(prefix)) return true
+  if (useResourceStore.getState().definitionIdByPrefix.has(prefix)) return true
+  return isStaticCanonicalDefinitionId(prefix)
+}
+
+/**
+ * Imperative RecordId canonicalization — parses the id exactly once. No-op
+ * when the prefix is unknown to both tiers.
+ */
+export function getNormalizedRecordId(recordId: RecordId): RecordId {
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  if (!entityDefinitionId || !entityInstanceId) return recordId
+  const canonical = getNormalizedDefinitionId(entityDefinitionId)
+  if (canonical === entityDefinitionId) return recordId
+  return toRecordId(canonical, entityInstanceId)
+}
+
+/**
+ * Canonicalize a RecordId, or return null when its prefix is not yet
+ * resolvable (unknown dynamic alias pre-hydration). Single parse — use this
+ * in drain/flush loops that must both normalize and gate.
+ */
+export function tryNormalizeRecordId(recordId: RecordId): RecordId | null {
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  if (!entityDefinitionId || !entityInstanceId) return null
+  const staticCanonical = resolveStaticPrefix(entityDefinitionId)
+  if (staticCanonical) {
+    return staticCanonical === entityDefinitionId
+      ? recordId
+      : toRecordId(staticCanonical, entityInstanceId)
+  }
+  const mapped = useResourceStore.getState().definitionIdByPrefix.get(entityDefinitionId)
+  if (mapped) {
+    return mapped === entityDefinitionId ? recordId : toRecordId(mapped, entityInstanceId)
+  }
+  return isStaticCanonicalDefinitionId(entityDefinitionId) ? recordId : null
+}
+
+/** True when {@link tryNormalizeRecordId} would resolve this id. */
+export function canNormalizeRecordId(recordId: RecordId): boolean {
+  const { entityDefinitionId } = parseRecordId(recordId)
+  if (!entityDefinitionId) return false
+  return canNormalizeDefinitionId(entityDefinitionId)
+}
+
+// ─────────────────────────────────────────────────────────────────
+// HOOKS
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Hook variant of {@link getNormalizedRecordId}. Recomputes when prefix
+ * mappings change (seed → hydration transition, resource created/renamed),
+ * without subscribing to the resource store itself.
+ */
+export function useNormalizedRecordId(recordId: RecordId): RecordId
+export function useNormalizedRecordId(
+  recordId: RecordId | null | undefined
+): RecordId | null | undefined
 export function useNormalizedRecordId(
   recordId: RecordId | null | undefined
 ): RecordId | null | undefined {
-  const hasLoaded = useResourceStore((s) => s.hasLoadedOnce)
-
+  const epoch = usePrefixEpoch()
+  // biome-ignore lint/correctness/useExhaustiveDependencies: epoch invalidates the store-derived result
   return useMemo(() => {
     if (!recordId) return recordId
-    if (!hasLoaded) return recordId
     return getNormalizedRecordId(recordId)
-  }, [recordId, hasLoaded])
+  }, [recordId, epoch])
 }
 
 /**
- * Plural variant of {@link useNormalizedRecordId}. Maps each id through the
- * same imperative lookup. Returns the input array unchanged when resources
- * haven't loaded yet.
+ * Plural variant of {@link useNormalizedRecordId}. Returns the input array
+ * reference when nothing changed.
  */
 export function useNormalizedRecordIds(recordIds: RecordId[]): RecordId[] {
-  const hasLoaded = useResourceStore((s) => s.hasLoadedOnce)
-
+  const epoch = usePrefixEpoch()
+  // biome-ignore lint/correctness/useExhaustiveDependencies: epoch invalidates the store-derived result
   return useMemo(() => {
-    if (!hasLoaded) return recordIds
     let changed = false
     const normalized = recordIds.map((rid) => {
       const next = getNormalizedRecordId(rid)
@@ -63,17 +172,12 @@ export function useNormalizedRecordIds(recordIds: RecordId[]): RecordId[] {
       return next
     })
     return changed ? normalized : recordIds
-  }, [recordIds, hasLoaded])
+  }, [recordIds, epoch])
 }
 
-/**
- * Imperative variant — reads the current resource store state directly.
- * Use from non-hook contexts (mutation callbacks, fetch queue, etc.).
- */
-export function getNormalizedRecordId(recordId: RecordId): RecordId {
-  const { entityDefinitionId } = parseRecordId(recordId)
-  if (!entityDefinitionId) return recordId
-  const resource = useResourceStore.getState().resourceMap.get(entityDefinitionId)
-  if (!resource) return recordId
-  return normalizeRecordId(recordId, resource)
+/** Hook variant of {@link getNormalizedDefinitionId}. */
+export function useNormalizedDefinitionId(prefix: string): string {
+  const epoch = usePrefixEpoch()
+  // biome-ignore lint/correctness/useExhaustiveDependencies: epoch invalidates the store-derived result
+  return useMemo(() => getNormalizedDefinitionId(prefix), [prefix, epoch])
 }

--- a/apps/web/src/components/workflow/nodes/core/crud/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/crud/trace-renderer.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { toRecordId } from '@auxx/lib/resources/client'
 import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
 import { Badge } from '@auxx/ui/components/badge'
 import { AlertCircle, Database } from 'lucide-react'
@@ -66,7 +67,7 @@ export function CrudTraceRenderer({ execution }: TraceRendererProps) {
           <span className='truncate font-mono text-[10px] opacity-70'>{outputs.id}</span>
         </div>
       ) : (
-        <EntityCardItem recordId={`${metadata.resourceType}:${outputs.id}`} />
+        <EntityCardItem recordId={toRecordId(metadata.resourceType, outputs.id)} />
       )}
     </BlockCard>
   )

--- a/apps/web/src/components/workflow/nodes/core/find/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/find/trace-renderer.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { toRecordId } from '@auxx/lib/resources/client'
 import { EntityListBlock } from '~/components/kopilot/ui/blocks/entity-list-block'
 import { ThreadListBlock } from '~/components/kopilot/ui/blocks/thread-list-block'
 import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
@@ -56,7 +57,7 @@ export function FindTraceRenderer({ execution }: TraceRendererProps) {
         <ThreadListBlock data={{ threadIds: records.map((r) => r.id) }} skipEntrance />
       ) : (
         <EntityListBlock
-          data={{ recordIds: records.map((r) => `${resourceType}:${r.id}`) }}
+          data={{ recordIds: records.map((r) => toRecordId(resourceType, r.id)) }}
           skipEntrance
         />
       )}

--- a/apps/web/src/stores/create-hydration-store.ts
+++ b/apps/web/src/stores/create-hydration-store.ts
@@ -46,6 +46,13 @@ export interface HydrationStoreActions<TValue> {
   /** Mark keys as loading (called when fetch starts) */
   markLoading: (keys: string[]) => void
 
+  /**
+   * Atomically drain queued keys and mark (possibly different) keys as
+   * loading. Used by canonicalizing batchers: pending is drained by the
+   * as-queued (possibly alias) form while loading tracks the canonical form.
+   */
+  drainToLoading: (drainKeys: string[], loadKeys: string[]) => void
+
   /** Add hydrated items to the store. If requestedKeys provided, marks missing keys as not found (null). */
   addItems: (items: Record<string, TValue>, requestedKeys?: string[]) => void
 
@@ -152,6 +159,22 @@ export function createHydrationStore<TValue>(options: HydrationStoreOptions<TVal
 
           for (const key of keys) {
             newPending.delete(key)
+            newLoading.add(key)
+          }
+
+          return { pendingIds: newPending, loadingIds: newLoading }
+        })
+      },
+
+      drainToLoading: (drainKeys, loadKeys) => {
+        set((state) => {
+          const newPending = new Set(state.pendingIds)
+          const newLoading = new Set(state.loadingIds)
+
+          for (const key of drainKeys) {
+            newPending.delete(key)
+          }
+          for (const key of loadKeys) {
             newLoading.add(key)
           }
 

--- a/packages/lib/src/dehydration/service.ts
+++ b/packages/lib/src/dehydration/service.ts
@@ -132,7 +132,37 @@ export class DehydrationService {
       organizationId = organizations[0]?.id ?? null
     }
 
-    // 4. Assemble (pure function, no DB calls)
+    // 4. Slim alias-prefix → EntityDefinition UUID map for the active org.
+    // Only the org-dynamic mappings ship here: def-backed entityTypes and
+    // apiSlugs (system-typed + custom defs). Legacy system types (thread,
+    // message, …) resolve through the static tier bundled with the client
+    // (`@auxx/lib/resources/static-prefixes`) and never ride the payload.
+    // Best-effort — without it the client falls back to gating unresolved
+    // prefixes on resource hydration.
+    let resourceIdMap: Record<string, string> | undefined
+    if (organizationId) {
+      try {
+        const { entityDefs, entityDefSlugs } = await this.orgCache.getOrRecompute(organizationId, [
+          'entityDefs',
+          'entityDefSlugs',
+        ])
+        resourceIdMap = {}
+        for (const [entityType, defId] of Object.entries(entityDefs)) {
+          resourceIdMap[entityType] = defId
+          resourceIdMap[defId] = defId
+        }
+        for (const [apiSlug, defId] of Object.entries(entityDefSlugs)) {
+          resourceIdMap[apiSlug] = defId
+          resourceIdMap[defId] = defId
+        }
+      } catch (error) {
+        logger.warn('Failed to derive resourceIdMap during dehydration', {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    // 5. Assemble (pure function, no DB calls)
     return {
       user: userProfile,
       organizationId,
@@ -140,6 +170,7 @@ export class DehydrationService {
       settingsCatalog: SETTINGS_CATALOG,
       environment: buildEnvironment(),
       timestamp: Date.now(),
+      resourceIdMap,
     }
   }
 

--- a/packages/lib/src/dehydration/types.ts
+++ b/packages/lib/src/dehydration/types.ts
@@ -19,6 +19,16 @@ export interface DehydratedState {
   settingsCatalog: Record<string, any>
   environment: DehydratedEnvironment
   timestamp: number
+  /**
+   * Slim alias-prefix → EntityDefinition UUID map for the ACTIVE org only.
+   * Carries ONLY org-dynamic mappings: def-backed entityTypes (`contact`,
+   * `work_order`, …), apiSlugs (system-typed + custom), and identity entries
+   * for their def ids. Legacy system types (thread, message, …) resolve via
+   * the static tier bundled with the client and are never included. Seeds
+   * client-side RecordId normalization before `resource.list` hydrates the
+   * resource store, so record fetching never waits on hydration on hard loads.
+   */
+  resourceIdMap?: Record<string, string>
 }
 
 /**

--- a/packages/lib/src/resources/client.ts
+++ b/packages/lib/src/resources/client.ts
@@ -124,3 +124,10 @@ export {
   toRecordId,
   toRecordIds,
 } from './resource-id'
+// Static prefix tier for RecordId canonicalization (pure, build-time)
+export {
+  isDynamicAliasPrefix,
+  isStaticCanonicalDefinitionId,
+  LEGACY_SYSTEM_TYPES,
+  resolveStaticPrefix,
+} from './static-prefixes'

--- a/packages/lib/src/resources/static-prefixes.test.ts
+++ b/packages/lib/src/resources/static-prefixes.test.ts
@@ -1,0 +1,59 @@
+// packages/lib/src/resources/static-prefixes.test.ts
+
+import { describe, expect, it } from 'vitest'
+import {
+  isDynamicAliasPrefix,
+  isStaticCanonicalDefinitionId,
+  LEGACY_SYSTEM_TYPES,
+  resolveStaticPrefix,
+} from './static-prefixes'
+
+describe('static prefix tier', () => {
+  it('resolves legacy system names to themselves with no org data', () => {
+    expect(resolveStaticPrefix('thread')).toBe('thread')
+    expect(resolveStaticPrefix('message')).toBe('message')
+    expect(resolveStaticPrefix('user')).toBe('user')
+  })
+
+  it('resolves legacy-type apiSlugs to their system name statically', () => {
+    expect(resolveStaticPrefix('threads')).toBe('thread')
+    expect(resolveStaticPrefix('messages')).toBe('message')
+    expect(resolveStaticPrefix('users')).toBe('user')
+  })
+
+  it('does NOT resolve def-backed entityTypes — those are org-dynamic', () => {
+    expect(resolveStaticPrefix('contact')).toBeUndefined()
+    expect(resolveStaticPrefix('ticket')).toBeUndefined()
+    expect(resolveStaticPrefix('work_order')).toBeUndefined()
+  })
+
+  it('classifies def-backed entityTypes and their apiSlugs as dynamic aliases', () => {
+    expect(isDynamicAliasPrefix('contact')).toBe(true)
+    expect(isDynamicAliasPrefix('contacts')).toBe(true)
+    expect(isDynamicAliasPrefix('work_order')).toBe(true)
+    // ModelTypeMeta apiSlugs are hyphenated; org DB slugs resolve dynamically
+    expect(isDynamicAliasPrefix('work-orders')).toBe(true)
+    // Legacy types are NOT dynamic aliases
+    expect(isDynamicAliasPrefix('thread')).toBe(false)
+    // Unknown strings are neither
+    expect(isDynamicAliasPrefix('some_custom_slug')).toBe(false)
+  })
+
+  it('treats legacy names and long-form definition ids as statically canonical', () => {
+    expect(isStaticCanonicalDefinitionId('thread')).toBe(true)
+    expect(isStaticCanonicalDefinitionId('cm1234abc567def890ghij')).toBe(true)
+    // Aliases are not canonical, whatever their length
+    expect(isStaticCanonicalDefinitionId('contact')).toBe(false)
+    expect(isStaticCanonicalDefinitionId('threads')).toBe(false)
+    // Short unknown prefixes are not canonical
+    expect(isStaticCanonicalDefinitionId('foo')).toBe(false)
+  })
+
+  it('legacy set excludes every def-backed type and the entity marker', () => {
+    expect(LEGACY_SYSTEM_TYPES).not.toContain('entity')
+    expect(LEGACY_SYSTEM_TYPES).not.toContain('contact')
+    expect(LEGACY_SYSTEM_TYPES).not.toContain('work_order')
+    expect(LEGACY_SYSTEM_TYPES).toContain('thread')
+    expect(LEGACY_SYSTEM_TYPES).toContain('message')
+  })
+})

--- a/packages/lib/src/resources/static-prefixes.ts
+++ b/packages/lib/src/resources/static-prefixes.ts
@@ -1,0 +1,68 @@
+// packages/lib/src/resources/static-prefixes.ts
+//
+// Pure static tier of RecordId prefix resolution. Client-safe by construction:
+// only build-time constants, no React, no stores, no server dependencies.
+//
+// Canonical prefix = `entityDefinitionId`:
+// - Def-backed types (ENTITY_DEFINITION_TYPES + custom entities): the
+//   EntityDefinition row id (CUID) — org-specific, resolved by the dynamic tier.
+// - Legacy system types (thread, message, user, …): the modelType string itself
+//   (`SystemResource.entityDefinitionId === id`), knowable at build time.
+
+import { type ModelType, ModelTypeMeta, ModelTypeValues } from '@auxx/database/enums'
+import { ENTITY_DEFINITION_TYPES, isEntityDefinitionType } from '@auxx/types/resource'
+
+/**
+ * Legacy system model types without an EntityDefinition row. For these the
+ * modelType string IS the canonical entityDefinitionId (e.g. `thread`).
+ */
+export const LEGACY_SYSTEM_TYPES = ModelTypeValues.filter(
+  (t): t is ModelType => t !== 'entity' && !isEntityDefinitionType(t)
+)
+
+/** prefix → canonical id for everything resolvable at build time. */
+const staticCanonicalByPrefix = new Map<string, string>()
+for (const t of LEGACY_SYSTEM_TYPES) {
+  staticCanonicalByPrefix.set(t, t)
+  const apiSlug = ModelTypeMeta[t]?.apiSlug
+  if (apiSlug) staticCanonicalByPrefix.set(apiSlug, t)
+}
+
+/**
+ * Prefixes that are known org-dynamic aliases: def-backed entityTypes
+ * (`contact`, `work_order`, …) and their apiSlugs (`contacts`, `work_orders`, …).
+ * These always need the org's entityDefs/entityDefSlugs mapping to resolve.
+ */
+const dynamicAliasPrefixes = new Set<string>()
+for (const t of ENTITY_DEFINITION_TYPES) {
+  dynamicAliasPrefixes.add(t)
+  const meta = (ModelTypeMeta as Partial<Record<string, { apiSlug?: string }>>)[t]
+  if (meta?.apiSlug) dynamicAliasPrefixes.add(meta.apiSlug)
+}
+
+/**
+ * Resolve a prefix through the static tier. Returns the canonical id for
+ * legacy system names and their apiSlugs (`threads` → `thread`), undefined
+ * for everything else (org-dynamic aliases, CUIDs, unknown strings).
+ */
+export function resolveStaticPrefix(prefix: string): string | undefined {
+  return staticCanonicalByPrefix.get(prefix)
+}
+
+/**
+ * True when the prefix is a known org-dynamic alias (def-backed entityType or
+ * its apiSlug) — resolvable only via the org's dynamic prefix map.
+ */
+export function isDynamicAliasPrefix(prefix: string): boolean {
+  return dynamicAliasPrefixes.has(prefix)
+}
+
+/**
+ * True when the prefix is already a canonical definition id: a legacy system
+ * name, or a long-form EntityDefinition id (same validated convention as the
+ * server's `isCustomResourceId` — length ≥ 20 and not a known alias).
+ */
+export function isStaticCanonicalDefinitionId(prefix: string): boolean {
+  if (staticCanonicalByPrefix.get(prefix) === prefix) return true
+  return prefix.length >= 20 && !dynamicAliasPrefixes.has(prefix)
+}


### PR DESCRIPTION
## Problem

Detail pages flashed **"Record Not Found"** on hard first load and double-fetched records. Root cause: alias-form RecordId prefixes (`work_order:x`, `contacts:x`) entered the batch queues before `resource.list` hydrated, so bookkeeping split across alias/UUID cache slots that no post-hydration reader watches. The same fragmentation existed on the field half of field-value keys (`work_order:status` / `work_order_status` vs the CustomField row-id form that saves and realtime publish under).

## Approach

**Canonical prefix = `entityDefinitionId`** — the EntityDefinition CUID for def-backed types (contact, ticket, work_order, custom defs) and the modelType string itself for legacy system types (thread, message, user). The `toRecordId('work_order', id)` idiom stays supported ingress everywhere; canonicalization is structural, at store/queue boundaries.

Resolution is **two-tier**:
- **Static tier** (`@auxx/lib/resources/static-prefixes`, pure/build-time): legacy system names and their apiSlugs (`threads` → `thread`) resolve with no seed, no store, no hydration — they can never be gated.
- **Dynamic tier** (`resourceStore.definitionIdByPrefix`): org-specific entityType/apiSlug → def CUID, seeded from dehydrated state (now derived from the slim `entityDefs`/`entityDefSlugs` caches instead of the full `resources` projection) and replaced **reference-stably** on hydration so field-metadata updates never fan out to normalization consumers.

## Hardening highlights

- `usePrefixEpoch()` (bumps exactly when mappings change) replaces the sticky readiness boolean that left memoized hook results stale across the seed→hydration transition.
- `buildCanonicalFieldValueKey` canonicalizes **both** key halves — def prefix and field id (static key / bare systemAttribute → row-id form), preserves `@app:` encoding, resolves drill-down FieldPath segments individually. Saved-view column ids normalize once at syncer ingress, never in storage.
- Record + relationship batching drain per-id: normalize once, dedupe **before** capacity, unresolved aliases stay pending and release when the prefix map changes.
- `FieldValueFetchQueue` rewritten: Map-keyed pending (O(1) dedupe, ~linear large-batch enqueue), no timer polling, org-switch `reset()` + generation guard so in-flight responses can't write into the next org's stores. Record/relationship fetchers drop late responses via `loadingIds` membership.
- `useFieldCellState`: value/loading/AI/managed state through one shallow subscription per table cell.

## Verification

- 47 web + 6 lib unit tests (seed/hydration transitions, alias+canonical collapse, both-halves re-keying, generation discard after org reset, no-timer-left-behind, 10k-combination batch shape).
- `packages/lib` typecheck clean; apps/web errors verified net-zero vs the known stale-composite baseline.
- Live browser: work-orders list issues ONE `record.getByIds` with all items def-CUID-prefixed + one `fieldValue.batchGet`; hard-loading a detail page fires a single early canonical fetch off the dehydrated seed with no Not Found flash; mail inbox (static-tier threads) clean.

Still owed (follow-up): adversarial browser cases — bogus id, org switch with batches in flight, slow-network throttle, def rename mid-session.