### PR TITLE
feat(money): surface extra-work invoicing across billing states

### DIFF
--- a/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
+++ b/apps/web/src/components/dispatch/ui/board/dispatch-board.tsx
@@ -56,7 +56,9 @@ export function DispatchBoard() {
   const canEdit = isAdminOrOwner
 
   const data = useBoardData()
-  const mutations = useBoardMutations(data.range)
+  // Optimistic cache surgery targets the `getBoard` query key, which is now the deterministic
+  // `fetchWindow` (not the visible `range`) — pass the same value so patches/rollbacks land.
+  const mutations = useBoardMutations(data.fetchWindow)
   useBoardRealtime()
 
   // Route planner data (09-route-planner.md §A) lives here, not inside `RoutePlannerView`
@@ -94,6 +96,7 @@ export function DispatchBoard() {
   const { backgroundEvents, isNonWorkingDay } = useAvailabilityShading({
     view: data.view,
     range: data.range,
+    fetchWindow: data.fetchWindow,
     workerUserIds,
   })
 

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-availability-shading.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-availability-shading.ts
@@ -3,15 +3,7 @@
 'use client'
 
 import type { BackgroundEvent } from '@auxx/ui/components/event-calendar'
-import {
-  addMonths,
-  addWeeks,
-  endOfMonth,
-  format,
-  startOfMonth,
-  subMonths,
-  subWeeks,
-} from 'date-fns'
+import { format } from 'date-fns'
 import { useCallback, useEffect, useMemo } from 'react'
 import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
@@ -31,20 +23,25 @@ const ORG_KEY = availabilitySubjectKey({ type: 'organization' })
 const workerKey = (userId: string) => availabilitySubjectKey({ type: 'worker', userId })
 /**
  * Availability shading (07 §D.2 · 12-availability-cache.md), redesigned onto a client cache: instead
- * of re-querying `availability.resolve` for each visible window, we over-fetch a 3-month window,
- * record what's loaded in `useAvailabilityCacheStore`, and fetch only the not-yet-loaded gaps — so a
- * month already shown never re-fetches. Non-working days paint immediately from the persisted org
- * weekly-working-days baseline, then refine as resolved (exception-aware) days stream in. Day mode
- * shades each worker column from its own schedule + the Unassigned column from org hours; week mode
- * shades org-wide; month tints non-working days via `isNonWorkingDay`. Hints only — never gates a drop.
+ * of re-querying `availability.resolve` for each visible window, we fetch the deterministic
+ * `fetchWindow` (padded ±1 month/week, owned by `useBoardData`), record what's loaded in
+ * `useAvailabilityCacheStore`, and fetch only the not-yet-loaded gaps — so a month already shown
+ * never re-fetches, and the fetch no longer chases the calendar's noisy visible-range echo (which
+ * churns on scroll/re-measure). `range` is the VISIBLE window and drives painting only. Non-working
+ * days paint immediately from the persisted org weekly-working-days baseline, then refine as resolved
+ * (exception-aware) days stream in. Day mode shades each worker column from its own schedule + the
+ * Unassigned column from org hours; week mode shades org-wide; month tints non-working days via
+ * `isNonWorkingDay`. Hints only — never gates a drop.
  */
 export function useAvailabilityShading({
   view,
   range,
+  fetchWindow: fetchWindowRange,
   workerUserIds,
 }: {
   view: BoardViewMode
   range: DateRange
+  fetchWindow: DateRange
   workerUserIds: string[]
 }): {
   backgroundEvents: BackgroundEvent[]
@@ -67,13 +64,16 @@ export function useAvailabilityShading({
     )
   }, [orgWeekly.data, setWeeklyWorkingDays])
 
-  // 3-month over-fetch window (±1 month around the visible month; ±1 week for day/week) — covers the
-  // month grid's leading/trailing spill days AND adjacent-month scroll in one cache-tracked fetch.
-  const fetchWindow = useMemo<IsoRange>(() => {
-    const from = view === 'month' ? startOfMonth(subMonths(range.from, 1)) : subWeeks(range.from, 1)
-    const to = view === 'month' ? endOfMonth(addMonths(range.to, 1)) : addWeeks(range.to, 1)
-    return { from: format(from, 'yyyy-MM-dd'), to: format(to, 'yyyy-MM-dd') }
-  }, [view, range.from, range.to])
+  // The board's deterministic fetch window (padded ±1 month/week in `useBoardData`), as ISO strings
+  // for the day-granular cache. Only changes when the settled month/week does, so the gap-only
+  // fetch runs once per window instead of re-firing on every scroll-frame range echo.
+  const fetchWindow = useMemo<IsoRange>(
+    () => ({
+      from: format(fetchWindowRange.from, 'yyyy-MM-dd'),
+      to: format(fetchWindowRange.to, 'yyyy-MM-dd'),
+    }),
+    [fetchWindowRange.from, fetchWindowRange.to]
+  )
 
   // Subjects to cover: org always; each visible worker in day view.
   const subjectList = useMemo<Array<{ key: string; subject: AvailabilitySubject }>>(() => {

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
@@ -4,10 +4,22 @@
 
 import { weekStartToIndex } from '@auxx/lib/availability/client'
 import { getOptionColorHex } from '@auxx/lib/custom-fields/client'
-import { format, isSameDay, startOfDay } from 'date-fns'
+import {
+  addMonths,
+  addWeeks,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameDay,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+  subWeeks,
+} from 'date-fns'
 import { createParser, parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useCallback, useMemo } from 'react'
-import { useCalendarRange } from '~/components/calendar/core/use-calendar-range'
+import { type DateRange, useCalendarRange } from '~/components/calendar/core/use-calendar-range'
 import { useSettings } from '~/hooks/use-settings'
 import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
@@ -96,8 +108,33 @@ export function useBoardData() {
   const setDateAbsolute = useCallback((day: Date) => setDateParam(startOfDay(day)), [setDateParam])
 
   // `date`/`view` are owned here (URL); the shared range hook is fed them controlled and only
-  // supplies the derived `range` + `handleRangeChange`.
+  // supplies the derived `range` + `handleRangeChange`. `range` is the VISIBLE (painted) window,
+  // echoed from the calendar's `onRangeChange` — it churns as the virtualized stream scrolls and
+  // re-measures, so it drives painting only, never a fetch.
   const { range, handleRangeChange } = useCalendarRange('day', weekStartsOn, { date, view })
+
+  // The FETCH window — deterministic from `date`+`view`, so it only changes when the settled
+  // month/week actually changes (never on scroll frames or the month stream's mount-time
+  // re-emits). Padded ±1 whole month/week for cache-ahead when scrolling to a neighbor. `getBoard`
+  // and availability both read this, so a month-view load fires each query exactly once instead of
+  // chasing the noisy visible-range echo. Day/timeline are genuine rolling day-streams (plan 18)
+  // whose fetch must follow the scroll, so they keep the visible `range`.
+  const fetchWindow = useMemo<DateRange>(() => {
+    if (view === 'month') {
+      const monthStart = startOfMonth(endOfWeek(date, { weekStartsOn }))
+      return {
+        from: startOfMonth(subMonths(monthStart, 1)),
+        to: endOfMonth(addMonths(monthStart, 1)),
+      }
+    }
+    if (view === 'week') {
+      return {
+        from: startOfWeek(subWeeks(date, 1), { weekStartsOn }),
+        to: endOfWeek(addWeeks(date, 1), { weekStartsOn }),
+      }
+    }
+    return range
+  }, [view, date, weekStartsOn, range])
 
   // Board↔Map toggle (09-route-planner.md §A, contract item 7) — sibling state to the sidebar's
   // `open`, deliberately NOT a `BoardViewMode` so the month-view debounce and `view === 'day'`
@@ -113,7 +150,7 @@ export function useBoardData() {
   const showCanceled = useDispatchSidebarStore((s) => s.showCanceled)
 
   const boardQuery = api.dispatch.getBoard.useQuery(
-    { from: range.from, to: range.to },
+    { from: fetchWindow.from, to: fetchWindow.to },
     { placeholderData: (prev) => prev, staleTime: ORG_STATIC_STALE_TIME }
   )
 
@@ -215,6 +252,7 @@ export function useBoardData() {
     setView,
     weekStartsOn,
     range,
+    fetchWindow,
     handleRangeChange,
     allWorkers,
     workers,

--- a/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-utils.ts
+++ b/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-utils.ts
@@ -1,7 +1,7 @@
 // apps/web/src/components/dispatch/ui/job-schedule/job-schedule-utils.ts
 
 import type { Variant } from '@auxx/ui/components/badge'
-import { format } from 'date-fns'
+import { format, startOfDay } from 'date-fns'
 import type { JobVisit } from './use-job-visits'
 
 /** Badge tone per visit status — mirrors `WORK_ORDER_STATUS_OPTIONS`' color choices. */
@@ -84,11 +84,16 @@ export function isVisitDispatchable(visit: {
   return startKey === dayKey(now) || startKey === dayKey(new Date(now.getTime() + 86_400_000))
 }
 
-/** Visits that already ran their course — done/canceled, or a past scheduled window. */
+/**
+ * Visits that already ran their course — done/canceled, or a scheduled window that ended on
+ * an earlier day. A scheduled visit stays in "upcoming" for the whole of its day: it only
+ * drops into history once its end lands before the start of today, so a visit earlier today
+ * (already elapsed by the clock) is still shown as scheduled rather than filed away.
+ */
 export function isPastVisit(visit: Pick<JobVisit, 'status' | 'endTime'>): boolean {
   if (visit.status === 'done' || visit.status === 'canceled') return true
   if (!visit.endTime) return false
-  return new Date(visit.endTime).getTime() < Date.now()
+  return new Date(visit.endTime).getTime() < startOfDay(new Date()).getTime()
 }
 
 /**

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
@@ -61,6 +61,9 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
   // blur/Enter commits and an Escape reverts without re-render churn on every keystroke.
   const [durationDraft, setDurationDraft] = useState<number | undefined | null>(null)
   const [billingOpen, setBillingOpen] = useState(false)
+  // Which dialog flavor the last-clicked billing button wants: base visit invoice vs
+  // extra-work invoice (plan money/19 §F.2 — per_visit visits need both).
+  const [billingMode, setBillingMode] = useState<'primary' | 'extra'>('primary')
   const { billing } = useWorkOrderBillingState(recordId)
   const setVisitDuration = api.dispatch.setVisitDuration.useMutation({
     onError: (error) => toastError({ title: 'Error saving duration', description: error.message }),
@@ -268,8 +271,31 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
           {billing.basis === 'per_visit' &&
             visit.status === 'done' &&
             invoiceState === 'uninvoiced' && (
-              <Button variant='outline' size='sm' onClick={() => setBillingOpen(true)}>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => {
+                  setBillingMode('primary')
+                  setBillingOpen(true)
+                }}>
                 Invoice this visit
+              </Button>
+            )}
+          {/* Per-visit extras when the base can't carry them (base already invoiced, or the
+              visit hasn't happened yet) get their own separate-invoice door — the
+              forgotten-material flow (plan money/19 §F.2). Uninvoiced done visits are excluded:
+              their extras ride along with `createVisitInvoice`. */}
+          {billing.basis === 'per_visit' &&
+            billing.extraWorkVisitIds.includes(visit.id) &&
+            !(visit.status === 'done' && invoiceState === 'uninvoiced') && (
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => {
+                  setBillingMode('extra')
+                  setBillingOpen(true)
+                }}>
+                Invoice extra work
               </Button>
             )}
           {billingVisit.invoiceId && (billingVisit.invoiceCount ?? 0) === 1 && (
@@ -300,7 +326,13 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
                   }>
                   Add to contract
                 </Button>
-                <Button variant='outline' size='sm' onClick={() => setBillingOpen(true)}>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={() => {
+                    setBillingMode('extra')
+                    setBillingOpen(true)
+                  }}>
                   Bill as extra work
                 </Button>
               </div>
@@ -332,7 +364,7 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
           workOrderRecordId={recordId}
           billing={billing}
           initialVisitIds={[visit.id]}
-          mode={billing.basis === 'fixed_contract' ? 'extra' : 'primary'}
+          mode={billing.basis === 'fixed_contract' ? 'extra' : billingMode}
         />
       </div>
     </ScrollArea>

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
@@ -1,7 +1,9 @@
 // apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
 'use client'
 
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
 import { BILLING_BASIS_LABELS, BILLING_TIMING_LABELS } from '@auxx/lib/money/client'
+import { toRecordId } from '@auxx/types/resource'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { Skeleton } from '@auxx/ui/components/skeleton'
@@ -17,6 +19,10 @@ import { resolveBillingAction, type WorkOrderBillingView } from '~/components/mo
 import { useWorkOrderBillingState } from '~/components/money/billing/use-work-order-billing-state'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
 import { useOpenRecord } from '~/components/records/record-drill-panels'
+import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
+import { useSystemField } from '~/components/resources/hooks/use-field'
+import { useResources } from '~/components/resources/hooks/use-resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { api } from '~/trpc/react'
 import { BillingScheduleRow } from './billing-schedule-row'
 import type { PaymentCandidate } from './work-order-billing-payments-block'
@@ -27,9 +33,30 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
   const [extraOpen, setExtraOpen] = useState(false)
   const [planOpen, setPlanOpen] = useState(false)
   const [scheduleOpen, setScheduleOpen] = useState(false)
+  const [newInvoiceOpen, setNewInvoiceOpen] = useState(false)
   const { billing, isLoading } = useWorkOrderBillingState(recordId)
   const utils = api.useUtils()
+  const openRecord = useOpenRecord()
   const isSection = variant === 'section'
+  // Quick manual invoice (plan money/19 follow-up): the generic invoice create dialog
+  // (contact / work order / due date) with both relations prefilled from this job. The
+  // saved draft opens straight in the invoice drawer so lines can be added immediately.
+  const { getResourceById } = useResources()
+  const invoiceDefId = getResourceById('invoices')?.id
+  const invoiceContactField = useSystemField('invoice_contact')
+  const invoiceWorkOrderField = useSystemField('invoice_work_order')
+  const { values: workOrderValues } = useSystemValues(recordId, ['work_order_contact'], {
+    autoFetch: true,
+  })
+  const newInvoicePresets = useMemo(() => {
+    const presets: Record<string, unknown> = {}
+    if (invoiceWorkOrderField) presets[invoiceWorkOrderField.id] = [recordId]
+    const contactRecordIds = extractRelationshipRecordIds(workOrderValues.work_order_contact)
+    if (invoiceContactField && contactRecordIds.length > 0) {
+      presets[invoiceContactField.id] = contactRecordIds
+    }
+    return presets
+  }, [invoiceContactField, invoiceWorkOrderField, recordId, workOrderValues.work_order_contact])
   const paymentCandidates: PaymentCandidate[] = useMemo(
     () =>
       billing.invoices
@@ -54,7 +81,11 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
           isSection ? 'overflow-auto pe-3' : 'min-h-0 flex-1 overflow-auto'
         )}>
         <SummaryStrip billing={billing} />
-        <NextAction billing={billing} onAction={() => setActionOpen(true)} />
+        <NextAction
+          billing={billing}
+          onAction={() => setActionOpen(true)}
+          onExtra={() => setExtraOpen(true)}
+        />
 
         <TuckedSection
           label='Billing plan'
@@ -127,7 +158,15 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
           />
         </TuckedSection>
 
-        <TuckedSection label='Invoices'>
+        <TuckedSection
+          label='Invoices'
+          action={
+            invoiceDefId ? (
+              <Button variant='ghost' size='xs' onClick={() => setNewInvoiceOpen(true)}>
+                New invoice
+              </Button>
+            ) : undefined
+          }>
           <InvoiceRows billing={billing} />
         </TuckedSection>
 
@@ -168,8 +207,19 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
         workOrderRecordId={recordId}
         billing={billing}
         mode='extra'
-        initialVisitIds={billing.extraWorkVisitIds}
       />
+      {invoiceDefId && (
+        <RecordEditorDialog
+          open={newInvoiceOpen}
+          onOpenChange={setNewInvoiceOpen}
+          entityDefinitionId={invoiceDefId}
+          presetValues={newInvoicePresets}
+          onSaved={(instanceId) => {
+            void utils.money.getWorkOrderBillingState.invalidate({ workOrderRecordId: recordId })
+            if (instanceId) openRecord?.(toRecordId('invoice', instanceId))
+          }}
+        />
+      )}
     </div>
   )
 }
@@ -222,14 +272,17 @@ function SummaryCell({
 function NextAction({
   billing,
   onAction,
+  onExtra,
 }: {
   billing: WorkOrderBillingView
   onAction: () => void
+  onExtra: () => void
 }) {
   const openRecord = useOpenRecord()
   const action = resolveBillingAction(billing)
   const handleClick = () => {
     if (action.kind === 'create') return onAction()
+    if (action.kind === 'create_extra') return onExtra()
     if (action.kind === 'review_draft') {
       if (action.draftInvoiceRecordId) return openRecord?.(action.draftInvoiceRecordId)
       return onAction()
@@ -262,6 +315,9 @@ function NextAction({
   )
 }
 
+/** The two billing streams rendered distinctly (plan money/19 §F): the base
+ * (contract/visit/period) row, a done-visit extra-work row, and a muted hint for extras staged
+ * on visits that haven't happened yet — deliberately billable, never claimed as ready. */
 function UninvoicedWork({
   billing,
   onPrimary,
@@ -271,11 +327,16 @@ function UninvoicedWork({
   onPrimary: () => void
   onExtra: () => void
 }) {
-  if (
-    billing.remaining <= 0 &&
-    billing.eligibleVisits.length === 0 &&
-    billing.extraWorkVisitIds.length === 0
-  ) {
+  const doneExtras = billing.extraWork.filter((row) => row.visitStatus === 'done')
+  const plannedExtras = billing.extraWork.filter((row) => row.visitStatus !== 'done')
+  const doneExtraVisitCount = new Set(doneExtras.map((row) => row.visitId)).size
+  const doneExtraTotal = doneExtras.reduce((sum, row) => sum + row.amount, 0)
+  const plannedExtraTotal = plannedExtras.reduce((sum, row) => sum + row.amount, 0)
+  const showBase =
+    billing.basis === 'per_visit' ? billing.eligibleVisits.length > 0 : billing.remaining > 0
+  const extraIsPrimary = resolveBillingAction(billing).kind === 'create_extra'
+
+  if (!showBase && billing.extraWork.length === 0) {
     return (
       <p className='p-3 text-sm text-muted-foreground'>
         {billing.basis === 'fixed_contract'
@@ -287,29 +348,56 @@ function UninvoicedWork({
     )
   }
   return (
-    <div className='flex items-center justify-between gap-3 p-3 text-sm'>
-      <div>
-        <div className='font-medium'>
-          {billing.eligibleVisits.length > 0
-            ? `${billing.eligibleVisits.length} eligible visit${billing.eligibleVisits.length === 1 ? '' : 's'}`
-            : formatCurrency(billing.remaining, billing.currencyCode)}
+    <div className='divide-y'>
+      {showBase && (
+        <div className='flex items-center justify-between gap-3 p-3 text-sm'>
+          <div>
+            <div className='font-medium'>
+              {billing.basis === 'per_visit'
+                ? `${billing.eligibleVisits.length} eligible visit${billing.eligibleVisits.length === 1 ? '' : 's'}`
+                : formatCurrency(billing.remaining, billing.currencyCode)}
+            </div>
+            <div className='text-xs text-muted-foreground'>
+              {billing.basis === 'per_visit'
+                ? formatCurrency(
+                    billing.eligibleVisits.reduce((sum, visit) => sum + visit.amount, 0),
+                    billing.currencyCode
+                  )
+                : 'Available for the next invoice'}
+            </div>
+          </div>
+          <Button variant='outline' size='sm' onClick={onPrimary}>
+            Create invoice
+          </Button>
         </div>
-        <div className='text-xs text-muted-foreground'>
-          {billing.extraWorkVisitIds.length > 0
-            ? `${billing.extraWorkVisitIds.length} visit${billing.extraWorkVisitIds.length === 1 ? '' : 's'} with extra work`
-            : 'Available for the next invoice'}
-        </div>
-      </div>
-      <div className='flex gap-2'>
-        {billing.extraWorkVisitIds.length > 0 && (
-          <Button variant='ghost' size='sm' onClick={onExtra}>
+      )}
+      {doneExtras.length > 0 && (
+        <div className='flex items-center justify-between gap-3 p-3 text-sm'>
+          <div>
+            <div className='font-medium'>
+              Extra work on {doneExtraVisitCount} visit{doneExtraVisitCount === 1 ? '' : 's'}
+            </div>
+            <div className='text-xs text-muted-foreground'>
+              {formatCurrency(doneExtraTotal, billing.currencyCode)}
+            </div>
+          </div>
+          <Button variant={extraIsPrimary ? 'outline' : 'ghost'} size='sm' onClick={onExtra}>
             Invoice extra work
           </Button>
-        )}
-        <Button variant='outline' size='sm' onClick={onPrimary}>
-          Create invoice
-        </Button>
-      </div>
+        </div>
+      )}
+      {plannedExtras.length > 0 && (
+        <div className='flex items-center justify-between gap-3 p-3 text-sm'>
+          <p className='text-xs text-muted-foreground'>
+            {formatCurrency(plannedExtraTotal, billing.currencyCode)} staged on upcoming visits
+          </p>
+          {doneExtras.length === 0 && (
+            <Button variant='ghost' size='sm' onClick={onExtra}>
+              Invoice extra work
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   )
 }
@@ -386,10 +474,18 @@ function nextActionDescription(billing: WorkOrderBillingView) {
     return `${formatCurrency(billing.balanceDue, billing.currencyCode)} remains due on issued invoices.`
   if (billing.state === 'scheduled' && billing.nextInvoiceDate)
     return `The next draft is scheduled for ${formatDate(billing.nextInvoiceDate)}.`
-  if (billing.state === 'ready_to_invoice')
-    return billing.eligibleVisits.length
-      ? `${billing.eligibleVisits.length} completed visit${billing.eligibleVisits.length === 1 ? '' : 's'} can be invoiced.`
-      : `${formatCurrency(billing.remaining, billing.currencyCode)} is ready to invoice.`
+  if (billing.state === 'ready_to_invoice') {
+    if (billing.eligibleVisits.length) {
+      return `${billing.eligibleVisits.length} completed visit${billing.eligibleVisits.length === 1 ? '' : 's'} can be invoiced.`
+    }
+    const extraVisitCount = new Set(
+      billing.extraWork.filter((row) => row.visitStatus === 'done').map((row) => row.visitId)
+    ).size
+    if (extraVisitCount > 0) {
+      return `Extra work on ${extraVisitCount} visit${extraVisitCount === 1 ? '' : 's'} can be invoiced.`
+    }
+    return `${formatCurrency(billing.remaining, billing.currencyCode)} is ready to invoice.`
+  }
   return 'No billing action is currently required.'
 }
 function formatDate(value: string) {

--- a/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
+++ b/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
@@ -119,7 +119,11 @@ export function WorkOrderBillingCard({ recordId, entityInstanceId }: DrawerTabPr
   const openRecord = useOpenRecord()
   const router = useRouter()
   const action = resolveBillingAction(billing)
-  const isActionable = action.kind === 'create' || action.kind === 'review_draft'
+  const doneExtraVisitCount = new Set(
+    billing.extraWork.filter((row) => row.visitStatus === 'done').map((row) => row.visitId)
+  ).size
+  const isActionable =
+    action.kind === 'create' || action.kind === 'create_extra' || action.kind === 'review_draft'
   const handleToggleOpen = () => {
     if (action.kind === 'review_draft' && action.draftInvoiceRecordId) {
       openRecord?.(action.draftInvoiceRecordId)
@@ -154,11 +158,13 @@ export function WorkOrderBillingCard({ recordId, entityInstanceId }: DrawerTabPr
           <span className='text-xs'>
             {billing.eligibleVisits.length
               ? `${billing.eligibleVisits.length} eligible visit${billing.eligibleVisits.length === 1 ? '' : 's'}`
-              : billing.nextInvoiceDate
-                ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(
-                    new Date(billing.nextInvoiceDate)
-                  )
-                : 'No action required'}
+              : action.kind === 'create_extra'
+                ? `Extra work on ${doneExtraVisitCount} visit${doneExtraVisitCount === 1 ? '' : 's'}`
+                : billing.nextInvoiceDate
+                  ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(
+                      new Date(billing.nextInvoiceDate)
+                    )
+                  : 'No action required'}
           </span>
         }
         trailing={isActionable ? <ArrowRight className='size-4' /> : undefined}
@@ -189,6 +195,7 @@ export function WorkOrderBillingCard({ recordId, entityInstanceId }: DrawerTabPr
         onOpenChange={setDialogOpen}
         workOrderRecordId={recordId}
         billing={billing}
+        mode={action.kind === 'create_extra' ? 'extra' : 'primary'}
       />
     </div>
   )

--- a/apps/web/src/components/money/billing/billing-action-dialog.tsx
+++ b/apps/web/src/components/money/billing/billing-action-dialog.tsx
@@ -4,7 +4,6 @@
 import { FieldType } from '@auxx/database/enums'
 import type { RecordId } from '@auxx/types/resource'
 import { Button } from '@auxx/ui/components/button'
-import { Checkbox } from '@auxx/ui/components/checkbox'
 import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
 import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
 import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
@@ -44,11 +43,19 @@ export function BillingActionDialog({
   const [page, setPage] = useState<Page>('choose')
   const [fixedChoice, setFixedChoice] = useState<FixedChoice>('remaining')
   const [inputValue, setInputValue] = useState<number | null>(null)
-  const defaultVisits = useMemo(
-    () =>
-      initialVisitIds?.length ? initialVisitIds : billing.eligibleVisits.map((visit) => visit.id),
-    [billing.eligibleVisits, initialVisitIds]
-  )
+  const defaultVisits = useMemo(() => {
+    if (initialVisitIds?.length) return initialVisitIds
+    // Extra mode defaults to DONE visits' extras only — upcoming visits' staged extras are
+    // opt-in (plan money/19 §2: pre-billing is deliberate, never the default).
+    if (mode === 'extra') {
+      return [
+        ...new Set(
+          billing.extraWork.filter((row) => row.visitStatus === 'done').map((row) => row.visitId)
+        ),
+      ]
+    }
+    return billing.eligibleVisits.map((visit) => visit.id)
+  }, [billing.eligibleVisits, billing.extraWork, initialVisitIds, mode])
   const [visitIds, setVisitIds] = useState<string[]>(defaultVisits)
   const utils = api.useUtils()
 
@@ -103,8 +110,9 @@ export function BillingActionDialog({
   }, [billing, fixedChoice, inputValue])
 
   const isExtra = mode === 'extra'
-  const canContinue =
-    isExtra || billing.basis === 'per_visit'
+  const canContinue = isExtra
+    ? selectedExtraAmount(billing, visitIds) > 0
+    : billing.basis === 'per_visit'
       ? visitIds.length > 0
       : billing.basis === 'fixed_contract'
         ? amount > 0 && amount <= billing.remaining
@@ -158,7 +166,9 @@ export function BillingActionDialog({
         <DialogNavPages value={page}>
           <DialogNavPage value='choose' size='md'>
             <div className='space-y-4 p-4'>
-              {isExtra || billing.basis === 'per_visit' ? (
+              {isExtra ? (
+                <ExtraWorkPicker billing={billing} value={visitIds} onChange={setVisitIds} />
+              ) : billing.basis === 'per_visit' ? (
                 <VisitPicker billing={billing} value={visitIds} onChange={setVisitIds} />
               ) : billing.basis === 'fixed_contract' ? (
                 <FixedAmountPicker
@@ -197,7 +207,10 @@ export function BillingActionDialog({
                 <PreviewRow
                   label='Amount on this invoice'
                   value={formatCurrency(
-                    amount || selectedVisitAmount(billing, visitIds),
+                    amount ||
+                      (isExtra
+                        ? selectedExtraAmount(billing, visitIds)
+                        : selectedVisitAmount(billing, visitIds)),
                     billing.currencyCode
                   )}
                 />
@@ -361,34 +374,123 @@ function VisitPicker({
           resizeId='billing-action-visits'
           defaultLabelWidth={200}
           className='p-0'>
-          {billing.eligibleVisits.map((visit) => {
-            const selected = value.includes(visit.id)
-            return (
-              <FieldPanelRow
-                key={visit.id}
-                title={visit.label}
-                description={
-                  visit.serviceDate
-                    ? `Service date: ${format(new Date(visit.serviceDate), 'PP')}`
-                    : undefined
-                }>
-                <label className='flex min-h-8 cursor-pointer items-center justify-between gap-3 px-2'>
-                  <span className='text-sm tabular-nums'>
-                    {formatCurrency(visit.amount, billing.currencyCode)}
-                  </span>
-                  <Checkbox
-                    checked={selected}
-                    onCheckedChange={(checked) =>
-                      onChange(
-                        checked ? [...value, visit.id] : value.filter((id) => id !== visit.id)
-                      )
-                    }
-                  />
-                </label>
-              </FieldPanelRow>
-            )
-          })}
+          {billing.eligibleVisits.map((visit) => (
+            <FieldPanelRow
+              key={visit.id}
+              title={visit.label}
+              description={[
+                formatCurrency(visit.amount, billing.currencyCode),
+                visit.serviceDate
+                  ? `Service date: ${format(new Date(visit.serviceDate), 'PP')}`
+                  : undefined,
+              ]
+                .filter(Boolean)
+                .join(' · ')}>
+              <FieldInputAdapter
+                fieldType={FieldType.CHECKBOX}
+                value={value.includes(visit.id)}
+                onChange={(checked) =>
+                  onChange(checked ? [...value, visit.id] : value.filter((id) => id !== visit.id))
+                }
+              />
+            </FieldPanelRow>
+          ))}
         </FieldPanel>
+      )}
+    </div>
+  )
+}
+
+interface ExtraWorkVisitGroup {
+  visitId: string
+  visitStatus: string
+  serviceDate?: string | null
+  amount: number
+  lineNames: string[]
+}
+
+/** Group billable extras by visit, preserving the server's visit-date ordering. */
+function groupExtraWorkByVisit(billing: WorkOrderBillingView): ExtraWorkVisitGroup[] {
+  const groups = new Map<string, ExtraWorkVisitGroup>()
+  for (const row of billing.extraWork) {
+    const group = groups.get(row.visitId) ?? {
+      visitId: row.visitId,
+      visitStatus: row.visitStatus,
+      serviceDate: row.serviceDate,
+      amount: 0,
+      lineNames: [],
+    }
+    group.amount += row.amount
+    if (row.name) group.lineNames.push(row.name)
+    groups.set(row.visitId, group)
+  }
+  return [...groups.values()]
+}
+
+function ExtraWorkPicker({
+  billing,
+  value,
+  onChange,
+}: {
+  billing: WorkOrderBillingView
+  value: string[]
+  onChange: (ids: string[]) => void
+}) {
+  const groups = groupExtraWorkByVisit(billing)
+  const done = groups.filter((group) => group.visitStatus === 'done')
+  const upcoming = groups.filter((group) => group.visitStatus !== 'done')
+
+  if (groups.length === 0) {
+    return (
+      <p className='rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground'>
+        No extra work is ready to invoice.
+      </p>
+    )
+  }
+
+  const renderRow = (group: ExtraWorkVisitGroup, upcomingRow: boolean) => (
+    <FieldPanelRow
+      key={group.visitId}
+      title={group.serviceDate ? format(new Date(group.serviceDate), 'PP') : 'Unscheduled visit'}
+      description={[
+        formatCurrency(group.amount, billing.currencyCode),
+        upcomingRow ? 'Visit not yet done' : undefined,
+        group.lineNames.join(', ') || undefined,
+      ]
+        .filter(Boolean)
+        .join(' · ')}>
+      <FieldInputAdapter
+        fieldType={FieldType.CHECKBOX}
+        value={value.includes(group.visitId)}
+        onChange={(checked) =>
+          onChange(checked ? [...value, group.visitId] : value.filter((id) => id !== group.visitId))
+        }
+      />
+    </FieldPanelRow>
+  )
+
+  return (
+    <div className='space-y-3'>
+      {done.length > 0 && (
+        <FieldPanel
+          orientation='responsive'
+          resizeId='billing-action-extras'
+          defaultLabelWidth={200}
+          className='p-0'>
+          {done.map((group) => renderRow(group, false))}
+        </FieldPanel>
+      )}
+      {upcoming.length > 0 && (
+        <div className='space-y-1.5'>
+          <p className='px-1 text-xs text-muted-foreground'>Not yet done</p>
+          <FieldPanel
+            orientation='responsive'
+            resizeId='billing-action-extras-upcoming'
+            defaultLabelWidth={200}
+            className='p-0'>
+            {upcoming.map((group) => renderRow(group, true))}
+          </FieldPanel>
+        </div>
       )}
     </div>
   )
@@ -408,6 +510,12 @@ function selectedVisitAmount(billing: WorkOrderBillingView, ids: string[]) {
   return billing.eligibleVisits
     .filter((visit) => ids.includes(visit.id))
     .reduce((sum, visit) => sum + visit.amount, 0)
+}
+
+function selectedExtraAmount(billing: WorkOrderBillingView, ids: string[]) {
+  return billing.extraWork
+    .filter((row) => ids.includes(row.visitId))
+    .reduce((sum, row) => sum + row.amount, 0)
 }
 
 function chooseLabel(billing: WorkOrderBillingView, extra: boolean) {

--- a/apps/web/src/components/money/billing/types.ts
+++ b/apps/web/src/components/money/billing/types.ts
@@ -36,6 +36,17 @@ export interface BillingVisitRow {
   invoiceId?: string
 }
 
+/** One billable visit-pinned extra line (plan money/19 §B) — the server already filtered out
+ * unpriced lines and canceled/dangling visits. */
+export interface BillingExtraWorkRow {
+  id: string
+  visitId: string
+  visitStatus: string
+  serviceDate?: string | null
+  name: string
+  amount: number
+}
+
 export interface BillingInstallmentRow {
   id: string
   name: string
@@ -61,6 +72,7 @@ export interface WorkOrderBillingView {
   depositApplied: number
   nextInvoiceDate?: string | null
   eligibleVisits: BillingVisitRow[]
+  extraWork: BillingExtraWorkRow[]
   extraWorkVisitIds: string[]
   installments: BillingInstallmentRow[]
   invoices: BillingInvoiceRow[]
@@ -93,6 +105,7 @@ const EMPTY_WORK_ORDER_BILLING: WorkOrderBillingView = {
   depositApplied: 0,
   nextInvoiceDate: null,
   eligibleVisits: [],
+  extraWork: [],
   extraWorkVisitIds: [],
   installments: [],
   invoices: [],
@@ -131,7 +144,8 @@ export function normalizeWorkOrderBilling(
     depositApplied: data.summary.depositApplied,
     nextInvoiceDate: data.nextInvoiceDate,
     eligibleVisits: data.eligibleVisits.map(normalizeVisit),
-    extraWorkVisitIds: data.extraWork.map((item) => item.visitId).filter(Boolean),
+    extraWork: data.extraWork.map(normalizeExtraWork),
+    extraWorkVisitIds: [...new Set(data.extraWork.map((item) => item.visitId).filter(Boolean))],
     installments: data.installments.map(normalizeInstallment),
     invoices: data.invoices.map(normalizeInvoice),
   }
@@ -167,6 +181,19 @@ function normalizeVisit(visit: WorkOrderBillingVisitData): BillingVisitRow {
   }
 }
 
+function normalizeExtraWork(
+  item: WorkOrderBillingStateData['extraWork'][number]
+): BillingExtraWorkRow {
+  return {
+    id: item.id,
+    visitId: item.visitId,
+    visitStatus: item.visitStatus,
+    serviceDate: item.serviceDate,
+    name: item.name,
+    amount: item.amount,
+  }
+}
+
 function normalizeInstallment(item: WorkOrderBillingInstallmentData): BillingInstallmentRow {
   return {
     id: item.id,
@@ -193,14 +220,15 @@ function normalizeInvoice(invoice: WorkOrderBillingInvoiceData): BillingInvoiceR
   }
 }
 
-// ─── One next-action condition (work-order invoice flow plan §5.3) ─────────────────────────────
+// ─── One next-action condition (work-order invoice flow plan §5.3 + money/19 §D) ───────────────
 // Every billing surface (full Billing tab, work-order drawer card, header "Create invoice"
 // action) must agree on whether an invoice/recurring-charge action is available and what it's
-// called. Building this from `state`/`basis`/`timing`/`summary` — never from `eligibleVisits`
-// counts — keeps it correct even before the server-side eligible-visits gating in the plan lands.
+// called. Server-side gating exists now (plan money/19): `ready_to_invoice` means performed
+// work, `eligibleVisits` lists done unbilled-base visits, and `extraWork` carries visit status —
+// so the router deliberately reads them to pick between the base and extra-work dialogs.
 
 export interface BillingAction {
-  kind: 'create' | 'review_draft' | 'view_invoices' | 'none'
+  kind: 'create' | 'create_extra' | 'review_draft' | 'view_invoices' | 'none'
   label: string
   /** Set for `review_draft` when exactly one draft invoice is linked — surfaces can open it
    * directly instead of re-opening the create dialog. */
@@ -244,6 +272,16 @@ export function resolveBillingAction(billing: WorkOrderBillingView): BillingActi
   }
   if (billing.state === 'ready_to_invoice') {
     const pendingInstallment = billing.installments.some((item) => item.status === 'pending')
+    // Per-visit readiness driven only by extras (base fully billed or extras on an
+    // already-invoiced visit): the base dialog would dead-end, so the extra-work dialog is
+    // the primary action (plan money/19 D1).
+    if (
+      billing.basis === 'per_visit' &&
+      billing.eligibleVisits.length === 0 &&
+      billing.extraWork.some((row) => row.visitStatus === 'done')
+    ) {
+      return { kind: 'create_extra', label: 'Invoice extra work' }
+    }
     return { kind: 'create', label: pendingInstallment ? 'Generate installment' : 'Create invoice' }
   }
   if (billing.state === 'scheduled') {

--- a/apps/web/src/components/money/ui/invoice/create-invoice-action.tsx
+++ b/apps/web/src/components/money/ui/invoice/create-invoice-action.tsx
@@ -20,11 +20,14 @@ import { useWorkOrderBillingState } from '~/components/money/billing/use-work-or
 export function CreateInvoiceAction({ recordId }: DrawerActionProps) {
   const [open, setOpen] = useState(false)
   const { billing, isLoading } = useWorkOrderBillingState(recordId)
-  const canCreate = resolveBillingAction(billing).kind === 'create'
+  const action = resolveBillingAction(billing)
+  const canCreate = action.kind === 'create' || action.kind === 'create_extra'
 
   return (
     <>
-      <Tooltip content='Create invoice' allowInteraction>
+      <Tooltip
+        content={action.kind === 'create_extra' ? 'Invoice extra work' : 'Create invoice'}
+        allowInteraction>
         <Button
           variant='ghost'
           size='icon-xs'
@@ -38,6 +41,7 @@ export function CreateInvoiceAction({ recordId }: DrawerActionProps) {
         onOpenChange={setOpen}
         workOrderRecordId={recordId}
         billing={billing}
+        mode={action.kind === 'create_extra' ? 'extra' : 'primary'}
       />
     </>
   )

--- a/apps/worker/scripts/verify-money-extra-work.ts
+++ b/apps/worker/scripts/verify-money-extra-work.ts
@@ -1,0 +1,546 @@
+// apps/worker/scripts/verify-money-extra-work.ts
+/**
+ * Extra-work invoicing verification (plans/dispatch/money/19-extra-work-invoicing-surfacing.md §5).
+ *
+ * Exercises the readiness split (performed work only) and the extra-work invoice flow:
+ *  1. done visit + base invoiced + new extra → ready_to_invoice, second invoice via
+ *     createExtraWorkInvoice, no double-billing either direction;
+ *  2. extra staged on a scheduled (future) visit → NOT ready, but deliberately billable;
+ *  3. extra on a canceled visit → excluded everywhere, command rejects;
+ *  4. unpriced extra → invisible until priced, then flips readiness;
+ *  5. done visit with base NOT invoiced + extra → eligibleVisits amount = template + extra and
+ *     createVisitInvoice totals match;
+ *  6. the live-repro shape (zero done visits, future extra) → not ready until the visit is done.
+ *
+ * Creates records prefixed "[EW-verify]" and deletes them at the end (try/finally).
+ * WorkOrderVisit rows cascade off EntityInstance deletes.
+ *
+ * Run (from repo root) under the worker runtime:
+ *   node --conditions source --env-file .env --import tsx/esm \
+ *     apps/worker/scripts/verify-money-extra-work.ts
+ */
+
+import { database } from '@auxx/database'
+import { scheduleVisit, setVisitStatus } from '@auxx/lib/dispatch'
+import {
+  computeWorkOrderBillingProjection,
+  createExtraWorkInvoice,
+  createVisitInvoice,
+  getWorkOrderBillingState,
+} from '@auxx/lib/money'
+import { UnifiedCrudHandler } from '@auxx/lib/resources'
+
+/** Build a RecordId string without pulling in `@auxx/types` (not a worker dependency). */
+function toRecordId(entityDefinitionId: string, entityInstanceId: string) {
+  return `${entityDefinitionId}:${entityInstanceId}` as never
+}
+
+let pass = 0
+let fail = 0
+function check(name: string, ok: boolean, detail?: unknown) {
+  if (ok) {
+    pass++
+    console.log(`  ✅ ${name}`)
+  } else {
+    fail++
+    console.log(`  ❌ ${name}`, detail ?? '')
+  }
+}
+
+/** Run `fn`, expecting it to throw. Returns the caught error (or `undefined` if it didn't). */
+async function expectThrow(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+    return undefined
+  } catch (err) {
+    return err ?? new Error('threw a falsy value')
+  }
+}
+
+async function fieldId(organizationId: string, entityType: string, systemAttribute: string) {
+  const def = await database.query.EntityDefinition.findFirst({
+    columns: { id: true },
+    where: (t, { and, eq }) =>
+      and(eq(t.organizationId, organizationId), eq(t.entityType, entityType)),
+  })
+  if (!def) return null
+  const field = await database.query.CustomField.findFirst({
+    columns: { id: true },
+    where: (t, { and, eq }) =>
+      and(eq(t.entityDefinitionId, def.id), eq(t.systemAttribute, systemAttribute)),
+  })
+  return field?.id ?? null
+}
+
+async function numberValue(
+  organizationId: string,
+  entityType: string,
+  instanceId: string,
+  systemAttribute: string
+): Promise<number> {
+  const fid = await fieldId(organizationId, entityType, systemAttribute)
+  if (!fid) return 0
+  const fv = await database.query.FieldValue.findFirst({
+    where: (t, { and, eq }) => and(eq(t.entityId, instanceId), eq(t.fieldId, fid)),
+  })
+  return Number(fv?.valueNumber ?? 0)
+}
+
+async function activeVisitAllocations(visitId: string) {
+  return database.query.InvoiceVisitAllocation.findMany({
+    where: (t, { and, eq }) => and(eq(t.visitId, visitId), eq(t.status, 'active')),
+  })
+}
+
+async function activeLineAllocations(invoiceId: string) {
+  return database.query.InvoiceLineAllocation.findMany({
+    where: (t, { and, eq }) => and(eq(t.invoiceId, invoiceId), eq(t.status, 'active')),
+  })
+}
+
+async function main() {
+  const user = await database.query.User.findFirst({
+    columns: { id: true },
+    where: (t, { eq }) => eq(t.email, 'm4rkuskk@gmail.com'),
+  })
+  if (!user) throw new Error('Dev user not found')
+  const organizationId = 'u45w22ft66ymiaa19ohs7m9f' // Marki Corp (primary dev org)
+  const userId = user.id
+  console.log(`Org ${organizationId}, user ${userId}`)
+
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  const scope = { organizationId, userId }
+
+  const createdLineIds: string[] = []
+  const createdInvoiceIds: string[] = []
+  const createdWorkOrderIds: string[] = []
+
+  const dayMs = 24 * 60 * 60 * 1000
+  const hourMs = 60 * 60 * 1000
+  const yesterday = new Date(Date.now() - dayMs)
+  const nextWeek = new Date(Date.now() + 7 * dayMs)
+
+  /** per_visit WO with as_needed timing (no auto-draft door) + its M1 placeholder visit. */
+  async function newWorkOrder(title: string) {
+    const wo = await handler.create('work_order', {
+      work_order_title: title,
+      work_order_contact: contactRecordId,
+      work_order_invoice_timing: 'as_needed',
+    })
+    createdWorkOrderIds.push(wo.instance.id)
+    const visit = await database.query.WorkOrderVisit.findFirst({
+      where: (t, { eq }) => eq(t.workOrderId, wo.instance.id),
+    })
+    if (!visit) throw new Error(`No placeholder visit on ${title}`)
+    return { wo, visit }
+  }
+
+  async function createLine(input: {
+    name: string
+    workOrderRecordId: unknown
+    unitPrice?: number
+    visitId?: string
+  }) {
+    const line = await handler.create('line_item', {
+      line_item_name: input.name,
+      line_item_qty: 1,
+      ...(input.unitPrice === undefined ? {} : { line_item_unit_price: input.unitPrice }),
+      line_item_taxable: false,
+      line_item_work_order: input.workOrderRecordId,
+      ...(input.visitId ? { line_item_visit_id: input.visitId } : {}),
+    })
+    createdLineIds.push(line.instance.id)
+    return line
+  }
+
+  async function billingState(workOrderInstanceId: string) {
+    return getWorkOrderBillingState({ ...scope, workOrderInstanceId })
+  }
+  async function projection(workOrderInstanceId: string) {
+    return computeWorkOrderBillingProjection({ ...scope, workOrderInstanceId })
+  }
+
+  const contactDef = await database.query.EntityDefinition.findFirst({
+    columns: { id: true },
+    where: (t, { and, eq }) =>
+      and(eq(t.organizationId, organizationId), eq(t.entityType, 'contact')),
+  })
+  const contact = contactDef
+    ? await database.query.EntityInstance.findFirst({
+        columns: { id: true },
+        where: (t, { eq }) => eq(t.entityDefinitionId, contactDef.id),
+      })
+    : null
+  if (!contact) throw new Error('No contact in org — cannot test invoices')
+  const contactRecordId = toRecordId('contact', contact.id)
+
+  try {
+    // ══════════════════════════════════════════════════════════════════════
+    // 1. Forgotten material: done + base invoiced + new extra
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('1: done visit, base invoiced, forgotten-material extra')
+    const c1 = await newWorkOrder('[EW-verify] Case1 forgotten material')
+    await createLine({
+      name: '[EW-verify] C1 template',
+      workOrderRecordId: c1.wo.recordId,
+      unitPrice: 11000,
+    })
+    await scheduleVisit({
+      ...scope,
+      visitId: c1.visit.id,
+      startTime: yesterday,
+      endTime: new Date(yesterday.getTime() + hourMs),
+    })
+    await setVisitStatus({ ...scope, visitId: c1.visit.id, status: 'done' })
+
+    const inv1 = await createVisitInvoice({
+      ...scope,
+      workOrderInstanceId: c1.wo.instance.id,
+      visitIds: [c1.visit.id],
+    })
+    createdInvoiceIds.push(inv1.instanceId)
+    const baseAllocs = await activeVisitAllocations(c1.visit.id)
+    check(
+      'case1: base invoice → one active base visit allocation',
+      baseAllocs.filter((row) => row.kind === 'base').length === 1,
+      baseAllocs
+    )
+    const stateAfterBase = await billingState(c1.wo.instance.id)
+    check(
+      'case1: eligibleVisits empty after base invoice',
+      stateAfterBase.eligibleVisits.length === 0
+    )
+    check('case1: no extra work yet', stateAfterBase.extraWork.length === 0)
+
+    const extra1 = await createLine({
+      name: '[EW-verify] C1 forgotten material',
+      workOrderRecordId: c1.wo.recordId,
+      unitPrice: 9000,
+      visitId: c1.visit.id,
+    })
+    const proj1 = await projection(c1.wo.instance.id)
+    check(
+      'case1: extra on done visit → ready_to_invoice',
+      proj1.state === 'ready_to_invoice',
+      proj1.state
+    )
+    check('case1: uninvoicedAmount = 9000', proj1.uninvoicedAmount === 9000, proj1.uninvoicedAmount)
+    const state1 = await billingState(c1.wo.instance.id)
+    check('case1: eligibleVisits still empty (base allocated)', state1.eligibleVisits.length === 0)
+    check(
+      'case1: extraWork = one done-visit row of 9000',
+      state1.extraWork.length === 1 &&
+        state1.extraWork[0]!.visitStatus === 'done' &&
+        state1.extraWork[0]!.amount === 9000 &&
+        state1.extraWork[0]!.visitId === c1.visit.id &&
+        !!state1.extraWork[0]!.serviceDate,
+      state1.extraWork
+    )
+
+    const inv2 = await createExtraWorkInvoice({
+      ...scope,
+      workOrderInstanceId: c1.wo.instance.id,
+      visitIds: [c1.visit.id],
+    })
+    createdInvoiceIds.push(inv2.instanceId)
+    const inv2Total = await numberValue(organizationId, 'invoice', inv2.instanceId, 'invoice_total')
+    check('case1: extra invoice total = 9000', inv2Total === 9000, inv2Total)
+    const inv2LineAllocs = await activeLineAllocations(inv2.instanceId)
+    check(
+      'case1: one visit_addition line allocation on the extra invoice',
+      inv2LineAllocs.length === 1 &&
+        inv2LineAllocs[0]!.kind === 'visit_addition' &&
+        inv2LineAllocs[0]!.sourceLineItemId === extra1.instance.id,
+      inv2LineAllocs
+    )
+    const allocsAfterExtra = await activeVisitAllocations(c1.visit.id)
+    check(
+      'case1: visit carries base + additional allocations, base untouched',
+      allocsAfterExtra.filter((row) => row.kind === 'base').length === 1 &&
+        allocsAfterExtra.filter((row) => row.kind === 'additional').length === 1,
+      allocsAfterExtra
+    )
+    const rebill = await expectThrow(() =>
+      createExtraWorkInvoice({
+        ...scope,
+        workOrderInstanceId: c1.wo.instance.id,
+        visitIds: [c1.visit.id],
+      })
+    )
+    check('case1: re-billing the same extra rejects', rebill !== undefined, rebill)
+    const proj1After = await projection(c1.wo.instance.id)
+    check(
+      'case1: not ready after extra invoiced (drafts pending)',
+      proj1After.state !== 'ready_to_invoice' && proj1After.uninvoicedAmount === 0,
+      { state: proj1After.state, uninvoiced: proj1After.uninvoicedAmount }
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 2. Pre-billing: extra staged on a future (scheduled) visit
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('2: extra on a scheduled future visit')
+    const c2 = await newWorkOrder('[EW-verify] Case2 pre-bill')
+    await createLine({
+      name: '[EW-verify] C2 template',
+      workOrderRecordId: c2.wo.recordId,
+      unitPrice: 11000,
+    })
+    await scheduleVisit({
+      ...scope,
+      visitId: c2.visit.id,
+      startTime: nextWeek,
+      endTime: new Date(nextWeek.getTime() + hourMs),
+    })
+    await createLine({
+      name: '[EW-verify] C2 special-order part',
+      workOrderRecordId: c2.wo.recordId,
+      unitPrice: 5000,
+      visitId: c2.visit.id,
+    })
+    const proj2 = await projection(c2.wo.instance.id)
+    check(
+      'case2: future extra does NOT make the WO ready',
+      proj2.state !== 'ready_to_invoice' && proj2.uninvoicedAmount === 0,
+      { state: proj2.state, uninvoiced: proj2.uninvoicedAmount }
+    )
+    const state2 = await billingState(c2.wo.instance.id)
+    check(
+      "case2: extraWork lists the staged extra with visitStatus 'scheduled'",
+      state2.extraWork.length === 1 && state2.extraWork[0]!.visitStatus === 'scheduled',
+      state2.extraWork
+    )
+    check('case2: eligibleVisits empty', state2.eligibleVisits.length === 0)
+    const inv3 = await createExtraWorkInvoice({
+      ...scope,
+      workOrderInstanceId: c2.wo.instance.id,
+      visitIds: [c2.visit.id],
+    })
+    createdInvoiceIds.push(inv3.instanceId)
+    const inv3Total = await numberValue(organizationId, 'invoice', inv3.instanceId, 'invoice_total')
+    check('case2: deliberate pre-bill succeeds at 5000', inv3Total === 5000, inv3Total)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 3. Canceled visit extras are not billable
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('3: extra on a canceled visit')
+    const c3 = await newWorkOrder('[EW-verify] Case3 canceled')
+    await scheduleVisit({
+      ...scope,
+      visitId: c3.visit.id,
+      startTime: nextWeek,
+      endTime: new Date(nextWeek.getTime() + hourMs),
+    })
+    await createLine({
+      name: '[EW-verify] C3 extra',
+      workOrderRecordId: c3.wo.recordId,
+      unitPrice: 4000,
+      visitId: c3.visit.id,
+    })
+    await setVisitStatus({ ...scope, visitId: c3.visit.id, status: 'canceled' })
+    const state3 = await billingState(c3.wo.instance.id)
+    check(
+      'case3: canceled-visit extra excluded from extraWork',
+      state3.extraWork.length === 0,
+      state3.extraWork
+    )
+    const proj3 = await projection(c3.wo.instance.id)
+    check(
+      'case3: canceled-visit extra excluded from readiness',
+      proj3.uninvoicedAmount === 0,
+      proj3.uninvoicedAmount
+    )
+    const canceledBill = await expectThrow(() =>
+      createExtraWorkInvoice({
+        ...scope,
+        workOrderInstanceId: c3.wo.instance.id,
+        visitIds: [c3.visit.id],
+      })
+    )
+    check('case3: command rejects canceled-visit extras', canceledBill !== undefined, canceledBill)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 4. Unpriced extras are drafts, not billable work
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('4: unpriced extra until priced')
+    const c4 = await newWorkOrder('[EW-verify] Case4 unpriced')
+    await scheduleVisit({
+      ...scope,
+      visitId: c4.visit.id,
+      startTime: yesterday,
+      endTime: new Date(yesterday.getTime() + hourMs),
+    })
+    await setVisitStatus({ ...scope, visitId: c4.visit.id, status: 'done' })
+    const unpriced = await createLine({
+      name: '[EW-verify] C4 unpriced extra',
+      workOrderRecordId: c4.wo.recordId,
+      visitId: c4.visit.id,
+    })
+    const state4 = await billingState(c4.wo.instance.id)
+    check(
+      'case4: unpriced extra absent from extraWork',
+      state4.extraWork.length === 0,
+      state4.extraWork
+    )
+    const proj4 = await projection(c4.wo.instance.id)
+    check(
+      'case4: unpriced extra adds nothing to uninvoicedAmount',
+      proj4.uninvoicedAmount === 0,
+      proj4.uninvoicedAmount
+    )
+    await handler.update(unpriced.recordId, { line_item_unit_price: 9000 })
+    const proj4Priced = await projection(c4.wo.instance.id)
+    check(
+      'case4: pricing the extra flips readiness to 9000',
+      proj4Priced.uninvoicedAmount === 9000 && proj4Priced.state === 'ready_to_invoice',
+      { state: proj4Priced.state, uninvoiced: proj4Priced.uninvoicedAmount }
+    )
+    const state4Priced = await billingState(c4.wo.instance.id)
+    check(
+      'case4: priced extra appears in extraWork',
+      state4Priced.extraWork.length === 1,
+      state4Priced.extraWork
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 5. Base + extra ride together when the base is uninvoiced
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('5: done visit, base uninvoiced, extra rides along')
+    const c5 = await newWorkOrder('[EW-verify] Case5 ride-along')
+    await createLine({
+      name: '[EW-verify] C5 template',
+      workOrderRecordId: c5.wo.recordId,
+      unitPrice: 11000,
+    })
+    await scheduleVisit({
+      ...scope,
+      visitId: c5.visit.id,
+      startTime: yesterday,
+      endTime: new Date(yesterday.getTime() + hourMs),
+    })
+    await setVisitStatus({ ...scope, visitId: c5.visit.id, status: 'done' })
+    await createLine({
+      name: '[EW-verify] C5 extra',
+      workOrderRecordId: c5.wo.recordId,
+      unitPrice: 9000,
+      visitId: c5.visit.id,
+    })
+    const state5 = await billingState(c5.wo.instance.id)
+    check(
+      'case5: eligibleVisits amount = template + extra (20000)',
+      state5.eligibleVisits.length === 1 && state5.eligibleVisits[0]!.amount === 20000,
+      state5.eligibleVisits
+    )
+    const inv5 = await createVisitInvoice({
+      ...scope,
+      workOrderInstanceId: c5.wo.instance.id,
+      visitIds: [c5.visit.id],
+    })
+    createdInvoiceIds.push(inv5.instanceId)
+    const inv5Total = await numberValue(organizationId, 'invoice', inv5.instanceId, 'invoice_total')
+    check('case5: visit invoice total = 20000 (matches picker)', inv5Total === 20000, inv5Total)
+    const state5After = await billingState(c5.wo.instance.id)
+    check(
+      'case5: extra consumed — extraWork empty',
+      state5After.extraWork.length === 0,
+      state5After.extraWork
+    )
+    const rideAgain = await expectThrow(() =>
+      createExtraWorkInvoice({
+        ...scope,
+        workOrderInstanceId: c5.wo.instance.id,
+        visitIds: [c5.visit.id],
+      })
+    )
+    check('case5: consumed extra cannot be billed again', rideAgain !== undefined, rideAgain)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 6. The live-repro shape: zero done visits + future extra
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('6: repro shape — not ready until the visit is done')
+    const c6 = await newWorkOrder('[EW-verify] Case6 repro shape')
+    await createLine({
+      name: '[EW-verify] C6 template',
+      workOrderRecordId: c6.wo.recordId,
+      unitPrice: 11000,
+    })
+    await scheduleVisit({
+      ...scope,
+      visitId: c6.visit.id,
+      startTime: nextWeek,
+      endTime: new Date(nextWeek.getTime() + hourMs),
+    })
+    await createLine({
+      name: '[EW-verify] C6 staged extra',
+      workOrderRecordId: c6.wo.recordId,
+      unitPrice: 9000,
+      visitId: c6.visit.id,
+    })
+    const proj6 = await projection(c6.wo.instance.id)
+    check(
+      'case6: repro shape is NOT ready anymore',
+      proj6.state !== 'ready_to_invoice' && proj6.uninvoicedAmount === 0,
+      { state: proj6.state, uninvoiced: proj6.uninvoicedAmount }
+    )
+    await scheduleVisit({
+      ...scope,
+      visitId: c6.visit.id,
+      startTime: yesterday,
+      endTime: new Date(yesterday.getTime() + hourMs),
+    })
+    await setVisitStatus({ ...scope, visitId: c6.visit.id, status: 'done' })
+    const proj6Done = await projection(c6.wo.instance.id)
+    check(
+      'case6: done visit → ready with base + extra (20000)',
+      proj6Done.state === 'ready_to_invoice' && proj6Done.uninvoicedAmount === 20000,
+      { state: proj6Done.state, uninvoiced: proj6Done.uninvoicedAmount }
+    )
+    const state6 = await billingState(c6.wo.instance.id)
+    check(
+      'case6: one eligible visit quoted at 20000',
+      state6.eligibleVisits.length === 1 && state6.eligibleVisits[0]!.amount === 20000,
+      state6.eligibleVisits
+    )
+  } finally {
+    console.log(
+      `Cleanup: ${createdLineIds.length} lines, ${createdInvoiceIds.length} invoices, ` +
+        `${createdWorkOrderIds.length} work orders`
+    )
+    for (const id of [...new Set(createdInvoiceIds)]) {
+      try {
+        await handler.delete(toRecordId('invoice', id))
+      } catch (err) {
+        console.log(`  cleanup failed for invoice:${id}:`, err instanceof Error ? err.message : err)
+      }
+    }
+    for (const id of [...new Set(createdLineIds)]) {
+      try {
+        await handler.delete(toRecordId('line_item', id))
+      } catch (err) {
+        console.log(
+          `  cleanup failed for line_item:${id}:`,
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+    for (const id of [...new Set(createdWorkOrderIds)]) {
+      try {
+        await handler.delete(toRecordId('work_order', id))
+      } catch (err) {
+        console.log(
+          `  cleanup failed for work_order:${id}:`,
+          err instanceof Error ? err.message : err
+        )
+      }
+    }
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`)
+  if (fail > 0) process.exitCode = 1
+}
+
+main()
+  .catch((err) => {
+    console.error(err)
+    process.exitCode = 1
+  })
+  .finally(() => process.exit())

--- a/packages/lib/src/money/billing-commands.ts
+++ b/packages/lib/src/money/billing-commands.ts
@@ -485,12 +485,33 @@ export async function createExtraWorkInvoice(
         input.visitIds.includes(line.visitId) &&
         (!input.sourceLineIds || input.sourceLineIds.includes(line.id))
     )
+    // Plan money/19 §C: extras on canceled visits are not billable (restore the visit or
+    // re-pin the line first); dangling visit ids drop out via the fetched-visit check.
+    // Future/scheduled visits stay deliberately accepted — pre-billing staged material is
+    // a supported flow. Unpriced lines follow the other builders' `amount > 0` convention.
+    const selectedVisitIds = [...new Set(selected.map((line) => line.visitId!))]
+    const visitRows = selectedVisitIds.length
+      ? await db.query.WorkOrderVisit.findMany({
+          where: and(
+            eq(schema.WorkOrderVisit.organizationId, input.organizationId),
+            eq(schema.WorkOrderVisit.workOrderId, input.workOrderInstanceId),
+            inArray(schema.WorkOrderVisit.id, selectedVisitIds)
+          ),
+          columns: { id: true, status: true },
+        })
+      : []
+    const visitStatusById = new Map(visitRows.map((row) => [row.id, row.status]))
+    if (selected.some((line) => visitStatusById.get(line.visitId!) === 'canceled')) {
+      throw new BadRequestError('Extra work on a canceled visit cannot be invoiced')
+    }
     const allocated = await getActiveAllocatedAmounts({
       db,
       organizationId: input.organizationId,
       sourceLineItemIds: selected.map((line) => line.id),
     })
-    const eligible = selected.filter((line) => !allocated.has(line.id))
+    const eligible = selected.filter(
+      (line) => !allocated.has(line.id) && line.amount > 0 && visitStatusById.has(line.visitId!)
+    )
     if (eligible.length === 0)
       throw new BadRequestError('No selected extra work is ready to invoice')
     const shell = await createInvoiceShell({ ...input, db, publishEvents: false })

--- a/packages/lib/src/money/billing-projection.ts
+++ b/packages/lib/src/money/billing-projection.ts
@@ -397,9 +397,16 @@ export async function computeWorkOrderBillingProjection(input: {
       0
     )
   } else if (basis === 'per_visit') {
+    // Plan money/19 §A: readiness counts performed work only. `visits` is already the WO's
+    // DONE visits, so extras pinned to scheduled/canceled/dangling visit ids are excluded —
+    // they stay deliberately billable through `createExtraWorkInvoice`, but a planned extra
+    // is not a receivable and must not flip the badge to ready_to_invoice.
+    const doneVisitIds = new Set(visits.map((visit) => visit.id))
     const eligibleVisitCount = visits.filter((visit) => !allocatedVisitIds.has(visit.id)).length
     const additions = lines
-      .filter((line) => line.visitId && !allocatedBySource.has(line.id))
+      .filter(
+        (line) => line.visitId && doneVisitIds.has(line.visitId) && !allocatedBySource.has(line.id)
+      )
       .reduce((total, line) => total + line.amount, 0)
     uninvoicedAmount = eligibleVisitCount * billingAmount + additions
   } else if (basis === 'recurring_flat') {

--- a/packages/lib/src/money/billing-state.ts
+++ b/packages/lib/src/money/billing-state.ts
@@ -78,11 +78,12 @@ export async function getWorkOrderBillingState(input: {
   const handler = new UnifiedCrudHandler(input.organizationId, input.userId)
   const [visits, activeVisits, installments, linkedInvoices, payments, uninvoicedLines] =
     await Promise.all([
+      // All statuses — done visits feed eligibleVisits, the rest feed extra-work enrichment
+      // (plan money/19 §B: the client needs visit status/date to split done vs upcoming extras).
       database.query.WorkOrderVisit.findMany({
         where: and(
           eq(schema.WorkOrderVisit.organizationId, input.organizationId),
-          eq(schema.WorkOrderVisit.workOrderId, input.workOrderInstanceId),
-          eq(schema.WorkOrderVisit.status, 'done')
+          eq(schema.WorkOrderVisit.workOrderId, input.workOrderInstanceId)
         ),
         orderBy: [asc(schema.WorkOrderVisit.startTime)],
       }),
@@ -145,13 +146,35 @@ export async function getWorkOrderBillingState(input: {
     rows.push(allocation)
     allocationsByVisit.set(allocation.visitId, rows)
   }
+  const visitById = new Map(visits.map((visit) => [visit.id, visit]))
+  // Billable extra work (plan money/19 §B): visit-pinned unallocated lines with a real price on
+  // a real, non-canceled visit. Unpriced lines are drafts, not billable work; canceled visits'
+  // extras are excluded everywhere (readiness, list, and the command itself).
+  const billableExtras = uninvoicedLines.filter((line) => {
+    if (!line.visitId || (line.lineTotal ?? 0) <= 0) return false
+    const visit = visitById.get(line.visitId)
+    return visit !== undefined && visit.status !== 'canceled'
+  })
+  const extrasTotalByVisit = new Map<string, number>()
+  for (const line of billableExtras) {
+    extrasTotalByVisit.set(
+      line.visitId!,
+      (extrasTotalByVisit.get(line.visitId!) ?? 0) + (line.lineTotal ?? 0)
+    )
+  }
   const eligibleVisits = visits
-    .filter((visit) => !allocationsByVisit.get(visit.id)?.some((row) => row.kind === 'base'))
+    .filter(
+      (visit) =>
+        visit.status === 'done' &&
+        !allocationsByVisit.get(visit.id)?.some((row) => row.kind === 'base')
+    )
     .map((visit, index) => ({
       id: visit.id,
       label: `Visit ${index + 1}`,
       serviceDate: visit.occurrenceDate ?? visit.startTime?.toISOString().split('T')[0] ?? null,
-      amount: projection.billingAmount,
+      // `createVisitInvoice` copies the job template PLUS this visit's unallocated extras —
+      // the picker/preview must quote what the invoice will actually total (plan money/19 D5).
+      amount: projection.billingAmount + (extrasTotalByVisit.get(visit.id) ?? 0),
       invoiceState: 'uninvoiced' as const,
     }))
   return {
@@ -169,14 +192,18 @@ export async function getWorkOrderBillingState(input: {
       depositApplied,
     },
     eligibleVisits,
-    extraWork: uninvoicedLines
-      .filter((line) => line.visitId)
-      .map((line) => ({
+    extraWork: billableExtras.map((line) => {
+      const visit = visitById.get(line.visitId!)!
+      return {
         id: line.instanceId,
         sourceLineId: line.instanceId,
         visitId: line.visitId!,
+        visitStatus: visit.status,
+        serviceDate: visit.occurrenceDate ?? visit.startTime?.toISOString().split('T')[0] ?? null,
+        name: line.name,
         amount: line.lineTotal ?? 0,
-      })),
+      }
+    }),
     installments,
     invoices: await invoiceRows({
       organizationId: input.organizationId,


### PR DESCRIPTION
## Summary

Splits billable **extra work** from base work across every billing surface, and makes the dispatch board's fetch window deterministic.

### Money — extra-work invoicing
- **Server** (`billing-state`): reports every visit-pinned extra with its visit status/date, so the client can split done vs upcoming extras. Now fetches visits of all statuses (not just `done`).
- **Readiness** (`billing-projection`): counts performed work only — extras staged on scheduled/canceled/dangling visits no longer flip the badge to `ready_to_invoice` (they stay deliberately billable via `createExtraWorkInvoice`).
- **Command** (`billing-commands`): rejects extras on canceled visits; filters unpriced/dangling lines.
- **Action model** (`types.ts`): new `create_extra` action when readiness is driven purely by extras, so surfaces open the extra-work dialog instead of a dead-end base dialog.
- **UI**: extra-work picker grouped by visit (done vs upcoming), billing tab splits done/planned extra rows, visit detail gains an "Invoice extra work" door, and a manual "New invoice" flow prefills contact + work order.

### Dispatch board — deterministic fetch window
`getBoard` and availability shading now read a padded window derived from the settled date/view instead of chasing the calendar's noisy visible-range echo, so each query fires once per settled window rather than on every scroll frame.

## Testing
Adds `apps/worker/scripts/verify-money-extra-work.ts` — exercises the readiness split, pre-billing, canceled/unpriced exclusion, ride-along, and the live-repro shape end-to-end (self-cleaning).