### PR TITLE
feat(signals): phase 2 — email open pixel + click wrapping

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -38,6 +38,7 @@ import organizations from './routes/organizations'
 import recordingWebhooks from './routes/recording-webhooks'
 import settings from './routes/settings'
 import storage from './routes/storage'
+import tracking from './routes/tracking'
 import unsubscribe from './routes/unsubscribe'
 import webhookHandlers from './routes/webhook-handlers'
 import webhooks from './routes/webhooks'
@@ -103,6 +104,7 @@ async function main() {
   app.route('/webhooks/email-events', emailEvents) // SES config-set → SNS delivery target (before generic /webhooks)
   app.route('/webhooks', webhooks) // Public webhook receiver (no /api/v1 prefix)
   app.route('/u', unsubscribe) // Public List-Unsubscribe landing (GET confirm / RFC 8058 one-click POST)
+  app.route('/t', tracking) // Public email open-pixel / click-redirect tracking (no auth — signed token)
 
   // 404 handler
   app.notFound((c) => {

--- a/apps/api/src/routes/tracking.ts
+++ b/apps/api/src/routes/tracking.ts
@@ -1,0 +1,193 @@
+// apps/api/src/routes/tracking.ts
+// Public email-tracking endpoints — open pixel + click redirect (Phase 2 of
+// plans/signals/02-email-engagement.md "Tracking endpoints"). No auth — the signed token IS
+// the auth (`verifyTrackingToken`/`verifyClickUrl` from `@auxx/lib/signals`). Two isolation
+// rules drive the shape of both routes:
+//   1. `GET /o/:token` (open pixel) ALWAYS serves the gif — token garbage, a missing Message
+//      row, or a `recordSignal` throw must never surface as a broken image. Processing runs
+//      fully inside its own try/catch, logged the way `email-events.ts` logs ingestion
+//      failures, never awaited into the response.
+//   2. `GET|HEAD /c/:token` (click redirect) is the opposite: an unverified `u=` MUST 400
+//      rather than redirect — the signature check on `u` is the open-redirect guard, so a
+//      failure there can't be papered over the way pixel failures are.
+// HEAD is handled alongside GET for `/c/:token` because Outlook SafeLinks probes links with a
+// HEAD request before a human's GET follows; it gets the same verify + redirect but records no
+// signal, so a scanner sweep doesn't fabricate a click.
+
+import { database, schema } from '@auxx/database'
+import {
+  classifyTrackingHit,
+  recordSignal,
+  type TrackingTokenPayload,
+  toSignalRecordKey,
+  verifyClickUrl,
+  verifyTrackingToken,
+} from '@auxx/lib/signals'
+import { createScopedLogger } from '@auxx/logger'
+import { eq } from 'drizzle-orm'
+import { Hono } from 'hono'
+
+const log = createScopedLogger('tracking-route')
+
+/** 1x1 transparent GIF — served for every `/o/:token` hit, valid token or not. */
+const PIXEL_GIF = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64')
+
+const PIXEL_HEADERS = { 'Content-Type': 'image/gif', 'Cache-Control': 'no-store, private' }
+
+interface RequestMeta {
+  userAgent?: string
+  ip?: string
+}
+
+function clientIp(headerValue: string | undefined): string | undefined {
+  return headerValue?.split(',')[0]?.trim() || undefined
+}
+
+/** Minute-granularity bucket — dedupes rapid duplicate hits (prefetch/proxy re-fetch, the
+ * HEAD-then-GET double-fire on click) within a minute while still letting a genuine repeat
+ * open/click later record as its own signal. */
+function minuteBucket(): number {
+  return Math.floor(Date.now() / 60000)
+}
+
+const tracking = new Hono()
+
+tracking.get('/o/:token', async (c) => {
+  try {
+    await recordOpen(c.req.param('token'), {
+      userAgent: c.req.header('user-agent'),
+      ip: clientIp(c.req.header('x-forwarded-for')),
+    })
+  } catch (error) {
+    log.error('Failed to process open-pixel hit', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+  return c.body(PIXEL_GIF, 200, PIXEL_HEADERS)
+})
+
+tracking.on(['GET', 'HEAD'], '/c/:token', async (c) => {
+  const token = c.req.param('token')
+  const url = c.req.query('u')
+
+  const verified = await verifyTrackingToken(token)
+  if (
+    !verified.value ||
+    verified.value.type !== 'click' ||
+    !url ||
+    !verifyClickUrl(verified.value, url) ||
+    !(url.startsWith('http://') || url.startsWith('https://'))
+  ) {
+    return c.text('Invalid tracking link', 400)
+  }
+  const payload = verified.value
+
+  // HEAD is Outlook SafeLinks pre-fetching the link, not a human click — verify + redirect the
+  // same way, but never record a signal for it.
+  if (c.req.method === 'GET') {
+    try {
+      await recordClick(payload, url, {
+        userAgent: c.req.header('user-agent'),
+        ip: clientIp(c.req.header('x-forwarded-for')),
+      })
+    } catch (error) {
+      log.error('Failed to process click-redirect hit', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  c.header('Cache-Control', 'no-store, private')
+  return c.redirect(url, 302)
+})
+
+/** Verifies the open token, resolves the Message it belongs to, classifies the hit, and writes
+ * an `email:opened` signal. Every failure mode (bad token, wrong type, unknown/mismatched
+ * message) is a silent no-op — the caller's try/catch + always-serve-the-pixel behavior is
+ * what keeps this from ever affecting the HTTP response. */
+async function recordOpen(token: string, request: RequestMeta): Promise<void> {
+  const verified = await verifyTrackingToken(token)
+  if (!verified.value || verified.value.type !== 'open') return
+  const payload = verified.value
+
+  // Mirrors `email-events.ts`'s `resolveMessageBySesId` DB-access style, but the tracking
+  // token already carries the Message row id directly (no externalId hop needed).
+  const message = await database.query.Message.findFirst({
+    where: eq(schema.Message.id, payload.messageId),
+  })
+  if (!message || message.organizationId !== payload.organizationId) return
+
+  const sentAt = message.sentAt ?? message.createdAt
+  const { isBot, botReason } = classifyTrackingHit({ userAgent: request.userAgent, sentAt })
+
+  const contactId = payload.contactEntityInstanceId
+  const result = await recordSignal({
+    organizationId: payload.organizationId,
+    kind: 'email:opened',
+    subtype: 'default',
+    dedupeKey: `track:o:${payload.messageId}:${contactId ?? 'anon'}:${minuteBucket()}`,
+    contactEntityInstanceId: contactId,
+    messageId: payload.messageId,
+    title: 'Email opened',
+    isBot,
+    metadata: {
+      userAgent: request.userAgent,
+      ip: request.ip,
+      ...(botReason ? { botReason } : {}),
+    },
+    links: contactId ? [toSignalRecordKey('contact', contactId)] : [],
+  })
+  if (result.error) {
+    log.error('recordSignal failed for open-pixel hit', {
+      organizationId: payload.organizationId,
+      messageId: payload.messageId,
+      error: result.error.message,
+    })
+  }
+}
+
+/** Resolves the Message the (already URL-verified) click token belongs to and writes an
+ * `email:clicked` signal. Same silent-no-op-on-failure shape as {@link recordOpen} — called
+ * only after the redirect response is already being sent, so a failure here must never
+ * surface to the caller. */
+async function recordClick(
+  payload: TrackingTokenPayload,
+  url: string,
+  request: RequestMeta
+): Promise<void> {
+  const message = await database.query.Message.findFirst({
+    where: eq(schema.Message.id, payload.messageId),
+  })
+  if (!message || message.organizationId !== payload.organizationId) return
+
+  const sentAt = message.sentAt ?? message.createdAt
+  const { isBot, botReason } = classifyTrackingHit({ userAgent: request.userAgent, sentAt })
+
+  const contactId = payload.contactEntityInstanceId
+  const result = await recordSignal({
+    organizationId: payload.organizationId,
+    kind: 'email:clicked',
+    subtype: 'default',
+    dedupeKey: `track:c:${payload.messageId}:${payload.urlHash}:${minuteBucket()}`,
+    contactEntityInstanceId: contactId,
+    messageId: payload.messageId,
+    title: 'Email link clicked',
+    isBot,
+    metadata: {
+      userAgent: request.userAgent,
+      ip: request.ip,
+      linkUrl: url,
+      ...(botReason ? { botReason } : {}),
+    },
+    links: contactId ? [toSignalRecordKey('contact', contactId)] : [],
+  })
+  if (result.error) {
+    log.error('recordSignal failed for click-redirect hit', {
+      organizationId: payload.organizationId,
+      messageId: payload.messageId,
+      error: result.error.message,
+    })
+  }
+}
+
+export default tracking

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/integration-settings-advanced.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/integration-settings-advanced.tsx
@@ -5,15 +5,30 @@
 import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
-import { Ban, MailMinus, MailPlus, ShieldCheck, UserCheck, Users, UserX } from 'lucide-react'
+import { ToggleCard } from '@auxx/ui/components/toggle-card'
+import {
+  Ban,
+  Eye,
+  MailMinus,
+  MailPlus,
+  MousePointerClick,
+  ShieldCheck,
+  UserCheck,
+  Users,
+  UserX,
+} from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { SettingsSection } from '~/components/global/settings-page'
 import { api } from '~/trpc/react'
 import { EmailFilterSection } from './email-list-dialog'
 
+/** Provider types that can send outgoing email and support open/click tracking. */
+const EMAIL_TRACKING_PROVIDERS = new Set(['google', 'outlook', 'email'])
+
 interface IntegrationSettingsAdvancedProps {
   integration: {
     id: string
+    provider: string
     settings?: {
       recordCreation?: {
         mode: 'all' | 'selective' | 'none'
@@ -21,6 +36,10 @@ interface IntegrationSettingsAdvancedProps {
       excludeSenders?: string[]
       excludeRecipients?: string[]
       onlyProcessRecipients?: string[]
+      tracking?: {
+        opens?: boolean
+        clicks?: boolean
+      }
     }
     [key: string]: any
   }
@@ -78,6 +97,36 @@ export default function IntegrationSettingsAdvanced({
     })
   }
 
+  // Email open/click tracking — only meaningful for channels that send outgoing
+  // email. Defaults: opens on for all email providers; clicks on only for the
+  // `email` (forwarding) provider — link-wrapping 1:1 personal mail (google/
+  // outlook) is a deliverability risk, so it's opt-in there.
+  const showTracking = EMAIL_TRACKING_PROVIDERS.has(integration.provider)
+  const [trackOpens, setTrackOpens] = useState<boolean>(
+    integration.settings?.tracking?.opens ?? true
+  )
+  const [trackClicks, setTrackClicks] = useState<boolean>(
+    integration.settings?.tracking?.clicks ?? integration.provider === 'email'
+  )
+
+  // updateSettings merges shallowly at the top level, so a partial `tracking`
+  // object would overwrite (not merge into) the previously saved one. Always
+  // send both fields together to avoid clobbering the sibling toggle.
+  const handleTrackOpensChange = (next: boolean) => {
+    setTrackOpens(next)
+    updateSettings.mutate({
+      integrationId: integration.id,
+      settings: { tracking: { opens: next, clicks: trackClicks } },
+    })
+  }
+  const handleTrackClicksChange = (next: boolean) => {
+    setTrackClicks(next)
+    updateSettings.mutate({
+      integrationId: integration.id,
+      settings: { tracking: { opens: trackOpens, clicks: next } },
+    })
+  }
+
   return (
     <div className='space-y-4 sm:space-y-10 p-3 sm:p-6'>
       {/* Record Creation */}
@@ -109,6 +158,33 @@ export default function IntegrationSettingsAdvanced({
           />
         </RadioGroup>
       </SettingsSection>
+
+      {/* Email Tracking — only for channels that send outgoing email */}
+      {showTracking && (
+        <SettingsSection
+          icon={Eye}
+          title='Email Tracking'
+          description='Track engagement on outgoing emails sent from this channel.'>
+          <div className='space-y-2'>
+            <ToggleCard
+              icon={<Eye className='size-3.5' />}
+              title='Track email opens'
+              description='Add an invisible open-tracking pixel to outgoing emails.'
+              checked={trackOpens}
+              onCheckedChange={handleTrackOpensChange}
+              disabled={!canManage || updateSettings.isPending}
+            />
+            <ToggleCard
+              icon={<MousePointerClick className='size-3.5' />}
+              title='Track link clicks'
+              description='Rewrite links in outgoing emails through a tracking redirect.'
+              checked={trackClicks}
+              onCheckedChange={handleTrackClicksChange}
+              disabled={!canManage || updateSettings.isPending}
+            />
+          </div>
+        </SettingsSection>
+      )}
 
       {/* Email Filtering Rules */}
       <EmailFilterSection

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -598,6 +598,12 @@ export const channelRouter = createTRPCRouter({
           excludeRecipients: z.array(z.string().toLowerCase().trim()).optional(),
           onlyProcessRecipients: z.array(z.string().toLowerCase().trim()).optional(),
           bidirectionalSyncEnabled: z.boolean().optional(),
+          tracking: z
+            .object({
+              opens: z.boolean().optional(),
+              clicks: z.boolean().optional(),
+            })
+            .optional(),
         }),
       })
     )

--- a/packages/config/src/urls.ts
+++ b/packages/config/src/urls.ts
@@ -269,6 +269,14 @@ export const API_URL = resolveAppUrl('api')
 export const LAMBDA_URL = resolveAppUrl('lambda')
 export const KB_URL = resolveAppUrl('kb')
 
+/**
+ * Public email-tracking URL (open pixel + click-redirect links).
+ * Defaults to `API_URL` — a dedicated `TRACK_URL` env var lets a tracking domain be split
+ * off from the API later (e.g. for deliverability / domain-reputation isolation) without
+ * touching any call site.
+ */
+export const TRACK_URL = readEnv('TRACK_URL') || API_URL
+
 // ─── Internal URL exports (service-to-service) ──────────
 
 /** Internal API URL for server-to-server calls. Falls back to public API_URL. */

--- a/packages/lib/src/channels/types.ts
+++ b/packages/lib/src/channels/types.ts
@@ -30,4 +30,16 @@ export interface ChannelSettings {
    * `supportsBidirectionalStatusSync`.
    */
   bidirectionalSyncEnabled?: boolean
+  /**
+   * Email open-pixel and link-click tracking on outgoing mail. Defaults when
+   * unset:
+   * - `opens`: `true` for all email channel types.
+   * - `clicks`: `true` for the `email` (forwarding) provider type only;
+   *   `false` for `google`/`outlook` — link-wrapping 1:1 personal mail is a
+   *   deliverability risk, so it's opt-in there.
+   */
+  tracking?: {
+    opens?: boolean
+    clicks?: boolean
+  }
 }

--- a/packages/lib/src/messages/message-reconciler.service.ts
+++ b/packages/lib/src/messages/message-reconciler.service.ts
@@ -212,6 +212,11 @@ export class MessageReconcilerService {
       externalId: providerData.externalId,
     })
 
+    const existing = await this.db.query.Message.findFirst({
+      where: (messages, { eq }) => eq(messages.id, existingMessageId),
+      columns: { threadId: true, textPlain: true, textHtml: true, snippet: true },
+    })
+
     // Update the message with provider data
     await this.db
       .update(schema.Message)
@@ -223,10 +228,12 @@ export class MessageReconcilerService {
         // Update status
         sendStatus: SendStatus.SENT,
 
-        // Fill in any missing content
-        textPlain: providerData.textPlain || undefined,
-        textHtml: providerData.textHtml || undefined,
-        snippet: providerData.snippet || undefined,
+        // Fill in any missing content — never overwrite what we composed. The provider's
+        // Sent-folder copy carries the tracking pixel/wrapped links injected at send time;
+        // the stored row must keep the clean HTML or the app UI would fire self-opens.
+        textPlain: existing?.textPlain ? undefined : providerData.textPlain || undefined,
+        textHtml: existing?.textHtml ? undefined : providerData.textHtml || undefined,
+        snippet: existing?.snippet ? undefined : providerData.snippet || undefined,
 
         // Update timestamps
         sentAt: providerData.sentAt,

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -5,6 +5,7 @@ import type { ParticipantRole as ParticipantRoleType } from '@auxx/database/type
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { and, asc, desc, eq, sql } from 'drizzle-orm'
+import { getOrgCache } from '../cache'
 import { touchActivityForThreadLinks } from '../entity-instances/activity'
 import { ForbiddenError, UsageLimitError } from '../errors'
 import { FileService } from '../files/core/file-service'
@@ -19,6 +20,7 @@ import { getRealtimeService, publishMessageCreated } from '../realtime'
 import { Result } from '../result'
 import { isSuppressed } from '../sequences/suppression'
 import { getOrganizationSetting } from '../settings/settings-service'
+import { instrumentEmailHtml } from '../signals/email/instrument-html'
 import { buildUnsubscribeUrl, issueUnsubscribeToken } from '../signals/unsubscribe'
 import { createUsageGuard } from '../usage/create-usage-guard'
 import { MessageComposerService } from './message-composer.service'
@@ -235,6 +237,19 @@ export class MessageSenderService {
         emailContext,
         automated: isAutomatedSend,
       })
+      // Step 5.6: Email open/click tracking instrumentation (signals plan 02 "Open + click
+      // tracking", Phase 2). ALL outbound email gets tracking, not just automated sends —
+      // `isAutomatedSend` is unrelated. Best-effort — never blocks or fails the send.
+      if (finalContent.html) {
+        finalContent.html = await this.applyEmailTracking({
+          organizationId: input.organizationId,
+          integrationId: input.integrationId,
+          messageId: composed.id,
+          html: finalContent.html,
+          emailContext,
+          unsubscribeUrl: unsubscribe?.url,
+        })
+      }
       // Step 6: Send via provider
       const sendResult = await this.sendViaProvider({
         integrationId: input.integrationId,
@@ -531,6 +546,59 @@ export class MessageSenderService {
         error: error instanceof Error ? error.message : String(error),
       })
       return undefined
+    }
+  }
+
+  /**
+   * Instruments outbound HTML with open/click tracking (signals plan 02, Phase 2). No-op
+   * (returns `html` unchanged) when there's no linked contact — a signal with no contact is
+   * worthless in v1 — or when the channel's provider type / tracking settings resolve to
+   * both `opens` and `clicks` off. Reads channel settings + provider type off the org cache
+   * (`channels`), never a fresh query. Best-effort: any failure (cache read, token issuance)
+   * logs a warning and returns the original `html` so tracking can never block or fail a send.
+   */
+  private async applyEmailTracking(params: {
+    organizationId: string
+    integrationId: string
+    messageId: string
+    html: string
+    emailContext: { email: string; contactEntityInstanceId: string } | null
+    unsubscribeUrl?: string
+  }): Promise<string> {
+    if (!params.emailContext?.contactEntityInstanceId) return params.html
+    try {
+      const channels = await getOrgCache().get(params.organizationId, 'channels')
+      const channel = channels.find((c) => c.id === params.integrationId)
+      if (!channel) return params.html
+      const providerType = channel.provider
+      if (
+        providerType !== IntegrationProviderType.google &&
+        providerType !== IntegrationProviderType.outlook &&
+        providerType !== IntegrationProviderType.email
+      ) {
+        return params.html
+      }
+      const opens = channel.settings?.tracking?.opens ?? true
+      const clicks =
+        channel.settings?.tracking?.clicks ?? providerType === IntegrationProviderType.email
+      if (!opens && !clicks) return params.html
+      return await instrumentEmailHtml({
+        html: params.html,
+        organizationId: params.organizationId,
+        messageId: params.messageId,
+        contactEntityInstanceId: params.emailContext.contactEntityInstanceId,
+        channelId: params.integrationId,
+        opens,
+        clicks,
+        skipUrls: params.unsubscribeUrl ? [params.unsubscribeUrl] : [],
+      })
+    } catch (error) {
+      logger.warn('Email tracking instrumentation failed; sending untracked', {
+        organizationId: params.organizationId,
+        messageId: params.messageId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return params.html
     }
   }
 

--- a/packages/lib/src/signals/email/__tests__/bot-detection.test.ts
+++ b/packages/lib/src/signals/email/__tests__/bot-detection.test.ts
@@ -1,0 +1,44 @@
+// packages/lib/src/signals/email/__tests__/bot-detection.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { classifyTrackingHit } from '../bot-detection'
+
+describe('classifyTrackingHit', () => {
+  it('flags a known bot/proxy user-agent', () => {
+    const result = classifyTrackingHit({ userAgent: 'GoogleImageProxy/1.0' })
+    expect(result).toEqual({ isBot: true, botReason: 'ua' })
+  })
+
+  it('matches bot user-agent patterns case-insensitively', () => {
+    const result = classifyTrackingHit({ userAgent: 'Mozilla/5.0 curl/8.4.0' })
+    expect(result).toEqual({ isBot: true, botReason: 'ua' })
+  })
+
+  it('flags a hit landing under 10s after send as a prefetch', () => {
+    const sentAt = new Date('2026-01-01T00:00:00.000Z')
+    const now = new Date('2026-01-01T00:00:05.000Z')
+    const result = classifyTrackingHit({ userAgent: 'Mozilla/5.0', sentAt, now })
+    expect(result).toEqual({ isBot: true, botReason: 'prefetch' })
+  })
+
+  it('does not flag a hit landing 10s or more after send', () => {
+    const sentAt = new Date('2026-01-01T00:00:00.000Z')
+    const now = new Date('2026-01-01T00:00:10.000Z')
+    const result = classifyTrackingHit({ userAgent: 'Mozilla/5.0', sentAt, now })
+    expect(result).toEqual({ isBot: false })
+  })
+
+  it('passes a clean, real-looking user-agent', () => {
+    const result = classifyTrackingHit({
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    })
+    expect(result).toEqual({ isBot: false })
+  })
+
+  it('does not flag a missing user-agent on its own', () => {
+    expect(classifyTrackingHit({})).toEqual({ isBot: false })
+    expect(classifyTrackingHit({ userAgent: null })).toEqual({ isBot: false })
+    expect(classifyTrackingHit({ userAgent: '' })).toEqual({ isBot: false })
+  })
+})

--- a/packages/lib/src/signals/email/__tests__/instrument-html.test.ts
+++ b/packages/lib/src/signals/email/__tests__/instrument-html.test.ts
@@ -1,0 +1,126 @@
+// packages/lib/src/signals/email/__tests__/instrument-html.test.ts
+
+import { API_URL, TRACK_URL } from '@auxx/config/urls'
+import { describe, expect, it } from 'vitest'
+import { instrumentEmailHtml } from '../instrument-html'
+
+const BASE_INPUT = {
+  organizationId: 'org_1',
+  messageId: 'msg_1',
+  contactEntityInstanceId: 'contact_1',
+  channelId: 'channel_1',
+}
+
+/** Extracts every `href="..."`/`href='...'` value from HTML, in document order. */
+function extractHrefs(html: string): string[] {
+  return [...html.matchAll(/href\s*=\s*"([^"]*)"|href\s*=\s*'([^']*)'/gi)].map(
+    (m) => m[1] ?? m[2] ?? ''
+  )
+}
+
+describe('instrumentEmailHtml', () => {
+  it('injects the open pixel immediately before </body>', async () => {
+    const html = '<html><body><p>hi</p></body></html>'
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: true, clicks: false })
+    expect(out).toMatch(/<img src="[^"]+\/t\/o\/[^"]+"[^>]*\/>\s*<\/body>/)
+    expect(out.indexOf('</body>')).toBeGreaterThan(out.indexOf('<img'))
+  })
+
+  it('appends the open pixel at the end when there is no </body>', async () => {
+    const html = '<p>no body tag here</p>'
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: true, clicks: false })
+    expect(out.startsWith(html)).toBe(true)
+    expect(out).toMatch(/<img src="[^"]+\/t\/o\/[^"]+"[^>]*\/>$/)
+  })
+
+  it('reuses the same token for the same URL appearing twice', async () => {
+    const html = `
+      <a href="https://example.com/a">first</a>
+      <a href="https://example.com/a">second</a>
+    `
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: false, clicks: true })
+    const hrefs = extractHrefs(out)
+    expect(hrefs).toHaveLength(2)
+    expect(hrefs[0]).toBe(hrefs[1])
+    expect(hrefs[0]).toContain(`${TRACK_URL}/t/c/`)
+  })
+
+  it('skips mailto:, tel:, #fragment, and cid: links', async () => {
+    const html = [
+      '<a href="mailto:a@example.com">mail</a>',
+      '<a href="tel:+15551234567">call</a>',
+      '<a href="#section">jump</a>',
+      '<a href="cid:logo123">logo</a>',
+    ].join('\n')
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: false, clicks: true })
+    expect(extractHrefs(out)).toEqual([
+      'mailto:a@example.com',
+      'tel:+15551234567',
+      '#section',
+      'cid:logo123',
+    ])
+  })
+
+  it('skips caller-supplied skipUrls', async () => {
+    const skipUrl = 'https://example.com/keep-plain'
+    const html = `<a href="${skipUrl}">keep</a>`
+    const out = await instrumentEmailHtml({
+      ...BASE_INPUT,
+      html,
+      opens: false,
+      clicks: true,
+      skipUrls: [skipUrl],
+    })
+    expect(extractHrefs(out)).toEqual([skipUrl])
+  })
+
+  it('skips unsubscribe links (API_URL/u/...)', async () => {
+    const unsubUrl = `${API_URL}/u/some-token`
+    const html = `<a href="${unsubUrl}">unsubscribe</a>`
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: false, clicks: true })
+    expect(extractHrefs(out)).toEqual([unsubUrl])
+  })
+
+  it('does not re-wrap a link that is already a tracking link', async () => {
+    const alreadyTracked = `${TRACK_URL}/t/c/some-existing-token?u=https%3A%2F%2Fexample.com`
+    const html = `<a href="${alreadyTracked}">go</a>`
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: false, clicks: true })
+    expect(extractHrefs(out)).toEqual([alreadyTracked])
+  })
+
+  it('opens-only: injects a pixel and leaves links untouched', async () => {
+    const html = '<body><a href="https://example.com/a">a</a></body>'
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: true, clicks: false })
+    expect(extractHrefs(out)).toEqual(['https://example.com/a'])
+    expect(out).toContain('/t/o/')
+  })
+
+  it('clicks-only: wraps links and injects no pixel', async () => {
+    const html = '<body><a href="https://example.com/a">a</a></body>'
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: false, clicks: true })
+    expect(out).not.toContain('/t/o/')
+    expect(extractHrefs(out)[0]).toContain('/t/c/')
+  })
+
+  it('returns html unchanged when both opens and clicks are false', async () => {
+    const html = '<body><a href="https://example.com/a">a</a></body>'
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: false, clicks: false })
+    expect(out).toBe(html)
+  })
+
+  it('preserves other attributes on rewrapped anchors', async () => {
+    const html =
+      '<a class="btn" href="https://example.com/a" target="_blank" rel="noopener">click</a>'
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: false, clicks: true })
+    expect(out).toContain('class="btn"')
+    expect(out).toContain('target="_blank"')
+    expect(out).toContain('rel="noopener"')
+    expect(out).not.toContain('href="https://example.com/a"')
+  })
+
+  it('preserves single-quoted href attributes and their quote style', async () => {
+    const html = "<a href='https://example.com/a'>click</a>"
+    const out = await instrumentEmailHtml({ ...BASE_INPUT, html, opens: false, clicks: true })
+    expect(out).toMatch(/href='[^']+\/t\/c\/[^']+'/)
+  })
+})

--- a/packages/lib/src/signals/email/__tests__/tracking-tokens.test.ts
+++ b/packages/lib/src/signals/email/__tests__/tracking-tokens.test.ts
@@ -1,0 +1,106 @@
+// packages/lib/src/signals/email/__tests__/tracking-tokens.test.ts
+
+import { API_URL, TRACK_URL } from '@auxx/config/urls'
+import { describe, expect, it } from 'vitest'
+import { Result } from '../../../result'
+import {
+  buildClickTrackingUrl,
+  buildOpenPixelUrl,
+  issueClickToken,
+  issueOpenToken,
+  verifyClickUrl,
+  verifyTrackingToken,
+} from '../tracking-tokens'
+
+describe('tracking-tokens', () => {
+  it('round-trips an open token', async () => {
+    const token = await issueOpenToken({
+      organizationId: 'org_1',
+      messageId: 'msg_1',
+      contactEntityInstanceId: 'contact_1',
+      channelId: 'channel_1',
+    })
+
+    const result = await verifyTrackingToken(token)
+    expect(Result.isOk(result)).toBe(true)
+    if (!Result.isOk(result)) return
+    expect(result.value).toEqual({
+      type: 'open',
+      organizationId: 'org_1',
+      messageId: 'msg_1',
+      contactEntityInstanceId: 'contact_1',
+      channelId: 'channel_1',
+    })
+  })
+
+  it('round-trips a click token, including the url hash', async () => {
+    const url = 'https://example.com/product?utm=1'
+    const token = await issueClickToken({
+      organizationId: 'org_1',
+      messageId: 'msg_1',
+      url,
+    })
+
+    const result = await verifyTrackingToken(token)
+    expect(Result.isOk(result)).toBe(true)
+    if (!Result.isOk(result)) return
+    expect(result.value.type).toBe('click')
+    expect(result.value.urlHash).toBeDefined()
+    expect(verifyClickUrl(result.value, url)).toBe(true)
+  })
+
+  it('omits optional claims from the payload when not provided', async () => {
+    const token = await issueOpenToken({ organizationId: 'org_1', messageId: 'msg_1' })
+    const result = await verifyTrackingToken(token)
+    expect(Result.isOk(result)).toBe(true)
+    if (!Result.isOk(result)) return
+    expect(result.value.contactEntityInstanceId).toBeUndefined()
+    expect(result.value.channelId).toBeUndefined()
+  })
+
+  it('fails verification for a tampered token', async () => {
+    const token = await issueOpenToken({ organizationId: 'org_1', messageId: 'msg_1' })
+    const tampered = `${token.slice(0, -2)}zz`
+
+    const result = await verifyTrackingToken(tampered)
+    expect(Result.isOk(result)).toBe(false)
+  })
+
+  it('fails verification for a token minted with a different scope', async () => {
+    const { SignJWT } = await import('jose')
+    const secret = new TextEncoder().encode('public-workflow-secret-change-me')
+    const wrongScopeToken = await new SignJWT({
+      scope: 'email-unsubscribe',
+      t: 'o',
+      o: 'org_1',
+      m: 'msg_1',
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt()
+      .sign(secret)
+
+    const result = await verifyTrackingToken(wrongScopeToken)
+    expect(Result.isOk(result)).toBe(false)
+  })
+
+  it('rejects a click url that does not match the token hash', async () => {
+    const token = await issueClickToken({
+      organizationId: 'org_1',
+      messageId: 'msg_1',
+      url: 'https://example.com/a',
+    })
+    const result = await verifyTrackingToken(token)
+    expect(Result.isOk(result)).toBe(true)
+    if (!Result.isOk(result)) return
+    expect(verifyClickUrl(result.value, 'https://example.com/b')).toBe(false)
+  })
+
+  it('builds the open-pixel and click-tracking URLs off TRACK_URL', () => {
+    expect(buildOpenPixelUrl('tok')).toBe(`${TRACK_URL}/t/o/tok`)
+    expect(buildClickTrackingUrl('tok', 'https://example.com/x?y=1')).toBe(
+      `${TRACK_URL}/t/c/tok?u=${encodeURIComponent('https://example.com/x?y=1')}`
+    )
+    // Guards against TRACK_URL silently drifting from API_URL in this test env.
+    expect(TRACK_URL).toBe(API_URL)
+  })
+})

--- a/packages/lib/src/signals/email/bot-detection.ts
+++ b/packages/lib/src/signals/email/bot-detection.ts
@@ -1,0 +1,71 @@
+// packages/lib/src/signals/email/bot-detection.ts
+// Classifies open-pixel / click-redirect hits as bot noise vs a real human read (Phase 2 of
+// plans/signals/02-email-engagement.md "Open + click tracking"). Two independent tells: a
+// known scanner/proxy/bot user-agent substring, or a hit landing implausibly fast after send
+// (mailbox-provider link/image prescanning — Apple Mail Privacy Protection, corporate gateways).
+// Pure/sync — no DB, no imports beyond the language — so it can run inline on the hot tracking
+// endpoint before any signal gets recorded.
+
+/** Case-insensitive substrings matched against the request's User-Agent header. */
+const BOT_UA_PATTERNS = [
+  'googleimageproxy',
+  'ggpht.com',
+  'yahoomailproxy',
+  'barracuda',
+  'mimecast',
+  'proofpoint',
+  'messagelabs',
+  'symantec',
+  'trendmicro',
+  'slackbot',
+  'bingbot',
+  'python-requests',
+  'python-urllib',
+  'curl/',
+  'wget/',
+  'go-http-client',
+  'okhttp',
+  'headlesschrome',
+  'phantomjs',
+  'crawler',
+  'spider',
+  'linkcheck',
+  'scanner',
+  'urlscan',
+  'validator',
+] as const
+
+/** Hits landing this soon after send are near-certainly a provider's prefetch/scan, not a human open. */
+const PREFETCH_WINDOW_MS = 10_000
+
+export interface TrackingHitContext {
+  userAgent?: string | null
+  sentAt?: Date | null
+  now?: Date
+}
+
+export interface TrackingHitClassification {
+  isBot: boolean
+  botReason?: 'ua' | 'prefetch'
+}
+
+/**
+ * Classifies a single open/click hit. A missing or empty User-Agent is NOT treated as a bot
+ * signal on its own — several mainstream mail clients strip it — so absence of evidence isn't
+ * evidence of a bot.
+ */
+export function classifyTrackingHit(ctx: TrackingHitContext): TrackingHitClassification {
+  const userAgent = ctx.userAgent?.toLowerCase().trim()
+  if (userAgent && BOT_UA_PATTERNS.some((pattern) => userAgent.includes(pattern))) {
+    return { isBot: true, botReason: 'ua' }
+  }
+
+  if (ctx.sentAt) {
+    const now = ctx.now ?? new Date()
+    if (now.getTime() - ctx.sentAt.getTime() < PREFETCH_WINDOW_MS) {
+      return { isBot: true, botReason: 'prefetch' }
+    }
+  }
+
+  return { isBot: false }
+}

--- a/packages/lib/src/signals/email/instrument-html.ts
+++ b/packages/lib/src/signals/email/instrument-html.ts
@@ -1,0 +1,137 @@
+// packages/lib/src/signals/email/instrument-html.ts
+// Single instrumentation entry point every send path calls before dispatch (Phase 2 of
+// plans/signals/02-email-engagement.md "Open + click tracking"). Injects an open pixel and/or
+// rewrites `<a href>` links to click-tracking redirects, using the tokens minted by
+// `./tracking-tokens.ts`. Regex-based HTML rewriting — the input is our own generated email
+// HTML, not adversarial user markup, so a full HTML parser is unnecessary overhead here.
+
+import { API_URL, TRACK_URL } from '@auxx/config/urls'
+import {
+  buildClickTrackingUrl,
+  buildOpenPixelUrl,
+  issueClickToken,
+  issueOpenToken,
+} from './tracking-tokens'
+
+export interface InstrumentEmailHtmlInput {
+  html: string
+  organizationId: string
+  messageId: string
+  contactEntityInstanceId?: string
+  channelId?: string
+  opens: boolean
+  clicks: boolean
+  /** Exact URLs never to wrap (e.g. the unsubscribe URL — it must stay a plain, unwrapped link). */
+  skipUrls?: string[]
+}
+
+const A_TAG_REGEX = /<a\b[^>]*>/gi
+const HREF_ATTR_REGEX = /(?<![\w-])href\s*=\s*("([^"]*)"|'([^']*)')/i
+const CLOSING_BODY_REGEX = /<\/body\s*>/i
+
+/** Extracts and trims the `href` attribute value from a single `<a ...>` tag, if present. */
+function extractHref(tag: string): string | undefined {
+  const match = tag.match(HREF_ATTR_REGEX)
+  if (!match) return undefined
+  const raw = match[2] !== undefined ? match[2] : match[3]
+  return raw?.trim()
+}
+
+/** Links we never wrap: non-http(s) schemes, already-tracked links, unsubscribe links, and caller-supplied exclusions. */
+function shouldSkipHref(href: string, skipUrls: Set<string>): boolean {
+  if (!/^https?:\/\//i.test(href)) return true
+  if (href.startsWith(TRACK_URL)) return true
+  if (href.startsWith(`${API_URL}/u`)) return true
+  if (skipUrls.has(href)) return true
+  return false
+}
+
+/** Replaces just the `href` value within a single `<a ...>` tag, preserving its quote style and every other attribute. */
+function replaceHref(tag: string, trackingUrl: string): string {
+  return tag.replace(HREF_ATTR_REGEX, (_full, _quoted, doubleQuoted) =>
+    doubleQuoted !== undefined ? `href="${trackingUrl}"` : `href='${trackingUrl}'`
+  )
+}
+
+interface ClickWrapContext {
+  organizationId: string
+  messageId: string
+  contactEntityInstanceId?: string
+  channelId?: string
+  skipUrls: Set<string>
+}
+
+/**
+ * Rewrites every wrappable `<a href="http(s)://...">` in the HTML to a click-tracking
+ * redirect URL. One token is issued per unique URL — a URL repeated across multiple links
+ * (e.g. a CTA button mirrored in the header and footer) reuses the same token.
+ */
+async function wrapClickLinks(html: string, ctx: ClickWrapContext): Promise<string> {
+  const uniqueUrls = new Set<string>()
+  for (const match of html.matchAll(A_TAG_REGEX)) {
+    const href = extractHref(match[0])
+    if (href && !shouldSkipHref(href, ctx.skipUrls)) uniqueUrls.add(href)
+  }
+  if (uniqueUrls.size === 0) return html
+
+  const entries = await Promise.all(
+    Array.from(uniqueUrls).map(async (url) => {
+      const token = await issueClickToken({
+        organizationId: ctx.organizationId,
+        messageId: ctx.messageId,
+        contactEntityInstanceId: ctx.contactEntityInstanceId,
+        channelId: ctx.channelId,
+        url,
+      })
+      return [url, buildClickTrackingUrl(token, url)] as const
+    })
+  )
+  const trackingUrlByOriginal = new Map(entries)
+
+  return html.replace(A_TAG_REGEX, (tag) => {
+    const href = extractHref(tag)
+    const trackingUrl = href ? trackingUrlByOriginal.get(href) : undefined
+    return trackingUrl ? replaceHref(tag, trackingUrl) : tag
+  })
+}
+
+/** Injects the 1x1 open-tracking pixel immediately before `</body>`, or appends it if there's no `</body>`. */
+function injectOpenPixel(html: string, token: string): string {
+  const pixel = `<img src="${buildOpenPixelUrl(token)}" width="1" height="1" alt="" style="display:none;max-width:1px;max-height:1px;" />`
+  return CLOSING_BODY_REGEX.test(html)
+    ? html.replace(CLOSING_BODY_REGEX, `${pixel}</body>`)
+    : `${html}${pixel}`
+}
+
+/**
+ * Instruments outbound email HTML for open/click tracking. The single call site every send
+ * path (sequences, receipts, document sends, manual replies) routes through — callers just
+ * flip `opens`/`clicks` per the org/channel's tracking settings.
+ */
+export async function instrumentEmailHtml(input: InstrumentEmailHtmlInput): Promise<string> {
+  if (!input.opens && !input.clicks) return input.html
+
+  let html = input.html
+
+  if (input.clicks) {
+    html = await wrapClickLinks(html, {
+      organizationId: input.organizationId,
+      messageId: input.messageId,
+      contactEntityInstanceId: input.contactEntityInstanceId,
+      channelId: input.channelId,
+      skipUrls: new Set(input.skipUrls ?? []),
+    })
+  }
+
+  if (input.opens) {
+    const token = await issueOpenToken({
+      organizationId: input.organizationId,
+      messageId: input.messageId,
+      contactEntityInstanceId: input.contactEntityInstanceId,
+      channelId: input.channelId,
+    })
+    html = injectOpenPixel(html, token)
+  }
+
+  return html
+}

--- a/packages/lib/src/signals/email/tracking-tokens.ts
+++ b/packages/lib/src/signals/email/tracking-tokens.ts
@@ -1,0 +1,149 @@
+// packages/lib/src/signals/email/tracking-tokens.ts
+// Stateless signed tracking tokens for the open-pixel and click-redirect endpoints (Phase 2 of
+// plans/signals/02-email-engagement.md "Open + click tracking"). Mirrors the jose HS256 shape
+// of `../unsubscribe.ts` — same secret + `configService` pattern, own `scope` claim. Unlike the
+// unsubscribe token, this one carries NO expiry: an open/click on a months-old email must still
+// resolve, so the token has to stay verifiable indefinitely.
+
+import { createHash } from 'node:crypto'
+import { TRACK_URL } from '@auxx/config/urls'
+import { configService } from '@auxx/credentials'
+import { jwtVerify, SignJWT } from 'jose'
+import { Result, type TypedResult } from '../../result'
+
+/** Discriminates this token from every other JWT the app issues (passports, unsubscribe, login). */
+const TRACKING_TOKEN_SCOPE = 'email-track' as const
+
+/**
+ * Read the shared JWT signing secret. Same env var + fallback as `../unsubscribe.ts`
+ * (`PUBLIC_WORKFLOW_JWT_SECRET`) — one shared secret, discriminated by `scope`.
+ */
+function getJwtSecret(): Uint8Array {
+  return new TextEncoder().encode(
+    configService.get<string>('PUBLIC_WORKFLOW_JWT_SECRET') || 'public-workflow-secret-change-me'
+  )
+}
+
+/** Raw JWT claim shape — kept compact ('o', 'c', 'ch', 'u'...) since these land in URLs. */
+interface TrackingTokenClaims {
+  scope: typeof TRACKING_TOKEN_SCOPE
+  /** 'o' = open pixel, 'c' = click redirect. */
+  t: 'o' | 'c'
+  /** organizationId */
+  o: string
+  /** messageId (the Message DB row id) */
+  m: string
+  /** contactEntityInstanceId, if known at send time */
+  c?: string
+  /** channelId, if known at send time */
+  ch?: string
+  /** hex sha256 of the exact original URL — click tokens only */
+  u?: string
+}
+
+/** Normalized tracking-token payload, decoupled from the compact wire claim names. */
+export interface TrackingTokenPayload {
+  type: 'open' | 'click'
+  organizationId: string
+  messageId: string
+  contactEntityInstanceId?: string
+  channelId?: string
+  /** hex sha256 of the exact original URL — present on click tokens only. */
+  urlHash?: string
+}
+
+interface IssueTokenInput {
+  organizationId: string
+  messageId: string
+  contactEntityInstanceId?: string
+  channelId?: string
+}
+
+async function signTrackingToken(claims: TrackingTokenClaims): Promise<string> {
+  return new SignJWT({ ...claims })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .sign(getJwtSecret())
+}
+
+/** Issues a signed open-pixel token — no DB row, no expiry (opens can fire months after send). */
+export async function issueOpenToken(input: IssueTokenInput): Promise<string> {
+  return signTrackingToken({
+    scope: TRACKING_TOKEN_SCOPE,
+    t: 'o',
+    o: input.organizationId,
+    m: input.messageId,
+    ...(input.contactEntityInstanceId ? { c: input.contactEntityInstanceId } : {}),
+    ...(input.channelId ? { ch: input.channelId } : {}),
+  })
+}
+
+/**
+ * Issues a signed click-redirect token, binding the token to the exact original URL via a
+ * sha256 hash claim ({@link verifyClickUrl} re-checks it at redirect time so a token can't be
+ * replayed against a different URL).
+ */
+export async function issueClickToken(input: IssueTokenInput & { url: string }): Promise<string> {
+  return signTrackingToken({
+    scope: TRACKING_TOKEN_SCOPE,
+    t: 'c',
+    o: input.organizationId,
+    m: input.messageId,
+    ...(input.contactEntityInstanceId ? { c: input.contactEntityInstanceId } : {}),
+    ...(input.channelId ? { ch: input.channelId } : {}),
+    u: hashUrl(input.url),
+  })
+}
+
+/** Verifies signature + scope. Rejects any token not minted by {@link issueOpenToken}/{@link issueClickToken}. */
+export async function verifyTrackingToken(
+  token: string
+): Promise<TypedResult<TrackingTokenPayload, Error>> {
+  try {
+    const { payload } = await jwtVerify(token, getJwtSecret())
+    if (payload.scope !== TRACKING_TOKEN_SCOPE) {
+      return Result.error(new Error('Invalid tracking token scope'))
+    }
+    const claims = payload as unknown as TrackingTokenClaims
+    if (
+      (claims.t !== 'o' && claims.t !== 'c') ||
+      typeof claims.o !== 'string' ||
+      typeof claims.m !== 'string'
+    ) {
+      return Result.error(new Error('Malformed tracking token payload'))
+    }
+    return Result.ok({
+      type: claims.t === 'o' ? 'open' : 'click',
+      organizationId: claims.o,
+      messageId: claims.m,
+      ...(claims.c ? { contactEntityInstanceId: claims.c } : {}),
+      ...(claims.ch ? { channelId: claims.ch } : {}),
+      ...(claims.u ? { urlHash: claims.u } : {}),
+    })
+  } catch (error) {
+    return Result.error(error instanceof Error ? error : new Error('Invalid tracking token'))
+  }
+}
+
+/** hex sha256 of a URL, used to bind a click token to its original destination. */
+function hashUrl(url: string): string {
+  return createHash('sha256').update(url, 'utf8').digest('hex')
+}
+
+/**
+ * Re-checks a click token's URL hash against the URL a redirect is about to serve — guards
+ * against a token being replayed with a swapped `u=` query param at the redirect endpoint.
+ */
+export function verifyClickUrl(payload: TrackingTokenPayload, url: string): boolean {
+  return payload.urlHash === hashUrl(url)
+}
+
+/** Builds the public `/t/o/:token` open-pixel URL embedded in the instrumented HTML. */
+export function buildOpenPixelUrl(token: string): string {
+  return `${TRACK_URL}/t/o/${token}`
+}
+
+/** Builds the public `/t/c/:token?u=...` click-redirect URL an `<a href>` is rewritten to. */
+export function buildClickTrackingUrl(token: string, originalUrl: string): string {
+  return `${TRACK_URL}/t/c/${token}?u=${encodeURIComponent(originalUrl)}`
+}

--- a/packages/lib/src/signals/index.ts
+++ b/packages/lib/src/signals/index.ts
@@ -3,6 +3,19 @@
 // plans/signals/01-signal-store.md). Explicit named exports only — see CLAUDE.md's "Module
 // Exports" convention.
 
+export type { TrackingHitClassification, TrackingHitContext } from './email/bot-detection'
+export { classifyTrackingHit } from './email/bot-detection'
+export type { InstrumentEmailHtmlInput } from './email/instrument-html'
+export { instrumentEmailHtml } from './email/instrument-html'
+export type { TrackingTokenPayload } from './email/tracking-tokens'
+export {
+  buildClickTrackingUrl,
+  buildOpenPixelUrl,
+  issueClickToken,
+  issueOpenToken,
+  verifyClickUrl,
+  verifyTrackingToken,
+} from './email/tracking-tokens'
 export type {
   ListSignalsFilters,
   ListSignalsParams,


### PR DESCRIPTION
## Summary

Phase 2 of `plans/signals` — our own open-pixel + click-link tracking on **all** outbound email send paths (Gmail, Outlook, email-forwarding, scheduled, sequence). Follows Phase 0+1 (#1210). No schema migration — Phase 0 already shipped the `email:opened`/`email:clicked` kinds, the `isBot` column, and the open/click rollups.

## What's in here

- **Tracking tokens** (`packages/lib/src/signals/email/tracking-tokens.ts`) — stateless HS256 JWTs mirroring the Phase 1 unsubscribe-token pattern (same secret, own `scope`), compact claims to keep URLs short, no expiry (opens can fire months after send). Click tokens embed a sha256 of the exact destination URL — the redirect endpoint re-verifies it, which is the open-redirect guard (no allowlist table needed).
- **`instrumentEmailHtml()`** — single instrumentation entry point: injects the 1×1 pixel before `</body>`, rewrites `<a href>` links to `/t/c/<token>?u=<url>` with one token per unique URL. Never wraps mailto/tel/#/cid, unsubscribe links, or already-tracked URLs.
- **Bot classification** — scanner/proxy UA substrings + hits landing <10s after send flagged as prefetch (Apple MPP / gateway scanners). Bot hits are stored with `isBot: true` and skip rollups (Phase 0 behavior).
- **Routes** (`apps/api/src/routes/tracking.ts`, mounted at `/t`) — `GET /t/o/:token` always serves the gif, even on garbage tokens; `GET|HEAD /t/c/:token?u=` 400s unless the token's URL hash verifies, and HEAD (SafeLinks probes) redirects without recording. Minute-bucket dedupe keys absorb proxy re-fetches and HEAD-then-GET double-fires.
- **Send wiring** — one best-effort block in `MessageSenderService` (right after signature/unsubscribe, before `sendViaProvider`), so every provider path is covered by a single choke point. Channel settings read from the org cache; instrumentation failures log and send untracked.
- **Per-channel settings** — `ChannelSettings.tracking.{opens,clicks}` + toggles in channel advanced settings. Defaults: opens on for all email channels; clicks on only for forwarding channels (link-wrapping 1:1 personal-domain mail is a deliverability risk, so opt-in for Gmail/Outlook).
- **`TRACK_URL` config** defaulting to `API_URL` — tracking serves from api.auxx.ai now; the track.auxx.ai cutover is DNS + one env var, no code change.
- **Fix (self-open guard):** sent-folder sync reconciliation (`mergeIncomingProviderData`) previously overwrote the stored message HTML with the provider's Sent copy — which now contains the pixel, so rendering the message in our own UI would have fired fake opens. It now only fills genuinely missing content.

## v1 scope notes

- Only sends with a linked contact get instrumented (a signal with no contact is worthless in v1).
- Providers google/outlook/email only; the failed-send retry path re-sends stored HTML untracked.
- Bot filtering v1 has no IP-range matching or cross-recipient scanner correlation yet.

## Testing

- 25 new unit tests (tokens round-trip/tamper/url-hash, instrumentation skip rules + attribute preservation, bot classification) — all green.
- Scoped typechecks of packages/lib, apps/web, apps/api: zero errors in changed files.
- Biome clean on all changed files.