### PR TITLE
fix(worker): register missing event-handler jobs (message signals, bounce)

### DIFF
--- a/apps/worker/src/workers/worker-definitions/events-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/events-worker.ts
@@ -2,9 +2,13 @@ import {
   createAuditLog,
   createEventJob,
   createTimelineEvent,
+  deriveMessageReplySignal,
+  deriveThreadResolvedSignal,
   handleFieldTriggerJob,
   handleRecordRules,
   handleSyncRecordRules,
+  ingestBounceMessage,
+  projectSignalToTimeline,
   publishEventJob,
   publishThreadEventToRealtime,
   publishToAnalyticsJob,
@@ -41,6 +45,12 @@ const eventHandlersJobMappings = {
   handleRecordRules,
   handleSyncRecordRules,
   publishThreadEventToRealtime,
+  // Message-signal + bounce + signal-projection handlers, fanned out from
+  // publishEventJob (message:received, ticket:status:changed, signal:recorded).
+  deriveMessageReplySignal,
+  deriveThreadResolvedSignal,
+  ingestBounceMessage,
+  projectSignalToTimeline,
 }
 
 // IO-bound handlers; concurrency > 1 drops the queue-global FIFO ordering,


### PR DESCRIPTION
## Problem

Prod worker is throwing a continuous `Job function not found` storm:
```
Job failed { jobName: "deriveMessageReplySignal", error: "Job function not found: deriveMessageReplySignal" }
Job failed { jobName: "ingestBounceMessage",       error: "Job function not found: ingestBounceMessage" }
```

## Root cause

The signals feature (#1210–#1217) added `deriveMessageReplySignal`, `deriveThreadResolvedSignal`, `ingestBounceMessage` and `projectSignalToTimeline` to the `EventHandlers` map, but they were never registered in the worker's `eventHandlersJobMappings`. `publishEventJob` fans each event out into the `eventHandlers` queue **by handler name**, so every `message:received` / `ticket:status:changed` / `signal:recorded` event enqueues jobs the worker can't resolve → retried 4–5× → the log storm.

Core message ingestion (`createTimelineEvent`, `triggerMessageWorkflows`) was registered and kept working, but reply-signal derivation and bounce ingestion were fully broken.

## Fix

Register all four handlers in `eventHandlersJobMappings` (`apps/worker/src/workers/worker-definitions/events-worker.ts`).

## Test plan
- [ ] Deploy worker; confirm the `Job function not found` errors stop and the eventHandlers failed set drains.