### PR TITLE
refactor(money): centralize line builder values

### DIFF
--- a/apps/web/src/components/money/hooks/use-catalog-groups.ts
+++ b/apps/web/src/components/money/hooks/use-catalog-groups.ts
@@ -15,6 +15,7 @@ import type { RecordMeta } from '~/components/resources/store/record-store'
 
 /** Catalog group record shape from `useAllRecords` (systemAttribute-keyed field values). */
 export interface CatalogGroupRecord extends RecordMeta {
+  recordId: RecordId
   fieldValues: {
     catalog_group_name?: string
     catalog_group_description?: string | null
@@ -91,11 +92,13 @@ interface UseCatalogGroupsResult {
  * entity — plans/dispatch/money/09-product-groups.md) via the generic record
  * system. Same "small dataset, no pagination" shape as `useCatalogItems`.
  */
-export function useCatalogGroups(): UseCatalogGroupsResult {
+export function useCatalogGroups(options: { enabled?: boolean } = {}): UseCatalogGroupsResult {
+  const { enabled = true } = options
   const { records, entityDefinitionId, fields, isLoading, refresh, appendRecord, removeRecord } =
     useAllRecords<CatalogGroupRecord>({
       apiSlug: 'catalog-groups',
       includeArchived: false,
+      enabled,
     })
 
   const { groups, groupMap } = useMemo(() => {

--- a/apps/web/src/components/money/hooks/use-catalog-items.ts
+++ b/apps/web/src/components/money/hooks/use-catalog-items.ts
@@ -12,6 +12,7 @@ import type { RecordMeta } from '~/components/resources/store/record-store'
 
 /** Catalog item record shape from `useAllRecords` (systemAttribute-keyed field values). */
 export interface CatalogItemRecord extends RecordMeta {
+  recordId: RecordId
   fieldValues: {
     catalog_item_name?: string
     catalog_item_description?: string | null
@@ -98,11 +99,13 @@ interface UseCatalogItemsResult {
  * shape as `useInboxes`/`useTagHierarchy` — the catalog settings page is the
  * only consumer, so this lives under `money/hooks` rather than `resources`.
  */
-export function useCatalogItems(): UseCatalogItemsResult {
+export function useCatalogItems(options: { enabled?: boolean } = {}): UseCatalogItemsResult {
+  const { enabled = true } = options
   const { records, entityDefinitionId, fields, isLoading, refresh, appendRecord, removeRecord } =
     useAllRecords<CatalogItemRecord>({
       apiSlug: 'catalog-items',
       includeArchived: false,
+      enabled,
     })
 
   const { items, itemMap } = useMemo(() => {

--- a/apps/web/src/components/money/ui/line-builder/catalog-group-resolver.test.ts
+++ b/apps/web/src/components/money/ui/line-builder/catalog-group-resolver.test.ts
@@ -1,0 +1,105 @@
+// apps/web/src/components/money/ui/line-builder/catalog-group-resolver.test.ts
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import { describe, expect, it } from 'vitest'
+import type { CatalogGroup } from '../../hooks/use-catalog-groups'
+import type { CatalogItem } from '../../hooks/use-catalog-items'
+import { resolveCatalogGroup, resolvedCatalogGroupTotal } from './catalog-group-resolver'
+
+function catalogItem(overrides: Partial<CatalogItem> = {}): CatalogItem {
+  return {
+    id: 'item-1',
+    recordId: 'catalog-def:item-1' as RecordId,
+    name: 'Service visit',
+    description: 'Default description',
+    category: 'service',
+    defaultUnitPriceCents: 12500,
+    defaultUnit: 'hour',
+    taxable: true,
+    active: true,
+    partRecordId: null,
+    cost: null,
+    markup: null,
+    ...overrides,
+  }
+}
+
+function catalogGroup(overrides: Partial<CatalogGroup> = {}): CatalogGroup {
+  return {
+    id: 'group-1',
+    recordId: 'catalog-group-def:group-1' as RecordId,
+    name: 'Maintenance package',
+    description: null,
+    entries: [],
+    taxRateId: 'tax-standard',
+    discountType: 'percent',
+    discountValue: 10,
+    active: true,
+    ...overrides,
+  }
+}
+
+describe('resolveCatalogGroup', () => {
+  it('snapshots item values and applies entry overrides in source order', () => {
+    const second = catalogItem({
+      id: 'item-2',
+      recordId: 'catalog-def:item-2' as RecordId,
+      name: 'Replacement filter',
+      active: false,
+      defaultUnitPriceCents: 5000,
+      defaultUnit: 'each',
+    })
+    const itemMap = new Map([
+      ['item-1', catalogItem()],
+      ['item-2', second],
+    ])
+    const group = catalogGroup({
+      entries: [
+        {
+          id: 'entry-1',
+          catalogItemId: 'item-1',
+          qty: 2,
+          description: 'Group description',
+          taxable: false,
+        },
+        { id: 'entry-2', catalogItemId: 'item-2', qty: 1 },
+      ],
+    })
+
+    const resolved = resolveCatalogGroup(group, itemMap)
+
+    expect(resolved.lines).toHaveLength(2)
+    expect(resolved.lines[0]).toMatchObject({
+      name: 'Service visit',
+      description: 'Group description',
+      category: 'service',
+      taxable: false,
+      qty: 2,
+      unit: 'hour',
+      unitPriceCents: 12500,
+      catalogItemRecordId: 'catalog-def:item-1',
+    })
+    expect(resolved.lines[1]).toMatchObject({
+      name: 'Replacement filter',
+      description: 'Default description',
+      taxable: true,
+      qty: 1,
+    })
+    expect(resolvedCatalogGroupTotal(resolved)).toBe(30000)
+  })
+
+  it('skips dangling item ids and reports one aggregate count', () => {
+    const group = catalogGroup({
+      entries: [
+        { id: 'missing-1', catalogItemId: 'deleted-1', qty: 1 },
+        { id: 'valid', catalogItemId: 'item-1', qty: 1 },
+        { id: 'missing-2', catalogItemId: 'deleted-2', qty: 1 },
+      ],
+    })
+
+    const resolved = resolveCatalogGroup(group, new Map([['item-1', catalogItem()]]))
+
+    expect(resolved.lines.map((line) => line.name)).toEqual(['Service visit'])
+    expect(resolved.skippedCount).toBe(2)
+  })
+})

--- a/apps/web/src/components/money/ui/line-builder/catalog-group-resolver.ts
+++ b/apps/web/src/components/money/ui/line-builder/catalog-group-resolver.ts
@@ -1,0 +1,69 @@
+// apps/web/src/components/money/ui/line-builder/catalog-group-resolver.ts
+
+import type { CatalogGroup } from '../../hooks/use-catalog-groups'
+import type { CatalogItem } from '../../hooks/use-catalog-items'
+import { DEFAULT_LINE_VALUES, type LinePatch, type LineValues } from './line-values'
+
+/** One selected group resolved entirely from the already-loaded catalog. */
+export interface ResolvedCatalogGroup {
+  name: string
+  taxRateId: string | null
+  discountType: 'percent' | 'amount' | null
+  discountValue: number | null
+  lines: LineValues[]
+  skippedCount: number
+}
+
+/** Snapshot the values a direct catalog pick copies onto an existing line. */
+export function catalogItemToLinePatch(item: CatalogItem): LinePatch {
+  return {
+    name: item.name,
+    description: item.description,
+    category: item.category,
+    taxable: item.taxable,
+    unitPriceCents: item.defaultUnitPriceCents,
+    unit: item.defaultUnit,
+    optional: false,
+    optionalSelected: true,
+    catalogItemRecordId: item.recordId,
+  }
+}
+
+/** Resolve group entries against a preloaded catalog item map without fetching. */
+export function resolveCatalogGroup(
+  group: CatalogGroup,
+  itemMap: Map<string, CatalogItem>
+): ResolvedCatalogGroup {
+  const lines: LineValues[] = []
+  let skippedCount = 0
+
+  for (const entry of group.entries) {
+    const item = itemMap.get(entry.catalogItemId)
+    if (!item) {
+      skippedCount++
+      continue
+    }
+
+    lines.push({
+      ...DEFAULT_LINE_VALUES,
+      ...catalogItemToLinePatch(item),
+      description: entry.description ?? item.description,
+      taxable: entry.taxable ?? item.taxable,
+      qty: entry.qty,
+    })
+  }
+
+  return {
+    name: group.name,
+    taxRateId: group.taxRateId,
+    discountType: group.discountType,
+    discountValue: group.discountValue,
+    lines,
+    skippedCount,
+  }
+}
+
+/** Total preview for a resolved product group, in integer cents. */
+export function resolvedCatalogGroupTotal(group: ResolvedCatalogGroup): number {
+  return group.lines.reduce((sum, line) => sum + (line.unitPriceCents ?? 0) * line.qty, 0)
+}

--- a/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
+++ b/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
@@ -9,14 +9,10 @@
 // our option shape (name + price + category + part) doesn't fit the plain
 // Option/OptionGroup shape ComboPicker expects.
 //
-// Data: `useAllRecords({ apiSlug: 'catalog-items' })` — catalog items are an
-// org-scoped small dataset (same shape as tags/inboxes), so the "fetch
-// everything with field values in one call" hook fits better than the
-// paginated `useRecordList` used for large lists.
+// Data is owned by `LineBuilder`: one `useCatalogItems` / `useCatalogGroups`
+// load serves every row. This component only filters the supplied data while
+// open and emits the selected domain object.
 
-import type { LineItemUnit } from '@auxx/lib/money/client'
-import { toRecordId } from '@auxx/lib/resources/client'
-import type { RecordId } from '@auxx/types/resource'
 import {
   Command,
   CommandDetailItem,
@@ -31,86 +27,10 @@ import { cn } from '@auxx/ui/lib/utils'
 import { Boxes, Package, Plus, Settings2 } from 'lucide-react'
 import Link from 'next/link'
 import { type ReactNode, useMemo, useState } from 'react'
-import { parseCatalogGroupEntries } from '~/components/money/catalog-group-types'
-import type { RecordMeta } from '~/components/resources'
-import { useAllRecords } from '~/components/resources/hooks/use-all-records'
+import type { CatalogGroup } from '~/components/money/hooks/use-catalog-groups'
+import type { CatalogItem } from '~/components/money/hooks/use-catalog-items'
 import { useUser } from '~/hooks/use-user'
-
-/** Value copied onto the line when a catalog item is picked. */
-export interface CatalogItemPick {
-  recordId: RecordId
-  name: string
-  description: string | null
-  category: string | null
-  taxable: boolean
-  unitPrice: number | null
-  /** Copied exactly, including `null` (money plan 13 §5) — never re-derived. */
-  defaultUnit: LineItemUnit | null
-}
-
-/** One resolved line payload inside a picked group's explode (plans/dispatch/money/09-product-groups.md). */
-export interface CatalogGroupPickLine {
-  name: string
-  description: string | null
-  category: string | null
-  taxable: boolean
-  unitPrice: number | null
-  /** The resolved catalog item's current unit, snapshotted at explosion time (money plan 13 §5). */
-  unit: LineItemUnit | null
-  qty: number
-  /** EntityInstance id of the `catalog_item` (NOT the branded RecordId). */
-  catalogItemId: string
-}
-
-/**
- * Value handed to the line builder when a group is picked — resolution
- * (entry → catalog item lookup, dangling-id skip) happens here in the picker,
- * where both datasets are already loaded; the builder just writes.
- */
-export interface CatalogGroupPick {
-  name: string
-  taxRateId: string | null
-  discountType: 'percent' | 'amount' | null
-  discountValue: number | null
-  lines: CatalogGroupPickLine[]
-  /** Count of entries whose `catalogItemId` no longer resolves to a catalog item. */
-  skippedCount: number
-}
-
-interface CatalogItemFieldValues {
-  catalog_item_name?: string
-  catalog_item_description?: string | null
-  catalog_item_category?: unknown
-  catalog_item_default_unit_price?: number | null
-  catalog_item_default_unit?: LineItemUnit | LineItemUnit[] | null
-  catalog_item_taxable?: boolean
-  catalog_item_active?: boolean
-  catalog_item_part?: unknown
-}
-
-interface CatalogItemRow extends RecordMeta {
-  fieldValues: CatalogItemFieldValues
-}
-
-interface CatalogGroupFieldValues {
-  catalog_group_name?: string
-  catalog_group_description?: string | null
-  catalog_group_entries?: unknown
-  catalog_group_tax_rate_id?: string | null
-  catalog_group_discount_type?: unknown
-  catalog_group_discount_value?: number | null
-  catalog_group_active?: boolean
-}
-
-interface CatalogGroupRow extends RecordMeta {
-  fieldValues: CatalogGroupFieldValues
-}
-
-/** SINGLE_SELECT values come back as arrays — normalize to the first value. */
-function firstOf<T>(value: T | T[] | null | undefined): T | null {
-  if (Array.isArray(value)) return (value[0] ?? null) as T | null
-  return (value ?? null) as T | null
-}
+import { resolveCatalogGroup, resolvedCatalogGroupTotal } from './catalog-group-resolver'
 
 /** `price` is integer cents (FieldType.CURRENCY storage convention). */
 function formatPrice(price: number | null, currencyCode: string): string {
@@ -121,59 +41,7 @@ function formatPrice(price: number | null, currencyCode: string): string {
 }
 
 function titleCase(value: string): string {
-  return value.length ? value[0].toUpperCase() + value.slice(1) : value
-}
-
-/**
- * Resolve a `catalog_group` row's entries against the already-loaded catalog
- * item records — the explode payload's shape (money 09-product-groups.md
- * "Line-builder consumption" §1). Dangling `catalogItemId`s are skipped and
- * counted (logged by the caller); inactive items still resolve (deliberate
- * group membership).
- */
-function resolveGroup(
-  group: CatalogGroupRow,
-  itemsById: Map<string, CatalogItemRow>
-): CatalogGroupPick {
-  const entries = parseCatalogGroupEntries(group.fieldValues.catalog_group_entries)
-  const lines: CatalogGroupPickLine[] = []
-  let skippedCount = 0
-
-  for (const entry of entries) {
-    const item = itemsById.get(entry.catalogItemId)
-    if (!item) {
-      skippedCount++
-      console.warn(
-        `Catalog group "${group.fieldValues.catalog_group_name ?? group.id}" references a deleted catalog item (${entry.catalogItemId}) — entry skipped.`
-      )
-      continue
-    }
-    lines.push({
-      name: item.fieldValues.catalog_item_name ?? '',
-      description: entry.description ?? item.fieldValues.catalog_item_description ?? null,
-      category: firstOf<string>(item.fieldValues.catalog_item_category),
-      taxable: entry.taxable ?? item.fieldValues.catalog_item_taxable !== false,
-      unitPrice: item.fieldValues.catalog_item_default_unit_price ?? null,
-      // Same snapshot boundary as price — no entry-level override exists for unit.
-      unit: firstOf<LineItemUnit>(item.fieldValues.catalog_item_default_unit),
-      qty: entry.qty,
-      catalogItemId: entry.catalogItemId,
-    })
-  }
-
-  return {
-    name: group.fieldValues.catalog_group_name ?? '',
-    taxRateId: group.fieldValues.catalog_group_tax_rate_id ?? null,
-    discountType: firstOf<'percent' | 'amount'>(group.fieldValues.catalog_group_discount_type),
-    discountValue: group.fieldValues.catalog_group_discount_value ?? null,
-    lines,
-    skippedCount,
-  }
-}
-
-/** Σ resolvable-line `unitPrice × qty` — the picker's group total display. */
-function groupTotal(pick: CatalogGroupPick): number {
-  return pick.lines.reduce((sum, line) => sum + (line.unitPrice ?? 0) * line.qty, 0)
+  return value.length ? value.charAt(0).toUpperCase() + value.slice(1) : value
 }
 
 export interface CatalogPickerProps {
@@ -183,9 +51,14 @@ export interface CatalogPickerProps {
   initialQuery?: string
   /** Org currency code (from `organization.currency`) for price display. */
   currencyCode?: string
-  onSelectCatalogItem: (item: CatalogItemPick) => void
-  /** Picking a group explodes its resolved entries into plain line items. */
-  onSelectGroup: (group: CatalogGroupPick) => void
+  /** Shared catalog data loaded once by `LineBuilder`. */
+  items: CatalogItem[]
+  groups: CatalogGroup[]
+  itemMap: Map<string, CatalogItem>
+  isLoading: boolean
+  onSelectCatalogItem: (item: CatalogItem) => void
+  /** Picking a group lets `LineBuilder` resolve and explode its entries. */
+  onSelectGroup: (group: CatalogGroup) => void
   /** User typed text with no catalog match — add as an ad-hoc line, no catalog rel. */
   onFreeText: (text: string) => void
   /** Return focus to the name input once the picker closes (pick / Escape / outside). */
@@ -206,6 +79,10 @@ export function CatalogPicker({
   onOpenChange,
   initialQuery = '',
   currencyCode = 'USD',
+  items,
+  groups: catalogGroups,
+  itemMap,
+  isLoading,
   onSelectCatalogItem,
   onSelectGroup,
   onFreeText,
@@ -215,41 +92,28 @@ export function CatalogPicker({
   const [query, setQuery] = useState(initialQuery)
   const { isAdminOrOwner } = useUser()
 
-  const { records, isLoading: itemsLoading } = useAllRecords<CatalogItemRow>({
-    apiSlug: 'catalog-items',
-    enabled: open,
-  })
-
-  const { records: groupRecords, isLoading: groupsLoading } = useAllRecords<CatalogGroupRow>({
-    apiSlug: 'catalog-groups',
-    enabled: open,
-  })
-
   const groupPicks = useMemo(() => {
+    if (!open) return []
     const q = query.trim().toLowerCase()
-    const itemsById = new Map(records.map((r) => [r.id, r]))
-    const active = groupRecords.filter((g) => g.fieldValues.catalog_group_active !== false)
-    const filtered = q
-      ? active.filter((g) => (g.fieldValues.catalog_group_name ?? '').toLowerCase().includes(q))
-      : active
+    const active = catalogGroups.filter((group) => group.active)
+    const filtered = q ? active.filter((group) => group.name.toLowerCase().includes(q)) : active
 
     return filtered
-      .map((row) => ({ id: row.id, pick: resolveGroup(row, itemsById) }))
-      .sort((a, b) => a.pick.name.localeCompare(b.pick.name))
-  }, [groupRecords, records, query])
+      .map((group) => ({ group, resolved: resolveCatalogGroup(group, itemMap) }))
+      .sort((a, b) => a.group.name.localeCompare(b.group.name))
+  }, [open, catalogGroups, itemMap, query])
 
-  const groups = useMemo(() => {
+  const itemGroups = useMemo(() => {
+    if (!open) return []
     const q = query.trim().toLowerCase()
-    const active = records.filter((r) => r.fieldValues.catalog_item_active !== false)
-    const filtered = q
-      ? active.filter((r) => (r.fieldValues.catalog_item_name ?? '').toLowerCase().includes(q))
-      : active
+    const active = items.filter((item) => item.active)
+    const filtered = q ? active.filter((item) => item.name.toLowerCase().includes(q)) : active
 
-    const byCategory = new Map<string, CatalogItemRow[]>()
-    for (const row of filtered) {
-      const category = firstOf<string>(row.fieldValues.catalog_item_category) ?? 'other'
+    const byCategory = new Map<string, CatalogItem[]>()
+    for (const item of filtered) {
+      const category = item.category || 'other'
       const bucket = byCategory.get(category) ?? []
-      bucket.push(row)
+      bucket.push(item)
       byCategory.set(category, bucket)
     }
 
@@ -258,31 +122,19 @@ export function CatalogPicker({
       .map(([category, rows]) => ({
         category,
         label: titleCase(category),
-        rows: rows.sort((a, b) =>
-          (a.fieldValues.catalog_item_name ?? '').localeCompare(
-            b.fieldValues.catalog_item_name ?? ''
-          )
-        ),
+        rows: rows.sort((a, b) => a.name.localeCompare(b.name)),
       }))
-  }, [records, query])
+  }, [open, items, query])
 
-  const hasAnyMatch = groups.some((g) => g.rows.length > 0) || groupPicks.length > 0
+  const hasAnyMatch = itemGroups.some((group) => group.rows.length > 0) || groupPicks.length > 0
 
-  const handlePick = (row: CatalogItemRow) => {
-    onSelectCatalogItem({
-      recordId: toRecordId('catalog_item', row.id),
-      name: row.fieldValues.catalog_item_name ?? '',
-      description: row.fieldValues.catalog_item_description ?? null,
-      category: firstOf<string>(row.fieldValues.catalog_item_category),
-      taxable: row.fieldValues.catalog_item_taxable !== false,
-      unitPrice: row.fieldValues.catalog_item_default_unit_price ?? null,
-      defaultUnit: firstOf<LineItemUnit>(row.fieldValues.catalog_item_default_unit),
-    })
+  const handlePick = (item: CatalogItem) => {
+    onSelectCatalogItem(item)
     onOpenChange(false)
   }
 
-  const handlePickGroup = (pick: CatalogGroupPick) => {
-    onSelectGroup(pick)
+  const handlePickGroup = (group: CatalogGroup) => {
+    onSelectGroup(group)
     onOpenChange(false)
   }
 
@@ -320,21 +172,21 @@ export function CatalogPicker({
             scrollAreaStyle={{
               height: 'min(300px, calc(var(--radix-popover-content-available-height) - 78px))',
             }}>
-            {!(itemsLoading || groupsLoading) && !hasAnyMatch && !query.trim() && (
+            {!isLoading && !hasAnyMatch && !query.trim() && (
               <CommandEmpty>No products or services yet</CommandEmpty>
             )}
 
             {groupPicks.length > 0 && (
               <CommandGroup heading='Groups'>
-                {groupPicks.map(({ id, pick }) => {
-                  const count = pick.lines.length + pick.skippedCount
+                {groupPicks.map(({ group, resolved }) => {
+                  const count = group.entries.length
                   return (
                     <CommandDetailItem
-                      key={id}
-                      value={`group-${id}`}
-                      onSelect={() => handlePickGroup(pick)}
+                      key={group.id}
+                      value={`group-${group.id}`}
+                      onSelect={() => handlePickGroup(group)}
                       icon={<Boxes className='size-4' />}
-                      title={pick.name}
+                      title={group.name}
                       secondary={
                         <span className='text-muted-foreground text-xs'>
                           {count} item{count === 1 ? '' : 's'}
@@ -342,7 +194,7 @@ export function CatalogPicker({
                       }
                       trailing={
                         <span className='text-muted-foreground text-xs'>
-                          {formatPrice(groupTotal(pick), currencyCode)}
+                          {formatPrice(resolvedCatalogGroupTotal(resolved), currencyCode)}
                         </span>
                       }
                     />
@@ -351,27 +203,24 @@ export function CatalogPicker({
               </CommandGroup>
             )}
 
-            {groups.map(
+            {itemGroups.map(
               (group) =>
                 group.rows.length > 0 && (
                   <CommandGroup key={group.category} heading={group.label}>
-                    {group.rows.map((row) => (
+                    {group.rows.map((item) => (
                       <CommandDetailItem
-                        key={row.id}
-                        value={row.id}
-                        onSelect={() => handlePick(row)}
-                        title={row.fieldValues.catalog_item_name ?? ''}
+                        key={item.id}
+                        value={item.id}
+                        onSelect={() => handlePick(item)}
+                        title={item.name}
                         secondary={
-                          row.fieldValues.catalog_item_part != null ? (
+                          item.partRecordId ? (
                             <span className='text-muted-foreground text-xs'>Linked part</span>
                           ) : undefined
                         }
                         trailing={
                           <span className='text-muted-foreground text-xs'>
-                            {formatPrice(
-                              row.fieldValues.catalog_item_default_unit_price ?? null,
-                              currencyCode
-                            )}
+                            {formatPrice(item.defaultUnitPriceCents, currencyCode)}
                           </span>
                         }
                       />

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -16,8 +16,10 @@
 // `/` on an empty cell opens the catalog picker.
 //
 // Data flow:
-// - Line cell reads: `useSystemValues` (field-value store, autoFetch).
-// - Line cell writes: `useSaveFieldValue` with systemAttribute keys — the
+// - `LineBuilder` preloads the displayed line-id × field matrix once through
+//   `useFieldValueSyncer`; each `LineRow` keeps one passive store subscription.
+// - Cells emit semantic patches to the builder's single `useSaveFieldValue`
+//   owner. Optimistic store writes repaint rows/totals immediately; the
 //   server-side field-change hooks (§F.2) recompute lineTotal + quote totals
 //   and publish via realtime back into the same store.
 // - Totals footer: pure client math via `computeDocumentTotals` /
@@ -69,6 +71,9 @@ import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { Plus, ReceiptText } from 'lucide-react'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import type { CatalogGroup } from '~/components/money/hooks/use-catalog-groups'
+import { useCatalogGroups } from '~/components/money/hooks/use-catalog-groups'
+import { useCatalogItems } from '~/components/money/hooks/use-catalog-items'
 import {
   type RecordId,
   type RecordMeta,
@@ -77,12 +82,14 @@ import {
   useResource,
   useResourceFields,
 } from '~/components/resources'
+import { useFieldValueSyncer } from '~/components/resources/hooks/use-field-value-syncer'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSeedCreatedRecord } from '~/components/resources/hooks/use-seed-created-record'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useResourceStore } from '~/components/resources/store/resource-store'
 import { useSettings } from '~/hooks/use-settings'
 import { api } from '~/trpc/react'
-import type { CatalogGroupPick, CatalogGroupPickLine } from './catalog-picker'
+import { type ResolvedCatalogGroup, resolveCatalogGroup } from './catalog-group-resolver'
 import {
   type CategoryOption,
   type DraftLine,
@@ -92,6 +99,14 @@ import {
   LineRow,
   relKeyForDocumentType,
 } from './line-rows'
+import {
+  BASE_LINE_SYSTEM_ATTRIBUTES,
+  diffLineValues,
+  type LinePatch,
+  type LineValues,
+  linePatchToFieldValues,
+  QUOTE_LINE_SYSTEM_ATTRIBUTES,
+} from './line-values'
 import { TotalsFooter } from './totals-footer'
 import { useLineHotkeys } from './use-line-hotkeys'
 import { useLineNav } from './use-line-nav'
@@ -119,10 +134,11 @@ const PAGE_SIZE = 100
 const INITIAL_DRAFT_COUNT = 3
 /** Stable sort ref — `useRecordList` keys its cache off this object. */
 const LINE_SORT = [{ id: 'sortOrder', desc: false }]
+/** Every fixed line-builder field is visible to the shared syncer. */
+const LINE_FIELD_VISIBILITY = {}
 
-// Document billing mirrors read for the group-explode set-if-unset checks (steps 4–5,
-// money 09-product-groups.md "Line-builder consumption") — the same attrs `TotalsFooter`
-// reads, minus the invoice-only ledger-sync mirrors this doesn't need.
+// Document billing mirrors read once for group set-if-unset checks and `TotalsFooter`.
+// Invoice mode also carries its read-only paid/balance ledger mirrors.
 const QUOTE_BILLING_ATTRS = [
   'quote_discount_type',
   'quote_discount_value',
@@ -134,6 +150,8 @@ const INVOICE_BILLING_ATTRS = [
   'invoice_discount_value',
   'invoice_tax_name',
   'invoice_tax_rate',
+  'invoice_amount_paid',
+  'invoice_balance',
 ]
 
 /** Org tax rate preset (`documents.taxRates` setting, money MQ1 build spec §G.1). */
@@ -174,6 +192,18 @@ export function LineBuilder({
       color: o.color,
     }))
   }, [lineItemFields])
+  // Catalog data is shared by every row picker. Editable builders preload it
+  // once so opening a picker or resolving a product group never starts a fetch.
+  const catalogEnabled = !!entityDefinitionId && !readOnly
+  const {
+    items: catalogItems,
+    itemMap: catalogItemMap,
+    isLoading: catalogItemsLoading,
+  } = useCatalogItems({ enabled: catalogEnabled })
+  const { groups: catalogGroups, isLoading: catalogGroupsLoading } = useCatalogGroups({
+    enabled: catalogEnabled,
+  })
+  const catalogLoading = catalogItemsLoading || catalogGroupsLoading
   const { getSetting } = useSettings({})
   const currencyCode = (getSetting('organization.currency') as string | null) ?? 'USD'
 
@@ -186,8 +216,12 @@ export function LineBuilder({
     documentType === 'invoice' ? INVOICE_BILLING_ATTRS : QUOTE_BILLING_ATTRS,
     { autoFetch: hasBilling, enabled: hasBilling }
   )
-  const taxRates = ((getSetting('documents.taxRates') as TaxRatePreset[] | null) ?? []).filter(
-    (r) => r && typeof r.rate === 'number'
+  const taxRates = useMemo(
+    () =>
+      ((getSetting('documents.taxRates') as TaxRatePreset[] | null) ?? []).filter(
+        (rate) => rate && typeof rate.rate === 'number'
+      ),
+    [getSetting]
   )
 
   const [orderOverride, setOrderOverride] = useState<string[] | null>(null)
@@ -340,7 +374,7 @@ export function LineBuilder({
     )
     initialDraftIdsRef.current = new Set(initialDrafts.map((draft) => draft.draftId))
     setDrafts(initialDrafts)
-    setLastAddedDraftId(initialDrafts[0].draftId)
+    setLastAddedDraftId(initialDrafts[0]?.draftId ?? null)
   }, [entityDefinitionId, readOnly, displayRecords.length])
 
   // When persisted lines arrive, hide/remove the initial loading placeholders
@@ -365,6 +399,23 @@ export function LineBuilder({
     [entityDefinitionId, displayRecords]
   )
 
+  // Match records-view's fetch ownership: queue the complete displayed
+  // record-id × line-field matrix once, while rows subscribe passively.
+  const systemAttributeMap = useResourceStore((state) => state.systemAttributeMap)
+  const lineFieldIds = useMemo(() => {
+    const attributes =
+      documentType === 'quote' ? QUOTE_LINE_SYSTEM_ATTRIBUTES : BASE_LINE_SYSTEM_ATTRIBUTES
+    return attributes
+      .map((attribute) => systemAttributeMap[attribute])
+      .filter((fieldId): fieldId is NonNullable<typeof fieldId> => !!fieldId)
+  }, [documentType, systemAttributeMap])
+  useFieldValueSyncer({
+    recordIds: lineRecordIds,
+    columnVisibility: LINE_FIELD_VISIBILITY,
+    resourceFieldIds: lineFieldIds,
+    enabled: lineRecordIds.length > 0 && lineFieldIds.length > 0,
+  })
+
   // Mutations (stable fns destructured — the wrapper objects churn per render).
   const reorderLines = api.money.reorderLines.useMutation()
   const recomputeTotals = api.money.recomputeTotals.useMutation()
@@ -377,8 +428,54 @@ export function LineBuilder({
   const { mutateAsync: deleteInvoiceLineMutateAsync } = deleteInvoiceLine
   const { mutateAsync: createMutateAsync } = createRecord
 
-  const { saveMultipleAsync } = useSaveFieldValue()
+  const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue()
   const { seedCreatedRecord } = useSeedCreatedRecord()
+
+  /** Persist one semantic line patch through the single optimistic save owner. */
+  const updateLine = useCallback(
+    (recordId: RecordId, patch: LinePatch) => {
+      const updates = linePatchToFieldValues(patch)
+      if (updates.length === 0) return
+      if (updates.length === 1) {
+        const update = updates[0]
+        if (!update) return
+        saveFieldValue(recordId, update.fieldId, update.value, update.fieldType)
+        return
+      }
+      void saveMultipleAsync(recordId, updates)
+    },
+    [saveFieldValue, saveMultipleAsync]
+  )
+
+  const updateDiscount = useCallback(
+    (type: 'percent' | 'amount' | null, value: number | null) => {
+      if (!hasBilling) return
+      void saveMultipleAsync(docRecordId, [
+        {
+          fieldId: `${billingPrefix}_discount_type`,
+          value: type,
+          fieldType: FieldType.SINGLE_SELECT,
+        },
+        {
+          fieldId: `${billingPrefix}_discount_value`,
+          value,
+          fieldType: FieldType.NUMBER,
+        },
+      ])
+    },
+    [hasBilling, saveMultipleAsync, docRecordId, billingPrefix]
+  )
+
+  const updateTax = useCallback(
+    (name: string | null, rate: number | null) => {
+      if (!hasBilling) return
+      void saveMultipleAsync(docRecordId, [
+        { fieldId: `${billingPrefix}_tax_name`, value: name, fieldType: FieldType.TEXT },
+        { fieldId: `${billingPrefix}_tax_rate`, value: rate, fieldType: FieldType.NUMBER },
+      ])
+    },
+    [hasBilling, saveMultipleAsync, docRecordId, billingPrefix]
+  )
 
   const deleteLine = useCallback(
     async (lineId: string) => {
@@ -439,7 +536,7 @@ export function LineBuilder({
    * completion handler diffs + flushes them once it resolves.
    */
   const createDraft = useCallback(
-    async (draftId: string, overrides: Partial<DraftLine> = {}) => {
+    async (draftId: string, overrides: LinePatch = {}) => {
       // The first real edit promotes an initial loading placeholder to a normal
       // draft, so an arriving persisted list cannot remove the user's work.
       initialDraftIdsRef.current.delete(draftId)
@@ -449,9 +546,10 @@ export function LineBuilder({
       }
 
       const draftIndex = draftsRef.current.findIndex((d) => d.draftId === draftId)
-      if (draftIndex === -1 || !entityDefinitionId) return
+      const currentDraft = draftsRef.current[draftIndex]
+      if (!currentDraft || !entityDefinitionId) return
       const snapshot: DraftLine = {
-        ...draftsRef.current[draftIndex],
+        ...currentDraft,
         ...overrides,
         creating: true,
       }
@@ -486,121 +584,13 @@ export function LineBuilder({
           recordId: result.recordId,
           listKey,
           instance: result.instance,
-          values: [
-            { fieldId: 'line_item_name', value: snapshot.name, fieldType: FieldType.TEXT },
-            {
-              fieldId: 'line_item_description',
-              value: snapshot.description,
-              fieldType: FieldType.TEXT,
-            },
-            {
-              fieldId: 'line_item_category',
-              value: snapshot.category,
-              fieldType: FieldType.SINGLE_SELECT,
-            },
-            { fieldId: 'line_item_qty', value: snapshot.qty, fieldType: FieldType.NUMBER },
-            {
-              fieldId: 'line_item_unit',
-              value: snapshot.unit,
-              fieldType: FieldType.SINGLE_SELECT,
-            },
-            {
-              fieldId: 'line_item_unit_price',
-              value: snapshot.unitPriceCents,
-              fieldType: FieldType.CURRENCY,
-            },
-            {
-              fieldId: 'line_item_taxable',
-              value: snapshot.taxable,
-              fieldType: FieldType.CHECKBOX,
-            },
-            {
-              fieldId: 'line_item_optional',
-              value: snapshot.optional,
-              fieldType: FieldType.CHECKBOX,
-            },
-            {
-              fieldId: 'line_item_optional_selected',
-              value: snapshot.optionalSelected,
-              fieldType: FieldType.CHECKBOX,
-            },
-          ],
+          values: linePatchToFieldValues(snapshot),
         })
 
         // Diff whatever landed locally while the create was in flight, and
         // flush just the changed fields against the now-real record.
         const latest = draftsRef.current.find((d) => d.draftId === draftId) ?? snapshot
-        const changed: Array<{ fieldId: string; value: unknown; fieldType: FieldType }> = []
-        if (latest.name !== snapshot.name) {
-          changed.push({
-            fieldId: 'line_item_name',
-            value: latest.name,
-            fieldType: FieldType.TEXT,
-          })
-        }
-        if (latest.description !== snapshot.description) {
-          changed.push({
-            fieldId: 'line_item_description',
-            value: latest.description,
-            fieldType: FieldType.TEXT,
-          })
-        }
-        if (latest.category !== snapshot.category) {
-          changed.push({
-            fieldId: 'line_item_category',
-            value: latest.category,
-            fieldType: FieldType.SINGLE_SELECT,
-          })
-        }
-        if (latest.taxable !== snapshot.taxable) {
-          changed.push({
-            fieldId: 'line_item_taxable',
-            value: latest.taxable,
-            fieldType: FieldType.CHECKBOX,
-          })
-        }
-        if (latest.qty !== snapshot.qty) {
-          changed.push({
-            fieldId: 'line_item_qty',
-            value: latest.qty,
-            fieldType: FieldType.NUMBER,
-          })
-        }
-        if (latest.unit !== snapshot.unit) {
-          changed.push({
-            fieldId: 'line_item_unit',
-            value: latest.unit,
-            fieldType: FieldType.SINGLE_SELECT,
-          })
-        }
-        if (latest.unitPriceCents !== snapshot.unitPriceCents) {
-          changed.push({
-            fieldId: 'line_item_unit_price',
-            value: latest.unitPriceCents,
-            fieldType: FieldType.CURRENCY,
-          })
-        }
-        if (latest.optional !== snapshot.optional) {
-          changed.push({
-            fieldId: 'line_item_optional',
-            value: latest.optional,
-            fieldType: FieldType.CHECKBOX,
-          })
-        }
-        if (latest.optionalSelected !== snapshot.optionalSelected) {
-          changed.push({
-            fieldId: 'line_item_optional_selected',
-            value: latest.optionalSelected,
-            fieldType: FieldType.CHECKBOX,
-          })
-        }
-        if (latest.catalogItemRecordId !== snapshot.catalogItemRecordId) {
-          changed.push({
-            fieldId: 'line_item_catalog_item',
-            value: latest.catalogItemRecordId,
-            fieldType: FieldType.RELATIONSHIP,
-          })
-        }
+        const changed = linePatchToFieldValues(diffLineValues(snapshot, latest))
         if (changed.length > 0) {
           await saveMultipleAsync(result.recordId, changed)
         }
@@ -646,18 +636,11 @@ export function LineBuilder({
    * "group-exploded lines start required" rule, money plan 18 §3).
    */
   const applyGroupPickRestAndBilling = useCallback(
-    (pick: CatalogGroupPick, rest: CatalogGroupPickLine[]) => {
+    (pick: ResolvedCatalogGroup, rest: LineValues[]) => {
       if (rest.length > 0) {
         const bundleDrafts: DraftLine[] = rest.map((line) => ({
           ...freshDraft(generateId()),
-          name: line.name,
-          description: line.description,
-          category: line.category,
-          taxable: line.taxable,
-          qty: line.qty,
-          unit: line.unit,
-          unitPriceCents: line.unitPrice,
-          catalogItemRecordId: toRecordId('catalog_item', line.catalogItemId),
+          ...line,
         }))
         // Write through draftsRef (normally render-synced) so the sequential
         // createDraft calls below can resolve these drafts before React
@@ -680,18 +663,7 @@ export function LineBuilder({
           | null
           | undefined
         if (pick.discountType && pick.discountValue !== null && currentDiscountValue == null) {
-          void saveMultipleAsync(docRecordId, [
-            {
-              fieldId: `${billingPrefix}_discount_type`,
-              value: pick.discountType,
-              fieldType: FieldType.SINGLE_SELECT,
-            },
-            {
-              fieldId: `${billingPrefix}_discount_value`,
-              value: pick.discountValue,
-              fieldType: FieldType.NUMBER,
-            },
-          ])
+          updateDiscount(pick.discountType, pick.discountValue)
         }
 
         const currentTaxRate = billingValues[`${billingPrefix}_tax_rate`] as
@@ -701,32 +673,11 @@ export function LineBuilder({
         if (pick.taxRateId && currentTaxRate == null) {
           // A deleted preset id silently no-ops — no tax write.
           const preset = taxRates.find((r) => r.id === pick.taxRateId)
-          if (preset) {
-            void saveMultipleAsync(docRecordId, [
-              {
-                fieldId: `${billingPrefix}_tax_name`,
-                value: preset.name,
-                fieldType: FieldType.TEXT,
-              },
-              {
-                fieldId: `${billingPrefix}_tax_rate`,
-                value: preset.rate,
-                fieldType: FieldType.NUMBER,
-              },
-            ])
-          }
+          if (preset) updateTax(preset.name, preset.rate)
         }
       }
     },
-    [
-      docRecordId,
-      hasBilling,
-      billingPrefix,
-      billingValues,
-      taxRates,
-      saveMultipleAsync,
-      createDraft,
-    ]
+    [hasBilling, billingPrefix, billingValues, taxRates, updateDiscount, updateTax, createDraft]
   )
 
   /**
@@ -735,73 +686,47 @@ export function LineBuilder({
    * entries 2…N append as new lines via {@link applyGroupPickRestAndBilling}.
    */
   const handleGroupPick = useCallback(
-    async (recordId: RecordId, pick: CatalogGroupPick) => {
+    (recordId: RecordId, group: CatalogGroup) => {
+      const pick = resolveCatalogGroup(group, catalogItemMap)
       if (pick.skippedCount > 0) {
         console.warn(`Catalog group "${pick.name}" skipped ${pick.skippedCount} dangling item(s).`)
       }
       if (pick.lines.length === 0) return
 
       const [first, ...rest] = pick.lines
+      if (!first) return
 
       // Step 1: entry #1 fills the CURRENT line — the handlePick shape (catalog-picker.tsx)
       // plus qty, which the single-item pick leaves untouched. Resets optional/optionalSelected
       // to required (money plan 18 §3) — same "pick overwrites the line's identity" precedent
       // as taxable already follows.
-      void saveMultipleAsync(recordId, [
-        { fieldId: 'line_item_name', value: first.name, fieldType: FieldType.TEXT },
-        { fieldId: 'line_item_description', value: first.description, fieldType: FieldType.TEXT },
-        {
-          fieldId: 'line_item_category',
-          value: first.category,
-          fieldType: FieldType.SINGLE_SELECT,
-        },
-        { fieldId: 'line_item_taxable', value: first.taxable, fieldType: FieldType.CHECKBOX },
-        { fieldId: 'line_item_unit_price', value: first.unitPrice, fieldType: FieldType.CURRENCY },
-        { fieldId: 'line_item_unit', value: first.unit, fieldType: FieldType.SINGLE_SELECT },
-        { fieldId: 'line_item_qty', value: first.qty, fieldType: FieldType.NUMBER },
-        { fieldId: 'line_item_optional', value: false, fieldType: FieldType.CHECKBOX },
-        { fieldId: 'line_item_optional_selected', value: true, fieldType: FieldType.CHECKBOX },
-        {
-          fieldId: 'line_item_catalog_item',
-          value: toRecordId('catalog_item', first.catalogItemId),
-          fieldType: FieldType.RELATIONSHIP,
-        },
-      ])
+      updateLine(recordId, first)
 
       // Known v1 edge: picking on a middle line still appends `rest` at the list end.
       applyGroupPickRestAndBilling(pick, rest)
     },
-    [saveMultipleAsync, applyGroupPickRestAndBilling]
+    [catalogItemMap, updateLine, applyGroupPickRestAndBilling]
   )
 
   /** Same explode intent as {@link handleGroupPick}, targeting a phantom draft. */
   const handleGroupPickDraft = useCallback(
-    async (draftId: string, pick: CatalogGroupPick) => {
+    (draftId: string, group: CatalogGroup) => {
+      const pick = resolveCatalogGroup(group, catalogItemMap)
       if (pick.skippedCount > 0) {
         console.warn(`Catalog group "${pick.name}" skipped ${pick.skippedCount} dangling item(s).`)
       }
       if (pick.lines.length === 0) return
 
       const [first, ...rest] = pick.lines
+      if (!first) return
 
       // Step 1: entry #1's values become THIS draft's create. Catalog/group-exploded
       // lines start required (money plan 18 §3).
-      void createDraft(draftId, {
-        name: first.name,
-        description: first.description,
-        category: first.category,
-        taxable: first.taxable,
-        unitPriceCents: first.unitPrice,
-        unit: first.unit,
-        qty: first.qty,
-        catalogItemRecordId: toRecordId('catalog_item', first.catalogItemId),
-        optional: false,
-        optionalSelected: true,
-      })
+      void createDraft(draftId, first)
 
       applyGroupPickRestAndBilling(pick, rest)
     },
-    [createDraft, applyGroupPickRestAndBilling]
+    [catalogItemMap, createDraft, applyGroupPickRestAndBilling]
   )
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
@@ -956,6 +881,11 @@ export function LineBuilder({
                     readOnly={readOnly}
                     currencyCode={currencyCode}
                     documentType={documentType}
+                    catalogItems={catalogItems}
+                    catalogGroups={catalogGroups}
+                    catalogItemMap={catalogItemMap}
+                    catalogLoading={catalogLoading}
+                    onUpdateLine={updateLine}
                     deleteLine={deleteLine}
                     onSelectGroup={handleGroupPick}
                   />
@@ -976,6 +906,10 @@ export function LineBuilder({
                 categoryOptions={categoryOptions}
                 currencyCode={currencyCode}
                 documentType={documentType}
+                catalogItems={catalogItems}
+                catalogGroups={catalogGroups}
+                catalogItemMap={catalogItemMap}
+                catalogLoading={catalogLoading}
                 deleteDraft={deleteDraft}
                 createDraft={createDraft}
                 onSelectGroup={handleGroupPickDraft}
@@ -985,12 +919,15 @@ export function LineBuilder({
       </div>
 
       <TotalsFooter
-        documentRecordId={docRecordId}
         documentType={documentType}
         readOnly={readOnly}
         currencyCode={currencyCode}
         lineRecordIds={lineRecordIds}
         draftLines={visibleDrafts}
+        billingValues={billingValues}
+        taxRates={taxRates}
+        onUpdateDiscount={updateDiscount}
+        onUpdateTax={updateTax}
       />
     </div>
   )

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -3,10 +3,9 @@
 'use client'
 
 // Row + cell components for the line-items builder (line-builder.tsx). Split
-// out once the builder file crossed the ~800-line component threshold
-// (CLAUDE.md "Component Architecture"): this file owns the presentational
-// cell views, their store-bound wrappers for real (persisted) rows, and the
-// two row shells (`LineRow` for real records, `DraftLineRow` for phantom
+// out once the builder file crossed the ~800-line component threshold:
+// this file owns presentational cell views and the two row shells (`LineRow`
+// for real records, `DraftLineRow` for phantom
 // draft lines — see line-builder.tsx's file-header comment for the draft
 // lifecycle). `LineBuilder` itself (state, mutations, data fetching) stays in
 // line-builder.tsx.
@@ -24,7 +23,6 @@
 // taxable, delete). Qty/rate are chromeless inline editors; total is
 // computed. The drag grip floats in the left gutter, hover-revealed.
 
-import { FieldType } from '@auxx/database/enums'
 import {
   computeLineTotal,
   formatLineItemUnit,
@@ -63,10 +61,20 @@ import {
   X,
 } from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
+import type { CatalogGroup } from '~/components/money/hooks/use-catalog-groups'
+import type { CatalogItem } from '~/components/money/hooks/use-catalog-items'
 import { type RecordId, type RecordMeta, toRecordId } from '~/components/resources'
-import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
-import { type CatalogGroupPick, type CatalogItemPick, CatalogPicker } from './catalog-picker'
+import { catalogItemToLinePatch } from './catalog-group-resolver'
+import { CatalogPicker } from './catalog-picker'
+import {
+  BASE_LINE_SYSTEM_ATTRIBUTES,
+  DEFAULT_LINE_VALUES,
+  type LinePatch,
+  type LineValues,
+  lineValuesFromSystemValues,
+  QUOTE_LINE_SYSTEM_ATTRIBUTES,
+} from './line-values'
 import { formatCurrency, titleCase } from './shared'
 import { LINE_ROW_ACTION_EVENT, type LineRowAction } from './use-line-hotkeys'
 
@@ -77,23 +85,6 @@ import { LINE_ROW_ACTION_EVENT, type LineRowAction } from './use-line-hotkeys'
  * smart `2.375 cy` quantity+unit cell, money plan 13 §5) │ rate │ total.
  */
 export const LINE_COLS = 'minmax(10rem, 1fr) 5.5rem 5.5rem 6.5rem'
-
-// Module-level (stable-reference) attribute lists — `useSystemValues` memoizes
-// on the array identity, so these must never be inline literals. Taxable rides
-// with the name attrs: everything that shows it (rest badge, `⋯` menu toggle)
-// lives in the name cell.
-const NAME_ATTRS = [
-  'line_item_name',
-  'line_item_description',
-  'line_item_category',
-  'line_item_taxable',
-]
-const QTY_ATTRS = ['line_item_qty', 'line_item_unit']
-const PRICE_ATTRS = ['line_item_unit_price']
-const TOTAL_ATTRS = ['line_item_qty', 'line_item_unit_price']
-// Optional/optionalSelected (money plan 18 §3) — quotes only; `LineRow` gates the
-// fetch on `documentType === 'quote'` so non-quote surfaces never subscribe.
-const OPTIONAL_ATTRS = ['line_item_optional', 'line_item_optional_selected']
 
 /**
  * One selectable line category — the builder receives these from the
@@ -143,36 +134,15 @@ function badgeVariantForColor(color: string | undefined): Variant {
  * `unit`/`optional`/`optionalSelected` mirror `line_item_unit`/`line_item_optional`/
  * `line_item_optional_selected` (money plans 13 §5, 18 §3).
  */
-export interface DraftLine {
+export interface DraftLine extends LineValues {
   draftId: string
-  name: string
-  description: string | null
-  category: string | null
-  taxable: boolean
-  qty: number
-  unit: LineItemUnit | null
-  unitPriceCents: number | null
-  /** Customer-selectable upsell (quotes only) — always `false` outside quote builders. */
-  optional: boolean
-  /** Pre-check state; meaningful only when `optional` is true. */
-  optionalSelected: boolean
-  catalogItemRecordId: RecordId | null
   creating: boolean
 }
 
 export function freshDraft(draftId: string): DraftLine {
   return {
+    ...DEFAULT_LINE_VALUES,
     draftId,
-    name: '',
-    description: null,
-    category: null,
-    taxable: true,
-    qty: 1,
-    unit: 'each',
-    unitPriceCents: null,
-    optional: false,
-    optionalSelected: true,
-    catalogItemRecordId: null,
     creating: false,
   }
 }
@@ -255,8 +225,8 @@ function GripSlot({
   attributes,
   listeners,
 }: {
-  attributes?: Record<string, unknown>
-  listeners?: Record<string, unknown>
+  attributes?: ReturnType<typeof useSortable>['attributes']
+  listeners?: ReturnType<typeof useSortable>['listeners']
 }) {
   return (
     <span
@@ -465,6 +435,10 @@ function LineNameCellView({
   taxable,
   readOnly,
   currencyCode,
+  catalogItems,
+  catalogGroups,
+  catalogItemMap,
+  catalogLoading,
   autoFocus = false,
   showOptionalControls,
   optional,
@@ -486,6 +460,10 @@ function LineNameCellView({
   taxable: boolean
   readOnly: boolean
   currencyCode: string
+  catalogItems: CatalogItem[]
+  catalogGroups: CatalogGroup[]
+  catalogItemMap: Map<string, CatalogItem>
+  catalogLoading: boolean
   /** Focus the name input on mount — set for a freshly added draft row. */
   autoFocus?: boolean
   /** Quotes only (money plan 18 §3) — work-order/invoice builders pass `false`. */
@@ -495,8 +473,8 @@ function LineNameCellView({
   onToggleOptional: (next: boolean) => void
   onToggleOptionalSelected: (next: boolean) => void
   onToggleTaxable: (next: boolean) => void
-  onPickCatalogItem: (pick: CatalogItemPick) => void
-  onSelectGroup: (pick: CatalogGroupPick) => void
+  onPickCatalogItem: (item: CatalogItem) => void
+  onSelectGroup: (group: CatalogGroup) => void
   onFreeText: (text: string) => void
   onCommitDescription: (value: string | null) => void
   onCommitCategory: (value: string | null) => void
@@ -665,6 +643,10 @@ function LineNameCellView({
         onOpenChange={setPickerOpen}
         initialQuery={value}
         currencyCode={currencyCode}
+        items={catalogItems}
+        groups={catalogGroups}
+        itemMap={catalogItemMap}
+        isLoading={catalogLoading}
         onSelectCatalogItem={onPickCatalogItem}
         onSelectGroup={onSelectGroup}
         onFreeText={onFreeText}
@@ -761,93 +743,6 @@ function LineNameCellView({
   )
 }
 
-/** Store-bound wrapper around {@link LineNameCellView} for real (persisted) line rows. */
-function LineNameCell({
-  recordId,
-  categoryOptions,
-  readOnly,
-  currencyCode,
-  showOptionalControls,
-  optional,
-  optionalSelected,
-  onToggleOptional,
-  onToggleOptionalSelected,
-  onSelectGroup,
-  onDelete,
-}: {
-  recordId: RecordId
-  categoryOptions: CategoryOption[]
-  readOnly: boolean
-  currencyCode: string
-  showOptionalControls: boolean
-  optional: boolean
-  optionalSelected: boolean
-  onToggleOptional: (next: boolean) => void
-  onToggleOptionalSelected: (next: boolean) => void
-  onSelectGroup: (pick: CatalogGroupPick) => void
-  onDelete: () => void
-}) {
-  const { values } = useSystemValues(recordId, NAME_ATTRS, { autoFetch: true })
-  const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue()
-
-  const name = (values.line_item_name as string | undefined) ?? ''
-  const description = (values.line_item_description as string | null | undefined) ?? null
-  const category = (values.line_item_category as string | null | undefined) ?? null
-  const taxable = (values.line_item_taxable as boolean | undefined) !== false
-
-  const handlePick = (pick: CatalogItemPick) => {
-    // COPY the catalog defaults onto the line (snapshot — catalog price changes
-    // never rewrite documents) + keep the provenance relationship. A catalog/group
-    // pick always resets the line to required (money plan 18 §3) — the same
-    // "this pick overwrites the line's identity" precedent taxable already follows.
-    void saveMultipleAsync(recordId, [
-      { fieldId: 'line_item_name', value: pick.name, fieldType: FieldType.TEXT },
-      { fieldId: 'line_item_description', value: pick.description, fieldType: FieldType.TEXT },
-      { fieldId: 'line_item_category', value: pick.category, fieldType: FieldType.SINGLE_SELECT },
-      { fieldId: 'line_item_taxable', value: pick.taxable, fieldType: FieldType.CHECKBOX },
-      { fieldId: 'line_item_unit_price', value: pick.unitPrice, fieldType: FieldType.CURRENCY },
-      { fieldId: 'line_item_unit', value: pick.defaultUnit, fieldType: FieldType.SINGLE_SELECT },
-      { fieldId: 'line_item_optional', value: false, fieldType: FieldType.CHECKBOX },
-      { fieldId: 'line_item_optional_selected', value: true, fieldType: FieldType.CHECKBOX },
-      {
-        fieldId: 'line_item_catalog_item',
-        value: pick.recordId,
-        fieldType: FieldType.RELATIONSHIP,
-      },
-    ])
-  }
-
-  return (
-    <LineNameCellView
-      name={name}
-      description={description}
-      category={category}
-      categoryOptions={categoryOptions}
-      taxable={taxable}
-      readOnly={readOnly}
-      currencyCode={currencyCode}
-      showOptionalControls={showOptionalControls}
-      optional={optional}
-      optionalSelected={optionalSelected}
-      onToggleOptional={onToggleOptional}
-      onToggleOptionalSelected={onToggleOptionalSelected}
-      onToggleTaxable={(next) =>
-        saveFieldValue(recordId, 'line_item_taxable', next, FieldType.CHECKBOX)
-      }
-      onPickCatalogItem={handlePick}
-      onSelectGroup={onSelectGroup}
-      onFreeText={(text) => saveFieldValue(recordId, 'line_item_name', text, FieldType.TEXT)}
-      onCommitDescription={(value) =>
-        saveFieldValue(recordId, 'line_item_description', value, FieldType.TEXT)
-      }
-      onCommitCategory={(value) =>
-        saveFieldValue(recordId, 'line_item_category', value, FieldType.SINGLE_SELECT)
-      }
-      onDelete={onDelete}
-    />
-  )
-}
-
 /**
  * Chromeless inline number editor view — quiet at rest, editable on click (the
  * cell-treatment lock in 01-ui #1). Commits on blur/Enter, no-ops if the value
@@ -896,33 +791,6 @@ function PriceCellView({
       }}
       inputMode='decimal'
       className='h-full w-full rounded-sm border-none bg-transparent px-2 text-right text-sm tabular-nums outline-none'
-    />
-  )
-}
-
-/** Store-bound wrapper around {@link PriceCellView} for real line rows. */
-function PriceCell({
-  recordId,
-  readOnly,
-  currencyCode,
-}: {
-  recordId: RecordId
-  readOnly: boolean
-  currencyCode: string
-}) {
-  const { values } = useSystemValues(recordId, PRICE_ATTRS, { autoFetch: true })
-  const { saveFieldValue } = useSaveFieldValue()
-
-  const raw = (values.line_item_unit_price as number | null | undefined) ?? null
-
-  return (
-    <PriceCellView
-      value={raw}
-      readOnly={readOnly}
-      currencyCode={currencyCode}
-      onCommit={(next) =>
-        saveFieldValue(recordId, 'line_item_unit_price', next, FieldType.CURRENCY)
-      }
     />
   )
 }
@@ -1036,43 +904,6 @@ function QuantityCellView({
   )
 }
 
-/** Store-bound wrapper around {@link QuantityCellView} for real line rows. */
-function QuantityCell({ recordId, readOnly }: { recordId: RecordId; readOnly: boolean }) {
-  const { values } = useSystemValues(recordId, QTY_ATTRS, { autoFetch: true })
-  const { saveMultipleAsync } = useSaveFieldValue()
-
-  const qty = (values.line_item_qty as number | null | undefined) ?? 1
-  const unit = (values.line_item_unit as LineItemUnit | null | undefined) ?? null
-
-  return (
-    <QuantityCellView
-      quantity={qty}
-      unit={unit}
-      readOnly={readOnly}
-      onCommit={(next) => {
-        // Only the fields that actually changed — a combined save so realtime
-        // observers never see qty/unit half-updated relative to each other.
-        const changed: Array<{ fieldId: string; value: unknown; fieldType: FieldType }> = []
-        if (next.quantity !== qty) {
-          changed.push({
-            fieldId: 'line_item_qty',
-            value: next.quantity,
-            fieldType: FieldType.NUMBER,
-          })
-        }
-        if (next.unit !== unit) {
-          changed.push({
-            fieldId: 'line_item_unit',
-            value: next.unit,
-            fieldType: FieldType.SINGLE_SELECT,
-          })
-        }
-        if (changed.length > 0) void saveMultipleAsync(recordId, changed)
-      }}
-    />
-  )
-}
-
 /** Read-only computed line total view — `computeLineTotal` over plain values. */
 function LineTotalCellView({
   qty,
@@ -1089,16 +920,6 @@ function LineTotalCellView({
       {formatCurrency(lineTotal, currencyCode)}
     </div>
   )
-}
-
-/** Store-bound wrapper around {@link LineTotalCellView} for real line rows. */
-function LineTotalCell({ recordId, currencyCode }: { recordId: RecordId; currencyCode: string }) {
-  const { values } = useSystemValues(recordId, TOTAL_ATTRS, { autoFetch: true })
-
-  const qty = (values.line_item_qty as number | null | undefined) ?? 1
-  const unitPrice = (values.line_item_unit_price as number | null | undefined) ?? null
-
-  return <LineTotalCellView qty={qty} unitPrice={unitPrice} currencyCode={currencyCode} />
 }
 
 /** Right-aligned shortcut hint in a `⋯` menu item — the platform modifier + literal keys. */
@@ -1203,6 +1024,11 @@ export function LineRow({
   readOnly,
   currencyCode,
   documentType,
+  catalogItems,
+  catalogGroups,
+  catalogItemMap,
+  catalogLoading,
+  onUpdateLine,
   deleteLine,
   onSelectGroup,
 }: {
@@ -1213,28 +1039,23 @@ export function LineRow({
   readOnly: boolean
   currencyCode: string
   documentType: 'quote' | 'work_order' | 'invoice'
+  catalogItems: CatalogItem[]
+  catalogGroups: CatalogGroup[]
+  catalogItemMap: Map<string, CatalogItem>
+  catalogLoading: boolean
+  onUpdateLine: (recordId: RecordId, patch: LinePatch) => void
   deleteLine: (lineId: string) => void
-  onSelectGroup: (recordId: RecordId, pick: CatalogGroupPick) => void
+  onSelectGroup: (recordId: RecordId, group: CatalogGroup) => void
 }) {
   const recordId = toRecordId(entityDefinitionId, record.id)
   const isQuote = documentType === 'quote'
+  const systemAttributes = isQuote ? QUOTE_LINE_SYSTEM_ATTRIBUTES : BASE_LINE_SYSTEM_ATTRIBUTES
+  const { values } = useSystemValues(recordId, systemAttributes, { autoFetch: false })
+  const line = lineValuesFromSystemValues(values, isQuote)
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: record.id,
     disabled: readOnly,
   })
-
-  // Optional/optionalSelected (money plan 18 §3) — read once here so the row's
-  // muted/indented treatment and both cells that expose it (name badge/checkbox,
-  // actions toggle) stay in agreement. Gated on `isQuote`: work-order/invoice
-  // builders never fetch or show any of it.
-  const { values: optionalValues } = useSystemValues(recordId, OPTIONAL_ATTRS, {
-    autoFetch: isQuote,
-    enabled: isQuote,
-  })
-  const { saveFieldValue } = useSaveFieldValue()
-  const optional = isQuote && (optionalValues.line_item_optional as boolean | undefined) === true
-  const optionalSelected =
-    !isQuote || (optionalValues.line_item_optional_selected as boolean | undefined) !== false
 
   return (
     <div
@@ -1243,30 +1064,65 @@ export function LineRow({
       className={cn(isDragging && 'relative z-10 opacity-80')}>
       <LineGridRow
         rowIndex={rowIndex}
-        optional={optional}
+        optional={line.optional}
         grip={readOnly ? null : <GripSlot attributes={attributes} listeners={listeners} />}
         name={
-          <LineNameCell
-            recordId={recordId}
+          <LineNameCellView
+            name={line.name}
+            description={line.description}
+            category={line.category}
             categoryOptions={categoryOptions}
+            taxable={line.taxable}
             readOnly={readOnly}
             currencyCode={currencyCode}
+            catalogItems={catalogItems}
+            catalogGroups={catalogGroups}
+            catalogItemMap={catalogItemMap}
+            catalogLoading={catalogLoading}
             showOptionalControls={isQuote}
-            optional={optional}
-            optionalSelected={optionalSelected}
-            onToggleOptional={(next) =>
-              saveFieldValue(recordId, 'line_item_optional', next, FieldType.CHECKBOX)
+            optional={line.optional}
+            optionalSelected={line.optionalSelected}
+            onToggleOptional={(optional) => onUpdateLine(recordId, { optional })}
+            onToggleOptionalSelected={(optionalSelected) =>
+              onUpdateLine(recordId, { optionalSelected })
             }
-            onToggleOptionalSelected={(next) =>
-              saveFieldValue(recordId, 'line_item_optional_selected', next, FieldType.CHECKBOX)
-            }
-            onSelectGroup={(pick) => onSelectGroup(recordId, pick)}
+            onToggleTaxable={(taxable) => onUpdateLine(recordId, { taxable })}
+            onPickCatalogItem={(item) => onUpdateLine(recordId, catalogItemToLinePatch(item))}
+            onSelectGroup={(group) => onSelectGroup(recordId, group)}
+            onFreeText={(name) => onUpdateLine(recordId, { name })}
+            onCommitDescription={(description) => onUpdateLine(recordId, { description })}
+            onCommitCategory={(category) => onUpdateLine(recordId, { category })}
             onDelete={() => deleteLine(record.id)}
           />
         }
-        qty={<QuantityCell recordId={recordId} readOnly={readOnly} />}
-        price={<PriceCell recordId={recordId} readOnly={readOnly} currencyCode={currencyCode} />}
-        total={<LineTotalCell recordId={recordId} currencyCode={currencyCode} />}
+        qty={
+          <QuantityCellView
+            quantity={line.qty}
+            unit={line.unit}
+            readOnly={readOnly}
+            onCommit={(next) => {
+              const patch: LinePatch = {}
+              if (next.quantity !== line.qty) patch.qty = next.quantity
+              if (next.unit !== line.unit) patch.unit = next.unit
+              onUpdateLine(recordId, patch)
+            }}
+          />
+        }
+        price={
+          <PriceCellView
+            value={line.unitPriceCents}
+            readOnly={readOnly}
+            currencyCode={currencyCode}
+            onCommit={(unitPriceCents) => onUpdateLine(recordId, { unitPriceCents })}
+          />
+        }
+        total={
+          <LineTotalCellView
+            qty={line.qty}
+            unitPrice={line.unitPriceCents}
+            currencyCode={currencyCode}
+          />
+        }
       />
     </div>
   )
@@ -1286,6 +1142,10 @@ export function DraftLineRow({
   categoryOptions,
   currencyCode,
   documentType,
+  catalogItems,
+  catalogGroups,
+  catalogItemMap,
+  catalogLoading,
   deleteDraft,
   createDraft,
   onSelectGroup,
@@ -1297,9 +1157,13 @@ export function DraftLineRow({
   categoryOptions: CategoryOption[]
   currencyCode: string
   documentType: 'quote' | 'work_order' | 'invoice'
+  catalogItems: CatalogItem[]
+  catalogGroups: CatalogGroup[]
+  catalogItemMap: Map<string, CatalogItem>
+  catalogLoading: boolean
   deleteDraft: (draftId: string) => void
-  createDraft: (draftId: string, overrides?: Partial<DraftLine>) => Promise<void>
-  onSelectGroup: (draftId: string, pick: CatalogGroupPick) => void
+  createDraft: (draftId: string, overrides?: LinePatch) => Promise<void>
+  onSelectGroup: (draftId: string, group: CatalogGroup) => void
 }) {
   const isQuote = documentType === 'quote'
 
@@ -1317,6 +1181,10 @@ export function DraftLineRow({
           taxable={draft.taxable}
           readOnly={false}
           currencyCode={currencyCode}
+          catalogItems={catalogItems}
+          catalogGroups={catalogGroups}
+          catalogItemMap={catalogItemMap}
+          catalogLoading={catalogLoading}
           autoFocus={autoFocus}
           showOptionalControls={isQuote}
           optional={draft.optional}
@@ -1326,20 +1194,10 @@ export function DraftLineRow({
             void createDraft(draft.draftId, { optionalSelected: next })
           }
           onToggleTaxable={(next) => void createDraft(draft.draftId, { taxable: next })}
-          onPickCatalogItem={(pick) =>
-            void createDraft(draft.draftId, {
-              name: pick.name,
-              description: pick.description,
-              category: pick.category,
-              taxable: pick.taxable,
-              unitPriceCents: pick.unitPrice,
-              unit: pick.defaultUnit,
-              catalogItemRecordId: pick.recordId,
-              optional: false,
-              optionalSelected: true,
-            })
+          onPickCatalogItem={(item) =>
+            void createDraft(draft.draftId, catalogItemToLinePatch(item))
           }
-          onSelectGroup={(pick) => onSelectGroup(draft.draftId, pick)}
+          onSelectGroup={(group) => onSelectGroup(draft.draftId, group)}
           onFreeText={(text) => void createDraft(draft.draftId, { name: text })}
           onCommitDescription={(value) => void createDraft(draft.draftId, { description: value })}
           onCommitCategory={(value) => void createDraft(draft.draftId, { category: value })}

--- a/apps/web/src/components/money/ui/line-builder/line-values.test.ts
+++ b/apps/web/src/components/money/ui/line-builder/line-values.test.ts
@@ -1,0 +1,43 @@
+// apps/web/src/components/money/ui/line-builder/line-values.test.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_LINE_VALUES, diffLineValues, linePatchToFieldValues } from './line-values'
+
+describe('linePatchToFieldValues', () => {
+  it('maps semantic keys to system attributes and field types', () => {
+    expect(
+      linePatchToFieldValues({
+        name: 'Drain repair',
+        qty: 2,
+        unit: 'hour',
+        unitPriceCents: 12500,
+      })
+    ).toEqual([
+      { fieldId: 'line_item_name', value: 'Drain repair', fieldType: FieldType.TEXT },
+      { fieldId: 'line_item_qty', value: 2, fieldType: FieldType.NUMBER },
+      { fieldId: 'line_item_unit', value: 'hour', fieldType: FieldType.SINGLE_SELECT },
+      {
+        fieldId: 'line_item_unit_price',
+        value: 12500,
+        fieldType: FieldType.CURRENCY,
+      },
+    ])
+  })
+
+  it('retains explicit null and false while omitting absent keys', () => {
+    expect(linePatchToFieldValues({ description: null, taxable: false })).toEqual([
+      { fieldId: 'line_item_description', value: null, fieldType: FieldType.TEXT },
+      { fieldId: 'line_item_taxable', value: false, fieldType: FieldType.CHECKBOX },
+    ])
+  })
+
+  it('returns only changed snapshot values', () => {
+    const after = { ...DEFAULT_LINE_VALUES, qty: 3, unit: null, optional: true }
+    expect(diffLineValues(DEFAULT_LINE_VALUES, after)).toEqual({
+      qty: 3,
+      unit: null,
+      optional: true,
+    })
+  })
+})

--- a/apps/web/src/components/money/ui/line-builder/line-values.ts
+++ b/apps/web/src/components/money/ui/line-builder/line-values.ts
@@ -1,0 +1,127 @@
+// apps/web/src/components/money/ui/line-builder/line-values.ts
+
+import { FieldType } from '@auxx/database/enums'
+import type { FieldType as FieldTypeValue } from '@auxx/database/types'
+import type { LineItemUnit } from '@auxx/lib/money/client'
+import type { RecordId } from '@auxx/lib/resources/client'
+
+/** Persisted and draft values edited by one line-builder row. */
+export interface LineValues {
+  name: string
+  description: string | null
+  category: string | null
+  taxable: boolean
+  qty: number
+  unit: LineItemUnit | null
+  unitPriceCents: number | null
+  optional: boolean
+  optionalSelected: boolean
+  catalogItemRecordId: RecordId | null
+}
+
+/** Semantic update emitted by a row; absent keys are not written. */
+export type LinePatch = Partial<LineValues>
+
+/** Field-value mutation input used by the shared save hook. */
+export interface LineFieldValueUpdate {
+  fieldId: string
+  value: unknown
+  fieldType: FieldTypeValue
+}
+
+/** Defaults shared by persisted rows and phantom drafts. */
+export const DEFAULT_LINE_VALUES: LineValues = {
+  name: '',
+  description: null,
+  category: null,
+  taxable: true,
+  qty: 1,
+  unit: 'each',
+  unitPriceCents: null,
+  optional: false,
+  optionalSelected: true,
+  catalogItemRecordId: null,
+}
+
+/** Fields every quote/work-order/invoice row renders. */
+export const BASE_LINE_SYSTEM_ATTRIBUTES = [
+  'line_item_name',
+  'line_item_description',
+  'line_item_category',
+  'line_item_taxable',
+  'line_item_qty',
+  'line_item_unit',
+  'line_item_unit_price',
+]
+
+/** Quote-only selection fields appended to the base row values. */
+export const QUOTE_LINE_SYSTEM_ATTRIBUTES = [
+  ...BASE_LINE_SYSTEM_ATTRIBUTES,
+  'line_item_optional',
+  'line_item_optional_selected',
+]
+
+const LINE_FIELD_CONFIG: {
+  [K in keyof LineValues]: { fieldId: string; fieldType: FieldTypeValue }
+} = {
+  name: { fieldId: 'line_item_name', fieldType: FieldType.TEXT },
+  description: { fieldId: 'line_item_description', fieldType: FieldType.TEXT },
+  category: { fieldId: 'line_item_category', fieldType: FieldType.SINGLE_SELECT },
+  taxable: { fieldId: 'line_item_taxable', fieldType: FieldType.CHECKBOX },
+  qty: { fieldId: 'line_item_qty', fieldType: FieldType.NUMBER },
+  unit: { fieldId: 'line_item_unit', fieldType: FieldType.SINGLE_SELECT },
+  unitPriceCents: { fieldId: 'line_item_unit_price', fieldType: FieldType.CURRENCY },
+  optional: { fieldId: 'line_item_optional', fieldType: FieldType.CHECKBOX },
+  optionalSelected: {
+    fieldId: 'line_item_optional_selected',
+    fieldType: FieldType.CHECKBOX,
+  },
+  catalogItemRecordId: {
+    fieldId: 'line_item_catalog_item',
+    fieldType: FieldType.RELATIONSHIP,
+  },
+}
+
+const LINE_VALUE_KEYS = Object.keys(LINE_FIELD_CONFIG) as Array<keyof LineValues>
+
+/** Convert a semantic patch into field-value mutation inputs. */
+export function linePatchToFieldValues(patch: LinePatch): LineFieldValueUpdate[] {
+  const updates: LineFieldValueUpdate[] = []
+  for (const key of LINE_VALUE_KEYS) {
+    if (!Object.hasOwn(patch, key)) continue
+    const config = LINE_FIELD_CONFIG[key]
+    updates.push({ ...config, value: patch[key] })
+  }
+  return updates
+}
+
+/** Return only values that changed between two line snapshots. */
+export function diffLineValues(before: LineValues, after: LineValues): LinePatch {
+  const patch: LinePatch = {}
+  for (const key of LINE_VALUE_KEYS) {
+    if (!Object.is(before[key], after[key])) {
+      ;(patch as Record<keyof LineValues, unknown>)[key] = after[key]
+    }
+  }
+  return patch
+}
+
+/** Normalize one passive `useSystemValues` result into the row's value shape. */
+export function lineValuesFromSystemValues(
+  values: Record<string, unknown>,
+  isQuote: boolean
+): LineValues {
+  return {
+    name: (values.line_item_name as string | null | undefined) ?? '',
+    description: (values.line_item_description as string | null | undefined) ?? null,
+    category: (values.line_item_category as string | null | undefined) ?? null,
+    taxable: (values.line_item_taxable as boolean | undefined) !== false,
+    qty: (values.line_item_qty as number | null | undefined) ?? 1,
+    unit: (values.line_item_unit as LineItemUnit | null | undefined) ?? null,
+    unitPriceCents: (values.line_item_unit_price as number | null | undefined) ?? null,
+    optional: isQuote && (values.line_item_optional as boolean | undefined) === true,
+    optionalSelected:
+      !isQuote || (values.line_item_optional_selected as boolean | undefined) !== false,
+    catalogItemRecordId: null,
+  }
+}

--- a/apps/web/src/components/money/ui/line-builder/shared.ts
+++ b/apps/web/src/components/money/ui/line-builder/shared.ts
@@ -18,5 +18,5 @@ export function formatCurrency(value: number | null | undefined, currencyCode: s
 
 /** Capitalize a category value for chip display ('service' → 'Service'). */
 export function titleCase(value: string): string {
-  return value.length ? value[0].toUpperCase() + value.slice(1) : value
+  return value.length ? value.charAt(0).toUpperCase() + value.slice(1) : value
 }

--- a/apps/web/src/components/money/ui/line-builder/totals-footer.tsx
+++ b/apps/web/src/components/money/ui/line-builder/totals-footer.tsx
@@ -5,10 +5,12 @@
 // Totals footer for the line builder (money MQ1 build spec §H.1): subtotal →
 // discount → tax → total (the add-line row lives in the builder itself).
 // All amounts are computed client-side with `computeDocumentTotals` from
-// `@auxx/lib/money/client` — the exact function the server-side recompute hook
-// uses — over the same optimistic field-value store the editors write to.
+// `@auxx/lib/money/client` over the same optimistic field-value store the
+// editors write to. `LineBuilder` owns fetching and mutations; this footer is
+// a passive aggregate subscriber plus totals UI.
 
 import { FieldType } from '@auxx/database/enums'
+import type { FieldType as FieldTypeValue } from '@auxx/database/types'
 import { formatToRawValue } from '@auxx/lib/field-values/client'
 import {
   computeDocumentTotals,
@@ -25,47 +27,25 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { cn } from '@auxx/ui/lib/utils'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { RecordId } from '~/components/resources'
-import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
-import { useSystemValues } from '~/components/resources/hooks/use-system-values'
-import { fieldValueFetchQueue } from '~/components/resources/store/field-value-fetch-queue'
 import {
   buildFieldValueKey,
   type CustomFieldValueState,
   useFieldValueStore,
 } from '~/components/resources/store/field-value-store'
 import { useResourceStore } from '~/components/resources/store/resource-store'
-import { useSettings } from '~/hooks/use-settings'
 import type { DraftLine } from './line-rows'
 import { formatCurrency } from './shared'
 
 /** Org tax rate preset (`documents.taxRates` setting, §G.1). */
-interface TaxRatePreset {
+export interface TaxRatePreset {
   id: string
   name: string
   rate: number
   isDefault?: boolean
 }
-
-const QUOTE_BILLING_ATTRS = [
-  'quote_discount_type',
-  'quote_discount_value',
-  'quote_tax_name',
-  'quote_tax_rate',
-]
-
-// Invoice mode also reads the ledger-sync mirrors (`invoice_amount_paid`/`invoice_balance`,
-// money MI1 build spec §J.2) — appended to the same billing fetch, one document.
-const INVOICE_BILLING_ATTRS = [
-  'invoice_discount_type',
-  'invoice_discount_value',
-  'invoice_tax_name',
-  'invoice_tax_rate',
-  'invoice_amount_paid',
-  'invoice_balance',
-]
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Totals data — all lines' qty/unitPrice/taxable, reactively from the store
@@ -75,8 +55,7 @@ const INVOICE_BILLING_ATTRS = [
  * Subscribe to every REAL line's qty/unitPrice/taxable/optional/optionalSelected and shape
  * them as `LineForTotals[]`, then append local phantom draft lines' equivalent values
  * (`draftLines` — pure client state, no store fetch needed) so the optimistic footer counts
- * in-progress rows too. Queues its own store fetches — virtualized rows outside the viewport
- * never mount their cells, so the footer can't rely on cell subscriptions alone.
+ * in-progress rows too. `LineBuilder` preloads these keys; the footer only subscribes.
  */
 function useLinesForTotals(lineRecordIds: RecordId[], draftLines: DraftLine[]): LineForTotals[] {
   const systemAttributeMap = useResourceStore((s) => s.systemAttributeMap)
@@ -85,20 +64,6 @@ function useLinesForTotals(lineRecordIds: RecordId[], draftLines: DraftLine[]): 
   const taxableRef = systemAttributeMap.line_item_taxable
   const optionalRef = systemAttributeMap.line_item_optional
   const optionalSelectedRef = systemAttributeMap.line_item_optional_selected
-
-  useEffect(() => {
-    if (!qtyRef || !priceRef || !taxableRef || !optionalRef || !optionalSelectedRef) return
-    if (lineRecordIds.length === 0) return
-    fieldValueFetchQueue.queueFetchBatch(
-      lineRecordIds.flatMap((recordId) => [
-        { recordId, fieldRef: qtyRef },
-        { recordId, fieldRef: priceRef },
-        { recordId, fieldRef: taxableRef },
-        { recordId, fieldRef: optionalRef },
-        { recordId, fieldRef: optionalSelectedRef },
-      ])
-    )
-  }, [lineRecordIds, qtyRef, priceRef, taxableRef, optionalRef, optionalSelectedRef])
 
   const keys = useMemo(() => {
     if (!qtyRef || !priceRef || !taxableRef || !optionalRef || !optionalSelectedRef) return []
@@ -137,7 +102,7 @@ function useLinesForTotals(lineRecordIds: RecordId[], draftLines: DraftLine[]): 
       keys.map((k) => {
         // formatToRawValue returns arrays for array-stored values — collapse to
         // the scalar (the same treatment useSystemValues applies).
-        const scalar = (raw: unknown, fieldType: FieldType): unknown => {
+        const scalar = (raw: unknown, fieldType: FieldTypeValue): unknown => {
           if (raw === undefined) return undefined
           const formatted = formatToRawValue(raw, fieldType)
           return Array.isArray(formatted) ? formatted[0] : formatted
@@ -173,20 +138,27 @@ function useLinesForTotals(lineRecordIds: RecordId[], draftLines: DraftLine[]): 
 // ─────────────────────────────────────────────────────────────────────────────
 
 export function TotalsFooter({
-  documentRecordId,
   documentType,
   readOnly,
   currencyCode,
   lineRecordIds,
   draftLines,
+  billingValues,
+  taxRates,
+  onUpdateDiscount,
+  onUpdateTax,
 }: {
-  documentRecordId: RecordId
   documentType: 'quote' | 'work_order' | 'invoice'
   readOnly: boolean
   currencyCode: string
   lineRecordIds: RecordId[]
   /** Local phantom draft lines not yet persisted — counted optimistically (money plan 18 §3). */
   draftLines: DraftLine[]
+  /** Parent-document billing values fetched once by `LineBuilder`. */
+  billingValues: Record<string, unknown>
+  taxRates: TaxRatePreset[]
+  onUpdateDiscount: (type: DiscountType | null, value: number | null) => void
+  onUpdateTax: (name: string | null, rate: number | null) => void
 }) {
   const isQuote = documentType === 'quote'
   const isInvoice = documentType === 'invoice'
@@ -195,18 +167,7 @@ export function TotalsFooter({
   const hasBilling = isQuote || isInvoice
   const prefix = isInvoice ? 'invoice' : 'quote'
   const lines = useLinesForTotals(lineRecordIds, draftLines)
-  const { saveMultipleAsync } = useSaveFieldValue()
-  const { getSetting } = useSettings({})
   const [discountDraft, setDiscountDraft] = useState<string | null>(null)
-
-  // Billing inputs — the document's own mirrored fields, read through the same optimistic
-  // store the discount/tax editors write to, so the footer recomputes instantly while the
-  // roundtrip (and the §F.2/§G.1 hook) settles.
-  const { values: billingValues } = useSystemValues(
-    documentRecordId,
-    isInvoice ? INVOICE_BILLING_ATTRS : QUOTE_BILLING_ATTRS,
-    { autoFetch: hasBilling, enabled: hasBilling }
-  )
 
   const discountType =
     (billingValues[`${prefix}_discount_type`] as DiscountType | null | undefined) ?? null
@@ -225,27 +186,18 @@ export function TotalsFooter({
   const billing: DocumentBillingInputs = hasBilling ? { discountType, discountValue, taxRate } : {}
   const totals = computeDocumentTotals(lines, billing)
 
-  const taxRates = ((getSetting('documents.taxRates') as TaxRatePreset[] | null) ?? []).filter(
-    (r) => r && typeof r.rate === 'number'
-  )
   const selectedTaxId =
     taxRate !== null
       ? (taxRates.find((r) => r.rate === taxRate && r.name === taxName)?.id ?? '__custom__')
       : '__none__'
 
   const writeDiscount = (type: DiscountType | null, value: number | null) => {
-    void saveMultipleAsync(documentRecordId, [
-      { fieldId: `${prefix}_discount_type`, value: type, fieldType: FieldType.SINGLE_SELECT },
-      { fieldId: `${prefix}_discount_value`, value, fieldType: FieldType.NUMBER },
-    ])
+    onUpdateDiscount(type, value)
   }
 
   const writeTax = (preset: TaxRatePreset | null) => {
     // Snapshot name+rate at pick — editing a preset later never rewrites documents.
-    void saveMultipleAsync(documentRecordId, [
-      { fieldId: `${prefix}_tax_name`, value: preset?.name ?? null, fieldType: FieldType.TEXT },
-      { fieldId: `${prefix}_tax_rate`, value: preset?.rate ?? null, fieldType: FieldType.NUMBER },
-    ])
+    onUpdateTax(preset?.name ?? null, preset?.rate ?? null)
   }
 
   // Amount discounts are stored as integer cents (CURRENCY convention); percent


### PR DESCRIPTION
## Summary

- move line value synchronization and persistence ownership out of individual cells
- keep field edits immediately optimistic while consolidating save behavior in the line builder
- preload catalog items and groups once, then resolve product-group labels from the existing record data
- make totals and row cells passive consumers of builder-owned values
- add focused tests for line value projection and catalog group resolution

## Verification

- pnpm exec vitest run src/components/money/ui/line-builder/line-values.test.ts src/components/money/ui/line-builder/catalog-group-resolver.test.ts
- focused Biome check for all changed files
- git diff --check
- changed line-builder paths produced no TypeScript errors; the full web typecheck still reports unrelated pre-existing errors

## Notes

- the implementation plan remains local under plans/dispatch because the plans directory is gitignored