### PR TITLE
feat(sequences): block deleting seeded template sequences

### DIFF
--- a/apps/web/src/components/sequences/ui/list/sequence-card.tsx
+++ b/apps/web/src/components/sequences/ui/list/sequence-card.tsx
@@ -19,6 +19,7 @@ export interface SequenceCardData {
   status: SequenceStatus
   publishedAt: Date | string | null
   hasUnpublishedChanges: boolean
+  templateKey: string | null
   createdAt: Date | string
   updatedAt: Date | string
 }
@@ -88,10 +89,12 @@ export function SequenceCard({ sequence, onDelete }: SequenceCardProps) {
               <FileText />
               Open
             </DropdownMenuItem>
-            <DropdownMenuItem variant='destructive' onClick={wrap(() => void handleDelete())}>
-              <Trash2 />
-              Delete
-            </DropdownMenuItem>
+            {!sequence.templateKey && (
+              <DropdownMenuItem variant='destructive' onClick={wrap(() => void handleDelete())}>
+                <Trash2 />
+                Delete
+              </DropdownMenuItem>
+            )}
           </>
         }
       />

--- a/packages/lib/src/sequences/crud.ts
+++ b/packages/lib/src/sequences/crud.ts
@@ -12,7 +12,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { generateId } from '@auxx/utils'
 import { and, count, eq } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
-import { ConflictError, NotFoundError } from '../errors'
+import { ConflictError, ForbiddenError, NotFoundError } from '../errors'
 import { grantSequenceCreatorAccess } from './access'
 import { exitActiveRunsForSequence } from './runtime'
 import type { CreateSequenceInput, SequenceEntity, UpdateSequenceFields } from './types'
@@ -209,8 +209,10 @@ export async function getSequence(
 }
 
 /**
- * Delete a sequence and everything under it. Forbidden while any run is
- * still active (in-flight enrollments must exit/complete first). Deleting
+ * Delete a sequence and everything under it. Forbidden for seeded template
+ * sequences (`templateKey` set — they're only ever created at org seed, so a
+ * delete is permanent) and while any run is still active (in-flight
+ * enrollments must exit/complete first). Deleting
  * the hidden `WorkflowApp` cascades onto its `Workflow` row (FK) AND onto the
  * `Sequence` row itself (`Sequence.workflowAppId` FK is `onDelete: 'cascade'`),
  * which in turn cascades onto `SequenceStep`/`SequenceRun` — one delete call
@@ -228,6 +230,12 @@ export async function deleteSequence(
     ),
   })
   if (!sequence) return err(new NotFoundError('Sequence not found'))
+
+  if (sequence.templateKey) {
+    return err(
+      new ForbiddenError("Built-in notification sequences can't be deleted — disable them instead")
+    )
+  }
 
   const [{ activeCount }] = await db
     .select({ activeCount: count() })


### PR DESCRIPTION
## Summary
- `deleteSequence` now returns a `ForbiddenError` for sequences with a `templateKey` — the 5 seeded client-notification sequences are only ever created at org seed (idempotent on `(organizationId, templateKey)`), so deleting one was permanent and left the future client-notifications settings page with nothing to toggle
- hide the Delete item in the sequences-list card dropdown for seeded sequences (the settings drawer already hid its delete button via `isSeededTrigger`)

## Notes
- `sequence.list` already returns `templateKey` (full row spread); only the `SequenceCardData` interface needed the field added