### PR TITLE
fix(apps): apply own-client gate to app connect methods in getBySlug

### DIFF
--- a/apps/web/src/components/apps/hooks/use-connect-flow.tsx
+++ b/apps/web/src/components/apps/hooks/use-connect-flow.tsx
@@ -35,6 +35,10 @@ export interface ConnectFlowDefinition {
   connectionType: string
   description?: string | null
   connectionVariables?: ConnectionVariable[] | null
+  /** OAuth own-client gate (§3.1) — threaded into the connect dialog's banner + fields. */
+  requiresOwnClient?: boolean
+  ownClientOptional?: boolean
+  ownClientReason?: 'no-platform-client' | 'pending-approval' | null
 }
 
 export interface ConnectTarget {
@@ -461,6 +465,9 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
       connectionType: activeDef.connectionType,
       global: args.scope === 'organization',
       connectionVariables: activeDef.connectionVariables ?? [],
+      requiresOwnClient: activeDef.requiresOwnClient,
+      ownClientOptional: activeDef.ownClientOptional,
+      ownClientReason: activeDef.ownClientReason,
     }
   }, [args, activeDef])
 

--- a/apps/web/src/components/apps/ui/app-connections.tsx
+++ b/apps/web/src/components/apps/ui/app-connections.tsx
@@ -94,6 +94,9 @@ function AppConnections({ app, returnTo, scope, onConnectionCreated }: Props) {
       connectionType: m.connectionType,
       description: m.description ?? undefined,
       connectionVariables: m.connectionVariables,
+      requiresOwnClient: m.requiresOwnClient,
+      ownClientOptional: m.ownClientOptional,
+      ownClientReason: m.ownClientReason,
     })),
   }
   const personalMethods = methods.filter((m) => !m.global)

--- a/packages/lib/src/apps/get-app-details.ts
+++ b/packages/lib/src/apps/get-app-details.ts
@@ -8,6 +8,10 @@ import {
   listAppConnectionDefinitions,
 } from '@auxx/services/app-connections'
 import { getCachedAppBySlug } from '../cache/app-cache-helpers'
+import {
+  gateConnectionVariables,
+  resolveOwnClientRequirement,
+} from '../connections/resolve-connection-definition'
 
 /**
  * Input parameters for getAppWithInstallationStatus
@@ -41,6 +45,22 @@ export interface AppCapabilitySummary {
   /** Derived connection descriptor, or null when the app needs no connection. */
   connection: { label: string } | null
 }
+
+/**
+ * Own-client gate flags (§3.1) attached to every method/definition the connect UI renders.
+ * `@auxx/services` can't import `@auxx/lib` (tier rule), so the gate is computed here —
+ * mirroring the installed-apps cache provider so both read paths agree.
+ */
+export interface OwnClientGate {
+  /** BYO client id/secret are mandatory (def has no platform client). */
+  requiresOwnClient: boolean
+  /** Platform client pending verification — BYO offered as an optional alternative. */
+  ownClientOptional: boolean
+  ownClientReason: 'no-platform-client' | 'pending-approval' | null
+}
+
+export type GatedConnectionMethod = ConnectionMethod & OwnClientGate
+export type GatedConnectionDefinitionSummary = ConnectionDefinitionSummary & OwnClientGate
 
 /**
  * App details with installation status
@@ -78,11 +98,11 @@ export interface AppWithStatusOutput {
     installedAt?: Date
     currentDeploymentId?: string
     // Every connection method the app exposes — the connect picker appears when length > 1.
-    methods: ConnectionMethod[]
+    methods: GatedConnectionMethod[]
     // Derived two-slot view (first method per scope) kept for presence/scope consumers.
     connectionDefinitions: {
-      user?: ConnectionDefinitionSummary
-      organization?: ConnectionDefinitionSummary
+      user?: GatedConnectionDefinitionSummary
+      organization?: GatedConnectionDefinitionSummary
     }
   }
   availableDeployments: Array<{
@@ -171,15 +191,91 @@ export async function getAppWithInstallationStatus(
   // apps. The per-scope two-slot view stays installed-only (only meaningful once connected).
   const connectionDefinitions: AppWithStatusOutput['installation']['connectionDefinitions'] = {}
   const methodsResult = await listAppConnectionDefinitions(cachedApp.id)
-  const methods: ConnectionMethod[] = methodsResult.isOk() ? methodsResult.value : []
+  const rawMethods: ConnectionMethod[] = methodsResult.isOk() ? methodsResult.value : []
+
+  // Own-client gate (§3.1): fetch the client/approval columns the services listing omits and
+  // shape each method's variables (inject/require/drop the BYO client fields). Without this,
+  // a pending-approval OAuth method with no declared variables connects one-click and the
+  // user never sees the platform-or-BYO choice.
+  const gateRows = rawMethods.length
+    ? await db.query.ConnectionDefinition.findMany({
+        where: (d, { inArray }) =>
+          inArray(
+            d.id,
+            rawMethods.map((m) => m.id)
+          ),
+        columns: {
+          id: true,
+          global: true,
+          oauth2ClientId: true,
+          oauth2ClientSecret: true,
+          platformClientApproved: true,
+        },
+      })
+    : []
+  const gateRowById = new Map(gateRows.map((r) => [r.id, r]))
+  const NO_GATE: OwnClientGate = {
+    requiresOwnClient: false,
+    ownClientOptional: false,
+    ownClientReason: null,
+  }
+  const gateFor = (row: (typeof gateRows)[number] | undefined, connectionType: string) => {
+    if (!row || connectionType !== 'oauth2-code') return NO_GATE
+    const gate = resolveOwnClientRequirement(row)
+    return {
+      requiresOwnClient: gate.requiresOwnClient,
+      ownClientOptional: gate.ownClientOptional,
+      ownClientReason: gate.reason,
+    }
+  }
+
+  const methods: GatedConnectionMethod[] = rawMethods.map((m) => {
+    const gate = gateFor(gateRowById.get(m.id), m.connectionType)
+    return {
+      ...m,
+      ...gate,
+      connectionVariables: gateConnectionVariables(m.connectionType, m.connectionVariables, gate),
+    }
+  })
+
   if (installation) {
     const [userConnDef, orgConnDef] = await Promise.all([
       getAppConnectionDefinition(cachedApp.id, false),
       getAppConnectionDefinition(cachedApp.id, true),
     ])
-    if (userConnDef.isOk() && userConnDef.value) connectionDefinitions.user = userConnDef.value
+    // The two-slot summaries carry no row id — match their gate row by scope. (`findFirst`
+    // per scope and this `find` can only disagree when an app has >1 method in one scope,
+    // which no app does today; the flow resolves by method id in that case anyway.)
+    const gateForScope = (global: boolean, connectionType: string) =>
+      gateFor(
+        gateRows.find((r) => r.global === global),
+        connectionType
+      )
+    if (userConnDef.isOk() && userConnDef.value) {
+      const def = userConnDef.value
+      const gate = gateForScope(false, def.connectionType)
+      connectionDefinitions.user = {
+        ...def,
+        ...gate,
+        connectionVariables: gateConnectionVariables(
+          def.connectionType,
+          def.connectionVariables ?? [],
+          gate
+        ),
+      }
+    }
     if (orgConnDef.isOk() && orgConnDef.value) {
-      connectionDefinitions.organization = orgConnDef.value
+      const def = orgConnDef.value
+      const gate = gateForScope(true, def.connectionType)
+      connectionDefinitions.organization = {
+        ...def,
+        ...gate,
+        connectionVariables: gateConnectionVariables(
+          def.connectionType,
+          def.connectionVariables ?? [],
+          gate
+        ),
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

The installed-app connections page (`/app/settings/apps/installed/<slug>/connections` → `apps.getBySlug` → `listAppConnectionDefinitions` in `@auxx/services`) never computed the own-client gate (§3.1). For a pending-approval OAuth method with no declared connection variables (the `gog-*` Google apps after the legacy `clientid`/`secret` vars were removed), `useConnectFlow.start` saw zero variables and kicked off OAuth directly — the user never got the platform-or-BYO dialog. The connections gallery (installed-apps cache provider) already gated correctly, so the two read paths disagreed.

## Fix

- **`packages/lib/src/apps/get-app-details.ts`** — `@auxx/services` can't import `@auxx/lib` (tier rule), so the gate is applied lib-side: fetch the `oauth2ClientId`/`oauth2ClientSecret`/`platformClientApproved` columns the services listing omits, attach `requiresOwnClient`/`ownClientOptional`/`ownClientReason` to every method and two-slot summary, and shape `connectionVariables` via the shared `gateConnectionVariables` (injects the optional canonical BYO pair for `pending-approval`, requires it for `no-platform-client`, strips it when approved).
- **`use-connect-flow.tsx`** — thread the gate fields through `ConnectFlowDefinition` into `ConnectionDetailDialog` so the pending-verification banner renders (the `DetailMethod`/`ConnectionDetailPage` side already supported them).
- **`app-connections.tsx`** — pass the gate fields into the flow target methods.

## Verification

- `packages/lib` + `apps/web` typecheck: no new errors (pre-existing errors on main unchanged).
- With a `gog-*` row at `platformClientApproved=false` and empty `connectionVariables`, Add Connection on the installed-app page now opens the dialog with the pending-verification note + optional Client ID/Client Secret pair; leaving them empty connects via the platform client, filling them routes through the BYO client (server routes already honor the precedence).
- An approved method (`platformClientApproved=true`) stays one-click.