### PR TITLE
feat(dispatch): skip-this-and-future visits + instant line-builder adds/deletes

### DIFF
--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-mutations.ts
@@ -132,11 +132,29 @@ export function useBoardMutations(range: DateRange) {
     onSettled: settle,
   })
 
+  // "Skip this and future visits" — the target's own tombstone is patched optimistically; the
+  // deleted later siblings sweep away on the settle invalidate (the `applyToSeries` rationale).
+  const cancelVisitFollowing = api.dispatch.cancelVisitFollowing.useMutation({
+    onMutate: async (vars) => {
+      await utils.dispatch.getBoard.cancel(range)
+      return { previous: patchVisit(vars.visitId, { status: 'canceled' }) }
+    },
+    onError: (error, _vars, ctx) => {
+      rollback(ctx?.previous)
+      toastError({
+        title: 'Error skipping visits',
+        description: error.message,
+      })
+    },
+    onSettled: settle,
+  })
+
   return {
     scheduleVisit,
     unscheduleVisit,
     setVisitStatus,
     dispatchVisit,
     applyToSeries,
+    cancelVisitFollowing,
   }
 }

--- a/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/board/visit-popover.tsx
@@ -26,7 +26,7 @@ import {
 import { useResource } from '~/components/resources'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
-import { isVisitDispatchable } from '../job-schedule/job-schedule-utils'
+import { cancelVisitConfirmOptions, isVisitDispatchable } from '../job-schedule/job-schedule-utils'
 import type { ExistingVisitForOverlap } from '../schedule-popover'
 import { AssigneeRow } from '../shared/assignee-row'
 import { InlineEventTimePicker } from '../shared/inline-event-time-picker'
@@ -114,11 +114,14 @@ export function VisitPopoverContent({
   })
 
   /** Repeat-row commits never go through the scope chooser and always re-anchor from the
-   * chip's current start (decision #3 / plan §4.2). */
+   * chip's current start (decision #3 / plan §4.2). Fired by the editor's explicit Save
+   * button only — closing the page without saving discards instead (`resetToRule` below). */
   const commitRecurrence = () => {
     if (!editor.wantsRecurrenceWrite || !editor.patternValid) return
     const input = editor.buildSetRecurrenceInput(event.start, event.end, event.assigneeUserId)
-    if (input) setRecurrence.mutate(input)
+    if (!input) return
+    setRecurrence.mutate(input)
+    editor.markSaved()
   }
 
   const hints = useScheduleHints({
@@ -128,6 +131,18 @@ export function VisitPopoverContent({
     endTime: event.end,
     existingVisits,
   })
+
+  /** Confirmed cancel with the series-scope choice: primary = this visit only (the existing
+   * tombstone), alternate = "Skip this and future visits" (tombstone + series ends here). */
+  const handleCancel = async () => {
+    const choice = await confirm(cancelVisitConfirmOptions(Boolean(event.recurrenceRuleId)))
+    if (!choice) return
+    if (choice === 'alternate') {
+      mutations.cancelVisitFollowing.mutate({ visitId: event.id })
+    } else {
+      mutations.setVisitStatus.mutate({ visitId: event.id, status: 'canceled' })
+    }
+  }
 
   const handleDispatch = async () => {
     if (event.dispatchedAt) {
@@ -281,9 +296,20 @@ export function VisitPopoverContent({
                 : undefined
           }
           disabled={!canEdit || !workOrderRecordId || editor.repeatLocked}
-          renderEditor={() => <RepeatEditor editor={editor} />}
+          renderEditor={(close) => (
+            <RepeatEditor
+              editor={editor}
+              saving={setRecurrence.isPending}
+              onSave={() => {
+                commitRecurrence()
+                close()
+              }}
+            />
+          )}
           onOpenChange={(open) => {
-            if (!open) commitRecurrence()
+            // Save already cleared `repeatsTouched`, so this only fires on close-without-save:
+            // discard the staged edits so the collapsed pill never shows an unwritten cadence.
+            if (!open && editor.repeatsTouched) editor.resetToRule()
           }}
         />
 
@@ -310,11 +336,12 @@ export function VisitPopoverContent({
                     <Button
                       size='sm'
                       variant='ghost'
-                      onClick={() =>
-                        mutations.setVisitStatus.mutate({ visitId: event.id, status: 'canceled' })
-                      }
-                      loading={mutations.setVisitStatus.isPending}>
-                      Cancel visit
+                      onClick={handleCancel}
+                      loading={
+                        mutations.setVisitStatus.isPending ||
+                        mutations.cancelVisitFollowing.isPending
+                      }>
+                      {event.recurrenceRuleId ? 'Skip visit' : 'Cancel visit'}
                     </Button>
                   )}
                 </div>

--- a/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-utils.ts
+++ b/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-utils.ts
@@ -114,6 +114,33 @@ export function movedFromLabel(
   return `Moved from ${format(occurrence, 'EEE, MMM d')}`
 }
 
+/**
+ * Confirm-dialog copy for the cancel/skip action — ONE source for the board popover and every
+ * job-schedule surface. Series rows offer the extra "Skip this and future visits" choice
+ * (`alternateText` resolves `'alternate'` from `useConfirm`), which routes to
+ * `dispatch.cancelVisitFollowing` (tombstone + series ends at this occurrence).
+ */
+export function cancelVisitConfirmOptions(isSeries: boolean) {
+  return isSeries
+    ? {
+        title: 'Skip this visit?',
+        description:
+          'The visit stays in the job\'s history as skipped and won\'t be regenerated. "Skip this and future visits" also ends the series after this one.',
+        confirmText: 'Skip visit',
+        alternateText: 'Skip this and future visits',
+        cancelText: 'Keep visit',
+        destructive: true,
+      }
+    : {
+        title: 'Cancel this visit?',
+        description:
+          "The visit stays in the job's history as canceled. This does not cancel the job.",
+        confirmText: 'Cancel visit',
+        cancelText: 'Keep visit',
+        destructive: true,
+      }
+}
+
 /** Newest-first split of a work order's visits into "upcoming" and "history" (07 §F.3). */
 export function splitJobVisits(visits: JobVisit[]): { upcoming: JobVisit[]; history: JobVisit[] } {
   const upcoming: JobVisit[] = []

--- a/apps/web/src/components/dispatch/ui/job-schedule/schedule-visit-row.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/schedule-visit-row.tsx
@@ -12,7 +12,12 @@ import { useActors } from '~/components/resources/hooks/use-actor'
 import { useConfirm } from '~/hooks/use-confirm'
 import { visitStatusLabel } from '../board/types'
 import { type ExistingVisitForOverlap, SchedulePopover } from '../schedule-popover'
-import { formatVisitWindow, movedFromLabel, VISIT_STATUS_BADGE_VARIANT } from './job-schedule-utils'
+import {
+  cancelVisitConfirmOptions,
+  formatVisitWindow,
+  movedFromLabel,
+  VISIT_STATUS_BADGE_VARIANT,
+} from './job-schedule-utils'
 import type { JobVisit, UseJobVisitsResult } from './use-job-visits'
 
 export interface ScheduleVisitRowProps {
@@ -60,27 +65,13 @@ export function ScheduleVisitRow({
   const moved = movedFromLabel(visit)
 
   const handleCancel = async () => {
-    const confirmed = await confirm(
-      isSeries
-        ? {
-            title: 'Skip this visit?',
-            description:
-              "The visit stays in the job's history as skipped and won't be regenerated. This does not affect other visits.",
-            confirmText: 'Skip visit',
-            cancelText: 'Keep visit',
-            destructive: true,
-          }
-        : {
-            title: 'Cancel this visit?',
-            description:
-              "The visit stays in the job's history as canceled. This does not cancel the job.",
-            confirmText: 'Cancel visit',
-            cancelText: 'Keep visit',
-            destructive: true,
-          }
-    )
-    if (!confirmed) return
-    mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
+    const choice = await confirm(cancelVisitConfirmOptions(isSeries))
+    if (!choice) return
+    if (choice === 'alternate') {
+      mutations.cancelVisitFollowing.mutate({ visitId: visit.id })
+    } else {
+      mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
+    }
   }
 
   return (

--- a/apps/web/src/components/dispatch/ui/job-schedule/use-job-visits.ts
+++ b/apps/web/src/components/dispatch/ui/job-schedule/use-job-visits.ts
@@ -74,6 +74,11 @@ export function useJobVisits(workOrderRecordId: RecordId) {
     onError: onErrorToast('Error restoring visit'),
     onSuccess: invalidate,
   })
+  // "Skip this and future visits" — tombstones the target and ends its series there.
+  const cancelVisitFollowing = api.dispatch.cancelVisitFollowing.useMutation({
+    onError: onErrorToast('Error skipping visits'),
+    onSuccess: invalidate,
+  })
 
   // `SchedulePopoverContent`'s overlap-hint input (07 §D.4) — this job's own
   // other scheduled visits (multi-visit is a planned extension; harmless no-op
@@ -105,6 +110,7 @@ export function useJobVisits(workOrderRecordId: RecordId) {
       setVisitStatus,
       dispatchVisit,
       restoreVisit,
+      cancelVisitFollowing,
     },
     /** Re-fetch this work order's visits — pair with `SchedulePopover`'s `onScheduled`/
      * `onUnscheduled` callbacks, since that component owns its own mutation (not one of

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-card.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-card.tsx
@@ -23,7 +23,11 @@ import {
 } from '../board/types'
 import { getVisitDayContext, isExecutionReady } from '../board/utils'
 import { type ExistingVisitForOverlap, SchedulePopover } from '../schedule-popover'
-import { isVisitDispatchable, movedFromLabel } from './job-schedule-utils'
+import {
+  cancelVisitConfirmOptions,
+  isVisitDispatchable,
+  movedFromLabel,
+} from './job-schedule-utils'
 import type { JobVisit, UseJobVisitsResult } from './use-job-visits'
 import { VisitDateBlock } from './visit-date-block'
 
@@ -104,27 +108,13 @@ export function VisitCard({
   const isSeries = Boolean(visit.recurrenceRuleId)
 
   const handleCancel = async () => {
-    const confirmed = await confirm(
-      isSeries
-        ? {
-            title: 'Skip this visit?',
-            description:
-              "The visit stays in the job's history as skipped and won't be regenerated. This does not affect other visits.",
-            confirmText: 'Skip visit',
-            cancelText: 'Keep visit',
-            destructive: true,
-          }
-        : {
-            title: 'Cancel this visit?',
-            description:
-              "The visit stays in the job's history as canceled. This does not cancel the job.",
-            confirmText: 'Cancel visit',
-            cancelText: 'Keep visit',
-            destructive: true,
-          }
-    )
-    if (!confirmed) return
-    mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
+    const choice = await confirm(cancelVisitConfirmOptions(isSeries))
+    if (!choice) return
+    if (choice === 'alternate') {
+      mutations.cancelVisitFollowing.mutate({ visitId: visit.id })
+    } else {
+      mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
+    }
   }
 
   return (

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
@@ -35,6 +35,7 @@ import { api } from '~/trpc/react'
 import { visitStatusLabel } from '../board/types'
 import { SchedulePopover } from '../schedule-popover'
 import {
+  cancelVisitConfirmOptions,
   isVisitDispatchable,
   movedFromLabel,
   resolveVisitDurationMinutes,
@@ -117,27 +118,13 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
   }
 
   const handleCancel = async () => {
-    const confirmed = await confirm(
-      isSeries
-        ? {
-            title: 'Skip this visit?',
-            description:
-              "The visit stays in the job's history as skipped and won't be regenerated. This does not affect other visits.",
-            confirmText: 'Skip visit',
-            cancelText: 'Keep visit',
-            destructive: true,
-          }
-        : {
-            title: 'Cancel this visit?',
-            description:
-              "The visit stays in the job's history as canceled. This does not cancel the job.",
-            confirmText: 'Cancel visit',
-            cancelText: 'Keep visit',
-            destructive: true,
-          }
-    )
-    if (!confirmed) return
-    mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
+    const choice = await confirm(cancelVisitConfirmOptions(isSeries))
+    if (!choice) return
+    if (choice === 'alternate') {
+      mutations.cancelVisitFollowing.mutate({ visitId: visit.id })
+    } else {
+      mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
+    }
   }
 
   return (

--- a/apps/web/src/components/dispatch/ui/schedule-popover.tsx
+++ b/apps/web/src/components/dispatch/ui/schedule-popover.tsx
@@ -177,12 +177,14 @@ export function SchedulePopoverContent({
     applyToSeries.mutate({ visitId, scope, changes: { assigneeUserId: userId } })
   }
 
-  /** Fires on the Repeat row's nested editor closing, in scheduled (non-draft) mode only. */
+  /** Scheduled (non-draft) mode's cadence commit — fired by the Repeat editor's explicit Save
+   * button; closing the page without saving discards instead (`resetToRule` below). */
   const commitRecurrence = () => {
     if (!editor.wantsRecurrenceWrite || !editor.patternValid || !startTime || !endTime) return
     const input = editor.buildSetRecurrenceInput(startTime, endTime, assigneeUserId)
     if (!input) return
     setRecurrence.mutate(input)
+    editor.markSaved()
   }
 
   const canSave = Boolean(startTime && endTime) && editor.patternValid
@@ -271,9 +273,25 @@ export function SchedulePopoverContent({
                 : undefined
           }
           disabled={editor.repeatLocked}
-          renderEditor={() => <RepeatEditor editor={editor} />}
+          renderEditor={(close) => (
+            <RepeatEditor
+              editor={editor}
+              // Draft mode has no Save — the staged Repeat commits with the Schedule button.
+              saving={setRecurrence.isPending}
+              onSave={
+                isDraft
+                  ? undefined
+                  : () => {
+                      commitRecurrence()
+                      close()
+                    }
+              }
+            />
+          )}
           onOpenChange={(open) => {
-            if (!open && !isDraft) commitRecurrence()
+            // Non-draft close-without-save = discard (Save cleared `repeatsTouched` already);
+            // draft mode keeps its staged edits for the Schedule commit.
+            if (!open && !isDraft && editor.repeatsTouched) editor.resetToRule()
           }}
         />
       )}

--- a/apps/web/src/components/dispatch/ui/shared/repeat-editor.tsx
+++ b/apps/web/src/components/dispatch/ui/shared/repeat-editor.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { Button } from '@auxx/ui/components/button'
 import {
   Select,
   SelectContent,
@@ -19,6 +20,14 @@ import type { RecurrenceEditor } from './use-recurrence-editor'
 export interface RepeatEditorProps {
   editor: RecurrenceEditor
   disabled?: boolean
+  /**
+   * Explicit commit affordance — renders a footer Save button (enabled once the cadence was
+   * actually edited and is valid). Consumers that autosave pass "commit + close" here and treat
+   * a close WITHOUT save as discard (`editor.resetToRule`); draft-mode consumers (the schedule
+   * popover's create flow) omit it — their staged Repeat commits with the Schedule button.
+   */
+  onSave?: () => void
+  saving?: boolean
 }
 
 /**
@@ -26,7 +35,7 @@ export interface RepeatEditorProps {
  * (custom) + `RecurrenceEndFields`, driven entirely by `useRecurrenceEditor`. Injected via the
  * base `EventRepeatSection`'s `renderEditor` slot by both the board and schedule popovers.
  */
-export function RepeatEditor({ editor, disabled }: RepeatEditorProps) {
+export function RepeatEditor({ editor, disabled, onSave, saving }: RepeatEditorProps) {
   const {
     repeatMode,
     hasExistingRule,
@@ -98,6 +107,17 @@ export function RepeatEditor({ editor, disabled }: RepeatEditorProps) {
         <p className='px-0.5 text-xs text-destructive'>
           Pick at least one weekday, or fix the end condition, to save this pattern.
         </p>
+      )}
+
+      {onSave && (
+        <Button
+          size='sm'
+          className='w-full'
+          disabled={!wantsRecurrenceWrite || !patternValid}
+          loading={saving}
+          onClick={onSave}>
+          Save
+        </Button>
       )}
     </div>
   )

--- a/apps/web/src/components/dispatch/ui/shared/use-recurrence-editor.ts
+++ b/apps/web/src/components/dispatch/ui/shared/use-recurrence-editor.ts
@@ -86,7 +86,7 @@ export function useRecurrenceEditor({
   const repeatLocked = !hasExistingRule && workOrderHasRule
 
   const [repeatMode, setRepeatMode] = useState<RecurrencePreset>('none')
-  const [customPattern, setCustomPattern] = useState<RecurrencePattern>(
+  const [customPattern, setCustomPatternRaw] = useState<RecurrencePattern>(
     defaultCustomPattern(initialStartTime ?? undefined)
   )
   // Ends (until/count) live independently of the preset/custom pattern — both popovers edit
@@ -109,8 +109,19 @@ export function useRecurrenceEditor({
     const preset = classifyPreset(pattern)
     setRepeatMode(preset)
     setEndsRaw({ until: pattern.until, count: pattern.count })
-    if (preset === 'custom') setCustomPattern({ ...pattern, until: undefined, count: undefined })
+    if (preset === 'custom') setCustomPatternRaw({ ...pattern, until: undefined, count: undefined })
   }, [recurrenceQuery.data, recurrenceQuery.isLoading, hasExistingRule])
+
+  /**
+   * Marks Repeats as touched alongside the pattern update — a weekday-chip/interval edit inside
+   * an already-Custom rule is a cadence edit too. The raw setter never engaged
+   * `wantsRecurrenceWrite`, so those edits silently no-oped at commit time (the "We,Th → Tu
+   * does nothing" bug).
+   */
+  const setCustomPattern = (next: RecurrencePattern) => {
+    setRepeatsTouched(true)
+    setCustomPatternRaw(next)
+  }
 
   // Preset patterns anchor on the LIVE start time (the date/time the user has staged/picked
   // this session), falling back to the visit's existing start when nothing's been touched yet.
@@ -169,6 +180,31 @@ export function useRecurrenceEditor({
     setEndsRaw(next)
   }
 
+  /** Call right after firing `setRecurrence` — the staged state now IS the saved state, so a
+   * subsequent close must neither re-commit nor discard it. */
+  const markSaved = () => setRepeatsTouched(false)
+
+  /**
+   * Discard staged Repeats edits — re-seed from the existing rule (same mapping as the init
+   * effect) or back to the 'none' default. Consumers call this when the editor page closes
+   * with unsaved edits, so the collapsed Repeat pill never shows a cadence that was never
+   * written.
+   */
+  const resetToRule = () => {
+    setRepeatsTouched(false)
+    if (!recurrenceQuery.data || !hasExistingRule) {
+      setRepeatMode('none')
+      setEndsRaw({})
+      setCustomPatternRaw(defaultCustomPattern(initialStartTime ?? undefined))
+      return
+    }
+    const pattern = recurrenceQuery.data.pattern as unknown as RecurrencePattern
+    const preset = classifyPreset(pattern)
+    setRepeatMode(preset)
+    setEndsRaw({ until: pattern.until, count: pattern.count })
+    if (preset === 'custom') setCustomPatternRaw({ ...pattern, until: undefined, count: undefined })
+  }
+
   /** The `dispatch.setRecurrence` payload for the current pattern, or `null` if not writable. */
   const buildSetRecurrenceInput = (
     inputStartTime: Date,
@@ -206,6 +242,8 @@ export function useRecurrenceEditor({
     ends,
     setEnds,
     repeatsTouched,
+    markSaved,
+    resetToRule,
     handleRepeatModeChange,
     effectivePattern,
     recurrenceSummary,

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -39,17 +39,30 @@
 //   against the real record. An untouched draft simply vanishes on unmount.
 //   An editable builder initially seeds three of these drafts as local loading
 //   placeholders. If persisted rows arrive, they replace only those initial
-//   drafts; they still follow the same no-save-until-edited rule.
-// - Group explode: a catalog-group pick fills the picked line (entry #1) and
-//   pushes entries 2…N as pre-filled phantom drafts in the same frame, then
-//   materializes them through the same createDraft → seed pipeline — the
-//   bundle is fully visible (and totaled) before any create resolves, and no
-//   row ever shifts position while the creates land.
+//   drafts; they still follow the same no-save-until-edited rule. An editable
+//   builder also never renders zero rows: when the last real row and draft
+//   are gone, one placeholder draft re-seeds automatically.
+//   Every draft-state write goes through `mutateDrafts`, which updates
+//   `draftsRef` synchronously and mirrors it into state — a plain `setDrafts`
+//   built from a stale ref once clobbered a queued functional update and
+//   persisted a blank line (plans/dispatch/31 §1.1), so the ref is the single
+//   source of truth and `setDrafts` is never called directly.
+// - Group explode: a catalog-group pick fills the picked line (entry #1),
+//   stages entries 2…N as pre-filled phantom drafts in the same frame (also
+//   dropping any untouched initial placeholders so the bundle lands directly
+//   under the picked row), then materializes the whole bundle through ONE
+//   `record.createMany` round-trip (`createDrafts`) — the bundle is fully
+//   visible (and totaled) before any create resolves. On the draft-row path
+//   the bundle create waits for entry #1's own create so real rows always
+//   land in visual order.
 // - Reorder: dnd-kit sortable rows (grip handle) → `api.money.reorderLines`.
 //   Draft rows aren't part of the sortable set — they pin after the real rows.
-// - Delete: real rows → `api.record.delete` + `api.money.recomputeTotals`
-//   (delete path doesn't fire field-change hooks, §F.2). Draft rows → local
-//   splice, no network.
+// - Delete: optimistic — `removeRecord` drops the row from the record store
+//   (and every cached list, so `TotalsFooter` repaints in the same frame),
+//   then `api.record.delete` + `api.money.recomputeTotals` (delete path
+//   doesn't fire field-change hooks, §F.2) fire without awaiting; an error
+//   restores the row via `invalidateRecord` + `refresh()`. Draft rows →
+//   local splice, no network.
 
 import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
@@ -79,6 +92,7 @@ import {
   type RecordMeta,
   toRecordId,
   useRecordList,
+  useRecordStore,
   useResource,
   useResourceFields,
 } from '~/components/resources'
@@ -230,7 +244,16 @@ export function LineBuilder({
   // a keyboard-driven or button-driven "add row" lands the caret ready to type.
   const [lastAddedDraftId, setLastAddedDraftId] = useState<string | null>(null)
   const draftsRef = useRef<DraftLine[]>([])
-  draftsRef.current = drafts
+  /**
+   * Single draft-state writer: applies the update to `draftsRef` synchronously
+   * and mirrors the result into state, so two writers in one tick can never
+   * clobber each other's queued update (the plan-31 §1.1 blank-line bug).
+   * `fn` runs exactly once, synchronously — side effects inside are safe.
+   */
+  const mutateDrafts = useCallback((fn: (prev: DraftLine[]) => DraftLine[]) => {
+    draftsRef.current = fn(draftsRef.current)
+    setDrafts(draftsRef.current)
+  }, [])
   // An editable document starts with a small working set of local-only rows.
   // Track just these initial rows so persisted records can replace them without
   // hiding drafts the user explicitly added later.
@@ -373,9 +396,9 @@ export function LineBuilder({
       freshDraft(generateId())
     )
     initialDraftIdsRef.current = new Set(initialDrafts.map((draft) => draft.draftId))
-    setDrafts(initialDrafts)
+    mutateDrafts(() => initialDrafts)
     setLastAddedDraftId(initialDrafts[0]?.draftId ?? null)
-  }, [entityDefinitionId, readOnly, displayRecords.length])
+  }, [entityDefinitionId, readOnly, displayRecords.length, mutateDrafts])
 
   // When persisted lines arrive, hide/remove the initial loading placeholders
   // in the same render. A draft becomes non-placeholder before its first
@@ -389,9 +412,26 @@ export function LineBuilder({
     if (displayRecords.length === 0 || initialDraftIdsRef.current.size === 0) return
     const initialDraftIds = initialDraftIdsRef.current
     initialDraftIdsRef.current = new Set()
-    setDrafts((current) => current.filter((draft) => !initialDraftIds.has(draft.draftId)))
+    mutateDrafts((current) => current.filter((draft) => !initialDraftIds.has(draft.draftId)))
     setLastAddedDraftId((current) => (current && initialDraftIds.has(current) ? null : current))
-  }, [displayRecords.length])
+  }, [displayRecords.length, mutateDrafts])
+
+  // An editable builder never renders zero rows: when the last real row AND
+  // the last draft are gone (final line deleted, last placeholder trashed),
+  // re-seed one placeholder draft. It shares the initial-placeholder
+  // lifecycle — hidden again if a persisted row (re)appears (e.g. a failed
+  // delete restoring via refresh()), no record until its first edit. The
+  // initial-seed effect above owns the first paint (3 placeholders); this
+  // only re-arms after it.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-check on any row-set change; refs hold the truth
+  useEffect(() => {
+    if (!entityDefinitionId || readOnly || !seededInitialDraftsRef.current) return
+    if (displayRecords.length > 0 || draftsRef.current.length > 0) return
+    const draft = freshDraft(generateId())
+    initialDraftIdsRef.current.add(draft.draftId)
+    mutateDrafts(() => [draft])
+    setLastAddedDraftId(draft.draftId)
+  }, [entityDefinitionId, readOnly, displayRecords.length, drafts.length, mutateDrafts])
 
   const lineRecordIds = useMemo(
     () =>
@@ -422,11 +462,13 @@ export function LineBuilder({
   const deleteRecord = api.record.delete.useMutation()
   const deleteInvoiceLine = api.money.deleteInvoiceLine.useMutation()
   const createRecord = api.record.create.useMutation()
+  const createManyRecords = api.record.createMany.useMutation()
   const { mutate: reorderMutate } = reorderLines
   const { mutate: recomputeMutate } = recomputeTotals
   const { mutateAsync: deleteMutateAsync } = deleteRecord
   const { mutateAsync: deleteInvoiceLineMutateAsync } = deleteInvoiceLine
   const { mutateAsync: createMutateAsync } = createRecord
+  const { mutateAsync: createManyMutateAsync } = createManyRecords
 
   const { saveFieldValue, saveMultipleAsync } = useSaveFieldValue()
   const { seedCreatedRecord } = useSeedCreatedRecord()
@@ -478,26 +520,38 @@ export function LineBuilder({
   )
 
   const deleteLine = useCallback(
-    async (lineId: string) => {
+    (lineId: string) => {
       if (!entityDefinitionId) return
-      try {
-        if (documentType === 'invoice') {
-          // Unstamps the gathered source line + recomputes totals server-side
-          // (money MI1 build spec §G.3) — NOT the quote's record.delete + recompute pair.
-          await deleteInvoiceLineMutateAsync({
-            lineRecordId: toRecordId(entityDefinitionId, lineId),
-          })
-        } else {
-          await deleteMutateAsync({ recordId: toRecordId(entityDefinitionId, lineId) })
-          // Deletes don't fire field-change hooks — recompute explicitly (§F.2).
-          if (documentType === 'quote') recomputeMutate({ quoteRecordId: docRecordId })
-        }
+      // Optimistic: drop the record from the store (and every cached list —
+      // `lineRecordIds` shrinks, so the row AND the totals footer repaint in
+      // this frame), then fire the delete without awaiting. No `refresh()` on
+      // success — the store is already correct, and the refetch is what made
+      // deletes feel slow.
+      useRecordStore.getState().removeRecord(entityDefinitionId, lineId)
+      const restoreOnError = (error: unknown) => {
+        // `removeRecord` marked the id not-found, which `requestRecord` would
+        // skip — clear that marker first so the refetched list can resurrect
+        // the row.
+        useRecordStore.getState().invalidateRecord(entityDefinitionId, lineId)
         refresh()
-      } catch (error) {
         toastError({
           title: 'Error deleting line',
           description: error instanceof Error ? error.message : 'Could not delete the line',
         })
+      }
+      if (documentType === 'invoice') {
+        // Unstamps the gathered source line + recomputes totals server-side
+        // (money MI1 build spec §G.3) — NOT the quote's record.delete + recompute pair.
+        deleteInvoiceLineMutateAsync({
+          lineRecordId: toRecordId(entityDefinitionId, lineId),
+        }).catch(restoreOnError)
+      } else {
+        deleteMutateAsync({ recordId: toRecordId(entityDefinitionId, lineId) })
+          .then(() => {
+            // Deletes don't fire field-change hooks — recompute explicitly (§F.2).
+            if (documentType === 'quote') recomputeMutate({ quoteRecordId: docRecordId })
+          })
+          .catch(restoreOnError)
       }
     },
     [
@@ -512,11 +566,14 @@ export function LineBuilder({
   )
 
   /** Draft delete (trash icon) — local splice, no network. */
-  const deleteDraft = useCallback((draftId: string) => {
-    creatingDraftIdsRef.current.delete(draftId)
-    initialDraftIdsRef.current.delete(draftId)
-    setDrafts((prev) => prev.filter((d) => d.draftId !== draftId))
-  }, [])
+  const deleteDraft = useCallback(
+    (draftId: string) => {
+      creatingDraftIdsRef.current.delete(draftId)
+      initialDraftIdsRef.current.delete(draftId)
+      mutateDrafts((prev) => prev.filter((d) => d.draftId !== draftId))
+    },
+    [mutateDrafts]
+  )
 
   /**
    * "+ Add line item" (and keyboard nav past the last row) — pushes a
@@ -525,8 +582,34 @@ export function LineBuilder({
   const addLine = useCallback(() => {
     const draft = freshDraft(generateId())
     setLastAddedDraftId(draft.draftId)
-    setDrafts((prev) => [...prev, draft])
-  }, [])
+    mutateDrafts((prev) => [...prev, draft])
+  }, [mutateDrafts])
+
+  /** Build a draft's `record.create` values payload (shared by the single and bulk paths). */
+  const draftCreateValues = useCallback(
+    (snapshot: DraftLine, sortOrder: number): Record<string, unknown> => {
+      const relKey = relKeyForDocumentType(documentType)
+      const values: Record<string, unknown> = {
+        line_item_qty: snapshot.qty,
+        line_item_unit: snapshot.unit,
+        line_item_taxable: snapshot.taxable,
+        line_item_optional: snapshot.optional,
+        line_item_optional_selected: snapshot.optionalSelected,
+        line_item_sort_order: sortOrder,
+        [relKey]: documentRecordId,
+      }
+      if (visitId) values.line_item_visit_id = visitId
+      if (snapshot.name) values.line_item_name = snapshot.name
+      if (snapshot.description) values.line_item_description = snapshot.description
+      if (snapshot.category) values.line_item_category = snapshot.category
+      if (snapshot.unitPriceCents !== null) values.line_item_unit_price = snapshot.unitPriceCents
+      if (snapshot.catalogItemRecordId) {
+        values.line_item_catalog_item = snapshot.catalogItemRecordId
+      }
+      return values
+    },
+    [documentType, documentRecordId, visitId]
+  )
 
   /**
    * Fire the draft's first `record.create`, carrying every accumulated draft
@@ -541,7 +624,9 @@ export function LineBuilder({
       // draft, so an arriving persisted list cannot remove the user's work.
       initialDraftIdsRef.current.delete(draftId)
       if (creatingDraftIdsRef.current.has(draftId)) {
-        setDrafts((prev) => prev.map((d) => (d.draftId === draftId ? { ...d, ...overrides } : d)))
+        mutateDrafts((prev) =>
+          prev.map((d) => (d.draftId === draftId ? { ...d, ...overrides } : d))
+        )
         return
       }
 
@@ -555,26 +640,9 @@ export function LineBuilder({
       }
 
       creatingDraftIdsRef.current.add(draftId)
-      setDrafts((prev) => prev.map((d) => (d.draftId === draftId ? snapshot : d)))
+      mutateDrafts((prev) => prev.map((d) => (d.draftId === draftId ? snapshot : d)))
 
-      const relKey = relKeyForDocumentType(documentType)
-      const values: Record<string, unknown> = {
-        line_item_qty: snapshot.qty,
-        line_item_unit: snapshot.unit,
-        line_item_taxable: snapshot.taxable,
-        line_item_optional: snapshot.optional,
-        line_item_optional_selected: snapshot.optionalSelected,
-        line_item_sort_order: displayIdsRef.current.length + draftIndex,
-        [relKey]: documentRecordId,
-      }
-      if (visitId) values.line_item_visit_id = visitId
-      if (snapshot.name) values.line_item_name = snapshot.name
-      if (snapshot.description) values.line_item_description = snapshot.description
-      if (snapshot.category) values.line_item_category = snapshot.category
-      if (snapshot.unitPriceCents !== null) values.line_item_unit_price = snapshot.unitPriceCents
-      if (snapshot.catalogItemRecordId) {
-        values.line_item_catalog_item = snapshot.catalogItemRecordId
-      }
+      const values = draftCreateValues(snapshot, displayIdsRef.current.length + draftIndex)
 
       try {
         const result = await createMutateAsync({ entityDefinitionId: 'line_item', values })
@@ -596,10 +664,10 @@ export function LineBuilder({
         }
 
         creatingDraftIdsRef.current.delete(draftId)
-        setDrafts((prev) => prev.filter((d) => d.draftId !== draftId))
+        mutateDrafts((prev) => prev.filter((d) => d.draftId !== draftId))
       } catch (error) {
         creatingDraftIdsRef.current.delete(draftId)
-        setDrafts((prev) =>
+        mutateDrafts((prev) =>
           prev.map((d) => (d.draftId === draftId ? { ...d, creating: false } : d))
         )
         toastError({
@@ -610,9 +678,8 @@ export function LineBuilder({
     },
     [
       entityDefinitionId,
-      documentType,
-      documentRecordId,
-      visitId,
+      draftCreateValues,
+      mutateDrafts,
       createMutateAsync,
       saveMultipleAsync,
       seedCreatedRecord,
@@ -621,42 +688,126 @@ export function LineBuilder({
   )
 
   /**
-   * Steps 2 (append entries 2…N) + 4–5 (document discount/tax set-if-unset)
-   * of a catalog-group explode (money 09-product-groups.md "Line-builder
-   * consumption") — shared by the real-row and draft-row group-pick paths.
-   * Entries 2…N land as pre-filled phantom drafts IMMEDIATELY — instant
-   * paint, and totals are right on the first frame (`TotalsFooter` already
-   * folds drafts into its math). They then materialize through the normal
-   * `createDraft` → `seedCreatedRecord` pipeline, each draft swapping in
-   * place for its real row with zero refetch — no `refresh()`, so the list
-   * never reshuffles mid-explode. Creates run sequentially: the list cache
-   * appends in completion order, so completion order must equal draft order
-   * to agree with the `line_item_sort_order` stamps (freshDraft's
-   * optional=false / optionalSelected=true defaults are exactly the
-   * "group-exploded lines start required" rule, money plan 18 §3).
+   * Materialize a staged bundle of pre-filled drafts through ONE
+   * `record.createMany` round-trip (plan 31 §D). Marks every draft
+   * `creating`, calls `createMany` (all-or-nothing server-side), then per
+   * result — in input order, so the list cache appends agree with the
+   * `line_item_sort_order` stamps — seeds the record + field-value caches and
+   * diff-flushes anything the user edited while the create was in flight.
+   * On error, every bundle draft resets to editable with one toast.
    */
-  const applyGroupPickRestAndBilling = useCallback(
-    (pick: ResolvedCatalogGroup, rest: LineValues[]) => {
-      if (rest.length > 0) {
-        const bundleDrafts: DraftLine[] = rest.map((line) => ({
-          ...freshDraft(generateId()),
-          ...line,
-        }))
-        // Write through draftsRef (normally render-synced) so the sequential
-        // createDraft calls below can resolve these drafts before React
-        // re-renders; per-line failures keep the draft editable + toast
-        // inside createDraft, so there's no explode-level error handling.
-        draftsRef.current = [...draftsRef.current, ...bundleDrafts]
-        setDrafts(draftsRef.current)
-        void (async () => {
-          for (const draft of bundleDrafts) {
-            await createDraft(draft.draftId)
-          }
-        })()
+  const createDrafts = useCallback(
+    async (bundleDrafts: DraftLine[]) => {
+      if (!entityDefinitionId || bundleDrafts.length === 0) return
+      const draftIds = new Set(bundleDrafts.map((d) => d.draftId))
+      for (const draftId of draftIds) {
+        initialDraftIdsRef.current.delete(draftId)
+        creatingDraftIdsRef.current.add(draftId)
       }
 
-      // Steps 4–5: document discount/tax set-if-unset — quote/invoice only, never
-      // overwriting a value the document already has.
+      // Snapshot each draft's CURRENT values (edits may have landed since
+      // staging) while marking them all `creating` in one write.
+      const snapshots = new Map<string, DraftLine>()
+      mutateDrafts((prev) =>
+        prev.map((d) => {
+          if (!draftIds.has(d.draftId)) return d
+          const snapshot: DraftLine = { ...d, creating: true }
+          snapshots.set(d.draftId, snapshot)
+          return snapshot
+        })
+      )
+
+      const orderedDrafts = bundleDrafts.filter((d) => snapshots.has(d.draftId))
+      const records = orderedDrafts.map((draft) => {
+        const draftIndex = draftsRef.current.findIndex((d) => d.draftId === draft.draftId)
+        return draftCreateValues(
+          snapshots.get(draft.draftId)!,
+          displayIdsRef.current.length + draftIndex
+        )
+      })
+      if (records.length === 0) return
+
+      try {
+        const results = await createManyMutateAsync({ entityDefinitionId: 'line_item', records })
+
+        const flushes: Promise<unknown>[] = []
+        results.forEach((result, i) => {
+          const draft = orderedDrafts[i]
+          const snapshot = draft ? snapshots.get(draft.draftId) : undefined
+          if (!draft || !snapshot) return
+          seedCreatedRecord({
+            entityDefinitionId,
+            recordId: result.recordId,
+            listKey,
+            instance: result.instance,
+            values: linePatchToFieldValues(snapshot),
+          })
+          const latest = draftsRef.current.find((d) => d.draftId === draft.draftId) ?? snapshot
+          const changed = linePatchToFieldValues(diffLineValues(snapshot, latest))
+          if (changed.length > 0) flushes.push(saveMultipleAsync(result.recordId, changed))
+        })
+
+        for (const draftId of draftIds) creatingDraftIdsRef.current.delete(draftId)
+        mutateDrafts((prev) => prev.filter((d) => !draftIds.has(d.draftId)))
+        await Promise.all(flushes)
+      } catch (error) {
+        for (const draftId of draftIds) creatingDraftIdsRef.current.delete(draftId)
+        mutateDrafts((prev) =>
+          prev.map((d) => (draftIds.has(d.draftId) ? { ...d, creating: false } : d))
+        )
+        toastError({
+          title: 'Error adding lines',
+          description: error instanceof Error ? error.message : 'Could not add the lines',
+        })
+      }
+    },
+    [
+      entityDefinitionId,
+      draftCreateValues,
+      mutateDrafts,
+      createManyMutateAsync,
+      saveMultipleAsync,
+      seedCreatedRecord,
+      listKey,
+    ]
+  )
+
+  /**
+   * Step 2 of a catalog-group explode (money 09-product-groups.md
+   * "Line-builder consumption"): stage entries 2…N as pre-filled phantom
+   * drafts IMMEDIATELY — instant paint, and totals are right on the first
+   * frame (`TotalsFooter` already folds drafts into its math). The same write
+   * drops any untouched initial placeholder drafts (plan 31 §C) so the bundle
+   * lands directly under the picked row instead of below empty warm-up rows.
+   * Returns the staged drafts for {@link createDrafts} to materialize
+   * (freshDraft's optional=false / optionalSelected=true defaults are exactly
+   * the "group-exploded lines start required" rule, money plan 18 §3).
+   */
+  const stageBundleDrafts = useCallback(
+    (rest: LineValues[]): DraftLine[] => {
+      if (rest.length === 0) return []
+      const bundleDrafts: DraftLine[] = rest.map((line) => ({
+        ...freshDraft(generateId()),
+        ...line,
+      }))
+      const initialDraftIds = initialDraftIdsRef.current
+      initialDraftIdsRef.current = new Set()
+      mutateDrafts((prev) => [
+        ...prev.filter((d) => !initialDraftIds.has(d.draftId)),
+        ...bundleDrafts,
+      ])
+      setLastAddedDraftId((current) => (current && initialDraftIds.has(current) ? null : current))
+      return bundleDrafts
+    },
+    [mutateDrafts]
+  )
+
+  /**
+   * Steps 4–5 of a catalog-group explode: document discount/tax set-if-unset —
+   * quote/invoice only, never overwriting a value the document already has.
+   */
+  const applyGroupBilling = useCallback(
+    (pick: ResolvedCatalogGroup) => {
       if (hasBilling) {
         const currentDiscountValue = billingValues[`${billingPrefix}_discount_value`] as
           | number
@@ -677,13 +828,14 @@ export function LineBuilder({
         }
       }
     },
-    [hasBilling, billingPrefix, billingValues, taxRates, updateDiscount, updateTax, createDraft]
+    [hasBilling, billingPrefix, billingValues, taxRates, updateDiscount, updateTax]
   )
 
   /**
    * Explode a picked catalog group onto a REAL line (money 09-product-groups.md
    * "Line-builder consumption"): entry #1 fills the line whose picker was open,
-   * entries 2…N append as new lines via {@link applyGroupPickRestAndBilling}.
+   * entries 2…N are staged in the same frame and materialized through one
+   * `record.createMany`.
    */
   const handleGroupPick = useCallback(
     (recordId: RecordId, group: CatalogGroup) => {
@@ -703,9 +855,11 @@ export function LineBuilder({
       updateLine(recordId, first)
 
       // Known v1 edge: picking on a middle line still appends `rest` at the list end.
-      applyGroupPickRestAndBilling(pick, rest)
+      const bundleDrafts = stageBundleDrafts(rest)
+      applyGroupBilling(pick)
+      void createDrafts(bundleDrafts)
     },
-    [catalogItemMap, updateLine, applyGroupPickRestAndBilling]
+    [catalogItemMap, updateLine, stageBundleDrafts, applyGroupBilling, createDrafts]
   )
 
   /** Same explode intent as {@link handleGroupPick}, targeting a phantom draft. */
@@ -721,12 +875,22 @@ export function LineBuilder({
       if (!first) return
 
       // Step 1: entry #1's values become THIS draft's create. Catalog/group-exploded
-      // lines start required (money plan 18 §3).
-      void createDraft(draftId, first)
+      // lines start required (money plan 18 §3). Called BEFORE staging so its
+      // synchronous prefix promotes the picked draft out of the initial
+      // placeholder set — otherwise the §C cleanup below would drop it.
+      const firstCreate = createDraft(draftId, first)
 
-      applyGroupPickRestAndBilling(pick, rest)
+      const bundleDrafts = stageBundleDrafts(rest)
+      applyGroupBilling(pick)
+
+      // Materialize the bundle only after entry #1's create settles: real rows
+      // append to the list cache in completion order, so entry #1 must land
+      // first for the persisted rows to match the on-screen (and sort_order)
+      // order. The bundle rows are already painted as drafts, so this costs
+      // nothing visually. `createDraft` never rejects (it toasts internally).
+      void firstCreate.then(() => createDrafts(bundleDrafts))
     },
-    [catalogItemMap, createDraft, applyGroupPickRestAndBilling]
+    [catalogItemMap, createDraft, stageBundleDrafts, applyGroupBilling, createDrafts]
   )
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))

--- a/apps/web/src/hooks/use-confirm.tsx
+++ b/apps/web/src/hooks/use-confirm.tsx
@@ -18,10 +18,17 @@ interface ConfirmOptions {
   description?: string
   confirmText?: string
   cancelText?: string
+  /** Optional third choice between Cancel and Confirm (e.g. "Skip this and future visits") —
+   * resolves the promise with `'alternate'`. Both truthy results mean the user proceeded;
+   * callers that never pass this keep the plain boolean contract. */
+  alternateText?: string
   destructive?: boolean
 }
 
-type ConfirmCallback = (value: boolean) => void
+/** `true` = primary confirm, `'alternate'` = the optional third button, `false` = canceled. */
+export type ConfirmResult = boolean | 'alternate'
+
+type ConfirmCallback = (value: ConfirmResult) => void
 
 /**
  * Hook for creating confirmation dialogs before performing destructive actions
@@ -36,13 +43,14 @@ export function useConfirm() {
   // put `confirm` in callback dep arrays; an unstable identity there cascades
   // into the records-table column defs (primaryCellRender) and re-renders the
   // whole grid on unrelated updates.
-  const confirm = useCallback((options: ConfirmOptions = {}): Promise<boolean> => {
+  const confirm = useCallback((options: ConfirmOptions = {}): Promise<ConfirmResult> => {
     return new Promise((resolve) => {
       setOptions({
         title: options.title || 'Confirm',
         description: options.description || 'Are you sure?',
         confirmText: options.confirmText || 'Confirm',
         cancelText: options.cancelText || 'Cancel',
+        alternateText: options.alternateText,
         destructive: options.destructive || false,
       })
 
@@ -51,17 +59,14 @@ export function useConfirm() {
     })
   }, [])
 
-  const handleConfirm = () => {
+  const resolveWith = (value: ConfirmResult) => {
     setOpen(false)
-    callback?.(true)
+    callback?.(value)
     setCallback(null)
   }
 
-  const handleCancel = () => {
-    setOpen(false)
-    callback?.(false)
-    setCallback(null)
-  }
+  const handleConfirm = () => resolveWith(true)
+  const handleCancel = () => resolveWith(false)
 
   const ConfirmDialog = () => (
     <Dialog open={open} onOpenChange={(open) => !open && handleCancel()}>
@@ -82,6 +87,15 @@ export function useConfirm() {
             data-testid='confirmation-modal-cancel-button'>
             {options.cancelText} <Kbd shortcut='esc' variant='ghost' size='sm' />
           </Button>
+          {options.alternateText && (
+            <Button
+              size='sm'
+              variant='outline'
+              onClick={() => resolveWith('alternate')}
+              data-testid='confirmation-modal-alternate-button'>
+              {options.alternateText}
+            </Button>
+          )}
           <Button
             data-dialog-submit
             size='sm'

--- a/apps/web/src/server/api/routers/dispatch.ts
+++ b/apps/web/src/server/api/routers/dispatch.ts
@@ -9,6 +9,7 @@ import {
   advanceMyVisit,
   applyRouteTimes,
   assignVisit,
+  cancelVisitFollowing,
   closeMyVisit,
   convertRequestToWorkOrder,
   createQcItemTemplate,
@@ -221,6 +222,20 @@ export const dispatchRouter = createTRPCRouter({
         status: input.status,
         excludeSocketId: excludeSocketId(ctx),
       })
+    }),
+  // "Skip this and future visits" — tombstones the target occurrence AND ends its series
+  // there (`until` stamp + later-scheduled-row cleanup). Single-row cancels keep going
+  // through `setVisitStatus`.
+  cancelVisitFollowing: dispatchAdminProcedure
+    .input(z.object({ visitId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await cancelVisitFollowing({
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.user.id,
+        visitId: input.visitId,
+        excludeSocketId: excludeSocketId(ctx),
+      })
+      return { success: true }
     }),
   dispatchVisit: dispatchAdminProcedure
     .input(z.object({ visitId: z.string() }))

--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -7,6 +7,7 @@ import { BadRequestError } from '@auxx/lib/errors'
 import { getDescendantIds } from '@auxx/lib/field-values'
 import { getRecordIdentityViews } from '@auxx/lib/identity'
 import {
+  type CreateEntityResult,
   type LookupCandidate,
   RESOURCE_TABLE_REGISTRY,
   UnifiedCrudHandler,
@@ -121,6 +122,15 @@ const getByIdLegacyInputSchema = z.object({
 const createInputSchema = z.object({
   entityDefinitionId: z.string(),
   values: z.record(z.string(), z.any()).optional(),
+})
+
+/**
+ * Input for createMany mutation. Capped at 50 — the caller is an interactive
+ * bulk add (e.g. a catalog-group explode), not an import pipeline.
+ */
+const createManyInputSchema = z.object({
+  entityDefinitionId: z.string(),
+  records: z.array(z.record(z.string(), z.any())).min(1).max(50),
 })
 
 /**
@@ -445,6 +455,46 @@ export const recordRouter = createTRPCRouter({
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message: `Failed to create record: ${error.message}`,
+      })
+    }
+  }),
+
+  /**
+   * Create multiple entity instances in one round-trip (plans/dispatch/31 §D).
+   * Runs the exact single-create pipeline per record, in input order, and
+   * returns `{ recordId, instance }` per row in the same order.
+   *
+   * Deliberately NOT wrapped in a DB transaction: the synchronous field-change
+   * hooks (e.g. the money totals recompute, `totals-hooks.ts`) read and write
+   * through pool-scoped services, so rows created inside an open transaction
+   * would be invisible to their reads and their writes would FK-fail against
+   * the uncommitted instances. All-or-nothing is approximated instead: a
+   * mid-loop failure deletes the rows already created, then rethrows.
+   */
+  createMany: protectedProcedure.input(createManyInputSchema).mutation(async ({ ctx, input }) => {
+    const { organizationId, user } = ctx.session
+    const handler = new UnifiedCrudHandler(organizationId, user.id, ctx.db, getSocketId(ctx))
+    const created: Array<Pick<CreateEntityResult, 'recordId' | 'instance'>> = []
+
+    try {
+      for (const values of input.records) {
+        const result = await handler.create(input.entityDefinitionId, values)
+        created.push({ recordId: result.recordId, instance: result.instance })
+      }
+      return created
+    } catch (error: any) {
+      // Compensate best-effort — a failed cleanup delete must not mask the
+      // original error, so each one is swallowed individually.
+      for (const row of [...created].reverse()) {
+        try {
+          await handler.delete(row.recordId)
+        } catch {
+          // Leave the orphan; the original error below is what the user sees.
+        }
+      }
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: `Failed to create records: ${error.message}`,
       })
     }
   }),

--- a/apps/worker/scripts/verify-dispatch-scheduling-fixes.ts
+++ b/apps/worker/scripts/verify-dispatch-scheduling-fixes.ts
@@ -37,7 +37,9 @@
 import { database } from '@auxx/database'
 import {
   addVisit,
+  cancelVisitFollowing,
   dispatchVisit,
+  materializeVisits,
   restoreVisit,
   scheduleVisit,
   setRecurrenceRule,
@@ -650,6 +652,94 @@ async function main() {
       'unscheduleVisit rejected on a series-linked visit',
       errSeriesUnschedule instanceof BadRequestError,
       errSeriesUnschedule
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 8. cancelVisitFollowing ("Skip this and future visits"): tombstones the target, stamps
+    //    pattern.until = its occurrenceDate (count stripped), deletes LATER scheduled series
+    //    rows, leaves earlier/done rows + rule-less extras alone, and a re-materialize never
+    //    regenerates past the stamp.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('8: cancel this-and-following')
+    const wo8 = await createWO('cancel following')
+    await setRecurrenceRule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo8.instance.id,
+      // Daily + count so the window holds several rows and the count-strip is provable.
+      pattern: { frequency: 'daily', interval: 1, count: 10 },
+      template: { startMinute: 540, durationMinutes: 60 },
+      timezone: 'UTC',
+      effectiveFrom: todayIso,
+    })
+    const wo8Rows = await getVisitsSorted(wo8.instance.id)
+    const seriesRows8 = wo8Rows.filter((r) => r.recurrenceRuleId != null)
+    check('setup: several series rows materialized', seriesRows8.length >= 4, seriesRows8.length)
+    const [first8, target8] = seriesRows8
+    if (!first8 || !target8) throw new Error('section 8 setup failed')
+
+    // Earlier occurrence goes done — must survive the cut untouched.
+    await setVisitStatus({ organizationId, userId, visitId: first8.id, status: 'done' })
+    // Deliberate rule-less extra — must survive too.
+    const extra8 = await addVisit({ organizationId, userId, workOrderInstanceId: wo8.instance.id })
+
+    // Rule-less rows are rejected before anything is written.
+    const errCancelExtra = await expectThrow(() =>
+      cancelVisitFollowing({ organizationId, userId, visitId: extra8.id })
+    )
+    check(
+      'cancelVisitFollowing rejected on a rule-less visit',
+      errCancelExtra instanceof BadRequestError,
+      errCancelExtra
+    )
+
+    await cancelVisitFollowing({ organizationId, userId, visitId: target8.id })
+    const rowsAfter8 = await getVisitsSorted(wo8.instance.id)
+    const targetAfter8 = rowsAfter8.find((r) => r.id === target8.id)
+    check('target occurrence is tombstoned (canceled)', targetAfter8?.status === 'canceled')
+    const laterScheduled8 = rowsAfter8.filter(
+      (r) =>
+        r.recurrenceRuleId != null &&
+        r.status === 'scheduled' &&
+        r.occurrenceDate != null &&
+        target8.occurrenceDate != null &&
+        r.occurrenceDate > target8.occurrenceDate
+    )
+    check('all later scheduled series rows deleted', laterScheduled8.length === 0, laterScheduled8)
+    check(
+      'earlier done occurrence untouched',
+      rowsAfter8.find((r) => r.id === first8.id)?.status === 'done'
+    )
+    check(
+      'rule-less extra visit untouched',
+      rowsAfter8.some((r) => r.id === extra8.id)
+    )
+
+    const rule8 = await database.query.RecurrenceRule.findFirst({
+      where: (t, { eq }) => eq(t.subjectId, wo8.instance.id),
+    })
+    const pattern8 = rule8?.pattern as RecurrencePattern | undefined
+    check(
+      'pattern.until stamped with the target occurrenceDate',
+      pattern8?.until === target8.occurrenceDate,
+      pattern8
+    )
+    check('pattern.count stripped (until/count are exclusive)', pattern8?.count === undefined)
+
+    // The sweep path must not resurrect anything past the stamp.
+    if (rule8) await materializeVisits(rule8, { userId })
+    const rowsReswept8 = await getVisitsSorted(wo8.instance.id)
+    const regenerated8 = rowsReswept8.filter(
+      (r) =>
+        r.recurrenceRuleId != null &&
+        r.occurrenceDate != null &&
+        target8.occurrenceDate != null &&
+        r.occurrenceDate > target8.occurrenceDate
+    )
+    check('re-materialize regenerates nothing past until', regenerated8.length === 0, regenerated8)
+    check(
+      'tombstone still blocks its own date after re-materialize (no duplicate row)',
+      rowsReswept8.filter((r) => r.occurrenceDate === target8.occurrenceDate).length === 1
     )
   } finally {
     // ── Cleanup ──

--- a/packages/lib/src/dispatch/index.ts
+++ b/packages/lib/src/dispatch/index.ts
@@ -58,8 +58,14 @@ export {
   setMyQcItemNote,
   updateQcItemTemplate,
 } from './qc'
-export type { EngagementActionInput, RecurrenceTemplate, SetRecurrenceRuleInput } from './recurring'
+export type {
+  CancelVisitFollowingInput,
+  EngagementActionInput,
+  RecurrenceTemplate,
+  SetRecurrenceRuleInput,
+} from './recurring'
 export {
+  cancelVisitFollowing,
   endEngagement,
   getWorkOrderStatus,
   materializeVisits,

--- a/packages/lib/src/dispatch/recurring/engagement-actions.ts
+++ b/packages/lib/src/dispatch/recurring/engagement-actions.ts
@@ -7,13 +7,15 @@
 import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { toRecordId } from '@auxx/types/resource'
-import { and, eq, gte, or } from 'drizzle-orm'
+import { and, eq, gt, gte, or } from 'drizzle-orm'
 import { getEntityDefIdResolver, getOrgCache } from '../../cache'
-import { NotFoundError } from '../../errors'
+import { BadRequestError, NotFoundError } from '../../errors'
 import { FieldValueService } from '../../field-values/field-value-service'
+import type { RecurrencePattern } from '../../recurrence'
 import { exitRunsForDeadVisitSubjects } from '../../sequences/hooks'
 import { publishVisitChanged } from '../broadcast'
 import { mirrorVisitOntoWorkOrder } from '../mirror'
+import { setVisitStatus } from '../visit-mutations'
 import { materializeVisits, todayLocalDate } from './materialize'
 
 const logger = createScopedLogger('dispatch:recurring:engagement-actions')
@@ -166,4 +168,85 @@ export async function endEngagement(input: EngagementActionInput): Promise<void>
   await writeEngagementStatus(rule, input.userId, 'ended')
   await mirrorAndBroadcast(rule, input.userId, input.excludeSocketId)
   await exitRunsForDeletedRows(rule.organizationId, rule.id, deletedVisitIds)
+}
+
+/** Input for {@link cancelVisitFollowing}. */
+export interface CancelVisitFollowingInput {
+  organizationId: string
+  userId: string
+  /** A series occurrence — must carry `recurrenceRuleId` + `occurrenceDate`. */
+  visitId: string
+  /** Realtime echo-suppression — the acting client's own socket id (07 §B.4). */
+  excludeSocketId?: string
+}
+
+/**
+ * Cancel a series occurrence AND everything after it — the "Skip this and future visits"
+ * choice on the cancel confirm. Three writes:
+ *
+ * 1. Tombstones the target via {@link setVisitStatus} (transition guard, `dispatchedAt`
+ *    clear, worker cancel notice, sequence exits, status roll-up — the full cancel path).
+ * 2. Stamps the rule's pattern with `until = occurrenceDate` so the sweep never generates
+ *    past it. `until` is inclusive, and the fresh tombstone blocks its own date (the
+ *    materializer's ANY-row skip) — so a later Restore revives the target as the series'
+ *    final occurrence. `count` is stripped (`until`/`count` are mutually exclusive).
+ * 3. Deletes the rule's LATER `scheduled` rows, slot-based (`occurrenceDate` strictly
+ *    after the target's) — detached overrides included, their slot is gone with the
+ *    series; `done`/in-flight rows stay as history, existing tombstones stay.
+ *
+ * Unlike {@link endEngagement} this never touches `work_order_status` — occurrences
+ * before the target may still be upcoming, and ending the whole engagement remains an
+ * explicit job-level action. Rule-less "extra" visits on the job are untouched.
+ */
+export async function cancelVisitFollowing(input: CancelVisitFollowingInput): Promise<void> {
+  const { organizationId, userId, visitId, excludeSocketId } = input
+
+  const visit = await database.query.WorkOrderVisit.findFirst({
+    where: and(
+      eq(schema.WorkOrderVisit.id, visitId),
+      eq(schema.WorkOrderVisit.organizationId, organizationId)
+    ),
+  })
+  if (!visit) throw new NotFoundError('Visit not found')
+  if (!visit.recurrenceRuleId || !visit.occurrenceDate) {
+    throw new BadRequestError('Visit is not part of a recurring series')
+  }
+  const rule = await database.query.RecurrenceRule.findFirst({
+    where: and(
+      eq(schema.RecurrenceRule.id, visit.recurrenceRuleId),
+      eq(schema.RecurrenceRule.organizationId, organizationId)
+    ),
+  })
+  if (!rule) throw new NotFoundError('Recurrence rule not found')
+
+  await setVisitStatus({ organizationId, userId, visitId, status: 'canceled', excludeSocketId })
+
+  const { count: _count, ...pattern } = rule.pattern as unknown as RecurrencePattern
+  await database
+    .update(schema.RecurrenceRule)
+    .set({
+      pattern: { ...pattern, until: visit.occurrenceDate } as unknown as Record<string, unknown>,
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.RecurrenceRule.id, rule.id))
+
+  const deleted = await database
+    .delete(schema.WorkOrderVisit)
+    .where(
+      and(
+        eq(schema.WorkOrderVisit.recurrenceRuleId, rule.id),
+        eq(schema.WorkOrderVisit.status, 'scheduled'),
+        gt(schema.WorkOrderVisit.occurrenceDate, visit.occurrenceDate)
+      )
+    )
+    .returning({ id: schema.WorkOrderVisit.id })
+  await exitRunsForDeletedRows(
+    organizationId,
+    rule.id,
+    deleted.map((row) => row.id)
+  )
+
+  // The deletions can change the job's next-visit mirror — mirror + broadcast once more on
+  // top of `setVisitStatus`'s own (which ran before the future rows disappeared).
+  await mirrorAndBroadcast(rule, userId, excludeSocketId)
 }

--- a/packages/lib/src/dispatch/recurring/index.ts
+++ b/packages/lib/src/dispatch/recurring/index.ts
@@ -2,8 +2,13 @@
 //
 // Public surface of the dispatch recurring engine (M2c, plans/dispatch/06-recurring-engine.md).
 
-export type { EngagementActionInput } from './engagement-actions'
-export { endEngagement, pauseEngagement, resumeEngagement } from './engagement-actions'
+export type { CancelVisitFollowingInput, EngagementActionInput } from './engagement-actions'
+export {
+  cancelVisitFollowing,
+  endEngagement,
+  pauseEngagement,
+  resumeEngagement,
+} from './engagement-actions'
 export { getWorkOrderStatus, materializeVisits, sweepRecurringVisits } from './materialize'
 export type { RecurrenceTemplate, SetRecurrenceRuleInput } from './rule-mutations'
 export { setRecurrenceRule } from './rule-mutations'

--- a/packages/ui/src/components/event-calendar/event-popover/event-popover-sections.tsx
+++ b/packages/ui/src/components/event-calendar/event-popover/event-popover-sections.tsx
@@ -321,6 +321,12 @@ export function EventDateTimeSection({
   const [localTime, setLocalTime] = React.useState<{ start: Date; end: Date } | null>(() =>
     start && end ? { start, end } : null
   )
+  // The just-picked date, shown until the commit round-trips into new props — without it the
+  // Date row snaps back to the old value the moment the calendar closes. Tagged with the
+  // `start` it was staged against so it self-invalidates once props actually move.
+  const [pending, setPending] = React.useState<{ baseMs: number | null; start: Date } | null>(null)
+  const startMs = start?.getTime() ?? null
+  const pendingStart = pending && pending.baseMs === startMs ? pending.start : null
 
   React.useEffect(() => {
     if (openEditor !== 'time' && start && end) setLocalTime({ start, end })
@@ -338,7 +344,12 @@ export function EventDateTimeSection({
       newEnd = addMinutes(newStart, 60)
     }
     setOpenEditor(null)
-    gate((scope) => onChange?.({ start: newStart, end: newEnd }, scope))
+    setPending({ baseMs: startMs, start: newStart })
+    // A calendar pick moves THIS occurrence to another day, so it never opens the scope
+    // chooser: series scopes can't express a day move (the rule's pattern owns weekdays —
+    // `applyToSeries` carries only time-of-day/duration, so a gated day move would silently
+    // no-op). Cadence/day changes for the whole series live in the Repeat editor.
+    onChange?.({ start: newStart, end: newEnd }, 'this')
   }
 
   /**
@@ -384,7 +395,9 @@ export function EventDateTimeSection({
             icon={<CalendarDays />}
             title='Date'
             warnings={warnings}
-            description={start ? format(start, 'PPP') : 'No date'}
+            description={
+              pendingStart ? format(pendingStart, 'PPP') : start ? format(start, 'PPP') : 'No date'
+            }
             trailing={
               <div className='flex items-center gap-2'>
                 {onDateToggle && (
@@ -407,7 +420,11 @@ export function EventDateTimeSection({
           />
           <AnimatedCollapsibleContent open={openEditor === 'date'}>
             <div className='pt-3 pb-1'>
-              <Calendar mode='single' selected={start ?? undefined} onSelect={handleDateSelect} />
+              <Calendar
+                mode='single'
+                selected={pendingStart ?? start ?? undefined}
+                onSelect={handleDateSelect}
+              />
             </div>
           </AnimatedCollapsibleContent>
         </div>


### PR DESCRIPTION
## Summary

Two coherent bodies of dispatch work that had accumulated on `main`.

### Dispatch scheduling / recurrence
- **`cancelVisitFollowing` — "Skip this and future visits"**: tombstones the target occurrence via the full `setVisitStatus` cancel path, stamps `pattern.until = occurrenceDate` (with `count` stripped, since they're mutually exclusive), and deletes the rule's later `scheduled` rows. Earlier/`done` rows, existing tombstones, and rule-less "extra" visits are left alone; `work_order_status` is untouched. Exposed as `dispatch.cancelVisitFollowing` and offered as the optional second confirm choice across every cancel surface (board popover, job-schedule row/card/detail panel) via a shared `cancelVisitConfirmOptions`.
- **`useConfirm` alternate button**: optional third choice resolving `'alternate'`; existing callers keep the plain boolean contract.
- **Repeat editor Save/discard**: explicit Save button; closing the editor without saving now discards staged edits (`resetToRule`) instead of silently committing. A weekday/interval edit inside an already-Custom rule now marks Repeats touched — fixes the "We,Th → Tu does nothing" no-op at commit time.
- **Event date-pick**: shows the just-picked date optimistically until the commit round-trips into new props (no snap-back on close); a calendar day move commits as `'this'` and never opens the series scope chooser (a series scope can't express a day move).

### Line-builder (plan 31 — instant adds/deletes)
- **`record.createMany`**: batches a catalog-group explode into one round-trip (capped at 50). Deliberately **not** a DB transaction — the synchronous field-change hooks (money totals recompute) read/write through pool-scoped services and can't see rows inside an open tx; all-or-nothing is approximated with best-effort compensating deletes on mid-loop failure.
- **Group explode** stages entries 2…N as pre-filled drafts (instant paint + correct totals on the first frame), then materializes the bundle through `createDrafts`.
- **Optimistic deletes**: `removeRecord` drops the row from the store (and every cached list, so the totals footer repaints in-frame), then delete + recompute fire without awaiting; an error restores via `invalidateRecord` + `refresh()`.
- All draft-state writes now go through `mutateDrafts` (ref-synchronous) to kill the blank-line clobber from a stale-ref `setDrafts`; an editable builder never renders zero rows.

### Tests
- Adds section 8 to `verify-dispatch-scheduling-fixes.ts` exercising `cancelVisitFollowing`: tombstone, `until` stamp + `count` strip, later-row deletion, earlier/done + rule-less survival, rule-less rejection, and re-materialize idempotency.

## Test plan
- [ ] `npx dotenv -- npx tsx apps/worker/scripts/verify-dispatch-scheduling-fixes.ts`
- [ ] Skip-this-and-future from board popover + each job-schedule surface
- [ ] Catalog-group explode adds the full bundle in order; totals correct pre-resolve
- [ ] Line delete repaints instantly; failed delete restores the row