### PR TITLE
fix(ui): crossfade same-depth NavStack swaps via new 'replace' direction

### DIFF
--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -506,7 +506,9 @@ export function BaseEntityDrawer({
   // (e.g. clicking a different sidebar row without closing the drawer first)
   // — but NOT on initial mount, so a cold-load deep link (?record=…&peek=…)
   // survives. `peek.clear()` resets `tab`/`panel`/`item` too, so a new base
-  // record always lands on a fresh single-frame stack.
+  // record always lands on a fresh single-frame stack. Rendering doesn't wait
+  // for this effect: `useRecordPeekStack` already drops the stale frames at
+  // render time (one 'replace' update), this just syncs the URL params.
   const prevRecordIdRef = React.useRef(recordId)
   React.useEffect(() => {
     const prevRecordId = prevRecordIdRef.current

--- a/apps/web/src/components/records/record-drill-panels.tsx
+++ b/apps/web/src/components/records/record-drill-panels.tsx
@@ -203,6 +203,14 @@ export interface RecordPeekStack {
  * Push/pop/clear all write `peek` AND clear `tab`/`panel`/`item` in the SAME
  * `useQueryStates` batch — one history entry, no intermediate render with a
  * new top frame but a stale drill/tab from the frame it replaced.
+ *
+ * When the BASE record changes while mounted (clicking another row with the
+ * drawer open), the URL still carries the previous record's `peek` frames
+ * until the host's clearing effect lands a paint later — long enough for the
+ * frame NavStack to see the stack shrink and slide 'back' from a stale frame.
+ * Stale frames are dropped at RENDER time instead, so the whole stack
+ * re-bases in one update (a NavStack 'replace'); the ref initializes to the
+ * first base, so a cold-load deep link (?id=…&peek=…) still hydrates its stack.
  */
 export function useRecordPeekStack(baseRecordId: RecordId | null): RecordPeekStack {
   const [{ peek }, setState] = useQueryStates({
@@ -212,10 +220,19 @@ export function useRecordPeekStack(baseRecordId: RecordId | null): RecordPeekSta
     item: parseAsString,
   })
 
+  const prevBaseRef = React.useRef(baseRecordId)
+  const peekStaleRef = React.useRef(false)
+  if (prevBaseRef.current !== baseRecordId) {
+    if (prevBaseRef.current !== null && baseRecordId !== null) peekStaleRef.current = true
+    prevBaseRef.current = baseRecordId
+  }
+  if (!peek || peek.length === 0) peekStaleRef.current = false
+  const livePeek = peekStaleRef.current ? null : peek
+
   const frames = React.useMemo<RecordId[]>(() => {
     if (!baseRecordId) return []
-    return [baseRecordId, ...((peek ?? []) as RecordId[])]
-  }, [baseRecordId, peek])
+    return [baseRecordId, ...((livePeek ?? []) as RecordId[])]
+  }, [baseRecordId, livePeek])
 
   const depth = frames.length
   const top = frames[depth - 1] ?? null

--- a/packages/ui/src/components/nav-stack.tsx
+++ b/packages/ui/src/components/nav-stack.tsx
@@ -33,19 +33,29 @@ const DIM = 0.6
 //   opacity); exiting = back (parallaxes left, dims).
 // back (pop):     entering = back (slides from the left, dim → full); exiting =
 //   front (slides off to the right, stays full opacity).
+// replace:        no travel — quick crossfade in place. Used when the stack
+//   changes without one being a prefix of the other (e.g. the drawer's base
+//   record swaps under an unchanged depth): semantically a replace, not a
+//   navigation, so it must not read as a push/pop.
 
-type Direction = 'forward' | 'back'
+type Direction = 'forward' | 'back' | 'replace'
 
 const slideVariants = {
-  enter: (dir: Direction) => ({
-    x: dir === 'forward' ? '100%' : PARALLAX,
-    opacity: dir === 'forward' ? 1 : DIM,
-  }),
+  enter: (dir: Direction) =>
+    dir === 'replace'
+      ? { x: '0%', opacity: 0 }
+      : {
+          x: dir === 'forward' ? '100%' : PARALLAX,
+          opacity: dir === 'forward' ? 1 : DIM,
+        },
   center: { x: '0%', opacity: 1 },
-  exit: (dir: Direction) => ({
-    x: dir === 'forward' ? PARALLAX : '100%',
-    opacity: dir === 'forward' ? DIM : 1,
-  }),
+  exit: (dir: Direction) =>
+    dir === 'replace'
+      ? { x: '0%', opacity: 0 }
+      : {
+          x: dir === 'forward' ? PARALLAX : '100%',
+          opacity: dir === 'forward' ? DIM : 1,
+        },
 }
 
 /** Reduced-motion fallback: crossfade only, no horizontal travel (matches `dialog-nav`). */
@@ -57,9 +67,15 @@ const fadeVariants = {
 
 /** Shared-bar content: the iOS title/back-button cross-slide (small travel + fade). */
 const barVariants = {
-  enter: (dir: Direction) => ({ x: dir === 'forward' ? '30%' : '-30%', opacity: 0 }),
+  enter: (dir: Direction) =>
+    dir === 'replace'
+      ? { x: '0%', opacity: 0 }
+      : { x: dir === 'forward' ? '30%' : '-30%', opacity: 0 },
   center: { x: '0%', opacity: 1 },
-  exit: (dir: Direction) => ({ x: dir === 'forward' ? '-30%' : '30%', opacity: 0 }),
+  exit: (dir: Direction) =>
+    dir === 'replace'
+      ? { x: '0%', opacity: 0 }
+      : { x: dir === 'forward' ? '-30%' : '30%', opacity: 0 },
 }
 
 // ── Context ──────────────────────────────────────────────────────────────────
@@ -109,7 +125,9 @@ export interface NavStackProps {
  * iOS-style push/pop navigation stack. Holds a stack of string keys (top = last);
  * declare one `<NavStackPanel value="…">` per level and the stack selects which
  * is on top. Push slides the next screen in from the right while the current one
- * parallaxes left; pop reverses it. Content-agnostic — see `plans/ui/nav-stack.md`.
+ * parallaxes left; pop reverses it. A stack change where neither side extends
+ * the other (a same-depth key swap or full re-base) crossfades in place instead
+ * of sliding. Content-agnostic — see `plans/ui/nav-stack.md`.
  */
 export function NavStack({
   children,
@@ -140,7 +158,16 @@ export function NavStack({
   const dirRef = useRef<Direction>('forward')
   const prev = prevStackRef.current
   if (prev.length !== stack.length || prev.some((k, i) => k !== stack[i])) {
-    dirRef.current = stack.length < prev.length ? 'back' : 'forward'
+    // Push/pop only when one stack extends the other. Anything else — the top
+    // key swapped at the same depth, or the whole stack re-based — is a
+    // 'replace': the content swaps in place instead of sliding.
+    const isPrefixOf = (a: string[], b: string[]) => a.every((k, i) => k === b[i])
+    dirRef.current =
+      stack.length > prev.length && isPrefixOf(prev, stack)
+        ? 'forward'
+        : stack.length < prev.length && isPrefixOf(stack, prev)
+          ? 'back'
+          : 'replace'
     prevStackRef.current = stack
   }
 
@@ -241,7 +268,7 @@ export function NavStackPanels({ className }: NavStackPanelsProps) {
           initial='enter'
           animate='center'
           exit='exit'
-          transition={reduce ? { duration: 0.15 } : SPRING}
+          transition={reduce || direction === 'replace' ? { duration: 0.15 } : SPRING}
           style={{ zIndex: activeIndex }}
           className={cn(
             'relative w-full bg-background shadow-[-8px_0_24px_rgba(0,0,0,0.08)]',
@@ -283,7 +310,7 @@ export function NavStackBar({ className }: NavStackBarProps) {
           initial='enter'
           animate='center'
           exit='exit'
-          transition={reduce ? { duration: 0.15 } : SPRING}>
+          transition={reduce || direction === 'replace' ? { duration: 0.15 } : SPRING}>
           {active?.bar}
         </motion.div>
       </AnimatePresence>


### PR DESCRIPTION
## Problem

In records view, clicking row A then row B swapped the drawer's single NavStack frame key (`0:recA` → `0:recB`). NavStack treated **any** top-key change as a push and played the full forward slide + parallax — a navigation animation for what is semantically a replace.

Worse, clicking a different row while a **peeked** record was open played a phantom 'back' slide: the URL still carried the previous record's `peek` frames for one paint until the clearing effect landed, so the stack visibly shrank from a stale frame into the new record.

## Fix

**`nav-stack.tsx`** — new `'replace'` direction:
- Direction inference only calls it a push/pop when one stack is a prefix of the other (longer + extends previous = `forward`, shorter + prefix of previous = `back`). Anything else — same-depth key swap or full re-base — is `'replace'`.
- Replace variants have zero horizontal travel; `NavStackPanels` and `NavStackBar` use a 150ms crossfade for it (same feel as the reduced-motion fallback) instead of the spring.

**`record-drill-panels.tsx`** — `useRecordPeekStack` drops stale peek frames at **render time** when the base record changes while mounted, so the whole stack re-bases in one `'replace'` update; the host's clearing effect now just syncs the URL. The guard ref initializes to the first base, so cold-load deep links (`?id=…&peek=…`) still hydrate their full stack.

## Behavior

- Row A → row B: drawer content crossfades in place, no slide.
- Drilling into a related record (`useOpenRecord` → peek push) and backing out: unchanged slide/parallax.
- Truncate-to-visited (SR→QT→SR cycle): still a 'back' slide (shrunk stack is a prefix).
- Other NavStack consumers (drill panels, detail-view sections, evals, procedures, connectors) only make prefix-preserving changes and are unaffected; sibling-panel jumps at the same depth now crossfade, matching replace semantics.

## Verification

- Verified live in the browser: row switching replaces instantly, drill push/pop still animates.
- `tsc --noEmit` clean for the changed files in both `@auxx/ui` and `apps/web`; Biome clean.