### PR TITLE
feat(messages): automated-send rate limits — recipient cooldown + org circuit breaker

### DIFF
--- a/packages/lib/src/messages/__tests__/automated-send-guard.test.ts
+++ b/packages/lib/src/messages/__tests__/automated-send-guard.test.ts
@@ -1,0 +1,134 @@
+// packages/lib/src/messages/__tests__/automated-send-guard.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const store = new Map<string, number>()
+const redis = {
+  incr: vi.fn(async (key: string) => {
+    const next = (store.get(key) ?? 0) + 1
+    store.set(key, next)
+    return next
+  }),
+  pexpire: vi.fn(async () => 1),
+  pttl: vi.fn(async () => 60_000),
+}
+
+vi.mock('@auxx/redis', () => ({
+  getRedisClient: async () => redis,
+}))
+
+const settings = {
+  'email.automation.maxPerRecipientPerHour': 2,
+  'email.automation.maxPerOrgPer15Min': 30,
+} as Record<string, unknown>
+
+vi.mock('../../settings/settings-service', () => ({
+  getOrganizationSetting: vi.fn(async ({ key }: { key: string }) => settings[key]),
+}))
+
+const sendNotification = vi.fn(async () => ({}))
+vi.mock('../../notifications/notification-service', () => ({
+  NotificationService: class {
+    sendNotification = sendNotification
+  },
+}))
+vi.mock('../../cache', () => ({
+  getCachedMembers: vi.fn(async () => [
+    { userId: 'admin-1', role: 'OWNER', status: 'ACTIVE' },
+    { userId: 'admin-2', role: 'ADMIN', status: 'ACTIVE' },
+  ]),
+}))
+
+import { checkAutomatedSendLimits, notifyAdminsOfSendBreakerTrip } from '../automated-send-guard'
+
+beforeEach(() => {
+  store.clear()
+  sendNotification.mockClear()
+  settings['email.automation.maxPerRecipientPerHour'] = 2
+  settings['email.automation.maxPerOrgPer15Min'] = 30
+})
+
+describe('checkAutomatedSendLimits', () => {
+  it('allows sends under both limits', async () => {
+    const result = await checkAutomatedSendLimits({
+      organizationId: 'org-1',
+      recipientEmail: 'a@example.com',
+    })
+    expect(result.allowed).toBe(true)
+  })
+
+  it('blocks the 3rd send to the same recipient within the hour', async () => {
+    await checkAutomatedSendLimits({ organizationId: 'org-1', recipientEmail: 'a@example.com' })
+    await checkAutomatedSendLimits({ organizationId: 'org-1', recipientEmail: 'a@example.com' })
+    const blocked = await checkAutomatedSendLimits({
+      organizationId: 'org-1',
+      recipientEmail: 'a@example.com',
+    })
+    expect(blocked).toMatchObject({ allowed: false, scope: 'recipient', limit: 2, firstTrip: true })
+
+    // Subsequent blocks in the same window are not first trips.
+    const again = await checkAutomatedSendLimits({
+      organizationId: 'org-1',
+      recipientEmail: 'A@Example.com', // case-insensitive key
+    })
+    expect(again).toMatchObject({ allowed: false, scope: 'recipient', firstTrip: false })
+  })
+
+  it('does not count a recipient-blocked send against the org window', async () => {
+    for (let i = 0; i < 3; i++) {
+      await checkAutomatedSendLimits({ organizationId: 'org-1', recipientEmail: 'a@example.com' })
+    }
+    expect(store.get('ratelimit:autosend:org:org-1')).toBe(2)
+  })
+
+  it('trips the org circuit breaker across distinct recipients, notifying only once', async () => {
+    let last: Awaited<ReturnType<typeof checkAutomatedSendLimits>> = { allowed: true }
+    for (let i = 0; i < 31; i++) {
+      last = await checkAutomatedSendLimits({
+        organizationId: 'org-2',
+        recipientEmail: `r${i}@example.com`,
+      })
+    }
+    expect(last).toMatchObject({ allowed: false, scope: 'org', limit: 30, firstTrip: true })
+
+    const next = await checkAutomatedSendLimits({
+      organizationId: 'org-2',
+      recipientEmail: 'r31@example.com',
+    })
+    expect(next).toMatchObject({ allowed: false, scope: 'org', firstTrip: false })
+  })
+
+  it('treats a limit of 0 as disabled', async () => {
+    settings['email.automation.maxPerRecipientPerHour'] = 0
+    settings['email.automation.maxPerOrgPer15Min'] = 0
+    for (let i = 0; i < 50; i++) {
+      const result = await checkAutomatedSendLimits({
+        organizationId: 'org-3',
+        recipientEmail: 'same@example.com',
+      })
+      expect(result.allowed).toBe(true)
+    }
+    expect(store.size).toBe(0)
+  })
+})
+
+describe('notifyAdminsOfSendBreakerTrip', () => {
+  it('sends a notification to every owner/admin', async () => {
+    await notifyAdminsOfSendBreakerTrip({ organizationId: 'org-1', limit: 30 })
+    expect(sendNotification).toHaveBeenCalledTimes(2)
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'SYSTEM_MESSAGE',
+        userId: 'admin-1',
+        organizationId: 'org-1',
+      })
+    )
+  })
+
+  it('never throws when notification delivery fails', async () => {
+    sendNotification.mockRejectedValueOnce(new Error('realtime down'))
+    await expect(
+      notifyAdminsOfSendBreakerTrip({ organizationId: 'org-1', limit: 30 })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/messages/automated-send-guard.ts
+++ b/packages/lib/src/messages/automated-send-guard.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/messages/automated-send-guard.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { getOrganizationSetting } from '../settings/settings-service'
+import { checkFixedWindowLimit } from '../utils/rate-limiter/fixed-window'
+
+const logger = createScopedLogger('automated-send-guard')
+
+/** Per-recipient cooldown window (1 hour). */
+export const RECIPIENT_WINDOW_MS = 60 * 60 * 1000
+/** Org circuit-breaker window (15 minutes). */
+export const ORG_WINDOW_MS = 15 * 60 * 1000
+
+export type AutomatedSendLimitResult =
+  | { allowed: true }
+  | {
+      allowed: false
+      scope: 'recipient' | 'org'
+      limit: number
+      count: number
+      /** True on the first blocked send of an org window — the caller should notify admins. */
+      firstTrip: boolean
+    }
+
+/**
+ * Rate limits for automated email sends (machine-mail plan Phase 3) — the
+ * defense-in-depth layer for whatever machine-mail detection misses. Two fixed
+ * windows, checked in order of value:
+ *
+ * 1. Per-recipient cooldown (default 2/hour) — loops hop threads, so per-thread
+ *    caps miss them; a single address getting hammered is the loop signature.
+ * 2. Org circuit breaker (default 30 automated sends/15 min) — catches fan-out
+ *    loops across many recipients.
+ *
+ * Thresholds are org settings; 0 disables a limit. Fails open when Redis is
+ * unavailable (guardrail, not billing enforcement).
+ */
+export async function checkAutomatedSendLimits(opts: {
+  organizationId: string
+  recipientEmail: string
+}): Promise<AutomatedSendLimitResult> {
+  const { organizationId, recipientEmail } = opts
+
+  const [recipientRaw, orgRaw] = await Promise.all([
+    getOrganizationSetting({ organizationId, key: 'email.automation.maxPerRecipientPerHour' }),
+    getOrganizationSetting({ organizationId, key: 'email.automation.maxPerOrgPer15Min' }),
+  ])
+  const recipientLimit = typeof recipientRaw === 'number' ? recipientRaw : 0
+  const orgLimit = typeof orgRaw === 'number' ? orgRaw : 0
+
+  if (recipientLimit > 0) {
+    const recipient = await checkFixedWindowLimit({
+      key: `ratelimit:autosend:recipient:${organizationId}:${recipientEmail.toLowerCase()}`,
+      limit: recipientLimit,
+      windowMs: RECIPIENT_WINDOW_MS,
+    })
+    if (!recipient.allowed) {
+      logger.warn('Automated send blocked: per-recipient cooldown', {
+        organizationId,
+        recipientEmail,
+        count: recipient.count,
+        limit: recipientLimit,
+      })
+      return {
+        allowed: false,
+        scope: 'recipient',
+        limit: recipientLimit,
+        count: recipient.count,
+        firstTrip: recipient.count === recipientLimit + 1,
+      }
+    }
+  }
+
+  if (orgLimit > 0) {
+    const org = await checkFixedWindowLimit({
+      key: `ratelimit:autosend:org:${organizationId}`,
+      limit: orgLimit,
+      windowMs: ORG_WINDOW_MS,
+    })
+    if (!org.allowed) {
+      logger.warn('Automated send blocked: org circuit breaker', {
+        organizationId,
+        count: org.count,
+        limit: orgLimit,
+      })
+      return {
+        allowed: false,
+        scope: 'org',
+        limit: orgLimit,
+        count: org.count,
+        // INCR makes the count exact: only the first blocked send in the window notifies.
+        firstTrip: org.count === orgLimit + 1,
+      }
+    }
+  }
+
+  return { allowed: true }
+}
+
+/**
+ * Notify org owners/admins that the automated-send circuit breaker tripped.
+ * Best-effort — never throws (the caller is about to throw the ForbiddenError
+ * that actually blocks the send).
+ */
+export async function notifyAdminsOfSendBreakerTrip(opts: {
+  organizationId: string
+  limit: number
+}): Promise<void> {
+  const { organizationId, limit } = opts
+  try {
+    // Lazy imports: notification-service pulls the realtime barrel (vi.mock breaks on it).
+    const [{ getCachedMembers }, { NotificationService }] = await Promise.all([
+      import('../cache'),
+      import('../notifications/notification-service'),
+    ])
+    const admins = await getCachedMembers(organizationId, {
+      status: 'ACTIVE',
+      roles: ['OWNER', 'ADMIN'],
+    })
+    const service = new NotificationService()
+    await Promise.all(
+      admins.map((admin) =>
+        service.sendNotification({
+          type: 'SYSTEM_MESSAGE',
+          userId: admin.userId,
+          entityId: organizationId,
+          entityType: 'Organization',
+          organizationId,
+          message:
+            `Automated email sending paused: more than ${limit} automated emails were sent ` +
+            'in 15 minutes, which usually means a workflow or sequence is misbehaving. ' +
+            'Automated sends are blocked until the rate drops.',
+        })
+      )
+    )
+  } catch (error) {
+    logger.error('Failed to notify admins of send circuit breaker trip', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -23,6 +23,7 @@ import { getOrganizationSetting } from '../settings/settings-service'
 import { instrumentEmailHtml } from '../signals/email/instrument-html'
 import { buildUnsubscribeUrl, issueUnsubscribeToken } from '../signals/unsubscribe'
 import { createUsageGuard } from '../usage/create-usage-guard'
+import { checkAutomatedSendLimits, notifyAdminsOfSendBreakerTrip } from './automated-send-guard'
 import { MessageComposerService } from './message-composer.service'
 import { MessageReconcilerService } from './message-reconciler.service'
 import { ThreadManagerService } from './thread-manager.service'
@@ -187,6 +188,27 @@ export class MessageSenderService {
         if (suppressed) {
           throw new ForbiddenError(
             `Recipient ${emailContext.email} is unsubscribed or bounced; automated send blocked`
+          )
+        }
+        // Rate limits for automated sends (machine-mail plan Phase 3) — per-recipient
+        // cooldown + org circuit breaker. Defense-in-depth behind machine-mail detection.
+        const rateLimit = await checkAutomatedSendLimits({
+          organizationId: input.organizationId,
+          recipientEmail: emailContext.email,
+        })
+        if (!rateLimit.allowed) {
+          if (rateLimit.scope === 'org' && rateLimit.firstTrip) {
+            await notifyAdminsOfSendBreakerTrip({
+              organizationId: input.organizationId,
+              limit: rateLimit.limit,
+            })
+          }
+          throw new ForbiddenError(
+            rateLimit.scope === 'recipient'
+              ? `Automated send to ${emailContext.email} blocked: recipient received ` +
+                  `${rateLimit.limit} automated emails in the last hour (possible loop)`
+              : `Automated send blocked: organization exceeded ${rateLimit.limit} automated ` +
+                  'emails in 15 minutes (circuit breaker tripped, admins notified)'
           )
         }
       }

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -230,6 +230,26 @@ export const SETTINGS_CATALOG = {
       'support threads should not necessarily carry an unsubscribe link). Automated/' +
       'scheduled/sequence sends always include it.',
   },
+  // Automated-send rate limits (machine-mail plan Phase 3) — guardrails against
+  // auto-reply loops. Human sends are never limited.
+  'email.automation.maxPerRecipientPerHour': {
+    scope: 'COMMUNICATION',
+    access: 'org',
+    fieldType: 'NUMBER',
+    defaultValue: 2,
+    description:
+      'Max automated emails to a single recipient per hour (0 disables). Loops hop ' +
+      'threads, so this per-address cooldown is the primary loop breaker.',
+  },
+  'email.automation.maxPerOrgPer15Min': {
+    scope: 'COMMUNICATION',
+    access: 'org',
+    fieldType: 'NUMBER',
+    defaultValue: 30,
+    description:
+      'Circuit breaker: max automated emails across the organization per 15 minutes ' +
+      '(0 disables). Tripping it blocks automated sends and notifies admins.',
+  },
 
   ...sidebarSettings,
 


### PR DESCRIPTION
## Summary

Machine-mail plan **Phase 3** — the defense-in-depth layer for whatever machine-mail detection misses (follows #1214 inbound gates and #1215 outbound RFC 3834 headers). Runs in `MessageSenderService` Step 2.5 right after the suppression check, for automated email sends only (`isAutomatedSend` — Answer node, Kopilot mail tools, sequences); human sends are never limited.

- **Per-recipient cooldown first** (default 2/hour): loops hop threads, so per-thread caps miss them — a single address getting hammered is the loop signature
- **Org circuit breaker second** (default 30 automated sends/15 min): catches fan-out loops across many recipients
- Thresholds are org settings-catalog keys (`email.automation.maxPerRecipientPerHour`, `email.automation.maxPerOrgPer15Min`); `0` disables a limit. No UI (same precedent as `email.unsubscribeOn1to1Replies`)
- A block throws `ForbiddenError`, so the Answer node / sequence fails loudly
- **First blocked send of an org window notifies OWNER/ADMIN members** (`SYSTEM_MESSAGE` bell notification) — exactly once per window, since Redis INCR gives an exact count (`count === limit + 1`)
- Recipient-blocked sends never increment the org counter — one looping address can't trip the org breaker alone
- Uses the existing `checkFixedWindowLimit` (atomic Redis, fails open — guardrail, not billing enforcement)

Resolves the plan's open decision 5 per its recommendation: block + notify, no auto-disable of the workflow app.

## Test plan

- [x] 7 new unit tests (`automated-send-guard.test.ts`): cooldown block + case-insensitive recipient keys, first-trip-only notification semantics, org trip across distinct recipients, recipient-blocked sends not counting toward org window, 0-disables, admin fan-out, notify-never-throws
- [x] Biome clean; `tsc` on packages/lib shows only pre-existing errors in untouched code