### PR TITLE
fix: migration 035 dropped-column ref, entity apiSlug collisions, dompurify dedupe

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -108,7 +108,7 @@
     "dagre": "^0.8.5",
     "date-fns": "catalog:",
     "date-fns-tz": "^3.2.0",
-    "dompurify": "^3.2.4",
+    "dompurify": "^3.4.0",
     "dotenv": "catalog:",
     "drizzle-orm": "catalog:",
     "googleapis": "catalog:",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
     ]
   },
   "pnpm": {
+    "overrides": {
+      "dompurify": "^3.4.0"
+    },
     "onlyBuiltDependencies": [
       "deno"
     ],

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1234,7 +1234,7 @@
     "date-fns": "catalog:",
     "date-fns-tz": "^3.2.0",
     "decode-ico": "^0.4.0",
-    "dompurify": "^3.2.4",
+    "dompurify": "^3.4.0",
     "drizzle-orm": "catalog:",
     "email-reply-parser": "^1.9.4",
     "fast-diff": "^1.3.0",

--- a/packages/lib/src/data-migrations/migrations/035-usersetting-rekey-backfill.ts
+++ b/packages/lib/src/data-migrations/migrations/035-usersetting-rekey-backfill.ts
@@ -3,7 +3,7 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { eq, inArray, isNull, or } from 'drizzle-orm'
+import { inArray } from 'drizzle-orm'
 import { getOrgCache } from '../../cache'
 import type { DataMigrationDef } from '../types'
 
@@ -18,44 +18,23 @@ const DEAD_APPEARANCE_KEYS = [
 ]
 
 /**
- * Settings v2 `UserSetting` re-key (plans/settings/v2/README.md §Service
- * refactor): backfills the new `organizationId`/`key` columns on `UserSetting`
- * from each row's parent `OrganizationSetting`, still reachable at this point
- * via the (not-yet-dropped) `organizationSettingId` FK — a second schema
- * migration tightens the new columns to NOT NULL and drops that FK once this
- * backfill has run. Also deletes stored `OrganizationSetting` rows for the
- * four dead `appearance.*` keys; any surviving `UserSetting` children
- * cascade-delete via the (still-present) FK.
+ * Settings v2 dead-key cleanup (plans/settings/v2/README.md §Deletions):
+ * deletes stored `OrganizationSetting` and `UserSetting` rows for the four
+ * removed `appearance.*` keys.
  *
- * Idempotent: only backfills rows still missing `organizationId`/`key`; the
- * appearance-key delete is a no-op once already removed.
+ * The `UserSetting` re-key this migration originally performed now happens
+ * inline in drizzle migration `0273_settings_v2_rekey_drop_legacy_fk.sql` —
+ * that file also drops the legacy `organizationSettingId` FK (from the DB and
+ * the schema), so the join-based backfill is no longer expressible here. The
+ * FK cascade the original delete relied on is gone with it, hence the explicit
+ * `UserSetting` delete by key.
+ *
+ * Idempotent: both deletes are no-ops once the rows are gone.
  */
 export const migration035UserSettingRekeyBackfill: DataMigrationDef = {
   id: '035-usersetting-rekey-backfill',
-  description: 'Backfill UserSetting.organizationId/key + delete dead appearance.* settings',
+  description: 'Delete dead appearance.* organization/user settings (settings v2)',
   async run(db: Database): Promise<void> {
-    const rows = await db
-      .select({
-        id: schema.UserSetting.id,
-        organizationId: schema.OrganizationSetting.organizationId,
-        key: schema.OrganizationSetting.key,
-      })
-      .from(schema.UserSetting)
-      .innerJoin(
-        schema.OrganizationSetting,
-        eq(schema.UserSetting.organizationSettingId, schema.OrganizationSetting.id)
-      )
-      .where(or(isNull(schema.UserSetting.organizationId), isNull(schema.UserSetting.key)))
-
-    for (const row of rows) {
-      await db
-        .update(schema.UserSetting)
-        .set({ organizationId: row.organizationId, key: row.key })
-        .where(eq(schema.UserSetting.id, row.id))
-    }
-
-    logger.info('Backfilled UserSetting organizationId/key', { rowsBackfilled: rows.length })
-
     const deadOrgSettings = await db
       .select({
         id: schema.OrganizationSetting.id,
@@ -72,6 +51,8 @@ export const migration035UserSettingRekeyBackfill: DataMigrationDef = {
         )
       )
     }
+
+    await db.delete(schema.UserSetting).where(inArray(schema.UserSetting.key, DEAD_APPEARANCE_KEYS))
 
     const affectedOrgs = new Set(deadOrgSettings.map((s) => s.organizationId))
     for (const orgId of affectedOrgs) {

--- a/packages/lib/src/seed/entity-migrations/helpers.ts
+++ b/packages/lib/src/seed/entity-migrations/helpers.ts
@@ -5,7 +5,7 @@ import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { toFieldId, toResourceFieldId } from '@auxx/types/field'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { onCacheEvent } from '../../cache/invalidate'
 import {
   createDefaultFieldViewConfig,
@@ -108,9 +108,23 @@ export async function loadExistingState(
 
 // ─── Ensure EntityDefinitions ────────────────────────────────────────
 
+/** First slug not in `takenSlugs`: `base`, then `base-2`, `base-3`, … */
+function resolveFreeSlug(base: string, takenSlugs: Set<string>): string {
+  if (!takenSlugs.has(base)) return base
+  let n = 2
+  while (takenSlugs.has(`${base}-${n}`)) n++
+  return `${base}-${n}`
+}
+
 /**
  * Create missing EntityDefinitions. Returns a map of entityType → id for all
  * entities (both existing and newly created).
+ *
+ * A migrated org may already hold a user-created custom entity (entityType
+ * NULL, so invisible to `ExistingState.entityDefs`) on the same apiSlug — the
+ * `(apiSlug, organizationId)` unique index only covers non-archived rows, so
+ * the system def falls back to a suffixed free slug instead of failing the
+ * whole migration.
  */
 export async function ensureEntityDefinitions(
   db: Database,
@@ -122,6 +136,9 @@ export async function ensureEntityDefinitions(
   const entityDefIds = new Map<string, string>()
   const now = new Date()
 
+  // Loaded on first insert only — already-migrated orgs skip the query.
+  let takenSlugs: Set<string> | undefined
+
   for (const entity of entities) {
     const existingDef = existing.entityDefs.get(entity.entityType)
     if (existingDef) {
@@ -129,12 +146,36 @@ export async function ensureEntityDefinitions(
       continue
     }
 
+    takenSlugs ??= new Set(
+      (
+        await db
+          .select({ apiSlug: schema.EntityDefinition.apiSlug })
+          .from(schema.EntityDefinition)
+          .where(
+            and(
+              eq(schema.EntityDefinition.organizationId, organizationId),
+              isNull(schema.EntityDefinition.archivedAt)
+            )
+          )
+      ).map((d) => d.apiSlug)
+    )
+
+    const apiSlug = resolveFreeSlug(entity.apiSlug, takenSlugs)
+    if (apiSlug !== entity.apiSlug) {
+      logger.warn(
+        `apiSlug '${entity.apiSlug}' already taken — creating '${entity.entityType}' as '${apiSlug}'`,
+        {
+          organizationId,
+        }
+      )
+    }
+
     const [created] = await db
       .insert(schema.EntityDefinition)
       .values({
         organizationId,
         entityType: entity.entityType,
-        apiSlug: entity.apiSlug,
+        apiSlug,
         singular: entity.singular,
         plural: entity.plural,
         icon: entity.icon,
@@ -146,6 +187,7 @@ export async function ensureEntityDefinitions(
 
     if (!created) throw new Error(`Failed to create EntityDefinition: ${entity.entityType}`)
 
+    takenSlugs.add(apiSlug)
     entityDefIds.set(entity.entityType, created.id)
     state.entityDefsCreated++
     logger.info(`Created EntityDefinition: ${entity.entityType}`, { id: created.id })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ catalogs:
       specifier: 4.1.5
       version: 4.1.5
 
+overrides:
+  dompurify: ^3.4.0
+
 importers:
 
   .:
@@ -1130,8 +1133,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0(date-fns@4.1.0)
       dompurify:
-        specifier: ^3.2.4
-        version: 3.3.1
+        specifier: ^3.4.0
+        version: 3.4.0
       dotenv:
         specifier: 'catalog:'
         version: 16.6.1
@@ -1951,7 +1954,7 @@ importers:
         specifier: ^0.4.0
         version: 0.4.1
       dompurify:
-        specifier: ^3.2.4
+        specifier: ^3.4.0
         version: 3.4.0
       drizzle-orm:
         specifier: 'catalog:'
@@ -9916,12 +9919,6 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
-
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
-
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
   dompurify@3.4.0:
     resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
@@ -23386,14 +23383,6 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.2.7:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
-  dompurify@3.3.1:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
   dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -26065,7 +26054,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.0
       marked: 14.0.0
 
   motion-dom@12.34.3:


### PR DESCRIPTION
The remainder of the working tree — three unrelated changes, one commit each so release-please can classify them separately.

### `fix(database)` — migration 035 referenced a dropped column ⚠️
`0273_settings_v2_rekey_drop_legacy_fk.sql` (shipped in #1222) drops `UserSetting.organizationSettingId` from both the database and the Drizzle schema. Migration 035 still joined on it, so the file referenced a column that no longer exists.

The re-key backfill now happens inline in that SQL migration, so 035 keeps only the dead `appearance.*` key cleanup. The FK cascade the original delete relied on went away with the constraint, hence the explicit `UserSetting` delete by key. Both deletes are idempotent.

### `fix(seed)` — apiSlug collisions failed the whole entity migration
A migrated org can already hold a user-created custom entity on the same `apiSlug`. Its `entityType` is NULL so it's invisible to `ExistingState.entityDefs`, and the `(apiSlug, organizationId)` unique index only covers non-archived rows — the insert then failed the entire migration.

`ensureEntityDefinitions` now resolves to the first free slug (`base`, `base-2`, `base-3`, …) and warns when it has to suffix. The taken-slug query is lazy, so already-migrated orgs never run it.

### `chore(deps)` — dedupe dompurify
A pnpm override pinning `dompurify` to `^3.4.0`, with the web and lib specifiers bumped to match. Collapses three resolved copies into one: `3.2.7` (transitively via `monaco-editor`) and `3.3.1` are gone.

---

**Verification:** `pnpm --filter @auxx/lib typecheck` passes with these changes; Biome ran clean on every commit. The seed slug-collision path and the 035 deletes were not exercised against a real database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
