### PR TITLE
fix(money): build public quote redirect urls from buildQuoteViewUrl

### DIFF
--- a/apps/web/src/app/(public)/quote/[token]/accept/route.ts
+++ b/apps/web/src/app/(public)/quote/[token]/accept/route.ts
@@ -1,7 +1,7 @@
 // apps/web/src/app/(public)/quote/[token]/accept/route.ts
 
 import { AuxxError } from '@auxx/lib/errors'
-import { acceptQuoteByToken } from '@auxx/lib/money'
+import { acceptQuoteByToken, buildQuoteViewUrl } from '@auxx/lib/money'
 import { createScopedLogger } from '@auxx/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 
@@ -32,13 +32,13 @@ export async function POST(
       name: typeof name === 'string' ? name : undefined,
       selectedLineIds,
     })
-    const redirectUrl = new URL(`/quote/${token}`, request.url)
+    const redirectUrl = new URL(buildQuoteViewUrl(token))
     redirectUrl.searchParams.set('state', 'accepted')
     return NextResponse.redirect(redirectUrl, { status: 303 })
   } catch (error) {
     const message = error instanceof AuxxError ? error.message : 'Unable to accept this quote'
     logger.error('Quote accept failed', { token, error: message })
-    const redirectUrl = new URL(`/quote/${token}`, request.url)
+    const redirectUrl = new URL(buildQuoteViewUrl(token))
     redirectUrl.searchParams.set('state', 'error')
     redirectUrl.searchParams.set('message', message)
     return NextResponse.redirect(redirectUrl, { status: 303 })

--- a/apps/web/src/app/(public)/quote/[token]/decline/route.ts
+++ b/apps/web/src/app/(public)/quote/[token]/decline/route.ts
@@ -1,7 +1,7 @@
 // apps/web/src/app/(public)/quote/[token]/decline/route.ts
 
 import { AuxxError } from '@auxx/lib/errors'
-import { declineQuoteByToken } from '@auxx/lib/money'
+import { buildQuoteViewUrl, declineQuoteByToken } from '@auxx/lib/money'
 import { createScopedLogger } from '@auxx/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 
@@ -22,13 +22,13 @@ export async function POST(
 
   try {
     await declineQuoteByToken(token, { reason: typeof reason === 'string' ? reason : undefined })
-    const redirectUrl = new URL(`/quote/${token}`, request.url)
+    const redirectUrl = new URL(buildQuoteViewUrl(token))
     redirectUrl.searchParams.set('state', 'declined')
     return NextResponse.redirect(redirectUrl, { status: 303 })
   } catch (error) {
     const message = error instanceof AuxxError ? error.message : 'Unable to decline this quote'
     logger.error('Quote decline failed', { token, error: message })
-    const redirectUrl = new URL(`/quote/${token}`, request.url)
+    const redirectUrl = new URL(buildQuoteViewUrl(token))
     redirectUrl.searchParams.set('state', 'error')
     redirectUrl.searchParams.set('message', message)
     return NextResponse.redirect(redirectUrl, { status: 303 })

--- a/apps/web/src/app/(public)/quote/[token]/deposit-checkout/route.ts
+++ b/apps/web/src/app/(public)/quote/[token]/deposit-checkout/route.ts
@@ -1,7 +1,11 @@
 // apps/web/src/app/(public)/quote/[token]/deposit-checkout/route.ts
 
 import { AuxxError } from '@auxx/lib/errors'
-import { createStripeDepositCheckout, resolveQuoteByPublicToken } from '@auxx/lib/money'
+import {
+  buildQuoteViewUrl,
+  createStripeDepositCheckout,
+  resolveQuoteByPublicToken,
+} from '@auxx/lib/money'
 import { createScopedLogger } from '@auxx/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 
@@ -36,7 +40,7 @@ export async function POST(
   } catch (error) {
     const message = error instanceof AuxxError ? error.message : 'Unable to start checkout'
     logger.error('Stripe deposit checkout failed', { token, error: message })
-    const redirectUrl = new URL(`/quote/${token}`, request.url)
+    const redirectUrl = new URL(buildQuoteViewUrl(token))
     redirectUrl.searchParams.set('state', 'error')
     redirectUrl.searchParams.set('message', message)
     return NextResponse.redirect(redirectUrl, { status: 303 })

--- a/apps/web/src/app/(public)/quote/[token]/request-update/route.ts
+++ b/apps/web/src/app/(public)/quote/[token]/request-update/route.ts
@@ -1,7 +1,7 @@
 // apps/web/src/app/(public)/quote/[token]/request-update/route.ts
 
 import { AuxxError } from '@auxx/lib/errors'
-import { requestQuoteUpdateByToken } from '@auxx/lib/money'
+import { buildQuoteViewUrl, requestQuoteUpdateByToken } from '@auxx/lib/money'
 import { createScopedLogger } from '@auxx/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 
@@ -13,21 +13,21 @@ const logger = createScopedLogger('quote-request-update')
  * (→ `?state=error&message=...`).
  */
 export async function POST(
-  request: NextRequest,
+  _request: NextRequest,
   { params }: { params: Promise<{ token: string }> }
 ) {
   const { token } = await params
 
   try {
     await requestQuoteUpdateByToken(token)
-    const redirectUrl = new URL(`/quote/${token}`, request.url)
+    const redirectUrl = new URL(buildQuoteViewUrl(token))
     redirectUrl.searchParams.set('state', 'update-requested')
     return NextResponse.redirect(redirectUrl, { status: 303 })
   } catch (error) {
     const message =
       error instanceof AuxxError ? error.message : 'Unable to request an updated quote'
     logger.error('Quote request-update failed', { token, error: message })
-    const redirectUrl = new URL(`/quote/${token}`, request.url)
+    const redirectUrl = new URL(buildQuoteViewUrl(token))
     redirectUrl.searchParams.set('state', 'error')
     redirectUrl.searchParams.set('message', message)
     return NextResponse.redirect(redirectUrl, { status: 303 })


### PR DESCRIPTION
## What

The public quote action routes — accept / decline / deposit-checkout / request-update — built their post-action redirect from `new URL(`/quote/${token}`, request.url)`. `request.url` resolves to the **internal** request origin behind a proxy, so the customer could be redirected to the wrong host.

Switch them to the existing `buildQuoteViewUrl(token)` helper (`@auxx/lib/money`, quote-public-token.ts:88) so the redirect always targets the correct public quote URL. `request-update` no longer references `request`, so it's renamed `_request`.

## Test plan
- [ ] Accept / decline / request-update / start-deposit on a public quote → lands on the correct public `/quote/:token?state=...` URL (success and error states).