### PR TITLE
feat(view-config): drive panel defaults from registry, stop seeding panel views

### DIFF
--- a/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-resource-view.tsx
@@ -26,6 +26,7 @@ import { CustomFieldCell } from './components/custom-field-cell'
 import { DynamicTableFooter } from './components/dynamic-table-footer'
 import { getIconForFieldType } from './custom-field-column-factory'
 import { DynamicView } from './dynamic-view'
+import { useDefaultTablePersistence } from './hooks/use-default-table-persistence'
 import { useColumnVisibility, useTableFilters, useTableSorting } from './stores/store-selectors'
 import type { BulkAction, CellSelectionConfig, ExtendedColumnDef } from './types'
 
@@ -228,7 +229,7 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
         accessorFn: () => undefined,
         header: field.name ?? field.label,
         fieldType: field.fieldType as FieldType,
-        defaultVisible: field.showInPanel !== false,
+        defaultVisible: field.showInTable ?? field.showInPanel !== false,
         icon: getIconForFieldType(field.fieldType!),
         enableSorting: field.fieldType !== 'RELATIONSHIP' && field.capabilities.sortable !== false,
         enableFiltering:
@@ -290,6 +291,14 @@ export function DynamicResourceView<TRow extends RecordMeta = RecordMeta>({
 
     return primaryColumn ? [primaryColumn, ...otherColumns] : otherColumns
   }, [customFields, resource, createEntityFieldColumn, entityDefinitionId])
+
+  // Persist per-user personalization (column widths/order/pinning + sparse
+  // visibility delta) of the default (unnamed) table. No-ops for named views.
+  useDefaultTablePersistence({
+    tableId,
+    columns,
+    enabled: !!entityDefinitionId && isConfigReady,
+  })
 
   if (isLoading) {
     if (embedded) {

--- a/apps/web/src/components/dynamic-table/hooks/use-default-table-persistence.ts
+++ b/apps/web/src/components/dynamic-table/hooks/use-default-table-persistence.ts
@@ -1,0 +1,217 @@
+// apps/web/src/components/dynamic-table/hooks/use-default-table-persistence.ts
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { useDebouncedCallback } from '~/hooks/use-debounced-value'
+import { api } from '~/trpc/react'
+import { useDynamicTableStore } from '../stores/dynamic-table-store'
+import {
+  useActiveViewId,
+  usePersonalTableView,
+  useViewStoreInitialized,
+} from '../stores/store-selectors'
+import type { ExtendedColumnDef, TableView, ViewConfig } from '../types'
+import { PERSONAL_TABLE_VIEW_NAME } from '../utils/constants'
+
+const DEBOUNCE_MS = 400
+
+interface UseDefaultTablePersistenceOptions {
+  /** Table id the default table reads (`entity-${entityDefinitionId}`). */
+  tableId: string
+  /** Column defs (carry `defaultVisible`) used to compute registry defaults. */
+  columns: ExtendedColumnDef[]
+  /** Gate — only run once the resource + columns are ready. */
+  enabled: boolean
+}
+
+/** Stable signature of the persisted personal state (for change detection). */
+function serialize(
+  sparseVisibility: Record<string, boolean>,
+  columnSizing: Record<string, number>,
+  columnOrder: string[],
+  columnPinning: ViewConfig['columnPinning']
+): string {
+  return JSON.stringify({
+    v: sparseVisibility,
+    s: columnSizing,
+    o: columnOrder,
+    p: columnPinning ?? null,
+  })
+}
+
+/**
+ * Persists per-user personalization of the DEFAULT (unnamed, `activeViewId ===
+ * null`) table into a dedicated `TableView` override row (sentinel name,
+ * `isShared:false`), keyed by `tableId` (`entity-${entityDefinitionId}`), so it's
+ * found on reload — the fix for the old `entity-<id>` vs `<id>` key mismatch.
+ *
+ * - Column visibility default is the LIVE registry (`showInTable` / `showInPanel`)
+ *   via each column's `defaultVisible`. Only columns the user toggled AWAY from
+ *   that default (plus any user-added `::` path columns) are stored — a SPARSE
+ *   `columnVisibility` delta. A resize therefore never writes a full visibility
+ *   snapshot, so a registry default flip still reaches un-toggled columns.
+ * - `columnSizing` / `columnOrder` / `columnPinning` are stored verbatim (full
+ *   maps) — this is the column-width persistence requirement.
+ *
+ * Named/saved views (`activeViewId` set) are untouched — this hook no-ops for them.
+ */
+export function useDefaultTablePersistence({
+  tableId,
+  columns,
+  enabled,
+}: UseDefaultTablePersistenceOptions) {
+  const initialized = useViewStoreInitialized()
+  const activeViewId = useActiveViewId(tableId)
+  const personalView = usePersonalTableView(tableId)
+
+  const updateSessionConfig = useDynamicTableStore((s) => s.updateSessionConfig)
+  const addView = useDynamicTableStore((s) => s.addView)
+
+  const sessionConfig = useDynamicTableStore(useShallow((s) => s.sessionConfigs[tableId]))
+
+  // Live registry default visibility per column — mirrors computeInitialViewConfig
+  // (columns that can't be hidden are omitted; `defaultVisible === true` = shown).
+  const registryVisibility = useMemo(() => {
+    const map: Record<string, boolean> = {}
+    for (const col of columns) {
+      const id = col.id
+      if (!id || col.enableHiding === false) continue
+      map[id] = col.defaultVisible === true
+    }
+    return map
+  }, [columns])
+
+  const isDefaultTable = enabled && initialized && activeViewId === null && columns.length > 0
+
+  const hydratedRef = useRef<string | null>(null)
+  const lastPersistedRef = useRef<string | null>(null)
+  const rowIdRef = useRef<string | null>(null)
+  const creatingRef = useRef(false)
+
+  const createMutation = api.tableView.create.useMutation({
+    onSuccess: (view) => {
+      rowIdRef.current = view.id
+      addView(view as TableView)
+    },
+    onSettled: () => {
+      creatingRef.current = false
+    },
+  })
+  const updateMutation = api.tableView.update.useMutation()
+
+  // ── Hydrate the session config from the personal override row (once) ──────────
+  useEffect(() => {
+    if (!isDefaultTable) return
+    if (hydratedRef.current === tableId) return
+    hydratedRef.current = tableId
+
+    if (!personalView) return
+    rowIdRef.current = personalView.id
+    const cfg = personalView.config as ViewConfig
+    const sparseVis = cfg.columnVisibility ?? {}
+    const sizing = cfg.columnSizing ?? {}
+    const order = cfg.columnOrder ?? []
+    const pinning = cfg.columnPinning
+
+    // Seed a FULL visibility map (registry defaults overlaid with the sparse
+    // personal delta) so use-dynamic-table's own default-seed effect sees a
+    // non-empty config and does not overwrite it.
+    updateSessionConfig(tableId, {
+      columnVisibility: { ...registryVisibility, ...sparseVis },
+      columnSizing: sizing,
+      columnOrder: order,
+      columnPinning: pinning,
+    })
+
+    // Record what we just hydrated so the first persist run is a no-op.
+    lastPersistedRef.current = serialize(sparseVis, sizing, order, pinning)
+  }, [isDefaultTable, tableId, personalView, registryVisibility, updateSessionConfig])
+
+  // Reset hydration bookkeeping when switching tables.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: tableId intentionally drives the cleanup — refs are reset when the table id changes.
+  useEffect(() => {
+    return () => {
+      hydratedRef.current = null
+      lastPersistedRef.current = null
+      rowIdRef.current = null
+    }
+  }, [tableId])
+
+  const persist = useCallback(() => {
+    if (!isDefaultTable) return
+    if (creatingRef.current) return
+
+    const cfg = useDynamicTableStore.getState().sessionConfigs[tableId]
+    if (!cfg) return
+
+    const fullVis = cfg.columnVisibility ?? {}
+    const sparse: Record<string, boolean> = {}
+    for (const [colId, visible] of Object.entries(fullVis)) {
+      if (colId.includes('::')) {
+        // User-added path column — its presence is meaningful, always keep it.
+        sparse[colId] = visible
+        continue
+      }
+      const def = registryVisibility[colId]
+      if (def === undefined) continue // special/unknown column — not our concern
+      if (visible !== def) sparse[colId] = visible
+    }
+
+    const sizing = cfg.columnSizing ?? {}
+    const order = cfg.columnOrder ?? []
+    const pinning = cfg.columnPinning
+
+    const serialized = serialize(sparse, sizing, order, pinning)
+    if (serialized === lastPersistedRef.current) return
+
+    const rowId = rowIdRef.current ?? personalView?.id ?? null
+    const meaningful =
+      Object.keys(sparse).length > 0 || Object.keys(sizing).length > 0 || order.length > 0
+
+    // Don't create a row until there's genuine personalization; but always update
+    // an existing row (e.g. when the user resets everything back to defaults).
+    if (!rowId && !meaningful) return
+
+    lastPersistedRef.current = serialized
+
+    const config: ViewConfig = {
+      filters: [],
+      sorting: [],
+      columnVisibility: sparse,
+      columnOrder: order,
+      columnSizing: sizing,
+      columnPinning: pinning,
+      viewType: 'table',
+    }
+
+    if (rowId) {
+      updateMutation.mutate({ id: rowId, config })
+    } else {
+      creatingRef.current = true
+      createMutation.mutate({
+        tableId,
+        name: PERSONAL_TABLE_VIEW_NAME,
+        contextType: 'table',
+        isShared: false,
+        isDefault: false,
+        config,
+      })
+    }
+  }, [isDefaultTable, tableId, registryVisibility, personalView, createMutation, updateMutation])
+
+  const debouncedPersist = useDebouncedCallback(persist, DEBOUNCE_MS)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: sessionConfig is the intentional trigger — a change to it schedules a (debounced) persist; the effect body reads the live config via getState() inside `persist`.
+  useEffect(() => {
+    if (!isDefaultTable) return
+    if (hydratedRef.current !== tableId) return
+    debouncedPersist()
+  }, [sessionConfig, isDefaultTable, tableId, debouncedPersist])
+
+  useEffect(() => {
+    return () => {
+      debouncedPersist.cancel?.()
+    }
+  }, [debouncedPersist])
+}

--- a/apps/web/src/components/dynamic-table/stores/store-selectors.ts
+++ b/apps/web/src/components/dynamic-table/stores/store-selectors.ts
@@ -23,14 +23,42 @@ import {
   EMPTY_FILTERS,
   EMPTY_SORTING,
   EMPTY_VIEWS,
+  PERSONAL_TABLE_VIEW_NAME,
 } from '../utils/constants'
 import { useDynamicTableStore } from './dynamic-table-store'
 
+/** True for the per-user default-table override row (not a named/saved view). */
+function isPersonalTableView(view: TableView): boolean {
+  return view.name === PERSONAL_TABLE_VIEW_NAME && !view.isShared && !view.isDefault
+}
+
 // ─── View Selectors ───────────────────────────────────────────────────────────
 
-/** Get all views for a table */
+/**
+ * Get all named/saved views for a table. The per-user default-table override row
+ * (sentinel name, personal, non-default) is excluded — it is not a saved view and
+ * must never appear in the view picker or be auto-selected as the default view.
+ */
 export function useTableViews(tableId: string): TableView[] {
-  return useDynamicTableStore((s) => s.viewsByTableId[tableId] ?? EMPTY_VIEWS)
+  return useDynamicTableStore(
+    useShallow((s) => {
+      const views = s.viewsByTableId[tableId] ?? EMPTY_VIEWS
+      const named = views.filter((v) => !isPersonalTableView(v))
+      // Preserve the stable empty ref when nothing is filtered/empty.
+      return named.length === views.length ? views : named
+    })
+  )
+}
+
+/**
+ * Get the per-user override row backing the DEFAULT (unnamed) table, if any.
+ * Keyed by the same `tableId` the table reads (`entity-${entityDefinitionId}`).
+ */
+export function usePersonalTableView(tableId: string): TableView | null {
+  return useDynamicTableStore((s) => {
+    const views = s.viewsByTableId[tableId] ?? EMPTY_VIEWS
+    return views.find(isPersonalTableView) ?? null
+  })
 }
 
 /** Get active view for a table */

--- a/apps/web/src/components/dynamic-table/utils/constants.ts
+++ b/apps/web/src/components/dynamic-table/utils/constants.ts
@@ -26,6 +26,17 @@ import type { ColumnFormatting, SortOption, TableView } from '../types'
 // ============================================================================
 
 export const EMPTY_VIEWS: TableView[] = []
+
+/**
+ * Sentinel name for the per-user override row that backs the DEFAULT (unnamed)
+ * table. It stores this user's column sizing/order/pinning (full maps) plus a
+ * SPARSE columnVisibility delta (only columns they explicitly toggled), keyed by
+ * `entity-${entityDefinitionId}` (the id the table actually reads). It is
+ * `isShared:false, isDefault:false` and is filtered out of the named-view picker
+ * (`useTableViews`) — it is not a saved view, just personalization for the
+ * live-default table. See `use-default-table-persistence.ts`.
+ */
+export const PERSONAL_TABLE_VIEW_NAME = '__personal_table__'
 export const EMPTY_FILTERS: ConditionGroup[] = []
 export const EMPTY_SORTING: SortingState = []
 export const EMPTY_COLUMN_ORDER: ColumnOrderState = []

--- a/packages/lib/src/resources/registry/common-fields.ts
+++ b/packages/lib/src/resources/registry/common-fields.ts
@@ -20,6 +20,10 @@ export const CREATED_BY_FIELD: ResourceField = {
   systemAttribute: CREATED_BY_FIELD_CONFIG.systemAttribute,
   systemSortOrder: 'az',
   dbColumn: CREATED_BY_FIELD_CONFIG.dbColumn,
+  // Hidden by default in both the panel and the default table — every seeded
+  // panel/table default view excluded `created_by_id`. This is the live
+  // registry default now that those default views are no longer materialized.
+  showInPanel: false,
   nullable: true,
   capabilities: {
     filterable: true,

--- a/packages/lib/src/resources/registry/field-types.ts
+++ b/packages/lib/src/resources/registry/field-types.ts
@@ -258,6 +258,18 @@ export interface ResourceField {
   showInPanel?: boolean
 
   /**
+   * Whether to show this field as a column in the default (list) table view.
+   * When unset, the table default resolves to `showInPanel !== false` — i.e. the
+   * table mirrors the panel default. Set this explicitly only when the table
+   * default must diverge from the panel: e.g. a long-form description shown in
+   * the panel but hidden from the table (`showInPanel` unset/true, `showInTable:
+   * false`), or a computed column hidden from the panel but useful as a table
+   * column (`showInPanel: false`, `showInTable: true`). Read live by the table's
+   * `defaultVisible` — no per-org materialization.
+   */
+  showInTable?: boolean
+
+  /**
    * When false, the field is hidden from the default create/update dialogs
    * unless an org view explicitly enables it. Defaults to true.
    */

--- a/packages/lib/src/resources/registry/resources/company-fields.ts
+++ b/packages/lib/src/resources/registry/resources/company-fields.ts
@@ -130,6 +130,7 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'company_x_follower_count',
     systemSortOrder: 'a3c',
+    showInTable: false, // panel shows it; hidden from the default table columns
     nullable: true,
     capabilities: {
       filterable: true,
@@ -235,6 +236,7 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'company_funding_raised',
     systemSortOrder: 'a6a',
+    showInPanel: false, // excluded from both the panel and table default views
     nullable: true,
     options: {
       currencyCode: 'USD',

--- a/packages/lib/src/resources/registry/resources/invoice-fields.ts
+++ b/packages/lib/src/resources/registry/resources/invoice-fields.ts
@@ -258,6 +258,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'invoice_tax_name',
     systemSortOrder: 'a9',
+    showInTable: false, // shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: true,
@@ -432,6 +433,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'invoice_notes',
     systemSortOrder: 'aG',
+    showInTable: false, // long-form; shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: false,
@@ -453,6 +455,7 @@ export const INVOICE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'invoice_terms',
     systemSortOrder: 'aH',
+    showInTable: false, // shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: false,

--- a/packages/lib/src/resources/registry/resources/meeting-fields.ts
+++ b/packages/lib/src/resources/registry/resources/meeting-fields.ts
@@ -202,6 +202,7 @@ export const MEETING_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'meeting_agenda',
     systemSortOrder: 'a8',
+    showInTable: false, // long-form; shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: false,
@@ -222,6 +223,7 @@ export const MEETING_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'meeting_notes',
     systemSortOrder: 'a9',
+    showInTable: false, // long-form; shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: false,
@@ -242,6 +244,7 @@ export const MEETING_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'meeting_action_items',
     systemSortOrder: 'aA',
+    showInTable: false, // long-form; shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: false,

--- a/packages/lib/src/resources/registry/resources/part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/part-fields.ts
@@ -265,6 +265,8 @@ export const PART_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'part_quantity_on_hand',
     systemSortOrder: 'a6a',
+    showInPanel: false, // shown in the drawer's stock section, not as a panel field row
+    showInTable: true, // but useful as a default column in the parts list
     nullable: true,
     capabilities: {
       filterable: true,
@@ -286,6 +288,8 @@ export const PART_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'part_stock_status',
     systemSortOrder: 'a6b',
+    showInPanel: false, // shown in the drawer's stock section, not as a panel field row
+    showInTable: true, // but useful as a default column in the parts list
     nullable: true,
     options: { options: StockStatus.values },
     capabilities: {

--- a/packages/lib/src/resources/registry/resources/quote-fields.ts
+++ b/packages/lib/src/resources/registry/resources/quote-fields.ts
@@ -323,6 +323,7 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'quote_tax_name',
     systemSortOrder: 'aB',
+    showInTable: false, // shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: true,
@@ -445,6 +446,7 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'quote_notes',
     systemSortOrder: 'aG',
+    showInTable: false, // long-form; shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: false,
@@ -466,6 +468,7 @@ export const QUOTE_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'quote_terms',
     systemSortOrder: 'aH',
+    showInTable: false, // shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: false,

--- a/packages/lib/src/resources/registry/resources/service-request-fields.ts
+++ b/packages/lib/src/resources/registry/resources/service-request-fields.ts
@@ -116,6 +116,7 @@ export const SERVICE_REQUEST_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'service_request_description',
     systemSortOrder: 'a5',
+    showInTable: false, // long-form; shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: false,

--- a/packages/lib/src/resources/registry/resources/vendor-part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/vendor-part-fields.ts
@@ -43,6 +43,8 @@ export const VENDOR_PART_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'vendor_part_part',
     systemSortOrder: 'a1',
+    showInPanel: false, // vendor parts are viewed in the context of their part (drawer tab)
+    showInTable: true, // keep the part column in the (internal) vendor-part list
     nullable: false,
     capabilities: {
       filterable: true,

--- a/packages/lib/src/resources/registry/resources/work-order-fields.ts
+++ b/packages/lib/src/resources/registry/resources/work-order-fields.ts
@@ -145,6 +145,7 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'work_order_description',
     systemSortOrder: 'a4',
+    showInTable: false, // long-form; shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: false,
@@ -441,6 +442,7 @@ export const WORK_ORDER_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'work_order_completion_notes',
     systemSortOrder: 'aF',
+    showInTable: false, // long-form; shown in the panel, hidden from default table columns
     nullable: true,
     capabilities: {
       filterable: false,

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -48,6 +48,7 @@ import { migration042QuoteDepositFields } from './migrations/042-quote-deposit-f
 import { migration043WorkOrderBillingAllocations } from './migrations/043-work-order-billing-allocations'
 import { migration044LinePricingFields } from './migrations/044-line-pricing-fields'
 import { migration045DefaultEntityDashboards } from './migrations/045-default-entity-dashboards'
+import { migration046LayeredDefaultViews } from './migrations/046-layered-default-views'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -101,6 +102,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration043WorkOrderBillingAllocations,
   migration044LinePricingFields,
   migration045DefaultEntityDashboards,
+  migration046LayeredDefaultViews,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/046-layered-default-views.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/046-layered-default-views.ts
@@ -1,0 +1,188 @@
+// packages/lib/src/seed/entity-migrations/migrations/046-layered-default-views.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray } from 'drizzle-orm'
+import type { FieldViewConfig } from '../../../conditions/field-view-config'
+import { RESOURCE_FIELD_REGISTRY } from '../../../resources/registry/field-registry'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:046')
+
+/**
+ * Migration 046: Kill the default-view migration treadmill (plans/view-config).
+ *
+ * Panel + table default visibility/order is now computed live from the registry
+ * (`showInPanel` / `showInTable` / `systemSortOrder`), and `createFieldViews` no
+ * longer seeds `contextType:'panel'`/`'table'` rows. This one-time migration
+ * reconciles orgs seeded under the old scheme so removing those rows preserves
+ * behavior:
+ *
+ * 1. DELETE the dead `contextType:'table'` default rows. They were keyed by the
+ *    bare `entityDefinitionId` while the table reads `entity-${entityDefinitionId}`
+ *    (a key mismatch, plan §2.2), so they were never read — pure dead weight.
+ *    Named/saved table views live under `entity-${id}` and are left untouched.
+ *
+ * 2. SLIM each seeded `contextType:'panel'` default row to a sparse override:
+ *    drop every `fieldVisibility` entry whose value already equals the new live
+ *    registry default (`showInPanel !== false`), keeping only genuine deviations
+ *    (e.g. a field a user toggled, or a seed artifact that diverges from the
+ *    registry). If nothing remains AND `fieldOrder` is still the registry
+ *    (`systemSortOrder`) order, the row is fully covered by live defaults and is
+ *    deleted; otherwise the slimmed row is kept so the read path (`useFieldView`
+ *    → `resolveFieldVisible`) layers the remaining deltas over the registry.
+ *
+ * Idempotent: re-running slims an already-sparse row to itself (all remaining
+ * entries are deviations) and finds no dead table rows, so it no-ops.
+ *
+ * Only touches `isDefault:true && isShared:true` rows keyed by a bare
+ * `entityDefinitionId` — the seeded system defaults. User-created named views
+ * (a real name, keyed `entity-${id}`) are never matched.
+ */
+export const migration046LayeredDefaultViews: EntityMigration = {
+  id: '046-layered-default-views',
+  description: 'Drop dead table default views + slim seeded panel defaults to sparse overrides',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    let changed = false
+
+    // EntityDefinitions for this org — their ids are the bare `tableId`s the old
+    // seeder used, and they map tableId → entityType for registry lookups.
+    const defs = await db
+      .select({ id: schema.EntityDefinition.id, entityType: schema.EntityDefinition.entityType })
+      .from(schema.EntityDefinition)
+      .where(eq(schema.EntityDefinition.organizationId, organizationId))
+
+    const entityDefIds = defs.map((d) => d.id)
+    if (entityDefIds.length === 0) return { ...state, alreadyUpToDate: true }
+
+    const defIdToType = new Map(defs.map((d) => [d.id, d.entityType]))
+
+    // ── Step 1: delete the dead contextType='table' default rows ──────────────
+    // Guarded by `tableId ∈ entityDefIds` so named/saved table views (keyed
+    // `entity-${id}`, never a bare EntityDefinition id) are never deleted.
+    const deletedTable = await db
+      .delete(schema.TableView)
+      .where(
+        and(
+          eq(schema.TableView.organizationId, organizationId),
+          eq(schema.TableView.isDefault, true),
+          eq(schema.TableView.contextType, 'table'),
+          inArray(schema.TableView.tableId, entityDefIds)
+        )
+      )
+      .returning({ id: schema.TableView.id })
+    if (deletedTable.length > 0) changed = true
+
+    // ── Step 2: slim the seeded contextType='panel' default rows ──────────────
+    const panelRows = await db
+      .select({
+        id: schema.TableView.id,
+        tableId: schema.TableView.tableId,
+        config: schema.TableView.config,
+      })
+      .from(schema.TableView)
+      .where(
+        and(
+          eq(schema.TableView.organizationId, organizationId),
+          eq(schema.TableView.isDefault, true),
+          eq(schema.TableView.isShared, true),
+          eq(schema.TableView.contextType, 'panel'),
+          inArray(schema.TableView.tableId, entityDefIds)
+        )
+      )
+
+    if (panelRows.length > 0) {
+      // customFieldId → systemAttribute, to resolve a resourceFieldId
+      // (`${entityDefId}:${customFieldId}`) to its registry field def.
+      const fields = await db
+        .select({
+          id: schema.CustomField.id,
+          systemAttribute: schema.CustomField.systemAttribute,
+        })
+        .from(schema.CustomField)
+        .where(eq(schema.CustomField.organizationId, organizationId))
+      const fieldIdToSysAttr = new Map(fields.map((f) => [f.id, f.systemAttribute]))
+
+      // Per-entityType systemAttribute → registry ResourceField.
+      const registryByType = new Map<string, Map<string, ResourceField>>()
+      const registryFor = (entityType: string): Map<string, ResourceField> | undefined => {
+        if (registryByType.has(entityType)) return registryByType.get(entityType)
+        const defsForType = RESOURCE_FIELD_REGISTRY[entityType]
+        if (!defsForType) {
+          registryByType.set(entityType, new Map())
+          return registryByType.get(entityType)
+        }
+        const bySysAttr = new Map<string, ResourceField>()
+        for (const field of Object.values(defsForType)) {
+          if (field.systemAttribute) bySysAttr.set(field.systemAttribute, field)
+        }
+        registryByType.set(entityType, bySysAttr)
+        return bySysAttr
+      }
+
+      for (const row of panelRows) {
+        const entityType = defIdToType.get(row.tableId)
+        if (!entityType) continue
+        const bySysAttr = registryFor(entityType)
+        if (!bySysAttr) continue
+
+        const resolveField = (resourceFieldId: string): ResourceField | undefined => {
+          const colon = resourceFieldId.indexOf(':')
+          const customFieldId = colon === -1 ? resourceFieldId : resourceFieldId.slice(colon + 1)
+          const sysAttr = fieldIdToSysAttr.get(customFieldId)
+          if (!sysAttr) return undefined
+          return bySysAttr.get(sysAttr)
+        }
+        // Live registry default: hidden only when showInPanel === false.
+        const registryVisible = (resourceFieldId: string): boolean =>
+          resolveField(resourceFieldId)?.showInPanel !== false
+
+        const config = row.config as FieldViewConfig
+        const fieldVisibility = config.fieldVisibility ?? {}
+
+        const slim: Record<string, boolean> = {}
+        for (const [resourceFieldId, visible] of Object.entries(fieldVisibility)) {
+          if (visible !== registryVisible(resourceFieldId)) slim[resourceFieldId] = visible
+        }
+
+        const slimCount = Object.keys(slim).length
+        const originalCount = Object.keys(fieldVisibility).length
+
+        // Is fieldOrder still the registry (systemSortOrder) order it was seeded in?
+        const fieldOrder = config.fieldOrder ?? []
+        const sortedOrder = [...fieldOrder].sort((a, b) => {
+          const sa = resolveField(a)?.systemSortOrder ?? 'zz'
+          const sb = resolveField(b)?.systemSortOrder ?? 'zz'
+          return sa.localeCompare(sb)
+        })
+        const orderIsDefault =
+          fieldOrder.length === sortedOrder.length &&
+          fieldOrder.every((id, i) => id === sortedOrder[i])
+
+        if (slimCount === 0 && orderIsDefault) {
+          // Fully covered by live registry defaults + order → drop the row.
+          await db.delete(schema.TableView).where(eq(schema.TableView.id, row.id))
+          changed = true
+        } else if (slimCount !== originalCount) {
+          // Some entries were dropped → persist the slimmed sparse override,
+          // preserving fieldOrder + showLabels for the read path to layer on.
+          await db
+            .update(schema.TableView)
+            .set({
+              config: { ...config, fieldVisibility: slim },
+              updatedAt: new Date(),
+            })
+            .where(eq(schema.TableView.id, row.id))
+          changed = true
+        }
+        // else: already sparse (no entries matched a default) → idempotent no-op.
+      }
+    }
+
+    if (changed) logger.info('Migration 046 applied', { organizationId })
+    return { ...state, alreadyUpToDate: !changed }
+  },
+}

--- a/packages/lib/src/seed/entity-seeder/create-field-views.ts
+++ b/packages/lib/src/seed/entity-seeder/create-field-views.ts
@@ -25,47 +25,27 @@ interface FieldViewSeedConfig {
 }
 
 /**
- * Default field view configs for core entities.
+ * Default field view configs for core entities — DIALOG CONTEXTS ONLY.
+ *
+ * Panel and table default views are NO LONGER seeded. Their field visibility and
+ * order are computed live from the registry (`showInPanel` / `showInTable` /
+ * `systemSortOrder`), so changing a default is a code-only change with no per-org
+ * entity migration (see `use-field-view.ts` / `dynamic-resource-view.tsx`). Only
+ * create/edit dialog defaults remain materialized here — create dialogs are
+ * allowlists (`includeFields`), awkward to express as per-field registry flags.
+ *
  * Uses systemAttribute (from field definitions) for reliable field identification.
  */
 export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   // ============================================================================
-  // CONTACT FIELD VIEWS
+  // CONTACT DIALOGS
   // ============================================================================
-
-  // Contact panel view - shows most fields except system internals
-  {
-    entityType: 'contact',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'first_name',
-      'last_name',
-      'contact_tickets',
-      'contact_meetings',
-      'contact_work_orders',
-      'contact_service_requests',
-      'contact_quotes',
-      'contact_invoices',
-      'contact_balance_due',
-      'contact_uninvoiced_amount',
-      'contact_billing_revision',
-    ],
-  },
-
-  // Contact create dialog - minimal fields for quick creation
   {
     entityType: 'contact',
     contextType: 'dialog_create',
     name: 'Default Create Dialog',
     includeFields: ['full_name', 'primary_email', 'phone'],
   },
-
-  // Contact edit dialog - editable fields (excludes auto-generated)
   {
     entityType: 'contact',
     contextType: 'dialog_edit',
@@ -81,25 +61,8 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   },
 
   // ============================================================================
-  // TICKET FIELD VIEWS
+  // TICKET DIALOGS
   // ============================================================================
-
-  // Ticket panel view - shows most fields except system internals
-  {
-    entityType: 'ticket',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'parent_ticket_id',
-      'ticket_child_tickets',
-    ],
-  },
-
-  // Ticket create dialog - essential fields for ticket creation
   {
     entityType: 'ticket',
     contextType: 'dialog_create',
@@ -112,8 +75,6 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
       'ticket_description',
     ],
   },
-
-  // Ticket edit dialog - editable fields (excludes auto-generated)
   {
     entityType: 'ticket',
     contextType: 'dialog_edit',
@@ -127,31 +88,10 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
       'ticket_child_tickets',
     ],
   },
-  // ============================================================================
-  // PART FIELD VIEWS
-  // ============================================================================
 
-  // Part panel view — hide relationship fields (managed by drawer tabs) + system internals
-  {
-    entityType: 'part',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'part_quantity_on_hand',
-      'part_stock_status',
-      // Relationship fields — dedicated drawer tabs exist for these
-      'part_vendor_parts',
-      'part_subparts',
-      'part_used_in_assemblies',
-      'part_stock_movements',
-    ],
-  },
-
-  // Part create dialog — minimal fields for quick creation
+  // ============================================================================
+  // PART DIALOG
+  // ============================================================================
   {
     entityType: 'part',
     contextType: 'dialog_create',
@@ -160,18 +100,8 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   },
 
   // ============================================================================
-  // VENDOR PART FIELD VIEWS
+  // VENDOR PART DIALOG
   // ============================================================================
-
-  // Vendor Part panel view — show all fields except system internals
-  {
-    entityType: 'vendor_part',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id', 'vendor_part_part'],
-  },
-
-  // Vendor Part create dialog — essential fields only
   {
     entityType: 'vendor_part',
     contextType: 'dialog_create',
@@ -186,41 +116,8 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   },
 
   // ============================================================================
-  // COMPANY FIELD VIEWS
+  // COMPANY DIALOG
   // ============================================================================
-
-  // Company panel view — show most fields except system internals
-  {
-    entityType: 'company',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'company_meetings',
-      'company_funding_raised',
-    ],
-  },
-
-  // Company table view — hide logo (avatar shown inline in table row)
-  {
-    entityType: 'company',
-    contextType: 'table',
-    name: 'Default Table View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'company_logo',
-      'company_funding_raised',
-      'company_x_follower_count',
-    ],
-  },
-
-  // Company create dialog — minimal fields for quick creation
   {
     entityType: 'company',
     contextType: 'dialog_create',
@@ -234,34 +131,8 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   },
 
   // ============================================================================
-  // MEETING FIELD VIEWS
+  // MEETING DIALOG
   // ============================================================================
-
-  // Meeting panel view — show most fields except system internals
-  {
-    entityType: 'meeting',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
-  },
-
-  // Meeting table view — hide long-form note fields in the default list
-  {
-    entityType: 'meeting',
-    contextType: 'table',
-    name: 'Default Table View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'meeting_agenda',
-      'meeting_notes',
-      'meeting_action_items',
-    ],
-  },
-
-  // Meeting create dialog — essential scheduling fields only
   {
     entityType: 'meeting',
     contextType: 'dialog_create',
@@ -277,58 +148,8 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   },
 
   // ============================================================================
-  // WORK ORDER FIELD VIEWS
+  // WORK ORDER DIALOG
   // ============================================================================
-  {
-    entityType: 'work_order',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'work_order_pricing_model', // edited with timing in the purpose-built billing-plan flow
-      'work_order_invoice_timing', // edited together in the purpose-built billing-plan flow
-      // surfaced via the job view's Origin card + line-items/invoice UI, not field rows
-      'work_order_quote',
-      'work_order_line_items',
-      'work_order_invoices',
-      'work_order_billing_state',
-      'work_order_billing_amount',
-      'work_order_amount_drafted',
-      'work_order_amount_invoiced',
-      'work_order_uninvoiced_amount',
-      'work_order_balance_due',
-      'work_order_invoice_count',
-      'work_order_next_invoice_date',
-      'work_order_billing_revision',
-    ],
-  },
-  {
-    entityType: 'work_order',
-    contextType: 'table',
-    name: 'Default Table View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'work_order_description',
-      'work_order_completion_notes',
-      'work_order_pricing_model', // edited with timing in the purpose-built billing-plan flow
-      'work_order_invoice_timing', // edited together in the purpose-built billing-plan flow
-      'work_order_billing_state',
-      'work_order_billing_amount',
-      'work_order_amount_drafted',
-      'work_order_amount_invoiced',
-      'work_order_uninvoiced_amount',
-      'work_order_balance_due',
-      'work_order_invoice_count',
-      'work_order_next_invoice_date',
-      'work_order_billing_revision',
-    ],
-  },
   {
     entityType: 'work_order',
     contextType: 'dialog_create',
@@ -345,34 +166,8 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   },
 
   // ============================================================================
-  // SERVICE REQUEST FIELD VIEWS
+  // SERVICE REQUEST DIALOG
   // ============================================================================
-  {
-    entityType: 'service_request',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    // work_orders + quotes render as dedicated overview blocks, not field rows
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'service_request_work_orders',
-      'service_request_quotes',
-    ],
-  },
-  {
-    entityType: 'service_request',
-    contextType: 'table',
-    name: 'Default Table View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'service_request_description',
-    ],
-  },
   {
     entityType: 'service_request',
     contextType: 'dialog_create',
@@ -390,46 +185,8 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   },
 
   // ============================================================================
-  // QUOTE FIELD VIEWS
+  // QUOTE DIALOG
   // ============================================================================
-  {
-    entityType: 'quote',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    // money totals (discount/tax/subtotal/total) live in the line-items card below
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'quote_line_items',
-      'quote_work_orders',
-      'quote_discount_type',
-      'quote_discount_value',
-      'quote_tax_rate',
-      'quote_subtotal',
-      'quote_tax_total',
-      'quote_total',
-    ],
-  },
-  {
-    entityType: 'quote',
-    contextType: 'table',
-    name: 'Default Table View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'quote_line_items',
-      'quote_work_orders',
-      'quote_notes',
-      'quote_terms',
-      'quote_discount_type',
-      'quote_discount_value',
-      'quote_tax_name',
-    ],
-  },
   {
     entityType: 'quote',
     contextType: 'dialog_create',
@@ -438,144 +195,22 @@ export const FIELD_VIEW_CONFIGS: FieldViewSeedConfig[] = [
   },
 
   // ============================================================================
-  // LINE ITEM FIELD VIEWS (no dialog_create — never created via generic dialog)
+  // INVOICE DIALOG
   // ============================================================================
-  {
-    entityType: 'line_item',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
-  },
-  {
-    entityType: 'line_item',
-    contextType: 'table',
-    name: 'Default Table View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'line_item_discount',
-      'line_item_sort_order',
-      'line_item_visit_id',
-    ],
-  },
-
-  // ============================================================================
-  // CATALOG ITEM FIELD VIEWS (no dialog_create — never created via generic dialog)
-  // ============================================================================
-  {
-    entityType: 'catalog_item',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
-  },
-  {
-    entityType: 'catalog_item',
-    contextType: 'table',
-    name: 'Default Table View',
-    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id', 'catalog_item_line_items'],
-  },
-
-  // ============================================================================
-  // CATALOG GROUP FIELD VIEWS (no dialog_create — never created via generic dialog)
-  // ============================================================================
-  {
-    entityType: 'catalog_group',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
-  },
-  {
-    entityType: 'catalog_group',
-    contextType: 'table',
-    name: 'Default Table View',
-    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id', 'catalog_group_entries'],
-  },
-
-  // ============================================================================
-  // INVOICE FIELD VIEWS
-  // ============================================================================
-  {
-    entityType: 'invoice',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    // money totals (discount/tax/subtotal/total) live in the line-items card below
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'invoice_line_items',
-      'invoice_payments',
-      'invoice_pdf_asset',
-      'invoice_discount_type',
-      'invoice_discount_value',
-      'invoice_tax_rate',
-      'invoice_subtotal',
-      'invoice_tax_total',
-      'invoice_total',
-      'invoice_billing_kind',
-      'invoice_service_period_start',
-      'invoice_service_period_end',
-      'invoice_visit_count',
-      'invoice_progress_percent',
-      'invoice_installment_name',
-    ],
-  },
-  {
-    entityType: 'invoice',
-    contextType: 'table',
-    name: 'Default Table View',
-    excludeFields: [
-      'id',
-      'created_at',
-      'updated_at',
-      'created_by_id',
-      'invoice_line_items',
-      'invoice_payments',
-      'invoice_pdf_asset',
-      'invoice_notes',
-      'invoice_terms',
-      'invoice_discount_type',
-      'invoice_discount_value',
-      'invoice_tax_name',
-      'invoice_billing_kind',
-      'invoice_service_period_start',
-      'invoice_service_period_end',
-      'invoice_visit_count',
-      'invoice_progress_percent',
-      'invoice_installment_name',
-    ],
-  },
   {
     entityType: 'invoice',
     contextType: 'dialog_create',
     name: 'Default Create Dialog',
     includeFields: ['invoice_contact', 'invoice_work_order', 'invoice_due_date'],
   },
-
-  // ============================================================================
-  // PAYMENT FIELD VIEWS (no dialog_create — the requireLedgerProvenance guard blocks
-  // generic creates; the ledger's recordManualPayment is the only writer, §F.3)
-  // ============================================================================
-  {
-    entityType: 'payment',
-    contextType: 'panel',
-    name: 'Default Panel View',
-    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
-  },
-  {
-    entityType: 'payment',
-    contextType: 'table',
-    name: 'Default Table View',
-    excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
-  },
 ]
 
 /**
  * Pass 7: Create Default Field Views
- * Create default field views for panel and dialog contexts with resolved field IDs.
+ * Seeds default field views for the create/edit DIALOG contexts only, with
+ * resolved field IDs. Panel and table defaults are computed live from the
+ * registry (`showInPanel` / `showInTable` / `systemSortOrder`) and are no longer
+ * materialized — see `FIELD_VIEW_CONFIGS`.
  */
 export async function createFieldViews(
   db: Database,


### PR DESCRIPTION
## What

Panel (and table) default field visibility/order now come **live from the resource registry** (`showInPanel` / `showInTable` / `systemSortOrder`) instead of materialized per-org `TableView` snapshots. Changing a default is now a **code-only** change — no per-org entity migration.

## Changes

- Add `showInTable` to `FieldTypeDefinition`; encode the old panel/table exclusion lists as `showInPanel` / `showInTable` flags across `registry/resources/*-fields.ts` (+ `common-fields.ts` for `created_by_id`).
- `create-field-views` seeds **dialog contexts only** — panel/table default rows are no longer materialized.
- Migration **046** reconciles existing orgs: slims seeded `panel` defaults to sparse overrides (dropping entries that match the live registry default), and deletes the dead `contextType:'table'` rows.
- Per-user **default-table persistence hook** — sparse visibility delta + column sizing/order/pinning, keyed by `entity-${id}` (fixes the old `entity-<id>` vs `<id>` key mismatch).

## Verification

**Panel path — verified end-to-end in-browser.** With seeding stopped, the read path (`resolveFieldVisible`) applies `showInPanel` live regardless of any residual sparse seeded row. Work-order billing fields (`showInPanel:false`) don't render as panel field rows (surfaced via the billing card instead); `description` / `completion_notes` show in the panel but are `showInTable:false`. Flipping a registry flag reaches the panel with no migration — the treadmill is dead.

## Known follow-up (table side — NOT in scope here)

Core entities still auto-select **seeded named default table views** (`All Work Orders`, `All Tickets`, `Quote Pipeline`, …) via `create-default-views.ts`, keyed correctly by `entity-${id}` with `isDefault:true`. So on those tables `activeViewId !== null`, which means `showInTable` is bypassed (Description/Completion Notes still show) and the per-user width hook stays dormant (it only engages in session mode). The fix — drop the seeded `isDefault` table views, push view-type/sort/pinning/kanban into the registry, migrate existing rows — is captured in the plan doc (§2.2 correction note, local `plans/`).