### PR TITLE
fix: google oauth scopes, oauth popup lifecycle, ci build tuning, per-page canonicals

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -48,10 +48,10 @@ concurrency:
 jobs:
   build-and-publish:
     name: ${{ matrix.name }}
-    # web compiles most of the monorepo through Turbopack — it alone gets a paid
-    # 8-core larger runner (billed even on public repos); everything else stays on
-    # the free standard runner. See plans/docker/web-image-build-speed.md.
-    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
+    # PR builds are async can-it-build checks — everything stays on free standard
+    # runners here. Only the release build (release-please.yml) pays for the
+    # 16-core runner on web. See plans/docker/web-image-build-speed.md.
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +59,6 @@ jobs:
           - name: web
             file: apps/web/Dockerfile
             image: ghcr.io/auxx-ai/web
-            runner: ubuntu-8-core
           - name: api
             file: apps/api/Dockerfile
             image: ghcr.io/auxx-ai/api
@@ -169,7 +168,6 @@ jobs:
           context: .
           file: ${{ matrix.file }}
           platforms: linux/amd64
-          pull: true
           push: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -179,5 +177,8 @@ jobs:
             BUILD_TIME=${{ steps.build_time.outputs.build_time }}
             POSTHOG_KEY=${{ vars.POSTHOG_KEY }}
             POSTHOG_HOST=${{ vars.POSTHOG_HOST }}
+          # mode=min caches only final-stage layers — the mode=max multi-GB
+          # buildcache push was the job's network tail; the Next compile was
+          # never cacheable anyway. See plans/docker/web-image-build-speed.md.
           cache-from: type=registry,ref=${{ matrix.image }}:buildcache
-          cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
+          cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=min

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
     name: Docker ${{ matrix.name }}
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    # web alone gets the paid 8-core larger runner; see
+    # web alone gets the paid 16-core larger runner; see
     # plans/docker/web-image-build-speed.md.
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     strategy:
@@ -39,7 +39,7 @@ jobs:
           - name: web
             file: apps/web/Dockerfile
             image: ghcr.io/auxx-ai/web
-            runner: ubuntu-8-core
+            runner: ubuntu-16-core
           - name: api
             file: apps/api/Dockerfile
             image: ghcr.io/auxx-ai/api
@@ -94,7 +94,6 @@ jobs:
           context: .
           file: ${{ matrix.file }}
           platforms: linux/amd64
-          pull: true
           push: true
           tags: |
             ${{ matrix.image }}:latest
@@ -106,8 +105,11 @@ jobs:
             BUILD_TIME=${{ steps.build_time.outputs.build_time }}
             POSTHOG_KEY=${{ vars.POSTHOG_KEY }}
             POSTHOG_HOST=${{ vars.POSTHOG_HOST }}
+          # mode=min caches only final-stage layers — the mode=max multi-GB
+          # buildcache push was the job's network tail; the Next compile was
+          # never cacheable anyway. See plans/docker/web-image-build-speed.md.
           cache-from: type=registry,ref=${{ matrix.image }}:buildcache
-          cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
+          cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=min
 
   sst-platform-deploy:
     needs: release-please

--- a/apps/docs/src/app/(docs)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(docs)/[[...slug]]/page.tsx
@@ -46,5 +46,6 @@ export async function generateMetadata(props: { params: Promise<{ slug?: string[
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: { canonical: page.url },
   }
 }

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -58,9 +58,6 @@ export const metadata: Metadata = {
       'Documentation, guides, and API reference for Auxx.ai — AI-powered email support for Shopify businesses',
     creator: '@auxxlift',
   },
-  alternates: {
-    canonical: 'https://docs.auxx.ai',
-  },
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/homepage/src/app/blog/category/[slug]/page.tsx
+++ b/apps/homepage/src/app/blog/category/[slug]/page.tsx
@@ -30,6 +30,7 @@ export async function generateMetadata({
   return {
     title: `${category.title} | Blog | ${config.shortName}`,
     description: `Browse ${category.title} articles on the ${config.shortName} blog.`,
+    alternates: { canonical: `/blog/category/${slug}` },
   }
 }
 

--- a/apps/homepage/src/app/blog/page.tsx
+++ b/apps/homepage/src/app/blog/page.tsx
@@ -10,6 +10,7 @@ import { BlogListWithPagination } from './_components/blog-list-with-pagination'
 export const revalidate = 3600
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/blog' },
   title: `Blog | ${config.shortName}`,
   description:
     'Insights on AI-powered customer support, e-commerce automation, and growing your Shopify business.',

--- a/apps/homepage/src/app/company/page.tsx
+++ b/apps/homepage/src/app/company/page.tsx
@@ -7,6 +7,7 @@ import { ImageIllustration } from '../_components/sections/image-illustration'
 import HowCanWeHelp from './_components/how-can-we-help'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/company' },
   title: `About ${config.shortName} | AI Customer Support Innovators`,
   description: `${config.shortName} helps CX leaders automate support with AI-driven workflows, deep Shopify alignment, and a human-approved customer experience team focused on faster resolutions.`,
 }

--- a/apps/homepage/src/app/faq/page.tsx
+++ b/apps/homepage/src/app/faq/page.tsx
@@ -60,6 +60,7 @@ const faqs: FaqItem[] = [
 ]
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/faq' },
   title: `Frequently Asked Questions | ${config.shortName}`,
   description:
     'Find answers to common questions about Auxx.ai, the open-source AI-powered customer support platform for Shopify. Learn about pricing, integrations, self-hosting, and more.',

--- a/apps/homepage/src/app/imprint/page.tsx
+++ b/apps/homepage/src/app/imprint/page.tsx
@@ -7,6 +7,7 @@ import Header from '../_components/main/header'
 
 // metadata configures the imprint page title and description for search engines and social previews.
 export const metadata: Metadata = {
+  alternates: { canonical: '/imprint' },
   title: `Imprint | ${config.shortName}`,
   description: `${config.shortName} legal disclosure outlining company details, contact information, and statutory notices in accordance with § 5 TMG.`,
 }

--- a/apps/homepage/src/app/layout.tsx
+++ b/apps/homepage/src/app/layout.tsx
@@ -68,9 +68,6 @@ export const metadata: Metadata = {
     creator: '@auxxlift',
   },
   manifest: '/site.webmanifest',
-  alternates: {
-    canonical: config.urls.homepage,
-  },
 }
 
 function OrganizationJsonLd() {

--- a/apps/homepage/src/app/page.tsx
+++ b/apps/homepage/src/app/page.tsx
@@ -20,6 +20,7 @@ import BuildDashboardsSection from './platform/reporting/_components/build-dashb
 import WorkflowContent from './platform/workflow/_components/workflow-content'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/' },
   title: `AI Customer Support Platform | ${config.shortName}`,
   description: `Scale delightful support with ${config.shortName}'s AI-powered inbox, instant Shopify insights, and automated workflows that convert every customer interaction into revenue.`,
 }

--- a/apps/homepage/src/app/platform/ai/kopilot/page.tsx
+++ b/apps/homepage/src/app/platform/ai/kopilot/page.tsx
@@ -14,6 +14,7 @@ import KopilotPromptLibrary from './_components/kopilot-prompt-library'
 import KopilotTestimonial from './_components/kopilot-testimonial'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/ai/kopilot' },
   title: `Kopilot — Workspace AI | ${config.shortName}`,
   description: `${config.shortName} Kopilot searches, updates, and creates across mail, contacts, tickets, and knowledge. Grounded in your data and powered by your own model.`,
 }

--- a/apps/homepage/src/app/platform/crm/page.tsx
+++ b/apps/homepage/src/app/platform/crm/page.tsx
@@ -11,6 +11,7 @@ import CustomerProfilesSection from './_components/customer-profiles-section'
 import HowItWorksSection from './_components/how-it-works-section'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/crm' },
   title: `AI-Powered CRM | ${config.shortName}`,
   description: `Centralize customer history, automate follow-ups, and surface revenue opportunities with ${config.shortName}'s CRM built for modern support teams.`,
 }

--- a/apps/homepage/src/app/platform/data-model/page.tsx
+++ b/apps/homepage/src/app/platform/data-model/page.tsx
@@ -14,6 +14,7 @@ import KbEditorSection from './_components/kb-editor-section'
 import KnowledgeBaseSection from './_components/knowledge-base-section'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/data-model' },
   title: `Data Model — Knowledge Base & Datasets | ${config.shortName}`,
   description: `Author articles in the ${config.shortName} knowledge base or upload your own PDFs and docs as datasets. Both feed Kopilot and AI replies with grounded, cited answers.`,
 }

--- a/apps/homepage/src/app/platform/integration/page.tsx
+++ b/apps/homepage/src/app/platform/integration/page.tsx
@@ -10,6 +10,7 @@ import IntegrationHero from './_components/integration-hero'
 import MarketplaceSection from './_components/marketplace-section'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/integration' },
   title: `Integrations & API | ${config.shortName}`,
   description: `Connect ${config.shortName} with Shopify, email, and internal tools using prebuilt connectors and a flexible API to automate customer operations end-to-end.`,
 }

--- a/apps/homepage/src/app/platform/knowledge-base/page.tsx
+++ b/apps/homepage/src/app/platform/knowledge-base/page.tsx
@@ -9,6 +9,7 @@ import KBHero from './_components/kb-hero'
 import PublishArticle from './_components/publish-article'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/knowledge-base' },
   title: `Knowledge Base Builder | ${config.shortName}`,
   description: `Launch self-service libraries with ${config.shortName}, repurpose support answers into SEO-ready articles, and keep help content synced automatically.`,
 }

--- a/apps/homepage/src/app/platform/live-chat/page.tsx
+++ b/apps/homepage/src/app/platform/live-chat/page.tsx
@@ -9,6 +9,7 @@ import LiveChatFeature from './_components/live-chat-feature'
 import LiveChatHero from './_components/live-chat-hero'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/live-chat' },
   title: `Live Chat Suite | ${config.shortName}`,
   description: `${config.shortName} delivers real-time live chat, AI suggestions, and proactive prompts that convert browsing shoppers into loyal customers.`,
 }

--- a/apps/homepage/src/app/platform/manufacturing/page.tsx
+++ b/apps/homepage/src/app/platform/manufacturing/page.tsx
@@ -8,6 +8,7 @@ import ManufacturingFeature from './_components/manufacturing-feature'
 import ManufacturingHero from './_components/manufacturing-hero'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/manufacturing' },
   title: `Manufacturing Support | ${config.shortName}`,
   description: `${config.shortName} helps manufacturing teams coordinate parts requests, warranty claims, and dealer communications with AI-powered workflows.`,
 }

--- a/apps/homepage/src/app/platform/messaging/page.tsx
+++ b/apps/homepage/src/app/platform/messaging/page.tsx
@@ -12,6 +12,7 @@ import NoMissedMessages from './_components/no-missed-messages'
 import ProviderIntegrationsSection from './_components/provider-integration'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/messaging' },
   title: `Omnichannel Messaging | ${config.shortName}`,
   description: `Unify email, chat, SMS, and social messages with ${config.shortName}'s AI-driven routing to ensure no customer inquiry slips through the cracks.`,
 }

--- a/apps/homepage/src/app/platform/page.tsx
+++ b/apps/homepage/src/app/platform/page.tsx
@@ -14,6 +14,7 @@ import { IntegrationsAndApiSection } from './_components/integrations-and-api-se
 import { TestimonialsAndProofSection } from './_components/testimonials-and-proof-section'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform' },
   title: `Platform Overview | ${config.shortName}`,
   description: `Explore ${config.shortName}'s AI platform—shared inbox, automation builder, and analytics that help ecommerce teams deliver five-star support at scale.`,
 }

--- a/apps/homepage/src/app/platform/reporting/page.tsx
+++ b/apps/homepage/src/app/platform/reporting/page.tsx
@@ -15,6 +15,7 @@ import ReportingFinalCta from './_components/reporting-final-cta'
 import ReportingHero from './_components/reporting-hero'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/reporting' },
   title: `Reporting & Dashboards | ${config.shortName}`,
   description: `Build live dashboards over every ticket, contact, and conversation. ${config.shortName} turns your support and CRM data into charts, KPIs, and shareable reports.`,
 }

--- a/apps/homepage/src/app/platform/ticketing/page.tsx
+++ b/apps/homepage/src/app/platform/ticketing/page.tsx
@@ -10,6 +10,7 @@ import TicketingFeature from './_components/ticketing-feature'
 import TicketingHero from './_components/ticketing-hero'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/ticketing' },
   title: `Ticketing System | ${config.shortName}`,
   description: `Route, prioritize, and resolve high-volume tickets with ${config.shortName}'s AI-suggested replies, automations, and real-time Shopify context.`,
 }

--- a/apps/homepage/src/app/platform/workflow/page.tsx
+++ b/apps/homepage/src/app/platform/workflow/page.tsx
@@ -11,6 +11,7 @@ import WorkflowContent from './_components/workflow-content'
 import WorkflowHero from './_components/workflow-hero'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/platform/workflow' },
   title: `Workflow Automation | ${config.shortName}`,
   description: `Build drag-and-drop automations with ${config.shortName} to triage tickets, trigger order actions, and scale customer support without sacrificing quality.`,
 }

--- a/apps/homepage/src/app/pricing/page.tsx
+++ b/apps/homepage/src/app/pricing/page.tsx
@@ -9,6 +9,7 @@ import PlansSection from '../_components/sections/plans-section'
 import PricingSection from '../_components/sections/pricing-section'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/pricing' },
   title: `Pricing | ${config.shortName}`,
   description: `Choose a ${config.shortName} plan that scales with your support volume, from AI-assisted agents to fully automated Shopify customer care with transparent ROI benchmarks.`,
 }

--- a/apps/homepage/src/app/privacy-policy/page.tsx
+++ b/apps/homepage/src/app/privacy-policy/page.tsx
@@ -6,6 +6,7 @@ import FooterSection from '../_components/main/footer-section'
 import Header from '../_components/main/header'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/privacy-policy' },
   title: `Privacy Policy | ${config.shortName}`,
   description: `Understand how ${config.shortName} protects customer data, email content, and Shopify information with enterprise-grade security and compliance.`,
 }

--- a/apps/homepage/src/app/solutions/customer-support-teams/page.tsx
+++ b/apps/homepage/src/app/solutions/customer-support-teams/page.tsx
@@ -13,6 +13,7 @@ import ShopifyHero from './_components/support-hero'
 import TestimonialsSection from './_components/testimonials'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/solutions/customer-support-teams' },
   title: `Customer Support Teams | ${config.shortName}`,
   description: `Empower customer support teams with ${config.shortName}'s AI workflows, unified inbox, and Shopify automations that shrink resolution times and lift CSAT scores.`,
 }

--- a/apps/homepage/src/app/solutions/customers/page.tsx
+++ b/apps/homepage/src/app/solutions/customers/page.tsx
@@ -7,6 +7,7 @@ import TestimonialsSection from '../../_components/sections/testimonials-section
 import { BreadcrumbJsonLd } from '../../_components/seo/breadcrumb-json-ld'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/solutions/customers' },
   title: `Customer Stories | ${config.shortName}`,
   description: `See how growth-minded brands use ${config.shortName} to automate customer conversations, drive retention, and deliver premium experiences across every channel.`,
 }

--- a/apps/homepage/src/app/solutions/shopify-stores/page.tsx
+++ b/apps/homepage/src/app/solutions/shopify-stores/page.tsx
@@ -13,6 +13,7 @@ import ShopifyHero from './_components/shopify-hero'
 import TestimonialsSection from './_components/testimonials'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/solutions/shopify-stores' },
   title: `Shopify Store Support | ${config.shortName}`,
   description: `${config.shortName} connects directly to Shopify to resolve tickets, automate refunds, and deliver upsell-ready responses that turn support into a profit center.`,
 }

--- a/apps/homepage/src/app/solutions/small-business/page.tsx
+++ b/apps/homepage/src/app/solutions/small-business/page.tsx
@@ -14,6 +14,7 @@ import SmallBusinessHero from './_components/small-business-hero'
 import TestimonialsSection from './_components/testimonials'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/solutions/small-business' },
   title: `Small Business Automation | ${config.shortName}`,
   description: `${config.shortName} equips lean teams with AI-powered support, proactive Shopify insights, and automation that keeps response times fast without growing headcount.`,
 }

--- a/apps/homepage/src/app/startups/page.tsx
+++ b/apps/homepage/src/app/startups/page.tsx
@@ -11,6 +11,7 @@ import StartupHero from './_components/startup-hero'
 import StartupsFaq from './_components/startups-faq'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/startups' },
   title: `Startup Program | ${config.shortName}`,
   description: `Early-stage teams get up to 90% off the ${config.shortName} platform fee — a founder-friendly discount that steps down as you grow. CRM and helpdesk in one, from day one.`,
 }

--- a/apps/homepage/src/app/terms-of-service/page.tsx
+++ b/apps/homepage/src/app/terms-of-service/page.tsx
@@ -6,6 +6,7 @@ import FooterSection from '../_components/main/footer-section'
 import Header from '../_components/main/header'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/terms-of-service' },
   title: `Terms of Service | ${config.shortName}`,
   description: `Review the ${config.shortName} Terms of Service covering subscriptions, AI-generated output, acceptable use, liability, and dispute resolution.`,
 }

--- a/apps/homepage/src/app/what-is-auxx-ai/page.tsx
+++ b/apps/homepage/src/app/what-is-auxx-ai/page.tsx
@@ -7,6 +7,7 @@ import FooterSection from '../_components/main/footer-section'
 import Header from '../_components/main/header'
 
 export const metadata: Metadata = {
+  alternates: { canonical: '/what-is-auxx-ai' },
   title: `What is Auxx.ai? | ${config.shortName}`,
   description: `${config.shortName} is an open-source, AI-powered customer support platform built for Shopify businesses. It connects email, live chat, and Shopify data to automate ticket resolution and streamline support workflows.`,
 }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -37,6 +37,12 @@ const nextConfig = {
   ],
   experimental: {
     turbopackFileSystemCacheForDev: true,
+    // Persists Turbopack's incremental state in .next/cache across production
+    // builds. Only pays off where .next/cache survives between builds (local
+    // builds today; CI needs a persistent-disk builder, e.g. Depot — see
+    // plans/docker/web-image-build-speed.md). Hosted CI runners start empty,
+    // so there it just writes an unused cache.
+    turbopackFileSystemCacheForBuild: true,
     webpackMemoryOptimizations: true,
   },
   poweredByHeader: false,

--- a/apps/web/src/components/apps/hooks/use-connect-flow.tsx
+++ b/apps/web/src/components/apps/hooks/use-connect-flow.tsx
@@ -88,6 +88,13 @@ export interface ConnectFlowArgs {
    * `personal=1`, read by the authorize route's `supportsPersonalChannelConnection` gate.
    */
   personal?: boolean
+  /**
+   * Custom authoritative verify for the OAuth popup (see `useOAuthPopup`), replacing the default
+   * connection-list snapshot verify. Required when the credential isn't visible in
+   * `connections.list` / `apps.listConnections` — e.g. channel credentials, which only the
+   * `channelReauth` router can observe — where the default verify polls `null` forever.
+   */
+  verify?: () => Promise<string | boolean | null>
 }
 
 export interface UseConnectFlow {
@@ -266,7 +273,7 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
         popupUrl: `${baseUrl}?${popupParams}`,
         fallbackUrl,
         channelName: 'oauth-app-connect',
-        verify: buildConnectionVerify(utils, a),
+        verify: a.verify ?? buildConnectionVerify(utils, a),
         onDone: (ok, credId) => {
           invalidateForOwner(owner)
           setArgs(null)

--- a/apps/web/src/components/channels/hooks/use-channel-reconnect.ts
+++ b/apps/web/src/components/channels/hooks/use-channel-reconnect.ts
@@ -62,6 +62,23 @@ export function useChannelReconnect() {
 
         integrationByCredential.current.set(status.credentialId, integrationId)
 
+        // Channel credentials never appear in `connections.list`, so `useConnectFlow`'s default
+        // snapshot verify can't observe this reconnect (it polls null forever — which used to let
+        // the popup's cancel heuristic win and kill the window mid-login). Poll the channel's own
+        // auth status instead: a successful OAuth callback clears `requiresReauth`. Only usable
+        // when the flag is set going in — otherwise there is no flip to observe and the popup's
+        // message channel is the sole settle signal.
+        const credentialId = status.credentialId
+        const verify = status.requiresReauth
+          ? async () => {
+              const fresh = await utils.channelReauth.getAuthStatus.fetch(
+                { integrationId },
+                { staleTime: 0 }
+              )
+              return fresh.requiresReauth ? null : credentialId
+            }
+          : undefined
+
         const def: ConnectFlowDefinition = { connectionType: 'oauth2-code' }
         flow.start({
           target: {
@@ -79,6 +96,7 @@ export function useChannelReconnect() {
           scope: 'organization',
           connectionId: status.credentialId,
           returnTo: RETURN_TO,
+          verify,
         })
       } catch (error) {
         toastError({

--- a/apps/web/src/hooks/use-oauth-popup.ts
+++ b/apps/web/src/hooks/use-oauth-popup.ts
@@ -97,11 +97,28 @@ export function useOAuthPopup() {
 
       let settled = false
 
-      /** Settle exactly once: a toast only on explicit failure (not on cancel/timeout). */
-      const finish = (ok: boolean, credId?: string | null, error?: string | null) => {
+      /**
+       * Settle exactly once: a toast only on explicit failure (not on cancel/timeout).
+       * The popup is closed only on an authoritative settle (callback message / verify success) —
+       * the cancel and timeout heuristics can fire while the user is still mid-consent in the
+       * popup, and closing it there kills a login the user is actively completing.
+       */
+      const finish = (
+        ok: boolean,
+        credId?: string | null,
+        error?: string | null,
+        opts?: { closePopup?: boolean }
+      ) => {
         if (settled) return
         settled = true
         teardown()
+        if (opts?.closePopup !== false) {
+          try {
+            if (!popup.closed) popup.close()
+          } catch {
+            // COOP-severed popups block the close — the termination page closes itself instead.
+          }
+        }
         if (!ok && error) {
           toastError({ title: 'Failed to connect', description: error })
         }
@@ -175,11 +192,16 @@ export function useOAuthPopup() {
             }
             if (settled) return
           }
-          finish(false)
+          // Heuristic cancel — never close the popup here: the focus-return signal can fire while
+          // the user is still authenticating in it (macOS focus bounce, a stray click on the
+          // opener), and killing the window mid-login is unrecoverable.
+          finish(false, null, null, { closePopup: false })
         }, cancelGraceMs)
       }
 
-      // `sawBlur` gates the focus-return so the initial open (opener still focused) isn't read as a return.
+      // `sawBlur` gates the focus-return (both the watchdog and the focus event) so the initial
+      // open — opener still focused, or a stray focus event before the popup ever took focus —
+      // isn't read as a return.
       let sawBlur = false
       const watchdog = setInterval(() => {
         if (settled) return
@@ -189,12 +211,20 @@ export function useOAuthPopup() {
         }
         if (sawBlur) scheduleCancelCheck()
       }, 400)
-      const onFocus = () => scheduleCancelCheck()
+      const onFocus = () => {
+        if (sawBlur) scheduleCancelCheck()
+      }
       window.addEventListener('focus', onFocus)
 
       // Hard ceiling so an undetectable user-cancel doesn't spin forever / leave the UI disabled.
-      const giveUpTimer = setTimeout(() => finish(false), timeoutMs)
+      const giveUpTimer = setTimeout(
+        () => finish(false, null, null, { closePopup: false }),
+        timeoutMs
+      )
 
+      // Teardown never closes the popup — `cancel()` and unmount reach here directly, and both
+      // can race a login the user is still completing. `finish` owns the close on an
+      // authoritative settle.
       teardownRef.current = () => {
         window.removeEventListener('message', onMessage)
         window.removeEventListener('focus', onFocus)
@@ -203,11 +233,6 @@ export function useOAuthPopup() {
         if (verifyInterval) clearInterval(verifyInterval)
         if (cancelTimer) clearTimeout(cancelTimer)
         clearTimeout(giveUpTimer)
-        try {
-          if (!popup.closed) popup.close()
-        } catch {
-          // ignore
-        }
         setPending(false)
       }
     },

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -136,6 +136,7 @@ export async function proxy(req: NextRequest) {
       maxAge: 60,
       path: '/',
       httpOnly: false, // client JS needs to read this
+      secure: true,
       sameSite: 'lax',
     })
 
@@ -146,7 +147,8 @@ export async function proxy(req: NextRequest) {
     response.cookies.set('auxx-org-deep-link', pathname + search, {
       maxAge: 300, // 5 minutes — enough to complete login
       path: '/',
-      httpOnly: false,
+      httpOnly: true, // only read server-side, in (protected)/layout.tsx
+      secure: true,
       sameSite: 'lax',
     })
 
@@ -157,7 +159,7 @@ export async function proxy(req: NextRequest) {
 export const config = {
   matcher: [
     // Skip Next.js internals and all static files, unless found in search params
-    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|mp3|mp4|webm|ogg|wav|m4a|aac)).*)',
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|mp3|mp4|webm|ogg|wav|m4a|aac|txt|xml)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
   ],

--- a/packages/lib/src/connections/providers/defs.ts
+++ b/packages/lib/src/connections/providers/defs.ts
@@ -32,7 +32,9 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
     oauth2AccessTokenUrl: 'https://oauth2.googleapis.com/token',
     oauth2Scopes: [
       'https://www.googleapis.com/auth/gmail.modify',
-      'https://www.googleapis.com/auth/drive',
+      // drive.file (per-file, non-sensitive) instead of full `drive` — full Drive
+      // is a Google "restricted" scope and would pull Drive into the CASA audit.
+      'https://www.googleapis.com/auth/drive.file',
       'https://www.googleapis.com/auth/spreadsheets',
       'https://www.googleapis.com/auth/calendar',
       'https://www.googleapis.com/auth/userinfo.email',
@@ -77,9 +79,10 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
   },
   // ────────────────────────────────────────────────────────────────────────
   // Mail-centric channel providers (org-shared). Distinct from the kitchen-sink
-  // googleOAuth2Api/outlookOAuth2Api: scopes match exactly what the live
-  // GoogleOAuthService/OutlookOAuthService request (incl. Gmail pubsub `watch`)
-  // so existing grants keep working without re-consent. Channels fold onto these.
+  // googleOAuth2Api/outlookOAuth2Api. Channels fold onto these. Gmail scopes are
+  // the minimal set for Google OAuth verification: gmail.modify already includes
+  // read/send/labels, and `users.watch` needs no pubsub scope (the platform topic
+  // grants publish to gmail-api-push). Existing broader grants stay valid.
   // ────────────────────────────────────────────────────────────────────────
   {
     providerKey: 'gmail',
@@ -90,10 +93,6 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
     oauth2AccessTokenUrl: 'https://oauth2.googleapis.com/token',
     oauth2Scopes: [
       'https://www.googleapis.com/auth/gmail.modify',
-      'https://www.googleapis.com/auth/gmail.send',
-      'https://www.googleapis.com/auth/gmail.labels',
-      'https://www.googleapis.com/auth/gmail.readonly',
-      'https://www.googleapis.com/auth/pubsub', // Gmail watch
       'https://www.googleapis.com/auth/userinfo.email',
       'https://www.googleapis.com/auth/userinfo.profile',
     ],

--- a/packages/workflow-nodes/src/credentials/google-oauth2.credentials.ts
+++ b/packages/workflow-nodes/src/credentials/google-oauth2.credentials.ts
@@ -40,7 +40,7 @@ export class GoogleOAuth2Api implements ICredentialType {
     // Fixed scopes - covers common Google API integrations
     scopes: [
       'https://www.googleapis.com/auth/gmail.modify', // Gmail read/write
-      'https://www.googleapis.com/auth/drive', // Google Drive
+      'https://www.googleapis.com/auth/drive.file', // Drive per-file access (full `drive` is restricted)
       'https://www.googleapis.com/auth/spreadsheets', // Google Sheets
       'https://www.googleapis.com/auth/calendar', // Google Calendar
       'https://www.googleapis.com/auth/userinfo.email', // User email info


### PR DESCRIPTION
Four independent fixes that were sitting together in the working tree, split into one commit each.

### `fix(connections)` — minimize Google OAuth scopes
Full `drive` is a Google **restricted** scope and would pull Drive into the CASA audit, so it drops to `drive.file` (per-file, non-sensitive). The gmail channel provider also sheds `gmail.send`, `gmail.labels`, `gmail.readonly` and `pubsub`: `gmail.modify` already covers read/send/labels, and `users.watch` needs no pubsub scope because the platform topic grants publish to `gmail-api-push`.

Existing broader grants stay valid — no re-consent.

### `fix(web)` — keep the OAuth popup open until an authoritative settle
The cancel and timeout heuristics could fire while the user was still mid-consent (macOS focus bounce, a stray click on the opener) and tear the popup down, killing a login unrecoverably. Now only a callback message or a successful verify closes the window; `teardown` never closes it. The focus listener is gated on `sawBlur`, matching the watchdog.

Channel credentials never appear in `connections.list`, so `useConnectFlow`'s default snapshot verify polled `null` forever and let the cancel heuristic win. Added a `verify` override; channel reconnect polls `channelReauth.getAuthStatus` instead.

Also: `secure` on the org-handle and deep-link cookies, `httpOnly` on the deep-link cookie (only read server-side), and `txt|xml` added to the static matcher.

### `ci(docker)` — runner and cache tuning
PR builds are async can-it-build checks, so they all return to free standard runners; only the release build pays for a larger runner, and web goes 8-core → 16-core there. `cache-to` drops from `mode=max` to `mode=min` — the multi-GB buildcache push was the job's network tail and the Next compile was never cacheable. `pull: true` removed so the base image isn't re-pulled every run.

`turbopackFileSystemCacheForBuild` is enabled, but only pays off where `.next/cache` survives between builds (local today; CI would need a persistent-disk builder).

### `fix(seo)` — per-page canonicals
A canonical in the root layout metadata applied the site root URL to every page that didn't override it, so every homepage and docs route advertised the same canonical. Removed from both layouts, declared per page via `alternates.canonical`.

---

**Not included** (still uncommitted locally, separate workstream): the dompurify 3.4 bump and the settings-v2 migration 035 / seed-helper slug-collision changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
