### PR TITLE
fix(recording): truthful bot outcomes, ai pipeline guards, no-recording ui

### DIFF
--- a/apps/web/src/components/calls/ui/recording-detail.tsx
+++ b/apps/web/src/components/calls/ui/recording-detail.tsx
@@ -1,8 +1,12 @@
 // apps/web/src/components/calls/ui/recording-detail.tsx
 'use client'
 
-import { type BotStatus, TERMINAL_STATUSES } from '@auxx/lib/recording/client'
-import { Badge } from '@auxx/ui/components/badge'
+import {
+  type BotStatus,
+  deriveRecordingOutcome,
+  formatRecordingFailure,
+  TERMINAL_STATUSES,
+} from '@auxx/lib/recording/client'
 import { Button } from '@auxx/ui/components/button'
 import {
   DropdownMenu,
@@ -49,22 +53,8 @@ import { RecordingMeeting } from './recording-meeting'
 import { RecordingSpeakers } from './recording-speakers'
 import { RecordingSummary } from './recording-summary'
 import { RecordingTranscript } from './recording-transcript'
+import { RecordingStatusBadge } from './recordings/recording-status-badge'
 import { useRecordingPlayer } from './use-recording-player'
-
-const STATUS_BADGE_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  created: 'outline',
-  joining: 'secondary',
-  waiting: 'secondary',
-  admitted: 'secondary',
-  recording: 'default',
-  processing: 'secondary',
-  completed: 'default',
-  failed: 'destructive',
-  kicked: 'destructive',
-  denied: 'destructive',
-  timeout: 'destructive',
-  cancelled: 'outline',
-}
 
 // TODO: Remove mock data once real recordings exist
 export type MockRecordingParticipant = {
@@ -317,12 +307,22 @@ export function RecordingDetail({ recordingId }: { recordingId: string }) {
     }
   }, [isDesktop, tab, setTab])
 
+  const { data: realRecording, isLoading } = api.recording.getById.useQuery(
+    { id: recordingId },
+    { enabled: !USE_MOCK_DATA }
+  )
+  const recording = USE_MOCK_DATA ? (MOCK_RECORDINGS[recordingId] ?? null) : realRecording
+
+  // 'no_recording' = the bot ended without capturing anything — no video, no
+  // transcript, no AI content. One empty state instead of dead-end AI panels.
+  const outcome = recording ? deriveRecordingOutcome(recording) : 'scheduled'
+
   // Summary sidebar — docked-only, no overlay: the mobile Summary tab (above)
   // already covers the narrow/undocked case.
   const { dockedPanels } = useDockedPanels([
     {
       key: 'summary-sidebar',
-      open: { docked: true, overlay: false },
+      open: { docked: outcome !== 'no_recording', overlay: false },
       content: (
         <div className='h-full overflow-y-auto'>
           <RecordingSummary recordingId={recordingId} />
@@ -330,12 +330,6 @@ export function RecordingDetail({ recordingId }: { recordingId: string }) {
       ),
     },
   ])
-
-  const { data: realRecording, isLoading } = api.recording.getById.useQuery(
-    { id: recordingId },
-    { enabled: !USE_MOCK_DATA }
-  )
-  const recording = USE_MOCK_DATA ? (MOCK_RECORDINGS[recordingId] ?? null) : realRecording
 
   const { data: videoSession } = api.recording.getVideoSession.useQuery(
     { id: recordingId },
@@ -435,12 +429,7 @@ export function RecordingDetail({ recordingId }: { recordingId: string }) {
       <MainPageHeader
         action={
           <div className='flex items-center gap-2'>
-            <Badge variant={STATUS_BADGE_VARIANT[recording.status] ?? 'outline'}>
-              {isActive && (
-                <span className='mr-1.5 inline-block size-1.5 animate-pulse rounded-full bg-current' />
-              )}
-              {recording.status}
-            </Badge>
+            <RecordingStatusBadge status={recording.status as BotStatus} />
 
             {isActive && (
               <Button
@@ -461,36 +450,40 @@ export function RecordingDetail({ recordingId }: { recordingId: string }) {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align='end'>
-                <DropdownMenuItem
-                  onSelect={async (e) => {
-                    e.preventDefault()
-                    const confirmed = await confirm({
-                      title: 'Regenerate transcript?',
-                      description:
-                        'This will re-fetch the transcript from the provider and re-run all AI analysis.',
-                      confirmText: 'Regenerate',
-                      cancelText: 'Cancel',
-                    })
-                    if (confirmed) {
-                      regenerateTranscript.mutate({ recordingId })
-                    }
-                  }}>
-                  <RefreshCw /> Regenerate transcript
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onSelect={() => regenerateAi.mutate({ recordingId, scope: 'summary' })}>
-                  <Sparkles /> Regenerate summary
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onSelect={() => regenerateAi.mutate({ recordingId, scope: 'chapters' })}>
-                  <Sparkles /> Regenerate chapters
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onSelect={() => regenerateAi.mutate({ recordingId, scope: 'all' })}>
-                  <Sparkles /> Regenerate all AI
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
+                {outcome !== 'no_recording' && (
+                  <>
+                    <DropdownMenuItem
+                      onSelect={async (e) => {
+                        e.preventDefault()
+                        const confirmed = await confirm({
+                          title: 'Regenerate transcript?',
+                          description:
+                            'This will re-fetch the transcript from the provider and re-run all AI analysis.',
+                          confirmText: 'Regenerate',
+                          cancelText: 'Cancel',
+                        })
+                        if (confirmed) {
+                          regenerateTranscript.mutate({ recordingId })
+                        }
+                      }}>
+                      <RefreshCw /> Regenerate transcript
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onSelect={() => regenerateAi.mutate({ recordingId, scope: 'summary' })}>
+                      <Sparkles /> Regenerate summary
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={() => regenerateAi.mutate({ recordingId, scope: 'chapters' })}>
+                      <Sparkles /> Regenerate chapters
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={() => regenerateAi.mutate({ recordingId, scope: 'all' })}>
+                      <Sparkles /> Regenerate all AI
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </>
+                )}
                 <DropdownMenuItem
                   className='text-destructive focus:text-destructive'
                   onSelect={async (e) => {
@@ -523,113 +516,128 @@ export function RecordingDetail({ recordingId }: { recordingId: string }) {
       <MainPageContent dockedPanels={dockedPanels}>
         <ConfirmDialog />
 
-        <div className='flex-1 h-full flex flex-col min-h-0'>
-          {/* Video Player — 16:9 placeholder with collapse animation */}
-          <AnimatePresence initial={false}>
-            {showVideo && (
-              <motion.div
-                initial={{ height: 0, opacity: 0, filter: 'blur(3px)', overflow: 'hidden' }}
-                animate={{
-                  height: 'auto',
-                  opacity: 1,
-                  filter: 'blur(0px)',
-                  overflow: 'hidden',
-                  transitionEnd: { overflow: 'visible' },
-                }}
-                exit={{ height: 0, opacity: 0, filter: 'blur(3px)', overflow: 'hidden' }}
-                transition={{ type: 'spring', stiffness: 300, damping: 30 }}>
-                <div className='p-3'>
-                  {recording.status === 'completed' && videoSession?.url ? (
-                    <div className='overflow-hidden rounded-lg'>
-                      <VideoPlayer
-                        videoId={recordingId}
-                        sourceUrl={videoSession.url}
-                        thumbnailStoryboardUrl={videoSession.storyboardUrl ?? undefined}
-                        previewThumbnailUrl={videoSession.previewUrl ?? undefined}
-                        borderRadius='8'
-                        hasBorder={false}
-                        chapters={chapters?.map((c) => ({
-                          start: c.startMs / 1000,
-                          end: c.endMs / 1000,
-                          title: c.title,
-                        }))}
-                      />
-                    </div>
-                  ) : (
-                    <div className='flex items-center justify-center rounded-lg border bg-muted aspect-video'>
-                      <div className='flex flex-col items-center gap-2 text-muted-foreground'>
-                        <Video className='size-10' />
-                        <span className='text-sm'>
-                          {recording.status === 'processing'
-                            ? 'Recording is being processed...'
-                            : recording.status === 'completed' && !recording.videoAssetId
-                              ? 'Video not yet available'
-                              : 'Video player'}
-                        </span>
+        {outcome === 'no_recording' ? (
+          <div className='flex-1 h-full flex flex-col min-h-0 overflow-y-auto'>
+            <EmptyState
+              icon={VideoOff}
+              title='No recording was captured'
+              description={formatRecordingFailure(recording.failureReason)}
+              className='py-12'
+            />
+            <RecordingMeeting recording={recording} />
+          </div>
+        ) : (
+          <div className='flex-1 h-full flex flex-col min-h-0'>
+            {/* Video Player — 16:9 placeholder with collapse animation */}
+            <AnimatePresence initial={false}>
+              {showVideo && (
+                <motion.div
+                  initial={{ height: 0, opacity: 0, filter: 'blur(3px)', overflow: 'hidden' }}
+                  animate={{
+                    height: 'auto',
+                    opacity: 1,
+                    filter: 'blur(0px)',
+                    overflow: 'hidden',
+                    transitionEnd: { overflow: 'visible' },
+                  }}
+                  exit={{ height: 0, opacity: 0, filter: 'blur(3px)', overflow: 'hidden' }}
+                  transition={{ type: 'spring', stiffness: 300, damping: 30 }}>
+                  <div className='p-3'>
+                    {recording.status === 'completed' && videoSession?.url ? (
+                      <div className='overflow-hidden rounded-lg'>
+                        <VideoPlayer
+                          videoId={recordingId}
+                          sourceUrl={videoSession.url}
+                          thumbnailStoryboardUrl={videoSession.storyboardUrl ?? undefined}
+                          previewThumbnailUrl={videoSession.previewUrl ?? undefined}
+                          borderRadius='8'
+                          hasBorder={false}
+                          chapters={chapters?.map((c) => ({
+                            start: c.startMs / 1000,
+                            end: c.endMs / 1000,
+                            title: c.title,
+                          }))}
+                        />
                       </div>
-                    </div>
-                  )}
-                </div>
+                    ) : (
+                      <div className='flex items-center justify-center rounded-lg border bg-muted aspect-video'>
+                        <div className='flex flex-col items-center gap-2 text-muted-foreground'>
+                          <Video className='size-10' />
+                          <span className='text-sm'>
+                            {recording.status === 'processing'
+                              ? 'Recording is being processed...'
+                              : recording.status === 'completed' && !recording.videoAssetId
+                                ? 'Video not yet available'
+                                : 'Video player'}
+                          </span>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            {/* Tabs */}
+            <Tabs
+              value={tab ?? 'transcript'}
+              onValueChange={setTab}
+              className='flex-1 flex flex-col min-h-0'>
+              <motion.div
+                initial={false}
+                animate={{
+                  borderTopLeftRadius: showVideo ? 0 : 8,
+                  borderTopRightRadius: showVideo ? 0 : 8,
+                  borderTopWidth: showVideo ? 1 : 0,
+                }}
+                style={{ borderTopStyle: 'solid', borderTopColor: 'var(--border)' }}
+                transition={{ type: 'spring', stiffness: 300, damping: 30 }}>
+                <TabsList className='border-b w-full justify-start rounded-none bg-primary-150 px-2'>
+                  <TabsTrigger value='summary' variant='outline' className='lg:hidden'>
+                    <BookOpen /> Summary
+                  </TabsTrigger>
+                  <TabsTrigger value='transcript' variant='outline'>
+                    <FileText /> Transcript
+                  </TabsTrigger>
+                  <TabsTrigger value='speakers' variant='outline'>
+                    <Users /> Speakers
+                  </TabsTrigger>
+                  <TabsTrigger value='meeting' variant='outline'>
+                    <CalendarDays /> Meeting
+                  </TabsTrigger>
+
+                  {/* Video toggle */}
+                  <div className='ml-auto flex items-center'>
+                    <Tooltip content={showVideo ? 'Hide video' : 'Show video'}>
+                      <Button
+                        variant='ghost'
+                        size='icon-sm'
+                        onClick={() => setShowVideo((v) => !v)}>
+                        {showVideo ? <VideoOff /> : <Video />}
+                      </Button>
+                    </Tooltip>
+                  </div>
+                </TabsList>
               </motion.div>
-            )}
-          </AnimatePresence>
 
-          {/* Tabs */}
-          <Tabs
-            value={tab ?? 'transcript'}
-            onValueChange={setTab}
-            className='flex-1 flex flex-col min-h-0'>
-            <motion.div
-              initial={false}
-              animate={{
-                borderTopLeftRadius: showVideo ? 0 : 8,
-                borderTopRightRadius: showVideo ? 0 : 8,
-                borderTopWidth: showVideo ? 1 : 0,
-              }}
-              style={{ borderTopStyle: 'solid', borderTopColor: 'var(--border)' }}
-              transition={{ type: 'spring', stiffness: 300, damping: 30 }}>
-              <TabsList className='border-b w-full justify-start rounded-none bg-primary-150 px-2'>
-                <TabsTrigger value='summary' variant='outline' className='lg:hidden'>
-                  <BookOpen /> Summary
-                </TabsTrigger>
-                <TabsTrigger value='transcript' variant='outline'>
-                  <FileText /> Transcript
-                </TabsTrigger>
-                <TabsTrigger value='speakers' variant='outline'>
-                  <Users /> Speakers
-                </TabsTrigger>
-                <TabsTrigger value='meeting' variant='outline'>
-                  <CalendarDays /> Meeting
-                </TabsTrigger>
+              <TabsContent value='summary' className='flex flex-col flex-1 min-h-0 overflow-y-auto'>
+                <RecordingSummary recordingId={recordingId} />
+              </TabsContent>
 
-                {/* Video toggle */}
-                <div className='ml-auto flex items-center'>
-                  <Tooltip content={showVideo ? 'Hide video' : 'Show video'}>
-                    <Button variant='ghost' size='icon-sm' onClick={() => setShowVideo((v) => !v)}>
-                      {showVideo ? <VideoOff /> : <Video />}
-                    </Button>
-                  </Tooltip>
-                </div>
-              </TabsList>
-            </motion.div>
+              <TabsContent value='transcript' className='flex flex-col flex-1 min-h-0'>
+                <RecordingTranscript recordingId={recordingId} />
+              </TabsContent>
 
-            <TabsContent value='summary' className='flex flex-col flex-1 min-h-0 overflow-y-auto'>
-              <RecordingSummary recordingId={recordingId} />
-            </TabsContent>
+              <TabsContent value='speakers' className='flex flex-col flex-1 min-h-0'>
+                <RecordingSpeakers recordingId={recordingId} />
+              </TabsContent>
 
-            <TabsContent value='transcript' className='flex flex-col flex-1 min-h-0'>
-              <RecordingTranscript recordingId={recordingId} />
-            </TabsContent>
-
-            <TabsContent value='speakers' className='flex flex-col flex-1 min-h-0'>
-              <RecordingSpeakers recordingId={recordingId} />
-            </TabsContent>
-
-            <TabsContent value='meeting' className='flex flex-col flex-1 min-h-0 overflow-y-auto'>
-              <RecordingMeeting recording={recording} />
-            </TabsContent>
-          </Tabs>
-        </div>
+              <TabsContent value='meeting' className='flex flex-col flex-1 min-h-0 overflow-y-auto'>
+                <RecordingMeeting recording={recording} />
+              </TabsContent>
+            </Tabs>
+          </div>
+        )}
       </MainPageContent>
     </MainPage>
   )

--- a/apps/web/src/components/calls/ui/recording-summary.tsx
+++ b/apps/web/src/components/calls/ui/recording-summary.tsx
@@ -1,6 +1,11 @@
 // apps/web/src/components/calls/ui/recording-summary.tsx
 'use client'
 
+import {
+  type BotStatus,
+  deriveRecordingOutcome,
+  TERMINAL_STATUSES,
+} from '@auxx/lib/recording/client'
 import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import { Section } from '@auxx/ui/components/section'
@@ -17,9 +22,17 @@ export function RecordingSummary({ recordingId }: { recordingId: string }) {
     { id: recordingId },
     {
       refetchInterval: (query) => {
-        const status = (query.state.data as { aiProcessingStatus?: string } | undefined)
-          ?.aiProcessingStatus
-        return status === 'processing' || status === 'pending' ? 3000 : false
+        const data = query.state.data as
+          | { aiProcessingStatus?: string; hasTranscript?: boolean; status?: string }
+          | undefined
+        if (!data) return false
+        const aiStatus = data.aiProcessingStatus
+        const botTerminal = TERMINAL_STATUSES.includes(data.status as BotStatus)
+        // Poll while AI work is running or can still start; a terminal bot
+        // without a transcript will never produce a summary — stop polling.
+        if (aiStatus === 'processing') return 3000
+        if (aiStatus === 'pending' && (data.hasTranscript || !botTerminal)) return 3000
+        return false
       },
     }
   )
@@ -34,38 +47,56 @@ export function RecordingSummary({ recordingId }: { recordingId: string }) {
     },
   })
 
-  const status = recording?.aiProcessingStatus ?? 'pending'
+  const aiStatus = recording?.aiProcessingStatus ?? 'pending'
   const summaryText = recording?.summaryText ?? ''
+  const hasTranscript = recording?.hasTranscript ?? false
+  const botTerminal = recording ? TERMINAL_STATUSES.includes(recording.status as BotStatus) : false
+
+  // Nothing was ever captured — the parent renders the no-recording state.
+  if (recording && deriveRecordingOutcome(recording) === 'no_recording') {
+    return null
+  }
+
+  // Only claim work is happening when it actually is: post-processing running,
+  // or a transcript exists and processing is about to start.
+  const isGenerating = aiStatus === 'processing' || (aiStatus === 'pending' && hasTranscript)
+  const isUpcomingOrLive = aiStatus === 'pending' && !hasTranscript && !botTerminal
 
   return (
     <div className='flex flex-col'>
       <Section title='Summary' icon={<BookOpen className='size-3.5' />} collapsible={false}>
-        {status === 'pending' || status === 'processing' ? (
+        {isGenerating ? (
           <div className='py-4 space-y-3'>
             <Skeleton className='h-4 w-3/4' />
             <Skeleton className='h-4 w-full' />
             <Skeleton className='h-4 w-5/6' />
             <p className='text-xs text-muted-foreground pt-2'>Generating summary...</p>
           </div>
-        ) : status === 'failed' ? (
-          <Alert variant='destructive' className=' flex justify-between py-1'>
-            <div className='flex h-7 items-center'>
-              <AlertCircle className='size-4 mr-2' />
-
-              <span className=''>Summary generation failed. Please try again.</span>
+        ) : isUpcomingOrLive ? (
+          <p className='py-4 text-sm text-muted-foreground'>Summary will appear after the call.</p>
+        ) : aiStatus === 'failed' ? (
+          <Alert variant='destructive' className='flex justify-between py-1'>
+            <div className='flex min-h-7 items-center'>
+              <AlertCircle className='size-4 mr-2 shrink-0' />
+              <AlertDescription>
+                {recording?.aiProcessingError?.split('\n')[0] ??
+                  'Summary generation failed. Please try again.'}
+              </AlertDescription>
             </div>
-            <Button
-              variant='outline'
-              size='xs'
-              loading={regenerate.isPending}
-              onClick={() => regenerate.mutate({ recordingId, scope: 'summary' })}
-              className=' pl-2!'>
-              <RefreshCw /> Retry
-            </Button>
+            {hasTranscript && (
+              <Button
+                variant='outline'
+                size='xs'
+                loading={regenerate.isPending}
+                onClick={() => regenerate.mutate({ recordingId, scope: 'summary' })}
+                className=' pl-2!'>
+                <RefreshCw /> Retry
+              </Button>
+            )}
           </Alert>
         ) : summaryText ? (
           <p className='text-sm leading-relaxed text-muted-foreground'>{summaryText}</p>
-        ) : (
+        ) : hasTranscript ? (
           <div className='flex flex-col items-center gap-2 py-6 text-sm text-muted-foreground'>
             <span>No summary available yet.</span>
             <Button
@@ -76,11 +107,19 @@ export function RecordingSummary({ recordingId }: { recordingId: string }) {
               <RefreshCw /> Generate summary
             </Button>
           </div>
+        ) : (
+          <p className='py-4 text-sm text-muted-foreground'>
+            No transcript available for this recording.
+          </p>
         )}
       </Section>
-      <RecordingChapters recordingId={recordingId} />
-      <RecordingActionItems recordingId={recordingId} />
-      <RecordingInsights recordingId={recordingId} />
+      {hasTranscript && (
+        <>
+          <RecordingChapters recordingId={recordingId} />
+          <RecordingActionItems recordingId={recordingId} />
+          <RecordingInsights recordingId={recordingId} />
+        </>
+      )}
     </div>
   )
 }

--- a/apps/web/src/server/api/routers/recording.ts
+++ b/apps/web/src/server/api/routers/recording.ts
@@ -3,17 +3,20 @@
 import { database as db, schema } from '@auxx/database'
 import type { AIPostProcessJobData, TranscribeRecordingJobData } from '@auxx/lib/jobs'
 import { getQueue, Queues } from '@auxx/lib/jobs/queues'
+import type { BotStatus } from '@auxx/lib/recording'
 import {
   BOT_STATUSES,
   cancelBot,
   createInsightTemplate,
   createMeeting,
   deleteRecording,
+  FAILURE_TERMINAL_STATUSES,
   getInsightDetail,
   getRecordingDetail,
   getRecordingVideoUrl,
   getTranscript,
   getUtterances,
+  hasCompletedTranscript,
   listChapters,
   listInsights,
   listInsightTemplates,
@@ -60,6 +63,7 @@ export const recordingRouter = createTRPCRouter({
       ...detail.recording,
       calendarEvent: detail.calendarEvent,
       participants: detail.participants,
+      hasTranscript: detail.hasTranscript,
     }
   }),
 
@@ -355,6 +359,19 @@ export const recordingRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const organizationId = ctx.session.organizationId
 
+      // AI generation is impossible without a transcript — reject up front
+      // instead of enqueueing a job that can only fail.
+      const hasTranscript = await hasCompletedTranscript({
+        recordingId: input.recordingId,
+        organizationId,
+      })
+      if (!hasTranscript) {
+        throw new TRPCError({
+          code: 'UNPROCESSABLE_CONTENT',
+          message: 'No transcript available for this recording — nothing to regenerate from',
+        })
+      }
+
       // Mark the recording as processing so the UI reflects pending state immediately.
       await db
         .update(schema.CallRecording)
@@ -407,6 +424,12 @@ export const recordingRouter = createTRPCRouter({
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'Recording has no external bot ID — cannot refetch transcript',
+        })
+      }
+      if (FAILURE_TERMINAL_STATUSES.includes(recording.status as BotStatus)) {
+        throw new TRPCError({
+          code: 'UNPROCESSABLE_CONTENT',
+          message: 'The bot never recorded this meeting — there is no transcript to fetch',
         })
       }
 

--- a/packages/lib/src/jobs/recording/handle-webhook-job.ts
+++ b/packages/lib/src/jobs/recording/handle-webhook-job.ts
@@ -4,6 +4,7 @@ import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
 import { handleBotStatusChange } from '../../recording/bot'
 import type { BotStatus, BotWebhookEventType } from '../../recording/bot/types'
+import { FAILURE_TERMINAL_STATUSES } from '../../recording/bot/types'
 import { findRecording } from '../../recording/recording-queries'
 import { getQueue, Queues } from '../queues'
 import type { JobContext } from '../types'
@@ -93,6 +94,15 @@ async function onRecordingReady(job: Job<HandleRecordingWebhookJobData>, externa
     return
   }
 
+  if (FAILURE_TERMINAL_STATUSES.includes(recording.status as BotStatus)) {
+    logger.info('Skipping recording processing — bot ended without a recording', {
+      jobId: job.id,
+      recordingId: recording.id,
+      status: recording.status,
+    })
+    return
+  }
+
   const queue = getQueue(Queues.recordingProcessingQueue)
   await queue.add(
     'processRecordingJob',
@@ -115,6 +125,15 @@ async function onTranscriptReady(job: Job<HandleRecordingWebhookJobData>, extern
 
   if (!recording) {
     logger.error('Recording not found for transcript_ready event', { externalBotId })
+    return
+  }
+
+  if (FAILURE_TERMINAL_STATUSES.includes(recording.status as BotStatus)) {
+    logger.info('Skipping transcription — bot ended without a recording', {
+      jobId: job.id,
+      recordingId: recording.id,
+      status: recording.status,
+    })
     return
   }
 

--- a/packages/lib/src/jobs/recording/transcribe-recording-job.ts
+++ b/packages/lib/src/jobs/recording/transcribe-recording-job.ts
@@ -1,6 +1,10 @@
 // packages/lib/src/jobs/recording/transcribe-recording-job.ts
 
 import { createScopedLogger } from '@auxx/logger'
+import { UnrecoverableError } from 'bullmq'
+import type { BotStatus } from '../../recording/bot/types'
+import { FAILURE_TERMINAL_STATUSES } from '../../recording/bot/types'
+import { findRecording } from '../../recording/recording-queries'
 import { processTranscript } from '../../recording/transcription'
 import { getQueue, Queues } from '../queues'
 import type { JobContext } from '../types'
@@ -26,6 +30,14 @@ export const transcribeRecordingJob = async (ctx: JobContext<TranscribeRecording
     recordingId,
     organizationId,
   })
+
+  // A bot that never recorded has no transcript to fetch — retrying won't help.
+  const recording = await findRecording({ id: recordingId, organizationId })
+  if (recording && FAILURE_TERMINAL_STATUSES.includes(recording.status as BotStatus)) {
+    throw new UnrecoverableError(
+      `Recording ${recordingId} ended without a recording (status: ${recording.status}) — no transcript to fetch`
+    )
+  }
 
   const result = await processTranscript({ recordingId, organizationId })
 

--- a/packages/lib/src/recording/ai/post-process.ts
+++ b/packages/lib/src/recording/ai/post-process.ts
@@ -2,6 +2,7 @@
 
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { UnrecoverableError } from 'bullmq'
 import { eq } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { publisher } from '../../events/publisher'
@@ -29,6 +30,36 @@ export async function runAIPostProcess(
   params: RunAIPostProcessParams
 ): Promise<Result<void, Error>> {
   const { db, organizationId, callRecordingId, scope = 'all', userId } = params
+
+  // Nothing to process without a transcript — fail fast with the real reason
+  // instead of fanning out generators that can only produce generic errors.
+  const [transcript] = await db
+    .select({ id: schema.Transcript.id, fullText: schema.Transcript.fullText })
+    .from(schema.Transcript)
+    .where(eq(schema.Transcript.callRecordingId, callRecordingId))
+    .limit(1)
+
+  if (!transcript?.fullText) {
+    const [recording] = await db
+      .select({ failureReason: schema.CallRecording.failureReason })
+      .from(schema.CallRecording)
+      .where(eq(schema.CallRecording.id, callRecordingId))
+      .limit(1)
+
+    const message = recording?.failureReason
+      ? `No transcript — ${recording.failureReason}`
+      : 'No transcript available for this recording'
+
+    await db
+      .update(schema.CallRecording)
+      .set({ aiProcessingStatus: 'failed', aiProcessingError: message })
+      .where(eq(schema.CallRecording.id, callRecordingId))
+
+    logger.warn('AI post-processing skipped — no transcript', { callRecordingId })
+    // UnrecoverableError: when thrown by the job wrapper, BullMQ skips retries —
+    // a missing transcript is permanent, not transient.
+    return err(new UnrecoverableError(message))
+  }
 
   await db
     .update(schema.CallRecording)

--- a/packages/lib/src/recording/ai/summary-generator.ts
+++ b/packages/lib/src/recording/ai/summary-generator.ts
@@ -83,20 +83,35 @@ export async function generateSummary(
     participants: participants.map((p) => ({ name: p.name, isHost: p.isOrganizer })),
   })
 
+  const invokeParams = {
+    provider,
+    model,
+    organizationId,
+    userId: userId ?? recording.createdById,
+    messages: [
+      { role: 'system' as const, content: systemPrompt },
+      { role: 'user' as const, content: buildSummaryUserPrompt(transcript.fullText) },
+    ],
+    parameters: { temperature: 0.2, max_tokens: 2000 },
+    context: { source: 'other' as const, recordingId: callRecordingId, kind: 'recording-summary' },
+  }
+
   try {
-    const response = await orchestrator.invoke({
-      provider,
-      model,
-      organizationId,
-      userId: userId ?? recording.createdById,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: buildSummaryUserPrompt(transcript.fullText) },
-      ],
-      parameters: { temperature: 0.2, max_tokens: 2000 },
-      structuredOutput: { enabled: true, schema: SUMMARY_JSON_SCHEMA },
-      context: { source: 'other', recordingId: callRecordingId, kind: 'recording-summary' },
-    })
+    let response: Awaited<ReturnType<typeof orchestrator.invoke>>
+    try {
+      response = await orchestrator.invoke({
+        ...invokeParams,
+        structuredOutput: { enabled: true, schema: SUMMARY_JSON_SCHEMA },
+      })
+    } catch (error) {
+      if (!isStructuredOutputUnsupported(error)) throw error
+      // The prompt already demands strict JSON, so plain text + safeParseJson works.
+      logger.warn('Model rejected structured output — retrying with prompt-based JSON', {
+        callRecordingId,
+        model,
+      })
+      response = await orchestrator.invoke(invokeParams)
+    }
 
     const raw: unknown = response.structured_output ?? safeParseJson(response.content)
     const parsed = SummaryResponseSchema.safeParse(raw)
@@ -139,6 +154,12 @@ function normalizeActionItems(items: SummaryResponse['actionItems']): ActionItem
     dueDate: item.dueDate,
     priority: item.priority,
   }))
+}
+
+/** Some models (BYO/custom) reject response_format json_schema — detectable only from the error. */
+function isStructuredOutputUnsupported(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /response_format|json_schema|structured.?output/i.test(message)
 }
 
 function safeParseJson(content: string | null | undefined): unknown {

--- a/packages/lib/src/recording/bot/__tests__/types.test.ts
+++ b/packages/lib/src/recording/bot/__tests__/types.test.ts
@@ -1,0 +1,78 @@
+// packages/lib/src/recording/bot/__tests__/types.test.ts
+
+import { describe, expect, it } from 'vitest'
+import {
+  deriveRecordingOutcome,
+  FAILURE_REASONS,
+  FAILURE_SUB_CODE_STATUS,
+  formatRecordingFailure,
+} from '../types'
+
+describe('deriveRecordingOutcome', () => {
+  it('maps failure-terminal statuses to no_recording', () => {
+    for (const status of ['failed', 'kicked', 'denied', 'timeout', 'cancelled'] as const) {
+      expect(deriveRecordingOutcome({ status })).toBe('no_recording')
+    }
+  })
+
+  it('maps completed without artifacts to no_recording', () => {
+    expect(deriveRecordingOutcome({ status: 'completed' })).toBe('no_recording')
+    expect(deriveRecordingOutcome({ status: 'completed', videoAssetId: null })).toBe('no_recording')
+  })
+
+  it('maps completed with a transcript or video to ready', () => {
+    expect(deriveRecordingOutcome({ status: 'completed', hasTranscript: true })).toBe('ready')
+    expect(deriveRecordingOutcome({ status: 'completed', videoAssetId: 'asset_1' })).toBe('ready')
+  })
+
+  it('maps pre-meeting statuses to scheduled', () => {
+    expect(deriveRecordingOutcome({ status: 'created' })).toBe('scheduled')
+    expect(deriveRecordingOutcome({ status: 'joining' })).toBe('scheduled')
+  })
+
+  it('maps in-progress statuses to live', () => {
+    for (const status of ['waiting', 'admitted', 'recording', 'processing'] as const) {
+      expect(deriveRecordingOutcome({ status })).toBe('live')
+    }
+  })
+})
+
+describe('failure sub_code mapping', () => {
+  it('maps waiting-room timeouts to timeout status', () => {
+    expect(FAILURE_SUB_CODE_STATUS.timeout_exceeded_waiting_room).toBe('timeout')
+    expect(FAILURE_SUB_CODE_STATUS.call_ended_by_platform_waiting_room_timeout).toBe('timeout')
+  })
+
+  it('maps blocked bots to denied status', () => {
+    expect(FAILURE_SUB_CODE_STATUS.google_meet_bot_blocked).toBe('denied')
+    expect(FAILURE_SUB_CODE_STATUS.zoom_bot_blocked).toBe('denied')
+  })
+
+  it('has a human-readable reason for every mapped sub_code', () => {
+    for (const subCode of Object.keys(FAILURE_SUB_CODE_STATUS)) {
+      expect(FAILURE_REASONS[subCode], `missing reason for ${subCode}`).toBeTruthy()
+    }
+  })
+})
+
+describe('formatRecordingFailure', () => {
+  it('translates known sub_codes and statuses', () => {
+    expect(formatRecordingFailure('timeout_exceeded_waiting_room')).toBe(
+      'The notetaker was never admitted to the meeting'
+    )
+    expect(formatRecordingFailure('timeout')).toBe(
+      'The notetaker was never admitted to the meeting'
+    )
+  })
+
+  it('passes through already-friendly reasons', () => {
+    expect(formatRecordingFailure('Bot was denied entry to the meeting')).toBe(
+      'Bot was denied entry to the meeting'
+    )
+  })
+
+  it('falls back to generic copy when empty', () => {
+    expect(formatRecordingFailure(null)).toBe('The meeting ended without a recording')
+    expect(formatRecordingFailure(undefined)).toBe('The meeting ended without a recording')
+  })
+})

--- a/packages/lib/src/recording/bot/bot-manager.ts
+++ b/packages/lib/src/recording/bot/bot-manager.ts
@@ -9,7 +9,12 @@ import { getOrganizationSetting } from '../../settings/settings-service'
 import { findRecording, updateRecording } from '../recording-queries'
 import { getProvider } from './providers'
 import type { BotProviderId, BotStatus } from './types'
-import { STATUS_ORDINAL, TERMINAL_STATUSES } from './types'
+import {
+  FAILURE_REASONS,
+  FAILURE_SUB_CODE_STATUS,
+  STATUS_ORDINAL,
+  TERMINAL_STATUSES,
+} from './types'
 
 const logger = createScopedLogger('recording:bot-manager')
 
@@ -182,20 +187,45 @@ export async function handleBotStatusChange(params: {
     return ok(recording)
   }
 
-  const updates: Record<string, unknown> = {
-    status: newStatus,
+  // A bot that ends 'completed'/'processing' without ever recording didn't
+  // succeed — downgrade to the truthful failure status (e.g. waiting-room
+  // timeout) instead of showing a green "Completed" for an empty recording.
+  let effectiveStatus = newStatus
+  if (
+    (newStatus === 'completed' || newStatus === 'processing') &&
+    !recording.startedAt &&
+    STATUS_ORDINAL[currentStatus] < STATUS_ORDINAL.recording
+  ) {
+    effectiveStatus =
+      (subCode ? FAILURE_SUB_CODE_STATUS[subCode] : undefined) ??
+      (currentStatus === 'waiting' ? 'timeout' : 'failed')
+    logger.info('Downgrading terminal status — bot never recorded', {
+      recordingId: recording.id,
+      currentStatus,
+      reportedStatus: newStatus,
+      effectiveStatus,
+      subCode,
+    })
   }
 
-  if (newStatus === 'recording' && !recording.startedAt) {
+  const updates: Record<string, unknown> = {
+    status: effectiveStatus,
+  }
+
+  if (effectiveStatus === 'recording' && !recording.startedAt) {
     updates.startedAt = new Date()
   }
 
-  if (TERMINAL_STATUSES.includes(newStatus) && !recording.endedAt) {
+  if (TERMINAL_STATUSES.includes(effectiveStatus) && !recording.endedAt) {
     updates.endedAt = new Date()
   }
 
-  if (['failed', 'kicked', 'denied', 'timeout'].includes(newStatus)) {
-    updates.failureReason = subCode ?? newStatus
+  if (['failed', 'kicked', 'denied', 'timeout'].includes(effectiveStatus)) {
+    updates.failureReason =
+      (subCode ? FAILURE_REASONS[subCode] : undefined) ??
+      FAILURE_REASONS[effectiveStatus] ??
+      subCode ??
+      effectiveStatus
   }
 
   if (metadata) {
@@ -210,7 +240,7 @@ export async function handleBotStatusChange(params: {
   logger.info('Bot status updated', {
     recordingId: recording.id,
     oldStatus: currentStatus,
-    newStatus,
+    newStatus: effectiveStatus,
     subCode,
   })
 
@@ -251,19 +281,20 @@ export async function pollBotStatus(params: {
     return err(statusResult.error)
   }
 
-  const { status: providerStatus } = statusResult.value
+  const { status: providerStatus, subCode } = statusResult.value
 
   if (providerStatus !== currentStatus) {
     const updateResult = await handleBotStatusChange({
       externalBotId: recording.externalBotId,
       newStatus: providerStatus,
+      subCode,
     })
 
     if (updateResult.isErr()) {
       return err(updateResult.error)
     }
 
-    return ok(providerStatus)
+    return ok(updateResult.value.status as BotStatus)
   }
 
   return ok(currentStatus)

--- a/packages/lib/src/recording/bot/index.ts
+++ b/packages/lib/src/recording/bot/index.ts
@@ -22,10 +22,14 @@ export type {
   ExternalTranscriptData,
   ExternalUtterance,
   MeetingPlatform,
+  RecordingOutcome,
 } from './types'
 export {
   BOT_PROVIDER_IDS,
   BOT_STATUSES,
+  deriveRecordingOutcome,
+  FAILURE_TERMINAL_STATUSES,
+  formatRecordingFailure,
   MEETING_PLATFORMS,
   STATUS_ORDINAL,
   TERMINAL_STATUSES,

--- a/packages/lib/src/recording/bot/providers/recall-provider.ts
+++ b/packages/lib/src/recording/bot/providers/recall-provider.ts
@@ -144,7 +144,7 @@ interface RecallMediaShortcuts {
 
 interface RecallBotResponse {
   id: string
-  status_changes: { code: string; created_at: string }[]
+  status_changes: { code: string; sub_code?: string | null; created_at: string }[]
   recordings?: { id: string; media_shortcuts?: RecallMediaShortcuts }[]
   media_shortcuts?: RecallMediaShortcuts
   metadata?: Record<string, unknown>
@@ -269,9 +269,13 @@ export function createRecallProvider(config: RecallApiClientConfig): BotProvider
         const endedChange = statusChanges.find(
           (s) => s.code === 'bot.call_ended' || s.code === 'bot.done'
         )
+        // The informative sub_code usually rides on call_ended, not the final done
+        // entry — take the last non-null one across the whole history.
+        const subCode = [...statusChanges].reverse().find((s) => s.sub_code)?.sub_code ?? undefined
 
         return ok({
           status: mappedStatus,
+          subCode,
           joinedAt: joinedChange ? new Date(joinedChange.created_at) : undefined,
           recordingStartedAt: recordingChange ? new Date(recordingChange.created_at) : undefined,
           recordingEndedAt: endedChange ? new Date(endedChange.created_at) : undefined,

--- a/packages/lib/src/recording/bot/types.ts
+++ b/packages/lib/src/recording/bot/types.ts
@@ -40,6 +40,79 @@ export const TERMINAL_STATUSES: BotStatus[] = [
   'cancelled',
 ]
 
+/** Terminal statuses where the bot ended without a usable recording */
+export const FAILURE_TERMINAL_STATUSES: BotStatus[] = [
+  'failed',
+  'kicked',
+  'denied',
+  'timeout',
+  'cancelled',
+]
+
+/**
+ * Recall sub_codes (attached to call_ended/done/fatal status changes) that mean
+ * the bot ended without ever recording. Maps to the truthful terminal status.
+ * See https://docs.recall.ai/docs/sub-codes
+ */
+export const FAILURE_SUB_CODE_STATUS: Record<string, BotStatus> = {
+  timeout_exceeded_waiting_room: 'timeout',
+  call_ended_by_platform_waiting_room_timeout: 'timeout',
+  timeout_exceeded_noone_joined: 'timeout',
+  google_meet_bot_blocked: 'denied',
+  zoom_bot_blocked: 'denied',
+  meeting_not_accessible: 'denied',
+  meeting_not_found: 'failed',
+  meeting_not_started: 'failed',
+  bot_errored: 'failed',
+}
+
+/** Human-readable failure reasons keyed by sub_code (fallbacks by BotStatus). */
+export const FAILURE_REASONS: Record<string, string> = {
+  timeout_exceeded_waiting_room: 'The notetaker was never admitted to the meeting',
+  call_ended_by_platform_waiting_room_timeout: 'The notetaker was never admitted to the meeting',
+  timeout_exceeded_noone_joined: 'No one joined the meeting',
+  google_meet_bot_blocked: 'The notetaker was blocked from joining the meeting',
+  zoom_bot_blocked: 'The notetaker was blocked from joining the meeting',
+  meeting_not_accessible: 'The meeting was not accessible to the notetaker',
+  meeting_not_found: 'The meeting could not be found',
+  meeting_not_started: 'The meeting never started',
+  bot_errored: 'The notetaker encountered an unexpected error',
+  // Status-level fallbacks
+  timeout: 'The notetaker was never admitted to the meeting',
+  denied: 'The notetaker was denied entry to the meeting',
+  kicked: 'The notetaker was removed from the meeting',
+  failed: 'The notetaker failed to record the meeting',
+  cancelled: 'The recording was cancelled',
+}
+
+/** Best human-readable copy for a stored failureReason / sub_code / status. */
+export function formatRecordingFailure(reason: string | null | undefined): string {
+  if (!reason) return 'The meeting ended without a recording'
+  return FAILURE_REASONS[reason] ?? reason
+}
+
+// --- Recording Outcome (derived, drives UI states) ---
+
+export type RecordingOutcome = 'scheduled' | 'live' | 'ready' | 'no_recording'
+
+/**
+ * Collapse bot status + captured artifacts into the single outcome the UI
+ * should render: pre-meeting, in-progress, usable recording, or nothing captured.
+ */
+export function deriveRecordingOutcome(recording: {
+  status: BotStatus | string
+  hasTranscript?: boolean
+  videoAssetId?: string | null
+}): RecordingOutcome {
+  const status = recording.status as BotStatus
+  if (FAILURE_TERMINAL_STATUSES.includes(status)) return 'no_recording'
+  if (status === 'completed') {
+    return recording.hasTranscript || recording.videoAssetId ? 'ready' : 'no_recording'
+  }
+  if (status === 'created' || status === 'joining') return 'scheduled'
+  return 'live'
+}
+
 /** Ordered status progression for forward-transition enforcement */
 export const STATUS_ORDINAL: Record<BotStatus, number> = {
   created: 0,

--- a/packages/lib/src/recording/client/index.ts
+++ b/packages/lib/src/recording/client/index.ts
@@ -6,10 +6,14 @@ export type {
   BotStatus,
   BotWebhookEventType,
   MeetingPlatform,
+  RecordingOutcome,
 } from '../bot/types'
 export {
   BOT_PROVIDER_IDS,
   BOT_STATUSES,
+  deriveRecordingOutcome,
+  FAILURE_TERMINAL_STATUSES,
+  formatRecordingFailure,
   MEETING_PLATFORMS,
   TERMINAL_STATUSES,
 } from '../bot/types'

--- a/packages/lib/src/recording/index.ts
+++ b/packages/lib/src/recording/index.ts
@@ -29,6 +29,7 @@ export {
   findRecording,
   findUpcomingCalendarEvents,
   getRecordingDetail,
+  hasCompletedTranscript,
   listRecordings,
   updateRecording,
 } from './recording-queries'

--- a/packages/lib/src/recording/recording-queries.ts
+++ b/packages/lib/src/recording/recording-queries.ts
@@ -273,6 +273,7 @@ interface RecordingDetail {
   recording: CallRecordingEntity
   calendarEvent: CalendarEventEntity | null
   participants: MeetingParticipantEntity[]
+  hasTranscript: boolean
 }
 
 /** Get a single recording with its calendar event and meeting participants. */
@@ -282,6 +283,8 @@ export async function getRecordingDetail(
 ): Promise<RecordingDetail | undefined> {
   const recording = await findRecording({ id, organizationId })
   if (!recording) return undefined
+
+  const hasTranscript = await hasCompletedTranscript({ recordingId: recording.id, organizationId })
 
   let calendarEvent: CalendarEventEntity | null = null
   if (recording.calendarEventId) {
@@ -301,5 +304,24 @@ export async function getRecordingDetail(
       .where(eq(schema.MeetingParticipant.calendarEventId, recording.calendarEventId))
   }
 
-  return { recording, calendarEvent, participants }
+  return { recording, calendarEvent, participants, hasTranscript }
+}
+
+/** Whether a completed transcript exists for a recording. */
+export async function hasCompletedTranscript(params: {
+  recordingId: string
+  organizationId: string
+}): Promise<boolean> {
+  const [row] = await db
+    .select({ id: schema.Transcript.id })
+    .from(schema.Transcript)
+    .where(
+      and(
+        eq(schema.Transcript.callRecordingId, params.recordingId),
+        eq(schema.Transcript.organizationId, params.organizationId),
+        eq(schema.Transcript.status, 'completed')
+      )
+    )
+    .limit(1)
+  return !!row
 }


### PR DESCRIPTION
## Why

Prod test on Jul 20: the meeting bot was never admitted from the Google Meet waiting room, yet the recording ended as a green **Completed**, the summary panel showed a perpetual "Generating summary..." then a generic "Summary generation failed. Please try again." with a Retry button that could never succeed, and the transcribe/ai jobs burned retries against a recording that has no media.

## What

**Truthful terminal status (lib/recording/bot)**
- `getBotStatus()` now carries Recall's `sub_code` through the poll path (it rides on `call_ended`, not the final `done` entry)
- `handleBotStatusChange()` downgrades `completed`/`processing` to `timeout`/`denied`/`failed` when the bot never started recording, and stores human-readable `failureReason` copy (sub_code map verified against Recall docs)
- new shared `FAILURE_TERMINAL_STATUSES`, `RecordingOutcome` + `deriveRecordingOutcome()`, `formatRecordingFailure()` — exported client-safe

**Pipeline guards**
- webhook handler skips enqueueing processing/transcription for failure-terminal recordings
- `transcribeRecordingJob` / `runAIPostProcess` throw `UnrecoverableError` on permanent no-transcript conditions (no retry burn); post-process records the real reason in `aiProcessingError`
- `regenerate` 422s up front without a transcript (via new `hasCompletedTranscript()` lib helper); `regenerateTranscript` 422s for failure-terminal recordings
- `getById` exposes `hasTranscript`

**UI**
- recording detail derives one outcome: `no_recording` renders a single empty state with the failure reason ("The notetaker was never admitted to the meeting") and hides video, summary sidebar, and regenerate menu items; status badge consolidated to `RecordingStatusBadge`
- summary panel: `pending` no longer renders as generating, `failed` surfaces the stored `aiProcessingError`, retry/generate hidden without a transcript, 3s polling stops on dead recordings

**BYO models**
- summary generator retries with prompt-based JSON when the model rejects `response_format: json_schema`

## Tests
- 11 unit tests for outcome derivation, sub_code maps, and failure copy (`bot/__tests__/types.test.ts`)
- biome clean; typecheck clean on touched files (remaining `JobContext` errors are the pre-existing repo-wide `jobs/types.ts` vs `jobs/types/` shadowing)

## Manual verification path
1. Schedule a meeting, don't admit the bot → badge `Timeout`, "No recording was captured", no summary panel/retry, no retrying jobs in worker logs
2. Admit the bot → recording → transcript → summary/chapters/insights unchanged