### PR TITLE
feat(messages): rfc 3834 loop-prevention headers on automated sends

### DIFF
--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -259,6 +259,7 @@ export class MessageSenderService {
         threadContext: threadContext,
         attachments: attachmentFiles,
         unsubscribe,
+        automated: isAutomatedSend,
       })
       // Step 7: Reconcile with provider response. Per-message bookkeeping
       // (sendStatus, sentAt, externalId) always runs; the thread-level
@@ -644,6 +645,7 @@ export class MessageSenderService {
     threadContext: ThreadContext
     attachments?: AttachmentFile[]
     unsubscribe?: { url: string }
+    automated?: boolean
   }): Promise<ProviderSendResponse> {
     if (!this.providerRegistry) {
       throw new Error('Provider registry not initialized')
@@ -678,6 +680,7 @@ export class MessageSenderService {
         externalThreadId: sanitizedExternalThreadId, // Use sanitized ID
         attachments: input.attachments, // Pass attachments to provider
         unsubscribe: input.unsubscribe, // List-Unsubscribe header (email providers only)
+        automated: input.automated, // RFC 3834 loop-prevention headers (email providers only)
       } as any)
       return {
         success: result.success,

--- a/packages/lib/src/providers/channel-provider.interface.ts
+++ b/packages/lib/src/providers/channel-provider.interface.ts
@@ -55,6 +55,13 @@ export interface SendMessageOptions {
    * `MessageSenderService` for outbound email to a known contact. Providers that can't
    * honor a non-`x-` custom header (Outlook/Graph) skip it — see outlook-provider.ts. */
   unsubscribe?: { url: string }
+
+  /** RFC 3834 loop-prevention headers for automated sends (Answer node, Kopilot tools,
+   * sequences — `MessageSenderService.isAutomatedSend`). Email providers stamp
+   * `Auto-Submitted: auto-replied` + `X-Auto-Response-Suppress: All` so compliant remote
+   * systems (incl. Google/Microsoft NDR logic) don't re-reply to us; Outlook/Graph can
+   * only carry the `x-` header (machine-mail plan Phase 2). */
+  automated?: boolean
 }
 
 export interface SendEmailOptions {

--- a/packages/lib/src/providers/email/email-forwarding-provider.ts
+++ b/packages/lib/src/providers/email/email-forwarding-provider.ts
@@ -107,14 +107,23 @@ export class EmailForwardingProvider
       cid: a.contentId,
     }))
 
-    // List-Unsubscribe + one-click (RFC 8058) — signals plan 02. `EmailOptions.headers`
-    // already flows straight through to nodemailer's `sendMail`.
-    const headers = params.unsubscribe?.url
-      ? {
-          'List-Unsubscribe': `<${params.unsubscribe.url}>`,
-          'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
-        }
-      : undefined
+    // List-Unsubscribe + one-click (RFC 8058) — signals plan 02 — and RFC 3834
+    // loop-prevention headers for automated sends (machine-mail plan Phase 2).
+    // `EmailOptions.headers` flows straight through to nodemailer's `sendMail`.
+    const headers: Record<string, string> = {
+      ...(params.unsubscribe?.url
+        ? {
+            'List-Unsubscribe': `<${params.unsubscribe.url}>`,
+            'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+          }
+        : {}),
+      ...(params.automated
+        ? {
+            'Auto-Submitted': 'auto-replied',
+            'X-Auto-Response-Suppress': 'All',
+          }
+        : {}),
+    }
 
     const emailResult = await NodemailerService.getInstance().sendEmail({
       from,
@@ -129,7 +138,7 @@ export class EmailForwardingProvider
       references: params.references,
       messageId: params.messageId,
       attachments,
-      headers,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
     })
 
     if (!emailResult.success) {

--- a/packages/lib/src/providers/google/__tests__/google-provider.mime.test.ts
+++ b/packages/lib/src/providers/google/__tests__/google-provider.mime.test.ts
@@ -90,4 +90,30 @@ describe('GoogleProvider MIME building', () => {
     // Inline attachment should have Content-ID
     expect(raw).toContain('Content-ID: <cid123>')
   })
+
+  it('stamps RFC 3834 loop-prevention headers on automated sends', async () => {
+    const raw: string = await createEmailMessage({
+      from: 'sender@example.com',
+      to: 'to@example.com',
+      subject: 'Automated reply',
+      text: 'hello',
+      automated: true,
+    })
+
+    const headerSection = raw.split('\r\n\r\n')[0]
+    expect(headerSection).toContain('Auto-Submitted: auto-replied')
+    expect(headerSection).toContain('X-Auto-Response-Suppress: All')
+  })
+
+  it('omits RFC 3834 headers on human sends', async () => {
+    const raw: string = await createEmailMessage({
+      from: 'sender@example.com',
+      to: 'to@example.com',
+      subject: 'Human reply',
+      text: 'hello',
+    })
+
+    expect(raw).not.toContain('Auto-Submitted')
+    expect(raw).not.toContain('X-Auto-Response-Suppress')
+  })
 })

--- a/packages/lib/src/providers/google/messages/create-message.ts
+++ b/packages/lib/src/providers/google/messages/create-message.ts
@@ -29,6 +29,8 @@ export interface CreateEmailMessageInput {
   /** List-Unsubscribe / List-Unsubscribe-Post headers (RFC 8058) — shape matches
    * `SendMessageOptions['unsubscribe']` so it flows through the provider's spread untouched. */
   unsubscribe?: { url: string }
+  /** RFC 3834 loop-prevention headers — matches `SendMessageOptions['automated']`. */
+  automated?: boolean
 }
 
 /**
@@ -52,6 +54,7 @@ export async function createEmailMessage(input: CreateEmailMessageInput): Promis
     references,
     messageId,
     unsubscribe,
+    automated,
   } = input
 
   // Generate boundaries
@@ -104,6 +107,13 @@ export async function createEmailMessage(input: CreateEmailMessageInput): Promis
   if (unsubscribe?.url) {
     headers.push(`List-Unsubscribe: <${unsubscribe.url}>`)
     headers.push(`List-Unsubscribe-Post: List-Unsubscribe=One-Click`)
+  }
+
+  // RFC 3834 loop prevention (machine-mail plan Phase 2) — `auto-replied`, not
+  // `auto-generated`: our own inbound detector tiers auto-generated as hard machine mail.
+  if (automated) {
+    headers.push(`Auto-Submitted: auto-replied`)
+    headers.push(`X-Auto-Response-Suppress: All`)
   }
 
   headers.push(`X-Mailer: Auxx-AI-Mailer/2.0`)

--- a/packages/lib/src/providers/imap/imap-send-message.ts
+++ b/packages/lib/src/providers/imap/imap-send-message.ts
@@ -52,7 +52,13 @@ export class ImapSmtpSendService {
         html: options.html,
         inReplyTo: options.inReplyTo,
         references: options.references,
-        headers: options.messageId ? { 'Message-ID': options.messageId } : undefined,
+        headers: {
+          ...(options.messageId ? { 'Message-ID': options.messageId } : {}),
+          // RFC 3834 loop prevention for automated sends (machine-mail plan Phase 2)
+          ...(options.automated
+            ? { 'Auto-Submitted': 'auto-replied', 'X-Auto-Response-Suppress': 'All' }
+            : {}),
+        },
       })
 
       logger.info('SMTP message sent', { messageId: result.messageId })

--- a/packages/lib/src/providers/outlook/outlook-provider.ts
+++ b/packages/lib/src/providers/outlook/outlook-provider.ts
@@ -348,6 +348,16 @@ export class OutlookProvider
         name: 'X-AuxxAi-Message',
         value: 'true',
       })
+      // RFC 3834 loop prevention for automated sends (machine-mail plan Phase 2). Graph
+      // only accepts `x-` custom headers (see the List-Unsubscribe note below), so
+      // `Auto-Submitted` can't ride along — but X-Auto-Response-Suppress is Microsoft's
+      // own loop-prevention header, the one that matters most for Exchange recipients.
+      if (options.automated) {
+        message.internetMessageHeaders.push({
+          name: 'X-Auto-Response-Suppress',
+          value: 'All',
+        })
+      }
       // List-Unsubscribe / List-Unsubscribe-Post (RFC 8058) — deliberately NOT injected here.
       // Microsoft Graph's `message` resource docs are explicit: "Add custom headers only
       // when creating a message, and name them starting with 'x-'"


### PR DESCRIPTION
## Summary

Machine-mail plan **Phase 2** — the outbound half of loop prevention (follow-up to #1214, which shipped the inbound gates + bounce suppression). Our automated sends previously set no RFC 3834 headers, so compliant remote systems (including Google/Microsoft NDR logic) had no signal to stop re-replying to us.

- `SendMessageOptions.automated`, fed by the existing `MessageSenderService.isAutomatedSend` classification (Answer node, Kopilot mail tools, sequences)
- **Gmail** raw MIME: `Auto-Submitted: auto-replied` + `X-Auto-Response-Suppress: All`
- **Outlook** Graph: `X-Auto-Response-Suppress: All` only — Graph rejects non-`x-` custom header names (same constraint already documented there for List-Unsubscribe); it's Microsoft's own loop-prevention header, the one that matters most for Exchange recipients
- **Nodemailer paths** (email forwarding + IMAP/SMTP): full header set

`auto-replied` rather than `auto-generated` is deliberate: our own inbound detector tiers `auto-generated` as *hard* machine mail, so this keeps an auxx-to-auxx automated send soft-tier. Mailgun is untouched — it's the system-email API service, not a channel send path.

## Test plan

- [x] 2 new tests on the Gmail MIME builder (headers present when `automated`, absent otherwise) — 4/4 pass
- [x] Biome clean on all touched files; `tsc` on packages/lib shows only pre-existing errors in untouched code