### PR TITLE
feat(sequences): suppression list tab on channels settings

### DIFF
--- a/apps/web/src/components/channels/ui/channels-page.tsx
+++ b/apps/web/src/components/channels/ui/channels-page.tsx
@@ -2,13 +2,14 @@
 'use client'
 
 import { FeatureKey } from '@auxx/lib/types'
-import { Button } from '@auxx/ui/components/button'
 import { ListCard } from '@auxx/ui/components/list-card'
-import { Lock, Plus, Waypoints } from 'lucide-react'
-import { useSearchParams } from 'next/navigation'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@auxx/ui/components/tabs'
+import { Lock, Waypoints } from 'lucide-react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useOAuthReturn } from '~/components/apps/hooks/use-oauth-return'
 import { useChannels, useChannelsLoading } from '~/components/channels/hooks/use-channels'
+import { useAdminGate } from '~/components/global/admin-gate'
 import { EmptyState } from '~/components/global/empty-state'
 import SettingsPage, { SettingsSection } from '~/components/global/settings-page'
 import { useInboxes } from '~/components/threads/hooks'
@@ -16,13 +17,16 @@ import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { ChannelCard } from './channel-card'
 import { ChannelGalleryDialog } from './channel-gallery-dialog'
 import { ChannelPlaceholderCard } from './channel-placeholder-card'
+import { SuppressionList } from './suppression-list'
 
 const BREADCRUMBS = [{ title: 'Settings', href: '/app/settings' }, { title: 'Channels' }]
 
 /**
- * Channels settings list page (channels v2). One section, one responsive ListCard grid with a
- * dashed placeholder that opens the gallery. Mounts `useOAuthReturn` so post-redirect connect
- * toasts fire here (the connect `returnTo` target), and opens the gallery on `?connect=1`.
+ * Channels settings page (channels v2): "Channels" tab — one responsive ListCard grid with a
+ * dashed placeholder that opens the gallery — plus an admin-only "Suppressions" tab (org-wide
+ * sequence suppression list; it lives here because all mail-flow config does). Mounts
+ * `useOAuthReturn` so post-redirect connect toasts fire here (the connect `returnTo` target),
+ * and opens the gallery on `?connect=1`.
  */
 export function ChannelsPage() {
   const channels = useChannels()
@@ -30,8 +34,21 @@ export function ChannelsPage() {
   const { inboxes } = useInboxes()
   const { hasAccess, isLoading: isFeatureLoading } = useFeatureFlags()
   const searchParams = useSearchParams()
+  const router = useRouter()
+  const { isAdminOrOwner } = useAdminGate()
 
   const [galleryOpen, setGalleryOpen] = useState(false)
+  const [activeTab, setActiveTab] = useState(() =>
+    searchParams.get('tab') === 'suppressions' ? 'suppressions' : 'channels'
+  )
+  // The Suppressions tab is admin-only (list/remove are adminProcedures) — clamp a
+  // deep link so non-admins never mount a query that would 403.
+  const effectiveTab = isAdminOrOwner ? activeTab : 'channels'
+
+  const handleTabChange = (value: string) => {
+    setActiveTab(value)
+    router.push(`/app/settings/channels?tab=${value}`, { scroll: false })
+  }
 
   // Post-redirect success/error toasts (Gmail/Outlook/social connects return here).
   useOAuthReturn()
@@ -60,48 +77,60 @@ export function ChannelsPage() {
   }
 
   return (
-    <SettingsPage
-      title='Channels'
-      description='Connect email, chat, social, and phone channels.'
-      breadcrumbs={BREADCRUMBS}
-      button={
-        <Button variant='outline' size='sm' onClick={() => setGalleryOpen(true)}>
-          <Plus />
-          Add
-        </Button>
-      }>
-      <div className='p-3 sm:p-6'>
-        <SettingsSection
-          icon={Waypoints}
-          title='Channels'
-          description='Email, chat, social, and phone channels connected to your workspace.'>
-          <div className='@container space-y-2'>
-            {isLoading ? (
-              <div className='grid gap-2 @md:grid-cols-2 @2xl:grid-cols-3'>
-                {[0, 1, 2].map((i) => (
-                  <ListCard key={i} loading descriptionLines={0} />
-                ))}
-              </div>
-            ) : (
-              <>
-                {channels.length > 0 && (
+    <Tabs value={effectiveTab} onValueChange={handleTabChange} className='w-full'>
+      <SettingsPage
+        title='Channels'
+        description='Connect email, chat, social, and phone channels.'
+        breadcrumbs={BREADCRUMBS}
+        button={
+          isAdminOrOwner ? (
+            <TabsList>
+              <TabsTrigger value='channels'>Channels</TabsTrigger>
+              <TabsTrigger value='suppressions'>Suppressions</TabsTrigger>
+            </TabsList>
+          ) : undefined
+        }>
+        <TabsContent value='channels'>
+          <div className='p-3 sm:p-6'>
+            <SettingsSection
+              icon={Waypoints}
+              title='Channels'
+              description='Email, chat, social, and phone channels connected to your workspace.'>
+              <div className='@container space-y-2'>
+                {isLoading ? (
                   <div className='grid gap-2 @md:grid-cols-2 @2xl:grid-cols-3'>
-                    {channels.map((channel) => (
-                      <ChannelCard key={channel.id} channel={channel} inboxes={inboxes} />
+                    {[0, 1, 2].map((i) => (
+                      <ListCard key={i} loading descriptionLines={0} />
                     ))}
                   </div>
+                ) : (
+                  <>
+                    {channels.length > 0 && (
+                      <div className='grid gap-2 @md:grid-cols-2 @2xl:grid-cols-3'>
+                        {channels.map((channel) => (
+                          <ChannelCard key={channel.id} channel={channel} inboxes={inboxes} />
+                        ))}
+                      </div>
+                    )}
+                    {/* Add card sits on its own row below the grid, sized like a single tile. */}
+                    <div className='grid gap-2 @md:grid-cols-2 @2xl:grid-cols-3'>
+                      <ChannelPlaceholderCard onClick={() => setGalleryOpen(true)} />
+                    </div>
+                  </>
                 )}
-                {/* Add card sits on its own row below the grid, sized like a single tile. */}
-                <div className='grid gap-2 @md:grid-cols-2 @2xl:grid-cols-3'>
-                  <ChannelPlaceholderCard onClick={() => setGalleryOpen(true)} />
-                </div>
-              </>
-            )}
+              </div>
+            </SettingsSection>
           </div>
-        </SettingsSection>
-      </div>
+        </TabsContent>
 
-      <ChannelGalleryDialog open={galleryOpen} onOpenChange={setGalleryOpen} />
-    </SettingsPage>
+        <TabsContent value='suppressions'>
+          <div className='p-3 sm:p-6'>
+            <SuppressionList />
+          </div>
+        </TabsContent>
+
+        <ChannelGalleryDialog open={galleryOpen} onOpenChange={setGalleryOpen} />
+      </SettingsPage>
+    </Tabs>
   )
 }

--- a/apps/web/src/components/channels/ui/suppression-list.tsx
+++ b/apps/web/src/components/channels/ui/suppression-list.tsx
@@ -1,0 +1,208 @@
+// apps/web/src/components/channels/ui/suppression-list.tsx
+'use client'
+
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@auxx/ui/components/input-group'
+import { toastError } from '@auxx/ui/components/toast'
+import {
+  TREE_SECONDARY_NOTRUNCATE,
+  TreeRow,
+  TreeRowButton,
+  TreeRowSkeleton,
+} from '@auxx/ui/components/tree-row'
+import { cn } from '@auxx/ui/lib/utils'
+import { formatRelativeTime } from '@auxx/utils'
+import { MailX, Plus, Search, Trash2, UserRound } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useDeferredValue, useState } from 'react'
+import { EmptyState } from '~/components/global/empty-state'
+import { SettingsSection } from '~/components/global/settings-page'
+import { useConfirm } from '~/hooks/use-confirm'
+import { api } from '~/trpc/react'
+
+/** Email-only — suppression matches exact addresses, domains would silently do nothing. */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/**
+ * Org-wide sequence suppression list (Suppressions tab on Channels settings).
+ * Flat TreeRow list of `SequenceSuppression` rows with search, manual add, and
+ * per-row remove (= resubscribe) behind a destructive confirm.
+ */
+export function SuppressionList() {
+  const router = useRouter()
+  const utils = api.useUtils()
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const [search, setSearch] = useState('')
+  const deferredSearch = useDeferredValue(search.trim())
+  const [addValue, setAddValue] = useState('')
+  const [addError, setAddError] = useState('')
+
+  const listQuery = api.suppression.list.useInfiniteQuery(
+    { search: deferredSearch || undefined },
+    { getNextPageParam: (last) => last.nextCursor }
+  )
+  const rows = listQuery.data?.pages.flatMap((page) => page.rows) ?? []
+
+  const addSuppression = api.suppression.add.useMutation({
+    onSuccess: () => {
+      setAddValue('')
+      utils.suppression.list.invalidate()
+    },
+    onError: (error) =>
+      toastError({ title: 'Error suppressing address', description: error.message }),
+  })
+  const removeSuppression = api.suppression.remove.useMutation({
+    onSuccess: () => utils.suppression.list.invalidate(),
+    onError: (error) =>
+      toastError({ title: 'Error removing suppression', description: error.message }),
+  })
+
+  const handleAdd = () => {
+    const normalized = addValue.trim().toLowerCase()
+    if (!normalized) return
+    if (!EMAIL_RE.test(normalized)) {
+      setAddError('Enter a valid email address')
+      return
+    }
+    setAddError('')
+    addSuppression.mutate({ email: normalized })
+  }
+
+  const handleRemove = async (row: { id: string; email: string; reason: string }) => {
+    const confirmed = await confirm({
+      title: `Remove ${row.email}?`,
+      description:
+        row.reason === 'bounce'
+          ? 'This address hard-bounced — future sends may fail. Removing the suppression allows sequences to email it again.'
+          : 'Removing the suppression allows sequences to email this address again.',
+      confirmText: 'Remove',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (confirmed) removeSuppression.mutate({ id: row.id })
+  }
+
+  return (
+    <SettingsSection
+      icon={MailX}
+      title='Suppressed addresses'
+      description='Addresses sequences will never email — collected from unsubscribes, hard bounces, and manual adds. Removing an entry resubscribes the address.'>
+      <div className='space-y-3'>
+        <div className='flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between'>
+          <InputGroup className='sm:max-w-xs'>
+            <InputGroupAddon>
+              <Search />
+            </InputGroupAddon>
+            <InputGroupInput
+              placeholder='Search by email'
+              value={search}
+              onChange={(e) => setSearch((e.target as HTMLInputElement).value)}
+            />
+          </InputGroup>
+          <div className='space-y-1'>
+            <InputGroup className='sm:w-80'>
+              <InputGroupInput
+                placeholder='Suppress an address, e.g. user@example.com'
+                value={addValue}
+                onChange={(e) => {
+                  setAddValue((e.target as HTMLInputElement).value)
+                  setAddError('')
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleAdd()
+                  }
+                }}
+              />
+              <InputGroupAddon align='inline-end'>
+                <InputGroupButton
+                  size='xs'
+                  onClick={handleAdd}
+                  disabled={!addValue.trim() || addSuppression.isPending}>
+                  <Plus />
+                  Add
+                </InputGroupButton>
+              </InputGroupAddon>
+            </InputGroup>
+            {addError && <p className='text-xs text-destructive'>{addError}</p>}
+          </div>
+        </div>
+
+        {listQuery.isLoading ? (
+          <div className='flex flex-col'>
+            {[0, 1, 2].map((i) => (
+              <TreeRowSkeleton key={i} />
+            ))}
+          </div>
+        ) : rows.length === 0 ? (
+          <EmptyState
+            icon={MailX}
+            title={deferredSearch ? 'No matches' : 'No suppressed addresses'}
+            description={
+              deferredSearch
+                ? 'No suppressed addresses match your search.'
+                : 'Unsubscribes and hard bounces will show up here automatically.'
+            }
+          />
+        ) : (
+          <div className={cn('flex flex-col', TREE_SECONDARY_NOTRUNCATE)}>
+            {rows.map((row) => (
+              <TreeRow
+                key={row.id}
+                rowClassName='hover:bg-primary-100'
+                icon={<MailX className='size-4 text-muted-foreground/60' />}
+                title={<span className='font-mono text-sm'>{row.email}</span>}
+                secondary={
+                  <span className='flex items-center gap-1.5'>
+                    <Badge variant='secondary' size='sm'>
+                      {row.reason}
+                    </Badge>
+                    <span className='text-xs text-muted-foreground'>
+                      {formatRelativeTime(row.createdAt, true)}
+                    </span>
+                  </span>
+                }
+                actions={
+                  <>
+                    {row.contactEntityInstanceId && (
+                      <TreeRowButton
+                        tooltipText='View contact'
+                        onClick={() => router.push(`/app/contacts/${row.contactEntityInstanceId}`)}>
+                        <UserRound />
+                      </TreeRowButton>
+                    )}
+                    <TreeRowButton
+                      variant='destructive'
+                      tooltipText='Remove suppression'
+                      onClick={() => void handleRemove(row)}>
+                      <Trash2 />
+                    </TreeRowButton>
+                  </>
+                }
+              />
+            ))}
+            {listQuery.hasNextPage && (
+              <Button
+                variant='ghost'
+                size='xs'
+                className='mt-1 self-center text-muted-foreground'
+                loading={listQuery.isFetchingNextPage}
+                onClick={() => void listQuery.fetchNextPage()}>
+                Load more
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+      <ConfirmDialog />
+    </SettingsSection>
+  )
+}

--- a/apps/web/src/server/api/root.ts
+++ b/apps/web/src/server/api/root.ts
@@ -81,6 +81,7 @@ import { shopifyRouter } from './routers/shopify'
 import { signalRouter } from './routers/signal'
 import { signatureRouter } from './routers/signature'
 import { snippetsRouter } from './routers/snippet'
+import { suppressionRouter } from './routers/suppression'
 import { syncHistoryRouter } from './routers/sync-history'
 import { tableViewRouter } from './routers/tableView'
 import { tagRouter } from './routers/tag'
@@ -177,6 +178,7 @@ export const appRouter = createTRPCRouter({
   signal: signalRouter,
   signature: signatureRouter,
   snippet: snippetsRouter,
+  suppression: suppressionRouter,
   syncHistory: syncHistoryRouter,
   tableView: tableViewRouter,
   tag: tagRouter,

--- a/apps/web/src/server/api/routers/suppression.ts
+++ b/apps/web/src/server/api/routers/suppression.ts
@@ -1,0 +1,50 @@
+// apps/web/src/server/api/routers/suppression.ts
+// Admin surface for the org-wide sequence suppression list (machine-mail Phase 4
+// slice 2 — Suppressions tab on Channels settings). A row blocks all sequence
+// enrollment for that address; removing it resubscribes.
+
+import { deleteSuppression, listSuppressions, upsertSuppression } from '@auxx/lib/sequences'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { adminProcedure, createTRPCRouter } from '~/server/api/trpc'
+
+const PAGE_SIZE = 50
+
+export const suppressionRouter = createTRPCRouter({
+  /** Newest-first page of suppression rows, optional email substring search. */
+  list: adminProcedure
+    .input(z.object({ search: z.string().trim().optional(), cursor: z.string().optional() }))
+    .query(async ({ ctx, input }) => {
+      const rows = await listSuppressions(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        search: input.search || undefined,
+        limit: PAGE_SIZE + 1,
+        before: input.cursor ? new Date(input.cursor) : undefined,
+      })
+      const hasMore = rows.length > PAGE_SIZE
+      const page = hasMore ? rows.slice(0, PAGE_SIZE) : rows
+      const nextCursor = hasMore ? page[page.length - 1]?.createdAt.toISOString() : undefined
+      return { rows: page, nextCursor }
+    }),
+
+  /** Manually suppress an address (reason `manual`). Idempotent. */
+  add: adminProcedure
+    .input(z.object({ email: z.string().trim().toLowerCase().email() }))
+    .mutation(async ({ ctx, input }) => {
+      await upsertSuppression(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        email: input.email,
+        reason: 'manual',
+      })
+    }),
+
+  /** Remove a suppression row (= resubscribe the address). */
+  remove: adminProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const removed = await deleteSuppression(ctx.db, ctx.session.organizationId, input.id)
+      if (!removed) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Suppression not found' })
+      }
+    }),
+})

--- a/packages/lib/src/sequences/index.ts
+++ b/packages/lib/src/sequences/index.ts
@@ -90,9 +90,19 @@ export type {
 // Subject enrollment internals (client-notifications plan §4.3) — shared by the event-trigger
 // hooks + the hourly enrollment sweep
 export { enrollSubjectInSequence } from './subject-enroll'
-export type { UpsertSuppressionInput } from './suppression'
+export type {
+  ListSuppressionsInput,
+  SequenceSuppressionRow,
+  UpsertSuppressionInput,
+} from './suppression'
 // Suppression
-export { isSuppressed, normalizeEmail, upsertSuppression } from './suppression'
+export {
+  deleteSuppression,
+  isSuppressed,
+  listSuppressions,
+  normalizeEmail,
+  upsertSuppression,
+} from './suppression'
 // Hourly enrollment sweep (client-notifications plan §4.3, decision #13)
 export { computeSweepLookaheadDays, runSequenceEnrollmentSweep } from './sweep'
 // Per-org enabled-trigger lookup (client-notifications plan §4.3/§7 open question #3)

--- a/packages/lib/src/sequences/suppression.ts
+++ b/packages/lib/src/sequences/suppression.ts
@@ -4,7 +4,9 @@
 // the org regardless of which sequence originally triggered it.
 
 import { type Database, schema } from '@auxx/database'
-import { and, eq } from 'drizzle-orm'
+import { and, desc, eq, ilike, lt } from 'drizzle-orm'
+
+export type SequenceSuppressionRow = typeof schema.SequenceSuppression.$inferSelect
 
 /** Lowercase + trim — the normalization applied before every suppression read/write. */
 export function normalizeEmail(email: string): string {
@@ -25,6 +27,56 @@ export async function isSuppressed(
     columns: { id: true },
   })
   return !!row
+}
+
+export interface ListSuppressionsInput {
+  organizationId: string
+  /** Case-insensitive substring match on the email. */
+  search?: string
+  limit: number
+  /** Cursor — only rows created strictly before this instant. */
+  before?: Date
+}
+
+/** Newest-first page of the org's suppression rows (Suppressions settings tab). */
+export async function listSuppressions(
+  db: Database,
+  input: ListSuppressionsInput
+): Promise<SequenceSuppressionRow[]> {
+  const search = input.search
+    ?.trim()
+    .toLowerCase()
+    .replace(/[%_\\]/g, '\\$&')
+  return db.query.SequenceSuppression.findMany({
+    where: and(
+      eq(schema.SequenceSuppression.organizationId, input.organizationId),
+      search ? ilike(schema.SequenceSuppression.email, `%${search}%`) : undefined,
+      input.before ? lt(schema.SequenceSuppression.createdAt, input.before) : undefined
+    ),
+    orderBy: desc(schema.SequenceSuppression.createdAt),
+    limit: input.limit,
+  })
+}
+
+/**
+ * Delete a suppression row (= resubscribe the address). Returns false when the
+ * row doesn't exist in this org.
+ */
+export async function deleteSuppression(
+  db: Database,
+  organizationId: string,
+  id: string
+): Promise<boolean> {
+  const deleted = await db
+    .delete(schema.SequenceSuppression)
+    .where(
+      and(
+        eq(schema.SequenceSuppression.organizationId, organizationId),
+        eq(schema.SequenceSuppression.id, id)
+      )
+    )
+    .returning({ id: schema.SequenceSuppression.id })
+  return deleted.length > 0
 }
 
 export interface UpsertSuppressionInput {


### PR DESCRIPTION
## Summary

Machine-mail phase 4 slice 2 — admins can now see and undo sequence suppressions. Today suppressed addresses are only visible as a per-message badge / per-contact timeline entry, and daemon addresses with no contact are invisible ("why aren't they getting our emails").

- **`suppression` tRPC router** (`list`/`add`/`remove`, all `adminProcedure`), backed by new `listSuppressions` (cursor-paginated newest-first, case-insensitive email search with LIKE escaping) and `deleteSuppression` (org-scoped) in `@auxx/lib/sequences` beside the existing `isSuppressed`/`upsertSuppression`.
- **`SuppressionList` component**: flat `TreeRow` rows — mono email, reason badge (`unsubscribe|manual|bounce`) + relative time, contact-link + destructive remove actions. Remove goes through `useConfirm` with extra hard-bounce warning copy on `bounce` rows. Manual add is email-only (suppression has no domain matching). `EmptyState`, skeleton loading, load-more.
- **Channels settings grows tabs**: Channels / Suppressions `TabsList` in the `SettingsPage` header, synced to `?tab=`. Tabs only render for admins; non-admin deep links to `?tab=suppressions` are clamped so the admin-only query never mounts. The header Add button is dropped so the tabs don't shift between tabs — the connect flow lives on the "Add a channel" placeholder card (and `?connect=1` still opens the gallery).

No schema changes; the list is org-wide data (`SequenceSuppression`) living under Channels navigationally.

## Test plan

- [x] typecheck clean for touched files (`packages/lib`, `apps/web`)
- [x] drove the flow in the browser: deep link opens the tab, empty state renders, manual add shows the row (`manual` badge + timestamp, input clears), remove confirm dialog shows resubscribe copy, removal returns to empty state, no console errors
- [x] Channels tab grid + placeholder card + gallery unaffected