### PR TITLE
fix(channels): byo-client disclosure, sync stage claim, reconnect + outlook webhook fixes

### DIFF
--- a/apps/web/src/components/connections/ui/connection-detail-dialog.tsx
+++ b/apps/web/src/components/connections/ui/connection-detail-dialog.tsx
@@ -17,10 +17,13 @@ import { useEffect, useMemo, useState } from 'react'
 import { useCredentialForm } from '~/components/connections/hooks/use-credential-form'
 import { api } from '~/trpc/react'
 import {
+  applyOwnClientDisclosure,
   ConnectionDetailPage,
   type DetailMethod,
   methodIsBareSecret,
+  methodOffersOwnClient,
 } from './connection-detail-page'
+import { validateConnectionVariables } from './connection-variable-validation'
 
 interface ConnectionDetailDialogProps {
   open: boolean
@@ -85,10 +88,26 @@ export function ConnectionDetailDialog({
 }: ConnectionDetailDialogProps) {
   const [token, setToken] = useState('')
   const [name, setName] = useState('')
+  // BYO disclosure (§3.1, ownClientOptional): platform login is primary; the client fields
+  // only render — and only become required — once the user opens the advanced section.
+  const [byoOpen, setByoOpen] = useState(false)
 
   // Stable across renders so the seed effect only fires on open / method change, not every render
-  // (a bare method's `?? []` would otherwise re-seed and wipe input on each render).
+  // (a bare method's `?? []` would otherwise re-seed and wipe input on each render). Kept as the
+  // FULL gated set (incl. optional BYO fields) so toggling the disclosure never reseeds the form.
   const variables = useMemo(() => method.connectionVariables ?? [], [method.connectionVariables])
+
+  // The disclosure-shaped view of the method: closed drops the BYO fields (one-click platform
+  // login), open renders them as required. Rendering/validation/submit all use this view.
+  const offersOwnClient = methodOffersOwnClient(method)
+  const effectiveMethod = useMemo(
+    () => applyOwnClientDisclosure(method, byoOpen),
+    [method, byoOpen]
+  )
+  const effectiveVariables = useMemo(
+    () => effectiveMethod.connectionVariables ?? [],
+    [effectiveMethod.connectionVariables]
+  )
 
   // Editing: load the masked stored values (secrets as the sentinel, plain vars real). Skipped for
   // a fresh connect, so "+ New connection" still starts blank and requires every secret entered.
@@ -100,7 +119,7 @@ export function ConnectionDetailDialog({
   const loaded = editLoad.data
 
   // Shared form lifecycle — field values/errors, seed-on-open, set-secret derivation, validation.
-  const { values, setValue, errors, savedSecrets, validate } = useCredentialForm({
+  const { values, setValue, errors, setErrors, savedSecrets } = useCredentialForm({
     open,
     variables,
     existingValues: loaded?.values,
@@ -109,30 +128,45 @@ export function ConnectionDetailDialog({
   })
 
   // Token + name are connection-specific (a bare API-key row, the editable connection name), so
-  // they seed alongside the shared values effect on open / load.
+  // they seed alongside the shared values effect on open / load. The BYO disclosure re-opens when
+  // editing a connection that was made with its own client (stored clientId), else starts closed.
   useEffect(() => {
     if (!open) return
     if (needsLoad && !loaded) return
     setToken(loaded?.tokenSet ? HIDDEN_VALUE : '')
     setName(initialName ?? method.label)
+    setByoOpen(!!loaded?.values?.clientId)
   }, [open, needsLoad, loaded, initialName, method.label])
 
   const bareSecret = methodIsBareSecret(method)
   const formPending = pending || (needsLoad && !loaded)
 
   // A bare-OAuth method has neither a token row nor variables — its edit dialog is name-only.
-  const hasFields = bareSecret || variables.length > 0
+  // Uses the disclosure-shaped set: a closed optional-BYO method is one-click platform login.
+  const hasFields = bareSecret || effectiveVariables.length > 0
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
-    const next = validate({ requireToken: bareSecret, token })
+    // Validate only the visible fields — with the disclosure open the BYO pair is required.
+    const next = validateConnectionVariables({
+      variables: effectiveVariables,
+      values,
+      requireToken: bareSecret,
+      token,
+    })
+    setErrors(next)
     if (Object.keys(next).length > 0) return
     const payload: { values?: Record<string, string>; secret?: string; name?: string } = {}
     if (showName) payload.name = name.trim()
     // Only the currently-visible fields ride along; a bare API-key method submits the token.
     if (hasFields) {
       if (bareSecret) payload.secret = token
-      else payload.values = values
+      else {
+        const visible = new Set(effectiveVariables.map((v) => v.key))
+        payload.values = Object.fromEntries(
+          Object.entries(values).filter(([key]) => visible.has(key))
+        )
+      }
     }
     onSubmit(payload)
   }
@@ -152,14 +186,18 @@ export function ConnectionDetailDialog({
             <DialogDescription>
               {description ??
                 method.description ??
-                `Provide the following details to connect ${method.label}.`}
+                (hasFields
+                  ? `Provide the following details to connect ${method.label}.`
+                  : `Sign in to connect ${method.label}.`)}
             </DialogDescription>
           </DialogHeader>
 
           <ConnectionDetailPage
-            methods={[method]}
+            methods={[effectiveMethod]}
             selectedMethodId={method.id}
             onMethodChange={() => {}}
+            byoOpen={byoOpen}
+            onByoOpenChange={offersOwnClient ? setByoOpen : undefined}
             values={values}
             onValueChange={setValue}
             token={token}

--- a/apps/web/src/components/connections/ui/connection-detail-page.tsx
+++ b/apps/web/src/components/connections/ui/connection-detail-page.tsx
@@ -2,12 +2,13 @@
 'use client'
 
 import type { ConnectionVariable } from '@auxx/database'
+import { Button } from '@auxx/ui/components/button'
 import { Field, FieldError, FieldLabel } from '@auxx/ui/components/field'
 import { Input } from '@auxx/ui/components/input'
 import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { cn } from '@auxx/ui/lib/utils'
-import { KeyRound, Plug } from 'lucide-react'
+import { ChevronDown, ChevronRight, KeyRound, Plug } from 'lucide-react'
 import { ConnectionVariableFields } from '~/components/connections/ui/connection-variable-fields'
 import { FieldPanel } from '~/components/global/forms/field-panel'
 
@@ -58,6 +59,13 @@ interface ConnectionDetailPageProps {
   savedSecrets?: Set<string>
   /** Editing: the bare token has a stored value (enables its revert button). */
   tokenSaved?: boolean
+  /**
+   * BYO disclosure state for an `ownClientOptional` method (§3.1): the parent reshapes the
+   * method via {@link applyOwnClientDisclosure} and owns this state; the page renders the
+   * "Use your own OAuth client (advanced)" toggle. Omit to render the client fields inline.
+   */
+  byoOpen?: boolean
+  onByoOpenChange?: (open: boolean) => void
   /** Override the root padding/layout (e.g. the dialog drops the gallery's `px-4 py-5`). */
   className?: string
 }
@@ -72,6 +80,35 @@ const TYPE_LABEL: Record<string, string> = {
 /** A secret/variable method needs the field step; bare OAuth connects one-click. */
 export function methodNeedsFields(method: DetailMethod): boolean {
   return method.connectionType === 'secret' || (method.connectionVariables?.length ?? 0) > 0
+}
+
+/** The BYO OAuth-client variable keys (client-side mirror of the server gate's set). */
+const BYO_CLIENT_KEYS = new Set(['clientId', 'clientSecret'])
+
+/** The platform client works and BYO is offered only as an opt-in alternative (§3.1). */
+export function methodOffersOwnClient(method: DetailMethod): boolean {
+  return (
+    method.connectionType === 'oauth2-code' &&
+    !!method.ownClientOptional &&
+    !method.requiresOwnClient
+  )
+}
+
+/**
+ * Apply the BYO-client disclosure to an `ownClientOptional` method: closed → the optional
+ * client fields are dropped so the platform login connects one-click; open → they render and
+ * become required (a half-filled client pair must never reach the OAuth kickoff). Mandatory
+ * (`requiresOwnClient`) and non-OAuth methods pass through untouched.
+ */
+export function applyOwnClientDisclosure<M extends DetailMethod>(method: M, byoOpen: boolean): M {
+  if (!methodOffersOwnClient(method)) return method
+  const vars = method.connectionVariables ?? []
+  return {
+    ...method,
+    connectionVariables: byoOpen
+      ? vars.map((v) => (BYO_CLIENT_KEYS.has(v.key) ? { ...v, required: true } : v))
+      : vars.filter((v) => !BYO_CLIENT_KEYS.has(v.key)),
+  }
 }
 
 /** A single-secret method (API key) with no structured variables. */
@@ -98,6 +135,8 @@ export function ConnectionDetailPage({
   disabled,
   savedSecrets,
   tokenSaved,
+  byoOpen,
+  onByoOpenChange,
   className,
   showName,
   name = '',
@@ -152,11 +191,25 @@ export function ConnectionDetailPage({
           {OWN_CLIENT_COPY[chosen.ownClientReason]}
         </div>
       )}
-      {chosen?.ownClientOptional && !chosen.requiresOwnClient && (
-        <div className='rounded-md border px-3 py-2 text-xs text-muted-foreground'>
-          This app's platform OAuth client is pending provider verification — you can connect with
-          it (you may see an "unverified app" warning during sign-in) or enter your own OAuth client
-          credentials below.
+      {chosen && methodOffersOwnClient(chosen) && (
+        <div className='flex flex-col gap-2'>
+          <div className='rounded-md border px-3 py-2 text-xs text-muted-foreground'>
+            This app's platform OAuth client is pending provider verification — you can continue
+            with it (you may see an "unverified app" warning during sign-in), or use your own OAuth
+            client.
+          </div>
+          {onByoOpenChange && (
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              className='h-auto w-fit gap-1 px-1 py-0.5 text-xs text-muted-foreground'
+              onClick={() => onByoOpenChange(!byoOpen)}
+              disabled={disabled}>
+              {byoOpen ? <ChevronDown /> : <ChevronRight />}
+              Use your own OAuth client (advanced)
+            </Button>
+          )}
         </div>
       )}
       {chosen && methodNeedsFields(chosen) && (

--- a/apps/web/src/components/connections/ui/credential-template-dialog.tsx
+++ b/apps/web/src/components/connections/ui/credential-template-dialog.tsx
@@ -10,9 +10,11 @@ import type { AppInstallation } from '~/components/apps/providers/apps-context'
 import { AppIcon } from '~/components/apps/ui/app-icon'
 import { type TemplateGalleryCategory, TemplateGalleryDialog } from '~/components/templates/ui'
 import {
+  applyOwnClientDisclosure,
   ConnectionDetailPage,
   methodIsBareSecret,
   methodNeedsFields,
+  methodOffersOwnClient,
 } from './connection-detail-page'
 import { appTarget, type ProviderRow, platformTarget } from './connection-targets'
 import { validateConnectionVariables } from './connection-variable-validation'
@@ -141,6 +143,9 @@ export function CredentialTemplateDialog({
   const [connectingId, setConnectingId] = useState<string | null>(null)
   // The method chosen on the detail page when an item exposes >1 (null until picked).
   const [selectedMethodId, setSelectedMethodId] = useState<string | null>(null)
+  // BYO disclosure (§3.1, ownClientOptional): platform login is primary; the client fields
+  // only render — and only become required — once the user opens the advanced section.
+  const [byoOpen, setByoOpen] = useState(false)
 
   const flow = useConnectFlow({
     onConnected: (credId) => {
@@ -242,6 +247,7 @@ export function CredentialTemplateDialog({
     setToken('')
     setName(restrictedItem.name)
     setErrors({})
+    setByoOpen(false)
   }, [open, restrictedItem])
 
   /** Resolve a row + chosen method to its connect target, scope, and the chosen method. */
@@ -262,6 +268,7 @@ export function CredentialTemplateDialog({
     setErrors({})
     setConnectingId(null)
     setSelectedMethodId(null)
+    setByoOpen(false)
   }
 
   /**
@@ -300,11 +307,18 @@ export function CredentialTemplateDialog({
   function handleConnect(item: CatalogItem) {
     const { target, scope, chosen } = resolve(item, selectedMethodId)
     if (!chosen) return
-    if (methodNeedsFields(chosen) && !validate(chosen)) return
+    // Disclosure-shaped view (§3.1): closed drops the optional BYO fields (platform login),
+    // open renders them as required — so validation and the submitted values match what's visible.
+    const effective = applyOwnClientDisclosure(chosen, byoOpen)
+    if (methodNeedsFields(effective) && !validate(effective)) return
     setConnectingId(item.id)
+    const visible = new Set((effective.connectionVariables ?? []).map((v) => v.key))
+    const visibleValues = Object.fromEntries(
+      Object.entries(values).filter(([key]) => visible.has(key))
+    )
     flow.connectWith(
       { target, scope, definitionId: chosen.id, name },
-      (chosen.connectionVariables?.length ?? 0) > 0 ? { values } : { secret: token }
+      visible.size > 0 ? { values: visibleValues } : { secret: token }
     )
   }
 
@@ -358,17 +372,24 @@ export function CredentialTemplateDialog({
       detailBusy={flow.pending}
       onDetailExit={resetFields}
       renderDetail={(item) => {
-        const { chosen } = resolve(item, selectedMethodId)
+        const { methods, chosen } = resolve(item, selectedMethodId)
         return (
           <ConnectionDetailPage
-            methods={resolve(item, selectedMethodId).methods}
+            // Disclosure-shaped (§3.1): the chosen method's optional BYO fields render only
+            // once the advanced section is open; other methods reset to closed on pick.
+            methods={methods.map((m) =>
+              applyOwnClientDisclosure(m, m.id === chosen?.id && byoOpen)
+            )}
             selectedMethodId={selectedMethodId}
             onMethodChange={(id) => {
               setSelectedMethodId(id)
               setValues({})
               setToken('')
               setErrors({})
+              setByoOpen(false)
             }}
+            byoOpen={byoOpen}
+            onByoOpenChange={chosen && methodOffersOwnClient(chosen) ? setByoOpen : undefined}
             values={values}
             onValueChange={(key, value) => setValues((prev) => ({ ...prev, [key]: value }))}
             token={token}

--- a/packages/lib/src/channels/provisioning-hook.ts
+++ b/packages/lib/src/channels/provisioning-hook.ts
@@ -9,7 +9,7 @@
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { Client } from '@microsoft/microsoft-graph-client'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { google } from 'googleapis'
 import { onCacheEvent } from '../cache'
 import type { PostConnectHook, PostConnectHookContext } from '../connections/post-connect-hooks'
@@ -119,6 +119,10 @@ async function upsertIntegration(args: {
 }): Promise<{ id: string; isNew: boolean }> {
   const { organizationId, provider, credentialId, email, metadataPatch } = args
 
+  // Live rows only: a disconnected channel is soft-deleted, and reconnecting the same mailbox
+  // must INSERT a fresh row (the partial unique index allows it) so it gets the full `isNew`
+  // provisioning — relinking the soft-deleted row would skip the backfill and leave `deletedAt`
+  // set, i.e. a channel that connects fine but never appears or syncs.
   const [existing] = await db
     .select({ id: schema.Integration.id, metadata: schema.Integration.metadata })
     .from(schema.Integration)
@@ -126,7 +130,8 @@ async function upsertIntegration(args: {
       and(
         eq(schema.Integration.organizationId, organizationId),
         eq(schema.Integration.provider, provider),
-        eq(schema.Integration.email, email)
+        eq(schema.Integration.email, email),
+        isNull(schema.Integration.deletedAt)
       )
     )
     .limit(1)

--- a/packages/lib/src/jobs/messages/sync-single-channel-messages-job.ts
+++ b/packages/lib/src/jobs/messages/sync-single-channel-messages-job.ts
@@ -3,7 +3,7 @@
 import { type Database, database as db, schema } from '@auxx/database'
 import { SYNC_STATUS } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { type ChannelProviderType, MessageService } from '../../email/message-service'
 import { publisher } from '../../events/publisher'
 import type { MessageSyncProcessingEvent } from '../../events/types'
@@ -69,16 +69,13 @@ export const syncSingleChannelMessagesJob = async (
   }) // Log parent syncJobId
 
   try {
-    // Update SyncJob status to IN_PROGRESS before starting the sync
-    await db
-      .update(schema.SyncJob)
-      .set({ status: 'IN_PROGRESS', startTime: new Date() })
-      .where(
-        and(eq(schema.SyncJob.id, syncJobId), eq(schema.SyncJob.organizationId, organizationId))
-      )
-
-    // Set integration sync state to SYNCING
-    await db
+    // Atomically claim the integration's sync stage. This single-phase sync (webhook push,
+    // manual "Sync now", scheduled sweep) must never run over the two-phase polling pipeline:
+    // it once stomped a fresh connect's `MESSAGES_IMPORT_PENDING` back to `IDLE`, orphaning the
+    // backfill's cached message ids so the channel never imported anything. Claim only from a
+    // stage no pipeline owns (`IDLE`/`FAILED`); anything else means list-fetch/import is queued
+    // or running and the poll will pick the new mail up — skip instead of clobbering.
+    const [claimed] = await db
       .update(schema.Integration)
       .set({
         syncStatus: 'SYNCING',
@@ -86,7 +83,41 @@ export const syncSingleChannelMessagesJob = async (
         syncStageStartedAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(schema.Integration.id, integrationId))
+      .where(
+        and(
+          eq(schema.Integration.id, integrationId),
+          inArray(schema.Integration.syncStage, ['IDLE', 'FAILED'])
+        )
+      )
+      .returning({ id: schema.Integration.id })
+
+    if (!claimed) {
+      logger.info('Skipping sync — polling pipeline owns the integration sync stage', {
+        bullmqJobId: job.id,
+        syncJobId,
+        integrationId,
+      })
+      await db
+        .update(schema.SyncJob)
+        .set({
+          status: SYNC_STATUS.COMPLETED,
+          endTime: new Date(),
+          error: 'Skipped: a polling sync was already in progress',
+          updatedAt: new Date(),
+        })
+        .where(
+          and(eq(schema.SyncJob.id, syncJobId), eq(schema.SyncJob.organizationId, organizationId))
+        )
+      return
+    }
+
+    // Update SyncJob status to IN_PROGRESS before starting the sync
+    await db
+      .update(schema.SyncJob)
+      .set({ status: 'IN_PROGRESS', startTime: new Date() })
+      .where(
+        and(eq(schema.SyncJob.id, syncJobId), eq(schema.SyncJob.organizationId, organizationId))
+      )
 
     // Publish processing event
     await publisher.publishLater({
@@ -103,7 +134,8 @@ export const syncSingleChannelMessagesJob = async (
     const isCancelled = await checkIfCancelled(db, syncJobId, organizationId)
     if (isCancelled) {
       logger.info(`Job ${job.id} was cancelled, exiting gracefully`, { syncJobId })
-      // Reset integration sync state on cancellation
+      // Reset integration sync state on cancellation (only the stage this job claimed —
+      // if the polling pipeline has since taken over, leave its stage untouched).
       await db
         .update(schema.Integration)
         .set({
@@ -112,14 +144,20 @@ export const syncSingleChannelMessagesJob = async (
           syncStageStartedAt: null,
           updatedAt: new Date(),
         })
-        .where(eq(schema.Integration.id, integrationId))
+        .where(
+          and(
+            eq(schema.Integration.id, integrationId),
+            eq(schema.Integration.syncStage, 'MESSAGE_LIST_FETCH')
+          )
+        )
       return
     }
 
     const messageService = new MessageService(organizationId)
     await messageService.syncMessages(integrationType, integrationId, since)
 
-    // On success: set integration to ACTIVE and reset throttle
+    // On success: set integration to ACTIVE and reset throttle. Conditional on the stage this
+    // job claimed, so a concurrently (re)started polling pipeline is never reset to IDLE.
     await db
       .update(schema.Integration)
       .set({
@@ -130,7 +168,12 @@ export const syncSingleChannelMessagesJob = async (
         throttleRetryAfter: null,
         updatedAt: new Date(),
       })
-      .where(eq(schema.Integration.id, integrationId))
+      .where(
+        and(
+          eq(schema.Integration.id, integrationId),
+          eq(schema.Integration.syncStage, 'MESSAGE_LIST_FETCH')
+        )
+      )
 
     // Mark parent SyncJob as COMPLETED
     await db
@@ -161,7 +204,12 @@ export const syncSingleChannelMessagesJob = async (
           syncStageStartedAt: null,
           updatedAt: new Date(),
         })
-        .where(eq(schema.Integration.id, integrationId))
+        .where(
+          and(
+            eq(schema.Integration.id, integrationId),
+            eq(schema.Integration.syncStage, 'MESSAGE_LIST_FETCH')
+          )
+        )
       return
     }
 
@@ -178,7 +226,8 @@ export const syncSingleChannelMessagesJob = async (
     const isFinalAttempt = job.attemptsMade + 1 >= maxAttempts
 
     if (!isFinalAttempt) {
-      // Keep integration marked as syncing while BullMQ retries
+      // Keep integration marked as syncing while BullMQ retries (only while this job still
+      // owns the stage — never re-stamp over a polling pipeline that has taken over).
       await db
         .update(schema.Integration)
         .set({
@@ -186,7 +235,12 @@ export const syncSingleChannelMessagesJob = async (
           syncStage: 'MESSAGE_LIST_FETCH',
           updatedAt: new Date(),
         })
-        .where(eq(schema.Integration.id, integrationId))
+        .where(
+          and(
+            eq(schema.Integration.id, integrationId),
+            eq(schema.Integration.syncStage, 'MESSAGE_LIST_FETCH')
+          )
+        )
       throw error
     }
 
@@ -213,7 +267,12 @@ export const syncSingleChannelMessagesJob = async (
         throttleRetryAfter: new Date(Date.now() + backoffMs),
         updatedAt: new Date(),
       })
-      .where(eq(schema.Integration.id, integrationId))
+      .where(
+        and(
+          eq(schema.Integration.id, integrationId),
+          eq(schema.Integration.syncStage, 'MESSAGE_LIST_FETCH')
+        )
+      )
 
     // Mark parent SyncJob as FAILED
     await db

--- a/packages/lib/src/providers/outlook/outlook-provider.ts
+++ b/packages/lib/src/providers/outlook/outlook-provider.ts
@@ -1,5 +1,6 @@
 // src/lib/providers/outlook/outlook-provider.ts // Adjusted path
 
+import { randomBytes } from 'node:crypto'
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { IntegrationProviderType } from '@auxx/database/enums'
@@ -487,7 +488,7 @@ export class OutlookProvider
     const webhookSecret =
       (this.integration?.metadata as any)?.webhookSecret ||
       configService.get<string>('OUTLOOK_WEBHOOK_SECRET') ||
-      crypto.randomBytes(20).toString('hex') // Use stored or fallback/generate secret
+      randomBytes(20).toString('hex') // Use stored or fallback/generate secret
     const subscriptionPayload = {
       changeType: 'created,updated', // Notify on new and potentially updated messages
       notificationUrl: callbackUrl,


### PR DESCRIPTION
## Summary

Four related channel/connection fixes found while debugging why a freshly connected Gmail channel never synced and why the Google app connect dialogs looked BYO-only.

### 1. Platform login primary, BYO client behind an advanced disclosure
For `ownClientOptional` (platform OAuth client pending Google verification, migration 039), the app connect dialogs previously rendered the optional client id/secret fields inline — reading as "BYO required" with no visible Google login. Now `ConnectionDetailPage` exposes `methodOffersOwnClient` + `applyOwnClientDisclosure`, and both dialog parents (`ConnectionDetailDialog`, `CredentialTemplateDialog`) render the platform login as the primary Connect action with the fields collapsed behind **Use your own OAuth client (advanced)** — same UX as the channel gallery (Part A). Opening the section makes both fields required (no half-filled client pair can reach OAuth); submitted values are filtered to visible fields; editing a connection with a stored `clientId` re-opens the section.

### 2. Legacy sync no longer clobbers the polling pipeline (the "new channel never imports" bug)
`syncSingleChannelMessagesJob` had only an **enqueue-time** "already syncing" guard. In prod, a sync was enqueued at connect while `syncStatus` was still `NOT_SYNCED`, ran ~15s later, stamped `MESSAGE_LIST_FETCH` over the backfill's `MESSAGES_IMPORT_PENDING`, did a no-op history sync (cursor already written), and reset the stage to `IDLE` — orphaning the ~1,700 cached message ids. The channel then polled an empty history diff forever. The job now **atomically claims** the stage (only from `IDLE`/`FAILED`, `UPDATE … RETURNING`) and skips gracefully when the polling pipeline owns it; every stage reset (success/cancel/retry/failure) is conditional on still owning `MESSAGE_LIST_FETCH`.

### 3. Reconnect after channel delete inserts a fresh integration
Channel disconnect soft-deletes the `Integration` row, and the partial unique index exists precisely so a reconnect can insert a new one — but `upsertIntegration` matched without filtering `deletedAt`, resurrecting the soft-deleted row as a relink: no `isNew` backfill, `deletedAt` still set, so the channel connected fine but never appeared or synced. The match is now scoped to live rows.

### 4. Outlook webhook renewal crash
`outlook-provider.ts` called `crypto.randomBytes(20)` with no import in scope — resolving to the global Web Crypto API and throwing `crypto.randomBytes is not a function` on every renewal (visible in prod worker logs), letting Graph subscriptions lapse. Now imports `randomBytes` from `node:crypto`.

## Test plan
- [ ] Connect dialog for a `gog-*` app (prod-state `platformClientApproved=false`): note + advanced disclosure, Connect with the section closed starts platform OAuth, opening it requires both fields and routes the BYO client (check `client_id` on the authorize redirect)
- [ ] Fresh Gmail channel connect: backfill imports; clicking Sync during the backfill logs "Skipping sync — polling pipeline owns the integration sync stage" instead of clobbering
- [ ] Delete a channel, reconnect the same mailbox: new Integration row, full backfill, channel visible
- [ ] Outlook webhook renewal succeeds (no crypto error in worker logs)