### PR TITLE
feat(dispatch): onboarding setup wizard + getting-started checklist

### DIFF
--- a/apps/web/src/app/(protected)/app/dispatch/layout.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/layout.tsx
@@ -10,6 +10,7 @@ import {
 } from '@auxx/ui/components/main-page'
 import { MainPageTabs } from '@auxx/ui/components/main-page-tabs'
 import { CalendarDays, Settings } from 'lucide-react'
+import { DispatchSetupWizardGate } from '~/components/dispatch/ui/setup-wizard/setup-wizard-gate'
 
 /**
  * Module header for `/app/dispatch/*` — Board · Settings tabs via
@@ -48,13 +49,16 @@ function DispatchLayoutHeader() {
  * Module shell for `/app/dispatch/*` — `MainPage` chrome + the Board·Settings
  * header (M2a, 07-m2-build.md §D.1). The board is the module home now; the
  * settings sub-tree (`dispatch/settings/*`) keeps its own secondary sidebar
- * layout untouched.
+ * layout untouched. `DispatchSetupWizardGate` (32-onboarding.md Part C) mounts
+ * here so the setup wizard can auto-open on first visit anywhere under this
+ * route tree; it renders nothing until its own gating conditions are met.
  */
 export default function DispatchLayout({ children }: { children: React.ReactNode }) {
   return (
     <MainPage>
       <DispatchLayoutHeader />
       {children}
+      <DispatchSetupWizardGate />
     </MainPage>
   )
 }

--- a/apps/web/src/components/dispatch/getting-started.ts
+++ b/apps/web/src/components/dispatch/getting-started.ts
@@ -1,0 +1,74 @@
+// apps/web/src/components/dispatch/getting-started.ts
+// Client-safe display catalog for the dispatch module's getting-started
+// checklist. Same shape and tone as the org-wide catalog
+// (`~/components/getting-started/client`) — labels, descriptions, icons and
+// CTAs (web concerns); the canonical key set + persisted state shapes come
+// from @auxx/lib/getting-started/client.
+
+import { DISPATCH_GOAL_KEYS, type DispatchGoalKey } from '@auxx/lib/getting-started/client'
+import type { GettingStartedGoal } from '~/components/getting-started/client'
+
+const GOALS: Record<DispatchGoalKey, Omit<GettingStartedGoal, 'key'>> = {
+  'add-workers': {
+    label: 'Add your workers',
+    description: 'Bring your field team into Auxx so you can assign and schedule their work.',
+    iconId: 'user-plus',
+    color: 'green',
+    ctaText: 'Add workers',
+    href: '/app/dispatch/settings/workers',
+    docsPath: '/help/dispatch/add-workers',
+  },
+  'set-address': {
+    label: 'Set your business address',
+    description: 'Add your business address so routes and schedules start from the right place.',
+    iconId: 'map-pin',
+    color: 'blue',
+    ctaText: 'Set address',
+    href: '/app/dispatch/settings/documents',
+    docsPath: '/help/dispatch/set-address',
+  },
+  'set-hours': {
+    label: 'Set operating hours',
+    description: 'Define when your team is available so the board and planner respect them.',
+    iconId: 'clock',
+    color: 'amber',
+    ctaText: 'Set hours',
+    href: '/app/dispatch/settings/availability',
+    docsPath: '/help/dispatch/set-hours',
+  },
+  'create-request': {
+    label: 'Log a service request',
+    description: 'Capture a customer request so it can be turned into scheduled work.',
+    iconId: 'clipboard-list',
+    color: 'teal',
+    ctaText: 'New service request',
+    href: '/app/service-requests',
+    docsPath: '/help/dispatch/create-request',
+  },
+  'create-work-order': {
+    label: 'Create a work order',
+    description: 'Turn a request into a work order your team can be assigned and dispatched to.',
+    iconId: 'wrench',
+    color: 'purple',
+    ctaText: 'New work order',
+    href: '/app/work-orders',
+    docsPath: '/help/dispatch/create-work-order',
+  },
+  'schedule-visit': {
+    label: 'Schedule a visit',
+    description: 'Put a job on the board and see your dispatch workflow come together.',
+    iconId: 'calendar-clock',
+    color: 'indigo',
+    ctaText: 'Open dispatch board',
+    href: '/app/dispatch',
+    docsPath: '/help/dispatch/schedule-visit',
+  },
+}
+
+/** Ordered display catalog (display order = DISPATCH_GOAL_KEYS order). */
+export const DISPATCH_GETTING_STARTED_GOALS: GettingStartedGoal[] = DISPATCH_GOAL_KEYS.map(
+  (key) => ({
+    key,
+    ...GOALS[key],
+  })
+)

--- a/apps/web/src/components/dispatch/ui/setup-wizard/dispatch-setup-wizard.tsx
+++ b/apps/web/src/components/dispatch/ui/setup-wizard/dispatch-setup-wizard.tsx
@@ -1,0 +1,125 @@
+// apps/web/src/components/dispatch/ui/setup-wizard/dispatch-setup-wizard.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { Dialog, DialogContent, DialogFooter } from '@auxx/ui/components/dialog'
+import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/dialog-nav'
+import { useEffect, useRef, useState } from 'react'
+import { api } from '~/trpc/react'
+import { WizardAddressPage } from './wizard-address-page'
+import { WizardDonePage } from './wizard-done-page'
+import { WizardHoursPage } from './wizard-hours-page'
+import type { WizardStepHandle } from './wizard-step-handle'
+import { WizardWelcomePage } from './wizard-welcome-page'
+import { WizardWorkersPage } from './wizard-workers-page'
+
+const PAGES = ['welcome', 'workers', 'address', 'hours', 'done'] as const
+type WizardPage = (typeof PAGES)[number]
+
+const PAGE_TITLES: Record<WizardPage, string> = {
+  welcome: 'Set up dispatch',
+  workers: 'Workers',
+  address: 'Business address',
+  hours: 'Operating hours',
+  done: "You're set",
+}
+
+export interface DispatchSetupWizardProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * `DispatchSetupWizard` (plans/dispatch/32-onboarding.md Part C) — a five-page `DialogNav` wizard
+ * covering the three dispatch must-haves (workers, business address, operating hours) before a
+ * "you're set" page pointing at the checklist for the remaining record-creation steps.
+ *
+ * Pages write real data (worker upsert, `documents.business` setting, weekly-hours mutation),
+ * never a wizard-local progress record. Workers saves on every pick; Address and Hours hold a
+ * local draft and expose a {@link WizardStepHandle} the shell consults before leaving the page
+ * in any direction — saving a dirty draft (Hours blocks instead when the draft is invalid), so
+ * Back/Continue/"Set up later" never lose anything.
+ *
+ * "Set up later" (any page) and reaching the last page both call `setWizardCompleted` for the
+ * `dispatch` checklist — one timestamp, so the wizard never auto-opens again either way.
+ */
+export function DispatchSetupWizard({ open, onOpenChange }: DispatchSetupWizardProps) {
+  const [page, setPage] = useState<WizardPage>('welcome')
+  const addressRef = useRef<WizardStepHandle | null>(null)
+  const hoursRef = useRef<WizardStepHandle | null>(null)
+
+  // Reset to the first page each time the wizard is (re)opened.
+  useEffect(() => {
+    if (open) setPage('welcome')
+  }, [open])
+
+  const utils = api.useUtils()
+  // Invalidate the cached status so a remounted gate (navigate away + back) sees the stamp —
+  // without this the stale `wizardCompletedAt: null` re-opens the wizard on every return visit.
+  const setWizardCompleted = api.gettingStarted.setWizardCompleted.useMutation({
+    onSuccess: () => utils.gettingStarted.getStatus.invalidate(),
+  })
+
+  const index = PAGES.indexOf(page)
+
+  /** Ask the current page (if it registered a handle) whether it's safe to navigate away. */
+  const attemptLeave = () => {
+    const handle =
+      page === 'address' ? addressRef.current : page === 'hours' ? hoursRef.current : null
+    return handle?.tryAdvance() ?? true
+  }
+
+  const goNext = () => {
+    if (attemptLeave()) setPage(PAGES[Math.min(index + 1, PAGES.length - 1)] ?? 'done')
+  }
+  const goBack = () => {
+    if (attemptLeave()) setPage(PAGES[Math.max(index - 1, 0)] ?? 'welcome')
+  }
+  const finish = () => {
+    if (!attemptLeave()) return
+    setWizardCompleted.mutate({ checklist: 'dispatch' })
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && finish()}>
+      <DialogContent size='content' position='tc' innerClassName='p-0'>
+        <DialogNav
+          title='Set up dispatch'
+          description='A few things to configure before your board is ready.'
+          onBack={page !== 'welcome' && page !== 'done' ? goBack : undefined}
+          crumbs={[{ label: PAGE_TITLES[page] }]}
+        />
+
+        <DialogNavPages value={page}>
+          <DialogNavPage value='welcome' size='md'>
+            <WizardWelcomePage />
+          </DialogNavPage>
+          <DialogNavPage value='workers' size='lg'>
+            <WizardWorkersPage />
+          </DialogNavPage>
+          <DialogNavPage value='address' size='lg'>
+            <WizardAddressPage ref={addressRef} />
+          </DialogNavPage>
+          <DialogNavPage value='hours' size='xl'>
+            <WizardHoursPage ref={hoursRef} />
+          </DialogNavPage>
+          <DialogNavPage value='done' size='md'>
+            <WizardDonePage onFinish={finish} />
+          </DialogNavPage>
+        </DialogNavPages>
+
+        {page !== 'done' && (
+          <DialogFooter className='border-t px-4 py-3 sm:justify-between'>
+            <Button variant='ghost' size='sm' onClick={finish}>
+              Set up later
+            </Button>
+            <Button variant='outline' size='sm' onClick={goNext}>
+              {page === 'welcome' ? 'Get started' : 'Continue'}
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/setup-wizard/setup-wizard-gate.tsx
+++ b/apps/web/src/components/dispatch/ui/setup-wizard/setup-wizard-gate.tsx
@@ -1,0 +1,54 @@
+// apps/web/src/components/dispatch/ui/setup-wizard/setup-wizard-gate.tsx
+'use client'
+
+import type { DispatchGoalKey } from '@auxx/lib/getting-started/client'
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import { useEffect, useState } from 'react'
+import { useUser } from '~/hooks/use-user'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { api } from '~/trpc/react'
+import { DispatchSetupWizard } from './dispatch-setup-wizard'
+
+/** The three wizard must-haves — an org where all three are already done never sees the wizard. */
+const WIZARD_GOAL_KEYS: readonly DispatchGoalKey[] = ['add-workers', 'set-address', 'set-hours']
+
+/**
+ * Auto-opens `DispatchSetupWizard` the first time an admin/owner visits `/app/dispatch`. Mounted
+ * once from the dispatch layout — renders nothing besides the (closed, by default) dialog.
+ *
+ * Opens when ALL of:
+ * - the dispatch checklist's `wizardCompletedAt` is `null` (never finished or skipped) and the
+ *   checklist isn't dismissed
+ * - the current user is ADMIN/OWNER (plain role check — never redirects, just doesn't render)
+ * - `FeatureKey.dispatch` is enabled for the org
+ * - the three wizard goals (workers/address/hours) aren't already all complete — an org that set
+ *   everything up before the wizard shipped never sees it
+ */
+export function DispatchSetupWizardGate() {
+  const { isAdminOrOwner } = useUser()
+  const { hasAccess } = useFeatureFlags()
+  const dispatchEnabled = hasAccess(FeatureKey.dispatch)
+  const shouldQuery = isAdminOrOwner && dispatchEnabled
+
+  const { data: status } = api.gettingStarted.getStatus.useQuery(
+    { checklist: 'dispatch' },
+    { enabled: shouldQuery }
+  )
+
+  const [open, setOpen] = useState(false)
+  const [hasAutoOpened, setHasAutoOpened] = useState(false)
+
+  const allWizardGoalsComplete =
+    !!status && WIZARD_GOAL_KEYS.every((key) => status.completedGoals.includes(key))
+
+  useEffect(() => {
+    if (hasAutoOpened || !shouldQuery || !status) return
+    if (status.wizardCompletedAt !== null || status.dismissed || allWizardGoalsComplete) return
+    setOpen(true)
+    setHasAutoOpened(true)
+  }, [hasAutoOpened, shouldQuery, status, allWizardGoalsComplete])
+
+  if (!shouldQuery) return null
+
+  return <DispatchSetupWizard open={open} onOpenChange={setOpen} />
+}

--- a/apps/web/src/components/dispatch/ui/setup-wizard/wizard-address-page.tsx
+++ b/apps/web/src/components/dispatch/ui/setup-wizard/wizard-address-page.tsx
@@ -1,0 +1,64 @@
+// apps/web/src/components/dispatch/ui/setup-wizard/wizard-address-page.tsx
+'use client'
+
+import { forwardRef, useImperativeHandle } from 'react'
+import { FieldPanel } from '~/components/global/forms/field-panel'
+import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
+import {
+  BusinessAddressFields,
+  normalizeAddress,
+} from '~/components/money/ui/settings/business-address-fields'
+import { useSettings } from '~/hooks/use-settings'
+import type { WizardStepHandle } from './wizard-step-handle'
+
+/**
+ * Page 3 of `DispatchSetupWizard` — the `documents.business.address` fields, reusing the shared
+ * {@link BusinessAddressFields} block extracted from the Documents settings page so both write
+ * the identical `AddressStruct` shape into the same `documents.business` org setting (the same
+ * value the Documents page displays and the route planner reads as its depot).
+ *
+ * Edits are held in a local draft and written once via `tryAdvance` when the shell navigates
+ * away (any direction) — one `updateOrganizationSetting` call per page-leave instead of one per
+ * keystroke, matching the Documents page's batched-save behavior. Address fields are free-form
+ * text, so a dirty draft always saves and navigation is never blocked.
+ */
+export const WizardAddressPage = forwardRef<WizardStepHandle>(
+  function WizardAddressPage(_props, ref) {
+    const { getSetting, updateOrganizationSetting } = useSettings({})
+
+    const rawBusiness = getSetting('documents.business')
+    const business = (rawBusiness && typeof rawBusiness === 'object' ? rawBusiness : {}) as Record<
+      string,
+      unknown
+    >
+    const server = normalizeAddress(business.address)
+
+    const { draft, setDraft, dirty, save } = useDirtyDraft(server, {
+      onSave: (next) =>
+        updateOrganizationSetting('documents.business', { ...business, address: next }),
+    })
+
+    useImperativeHandle(ref, () => ({
+      tryAdvance: () => {
+        if (dirty) save()
+        return true
+      },
+    }))
+
+    return (
+      <div className='flex flex-col gap-4 p-4'>
+        <p className='text-muted-foreground text-sm'>
+          Used as the depot for route planning, and printed on every quote and invoice.
+        </p>
+        <FieldPanel
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='dispatch-wizard-address'
+          defaultLabelWidth={140}
+          className='p-0'>
+          <BusinessAddressFields value={draft} onChange={setDraft} />
+        </FieldPanel>
+      </div>
+    )
+  }
+)

--- a/apps/web/src/components/dispatch/ui/setup-wizard/wizard-done-page.tsx
+++ b/apps/web/src/components/dispatch/ui/setup-wizard/wizard-done-page.tsx
@@ -1,0 +1,37 @@
+// apps/web/src/components/dispatch/ui/setup-wizard/wizard-done-page.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { PartyPopper } from 'lucide-react'
+import Link from 'next/link'
+
+interface WizardDonePageProps {
+  /** Stamps `setWizardCompleted` and closes the dialog. */
+  onFinish: () => void
+}
+
+/**
+ * Page 5 (last) of `DispatchSetupWizard` — a short "you're set" page pointing at the checklist's
+ * remaining record-creation steps (service request → work order → visit), which stay visible in
+ * the dispatch sidebar checklist after this wizard closes.
+ */
+export function WizardDonePage({ onFinish }: WizardDonePageProps) {
+  return (
+    <div className='flex flex-col items-center gap-3 px-4 py-6 text-center'>
+      <PartyPopper className='size-8 text-muted-foreground' />
+      <h2 className='font-medium text-foreground text-base'>You&apos;re set</h2>
+      <p className='max-w-xs text-muted-foreground text-sm'>
+        Next: log your first service request. The dispatch checklist keeps track of the remaining
+        steps — turning it into a work order and scheduling a visit.
+      </p>
+      <div className='mt-2 flex items-center gap-2'>
+        <Button variant='ghost' size='sm' onClick={onFinish}>
+          Close
+        </Button>
+        <Button variant='outline' size='sm' asChild onClick={onFinish}>
+          <Link href='/app/service-requests'>Log a service request</Link>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/setup-wizard/wizard-hours-page.tsx
+++ b/apps/web/src/components/dispatch/ui/setup-wizard/wizard-hours-page.tsx
@@ -1,0 +1,136 @@
+// apps/web/src/components/dispatch/ui/setup-wizard/wizard-hours-page.tsx
+'use client'
+
+import { detectTimezone } from '@auxx/config/client'
+import type { WeeklyHours } from '@auxx/lib/availability/client'
+import { weekStartToIndex } from '@auxx/lib/availability/client'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { forwardRef, useImperativeHandle } from 'react'
+import {
+  validateWeeklyDraft,
+  type WeeklyHoursDraft,
+  WeeklyHoursEditor,
+} from '~/components/availability/ui/weekly-hours-editor'
+import { useAvailabilityCacheStore } from '~/components/dispatch/stores/availability-cache-store'
+import { useDirtyDraft } from '~/components/global/forms/use-dirty-draft'
+import { useSettings } from '~/hooks/use-settings'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
+import { api } from '~/trpc/react'
+import type { WizardStepHandle } from './wizard-step-handle'
+
+const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6] as const
+
+/** Build the editor draft from the router's `getWeeklyHours` response (mirrors the availability settings page). */
+function buildDraftFromResponse(
+  weekly: WeeklyHours | null,
+  timezoneFallback: string
+): WeeklyHoursDraft {
+  const byDay = new Map(weekly?.days.map((d) => [d.dayOfWeek, d]))
+  return {
+    timezone: weekly?.timezone || timezoneFallback,
+    days: ALL_DAYS.map((dayOfWeek) => {
+      const day = byDay.get(dayOfWeek)
+      return {
+        dayOfWeek,
+        enabled: !!day && day.ranges.length > 0,
+        ranges: day?.ranges.map((r) => ({ start: r.start, end: r.end })) ?? [],
+      }
+    }),
+  }
+}
+
+/** Collapse an editor draft to the persisted `WeeklyHours` shape (drop disabled days / empty ranges). */
+function toWeeklyHours(draft: WeeklyHoursDraft): WeeklyHours {
+  return {
+    timezone: draft.timezone,
+    days: draft.days
+      .filter((d) => d.enabled)
+      .map((d) => ({
+        dayOfWeek: d.dayOfWeek,
+        ranges: d.ranges.filter(
+          (r): r is { start: number; end: number } => r.start != null && r.end != null
+        ),
+      }))
+      .filter((d) => d.ranges.length > 0),
+  }
+}
+
+function scalarSetting(value: unknown): string | null {
+  if (Array.isArray(value)) return (value[0] as string) ?? null
+  return (value as string) ?? null
+}
+
+/**
+ * Page 4 of `DispatchSetupWizard` — the org-subject `WeeklyHoursEditor` (05-availability.md
+ * §E.1), same draft/save mechanics as the Availability settings page. Unlike the auto-saving
+ * Workers/Address pages, hours need an explicit, validated save — so this page exposes a
+ * `tryAdvance` handle the wizard shell calls before navigating away in *either* direction
+ * (Back, Continue, or "Set up later"): it saves a dirty-and-valid draft, or blocks navigation
+ * with a toast when the draft is dirty but invalid, so entered hours are never silently lost.
+ */
+export const WizardHoursPage = forwardRef<WizardStepHandle>(function WizardHoursPage(_props, ref) {
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const utils = api.useUtils()
+
+  const weeklyQuery = api.availability.getWeeklyHours.useQuery(
+    { subject: { type: 'organization' } },
+    { staleTime: ORG_STATIC_STALE_TIME }
+  )
+
+  const saveWeeklyHours = api.availability.saveWeeklyHours.useMutation({
+    onSuccess: () => {
+      utils.availability.getWeeklyHours.invalidate({ subject: { type: 'organization' } })
+      useAvailabilityCacheStore.getState().invalidateAll()
+    },
+    onError: (error) =>
+      toastError({ title: 'Error saving weekly hours', description: error.message }),
+  })
+
+  const server = buildDraftFromResponse(weeklyQuery.data ?? null, detectTimezone())
+  const { draft, setDraft, dirty, save } = useDirtyDraft(server, {
+    isSaving: saveWeeklyHours.isPending,
+    onSave: (next) =>
+      saveWeeklyHours.mutate({ subject: { type: 'organization' }, weekly: toWeeklyHours(next) }),
+  })
+
+  useImperativeHandle(ref, () => ({
+    tryAdvance: () => {
+      if (!dirty) return true
+      if (!validateWeeklyDraft(draft)) {
+        toastError({
+          title: 'Fix your hours before continuing',
+          description: 'Some days have incomplete or overlapping time ranges.',
+        })
+        return false
+      }
+      save()
+      return true
+    },
+  }))
+
+  const weekStart = (scalarSetting(getSetting('organization.weekStart')) ?? 'monday') as
+    | 'monday'
+    | 'sunday'
+    | 'saturday'
+  const weekStartsOn = weekStartToIndex(weekStart)
+  const use24HourTime = Boolean(scalarSetting(getSetting('organization.use24HourTime')))
+
+  return (
+    <div className='flex flex-col gap-4 p-4'>
+      <p className='text-muted-foreground text-sm'>
+        The default schedule dispatch uses to determine when your organization is open.
+      </p>
+      {weeklyQuery.isSuccess ? (
+        <WeeklyHoursEditor
+          value={draft}
+          onChange={setDraft}
+          weekStartsOn={weekStartsOn}
+          use24HourTime={use24HourTime}
+        />
+      ) : (
+        <Skeleton className='h-48 w-full rounded-xl' />
+      )}
+    </div>
+  )
+})

--- a/apps/web/src/components/dispatch/ui/setup-wizard/wizard-step-handle.ts
+++ b/apps/web/src/components/dispatch/ui/setup-wizard/wizard-step-handle.ts
@@ -1,0 +1,17 @@
+// apps/web/src/components/dispatch/ui/setup-wizard/wizard-step-handle.ts
+
+/**
+ * Imperative handle a wizard page can expose (via `forwardRef`) so the wizard shell can ask it,
+ * right before navigating away in any direction, whether it's safe to leave. Pages that write
+ * their data immediately on every change (Workers) don't need one — pages with their own local
+ * draft (Business address, Operating hours) register one to save on leave.
+ */
+export interface WizardStepHandle {
+  /**
+   * Called before Back/Continue/"Set up later" moves off this page. Returns `true` when it's
+   * safe to navigate (saving a dirty-but-valid draft as a side effect first); returns `false`
+   * to block navigation (e.g. after showing a validation toast) so unsaved, invalid edits are
+   * never silently discarded.
+   */
+  tryAdvance: () => boolean
+}

--- a/apps/web/src/components/dispatch/ui/setup-wizard/wizard-welcome-page.tsx
+++ b/apps/web/src/components/dispatch/ui/setup-wizard/wizard-welcome-page.tsx
@@ -1,0 +1,40 @@
+// apps/web/src/components/dispatch/ui/setup-wizard/wizard-welcome-page.tsx
+'use client'
+
+import { GuideColumn, GuideConcept, GuideConcepts } from '@auxx/ui/components/guide'
+import { CalendarClock, MapPin, Users } from 'lucide-react'
+
+/**
+ * Page 1 of `DispatchSetupWizard` — a plain-language explainer of what dispatch is and the three
+ * must-haves the wizard sets up, built from the container-agnostic `@auxx/ui/components/guide`
+ * content primitives (docs/ui-design-guide.md §16), not a `GuideDialog` shell (the wizard already
+ * supplies its own `DialogNav`).
+ */
+export function WizardWelcomePage() {
+  return (
+    <div className='flex flex-col gap-4 p-4'>
+      <p className='text-muted-foreground text-sm'>
+        Dispatch schedules your team&apos;s on-site work: service requests turn into work orders,
+        work orders get visits, and visits land on a board organized by worker. Three things make it
+        useful right away.
+      </p>
+      <GuideColumn title="What we'll set up">
+        <GuideConcepts>
+          <GuideConcept glyph={<Users className='size-3.5 text-muted-foreground' />} term='Workers'>
+            The people who show up as columns on the board.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<MapPin className='size-3.5 text-muted-foreground' />}
+            term='Business address'>
+            Used as the depot for route planning and printed on quotes and invoices.
+          </GuideConcept>
+          <GuideConcept
+            glyph={<CalendarClock className='size-3.5 text-muted-foreground' />}
+            term='Operating hours'>
+            When your organization is open, shown as shading on the board.
+          </GuideConcept>
+        </GuideConcepts>
+      </GuideColumn>
+    </div>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/setup-wizard/wizard-workers-page.tsx
+++ b/apps/web/src/components/dispatch/ui/setup-wizard/wizard-workers-page.tsx
@@ -1,0 +1,69 @@
+// apps/web/src/components/dispatch/ui/setup-wizard/wizard-workers-page.tsx
+'use client'
+
+import { type ActorId, parseActorId, toActorId } from '@auxx/types/actor'
+import { toastError } from '@auxx/ui/components/toast'
+import { useState } from 'react'
+import { ActorPickerContent } from '~/components/pickers/actor-picker/actor-picker-content'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
+import { api } from '~/trpc/react'
+import { WorkerCard } from '../worker-card'
+
+/**
+ * Page 2 of `DispatchSetupWizard` — the same member picker + upsert mutation as
+ * `AddWorkerDialog`, rendered inline as a wizard page instead of a nested dialog, plus a
+ * read-only grid of already-added workers. Each pick immediately upserts a `DispatchWorker`
+ * row — there's no page-local draft, so leaving the page (forward or back) never loses anything.
+ */
+export function WizardWorkersPage() {
+  const utils = api.useUtils()
+  const [selected, setSelected] = useState<ActorId[]>([])
+
+  const { data: workers, isLoading } = api.dispatch.listWorkers.useQuery(undefined, {
+    staleTime: ORG_STATIC_STALE_TIME,
+  })
+
+  const upsertWorker = api.dispatch.upsertWorker.useMutation({
+    onSuccess: () => {
+      utils.dispatch.listWorkers.invalidate()
+      setSelected([])
+    },
+    onError: (error) => toastError({ title: 'Error adding worker', description: error.message }),
+  })
+
+  const excludeIds = (workers ?? []).map((worker) => toActorId('user', worker.userId))
+
+  return (
+    <div className='flex flex-col gap-4 p-4'>
+      <p className='text-muted-foreground text-sm'>
+        Add the people who&apos;ll be scheduled on the board.
+      </p>
+
+      {!isLoading && (workers?.length ?? 0) > 0 && (
+        <div className='@container'>
+          <div className='grid gap-2 @md:grid-cols-2'>
+            {(workers ?? []).map((worker) => (
+              <WorkerCard key={worker.id} worker={worker} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className='overflow-hidden rounded-xl border'>
+        <ActorPickerContent
+          value={selected}
+          onChange={setSelected}
+          target='user'
+          multi={false}
+          excludeIds={excludeIds}
+          placeholder='Search members to add...'
+          disabled={upsertWorker.isPending}
+          onSelectSingle={(actorId) => {
+            const { id: userId } = parseActorId(actorId)
+            upsertWorker.mutate({ userId })
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/dispatch/ui/sidebar/dispatch-sidebar.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/dispatch-sidebar.tsx
@@ -11,6 +11,8 @@ import {
 } from '@auxx/ui/components/sidebar'
 import { Switch } from '@auxx/ui/components/switch'
 import { useMemo } from 'react'
+import { DISPATCH_GETTING_STARTED_GOALS } from '~/components/dispatch/getting-started'
+import { GettingStartedGroup } from '~/components/getting-started/ui/getting-started-group'
 import {
   useDispatchSidebarStore,
   useHiddenWorkerIds,
@@ -145,6 +147,11 @@ export function DispatchSidebar({
          * `SidebarItem`'s own button/link root) so the trailing `Switch` — itself a real
          * `<button role="switch">` — never nests inside another interactive element. */
         <SidebarFooter className='p-2'>
+          <GettingStartedGroup
+            checklistId='dispatch'
+            catalog={DISPATCH_GETTING_STARTED_GOALS}
+            title='Dispatch setup'
+          />
           <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton asChild size='sm' className='h-7'>

--- a/apps/web/src/components/dispatch/ui/worker-card.tsx
+++ b/apps/web/src/components/dispatch/ui/worker-card.tsx
@@ -23,7 +23,8 @@ function workerStatus(worker: DispatchWorkerRow): ListCardStatus {
 
 interface WorkerCardProps {
   worker: DispatchWorkerRow
-  onClick: (worker: DispatchWorkerRow) => void
+  /** Omit to render a read-only tile (e.g. the dispatch setup wizard's already-added list). */
+  onClick?: (worker: DispatchWorkerRow) => void
 }
 
 /**
@@ -53,7 +54,7 @@ export function WorkerCard({ worker, onClick }: WorkerCardProps) {
           </Badge>
         ) : undefined
       }
-      onClick={() => onClick(worker)}
+      onClick={onClick ? () => onClick(worker) : undefined}
     />
   )
 }

--- a/apps/web/src/components/getting-started/client.ts
+++ b/apps/web/src/components/getting-started/client.ts
@@ -3,7 +3,7 @@
 // descriptions, icons and CTAs live here (web concerns); the canonical key set
 // + persisted state shapes come from @auxx/lib/getting-started/client.
 
-import { GOAL_KEYS, type GoalKey } from '@auxx/lib/getting-started/client'
+import { type GoalKey, MAIN_GOAL_KEYS, type MainGoalKey } from '@auxx/lib/getting-started/client'
 
 /** Chrome Web Store listing for the browser extension (published unlisted). */
 export const EXTENSION_STORE_URL =
@@ -30,7 +30,7 @@ export type GettingStartedGoal = {
   markOnClick?: boolean
 }
 
-const GOALS: Record<GoalKey, Omit<GettingStartedGoal, 'key'>> = {
+const GOALS: Record<MainGoalKey, Omit<GettingStartedGoal, 'key'>> = {
   'connect-email': {
     label: 'Connect your inbox',
     description: 'Link a Gmail or Outlook mailbox so Auxx can read and reply to support email.',
@@ -89,8 +89,8 @@ const GOALS: Record<GoalKey, Omit<GettingStartedGoal, 'key'>> = {
   },
 }
 
-/** Ordered display catalog (display order = GOAL_KEYS order). */
-export const GETTING_STARTED_GOALS: GettingStartedGoal[] = GOAL_KEYS.map((key) => ({
+/** Ordered display catalog (display order = MAIN_GOAL_KEYS order). */
+export const GETTING_STARTED_GOALS: GettingStartedGoal[] = MAIN_GOAL_KEYS.map((key) => ({
   key,
   ...GOALS[key],
 }))

--- a/apps/web/src/components/getting-started/hooks/use-getting-started.ts
+++ b/apps/web/src/components/getting-started/hooks/use-getting-started.ts
@@ -1,21 +1,24 @@
 // apps/web/src/components/getting-started/hooks/use-getting-started.ts
 'use client'
 
-import type { GoalKey } from '@auxx/lib/getting-started/client'
+import type { ChecklistId, GoalKey } from '@auxx/lib/getting-started/client'
 import { useMemo } from 'react'
 import { api } from '~/trpc/react'
-import { GETTING_STARTED_GOALS } from '../client'
+import type { GettingStartedGoal } from '../client'
 
 /**
- * Wraps the getting-started tRPC query and folds the server status into the
- * display catalog. Returns the displayed goals, a completed-key set, the
- * done/total ratio, and the mutation handlers (each invalidates the query).
+ * Wraps the getting-started tRPC query and folds the server status into a
+ * given display catalog. Returns the displayed goals, a completed-key set,
+ * the done/total ratio, and the mutation handlers (each invalidates the
+ * query). `checklistId` selects which checklist's state is read/written
+ * (`main` or `dispatch`); `catalog` is the checklist's display catalog.
  */
-export function useGettingStarted() {
+export function useGettingStarted(checklistId: ChecklistId, catalog: GettingStartedGoal[]) {
   const utils = api.useUtils()
-  const { data, isLoading } = api.gettingStarted.getStatus.useQuery(undefined, {
-    staleTime: 60_000,
-  })
+  const { data, isLoading } = api.gettingStarted.getStatus.useQuery(
+    { checklist: checklistId },
+    { staleTime: 60_000 }
+  )
 
   const invalidate = () => utils.gettingStarted.getStatus.invalidate()
 
@@ -26,7 +29,7 @@ export function useGettingStarted() {
   const setDismissed = api.gettingStarted.setDismissed.useMutation({ onSuccess: invalidate })
 
   // The displayed list is the whole catalog for v1 (no role/feature gating yet).
-  const goals = GETTING_STARTED_GOALS
+  const goals = catalog
   const completed = useMemo(() => new Set<GoalKey>(data?.completedGoals ?? []), [data])
 
   const done = goals.filter((g) => completed.has(g.key)).length
@@ -40,8 +43,9 @@ export function useGettingStarted() {
     total,
     allComplete: total > 0 && done === total,
     dismissed: data?.dismissed ?? false,
-    markGoalComplete: (key: GoalKey) => markGoalComplete.mutate({ key }),
-    completeAll: () => completeAll.mutate({ keys: goals.map((g) => g.key) }),
-    dismiss: () => setDismissed.mutate({ dismissed: true }),
+    markGoalComplete: (key: GoalKey) => markGoalComplete.mutate({ checklist: checklistId, key }),
+    completeAll: () =>
+      completeAll.mutate({ checklist: checklistId, keys: goals.map((g) => g.key) }),
+    dismiss: () => setDismissed.mutate({ checklist: checklistId, dismissed: true }),
   }
 }

--- a/apps/web/src/components/getting-started/ui/getting-started-group.tsx
+++ b/apps/web/src/components/getting-started/ui/getting-started-group.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/getting-started/ui/getting-started-group.tsx
 'use client'
 
+import type { ChecklistId } from '@auxx/lib/getting-started/client'
 import { Button } from '@auxx/ui/components/button'
 import { CollapsibleChevron } from '@auxx/ui/components/collapsible'
 import {
@@ -28,7 +29,7 @@ import type { GettingStartedGoal } from '../client'
 import { useGettingStarted } from '../hooks/use-getting-started'
 import { GettingStartedStep } from './getting-started-step'
 
-const SECTION_ID = 'getting-started'
+const SECTION_ID_PREFIX = 'getting-started'
 
 /** Stop a nested control's click from toggling the accordion header. */
 function stop(e: MouseEvent) {
@@ -36,17 +37,31 @@ function stop(e: MouseEvent) {
   e.preventDefault()
 }
 
+type Props = {
+  /** Which checklist's state this instance reads/writes (`main` or `dispatch`). */
+  checklistId: ChecklistId
+  /** Display catalog for this checklist (labels, icons, CTAs). */
+  catalog: GettingStartedGoal[]
+  /** Sidebar section header text. Defaults to "Getting started". */
+  title?: string
+}
+
 /**
- * Inline, animated getting-started checklist pinned in the sidebar footer. The
+ * Inline, animated getting-started checklist pinned in a sidebar footer. The
  * header accordions the step list open/closed (height spring via
  * `SidebarGroupCollapse`). Hovering the list reveals a fixed side panel —
  * anchored to the list, matching its height — that shows the hovered step's
  * description + CTA. Auto-hides once every goal is complete or dismissed.
+ * Generic over checklist (`main` in the app sidebar, `dispatch` in the
+ * dispatch module sidebar) — pass the checklist id and its display catalog.
  */
-export function GettingStartedGroup() {
+export function GettingStartedGroup({ checklistId, catalog, title = 'Getting started' }: Props) {
   const router = useRouter()
   const { docsUrl } = useEnv()
   const { getSectionOpen, toggleSection } = useSidebarState()
+  // Scoped per checklist so the main + dispatch widgets (visible together on
+  // dispatch pages) don't share one accordion open/closed state.
+  const sectionId = `${SECTION_ID_PREFIX}:${checklistId}`
   const {
     isLoading,
     goals,
@@ -58,7 +73,7 @@ export function GettingStartedGroup() {
     markGoalComplete,
     completeAll,
     dismiss,
-  } = useGettingStarted()
+  } = useGettingStarted(checklistId, catalog)
 
   const observerRef = useRef<ResizeObserver | null>(null)
   const [panelHeight, setPanelHeight] = useState<number>()
@@ -81,7 +96,7 @@ export function GettingStartedGroup() {
   // Hidden while loading, once dismissed, or all done. (Footer = post-onboarding.)
   if (isLoading || dismissed || allComplete || total === 0) return null
 
-  const isOpen = getSectionOpen(SECTION_ID, true)
+  const isOpen = getSectionOpen(sectionId, true)
 
   // Default the panel to the first incomplete step until the user hovers one.
   const activeGoal =
@@ -102,12 +117,12 @@ export function GettingStartedGroup() {
         <HoverCard openDelay={250} closeDelay={200}>
           <HoverCardTrigger asChild>
             <div ref={measureRef}>
-              <SidebarMenuButton asChild tooltip='Getting started'>
+              <SidebarMenuButton asChild tooltip={title}>
                 <div
-                  onClick={() => toggleSection(SECTION_ID)}
+                  onClick={() => toggleSection(sectionId)}
                   className='group/gs relative h-7 cursor-pointer'>
                   <Rocket className='size-4' />
-                  <span className='group-data-[collapsible=icon]:hidden'>Getting started</span>
+                  <span className='group-data-[collapsible=icon]:hidden'>{title}</span>
                   <CollapsibleChevron open={isOpen} className='ms-1 text-muted-foreground' />
 
                   <div className='ms-auto flex items-center gap-1 group-data-[collapsible=icon]:hidden'>

--- a/apps/web/src/components/global/sidebar/index.tsx
+++ b/apps/web/src/components/global/sidebar/index.tsx
@@ -10,6 +10,7 @@ import {
   SidebarRail,
 } from '@auxx/ui/components/sidebar'
 import type * as React from 'react'
+import { GETTING_STARTED_GOALS } from '~/components/getting-started/client'
 import { GettingStartedGroup } from '~/components/getting-started/ui/getting-started-group'
 import { MailSidebar } from '~/components/global/sidebar/mail-sidebar'
 import { SIDEBAR_MENU } from '~/constants/menu'
@@ -55,7 +56,7 @@ export default function AppSidebar({ user, ...props }: Prop) {
           <EntitySidebarNav />
         </SidebarContent>
         <SidebarFooter>
-          <GettingStartedGroup />
+          <GettingStartedGroup checklistId='main' catalog={GETTING_STARTED_GOALS} />
           <AppFooter />
         </SidebarFooter>
         <SidebarRail />

--- a/apps/web/src/components/money/ui/settings/business-address-fields.tsx
+++ b/apps/web/src/components/money/ui/settings/business-address-fields.tsx
@@ -1,0 +1,74 @@
+// apps/web/src/components/money/ui/settings/business-address-fields.tsx
+'use client'
+
+import {
+  type AddressStruct,
+  AddressStructFields,
+} from '~/components/fields/inputs/address-struct-input-field'
+import { FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+
+/** A business tax id label/value pair (e.g. `{ label: 'EIN', value: '12-3456789' }`). */
+export interface BusinessTaxId {
+  label: string
+  value: string
+}
+
+export const EMPTY_TAX_ID: BusinessTaxId = { label: '', value: '' }
+
+/** `documents.business` JSON blob shape — address is the canonical `AddressStruct`. */
+export interface BusinessInfo {
+  companyName: string
+  address: AddressStruct
+  phone: string
+  email: string
+  website: string
+  taxId: BusinessTaxId
+}
+
+/** Map a stored address blob (new `AddressStruct` or the legacy `{line1,line2,region,zip}`) to `AddressStruct`. */
+export function normalizeAddress(raw: unknown): AddressStruct {
+  const s = (raw && typeof raw === 'object' ? raw : {}) as Record<string, string>
+  return {
+    street1: s.street1 ?? s.line1 ?? '',
+    street2: s.street2 ?? s.line2 ?? '',
+    city: s.city ?? '',
+    state: s.state ?? s.region ?? '',
+    zipCode: s.zipCode ?? s.zip ?? '',
+    country: s.country ?? '',
+  }
+}
+
+/** Merge a stored (possibly partial/old-shape) `documents.business` value with defaults so the form never crashes on a fresh org. */
+export function normalizeBusiness(raw: unknown): BusinessInfo {
+  const source = (raw && typeof raw === 'object' ? raw : {}) as Partial<BusinessInfo>
+  return {
+    companyName: source.companyName ?? '',
+    address: normalizeAddress(source.address),
+    phone: source.phone ?? '',
+    email: source.email ?? '',
+    website: source.website ?? '',
+    taxId: { ...EMPTY_TAX_ID, ...(source.taxId ?? {}) },
+  }
+}
+
+export interface BusinessAddressFieldsProps {
+  value: AddressStruct
+  onChange: (next: AddressStruct) => void
+}
+
+/**
+ * The shared `documents.business.address` form row — used by both the Documents settings page
+ * (`documents-page.tsx`) and the dispatch setup wizard's Business address page, so the two
+ * surfaces stay in lockstep on the same `AddressStruct` shape. Presentational only: the caller
+ * owns reading/writing the `documents.business` setting and passes just the `address` slice.
+ */
+export function BusinessAddressFields({ value, onChange }: BusinessAddressFieldsProps) {
+  return (
+    <FieldPanelRow title='Address' type={BaseType.ADDRESS} showIcon>
+      <div className='py-2'>
+        <AddressStructFields value={value} onChange={onChange} className='flex flex-col gap-2' />
+      </div>
+    </FieldPanelRow>
+  )
+}

--- a/apps/web/src/components/money/ui/settings/documents-page.tsx
+++ b/apps/web/src/components/money/ui/settings/documents-page.tsx
@@ -8,10 +8,6 @@ import { getFileRefDownloadUrl, toFileRef } from '@auxx/types/file-ref'
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
 import { Building2, Eye, FileText, Lock, Mail, Palette, Receipt } from 'lucide-react'
-import {
-  type AddressStruct,
-  AddressStructFields,
-} from '~/components/fields/inputs/address-struct-input-field'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { EmptyState } from '~/components/global/empty-state'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
@@ -24,50 +20,12 @@ import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
 import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
+import {
+  BusinessAddressFields,
+  type BusinessInfo,
+  normalizeBusiness,
+} from './business-address-fields'
 import { type DocumentsLogo, DocumentsLogoCell } from './documents-logo-cell'
-
-interface BusinessTaxId {
-  label: string
-  value: string
-}
-
-/** `documents.business` JSON blob shape — address is the canonical `AddressStruct`. */
-interface BusinessInfo {
-  companyName: string
-  address: AddressStruct
-  phone: string
-  email: string
-  website: string
-  taxId: BusinessTaxId
-}
-
-const EMPTY_TAX_ID: BusinessTaxId = { label: '', value: '' }
-
-/** Map a stored address blob (new `AddressStruct` or the legacy `{line1,line2,region,zip}`) to `AddressStruct`. */
-function normalizeAddress(raw: unknown): AddressStruct {
-  const s = (raw && typeof raw === 'object' ? raw : {}) as Record<string, string>
-  return {
-    street1: s.street1 ?? s.line1 ?? '',
-    street2: s.street2 ?? s.line2 ?? '',
-    city: s.city ?? '',
-    state: s.state ?? s.region ?? '',
-    zipCode: s.zipCode ?? s.zip ?? '',
-    country: s.country ?? '',
-  }
-}
-
-/** Merge a stored (possibly partial/old-shape) value with defaults so the form never crashes on a fresh org. */
-function normalizeBusiness(raw: unknown): BusinessInfo {
-  const source = (raw && typeof raw === 'object' ? raw : {}) as Partial<BusinessInfo>
-  return {
-    companyName: source.companyName ?? '',
-    address: normalizeAddress(source.address),
-    phone: source.phone ?? '',
-    email: source.email ?? '',
-    website: source.website ?? '',
-    taxId: { ...EMPTY_TAX_ID, ...(source.taxId ?? {}) },
-  }
-}
 
 /** Scalar catalog keys the page draft owns (`documents.business` is handled separately as a blob). */
 const SCALAR_DRAFT_KEYS = [
@@ -368,15 +326,10 @@ function BusinessInfoSection({ business, onPatchBusiness, currency }: BusinessIn
           />
         </FieldPanelRow>
 
-        <FieldPanelRow title='Address' type={BaseType.ADDRESS} showIcon>
-          <div className='py-2'>
-            <AddressStructFields
-              value={business.address}
-              onChange={(address) => onPatchBusiness({ address })}
-              className='flex flex-col gap-2'
-            />
-          </div>
-        </FieldPanelRow>
+        <BusinessAddressFields
+          value={business.address}
+          onChange={(address) => onPatchBusiness({ address })}
+        />
 
         <FieldPanelRow title='Phone' type={BaseType.PHONE} showIcon>
           <FieldInputAdapter

--- a/apps/web/src/server/api/routers/getting-started.ts
+++ b/apps/web/src/server/api/routers/getting-started.ts
@@ -1,43 +1,86 @@
 // apps/web/src/server/api/routers/getting-started.ts
-// Slim router for the getting-started checklist — all logic lives in
-// @auxx/lib/getting-started. Each procedure just builds the lib ctx and delegates.
+// Slim router for the getting-started checklists (org-wide `main` + module
+// checklists like `dispatch`) — all logic lives in @auxx/lib/getting-started.
+// Each procedure just builds the lib ctx and delegates.
 
 import {
+  CHECKLIST_IDS,
   completeAllGoals,
-  GOAL_KEYS,
   getGettingStartedStatus,
+  isGoalKey,
   markGoalComplete,
   setDismissed,
+  setWizardCompleted,
 } from '@auxx/lib/getting-started'
+import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'
 
-const goalKeySchema = z.enum(GOAL_KEYS)
+const checklistSchema = z.enum(CHECKLIST_IDS)
+
+/** Narrow a string to a goal key valid for `checklist`, or throw `BAD_REQUEST`. */
+function requireGoalKey(checklist: (typeof CHECKLIST_IDS)[number], key: string) {
+  if (!isGoalKey(checklist, key)) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `"${key}" is not a valid goal for the "${checklist}" checklist`,
+    })
+  }
+  return key
+}
 
 export const gettingStartedRouter = createTRPCRouter({
-  /** Resolved checklist status: completed goal keys + dismissal flag. */
-  getStatus: protectedProcedure.query(({ ctx }) =>
-    getGettingStartedStatus({ db: ctx.db, organizationId: ctx.session.organizationId })
-  ),
+  /** Resolved checklist status: completed goal keys + dismissal + wizard flag. */
+  getStatus: protectedProcedure
+    .input(z.object({ checklist: checklistSchema.default('main') }).optional())
+    .query(({ ctx, input }) =>
+      getGettingStartedStatus(
+        { db: ctx.db, organizationId: ctx.session.organizationId },
+        input?.checklist ?? 'main'
+      )
+    ),
 
   /** Mark a single goal complete (e.g. the extension step). */
   markGoalComplete: protectedProcedure
-    .input(z.object({ key: goalKeySchema }))
+    .input(z.object({ checklist: checklistSchema.default('main'), key: z.string() }))
     .mutation(({ ctx, input }) =>
-      markGoalComplete({ db: ctx.db, organizationId: ctx.session.organizationId }, input.key)
+      markGoalComplete(
+        { db: ctx.db, organizationId: ctx.session.organizationId },
+        input.checklist,
+        requireGoalKey(input.checklist, input.key)
+      )
     ),
 
   /** "Mark all" — union the displayed goal keys into manual completions. */
   completeAll: protectedProcedure
-    .input(z.object({ keys: z.array(goalKeySchema) }))
-    .mutation(({ ctx, input }) =>
-      completeAllGoals({ db: ctx.db, organizationId: ctx.session.organizationId }, input.keys)
-    ),
+    .input(z.object({ checklist: checklistSchema.default('main'), keys: z.array(z.string()) }))
+    .mutation(({ ctx, input }) => {
+      const keys = input.keys.map((key) => requireGoalKey(input.checklist, key))
+      return completeAllGoals(
+        { db: ctx.db, organizationId: ctx.session.organizationId },
+        input.checklist,
+        keys
+      )
+    }),
 
   /** Dismiss or un-dismiss the widget. */
   setDismissed: protectedProcedure
-    .input(z.object({ dismissed: z.boolean() }))
+    .input(z.object({ checklist: checklistSchema.default('main'), dismissed: z.boolean() }))
     .mutation(({ ctx, input }) =>
-      setDismissed({ db: ctx.db, organizationId: ctx.session.organizationId }, input.dismissed)
+      setDismissed(
+        { db: ctx.db, organizationId: ctx.session.organizationId },
+        input.checklist,
+        input.dismissed
+      )
+    ),
+
+  /** Stamp the setup wizard as finished or skipped — never auto-opens again. */
+  setWizardCompleted: protectedProcedure
+    .input(z.object({ checklist: checklistSchema.default('main') }))
+    .mutation(({ ctx, input }) =>
+      setWizardCompleted(
+        { db: ctx.db, organizationId: ctx.session.organizationId },
+        input.checklist
+      )
     ),
 })

--- a/packages/lib/src/getting-started/client.ts
+++ b/packages/lib/src/getting-started/client.ts
@@ -3,11 +3,19 @@
 // widget. No server-only deps — display metadata (labels, icons, CTA routes)
 // lives in the web component, this only owns the canonical key set.
 
-/** The setting key under which getting-started state is persisted (per-org). */
+/** The setting key under which the org-wide getting-started state is persisted. */
 export const GETTING_STARTED_SETTING_KEY = 'onboarding.gettingStarted' as const
 
-/** Canonical, ordered list of onboarding goal keys. Order is display order. */
-export const GOAL_KEYS = [
+/** The setting key under which the dispatch getting-started state is persisted. */
+export const DISPATCH_GETTING_STARTED_SETTING_KEY = 'onboarding.dispatchGettingStarted' as const
+
+/** The known onboarding checklists. `main` is the org-wide checklist; `dispatch` is the module one. */
+export const CHECKLIST_IDS = ['main', 'dispatch'] as const
+
+export type ChecklistId = (typeof CHECKLIST_IDS)[number]
+
+/** Canonical, ordered list of org-wide onboarding goal keys. Order is display order. */
+export const MAIN_GOAL_KEYS = [
   'connect-email',
   'setup-agent',
   'create-workflow',
@@ -16,14 +24,41 @@ export const GOAL_KEYS = [
   'install-extension',
 ] as const
 
-export type GoalKey = (typeof GOAL_KEYS)[number]
+/** Canonical, ordered list of dispatch onboarding goal keys. Order is display order. */
+export const DISPATCH_GOAL_KEYS = [
+  'add-workers',
+  'set-address',
+  'set-hours',
+  'create-request',
+  'create-work-order',
+  'schedule-visit',
+] as const
 
-/**
- * Goals with no server-derivable signal — completion is only ever recorded
- * explicitly in `manualCompletions` (see §6 of the plan). Everything else is
- * auto-inferred from live org state.
- */
-export const MANUAL_GOAL_KEYS: readonly GoalKey[] = ['install-extension']
+export type MainGoalKey = (typeof MAIN_GOAL_KEYS)[number]
+export type DispatchGoalKey = (typeof DISPATCH_GOAL_KEYS)[number]
+export type GoalKey = MainGoalKey | DispatchGoalKey
+
+/** Per-checklist registry: setting key, goal-key set, and manual-only goals. */
+export const CHECKLISTS: Record<
+  ChecklistId,
+  {
+    settingKey: typeof GETTING_STARTED_SETTING_KEY | typeof DISPATCH_GETTING_STARTED_SETTING_KEY
+    goalKeys: readonly GoalKey[]
+    /** Goals with no server signal — completed only via manualCompletions. */
+    manualGoalKeys: readonly GoalKey[]
+  }
+> = {
+  main: {
+    settingKey: GETTING_STARTED_SETTING_KEY,
+    goalKeys: MAIN_GOAL_KEYS,
+    manualGoalKeys: ['install-extension'],
+  },
+  dispatch: {
+    settingKey: DISPATCH_GETTING_STARTED_SETTING_KEY,
+    goalKeys: DISPATCH_GOAL_KEYS,
+    manualGoalKeys: [],
+  },
+}
 
 /** Persisted per-org getting-started state (jsonb value of the setting). */
 export type GettingStartedState = {
@@ -31,6 +66,8 @@ export type GettingStartedState = {
   dismissedAt: string | null
   /** Goal keys completed explicitly (extension step, "mark all"). */
   manualCompletions: string[]
+  /** Dispatch wizard: stamped when finished OR skipped — either way, never auto-open again. */
+  wizardCompletedAt?: string | null
 }
 
 /** Default state for an org that has never touched the checklist. */
@@ -43,9 +80,11 @@ export const DEFAULT_GETTING_STARTED_STATE: GettingStartedState = {
 export type GettingStartedStatus = {
   completedGoals: GoalKey[]
   dismissed: boolean
+  /** ISO timestamp the setup wizard was finished/skipped; `null` = never run. */
+  wizardCompletedAt: string | null
 }
 
-/** Narrow an arbitrary string to a known GoalKey. */
-export function isGoalKey(value: string): value is GoalKey {
-  return (GOAL_KEYS as readonly string[]).includes(value)
+/** Narrow an arbitrary string to a goal key valid for the given checklist. */
+export function isGoalKey(checklistId: ChecklistId, value: string): value is GoalKey {
+  return (CHECKLISTS[checklistId].goalKeys as readonly string[]).includes(value)
 }

--- a/packages/lib/src/getting-started/get-status.ts
+++ b/packages/lib/src/getting-started/get-status.ts
@@ -1,8 +1,9 @@
 // packages/lib/src/getting-started/get-status.ts
 import { getOrgCache } from '../cache'
 import {
+  CHECKLISTS,
+  type ChecklistId,
   DEFAULT_GETTING_STARTED_STATE,
-  GETTING_STARTED_SETTING_KEY,
   type GettingStartedState,
   type GettingStartedStatus,
   type GoalKey,
@@ -11,37 +12,39 @@ import {
 import { getAutoInferredGoals } from './signals'
 import type { GettingStartedContext } from './types'
 
-/** Read persisted state from the `orgSettings` cache (defaults merged in). */
+/** Read a checklist's persisted state from the `orgSettings` cache (defaults merged in). */
 export async function getGettingStartedState(
-  ctx: GettingStartedContext
+  ctx: GettingStartedContext,
+  checklistId: ChecklistId
 ): Promise<GettingStartedState> {
   const settings = await getOrgCache().get(ctx.organizationId, 'orgSettings')
-  return (
-    (settings[GETTING_STARTED_SETTING_KEY] as GettingStartedState | undefined) ??
-    DEFAULT_GETTING_STARTED_STATE
-  )
+  const settingKey = CHECKLISTS[checklistId].settingKey
+  return (settings[settingKey] as GettingStartedState | undefined) ?? DEFAULT_GETTING_STARTED_STATE
 }
 
 /**
  * Resolve the full checklist status for an org: the union of auto-inferred
- * goals and explicitly-recorded manual completions, plus the dismissal flag.
- * Every read is cache-backed (one DB hit for the pending-invite check).
+ * goals and explicitly-recorded manual completions, plus the dismissal flag
+ * and wizard-completion timestamp. Every read is cache-backed (one DB hit per
+ * DB-touching signal).
  */
 export async function getGettingStartedStatus(
-  ctx: GettingStartedContext
+  ctx: GettingStartedContext,
+  checklistId: ChecklistId
 ): Promise<GettingStartedStatus> {
   const [state, autoGoals] = await Promise.all([
-    getGettingStartedState(ctx),
-    getAutoInferredGoals(ctx),
+    getGettingStartedState(ctx, checklistId),
+    getAutoInferredGoals(ctx, checklistId),
   ])
 
   const completed = new Set<GoalKey>(autoGoals)
   for (const key of state.manualCompletions) {
-    if (isGoalKey(key)) completed.add(key)
+    if (isGoalKey(checklistId, key)) completed.add(key)
   }
 
   return {
     completedGoals: [...completed],
     dismissed: state.dismissedAt !== null,
+    wizardCompletedAt: state.wizardCompletedAt ?? null,
   }
 }

--- a/packages/lib/src/getting-started/getting-started-service.ts
+++ b/packages/lib/src/getting-started/getting-started-service.ts
@@ -1,35 +1,43 @@
 // packages/lib/src/getting-started/getting-started-service.ts
 
-import type { GoalKey } from './client'
+import type { ChecklistId, GoalKey } from './client'
 import { getGettingStartedState, getGettingStartedStatus } from './get-status'
-import { completeAllGoals, markGoalComplete, setDismissed } from './mutations'
+import { completeAllGoals, markGoalComplete, setDismissed, setWizardCompleted } from './mutations'
 import type { GettingStartedContext } from './types'
 
 /**
  * Thin object wrapper over the functional getting-started API, holding a fixed
- * {@link GettingStartedContext}. Parity with `KBService` — callers that prefer
- * the object form use this; new code can call the functions directly.
+ * {@link GettingStartedContext} and {@link ChecklistId}. Parity with `KBService`
+ * — callers that prefer the object form use this; new code can call the
+ * functions directly.
  */
 export class GettingStartedService {
-  constructor(private readonly ctx: GettingStartedContext) {}
+  constructor(
+    private readonly ctx: GettingStartedContext,
+    private readonly checklistId: ChecklistId = 'main'
+  ) {}
 
   getStatus() {
-    return getGettingStartedStatus(this.ctx)
+    return getGettingStartedStatus(this.ctx, this.checklistId)
   }
 
   getState() {
-    return getGettingStartedState(this.ctx)
+    return getGettingStartedState(this.ctx, this.checklistId)
   }
 
   markGoalComplete(key: GoalKey) {
-    return markGoalComplete(this.ctx, key)
+    return markGoalComplete(this.ctx, this.checklistId, key)
   }
 
   completeAllGoals(keys: readonly string[]) {
-    return completeAllGoals(this.ctx, keys)
+    return completeAllGoals(this.ctx, this.checklistId, keys)
   }
 
   setDismissed(dismissed: boolean) {
-    return setDismissed(this.ctx, dismissed)
+    return setDismissed(this.ctx, this.checklistId, dismissed)
+  }
+
+  setWizardCompleted() {
+    return setWizardCompleted(this.ctx, this.checklistId)
   }
 }

--- a/packages/lib/src/getting-started/index.ts
+++ b/packages/lib/src/getting-started/index.ts
@@ -1,19 +1,30 @@
 // packages/lib/src/getting-started/index.ts
-// Server entrypoint for the getting-started checklist. Client-safe catalog/types
-// live in ./client (import those from the web widget).
+// Server entrypoint for the getting-started checklist engine. Client-safe
+// catalog/types live in ./client (import those from the web widget).
 
 export {
+  CHECKLIST_IDS,
+  CHECKLISTS,
+  type ChecklistId,
   DEFAULT_GETTING_STARTED_STATE,
+  DISPATCH_GETTING_STARTED_SETTING_KEY,
+  DISPATCH_GOAL_KEYS,
+  type DispatchGoalKey,
   GETTING_STARTED_SETTING_KEY,
   type GettingStartedState,
   type GettingStartedStatus,
-  GOAL_KEYS,
   type GoalKey,
   isGoalKey,
-  MANUAL_GOAL_KEYS,
+  MAIN_GOAL_KEYS,
+  type MainGoalKey,
 } from './client'
 export { getGettingStartedState, getGettingStartedStatus } from './get-status'
 export { GettingStartedService } from './getting-started-service'
-export { completeAllGoals, markGoalComplete, setDismissed } from './mutations'
+export {
+  completeAllGoals,
+  markGoalComplete,
+  setDismissed,
+  setWizardCompleted,
+} from './mutations'
 export { getAutoInferredGoals } from './signals'
 export type { GettingStartedContext } from './types'

--- a/packages/lib/src/getting-started/mutations.ts
+++ b/packages/lib/src/getting-started/mutations.ts
@@ -3,33 +3,39 @@ import type { Database, Transaction } from '@auxx/database'
 import { onCacheEvent } from '../cache'
 import { getOrganizationSetting, updateOrganizationSetting } from '../settings'
 import {
+  CHECKLISTS,
+  type ChecklistId,
   DEFAULT_GETTING_STARTED_STATE,
-  GETTING_STARTED_SETTING_KEY,
   type GettingStartedState,
   type GoalKey,
   isGoalKey,
 } from './client'
 import type { GettingStartedContext } from './types'
 
-/** Read the current persisted state directly (not via cache — write path). */
-async function readState(db: Database | Transaction | undefined, organizationId: string) {
+/** Read a checklist's current persisted state directly (not via cache — write path). */
+async function readState(
+  db: Database | Transaction | undefined,
+  organizationId: string,
+  checklistId: ChecklistId
+) {
   const value = await getOrganizationSetting({
     organizationId,
-    key: GETTING_STARTED_SETTING_KEY,
+    key: CHECKLISTS[checklistId].settingKey,
     db,
   })
   return (value as GettingStartedState | null) ?? DEFAULT_GETTING_STARTED_STATE
 }
 
-/** Persist new state + invalidate the org-settings cache. */
+/** Persist a checklist's new state + invalidate the org-settings cache. */
 async function writeState(
   db: Database | Transaction | undefined,
   organizationId: string,
+  checklistId: ChecklistId,
   state: GettingStartedState
 ) {
   await updateOrganizationSetting({
     organizationId,
-    key: GETTING_STARTED_SETTING_KEY,
+    key: CHECKLISTS[checklistId].settingKey,
     value: state,
     db,
   })
@@ -40,10 +46,14 @@ async function writeState(
  * Record a single goal as manually complete (e.g. the extension step). Unions
  * into `manualCompletions` — never clobbers, so concurrent writers are safe.
  */
-export async function markGoalComplete(ctx: GettingStartedContext, key: GoalKey): Promise<void> {
-  const state = await readState(ctx.db, ctx.organizationId)
+export async function markGoalComplete(
+  ctx: GettingStartedContext,
+  checklistId: ChecklistId,
+  key: GoalKey
+): Promise<void> {
+  const state = await readState(ctx.db, ctx.organizationId, checklistId)
   if (state.manualCompletions.includes(key)) return
-  await writeState(ctx.db, ctx.organizationId, {
+  await writeState(ctx.db, ctx.organizationId, checklistId, {
     ...state,
     manualCompletions: [...state.manualCompletions, key],
   })
@@ -55,24 +65,46 @@ export async function markGoalComplete(ctx: GettingStartedContext, key: GoalKey)
  */
 export async function completeAllGoals(
   ctx: GettingStartedContext,
+  checklistId: ChecklistId,
   keys: readonly string[]
 ): Promise<void> {
-  const state = await readState(ctx.db, ctx.organizationId)
+  const state = await readState(ctx.db, ctx.organizationId, checklistId)
   const union = new Set(state.manualCompletions)
   for (const key of keys) {
-    if (isGoalKey(key)) union.add(key)
+    if (isGoalKey(checklistId, key)) union.add(key)
   }
-  await writeState(ctx.db, ctx.organizationId, {
+  await writeState(ctx.db, ctx.organizationId, checklistId, {
     ...state,
     manualCompletions: [...union],
   })
 }
 
 /** Dismiss (stamp `dismissedAt`) or un-dismiss (clear it) the widget. */
-export async function setDismissed(ctx: GettingStartedContext, dismissed: boolean): Promise<void> {
-  const state = await readState(ctx.db, ctx.organizationId)
-  await writeState(ctx.db, ctx.organizationId, {
+export async function setDismissed(
+  ctx: GettingStartedContext,
+  checklistId: ChecklistId,
+  dismissed: boolean
+): Promise<void> {
+  const state = await readState(ctx.db, ctx.organizationId, checklistId)
+  await writeState(ctx.db, ctx.organizationId, checklistId, {
     ...state,
     dismissedAt: dismissed ? new Date().toISOString() : null,
+  })
+}
+
+/**
+ * Stamp `wizardCompletedAt` for a checklist's setup wizard (finished or
+ * skipped — either way it should never auto-open again). Idempotent: a
+ * checklist that's already stamped is left untouched.
+ */
+export async function setWizardCompleted(
+  ctx: GettingStartedContext,
+  checklistId: ChecklistId
+): Promise<void> {
+  const state = await readState(ctx.db, ctx.organizationId, checklistId)
+  if (state.wizardCompletedAt) return
+  await writeState(ctx.db, ctx.organizationId, checklistId, {
+    ...state,
+    wizardCompletedAt: new Date().toISOString(),
   })
 }

--- a/packages/lib/src/getting-started/signals.ts
+++ b/packages/lib/src/getting-started/signals.ts
@@ -1,17 +1,28 @@
 // packages/lib/src/getting-started/signals.ts
-// Per-goal completion signals, auto-inferred from live org state. Every signal
-// subtracts seeded defaults so a fresh org reads as "nothing done yet":
+// Per-goal completion signals, auto-inferred from live org state, keyed by checklist.
+// Every `main` signal subtracts seeded defaults so a fresh org reads as "nothing done yet":
 //   - email:    seeded mailboxes are `enabled: false` (example also isExample)
 //   - workflow: the example scenario seeds `[Example] …`-named workflows
 //   - members:  AI agents are synthetic users (userType !== 'USER')
 //   - agents:   no agent is seeded; a real one has name + setupCompletedAt set
-// Reads come from the per-org cache; only the pending-invite check touches the DB.
+// `dispatch` signals are plain existence checks — no seeded example workers/records exist.
+// Reads come from the per-org cache; only limit-1 DB lookups touch the database directly.
 
 import { database, schema } from '@auxx/database'
-import { and, eq } from 'drizzle-orm'
-import { getAllCachedCustomFields, getCachedAgents, getCachedMembers, getOrgCache } from '../cache'
-import type { GoalKey } from './client'
+import { and, eq, isNotNull } from 'drizzle-orm'
+import {
+  getAllCachedCustomFields,
+  getCachedAgents,
+  getCachedEntityDefId,
+  getCachedMembers,
+  getOrgCache,
+} from '../cache'
+import type { ChecklistId, GoalKey } from './client'
 import type { GettingStartedContext } from './types'
+
+type Signal = (ctx: GettingStartedContext) => Promise<boolean>
+
+// ── main checklist signals ──
 
 /** A real, enabled inbound mailbox (Gmail/Outlook) that isn't seeded demo data. */
 async function isEmailConnected(ctx: GettingStartedContext): Promise<boolean> {
@@ -64,23 +75,113 @@ async function hasHumanTeammate(ctx: GettingStartedContext): Promise<boolean> {
   return pending.length > 0
 }
 
-/** Map of auto-inferred goal → signal. `install-extension` has no signal. */
-const AUTO_SIGNALS: Partial<Record<GoalKey, (ctx: GettingStartedContext) => Promise<boolean>>> = {
-  'connect-email': isEmailConnected,
-  'setup-agent': hasConfiguredAgent,
-  'create-workflow': hasUserWorkflow,
-  'create-field': hasCustomField,
-  'invite-team': hasHumanTeammate,
+// ── dispatch checklist signals ──
+
+/** At least one `DispatchWorker` row for the org — active or not, any counts. */
+async function hasWorkers(ctx: GettingStartedContext): Promise<boolean> {
+  const db = ctx.db ?? database
+  const rows = await db
+    .select({ id: schema.DispatchWorker.id })
+    .from(schema.DispatchWorker)
+    .where(eq(schema.DispatchWorker.organizationId, ctx.organizationId))
+    .limit(1)
+  return rows.length > 0
+}
+
+/** `documents.business` has a filled-in address — canonical `street1`/`city`, or the legacy `line1`/`city` shape. */
+async function hasBusinessAddress(ctx: GettingStartedContext): Promise<boolean> {
+  const settings = await getOrgCache().get(ctx.organizationId, 'orgSettings')
+  const business = settings['documents.business'] as
+    | { address?: { street1?: string; city?: string; line1?: string } }
+    | undefined
+  const address = business?.address
+  if (!address) return false
+  const hasCanonical = Boolean(address.street1?.trim() && address.city?.trim())
+  const hasLegacy = Boolean(address.line1?.trim() && address.city?.trim())
+  return hasCanonical || hasLegacy
+}
+
+/** Any `OperatingHours` row (weekly or exception) on the organization subject. */
+async function hasOrgHours(ctx: GettingStartedContext): Promise<boolean> {
+  const db = ctx.db ?? database
+  const rows = await db
+    .select({ id: schema.OperatingHours.id })
+    .from(schema.OperatingHours)
+    .where(
+      and(
+        eq(schema.OperatingHours.organizationId, ctx.organizationId),
+        eq(schema.OperatingHours.subjectType, 'organization')
+      )
+    )
+    .limit(1)
+  return rows.length > 0
+}
+
+/** At least one `EntityInstance` of the given system entity type, for this org. */
+async function hasEntityInstance(ctx: GettingStartedContext, entityType: string): Promise<boolean> {
+  const entityDefinitionId = await getCachedEntityDefId(ctx.organizationId, entityType)
+  if (!entityDefinitionId) return false
+  const db = ctx.db ?? database
+  const rows = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, ctx.organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, entityDefinitionId)
+      )
+    )
+    .limit(1)
+  return rows.length > 0
+}
+
+const hasServiceRequest = (ctx: GettingStartedContext) => hasEntityInstance(ctx, 'service_request')
+const hasWorkOrder = (ctx: GettingStartedContext) => hasEntityInstance(ctx, 'work_order')
+
+/** At least one `WorkOrderVisit` that was ever scheduled (has a `startTime`) — canceled counts. */
+async function hasScheduledVisit(ctx: GettingStartedContext): Promise<boolean> {
+  const db = ctx.db ?? database
+  const rows = await db
+    .select({ id: schema.WorkOrderVisit.id })
+    .from(schema.WorkOrderVisit)
+    .where(
+      and(
+        eq(schema.WorkOrderVisit.organizationId, ctx.organizationId),
+        isNotNull(schema.WorkOrderVisit.startTime)
+      )
+    )
+    .limit(1)
+  return rows.length > 0
+}
+
+/** Map of checklist → auto-inferred goal → signal. Manual-only goals have no entry. */
+const AUTO_SIGNALS: Record<ChecklistId, Partial<Record<GoalKey, Signal>>> = {
+  main: {
+    'connect-email': isEmailConnected,
+    'setup-agent': hasConfiguredAgent,
+    'create-workflow': hasUserWorkflow,
+    'create-field': hasCustomField,
+    'invite-team': hasHumanTeammate,
+  },
+  dispatch: {
+    'add-workers': hasWorkers,
+    'set-address': hasBusinessAddress,
+    'set-hours': hasOrgHours,
+    'create-request': hasServiceRequest,
+    'create-work-order': hasWorkOrder,
+    'schedule-visit': hasScheduledVisit,
+  },
 }
 
 /**
- * Compute the set of auto-inferred completed goal keys for an org. Runs all
- * signals concurrently against the per-org cache.
+ * Compute the set of auto-inferred completed goal keys for a checklist. Runs
+ * all of that checklist's signals concurrently against the per-org cache.
  */
-export async function getAutoInferredGoals(ctx: GettingStartedContext): Promise<GoalKey[]> {
-  const entries = Object.entries(AUTO_SIGNALS) as Array<
-    [GoalKey, (ctx: GettingStartedContext) => Promise<boolean>]
-  >
+export async function getAutoInferredGoals(
+  ctx: GettingStartedContext,
+  checklistId: ChecklistId
+): Promise<GoalKey[]> {
+  const entries = Object.entries(AUTO_SIGNALS[checklistId]) as Array<[GoalKey, Signal]>
   const results = await Promise.all(entries.map(([, signal]) => signal(ctx)))
   return entries.filter((_, i) => results[i]).map(([key]) => key)
 }

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -132,6 +132,15 @@ export const SETTINGS_CATALOG = {
     description: 'Getting-started checklist state (dismissal + manual completions)',
   },
 
+  'onboarding.dispatchGettingStarted': {
+    scope: 'ONBOARDING',
+    access: 'org',
+    fieldType: 'JSON',
+    // GettingStartedState — { dismissedAt, manualCompletions, wizardCompletedAt }
+    defaultValue: { dismissedAt: null, manualCompletions: [], wizardCompletedAt: null },
+    description: 'Dispatch getting-started state (wizard + checklist dismissal/completions)',
+  },
+
   'notification.emailDigest': {
     scope: 'NOTIFICATION',
     access: 'user',


### PR DESCRIPTION
## Summary

First-visit onboarding for the dispatch module (plan: `plans/dispatch/32-onboarding.md`): a skippable setup wizard for the must-haves plus a persistent, signal-derived getting-started checklist — never blocking, pure guidance.

### Backend — multi-checklist engine
- `@auxx/lib/getting-started` generalized: a `CHECKLISTS` registry (`main` / `dispatch`) mapping each checklist to its settings key, goal keys, and manual-only goals. `GOAL_KEYS` → `MAIN_GOAL_KEYS` + new `DISPATCH_GOAL_KEYS`; all functions take a `checklistId`; new idempotent `setWizardCompleted` mutation; state gains an optional `wizardCompletedAt`.
- New org-settings catalog key `onboarding.dispatchGettingStarted` (jsonb, `ONBOARDING` scope — no migration).
- Six dispatch signals, all derived from live org data via limit-1 queries / the org cache: workers exist, `documents.business` address filled (legacy shape tolerated), org-subject operating hours exist, first service request, first work order, first scheduled visit. No feature-barrel imports (cycle-safe).
- Router: every `gettingStarted.*` procedure takes `checklist` (default `'main'`), goal keys validated per checklist; existing main-checklist behavior unchanged.

### Checklist UI
- `GettingStartedGroup` / `useGettingStarted` generalized to `(checklistId, catalog)`; main sidebar mount is pixel-identical.
- New dispatch display catalog; mounted as **Dispatch setup** in the dispatch sidebar footer. Accordion open/closed state now scoped per checklist (both widgets can be visible at once).

### Setup wizard
- `DispatchSetupWizard`: five `DialogNav` pages — welcome (guide primitives), workers (inline `ActorPickerContent` + `upsertWorker`), business address (shared `BusinessAddressFields` extracted from the Documents settings page — both surfaces write the identical `documents.business` shape), operating hours (`WeeklyHoursEditor`, org subject), done.
- Address + hours pages hold a dirty draft and save once on page-leave via a `WizardStepHandle` (hours blocks navigation on invalid ranges); workers saves per pick.
- Auto-open gate in the dispatch layout: admin/owner + `FeatureKey.dispatch` + never completed/skipped + checklist not dismissed + the three setup goals not already complete. Finish and skip (incl. ESC) both stamp `wizardCompletedAt` and invalidate the status query — the wizard never auto-opens twice.

## Test plan
- [x] `apps/web` tsc: zero errors in touched files (repo-wide pre-existing count unchanged minus review fixes)
- [x] `packages/lib` tsc: output byte-identical before/after
- [x] Biome clean on all touched files
- [x] Write path verified against dev DB (`wizardCompletedAt` persists; re-open regression fixed via query invalidation)
- [ ] Browser pass on a fresh org per `plans/dispatch/32-onboarding.md` §Verification checklist