### PR TITLE
feat(ui): main-page slot portals, tabs primitive, useDockedPanels + entity route shells

### DIFF
--- a/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/layout.tsx
+++ b/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/layout.tsx
@@ -109,11 +109,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
               }>
               <MainPageBreadcrumb>
-                <MainPageBreadcrumbItem
-                  title={app.title}
-                  href={`/${slug}/apps/${appSlug}`}
-                  last={true}
-                />
+                <MainPageBreadcrumbItem title={app.title} href={`/${slug}/apps/${appSlug}`} />
               </MainPageBreadcrumb>
             </MainPageHeader>
 

--- a/apps/build/src/app/(portal)/[slug]/settings/layout.tsx
+++ b/apps/build/src/app/(portal)/[slug]/settings/layout.tsx
@@ -41,11 +41,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           <MainPage>
             <MainPageHeader>
               <MainPageBreadcrumb>
-                <MainPageBreadcrumbItem
-                  title={`Settings`}
-                  href={`/${slug}/settings/general`}
-                  last={true}
-                />
+                <MainPageBreadcrumbItem title={`Settings`} href={`/${slug}/settings/general`} />
               </MainPageBreadcrumb>
             </MainPageHeader>
 

--- a/apps/web/src/app/(protected)/app/agents/[slug]/page.tsx
+++ b/apps/web/src/app/(protected)/app/agents/[slug]/page.tsx
@@ -6,17 +6,18 @@ import {
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
-  MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { Lock } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { AgentsProvider } from '~/components/agents'
 import { useAgent } from '~/components/agents/hooks/use-agent'
 import { useAgentRealtime } from '~/components/agents/hooks/use-agent-realtime'
 import { AgentDetailView } from '~/components/agents/ui/detail/agent-detail-view'
-import { EmptyState } from '~/components/global/empty-state'
-import { LoadingSpinner } from '~/components/global/loading-content'
+import {
+  MainPageLoading,
+  MainPageNoPermission,
+  MainPageNotFound,
+} from '~/components/global/main-page-states'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 
@@ -31,12 +32,10 @@ function AgentDetailLoader({ slug }: { slug: string }) {
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
             <MainPageBreadcrumbItem title='Agents' href='/app/agents' />
-            <MainPageBreadcrumbItem title='Loading…' last />
+            <MainPageBreadcrumbItem title='Loading…' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <LoadingSpinner />
-        </MainPageContent>
+        <MainPageLoading />
       </MainPage>
     )
   }
@@ -48,16 +47,10 @@ function AgentDetailLoader({ slug }: { slug: string }) {
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
             <MainPageBreadcrumbItem title='Agents' href='/app/agents' />
-            <MainPageBreadcrumbItem title='Not found' last />
+            <MainPageBreadcrumbItem title='Not found' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <EmptyState
-            title='Agent not found'
-            description='This agent may have been deleted.'
-            button={<div className='h-12' />}
-          />
-        </MainPageContent>
+        <MainPageNotFound title='Agent not found' description='This agent may have been deleted.' />
       </MainPage>
     )
   }
@@ -77,17 +70,13 @@ export default function AgentDetailPage() {
         <MainPageHeader>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
-            <MainPageBreadcrumbItem title='Agents' last />
+            <MainPageBreadcrumbItem title='Agents' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <EmptyState
-            icon={Lock}
-            title='Agents Not Available'
-            description='Agents are admin-only and require the agents feature on your plan.'
-            button={<div className='h-12' />}
-          />
-        </MainPageContent>
+        <MainPageNoPermission
+          title='Agents Not Available'
+          description='Agents are admin-only and require the agents feature on your plan.'
+        />
       </MainPage>
     )
   }

--- a/apps/web/src/app/(protected)/app/agents/page.tsx
+++ b/apps/web/src/app/(protected)/app/agents/page.tsx
@@ -26,7 +26,7 @@ export default function AgentsPage() {
         <MainPageHeader>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
-            <MainPageBreadcrumbItem title='Agents' last />
+            <MainPageBreadcrumbItem title='Agents' />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>

--- a/apps/web/src/app/(protected)/app/calls/page.tsx
+++ b/apps/web/src/app/(protected)/app/calls/page.tsx
@@ -31,7 +31,7 @@ function CallsPageContent() {
         }>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Calls' href='/app/calls' />
-          <MainPageBreadcrumbItem title='Recordings' last />
+          <MainPageBreadcrumbItem title='Recordings' />
         </MainPageBreadcrumb>
       </MainPageHeader>
 

--- a/apps/web/src/app/(protected)/app/companies/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/app/companies/dashboard/page.tsx
@@ -1,29 +1,13 @@
 // apps/web/src/app/(protected)/app/companies/dashboard/page.tsx
 'use client'
 
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
 import { EntityDashboardPage } from '~/components/dashboard/ui/entity-dashboard-page'
 
 /**
- * Companies entity dashboard (plan 02) — reached via the `ChartColumn` header
- * button on the companies list page (`RecordsView`). The companies layout is a
- * pass-through (no shared `MainPage`), so this route owns its own shell.
+ * Companies entity dashboard (plan 02) — reached via the Dashboard tab on the
+ * companies entity route. The companies `layout.tsx` (EntityRouteLayout) owns
+ * the MainPage shell; `EntityDashboardPage` renders its own MainPageContent.
  */
 export default function CompaniesDashboardPage() {
-  return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title='Companies' href='/app/companies' />
-          <MainPageBreadcrumbItem title='Dashboard' last />
-        </MainPageBreadcrumb>
-      </MainPageHeader>
-      <EntityDashboardPage slug='companies' />
-    </MainPage>
-  )
+  return <EntityDashboardPage slug='companies' />
 }

--- a/apps/web/src/app/(protected)/app/companies/layout.tsx
+++ b/apps/web/src/app/(protected)/app/companies/layout.tsx
@@ -1,15 +1,40 @@
 // apps/web/src/app/(protected)/app/companies/layout.tsx
 
-import type React from 'react'
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { EntityRouteLayout } from '~/components/records'
 
 type Props = { children: React.ReactNode; modal: React.ReactNode }
 
-function layout({ children, modal }: Props) {
+const BASE_PATH = '/app/companies'
+
+/**
+ * Companies layout — entity route shell (List | Dashboard tabs) for the list
+ * and dashboard pages. Detail (`[companyId]`) and import (`import/[jobId]`)
+ * routes own their own `MainPage` (via `DetailView`/`ImportPage`) and bypass
+ * the shell entirely.
+ */
+function CompaniesLayout({ children, modal }: Props) {
+  const pathname = usePathname()
+  const isDetailOrSpecialPage =
+    pathname !== BASE_PATH && !pathname.startsWith(`${BASE_PATH}/dashboard`)
+
+  if (isDetailOrSpecialPage) {
+    return (
+      <>
+        {children}
+        {modal}
+      </>
+    )
+  }
+
   return (
-    <>
-      {children} {modal}
-    </>
+    <EntityRouteLayout slug='companies' basePath={BASE_PATH}>
+      {children}
+      {modal}
+    </EntityRouteLayout>
   )
 }
 
-export default layout
+export default CompaniesLayout

--- a/apps/web/src/app/(protected)/app/companies/page.tsx
+++ b/apps/web/src/app/(protected)/app/companies/page.tsx
@@ -4,14 +4,9 @@
 import { RecordsView } from '~/components/records'
 
 /**
- * Companies page — renders the shared RecordsView for the companies resource
+ * Companies page — renders the shared RecordsView for the companies resource.
+ * The companies `layout.tsx` (EntityRouteLayout) owns the MainPage shell.
  */
 export default function CompaniesPage() {
-  return (
-    <RecordsView
-      slug='companies'
-      basePath='/app/companies'
-      dashboardHref='/app/companies/dashboard'
-    />
-  )
+  return <RecordsView slug='companies' basePath='/app/companies' />
 }

--- a/apps/web/src/app/(protected)/app/connectors/[connectorId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/connectors/[connectorId]/page.tsx
@@ -6,14 +6,12 @@ import {
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
-  MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { AlertTriangle } from 'lucide-react'
 import { use } from 'react'
 import { ConnectorDetailView } from '~/components/data-connectors/ui/connector-detail-view'
-import { EmptyState } from '~/components/global/empty-state'
-import { LoadingSpinner } from '~/components/global/loading-content'
+import { MainPageLoading, MainPageNotFound } from '~/components/global/main-page-states'
 import { api } from '~/trpc/react'
 
 interface ConnectorDetailPageProps {
@@ -35,17 +33,14 @@ export default function ConnectorDetailPage({ params }: ConnectorDetailPageProps
         <MainPageHeader>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Connectors' href='/app/connectors' />
-            <MainPageBreadcrumbItem title='Not found' last />
+            <MainPageBreadcrumbItem title='Not found' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <EmptyState
-            icon={AlertTriangle}
-            title='Connector not found'
-            description='This connector does not exist or you do not have access to it.'
-            button={<div className='h-12' />}
-          />
-        </MainPageContent>
+        <MainPageNotFound
+          icon={AlertTriangle}
+          title='Connector not found'
+          description='This connector does not exist or you do not have access to it.'
+        />
       </MainPage>
     )
   }
@@ -56,12 +51,10 @@ export default function ConnectorDetailPage({ params }: ConnectorDetailPageProps
         <MainPageHeader>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Connectors' href='/app/connectors' />
-            <MainPageBreadcrumbItem title='Loading…' last />
+            <MainPageBreadcrumbItem title='Loading…' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <LoadingSpinner />
-        </MainPageContent>
+        <MainPageLoading />
       </MainPage>
     )
   }

--- a/apps/web/src/app/(protected)/app/connectors/page.tsx
+++ b/apps/web/src/app/(protected)/app/connectors/page.tsx
@@ -69,7 +69,7 @@ export default function ConnectorsPage() {
           ) : undefined
         }>
         <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title='Connectors' href='/app/connectors' last />
+          <MainPageBreadcrumbItem title='Connectors' href='/app/connectors' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/app/(protected)/app/contacts/_components/contact-detail.tsx
+++ b/apps/web/src/app/(protected)/app/contacts/_components/contact-detail.tsx
@@ -169,7 +169,7 @@ export function ContactDetail({ id }: { id: string }) {
         }>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Contacts' href='/app/contacts' />
-          <MainPageBreadcrumbItem title={customerName} last />
+          <MainPageBreadcrumbItem title={customerName} />
         </MainPageBreadcrumb>
       </MainPageHeader>
 
@@ -233,7 +233,7 @@ function CustomerDetailSkeleton() {
       <MainPageHeader>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Contacts' href='/app/contacts' />
-          <MainPageBreadcrumbItem title='Loading...' last />
+          <MainPageBreadcrumbItem title='Loading...' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent
@@ -279,7 +279,7 @@ function CustomerNotFound({ router }: { router: any }) {
       <MainPageHeader>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Contacts' href='/app/contacts' />
-          <MainPageBreadcrumbItem title='Not Found' last />
+          <MainPageBreadcrumbItem title='Not Found' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/app/(protected)/app/contacts/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/app/contacts/dashboard/page.tsx
@@ -1,30 +1,13 @@
 // apps/web/src/app/(protected)/app/contacts/dashboard/page.tsx
 'use client'
 
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
 import { EntityDashboardPage } from '~/components/dashboard/ui/entity-dashboard-page'
 
 /**
- * Contacts entity dashboard (plan 02) — reached via the `ChartColumn` header
- * button on the contacts list page (`RecordsView`). The contacts layout is a
- * pass-through (no shared `MainPage`), so this route owns its own shell —
- * unlike tickets, whose layout already provides one for the RadioTab.
+ * Contacts entity dashboard (plan 02) — reached via the Dashboard tab on the
+ * contacts entity route. The contacts `layout.tsx` (EntityRouteLayout) owns
+ * the MainPage shell; `EntityDashboardPage` renders its own MainPageContent.
  */
 export default function ContactsDashboardPage() {
-  return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title='Contacts' href='/app/contacts' />
-          <MainPageBreadcrumbItem title='Dashboard' last />
-        </MainPageBreadcrumb>
-      </MainPageHeader>
-      <EntityDashboardPage slug='contacts' />
-    </MainPage>
-  )
+  return <EntityDashboardPage slug='contacts' />
 }

--- a/apps/web/src/app/(protected)/app/contacts/layout.tsx
+++ b/apps/web/src/app/(protected)/app/contacts/layout.tsx
@@ -1,13 +1,40 @@
-import type React from 'react'
+// apps/web/src/app/(protected)/app/contacts/layout.tsx
+
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { EntityRouteLayout } from '~/components/records'
 
 type Props = { children: React.ReactNode; modal: React.ReactNode }
 
-function layout({ children, modal }: Props) {
+const BASE_PATH = '/app/contacts'
+
+/**
+ * Contacts layout — entity route shell (List | Dashboard tabs) for the list
+ * and dashboard pages. Detail (`[contactId]`) and import (`import/[jobId]`)
+ * routes own their own `MainPage` (via `DetailView`/`ImportPage`) and bypass
+ * the shell entirely.
+ */
+function ContactsLayout({ children, modal }: Props) {
+  const pathname = usePathname()
+  const isDetailOrSpecialPage =
+    pathname !== BASE_PATH && !pathname.startsWith(`${BASE_PATH}/dashboard`)
+
+  if (isDetailOrSpecialPage) {
+    return (
+      <>
+        {children}
+        {modal}
+      </>
+    )
+  }
+
   return (
-    <>
-      {children} {modal}
-    </>
+    <EntityRouteLayout slug='contacts' basePath={BASE_PATH}>
+      {children}
+      {modal}
+    </EntityRouteLayout>
   )
 }
 
-export default layout
+export default ContactsLayout

--- a/apps/web/src/app/(protected)/app/contacts/page.tsx
+++ b/apps/web/src/app/(protected)/app/contacts/page.tsx
@@ -4,10 +4,9 @@
 import { RecordsView } from '~/components/records'
 
 /**
- * Contacts page — renders the shared RecordsView for the contacts resource
+ * Contacts page — renders the shared RecordsView for the contacts resource.
+ * The contacts `layout.tsx` (EntityRouteLayout) owns the MainPage shell.
  */
 export default function ContactsPage() {
-  return (
-    <RecordsView slug='contacts' basePath='/app/contacts' dashboardHref='/app/contacts/dashboard' />
-  )
+  return <RecordsView slug='contacts' basePath='/app/contacts' />
 }

--- a/apps/web/src/app/(protected)/app/custom/[slug]/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/app/custom/[slug]/dashboard/page.tsx
@@ -1,37 +1,16 @@
 // apps/web/src/app/(protected)/app/custom/[slug]/dashboard/page.tsx
 'use client'
 
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
 import { useParams } from 'next/navigation'
 import { EntityDashboardPage } from '~/components/dashboard/ui/entity-dashboard-page'
-import { useResource } from '~/components/resources'
 
 /**
  * Generic custom-entity dashboard (plan 02) — one wiring covers every custom
- * entity def via the `ChartColumn` header button on the records page
- * (`RecordsView`).
+ * entity def, reached via the Dashboard tab on the entity route. The
+ * `custom/[slug]/layout.tsx` (EntityRouteLayout) owns the MainPage shell;
+ * `EntityDashboardPage` renders its own MainPageContent.
  */
 export default function CustomEntityDashboardPage() {
   const params = useParams<{ slug: string }>()
-  const { resource } = useResource(params.slug)
-
-  return (
-    <MainPage>
-      <MainPageHeader>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem
-            title={resource?.plural ?? 'Records'}
-            href={`/app/custom/${params.slug}`}
-          />
-          <MainPageBreadcrumbItem title='Dashboard' last />
-        </MainPageBreadcrumb>
-      </MainPageHeader>
-      <EntityDashboardPage slug={params.slug} />
-    </MainPage>
-  )
+  return <EntityDashboardPage slug={params.slug} />
 }

--- a/apps/web/src/app/(protected)/app/custom/[slug]/layout.tsx
+++ b/apps/web/src/app/(protected)/app/custom/[slug]/layout.tsx
@@ -1,0 +1,32 @@
+// apps/web/src/app/(protected)/app/custom/[slug]/layout.tsx
+
+'use client'
+
+import { useParams, usePathname } from 'next/navigation'
+import { EntityRouteLayout } from '~/components/records'
+
+/**
+ * Custom entity layout — entity route shell (List | Dashboard tabs) for the
+ * list and dashboard pages, one wiring for every custom entity def. Detail
+ * (`[id]`) and import (`import/[jobId]`) routes own their own `MainPage`
+ * (via `DetailView`/`ImportPage`) and bypass the shell entirely.
+ */
+function CustomEntityLayout({ children }: { children: React.ReactNode }) {
+  const { slug } = useParams<{ slug: string }>()
+  const pathname = usePathname()
+  const basePath = `/app/custom/${slug}`
+  const isDetailOrSpecialPage =
+    pathname !== basePath && !pathname.startsWith(`${basePath}/dashboard`)
+
+  if (isDetailOrSpecialPage) {
+    return <>{children}</>
+  }
+
+  return (
+    <EntityRouteLayout slug={slug} basePath={basePath}>
+      {children}
+    </EntityRouteLayout>
+  )
+}
+
+export default CustomEntityLayout

--- a/apps/web/src/app/(protected)/app/custom/[slug]/page.tsx
+++ b/apps/web/src/app/(protected)/app/custom/[slug]/page.tsx
@@ -5,10 +5,11 @@ import { useParams } from 'next/navigation'
 import { RecordsView } from '~/components/records'
 
 /**
- * Custom entity records page
- * Reads slug from URL params and passes to RecordsView
+ * Custom entity records page — reads slug from URL params and passes to
+ * RecordsView. The custom entity `layout.tsx` (EntityRouteLayout) owns the
+ * MainPage shell.
  */
 export default function CustomEntityRecordsPage() {
   const params = useParams<{ slug: string }>()
-  return <RecordsView slug={params.slug} dashboardHref={`/app/custom/${params.slug}/dashboard`} />
+  return <RecordsView slug={params.slug} />
 }

--- a/apps/web/src/app/(protected)/app/dashboards/[dashboardId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/dashboards/[dashboardId]/page.tsx
@@ -6,61 +6,49 @@ import {
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
-  MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { AlertTriangle } from 'lucide-react'
 import { use } from 'react'
 import { DashboardDetailView } from '~/components/dashboard/ui/dashboard-detail-view'
-import { EmptyState } from '~/components/global/empty-state'
-import { LoadingSpinner } from '~/components/global/loading-content'
+import { MainPageLoading, MainPageNotFound } from '~/components/global/main-page-states'
 import { api } from '~/trpc/react'
 
 interface DashboardDetailPageProps {
   params: Promise<{ dashboardId: string }>
 }
 
-/** Dashboard detail — view + edit the versioned widget grid. See plans/dashboard/08. */
+/**
+ * Dashboard detail — view + edit the versioned widget grid. Owns the
+ * standalone `MainPage` shell (breadcrumb "Dashboards"); `DashboardDetailView`
+ * contributes the action cluster and the dashboard-switcher breadcrumb tail
+ * via `MainPageAction`/`MainPageCrumbs`. See plans/dashboard/08.
+ */
 export default function DashboardDetailPage({ params }: DashboardDetailPageProps) {
   const { dashboardId } = use(params)
   const dashboard = api.dashboard.get.useQuery({ id: dashboardId })
 
-  if (dashboard.isError || (!dashboard.isLoading && !dashboard.data)) {
-    return (
-      <MainPage>
-        <MainPageHeader>
-          <MainPageBreadcrumb>
-            <MainPageBreadcrumbItem title='Dashboards' href='/app/dashboards' />
-            <MainPageBreadcrumbItem title='Not found' last />
-          </MainPageBreadcrumb>
-        </MainPageHeader>
-        <MainPageContent>
-          <EmptyState
-            icon={AlertTriangle}
-            title='Dashboard not found'
-            description='This dashboard does not exist or you do not have access to it.'
-            button={<div className='h-12' />}
-          />
-        </MainPageContent>
-      </MainPage>
-    )
-  }
+  const isNotFound = dashboard.isError || (!dashboard.isLoading && !dashboard.data)
 
-  if (dashboard.isLoading || !dashboard.data) {
-    return (
-      <MainPage>
-        <MainPageHeader>
-          <MainPageBreadcrumb>
-            <MainPageBreadcrumbItem title='Dashboards' href='/app/dashboards' />
-            <MainPageBreadcrumbItem title='Loading…' last />
-          </MainPageBreadcrumb>
-        </MainPageHeader>
-        <MainPageContent>
-          <LoadingSpinner />
-        </MainPageContent>
-      </MainPage>
-    )
-  }
+  return (
+    <MainPage>
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem title='Dashboards' href='/app/dashboards' />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
 
-  return <DashboardDetailView dashboard={dashboard.data} />
+      {isNotFound ? (
+        <MainPageNotFound
+          icon={AlertTriangle}
+          title='Dashboard not found'
+          description='This dashboard does not exist or you do not have access to it.'
+        />
+      ) : dashboard.isLoading || !dashboard.data ? (
+        <MainPageLoading />
+      ) : (
+        <DashboardDetailView dashboard={dashboard.data} />
+      )}
+    </MainPage>
+  )
 }

--- a/apps/web/src/app/(protected)/app/datasets/[datasetId]/_components/dataset-detail-content.tsx
+++ b/apps/web/src/app/(protected)/app/datasets/[datasetId]/_components/dataset-detail-content.tsx
@@ -5,7 +5,6 @@
 import type { DocumentEntity as Document } from '@auxx/database/types'
 import { Badge } from '@auxx/ui/components/badge'
 import {
-  type DockedPanelConfig,
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
@@ -20,8 +19,7 @@ import { DocumentDetailDrawer } from '~/components/datasets/documents/document-d
 import { DocumentManagement } from '~/components/datasets/documents/document-management'
 import { DatasetSearch } from '~/components/datasets/search/dataset-search'
 import { DatasetSettings } from '~/components/datasets/settings/dataset-settings'
-import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
-import { useDockStore } from '~/stores/dock-store'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { DatasetActions } from './dataset-actions'
 import { useDatasetDetail } from './dataset-detail-provider'
 import { DatasetHeader } from './dataset-header'
@@ -31,11 +29,6 @@ import { DatasetHeader } from './dataset-header'
  * Includes MainPage, dock logic, and drawer state management.
  */
 export function DatasetDetailContent() {
-  const isDocked = useEffectiveDockState()
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const minWidth = useDockStore((state) => state.minWidth)
-  const maxWidth = useDockStore((state) => state.maxWidth)
   const { currentTab, setCurrentTab, dataset, documents } = useDatasetDetail()
 
   // Drawer state — synced to URL via ?id= param
@@ -65,39 +58,26 @@ export function DatasetDetailContent() {
     [setSelectedDocumentId]
   )
 
-  // Build docked panels - only show when on documents tab
-  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
-    if (!isDocked || !isDrawerOpen || !selectedDocument || !dataset || currentTab !== 'documents')
-      return []
-    return [
-      {
-        key: 'document-detail',
-        content: (
-          <DocumentDetailDrawer
-            document={selectedDocument}
-            open={isDrawerOpen}
-            onOpenChange={handleDrawerOpenChange}
-            datasetId={dataset.id}
-          />
-        ),
-        width: dockedWidth,
-        onWidthChange: setDockedWidth,
-        minWidth,
-        maxWidth,
-      },
-    ]
-  }, [
-    isDocked,
-    isDrawerOpen,
-    selectedDocument,
-    currentTab,
-    dataset,
-    handleDrawerOpenChange,
-    dockedWidth,
-    setDockedWidth,
-    minWidth,
-    maxWidth,
-  ])
+  // Docked panel only shows when on the documents tab; overlay (non-docked)
+  // mode shows regardless of tab, matching the pre-hook behavior.
+  const { dockedPanels, overlays } = useDockedPanels(
+    selectedDocument && dataset
+      ? [
+          {
+            key: 'document-detail',
+            open: { docked: isDrawerOpen && currentTab === 'documents', overlay: isDrawerOpen },
+            content: (
+              <DocumentDetailDrawer
+                document={selectedDocument}
+                open={isDrawerOpen}
+                onOpenChange={handleDrawerOpenChange}
+                datasetId={dataset.id}
+              />
+            ),
+          },
+        ]
+      : []
+  )
 
   if (!dataset) return null
 
@@ -109,7 +89,7 @@ export function DatasetDetailContent() {
       <MainPageHeader action={<DatasetActions />}>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Datasets' href='/app/datasets' />
-          <MainPageBreadcrumbItem title='Dataset Details' last />
+          <MainPageBreadcrumbItem title='Dataset Details' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent dockedPanels={dockedPanels}>
@@ -159,17 +139,9 @@ export function DatasetDetailContent() {
             <DatasetSettings dataset={dataset} />
           </TabsContent>
         </Tabs>
-
-        {/* Overlay drawer when NOT docked */}
-        {!isDocked && selectedDocument && isDrawerOpen && (
-          <DocumentDetailDrawer
-            document={selectedDocument}
-            open={isDrawerOpen}
-            onOpenChange={handleDrawerOpenChange}
-            datasetId={dataset.id}
-          />
-        )}
       </MainPageContent>
+
+      {overlays}
     </MainPage>
   )
 }

--- a/apps/web/src/app/(protected)/app/datasets/page.tsx
+++ b/apps/web/src/app/(protected)/app/datasets/page.tsx
@@ -39,7 +39,7 @@ function DatasetsPageContent() {
       <MainPageHeader action={<CreateDatasetButton />}>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Datasets' href='/app/datasets' />
-          <MainPageBreadcrumbItem title='Overview' last />
+          <MainPageBreadcrumbItem title='Overview' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/app/(protected)/app/dispatch/layout.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/layout.tsx
@@ -8,47 +8,38 @@ import {
   MainPageBreadcrumbItem,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import { MainPageTabs } from '@auxx/ui/components/main-page-tabs'
 import { CalendarDays, Settings } from 'lucide-react'
-import { usePathname, useRouter } from 'next/navigation'
-
-type DispatchTab = 'board' | 'settings'
 
 /**
- * Module header for `/app/dispatch/*` — the tickets-layout recipe
- * (`TicketsLayoutHeader`): a `RadioTab` switcher (Board · Settings) whose
- * active value is derived from the pathname, `router.push` on change.
+ * Module header for `/app/dispatch/*` — Board · Settings tabs via
+ * `MainPageTabs` in route mode (active tab derived from the pathname,
+ * `router.push` on select).
  */
 function DispatchLayoutHeader() {
-  const pathname = usePathname()
-  const router = useRouter()
-
-  const activeTab: DispatchTab = pathname.includes('/dispatch/settings') ? 'settings' : 'board'
-
-  const handleTabChange = (tab: DispatchTab) => {
-    router.push(tab === 'board' ? '/app/dispatch' : '/app/dispatch/settings')
-  }
-
   return (
     <MainPageHeader className='justify-start'>
       <MainPageBreadcrumb>
-        <MainPageBreadcrumbItem title='Dispatch' href='/app/dispatch' last />
+        <MainPageBreadcrumbItem title='Dispatch' href='/app/dispatch' />
       </MainPageBreadcrumb>
-      <RadioTab
-        value={activeTab}
-        onValueChange={handleTabChange}
-        size='sm'
-        radioGroupClassName='grid w-full'
-        className='border border-primary-200 flex w-full'>
-        <RadioTabItem value='board' size='sm' tooltip='Board'>
-          <CalendarDays />
-          <span className='hidden sm:inline'>Board</span>
-        </RadioTabItem>
-        <RadioTabItem value='settings' size='sm' tooltip='Settings'>
-          <Settings />
-          <span className='hidden sm:inline'>Settings</span>
-        </RadioTabItem>
-      </RadioTab>
+      <MainPageTabs
+        items={[
+          {
+            value: 'board',
+            label: 'Board',
+            icon: <CalendarDays />,
+            href: '/app/dispatch',
+            tooltip: 'Board',
+          },
+          {
+            value: 'settings',
+            label: 'Settings',
+            icon: <Settings />,
+            href: '/app/dispatch/settings',
+            tooltip: 'Settings',
+          },
+        ]}
+      />
     </MainPageHeader>
   )
 }

--- a/apps/web/src/app/(protected)/app/files/page.tsx
+++ b/apps/web/src/app/(protected)/app/files/page.tsx
@@ -3,7 +3,6 @@
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import {
-  type DockedPanelConfig,
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
@@ -12,22 +11,15 @@ import {
 } from '@auxx/ui/components/main-page'
 import { Lock } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect } from 'react'
 import { FilesManagement } from '~/components/files'
 import { FileDetailDrawer } from '~/components/files/file-detail-drawer'
 import { type FileItem, useFileSystemStore } from '~/components/files/files-store'
 import { EmptyState } from '~/components/global/empty-state'
-import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
-import { useDockStore } from '~/stores/dock-store'
 
 function FilesPageContent() {
-  const isDocked = useEffectiveDockState()
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const minWidth = useDockStore((state) => state.minWidth)
-  const maxWidth = useDockStore((state) => state.maxWidth)
-
   // ── URL state ───────────────────────────────────────────────────────────
   // ?folder=<folderId> mirrors the filesystem store's currentFolderId
   // ?id=<fileId> opens the file detail drawer
@@ -89,57 +81,37 @@ function FilesPageContent() {
     [setSelectedFileId]
   )
 
-  // Build docked panels
-  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
-    if (!isDocked || !isDrawerOpen || !selectedFile) return []
-    return [
-      {
-        key: 'file-detail',
-        content: (
-          <FileDetailDrawer
-            file={selectedFile}
-            setSelectedFile={handleSetSelectedFile}
-            onOpenChange={handleDrawerOpenChange}
-          />
-        ),
-        width: dockedWidth,
-        onWidthChange: setDockedWidth,
-        minWidth,
-        maxWidth,
-      },
-    ]
-  }, [
-    isDocked,
-    isDrawerOpen,
-    selectedFile,
-    handleDrawerOpenChange,
-    handleSetSelectedFile,
-    dockedWidth,
-    setDockedWidth,
-    minWidth,
-    maxWidth,
-  ])
+  const { dockedPanels, overlays } = useDockedPanels(
+    selectedFile
+      ? [
+          {
+            key: 'file-detail',
+            open: isDrawerOpen,
+            content: (
+              <FileDetailDrawer
+                file={selectedFile}
+                setSelectedFile={handleSetSelectedFile}
+                onOpenChange={handleDrawerOpenChange}
+              />
+            ),
+          },
+        ]
+      : []
+  )
 
   return (
     <MainPage>
       <MainPageHeader>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Files' href='/app/files' />
-          <MainPageBreadcrumbItem title='Management' last />
+          <MainPageBreadcrumbItem title='Management' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent dockedPanels={dockedPanels}>
         <FilesManagement onFileSelect={handleFileSelect} />
-
-        {/* Overlay drawer when NOT docked */}
-        {!isDocked && selectedFile && isDrawerOpen && (
-          <FileDetailDrawer
-            file={selectedFile}
-            setSelectedFile={handleSetSelectedFile}
-            onOpenChange={handleDrawerOpenChange}
-          />
-        )}
       </MainPageContent>
+
+      {overlays}
     </MainPage>
   )
 }

--- a/apps/web/src/app/(protected)/app/invoices/layout.tsx
+++ b/apps/web/src/app/(protected)/app/invoices/layout.tsx
@@ -1,15 +1,51 @@
 // apps/web/src/app/(protected)/app/invoices/layout.tsx
 
-import type React from 'react'
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { usePathname } from 'next/navigation'
+import { useResource } from '~/components/resources'
 
 type Props = { children: React.ReactNode; modal: React.ReactNode }
 
-function layout({ children, modal }: Props) {
+const BASE_PATH = '/app/invoices'
+
+/**
+ * Invoices layout — plain breadcrumb shell (no tabs; invoices has no
+ * dashboard sub-route and is drawer-only, money MI1 build spec §J.6).
+ * `RecordsView` (mounted by `invoices/page.tsx`) renders its own
+ * MainPageContent and contributes the Create button via `MainPageAction`.
+ * The import (`import/[jobId]`) route owns its own `MainPage` and bypasses
+ * the shell.
+ */
+export default function InvoicesLayout({ children, modal }: Props) {
+  const pathname = usePathname()
+  const { resource } = useResource('invoices')
+  const isDetailOrSpecialPage = pathname !== BASE_PATH
+
+  if (isDetailOrSpecialPage) {
+    return (
+      <>
+        {children}
+        {modal}
+      </>
+    )
+  }
+
   return (
-    <>
-      {children} {modal}
-    </>
+    <MainPage>
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem title={resource?.plural ?? 'Invoices'} href={BASE_PATH} />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
+      {children}
+      {modal}
+    </MainPage>
   )
 }
-
-export default layout

--- a/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
+++ b/apps/web/src/app/(protected)/app/mail/_components/mail-box.tsx
@@ -7,7 +7,6 @@ import { toRecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
 import { Kbd } from '@auxx/ui/components/kbd'
 import {
-  type DockedPanelConfig,
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
@@ -70,11 +69,10 @@ import {
 } from '~/components/threads'
 import { useInboxes } from '~/components/threads/hooks'
 import { useCompose } from '~/hooks/use-compose'
-import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useUser } from '~/hooks/use-user'
 import { safeLocalStorage } from '~/lib/safe-localstorage'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
-import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
 import {
   calculateBasePathForList,
@@ -190,13 +188,6 @@ function MailboxInner({
 
   // Get current user ID for personal inbox/assigned filtering
   const { userId } = useUser()
-
-  // Dock state for contact drawer
-  const isDocked = useEffectiveDockState()
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const minWidth = useDockStore((state) => state.minWidth)
-  const maxWidth = useDockStore((state) => state.maxWidth)
 
   // Contact drawer state from URL (shared with participant-display.tsx)
   const [contactId, setContactId] = useQueryState('contactId', { defaultValue: '' })
@@ -467,79 +458,45 @@ function MailboxInner({
     [participantId, setParticipantId]
   )
 
-  // Build docked panels for contact + ticket drawers
-  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
-    const panels: DockedPanelConfig[] = []
-
-    if (isDocked && isContactDrawerOpen) {
-      panels.push({
-        key: 'contact',
-        content: (
-          <ContactDrawer
-            contactId={contactId}
-            open={isContactDrawerOpen}
-            onOpenChange={handleContactDrawerClose}
+  // Docked/overlay panels for the contact, ticket, and participant drawers —
+  // stacked in the same array; the hook renders whichever are open into the
+  // right dock slot (or as overlays when not docked).
+  const { dockedPanels, overlays } = useDockedPanels([
+    {
+      key: 'contact',
+      open: isContactDrawerOpen,
+      content: (
+        <ContactDrawer
+          contactId={contactId}
+          open={isContactDrawerOpen}
+          onOpenChange={handleContactDrawerClose}
+        />
+      ),
+    },
+    {
+      key: 'ticket',
+      open: isTicketDrawerOpen,
+      content: (
+        <NestedThreadProvider value={true}>
+          <RecordDrawer
+            recordId={toRecordId('ticket', openTicketId)}
+            open={isTicketDrawerOpen}
+            onOpenChange={handleTicketDrawerClose}
           />
-        ),
-        width: dockedWidth,
-        onWidthChange: setDockedWidth,
-        minWidth,
-        maxWidth,
-      })
-    }
-
-    if (isDocked && isTicketDrawerOpen) {
-      panels.push({
-        key: 'ticket',
-        content: (
-          <NestedThreadProvider value={true}>
-            <RecordDrawer
-              recordId={toRecordId('ticket', openTicketId)}
-              open={isTicketDrawerOpen}
-              onOpenChange={handleTicketDrawerClose}
-            />
-          </NestedThreadProvider>
-        ),
-        width: dockedWidth,
-        onWidthChange: setDockedWidth,
-        minWidth,
-        maxWidth,
-      })
-    }
-
-    if (isDocked && isParticipantDrawerOpen) {
-      panels.push({
-        key: 'participant',
-        content: (
-          <ParticipantDrawer
-            participantId={participantId}
-            open={isParticipantDrawerOpen}
-            onOpenChange={handleParticipantDrawerClose}
-          />
-        ),
-        width: dockedWidth,
-        onWidthChange: setDockedWidth,
-        minWidth,
-        maxWidth,
-      })
-    }
-
-    return panels
-  }, [
-    isDocked,
-    isContactDrawerOpen,
-    contactId,
-    handleContactDrawerClose,
-    isTicketDrawerOpen,
-    openTicketId,
-    handleTicketDrawerClose,
-    isParticipantDrawerOpen,
-    participantId,
-    handleParticipantDrawerClose,
-    dockedWidth,
-    setDockedWidth,
-    minWidth,
-    maxWidth,
+        </NestedThreadProvider>
+      ),
+    },
+    {
+      key: 'participant',
+      open: isParticipantDrawerOpen,
+      content: (
+        <ParticipantDrawer
+          participantId={participantId}
+          open={isParticipantDrawerOpen}
+          onOpenChange={handleParticipantDrawerClose}
+        />
+      ),
+    },
   ])
 
   return (
@@ -584,17 +541,14 @@ function MailboxInner({
                       ? '/app/mail/drafts'
                       : '/app/mail/sent'
                   }
-                  last
                 />
               )}
               {isPersonalContext(contextType) &&
                 contextType !== InternalFilterContextType.DRAFTS &&
                 contextType !== InternalFilterContextType.SENT && (
-                  <MainPageBreadcrumbItem title={breadcrumbTitle} last />
+                  <MainPageBreadcrumbItem title={breadcrumbTitle} />
                 )}
-              {isSharedContext(contextType) && (
-                <MainPageBreadcrumbItem title={breadcrumbTitle} last />
-              )}
+              {isSharedContext(contextType) && <MainPageBreadcrumbItem title={breadcrumbTitle} />}
             </MainPageBreadcrumb>
           </MainPageHeader>
           <MainPageContent dockedPanels={dockedPanels}>
@@ -732,34 +686,7 @@ function MailboxInner({
           </MainPageContent>
         </MainPage>
 
-        {/* Overlay contact drawer when NOT docked */}
-        {!isDocked && (
-          <ContactDrawer
-            contactId={contactId}
-            open={isContactDrawerOpen}
-            onOpenChange={handleContactDrawerClose}
-          />
-        )}
-
-        {/* Overlay ticket drawer when NOT docked */}
-        {!isDocked && isTicketDrawerOpen && (
-          <NestedThreadProvider value={true}>
-            <RecordDrawer
-              recordId={toRecordId('ticket', openTicketId)}
-              open={isTicketDrawerOpen}
-              onOpenChange={handleTicketDrawerClose}
-            />
-          </NestedThreadProvider>
-        )}
-
-        {/* Overlay participant drawer when NOT docked */}
-        {!isDocked && (
-          <ParticipantDrawer
-            participantId={participantId}
-            open={isParticipantDrawerOpen}
-            onOpenChange={handleParticipantDrawerClose}
-          />
-        )}
+        {overlays}
       </DrawerContextProvider>
     </MailFilterProvider>
   )

--- a/apps/web/src/app/(protected)/app/parts/layout.tsx
+++ b/apps/web/src/app/(protected)/app/parts/layout.tsx
@@ -2,45 +2,21 @@
 
 'use client'
 
-import { Button } from '@auxx/ui/components/button'
-import { Kbd, KbdGroup } from '@auxx/ui/components/kbd'
 import {
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { Package, Plus } from 'lucide-react'
+import { Package } from 'lucide-react'
 import { usePathname } from 'next/navigation'
-import { parseAsBoolean, useQueryState } from 'nuqs'
 
-function PartsLayoutHeader() {
-  const [, setCreateDialogOpen] = useQueryState('create', parseAsBoolean.withDefault(false))
-
-  return (
-    <MainPageHeader
-      action={
-        <Button size='sm' onClick={() => setCreateDialogOpen(true)}>
-          <Plus />
-          Create Part
-          <KbdGroup variant='default' size='sm'>
-            <Kbd>c</Kbd>
-            <Kbd>p</Kbd>
-          </KbdGroup>
-        </Button>
-      }>
-      <MainPageBreadcrumb>
-        <MainPageBreadcrumbItem
-          title='Parts'
-          href='/app/parts'
-          icon={<Package className='size-4' />}
-          last
-        />
-      </MainPageBreadcrumb>
-    </MainPageHeader>
-  )
-}
-
+/**
+ * Parts layout — a plain breadcrumb shell (not an `EntityRouteLayout`; parts
+ * has no Dashboard tab). `RecordsView` (mounted by `parts/page.tsx`) renders
+ * its own MainPageContent and contributes the Create button via
+ * `MainPageAction`.
+ */
 export default function PartsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
 
@@ -56,7 +32,15 @@ export default function PartsLayout({ children }: { children: React.ReactNode })
 
   return (
     <MainPage>
-      <PartsLayoutHeader />
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem
+            title='Parts'
+            href='/app/parts'
+            icon={<Package className='size-4' />}
+          />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
       {children}
     </MainPage>
   )

--- a/apps/web/src/app/(protected)/app/parts/page.tsx
+++ b/apps/web/src/app/(protected)/app/parts/page.tsx
@@ -5,5 +5,5 @@
 import { RecordsView } from '~/components/records'
 
 export default function PartsPage() {
-  return <RecordsView slug='parts' basePath='/app/parts' embedded />
+  return <RecordsView slug='parts' basePath='/app/parts' />
 }

--- a/apps/web/src/app/(protected)/app/quotes/layout.tsx
+++ b/apps/web/src/app/(protected)/app/quotes/layout.tsx
@@ -1,15 +1,50 @@
 // apps/web/src/app/(protected)/app/quotes/layout.tsx
 
-import type React from 'react'
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { usePathname } from 'next/navigation'
+import { useResource } from '~/components/resources'
 
 type Props = { children: React.ReactNode; modal: React.ReactNode }
 
-function layout({ children, modal }: Props) {
+const BASE_PATH = '/app/quotes'
+
+/**
+ * Quotes layout — plain breadcrumb shell (no tabs; quotes has no dashboard
+ * sub-route). `RecordsView` (mounted by `quotes/page.tsx`) renders its own
+ * MainPageContent and contributes the Create button via `MainPageAction`.
+ * Detail (`[quoteId]`) and import (`import/[jobId]`) routes own their own
+ * `MainPage` and bypass the shell entirely.
+ */
+export default function QuotesLayout({ children, modal }: Props) {
+  const pathname = usePathname()
+  const { resource } = useResource('quotes')
+  const isDetailOrSpecialPage = pathname !== BASE_PATH
+
+  if (isDetailOrSpecialPage) {
+    return (
+      <>
+        {children}
+        {modal}
+      </>
+    )
+  }
+
   return (
-    <>
-      {children} {modal}
-    </>
+    <MainPage>
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem title={resource?.plural ?? 'Quotes'} href={BASE_PATH} />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
+      {children}
+      {modal}
+    </MainPage>
   )
 }
-
-export default layout

--- a/apps/web/src/app/(protected)/app/service-requests/layout.tsx
+++ b/apps/web/src/app/(protected)/app/service-requests/layout.tsx
@@ -1,0 +1,42 @@
+// apps/web/src/app/(protected)/app/service-requests/layout.tsx
+
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { usePathname } from 'next/navigation'
+import { useResource } from '~/components/resources'
+
+const BASE_PATH = '/app/service-requests'
+
+/**
+ * Service requests layout — plain breadcrumb shell (no tabs; service
+ * requests has no dashboard sub-route). `RecordsView` (mounted by
+ * `service-requests/page.tsx`) renders its own MainPageContent and
+ * contributes the Create button via `MainPageAction`. The import
+ * (`import/[jobId]`) route owns its own `MainPage` and bypasses the shell.
+ */
+export default function ServiceRequestsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const { resource } = useResource('service-requests')
+  const isDetailOrSpecialPage = pathname !== BASE_PATH
+
+  if (isDetailOrSpecialPage) {
+    return <>{children}</>
+  }
+
+  return (
+    <MainPage>
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem title={resource?.plural ?? 'Service Requests'} href={BASE_PATH} />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
+      {children}
+    </MainPage>
+  )
+}

--- a/apps/web/src/app/(protected)/app/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/settings/layout.tsx
@@ -27,7 +27,7 @@ export default function SettingsSidebar({ children }: { children: React.ReactNod
     <MainPage>
       <MainPageHeader>
         <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title='Settings' href='/app/settings/general' last />
+          <MainPageBreadcrumbItem title='Settings' href='/app/settings/general' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent className={cn(!isFullWidth && 'max-w-6xl')}>

--- a/apps/web/src/app/(protected)/app/tickets/layout.tsx
+++ b/apps/web/src/app/(protected)/app/tickets/layout.tsx
@@ -2,114 +2,15 @@
 
 'use client'
 
-import { FeatureKey } from '@auxx/lib/permissions/client'
-import { Button } from '@auxx/ui/components/button'
-import { Kbd, KbdGroup } from '@auxx/ui/components/kbd'
-import {
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
-import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
-import { ChartColumn, Plus, Settings, Tags } from 'lucide-react'
-import { usePathname, useRouter } from 'next/navigation'
-import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useFeatureFlags } from '~/providers/feature-flag-provider'
-
-/** Ticket tab types for navigation */
-type TicketTab = 'list' | 'dashboard' | 'settings'
-
-/**
- * Header component with RadioTab navigation for tickets section
- * Uses URL query state directly for create dialog (no TicketProvider)
- */
-function TicketsLayoutHeader() {
-  const pathname = usePathname()
-  const router = useRouter()
-  const { hasAccess } = useFeatureFlags()
-  const dashboardsEnabled = hasAccess(FeatureKey.dashboards)
-
-  // Create dialog state via URL query param
-  const [, setCreateDialogOpen] = useQueryState('create', parseAsBoolean.withDefault(false))
-
-  /** Determine active tab from current pathname */
-  const getActiveTab = (): TicketTab => {
-    if (pathname.includes('/tickets/settings')) return 'settings'
-    if (pathname.includes('/tickets/dashboard')) return 'dashboard'
-    return 'list'
-  }
-
-  const activeTab = getActiveTab()
-
-  /** Handle tab navigation */
-  const handleTabChange = (tab: TicketTab) => {
-    switch (tab) {
-      case 'list':
-        router.push('/app/tickets')
-        break
-      case 'dashboard':
-        router.push('/app/tickets/dashboard')
-        break
-      case 'settings':
-        router.push('/app/tickets/settings')
-        break
-    }
-  }
-
-  return (
-    <MainPageHeader
-      className='justify-start'
-      action={
-        <div className='flex items-center gap-2'>
-          <RadioTab
-            value={activeTab}
-            onValueChange={handleTabChange}
-            size='sm'
-            radioGroupClassName='grid w-full'
-            className='border border-primary-200 flex flex-1 w-full'>
-            <RadioTabItem value='list' size='sm' tooltip='Tickets'>
-              <Tags />
-              <span className='hidden sm:inline'>Tickets</span>
-            </RadioTabItem>
-            {dashboardsEnabled && (
-              <RadioTabItem value='dashboard' size='sm' tooltip='Dashboard'>
-                <ChartColumn />
-                <span className='hidden sm:inline'>Dashboard</span>
-              </RadioTabItem>
-            )}
-            <RadioTabItem value='settings' size='sm' tooltip='Settings'>
-              <Settings />
-              <span className='hidden sm:inline'>Settings</span>
-            </RadioTabItem>
-          </RadioTab>
-          {activeTab === 'list' && (
-            <Button
-              variant='info'
-              size='sm'
-              className='px-2'
-              onClick={() => setCreateDialogOpen(true)}>
-              <Plus />
-              <span className='hidden sm:inline'>New Ticket</span>
-              <KbdGroup variant='default' size='sm'>
-                <Kbd>c</Kbd>
-                <Kbd>t</Kbd>
-              </KbdGroup>
-            </Button>
-          )}
-        </div>
-      }>
-      <MainPageBreadcrumb>
-        <MainPageBreadcrumbItem title='Support Tickets' href='/app/tickets' last />
-      </MainPageBreadcrumb>
-    </MainPageHeader>
-  )
-}
+import { Settings } from 'lucide-react'
+import { usePathname } from 'next/navigation'
+import { EntityRouteLayout } from '~/components/records'
 
 /**
  * Shared layout for tickets section with conditional rendering
- * - For tabbed pages (list, dashboard, settings): renders MainPage with RadioTab header
- * - For detail/create pages: renders children only (they have their own layout)
+ * - For tabbed pages (list, dashboard, settings): renders EntityRouteLayout with
+ *   List | Dashboard | Settings tabs
+ * - For detail/create/import pages: renders children only (they have their own layout)
  *
  * Note: TicketProvider has been removed - data is now managed by useRecordList
  */
@@ -123,7 +24,7 @@ export default function TicketsLayout({
   const pathname = usePathname()
 
   // Check if we're on a ticket detail page, create page, or import page
-  // These pages have their own MainPage wrapper or don't need the RadioTab header
+  // These pages have their own MainPage wrapper or don't need the tabbed header
   const isDetailOrSpecialPage =
     /\/tickets\/[^/]+$/.test(pathname) &&
     !pathname.endsWith('/tickets') &&
@@ -140,13 +41,16 @@ export default function TicketsLayout({
     )
   }
 
-  // For tabbed pages, render with shared header
-  // Note: MainPageContent is rendered by child pages to support docking
+  // For tabbed pages, render with the shared entity route shell
   return (
-    <MainPage>
-      <TicketsLayoutHeader />
+    <EntityRouteLayout
+      slug='tickets'
+      basePath='/app/tickets'
+      extraTabs={[
+        { value: 'settings', label: 'Settings', icon: <Settings />, href: '/app/tickets/settings' },
+      ]}>
       {children}
       {modal}
-    </MainPage>
+    </EntityRouteLayout>
   )
 }

--- a/apps/web/src/app/(protected)/app/tickets/page.tsx
+++ b/apps/web/src/app/(protected)/app/tickets/page.tsx
@@ -5,9 +5,9 @@
 import { RecordsView } from '~/components/records/records-view'
 
 /**
- * Tickets list page
- * Uses RecordsView in embedded mode (layout provides MainPage wrapper with RadioTab header)
+ * Tickets list page — the tickets `layout.tsx` (EntityRouteLayout) owns the
+ * MainPage shell; RecordsView renders its own MainPageContent + contributions.
  */
 export default function TicketsListPage() {
-  return <RecordsView slug='tickets' basePath='/app/tickets' embedded />
+  return <RecordsView slug='tickets' basePath='/app/tickets' />
 }

--- a/apps/web/src/app/(protected)/app/today/pending/page.tsx
+++ b/apps/web/src/app/(protected)/app/today/pending/page.tsx
@@ -23,7 +23,7 @@ export default function PendingSendsRoute() {
         <MainPageHeader>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Today' href='/app/today' />
-            <MainPageBreadcrumbItem title='Pending sends' last />
+            <MainPageBreadcrumbItem title='Pending sends' />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>

--- a/apps/web/src/app/(protected)/app/work-orders/layout.tsx
+++ b/apps/web/src/app/(protected)/app/work-orders/layout.tsx
@@ -1,0 +1,42 @@
+// apps/web/src/app/(protected)/app/work-orders/layout.tsx
+
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { usePathname } from 'next/navigation'
+import { useResource } from '~/components/resources'
+
+const BASE_PATH = '/app/work-orders'
+
+/**
+ * Work orders layout — plain breadcrumb shell (no tabs; work orders has no
+ * dashboard sub-route). `RecordsView` (mounted by `work-orders/page.tsx`)
+ * renders its own MainPageContent and contributes the Create button via
+ * `MainPageAction`. Detail (`[workOrderId]`) and import (`import/[jobId]`)
+ * routes own their own `MainPage` and bypass the shell entirely.
+ */
+export default function WorkOrdersLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const { resource } = useResource('work-orders')
+  const isDetailOrSpecialPage = pathname !== BASE_PATH
+
+  if (isDetailOrSpecialPage) {
+    return <>{children}</>
+  }
+
+  return (
+    <MainPage>
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem title={resource?.plural ?? 'Work Orders'} href={BASE_PATH} />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
+      {children}
+    </MainPage>
+  )
+}

--- a/apps/web/src/app/(protected)/app/workflows/[workflowId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/[workflowId]/page.tsx
@@ -10,7 +10,7 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import { MainPageTabs } from '@auxx/ui/components/main-page-tabs'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
 import { ChartColumn, History, MousePointerClick, Settings, Workflow } from 'lucide-react'
@@ -152,25 +152,16 @@ export default function EditWorkflowPage({ params }: EditWorkflowPageProps) {
           className='justify-start'
           action={
             <div className='flex items-center gap-2 shrink-0'>
-              <RadioTab
+              <MainPageTabs
+                items={[
+                  { value: 'editor', label: 'Editor', icon: <Workflow /> },
+                  { value: 'analytics', label: 'Analytics', icon: <ChartColumn /> },
+                  { value: 'executions', label: 'Executions', icon: <History /> },
+                ]}
                 value={mode}
-                onValueChange={setMode}
-                size='sm'
-                radioGroupClassName='grid w-full'
-                className='border border-primary-200 flex flex-1 w-full shrink-0'>
-                <RadioTabItem value='editor' size='sm'>
-                  <Workflow />
-                  <span className='hidden sm:inline'>Editor</span>
-                </RadioTabItem>
-                <RadioTabItem value='analytics' size='sm'>
-                  <ChartColumn />
-                  <span className='hidden sm:inline'>Analytics</span>
-                </RadioTabItem>
-                <RadioTabItem value='executions' size='sm'>
-                  <History />
-                  <span className='hidden sm:inline'>Executions</span>
-                </RadioTabItem>
-              </RadioTab>
+                onValueChange={(v) => setMode(v as 'editor' | 'analytics' | 'executions')}
+                className='flex-1 shrink-0'
+              />
               <Tooltip content='Edit Workflow Details'>
                 <Button
                   variant='ghost'
@@ -187,7 +178,6 @@ export default function EditWorkflowPage({ params }: EditWorkflowPageProps) {
             <MainPageBreadcrumbItem
               title={isLoading ? <Skeleton className='h-4 w-32' /> : workflow.name}
               href={`/app/workflows/${workflowId}`}
-              last
             />
           </MainPageBreadcrumb>
         </MainPageHeader>

--- a/apps/web/src/app/(protected)/app/workflows/[workflowId]/test/page.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/[workflowId]/test/page.tsx
@@ -14,13 +14,13 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
-import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Switch } from '@auxx/ui/components/switch'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { ArrowLeft, TestTube2 } from 'lucide-react'
 import Link from 'next/link'
 import { use, useState } from 'react'
+import { MainPageLoading, MainPageNotFound } from '~/components/global/main-page-states'
 import { useAnalytics } from '~/hooks/use-analytics'
 import { api } from '~/trpc/react'
 
@@ -114,16 +114,11 @@ export default function TestWorkflowPage({ params }: TestWorkflowPageProps) {
         <MainPageHeader>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Workflows' href='/app/workflows' />
-            <MainPageBreadcrumbItem title={<Skeleton className='h-4 w-32' />} />
-            <MainPageBreadcrumbItem title='Test' last />
+            <MainPageBreadcrumbItem title='Loading…' />
+            <MainPageBreadcrumbItem title='Test' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='p-6 space-y-4'>
-            <Skeleton className='h-8 w-64' />
-            <Skeleton className='h-64 w-full' />
-          </div>
-        </MainPageContent>
+        <MainPageLoading />
       </MainPage>
     )
   }
@@ -135,24 +130,21 @@ export default function TestWorkflowPage({ params }: TestWorkflowPageProps) {
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Workflows' href='/app/workflows' />
             <MainPageBreadcrumbItem title='Not Found' />
-            <MainPageBreadcrumbItem title='Test' last />
+            <MainPageBreadcrumbItem title='Test' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='p-6 text-center'>
-            <h1 className='text-2xl font-bold text-destructive mb-2'>Workflow Not Found</h1>
-            <p className='text-muted-foreground mb-4'>
-              The workflow you're trying to test doesn't exist or you don't have permission to test
-              it.
-            </p>
+        <MainPageNotFound
+          title='Workflow Not Found'
+          description="The workflow you're trying to test doesn't exist or you don't have permission to test it."
+          action={
             <Button asChild>
               <Link href='/app/workflows'>
                 <ArrowLeft className='h-4 w-4 mr-2' />
                 Back to Workflows
               </Link>
             </Button>
-          </div>
-        </MainPageContent>
+          }
+        />
       </MainPage>
     )
   }
@@ -173,7 +165,7 @@ export default function TestWorkflowPage({ params }: TestWorkflowPageProps) {
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Workflows' href='/app/workflows' />
           <MainPageBreadcrumbItem title={workflow.name} href={`/app/workflows/${workflowId}`} />
-          <MainPageBreadcrumbItem title='Test' last />
+          <MainPageBreadcrumbItem title='Test' />
         </MainPageBreadcrumb>
       </MainPageHeader>
 

--- a/apps/web/src/app/(protected)/app/workflows/page.tsx
+++ b/apps/web/src/app/(protected)/app/workflows/page.tsx
@@ -71,7 +71,7 @@ function WorkflowsPageContent() {
       <MainPageHeader
         action={activeTab === 'sequences' ? <CreateSequenceButton /> : <CreateWorkflowButton />}>
         <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title='Automation' href='/app/workflows' last />
+          <MainPageBreadcrumbItem title='Automation' href='/app/workflows' />
         </MainPageBreadcrumb>
       </MainPageHeader>
 

--- a/apps/web/src/app/admin/apps/[id]/page.tsx
+++ b/apps/web/src/app/admin/apps/[id]/page.tsx
@@ -20,7 +20,6 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Switch } from '@auxx/ui/components/switch'
 import {
   Table,
@@ -37,6 +36,7 @@ import { ArrowLeft, Ban, CheckCircle, ExternalLink, Trash2, XCircle } from 'luci
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { use, useState } from 'react'
+import { MainPageLoading, MainPageNotFound } from '~/components/global/main-page-states'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 
@@ -287,60 +287,10 @@ export default function AppDetailPage({ params }: { params: Promise<{ id: string
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Apps' href='/admin/apps' />
-            <MainPageBreadcrumbItem title='Loading...' href='#' last />
+            <MainPageBreadcrumbItem title='Loading...' href='#' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='flex-1 overflow-hidden flex flex-col min-h-0 relative'>
-            <div className='overflow-auto flex-1 relative'>
-              <div className='grid lg:grid-cols-4'>
-                {/* App Information skeleton */}
-                <div className='col-span-2 p-6 space-y-4'>
-                  <div>
-                    <Skeleton className='h-5 w-32 mb-1' />
-                    <Skeleton className='h-4 w-48' />
-                  </div>
-                  <div className='overflow-hidden rounded-md border'>
-                    {Array.from({ length: 12 }).map((_, i) => (
-                      <div key={i} className='flex border-b last:border-b-0'>
-                        <div className='bg-muted/50 w-40 p-2'>
-                          <Skeleton className='h-4 w-24' />
-                        </div>
-                        <div className='flex-1 p-2'>
-                          <Skeleton className='h-4 w-32' />
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-                {/* Deployments skeleton */}
-                <div className='col-span-2 p-6 space-y-4'>
-                  <div>
-                    <Skeleton className='h-5 w-28 mb-1' />
-                    <Skeleton className='h-4 w-44' />
-                  </div>
-                  <div className='overflow-hidden rounded-md border'>
-                    <div className='flex border-b bg-muted/50 p-2 gap-8'>
-                      <Skeleton className='h-4 w-20' />
-                      <Skeleton className='h-4 w-14' />
-                      <Skeleton className='h-4 w-16' />
-                    </div>
-                    {Array.from({ length: 3 }).map((_, i) => (
-                      <div key={i} className='flex items-center border-b last:border-b-0 p-2 gap-8'>
-                        <div className='space-y-1'>
-                          <Skeleton className='h-4 w-20' />
-                          <Skeleton className='h-3 w-28' />
-                        </div>
-                        <Skeleton className='h-5 w-16 rounded-full' />
-                        <Skeleton className='h-7 w-20 rounded-md' />
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </MainPageContent>
+        <MainPageLoading />
       </MainPage>
     )
   }
@@ -352,18 +302,19 @@ export default function AppDetailPage({ params }: { params: Promise<{ id: string
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Apps' href='/admin/apps' />
-            <MainPageBreadcrumbItem title='Not Found' href='#' last />
+            <MainPageBreadcrumbItem title='Not Found' href='#' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='flex flex-col items-center justify-center h-full py-12'>
-            <p className='text-muted-foreground'>App not found</p>
+        <MainPageNotFound
+          title='App not found'
+          description=''
+          action={
             <Button variant='outline' className='mt-4' onClick={() => router.push('/admin/apps')}>
               <ArrowLeft />
               Back to Apps
             </Button>
-          </div>
-        </MainPageContent>
+          }
+        />
       </MainPage>
     )
   }
@@ -446,7 +397,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ id: string
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Apps' href='/admin/apps' />
-            <MainPageBreadcrumbItem title={app.title} href={`/admin/apps/${id}`} last />
+            <MainPageBreadcrumbItem title={app.title} href={`/admin/apps/${id}`} />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>

--- a/apps/web/src/app/admin/apps/page.tsx
+++ b/apps/web/src/app/admin/apps/page.tsx
@@ -106,7 +106,7 @@ export default function AppsPage() {
         <MainPageHeader>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
-            <MainPageBreadcrumbItem title='Apps' href='/admin/apps' last />
+            <MainPageBreadcrumbItem title='Apps' href='/admin/apps' />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>

--- a/apps/web/src/app/admin/data-migrations/page.tsx
+++ b/apps/web/src/app/admin/data-migrations/page.tsx
@@ -81,7 +81,7 @@ export default function DataMigrationsPage() {
           }>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
-            <MainPageBreadcrumbItem title='Data Migrations' href='/admin/data-migrations' last />
+            <MainPageBreadcrumbItem title='Data Migrations' href='/admin/data-migrations' />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>

--- a/apps/web/src/app/admin/developer-accounts/page.tsx
+++ b/apps/web/src/app/admin/developer-accounts/page.tsx
@@ -4,7 +4,6 @@
 import { Button } from '@auxx/ui/components/button'
 import { Input } from '@auxx/ui/components/input'
 import {
-  type DockedPanelConfig,
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
@@ -24,9 +23,8 @@ import {
 import { formatDistanceToNow } from 'date-fns'
 import { ChevronLeft, ChevronRight, Search } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
-import { useMemo, useState } from 'react'
-import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
-import { useDockStore } from '~/stores/dock-store'
+import { useState } from 'react'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { api } from '~/trpc/react'
 import { DeveloperAccountDrawer } from './_components/developer-account-drawer'
 
@@ -42,12 +40,6 @@ export default function DeveloperAccountsPage() {
     'selectedAccountId',
     parseAsString.withDefault('')
   )
-
-  const isDocked = useEffectiveDockState()
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const minWidth = useDockStore((state) => state.minWidth)
-  const maxWidth = useDockStore((state) => state.maxWidth)
 
   const { data: accounts, isLoading } = api.admin.getDeveloperAccounts.useQuery({
     limit: PAGE_SIZE,
@@ -81,34 +73,18 @@ export default function DeveloperAccountsPage() {
     if (!open) setSelectedAccountId(null)
   }
 
-  /** Docked panels */
-  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
-    if (!isDocked || !isDrawerOpen) return []
-    return [
-      {
-        key: 'developer-account',
-        content: (
-          <DeveloperAccountDrawer
-            account={selectedAccount}
-            open={isDrawerOpen}
-            onOpenChange={handleDrawerOpenChange}
-          />
-        ),
-        width: dockedWidth,
-        onWidthChange: setDockedWidth,
-        minWidth,
-        maxWidth,
-      },
-    ]
-  }, [
-    isDocked,
-    isDrawerOpen,
-    selectedAccount,
-    handleDrawerOpenChange,
-    dockedWidth,
-    setDockedWidth,
-    minWidth,
-    maxWidth,
+  const { dockedPanels, overlays } = useDockedPanels([
+    {
+      key: 'developer-account',
+      open: isDrawerOpen,
+      content: (
+        <DeveloperAccountDrawer
+          account={selectedAccount}
+          open={isDrawerOpen}
+          onOpenChange={handleDrawerOpenChange}
+        />
+      ),
+    },
   ])
 
   return (
@@ -117,11 +93,7 @@ export default function DeveloperAccountsPage() {
         <MainPageHeader>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
-            <MainPageBreadcrumbItem
-              title='Developer Accounts'
-              href='/admin/developer-accounts'
-              last
-            />
+            <MainPageBreadcrumbItem title='Developer Accounts' href='/admin/developer-accounts' />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent dockedPanels={dockedPanels}>
@@ -243,14 +215,7 @@ export default function DeveloperAccountsPage() {
         </MainPageContent>
       </MainPage>
 
-      {/* Drawer - overlay mode only (docked mode handled by dockedPanel above) */}
-      {!isDocked && (
-        <DeveloperAccountDrawer
-          account={selectedAccount}
-          open={isDrawerOpen}
-          onOpenChange={handleDrawerOpenChange}
-        />
-      )}
+      {overlays}
     </>
   )
 }

--- a/apps/web/src/app/admin/organizations/[id]/page.tsx
+++ b/apps/web/src/app/admin/organizations/[id]/page.tsx
@@ -28,7 +28,6 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { Separator } from '@auxx/ui/components/separator'
-import { Skeleton } from '@auxx/ui/components/skeleton'
 import { type StatCardData, StatCards } from '@auxx/ui/components/stat-card'
 import { Table, TableBody, TableCell, TableRow } from '@auxx/ui/components/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
@@ -59,6 +58,7 @@ import {
 import { useParams, useRouter } from 'next/navigation'
 import { useQueryState } from 'nuqs'
 import { useState } from 'react'
+import { MainPageLoading, MainPageNotFound } from '~/components/global/main-page-states'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import { ActionHistoryPanel } from './_components/action-history-panel'
@@ -258,23 +258,10 @@ export default function OrganizationDetailsPage() {
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Organizations' href='/admin/organizations' />
-            <MainPageBreadcrumbItem title='Loading...' href='#' last />
+            <MainPageBreadcrumbItem title='Loading...' href='#' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='grid gap-4 md:grid-cols-2'>
-            <Card className='border-none rounded-none shadow-none'>
-              <CardHeader>
-                <Skeleton className='h-5 w-24' />
-              </CardHeader>
-              <CardContent className='space-y-4'>
-                <Skeleton className='h-4 w-full' />
-                <Skeleton className='h-4 w-full' />
-                <Skeleton className='h-4 w-3/4' />
-              </CardContent>
-            </Card>
-          </div>
-        </MainPageContent>
+        <MainPageLoading />
       </MainPage>
     )
   }
@@ -286,12 +273,13 @@ export default function OrganizationDetailsPage() {
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Organizations' href='/admin/organizations' />
-            <MainPageBreadcrumbItem title='Not Found' href='#' last />
+            <MainPageBreadcrumbItem title='Not Found' href='#' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='flex flex-col items-center justify-center h-full py-12'>
-            <p className='text-muted-foreground'>Organization not found</p>
+        <MainPageNotFound
+          title='Organization not found'
+          description=''
+          action={
             <Button
               variant='outline'
               className='mt-4'
@@ -299,8 +287,8 @@ export default function OrganizationDetailsPage() {
               <ArrowLeft />
               Back to Organizations
             </Button>
-          </div>
-        </MainPageContent>
+          }
+        />
       </MainPage>
     )
   }
@@ -455,7 +443,6 @@ export default function OrganizationDetailsPage() {
             <MainPageBreadcrumbItem
               title={org.name || org.handle || 'Organization'}
               href={`/admin/organizations/${id}`}
-              last
             />
           </MainPageBreadcrumb>
         </MainPageHeader>

--- a/apps/web/src/app/admin/organizations/page.tsx
+++ b/apps/web/src/app/admin/organizations/page.tsx
@@ -44,7 +44,7 @@ export default function OrganizationsPage() {
         }>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Admin' href='/admin' />
-          <MainPageBreadcrumbItem title='Organizations' href='/admin/organizations' last />
+          <MainPageBreadcrumbItem title='Organizations' href='/admin/organizations' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/app/admin/plans/[id]/page.tsx
+++ b/apps/web/src/app/admin/plans/[id]/page.tsx
@@ -14,13 +14,13 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { ArrowLeft } from 'lucide-react'
 import { useParams, useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { FeatureLimitsCard } from '~/app/admin/_components/features'
+import { MainPageLoading, MainPageNotFound } from '~/components/global/main-page-states'
 import { api } from '~/trpc/react'
 import { FeaturesListEditor } from '../_components/features-list-editor'
 import { PlanDetailsCard } from '../_components/plan-details-card'
@@ -43,16 +43,10 @@ export default function PlanEditPage() {
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Plans' href='/admin/plans' />
-            <MainPageBreadcrumbItem title='Loading...' href={`/admin/plans/${planId}`} last />
+            <MainPageBreadcrumbItem title='Loading...' href={`/admin/plans/${planId}`} />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='space-y-6 p-6'>
-            <Skeleton className='h-10 w-full' />
-            <Skeleton className='h-20 w-full' />
-            <Skeleton className='h-10 w-full' />
-          </div>
-        </MainPageContent>
+        <MainPageLoading />
       </MainPage>
     )
   }
@@ -64,18 +58,19 @@ export default function PlanEditPage() {
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Plans' href='/admin/plans' />
-            <MainPageBreadcrumbItem title='Not Found' href={`/admin/plans/${planId}`} last />
+            <MainPageBreadcrumbItem title='Not Found' href={`/admin/plans/${planId}`} />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='flex flex-col items-center justify-center py-12 gap-4'>
-            <p className='text-center text-muted-foreground'>Plan not found</p>
+        <MainPageNotFound
+          title='Plan not found'
+          description=''
+          action={
             <Button variant='outline' onClick={() => router.push('/admin/plans')}>
               <ArrowLeft />
               Back to Plans
             </Button>
-          </div>
-        </MainPageContent>
+          }
+        />
       </MainPage>
     )
   }
@@ -178,7 +173,7 @@ function PlanEditForm({ plan }: { plan: any }) {
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Admin' href='/admin' />
           <MainPageBreadcrumbItem title='Plans' href='/admin/plans' />
-          <MainPageBreadcrumbItem title={plan.name} href={`/admin/plans/${plan.id}`} last />
+          <MainPageBreadcrumbItem title={plan.name} href={`/admin/plans/${plan.id}`} />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/app/admin/plans/new/page.tsx
+++ b/apps/web/src/app/admin/plans/new/page.tsx
@@ -27,7 +27,7 @@ export default function NewPlanPage() {
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Admin' href='/admin' />
           <MainPageBreadcrumbItem title='Plans' href='/admin/plans' />
-          <MainPageBreadcrumbItem title='New Plan' href='/admin/plans/new' last />
+          <MainPageBreadcrumbItem title='New Plan' href='/admin/plans/new' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/app/admin/plans/page.tsx
+++ b/apps/web/src/app/admin/plans/page.tsx
@@ -222,7 +222,7 @@ export default function PlansPage() {
           }>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
-            <MainPageBreadcrumbItem title='Plans' href='/admin/plans' last />
+            <MainPageBreadcrumbItem title='Plans' href='/admin/plans' />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>

--- a/apps/web/src/app/admin/users/[id]/page.tsx
+++ b/apps/web/src/app/admin/users/[id]/page.tsx
@@ -14,7 +14,6 @@ import {
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
 import { Separator } from '@auxx/ui/components/separator'
-import { Skeleton } from '@auxx/ui/components/skeleton'
 import { type StatCardData, StatCards } from '@auxx/ui/components/stat-card'
 import {
   Table,
@@ -42,6 +41,7 @@ import {
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { use, useState } from 'react'
+import { MainPageLoading, MainPageNotFound } from '~/components/global/main-page-states'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 /**
@@ -195,87 +195,10 @@ export default function UserDetailPage({ params }: { params: Promise<{ id: strin
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Users' href='/admin/users' />
-            <MainPageBreadcrumbItem title='Loading...' href='#' last />
+            <MainPageBreadcrumbItem title='Loading...' href='#' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='flex flex-col overflow-y-auto bg-card flex-1'>
-            {/* Stat cards */}
-            <div className='grid grid-cols-3 sticky top-0 z-10'>
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div key={i} className='border-b border-r last:border-r-0 p-4'>
-                  <Skeleton className='h-4 w-20 mb-2' />
-                  <Skeleton className='h-7 w-12' />
-                </div>
-              ))}
-            </div>
-            {/* Two-column cards */}
-            <div className='grid md:grid-cols-2'>
-              {/* User Information skeleton */}
-              <div className='p-6 space-y-4'>
-                <div>
-                  <Skeleton className='h-5 w-36 mb-1' />
-                  <Skeleton className='h-4 w-64' />
-                </div>
-                <div className='overflow-hidden rounded-md border'>
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <div key={i} className='flex border-b last:border-b-0'>
-                      <div className='bg-muted/50 w-32 p-2'>
-                        <Skeleton className='h-4 w-16' />
-                      </div>
-                      <div className='flex-1 p-2'>
-                        <Skeleton className='h-4 w-32' />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              {/* Security & Settings skeleton */}
-              <div className='p-6 space-y-4'>
-                <div>
-                  <Skeleton className='h-5 w-40 mb-1' />
-                  <Skeleton className='h-4 w-56' />
-                </div>
-                <div className='overflow-hidden rounded-md border'>
-                  {Array.from({ length: 6 }).map((_, i) => (
-                    <div key={i} className='flex border-b last:border-b-0'>
-                      <div className='bg-muted/50 w-44 p-2'>
-                        <Skeleton className='h-4 w-24' />
-                      </div>
-                      <div className='flex-1 p-2'>
-                        <Skeleton className='h-4 w-16' />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-            <Separator />
-            {/* Organizations skeleton */}
-            <div className='p-6 space-y-4'>
-              <div>
-                <Skeleton className='h-5 w-32 mb-1' />
-                <Skeleton className='h-4 w-72' />
-              </div>
-              <div className='overflow-hidden rounded-md border'>
-                <div className='flex border-b bg-muted/50 p-2 gap-4'>
-                  <Skeleton className='h-4 w-16' />
-                  <Skeleton className='h-4 w-16' />
-                  <Skeleton className='h-4 w-12' />
-                  <Skeleton className='h-4 w-16' />
-                </div>
-                {Array.from({ length: 2 }).map((_, i) => (
-                  <div key={i} className='flex border-b last:border-b-0 p-2 gap-4'>
-                    <Skeleton className='h-4 w-24' />
-                    <Skeleton className='h-4 w-20' />
-                    <Skeleton className='h-5 w-14 rounded-full' />
-                    <Skeleton className='h-4 w-20' />
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        </MainPageContent>
+        <MainPageLoading />
       </MainPage>
     )
   }
@@ -287,18 +210,19 @@ export default function UserDetailPage({ params }: { params: Promise<{ id: strin
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Users' href='/admin/users' />
-            <MainPageBreadcrumbItem title='Not Found' href='#' last />
+            <MainPageBreadcrumbItem title='Not Found' href='#' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='flex flex-col gap-4 items-center justify-center h-full py-12'>
-            <p className='text-muted-foreground'>User not found</p>
+        <MainPageNotFound
+          title='User not found'
+          description=''
+          action={
             <Button variant='outline' onClick={() => router.push('/admin/users')}>
               <ArrowLeft />
               Back to Users
             </Button>
-          </div>
-        </MainPageContent>
+          }
+        />
       </MainPage>
     )
   }
@@ -343,7 +267,7 @@ export default function UserDetailPage({ params }: { params: Promise<{ id: strin
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Users' href='/admin/users' />
-            <MainPageBreadcrumbItem title={getDisplayName()} href={`/admin/users/${id}`} last />
+            <MainPageBreadcrumbItem title={getDisplayName()} href={`/admin/users/${id}`} />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>

--- a/apps/web/src/app/admin/users/page.tsx
+++ b/apps/web/src/app/admin/users/page.tsx
@@ -19,7 +19,7 @@ export default function UsersPage() {
       <MainPageHeader>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Admin' href='/admin' />
-          <MainPageBreadcrumbItem title='Users' href='/admin/users' last />
+          <MainPageBreadcrumbItem title='Users' href='/admin/users' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/app/admin/workflows/[id]/page.tsx
+++ b/apps/web/src/app/admin/workflows/[id]/page.tsx
@@ -20,12 +20,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@auxx/ui/components/select'
-import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Textarea } from '@auxx/ui/components/textarea'
 import { toastError } from '@auxx/ui/components/toast'
 import { ArrowLeft, Copy, Download, Save, ScanSearch, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { use, useEffect, useState } from 'react'
+import { MainPageLoading } from '~/components/global/main-page-states'
 import CodeEditor, { CodeLanguage } from '~/components/workflow/ui/code-editor'
 import { api } from '~/trpc/react'
 
@@ -566,16 +566,10 @@ export default function WorkflowTemplateEditorPage({
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Workflow Templates' href='/admin/workflows' />
-            <MainPageBreadcrumbItem title='Loading...' last />
+            <MainPageBreadcrumbItem title='Loading...' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent>
-          <div className='space-y-6 max-w-2xl'>
-            <Skeleton className='h-10 w-full' />
-            <Skeleton className='h-32 w-full' />
-            <Skeleton className='h-10 w-full' />
-          </div>
-        </MainPageContent>
+        <MainPageLoading />
       </MainPage>
     )
   }
@@ -620,7 +614,7 @@ export default function WorkflowTemplateEditorPage({
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Admin' href='/admin' />
           <MainPageBreadcrumbItem title='Workflow Templates' href='/admin/workflows' />
-          <MainPageBreadcrumbItem title={isNew ? 'New Template' : template?.name || 'Edit'} last />
+          <MainPageBreadcrumbItem title={isNew ? 'New Template' : template?.name || 'Edit'} />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/app/admin/workflows/page.tsx
+++ b/apps/web/src/app/admin/workflows/page.tsx
@@ -164,7 +164,7 @@ export default function WorkflowTemplatesPage() {
           }>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
-            <MainPageBreadcrumbItem title='Workflow Templates' href='/admin/workflows' last />
+            <MainPageBreadcrumbItem title='Workflow Templates' href='/admin/workflows' />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>

--- a/apps/web/src/components/agents/ui/detail/agent-breadcrumb-switcher.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-breadcrumb-switcher.tsx
@@ -14,8 +14,7 @@ export function AgentBreadcrumbSwitcher({ activeAgent }: AgentBreadcrumbSwitcher
   return (
     <MainPageBreadcrumbDropdown
       label={activeAgent.name ?? 'Untitled agent'}
-      icon={<AgentAvatar agent={activeAgent} size={5} className='mr-1' />}
-      last>
+      icon={<AgentAvatar agent={activeAgent} size={5} className='mr-1' />}>
       <AgentSwitcherDropdownContent activeAgentId={activeAgent.id} />
     </MainPageBreadcrumbDropdown>
   )

--- a/apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
+++ b/apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
@@ -1,6 +1,9 @@
 // apps/web/src/components/agents/ui/detail/agent-detail-view.tsx
 'use client'
 
+import { Button } from '@auxx/ui/components/button'
+import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
+import { DrawerHeader } from '@auxx/ui/components/drawer'
 import {
   MainPage,
   MainPageBreadcrumb,
@@ -8,8 +11,9 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
+import { MessageSquare } from 'lucide-react'
 import { useState } from 'react'
-import { useMedia } from '~/hooks/use-media'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useDockStore } from '~/stores/dock-store'
 import type { AgentDetail } from '../../store/agent-store'
 import { AutosaveIndicator, type AutosaveState } from '../shared/autosave-indicator'
@@ -25,19 +29,60 @@ interface AgentDetailViewProps {
 }
 
 export function AgentDetailView({ agent }: AgentDetailViewProps) {
-  const isDesktop = useMedia('(min-width: 1024px)')
+  const [autosave, setAutosave] = useState<AutosaveState>({ kind: 'idle' })
+  // AgentDockedChat has no chrome of its own (unlike DockableDrawer-based panels
+  // elsewhere), so below the desktop breakpoint it needs an explicit trigger +
+  // drawer wrapper rather than branching on its own isDocked prop.
+  const [chatOverlayOpen, setChatOverlayOpen] = useState(false)
   const dockedWidth = useDockStore((state) => state.dockedWidth)
   const setDockedWidth = useDockStore((state) => state.setDockedWidth)
   const minWidth = useDockStore((state) => state.minWidth)
   const maxWidth = useDockStore((state) => state.maxWidth)
 
-  const [autosave, setAutosave] = useState<AutosaveState>({ kind: 'idle' })
+  const chatContent = <AgentDockedChat agentId={agent.id} />
+
+  const { dockedPanels, overlays, isDocked } = useDockedPanels([
+    {
+      key: 'agent-chat',
+      // Docked: always visible, matching the pre-hook behavior (no toggle).
+      // Overlay: only when the mobile trigger opens it.
+      open: { docked: true, overlay: chatOverlayOpen },
+      content: chatContent,
+      overlay: (
+        <DockableDrawer
+          open={chatOverlayOpen}
+          onOpenChange={setChatOverlayOpen}
+          isDocked={false}
+          width={dockedWidth}
+          onWidthChange={setDockedWidth}
+          minWidth={minWidth}
+          maxWidth={maxWidth}
+          title='Agent chat'>
+          <DrawerHeader
+            icon={<MessageSquare className='size-4' />}
+            title='Agent chat'
+            onClose={() => setChatOverlayOpen(false)}
+          />
+          {chatContent}
+        </DockableDrawer>
+      ),
+    },
+  ])
 
   return (
     <MainPage>
       <MainPageHeader
         action={
           <div className='flex items-center gap-2'>
+            {!isDocked && (
+              <Button
+                variant='ghost'
+                size='icon-sm'
+                aria-label='Open agent chat'
+                onClick={() => setChatOverlayOpen(true)}>
+                <MessageSquare />
+              </Button>
+            )}
             <AutosaveIndicator state={autosave} />
             {agent.setupCompletedAt != null ? (
               <AgentPublishCluster
@@ -59,27 +104,15 @@ export function AgentDetailView({ agent }: AgentDetailViewProps) {
         </MainPageBreadcrumb>
       </MainPageHeader>
 
-      <MainPageContent
-        dockedPanels={
-          isDesktop
-            ? [
-                {
-                  key: 'agent-chat',
-                  content: <AgentDockedChat agentId={agent.id} />,
-                  width: dockedWidth,
-                  onWidthChange: setDockedWidth,
-                  minWidth,
-                  maxWidth,
-                },
-              ]
-            : []
-        }>
+      <MainPageContent dockedPanels={dockedPanels}>
         {agent.setupCompletedAt == null ? (
           <AgentSetupMode agent={agent} />
         ) : (
           <AgentDetailTabs agent={agent} onAutosaveChange={setAutosave} />
         )}
       </MainPageContent>
+
+      {overlays}
     </MainPage>
   )
 }

--- a/apps/web/src/components/agents/ui/list/agents-page-content.tsx
+++ b/apps/web/src/components/agents/ui/list/agents-page-content.tsx
@@ -21,7 +21,7 @@ export function AgentsPageContent() {
       <MainPageHeader action={<CreateAgentButton />}>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Kopilot' href='/app/kopilot/new' />
-          <MainPageBreadcrumbItem title='Agents' last />
+          <MainPageBreadcrumbItem title='Agents' />
         </MainPageBreadcrumb>
       </MainPageHeader>
 

--- a/apps/web/src/components/calls/ui/recording-detail.tsx
+++ b/apps/web/src/components/calls/ui/recording-detail.tsx
@@ -4,7 +4,6 @@
 import { type BotStatus, TERMINAL_STATUSES } from '@auxx/lib/recording/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
-import { DrawerHeader } from '@auxx/ui/components/drawer'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,7 +18,6 @@ import {
   MainPageContent,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
 import { toastError } from '@auxx/ui/components/toast'
 import {
@@ -40,11 +38,12 @@ import { useRouter } from 'next/navigation'
 import { useQueryState } from 'nuqs'
 import { useEffect, useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
+import { MainPageLoading } from '~/components/global/main-page-states'
 import { Tooltip } from '~/components/global/tooltip'
 import { getOrCreateStore, VideoPlayer } from '~/components/video-player'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useMedia } from '~/hooks/use-media'
-import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
 import { RecordingMeeting } from './recording-meeting'
 import { RecordingSpeakers } from './recording-speakers'
@@ -317,10 +316,20 @@ export function RecordingDetail({ recordingId }: { recordingId: string }) {
       setTab('transcript')
     }
   }, [isDesktop, tab, setTab])
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const minWidth = useDockStore((state) => state.minWidth)
-  const maxWidth = useDockStore((state) => state.maxWidth)
+
+  // Summary sidebar — docked-only, no overlay: the mobile Summary tab (above)
+  // already covers the narrow/undocked case.
+  const { dockedPanels } = useDockedPanels([
+    {
+      key: 'summary-sidebar',
+      open: { docked: true, overlay: false },
+      content: (
+        <div className='h-full overflow-y-auto'>
+          <RecordingSummary recordingId={recordingId} />
+        </div>
+      ),
+    },
+  ])
 
   const { data: realRecording, isLoading } = api.recording.getById.useQuery(
     { id: recordingId },
@@ -411,7 +420,7 @@ export function RecordingDetail({ recordingId }: { recordingId: string }) {
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Calls' href='/app/calls' />
             <MainPageBreadcrumbItem title='Recordings' href='/app/calls' />
-            <MainPageBreadcrumbItem title='Not Found' last />
+            <MainPageBreadcrumbItem title='Not Found' />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>
@@ -507,29 +516,11 @@ export function RecordingDetail({ recordingId }: { recordingId: string }) {
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Calls' href='/app/calls' />
           <MainPageBreadcrumbItem title='Recordings' href='/app/calls' />
-          <MainPageBreadcrumbItem title={breadcrumbTitle} last />
+          <MainPageBreadcrumbItem title={breadcrumbTitle} />
         </MainPageBreadcrumb>
       </MainPageHeader>
 
-      <MainPageContent
-        dockedPanels={
-          isDesktop
-            ? [
-                {
-                  key: 'summary-sidebar',
-                  content: (
-                    <div className='h-full overflow-y-auto'>
-                      <RecordingSummary recordingId={recordingId} />
-                    </div>
-                  ),
-                  width: dockedWidth,
-                  onWidthChange: setDockedWidth,
-                  minWidth,
-                  maxWidth,
-                },
-              ]
-            : []
-        }>
+      <MainPageContent dockedPanels={dockedPanels}>
         <ConfirmDialog />
 
         <div className='flex-1 h-full flex flex-col min-h-0'>
@@ -645,46 +636,21 @@ export function RecordingDetail({ recordingId }: { recordingId: string }) {
 }
 
 /**
- * RecordingDetailSkeleton — loading skeleton
+ * RecordingDetailSkeleton — loading state. This component owns its own
+ * `MainPage`/`MainPageHeader` shell (the route mounts `RecordingDetail`
+ * directly with no ancestor shell), so only the body swaps to `MainPageLoading`.
  */
 function RecordingDetailSkeleton() {
-  const isDesktop = useMedia('(min-width: 1024px)')
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-
   return (
     <MainPage>
       <MainPageHeader>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Calls' href='/app/calls' />
           <MainPageBreadcrumbItem title='Recordings' href='/app/calls' />
-          <MainPageBreadcrumbItem title='Loading...' last />
+          <MainPageBreadcrumbItem title='Loading...' />
         </MainPageBreadcrumb>
       </MainPageHeader>
-      <MainPageContent
-        dockedPanels={
-          isDesktop
-            ? [
-                {
-                  key: 'summary-sidebar',
-                  content: (
-                    <div className='p-4 space-y-4'>
-                      <Skeleton className='h-6 w-24' />
-                      <Skeleton className='h-20 w-full' />
-                      <Skeleton className='h-6 w-24' />
-                      <Skeleton className='h-20 w-full' />
-                    </div>
-                  ),
-                  width: dockedWidth,
-                },
-              ]
-            : []
-        }>
-        <div className='p-3 space-y-4'>
-          <Skeleton className='aspect-video w-full rounded-lg' />
-          <Skeleton className='h-10 w-full' />
-          <Skeleton className='h-64 w-full' />
-        </div>
-      </MainPageContent>
+      <MainPageLoading title='Loading recording...' />
     </MainPage>
   )
 }

--- a/apps/web/src/components/config/config-view.tsx
+++ b/apps/web/src/components/config/config-view.tsx
@@ -22,8 +22,7 @@ import {
 } from '@auxx/ui/components/select'
 import { Search, X } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
-import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
-import { useDockStore } from '~/stores/dock-store'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { api } from '~/trpc/react'
 import { ConfigDrawer } from './config-drawer'
 import { useConfigStore } from './store/config-store'
@@ -36,13 +35,6 @@ import { ConfigTable } from './ui/config-table'
 export function ConfigView() {
   const { data: groups, isLoading } = api.configVariable.getGrouped.useQuery()
   const { data: status } = api.configVariable.getStatus.useQuery()
-
-  /** Dock state */
-  const isDocked = useEffectiveDockState()
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const minWidth = useDockStore((state) => state.minWidth)
-  const maxWidth = useDockStore((state) => state.maxWidth)
 
   /** Filter state from store */
   const search = useConfigStore((state) => state.search)
@@ -69,16 +61,20 @@ export function ConfigView() {
 
   const isDbEnabled = status?.isDbEnabled ?? false
 
-  /** Docked panel content */
-  const dockedPanel =
-    isDocked && isDrawerOpen ? (
-      <ConfigDrawer
-        variableKey={selectedKey}
-        open={isDrawerOpen}
-        onOpenChange={handleDrawerOpenChange}
-        isDbEnabled={isDbEnabled}
-      />
-    ) : undefined
+  const { dockedPanels, overlays } = useDockedPanels([
+    {
+      key: 'config-detail',
+      open: isDrawerOpen,
+      content: (
+        <ConfigDrawer
+          variableKey={selectedKey}
+          open={isDrawerOpen}
+          onOpenChange={handleDrawerOpenChange}
+          isDbEnabled={isDbEnabled}
+        />
+      ),
+    },
+  ])
 
   return (
     <>
@@ -86,15 +82,10 @@ export function ConfigView() {
         <MainPageHeader>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
-            <MainPageBreadcrumbItem title='Config' last />
+            <MainPageBreadcrumbItem title='Config' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent
-          dockedPanel={dockedPanel}
-          dockedPanelWidth={dockedWidth}
-          onDockedPanelWidthChange={setDockedWidth}
-          dockedPanelMinWidth={minWidth}
-          dockedPanelMaxWidth={maxWidth}>
+        <MainPageContent dockedPanels={dockedPanels}>
           {/* Filters */}
           <MainPageSubheader>
             <Select
@@ -142,15 +133,7 @@ export function ConfigView() {
         </MainPageContent>
       </MainPage>
 
-      {/* Detail drawer - overlay mode only (docked mode handled by dockedPanel above) */}
-      {!isDocked && (
-        <ConfigDrawer
-          variableKey={selectedKey}
-          open={isDrawerOpen}
-          onOpenChange={handleDrawerOpenChange}
-          isDbEnabled={isDbEnabled}
-        />
-      )}
+      {overlays}
     </>
   )
 }

--- a/apps/web/src/components/dashboard/ui/dashboard-detail-view.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboard-detail-view.tsx
@@ -10,43 +10,41 @@
 // the server draft (`use-dashboard-autosave`); Publish/Discard drive versioning
 // (`use-dashboard-publish`) — the agent versioning model.
 //
-// Two `variant`s (plan 02):
-//   - 'standalone' (`/app/dashboards/[dashboardId]`) — owns the full `MainPage`
-//     shell: breadcrumb `MainPageHeader` with the action cluster (Edit/Add
-//     widget/Done + publish) as the header action. Unchanged from pre-plan-02.
-//   - 'embedded' (entity routes, via `EntityDashboardPage`) — no MainPage/
-//     breadcrumb (the entity route/layout owns that); the action cluster
-//     renders in a slim toolbar row above the tab strip instead, and this
-//     component renders `MainPageContent` (with `dockedPanels`) itself,
-//     satisfying the entity layout's "child page owns MainPageContent"
-//     contract (mirrors `RecordsView`'s `embedded` prop).
+// One render path (plan 03, MainPage slots migration): this component never
+// owns `MainPage`/`MainPageHeader` — the calling route does, either
+// `/app/dashboards/[dashboardId]/page.tsx` (standalone) or an entity route's
+// `EntityRouteLayout` (via `EntityDashboardPage`). It renders `MainPageContent`
+// (with `dockedPanels`) and contributes the action cluster (Edit/Add widget/
+// Done + publish) via `MainPageAction` and the breadcrumb tail (dashboard
+// switcher + private-lock indicator) via `MainPageCrumbs` — both portal into
+// whichever ancestor shell mounted them, so behavior is identical either way.
 //
-// All store wiring (draft-store seed, autosave, publish) is identical in both
-// variants — the store is keyed by dashboard id, so a tickets-route mount and a
+// All store wiring (draft-store seed, autosave, publish) is identical on every
+// route — the store is keyed by dashboard id, so a tickets-route mount and a
 // dashboards-route mount of the SAME dashboard behave identically.
 //
 // Deferred (plan 08): global filter bar, drill-down, chart refresh.
 
 import type { DashboardWithLayout, WidgetKind } from '@auxx/lib/dashboards/client'
 import type { RecordId } from '@auxx/types/resource'
+import { BreadcrumbItem } from '@auxx/ui/components/breadcrumb'
 import {
-  MainPage,
-  MainPageBreadcrumb,
+  MainPageAction,
   MainPageBreadcrumbDropdown,
-  MainPageBreadcrumbItem,
   MainPageContent,
-  MainPageHeader,
+  MainPageCrumbs,
 } from '@auxx/ui/components/main-page'
 import { Lock } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useQueryState } from 'nuqs'
-import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useFavoriteToggle } from '~/components/favorites/hooks/use-favorite-toggle'
 import { FavoriteStarButton } from '~/components/favorites/ui/favorite-star-button'
 import { CommandAction, CommandContext } from '~/components/kbar/contextual'
 import { useCommandPaletteStore } from '~/components/kbar/store'
 import { RecordDrawer } from '~/components/records/record-drawer'
 import { useConfirm } from '~/hooks/use-confirm'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useDockStore } from '~/stores/dock-store'
 import { useDashboardAutosave } from '../hooks/use-dashboard-autosave'
@@ -68,18 +66,15 @@ import { DashboardWidget } from './widget/dashboard-widget'
 
 export function DashboardDetailView({
   dashboard,
-  variant = 'standalone',
   startInEditMode = false,
 }: {
   dashboard: DashboardWithLayout
-  /** 'standalone' (default) = own MainPage shell; 'embedded' = entity-route mount (plan 02). */
-  variant?: 'standalone' | 'embedded'
   /**
-   * Embedded-only: drop straight into edit mode once this dashboard's draft has
-   * been seeded — the entity dashboard empty-state's "Create" CTA publishes an
-   * empty v1 then wants the user editing it immediately, not viewing it. Gated
-   * on the seed (not just mount) so it can't race `seed()`'s own `isEditMode`
-   * reset for a freshly-seeded dashboard id.
+   * Entity-dashboard-only: drop straight into edit mode once this dashboard's
+   * draft has been seeded — the entity dashboard empty-state's "Create" CTA
+   * publishes an empty v1 then wants the user editing it immediately, not
+   * viewing it. Gated on the seed (not just mount) so it can't race `seed()`'s
+   * own `isEditMode` reset for a freshly-seeded dashboard id.
    */
   startInEditMode?: boolean
 }) {
@@ -191,21 +186,20 @@ export function DashboardDetailView({
 
   // Docked slot hosts the config panel while editing, or the record drawer in
   // view mode — they never overlap (records aren't clickable in edit mode).
-  const dockedPanelEntry = (key: string, content: ReactNode) => ({
-    key,
-    content,
-    width: dockedWidth,
-    onWidthChange: setDockedWidth,
-    minWidth: dockMinWidth,
-    maxWidth: dockMaxWidth,
-  })
-  const dockedPanels = !isDocked
-    ? []
-    : isEditMode
-      ? [dockedPanelEntry('widget-config', configPanel)]
-      : openRecordId
-        ? [dockedPanelEntry('record-detail', recordDrawer)]
-        : []
+  // Overlay mode: config panel opens on select; record drawer uses the same
+  // condition in both modes (RecordDrawer picks docked vs overlay itself).
+  const { dockedPanels, overlays } = useDockedPanels([
+    {
+      key: 'widget-config',
+      open: { docked: isEditMode, overlay: !!configWidgetId },
+      content: configPanel,
+    },
+    {
+      key: 'record-detail',
+      open: !isEditMode && !!openRecordId,
+      content: recordDrawer,
+    },
+  ])
 
   const commandContext = (
     // Command-palette scope for the open dashboard. Edit-only actions mirror
@@ -290,8 +284,8 @@ export function DashboardDetailView({
     </CommandContext>
   )
 
-  // Edit/Add-widget/Done + publish cluster — the header action in 'standalone',
-  // a slim toolbar row above the tab strip in 'embedded' (plan 02).
+  // Edit/Add-widget/Done + publish cluster — contributed into the calling
+  // route's header action cluster via `MainPageAction`.
   const actionCluster = (
     <div className='flex flex-row items-center gap-2'>
       <FavoriteStarButton
@@ -384,60 +378,34 @@ export function DashboardDetailView({
     </div>
   )
 
-  const overlays = (
-    <>
-      {/* Overlay mode (undocked / mobile) — the DockableDrawer renders its own
-          right-side Vaul drawer; docked mode routes these through dockedPanels
-          above. Config panel while editing, record drawer in view mode. */}
-      {!isDocked && configPanel}
-      {!isDocked && recordDrawer}
-    </>
-  )
-
-  if (variant === 'embedded') {
-    return (
-      <>
-        {commandContext}
-        <ConfirmDialog />
-        <MainPageContent dockedPanels={dockedPanels}>
-          <div className='flex min-h-0 flex-1 flex-col gap-2'>
-            <div className='flex shrink-0 items-center justify-end'>{actionCluster}</div>
-            {tabStripAndGrid}
-          </div>
-        </MainPageContent>
-        {overlays}
-      </>
-    )
-  }
-
   return (
-    <MainPage>
+    <>
       {commandContext}
       <ConfirmDialog />
-      <MainPageHeader action={actionCluster}>
-        <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title='Dashboards' href='/app/dashboards' />
-          <MainPageBreadcrumbDropdown
-            label={<span className='max-w-[24ch] truncate'>{dashboard.name}</span>}
-            last
-            popover
-            contentClassName='w-64'>
-            <DashboardSwitcherList
-              activeDashboardId={dashboard.id}
-              onSelectDashboard={(id) => router.push(`/app/dashboards/${id}`)}
-              onActiveDashboardDeleted={() => router.push('/app/dashboards')}
-            />
-          </MainPageBreadcrumbDropdown>
-        </MainPageBreadcrumb>
+
+      <MainPageAction>{actionCluster}</MainPageAction>
+      <MainPageCrumbs>
+        <MainPageBreadcrumbDropdown
+          label={<span className='max-w-[24ch] truncate'>{dashboard.name}</span>}
+          popover
+          contentClassName='w-64'>
+          <DashboardSwitcherList
+            activeDashboardId={dashboard.id}
+            onSelectDashboard={(id) => router.push(`/app/dashboards/${id}`)}
+            onActiveDashboardDeleted={() => router.push('/app/dashboards')}
+          />
+        </MainPageBreadcrumbDropdown>
         {dashboard.visibility === 'private' && (
-          <Lock className='ml-2 size-3.5 text-muted-foreground' aria-label='Private dashboard' />
+          <BreadcrumbItem>
+            <Lock className='size-3.5 text-muted-foreground' aria-label='Private dashboard' />
+          </BreadcrumbItem>
         )}
-      </MainPageHeader>
+      </MainPageCrumbs>
 
       <MainPageContent dockedPanels={dockedPanels}>{tabStripAndGrid}</MainPageContent>
 
       {overlays}
-    </MainPage>
+    </>
   )
 }
 

--- a/apps/web/src/components/dashboard/ui/dashboards-list-view.tsx
+++ b/apps/web/src/components/dashboard/ui/dashboards-list-view.tsx
@@ -31,7 +31,7 @@ function DashboardsPageContent() {
     <MainPage>
       <MainPageHeader action={<CreateDashboardButton registerShortcut />}>
         <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title='Dashboards' href='/app/dashboards' last />
+          <MainPageBreadcrumbItem title='Dashboards' href='/app/dashboards' />
         </MainPageBreadcrumb>
       </MainPageHeader>
 
@@ -57,7 +57,7 @@ export function DashboardsListView() {
       <MainPage>
         <MainPageHeader>
           <MainPageBreadcrumb>
-            <MainPageBreadcrumbItem title='Dashboards' href='/app/dashboards' last />
+            <MainPageBreadcrumbItem title='Dashboards' href='/app/dashboards' />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>

--- a/apps/web/src/components/dashboard/ui/entity-dashboard-page.tsx
+++ b/apps/web/src/components/dashboard/ui/entity-dashboard-page.tsx
@@ -13,10 +13,10 @@ import { FeatureKey } from '@auxx/lib/permissions/client'
 import { Button } from '@auxx/ui/components/button'
 import { MainPageContent } from '@auxx/ui/components/main-page'
 import { toastError } from '@auxx/ui/components/toast'
-import { ChartColumn, Lock } from 'lucide-react'
+import { ChartColumn } from 'lucide-react'
 import { useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
-import { LoadingSpinner } from '~/components/global/loading-content'
+import { MainPageLoading, MainPageNoPermission } from '~/components/global/main-page-states'
 import { useResources } from '~/components/resources'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
@@ -51,30 +51,21 @@ export function EntityDashboardPage({ slug }: { slug: string }) {
 
   if (!hasAccess(FeatureKey.dashboards)) {
     return (
-      <MainPageContent>
-        <EmptyState
-          icon={Lock}
-          title='Dashboards not available'
-          description='Upgrade your plan to build dashboards.'
-          button={<div className='h-12' />}
-        />
-      </MainPageContent>
+      <MainPageNoPermission
+        title='Dashboards not available'
+        description='Upgrade your plan to build dashboards.'
+      />
     )
   }
 
   if (query.isLoading) {
-    return (
-      <MainPageContent>
-        <LoadingSpinner />
-      </MainPageContent>
-    )
+    return <MainPageLoading />
   }
 
   if (query.data) {
     return (
       <DashboardDetailView
         dashboard={query.data}
-        variant='embedded'
         startInEditMode={query.data.id === justCreatedId}
       />
     )

--- a/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
+++ b/apps/web/src/components/data-connectors/ui/connector-detail-view.tsx
@@ -30,8 +30,7 @@ import { AppIcon } from '~/components/apps/ui/app-icon'
 import { Tooltip } from '~/components/global/tooltip'
 import { useResources } from '~/components/resources/hooks/use-resources'
 import { useConfirm } from '~/hooks/use-confirm'
-import { useMedia } from '~/hooks/use-media'
-import { useDockStore } from '~/stores/dock-store'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { api } from '~/trpc/react'
 import { useConnectorMutations } from '../hooks/use-connector-mutations'
 import { useConnectorSyncRealtime } from '../hooks/use-connector-sync-realtime'
@@ -68,11 +67,6 @@ function iconIdForType(type: string): string {
  */
 export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
   const router = useRouter()
-  const isDesktop = useMedia('(min-width: 1024px)')
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const minWidth = useDockStore((state) => state.minWidth)
-  const maxWidth = useDockStore((state) => state.maxWidth)
 
   const [confirm, ConfirmDialog] = useConfirm()
   const [, setTab] = useQueryState('tab')
@@ -235,6 +229,16 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
     />
   )
 
+  // Runs panel — docked-only, no overlay: below the desktop breakpoint (or
+  // undocked) `ConnectorDetailTabs` renders it inline via `mobileRunsPanel`.
+  const { dockedPanels, isDocked } = useDockedPanels([
+    {
+      key: 'connector-runs',
+      open: { docked: true, overlay: false },
+      content: runsPanel,
+    },
+  ])
+
   return (
     <MainPage>
       <ConfirmDialog />
@@ -377,7 +381,6 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
             icon={
               <AppIcon iconId={iconIdForType(connector.type)} fallbackIconId='plug' size='xs' />
             }
-            last
           />
           <ConnectorStatusLine
             status={liveStatus}
@@ -389,24 +392,10 @@ export function ConnectorDetailView({ connector }: ConnectorDetailViewProps) {
         </MainPageBreadcrumb>
       </MainPageHeader>
 
-      <MainPageContent
-        dockedPanels={
-          isDesktop
-            ? [
-                {
-                  key: 'connector-runs',
-                  content: runsPanel,
-                  width: dockedWidth,
-                  onWidthChange: setDockedWidth,
-                  minWidth,
-                  maxWidth,
-                },
-              ]
-            : []
-        }>
+      <MainPageContent dockedPanels={dockedPanels}>
         <ConnectorDetailTabs
           connector={connector}
-          mobileRunsPanel={!isDesktop ? runsPanel : null}
+          mobileRunsPanel={!isDocked ? runsPanel : null}
           sampleReviewBanner={
             // Parked-sample review (trial-sync §5.2): after a sample run pauses the
             // connector, offer to look at the records, then sync everything (resume).

--- a/apps/web/src/components/data-import/import-page.tsx
+++ b/apps/web/src/components/data-import/import-page.tsx
@@ -184,7 +184,7 @@ export function ImportPage({
         }>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title={resourceLabel} href={basePath} />
-          <MainPageBreadcrumbItem title='Import' last />
+          <MainPageBreadcrumbItem title='Import' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/components/detail-view/detail-view-not-found.tsx
+++ b/apps/web/src/components/detail-view/detail-view-not-found.tsx
@@ -23,7 +23,7 @@ export function DetailViewNotFound({ label, backUrl }: DetailViewNotFoundProps) 
       <MainPageHeader>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title={label ?? 'Records'} href={backUrl} />
-          <MainPageBreadcrumbItem title='Not Found' last />
+          <MainPageBreadcrumbItem title='Not Found' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/components/detail-view/detail-view-skeleton.tsx
+++ b/apps/web/src/components/detail-view/detail-view-skeleton.tsx
@@ -23,7 +23,7 @@ export function DetailViewSkeleton({ label, backUrl }: DetailViewSkeletonProps) 
       <MainPageHeader>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title={label ?? 'Records'} href={backUrl} />
-          <MainPageBreadcrumbItem title='Loading...' last />
+          <MainPageBreadcrumbItem title='Loading...' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent

--- a/apps/web/src/components/detail-view/detail-view.tsx
+++ b/apps/web/src/components/detail-view/detail-view.tsx
@@ -135,7 +135,7 @@ export function DetailView({ apiSlug, instanceId, backUrl: backUrlOverride }: De
         }>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title={plural ?? label ?? 'Records'} href={backUrl} />
-          <MainPageBreadcrumbItem title={displayName} last />
+          <MainPageBreadcrumbItem title={displayName} />
         </MainPageBreadcrumb>
       </MainPageHeader>
 

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -6,7 +6,7 @@ import { weekStartToIndex } from '@auxx/lib/availability/client'
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { isRecordId } from '@auxx/lib/resources/client'
 import { CalendarDndProvider } from '@auxx/ui/components/event-calendar'
-import { type DockedPanelConfig, MainPageContent } from '@auxx/ui/components/main-page'
+import { MainPageContent } from '@auxx/ui/components/main-page'
 import type { DragEndEvent } from '@dnd-kit/core'
 import { addMinutes } from 'date-fns'
 import { Lock } from 'lucide-react'
@@ -16,11 +16,10 @@ import { renderAppDragGhost } from '~/components/global/app-drag-overlay'
 import { EmptyState } from '~/components/global/empty-state'
 import { RecordDrawer } from '~/components/records/record-drawer'
 import { toRecordId, useResource } from '~/components/resources'
-import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
-import { useDockStore } from '~/stores/dock-store'
 import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
 import { useRoutePlannerData } from '../route-planner/hooks/use-route-planner-data'
 import { PlannerDndProvider } from '../route-planner/planner-dnd-provider'
@@ -107,7 +106,7 @@ export function DispatchBoard() {
   const [activeVisitId, setActiveVisitId] = useState<string | null>(null)
 
   // Dockable event panel (plan 21) — a board-scoped push column, separate from the page-level
-  // `useDockStore`/`DockedPanelConfig` dock further below that drives the record drawer; this
+  // `useDockedPanels` dock further below that drives the record drawer; this
   // one only ever knows about the calendar's selected event. `isEventDockOpen` alone (not the
   // side) is all `BoardCalendarGrid` needs to suppress the floating popover.
   const isEventDockOpen = useDispatchSidebarStore((s) => s.eventDock.open)
@@ -160,37 +159,21 @@ export function DispatchBoard() {
     [setDrawerParams]
   )
 
-  // Dock-aware drawer placement (records-view.tsx's recipe): user's dock preference on →
-  // the drawer renders as a resizable `MainPageContent` docked panel; off (or mobile) →
-  // the overlay `RecordDrawer` at the bottom of this component.
-  const isDocked = useEffectiveDockState()
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const dockMinWidth = useDockStore((state) => state.minWidth)
-  const dockMaxWidth = useDockStore((state) => state.maxWidth)
-  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
-    if (!isDocked || !drawerRecordId) return []
-    return [
-      {
-        key: 'record-detail',
-        content: (
-          <RecordDrawer open onOpenChange={handleDrawerOpenChange} recordId={drawerRecordId} />
-        ),
-        width: dockedWidth,
-        onWidthChange: setDockedWidth,
-        minWidth: dockMinWidth,
-        maxWidth: dockMaxWidth,
-      },
-    ]
-  }, [
-    isDocked,
-    drawerRecordId,
-    handleDrawerOpenChange,
-    dockedWidth,
-    setDockedWidth,
-    dockMinWidth,
-    dockMaxWidth,
-  ])
+  // Dock-aware drawer placement: user's dock preference on → the drawer renders
+  // as a resizable `MainPageContent` docked panel; off (or mobile) → overlay.
+  const { dockedPanels, overlays } = useDockedPanels(
+    drawerRecordId
+      ? [
+          {
+            key: 'record-detail',
+            open: true,
+            content: (
+              <RecordDrawer open onOpenChange={handleDrawerOpenChange} recordId={drawerRecordId} />
+            ),
+          },
+        ]
+      : []
+  )
 
   const existingVisits: ExistingVisitForOverlap[] = useMemo(
     () =>
@@ -396,13 +379,7 @@ export function DispatchBoard() {
           </CalendarDndProvider>
         )}
       </div>
-      {!isDocked && (
-        <RecordDrawer
-          open={!!drawerRecordId}
-          onOpenChange={handleDrawerOpenChange}
-          recordId={drawerRecordId ?? undefined}
-        />
-      )}
+      {overlays}
     </MainPageContent>
   )
 }

--- a/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
@@ -15,6 +15,7 @@ import {
   useMemo,
   useRef,
 } from 'react'
+import { MainPageLoading } from '~/components/global/main-page-states'
 import { type RecordMeta, toRecordId, useRecordList, useResource } from '~/components/resources'
 import { useFieldValueSyncer } from '~/components/resources/hooks/use-field-value-syncer'
 import type {
@@ -291,12 +292,14 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
   }, [customFields, resource, createEntityFieldColumn, entityDefinitionId])
 
   if (isLoading) {
-    const loader = (
-      <div className='flex h-full items-center justify-center'>
-        <Loader size='sm' title='Loading records...' subtitle='Please wait' />
-      </div>
-    )
-    return embedded ? loader : <MainPageContent>{loader}</MainPageContent>
+    if (embedded) {
+      return (
+        <div className='flex h-full items-center justify-center'>
+          <Loader size='sm' title='Loading records...' subtitle='Please wait' />
+        </div>
+      )
+    }
+    return <MainPageLoading title='Loading records...' subtitle='Please wait' />
   }
 
   if (!resource || !entityDefinitionId) return null

--- a/apps/web/src/components/global/main-page-states.tsx
+++ b/apps/web/src/components/global/main-page-states.tsx
@@ -1,0 +1,92 @@
+// apps/web/src/components/global/main-page-states.tsx
+
+import Loader from '@auxx/ui/components/loader'
+import { MainPageContent } from '@auxx/ui/components/main-page'
+import { FileText, Lock } from 'lucide-react'
+import type React from 'react'
+import { EmptyState } from '~/components/global/empty-state'
+
+/** Props accepted by `MainPageContent` — re-derived since it isn't exported as a type. */
+type MainPageContentProps = React.ComponentProps<typeof MainPageContent>
+
+/**
+ * `MainPageContent` + a centered `Loader` — the loading body for a route
+ * that owns its `MainPage` shell (header/breadcrumbs stay static; only the
+ * content area shows the spinner). See `docs/ui-design-guide.md` and
+ * plans/ui/main-page-slots/01-slot-primitives.md.
+ */
+function MainPageLoading({
+  title = 'Loading...',
+  subtitle = 'Please wait',
+  className,
+  ...props
+}: {
+  title?: string
+  subtitle?: string
+} & Omit<MainPageContentProps, 'children'>) {
+  return (
+    <MainPageContent className={className} {...props}>
+      <Loader size='sm' title={title} subtitle={subtitle} />
+    </MainPageContent>
+  )
+}
+MainPageLoading.displayName = 'MainPageLoading'
+
+interface MainPageEmptyProps extends Omit<MainPageContentProps, 'children'> {
+  icon?: React.ElementType
+  title?: string
+  description?: React.ReactNode
+  /** Node rendered below the description (button, link, etc). */
+  action?: React.ReactNode
+  /** Full escape hatch — replaces the entire `EmptyState` body. */
+  children?: React.ReactNode
+}
+
+/**
+ * `MainPageContent` + a centered "not found" `EmptyState`. Every part is an
+ * overridable prop; pass `children` to replace the body entirely.
+ */
+function MainPageNotFound({
+  icon = FileText,
+  title = 'Not found',
+  description = "This page could not be found or you don't have access to it.",
+  action,
+  children,
+  className,
+  ...props
+}: MainPageEmptyProps) {
+  return (
+    <MainPageContent className={className} {...props}>
+      {children ?? (
+        <EmptyState icon={icon} title={title} description={description} button={action} />
+      )}
+    </MainPageContent>
+  )
+}
+MainPageNotFound.displayName = 'MainPageNotFound'
+
+/**
+ * `MainPageContent` + a centered "no permission" `EmptyState` (feature-gated
+ * routes). Every part is an overridable prop; pass `children` to replace the
+ * body entirely.
+ */
+function MainPageNoPermission({
+  icon = Lock,
+  title = 'Not available',
+  description = 'Upgrade your plan to use this feature.',
+  action,
+  children,
+  className,
+  ...props
+}: MainPageEmptyProps) {
+  return (
+    <MainPageContent className={className} {...props}>
+      {children ?? (
+        <EmptyState icon={icon} title={title} description={description} button={action} />
+      )}
+    </MainPageContent>
+  )
+}
+MainPageNoPermission.displayName = 'MainPageNoPermission'
+
+export { MainPageLoading, MainPageNotFound, MainPageNoPermission }

--- a/apps/web/src/components/health/health-view.tsx
+++ b/apps/web/src/components/health/health-view.tsx
@@ -14,8 +14,7 @@ import {
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { RefreshCw } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
-import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
-import { useDockStore } from '~/stores/dock-store'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { api } from '~/trpc/react'
 import { HealthDetailDrawer } from './health-detail-drawer'
 import { HealthServiceCard } from './ui/health-service-card'
@@ -37,13 +36,6 @@ export function HealthView() {
   )
   const isDrawerOpen = !!selectedIndicator
 
-  /** Dock state */
-  const isDocked = useEffectiveDockState()
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const minWidth = useDockStore((state) => state.minWidth)
-  const maxWidth = useDockStore((state) => state.maxWidth)
-
   /** Open detail drawer for an indicator */
   const handleCardClick = (id: HealthIndicatorId) => {
     setSelectedIndicator(id)
@@ -54,15 +46,19 @@ export function HealthView() {
     if (!open) setSelectedIndicator(null)
   }
 
-  /** Docked panel content */
-  const dockedPanel =
-    isDocked && isDrawerOpen ? (
-      <HealthDetailDrawer
-        indicatorId={selectedIndicator as HealthIndicatorId}
-        open={isDrawerOpen}
-        onOpenChange={handleDrawerOpenChange}
-      />
-    ) : undefined
+  const { dockedPanels, overlays } = useDockedPanels([
+    {
+      key: 'health-detail',
+      open: isDrawerOpen,
+      content: (
+        <HealthDetailDrawer
+          indicatorId={selectedIndicator as HealthIndicatorId}
+          open={isDrawerOpen}
+          onOpenChange={handleDrawerOpenChange}
+        />
+      ),
+    },
+  ])
 
   return (
     <>
@@ -70,15 +66,10 @@ export function HealthView() {
         <MainPageHeader>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
-            <MainPageBreadcrumbItem title='Health' last />
+            <MainPageBreadcrumbItem title='Health' />
           </MainPageBreadcrumb>
         </MainPageHeader>
-        <MainPageContent
-          dockedPanel={dockedPanel}
-          dockedPanelWidth={dockedWidth}
-          onDockedPanelWidthChange={setDockedWidth}
-          dockedPanelMinWidth={minWidth}
-          dockedPanelMaxWidth={maxWidth}>
+        <MainPageContent dockedPanels={dockedPanels}>
           <MainPageSubheader>
             <Button
               variant='outline'
@@ -112,14 +103,7 @@ export function HealthView() {
         </MainPageContent>
       </MainPage>
 
-      {/* Detail drawer - overlay mode only (docked mode handled by dockedPanel above) */}
-      {!isDocked && (
-        <HealthDetailDrawer
-          indicatorId={selectedIndicator as HealthIndicatorId}
-          open={isDrawerOpen}
-          onOpenChange={handleDrawerOpenChange}
-        />
-      )}
+      {overlays}
     </>
   )
 }

--- a/apps/web/src/components/kb/ui/dialogs/kb-empty-state.tsx
+++ b/apps/web/src/components/kb/ui/dialogs/kb-empty-state.tsx
@@ -35,7 +35,7 @@ export function KBEmptyState() {
     <MainPage>
       <MainPageHeader>
         <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title='Knowledge base' href='/app/kb' last />
+          <MainPageBreadcrumbItem title='Knowledge base' href='/app/kb' />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>

--- a/apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-frame.tsx
@@ -5,7 +5,7 @@ import { MainPage, MainPageContent } from '@auxx/ui/components/main-page'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import type React from 'react'
 import { useMemo } from 'react'
-import { LoadingSpinner } from '~/components/global/loading-content'
+import { MainPageLoading } from '~/components/global/main-page-states'
 import { KopilotContext } from '~/components/kopilot/context/kopilot-context'
 import { useKnowledgeBase } from '../../hooks/use-knowledge-base'
 import { ArticlesTabArrow } from '../preview/articles-tab-arrow'
@@ -46,7 +46,11 @@ export function KBEditorFrame({ knowledgeBaseId, children }: KBEditorFrameProps)
   }, [knowledgeBase, knowledgeBaseId, activePanel])
 
   if (isLoading || !knowledgeBase) {
-    return <LoadingSpinner />
+    return (
+      <MainPage>
+        <MainPageLoading />
+      </MainPage>
+    )
   }
 
   return (

--- a/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
+++ b/apps/web/src/components/kb/ui/editor/kb-editor-header.tsx
@@ -9,7 +9,7 @@ import {
   MainPageBreadcrumbItem,
   MainPageHeader,
 } from '@auxx/ui/components/main-page'
-import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import { MainPageTabs } from '@auxx/ui/components/main-page-tabs'
 import { Book, Cog, Layout, Sparkles } from 'lucide-react'
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useEffect, useMemo } from 'react'
@@ -39,7 +39,7 @@ function getInitials(name?: string): string {
 
 /**
  * Persistent KB editor header — breadcrumb [Knowledge Bases ▸ KB-name dropdown],
- * action [KBPublishCluster + RadioTab General/Layout/Articles]. Sits inside
+ * action [KBPublishCluster + MainPageTabs General/Layout/Articles]. Sits inside
  * `MainPage` in the editor route segment layout.
  *
  * The learned KB ("AI Memory") gets trimmed chrome: no settings tabs (the
@@ -86,7 +86,6 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
           <MainPageBreadcrumbItem
             title={merged.name ?? 'AI Memory'}
             icon={<Sparkles className='size-4 text-primary' />}
-            last
           />
         ) : (
           <MainPageBreadcrumbDropdown
@@ -98,29 +97,33 @@ export function KBEditorHeader({ knowledgeBaseId, knowledgeBase }: KBEditorHeade
                 </AvatarFallback>
               </Avatar>
             }
-            last
             contentClassName='w-72'>
             <KBSwitcherDropdownContent />
           </MainPageBreadcrumbDropdown>
         )}
       </MainPageBreadcrumb>
       {!isLearned && (
-        <RadioTab value={panel} onValueChange={(v) => setPanel(v as KBEditorPanel)} size='sm'>
-          <RadioTabItem value='general' tooltip='General'>
-            <Cog />
-            <span className='hidden sm:inline'>General</span>
-          </RadioTabItem>
-          {LAYOUT_TAB_ENABLED && (
-            <RadioTabItem value='layout' tooltip='Layout'>
-              <Layout />
-              <span className='hidden sm:inline'>Layout</span>
-            </RadioTabItem>
-          )}
-          <RadioTabItem value='articles' tooltip='Articles' data-kb-articles-tab=''>
-            <Book />
-            <span className='hidden sm:inline'>Articles</span>
-          </RadioTabItem>
-        </RadioTab>
+        <MainPageTabs
+          value={panel}
+          onValueChange={(v) => setPanel(v as KBEditorPanel)}
+          items={[
+            { value: 'general', label: 'General', icon: <Cog />, tooltip: 'General' },
+            {
+              value: 'layout',
+              label: 'Layout',
+              icon: <Layout />,
+              tooltip: 'Layout',
+              hidden: !LAYOUT_TAB_ENABLED,
+            },
+            {
+              value: 'articles',
+              label: 'Articles',
+              icon: <Book />,
+              tooltip: 'Articles',
+              'data-kb-articles-tab': '',
+            },
+          ]}
+        />
       )}
     </MainPageHeader>
   )

--- a/apps/web/src/components/kb/ui/landing/kb-landing-shell.tsx
+++ b/apps/web/src/components/kb/ui/landing/kb-landing-shell.tsx
@@ -83,7 +83,6 @@ export function KBLandingShell() {
           <MainPageBreadcrumbDropdown
             label='Open a knowledge base'
             icon={<Book className='size-3.5' />}
-            last
             contentClassName='w-72'>
             <KBSwitcherDropdownContent />
           </MainPageBreadcrumbDropdown>

--- a/apps/web/src/components/kb/ui/sources/source-workspace.tsx
+++ b/apps/web/src/components/kb/ui/sources/source-workspace.tsx
@@ -119,7 +119,7 @@ export function SourceWorkspace({ sourceId }: { sourceId: string }) {
             className='hidden sm:inline-flex'
           />
           <MainPageBreadcrumbItem title='Sources' href='/app/kb?t=sources' />
-          <MainPageBreadcrumbItem title={source?.name ?? 'Source'} last />
+          <MainPageBreadcrumbItem title={source?.name ?? 'Source'} />
         </MainPageBreadcrumb>
       </MainPageHeader>
 

--- a/apps/web/src/components/kopilot/ui/blocks/auxx-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/auxx-block.tsx
@@ -12,6 +12,8 @@ interface AuxxBlockProps {
   type: string
   /** Validated block data produced by the tool that emitted this block */
   data: unknown
+  /** Streaming JSON currently ends mid-string — the trailing id may be truncated */
+  lastValueTruncated?: boolean
   /** Skip entrance animation when this block has already been seen (session restore) */
   skipEntrance?: boolean
 }
@@ -21,7 +23,7 @@ interface AuxxBlockProps {
  * Zod schema registered in BLOCK_SCHEMAS; invalid data falls back to a raw JSON
  * preview so the user still sees *something* instead of a silent drop.
  */
-export function AuxxBlock({ type, data, skipEntrance }: AuxxBlockProps) {
+export function AuxxBlock({ type, data, lastValueTruncated, skipEntrance }: AuxxBlockProps) {
   const schema = BLOCK_SCHEMAS[type]
   const Renderer = getBlockRenderer(type)
 
@@ -42,7 +44,11 @@ export function AuxxBlock({ type, data, skipEntrance }: AuxxBlockProps) {
       initial={skipEntrance ? false : { opacity: 0, scale: 0.95, y: 4 }}
       animate={{ opacity: 1, scale: 1, y: 0 }}
       transition={{ type: 'spring', stiffness: 400, damping: 25 }}>
-      <Renderer data={validated} skipEntrance={skipEntrance} />
+      <Renderer
+        data={validated}
+        lastValueTruncated={lastValueTruncated}
+        skipEntrance={skipEntrance}
+      />
     </motion.div>
   )
 }

--- a/apps/web/src/components/kopilot/ui/blocks/block-registry.ts
+++ b/apps/web/src/components/kopilot/ui/blocks/block-registry.ts
@@ -4,8 +4,13 @@ import type React from 'react'
 
 export interface BlockRendererProps<T = unknown> {
   data: T
-  /** True when data is from a partial streaming parse */
-  isPartial?: boolean
+  /**
+   * True when `data` came from a partial streaming parse whose JSON currently
+   * ends inside an unterminated string — the last streamed string value is a
+   * truncated prefix. Blocks that fetch by id should withhold the trailing id
+   * while this is set (see `useStreamSafeIds`).
+   */
+  lastValueTruncated?: boolean
   /** True when this block was already shown — skip entrance animations */
   skipEntrance?: boolean
 }

--- a/apps/web/src/components/kopilot/ui/blocks/draft-list-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/draft-list-block.tsx
@@ -15,9 +15,14 @@ import { useCompose } from '~/hooks/use-compose'
 import { BlockCard } from './block-card'
 import type { BlockRendererProps } from './block-registry'
 import type { DraftListData, DraftSnapshotData } from './block-schemas'
+import { useStreamSafeIds } from './use-stream-safe-ids'
 
-export function DraftListBlock({ data, skipEntrance }: BlockRendererProps<DraftListData>) {
-  const draftIds = data.draftIds ?? []
+export function DraftListBlock({
+  data,
+  lastValueTruncated,
+  skipEntrance,
+}: BlockRendererProps<DraftListData>) {
+  const draftIds = useStreamSafeIds(data.draftIds ?? [], lastValueTruncated)
   const snapshot = data.snapshot
 
   return (

--- a/apps/web/src/components/kopilot/ui/blocks/entity-card-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/entity-card-block.tsx
@@ -5,15 +5,18 @@
 import type { BlockRendererProps } from './block-registry'
 import type { EntityCardData } from './block-schemas'
 import { EntityCardItem } from './entity-card-item'
+import { useStreamSafeIds } from './use-stream-safe-ids'
 
-export function EntityCardBlock({ data }: BlockRendererProps<EntityCardData>) {
+export function EntityCardBlock({ data, lastValueTruncated }: BlockRendererProps<EntityCardData>) {
   // During streaming the partial-JSON parser may emit `{}` before `recordId`
-  // arrives. Skip render until we have something useful — `AuxxBlock` stays
-  // mounted, so when the id lands the card just fades in.
-  if (!data.recordId) return null
+  // arrives, then a half-streamed id while its string is unterminated. Skip
+  // render until the id is complete — `AuxxBlock` stays mounted, so when the
+  // id lands the card just fades in.
+  const [recordId] = useStreamSafeIds(data.recordId ? [data.recordId] : [], lastValueTruncated)
+  if (!recordId) return null
   return (
     <div className='not-prose my-2'>
-      <EntityCardItem recordId={data.recordId} snapshot={data.snapshot} />
+      <EntityCardItem recordId={recordId} snapshot={data.snapshot} />
     </div>
   )
 }

--- a/apps/web/src/components/kopilot/ui/blocks/entity-list-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/entity-list-block.tsx
@@ -9,9 +9,14 @@ import { BlockCard } from './block-card'
 import type { BlockRendererProps } from './block-registry'
 import type { EntityListData } from './block-schemas'
 import { EntityCardItem } from './entity-card-item'
+import { useStreamSafeIds } from './use-stream-safe-ids'
 
-export function EntityListBlock({ data, skipEntrance }: BlockRendererProps<EntityListData>) {
-  const recordIds = data.recordIds ?? []
+export function EntityListBlock({
+  data,
+  lastValueTruncated,
+  skipEntrance,
+}: BlockRendererProps<EntityListData>) {
+  const recordIds = useStreamSafeIds(data.recordIds ?? [], lastValueTruncated)
   const snapshot = data.snapshot
   const firstId = recordIds[0]
   const entityDefId = firstId ? getDefinitionId(firstId) : null

--- a/apps/web/src/components/kopilot/ui/blocks/table-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/table-block.tsx
@@ -11,7 +11,7 @@ import { VisuallyHidden } from '@auxx/ui/components/visually-hidden'
 import { cn } from '@auxx/ui/lib/utils'
 import { format, formatDistanceToNow } from 'date-fns'
 import { Maximize2, Minimize2 } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import { ActorBadge } from '~/components/resources/ui/actor-badge'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
@@ -211,11 +211,25 @@ export function ExpandButton({
   )
 }
 
-export function TableBlock({ data }: BlockRendererProps<TableBlockData>) {
+export function TableBlock({ data, lastValueTruncated }: BlockRendererProps<TableBlockData>) {
   // Default to empty arrays so partial streaming data (or a partial-JSON parse
   // result without `columns`/`rows`) renders an empty table instead of crashing.
   const columns = data.columns ?? []
-  const rows = data.rows ?? []
+  const rawRows = data.rows ?? []
+  // While the streaming JSON ends mid-string, the trailing cell's recordId /
+  // actorId may be a half-streamed prefix — render that one cell as plain text
+  // so the badge components don't fetch a truncated id. The cell's text stays
+  // visible; the badge appears once the id completes.
+  const rows = useMemo(() => {
+    if (!lastValueTruncated || rawRows.length === 0) return rawRows
+    const lastRow = rawRows[rawRows.length - 1]!
+    const lastCell = lastRow[lastRow.length - 1]
+    if (!lastCell || (!lastCell.recordId && !lastCell.actorId)) return rawRows
+    return [
+      ...rawRows.slice(0, -1),
+      [...lastRow.slice(0, -1), { ...lastCell, recordId: undefined, actorId: undefined }],
+    ]
+  }, [rawRows, lastValueTruncated])
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (

--- a/apps/web/src/components/kopilot/ui/blocks/task-list-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/task-list-block.tsx
@@ -14,10 +14,15 @@ import { BlockCard } from './block-card'
 import type { BlockRendererProps } from './block-registry'
 import type { TaskListData } from './block-schemas'
 import { TaskItemSkeleton, TaskRowLoading, TaskRowUnavailable } from './task-item-skeleton'
+import { useStreamSafeIds } from './use-stream-safe-ids'
 
-export function TaskListBlock({ data, skipEntrance }: BlockRendererProps<TaskListData>) {
+export function TaskListBlock({
+  data,
+  lastValueTruncated,
+  skipEntrance,
+}: BlockRendererProps<TaskListData>) {
   const router = useRouter()
-  const taskIds = data.taskIds ?? []
+  const taskIds = useStreamSafeIds(data.taskIds ?? [], lastValueTruncated)
   const snapshot = data.snapshot
   const { tasksByKey, notFoundIds } = useTasksByIds({ taskIds, enabled: taskIds.length > 0 })
   const notFoundSet = useMemo(() => new Set(notFoundIds), [notFoundIds])

--- a/apps/web/src/components/kopilot/ui/blocks/thread-list-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/thread-list-block.tsx
@@ -12,9 +12,14 @@ import { useThread } from '~/components/threads/hooks/use-thread'
 import { BlockCard } from './block-card'
 import type { BlockRendererProps } from './block-registry'
 import type { ThreadListData, ThreadSnapshotData } from './block-schemas'
+import { useStreamSafeIds } from './use-stream-safe-ids'
 
-export function ThreadListBlock({ data, skipEntrance }: BlockRendererProps<ThreadListData>) {
-  const threadIds = data.threadIds ?? []
+export function ThreadListBlock({
+  data,
+  lastValueTruncated,
+  skipEntrance,
+}: BlockRendererProps<ThreadListData>) {
+  const threadIds = useStreamSafeIds(data.threadIds ?? [], lastValueTruncated)
   const snapshot = data.snapshot
 
   return (

--- a/apps/web/src/components/kopilot/ui/blocks/use-stream-safe-ids.ts
+++ b/apps/web/src/components/kopilot/ui/blocks/use-stream-safe-ids.ts
@@ -1,0 +1,26 @@
+// apps/web/src/components/kopilot/ui/blocks/use-stream-safe-ids.ts
+
+'use client'
+
+import { useRef } from 'react'
+
+/**
+ * Filters a streaming id list so the trailing element is withheld while the
+ * fence's JSON currently ends inside an unterminated string — the only state
+ * in which that element can be a half-streamed id. Every earlier element was
+ * followed by a delimiter, so it is provably complete and renders immediately.
+ *
+ * Ids are ratcheted: once an id has rendered during a frame where all strings
+ * were closed, it stays visible even when a later field's string (e.g. a
+ * snapshot displayName) is mid-stream and flips `lastValueTruncated` back on.
+ * Completeness is judged purely by JSON structure — id shape is never
+ * inspected, so alias / system-attribute prefixes are unaffected.
+ */
+export function useStreamSafeIds(ids: string[], lastValueTruncated: boolean | undefined): string[] {
+  const shownRef = useRef<Set<string>>(new Set())
+  const safe = lastValueTruncated
+    ? ids.filter((id, i) => i < ids.length - 1 || shownRef.current.has(id))
+    : ids
+  for (const id of safe) shownRef.current.add(id)
+  return safe
+}

--- a/apps/web/src/components/kopilot/ui/kopilot-page-shell.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-page-shell.tsx
@@ -90,7 +90,7 @@ export function KopilotPageShell({ sessionId }: KopilotPageShellProps) {
       <MainPage>
         <MainPageHeader>
           <MainPageBreadcrumb>
-            <MainPageBreadcrumbItem title='Chats' href='/app/kopilot/new' first last />
+            <MainPageBreadcrumbItem title='Chats' href='/app/kopilot/new' />
           </MainPageBreadcrumb>
         </MainPageHeader>
         <MainPageContent>
@@ -131,10 +131,9 @@ export function KopilotPageShell({ sessionId }: KopilotPageShellProps) {
           </Button>
         }>
         <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title='Chats' href='/app/kopilot/new' first />
+          <MainPageBreadcrumbItem title='Chats' href='/app/kopilot/new' />
           <MainPageBreadcrumbDropdown
             label={<span className='max-w-[24ch] truncate'>{breadcrumbLabel}</span>}
-            last
             popover
             contentClassName='w-64'>
             <KopilotSessionList

--- a/apps/web/src/components/kopilot/ui/messages/assistant-message.tsx
+++ b/apps/web/src/components/kopilot/ui/messages/assistant-message.tsx
@@ -61,6 +61,7 @@ function buildMarkdownComponents(
         return <AuxxBlock type={auxxType} data={{}} />
       }
       let data: unknown
+      let lastValueTruncated = false
       try {
         data = JSON.parse(raw)
       } catch {
@@ -68,6 +69,10 @@ function buildMarkdownComponents(
         // in row-by-row instead of raw JSON.
         try {
           data = partialJsonParse(raw)
+          // The stream currently ends inside an unterminated string, so the
+          // last parsed string value is a truncated prefix — blocks that fetch
+          // by id use this to withhold the trailing id until it completes.
+          lastValueTruncated = partialJsonParse.lastStringUnterminated === true
         } catch {
           return (
             <pre className='not-prose'>
@@ -76,7 +81,7 @@ function buildMarkdownComponents(
           )
         }
       }
-      return <AuxxBlock type={auxxType} data={data} />
+      return <AuxxBlock type={auxxType} data={data} lastValueTruncated={lastValueTruncated} />
     },
     // Unwrap the <pre> that react-markdown wraps around our custom block so the
     // motion.div / cards aren't nested inside a monospace <pre>.

--- a/apps/web/src/components/kopilot/utils/partial-json.ts
+++ b/apps/web/src/components/kopilot/utils/partial-json.ts
@@ -147,6 +147,7 @@ export function stripComments(text: string): string {
 }
 
 export function parse(s: string | undefined | null): any {
+  parse.lastStringUnterminated = false
   if (s === undefined) {
     return undefined
   }
@@ -177,6 +178,12 @@ export function parse(s: string | undefined | null): any {
 
 export namespace parse {
   export let lastParseReminding: string | undefined
+  /**
+   * True when the most recent parse() call hit an unterminated string literal —
+   * i.e. the input ends mid-string, so the last parsed string value is a
+   * truncated prefix of whatever is still streaming in.
+   */
+  export let lastStringUnterminated: boolean | undefined
   export const onExtraToken: (text: string, data: any, reminding: string) => void = (
     text,
     data,
@@ -292,6 +299,7 @@ function parseString(s: string): ParseResult<string> {
       return [JSON.parse(str), s]
     }
   }
+  parse.lastStringUnterminated = true
   return [JSON.parse(`${fixEscapedCharacters(s)}"`), '']
 }
 
@@ -314,6 +322,7 @@ function parseSingleQuoteString(s: string): ParseResult<string> {
       return [JSON.parse(`"${str.slice(1, -1)}"`), s]
     }
   }
+  parse.lastStringUnterminated = true
   return [JSON.parse(`"${fixEscapedCharacters(s.slice(1))}"`), '']
 }
 
@@ -342,6 +351,7 @@ function parseBacktickString(s: string): ParseResult<string> {
     }
     buffer.push(c)
   }
+  parse.lastStringUnterminated = true
   return [buffer.join(''), s.slice(1)]
 }
 

--- a/apps/web/src/components/records/entity-route-layout.tsx
+++ b/apps/web/src/components/records/entity-route-layout.tsx
@@ -1,0 +1,81 @@
+// apps/web/src/components/records/entity-route-layout.tsx
+
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import { getIcon } from '@auxx/ui/components/icons'
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { MainPageTabs, type MainPageTabsItem } from '@auxx/ui/components/main-page-tabs'
+import { ChartColumn } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useResources } from '~/components/resources'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+
+interface EntityRouteLayoutProps {
+  /** Resource slug (entityDefinitionId or apiSlug), resolved via `useResources()`. */
+  slug: string
+  /** Base path for the entity's list route — the List tab href + breadcrumb href. */
+  basePath: string
+  /** Extra tabs appended after List | Dashboard (e.g. tickets' Settings tab). */
+  extraTabs?: MainPageTabsItem[]
+  children: ReactNode
+}
+
+/**
+ * Shared route shell for entity list routes (tickets, companies, contacts,
+ * `custom/[slug]`) — owns `MainPage` + `MainPageHeader` with the entity
+ * breadcrumb and List | Dashboard (+ extra) tabs. The Dashboard tab is
+ * feature-gated on `FeatureKey.dashboards`.
+ *
+ * `children` (`RecordsView`, `EntityDashboardPage`, ...) render only their
+ * own `MainPageContent` and contribute header actions / breadcrumb tails via
+ * `MainPageAction` / `MainPageCrumbs` — they never own the shell.
+ *
+ * While the resource is still resolving, the breadcrumb shows a neutral
+ * title rather than mounting a second `MainPage` tree.
+ */
+export function EntityRouteLayout({
+  slug,
+  basePath,
+  extraTabs = [],
+  children,
+}: EntityRouteLayoutProps) {
+  const { getResourceById } = useResources()
+  const { hasAccess } = useFeatureFlags()
+  const resource = getResourceById(slug)
+  const ResourceIcon = resource ? getIcon(resource.icon)?.icon : undefined
+
+  const items: MainPageTabsItem[] = [
+    {
+      value: 'list',
+      label: resource?.plural ?? 'List',
+      icon: ResourceIcon ? <ResourceIcon /> : undefined,
+      href: basePath,
+    },
+    {
+      value: 'dashboard',
+      label: 'Dashboard',
+      icon: <ChartColumn />,
+      href: `${basePath}/dashboard`,
+      hidden: !hasAccess(FeatureKey.dashboards),
+    },
+    ...extraTabs,
+  ]
+
+  return (
+    <MainPage>
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem title={resource?.plural ?? '...'} href={basePath} />
+        </MainPageBreadcrumb>
+        <MainPageTabs items={items} />
+      </MainPageHeader>
+      {children}
+    </MainPage>
+  )
+}

--- a/apps/web/src/components/records/index.ts
+++ b/apps/web/src/components/records/index.ts
@@ -1,4 +1,5 @@
 // apps/web/src/components/records/index.ts
 
+export { EntityRouteLayout } from './entity-route-layout'
 export { RecordDrawer } from './record-drawer'
 export { type EntityRow, RecordsView } from './records-view'

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -12,23 +12,13 @@ import { toFieldId, toResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
 import { DropdownMenuItem, DropdownMenuSeparator } from '@auxx/ui/components/dropdown-menu'
 import { Kbd, KbdGroup } from '@auxx/ui/components/kbd'
-import Loader from '@auxx/ui/components/loader'
-import {
-  type DockedPanelConfig,
-  MainPage,
-  MainPageBreadcrumb,
-  MainPageBreadcrumbItem,
-  MainPageContent,
-  MainPageHeader,
-} from '@auxx/ui/components/main-page'
+import { MainPageAction } from '@auxx/ui/components/main-page'
 import { useQueryClient } from '@tanstack/react-query'
 import {
   Archive,
-  ChartColumn,
   Combine,
   Database,
   Expand,
-  FileText,
   Play,
   Plus,
   Send,
@@ -49,6 +39,7 @@ import { useTableViewRealtime } from '~/components/dynamic-table/hooks/use-table
 import { decodeColumnId } from '~/components/dynamic-table/utils/column-id'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
 import { EmptyState } from '~/components/global/empty-state'
+import { MainPageLoading, MainPageNotFound } from '~/components/global/main-page-states'
 import { getCreateHotkey } from '~/components/global-create/system-hotkeys'
 import { CommandAction, CommandContext } from '~/components/kbar/contextual'
 import { useCommandPaletteStore } from '~/components/kbar/store'
@@ -69,10 +60,9 @@ import { useRelationshipStore } from '~/components/resources/store/relationship-
 import { useResourceStore } from '~/components/resources/store/resource-store'
 import { AddToSequenceDialog } from '~/components/sequences/ui/add-to-sequence-dialog'
 import { MassWorkflowTriggerDialog } from '~/components/workflow/mass-workflow-trigger-dialog'
-import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useEntityInstanceOperations } from '~/hooks/use-entity-instance-operations'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
-import { useDockStore } from '~/stores/dock-store'
 import { RecordDrawer } from './record-drawer'
 import { searchConditionsToGroup, useRecordsSearchStore } from './records-search-store'
 import { RecordsSearchBar } from './records-searchbar'
@@ -93,41 +83,23 @@ interface RecordsViewProps {
   slug: string
   /** Base URL path for breadcrumbs and import links. Defaults to /app/custom/${slug} */
   basePath?: string
-  /** When true, RecordsView renders without its own MainPage wrapper (parent provides it) */
-  embedded?: boolean
-  /**
-   * When set, shows a feature-gated `ChartColumn` header button linking here —
-   * the entity's dashboard sub-route (plan 02). Opt-in per caller (not derived
-   * from `slug`/`basePath`) since not every entity with a `RecordsView` list
-   * page has a `dashboard/page.tsx` sibling yet.
-   */
-  dashboardHref?: string
 }
 
 /**
  * RecordsView component
  * Composes DynamicResourceView with the records-specific primary cell,
- * bulk-action set, paste/fill/AI cell selection config, and dialogs.
+ * bulk-action set, paste/fill/AI cell selection config, and dialogs. Renders
+ * only `MainPageContent` + contributions (`MainPageAction` for Create) — the
+ * calling route (`EntityRouteLayout`) owns `MainPage`/`MainPageHeader`.
  */
-export function RecordsView({ slug, basePath, embedded, dashboardHref }: RecordsViewProps) {
+export function RecordsView({ slug, basePath }: RecordsViewProps) {
   const resolvedBasePath = basePath ?? `/app/custom/${slug}`
   const router = useRouter()
   const { hasAccess } = useFeatureFlags()
   const sequencesEnabled = hasAccess(FeatureKey.sequences)
-  // Dashboard header button (plan 02) — one wiring for contacts/companies'
-  // dedicated routes and every custom entity's `/app/custom/[slug]/dashboard`;
-  // callers without a dashboard sub-route simply don't pass `dashboardHref`.
-  const showDashboardButton = !!dashboardHref && hasAccess(FeatureKey.dashboards)
 
   // Cross-client saved-view refresh (e.g. Kopilot create/update/set-default).
   useTableViewRealtime()
-
-  // Dock state
-  const isDocked = useEffectiveDockState()
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const minWidth = useDockStore((state) => state.minWidth)
-  const maxWidth = useDockStore((state) => state.maxWidth)
 
   // Resource is needed in this scope for header/breadcrumb labels and to
   // build the cellSelection config. DynamicResourceView resolves its own
@@ -721,85 +693,38 @@ export function RecordsView({ slug, basePath, embedded, dashboardHref }: Records
   // element stays referentially stable too.
   const emptyStateElement = useMemo(() => <EmptyStateComponent />, [EmptyStateComponent])
 
-  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
-    if (!isDocked || !isDrawerOpen || !selectedInstanceId || !entityDefinitionId) return []
-    return [
-      {
-        key: 'record-detail',
-        content: (
-          <RecordDrawer
-            open={isDrawerOpen}
-            onOpenChange={handleDrawerOpenChange}
-            recordId={toRecordId(entityDefinitionId, selectedInstanceId)}
-            onDeleteInstance={handleDrawerDelete}
-            onMutationSuccess={refresh}
-          />
-        ),
-        width: dockedWidth,
-        onWidthChange: setDockedWidth,
-        minWidth,
-        maxWidth,
-      },
-    ]
-  }, [
-    isDocked,
-    isDrawerOpen,
-    selectedInstanceId,
-    entityDefinitionId,
-    handleDrawerOpenChange,
-    handleDrawerDelete,
-    refresh,
-    dockedWidth,
-    setDockedWidth,
-    minWidth,
-    maxWidth,
+  const { dockedPanels, overlays } = useDockedPanels([
+    {
+      key: 'record-detail',
+      open: isDrawerOpen,
+      content: (
+        <RecordDrawer
+          open={isDrawerOpen}
+          onOpenChange={handleDrawerOpenChange}
+          recordId={
+            selectedInstanceId && entityDefinitionId
+              ? toRecordId(entityDefinitionId, selectedInstanceId)
+              : undefined
+          }
+          onDeleteInstance={handleDrawerDelete}
+          onMutationSuccess={refresh}
+        />
+      ),
+    },
   ])
 
   // Loading state
   if (isLoading) {
-    const loadingContent = (
-      <MainPageContent>
-        <div className='flex h-full items-center justify-center'>
-          <Loader size='sm' title='Loading records...' subtitle='Please wait' />
-        </div>
-      </MainPageContent>
-    )
-    if (embedded) return loadingContent
-    return (
-      <MainPage>
-        <MainPageHeader>
-          <MainPageBreadcrumb>
-            <MainPageBreadcrumbItem title='Loading...' href={resolvedBasePath} last />
-          </MainPageBreadcrumb>
-        </MainPageHeader>
-        {loadingContent}
-      </MainPage>
-    )
+    return <MainPageLoading title='Loading records...' />
   }
 
   // Error state
   if (!resource) {
-    const errorContent = (
-      <MainPageContent>
-        <div className='flex h-full items-center justify-center'>
-          <EmptyState
-            icon={FileText}
-            title='Entity not found'
-            description={`The entity "${slug}" could not be found or you don't have access to it.`}
-          />
-        </div>
-      </MainPageContent>
-    )
-    if (embedded) return errorContent
     return (
-      <MainPage>
-        <MainPageHeader>
-          <MainPageBreadcrumb>
-            <MainPageBreadcrumbItem title='Not Found' href={resolvedBasePath} last />
-          </MainPageBreadcrumb>
-        </MainPageHeader>
-        {errorContent}
-      </MainPage>
+      <MainPageNotFound
+        title='Entity not found'
+        description={`The entity "${slug}" could not be found or you don't have access to it.`}
+      />
     )
   }
 
@@ -924,45 +849,20 @@ export function RecordsView({ slug, basePath, embedded, dashboardHref }: Records
         </CommandContext>
       )}
 
-      {embedded ? (
-        mainContent
-      ) : (
-        <MainPage>
-          <MainPageHeader
-            action={
-              <div className='flex items-center gap-2'>
-                {showDashboardButton && (
-                  <Button
-                    size='icon-sm'
-                    variant='outline'
-                    className='rounded-lg'
-                    aria-label={`${resource.label} dashboard`}
-                    onClick={() => router.push(dashboardHref as string)}>
-                    <ChartColumn />
-                  </Button>
-                )}
-                <Button
-                  size='sm'
-                  className='h-7 rounded-lg'
-                  onClick={() => setIsCreateDialogOpen(true)}>
-                  <Plus className='size-4' />
-                  Create {resource.label}
-                  {createHotkey && (
-                    <KbdGroup variant='default' size='sm'>
-                      <Kbd>{createHotkey[0]}</Kbd>
-                      <Kbd>{createHotkey[1]}</Kbd>
-                    </KbdGroup>
-                  )}
-                </Button>
-              </div>
-            }>
-            <MainPageBreadcrumb>
-              <MainPageBreadcrumbItem title={resource.plural} href={resolvedBasePath} last />
-            </MainPageBreadcrumb>
-          </MainPageHeader>
-          {mainContent}
-        </MainPage>
-      )}
+      <MainPageAction>
+        <Button size='sm' className='h-7 rounded-lg' onClick={() => setIsCreateDialogOpen(true)}>
+          <Plus className='size-4' />
+          Create {resource.label}
+          {createHotkey && (
+            <KbdGroup variant='default' size='sm'>
+              <Kbd>{createHotkey[0]}</Kbd>
+              <Kbd>{createHotkey[1]}</Kbd>
+            </KbdGroup>
+          )}
+        </Button>
+      </MainPageAction>
+
+      {mainContent}
 
       {/* Create/Edit Dialog — resolves the custom editor per entity type (e.g. Parts). */}
       {entityDefinitionId && isCreateDialogOpen && (
@@ -1029,20 +929,7 @@ export function RecordsView({ slug, basePath, embedded, dashboardHref }: Records
       <ConfirmDeleteDialog />
       <ConfirmArchiveDialog />
 
-      {/* Record Drawer - only render overlay when NOT docked */}
-      {!isDocked && (
-        <RecordDrawer
-          open={isDrawerOpen}
-          onOpenChange={handleDrawerOpenChange}
-          recordId={
-            selectedInstanceId && entityDefinitionId
-              ? toRecordId(entityDefinitionId, selectedInstanceId)
-              : undefined
-          }
-          onDeleteInstance={handleDrawerDelete}
-          onMutationSuccess={refresh}
-        />
-      )}
+      {overlays}
     </>
   )
 }

--- a/apps/web/src/components/schedule/ui/schedule-page.tsx
+++ b/apps/web/src/components/schedule/ui/schedule-page.tsx
@@ -20,7 +20,6 @@ import {
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import {
-  type DockedPanelConfig,
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
@@ -38,12 +37,12 @@ import {
   List,
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import { useCalendarRange } from '~/components/calendar/core/use-calendar-range'
 import type { TaskEvent } from '~/components/calendar/sources/tasks-source'
 import { LoadingContent } from '~/components/global/loading-content'
 import { TaskDialog } from '~/components/tasks/ui/task-dialog'
-import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { useIsMobile } from '~/hooks/use-mobile'
 import { useDockStore } from '~/stores/dock-store'
 import { useMySchedule } from '../hooks/use-my-schedule'
@@ -69,7 +68,6 @@ export function SchedulePage() {
   const [openTask, setOpenTask] = useState<TaskEvent['task'] | null>(null)
   const router = useRouter()
   const isMobile = useIsMobile()
-  const isDocked = useEffectiveDockState()
   const dockedWidth = useDockStore((state) => state.dockedWidth)
   const setDockedWidth = useDockStore((state) => state.setDockedWidth)
 
@@ -120,23 +118,20 @@ export function SchedulePage() {
     if (!open) setOpenVisitId(null)
   }, [])
 
-  // Standard docked-panel wiring (`files/page.tsx` pattern): when docked, the drawer renders
-  // inside MainPageContent's panel frame; when not, it mounts below as the overlay drawer.
-  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
-    if (!isDocked || !openVisitId) return []
-    return [
-      {
-        key: 'visit-detail',
-        content: (
-          <VisitDrawer visitId={openVisitId} open onOpenChange={handleVisitDrawerOpenChange} />
-        ),
-        width: dockedWidth,
-        onWidthChange: setDockedWidth,
-        minWidth: 400,
-        maxWidth: 800,
-      },
-    ]
-  }, [isDocked, openVisitId, handleVisitDrawerOpenChange, dockedWidth, setDockedWidth])
+  const { dockedPanels, overlays } = useDockedPanels(
+    openVisitId
+      ? [
+          {
+            key: 'visit-detail',
+            open: true,
+            content: (
+              <VisitDrawer visitId={openVisitId} open onOpenChange={handleVisitDrawerOpenChange} />
+            ),
+            width: { value: dockedWidth, set: setDockedWidth, min: 400, max: 800 },
+          },
+        ]
+      : []
+  )
 
   // Today/prev/next is dual-mode: list view keeps the scroll-list handle calls, a calendar
   // view drives `cal.setDate` by the active view's date-fns unit.
@@ -210,7 +205,7 @@ export function SchedulePage() {
           </div>
         }>
         <MainPageBreadcrumb>
-          <MainPageBreadcrumbItem title='Schedule' href='/app/schedule' last />
+          <MainPageBreadcrumbItem title='Schedule' href='/app/schedule' />
         </MainPageBreadcrumb>
       </MainPageHeader>
 
@@ -249,13 +244,7 @@ export function SchedulePage() {
         }}
       />
 
-      {!isDocked && (
-        <VisitDrawer
-          visitId={openVisitId}
-          open={openVisitId !== null}
-          onOpenChange={handleVisitDrawerOpenChange}
-        />
-      )}
+      {overlays}
 
       <TaskDialog
         open={openTask !== null}

--- a/apps/web/src/components/schedule/ui/visit-detail-page.tsx
+++ b/apps/web/src/components/schedule/ui/visit-detail-page.tsx
@@ -30,7 +30,7 @@ export function VisitDetailPage({ visitId }: VisitDetailPageProps) {
       <MainPageHeader>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Schedule' href='/app/schedule' />
-          <MainPageBreadcrumbItem title={title} last />
+          <MainPageBreadcrumbItem title={title} />
         </MainPageBreadcrumb>
       </MainPageHeader>
 

--- a/apps/web/src/components/sequences/ui/detail/sequence-detail-view.tsx
+++ b/apps/web/src/components/sequences/ui/detail/sequence-detail-view.tsx
@@ -5,7 +5,6 @@ import { SEQUENCE_TRIGGER_LABELS, type SequenceTriggerType } from '@auxx/lib/seq
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import {
-  type DockedPanelConfig,
   MainPage,
   MainPageBreadcrumb,
   MainPageBreadcrumbItem,
@@ -17,12 +16,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/ta
 import { toastError } from '@auxx/ui/components/toast'
 import { Mails, Pause, Pencil, Play, Send, Settings, UsersRound } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { EmptyState } from '~/components/global/empty-state'
 import { LoadingSpinner } from '~/components/global/loading-content'
 import { Tooltip } from '~/components/global/tooltip'
-import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
-import { useDockStore } from '~/stores/dock-store'
+import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { api } from '~/trpc/react'
 import { SequenceRecipients } from './sequence-recipients'
 import { SequenceSettingsDrawer } from './sequence-settings-drawer'
@@ -41,7 +39,7 @@ function Shell({ title, children }: { title: string; children: React.ReactNode }
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Workflows' href='/app/workflows' />
           <MainPageBreadcrumbItem title='Sequences' href='/app/workflows?t=sequences' />
-          <MainPageBreadcrumbItem title={title} last />
+          <MainPageBreadcrumbItem title={title} />
         </MainPageBreadcrumb>
       </MainPageHeader>
       <MainPageContent>{children}</MainPageContent>
@@ -57,11 +55,6 @@ function Shell({ title, children }: { title: string; children: React.ReactNode }
 export function SequenceDetailView({ sequenceId }: SequenceDetailViewProps) {
   const [tab, setTab] = useQueryState('tab', { defaultValue: 'editor' })
   const [settingsOpen, setSettingsOpen] = useState(false)
-  const isDocked = useEffectiveDockState()
-  const dockedWidth = useDockStore((state) => state.dockedWidth)
-  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
-  const minWidth = useDockStore((state) => state.minWidth)
-  const maxWidth = useDockStore((state) => state.maxWidth)
   const utils = api.useUtils()
 
   const { data, isLoading } = api.sequence.get.useQuery({ id: sequenceId })
@@ -77,21 +70,24 @@ export function SequenceDetailView({ sequenceId }: SequenceDetailViewProps) {
       toastError({ title: 'Failed to update sequence', description: error.message }),
   })
 
-  const dockedPanels = useMemo<DockedPanelConfig[]>(() => {
-    const sequence = data?.sequence
-    if (!isDocked || !settingsOpen || !sequence) return []
-
-    return [
-      {
-        key: 'sequence-settings',
-        content: <SequenceSettingsDrawer sequence={sequence} open onOpenChange={setSettingsOpen} />,
-        width: dockedWidth,
-        onWidthChange: setDockedWidth,
-        minWidth,
-        maxWidth,
-      },
-    ]
-  }, [data?.sequence, isDocked, settingsOpen, dockedWidth, setDockedWidth, minWidth, maxWidth])
+  const sequenceForPanel = data?.sequence
+  const { dockedPanels, overlays } = useDockedPanels(
+    sequenceForPanel
+      ? [
+          {
+            key: 'sequence-settings',
+            open: settingsOpen,
+            content: (
+              <SequenceSettingsDrawer
+                sequence={sequenceForPanel}
+                open
+                onOpenChange={setSettingsOpen}
+              />
+            ),
+          },
+        ]
+      : []
+  )
 
   if (isLoading && !data) {
     return (
@@ -186,7 +182,7 @@ export function SequenceDetailView({ sequenceId }: SequenceDetailViewProps) {
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Workflows' href='/app/workflows' />
           <MainPageBreadcrumbItem title='Sequences' href='/app/workflows?t=sequences' />
-          <MainPageBreadcrumbItem title={sequence.name} last />
+          <MainPageBreadcrumbItem title={sequence.name} />
         </MainPageBreadcrumb>
       </MainPageHeader>
 
@@ -225,13 +221,7 @@ export function SequenceDetailView({ sequenceId }: SequenceDetailViewProps) {
         </div>
       </MainPageContent>
 
-      {!isDocked && settingsOpen && (
-        <SequenceSettingsDrawer
-          sequence={sequence}
-          open={settingsOpen}
-          onOpenChange={setSettingsOpen}
-        />
-      )}
+      {overlays}
     </MainPage>
   )
 }

--- a/apps/web/src/components/tasks/ui/tasks-page.tsx
+++ b/apps/web/src/components/tasks/ui/tasks-page.tsx
@@ -39,7 +39,7 @@ export function TasksPage() {
       <MainPageHeader action={<CreateTaskButton />}>
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem title='Tasks' href='/app/tasks' />
-          <MainPageBreadcrumbItem title='Overview' last />
+          <MainPageBreadcrumbItem title='Overview' />
         </MainPageBreadcrumb>
       </MainPageHeader>
 

--- a/apps/web/src/hooks/use-docked-panels.tsx
+++ b/apps/web/src/hooks/use-docked-panels.tsx
@@ -1,0 +1,114 @@
+// apps/web/src/hooks/use-docked-panels.tsx
+'use client'
+
+import type { DockedPanelConfig } from '@auxx/ui/components/main-page'
+import { Fragment, type ReactNode, useMemo } from 'react'
+import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
+import { useDockStore } from '~/stores/dock-store'
+
+/**
+ * Width override for a single docked panel. Omitting `set` makes the panel
+ * non-resizable (no drag handle wired up) — used for fixed-width panels like
+ * the kb editor frame.
+ */
+interface DockedPanelWidth {
+  value: number
+  set?: (width: number) => void
+  min?: number
+  max?: number
+}
+
+/**
+ * One panel entry for {@link useDockedPanels}.
+ */
+export interface DockedPanelInput {
+  /** Unique key for the panel — also drives `MainPageContent`'s enter/exit animation. */
+  key: string
+  /**
+   * Single flag, or split docked/overlay open conditions when they differ (e.g. a
+   * config panel that stays open for the whole edit session when docked, but only
+   * opens on-select when overlay).
+   */
+  open: boolean | { docked: boolean; overlay: boolean }
+  /**
+   * Rendered in the docked slot. `DockableDrawer`-based components branch on their
+   * own `isDocked` prop internally, so the same node usually serves both docked and
+   * overlay.
+   */
+  content: ReactNode
+  /** Optional distinct overlay node; defaults to `content`. */
+  overlay?: ReactNode
+  /** Which side of `MainPageContent` the panel docks to. */
+  side?: 'left' | 'right'
+  /** Width override; default is the global dock store (dockedWidth/setDockedWidth/minWidth/maxWidth). */
+  width?: DockedPanelWidth
+  /** Optional className for the panel wrapper (e.g. responsive hiding). */
+  className?: string
+}
+
+/** Return value of {@link useDockedPanels}. */
+interface UseDockedPanelsResult {
+  /** Right-docked panels — pass to `MainPageContent dockedPanels`. */
+  dockedPanels: DockedPanelConfig[]
+  /** Left-docked panels — pass to `MainPageContent leftPanels`. */
+  leftPanels: DockedPanelConfig[]
+  /** Fragment of open overlay nodes when `!isDocked`. Place after `</MainPageContent>`,
+   * same as the hand-rolled `{!isDocked && <Drawer/>}` blocks it replaces. */
+  overlays: ReactNode
+  /** Effective dock state — same value `useEffectiveDockState()` returns. */
+  isDocked: boolean
+}
+
+function isOpen(open: DockedPanelInput['open'], mode: 'docked' | 'overlay'): boolean {
+  return typeof open === 'boolean' ? open : open[mode]
+}
+
+/**
+ * Packages the docked-panel recipe hand-rolled at every call site: dock-store
+ * width wiring + `useEffectiveDockState` + building `DockedPanelConfig[]` + the
+ * overlay fallback for narrow screens / undocked mode.
+ *
+ * When docked, panels whose docked-open flag is true render into
+ * `dockedPanels`/`leftPanels` (split by `side`) with dock-store width wiring
+ * unless `width` overrides. When not docked, those arrays are empty and
+ * `overlays` renders `overlay ?? content` for each overlay-open panel.
+ */
+export function useDockedPanels(panels: DockedPanelInput[]): UseDockedPanelsResult {
+  const isDocked = useEffectiveDockState()
+  const dockedWidth = useDockStore((state) => state.dockedWidth)
+  const setDockedWidth = useDockStore((state) => state.setDockedWidth)
+  const minWidth = useDockStore((state) => state.minWidth)
+  const maxWidth = useDockStore((state) => state.maxWidth)
+
+  return useMemo(() => {
+    const dockedPanels: DockedPanelConfig[] = []
+    const leftPanels: DockedPanelConfig[] = []
+    const overlayNodes: ReactNode[] = []
+
+    for (const panel of panels) {
+      if (isDocked) {
+        if (!isOpen(panel.open, 'docked')) continue
+        const width = panel.width
+        const config: DockedPanelConfig = {
+          key: panel.key,
+          content: panel.content,
+          width: width?.value ?? dockedWidth,
+          onWidthChange: width ? width.set : setDockedWidth,
+          minWidth: width?.min ?? minWidth,
+          maxWidth: width?.max ?? maxWidth,
+          className: panel.className,
+        }
+        ;(panel.side === 'left' ? leftPanels : dockedPanels).push(config)
+      } else if (isOpen(panel.open, 'overlay')) {
+        overlayNodes.push(<Fragment key={panel.key}>{panel.overlay ?? panel.content}</Fragment>)
+      }
+    }
+
+    return {
+      dockedPanels,
+      leftPanels,
+      overlays: <>{overlayNodes}</>,
+      isDocked,
+    }
+  }, [panels, isDocked, dockedWidth, setDockedWidth, minWidth, maxWidth])
+}

--- a/packages/ui/src/components/main-page-tabs.tsx
+++ b/packages/ui/src/components/main-page-tabs.tsx
@@ -1,0 +1,126 @@
+// packages/ui/src/components/main-page-tabs.tsx
+
+'use client'
+
+import { RadioTab, RadioTabItem } from '@auxx/ui/components/radio-tab'
+import { cn } from '@auxx/ui/lib/utils'
+import { usePathname, useRouter } from 'next/navigation'
+import type * as React from 'react'
+
+/**
+ * A single `MainPageTabs` entry.
+ *
+ * Route mode: give every item an `href`; the active tab is derived from
+ * `usePathname()` (longest-prefix match, exact match always wins) and
+ * selecting a tab calls `router.push(item.href)`.
+ *
+ * Controlled mode: omit `href` and drive `value`/`onValueChange` on
+ * `MainPageTabs` instead (e.g. query-param-backed tabs).
+ */
+interface MainPageTabsItem {
+  /** Stable id — matched against the pathname (route mode) or `value` (controlled mode). */
+  value: string
+  label: React.ReactNode
+  icon?: React.ReactNode
+  /** Route to navigate to on select. Presence of `href` drives route mode. */
+  href?: string
+  tooltip?: string
+  /** Omit the tab without reshuffling call-site arrays (feature gating). */
+  hidden?: boolean
+  /** Extra data-* attributes forwarded to the underlying `RadioTabItem` (e.g. anchor lookups). */
+  [dataAttr: `data-${string}`]: string | undefined
+}
+
+interface MainPageTabsProps {
+  items: MainPageTabsItem[]
+  /** Controlled mode value. Omit (with items using `href`) for route mode. */
+  value?: string
+  /** Controlled mode change handler. Ignored in route mode. */
+  onValueChange?: (value: string) => void
+  size?: 'sm' | 'xs'
+  className?: string
+}
+
+/**
+ * Header tab switcher for `MainPageHeader`'s left cluster (rendered as a
+ * child, after the breadcrumb) — replaces the hand-rolled `RadioTab` +
+ * pathname-sniffing duplicated across `tickets/layout.tsx` and
+ * `dispatch/layout.tsx`.
+ *
+ * Renders each item as a `RadioTab size='sm'|'xs'` entry with an icon and a
+ * `hidden sm:inline` responsive label, with an optional per-item tooltip.
+ *
+ * @example
+ * ```tsx
+ * <MainPageTabs
+ *   items={[
+ *     { value: 'list', label: 'Tickets', icon: <Tags />, href: '/app/tickets' },
+ *     { value: 'dashboard', label: 'Dashboard', icon: <ChartColumn />, href: '/app/tickets/dashboard', hidden: !dashboardsEnabled },
+ *   ]}
+ * />
+ * ```
+ */
+function MainPageTabs({ items, value, onValueChange, size = 'sm', className }: MainPageTabsProps) {
+  const pathname = usePathname()
+  const router = useRouter()
+
+  const visible = items.filter((item) => !item.hidden)
+  if (visible.length === 0) return null
+
+  const isRouteMode = value === undefined
+  const activeValue = isRouteMode ? longestPrefixMatch(visible, pathname) : value
+
+  const handleValueChange = isRouteMode
+    ? (next: string) => {
+        const item = visible.find((i) => i.value === next)
+        if (item?.href) router.push(item.href)
+      }
+    : onValueChange
+
+  return (
+    <RadioTab
+      value={activeValue}
+      onValueChange={handleValueChange}
+      size={size}
+      radioGroupClassName='grid w-full'
+      className={cn('border border-primary-200 flex w-full', className)}>
+      {visible.map((item) => {
+        const { value: itemValue, label, icon, href, tooltip, hidden, ...dataProps } = item
+        return (
+          <RadioTabItem
+            key={itemValue}
+            value={itemValue}
+            size={size}
+            tooltip={tooltip}
+            {...dataProps}>
+            {icon}
+            <span className='hidden sm:inline'>{label}</span>
+          </RadioTabItem>
+        )
+      })}
+    </RadioTab>
+  )
+}
+MainPageTabs.displayName = 'MainPageTabs'
+
+/**
+ * Longest-prefix match of `pathname` against items' `href` (exact match
+ * always wins over a shorter prefix) — handles `/app/tickets` vs
+ * `/app/tickets/dashboard` vs `/app/tickets/settings` without a
+ * hand-written pathname switch per route module.
+ */
+function longestPrefixMatch(items: MainPageTabsItem[], pathname: string): string | undefined {
+  const exact = items.find((item) => item.href === pathname)
+  if (exact) return exact.value
+
+  let best: MainPageTabsItem | undefined
+  for (const item of items) {
+    if (!item.href) continue
+    if (pathname.startsWith(item.href) && (!best || item.href.length > (best.href?.length ?? 0))) {
+      best = item
+    }
+  }
+  return best?.value
+}
+
+export { MainPageTabs, type MainPageTabsItem, type MainPageTabsProps }

--- a/packages/ui/src/components/main-page.tsx
+++ b/packages/ui/src/components/main-page.tsx
@@ -20,24 +20,39 @@ import { ChevronDown } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import Link from 'next/link'
 import React from 'react'
+import { createPortal } from 'react-dom'
 import { PanelFrame } from './panel-frame'
 import { PanelResizeHandle } from './panel-resize-handle'
 
 /**
  * apps/web/src/components/ui/main-page.tsx
- * MainPageContext and MainPageProvider for managing main page state (e.g., loading).
+ * MainPageContext and MainPageProvider for managing main page state (e.g., loading,
+ * and the header's action/breadcrumb portal targets).
  */
 interface MainPageContextProps {
   /**
    * Loading state for the main page.
    */
   loading: boolean
+  /** Portal target for `<MainPageAction>` — the header's action cluster, once mounted. */
+  actionsEl: HTMLElement | null
+  /** Portal target for `<MainPageCrumbs>` — the breadcrumb `<ol>`, once mounted. */
+  crumbsEl: HTMLElement | null
+  /** Registers the action cluster element. Pass directly as a ref callback. */
+  setActionsEl: (el: HTMLElement | null) => void
+  /** Registers the breadcrumb list element. Pass directly as a ref callback. */
+  setCrumbsEl: (el: HTMLElement | null) => void
 }
 
 const MainPageContext = React.createContext<MainPageContextProps | undefined>(undefined)
 
+const noopSetEl = (_el: HTMLElement | null) => {}
+
 /**
- * MainPageProvider component to provide MainPageContext to children.
+ * MainPageProvider component to provide MainPageContext to children. Owns the
+ * portal-target elements for `<MainPageAction>`/`<MainPageCrumbs>` as plain
+ * `useState` pairs — no effects needed, the setters double as stable ref
+ * callbacks for `MainPageHeader`/`MainPageBreadcrumb` to register into.
  * @param loading - loading state for the main page
  * @param children - React children
  */
@@ -45,17 +60,42 @@ export const MainPageProvider: React.FC<{ loading: boolean; children: React.Reac
   loading,
   children,
 }) => {
-  return <MainPageContext.Provider value={{ loading }}>{children}</MainPageContext.Provider>
+  const [actionsEl, setActionsEl] = React.useState<HTMLElement | null>(null)
+  const [crumbsEl, setCrumbsEl] = React.useState<HTMLElement | null>(null)
+  return (
+    <MainPageContext.Provider value={{ loading, actionsEl, crumbsEl, setActionsEl, setCrumbsEl }}>
+      {children}
+    </MainPageContext.Provider>
+  )
 }
 
 /**
- * useMainPage hook to access MainPageContext.
+ * useMainPage hook to access MainPageContext. Throws outside a MainPage —
+ * use this when a component requires the shell (e.g. reading `loading`).
  * @returns MainPageContextProps
  */
 export function useMainPage(): MainPageContextProps {
   const context = React.useContext(MainPageContext)
   if (!context) {
     throw new Error('useMainPage must be used within a MainPageProvider')
+  }
+  return context
+}
+
+/**
+ * Soft variant of `useMainPage` for slot-contributing components
+ * (`MainPageAction`, `MainPageCrumbs`, and the header/breadcrumb slot
+ * targets themselves) that may render outside a `MainPage` shell (tests,
+ * storybook, a page mid-migration) — returns nulls/no-ops instead of
+ * throwing so those call sites don't crash.
+ */
+export function useMainPageSlots(): Pick<
+  MainPageContextProps,
+  'actionsEl' | 'crumbsEl' | 'setActionsEl' | 'setCrumbsEl'
+> {
+  const context = React.useContext(MainPageContext)
+  if (!context) {
+    return { actionsEl: null, crumbsEl: null, setActionsEl: noopSetEl, setCrumbsEl: noopSetEl }
   }
   return context
 }
@@ -107,6 +147,7 @@ function MainPageHeader({
 }) {
   const headerRef = React.useRef<HTMLDivElement>(null)
   const triggerWrapperRef = React.useRef<HTMLDivElement>(null)
+  const { setActionsEl } = useMainPageSlots()
 
   React.useEffect(() => {
     const el = headerRef.current
@@ -137,7 +178,9 @@ function MainPageHeader({
         {children && <div className='flex items-center gap-1.5'>{children}</div>}
         {title && <span className='text-base'>{title}</span>}
       </div>
-      {action && <div className='ml-4 shrink-0 space-x-2'>{action}</div>}
+      <div ref={setActionsEl} className='ml-4 flex shrink-0 items-center gap-2'>
+        {action}
+      </div>
     </div>
   )
 }
@@ -145,25 +188,83 @@ MainPageHeader.displayName = 'MainPageHeader'
 
 /**
  * apps/web/src/components/ui/main-page.tsx
- * MainPageBreadcrumbs component - wrapper for shadcn Breadcrumbs.
+ * MainPageAction — portals `children` into `MainPageHeader`'s action cluster
+ * (the same container the `action` prop renders into, at order 0). Lets a
+ * feature component nested under the route's `MainPageHeader` contribute
+ * header actions without owning the header itself. Renders nothing if no
+ * ancestor `MainPage` has mounted the header yet; unmounting removes the
+ * portal automatically — no cleanup code needed.
+ */
+function MainPageAction({
+  children,
+  order = 10,
+}: {
+  children: React.ReactNode
+  /** Flex `order` within the action cluster. Inline `action` prop content defaults to 0. */
+  order?: number
+}) {
+  const { actionsEl } = useMainPageSlots()
+  if (!actionsEl) return null
+  return createPortal(
+    <div style={{ order }} className='flex items-center gap-2'>
+      {children}
+    </div>,
+    actionsEl
+  )
+}
+MainPageAction.displayName = 'MainPageAction'
+
+/**
+ * apps/web/src/components/ui/main-page.tsx
+ * MainPageBreadcrumbs component - wrapper for shadcn Breadcrumbs. Registers
+ * its `<ol>` as the `<MainPageCrumbs>` portal target so a nested component
+ * can append breadcrumb tail items after the page's static crumbs.
+ *
+ * Separators are follower-owned: each `MainPageBreadcrumbItem` /
+ * `MainPageBreadcrumbDropdown` renders its own LEADING separator (tagged
+ * `data-crumb-sep`), and this list hides only the very first one via CSS —
+ * so a crumb never needs to know whether a dynamic tail follows it.
  */
 const MainPageBreadcrumb: React.FC<React.ComponentProps<typeof Breadcrumb>> = ({
   children,
   className,
   ...props
 }) => {
+  const { setCrumbsEl } = useMainPageSlots()
   // Wrapper for shadcn Breadcrumbs for main page usage
   return (
     <Breadcrumb {...props} className={cn('shrink-0', className)}>
-      <BreadcrumbList className='flex-nowrap gap-0.5 sm:gap-0.5'>{children}</BreadcrumbList>
+      <BreadcrumbList
+        ref={setCrumbsEl}
+        className={cn(
+          'flex-nowrap gap-0.5 sm:gap-0.5',
+          '[&>li:first-child[data-crumb-sep]]:hidden'
+        )}>
+        {children}
+      </BreadcrumbList>
     </Breadcrumb>
   )
 }
 
 /**
  * apps/web/src/components/ui/main-page.tsx
+ * MainPageCrumbs — portals `children` (ordinary `MainPageBreadcrumbItem` /
+ * `MainPageBreadcrumbDropdown` elements) into `MainPageBreadcrumb`'s list,
+ * appended in DOM order after the page's static crumbs. Renders nothing if
+ * no ancestor `MainPageBreadcrumb` has mounted yet.
+ */
+function MainPageCrumbs({ children }: { children: React.ReactNode }) {
+  const { crumbsEl } = useMainPageSlots()
+  if (!crumbsEl) return null
+  return createPortal(children, crumbsEl)
+}
+MainPageCrumbs.displayName = 'MainPageCrumbs'
+
+/**
+ * apps/web/src/components/ui/main-page.tsx
  * MainPageBreadcrumbItem component - wrapper for shadcn BreadcrumbItem.
- * Supports href, onClick, title props, and arrow display for all but the last item.
+ * Supports href, onClick, title props. Renders its own leading separator
+ * (see `MainPageBreadcrumb` above).
  */
 interface MainPageBreadcrumbItemProps {
   /**
@@ -179,14 +280,6 @@ interface MainPageBreadcrumbItemProps {
    */
   onClick?: React.MouseEventHandler<HTMLAnchorElement | HTMLSpanElement>
   /**
-   * If true, this is the first breadcrumb item.
-   */
-  first?: boolean
-  /**
-   * If true, this is the last breadcrumb item (no arrow shown).
-   */
-  last?: boolean
-  /**
    * Additional className for the item.
    */
   className?: string
@@ -197,15 +290,15 @@ const MainPageBreadcrumbItem: React.FC<MainPageBreadcrumbItemProps> = ({
   title,
   href,
   onClick,
-  first,
-  last,
   icon,
   className,
   ...props
 }) => {
-  // Show arrow unless this is the last item
+  // Leading separator — hidden by MainPageBreadcrumb's list when this item
+  // is first (see `[&>li:first-child[data-crumb-sep]]:hidden`).
   return (
     <>
+      <BreadcrumbSeparator data-crumb-sep />
       <BreadcrumbItem className={className} {...props}>
         {href ? (
           <BreadcrumbLink href={href} asChild>
@@ -240,15 +333,6 @@ const MainPageBreadcrumbItem: React.FC<MainPageBreadcrumbItemProps> = ({
           </BreadcrumbPage>
         )}
       </BreadcrumbItem>
-      {!last && (
-        <BreadcrumbSeparator />
-        // <span
-        //   role="presentation"
-        //   aria-hidden="true"
-        //   className={cn('[&>svg]:w-3.5 [&>svg]:h-3.5 shrink-0 ')}>
-        //   <ChevronRight />
-        // </span>
-      )}
     </>
   )
 }
@@ -266,8 +350,6 @@ interface MainPageBreadcrumbDropdownProps {
   icon?: React.ReactNode
   /** Dropdown body (rendered inside DropdownMenuContent or PopoverContent). */
   children: React.ReactNode
-  /** If true, no separator chevron is rendered after this item. */
-  last?: boolean
   /** Extra className merged onto the breadcrumb item. */
   className?: string
   /** Extra className merged onto the floating content. */
@@ -286,7 +368,6 @@ const MainPageBreadcrumbDropdown: React.FC<MainPageBreadcrumbDropdownProps> = ({
   label,
   icon,
   children,
-  last,
   className,
   contentClassName,
   align = 'start',
@@ -306,6 +387,7 @@ const MainPageBreadcrumbDropdown: React.FC<MainPageBreadcrumbDropdownProps> = ({
 
   return (
     <>
+      <BreadcrumbSeparator data-crumb-sep />
       <BreadcrumbItem className={className}>
         {popover ? (
           <Popover>
@@ -323,7 +405,6 @@ const MainPageBreadcrumbDropdown: React.FC<MainPageBreadcrumbDropdownProps> = ({
           </DropdownMenu>
         )}
       </BreadcrumbItem>
-      {!last && <BreadcrumbSeparator />}
     </>
   )
 }
@@ -356,51 +437,19 @@ interface MainPageContentProps extends React.ComponentProps<'div'> {
   leftPanels?: DockedPanelConfig[]
   /** Right-docked panels configuration - supports multiple panels side by side */
   dockedPanels?: DockedPanelConfig[]
-
-  /** @deprecated Use dockedPanels instead - Optional docked panel content rendered on the right */
-  dockedPanel?: React.ReactNode
-  /** @deprecated Use dockedPanels instead - Width of docked panel */
-  dockedPanelWidth?: number
-  /** Callback when docked panel width changes via resize (legacy API) */
-  onDockedPanelWidthChange?: (width: number) => void
-  /** Min width for docked panel resize (legacy API) */
-  dockedPanelMinWidth?: number
-  /** Max width for docked panel resize (legacy API) */
-  dockedPanelMaxWidth?: number
 }
 
 /**
  * MainPageContent component with optional docked panel support.
- * Supports both legacy single-panel and new multi-panel configurations.
  */
 function MainPageContent({
   className,
   children,
   leftPanels,
   dockedPanels,
-  // Legacy props
-  dockedPanel,
-  dockedPanelWidth = 450,
-  onDockedPanelWidthChange,
-  dockedPanelMinWidth = 350,
-  dockedPanelMaxWidth = 800,
   ...props
 }: MainPageContentProps) {
-  // Convert legacy props to new format
-  const rightPanels: DockedPanelConfig[] =
-    dockedPanels ??
-    (dockedPanel
-      ? [
-          {
-            key: 'default',
-            content: dockedPanel,
-            width: dockedPanelWidth,
-            onWidthChange: onDockedPanelWidthChange,
-            minWidth: dockedPanelMinWidth,
-            maxWidth: dockedPanelMaxWidth,
-          },
-        ]
-      : [])
+  const rightPanels: DockedPanelConfig[] = dockedPanels ?? []
   const left: DockedPanelConfig[] = leftPanels ?? []
 
   const [isResizing, setIsResizing] = React.useState(false)
@@ -498,9 +547,11 @@ MainPageSubheader.displayName = 'MainPageSubheader'
 export {
   MainPage,
   MainPageHeader,
+  MainPageAction,
   MainPageSubheader,
   MainPageContent,
   MainPageBreadcrumb,
+  MainPageCrumbs,
   MainPageBreadcrumbItem,
   MainPageBreadcrumbDropdown,
   type DockedPanelConfig,


### PR DESCRIPTION
Implements `plans/ui/main-page-slots/` (all 4 phases). Inverts page-shell ownership: **routes always own `MainPage` + `MainPageHeader`; feature components contribute into it via portal slots** — killing the `embedded`/`variant` render-tree forks and the hand-rolled header rows.

## Phase 01 — slot primitives (`@auxx/ui`)
- `<MainPageAction order?>` portals children into the header's right cluster; the existing `action` prop keeps working (order 0).
- `<MainPageCrumbs>` portals breadcrumb-tail nodes (items/dropdowns) after the route's static crumbs.
- Breadcrumb separators flipped to follower-owned (leading, first hidden via CSS) — a base crumb never needs to know whether a dynamic tail exists. `first`/`last` props deleted repo-wide (54 call sites).
- `MainPageTabs`: route mode (longest-prefix pathname matching) + controlled mode; per-item `hidden`, tooltip, `data-*` pass-through.
- `MainPageLoading` / `MainPageNotFound` / `MainPageNoPermission` state components (apps/web) — every part overridable.

## Phase 02 — `useDockedPanels`
One hook packaging the ~15×-copied dock recipe (`useEffectiveDockState` + dock-store widths + `DockedPanelConfig[]` + `{!isDocked && <Drawer/>}` overlays), with split `open: {docked, overlay}` flags and per-panel width overrides. First consumers: `sequence-detail-view` (mechanical) and `agent-detail-view` — which gains a mobile overlay + toggle button, fixing the chat vanishing below 1024px.

## Phase 03 — entity routes (the payoff)
- `EntityRouteLayout`: tickets / companies / contacts / custom/[slug] share one route-owned shell with **List | Dashboard tabs** (dashboard feature-gated; tickets adds Settings). Detail routes bypass the shell as before.
- Deletes: `variant='embedded'` + fake toolbar row from `dashboard-detail-view` (publish cluster/favorite now portal into the real header; dashboard switcher crumb now appears on entity routes too), `embedded` from `records-view` (Create button now contributed via `MainPageAction`, keeping hotkey + Kbd hints), `TicketsLayoutHeader` and its pathname-sniffed New Ticket button (`?create=true` was already handled inside RecordsView).
- Blast radius handled: parts / work-orders / invoices / quotes / service-requests got minimal breadcrumb-only layouts since RecordsView no longer renders its own shell.

## Phase 04 — sweep
- `MainPageTabs` adoptions: dispatch layout, workflow editor (controlled mode), kb-editor header (`data-kb-articles-tab` anchor preserved — note the strip now gets the unified bordered look).
- `useDockedPanels` adoptions: files, mail-box (3 stacked drawers), datasets, admin developer-accounts, recording-detail + connector-detail (raw `isDesktop` idiom → responsive), config/health views (off the deprecated singular `dockedPanel` prop, now deleted from `MainPageContent`), dispatch-board + schedule-page ("pattern to copy" comments deleted with the copies).
- Loading-shell dedup across agents/connectors/workflow-test/admin detail pages (net −167 lines).
- Intentionally NOT migrated: `detail-view.tsx` (768px breakpoint + deliberately ignores the global dock toggle), `dynamic-resource-view.embedded` (its real caller is KB `ArticlesView`, not records-view — the plan's claim was wrong).

## Drive-by fix
`kopilot/ui/blocks/use-stream-safe-ids.ts` is included — it was left untracked when #1198 merged, and five committed kopilot block files already import it (main currently fails to resolve the module without it).

## Verification
- Biome clean on all 93 changed files; `@auxx/ui` typecheck: zero new errors vs baseline.
- apps/web `tsc --noEmit`: zero new errors in touched files (A/B-verified per phase against the known pre-existing baseline from the packages/seed type graph).
- Browser verify pass still owed (per-plan Verify sections in `plans/ui/main-page-slots/`).