### PR TITLE
feat(money): standalone new-invoice in work-order drawer + shared billing ui

### DIFF
--- a/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
@@ -1,14 +1,12 @@
 // apps/web/src/components/dispatch/ui/job-schedule/work-order-billing-tab.tsx
 'use client'
 
-import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
 import { BILLING_BASIS_LABELS, BILLING_TIMING_LABELS } from '@auxx/lib/money/client'
-import { toRecordId } from '@auxx/types/resource'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { EmptySection } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { TREE_SECONDARY_NOTRUNCATE, TreeRow } from '@auxx/ui/components/tree-row'
+import { TREE_SECONDARY_NOTRUNCATE } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
 import { TuckedSection } from '@auxx/ui/components/tucked-label'
 import { cn } from '@auxx/ui/lib/utils'
@@ -18,14 +16,13 @@ import type { DetailViewTabProps } from '~/components/detail-view'
 import { BillingActionDialog } from '~/components/money/billing/billing-action-dialog'
 import { BillingPlanDialog } from '~/components/money/billing/billing-plan-dialog'
 import { BillingScheduleDialog } from '~/components/money/billing/billing-schedule-dialog'
+import { BillingSummaryStrip } from '~/components/money/billing/billing-summary-strip'
+import { InvoiceTreeRow } from '~/components/money/billing/invoice-tree-row'
+import { NewWorkOrderInvoiceButton } from '~/components/money/billing/new-work-order-invoice-button'
 import { resolveBillingAction, type WorkOrderBillingView } from '~/components/money/billing/types'
 import { useWorkOrderBillingState } from '~/components/money/billing/use-work-order-billing-state'
 import { formatCurrency } from '~/components/money/ui/line-builder/shared'
 import { useRecordDrill } from '~/components/records/record-drill-panels'
-import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
-import { useSystemField } from '~/components/resources/hooks/use-field'
-import { useResources } from '~/components/resources/hooks/use-resources'
-import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { api } from '~/trpc/react'
 import { BillingScheduleRow } from './billing-schedule-row'
 import type { PaymentCandidate } from './work-order-billing-payments-block'
@@ -36,32 +33,12 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
   const [extraOpen, setExtraOpen] = useState(false)
   const [planOpen, setPlanOpen] = useState(false)
   const [scheduleOpen, setScheduleOpen] = useState(false)
-  const [newInvoiceOpen, setNewInvoiceOpen] = useState(false)
   const { billing, isLoading } = useWorkOrderBillingState(recordId)
   const utils = api.useUtils()
   // In-place invoice drill (the schedule-visit pattern) — `?panel=invoices&item=<recordId>`
   // pushes the InvoiceDetailPanel over this page/drawer surface.
   const drill = useRecordDrill()
   const isSection = variant === 'section'
-  // Quick manual invoice (plan money/19 follow-up): the generic invoice create dialog
-  // (contact / work order / due date) with both relations prefilled from this job. The
-  // saved draft opens straight in the invoice drawer so lines can be added immediately.
-  const { getResourceById } = useResources()
-  const invoiceDefId = getResourceById('invoices')?.id
-  const invoiceContactField = useSystemField('invoice_contact')
-  const invoiceWorkOrderField = useSystemField('invoice_work_order')
-  const { values: workOrderValues } = useSystemValues(recordId, ['work_order_contact'], {
-    autoFetch: true,
-  })
-  const newInvoicePresets = useMemo(() => {
-    const presets: Record<string, unknown> = {}
-    if (invoiceWorkOrderField) presets[invoiceWorkOrderField.id] = [recordId]
-    const contactRecordIds = extractRelationshipRecordIds(workOrderValues.work_order_contact)
-    if (invoiceContactField && contactRecordIds.length > 0) {
-      presets[invoiceContactField.id] = contactRecordIds
-    }
-    return presets
-  }, [invoiceContactField, invoiceWorkOrderField, recordId, workOrderValues.work_order_contact])
   const paymentCandidates: PaymentCandidate[] = useMemo(
     () =>
       billing.invoices
@@ -85,7 +62,7 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
           'flex flex-col gap-4 py-2',
           isSection ? 'overflow-auto pe-3' : 'min-h-0 flex-1 overflow-auto'
         )}>
-        <SummaryStrip billing={billing} />
+        <BillingSummaryStrip billing={billing} className='border-b pb-4' />
         <NextAction
           billing={billing}
           onAction={() => setActionOpen(true)}
@@ -166,11 +143,10 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
         <TuckedSection
           label='Invoices'
           action={
-            invoiceDefId ? (
-              <Button variant='ghost' size='xs' onClick={() => setNewInvoiceOpen(true)}>
-                New invoice
-              </Button>
-            ) : undefined
+            <NewWorkOrderInvoiceButton
+              workOrderRecordId={recordId}
+              onOpenInvoice={(invoiceRecordId) => drill.open('invoices', invoiceRecordId)}
+            />
           }>
           <InvoiceRows billing={billing} />
         </TuckedSection>
@@ -213,63 +189,6 @@ export function WorkOrderBillingTab({ recordId, variant = 'tab' }: DetailViewTab
         billing={billing}
         mode='extra'
       />
-      {invoiceDefId && (
-        <RecordEditorDialog
-          open={newInvoiceOpen}
-          onOpenChange={setNewInvoiceOpen}
-          entityDefinitionId={invoiceDefId}
-          presetValues={newInvoicePresets}
-          onSaved={(instanceId) => {
-            void utils.money.getWorkOrderBillingState.invalidate({ workOrderRecordId: recordId })
-            if (instanceId) drill.open('invoices', toRecordId('invoice', instanceId))
-          }}
-        />
-      )}
-    </div>
-  )
-}
-
-function SummaryStrip({ billing }: { billing: WorkOrderBillingView }) {
-  const firstLabel =
-    billing.basis === 'fixed_contract'
-      ? 'Contract value'
-      : billing.basis === 'per_visit'
-        ? 'Default visit price'
-        : 'Rate per billing period'
-  const showDepositHeld = billing.depositHeld > 0
-  return (
-    <div
-      className={cn(
-        'grid grid-cols-2 gap-3 border-b pb-4',
-        showDepositHeld ? 'sm:grid-cols-6' : 'sm:grid-cols-5'
-      )}>
-      <SummaryCell label={firstLabel} value={billing.billingAmount} billing={billing} />
-      <SummaryCell label='Drafted' value={billing.drafted} billing={billing} />
-      <SummaryCell label='Invoiced' value={billing.invoiced} billing={billing} />
-      <SummaryCell label='Remaining to invoice' value={billing.remaining} billing={billing} />
-      <SummaryCell label='Balance due' value={billing.balanceDue} billing={billing} />
-      {showDepositHeld && (
-        <SummaryCell label='Deposit held' value={billing.depositHeld} billing={billing} />
-      )}
-    </div>
-  )
-}
-
-function SummaryCell({
-  label,
-  value,
-  billing,
-}: {
-  label: string
-  value: number
-  billing: WorkOrderBillingView
-}) {
-  return (
-    <div className='flex flex-col gap-0.5'>
-      <span className='text-xs text-muted-foreground'>{label}</span>
-      <span className='font-medium text-sm tabular-nums'>
-        {formatCurrency(value, billing.currencyCode)}
-      </span>
     </div>
   )
 }
@@ -431,16 +350,10 @@ function InvoiceRows({ billing }: { billing: WorkOrderBillingView }) {
         visibleLimit={INVOICE_PREVIEW_LIMIT}
         className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}
         renderRow={(invoice) => (
-          <TreeRow
-            rowClassName='hover:bg-primary-100'
-            icon={<Receipt className='size-4' />}
-            title={<span className='text-sm'>{invoice.displayName}</span>}
-            secondary={
-              <span className='text-xs'>
-                {invoice.status} · {formatCurrency(invoice.total, billing.currencyCode)}
-              </span>
-            }
-            onDrill={() => drill.open('invoices', invoice.recordId)}
+          <InvoiceTreeRow
+            invoice={invoice}
+            currencyCode={billing.currencyCode}
+            onOpen={() => drill.open('invoices', invoice.recordId)}
           />
         )}
       />

--- a/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
+++ b/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
@@ -13,7 +13,7 @@
 import { Button } from '@auxx/ui/components/button'
 import { TreeRow } from '@auxx/ui/components/tree-row'
 import { TreeRowList } from '@auxx/ui/components/tree-row-list'
-import { ArrowRight, CreditCard, ExternalLink, History, Plus, Receipt } from 'lucide-react'
+import { ArrowRight, CreditCard, ExternalLink, History, Plus } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { Fragment, useState } from 'react'
 import { splitJobVisits } from '~/components/dispatch/ui/job-schedule/job-schedule-utils'
@@ -23,9 +23,11 @@ import { useJobVisits } from '~/components/dispatch/ui/job-schedule/use-job-visi
 import { SchedulePopover } from '~/components/dispatch/ui/schedule-popover'
 import { DrawerCardActions } from '~/components/drawers/drawer-card-actions'
 import { BillingActionDialog } from '~/components/money/billing/billing-action-dialog'
+import { BillingSummaryStrip } from '~/components/money/billing/billing-summary-strip'
+import { InvoiceTreeRow } from '~/components/money/billing/invoice-tree-row'
+import { NewWorkOrderInvoiceButton } from '~/components/money/billing/new-work-order-invoice-button'
 import { resolveBillingAction } from '~/components/money/billing/types'
 import { useWorkOrderBillingState } from '~/components/money/billing/use-work-order-billing-state'
-import { formatCurrency } from '~/components/money/ui/line-builder/shared'
 import { useOpenRecord, useRecordDrill } from '~/components/records/record-drill-panels'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import { EmptyRow, RowSkeleton, TREE_SECONDARY_NOTRUNCATE } from './related-record-row'
@@ -136,20 +138,13 @@ export function WorkOrderBillingCard({ recordId, entityInstanceId }: DrawerTabPr
 
   return (
     <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
-      <div className='grid grid-cols-2 gap-2 pb-2 text-xs'>
-        <div>
-          <span className='block text-muted-foreground'>Balance due</span>
-          <span className='font-medium tabular-nums'>
-            {formatCurrency(billing.balanceDue, billing.currencyCode)}
-          </span>
-        </div>
-        <div>
-          <span className='block text-muted-foreground'>Uninvoiced</span>
-          <span className='font-medium tabular-nums'>
-            {formatCurrency(billing.remaining, billing.currencyCode)}
-          </span>
-        </div>
-      </div>
+      <DrawerCardActions>
+        <NewWorkOrderInvoiceButton
+          workOrderRecordId={recordId}
+          onOpenInvoice={(invoiceRecordId) => openRecord?.(invoiceRecordId)}
+        />
+      </DrawerCardActions>
+      <BillingSummaryStrip billing={billing} className='pb-2' />
       <TreeRow
         rowClassName='hover:bg-primary-100'
         icon={<CreditCard className='size-4' />}
@@ -171,17 +166,11 @@ export function WorkOrderBillingCard({ recordId, entityInstanceId }: DrawerTabPr
         onToggleOpen={isActionable ? handleToggleOpen : undefined}
       />
       {billing.invoices.slice(0, 3).map((invoice) => (
-        <TreeRow
+        <InvoiceTreeRow
           key={invoice.recordId}
-          rowClassName='hover:bg-primary-100'
-          icon={<Receipt className='size-4' />}
-          title={<span className='text-sm'>{invoice.displayName}</span>}
-          secondary={
-            <span className='text-xs'>
-              {invoice.status} · {formatCurrency(invoice.total, billing.currencyCode)}
-            </span>
-          }
-          onToggleOpen={() => openRecord?.(invoice.recordId)}
+          invoice={invoice}
+          currencyCode={billing.currencyCode}
+          onOpen={() => openRecord?.(invoice.recordId)}
         />
       ))}
       <TreeRow

--- a/apps/web/src/components/money/billing/billing-summary-strip.tsx
+++ b/apps/web/src/components/money/billing/billing-summary-strip.tsx
@@ -1,0 +1,95 @@
+// apps/web/src/components/money/billing/billing-summary-strip.tsx
+'use client'
+
+// Shared billing summary cells — ONE `@container`-responsive strip used by both the
+// full-page Billing tab and the compact drawer Billing card. Cells reveal left-to-right as
+// the container widens, and the grid column count grows to match, so cells stay evenly
+// distributed at every width. A narrow container (the drawer at its ~400px min) keeps the
+// action-relevant tail — Remaining + Balance due — and drops the funnel head; a wide
+// container (the full page) shows the whole funnel in reading order. Purely container width,
+// no viewport breakpoints.
+
+import { cn } from '@auxx/ui/lib/utils'
+import type { WorkOrderBillingView } from '~/components/money/billing/types'
+import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+
+export function BillingSummaryStrip({
+  billing,
+  className,
+}: {
+  billing: WorkOrderBillingView
+  className?: string
+}) {
+  const firstLabel =
+    billing.basis === 'fixed_contract'
+      ? 'Contract value'
+      : billing.basis === 'per_visit'
+        ? 'Default visit price'
+        : 'Rate per billing period'
+  const showDeposit = billing.depositHeld > 0
+  return (
+    <div className={cn('@container', className)}>
+      {/* Column count tracks the number of revealed cells at each container breakpoint so
+          the grid never leaves a gap: 2 → 3 (@md) → 4 (@lg) → 5/6 (@xl, +deposit). */}
+      <div
+        className={cn(
+          'grid grid-cols-2 gap-3 @md:grid-cols-3 @lg:grid-cols-4',
+          showDeposit ? '@xl:grid-cols-6' : '@xl:grid-cols-5'
+        )}>
+        <Cell
+          label={firstLabel}
+          value={billing.billingAmount}
+          currencyCode={billing.currencyCode}
+          className='hidden @xl:flex'
+        />
+        <Cell
+          label='Drafted'
+          value={billing.drafted}
+          currencyCode={billing.currencyCode}
+          className='hidden @lg:flex'
+        />
+        <Cell
+          label='Invoiced'
+          value={billing.invoiced}
+          currencyCode={billing.currencyCode}
+          className='hidden @md:flex'
+        />
+        <Cell
+          label='Remaining to invoice'
+          value={billing.remaining}
+          currencyCode={billing.currencyCode}
+        />
+        <Cell label='Balance due' value={billing.balanceDue} currencyCode={billing.currencyCode} />
+        {showDeposit && (
+          <Cell
+            label='Deposit held'
+            value={billing.depositHeld}
+            currencyCode={billing.currencyCode}
+            className='hidden @xl:flex'
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Cell({
+  label,
+  value,
+  currencyCode,
+  className,
+}: {
+  label: string
+  value: number
+  currencyCode: string
+  className?: string
+}) {
+  return (
+    <div className={cn('flex flex-col gap-0.5', className)}>
+      <span className='text-xs text-muted-foreground'>{label}</span>
+      <span className='font-medium text-sm tabular-nums'>
+        {formatCurrency(value, currencyCode)}
+      </span>
+    </div>
+  )
+}

--- a/apps/web/src/components/money/billing/invoice-tree-row.tsx
+++ b/apps/web/src/components/money/billing/invoice-tree-row.tsx
@@ -1,0 +1,38 @@
+// apps/web/src/components/money/billing/invoice-tree-row.tsx
+'use client'
+
+// Shared single-line invoice row — Receipt icon, invoice name, `status · total` secondary,
+// trailing drill chevron. Rendered by both the full-page Billing tab's Invoices list and the
+// drawer Billing card so the two recipes never drift. `onOpen` drills into the invoice (page
+// → record drill panel, drawer → peek stack).
+
+import { TreeRow } from '@auxx/ui/components/tree-row'
+import { Receipt } from 'lucide-react'
+import type { WorkOrderBillingView } from '~/components/money/billing/types'
+import { formatCurrency } from '~/components/money/ui/line-builder/shared'
+
+type InvoiceSummary = WorkOrderBillingView['invoices'][number]
+
+export function InvoiceTreeRow({
+  invoice,
+  currencyCode,
+  onOpen,
+}: {
+  invoice: InvoiceSummary
+  currencyCode: string
+  onOpen: () => void
+}) {
+  return (
+    <TreeRow
+      rowClassName='hover:bg-primary-100'
+      icon={<Receipt className='size-4' />}
+      title={<span className='text-sm'>{invoice.displayName}</span>}
+      secondary={
+        <span className='text-xs'>
+          {invoice.status} · {formatCurrency(invoice.total, currencyCode)}
+        </span>
+      }
+      onDrill={onOpen}
+    />
+  )
+}

--- a/apps/web/src/components/money/billing/new-work-order-invoice-button.tsx
+++ b/apps/web/src/components/money/billing/new-work-order-invoice-button.tsx
@@ -1,0 +1,74 @@
+// apps/web/src/components/money/billing/new-work-order-invoice-button.tsx
+'use client'
+
+// Shared "New invoice" affordance for a work order — the standalone-invoice create flow
+// used by BOTH the full-page Billing tab (Invoices section header) and the drawer Billing
+// card (section-header action via DrawerCardActions). Owns the prefilled create dialog
+// (contact + work order, from this job) and the billing-state invalidation; the caller
+// supplies how the saved draft opens (page → record drill, drawer → peek stack). Returns
+// null when the invoices resource isn't available, so callers can render it unconditionally.
+
+import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import { type RecordId, toRecordId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import { useMemo, useState } from 'react'
+import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
+import { useSystemField } from '~/components/resources/hooks/use-field'
+import { useResources } from '~/components/resources/hooks/use-resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { api } from '~/trpc/react'
+
+export interface NewWorkOrderInvoiceButtonProps {
+  workOrderRecordId: RecordId
+  /** Opens the freshly-created draft — page drills into it, drawer peeks it. */
+  onOpenInvoice: (invoiceRecordId: RecordId) => void
+}
+
+export function NewWorkOrderInvoiceButton({
+  workOrderRecordId,
+  onOpenInvoice,
+}: NewWorkOrderInvoiceButtonProps) {
+  const [open, setOpen] = useState(false)
+  const utils = api.useUtils()
+  const { getResourceById } = useResources()
+  const invoiceDefId = getResourceById('invoices')?.id
+  const invoiceContactField = useSystemField('invoice_contact')
+  const invoiceWorkOrderField = useSystemField('invoice_work_order')
+  const { values: workOrderValues } = useSystemValues(workOrderRecordId, ['work_order_contact'], {
+    autoFetch: true,
+  })
+  const presetValues = useMemo(() => {
+    const presets: Record<string, unknown> = {}
+    if (invoiceWorkOrderField) presets[invoiceWorkOrderField.id] = [workOrderRecordId]
+    const contactRecordIds = extractRelationshipRecordIds(workOrderValues.work_order_contact)
+    if (invoiceContactField && contactRecordIds.length > 0) {
+      presets[invoiceContactField.id] = contactRecordIds
+    }
+    return presets
+  }, [
+    invoiceContactField,
+    invoiceWorkOrderField,
+    workOrderRecordId,
+    workOrderValues.work_order_contact,
+  ])
+
+  if (!invoiceDefId) return null
+
+  return (
+    <>
+      <Button variant='ghost' size='xs' onClick={() => setOpen(true)}>
+        New invoice
+      </Button>
+      <RecordEditorDialog
+        open={open}
+        onOpenChange={setOpen}
+        entityDefinitionId={invoiceDefId}
+        presetValues={presetValues}
+        onSaved={(instanceId) => {
+          void utils.money.getWorkOrderBillingState.invalidate({ workOrderRecordId })
+          if (instanceId) onOpenInvoice(toRecordId('invoice', instanceId))
+        }}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## What

- **Adds a "New invoice" action to the work-order drawer's Billing section header** (via `DrawerCardActions`), so a standalone invoice can be created without leaving the drawer for the full page. Previously the drawer's only invoice-creation path was the plan-driven billing-action row (disabled when nothing was ready to invoice) — there was no way to make a standalone invoice from the drawer.
- **Extracts three shared pieces** used by both the full-page `WorkOrderBillingTab` and the drawer `WorkOrderBillingCard`, killing the divergence between the two surfaces:
  - `NewWorkOrderInvoiceButton` — owns the prefilled create dialog (contact + work order from the job) and billing-state invalidation; the caller supplies how the saved draft opens (page drills, drawer peeks).
  - `InvoiceTreeRow` — the shared Receipt row, unified on a drill chevron.
  - `BillingSummaryStrip` — one `@container`-responsive strip. Cells reveal left-to-right as the container widens and the grid column count grows to match (no gaps): the narrow drawer keeps the action-relevant tail (Remaining to invoice + Balance due), the wide page shows the full funnel in reading order.

## Behavior changes to note

1. Drawer invoice rows now show a trailing drill chevron (were plain click rows).
2. Drawer summary went from a fixed 2 tiles to the container-responsive strip — same values at min width, more cells as the drawer is resized wider (up to its 800px max).
3. Page summary is unchanged in content/order at full width, but is now container-driven rather than viewport (`sm:`) driven.

## Testing

- `apps/web` `tsc --noEmit`: clean.
- Biome: clean.
- All `apps/web` source — no lib/dist change, no dev-server restart needed.
- Owed: browser pass across both surfaces (drawer at a couple of widths to confirm the reveal ladder, the new-invoice flow end-to-end on both, invoice-row chevron).