### PR TITLE
fix(database): inline usersetting rekey backfill + web 8-core docker runner

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -48,7 +48,10 @@ concurrency:
 jobs:
   build-and-publish:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    # web compiles most of the monorepo through Turbopack — it alone gets a paid
+    # 8-core larger runner (billed even on public repos); everything else stays on
+    # the free standard runner. See plans/docker/web-image-build-speed.md.
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -56,6 +59,7 @@ jobs:
           - name: web
             file: apps/web/Dockerfile
             image: ghcr.io/auxx-ai/web
+            runner: ubuntu-8-core
           - name: api
             file: apps/api/Dockerfile
             image: ghcr.io/auxx-ai/api

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,9 @@ jobs:
     name: Docker ${{ matrix.name }}
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
+    # web alone gets the paid 8-core larger runner; see
+    # plans/docker/web-image-build-speed.md.
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -37,6 +39,7 @@ jobs:
           - name: web
             file: apps/web/Dockerfile
             image: ghcr.io/auxx-ai/web
+            runner: ubuntu-8-core
           - name: api
             file: apps/api/Dockerfile
             image: ghcr.io/auxx-ai/api

--- a/packages/database/drizzle/0273_settings_v2_rekey_drop_legacy_fk.sql
+++ b/packages/database/drizzle/0273_settings_v2_rekey_drop_legacy_fk.sql
@@ -2,6 +2,18 @@ ALTER TABLE "UserSetting" DROP CONSTRAINT "UserSetting_organizationSettingId_Org
 --> statement-breakpoint
 DROP INDEX "UserSetting_organizationSettingId_idx";--> statement-breakpoint
 DROP INDEX "UserSetting_userId_organizationSettingId_key";--> statement-breakpoint
+-- Inline backfill: data migration 035 (runtime) normally fills these columns between
+-- 0272 and 0273, but a deploy that applies both files in one batch never runs it.
+-- Backfill from the parent OrganizationSetting via the legacy FK column (still
+-- present until the end of this file), then drop rows that cannot be rekeyed —
+-- they are unrepresentable in the new model.
+UPDATE "UserSetting" us
+SET "organizationId" = os."organizationId",
+    "key" = os."key"
+FROM "OrganizationSetting" os
+WHERE us."organizationSettingId" = os."id"
+  AND (us."organizationId" IS NULL OR us."key" IS NULL);--> statement-breakpoint
+DELETE FROM "UserSetting" WHERE "organizationId" IS NULL OR "key" IS NULL;--> statement-breakpoint
 ALTER TABLE "UserSetting" ALTER COLUMN "organizationId" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "UserSetting" ALTER COLUMN "key" SET NOT NULL;--> statement-breakpoint
 CREATE UNIQUE INDEX "UserSetting_userId_organizationId_key_key" ON "UserSetting" USING btree ("userId","organizationId","key");--> statement-breakpoint


### PR DESCRIPTION
## What

Two changes to unblock and speed up releases:

### 1. Migration 0273 — inline `UserSetting` rekey backfill (unblocks the failed Railway deploy)

The 0.1.184 Railway deploy failed in pre-deploy migration: `ALTER TABLE "UserSetting" ALTER COLUMN "organizationId" SET NOT NULL` hit rows with NULL `organizationId` (Postgres 23502).

Root cause: 0272/0273 were designed as a phased rekey with **runtime** data migration 035 backfilling the new columns between them. Prod jumped several releases, so both schema migrations ran in one pre-deploy batch and the backfill never happened. Any self-hosted install skipping versions would hit the same wall.

Fix: 0273 now backfills inline from `OrganizationSetting` via the legacy `organizationSettingId` FK column (still present at that point in the file) and deletes unrekeyable rows before enforcing NOT NULL.

- Verified by replicating the failing state (NULL rows + orphan row) in a scratch schema and running the edited file end-to-end with `ON_ERROR_STOP`.
- Safe for already-migrated DBs: drizzle doesn't re-run applied files; the failed prod attempt rolled back cleanly.
- Data migration 035 stays registered and is idempotent (finds nothing to do).

### 2. CI — web docker job on an 8-core larger runner

Web compiles most of the monorepo through Turbopack (~5–6 min of the job). Only the `web` matrix entry moves to the paid `ubuntu-8-core` runner (~$0.11/build); all other images stay on free standard runners via `runs-on: ${{ matrix.runner || 'ubuntu-latest' }}`.

The runner is already provisioned org-side (8-core/32GB, max 3 concurrent) and the default runner group now allows public repositories — without that, jobs would queue forever on a public repo.