### PR TITLE
feat(dispatch): persist board view + active date in the URL (nuqs)

### DIFF
--- a/apps/web/src/components/calendar/core/use-calendar-range.ts
+++ b/apps/web/src/components/calendar/core/use-calendar-range.ts
@@ -14,6 +14,24 @@ export interface DateRange {
   to: Date
 }
 
+/** The covering fetch window for a date in a given view — the day/week/month the calendar renders
+ * around `date`. Used to seed the initial `range` (below) so a deep-linked date+view fetches its
+ * real window on first paint instead of today's day and then correcting on mount. Mirrors
+ * `EventCalendar`'s own `rangeFrom/rangeTo` derivation. */
+function windowFor(date: Date, view: CalendarRangeView, weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6) {
+  if (view === 'month') {
+    const monthStart = startOfMonth(endOfWeek(date, { weekStartsOn }))
+    return {
+      from: startOfWeek(monthStart, { weekStartsOn }),
+      to: endOfWeek(endOfMonth(monthStart), { weekStartsOn }),
+    }
+  }
+  if (view === 'week') {
+    return { from: startOfWeek(date, { weekStartsOn }), to: endOfWeek(date, { weekStartsOn }) }
+  }
+  return { from: startOfDay(date), to: endOfDay(date) }
+}
+
 /**
  * Date/view/range state shared by every calendar shell consumer, extracted verbatim from
  * `dispatch/ui/board/hooks/use-board-data.ts:41-83` (plan §3.2). `range` is fed by
@@ -28,17 +46,27 @@ export function useCalendarRange(
    * quantize the week stream's fetch window (below) to whole weeks; a mismatched boundary still
    * over-covers the true visible range, it just doesn't align the padding to the org's actual
    * week start. */
-  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 1
+  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6 = 1,
+  /** Optional controlled `date`/`view` — when a consumer owns these elsewhere (e.g. the dispatch
+   * board persists them in the URL via nuqs), pass them here and this hook reads them instead of
+   * its own state; the returned `setDate`/`setView` then only drive the fallback internal state
+   * (unused by controlled consumers, which write through their own setters). Omit for the internal
+   * state behaviour (schedule page, records calendar view). */
+  controlled?: { date?: Date; view?: CalendarRangeView }
 ) {
-  const [date, setDate] = useState(() => new Date())
-  const [view, setView] = useState<CalendarRangeView>(initialView)
-  // Matches the calendar's own day-view range calc (`startOfDay`/`endOfDay`) so the first
-  // `onRangeChange` firing (in the calendar's mount effect) is a no-op query-key match
-  // instead of a second fetch.
-  const [range, setRange] = useState<DateRange>(() => ({
-    from: startOfDay(new Date()),
-    to: endOfDay(new Date()),
-  }))
+  const [internalDate, setInternalDate] = useState(() => new Date())
+  const [internalView, setInternalView] = useState<CalendarRangeView>(initialView)
+  const date = controlled?.date ?? internalDate
+  const view = controlled?.view ?? internalView
+  const setDate = setInternalDate
+  const setView = setInternalView
+  // Seed the fetch window from the (possibly controlled) date+view so a deep-linked month/week
+  // fetches its real range on first paint. For the default day view this equals the calendar's
+  // own day-view calc, so the first `onRangeChange` (in the calendar's mount effect) is a no-op
+  // query-key match instead of a second fetch.
+  const [range, setRange] = useState<DateRange>(() =>
+    windowFor(controlled?.date ?? new Date(), controlled?.view ?? initialView, weekStartsOn)
+  )
 
   const rangeDebounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   useEffect(() => () => clearTimeout(rangeDebounceRef.current), [])

--- a/apps/web/src/components/dispatch/ui/board/board-toolbar.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-toolbar.tsx
@@ -30,7 +30,11 @@ const RADIO_TAB_ITEM_CLASS = 'px-2'
 
 interface BoardToolbarProps {
   date: Date
+  /** Window navigation (prev/next chevrons) — steps the anchor by the active view's unit. In month
+   * view the board's reducer keeps the anchor's day-of-month; see `use-board-data.ts`. */
   onDateChange: (date: Date) => void
+  /** Absolute day jump (Today) — sets the exact day as the anchor, bypassing the month reducer. */
+  onDateSelect: (date: Date) => void
   view: BoardViewMode
   onViewChange: (view: BoardViewMode) => void
   weekStartsOn: WeekStartIndex
@@ -51,6 +55,7 @@ interface BoardToolbarProps {
 export function BoardToolbar({
   date,
   onDateChange,
+  onDateSelect,
   view,
   onViewChange,
   weekStartsOn,
@@ -99,7 +104,7 @@ export function BoardToolbar({
           variant='ghost'
           size='sm'
           onClick={() =>
-            onDateChange(
+            onDateSelect(
               effectiveView === 'week' ? startOfWeek(new Date(), { weekStartsOn }) : new Date()
             )
           }>

--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -2,7 +2,6 @@
 
 'use client'
 
-import { weekStartToIndex } from '@auxx/lib/availability/client'
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import { isRecordId } from '@auxx/lib/resources/client'
 import { CalendarDndProvider } from '@auxx/ui/components/event-calendar'
@@ -17,7 +16,6 @@ import { EmptyState } from '~/components/global/empty-state'
 import { RecordDrawer } from '~/components/records/record-drawer'
 import { toRecordId, useResource } from '~/components/resources'
 import { useDockedPanels } from '~/hooks/use-docked-panels'
-import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
@@ -35,7 +33,7 @@ import { useBoardMutations } from './hooks/use-board-mutations'
 import { useBoardRealtime } from './hooks/use-board-realtime'
 import type { DispatchVisitEvent } from './types'
 import { UNASSIGNED_RESOURCE_ID } from './types'
-import { computeOverlappingVisitIds, scalarSetting } from './utils'
+import { computeOverlappingVisitIds } from './utils'
 import { VisitChipContent } from './visit-chip-content'
 
 /**
@@ -87,12 +85,9 @@ export function DispatchBoard() {
     planner.setFilters({ workerIds: data.selectedWorkerIds, tags: selectedTagsSet })
   }, [selectedTagsSet, data.selectedWorkerIds, planner.setFilters])
 
-  const { getSetting } = useSettings({ scope: 'GENERAL' })
-  const weekStart = (scalarSetting(getSetting('organization.weekStart')) ?? 'monday') as
-    | 'monday'
-    | 'sunday'
-    | 'saturday'
-  const weekStartsOn = weekStartToIndex(weekStart)
+  // Org week-start (Mon/Sun/Sat) → `date-fns` index, derived once in `useBoardData` (it needs the
+  // same value for the month-anchor reducer) and reused here for the toolbar/grid/sidebar.
+  const weekStartsOn = data.weekStartsOn
 
   const workerUserIds = useMemo(() => data.workers.map((w) => w.userId), [data.workers])
   const { backgroundEvents, isNonWorkingDay } = useAvailabilityShading({
@@ -286,6 +281,7 @@ export function DispatchBoard() {
         <BoardToolbar
           date={data.date}
           onDateChange={data.setDate}
+          onDateSelect={data.setDateAbsolute}
           view={data.view}
           onViewChange={data.setView}
           weekStartsOn={weekStartsOn}
@@ -302,7 +298,7 @@ export function DispatchBoard() {
                 mode='map'
                 canEdit={canEdit}
                 date={data.date}
-                onDateChange={data.setDate}
+                onDateChange={data.setDateAbsolute}
                 visibleRange={data.range}
                 weekStartsOn={weekStartsOn}
                 allWorkers={data.allWorkers}
@@ -335,7 +331,7 @@ export function DispatchBoard() {
                 mode='calendar'
                 canEdit={canEdit}
                 date={data.date}
-                onDateChange={data.setDate}
+                onDateChange={data.setDateAbsolute}
                 visibleRange={data.range}
                 view={data.view}
                 weekStartsOn={weekStartsOn}

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
@@ -2,10 +2,13 @@
 
 'use client'
 
+import { weekStartToIndex } from '@auxx/lib/availability/client'
 import { getOptionColorHex } from '@auxx/lib/custom-fields/client'
-import { parseAsStringLiteral, useQueryState } from 'nuqs'
-import { useMemo } from 'react'
+import { format, isSameDay, startOfDay } from 'date-fns'
+import { createParser, parseAsStringLiteral, useQueryState } from 'nuqs'
+import { useCallback, useMemo } from 'react'
 import { useCalendarRange } from '~/components/calendar/core/use-calendar-range'
+import { useSettings } from '~/hooks/use-settings'
 import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 import { useHiddenWorkerIds } from '../../../stores/dispatch-sidebar-store'
@@ -17,11 +20,28 @@ import {
 } from '../types'
 import {
   isWorkerHidden,
+  scalarSetting,
   selectedWorkerIdsFromHidden,
   splitVisits,
   UNASSIGNED_COLOR,
   visitToEvent,
+  withPreservedDayOfMonth,
 } from '../utils'
+
+const BOARD_VIEWS = ['day', 'timeline', 'week', 'month'] as const
+
+/** `?date=` holds a bare local day (`YYYY-MM-DD`) — the board's active anchor, shared by Map and
+ * every board view. Parsed at LOCAL midnight (not `parseAsIsoDate`'s UTC midnight, which would
+ * shift the stored day back a calendar day in western timezones) so the anchor matches the
+ * dispatcher's local day. */
+const parseAsDay = createParser({
+  parse: (raw: string) => {
+    const parsed = new Date(`${raw}T00:00:00`)
+    return Number.isNaN(parsed.getTime()) ? null : startOfDay(parsed)
+  },
+  serialize: (date: Date) => format(date, 'yyyy-MM-dd'),
+  eq: (a: Date, b: Date) => isSameDay(a, b),
+})
 
 /** Re-export of the shared shell's range type — kept here so existing importers of this hook's
  * `DateRange` don't need to repoint (`use-board-mutations.ts`, `use-board-realtime.ts`,
@@ -29,10 +49,11 @@ import {
 export type { DateRange } from '~/components/calendar/core/use-calendar-range'
 
 /**
- * Board date/view/range/filter state + the `dispatch.getBoard` query (D.3). Date/view/range
- * state itself is the shared `useCalendarRange()` (plan §3.2, extracted verbatim from this
- * hook) — `range` is fed by `EventCalendar`'s `onRangeChange` — stored by timestamp so
- * identical ranges (same day/view recomputed) don't churn the query key.
+ * Board date/view/range/filter state + the `dispatch.getBoard` query (D.3). `date` and `view` are
+ * URL-persisted here (nuqs `?date=`/`?view=`, alongside `?mode=`) so a reload/deep-link restores
+ * the board; they're fed CONTROLLED into the shared `useCalendarRange()` (plan §3.2), which derives
+ * `range` from `EventCalendar`'s `onRangeChange` — stored by timestamp so identical ranges (same
+ * day/view recomputed) don't churn the query key.
  *
  * `selectedWorkerIds`/Unassigned-column visibility (v3 sidebar plan §1.1/§1.3) derive from the
  * persisted `dispatch-sidebar` store's Workers group hidden set (`useHiddenWorkerIds`) — the
@@ -41,7 +62,43 @@ export type { DateRange } from '~/components/calendar/core/use-calendar-range'
  * below keep their pre-v3 `Set<string> | null` contract untouched.
  */
 export function useBoardData() {
-  const { date, setDate, view, setView, range, handleRangeChange } = useCalendarRange()
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const weekStartsOn = weekStartToIndex(
+    (scalarSetting(getSetting('organization.weekStart')) ?? 'monday') as
+      | 'monday'
+      | 'sunday'
+      | 'saturday'
+  )
+
+  // Board view + active anchor date, both persisted in the URL (nuqs) so a reload/deep-link lands
+  // the dispatcher back where they were. `date` is a single day shared by Map (day-scoped) and
+  // every board view — each view derives its own window from it (`useCalendarRange` below).
+  const [view, setView] = useQueryState(
+    'view',
+    parseAsStringLiteral(BOARD_VIEWS).withDefault('day')
+  )
+  const [date, setDateParam] = useQueryState('date', parseAsDay.withDefault(startOfDay(new Date())))
+
+  // Two write paths into the anchor. `setDate` = window navigation (calendar scroll-settle +
+  // toolbar chevrons): in month view it keeps the anchor's day-of-month inside the newly viewed
+  // month (`withPreservedDayOfMonth`) so switching back to Map/Day returns to that day; every other
+  // view just takes the emitted first/leftmost day. `setDateAbsolute` = an exact day pick (mini
+  // calendar, Today), which always sets that day verbatim.
+  const setDate = useCallback(
+    (next: Date) =>
+      setDateParam((prev) =>
+        view === 'month'
+          ? withPreservedDayOfMonth(prev ?? next, next, weekStartsOn)
+          : startOfDay(next)
+      ),
+    [view, weekStartsOn, setDateParam]
+  )
+  const setDateAbsolute = useCallback((day: Date) => setDateParam(startOfDay(day)), [setDateParam])
+
+  // `date`/`view` are owned here (URL); the shared range hook is fed them controlled and only
+  // supplies the derived `range` + `handleRangeChange`.
+  const { range, handleRangeChange } = useCalendarRange('day', weekStartsOn, { date, view })
+
   // Board↔Map toggle (09-route-planner.md §A, contract item 7) — sibling state to the sidebar's
   // `open`, deliberately NOT a `BoardViewMode` so the month-view debounce and `view === 'day'`
   // gates stay untouched. Entering map mode doesn't change `view`; the map always renders
@@ -145,8 +202,10 @@ export function useBoardData() {
   return {
     date,
     setDate,
+    setDateAbsolute,
     view,
     setView,
+    weekStartsOn,
     range,
     handleRangeChange,
     allWorkers,

--- a/apps/web/src/components/dispatch/ui/board/utils.ts
+++ b/apps/web/src/components/dispatch/ui/board/utils.ts
@@ -6,6 +6,8 @@ import {
   addMonths,
   addWeeks,
   endOfWeek,
+  getDaysInMonth,
+  setDate as setDayOfMonth,
   startOfDay,
   startOfMonth,
   startOfWeek,
@@ -121,6 +123,24 @@ export function goToNextDate(view: BoardViewMode, date: Date, weekStartsOn: Week
   if (view === 'day' || view === 'timeline') return addDays(date, 1)
   if (view === 'week') return addWeeks(date, 1)
   return startOfWeek(addMonths(viewedMonthStart(date, weekStartsOn), 1), { weekStartsOn })
+}
+
+/**
+ * Month-view anchor reducer. The month stream re-anchors the board's active `date` on both
+ * chevron paging and scroll-settle (`month-view.tsx` emits the settled row's grid-boundary
+ * top-left day) — neither of which carries the day-of-month the user cares about. This keeps the
+ * previous anchor's day-of-month inside the newly *viewed* month (`startOfMonth(endOfWeek(...))`,
+ * the same "viewed month" rule the month stream uses), clamped to the month's length, so toggling
+ * to Map or Day view returns to that day. Day/week/timeline don't call this — their anchor is just
+ * the emitted first/leftmost day.
+ */
+export function withPreservedDayOfMonth(
+  prev: Date,
+  next: Date,
+  weekStartsOn: WeekStartIndex
+): Date {
+  const viewedMonth = startOfMonth(endOfWeek(next, { weekStartsOn }))
+  return setDayOfMonth(viewedMonth, Math.min(prev.getDate(), getDaysInMonth(viewedMonth)))
 }
 
 /** Only visits with both `startTime`/`endTime` render on the grid. */


### PR DESCRIPTION
## What

Extends the dispatch board's URL state beyond the existing `?mode=` (calendar|map) so a reload / deep-link restores where the dispatcher left off:

- **`?view=`** — `day` | `timeline` | `week` | `month`
- **`?date=`** — a bare local day (`YYYY-MM-DD`), the single **anchor day** shared by Map (day-scoped) and every board view

Defaults (`day` + today) are stripped from the URL so it stays clean until you navigate.

## How

- `date`/`view` move out of `useCalendarRange`'s internal `useState` into nuqs in `use-board-data.ts`. The shared hook (also used by the schedule page + records calendar view, left untouched) gains an optional `controlled?: { date?, view? }` arg; dispatch feeds it the URL values. It also seeds the initial `range` from the view's window so a deep-linked month/week fetches its real range on first paint instead of today's day then correcting on mount.
- `?date=` uses a custom `createParser` that parses at **local** midnight (not `parseAsIsoDate`'s UTC midnight, which shifts the day back one in western timezones), with `eq: isSameDay` so today/default is stripped.

### Month keeps the day-of-month

Month view re-anchors `date` on **both** chevron paging and scroll-settle (`month-view.tsx` emits the settled row's grid top-left day, e.g. Jul 28), which would lose the day. Two write paths:

- **Window navigation** (calendar `onDateChange` + toolbar chevrons) → `setDate` → in month view routes through new `withPreservedDayOfMonth(prev, next, weekStartsOn)`: keep the prior day-of-month inside `next`'s viewed month, clamped. Week/timeline take the emitted first/leftmost day.
- **Absolute picks** (mini-calendar, toolbar Today via new `onDateSelect` prop) → `setDateAbsolute` → the exact day, bypassing the reducer.

`weekStartsOn` is derived once in `useBoardData` (needed by the reducer) and reused in `dispatch-board.tsx`, dropping its duplicate `useSettings` block.

## Verified (browser, `/app/dispatch`)

Defaults clean → `?view=week`/`month` persist → month Next gives `date=2026-08-16` (day-of-month kept, not a grid boundary) → switching to Map inherits Aug 16 + `mode=map` → reload restores all three (mini-cal highlights 16 in August) → mini-cal pick of the 5th gives `date=2026-08-05` exact → Today+Day strips both back to clean.

web `tsc` clean on all 5 files (two pre-existing `schedule-page.tsx` errors are unrelated), Biome clean.