### PR TITLE
feat(dispatch): fold visit history into schedule disclosure + in-place line bundles

### DIFF
--- a/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
+++ b/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
@@ -61,10 +61,6 @@ export const DETAIL_VIEW_TAB_COMPONENTS: Record<
     import('../dispatch/ui/job-schedule/job-schedule-section').then((m) => ({
       default: m.JobScheduleSection,
     })),
-  'work_order:history': () =>
-    import('../dispatch/ui/job-schedule/job-schedule-section').then((m) => ({
-      default: m.VisitHistorySection,
-    })),
   'work_order:line-items': () =>
     import('../dispatch/ui/job-schedule/work-order-line-items-tab').then((m) => ({
       default: m.WorkOrderLineItemsTab,

--- a/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
@@ -3,11 +3,11 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { EmptySection } from '@auxx/ui/components/section'
-import { TREE_SECONDARY_NOTRUNCATE } from '@auxx/ui/components/tree-row'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { History, Plus } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { DetailSectionActions, type DetailViewTabProps } from '~/components/detail-view'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { SchedulePopover } from '../schedule-popover'
@@ -17,7 +17,7 @@ import { ScheduleVisitRow } from './schedule-visit-row'
 import { useJobVisits } from './use-job-visits'
 import { VisitCard } from './visit-card'
 
-/** Preview-row cap for the upcoming rows under the visit card and the History section. */
+/** Preview-row cap for the upcoming rows under the visit card. */
 const PREVIEW_LIMIT = 3
 
 /**
@@ -25,9 +25,9 @@ const PREVIEW_LIMIT = 3
  * spec §F.2/§F.3, 04 mock layout). One Schedule section carrying, top to bottom:
  * the recurrence row (recurring jobs — `RecurringEngagementCard`, which also
  * portals the engagement badge + Pause/Edit into the Section header), the
- * "Next visit" card, and the remaining upcoming visits as `ScheduleVisitRow`s
- * with an inline "Show more" expand. History stays its own section
- * (`VisitHistorySection`).
+ * "Next visit" card, the remaining upcoming visits as `ScheduleVisitRow`s
+ * with an inline "Show more" expand, and past visits collapsed behind an
+ * "N in history" disclosure row (the work-order drawer pattern).
  */
 export function JobScheduleSection({ recordId }: DetailViewTabProps) {
   const { visits, isLoading, canEdit, mutations, existingVisits, refresh } = useJobVisits(recordId)
@@ -37,10 +37,11 @@ export function JobScheduleSection({ recordId }: DetailViewTabProps) {
   const [, setPanel] = useQueryState('panel')
   const [, setItem] = useQueryState('item')
   const [addOpen, setAddOpen] = useState(false)
+  const [historyOpen, setHistoryOpen] = useState(false)
   const jobType = (values.work_order_job_type as string | undefined) ?? 'one_off'
   const status = (values.work_order_status as string | undefined) ?? 'new'
 
-  const { upcoming } = splitJobVisits(visits)
+  const { upcoming, history } = splitJobVisits(visits)
   // The primary card's target visit — also the recurring engine's "next-upcoming visit"
   // (06-recurring-engine.md §6): one-off has exactly one, so this stays jobType-agnostic.
   // Never falls back into history (plan 30 §G.2) — no upcoming visits is an empty state,
@@ -59,7 +60,9 @@ export function JobScheduleSection({ recordId }: DetailViewTabProps) {
   }
 
   return (
-    <div className='flex flex-col gap-3'>
+    // `pe-3` matches the Line-items/Billing/Communications sections' right inset
+    // so every job-page section shares one right edge, clear of the scrollbar.
+    <div className='flex flex-col gap-3 pe-3'>
       {canEdit && (
         <DetailSectionActions>
           {/* CREATE-mode SchedulePopover (no visitId) — nothing exists until Schedule commits,
@@ -121,58 +124,35 @@ export function JobScheduleSection({ recordId }: DetailViewTabProps) {
           )}
         />
       )}
-    </div>
-  )
-}
 
-/**
- * Registered as `work_order:history` — standalone visit History section: the
- * same `ScheduleVisitRow`s capped at PREVIEW_LIMIT, with the rest revealed by an
- * inline "Show more" expand. The section heading comes from the surrounding
- * `<Section>` — no block header here.
- */
-export function VisitHistorySection({ recordId }: DetailViewTabProps) {
-  const { visits, isLoading, canEdit, mutations, existingVisits, refresh } = useJobVisits(recordId)
-  const [, setPanel] = useQueryState('panel')
-  const [, setItem] = useQueryState('item')
-
-  const { history } = splitJobVisits(visits)
-
-  const openItem = (visitId: string) => {
-    void setPanel('visits')
-    void setItem(visitId)
-  }
-
-  const loading = isLoading && visits.length === 0
-  if (loading || history.length === 0) {
-    return (
-      <EmptySection
-        loading={loading}
-        icon={<History className='size-5' />}
-        title='No past visits yet'
-        description='Completed and canceled visits show up here.'
-      />
-    )
-  }
-
-  return (
-    <TreeRowList
-      items={history}
-      getKey={(visit) => visit.id}
-      visibleLimit={PREVIEW_LIMIT}
-      className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}
-      renderRow={(visit) => (
-        <ScheduleVisitRow
-          visit={visit}
-          canEdit={canEdit}
-          mutations={mutations}
-          existingVisits={existingVisits}
-          workOrderRecordId={recordId}
-          onRefresh={refresh}
-          onOpen={() => openItem(visit.id)}
-        />
+      {history.length > 0 && (
+        <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
+          <TreeRow
+            icon={<History className='size-4' />}
+            rowClassName='hover:bg-primary-100'
+            title={
+              <span className='text-sm text-muted-foreground'>{history.length} in history</span>
+            }
+            expandable
+            isOpen={historyOpen}
+            onToggleOpen={() => setHistoryOpen((open) => !open)}>
+            {history.map((visit) => (
+              <Fragment key={visit.id}>
+                <ScheduleVisitRow
+                  visit={visit}
+                  canEdit={canEdit}
+                  mutations={mutations}
+                  existingVisits={existingVisits}
+                  workOrderRecordId={recordId}
+                  onRefresh={refresh}
+                  onOpen={() => openItem(visit.id)}
+                />
+              </Fragment>
+            ))}
+          </TreeRow>
+        </div>
       )}
-    />
+    </div>
   )
 }
 

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
@@ -46,10 +46,12 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
 
   return (
     <div className={cn('flex flex-col', !isSection && 'h-full min-h-0')}>
+      {/* Section variant: `pe-3` matches the Line-items section's right inset so
+          the whole page column shares one right edge, clear of the scrollbar. */}
       <div
         className={cn(
           'flex flex-col gap-4 py-2',
-          isSection ? 'overflow-auto' : 'min-h-0 flex-1 overflow-auto'
+          isSection ? 'overflow-auto pe-3' : 'min-h-0 flex-1 overflow-auto'
         )}>
         <SummaryStrip billing={billing} />
         <NextAction billing={billing} onAction={() => setActionOpen(true)} />

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-communications-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-communications-tab.tsx
@@ -42,7 +42,12 @@ export function WorkOrderCommunicationsTab({
   }, [entityInstanceId, visits, invoiceRecordIds, quoteRecordIds])
 
   return (
-    <div className={cn(isSection ? 'max-h-[70vh] overflow-auto' : 'flex h-full min-h-0 flex-col')}>
+    // Section variant: `pe-3` matches the Line-items section's right inset so the
+    // list clears its own scrollbar and shares the page column's right edge.
+    <div
+      className={cn(
+        isSection ? 'max-h-[70vh] overflow-auto pe-3' : 'flex h-full min-h-0 flex-col'
+      )}>
       <CommunicationsList recordKeys={recordKeys} />
     </div>
   )

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-line-items-tab.tsx
@@ -26,11 +26,18 @@ export function WorkOrderLineItemsTab({ recordId, variant = 'tab' }: DetailViewT
 
   return (
     <div className={cn('flex flex-col ', isSection ? ' pe-3' : 'h-full min-h-0')}>
-      {jobType === 'recurring' && <TuckedLabel className='ms-4'>Billed each visit</TuckedLabel>}
+      {/* No inset — the label bar shares both edges with the builder frame below
+          (the frame overlaps its bottom via the label's -mb-3 tuck). */}
+      {jobType === 'recurring' && <TuckedLabel>Billed each visit</TuckedLabel>}
+      {/* `-ms-3 ps-3`: bleed the scroll container's clip edge 12px into the
+          section's own padding, then pad it back — the builder frame stays
+          visually aligned while the row drag grips (absolutely positioned
+          10px OUTSIDE the frame, GripSlot's `-left-2.5`) stay inside the
+          clip box instead of being cut off by `overflow-auto`. */}
       <div
         className={cn(
           'flex flex-col',
-          isSection ? 'max-h-[60vh] overflow-auto' : 'min-h-0 flex-1'
+          isSection ? '-ms-3 max-h-[60vh] overflow-auto ps-3' : 'min-h-0 flex-1'
         )}>
         <LineBuilder documentRecordId={recordId} documentType='work_order' />
       </div>

--- a/apps/web/src/components/money/ui/line-builder/line-builder.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-builder.tsx
@@ -52,7 +52,11 @@
 //   dropping any untouched initial placeholders so the bundle lands directly
 //   under the picked row), then materializes the whole bundle through ONE
 //   `record.createMany` round-trip (`createDrafts`) — the bundle is fully
-//   visible (and totaled) before any create resolves. On the draft-row path
+//   visible (and totaled) before any create resolves. The bundle stays
+//   together in place: on a middle REAL row the staged drafts carry an
+//   `anchorRecordId` (rendered interleaved under that row via `visualRows`)
+//   and the createMany completion reorders the persisted rows to match; on
+//   the draft-row path the drafts splice in right after the picked draft, and
 //   the bundle create waits for entry #1's own create so real rows always
 //   land in visual order.
 // - Reorder: dnd-kit sortable rows (grip handle) → `api.money.reorderLines`.
@@ -88,6 +92,7 @@ import type { CatalogGroup } from '~/components/money/hooks/use-catalog-groups'
 import { useCatalogGroups } from '~/components/money/hooks/use-catalog-groups'
 import { useCatalogItems } from '~/components/money/hooks/use-catalog-items'
 import {
+  parseRecordId,
   type RecordId,
   type RecordMeta,
   toRecordId,
@@ -433,6 +438,38 @@ export function LineBuilder({
     setLastAddedDraftId(draft.draftId)
   }, [entityDefinitionId, readOnly, displayRecords.length, drafts.length, mutateDrafts])
 
+  // Visual row list — each real row followed by any bundle drafts anchored to
+  // it (a catalog-group pick on a middle row), then unanchored drafts pinned
+  // at the tail. Nav row indexes are sequential across the interleaved list,
+  // so `useLineNav` and the focus-restore selector keep working unchanged.
+  const visualRows = useMemo(() => {
+    const anchored = new Map<string, DraftLine[]>()
+    const tailDrafts: DraftLine[] = []
+    const recordIds = new Set(displayRecords.map((r) => r.id))
+    for (const draft of visibleDrafts) {
+      // A dangling anchor (row deleted mid-flight) falls back to the tail.
+      if (draft.anchorRecordId && recordIds.has(draft.anchorRecordId)) {
+        const bucket = anchored.get(draft.anchorRecordId)
+        if (bucket) bucket.push(draft)
+        else anchored.set(draft.anchorRecordId, [draft])
+      } else {
+        tailDrafts.push(draft)
+      }
+    }
+    const rows: Array<
+      | { kind: 'record'; record: RecordMeta; rowIndex: number }
+      | { kind: 'draft'; draft: DraftLine; rowIndex: number }
+    > = []
+    for (const record of displayRecords) {
+      rows.push({ kind: 'record', record, rowIndex: rows.length })
+      for (const draft of anchored.get(record.id) ?? []) {
+        rows.push({ kind: 'draft', draft, rowIndex: rows.length })
+      }
+    }
+    for (const draft of tailDrafts) rows.push({ kind: 'draft', draft, rowIndex: rows.length })
+    return rows
+  }, [displayRecords, visibleDrafts])
+
   const lineRecordIds = useMemo(
     () =>
       entityDefinitionId ? displayRecords.map((r) => toRecordId(entityDefinitionId, r.id)) : [],
@@ -694,6 +731,8 @@ export function LineBuilder({
    * result — in input order, so the list cache appends agree with the
    * `line_item_sort_order` stamps — seeds the record + field-value caches and
    * diff-flushes anything the user edited while the create was in flight.
+   * Anchored bundles (a middle-row group pick) finish with one `reorderLines`
+   * that splices the created rows in directly after their anchor row.
    * On error, every bundle draft resets to editable with one toast.
    */
   const createDrafts = useCallback(
@@ -749,6 +788,32 @@ export function LineBuilder({
 
         for (const draftId of draftIds) creatingDraftIdsRef.current.delete(draftId)
         mutateDrafts((prev) => prev.filter((d) => !draftIds.has(d.draftId)))
+
+        // Anchored bundle (group pick on a middle row): the creates append at
+        // the list end, so splice the new rows in directly after their anchor
+        // and persist that order — otherwise the bundle tears apart on the
+        // next refetch. Anchor gone (deleted mid-flight) or already the last
+        // row → the natural append order is already correct.
+        const anchorRecordId = orderedDrafts[0]?.anchorRecordId
+        if (anchorRecordId) {
+          const createdIds = results.map((result) => result.instance.id)
+          const createdIdSet = new Set(createdIds)
+          const existing = displayIdsRef.current.filter((id) => !createdIdSet.has(id))
+          const anchorIndex = existing.indexOf(anchorRecordId)
+          if (anchorIndex !== -1 && anchorIndex < existing.length - 1) {
+            const nextOrder = [
+              ...existing.slice(0, anchorIndex + 1),
+              ...createdIds,
+              ...existing.slice(anchorIndex + 1),
+            ]
+            setOrderOverride(nextOrder)
+            reorderMutate({
+              documentRecordId: docRecordId,
+              orderedLineRecordIds: nextOrder.map((id) => toRecordId(entityDefinitionId, id)),
+            })
+          }
+        }
+
         await Promise.all(flushes)
       } catch (error) {
         for (const draftId of draftIds) creatingDraftIdsRef.current.delete(draftId)
@@ -763,11 +828,13 @@ export function LineBuilder({
     },
     [
       entityDefinitionId,
+      docRecordId,
       draftCreateValues,
       mutateDrafts,
       createManyMutateAsync,
       saveMultipleAsync,
       seedCreatedRecord,
+      reorderMutate,
       listKey,
     ]
   )
@@ -779,23 +846,35 @@ export function LineBuilder({
    * frame (`TotalsFooter` already folds drafts into its math). The same write
    * drops any untouched initial placeholder drafts (plan 31 §C) so the bundle
    * lands directly under the picked row instead of below empty warm-up rows.
+   * `position` keeps the bundle together on a middle-row pick: `anchorRecordId`
+   * pins the drafts under that real row (see `visualRows`), `afterDraftId`
+   * splices them into the drafts array right after the picked draft.
    * Returns the staged drafts for {@link createDrafts} to materialize
    * (freshDraft's optional=false / optionalSelected=true defaults are exactly
    * the "group-exploded lines start required" rule, money plan 18 §3).
    */
   const stageBundleDrafts = useCallback(
-    (rest: LineValues[]): DraftLine[] => {
+    (
+      rest: LineValues[],
+      position?: { anchorRecordId?: string; afterDraftId?: string }
+    ): DraftLine[] => {
       if (rest.length === 0) return []
       const bundleDrafts: DraftLine[] = rest.map((line) => ({
         ...freshDraft(generateId()),
         ...line,
+        anchorRecordId: position?.anchorRecordId,
       }))
       const initialDraftIds = initialDraftIdsRef.current
       initialDraftIdsRef.current = new Set()
-      mutateDrafts((prev) => [
-        ...prev.filter((d) => !initialDraftIds.has(d.draftId)),
-        ...bundleDrafts,
-      ])
+      mutateDrafts((prev) => {
+        const kept = prev.filter((d) => !initialDraftIds.has(d.draftId))
+        const at = position?.afterDraftId
+          ? kept.findIndex((d) => d.draftId === position.afterDraftId)
+          : -1
+        return at === -1
+          ? [...kept, ...bundleDrafts]
+          : [...kept.slice(0, at + 1), ...bundleDrafts, ...kept.slice(at + 1)]
+      })
       setLastAddedDraftId((current) => (current && initialDraftIds.has(current) ? null : current))
       return bundleDrafts
     },
@@ -854,8 +933,12 @@ export function LineBuilder({
       // as taxable already follows.
       updateLine(recordId, first)
 
-      // Known v1 edge: picking on a middle line still appends `rest` at the list end.
-      const bundleDrafts = stageBundleDrafts(rest)
+      // Anchor the staged drafts to the picked row so the bundle renders (and
+      // persists — createDrafts reorders after the createMany) directly under
+      // it instead of appending at the list end.
+      const bundleDrafts = stageBundleDrafts(rest, {
+        anchorRecordId: parseRecordId(recordId).entityInstanceId,
+      })
       applyGroupBilling(pick)
       void createDrafts(bundleDrafts)
     },
@@ -880,7 +963,9 @@ export function LineBuilder({
       // placeholder set — otherwise the §C cleanup below would drop it.
       const firstCreate = createDraft(draftId, first)
 
-      const bundleDrafts = stageBundleDrafts(rest)
+      // Splice the bundle right after the picked draft (not the drafts tail)
+      // so it stays together even with user-added drafts below.
+      const bundleDrafts = stageBundleDrafts(rest, { afterDraftId: draftId })
       applyGroupBilling(pick)
 
       // Materialize the bundle only after entry #1's create settles: real rows
@@ -948,7 +1033,12 @@ export function LineBuilder({
   useLayoutEffect(() => {
     const target = focusedCellRef.current
     if (!target || document.activeElement !== document.body) return
-    const sel = `[data-line-row="${target.row}"][data-line-col="${target.col}"]`
+    const totalRows = displayRecords.length + visibleDrafts.length
+    if (totalRows === 0) return
+    // Deleting the bottom row leaves the remembered index past the end — clamp
+    // it so focus lands on the row above instead of dropping out of the grid.
+    const row = Math.min(target.row, totalRows - 1)
+    const sel = `[data-line-row="${row}"][data-line-col="${target.col}"]`
     // The name cell rests as a `[data-cell-focusable]` text button (no <input>
     // until focused), so match that too — otherwise focus is lost after a
     // draft→real swap on the name column.
@@ -1035,50 +1125,51 @@ export function LineBuilder({
                 items={displayIdsRef.current}
                 strategy={verticalListSortingStrategy}
                 disabled={readOnly}>
-                {displayRecords.map((record, index) => (
-                  <LineRow
-                    key={record.id}
-                    record={record}
-                    rowIndex={index}
-                    entityDefinitionId={entityDefinitionId}
-                    categoryOptions={categoryOptions}
-                    readOnly={readOnly}
-                    currencyCode={currencyCode}
-                    documentType={documentType}
-                    catalogItems={catalogItems}
-                    catalogGroups={catalogGroups}
-                    catalogItemMap={catalogItemMap}
-                    catalogLoading={catalogLoading}
-                    onUpdateLine={updateLine}
-                    deleteLine={deleteLine}
-                    onSelectGroup={handleGroupPick}
-                  />
-                ))}
+                {/* Interleaved real rows + phantom drafts (`visualRows`): anchored
+                    bundle drafts render directly under their picked row, tail
+                    drafts after every real row. Drafts are never drag-sortable —
+                    only real record ids are in the SortableContext. */}
+                {visualRows.map((row) =>
+                  row.kind === 'record' ? (
+                    <LineRow
+                      key={row.record.id}
+                      record={row.record}
+                      rowIndex={row.rowIndex}
+                      entityDefinitionId={entityDefinitionId}
+                      categoryOptions={categoryOptions}
+                      readOnly={readOnly}
+                      currencyCode={currencyCode}
+                      documentType={documentType}
+                      catalogItems={catalogItems}
+                      catalogGroups={catalogGroups}
+                      catalogItemMap={catalogItemMap}
+                      catalogLoading={catalogLoading}
+                      onUpdateLine={updateLine}
+                      deleteLine={deleteLine}
+                      onSelectGroup={handleGroupPick}
+                    />
+                  ) : (
+                    <DraftLineRow
+                      key={row.draft.draftId}
+                      draft={row.draft}
+                      rowIndex={row.rowIndex}
+                      autoFocus={row.draft.draftId === lastAddedDraftId}
+                      categoryOptions={categoryOptions}
+                      currencyCode={currencyCode}
+                      documentType={documentType}
+                      catalogItems={catalogItems}
+                      catalogGroups={catalogGroups}
+                      catalogItemMap={catalogItemMap}
+                      catalogLoading={catalogLoading}
+                      deleteDraft={deleteDraft}
+                      createDraft={createDraft}
+                      onSelectGroup={handleGroupPickDraft}
+                    />
+                  )
+                )}
               </SortableContext>
             </DndContext>
           )}
-
-          {/* Phantom draft rows — pinned after the real rows, never drag-sortable.
-              They continue the nav index space (real count + draft index). */}
-          {!readOnly &&
-            visibleDrafts.map((draft, i) => (
-              <DraftLineRow
-                key={draft.draftId}
-                draft={draft}
-                rowIndex={displayRecords.length + i}
-                autoFocus={draft.draftId === lastAddedDraftId}
-                categoryOptions={categoryOptions}
-                currencyCode={currencyCode}
-                documentType={documentType}
-                catalogItems={catalogItems}
-                catalogGroups={catalogGroups}
-                catalogItemMap={catalogItemMap}
-                catalogLoading={catalogLoading}
-                deleteDraft={deleteDraft}
-                createDraft={createDraft}
-                onSelectGroup={handleGroupPickDraft}
-              />
-            ))}
         </div>
       </div>
 

--- a/apps/web/src/components/money/ui/line-builder/line-rows.tsx
+++ b/apps/web/src/components/money/ui/line-builder/line-rows.tsx
@@ -57,6 +57,7 @@ import {
   PackageSearch,
   Plus,
   Tag,
+  Tags,
   Trash2,
   X,
 } from 'lucide-react'
@@ -137,6 +138,12 @@ function badgeVariantForColor(color: string | undefined): Variant {
 export interface DraftLine extends LineValues {
   draftId: string
   creating: boolean
+  /**
+   * Real row this draft renders directly under — set on catalog-group bundle
+   * drafts staged from a middle row's pick, so the bundle stays together
+   * instead of pinning to the list tail. Absent → tail (the default).
+   */
+  anchorRecordId?: string
 }
 
 export function freshDraft(draftId: string): DraftLine {
@@ -232,7 +239,9 @@ function GripSlot({
     <span
       {...attributes}
       {...listeners}
-      className='-left-2.5 -translate-y-1/2 absolute top-1/2 flex h-5 w-5 cursor-grab items-center justify-center rounded-md border bg-background text-muted-foreground opacity-0 shadow-sm transition-opacity group-hover/tree-row:opacity-100'>
+      // z-10: the row's grid div is a later positioned sibling — without a
+      // z-index it hit-tests above the grip's inner half, eating drag starts.
+      className='-left-2.5 -translate-y-1/2 absolute top-1/2 z-10 flex h-5 w-5 cursor-grab items-center justify-center rounded-md border bg-background text-muted-foreground opacity-0 shadow-sm transition-opacity group-hover/tree-row:opacity-100'>
       <GripVertical className='size-3.5' />
     </span>
   )
@@ -734,7 +743,12 @@ function LineNameCellView({
         optional={optional}
         showOptionalToggle={showOptionalControls}
         hasDescription={!!description}
+        hasCategory={!!category}
         onEditDescription={() => setDescriptionDraft(description ?? '')}
+        // Deferred one frame: the category menu is a second Radix dropdown —
+        // opening it while the `⋯` menu is still tearing down would let the
+        // closing layer's dismiss handling swallow it.
+        onSetCategory={() => requestAnimationFrame(openCategoryMenu)}
         onToggleTaxable={onToggleTaxable}
         onToggleOptional={onToggleOptional}
         onDelete={onDelete}
@@ -940,16 +954,18 @@ function MenuShortcut({ keys }: { keys: string[] }) {
  * ever overlapping the editing buttons. Always visible (it occupies its flex
  * slot either way), styled like the other row action buttons; mouse/touch
  * only (`tabIndex={-1}`, mirroring the qty unit-dropdown precedent). Holds
- * the line-level actions: optional toggle (quotes only), taxable toggle,
- * delete — each item shows its row shortcut (use-line-hotkeys.ts). The drag
- * grip stays drag-only.
+ * the line-level actions: description, category, optional toggle (quotes
+ * only), taxable toggle, delete — each item shows its row shortcut
+ * (use-line-hotkeys.ts). The drag grip stays drag-only.
  */
 function LineRowMenu({
   taxable,
   optional,
   showOptionalToggle,
   hasDescription,
+  hasCategory,
   onEditDescription,
+  onSetCategory,
   onToggleTaxable,
   onToggleOptional,
   onDelete,
@@ -958,7 +974,9 @@ function LineRowMenu({
   optional: boolean
   showOptionalToggle: boolean
   hasDescription: boolean
+  hasCategory: boolean
   onEditDescription: () => void
+  onSetCategory: () => void
   onToggleTaxable: (next: boolean) => void
   onToggleOptional: (next: boolean) => void
   onDelete: () => void
@@ -987,6 +1005,11 @@ function LineRowMenu({
           <AlignLeft />
           {hasDescription ? 'Edit description' : 'Add description'}
           <MenuShortcut keys={['⇧', 'D']} />
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onSetCategory}>
+          <Tags />
+          {hasCategory ? 'Change category' : 'Add category'}
+          <MenuShortcut keys={['⇧', 'L']} />
         </DropdownMenuItem>
         {showOptionalToggle && (
           <DropdownMenuItem onSelect={() => onToggleOptional(!optional)}>

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -131,10 +131,10 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     // is a scroll-spy page, not content-swapping tabs.
     layout: 'sections',
     mainTabs: [
-      // Schedule carries the recurrence row, primary visit card AND the upcoming
-      // visit previews (04 mock) — no standalone upcoming-visits section.
+      // Schedule carries the recurrence row, primary visit card, the upcoming
+      // visit previews AND past visits behind an "N in history" disclosure
+      // (drawer parity) — no standalone upcoming-visits or history section.
       { value: 'schedule', label: 'Schedule', icon: 'calendar' },
-      { value: 'history', label: 'History', icon: 'history' },
       { value: 'line-items', label: 'Line items', icon: 'receipt-text' },
       { value: 'billing', label: 'Billing', icon: 'credit-card' },
       // Client-notifications plan §4.8/Phase 4 — outbound-message timeline (sequences +


### PR DESCRIPTION
## What

Two threads of dispatch/line-builder polish on the work-order (job) detail page.

### Job page — history as a disclosure
- Past visits now collapse behind an **"N in history"** disclosure row inside the **Schedule** section (the work-order-drawer pattern), instead of a separate top-level tab.
- Drops the standalone `work_order:history` tab from the detail-view registry and `detail-view-config` registry.
- Aligns every job-page section (Schedule / Line items / Billing / Communications) on one right edge with `pe-3`, so the column shares a single right inset clear of the scrollbar.

### Line builder — in-place bundles + row menu
- Catalog-group bundle drafts staged from a **middle row** now **anchor to the picked row**: they render interleaved directly under it (`visualRows`) and, on `createMany` completion, `createDrafts` reorders the persisted rows to match — the bundle no longer tears off to the list tail.
- Draft-path picks splice the bundle right after the picked draft (`afterDraftId`).
- Line-row `⋯` menu gains a **"Change/Add category"** action.
- Fixes: grip drag-start hit-testing (`z-10` so the row grid sibling stops eating drag starts) and focus-restore row-index clamp after deleting the bottom row.

## Test
- [ ] Browser pass on the job detail page: history disclosure open/close, middle-row group pick stays in place across refetch, category menu, grip drag, delete-bottom-row focus.