### PR TITLE
fix(connections): drive.metadata.readonly for sheets listing + stop logging tokens

### DIFF
--- a/apps/lambda/src/runtime-helpers/index.ts
+++ b/apps/lambda/src/runtime-helpers/index.ts
@@ -133,14 +133,6 @@ import type { GlobalThisExtensions } from './types.ts'
 export function injectServerRuntimeHelpers(context: RuntimeContext): void {
   console.log('[RuntimeHelpers] Injecting server runtime helpers')
 
-  // DEBUG: Log what connections we received
-  console.log('[RuntimeHelpers] Context connections:', {
-    hasUserConnection: !!context.userConnection,
-    hasOrgConnection: !!context.organizationConnection,
-    userConnection: context.userConnection,
-    orgConnection: context.organizationConnection,
-  })
-
   const g = globalThis as typeof globalThis & GlobalThisExtensions
 
   // 1. Inject registerSettingsSchema as global function

--- a/packages/lib/src/connections/providers/defs.ts
+++ b/packages/lib/src/connections/providers/defs.ts
@@ -32,9 +32,12 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
     oauth2AccessTokenUrl: 'https://oauth2.googleapis.com/token',
     oauth2Scopes: [
       'https://www.googleapis.com/auth/gmail.modify',
-      // drive.file (per-file, non-sensitive) instead of full `drive` — full Drive
-      // is a Google "restricted" scope and would pull Drive into the CASA audit.
+      // drive.file (per-file, non-sensitive) instead of full `drive`. Listing the
+      // user's spreadsheets needs drive.metadata.readonly — a Google "restricted"
+      // scope, accepted deliberately: gmail.modify already puts us through the
+      // CASA audit, and metadata-only is the narrowest scope files.list accepts.
       'https://www.googleapis.com/auth/drive.file',
+      'https://www.googleapis.com/auth/drive.metadata.readonly',
       'https://www.googleapis.com/auth/spreadsheets',
       'https://www.googleapis.com/auth/calendar.events',
       'https://www.googleapis.com/auth/calendar.readonly',

--- a/packages/lib/src/data-migrations/migrations/038-reseed-platform-providers-scope-trim.ts
+++ b/packages/lib/src/data-migrations/migrations/038-reseed-platform-providers-scope-trim.ts
@@ -8,7 +8,8 @@ import type { DataMigrationDef } from '../types'
  * Re-upsert the platform built-in ConnectionDefinition rows (`ensurePlatformProviders` only
  * runs via the seed CLI / reseed script, never at boot). This pass propagates:
  * - the Google OAuth verification scope trim (gmail: `gmail.modify`-only; googleOAuth2Api:
- *   `drive.file` + `calendar.events`/`calendar.readonly` instead of full `drive`/`calendar`)
+ *   `drive.file` + `drive.metadata.readonly` + `calendar.events`/`calendar.readonly` instead
+ *   of full `drive`/`calendar`)
  * - `platformClientApproved=false` for the gmail row via `GOOGLE_PLATFORM_CREDENTIALS_APPROVED`.
  *   With the split gate (`resolveOwnClientRequirement`) this no longer forces bring-your-own-
  *   client: a pending-approval platform client is `ownClientOptional`, so new Gmail connections

--- a/packages/workflow-nodes/src/credentials/google-oauth2.credentials.ts
+++ b/packages/workflow-nodes/src/credentials/google-oauth2.credentials.ts
@@ -41,6 +41,7 @@ export class GoogleOAuth2Api implements ICredentialType {
     scopes: [
       'https://www.googleapis.com/auth/gmail.modify', // Gmail read/write
       'https://www.googleapis.com/auth/drive.file', // Drive per-file access (full `drive` is restricted)
+      'https://www.googleapis.com/auth/drive.metadata.readonly', // List files (restricted; needed for spreadsheet pickers)
       'https://www.googleapis.com/auth/spreadsheets', // Google Sheets
       'https://www.googleapis.com/auth/calendar.events', // Calendar events read/write
       'https://www.googleapis.com/auth/calendar.readonly', // Calendar list/read


### PR DESCRIPTION
## Summary

- add `https://www.googleapis.com/auth/drive.metadata.readonly` to the `googleOAuth2Api` platform provider (and the mirrored workflow-nodes credential). The google-sheets spreadsheet picker uses Drive `files.list`, which `drive.file` cannot serve — after the scope trim it 403'd with INSUFFICIENT_PERMISSIONS (surfaced as the generic "You do not have permission to use this extension feature" toast). Every Drive scope that lists arbitrary files is Google-restricted; `gmail.modify` already commits us to the CASA audit, so we take the narrowest one (metadata only, no file content). Propagates to prod via the migration 038 reseed.
- remove the lambda runtime-helpers debug log that printed raw OAuth access tokens into Railway logs.

## Testing

- reproduced in prod: reconnected sheets connection token with `spreadsheets + drive.file` 403'd on `GET /drive/v3/files`; after granting `drive.metadata.readonly` the scope set is sufficient for `files.list` (remaining 403 tracked separately: Drive API enablement in the gog-sheets GCP project).
- `biome check` clean on all four files.