### PR TITLE
feat(connections): offer platform login or bring-your-own oauth client

### DIFF
--- a/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
+++ b/apps/build/src/app/(portal)/[slug]/apps/[app_slug]/connections/page.tsx
@@ -118,6 +118,9 @@ const connectionFormSchema = z
     oauth2TokenRequestAuthMethod: z.enum(['request-body', 'basic-auth']).optional(),
     oauth2RefreshSchedule: z.enum(['none', 'hourly', 'daily', 'weekly']).optional(),
     oauth2Pkce: z.boolean().optional(),
+    // When true, the platform OAuth client is pending verification, so organizations may
+    // connect with it OR bring their own client id/secret (persisted as platformClientApproved=false).
+    oauth2AllowOwnClient: z.boolean().optional(),
     oauth2CallbackBaseUrl: z
       .string()
       .refine((val) => !val || val === '' || z.string().url().safeParse(val).success, {
@@ -369,6 +372,7 @@ function MethodEditor({
       oauth2TokenRequestAuthMethod: 'request-body',
       oauth2RefreshSchedule: 'none',
       oauth2Pkce: false,
+      oauth2AllowOwnClient: false,
       oauth2CallbackBaseUrl: '',
       oauth2ScopeSeparator: '',
       oauth2AdditionalAuthorizeParams: '',
@@ -447,6 +451,7 @@ function MethodEditor({
           'request-body',
         oauth2RefreshSchedule: scheduleValue,
         oauth2Pkce: (features.pkce as boolean) ?? false,
+        oauth2AllowOwnClient: connection.platformClientApproved === false,
         oauth2CallbackBaseUrl: (features.callbackBaseUrl as string) ?? '',
         oauth2ScopeSeparator: (features.scopeSeparator as string) ?? '',
         oauth2AdditionalAuthorizeParams: features.additionalAuthorizeParams
@@ -478,7 +483,8 @@ function MethodEditor({
         features.scopeSeparator ||
         features.additionalAuthorizeParams ||
         features.additionalTokenParams ||
-        (features.callbackMetadataParams as string[])?.length
+        (features.callbackMetadataParams as string[])?.length ||
+        connection.platformClientApproved === false
       ) {
         setShowAdvanced(true)
       }
@@ -589,6 +595,9 @@ function MethodEditor({
       // Browser-redirect fields — oauth2-code only (client-credentials has no authorize step).
       ...(data.connectionType === 'oauth2-code' && {
         oauth2AuthorizeUrl: data.oauth2AuthorizeUrl,
+        // Own-client gate: "allow own client" toggles the platform client into pending-approval,
+        // which the connect flow renders as platform-login OR bring-your-own.
+        platformClientApproved: !data.oauth2AllowOwnClient,
         oauth2Features: {
           ...(data.oauth2Pkce && { pkce: true }),
           ...(data.oauth2CallbackBaseUrl && { callbackBaseUrl: data.oauth2CallbackBaseUrl }),
@@ -1033,6 +1042,30 @@ function MethodEditor({
                             <FieldDescription>
                               Enable Proof Key for Code Exchange (RFC 7636). Required by Airtable,
                               Zoom, Twitter/X, Linear, Figma, and other providers.
+                            </FieldDescription>
+                          </Field>
+                          <Field>
+                            <div className='flex items-center gap-3'>
+                              <Controller
+                                name='oauth2AllowOwnClient'
+                                control={control}
+                                render={({ field }) => (
+                                  <Switch
+                                    id='app-organization-allow-own-client'
+                                    checked={field.value ?? false}
+                                    onCheckedChange={field.onChange}
+                                  />
+                                )}
+                              />
+                              <FieldLabel htmlFor='app-organization-allow-own-client'>
+                                Let organizations use their own OAuth client
+                              </FieldLabel>
+                            </div>
+                            <FieldDescription>
+                              Turn on while the platform OAuth client is pending provider
+                              verification. Organizations can then connect with the platform client
+                              (they may see an unverified-app warning) or paste their own Client ID
+                              and Secret in the connect dialog's advanced section.
                             </FieldDescription>
                           </Field>
                           <Field>

--- a/apps/build/src/server/api/routers/connections.ts
+++ b/apps/build/src/server/api/routers/connections.ts
@@ -117,6 +117,9 @@ const methodFields = {
   oauth2RefreshUrl: z.string().optional(),
   oauth2ClientId: z.string().optional(),
   oauth2ClientSecret: z.string().optional(),
+  // Own-client gate (§3.1): false = platform OAuth client is pending verification, so the
+  // connect flow offers platform-login OR bring-your-own client. Default true (one-click platform).
+  platformClientApproved: z.boolean().optional(),
   oauth2Scopes: z
     .array(z.string())
     .optional()
@@ -193,6 +196,7 @@ function toColumnValues(input: MethodFieldsInput, oauth2ClientSecret: string | n
       ? encryptValue(input.oauth2ClientId)
       : input.oauth2ClientId,
     oauth2ClientSecret,
+    platformClientApproved: input.platformClientApproved ?? true,
     oauth2Scopes: input.oauth2Scopes || [],
     oauth2TokenRequestAuthMethod: input.oauth2TokenRequestAuthMethod || 'request-body',
     oauth2RefreshTokenIntervalSeconds: input.oauth2RefreshTokenIntervalSeconds,

--- a/apps/web/src/app/(protected)/app/settings/channels/_components/calendar-sync-toggle.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/calendar-sync-toggle.tsx
@@ -125,7 +125,7 @@ export function CalendarSyncToggle({ integrationId, disabled }: CalendarSyncTogg
             <span className='text-xs text-muted-foreground'>
               {integrationStatus?.lastCalendarSyncAt
                 ? `Last synced ${new Date(integrationStatus.lastCalendarSyncAt).toLocaleString()}`
-                : 'Grant calendar.readonly access to keep meetings in sync'}
+                : 'Grant calendar access to keep meetings in sync'}
             </span>
             {integrationStatus?.requiresReauth && integrationStatus.lastAuthError && (
               <span className='text-xs text-destructive'>{integrationStatus.lastAuthError}</span>

--- a/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
@@ -5,6 +5,7 @@ import type { OAuth2Features } from '@auxx/database'
 import { database as db } from '@auxx/database'
 import { resolveAppConnectionForRuntime } from '@auxx/lib/apps'
 import { resolveAppSlug } from '@auxx/lib/cache'
+import { resolveOAuth2Client, resolveOwnClientRequirement } from '@auxx/lib/connections'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { interpolateConnectionFields } from '@auxx/services/app-connections'
@@ -173,8 +174,28 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       if (value) connectionVariables[varDef.key] = value
     }
 
-    // Interpolate all connection fields with variables
+    // Own-client gate (§3.1): only a genuinely absent platform client forces BYO id/secret.
+    // A platform client pending verification is optional-BYO — the platform kickoff proceeds
+    // and the provider (e.g. Google) applies its own unverified-app gating.
+    const ownClient = resolveOwnClientRequirement(connDef)
+    if (
+      ownClient.requiresOwnClient &&
+      !(connectionVariables.clientId && connectionVariables.clientSecret)
+    ) {
+      return NextResponse.json(
+        {
+          error: 'This connection requires your own OAuth client id and secret',
+          reason: ownClient.reason,
+        },
+        { status: 400 }
+      )
+    }
+
+    // Interpolate all connection fields with variables (for authorize URL + non-client fields).
     const resolved = interpolateConnectionFields(connDef, connectionVariables)
+    // Client id follows §3.2 precedence: a per-connection BYO `clientId` var wins over the
+    // app's platform client. Same resolver the provider authorize route + token refresh use.
+    const { clientId: resolvedClientId } = resolveOAuth2Client(connDef, connectionVariables)
 
     // Store state in Redis with metadata (expires in 10 minutes)
     const redis = await getRedisClient()
@@ -206,7 +227,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     // Build OAuth authorization URL
     const authUrl = new URL(resolved.authorizeUrl)
-    authUrl.searchParams.set('client_id', resolved.clientId)
+    authUrl.searchParams.set('client_id', resolvedClientId)
     authUrl.searchParams.set('redirect_uri', `${callbackBase}/api/apps/${slug}/oauth2/callback`)
     const scopeSeparator = features.scopeSeparator || ' '
     authUrl.searchParams.set('scope', scopes.join(scopeSeparator))

--- a/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
@@ -4,6 +4,7 @@ import { WEBAPP_URL } from '@auxx/config/urls'
 import { database as db } from '@auxx/database'
 import { saveAppConnection } from '@auxx/lib/apps'
 import { resolveAppSlug } from '@auxx/lib/cache'
+import { resolveOAuth2Client } from '@auxx/lib/connections'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { interpolateConnectionFields } from '@auxx/services/app-connections'
@@ -210,12 +211,18 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     // Interpolate connection fields with stored variables
     const connectionVariables: Record<string, string> = metadata.connectionVariables ?? {}
     const resolved = interpolateConnectionFields(connDef, connectionVariables)
+    // Client id/secret follow §3.2 precedence: a per-connection BYO client wins over the
+    // app's platform client (matches the authorize route + token refresh).
+    const { clientId: oauthClientId, clientSecret: oauthClientSecret } = resolveOAuth2Client(
+      connDef,
+      connectionVariables
+    )
 
     // Exchange authorization code for access token
     const tokenRequestBody: Record<string, string> = {
       code,
-      client_id: resolved.clientId,
-      client_secret: resolved.clientSecret,
+      client_id: oauthClientId,
+      client_secret: oauthClientSecret,
       redirect_uri: `${callbackBase}/api/apps/${slug}/oauth2/callback`,
       grant_type: 'authorization_code',
     }
@@ -228,7 +235,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     // Append additional token params from connection definition
     if (features.additionalTokenParams) {
       for (const [key, value] of Object.entries(features.additionalTokenParams)) {
-        tokenRequestBody[key] = value
+        tokenRequestBody[key] = value as string
       }
     }
 
@@ -240,9 +247,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     if (connDef.oauth2TokenRequestAuthMethod === 'basic-auth') {
-      const basicAuth = Buffer.from(`${resolved.clientId}:${resolved.clientSecret}`).toString(
-        'base64'
-      )
+      const basicAuth = Buffer.from(`${oauthClientId}:${oauthClientSecret}`).toString('base64')
       tokenRequestHeaders['Authorization'] = `Basic ${basicAuth}`
       // Don't include client_id and client_secret in body for basic auth
       delete tokenRequestBody.client_id

--- a/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/authorize/route.ts
@@ -152,9 +152,12 @@ export async function GET(
       if (value) connectionVariables[varDef.key] = value
     }
 
-    // Approval gate (§3.1): when the platform client is unusable (absent or pending
-    // verification), the connection MUST bring its own client id/secret. Enforce
-    // server-side — the connect dialog already requires the fields, but never trust it.
+    // Approval gate (§3.1): only a genuinely absent platform client (`requiresOwnClient`,
+    // reason `no-platform-client`) forces BYO id/secret — enforce that server-side, never
+    // trusting the dialog. A platform client pending verification yields
+    // `requiresOwnClient: false` (BYO is optional), so the platform kickoff proceeds here
+    // and Google shows its own unverified-app gating; BYO vars, when supplied, still win in
+    // `resolveOAuth2Client`.
     const ownClient = resolveOwnClientRequirement(connDef)
     if (
       ownClient.requiresOwnClient &&

--- a/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
+++ b/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
@@ -8,7 +8,7 @@ import { KbdSubmit } from '@auxx/ui/components/kbd'
 import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { toastError } from '@auxx/ui/components/toast'
-import { Lock, Users, Waypoints } from 'lucide-react'
+import { ChevronDown, ChevronRight, Lock, Users, Waypoints } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import {
@@ -77,6 +77,8 @@ export function ChannelGalleryDialog({
   const [scope, setScope] = useState<'shared' | 'personal'>(defaultScope)
   const [clientId, setClientId] = useState('')
   const [clientSecret, setClientSecret] = useState('')
+  // Opt-in to BYO client from the optional "advanced" section (pending-approval case).
+  const [useOwnClient, setUseOwnClient] = useState(false)
   const [chatName, setChatName] = useState('')
 
   const isOAuth = selected?.kind === 'oauth-email' || selected?.kind === 'social'
@@ -109,11 +111,18 @@ export function ChannelGalleryDialog({
     setScope(defaultScope)
     setClientId('')
     setClientSecret('')
+    setUseOwnClient(false)
     setChatName('')
   }
 
+  // `requiresOwnClient` → BYO mandatory (no platform client). `ownClientOptional` →
+  // platform login works but the app is pending Google verification, so BYO is offered
+  // as an alternative the user can opt into via the advanced section.
   const needsOwnClient = !!prep.data?.requiresOwnClient
-  const ownClientReady = !needsOwnClient || (!!clientId.trim() && !!clientSecret.trim())
+  const ownClientOptional = !!prep.data?.ownClientOptional
+  // BYO fields are active (must be filled to connect) when mandatory, or opted-in.
+  const byoActive = needsOwnClient || (ownClientOptional && useOwnClient)
+  const ownClientReady = !byoActive || (!!clientId.trim() && !!clientSecret.trim())
 
   // ── Connect actions ────────────────────────────────────────────────────────
 
@@ -149,7 +158,11 @@ export function ChannelGalleryDialog({
           returnTo: RETURN_TO,
         },
         {
-          values: prep.data.requiresOwnClient
+          // Submit BYO client id/secret only when the user is actually using their own
+          // client (mandatory, or opted in via the advanced section). Otherwise start the
+          // platform-client flow (which, while pending verification, shows Google's
+          // "unverified app" warning and is limited to test users for restricted scopes).
+          values: byoActive
             ? { clientId: clientId.trim(), clientSecret: clientSecret.trim() }
             : undefined,
         }
@@ -200,39 +213,71 @@ export function ChannelGalleryDialog({
 
   // ── Detail steps ────────────────────────────────────────────────────────────
 
-  /** BYO OAuth-client rows (client id/secret) shown when the platform client is unusable. */
-  function renderOwnClientFields() {
-    if (!prep.data?.requiresOwnClient) return null
+  /** The client id/secret input rows — shared by the mandatory and optional BYO paths. */
+  function renderClientCredFields() {
     return (
-      <>
-        <p className='text-xs text-muted-foreground'>
-          {prep.data.ownClientReason === 'pending-approval'
-            ? 'Our platform app is pending verification — connect with your own OAuth client for now.'
-            : 'No platform app is configured — enter your own OAuth client credentials.'}
-        </p>
-        <FieldPanel orientation='responsive' resizeId={RESIZE_ID} className='p-0'>
-          <FieldPanelRow title='Client ID' type={BaseType.STRING} showIcon isRequired>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={clientId}
-              onChange={(v) => setClientId((v as string) ?? '')}
-              placeholder='Your OAuth client id'
-              disabled={flow.pending}
-            />
-          </FieldPanelRow>
-          <FieldPanelRow title='Client Secret' type={BaseType.STRING} showIcon isRequired>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              fieldOptions={{ secret: true }}
-              value={clientSecret}
-              onChange={(v) => setClientSecret((v as string) ?? '')}
-              placeholder='Your OAuth client secret'
-              disabled={flow.pending}
-            />
-          </FieldPanelRow>
-        </FieldPanel>
-      </>
+      <FieldPanel orientation='responsive' resizeId={RESIZE_ID} className='p-0'>
+        <FieldPanelRow title='Client ID' type={BaseType.STRING} showIcon isRequired>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            value={clientId}
+            onChange={(v) => setClientId((v as string) ?? '')}
+            placeholder='Your OAuth client id'
+            disabled={flow.pending}
+          />
+        </FieldPanelRow>
+        <FieldPanelRow title='Client Secret' type={BaseType.STRING} showIcon isRequired>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            fieldOptions={{ secret: true }}
+            value={clientSecret}
+            onChange={(v) => setClientSecret((v as string) ?? '')}
+            placeholder='Your OAuth client secret'
+            disabled={flow.pending}
+          />
+        </FieldPanelRow>
+      </FieldPanel>
     )
+  }
+
+  /**
+   * BYO OAuth-client section. Mandatory (`requiresOwnClient`, no platform client) renders the
+   * fields inline. Optional (`ownClientOptional`, platform app pending Google verification)
+   * keeps the platform login primary and tucks the fields behind an advanced disclosure.
+   */
+  function renderOwnClientFields() {
+    if (needsOwnClient) {
+      return (
+        <>
+          <p className='text-xs text-muted-foreground'>
+            No platform app is configured — enter your own OAuth client credentials.
+          </p>
+          {renderClientCredFields()}
+        </>
+      )
+    }
+    if (ownClientOptional) {
+      return (
+        <div className='flex flex-col gap-2'>
+          <p className='text-xs text-muted-foreground'>
+            This app's platform OAuth client is pending provider verification — during sign-in you
+            may see an "unverified app" warning (and access can be limited to test accounts). You
+            can continue with it, or use your own OAuth client below.
+          </p>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            className='h-auto w-fit gap-1 px-1 py-0.5 text-xs text-muted-foreground'
+            onClick={() => setUseOwnClient((v) => !v)}>
+            {useOwnClient ? <ChevronDown /> : <ChevronRight />}
+            Use your own OAuth client (advanced)
+          </Button>
+          {useOwnClient && renderClientCredFields()}
+        </div>
+      )
+    }
+    return null
   }
 
   function renderOAuthDetail(item: ChannelCatalogItem) {

--- a/apps/web/src/components/connections/ui/connection-detail-page.tsx
+++ b/apps/web/src/components/connections/ui/connection-detail-page.tsx
@@ -22,10 +22,12 @@ export interface DetailMethod {
   connectionVariables?: ConnectionVariable[] | null
   /** OAuth approval gate (§3.1): this connection must bring its own client id/secret. */
   requiresOwnClient?: boolean
+  /** Platform client works but is pending verification — BYO offered as an optional alternative. */
+  ownClientOptional?: boolean
   ownClientReason?: 'no-platform-client' | 'pending-approval' | null
 }
 
-/** Reason-specific copy for the BYO-client requirement banner (§3.1). */
+/** Copy for the mandatory BYO-client banner (§3.1) — shown only when `requiresOwnClient`. */
 const OWN_CLIENT_COPY: Record<NonNullable<DetailMethod['ownClientReason']>, string> = {
   'pending-approval':
     'Our platform app for this provider is pending verification — connect with your own OAuth app for now.',
@@ -148,6 +150,13 @@ export function ConnectionDetailPage({
       {chosen?.requiresOwnClient && chosen.ownClientReason && (
         <div className='rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400'>
           {OWN_CLIENT_COPY[chosen.ownClientReason]}
+        </div>
+      )}
+      {chosen?.ownClientOptional && !chosen.requiresOwnClient && (
+        <div className='rounded-md border px-3 py-2 text-xs text-muted-foreground'>
+          This app's platform OAuth client is pending provider verification — you can connect with
+          it (you may see an "unverified app" warning during sign-in) or enter your own OAuth client
+          credentials below.
         </div>
       )}
       {chosen && methodNeedsFields(chosen) && (

--- a/apps/web/src/components/connections/ui/credential-template-dialog.tsx
+++ b/apps/web/src/components/connections/ui/credential-template-dialog.tsx
@@ -35,6 +35,8 @@ type Method = {
   connectionVariables: AppInstallation['methods'][number]['connectionVariables']
   /** OAuth approval gate (§3.1): this connection must bring its own client id/secret. */
   requiresOwnClient?: boolean
+  /** Platform client works but is pending verification — BYO offered as an optional alternative. */
+  ownClientOptional?: boolean
   ownClientReason?: 'no-platform-client' | 'pending-approval' | null
 }
 
@@ -199,9 +201,11 @@ export function CredentialTemplateDialog({
         connectionType: p.connectionType,
         global: p.global ?? false,
         // `connectionVariables` are already gated server-side (§3.1): BYO client fields
-        // dropped when the platform client is usable, forced required when it must BYO.
+        // dropped when the platform client is usable, forced required when it must BYO,
+        // kept-but-optional when the platform client is pending approval.
         connectionVariables: p.connectionVariables ?? [],
         requiresOwnClient: p.requiresOwnClient,
+        ownClientOptional: p.ownClientOptional,
         ownClientReason: p.ownClientReason,
       },
     ]

--- a/apps/web/src/server/api/routers/calendar.ts
+++ b/apps/web/src/server/api/routers/calendar.ts
@@ -106,7 +106,7 @@ export const calendarRouter = createTRPCRouter({
     }),
 
   /**
-   * Start the incremental Google OAuth flow for calendar.readonly.
+   * Start the incremental Google OAuth flow for calendar.events.
    */
   enableSync: protectedProcedure
     .input(z.object({ integrationId: z.string() }))
@@ -132,7 +132,8 @@ export const calendarRouter = createTRPCRouter({
       const params = new URLSearchParams({
         connectionId: integration.credentialId,
         returnTo: `/app/settings/channels/${integration.id}?tab=settings`,
-        scope_add: 'https://www.googleapis.com/auth/calendar',
+        // calendar.events (not full calendar): sync only lists/inserts events on `primary`.
+        scope_add: 'https://www.googleapis.com/auth/calendar.events',
         pc_calendarGrant: '1',
       })
 

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -143,6 +143,7 @@ export const channelRouter = createTRPCRouter({
         connectionDefinitionId: def.id,
         authorizeUrl: `/api/connections/${providerKey}/oauth2/authorize`,
         requiresOwnClient: gate.requiresOwnClient,
+        ownClientOptional: gate.ownClientOptional,
         ownClientReason: gate.reason,
         supportsPersonalConnection: supportsPersonal,
       }

--- a/apps/web/src/server/api/routers/connections.ts
+++ b/apps/web/src/server/api/routers/connections.ts
@@ -9,9 +9,9 @@ import {
   splitSensitiveFields,
   updateCredential,
 } from '@auxx/credentials/store'
-import type { ConnectionVariable } from '@auxx/database'
 import { getOrgCache } from '@auxx/lib/cache'
 import {
+  gateConnectionVariables,
   mintClientCredentialToken,
   refreshCredentialTokens,
   resolveOwnClientRequirement,
@@ -36,27 +36,6 @@ const credentialKindSchema = z.enum(['app', 'mcp', 'connection'])
  * `expired` so a uniform status applies across every kind.
  */
 const CONNECTION_CIRCUIT_OPEN_THRESHOLD = 5
-
-/** The BYO OAuth client variable keys (§3.2). */
-const BYO_CLIENT_KEYS = new Set(['clientId', 'clientSecret'])
-
-/**
- * Project a provider's connect-form variables through the approval gate (§3.1). For
- * OAuth providers: drop the BYO client fields when the platform client is usable (so the
- * connect is one-click), keeping any other vars (e.g. Shopify's `shop`); force the client
- * fields required when the connection must bring its own. Non-OAuth defs pass through.
- */
-function gateConnectionVariables(
-  provider: { connectionType: string; connectionVariables?: ConnectionVariable[] },
-  requiresOwnClient: boolean
-): ConnectionVariable[] {
-  const vars = provider.connectionVariables ?? []
-  if (provider.connectionType !== 'oauth2-code') return vars
-  if (requiresOwnClient) {
-    return vars.map((v) => (BYO_CLIENT_KEYS.has(v.key) ? { ...v, required: true } : v))
-  }
-  return vars.filter((v) => !BYO_CLIENT_KEYS.has(v.key))
-}
 
 /**
  * The single connection surface over the `Credential` table. Covers listing,
@@ -204,6 +183,7 @@ export const connectionsRouter = createTRPCRouter({
       // gate would wrongly read as `no-platform-client` — only consult it for oauth2-code.
       const gate = p.connectionType === 'oauth2-code' ? gateByKey.get(p.providerKey) : undefined
       const requiresOwnClient = gate?.requiresOwnClient ?? false
+      const ownClientOptional = gate?.ownClientOptional ?? false
       return {
         providerKey: p.providerKey,
         label: p.label,
@@ -211,15 +191,26 @@ export const connectionsRouter = createTRPCRouter({
         connectionType: p.connectionType,
         global: p.global ?? false,
         // Gate the connect-form variables (§3.1): for OAuth providers, drop the optional
-        // BYO client fields when the platform client is usable (→ one-click connect), and
-        // force them required when the connection must bring its own. The server reads the
-        // ungated def for the authorize/callback exchange — this only shapes the UI form.
-        connectionVariables: gateConnectionVariables(p, requiresOwnClient),
+        // BYO client fields when the platform client is usable (→ one-click connect), force
+        // them required when the connection must bring its own, and keep-but-optional when
+        // the platform client is pending approval (user may try platform login OR BYO). The
+        // server reads the ungated def for the authorize/callback exchange — this only
+        // shapes the UI form.
+        connectionVariables: gateConnectionVariables(
+          p.connectionType,
+          p.connectionVariables ?? [],
+          {
+            requiresOwnClient,
+            ownClientOptional,
+          }
+        ),
         icon: p.uiMetadata?.icon ?? null,
         category: p.uiMetadata?.category ?? null,
-        // OAuth-only: whether this connection must bring its own client id/secret, and why.
-        // `false`/`null` for non-OAuth providers (no DB gate) and secret defs.
+        // OAuth-only: whether this connection must bring its own client id/secret, whether
+        // BYO is offered as an optional alternative, and why. `false`/`null` for non-OAuth
+        // providers (no DB gate) and secret defs.
         requiresOwnClient,
+        ownClientOptional,
         ownClientReason: gate?.reason ?? null,
       }
     })

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -374,6 +374,10 @@ export interface CachedInstalledApp {
     connectionType: string
     global: boolean
     connectionVariables: ConnectionVariable[]
+    /** OAuth own-client gate (§3.1): whether BYO client id/secret is required or offered. */
+    requiresOwnClient: boolean
+    ownClientOptional: boolean
+    ownClientReason: 'no-platform-client' | 'pending-approval' | null
   }[]
 
   /**

--- a/packages/lib/src/cache/providers/installed-apps-provider.ts
+++ b/packages/lib/src/cache/providers/installed-apps-provider.ts
@@ -4,6 +4,10 @@ import { schema } from '@auxx/database'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { getBuiltinAuxxInstalledRow } from '../../agents/builtin-installed-row'
 import { getRegisteredToolName } from '../../ai/kopilot/capabilities/apps/tool-naming'
+import {
+  gateConnectionVariables,
+  resolveOwnClientRequirement,
+} from '../../connections/resolve-connection-definition'
 import type { CachedAction, CachedAgentTool, CachedInstalledApp } from '../org-cache-keys'
 import type { CacheProvider } from '../org-cache-provider'
 
@@ -50,6 +54,11 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
               connectionType: true,
               oauth2Features: true,
               connectionVariables: true,
+              // Own-client gate (§3.1): a pending-verification platform client lets the app
+              // offer platform-login OR bring-your-own client.
+              oauth2ClientId: true,
+              oauth2ClientSecret: true,
+              platformClientApproved: true,
             },
           })
         : []
@@ -152,15 +161,31 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
               createdAt: inst.currentDeployment.createdAt.toISOString(),
             }
           : null,
-        methods: (methodsByAppId.get(inst.app.id) ?? []).map((def) => ({
-          id: def.id,
-          key: def.key,
-          label: def.label,
-          description: def.description,
-          connectionType: def.connectionType,
-          global: def.global ?? false,
-          connectionVariables: def.connectionVariables ?? [],
-        })),
+        methods: (methodsByAppId.get(inst.app.id) ?? []).map((def) => {
+          // Own-client gate (§3.1): reused verbatim from the platform-provider path so the
+          // connect dialog renders the same platform-primary + optional-BYO UI for apps.
+          const gate = resolveOwnClientRequirement({
+            oauth2ClientId: def.oauth2ClientId,
+            oauth2ClientSecret: def.oauth2ClientSecret,
+            platformClientApproved: def.platformClientApproved,
+          })
+          return {
+            id: def.id,
+            key: def.key,
+            label: def.label,
+            description: def.description,
+            connectionType: def.connectionType,
+            global: def.global ?? false,
+            connectionVariables: gateConnectionVariables(
+              def.connectionType,
+              def.connectionVariables ?? [],
+              gate
+            ),
+            requiresOwnClient: gate.requiresOwnClient,
+            ownClientOptional: gate.ownClientOptional,
+            ownClientReason: gate.reason,
+          }
+        }),
         connectionDefinitions: (() => {
           const defs = connDefsByAppId.get(inst.app.id) ?? {}
           const toCached = (def: (typeof connectionDefs)[0] | undefined) =>

--- a/packages/lib/src/connections/index.ts
+++ b/packages/lib/src/connections/index.ts
@@ -29,8 +29,11 @@ export {
   runPostConnectHook,
 } from './post-connect-hooks'
 export {
+  BYO_CLIENT_KEYS,
+  BYO_CLIENT_VARS,
   type ConnectionDefinitionForRefresh,
   type CredentialOwner,
+  gateConnectionVariables,
   loadDefinitionForCredential,
   resolveOAuth2Client,
   resolveOAuth2RefreshConfig,

--- a/packages/lib/src/connections/providers/defs.ts
+++ b/packages/lib/src/connections/providers/defs.ts
@@ -36,7 +36,8 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
       // is a Google "restricted" scope and would pull Drive into the CASA audit.
       'https://www.googleapis.com/auth/drive.file',
       'https://www.googleapis.com/auth/spreadsheets',
-      'https://www.googleapis.com/auth/calendar',
+      'https://www.googleapis.com/auth/calendar.events',
+      'https://www.googleapis.com/auth/calendar.readonly',
       'https://www.googleapis.com/auth/userinfo.email',
       'https://www.googleapis.com/auth/userinfo.profile',
     ],

--- a/packages/lib/src/connections/resolve-connection-definition.ts
+++ b/packages/lib/src/connections/resolve-connection-definition.ts
@@ -4,7 +4,7 @@
 // `kind`-branch in refreshCredentialTokens — every credential resolves its
 // definition the same way, by connectionDefinitionId or by owner.
 
-import { type AuthApply, database as db, schema } from '@auxx/database'
+import { type AuthApply, type ConnectionVariable, database as db, schema } from '@auxx/database'
 import { interpolateConnectionFields } from '@auxx/services/app-connections'
 import { and, eq } from 'drizzle-orm'
 
@@ -99,15 +99,19 @@ export async function loadDefinitionForCredential(
 }
 
 /**
- * Decide whether a connection MUST bring its own OAuth client, and why (§3.1).
- * "Force BYO" fires for either reason, collapsed into one signal:
- *  - `no-platform-client` — the def has no platform client (its env var was unset at
+ * Decide how a connection may obtain its OAuth client (§3.1). Two signals:
+ *  - `requiresOwnClient` — BYO client id/secret are MANDATORY. Fires only for
+ *    `no-platform-client`: the def has no platform client (its env var was unset at
  *    seed time, so the column is blank); a column null-check IS the env-presence check.
- *  - `pending-approval`   — a platform client exists but its app is not yet verified
- *    (`platformClientApproved=false`, e.g. Google restricted scopes).
+ *  - `ownClientOptional` — BYO is OFFERED as an alternative but not required. Fires for
+ *    `pending-approval`: a platform client exists but its app is not yet Google-verified
+ *    (`platformClientApproved=false`, e.g. Google restricted scopes). The user may try
+ *    the platform login (Google shows an "unverified app" warning and, for restricted
+ *    scopes, only lets test users through) OR supply their own OAuth client.
  *
- * The gate decides *required vs optional*; `resolveOAuth2Client` decides *which client
- * is used*. No per-provider code — works for any OAuth2 def.
+ * The gate decides *required / optional / neither*; `resolveOAuth2Client` decides *which
+ * client is used* (per-credential vars win over the platform client). No per-provider
+ * code — works for any OAuth2 def.
  */
 export function resolveOwnClientRequirement(def: {
   oauth2ClientId: string | null
@@ -115,12 +119,60 @@ export function resolveOwnClientRequirement(def: {
   platformClientApproved: boolean
 }): {
   requiresOwnClient: boolean
+  ownClientOptional: boolean
   reason: 'no-platform-client' | 'pending-approval' | null
 } {
   const platformClientPresent = !!def.oauth2ClientId && !!def.oauth2ClientSecret
-  if (!platformClientPresent) return { requiresOwnClient: true, reason: 'no-platform-client' }
-  if (!def.platformClientApproved) return { requiresOwnClient: true, reason: 'pending-approval' }
-  return { requiresOwnClient: false, reason: null }
+  if (!platformClientPresent)
+    return { requiresOwnClient: true, ownClientOptional: false, reason: 'no-platform-client' }
+  if (!def.platformClientApproved)
+    return { requiresOwnClient: false, ownClientOptional: true, reason: 'pending-approval' }
+  return { requiresOwnClient: false, ownClientOptional: false, reason: null }
+}
+
+/** The BYO OAuth client variable keys (§3.2) — provider-agnostic. */
+export const BYO_CLIENT_KEYS = new Set(['clientId', 'clientSecret'])
+
+/**
+ * Canonical BYO client var descriptors, injected into the connect form when a connection
+ * offers/requires an own client and the def didn't declare them itself. Keeps every
+ * OAuth2 connection (platform provider, channel, or app) uniform — a provider/app opts in
+ * purely via `platformClientApproved`, without hand-authoring these two variables.
+ */
+export const BYO_CLIENT_VARS: ConnectionVariable[] = [
+  { key: 'clientId', label: 'Client ID', placeholder: 'Your OAuth client id' },
+  {
+    key: 'clientSecret',
+    label: 'Client Secret',
+    secret: true,
+    placeholder: 'Your OAuth client secret',
+  },
+]
+
+/**
+ * Shape an OAuth2 connection's connect-form variables per the own-client gate (§3.1),
+ * provider-agnostic:
+ *  - `requiresOwnClient` → BYO client fields present + required (no platform client).
+ *  - `ownClientOptional` → BYO client fields present + optional (platform client pending
+ *    verification; user may use it OR their own).
+ *  - neither            → BYO client fields removed (one-click platform connect).
+ * BYO fields are injected when the def didn't declare them. Non-`oauth2-code` defs pass
+ * through untouched.
+ */
+export function gateConnectionVariables(
+  connectionType: string,
+  vars: ConnectionVariable[],
+  gate: { requiresOwnClient: boolean; ownClientOptional: boolean }
+): ConnectionVariable[] {
+  if (connectionType !== 'oauth2-code') return vars
+  if (gate.requiresOwnClient || gate.ownClientOptional) {
+    const hasByo = vars.some((v) => BYO_CLIENT_KEYS.has(v.key))
+    const base = hasByo ? vars : [...vars, ...BYO_CLIENT_VARS]
+    return base.map((v) =>
+      BYO_CLIENT_KEYS.has(v.key) ? { ...v, required: gate.requiresOwnClient } : v
+    )
+  }
+  return vars.filter((v) => !BYO_CLIENT_KEYS.has(v.key))
 }
 
 /**

--- a/packages/lib/src/data-migrations/migrations/038-reseed-platform-providers-scope-trim.ts
+++ b/packages/lib/src/data-migrations/migrations/038-reseed-platform-providers-scope-trim.ts
@@ -1,0 +1,27 @@
+// packages/lib/src/data-migrations/migrations/038-reseed-platform-providers-scope-trim.ts
+
+import type { Database } from '@auxx/database'
+import { ensurePlatformProviders } from '../../connections/providers'
+import type { DataMigrationDef } from '../types'
+
+/**
+ * Re-upsert the platform built-in ConnectionDefinition rows (`ensurePlatformProviders` only
+ * runs via the seed CLI / reseed script, never at boot). This pass propagates:
+ * - the Google OAuth verification scope trim (gmail: `gmail.modify`-only; googleOAuth2Api:
+ *   `drive.file` + `calendar.events`/`calendar.readonly` instead of full `drive`/`calendar`)
+ * - `platformClientApproved=false` for the gmail row via `GOOGLE_PLATFORM_CREDENTIALS_APPROVED`.
+ *   With the split gate (`resolveOwnClientRequirement`) this no longer forces bring-your-own-
+ *   client: a pending-approval platform client is `ownClientOptional`, so new Gmail connections
+ *   may still use the platform login (Google shows its "unverified app" gating) OR supply their
+ *   own OAuth client, until Google verification completes.
+ *
+ * Idempotent: SELECTs by `(providerKey, major)` and UPDATEs in place, keeping row ids stable
+ * so existing `Credential.connectionDefinitionId` FKs survive. Safe to re-run.
+ */
+export const migration038ReseedPlatformProvidersScopeTrim: DataMigrationDef = {
+  id: '038-reseed-platform-providers-scope-trim',
+  description: 'Re-upsert platform connection providers (Google scope trim + gmail approval gate)',
+  async run(db: Database): Promise<void> {
+    await ensurePlatformProviders(db)
+  },
+}

--- a/packages/lib/src/data-migrations/migrations/039-google-app-client-pending-approval.ts
+++ b/packages/lib/src/data-migrations/migrations/039-google-app-client-pending-approval.ts
@@ -1,0 +1,43 @@
+// packages/lib/src/data-migrations/migrations/039-google-app-client-pending-approval.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-039')
+
+/**
+ * Bring app-owned Google OAuth connections (the first-party `gog-sheets` / `gog-calendar` /
+ * `gog-contacts` apps, and any future Google app) under the same own-client gate as the
+ * platform providers. Their `ConnectionDefinition` rows share the Google OAuth app that's
+ * pending verification, but `platformClientApproved` has never been written for app rows
+ * (defaults to `true`), so the connect flow forced the unverified platform client with no
+ * bring-your-own escape hatch.
+ *
+ * Set `platformClientApproved` from the SAME env flag the platform providers use
+ * (`GOOGLE_PLATFORM_CREDENTIALS_APPROVED`): `false` → the connect dialog offers platform-login
+ * OR a user-supplied client (`resolveOwnClientRequirement` → `ownClientOptional`); once Google
+ * verification completes and the flag flips, re-running promotes these rows back to approved.
+ *
+ * Idempotent: a scoped UPDATE keyed on app-owned Google `oauth2-code` rows.
+ */
+export const migration039GoogleAppClientPendingApproval: DataMigrationDef = {
+  id: '039-google-app-client-pending-approval',
+  description:
+    'Set app-owned Google OAuth rows to platformClientApproved per GOOGLE_PLATFORM_CREDENTIALS_APPROVED',
+  async run(db: Database): Promise<void> {
+    const approved = process.env.GOOGLE_PLATFORM_CREDENTIALS_APPROVED !== 'false'
+    const result = await db.execute(sql`
+      UPDATE "ConnectionDefinition"
+         SET "platformClientApproved" = ${approved}
+       WHERE "appId" IS NOT NULL
+         AND "connectionType" = 'oauth2-code'
+         AND "oauth2AuthorizeUrl" ILIKE '%accounts.google.com%'
+    `)
+    logger.info('Set platformClientApproved on app-owned Google OAuth rows', {
+      approved,
+      rowCount: (result as { rowCount?: number | null }).rowCount ?? 0,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -15,6 +15,8 @@ import { migration034RetireInboxVisibility } from './migrations/034-retire-inbox
 import { migration035UserSettingRekeyBackfill } from './migrations/035-usersetting-rekey-backfill'
 import { migration036DocumentsTaxRatesScope } from './migrations/036-documents-taxrates-scope'
 import { migration037BackfillMessageMachineMailTier } from './migrations/037-backfill-message-machine-mail-tier'
+import { migration038ReseedPlatformProvidersScopeTrim } from './migrations/038-reseed-platform-providers-scope-trim'
+import { migration039GoogleAppClientPendingApproval } from './migrations/039-google-app-client-pending-approval'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -46,6 +48,8 @@ function buildRegistry(): DataMigrationDef[] {
     migration035UserSettingRekeyBackfill,
     migration036DocumentsTaxRatesScope,
     migration037BackfillMessageMachineMailTier,
+    migration038ReseedPlatformProvidersScopeTrim,
+    migration039GoogleAppClientPendingApproval,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/workflow-nodes/src/credentials/google-oauth2.credentials.ts
+++ b/packages/workflow-nodes/src/credentials/google-oauth2.credentials.ts
@@ -42,7 +42,8 @@ export class GoogleOAuth2Api implements ICredentialType {
       'https://www.googleapis.com/auth/gmail.modify', // Gmail read/write
       'https://www.googleapis.com/auth/drive.file', // Drive per-file access (full `drive` is restricted)
       'https://www.googleapis.com/auth/spreadsheets', // Google Sheets
-      'https://www.googleapis.com/auth/calendar', // Google Calendar
+      'https://www.googleapis.com/auth/calendar.events', // Calendar events read/write
+      'https://www.googleapis.com/auth/calendar.readonly', // Calendar list/read
       'https://www.googleapis.com/auth/userinfo.email', // User email info
       'https://www.googleapis.com/auth/userinfo.profile', // User profile info
     ],


### PR DESCRIPTION
## What

While a platform OAuth app is pending provider verification, connections now offer **both** the platform client *and* a user-supplied client id/secret, instead of forcing bring-your-own only. Provider-agnostic — works for platform providers, the Gmail channel, and `apps/build` apps (Google Sheets/Calendar/Contacts, or any OAuth app).

## Why

Our Google app is pending verification (`GOOGLE_PLATFORM_CREDENTIALS_APPROVED='false'`). Previously that forced BYO-only for Gmail, and apps didn't participate in the gate at all — so users couldn't try the platform login (needed for the verification demo) and Sheets/Calendar had no BYO escape hatch.

## How

**Gate (provider-agnostic, `@auxx/lib/connections`)**
- `resolveOwnClientRequirement` → `{requiresOwnClient, ownClientOptional, reason}`. `no-platform-client` = mandatory BYO; `pending-approval` = **optional** BYO (platform login still works).
- Shared `gateConnectionVariables` + `BYO_CLIENT_VARS` — injects `clientId`/`clientSecret` fields when offered/required, so no provider or app hand-declares them. Replaces the web router's local copy.

**UI**
- Gmail channel dialog + generic connections detail page: **platform button primary**, BYO in a collapsed *"Use your own OAuth client (advanced)"* section. Copy is provider-neutral.

**Apps path**
- `installed-apps` org cache computes the gate per app method (feeds the connect dialog for free).
- App `authorize` + `callback` routes resolve the client via `resolveOAuth2Client` (per-connection BYO wins). Refresh already did.
- `apps/build` connection editor: **"Let organizations use their own OAuth client"** switch in the advanced section (writes `platformClientApproved`).

**Data**
- Migration **039**: sets `platformClientApproved` on app-owned Google OAuth rows from `GOOGLE_PLATFORM_CREDENTIALS_APPROVED`.
- Also folds in the pending Google-verification **scope trim** (calendar.events/readonly, gmail.modify-only) + migration **038** that were already in the working tree.

## Test plan
- [ ] With gmail/app rows at `platformClientApproved=false`: connect dialog shows platform primary + collapsed BYO; platform connect kicks off without client fields; BYO advanced fields redirect with the user's `client_id`.
- [ ] Row at `platformClientApproved=true` → one-click platform, no BYO shown.
- [ ] `apps/build` toggle round-trips `platformClientApproved`.
- [ ] Run migrations 038 + 039.