### PR TITLE
feat(money): cap payments list rows + invoice-drill fallback for full page

### DIFF
--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
@@ -27,7 +27,11 @@ import { getInitials } from '~/components/groups/utils/group-utils'
 import { BillingActionDialog } from '~/components/money/billing/billing-action-dialog'
 import { useWorkOrderBillingState } from '~/components/money/billing/use-work-order-billing-state'
 import { LineBuilder } from '~/components/money/ui/line-builder/line-builder'
-import { type RecordDrillContext, useOpenRecord } from '~/components/records/record-drill-panels'
+import {
+  type RecordDrillContext,
+  useOpenRecord,
+  useRecordDrill,
+} from '~/components/records/record-drill-panels'
 import { useActors } from '~/components/resources/hooks/use-actor'
 import { BaseType } from '~/components/workflow/types'
 import { useConfirm } from '~/hooks/use-confirm'
@@ -57,6 +61,7 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
   const visit = visits.find((v) => v.id === itemId)
   const [confirm, ConfirmDialog] = useConfirm()
   const openRecord = useOpenRecord()
+  const drill = useRecordDrill()
   // Plan 20 §4.1a — explicit duration write. Never touches the schedule; draft state so a
   // blur/Enter commits and an Escape reverts without re-render churn on every keystroke.
   const [durationDraft, setDurationDraft] = useState<number | undefined | null>(null)
@@ -302,13 +307,15 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
             <Button
               variant='ghost'
               size='sm'
-              onClick={() =>
-                openRecord?.(
-                  billingVisit.invoiceId!.includes(':')
-                    ? (billingVisit.invoiceId as RecordId)
-                    : toRecordId('invoice', billingVisit.invoiceId!)
-                )
-              }>
+              onClick={() => {
+                const invoiceRecordId = billingVisit.invoiceId!.includes(':')
+                  ? (billingVisit.invoiceId as RecordId)
+                  : toRecordId('invoice', billingVisit.invoiceId!)
+                // Drawer: push the full invoice drawer frame (peek stack). Full page has
+                // no peek stack — switch to the in-place `invoices` drill instead.
+                if (openRecord) openRecord(invoiceRecordId)
+                else drill.open('invoices', invoiceRecordId)
+              }}>
               View invoice
             </Button>
           )}

--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-payments-block.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-payments-block.tsx
@@ -56,6 +56,9 @@ export interface WorkOrderBillingPaymentsBlockProps {
   onSettled?: () => void
 }
 
+/** How many payments render before the inline "Show more" row collapses the rest. */
+const PAYMENT_PREVIEW_LIMIT = 5
+
 /** Payments block — the shared ledger list + "Record payment" (billing tab §D block 5). */
 export function WorkOrderBillingPaymentsBlock({
   workOrderRecordId,
@@ -131,7 +134,7 @@ export function WorkOrderBillingPaymentsBlock({
   }
 
   return (
-    <div>
+    <div className='p-1.5'>
       <PaymentsList
         payments={payments}
         isLoading={isLoading}
@@ -141,6 +144,7 @@ export function WorkOrderBillingPaymentsBlock({
         onRefund={handleRefund}
         deletePending={deletePayment.isPending}
         refundPending={refundTransaction.isPending}
+        visibleLimit={PAYMENT_PREVIEW_LIMIT}
         renderRowSuffix={(payment) => {
           const invoiceRecordId = invoiceByTransactionId.get(payment.id)
           return invoiceRecordId ? <PaymentInvoiceChip invoiceRecordId={invoiceRecordId} /> : null

--- a/apps/web/src/components/fields/hooks/use-field-view.ts
+++ b/apps/web/src/components/fields/hooks/use-field-view.ts
@@ -2,7 +2,6 @@
 'use client'
 
 import type { FieldViewConfig, ViewContextType } from '@auxx/lib/conditions/client'
-import { createDefaultFieldViewConfig } from '@auxx/lib/conditions/client'
 import type { ResourceField } from '@auxx/lib/resources/client'
 import { useCallback, useMemo } from 'react'
 import {
@@ -56,6 +55,30 @@ export function isFieldDefaultHiddenInDialogs(
 }
 
 /**
+ * Resolve a field's effective visibility for a context.
+ *
+ * An explicit `fieldVisibility` entry (a real user/org choice) always wins.
+ * When there is no explicit entry, fall back to the registry default for the
+ * context: `showInPanel === false` hides in the panel, and the dialog
+ * default-hidden rule applies in create/edit dialogs. This is the single source
+ * of truth used by BOTH the rendered panel list and the edit-mode toggle switch,
+ * so they can never disagree (previously `isFieldVisible` ignored `showInPanel`
+ * and reported every field as "on" in edit mode for the default view).
+ */
+export function resolveFieldVisible(
+  field: ResourceField,
+  contextType: ViewContextType,
+  fieldVisibility: Record<string, boolean>
+): boolean {
+  const fieldId = field.resourceFieldId ?? field.id ?? field.key
+  const explicit = fieldVisibility[fieldId]
+  if (explicit !== undefined) return explicit
+  if (contextType === 'panel' && field.showInPanel === false) return false
+  if (isFieldDefaultHiddenInDialogs(field, contextType)) return false
+  return true
+}
+
+/**
  * Hook for consuming org-wide field view configuration from the store.
  * Returns default config if no org view exists.
  */
@@ -77,21 +100,23 @@ export function useFieldView({
   // Loading if store not initialized yet
   const isLoading = !initialized
 
-  // Compute effective config (from store or default)
+  // Compute effective config (from store or default). The default is SPARSE —
+  // an empty `fieldVisibility` so each field resolves to its registry default
+  // (showInPanel / dialog rule) via resolveFieldVisible, rather than being
+  // forced visible. `fieldOrder` still lists every field for ordering.
   const config = useMemo((): FieldViewConfig => {
     if (storedConfig) return storedConfig
-    return createDefaultFieldViewConfig(fieldIds)
+    return { fieldVisibility: {}, fieldOrder: fieldIds, showLabels: true }
   }, [storedConfig, fieldIds])
 
   // Whether we're using a stored org view or the generated default
   const hasOrgView = !!view
 
-  // Fields with no explicit `fieldVisibility` entry fall back to the dialog
-  // default-hidden rule (see isFieldDefaultHiddenInDialogs) — table/kanban/panel
-  // contexts are unaffected.
-  const defaultHiddenInDialogs = useCallback(
-    (field: ResourceField): boolean => isFieldDefaultHiddenInDialogs(field, contextType),
-    [contextType]
+  // Fast lookup for isFieldVisible
+  const fieldById = useMemo(
+    () =>
+      new Map<string, ResourceField>(fields.map((f) => [f.resourceFieldId ?? f.id ?? f.key, f])),
+    [fields]
   )
 
   // Get visible fields in configured order.
@@ -101,7 +126,9 @@ export function useFieldView({
     const { fieldVisibility, fieldOrder } = config
 
     // Create a map of fields by their ID
-    const fieldMap = new Map(fields.map((f) => [f.resourceFieldId ?? f.id ?? f.key, f]))
+    const fieldMap = new Map<string, ResourceField>(
+      fields.map((f) => [f.resourceFieldId ?? f.id ?? f.key, f])
+    )
 
     // Return fields in order, filtering by visibility
     const orderedFields: ResourceField[] = []
@@ -111,27 +138,20 @@ export function useFieldView({
       const field = fieldMap.get(fieldId)
       if (!field) continue
       if (field.capabilities.hidden) continue
-      // When no org view exists, also respect showInPanel from field definitions
-      if (fieldVisibility[fieldId] === false) continue
-      if (!hasOrgView && field.showInPanel === false) continue
-      // No explicit visibility entry for this field — fall back to the
-      // dialog default-hidden rule (explicit entries above already won).
-      if (fieldVisibility[fieldId] === undefined && defaultHiddenInDialogs(field)) continue
+      if (!resolveFieldVisible(field, contextType, fieldVisibility)) continue
       orderedFields.push(field)
       fieldMap.delete(fieldId)
     }
 
     // Then add any remaining fields not in order (new fields added after view was configured)
-    for (const [fieldId, field] of fieldMap) {
+    for (const [, field] of fieldMap) {
       if (field.capabilities.hidden) continue
-      if (fieldVisibility[fieldId] === false) continue
-      if (!hasOrgView && field.showInPanel === false) continue
-      if (fieldVisibility[fieldId] === undefined && defaultHiddenInDialogs(field)) continue
+      if (!resolveFieldVisible(field, contextType, fieldVisibility)) continue
       orderedFields.push(field)
     }
 
     return orderedFields
-  }, [config, fields, hasOrgView, defaultHiddenInDialogs])
+  }, [config, fields, contextType])
 
   // Get all fields in configured order (for edit mode — includes fields the
   // user has toggled off but NOT registry-hidden fields).
@@ -139,7 +159,7 @@ export function useFieldView({
     const { fieldOrder } = config
 
     // Create a map of fields by their ID — exclude registry-hidden up front
-    const fieldMap = new Map(
+    const fieldMap = new Map<string, ResourceField>(
       fields
         .filter((f) => !f.capabilities.hidden)
         .map((f) => [f.resourceFieldId ?? f.id ?? f.key, f])
@@ -164,12 +184,16 @@ export function useFieldView({
     return orderedFields
   }, [config, fields])
 
-  // Check if a field is visible
+  // Check if a field is visible — mirrors getVisibleFields exactly so the
+  // edit-mode toggle switch reflects the field's real effective visibility
+  // (registry default when there's no explicit user choice), not a blanket "on".
   const isFieldVisible = useCallback(
     (fieldId: string): boolean => {
-      return config.fieldVisibility[fieldId] !== false
+      const field = fieldById.get(fieldId)
+      if (!field) return config.fieldVisibility[fieldId] !== false
+      return resolveFieldVisible(field, contextType, config.fieldVisibility)
     },
-    [config]
+    [fieldById, config, contextType]
   )
 
   return {

--- a/apps/web/src/components/fields/hooks/use-toggle-field-visibility.ts
+++ b/apps/web/src/components/fields/hooks/use-toggle-field-visibility.ts
@@ -2,7 +2,6 @@
 'use client'
 
 import type { FieldViewConfig, ViewContextType } from '@auxx/lib/conditions/client'
-import { createDefaultFieldViewConfig } from '@auxx/lib/conditions/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback } from 'react'
 import { useDynamicTableStore } from '~/components/dynamic-table/stores/dynamic-table-store'
@@ -111,14 +110,14 @@ export function useToggleFieldVisibility({
           },
         })
       } else {
-        // No view exists - create one with the visibility change
-        const defaultConfig = createDefaultFieldViewConfig(fieldIds)
+        // No view exists - create one storing ONLY this field's choice.
+        // The config is sparse: every other field keeps resolving to its
+        // registry default (showInPanel / dialog rule) via resolveFieldVisible,
+        // so toggling one field no longer snapshots all fields as visible.
         const configWithChange: FieldViewConfig = {
-          ...defaultConfig,
-          fieldVisibility: {
-            ...defaultConfig.fieldVisibility,
-            [resourceFieldId]: visible,
-          },
+          fieldVisibility: { [resourceFieldId]: visible },
+          fieldOrder: fieldIds,
+          showLabels: true,
         }
 
         createView.mutate({

--- a/apps/web/src/components/money/ui/payments/payments-list.tsx
+++ b/apps/web/src/components/money/ui/payments/payments-list.tsx
@@ -10,6 +10,7 @@
 import { Badge, type Variant as BadgeVariant } from '@auxx/ui/components/badge'
 import { EmptySection } from '@auxx/ui/components/section'
 import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { format } from 'date-fns'
 import { CreditCard, RotateCcw, Trash2 } from 'lucide-react'
 import type { ReactNode } from 'react'
@@ -88,6 +89,9 @@ export interface PaymentsListProps {
   /** Optional slot rendered at the end of each row, after the action button/chip — e.g. the
    * work-order billing section's invoice chip/link. */
   renderRowSuffix?: (payment: PaymentRow) => ReactNode
+  /** Cap the always-visible rows behind `TreeRowList`'s inline "Show N more" collapse.
+   * Omit to show all. */
+  visibleLimit?: number
 }
 
 /** Presentational payments ledger list — rows, loading + empty states, and the admin-gated
@@ -103,6 +107,7 @@ export function PaymentsList({
   deletePending,
   refundPending,
   renderRowSuffix,
+  visibleLimit,
 }: PaymentsListProps) {
   // Charge id → its open/succeeded refund's status. A charge with a linked refund is no longer
   // refundable (the server would reject it) — it renders a chip instead of the Refund action.
@@ -131,8 +136,11 @@ export function PaymentsList({
   }
 
   return (
-    <div className='flex flex-col'>
-      {payments.map((payment) => {
+    <TreeRowList
+      items={payments}
+      getKey={(payment) => payment.id}
+      visibleLimit={visibleLimit}
+      renderRow={(payment) => {
         const action =
           payment.provider === 'manual'
             ? isAdmin && (
@@ -168,7 +176,6 @@ export function PaymentsList({
 
         return (
           <TreeRow
-            key={payment.id}
             icon={<CreditCard className='size-4' />}
             title={
               <span className='flex min-w-0 items-center gap-1.5'>
@@ -203,7 +210,7 @@ export function PaymentsList({
             }
           />
         )
-      })}
-    </div>
+      }}
+    />
   )
 }


### PR DESCRIPTION
## Summary
- `PaymentsList` now renders through `TreeRowList` with an optional `visibleLimit`, so long payment ledgers collapse behind an inline "Show more" row — wired up in `WorkOrderBillingPaymentsBlock` at 5 rows.
- `VisitDetailPanel`'s "View invoice" action now falls back to `useRecordDrill().open('invoices', ...)` when there's no peek-stack drawer to push into (the full-page surface has no `useOpenRecord`), instead of silently no-oping.
- Reworked field visibility (`use-field-view.ts` / `use-toggle-field-visibility.ts`) to a sparse `fieldVisibility` override resolved via a new shared `resolveFieldVisible` helper, instead of snapshotting every field as visible on the first toggle. The rendered field list and the edit-mode toggle switch now share one source of truth.

## Test plan
- [x] `tsc --noEmit` clean on all touched files (2 pre-existing, unrelated errors on `main` in `use-toggle-field-visibility.ts` / `payments-list.tsx` are untouched by this diff)
- [ ] Manually toggle field visibility on a panel with no existing view and confirm other fields keep their registry default instead of all going "on"
- [ ] Manually verify payments list "Show more" collapse on a work order with >5 payments
- [ ] Manually verify "View invoice" from the visit detail panel on the full detail page (no drawer)