### PR TITLE
fix(connections): flag revoked oauth grants for reauth, clean stale scheduler

### DIFF
--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -166,6 +166,19 @@ export async function setupSchedules() {
   const calendarSyncQueue = getQueue(Queues.calendarSyncQueue)
   const datasetMaintenanceQueue = getQueue(Queues.datasetMaintenanceQueue)
 
+  // Schedulers whose job function was removed/renamed. `upsertJobScheduler` under a new id
+  // never deletes the old schedule from Redis, so a retired id keeps firing forever and each
+  // tick fails with "Job function not found". Explicit tombstones (not a remove-anything-unknown
+  // sweep — org-scoped reconcilers create dynamic ids we don't statically know).
+  const retiredSchedulerIds = [
+    // Renamed to webhookRenewalScannerJob in #920 (token refresh moved to the unified
+    // oauth2TokenRefreshScannerJob).
+    'integrationTokenRefreshScannerJob',
+  ]
+  for (const id of retiredSchedulerIds) {
+    await maintenanceQueue.removeJobScheduler(id).catch(() => {})
+  }
+
   await calendarSyncQueue.upsertJobScheduler(
     'calendarSyncScannerJob',
     { pattern: '*/5 * * * *' },

--- a/packages/credentials/src/store/record-refresh.ts
+++ b/packages/credentials/src/store/record-refresh.ts
@@ -48,12 +48,16 @@ export async function recordRefreshSuccess(
 
 /**
  * Record a failed token refresh: increment the breaker (a `permanent` failure jumps straight to
- * the reconnect threshold) and stamp `lastRefreshFailureAt`. Org-scoped.
+ * the reconnect threshold) and stamp `lastRefreshFailureAt`. A permanent failure (revoked/invalid
+ * refresh token — e.g. OAuth2 `invalid_grant`) also sets the classified reauth state
+ * (`requiresReauth` / `lastAuthError`), since no retry can recover it — only a reconnect. That
+ * flag is what surfaces the Reconnect action in the UI; `recordRefreshSuccess` clears it.
+ * Org-scoped.
  */
 export async function recordRefreshFailure(
   id: string,
   organizationId: string,
-  options?: { permanent?: boolean }
+  options?: { permanent?: boolean; authError?: string }
 ): Promise<Result<void, CredentialStoreError>> {
   const now = new Date()
   const nextFailures = options?.permanent
@@ -67,6 +71,11 @@ export async function recordRefreshFailure(
         consecutiveRefreshFailures: nextFailures,
         lastRefreshFailureAt: now,
         updatedAt: now,
+        ...(options?.permanent && {
+          requiresReauth: true,
+          lastAuthError: options.authError ?? 'Token refresh permanently failed',
+          lastAuthErrorAt: now,
+        }),
       })
       .where(
         and(eq(schema.Credential.id, id), eq(schema.Credential.organizationId, organizationId))

--- a/packages/lib/src/connections/__tests__/oauth2-refresh-request.test.ts
+++ b/packages/lib/src/connections/__tests__/oauth2-refresh-request.test.ts
@@ -22,6 +22,7 @@ vi.mock('drizzle-orm', () => ({
 const storeCalls = {
   rotated: [] as Record<string, unknown>[],
   refreshSuccess: [] as { expiresAt: Date | null }[],
+  refreshFailure: [] as { permanent?: boolean; authError?: string }[],
 }
 const storeState = {
   record: {} as Record<string, unknown>,
@@ -30,7 +31,14 @@ const storeState = {
 
 vi.mock('@auxx/credentials/store', () => ({
   insertCredential: async () => ok({ id: 'cred-1' }),
-  recordRefreshFailure: async () => ok(undefined),
+  recordRefreshFailure: async (
+    _id: string,
+    _org: string,
+    opts?: { permanent?: boolean; authError?: string }
+  ) => {
+    storeCalls.refreshFailure.push(opts ?? {})
+    return ok(undefined)
+  },
   recordRefreshSuccess: async (_id: string, _org: string, opts: { expiresAt: Date | null }) => {
     storeCalls.refreshSuccess.push(opts)
     return ok(undefined)
@@ -100,6 +108,7 @@ beforeEach(() => {
   fetchCalls.length = 0
   storeCalls.rotated.length = 0
   storeCalls.refreshSuccess.length = 0
+  storeCalls.refreshFailure.length = 0
   dbState.updates.length = 0
   interpolated.clientSecret = undefined
   interpolated.refreshUrl = ''
@@ -195,5 +204,40 @@ describe('refreshCredentialTokens (mcp)', () => {
     interpolated.refreshUrl = ''
     await refreshCredentialTokens('cred-1', 'org-1')
     expect(fetchCalls[0]?.url).toBe('https://as.example.com/token')
+  })
+})
+
+describe('refreshCredentialTokens failure classification', () => {
+  it('treats an invalid_grant response as permanent (opens the breaker, flags reauth)', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: false,
+      status: 400,
+      text: async () =>
+        JSON.stringify({
+          error: 'invalid_grant',
+          error_description: 'Token has been expired or revoked.',
+        }),
+    }))
+
+    const result = await refreshCredentialTokens('cred-1', 'org-1')
+
+    expect(result.success).toBe(false)
+    expect(result.circuitOpened).toBe(true)
+    expect(storeCalls.refreshFailure[0]?.permanent).toBe(true)
+    expect(storeCalls.refreshFailure[0]?.authError).toContain('invalid_grant')
+  })
+
+  it('keeps other token-endpoint failures retryable (breaker increments, no reauth jump)', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: false,
+      status: 503,
+      text: async () => 'upstream down',
+    }))
+
+    const result = await refreshCredentialTokens('cred-1', 'org-1')
+
+    expect(result.success).toBe(false)
+    expect(result.circuitOpened).toBe(false)
+    expect(storeCalls.refreshFailure[0]?.permanent).toBe(false)
   })
 })

--- a/packages/lib/src/connections/oauth2-token-grants.ts
+++ b/packages/lib/src/connections/oauth2-token-grants.ts
@@ -160,10 +160,18 @@ export async function refreshCredentialTokens(
     const errorMessage = error instanceof Error ? error.message : String(error)
     logger.error('Token refresh failed', { credentialId, error: errorMessage })
 
-    // An invalid refresh token is permanent — jump the breaker straight to the open threshold.
+    // A revoked/invalid refresh token is permanent — no retry can recover it. `invalid_grant`
+    // is the RFC 6749 §5.2 code every provider returns for a dead refresh token (revoked,
+    // expired, or issued to a different client); the message check covers non-endpoint
+    // failures that name the refresh token. Permanent jumps the breaker straight to the open
+    // threshold AND flags the credential `requiresReauth` so the UI surfaces Reconnect.
     const isPermanentFailure =
-      errorMessage.includes('refresh token') && errorMessage.includes('invalid')
-    await recordRefreshFailure(credentialId, organizationId, { permanent: isPermanentFailure })
+      (error instanceof OAuth2TokenRequestError && error.oauthError === 'invalid_grant') ||
+      (errorMessage.includes('refresh token') && errorMessage.includes('invalid'))
+    await recordRefreshFailure(credentialId, organizationId, {
+      permanent: isPermanentFailure,
+      authError: errorMessage,
+    })
 
     const newFailureCount = isPermanentFailure ? CIRCUIT_OPEN_THRESHOLD : previousFailureCount + 1
     return {
@@ -268,6 +276,32 @@ interface TokenResponse {
 }
 
 /**
+ * A non-2xx response from an OAuth2 token endpoint, carrying the RFC 6749 §5.2 error code
+ * parsed from the response body (`invalid_grant`, `invalid_client`, …) so callers classify
+ * failures structurally instead of substring-matching the message.
+ */
+export class OAuth2TokenRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly oauthError: string | null
+  ) {
+    super(message)
+    this.name = 'OAuth2TokenRequestError'
+  }
+}
+
+/** Extract the RFC 6749 `error` code from a token-endpoint error body, tolerating non-JSON. */
+function parseOAuthErrorCode(body: string): string | null {
+  try {
+    const parsed = JSON.parse(body)
+    return typeof parsed?.error === 'string' ? parsed.error : null
+  } catch {
+    return null
+  }
+}
+
+/**
  * POST a form-encoded OAuth2 token request, applying `basic-auth` vs `request-body` client
  * authentication uniformly. Shared by the refresh-token and client-credentials grants so the two
  * never drift on header/auth handling. `body` carries the grant-specific params; the client
@@ -309,7 +343,11 @@ async function postOAuth2TokenRequest(
 
   if (!response.ok) {
     const errorText = await response.text()
-    throw new Error(`${failureLabel}: ${response.status} ${errorText}`)
+    throw new OAuth2TokenRequestError(
+      `${failureLabel}: ${response.status} ${errorText}`,
+      response.status,
+      parseOAuthErrorCode(errorText)
+    )
   }
 
   return response.json()

--- a/packages/lib/src/providers/__tests__/auth-error-handler.test.ts
+++ b/packages/lib/src/providers/__tests__/auth-error-handler.test.ts
@@ -1,0 +1,94 @@
+// packages/lib/src/providers/__tests__/auth-error-handler.test.ts
+//
+// Classification of provider auth errors — in particular that Google's 401
+// ("Invalid Credentials" / UNAUTHENTICATED, the gaxios shape) maps to
+// REVOKED_ACCESS with requiresReauth, so the credential gets flagged and the
+// UI surfaces the Reconnect action instead of looping sync → throttle forever.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const reauthCalls: { integrationId: string; error: string; requiresReauth: boolean }[] = []
+
+vi.mock('../credential-auth-state', () => ({
+  markCredentialReauth: async (integrationId: string, error: string, requiresReauth: boolean) => {
+    reauthCalls.push({ integrationId, error, requiresReauth })
+  },
+  clearCredentialReauth: async () => {},
+}))
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => [{ metadata: {} }] }) }),
+    }),
+    update: () => ({ set: () => ({ where: async () => {} }) }),
+  },
+  schema: { Integration: { id: 'Integration.id', metadata: 'Integration.metadata' } },
+}))
+vi.mock('drizzle-orm', () => ({ eq: () => ({}) }))
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: () => {}, warn: () => {}, error: () => {} }),
+}))
+
+import { AuthErrorHandler, AuthErrorType } from '../auth-error-handler'
+
+beforeEach(() => {
+  reauthCalls.length = 0
+})
+
+describe('AuthErrorHandler (google)', () => {
+  const handler = () => new AuthErrorHandler('google', 'int-1')
+
+  it('classifies a gaxios 401 "Invalid Credentials" as revoked access requiring reauth', async () => {
+    const details = await handler().handleAuthError(
+      Object.assign(new Error('Invalid Credentials'), {
+        response: { status: 401, data: {} },
+      }),
+      'getLabels'
+    )
+
+    expect(details.type).toBe(AuthErrorType.REVOKED_ACCESS)
+    expect(details.requiresReauth).toBe(true)
+    expect(details.retryable).toBe(false)
+    expect(reauthCalls[0]).toMatchObject({ integrationId: 'int-1', requiresReauth: true })
+  })
+
+  it('classifies a numeric 401 code as revoked access', async () => {
+    const details = await handler().handleAuthError(
+      Object.assign(new Error('Request had invalid authentication credentials.'), { code: 401 }),
+      'sync'
+    )
+
+    expect(details.type).toBe(AuthErrorType.REVOKED_ACCESS)
+    expect(details.requiresReauth).toBe(true)
+  })
+
+  it('still classifies invalid_rapt as invalid grant requiring reauth', async () => {
+    const details = await handler().handleAuthError(
+      Object.assign(new Error('reauth related error (invalid_rapt)'), {
+        response: { status: 400, data: { error_subtype: 'invalid_rapt' } },
+      }),
+      'refresh'
+    )
+
+    expect(details.type).toBe(AuthErrorType.INVALID_GRANT)
+    expect(details.requiresReauth).toBe(true)
+  })
+
+  it('keeps rate limits retryable without reauth', async () => {
+    const details = await handler().handleAuthError(new Error('rate_limit exceeded'), 'sync')
+
+    expect(details.type).toBe(AuthErrorType.RATE_LIMITED)
+    expect(details.requiresReauth).toBe(false)
+    expect(details.retryable).toBe(true)
+    expect(reauthCalls[0]).toMatchObject({ requiresReauth: false })
+  })
+
+  it('leaves unclassified provider errors retryable without reauth', async () => {
+    const details = await handler().handleAuthError(new Error('backend blip'), 'sync')
+
+    expect(details.type).toBe(AuthErrorType.PROVIDER_ERROR)
+    expect(details.requiresReauth).toBe(false)
+    expect(details.retryable).toBe(true)
+  })
+})

--- a/packages/lib/src/providers/auth-error-handler.ts
+++ b/packages/lib/src/providers/auth-error-handler.ts
@@ -98,7 +98,16 @@ export class AuthErrorHandler {
         type = AuthErrorType.INVALID_GRANT
         requiresReauth = true
         retryable = false
-      } else if (errorMessage.includes('unauthorized') || errorCode === 'unauthorized') {
+      } else if (
+        // A 401 that reaches this handler means the grant is dead: google-auth-library
+        // auto-refreshes expired access tokens transparently, so an unrecoverable
+        // UNAUTHENTICATED ("Invalid Credentials") is a revoked grant, not a stale token.
+        error?.response?.status === 401 ||
+        error?.code === 401 ||
+        errorMessage.includes('Invalid Credentials') ||
+        errorMessage.includes('unauthorized') ||
+        errorCode === 'unauthorized'
+      ) {
         type = AuthErrorType.REVOKED_ACCESS
         requiresReauth = true
         retryable = false


### PR DESCRIPTION
## Problem (prod incident, 2026-07-21)

A Gmail channel's Google grant was revoked server-side. Every sync failed with 401 `Invalid Credentials` and every refresh with `invalid_grant: Token has been expired or revoked` — but the credential's `requiresReauth` flag never flipped, so the channel card never showed the **Reconnect** action. The user was stuck in a sync → throttle → sync loop with no exit (re-auth had to be triggered via an unrelated flow).

Three independent gaps, all fixed with protocol-level signals (HTTP 401, RFC 6749 `invalid_grant`) — no provider-specific hacks:

## Changes

1. **Sync-path classifier** (`packages/lib/src/providers/auth-error-handler.ts`) — a 401 reaching the handler (gaxios `response.status`, numeric `code`, or Google's `Invalid Credentials` message) now classifies as `REVOKED_ACCESS` with `requiresReauth: true`. Rationale: `google-auth-library` auto-refreshes expired access tokens transparently, so an unrecoverable 401 means the grant is dead. Previously this fell through to `PROVIDER_ERROR` and actively wrote `requiresReauth: false`.
2. **Refresh path** (`packages/lib/src/connections/oauth2-token-grants.ts`) — token-endpoint failures now throw a typed `OAuth2TokenRequestError` carrying the parsed RFC 6749 error code. `invalid_grant` is detected structurally and treated as permanent. The old check required the message to contain `'refresh token'`, which the real error (`Token refresh failed: 400 {"error": "invalid_grant", …}`) never matched.
3. **Credentials store** (`packages/credentials/src/store/record-refresh.ts`) — `recordRefreshFailure({ permanent })` now also sets `requiresReauth`/`lastAuthError`/`lastAuthErrorAt`. `recordRefreshSuccess` already clears them, so mark/clear stay symmetric in the store's single breaker writer. This gives non-channel credentials (apps, MCP, data connectors) the same reconnect signal for free.
4. **Worker** (`apps/worker/src/workers/index.ts`) — remove the retired `integrationTokenRefreshScannerJob` scheduler from Redis at startup. It was renamed to `webhookRenewalScannerJob` in #920, but `upsertJobScheduler` under a new id never deletes the old schedule — prod has been logging `Job function not found: integrationTokenRefreshScannerJob` every 15 minutes since. Kept as an explicit tombstone list (not a remove-unknown sweep — org-scoped reconcilers create dynamic scheduler ids).

No UI changes needed: once the flag is set truthfully, the existing channel card / sync-error toast render Reconnect, and the reconnect flow already resets throttle + sync state.

## Tests

- `auth-error-handler.test.ts` (new): gaxios-shaped 401 → `REVOKED_ACCESS` + reauth marked; numeric 401 code; `invalid_rapt` unchanged; rate-limit and unclassified errors stay retryable without reauth.
- `oauth2-refresh-request.test.ts` (extended): `invalid_grant` response → permanent failure, breaker opened, `authError` recorded; 503 → retryable, breaker increments.
- `@auxx/credentials` suite: 81 passed. Lib + worker typechecks: no new errors.