### PR TITLE
feat(money): show invoice number in drill nav bar + section icons

### DIFF
--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
@@ -6,10 +6,13 @@ import { BILLING_BASIS_LABELS, BILLING_TIMING_LABELS } from '@auxx/lib/money/cli
 import { toRecordId } from '@auxx/types/resource'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
+import { EmptySection } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { TuckedSection } from '@auxx/ui/components/tucked-label'
 import { cn } from '@auxx/ui/lib/utils'
-import { CreditCard, ExternalLink, ReceiptText } from 'lucide-react'
+import { CreditCard, Receipt } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import type { DetailViewTabProps } from '~/components/detail-view'
 import { BillingActionDialog } from '~/components/money/billing/billing-action-dialog'
@@ -18,7 +21,7 @@ import { BillingScheduleDialog } from '~/components/money/billing/billing-schedu
 import { resolveBillingAction, type WorkOrderBillingView } from '~/components/money/billing/types'
 import { useWorkOrderBillingState } from '~/components/money/billing/use-work-order-billing-state'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
-import { useOpenRecord } from '~/components/records/record-drill-panels'
+import { useRecordDrill } from '~/components/records/record-drill-panels'
 import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import { useSystemField } from '~/components/resources/hooks/use-field'
 import { useResources } from '~/components/resources/hooks/use-resources'
@@ -36,7 +39,9 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
   const [newInvoiceOpen, setNewInvoiceOpen] = useState(false)
   const { billing, isLoading } = useWorkOrderBillingState(recordId)
   const utils = api.useUtils()
-  const openRecord = useOpenRecord()
+  // In-place invoice drill (the schedule-visit pattern) — `?panel=invoices&item=<recordId>`
+  // pushes the InvoiceDetailPanel over this page/drawer surface.
+  const drill = useRecordDrill()
   const isSection = variant === 'section'
   // Quick manual invoice (plan money/19 follow-up): the generic invoice create dialog
   // (contact / work order / due date) with both relations prefilled from this job. The
@@ -216,7 +221,7 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
           presetValues={newInvoicePresets}
           onSaved={(instanceId) => {
             void utils.money.getWorkOrderBillingState.invalidate({ workOrderRecordId: recordId })
-            if (instanceId) openRecord?.(toRecordId('invoice', instanceId))
+            if (instanceId) drill.open('invoices', toRecordId('invoice', instanceId))
           }}
         />
       )}
@@ -278,18 +283,18 @@ function NextAction({
   onAction: () => void
   onExtra: () => void
 }) {
-  const openRecord = useOpenRecord()
+  const drill = useRecordDrill()
   const action = resolveBillingAction(billing)
   const handleClick = () => {
     if (action.kind === 'create') return onAction()
     if (action.kind === 'create_extra') return onExtra()
     if (action.kind === 'review_draft') {
-      if (action.draftInvoiceRecordId) return openRecord?.(action.draftInvoiceRecordId)
+      if (action.draftInvoiceRecordId) return drill.open('invoices', action.draftInvoiceRecordId)
       return onAction()
     }
     if (action.kind === 'view_invoices') {
       const target = billing.invoices[0]
-      if (target) openRecord?.(target.recordId)
+      if (target) drill.open('invoices', target.recordId)
     }
   }
   return (
@@ -402,34 +407,43 @@ function UninvoicedWork({
   )
 }
 
+/** How many invoices render before the inline "Show more" row collapses the rest. */
+const INVOICE_PREVIEW_LIMIT = 5
+
+/** Single-line invoice rows — the same `TreeRow` recipe as the work-order
+ * drawer's Billing section (`WorkOrderBillingCard`), capped behind the shared
+ * `TreeRowList` show-more collapse. */
 function InvoiceRows({ billing }: { billing: WorkOrderBillingView }) {
-  const openRecord = useOpenRecord()
+  const drill = useRecordDrill()
   if (billing.invoices.length === 0)
-    return <p className='p-3 text-sm text-muted-foreground'>No invoices yet.</p>
+    return (
+      <EmptySection
+        icon={<Receipt className='size-5' />}
+        title='No invoices yet'
+        description='Create an invoice to get started.'
+      />
+    )
   return (
-    <div className='divide-y'>
-      {billing.invoices.map((invoice) => (
-        <button
-          type='button'
-          key={invoice.recordId}
-          onClick={() => openRecord?.(invoice.recordId)}
-          className='flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-primary-100'>
-          <ReceiptText className='size-4 text-muted-foreground' />
-          <span className='min-w-0 flex-1'>
-            <span className='block truncate text-sm font-medium'>{invoice.displayName}</span>
-            <span className='text-xs text-muted-foreground'>
-              {invoice.visitCount
-                ? `${invoice.visitCount} visit${invoice.visitCount === 1 ? '' : 's'} · `
-                : ''}
-              {invoice.status}
-            </span>
-          </span>
-          <span className='text-sm tabular-nums'>
-            {formatCurrency(invoice.total, billing.currencyCode)}
-          </span>
-          <ExternalLink className='size-3.5 text-muted-foreground' />
-        </button>
-      ))}
+    <div className='p-1.5'>
+      <TreeRowList
+        items={billing.invoices}
+        getKey={(invoice) => invoice.recordId}
+        visibleLimit={INVOICE_PREVIEW_LIMIT}
+        className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}
+        renderRow={(invoice) => (
+          <TreeRow
+            rowClassName='hover:bg-primary-100'
+            icon={<Receipt className='size-4' />}
+            title={<span className='text-sm'>{invoice.displayName}</span>}
+            secondary={
+              <span className='text-xs'>
+                {invoice.status} · {formatCurrency(invoice.total, billing.currencyCode)}
+              </span>
+            }
+            onDrill={() => drill.open('invoices', invoice.recordId)}
+          />
+        )}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/drawers/base-entity-drawer.tsx
+++ b/apps/web/src/components/drawers/base-entity-drawer.tsx
@@ -16,6 +16,7 @@ import { OverflowTabsList, type TabDefinition, Tabs, TabsContent } from '@auxx/u
 import {
   CalendarClock,
   Clock,
+  CreditCard,
   ExternalLink,
   FileText,
   HouseIcon,
@@ -698,8 +699,10 @@ function TabCards({
  * A single tab card wrapped in its Section. Owns the Section header's actions-slot
  * element and exposes it to the lazily-loaded card via `DrawerCardActionsProvider`,
  * so the card can portal buttons into the header (see `DrawerCardActions`).
+ * Exported for surfaces that replay a drawer's card list outside the drawer
+ * itself (e.g. `InvoiceDetailPanel`).
  */
-function TabCardSection({
+export function TabCardSection({
   card,
   entityType,
   entityInstanceId,
@@ -799,6 +802,7 @@ function getIconComponent(iconName: string) {
     'file-text': FileText,
     'calendar-clock': CalendarClock,
     receipt: Receipt,
+    'credit-card': CreditCard,
     // Add more as needed
   }
   return icons[iconName] ?? HouseIcon

--- a/apps/web/src/components/money/ui/invoice/invoice-detail-panel.tsx
+++ b/apps/web/src/components/money/ui/invoice/invoice-detail-panel.tsx
@@ -1,0 +1,57 @@
+// apps/web/src/components/money/ui/invoice/invoice-detail-panel.tsx
+'use client'
+
+import { getEntityDrawerConfig } from '@auxx/lib/resources/client'
+import type { RecordId } from '@auxx/types/resource'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Section } from '@auxx/ui/components/section'
+import { HouseIcon } from 'lucide-react'
+import { TabCardSection } from '~/components/drawers/base-entity-drawer'
+import EntityFields from '~/components/fields/entity-fields'
+import type { RecordDrillContext } from '~/components/records/record-drill-panels'
+import { parseRecordId, useRecord } from '~/components/resources'
+
+/**
+ * InvoiceDetailPanel — the single-level `invoices` drill on a work order
+ * (deliberately NO list level; surfaces list invoices themselves and drill
+ * straight in). `itemId` carries the invoice's RecordId. Renders the SAME
+ * items as the regular invoice drawer by replaying its overview recipe: the
+ * Details fields block plus the invoice drawer config's overview cards (Line
+ * items with the document actions cluster, Billing context, Payments) through
+ * the shared `TabCardSection` wrapper — so the drill stays in lockstep with
+ * the drawer as cards are added or reordered.
+ */
+export function InvoiceDetailPanel({ itemId }: RecordDrillContext) {
+  const invoiceRecordId = (itemId ?? '') as RecordId
+  const { record } = useRecord({ recordId: invoiceRecordId, enabled: Boolean(itemId) })
+
+  if (!itemId) {
+    return <div className='p-6 text-sm text-muted-foreground'>Invoice not found.</div>
+  }
+
+  const { entityInstanceId } = parseRecordId(invoiceRecordId)
+  const cards = getEntityDrawerConfig('invoice').tabCards?.overview ?? []
+
+  return (
+    <ScrollArea className='h-full' scrollbarClassName='w-1.5 z-20' noFade>
+      <Section
+        title='Details'
+        className='[&>[data-slot=section]>[data-slot=section-content]]:pe-4'
+        initialOpen
+        collapsible={false}
+        icon={<HouseIcon className='size-4' />}>
+        <EntityFields recordId={invoiceRecordId} />
+      </Section>
+      {cards.map((card) => (
+        <TabCardSection
+          key={card.value}
+          card={card}
+          entityType='invoice'
+          entityInstanceId={entityInstanceId}
+          recordId={invoiceRecordId}
+          record={record}
+        />
+      ))}
+    </ScrollArea>
+  )
+}

--- a/apps/web/src/components/records/record-drill-panels.tsx
+++ b/apps/web/src/components/records/record-drill-panels.tsx
@@ -15,6 +15,7 @@ import dynamic from 'next/dynamic'
 import { parseAsArrayOf, parseAsString, useQueryState, useQueryStates } from 'nuqs'
 import * as React from 'react'
 import type { RecordId } from '~/components/resources'
+import { useRecord } from '~/components/resources'
 
 /**
  * Context handed to a `RecordDrillPanel`'s `bar`/`render`/`renderItem`. Shared
@@ -62,6 +63,10 @@ const VisitDetailPanel = dynamic(
   () => import('../dispatch/ui/job-schedule/visit-detail-panel').then((m) => m.VisitDetailPanel),
   { ssr: false, loading: DRILL_LOADING }
 )
+const InvoiceDetailPanel = dynamic(
+  () => import('../money/ui/invoice/invoice-detail-panel').then((m) => m.InvoiceDetailPanel),
+  { ssr: false, loading: DRILL_LOADING }
+)
 
 /** Back button + title — the `ProcedureDetailBar`/`agent-detail-tabs.tsx` shared-bar
  * pattern, kept inline (generic `@auxx/ui` primitives only) so this registry stays
@@ -78,6 +83,14 @@ export function DrillBackBar({ title }: { title: string }) {
   )
 }
 
+/** Nav-bar title for the `invoices` drill — the invoice's own `displayName`
+ * (its invoice number) once loaded, falling back to the generic label. */
+function InvoiceDrillBar({ itemId }: { itemId: string | null }) {
+  const invoiceRecordId = itemId as RecordId | null
+  const { record } = useRecord({ recordId: invoiceRecordId, enabled: Boolean(itemId) })
+  return <DrillBackBar title={record?.displayName ?? 'Invoice'} />
+}
+
 const RECORD_DRILL_PANELS: Record<string, RecordDrillPanel[]> = {
   work_order: [
     {
@@ -85,6 +98,14 @@ const RECORD_DRILL_PANELS: Record<string, RecordDrillPanel[]> = {
       bar: (ctx: RecordDrillContext) => <DrillBackBar title={ctx.itemId ? 'Visit' : 'Visits'} />,
       render: (ctx) => <VisitsListPanel {...ctx} />,
       renderItem: (ctx) => <VisitDetailPanel {...ctx} />,
+    },
+    {
+      // Single-level on purpose (no list panel — surfaces list invoices themselves
+      // and drill straight in): `render` reads the drilled invoice off ctx.itemId,
+      // so `open('invoices', recordId)` always lands a two-level stack.
+      value: 'invoices',
+      bar: (ctx: RecordDrillContext) => <InvoiceDrillBar itemId={ctx.itemId} />,
+      render: (ctx) => <InvoiceDetailPanel {...ctx} />,
     },
   ],
 }

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -149,9 +149,9 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     },
     tabCards: {
       overview: [
-        { value: 'lines', label: 'Line items', fullBleed: false },
-        { value: 'billing-context', label: 'Billing context' },
-        { value: 'payments', label: 'Payments' },
+        { value: 'lines', label: 'Line items', fullBleed: false, icon: 'file-text' },
+        { value: 'billing-context', label: 'Billing context', icon: 'calendar-clock' },
+        { value: 'payments', label: 'Payments', icon: 'credit-card' },
       ],
     },
   },


### PR DESCRIPTION
## Summary
- The work-order invoice drill panel's nav bar showed a static "Invoice" title; it now resolves and shows the invoice's own display name (invoice number) via `useRecord`.
- Added matching icons (`file-text`, `calendar-clock`, `credit-card`) to the invoice drawer's Line items, Billing context, and Payments sections.
- Registered the `credit-card` icon key in `base-entity-drawer.tsx`'s icon map — it was already referenced by the work-order Billing card but silently fell back to a house icon.
- Exported `TabCardSection` from `base-entity-drawer.tsx` so `InvoiceDetailPanel` (which replays the invoice drawer's overview cards in the drill panel) can use it.

## Test plan
- [x] `tsc --noEmit` clean on all touched files (apps/web, packages/lib)
- [ ] Manually drill into an invoice from a work order's Billing tab and confirm the nav bar shows the invoice number, with icons on each section