### PR TITLE
feat(homepage): dispatch feature page + industries landing pages

### DIFF
--- a/apps/homepage/src/app/_components/main/footer-section.tsx
+++ b/apps/homepage/src/app/_components/main/footer-section.tsx
@@ -16,6 +16,10 @@ const links = [
         href: '/platform/messaging',
       },
       {
+        title: 'Dispatch',
+        href: '/platform/dispatch',
+      },
+      {
         title: 'Getting started',
         href: urls.signup,
       },
@@ -72,6 +76,27 @@ const links = [
       {
         title: 'Auxx.ai vs n8n',
         href: '/blog/auxx-ai-vs-n8n',
+      },
+    ],
+  },
+  {
+    group: 'Industries',
+    items: [
+      {
+        title: 'HVAC',
+        href: '/industries/hvac',
+      },
+      {
+        title: 'Plumbing',
+        href: '/industries/plumbing',
+      },
+      {
+        title: 'Pest Control',
+        href: '/industries/pest-control',
+      },
+      {
+        title: 'All industries',
+        href: '/industries',
       },
     ],
   },
@@ -150,7 +175,7 @@ export default function FooterSection() {
             </div>
           </div>
 
-          <div className='md:col-span-4 grid gap-6 sm:grid-cols-2 md:grid-cols-5'>
+          <div className='md:col-span-4 grid gap-6 sm:grid-cols-2 md:grid-cols-3'>
             {links.map((link, index) => (
               <div key={index} className='space-y-4 text-sm'>
                 <span className='block font-medium'>{link.group}</span>

--- a/apps/homepage/src/app/_components/main/header.tsx
+++ b/apps/homepage/src/app/_components/main/header.tsx
@@ -2,9 +2,11 @@
 import {
   BarChart3,
   BookOpen,
+  Bug,
   Cloud,
   Code,
   Database,
+  Fan,
   GitBranch,
   Headset,
   HelpCircle,
@@ -16,7 +18,9 @@ import {
   Shield,
   ShoppingBag,
   Sparkles,
+  Truck,
   Users,
+  Wrench,
   X,
 } from 'lucide-react'
 import Link from 'next/link'
@@ -122,6 +126,12 @@ const platformGroups: PlatformGroup[] = [
         description: 'Parts, vendors & production',
         icon: <Shield className='stroke-foreground fill-blue-500/15' />,
       },
+      {
+        href: '/platform/dispatch',
+        name: 'Dispatch',
+        description: 'Field service scheduling & jobs',
+        icon: <Truck className='stroke-foreground fill-orange-500/15' />,
+      },
     ],
   },
   {
@@ -180,6 +190,27 @@ const useCases: FeatureLink[] = [
     name: 'For Support Teams',
     description: 'Reduce workload by 70%',
     icon: <Headset className='stroke-foreground fill-indigo-500/15' />,
+  },
+]
+
+const industryLinks: FeatureLink[] = [
+  {
+    href: '/industries/hvac',
+    name: 'HVAC',
+    description: 'Dispatch & equipment records',
+    icon: <Fan className='stroke-foreground fill-orange-500/15' />,
+  },
+  {
+    href: '/industries/plumbing',
+    name: 'Plumbing',
+    description: 'Same-day dispatch & invoicing',
+    icon: <Wrench className='stroke-foreground fill-sky-500/15' />,
+  },
+  {
+    href: '/industries/pest-control',
+    name: 'Pest Control',
+    description: 'Recurring treatments & routes',
+    icon: <Bug className='stroke-foreground fill-emerald-500/15' />,
   },
 ]
 
@@ -332,6 +363,10 @@ const MobileMenu = ({
     {
       groupName: 'Solutions',
       links: useCases,
+    },
+    {
+      groupName: 'Industries',
+      links: industryLinks,
     },
     {
       groupName: 'Resources',
@@ -489,7 +524,7 @@ const NavMenu = ({ docsUrl }: { docsUrl: string }) => {
             <Link href='/solutions/shopify-stores'>Solutions</Link>
           </NavigationMenuTrigger>
           <NavigationMenuContent className='origin-top pb-1.5 pl-1 pr-4 pt-1 backdrop-blur '>
-            <div className='min-w-2xl w-full grid grid-cols-2 gap-1'>
+            <div className='min-w-3xl w-full grid grid-cols-3 gap-1'>
               <div className='bg-card col-span-1 row-span-2 grid grid-rows-subgrid gap-1 rounded-xl border p-1 pt-3'>
                 <span className='text-muted-foreground ml-2 text-xs'>Use Cases</span>
                 <ul className=''>
@@ -500,6 +535,20 @@ const NavMenu = ({ docsUrl }: { docsUrl: string }) => {
                       title={useCase.name}
                       description={useCase.description}>
                       {useCase.icon}
+                    </ListItem>
+                  ))}
+                </ul>
+              </div>
+              <div className='bg-card col-span-1 row-span-2 grid grid-rows-subgrid gap-1 rounded-xl border p-1 pt-3'>
+                <span className='text-muted-foreground ml-2 text-xs'>Industries</span>
+                <ul className=''>
+                  {industryLinks.map((industry, index) => (
+                    <ListItem
+                      key={index}
+                      href={industry.href}
+                      title={industry.name}
+                      description={industry.description}>
+                      {industry.icon}
                     </ListItem>
                   ))}
                 </ul>

--- a/apps/homepage/src/app/_components/seo/faq-json-ld.tsx
+++ b/apps/homepage/src/app/_components/seo/faq-json-ld.tsx
@@ -1,0 +1,28 @@
+// apps/homepage/src/app/_components/seo/faq-json-ld.tsx
+
+type FaqEntry = {
+  question: string
+  answer: string
+}
+
+export function FaqJsonLd({ faqs }: { faqs: FaqEntry[] }) {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    })),
+  }
+
+  return (
+    <script
+      type='application/ld+json'
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  )
+}

--- a/apps/homepage/src/app/industries/[vertical]/page.tsx
+++ b/apps/homepage/src/app/industries/[vertical]/page.tsx
@@ -1,0 +1,72 @@
+// apps/homepage/src/app/industries/[vertical]/page.tsx
+
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { config } from '~/lib/config'
+import FooterSection from '../../_components/main/footer-section'
+import Header from '../../_components/main/header'
+import { BreadcrumbJsonLd } from '../../_components/seo/breadcrumb-json-ld'
+import IndustryCta from '../_components/industry-cta'
+import IndustryFaq from '../_components/industry-faq'
+import IndustryFeatures from '../_components/industry-features'
+import IndustryHero from '../_components/industry-hero'
+import IndustryPainPoints from '../_components/industry-pain-points'
+import IndustryPricingSection from '../_components/industry-pricing-section'
+import IndustryWorkflow from '../_components/industry-workflow'
+import { VERTICALS } from '../_data/verticals'
+
+export function generateStaticParams() {
+  return Object.keys(VERTICALS).map((vertical) => ({ vertical }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ vertical: string }>
+}): Promise<Metadata> {
+  const { vertical: slug } = await params
+  const vertical = VERTICALS[slug]
+  if (!vertical) return { title: 'Not Found' }
+
+  return {
+    title: `${vertical.metaTitle} | ${config.shortName}`,
+    description: vertical.metaDescription,
+    alternates: { canonical: `/industries/${slug}` },
+  }
+}
+
+export default async function IndustryVerticalPage({
+  params,
+}: {
+  params: Promise<{ vertical: string }>
+}) {
+  const { vertical: slug } = await params
+  const vertical = VERTICALS[slug]
+  if (!vertical) notFound()
+
+  return (
+    <div id='root' className='bg-background relative h-screen overflow-y-auto'>
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', href: 'https://auxx.ai' },
+          { name: 'Industries', href: 'https://auxx.ai/industries' },
+          { name: vertical.name },
+        ]}
+      />
+      <Header />
+      <main>
+        <IndustryHero vertical={vertical} />
+        <IndustryPainPoints vertical={vertical} />
+        <IndustryWorkflow vertical={vertical} />
+        <IndustryFeatures vertical={vertical} />
+        <IndustryPricingSection proseName={vertical.proseName} />
+        <IndustryFaq faqs={vertical.faqs} />
+        <IndustryCta
+          heading={`Run your ${vertical.proseName} business on one board.`}
+          currentSlug={vertical.slug}
+        />
+      </main>
+      <FooterSection />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/industries/_components/industry-cta.tsx
+++ b/apps/homepage/src/app/industries/_components/industry-cta.tsx
@@ -1,0 +1,61 @@
+// apps/homepage/src/app/industries/_components/industry-cta.tsx
+
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+import { VERTICALS } from '../_data/verticals'
+
+export default function IndustryCta({
+  heading,
+  currentSlug,
+}: {
+  heading: string
+  currentSlug: string
+}) {
+  const otherVerticals = Object.values(VERTICALS).filter((v) => v.slug !== currentSlug)
+
+  return (
+    <section
+      data-theme='dark'
+      className='border-foreground/10 relative overflow-hidden border-b bg-zinc-950 text-zinc-50'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_bottom,_rgba(255,255,255,0.08),_transparent_60%)]'
+      />
+      <div className='relative z-10 mx-auto max-w-4xl px-6 py-24 text-center md:py-32'>
+        <h2 className='text-balance text-5xl font-semibold tracking-tight md:text-6xl'>
+          {heading}
+        </h2>
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start Free Trial</Link>
+          </Button>
+          <Button
+            asChild
+            size='sm'
+            variant='outline'
+            className='border-zinc-700 bg-transparent text-zinc-50 hover:bg-zinc-900'>
+            <Link href={config.urls.demo}>Try Demo</Link>
+          </Button>
+        </div>
+
+        <div className='text-zinc-400 mt-10 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm'>
+          <span>Also on Auxx:</span>
+          {otherVerticals.map((vertical) => (
+            <Link
+              key={vertical.slug}
+              href={`/industries/${vertical.slug}`}
+              className='underline decoration-zinc-600 underline-offset-4 hover:text-zinc-50'>
+              {vertical.name}
+            </Link>
+          ))}
+          <Link
+            href='/platform/dispatch'
+            className='underline decoration-zinc-600 underline-offset-4 hover:text-zinc-50'>
+            Dispatch platform
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/industries/_components/industry-faq.tsx
+++ b/apps/homepage/src/app/industries/_components/industry-faq.tsx
@@ -1,0 +1,31 @@
+// apps/homepage/src/app/industries/_components/industry-faq.tsx
+
+import { FaqJsonLd } from '../../_components/seo/faq-json-ld'
+
+interface FaqEntry {
+  question: string
+  answer: string
+}
+
+export default function IndustryFaq({ faqs }: { faqs: FaqEntry[] }) {
+  return (
+    <section className='border-b'>
+      <FaqJsonLd faqs={faqs} />
+      <div className='mx-auto max-w-3xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Frequently asked questions.
+          </h2>
+        </div>
+        <dl className='mt-12 space-y-8'>
+          {faqs.map((faq) => (
+            <div key={faq.question}>
+              <dt className='text-foreground font-medium'>{faq.question}</dt>
+              <dd className='text-muted-foreground mt-2 text-sm'>{faq.answer}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/industries/_components/industry-features.tsx
+++ b/apps/homepage/src/app/industries/_components/industry-features.tsx
@@ -1,0 +1,51 @@
+// apps/homepage/src/app/industries/_components/industry-features.tsx
+
+import type { LucideIcon } from 'lucide-react'
+import { Bell, Clipboard, File, Map as MapIcon, Repeat, Zap } from 'lucide-react'
+import type { IndustryFeatureIcon, IndustryVertical } from '../_data/verticals'
+import { IndustryFieldsMock } from './industry-fields-mock'
+
+const ICONS: Record<IndustryFeatureIcon, LucideIcon> = {
+  repeat: Repeat,
+  zap: Zap,
+  clipboard: Clipboard,
+  map: MapIcon,
+  file: File,
+  bell: Bell,
+}
+
+export default function IndustryFeatures({ vertical }: { vertical: IndustryVertical }) {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Made for the way you work.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            The fields, quotes, and routes that match how {vertical.proseNameWithArticle} shop
+            actually runs a day.
+          </p>
+        </div>
+        <div className='mx-auto mt-12 grid max-w-5xl items-center gap-10 lg:grid-cols-2'>
+          <ul className='space-y-8'>
+            {vertical.featureEmphasis.map((feature) => {
+              const Icon = ICONS[feature.icon]
+              return (
+                <li key={feature.title} className='space-y-2'>
+                  <Icon className='text-muted-foreground size-5' />
+                  <div className='text-foreground font-medium'>{feature.title}</div>
+                  <p className='text-muted-foreground text-sm'>{feature.description}</p>
+                </li>
+              )
+            })}
+          </ul>
+          <IndustryFieldsMock
+            fields={vertical.sampleFields}
+            className='w-full max-w-md lg:mx-0 mx-auto'
+          />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/industries/_components/industry-fields-mock.tsx
+++ b/apps/homepage/src/app/industries/_components/industry-fields-mock.tsx
@@ -1,0 +1,45 @@
+// apps/homepage/src/app/industries/_components/industry-fields-mock.tsx
+
+import { cn } from '~/lib/utils'
+
+interface IndustryField {
+  label: string
+  value: string
+}
+
+/**
+ * Compact work-order record card mock showing a WO number, status pill, and a
+ * grid of trade-specific custom fields — mirrors the product's record detail panel.
+ */
+export function IndustryFieldsMock({
+  fields,
+  className,
+}: {
+  fields: IndustryField[]
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'bg-card ring-foreground/10 rounded-xl border border-transparent shadow-xl shadow-black/5 ring-1',
+        'overflow-hidden',
+        className
+      )}>
+      <div className='flex items-center justify-between gap-3 border-b px-4 py-3'>
+        <span className='truncate text-sm font-medium'>WO-1051</span>
+        <span className='bg-sky-500/15 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium text-sky-600 dark:text-sky-400'>
+          Scheduled
+        </span>
+      </div>
+
+      <dl className='grid grid-cols-2 gap-x-6 gap-y-3 px-4 py-4 text-xs'>
+        {fields.map((field) => (
+          <div key={field.label}>
+            <dt className='text-muted-foreground text-[10px]'>{field.label}</dt>
+            <dd className='text-foreground mt-0.5 font-medium'>{field.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/industries/_components/industry-hero.tsx
+++ b/apps/homepage/src/app/industries/_components/industry-hero.tsx
@@ -1,0 +1,43 @@
+// apps/homepage/src/app/industries/_components/industry-hero.tsx
+
+import { Wrench } from 'lucide-react'
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+import { MockMiniBoard } from '../../platform/dispatch/_mocks/board-mock'
+import type { IndustryVertical } from '../_data/verticals'
+
+export default function IndustryHero({ vertical }: { vertical: IndustryVertical }) {
+  return (
+    <section className='bg-muted/50 relative overflow-hidden border-b'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-x-0 top-0 -z-10 h-[600px] bg-[radial-gradient(ellipse_at_top,_var(--color-primary)/10,_transparent_60%)]'
+      />
+      <div className='mx-auto max-w-6xl px-6 pb-20 pt-32 text-center md:pt-40 lg:pt-48'>
+        <div className='border-foreground/10 bg-muted/40 mx-auto inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs'>
+          <Wrench className='size-3.5 text-orange-500' />
+          <span className='text-muted-foreground'>{vertical.badge}</span>
+        </div>
+
+        <h1 className='mt-6 text-balance text-5xl font-semibold tracking-tight md:text-7xl'>
+          {vertical.heroHeadline}
+        </h1>
+        <p className='text-muted-foreground relative mx-auto mt-4 max-w-2xl text-balance text-lg'>
+          {vertical.heroSubline}
+        </p>
+
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start Free Trial</Link>
+          </Button>
+          <Button asChild size='sm' variant='outline'>
+            <Link href={config.urls.demo}>Try Demo</Link>
+          </Button>
+        </div>
+
+        <MockMiniBoard rows={vertical.boardRows} className='mx-auto mt-12 max-w-4xl' />
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/industries/_components/industry-pain-points.tsx
+++ b/apps/homepage/src/app/industries/_components/industry-pain-points.tsx
@@ -1,0 +1,29 @@
+// apps/homepage/src/app/industries/_components/industry-pain-points.tsx
+
+import type { IndustryVertical } from '../_data/verticals'
+
+export default function IndustryPainPoints({ vertical }: { vertical: IndustryVertical }) {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>Sound familiar?</h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            The day-to-day pains of running {vertical.proseNameWithArticle} operation on
+            spreadsheets, sticky notes, and group texts.
+          </p>
+        </div>
+        <ul className='mx-auto mt-12 grid max-w-5xl gap-4 sm:grid-cols-3'>
+          {vertical.painPoints.map((pain) => (
+            <li
+              key={pain.title}
+              className='bg-card ring-foreground/10 rounded-xl border border-transparent p-5 ring-1'>
+              <div className='text-foreground font-medium'>{pain.title}</div>
+              <p className='text-muted-foreground mt-2 text-sm'>{pain.description}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/industries/_components/industry-pricing-section.tsx
+++ b/apps/homepage/src/app/industries/_components/industry-pricing-section.tsx
@@ -1,0 +1,30 @@
+// apps/homepage/src/app/industries/_components/industry-pricing-section.tsx
+
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+
+export default function IndustryPricingSection({ proseName }: { proseName: string }) {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-3xl px-6 py-16 text-center md:py-24'>
+        <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+          Software that doesn’t cost a truck payment.
+        </h2>
+        <p className='text-muted-foreground mt-4 text-balance text-lg'>
+          Simple plans, no enterprise onboarding fees, and nothing you need a sales call to
+          understand. Start as a solo {proseName} operator and grow into a full fleet without
+          switching software.
+        </p>
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm' variant='outline'>
+            <Link href='/pricing'>See pricing</Link>
+          </Button>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start Free Trial</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/industries/_components/industry-workflow.tsx
+++ b/apps/homepage/src/app/industries/_components/industry-workflow.tsx
@@ -1,0 +1,31 @@
+// apps/homepage/src/app/industries/_components/industry-workflow.tsx
+
+import type { IndustryVertical } from '../_data/verticals'
+
+export default function IndustryWorkflow({ vertical }: { vertical: IndustryVertical }) {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            How {vertical.proseName} shops run on Auxx.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            Request to quote to dispatch to paid invoice — one record, start to finish.
+          </p>
+        </div>
+        <ol className='mx-auto mt-12 grid max-w-5xl gap-8 sm:grid-cols-2 lg:grid-cols-4'>
+          {vertical.workflowSteps.map((step, index) => (
+            <li key={step.title} className='space-y-2'>
+              <div className='text-muted-foreground/30 text-4xl font-bold'>
+                {String(index + 1).padStart(2, '0')}
+              </div>
+              <div className='text-foreground font-medium'>{step.title}</div>
+              <p className='text-muted-foreground text-sm'>{step.description}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/industries/_data/verticals.ts
+++ b/apps/homepage/src/app/industries/_data/verticals.ts
@@ -1,0 +1,432 @@
+// apps/homepage/src/app/industries/_data/verticals.ts
+
+/** Icon keys mapped to lucide-react components in industry-features.tsx. */
+export type IndustryFeatureIcon = 'repeat' | 'zap' | 'clipboard' | 'map' | 'file' | 'bell'
+
+type BoardChipTone = 'sky' | 'emerald' | 'amber' | 'violet' | 'muted'
+
+/** Mirrors the `rows` prop of `MockMiniBoard` (platform/dispatch/_mocks/board-mock.tsx). */
+export interface IndustryBoardRow {
+  worker: string
+  tone: 'sky' | 'emerald' | 'amber' | 'violet'
+  chips: { label: string; start: number; span: number; tone: BoardChipTone }[]
+}
+
+export interface IndustryVertical {
+  slug: string
+  name: string
+  /** Trade name as it appears mid-sentence, with article — e.g. 'an HVAC', 'a plumbing' */
+  proseNameWithArticle: string
+  /** Trade name as it appears mid-sentence without article — e.g. 'HVAC', 'plumbing' */
+  proseName: string
+  /** `${metaTitle} | ${config.shortName}` */
+  metaTitle: string
+  metaDescription: string
+  badge: string
+  heroHeadline: string
+  heroSubline: string
+  painPoints: { title: string; description: string }[]
+  workflowSteps: { title: string; description: string }[]
+  featureEmphasis: { title: string; description: string; icon: IndustryFeatureIcon }[]
+  sampleFields: { label: string; value: string }[]
+  boardRows: IndustryBoardRow[]
+  faqs: { question: string; answer: string }[]
+}
+
+const hvac: IndustryVertical = {
+  slug: 'hvac',
+  name: 'HVAC',
+  proseNameWithArticle: 'an HVAC',
+  proseName: 'HVAC',
+  metaTitle: 'HVAC Dispatch & Scheduling Software',
+  metaDescription:
+    'HVAC dispatch software for scheduling techs, tracking equipment history, and quoting installs — work orders, quotes, and invoicing on one board.',
+  badge: 'For HVAC shops',
+  heroHeadline: 'HVAC dispatch software built around your equipment history.',
+  heroSubline:
+    'Schedule techs, track the model, serial, and refrigerant type on every unit, and quote the next install without digging through paper files.',
+  painPoints: [
+    {
+      title: 'The seasonal crunch buries the board',
+      description:
+        'Summer and winter swings pack the schedule solid, then go quiet for months. A board that only works at steady volume falls apart the first week of a heat wave.',
+    },
+    {
+      title: 'Equipment history lives in three different places',
+      description:
+        'The model and serial number are in a tech’s notebook, the warranty date is in an email, and the refrigerant type is a guess until someone climbs on the roof.',
+    },
+    {
+      title: 'Quotes and installs don’t talk to each other',
+      description:
+        'A quote gets approved over the phone, but nothing tells the board to schedule it — so the install gets remembered instead of dispatched.',
+    },
+  ],
+  workflowSteps: [
+    {
+      title: 'Request comes in',
+      description:
+        'A call about a furnace that won’t start or a request for an AC quote becomes a service request in one intake screen — phone, walk-in, or ticket.',
+    },
+    {
+      title: 'Quote the job',
+      description:
+        'Price the repair or the full system replacement, send it for approval, and the approved quote becomes a work order automatically — no re-entry.',
+    },
+    {
+      title: 'Dispatch the tech',
+      description:
+        'Drag the job onto the board next to the tech with the right availability. They get a dispatch notification the moment it’s scheduled.',
+    },
+    {
+      title: 'Invoice on completion',
+      description:
+        'The tech marks the job done from their phone, notes and photos attach to the record, and the invoice goes out the same day.',
+    },
+  ],
+  featureEmphasis: [
+    {
+      title: 'Equipment records that follow the unit',
+      description:
+        'Model, serial, refrigerant type, filter size, and install date live on the job record and carry forward into the next visit for that unit.',
+      icon: 'clipboard',
+    },
+    {
+      title: 'Quotes that turn into scheduled work',
+      description:
+        'Price a repair or a full system replacement, send it for approval, and the approved quote becomes a work order — no separate system for installs.',
+      icon: 'file',
+    },
+    {
+      title: 'A board built for seasonal swings',
+      description:
+        'Availability and time-off shading show who actually has room for another emergency call during a heat wave, not just who was free this morning.',
+      icon: 'zap',
+    },
+  ],
+  sampleFields: [
+    { label: 'Equipment', value: 'Trane XR16 condenser' },
+    { label: 'Model / Serial', value: 'XR16036 / A3J29812' },
+    { label: 'Refrigerant', value: 'R-410A' },
+    { label: 'Filter size', value: '20x25x1' },
+    { label: 'Warranty until', value: 'Aug 2028' },
+  ],
+  boardRows: [
+    {
+      worker: 'Marcus T.',
+      tone: 'sky',
+      chips: [
+        { label: 'AC compressor swap — Lakeside Dental', start: 1, span: 4, tone: 'sky' },
+        { label: 'Furnace tune-up — Alder Grove HOA', start: 6, span: 3, tone: 'emerald' },
+      ],
+    },
+    {
+      worker: 'Dana K.',
+      tone: 'emerald',
+      chips: [
+        { label: 'Heat pump inspection — Ridgeline Offices', start: 2, span: 3, tone: 'amber' },
+        { label: 'Refrigerant recharge — Court St Diner', start: 8, span: 3, tone: 'sky' },
+      ],
+    },
+    {
+      worker: 'Luis R.',
+      tone: 'amber',
+      chips: [
+        { label: 'Install quote walkthrough — Birchwood Homes', start: 3, span: 4, tone: 'violet' },
+      ],
+    },
+  ],
+  faqs: [
+    {
+      question: 'Can I track equipment details like model and serial number on every job?',
+      answer:
+        'Yes. Work orders are records with custom fields, so you can add equipment, model/serial, refrigerant type, filter size, and warranty date — and every field carries forward into future visits for that unit.',
+    },
+    {
+      question: 'Does the software handle installs and repairs, or just repairs?',
+      answer:
+        'Both. Quote a repair or a full system replacement, send it for approval, and the approved quote turns into a scheduled job automatically — no separate system for installs.',
+    },
+    {
+      question: 'How do I handle summer and winter volume swings?',
+      answer:
+        'The dispatch board shows availability and time-off shading in real time, so during a heat wave or cold snap you can see exactly who has room for another emergency call.',
+    },
+    {
+      question: 'Can technicians see their schedule and update jobs from their phone?',
+      answer:
+        'Yes. Techs get a mobile schedule with a status button (En route → On site → Done), plus completion notes and photo attachments — no separate app to install.',
+    },
+    {
+      question: 'Does it handle quoting and invoicing, or do I need another tool?',
+      answer:
+        'Quoting, approval, invoicing, deposits, and payments are all built in, along with PDF documents for both quotes and invoices.',
+    },
+  ],
+}
+
+const plumbing: IndustryVertical = {
+  slug: 'plumbing',
+  name: 'Plumbing',
+  proseNameWithArticle: 'a plumbing',
+  proseName: 'plumbing',
+  metaTitle: 'Plumbing Dispatch & Scheduling Software',
+  metaDescription:
+    'Plumbing scheduling software for same-day dispatch, job photos as proof of work, and invoicing — from emergency call to paid invoice on one board.',
+  badge: 'For plumbing companies',
+  heroHeadline: 'Plumbing dispatch software built for the calls that can’t wait.',
+  heroSubline:
+    'Get an emergency call onto the board in seconds, route the closest available plumber, and close the job with photos and an invoice before you leave the driveway.',
+  painPoints: [
+    {
+      title: 'Emergency calls blow up the day’s plan',
+      description:
+        'A burst pipe call means the whole board reshuffles. Sticky notes and group texts can’t keep up with that kind of change more than once a day.',
+    },
+    {
+      title: 'Callbacks with no job history',
+      description:
+        'A customer calls back about a leak from six months ago and nobody remembers what pipe material was behind that wall or what part got replaced.',
+    },
+    {
+      title: 'Paper invoices go missing',
+      description:
+        'A handwritten invoice left on a counter is a payment you may never collect. Chasing it down by phone eats the profit on the job.',
+    },
+  ],
+  workflowSteps: [
+    {
+      title: 'Call comes in',
+      description:
+        'A call about a leak, a clogged drain, or a failed water heater becomes a service request in seconds — no separate system to open mid-call.',
+    },
+    {
+      title: 'Quote or dispatch same day',
+      description:
+        'Quote the fix if it can wait, or skip straight to dispatch for anything that can’t — the record moves either way.',
+    },
+    {
+      title: 'Route the closest plumber',
+      description:
+        'Drag the job onto the board next to whoever’s closest and free. They get a dispatch notification the second it’s assigned.',
+    },
+    {
+      title: 'Invoice with photos attached',
+      description:
+        'Before-and-after photos and completion notes attach to the job on site, and the invoice goes out — no paper to lose.',
+    },
+  ],
+  featureEmphasis: [
+    {
+      title: 'A board built for same-day dispatch',
+      description:
+        'Availability and time-off shading show who’s free right now, not who was free when the schedule was made this morning.',
+      icon: 'zap',
+    },
+    {
+      title: 'Photos and notes as proof of work',
+      description:
+        'Completion notes and before-and-after photos attach to the job the moment it’s marked done — proof of work if a customer calls back.',
+      icon: 'clipboard',
+    },
+    {
+      title: 'Route the closest plumber, not the next one on the list',
+      description:
+        'The route planner suggests the shortest run between jobs so an emergency call goes to whoever can actually get there first.',
+      icon: 'map',
+    },
+  ],
+  sampleFields: [
+    { label: 'Fixture', value: 'Kitchen sink' },
+    { label: 'Pipe material', value: 'PEX' },
+    { label: 'Permit #', value: 'PL-22841' },
+    { label: 'Shutoff location', value: 'Basement, north wall' },
+    { label: 'Water heater age', value: '9 years' },
+  ],
+  boardRows: [
+    {
+      worker: 'Priya S.',
+      tone: 'violet',
+      chips: [
+        { label: 'Burst pipe — Fairview Apartments Unit 4', start: 1, span: 3, tone: 'amber' },
+        { label: 'Water heater install — Nguyen residence', start: 5, span: 4, tone: 'sky' },
+      ],
+    },
+    {
+      worker: 'Marcus T.',
+      tone: 'sky',
+      chips: [{ label: 'Drain clearing — Hilltop Cafe', start: 2, span: 3, tone: 'violet' }],
+    },
+    {
+      worker: 'Luis R.',
+      tone: 'amber',
+      chips: [
+        { label: 'Fixture replacement quote — Court St Diner', start: 4, span: 3, tone: 'sky' },
+        { label: 'Shutoff valve repair — Birchwood Homes', start: 8, span: 3, tone: 'emerald' },
+      ],
+    },
+  ],
+  faqs: [
+    {
+      question: 'Can I dispatch an emergency job the same day it comes in?',
+      answer:
+        'Yes. A call becomes a service request in seconds, and you can convert it straight to a scheduled job and drag it onto the board next to whoever’s closest and free.',
+    },
+    {
+      question: 'How do I keep a record of what was fixed if a customer calls back?',
+      answer:
+        'Every job is a record with completion notes and photo attachments, plus a visit history tied to the customer — so you can see exactly what pipe material or part was involved last time.',
+    },
+    {
+      question: 'Can I track permit numbers and shutoff locations on a job?',
+      answer:
+        'Yes. Add custom fields like permit #, pipe material, and shutoff location to work orders, and they show up on every future visit for that address.',
+    },
+    {
+      question: 'Does it help route techs between jobs?',
+      answer:
+        'The route planner suggests the shortest run between stops and lets you drag to reorder or reassign — useful for slotting an emergency call into an already-full day.',
+    },
+    {
+      question: 'Can customers pay online?',
+      answer:
+        'Yes. Invoices, deposits, and payments are built in, with PDF documents for both quotes and invoices.',
+    },
+  ],
+}
+
+const pestControl: IndustryVertical = {
+  slug: 'pest-control',
+  name: 'Pest Control',
+  proseNameWithArticle: 'a pest control',
+  proseName: 'pest control',
+  metaTitle: 'Pest Control Scheduling Software',
+  metaDescription:
+    'Pest control scheduling software for recurring treatment routes, chemical and target-pest records, and invoicing — quarterly visits that schedule themselves.',
+  badge: 'For pest control operators',
+  heroHeadline: 'Pest control software where recurring treatments schedule themselves.',
+  heroSubline:
+    'Set a quarterly or monthly route once and the visits keep generating — with the target pest, chemicals, and treatment areas logged on every job.',
+  painPoints: [
+    {
+      title: 'Recurring routes live in a spreadsheet',
+      description:
+        'Quarterly and monthly accounts get tracked in a spreadsheet someone has to remember to check every week, or a visit quietly slips a month.',
+    },
+    {
+      title: 'Chemical and treatment records are scattered',
+      description:
+        'What chemical was used, where, and how much matters for compliance and liability — and it shouldn’t live in a technician’s notebook.',
+    },
+    {
+      title: 'Route density kills the day',
+      description:
+        'Ten stops that are ten minutes apart beat four stops that are forty minutes apart. Without route planning, density is luck.',
+    },
+  ],
+  workflowSteps: [
+    {
+      title: 'Account signs up',
+      description:
+        'A new quarterly or monthly account becomes a service request, then a recurring job with the treatment schedule built in from the start.',
+    },
+    {
+      title: 'Quote the treatment plan',
+      description:
+        'Price the initial treatment and the ongoing service plan, send it for approval, and the approved quote sets up the recurring job.',
+    },
+    {
+      title: 'Visits generate and dispatch themselves',
+      description:
+        'Each visit rolls onto the board on schedule — nobody has to remember to book the next quarterly stop.',
+    },
+    {
+      title: 'Invoice on a schedule, not a memory',
+      description:
+        'Each completed visit closes out with treatment notes and an invoice, so recurring revenue doesn’t depend on someone remembering to bill it.',
+    },
+  ],
+  featureEmphasis: [
+    {
+      title: 'Recurring visits that generate themselves',
+      description:
+        'Set a quarterly or monthly schedule once and new visits roll onto the board automatically — nothing depends on someone remembering.',
+      icon: 'repeat',
+    },
+    {
+      title: 'Treatment records on every visit',
+      description:
+        'Target pest, chemicals used, and treatment areas log to the job record every time — the history a compliance question or a callback needs.',
+      icon: 'clipboard',
+    },
+    {
+      title: 'Route density that keeps techs moving',
+      description:
+        'The route planner groups stops so a tech’s day is ten close-together visits, not four spread across the county.',
+      icon: 'map',
+    },
+  ],
+  sampleFields: [
+    { label: 'Target pest', value: 'German cockroach' },
+    { label: 'Treatment type', value: 'Interior + exterior spray' },
+    { label: 'Chemicals used', value: 'Suspend Polyzone' },
+    { label: 'Treatment areas', value: 'Kitchen, basement, perimeter' },
+    { label: 'Reservice due', value: 'Oct 12, 2026' },
+  ],
+  boardRows: [
+    {
+      worker: 'Dana K.',
+      tone: 'emerald',
+      chips: [
+        { label: 'Quarterly treatment — Hawthorne Apartments', start: 1, span: 3, tone: 'emerald' },
+        { label: 'Rodent exclusion — Birchfield Warehouse', start: 5, span: 3, tone: 'sky' },
+      ],
+    },
+    {
+      worker: 'Priya S.',
+      tone: 'violet',
+      chips: [
+        { label: 'Termite inspection — Union Square Row Homes', start: 2, span: 3, tone: 'violet' },
+        { label: 'Monthly service — Court St Diner', start: 6, span: 2, tone: 'emerald' },
+      ],
+    },
+    {
+      worker: 'Luis R.',
+      tone: 'amber',
+      chips: [{ label: 'Quarterly treatment — Alder Grove HOA', start: 3, span: 3, tone: 'amber' }],
+    },
+  ],
+  faqs: [
+    {
+      question: 'Can I schedule quarterly or monthly pest control treatments automatically?',
+      answer:
+        'Yes — recurring jobs generate new visits on a rolling schedule, so a quarterly or monthly account doesn’t depend on anyone remembering to book the next stop.',
+    },
+    {
+      question: 'Can I log the chemicals and treatment areas used on each visit?',
+      answer:
+        'Yes. Add custom fields like target pest, treatment type, chemicals used, and treatment areas to the work order, and they’re logged on every visit.',
+    },
+    {
+      question: 'How do I keep a dense, efficient route for a day of treatments?',
+      answer:
+        'The route planner groups nearby stops and suggests an order, with drag-to-reorder if a same-day request comes in.',
+    },
+    {
+      question: 'What happens if a technician can’t complete a treatment as scheduled?',
+      answer:
+        'You can reschedule the visit from the board without disrupting the recurring schedule for future visits.',
+    },
+    {
+      question: 'Does it handle invoicing for recurring accounts?',
+      answer:
+        'Yes. Each completed visit can be invoiced individually, with payments and deposits built in.',
+    },
+  ],
+}
+
+export const VERTICALS: Record<string, IndustryVertical> = {
+  hvac,
+  plumbing,
+  'pest-control': pestControl,
+}

--- a/apps/homepage/src/app/industries/page.tsx
+++ b/apps/homepage/src/app/industries/page.tsx
@@ -1,0 +1,60 @@
+// apps/homepage/src/app/industries/page.tsx
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { config } from '~/lib/config'
+import FooterSection from '../_components/main/footer-section'
+import Header from '../_components/main/header'
+import { BreadcrumbJsonLd } from '../_components/seo/breadcrumb-json-ld'
+import { VERTICALS } from './_data/verticals'
+
+export const metadata: Metadata = {
+  alternates: { canonical: '/industries' },
+  title: `Industries | ${config.shortName}`,
+  description:
+    'Field service software for HVAC, plumbing, and pest control — scheduling, dispatch, work orders, and invoicing built around your trade.',
+}
+
+export default function IndustriesPage() {
+  const verticals = Object.values(VERTICALS)
+
+  return (
+    <div id='root' className='bg-background relative h-screen overflow-y-auto'>
+      <BreadcrumbJsonLd
+        items={[{ name: 'Home', href: 'https://auxx.ai' }, { name: 'Industries' }]}
+      />
+      <Header />
+      <main>
+        <section className='border-b'>
+          <div className='mx-auto max-w-6xl px-6 pb-16 pt-32 text-center md:pt-40 lg:pt-48'>
+            <h1 className='text-balance text-5xl font-semibold tracking-tight md:text-7xl'>
+              Field service software for your trade.
+            </h1>
+            <p className='text-muted-foreground relative mx-auto mt-4 max-w-2xl text-balance text-lg'>
+              The same dispatch board, work-order records, and invoicing — with the fields and
+              workflow of the trade you run.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+            <ul className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+              {verticals.map((vertical) => (
+                <li key={vertical.slug}>
+                  <Link
+                    href={`/industries/${vertical.slug}`}
+                    className='bg-card hover:ring-foreground/15 ring-foreground/10 flex h-full flex-col items-start gap-2 rounded-xl border p-5 ring-1 transition-shadow hover:shadow-sm'>
+                    <div className='text-foreground font-medium'>{vertical.name}</div>
+                    <p className='text-muted-foreground text-sm'>{vertical.heroSubline}</p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      </main>
+      <FooterSection />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/board-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/board-section.tsx
@@ -1,0 +1,84 @@
+// apps/homepage/src/app/platform/dispatch/_components/board-section.tsx
+
+import { BellRing, CalendarRange, MousePointerClick } from 'lucide-react'
+import { MockMiniBoard } from '../_mocks/board-mock'
+
+const beats = [
+  {
+    icon: MousePointerClick,
+    name: 'Drag to schedule',
+    description:
+      'Availability and time off shade automatically — you can only drop where a worker is free.',
+  },
+  {
+    icon: CalendarRange,
+    name: 'Day, week, month',
+    description:
+      "Zoom out to plan tomorrow's crew or the whole season, then back in to move one job.",
+  },
+  {
+    icon: BellRing,
+    name: 'Dispatch = notified',
+    description: 'The worker gets it in-app and by email the moment you dispatch. No phone tag.',
+  },
+]
+
+const ROWS = [
+  {
+    worker: 'Marcus T.',
+    tone: 'sky' as const,
+    chips: [
+      { label: 'Panel inspection', start: 1, span: 3, tone: 'sky' as const },
+      { label: 'Furnace tune-up', start: 6, span: 4, tone: 'emerald' as const },
+    ],
+  },
+  {
+    worker: 'Dana K.',
+    tone: 'emerald' as const,
+    chips: [
+      { label: 'Drain clearing', start: 2, span: 3, tone: 'amber' as const },
+      { label: 'AC compressor swap', start: 8, span: 4, tone: 'sky' as const },
+    ],
+  },
+  {
+    worker: 'Luis R.',
+    tone: 'amber' as const,
+    chips: [
+      { label: 'Quarterly treatment', start: 1, span: 4, tone: 'violet' as const },
+      { label: 'Water heater install', start: 7, span: 3, tone: 'emerald' as const },
+    ],
+  },
+  {
+    worker: 'Priya S.',
+    tone: 'violet' as const,
+    chips: [{ label: 'Drain clearing', start: 5, span: 4, tone: 'amber' as const }],
+  },
+]
+
+export default function BoardSection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            One board for the whole day.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            Drag a job onto a worker&apos;s timeline — they&apos;re notified in-app and by email the
+            moment you dispatch.
+          </p>
+        </div>
+        <MockMiniBoard rows={ROWS} className='mx-auto mt-12 max-w-3xl' />
+        <ul className='mx-auto mt-12 grid max-w-4xl gap-x-6 gap-y-8 sm:grid-cols-3'>
+          {beats.map((beat) => (
+            <li key={beat.name} className='space-y-2'>
+              <beat.icon className='text-muted-foreground size-5' />
+              <div className='text-foreground font-medium'>{beat.name}</div>
+              <p className='text-muted-foreground text-sm'>{beat.description}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/dispatch-faq-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/dispatch-faq-section.tsx
@@ -1,0 +1,74 @@
+// apps/homepage/src/app/platform/dispatch/_components/dispatch-faq-section.tsx
+
+import Link from 'next/link'
+import { FaqJsonLd } from '../../../_components/seo/faq-json-ld'
+
+const faqs = [
+  {
+    question: 'What does Auxx Dispatch include?',
+    answer:
+      'Service requests, quotes, a drag-to-schedule dispatch board, work orders, a worker mobile view, and invoicing with payments — all in one platform.',
+  },
+  {
+    question: 'Do my field workers need to install an app?',
+    answer:
+      'No. Workers log in from a mobile browser to see their schedule, advance job status, add notes and photos, and complete checklists — no app store install required.',
+  },
+  {
+    question: 'Can it handle recurring jobs?',
+    answer:
+      'Yes. Recurring visits generate automatically on a rolling window, and you can edit a single visit, all future visits, or the whole series.',
+  },
+  {
+    question: 'Are quotes and invoices included?',
+    answer:
+      'Yes. Quotes support customer approval and deposits, invoices generate as PDFs, and customers can pay online.',
+  },
+  {
+    question: 'Does it replace my helpdesk and CRM?',
+    answer:
+      "It doesn't replace them — it IS the same platform. Dispatch shares the same inbox, tickets, contacts, and AI as the rest of Auxx.",
+  },
+  {
+    question: 'Does it track workers with GPS?',
+    answer:
+      'Live GPS tracking and a customer "on the way" link are on the roadmap. Today, the dispatch board updates live as workers advance their job status.',
+  },
+  {
+    question: 'How is it priced?',
+    answer: 'Simple plans — no per-job fees. See current pricing on the pricing page.',
+  },
+]
+
+export default function DispatchFaqSection() {
+  return (
+    <section className='border-b'>
+      <FaqJsonLd faqs={faqs} />
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>Questions, answered.</h2>
+        </div>
+        <dl className='mx-auto mt-12 grid max-w-4xl gap-x-10 gap-y-8 lg:grid-cols-2'>
+          {faqs.map((faq) => (
+            <div key={faq.question}>
+              <dt className='text-foreground font-medium'>{faq.question}</dt>
+              <dd className='text-muted-foreground mt-1.5 text-sm'>
+                {faq.question === 'How is it priced?' ? (
+                  <>
+                    Simple plans — no per-job fees. See current{' '}
+                    <Link href='/pricing' className='underline underline-offset-2'>
+                      pricing
+                    </Link>
+                    .
+                  </>
+                ) : (
+                  faq.answer
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/dispatch-final-cta.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/dispatch-final-cta.tsx
@@ -1,0 +1,39 @@
+// apps/homepage/src/app/platform/dispatch/_components/dispatch-final-cta.tsx
+
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+
+export default function DispatchFinalCta() {
+  return (
+    <section
+      data-theme='dark'
+      className='border-foreground/10 relative overflow-hidden border-b bg-zinc-950 text-zinc-50'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_bottom,_rgba(255,255,255,0.08),_transparent_60%)]'
+      />
+      <div className='relative z-10 mx-auto max-w-4xl px-6 py-24 text-center md:py-32'>
+        <h2 className='text-balance text-5xl font-semibold tracking-tight md:text-6xl'>
+          Run your next job on Auxx.
+        </h2>
+        <p className='mt-4 text-balance text-lg text-zinc-400'>
+          Set up requests, the dispatch board, and invoicing in minutes — ready before your next
+          crew shift.
+        </p>
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start Free Trial</Link>
+          </Button>
+          <Button
+            asChild
+            size='sm'
+            variant='outline'
+            className='border-zinc-700 bg-transparent text-zinc-50 hover:bg-zinc-900'>
+            <Link href={config.urls.demo}>Try Demo</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/dispatch-hero.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/dispatch-hero.tsx
@@ -1,0 +1,45 @@
+// apps/homepage/src/app/platform/dispatch/_components/dispatch-hero.tsx
+
+import { Truck } from 'lucide-react'
+import Link from 'next/link'
+import { Button } from '~/components/ui/button'
+import { config } from '~/lib/config'
+import { MockDispatchBoard } from '../_mocks/board-mock'
+
+export default function DispatchHero() {
+  return (
+    <section className='bg-muted/50 relative overflow-hidden border-b'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-x-0 top-0 -z-10 h-[600px] bg-[radial-gradient(ellipse_at_top,_var(--color-primary)/10,_transparent_60%)]'
+      />
+      <div className='mx-auto max-w-6xl px-6 pb-20 pt-32 text-center md:pt-40 lg:pt-48'>
+        <div className='border-foreground/10 bg-muted/40 mx-auto inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs'>
+          <Truck className='size-3.5 text-orange-500' />
+          <span className='text-muted-foreground'>Dispatch — Field Service</span>
+        </div>
+
+        <h1 className='mt-6 text-balance text-5xl font-semibold tracking-tight md:text-7xl'>
+          Schedule the work. Dispatch the crew. Get paid.
+        </h1>
+        <p className='text-muted-foreground relative mx-auto mt-4 max-w-2xl text-balance text-lg'>
+          Service requests, quotes, work orders, and invoices — one dispatch board, with an
+          AI-powered CRM behind it.
+        </p>
+
+        <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+          <Button asChild size='sm'>
+            <Link href={config.urls.signup}>Start Free Trial</Link>
+          </Button>
+          <Button asChild size='sm' variant='outline'>
+            <Link href={config.urls.demo}>Try Demo</Link>
+          </Button>
+        </div>
+
+        <div className='mask-b-from-85% mx-auto mt-12 max-w-5xl text-left md:mt-16'>
+          <MockDispatchBoard />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/industries-grid.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/industries-grid.tsx
@@ -1,0 +1,63 @@
+// apps/homepage/src/app/platform/dispatch/_components/industries-grid.tsx
+
+import { Bug, Thermometer, Wrench } from 'lucide-react'
+import Link from 'next/link'
+
+const industries = [
+  {
+    icon: Thermometer,
+    name: 'HVAC',
+    description: 'Equipment records, seasonal tune-ups, install quotes.',
+    href: '/industries/hvac',
+    tone: 'text-sky-600 dark:text-sky-400',
+  },
+  {
+    icon: Wrench,
+    name: 'Plumbing',
+    description: "Same-day dispatch for the jobs that can't wait.",
+    href: '/industries/plumbing',
+    tone: 'text-amber-600 dark:text-amber-400',
+  },
+  {
+    icon: Bug,
+    name: 'Pest Control',
+    description: 'Recurring treatments that schedule themselves.',
+    href: '/industries/pest-control',
+    tone: 'text-emerald-600 dark:text-emerald-400',
+  },
+]
+
+export default function IndustriesGrid() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>Built for the trades.</h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            The same board, records, and invoicing — with the fields and rhythms of your trade.
+          </p>
+        </div>
+        <ul className='mx-auto mt-12 grid max-w-4xl gap-4 sm:grid-cols-3'>
+          {industries.map((industry) => (
+            <li key={industry.name}>
+              <Link
+                href={industry.href}
+                className='bg-card hover:ring-foreground/15 ring-foreground/10 flex h-full flex-col items-start gap-3 rounded-xl border p-5 ring-1 transition-shadow hover:shadow-sm'>
+                <div className='bg-background ring-foreground/10 flex size-9 shrink-0 items-center justify-center rounded-lg ring-1'>
+                  <industry.icon className={`size-4 ${industry.tone}`} />
+                </div>
+                <div className='space-y-0.5'>
+                  <div className='text-foreground font-medium'>{industry.name}</div>
+                  <p className='text-muted-foreground text-sm'>{industry.description}</p>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+        <p className='text-muted-foreground mx-auto mt-8 max-w-4xl text-center text-sm'>
+          More trades coming — electrical, cleaning, locksmith.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/intake-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/intake-section.tsx
@@ -1,0 +1,53 @@
+// apps/homepage/src/app/platform/dispatch/_components/intake-section.tsx
+
+import { History, Mail, Zap } from 'lucide-react'
+import { MockIntakeDialog } from '../_mocks/intake-dialog-mock'
+
+const beats = [
+  {
+    icon: Zap,
+    name: 'Fast entry',
+    description: 'A receptionist logs who, what, and where in one dialog — no app switching.',
+  },
+  {
+    icon: Mail,
+    name: 'Email becomes a job',
+    description: 'A support ticket converts straight to a work order, no retyping.',
+  },
+  {
+    icon: History,
+    name: 'History survives',
+    description: 'Converted requests stay linked to the job they became.',
+  },
+]
+
+export default function IntakeSection() {
+  return (
+    <section className='bg-muted/30 border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='grid items-center gap-12 lg:grid-cols-2'>
+          <div className='lg:max-w-md'>
+            <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+              Every request lands in one place.
+            </h2>
+            <p className='text-muted-foreground mt-4 text-lg'>
+              Phone call, walk-in, or an email thread — log it in seconds and nothing falls through.
+            </p>
+            <ul className='mt-8 space-y-6'>
+              {beats.map((beat) => (
+                <li key={beat.name} className='flex gap-3'>
+                  <beat.icon className='text-muted-foreground size-5 shrink-0' />
+                  <div>
+                    <div className='text-foreground font-medium'>{beat.name}</div>
+                    <p className='text-muted-foreground text-sm'>{beat.description}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <MockIntakeDialog className='mx-auto lg:justify-self-end' />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/job-records-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/job-records-section.tsx
@@ -1,0 +1,50 @@
+// apps/homepage/src/app/platform/dispatch/_components/job-records-section.tsx
+
+import { ListFilter, Tag, Workflow } from 'lucide-react'
+import { MockJobRecord } from '../_mocks/job-record-mock'
+
+const beats = [
+  {
+    icon: Tag,
+    name: 'Custom fields',
+    description: 'Track equipment, permits, serials — whatever your trade needs.',
+  },
+  {
+    icon: ListFilter,
+    name: 'Views & filters',
+    description: 'Saved views like Unscheduled, This week, By worker.',
+  },
+  {
+    icon: Workflow,
+    name: 'Record rules',
+    description: 'Status changes trigger follow-ups automatically.',
+  },
+]
+
+export default function JobRecordsSection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Organized job history, finally.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            Every work order is a full record — what was done, what was quoted, who did it, and when
+            — searchable forever.
+          </p>
+        </div>
+        <MockJobRecord className='mx-auto mt-12 max-w-lg' />
+        <ul className='mx-auto mt-12 grid max-w-4xl gap-x-6 gap-y-8 sm:grid-cols-3'>
+          {beats.map((beat) => (
+            <li key={beat.name} className='space-y-2'>
+              <beat.icon className='text-muted-foreground size-5' />
+              <div className='text-foreground font-medium'>{beat.name}</div>
+              <p className='text-muted-foreground text-sm'>{beat.description}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/money-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/money-section.tsx
@@ -1,0 +1,57 @@
+// apps/homepage/src/app/platform/dispatch/_components/money-section.tsx
+
+import { CreditCard, FileText, ShieldCheck } from 'lucide-react'
+import Link from 'next/link'
+import { MockMoneyStrip } from '../_mocks/money-mock'
+
+const beats = [
+  {
+    icon: ShieldCheck,
+    name: 'Quotes & approvals',
+    description: 'Send a quote, get a clean customer approval before work starts.',
+  },
+  {
+    icon: FileText,
+    name: 'Invoices & deposits',
+    description: 'Bill off the approved quote and collect a deposit up front.',
+  },
+  {
+    icon: CreditCard,
+    name: 'PDF documents & payments',
+    description: 'Branded PDFs and online payment, built into the same record.',
+  },
+]
+
+export default function MoneySection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Quote it. Invoice it. Get paid.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            Quotes with approvals, invoices with deposits, branded PDFs and online payment — built
+            into the same records.
+          </p>
+        </div>
+        <MockMoneyStrip className='mx-auto mt-12 max-w-3xl' />
+        <ul className='mx-auto mt-12 grid max-w-4xl gap-x-6 gap-y-8 sm:grid-cols-3'>
+          {beats.map((beat) => (
+            <li key={beat.name} className='space-y-2'>
+              <beat.icon className='text-muted-foreground size-5' />
+              <div className='text-foreground font-medium'>{beat.name}</div>
+              <p className='text-muted-foreground text-sm'>{beat.description}</p>
+            </li>
+          ))}
+        </ul>
+        <p className='text-muted-foreground mt-12 text-center text-sm'>
+          Just need an invoice?{' '}
+          <Link href='/free-tools/invoice-generator' className='text-foreground hover:underline'>
+            Try the free invoice generator →
+          </Link>
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/pipeline-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/pipeline-section.tsx
@@ -1,0 +1,49 @@
+// apps/homepage/src/app/platform/dispatch/_components/pipeline-section.tsx
+
+import { ChevronRight } from 'lucide-react'
+import {
+  MockInvoiceCard,
+  MockJobCard,
+  MockQuoteCard,
+  MockRequestCard,
+} from '../_mocks/pipeline-cards'
+
+const stages = [
+  { caption: 'Request', Card: MockRequestCard },
+  { caption: 'Quote', Card: MockQuoteCard },
+  { caption: 'Work order', Card: MockJobCard },
+  { caption: 'Invoice', Card: MockInvoiceCard },
+]
+
+export default function PipelineSection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>From request to paid.</h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            The whole field-service pipeline — request, quote, job, invoice — as linked records, not
+            five apps.
+          </p>
+        </div>
+        <div className='border-border/60 mx-auto mt-12 max-w-5xl border-l pl-4 lg:border-l-0 lg:pl-0'>
+          <div className='flex flex-col gap-8 lg:flex-row lg:items-center lg:gap-0'>
+            {stages.map((stage, i) => (
+              <div key={stage.caption} className='flex items-center gap-2 lg:flex-1'>
+                <div className='flex-1 space-y-2'>
+                  <stage.Card />
+                  <div className='text-muted-foreground text-center text-xs font-medium'>
+                    {stage.caption}
+                  </div>
+                </div>
+                {i < stages.length - 1 && (
+                  <ChevronRight className='text-muted-foreground/40 hidden size-5 shrink-0 lg:block' />
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/platform-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/platform-section.tsx
@@ -1,0 +1,70 @@
+// apps/homepage/src/app/platform/dispatch/_components/platform-section.tsx
+
+import { Bot, GitBranch, LineChart, Users } from 'lucide-react'
+import Link from 'next/link'
+
+const links = [
+  {
+    icon: Bot,
+    name: 'Kopilot',
+    description: 'Ask AI about any job, customer, or invoice.',
+    href: '/platform/ai/kopilot',
+    tone: 'text-violet-600 dark:text-violet-400',
+  },
+  {
+    icon: GitBranch,
+    name: 'Workflows',
+    description: 'Record rules and automations on every status change.',
+    href: '/platform/workflow',
+    tone: 'text-purple-600 dark:text-purple-400',
+  },
+  {
+    icon: LineChart,
+    name: 'Reporting',
+    description: 'Dashboards over jobs, revenue, and crew utilization.',
+    href: '/platform/reporting',
+    tone: 'text-sky-600 dark:text-sky-400',
+  },
+  {
+    icon: Users,
+    name: 'CRM',
+    description: 'Every work order hangs off a real contact and company.',
+    href: '/platform/crm',
+    tone: 'text-emerald-600 dark:text-emerald-400',
+  },
+]
+
+export default function PlatformSection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            It runs on the whole platform.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            Dispatch isn't a silo — jobs share contacts, automations, dashboards, and AI with
+            everything else in Auxx.
+          </p>
+        </div>
+        <ul className='mx-auto mt-12 grid max-w-4xl gap-4 sm:grid-cols-2'>
+          {links.map((link) => (
+            <li key={link.name}>
+              <Link
+                href={link.href}
+                className='bg-card hover:ring-foreground/15 ring-foreground/10 flex items-start gap-3.5 rounded-xl border p-5 ring-1 transition-shadow hover:shadow-sm'>
+                <div className='bg-background ring-foreground/10 flex size-9 shrink-0 items-center justify-center rounded-lg ring-1'>
+                  <link.icon className={`size-4 ${link.tone}`} />
+                </div>
+                <div className='space-y-0.5'>
+                  <div className='text-foreground font-medium'>{link.name}</div>
+                  <p className='text-muted-foreground text-sm'>{link.description}</p>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/roadmap-strip.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/roadmap-strip.tsx
@@ -1,0 +1,33 @@
+// apps/homepage/src/app/platform/dispatch/_components/roadmap-strip.tsx
+
+import { Globe, MapPin, MessageSquare, Navigation } from 'lucide-react'
+
+const items = [
+  { icon: MapPin, label: 'Live GPS tracking' },
+  { icon: Navigation, label: 'Customer "on the way" link' },
+  { icon: Globe, label: 'Online request form' },
+  { icon: MessageSquare, label: 'SMS notifications' },
+]
+
+export default function RoadmapStrip() {
+  return (
+    <div className='border-foreground/10 bg-muted/30 border-y'>
+      <div className='mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-8 gap-y-4 px-6 py-6'>
+        <span className='text-muted-foreground text-xs font-medium tracking-wide uppercase'>
+          On the roadmap
+        </span>
+        <ul className='flex flex-wrap items-center justify-center gap-x-6 gap-y-3'>
+          {items.map((item) => (
+            <li key={item.label} className='flex items-center gap-2'>
+              <item.icon className='text-muted-foreground size-4 shrink-0' />
+              <span className='text-foreground text-sm'>{item.label}</span>
+              <span className='border-foreground/15 text-muted-foreground rounded-full border px-2 py-0.5 text-[10px] font-medium'>
+                Coming
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/route-planner-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/route-planner-section.tsx
@@ -1,0 +1,50 @@
+// apps/homepage/src/app/platform/dispatch/_components/route-planner-section.tsx
+
+import { CheckCheck, GripVertical, Route } from 'lucide-react'
+import { MockRouteMap } from '../_mocks/route-map-mock'
+
+const beats = [
+  {
+    icon: Route,
+    name: 'Suggested routes',
+    description: 'A sensible stop order per worker, per day.',
+  },
+  {
+    icon: GripVertical,
+    name: 'Drag to change it',
+    description: 'Reorder stops or hand one to another worker.',
+  },
+  {
+    icon: CheckCheck,
+    name: 'Apply times',
+    description: 'Nothing moves on the schedule until you say so.',
+  },
+]
+
+export default function RoutePlannerSection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='mx-auto max-w-2xl text-center'>
+          <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+            Routes that plan themselves.
+          </h2>
+          <p className='text-muted-foreground mt-4 text-balance text-lg'>
+            Suggested stop order per worker, drag to reorder or reassign, then apply the times back
+            to the board.
+          </p>
+        </div>
+        <MockRouteMap className='mx-auto mt-12 max-w-5xl' />
+        <ul className='mx-auto mt-12 grid max-w-4xl gap-x-6 gap-y-8 sm:grid-cols-3'>
+          {beats.map((beat) => (
+            <li key={beat.name} className='space-y-2'>
+              <beat.icon className='text-muted-foreground size-5' />
+              <div className='text-foreground font-medium'>{beat.name}</div>
+              <p className='text-muted-foreground text-sm'>{beat.description}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_components/worker-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/worker-section.tsx
@@ -1,0 +1,54 @@
+// apps/homepage/src/app/platform/dispatch/_components/worker-section.tsx
+
+import { Calendar, Camera, MoveRight } from 'lucide-react'
+import { MockWorkerPhone } from '../_mocks/worker-phone-mock'
+
+const beats = [
+  {
+    icon: MoveRight,
+    name: 'One tap forward',
+    description: 'En route → On site → Done, and the board updates live.',
+  },
+  {
+    icon: Camera,
+    name: 'Proof of work',
+    description: 'Completion notes, photos, and quality checklists on every visit.',
+  },
+  {
+    icon: Calendar,
+    name: 'Their own schedule',
+    description: 'Each worker sees their day; the office keeps the full board.',
+  },
+]
+
+export default function WorkerSection() {
+  return (
+    <section className='border-b'>
+      <div className='mx-auto max-w-6xl px-6 py-16 md:py-24'>
+        <div className='grid items-center gap-12 lg:grid-cols-2 lg:gap-16'>
+          <div>
+            <h2 className='text-balance text-4xl font-semibold md:text-5xl'>
+              Your crew's whole day, on their phone.
+            </h2>
+            <p className='text-muted-foreground mt-4 text-balance text-lg'>
+              Workers log in on mobile web — no app store, no extra software — and advance the job
+              as they go.
+            </p>
+            <ul className='mt-10 space-y-6'>
+              {beats.map((beat) => (
+                <li key={beat.name} className='flex gap-3.5'>
+                  <beat.icon className='text-muted-foreground size-5 shrink-0' />
+                  <div>
+                    <div className='text-foreground font-medium'>{beat.name}</div>
+                    <p className='text-muted-foreground mt-1 text-sm'>{beat.description}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <MockWorkerPhone className='order-first lg:order-none' />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_mocks/board-mock.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_mocks/board-mock.tsx
@@ -1,0 +1,371 @@
+// apps/homepage/src/app/platform/dispatch/_mocks/board-mock.tsx
+
+import { CalendarDays, Repeat } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+type WorkerTone = 'sky' | 'emerald' | 'amber' | 'violet'
+type ChipTone = 'sky' | 'emerald' | 'amber' | 'violet' | 'muted'
+
+/** Avatar tint per worker — matches the shared sample-data tone assignments. */
+const WORKER_TONE_CLASS: Record<WorkerTone, string> = {
+  sky: 'bg-sky-500/15 text-sky-600 dark:text-sky-400',
+  emerald: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+  amber: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  violet: 'bg-violet-500/15 text-violet-600 dark:text-violet-400',
+}
+
+/** Job-chip fill per status/tone — `/15` bg + colored text, same pattern as status pills. */
+const CHIP_TONE_CLASS: Record<ChipTone, string> = {
+  sky: 'bg-sky-500/15 text-sky-700 dark:text-sky-400 ring-sky-500/20',
+  emerald: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 ring-emerald-500/20',
+  amber: 'bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/20',
+  violet: 'bg-violet-500/15 text-violet-700 dark:text-violet-400 ring-violet-500/20',
+  muted: 'bg-muted text-muted-foreground ring-foreground/10',
+}
+
+/** First-name + last-initial avatar text, e.g. "Marcus T." -> "MT". */
+function initials(name: string) {
+  return name
+    .split(' ')
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join('')
+    .toUpperCase()
+}
+
+interface MiniChip {
+  label: string
+  start: number
+  span: number
+  tone: ChipTone
+}
+
+interface MiniRow {
+  worker: string
+  tone: WorkerTone
+  chips: MiniChip[]
+}
+
+const DEFAULT_MINI_ROWS: MiniRow[] = [
+  {
+    worker: 'Marcus T.',
+    tone: 'sky',
+    chips: [
+      { label: 'AC compressor swap', start: 1, span: 4, tone: 'sky' },
+      { label: 'Panel inspection', start: 7, span: 3, tone: 'violet' },
+    ],
+  },
+  {
+    worker: 'Dana K.',
+    tone: 'emerald',
+    chips: [
+      { label: 'Water heater install', start: 2, span: 4, tone: 'emerald' },
+      { label: 'Drain clearing', start: 9, span: 3, tone: 'amber' },
+    ],
+  },
+  {
+    worker: 'Luis R.',
+    tone: 'amber',
+    chips: [
+      { label: 'Quarterly treatment', start: 3, span: 3, tone: 'sky' },
+      { label: 'Furnace tune-up', start: 8, span: 4, tone: 'emerald' },
+    ],
+  },
+]
+
+interface MockMiniBoardProps {
+  className?: string
+  rows?: MiniRow[]
+}
+
+/**
+ * Compact 3-row dispatch board: worker avatar + name, 12-column hour timeline,
+ * colored job chips. Used in the hero and reused (with custom `rows`) on
+ * industry pages for trade-specific job labels.
+ */
+export function MockMiniBoard({ className, rows = DEFAULT_MINI_ROWS }: MockMiniBoardProps) {
+  return (
+    <div
+      className={cn(
+        'bg-card ring-foreground/10 overflow-hidden rounded-xl border border-transparent shadow-xl shadow-black/5 ring-1',
+        className
+      )}>
+      <div className='divide-border/70 divide-y'>
+        {rows.map((row) => (
+          <div key={row.worker} className='flex items-center gap-2 px-3 py-2'>
+            <span
+              className={cn(
+                'flex size-6 shrink-0 items-center justify-center rounded-full text-[10px] font-medium',
+                WORKER_TONE_CLASS[row.tone]
+              )}>
+              {initials(row.worker)}
+            </span>
+            <span className='text-foreground w-16 shrink-0 truncate text-xs'>{row.worker}</span>
+            <div className='grid flex-1 grid-cols-12 gap-1'>
+              {row.chips.map((chip) => (
+                <div
+                  key={chip.label}
+                  style={{ gridColumn: `${chip.start} / span ${chip.span}` }}
+                  className={cn(
+                    'truncate rounded-md px-1.5 py-1 text-[10px] font-medium ring-1 ring-inset',
+                    CHIP_TONE_CLASS[chip.tone]
+                  )}>
+                  {chip.label}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// MockDispatchBoard — the full showcase board
+// ---------------------------------------------------------------------------
+
+const HOURS = [
+  '8:00',
+  '9:00',
+  '10:00',
+  '11:00',
+  '12:00',
+  '13:00',
+  '14:00',
+  '15:00',
+  '16:00',
+  '17:00',
+]
+
+type StatusTone = ChipTone | 'indigo'
+
+const STATUS_CHIP_CLASS: Record<StatusTone, string> = {
+  ...CHIP_TONE_CLASS,
+  indigo: 'bg-indigo-500/15 text-indigo-700 dark:text-indigo-400 ring-indigo-500/20',
+}
+
+type Block =
+  | { kind: 'off'; start: number; span: number; label?: string }
+  | {
+      kind: 'chip'
+      start: number
+      span: number
+      label: string
+      status: string
+      tone: StatusTone
+      recurring?: boolean
+    }
+  | {
+      kind: 'ghost'
+      start: number
+      span: number
+      label: string
+      status: string
+      tone: StatusTone
+    }
+  | { kind: 'dropTarget'; start: number; span: number }
+
+interface FullRow {
+  worker: string
+  tone: WorkerTone
+  blocks: Block[]
+}
+
+const FULL_ROWS: FullRow[] = [
+  {
+    worker: 'Marcus T.',
+    tone: 'sky',
+    blocks: [
+      { kind: 'off', start: 1, span: 1 },
+      {
+        kind: 'chip',
+        start: 2,
+        span: 3,
+        label: 'AC compressor swap — Lakeside Dental',
+        status: 'Scheduled',
+        tone: 'sky',
+      },
+      { kind: 'dropTarget', start: 6, span: 3 },
+      {
+        kind: 'ghost',
+        start: 9,
+        span: 3,
+        label: 'Panel inspection — Mercer St Bakery',
+        status: 'Dispatched',
+        tone: 'indigo',
+      },
+    ],
+  },
+  {
+    worker: 'Dana K.',
+    tone: 'emerald',
+    blocks: [
+      { kind: 'off', start: 1, span: 1 },
+      {
+        kind: 'chip',
+        start: 3,
+        span: 4,
+        label: 'Water heater install — Nguyen residence',
+        status: 'En route',
+        tone: 'amber',
+      },
+      {
+        kind: 'chip',
+        start: 8,
+        span: 2,
+        label: 'Drain clearing — Hilltop Cafe',
+        status: 'Done',
+        tone: 'emerald',
+      },
+      { kind: 'off', start: 12, span: 1 },
+    ],
+  },
+  {
+    worker: 'Luis R.',
+    tone: 'amber',
+    blocks: [
+      { kind: 'off', start: 1, span: 1 },
+      {
+        kind: 'chip',
+        start: 2,
+        span: 3,
+        label: 'Quarterly treatment — Hawthorne Apartments',
+        status: 'On site',
+        tone: 'violet',
+        recurring: true,
+      },
+      {
+        kind: 'chip',
+        start: 9,
+        span: 3,
+        label: 'Furnace tune-up — Alder Grove HOA',
+        status: 'New',
+        tone: 'muted',
+      },
+      { kind: 'off', start: 12, span: 1 },
+    ],
+  },
+  {
+    worker: 'Priya S.',
+    tone: 'violet',
+    blocks: [
+      { kind: 'off', start: 1, span: 1 },
+      { kind: 'off', start: 4, span: 6, label: 'Time off' },
+      { kind: 'off', start: 12, span: 1 },
+    ],
+  },
+]
+
+function BoardBlock({ block }: { block: Block }) {
+  if (block.kind === 'off') {
+    return (
+      <div
+        style={{ gridColumn: `${block.start} / span ${block.span}` }}
+        className='bg-muted/50 relative z-0 overflow-hidden rounded-md'>
+        <div
+          aria-hidden
+          className='absolute inset-0 bg-[repeating-linear-gradient(-45deg,var(--color-foreground),var(--color-foreground)_1px,transparent_1px,transparent_6px)] opacity-5'
+        />
+        {block.label ? (
+          <span className='text-muted-foreground relative z-10 flex h-full items-center justify-center text-[9px] font-medium'>
+            {block.label}
+          </span>
+        ) : null}
+      </div>
+    )
+  }
+
+  if (block.kind === 'dropTarget') {
+    return (
+      <div
+        style={{ gridColumn: `${block.start} / span ${block.span}` }}
+        className='border-sky-500/40 bg-sky-500/5 z-0 rounded-md border border-dashed'
+      />
+    )
+  }
+
+  const isGhost = block.kind === 'ghost'
+
+  return (
+    <div
+      style={{ gridColumn: `${block.start} / span ${block.span}` }}
+      className={cn(
+        'flex min-w-0 flex-col justify-center gap-0.5 rounded-md px-1.5 py-1 ring-1 ring-inset',
+        STATUS_CHIP_CLASS[block.tone],
+        isGhost ? 'z-20 -rotate-2 opacity-60 ring-2 ring-sky-500/50' : 'z-10'
+      )}>
+      <span className='flex items-center gap-1 truncate text-[10px] font-medium'>
+        {'recurring' in block && block.recurring ? <Repeat className='size-3 shrink-0' /> : null}
+        <span className='truncate'>{block.label}</span>
+      </span>
+      <span className='bg-background/60 w-fit rounded-full px-1 text-[9px] font-medium leading-tight'>
+        {block.status}
+      </span>
+    </div>
+  )
+}
+
+interface MockDispatchBoardProps {
+  className?: string
+}
+
+/**
+ * Full dispatch-board showcase: view toggle + date, 4 workers, a 12-column
+ * hour timeline with availability/time-off shading, status-toned job chips,
+ * a mid-drag ghost chip with drop target, and one recurring job.
+ */
+export function MockDispatchBoard({ className }: MockDispatchBoardProps) {
+  return (
+    <div
+      className={cn(
+        'bg-card ring-foreground/10 overflow-hidden rounded-xl border border-transparent shadow-xl shadow-black/5 ring-1',
+        className
+      )}>
+      <div className='flex items-center justify-between gap-3 border-b px-4 py-3'>
+        <div className='bg-muted flex items-center gap-1 rounded-lg p-0.5 text-[10px] font-medium'>
+          <span className='bg-background text-foreground rounded-md px-2 py-1 shadow-sm'>Day</span>
+          <span className='text-muted-foreground px-2 py-1'>Week</span>
+          <span className='text-muted-foreground px-2 py-1'>Month</span>
+        </div>
+        <div className='text-muted-foreground flex items-center gap-1.5 text-xs'>
+          <CalendarDays className='size-3.5' />
+          Mon, Jul 20
+        </div>
+      </div>
+
+      <div className='flex items-center border-b px-4 py-2'>
+        <div className='w-24 shrink-0 sm:w-32' />
+        <div className='text-muted-foreground grid flex-1 grid-cols-12 text-[10px]'>
+          {HOURS.map((hour, i) => (
+            <span key={hour} className={cn(i % 2 === 1 && 'hidden sm:inline')}>
+              {hour}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className='divide-border/70 divide-y'>
+        {FULL_ROWS.map((row) => (
+          <div key={row.worker} className='flex items-stretch gap-0 px-4 py-2.5'>
+            <div className='flex w-24 shrink-0 items-center gap-2 sm:w-32'>
+              <span
+                className={cn(
+                  'flex size-6 shrink-0 items-center justify-center rounded-full text-[10px] font-medium',
+                  WORKER_TONE_CLASS[row.tone]
+                )}>
+                {initials(row.worker)}
+              </span>
+              <span className='text-foreground truncate text-xs font-medium'>{row.worker}</span>
+            </div>
+            <div className='grid min-h-14 flex-1 grid-cols-12 gap-1'>
+              {row.blocks.map((block) => (
+                <BoardBlock key={`${row.worker}-${block.kind}-${block.start}`} block={block} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_mocks/intake-dialog-mock.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_mocks/intake-dialog-mock.tsx
@@ -1,0 +1,79 @@
+// apps/homepage/src/app/platform/dispatch/_mocks/intake-dialog-mock.tsx
+
+import { Phone, User } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+const FAKE_INPUT_CLASS =
+  'bg-muted/50 ring-border/60 text-foreground rounded-md px-2 py-1.5 text-xs ring-1'
+
+function FakeField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className='space-y-1'>
+      <div className='text-muted-foreground text-[10px] font-medium'>{label}</div>
+      {children}
+    </div>
+  )
+}
+
+/** Fast-entry service request dialog: fake fields only, no interactivity. */
+export function MockIntakeDialog({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'bg-card ring-foreground/10 w-full max-w-sm rounded-xl border border-transparent ring-1 shadow-xl shadow-black/5 overflow-hidden',
+        className
+      )}>
+      <div className='border-border/60 flex items-center justify-between border-b px-4 py-3'>
+        <span className='text-foreground text-sm font-medium'>New service request</span>
+        <span className='text-muted-foreground/50 text-xs'>✕</span>
+      </div>
+      <div className='space-y-3 px-4 py-3'>
+        <FakeField label='Contact'>
+          <div className={cn(FAKE_INPUT_CLASS, 'flex items-center justify-between gap-2')}>
+            <span className='flex items-center gap-1.5'>
+              <User className='text-muted-foreground size-3 shrink-0' />
+              Thanh Nguyen
+            </span>
+            <span className='bg-sky-500/15 text-sky-600 dark:text-sky-400 shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-medium'>
+              Contact
+            </span>
+          </div>
+        </FakeField>
+        <FakeField label='Phone'>
+          <div className={cn(FAKE_INPUT_CLASS, 'flex items-center gap-1.5')}>
+            <Phone className='text-muted-foreground size-3 shrink-0' />
+            (503) 555-0148
+          </div>
+        </FakeField>
+        <FakeField label='What needs doing'>
+          <div className={cn(FAKE_INPUT_CLASS, 'space-y-0.5')}>
+            <div>Old water heater is leaking, needs a full replacement —</div>
+            <div>50 gal, same closet location.</div>
+          </div>
+        </FakeField>
+        <FakeField label='Service address'>
+          <div className={FAKE_INPUT_CLASS}>412 Alder Ct, Beaverton, OR</div>
+        </FakeField>
+        <FakeField label='Preferred window'>
+          <div className='flex flex-wrap gap-1.5'>
+            {['Mon AM', 'Tue AM'].map((slot) => (
+              <span
+                key={slot}
+                className='bg-foreground text-background rounded-full px-2 py-0.5 text-[10px] font-medium'>
+                {slot}
+              </span>
+            ))}
+          </div>
+        </FakeField>
+      </div>
+      <div className='border-border/60 flex items-center justify-end gap-2 border-t px-4 py-3'>
+        <div className='text-muted-foreground rounded-md px-2.5 py-1.5 text-xs font-medium'>
+          Save request
+        </div>
+        <div className='bg-foreground text-background rounded-md px-2.5 py-1.5 text-xs font-medium'>
+          Convert to job
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_mocks/job-record-mock.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_mocks/job-record-mock.tsx
@@ -1,0 +1,107 @@
+// apps/homepage/src/app/platform/dispatch/_mocks/job-record-mock.tsx
+
+import { Plus } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+interface FieldProps {
+  label: string
+  value?: string
+  children?: React.ReactNode
+}
+
+function Field({ label, value, children }: FieldProps) {
+  return (
+    <div>
+      <dt className='text-muted-foreground text-[10px]'>{label}</dt>
+      <dd className='text-foreground mt-0.5 font-medium'>{children ?? value}</dd>
+    </div>
+  )
+}
+
+type TimelineTone = 'muted' | 'emerald' | 'sky' | 'hollow'
+
+const TIMELINE: { label: string; tone: TimelineTone }[] = [
+  { label: 'Request received', tone: 'muted' },
+  { label: 'Quote Q-2051 approved', tone: 'emerald' },
+  { label: 'Scheduled Tue 9:00', tone: 'sky' },
+  { label: 'Visit', tone: 'hollow' },
+]
+
+const DOT_CLASS: Record<TimelineTone, string> = {
+  muted: 'bg-muted-foreground/40',
+  emerald: 'bg-emerald-500',
+  sky: 'bg-sky-500',
+  hollow: 'border-muted-foreground/40 bg-background border',
+}
+
+const TEXT_CLASS: Record<TimelineTone, string> = {
+  muted: 'text-muted-foreground',
+  emerald: 'text-foreground',
+  sky: 'text-foreground',
+  hollow: 'text-muted-foreground',
+}
+
+/**
+ * A work-order detail record: header + status, a field grid, a compact visit
+ * timeline, and custom-field chips — echoing the product's record detail panel.
+ */
+export function MockJobRecord({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'bg-card ring-foreground/10 rounded-xl border border-transparent shadow-xl shadow-black/5 ring-1',
+        'overflow-hidden',
+        className
+      )}>
+      <div className='flex items-center justify-between gap-3 border-b px-4 py-3'>
+        <span className='truncate text-sm font-medium'>
+          WO-1042 · Water heater install — Nguyen residence
+        </span>
+        <span className='bg-sky-500/15 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium text-sky-600 dark:text-sky-400'>
+          Scheduled
+        </span>
+      </div>
+
+      <dl className='grid grid-cols-2 gap-x-6 gap-y-3 px-4 py-4 text-xs'>
+        <Field label='Contact' value='Thanh Nguyen' />
+        <Field label='Company' value='—' />
+        <Field label='Address' value='418 Alder Grove Ln' />
+        <Field label='Job type' value='One-off' />
+        <Field label='Window' value='Tue 9:00–12:00' />
+        <Field label='Assigned'>
+          <span className='inline-flex items-center gap-1.5'>
+            <span className='bg-emerald-500/15 flex size-4 shrink-0 items-center justify-center rounded-full text-[8px] font-medium text-emerald-600 dark:text-emerald-400'>
+              DK
+            </span>
+            Dana K.
+          </span>
+        </Field>
+      </dl>
+
+      <ol className='border-t px-4 py-4'>
+        {TIMELINE.map((step, i) => (
+          <li key={step.label} className='flex gap-2'>
+            <div className='flex flex-col items-center'>
+              <span className={cn('size-2 shrink-0 rounded-full', DOT_CLASS[step.tone])} />
+              {i < TIMELINE.length - 1 && <span className='bg-border w-px flex-1' />}
+            </div>
+            <span className={cn('pb-3 text-xs', TEXT_CLASS[step.tone])}>{step.label}</span>
+          </li>
+        ))}
+      </ol>
+
+      <div className='flex flex-wrap items-center gap-1.5 border-t px-4 py-3'>
+        <span className='border-border/70 bg-muted/40 text-muted-foreground rounded-full border px-2 py-1 text-[10px]'>
+          Heater model
+        </span>
+        <span className='border-border/70 bg-muted/40 text-muted-foreground rounded-full border px-2 py-1 text-[10px]'>
+          Permit #
+        </span>
+        <span className='border-border/70 text-muted-foreground/70 inline-flex items-center gap-1 rounded-full border border-dashed px-2 py-1 text-[10px]'>
+          <Plus className='size-2.5' />
+          Add field
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_mocks/money-mock.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_mocks/money-mock.tsx
@@ -1,0 +1,81 @@
+// apps/homepage/src/app/platform/dispatch/_mocks/money-mock.tsx
+
+import { Check, CreditCard } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+const PANEL_CLASS =
+  'bg-card ring-foreground/10 flex-1 rounded-xl border border-transparent ring-1 shadow-xl shadow-black/5 overflow-hidden'
+
+function PaidPill({ children }: { children: React.ReactNode }) {
+  return (
+    <span className='bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 rounded-full px-2 py-0.5 text-[10px] font-medium'>
+      {children}
+    </span>
+  )
+}
+
+/** Quote → invoice → payment, side by side: the money half of the pipeline. */
+export function MockMoneyStrip({ className }: { className?: string }) {
+  return (
+    <div className={cn('flex flex-col gap-4 md:flex-row', className)}>
+      <div className={PANEL_CLASS}>
+        <div className='flex items-center justify-between gap-2 px-3 pt-3'>
+          <span className='text-muted-foreground font-mono text-[10px]'>Q-2051</span>
+          <PaidPill>Approved</PaidPill>
+        </div>
+        <div className='text-foreground px-3 pt-1.5 text-lg font-semibold tracking-tight'>
+          $1,840.00
+        </div>
+        <div className='border-border/60 mt-3 flex items-center gap-2 border-t px-3 py-3'>
+          <div className='bg-muted/60 ring-border/60 flex size-9 shrink-0 flex-col justify-center gap-0.5 rounded px-1.5 ring-1'>
+            <span className='bg-muted-foreground/30 h-0.5 w-full rounded-full' />
+            <span className='bg-muted-foreground/30 h-0.5 w-3/4 rounded-full' />
+            <span className='bg-muted-foreground/30 h-0.5 w-full rounded-full' />
+            <span className='bg-muted-foreground/30 h-0.5 w-2/3 rounded-full' />
+          </div>
+          <span className='text-muted-foreground text-[10px]'>Customer-facing PDF</span>
+        </div>
+      </div>
+
+      <div className={PANEL_CLASS}>
+        <div className='px-3 pt-3'>
+          <span className='text-muted-foreground font-mono text-[10px]'>INV-3007</span>
+        </div>
+        <div className='text-muted-foreground mt-2 space-y-1 px-3 text-[10px]'>
+          <div className='flex items-center justify-between'>
+            <span>Water heater 50gal</span>
+            <span>$1,420.00</span>
+          </div>
+          <div className='flex items-center justify-between'>
+            <span>Labor</span>
+            <span>$420.00</span>
+          </div>
+        </div>
+        <div className='border-border/60 mt-2 flex items-center justify-between border-t px-3 py-2 text-xs font-medium'>
+          <span className='text-foreground'>Total</span>
+          <span className='text-foreground'>$1,840.00</span>
+        </div>
+        <div className='text-muted-foreground border-border/60 flex items-center justify-between border-t px-3 py-2 text-[10px]'>
+          <span>Deposit</span>
+          <span>$460.00</span>
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          PANEL_CLASS,
+          'flex flex-col items-center justify-center gap-2 px-3 py-6 text-center'
+        )}>
+        <span className='bg-emerald-500/15 flex size-9 items-center justify-center rounded-full'>
+          <Check className='text-emerald-600 dark:text-emerald-400 size-4' />
+        </span>
+        <div className='text-foreground text-xs font-medium'>Payment received</div>
+        <div className='text-muted-foreground flex items-center gap-1.5 text-[10px]'>
+          <CreditCard className='size-3 shrink-0' />
+          <span>•••• 4242</span>
+        </div>
+        <PaidPill>Paid</PaidPill>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_mocks/pipeline-cards.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_mocks/pipeline-cards.tsx
@@ -1,0 +1,125 @@
+// apps/homepage/src/app/platform/dispatch/_mocks/pipeline-cards.tsx
+
+import { CheckCircle2, Clock, Phone } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+const CARD_CLASS =
+  'bg-card ring-foreground/10 w-full rounded-xl border border-transparent ring-1 shadow-xl shadow-black/5 overflow-hidden'
+
+const PILL_TONE_CLASS = {
+  muted: 'bg-muted text-muted-foreground',
+  sky: 'bg-sky-500/15 text-sky-600 dark:text-sky-400',
+  emerald: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+} as const
+
+function StatusPill({
+  tone,
+  children,
+}: {
+  tone: keyof typeof PILL_TONE_CLASS
+  children: React.ReactNode
+}) {
+  return (
+    <span className={cn('rounded-full px-2 py-0.5 text-[10px] font-medium', PILL_TONE_CLASS[tone])}>
+      {children}
+    </span>
+  )
+}
+
+interface MockCardProps {
+  className?: string
+}
+
+/** REQ-1187 — a phoned-in service request, still New. */
+export function MockRequestCard({ className }: MockCardProps) {
+  return (
+    <div className={cn(CARD_CLASS, className)}>
+      <div className='flex items-center justify-between gap-2 px-3 pt-3'>
+        <span className='text-muted-foreground font-mono text-[10px]'>REQ-1187</span>
+        <StatusPill tone='muted'>New</StatusPill>
+      </div>
+      <div className='px-3 pt-1.5'>
+        <div className='text-foreground text-xs font-medium'>
+          Water heater install — Nguyen residence
+        </div>
+      </div>
+      <div className='text-muted-foreground border-border/60 mt-2 flex items-center gap-1.5 border-t px-3 py-2 text-[10px]'>
+        <Phone className='size-3 shrink-0' />
+        <span>Phone call</span>
+        <span className='text-muted-foreground/50'>·</span>
+        <Clock className='size-3 shrink-0' />
+        <span>Requested Tue AM</span>
+      </div>
+    </div>
+  )
+}
+
+/** Q-2051 — the approved quote for the same job, itemized. */
+export function MockQuoteCard({ className }: MockCardProps) {
+  return (
+    <div className={cn(CARD_CLASS, className)}>
+      <div className='flex items-center justify-between gap-2 px-3 pt-3'>
+        <span className='text-muted-foreground font-mono text-[10px]'>Q-2051</span>
+        <StatusPill tone='emerald'>Approved</StatusPill>
+      </div>
+      <div className='px-3 pt-1.5'>
+        <div className='text-foreground text-lg font-semibold tracking-tight'>$1,840.00</div>
+      </div>
+      <div className='text-muted-foreground border-border/60 mt-2 space-y-1 border-t px-3 py-2 text-[10px]'>
+        <div className='flex items-center justify-between'>
+          <span>Water heater 50gal</span>
+          <span>$1,420.00</span>
+        </div>
+        <div className='flex items-center justify-between'>
+          <span>Labor</span>
+          <span>$420.00</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** WO-1042 — the scheduled work order, assigned to Dana K. */
+export function MockJobCard({ className }: MockCardProps) {
+  return (
+    <div className={cn(CARD_CLASS, className)}>
+      <div className='flex items-center justify-between gap-2 px-3 pt-3'>
+        <span className='text-muted-foreground font-mono text-[10px]'>WO-1042</span>
+        <StatusPill tone='sky'>Scheduled</StatusPill>
+      </div>
+      <div className='px-3 pt-1.5'>
+        <div className='text-foreground text-xs font-medium'>
+          Water heater install — Nguyen residence
+        </div>
+      </div>
+      <div className='text-muted-foreground border-border/60 mt-2 flex items-center gap-2 border-t px-3 py-2 text-[10px]'>
+        <span className='bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 flex size-4 shrink-0 items-center justify-center rounded-full text-[9px] font-medium'>
+          DK
+        </span>
+        <span>Dana K.</span>
+        <span className='text-muted-foreground/50'>·</span>
+        <Clock className='size-3 shrink-0' />
+        <span>Tue 9:00–12:00</span>
+      </div>
+    </div>
+  )
+}
+
+/** INV-3007 — the paid invoice, deposit already applied. */
+export function MockInvoiceCard({ className }: MockCardProps) {
+  return (
+    <div className={cn(CARD_CLASS, className)}>
+      <div className='flex items-center justify-between gap-2 px-3 pt-3'>
+        <span className='text-muted-foreground font-mono text-[10px]'>INV-3007</span>
+        <StatusPill tone='emerald'>Paid</StatusPill>
+      </div>
+      <div className='px-3 pt-1.5'>
+        <div className='text-foreground text-lg font-semibold tracking-tight'>$1,840.00</div>
+      </div>
+      <div className='text-muted-foreground border-border/60 mt-2 flex items-center gap-1.5 border-t px-3 py-2 text-[10px]'>
+        <CheckCircle2 className='size-3 shrink-0 text-emerald-500' />
+        <span>$460.00 deposit applied</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_mocks/route-map-mock.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_mocks/route-map-mock.tsx
@@ -1,0 +1,137 @@
+// apps/homepage/src/app/platform/dispatch/_mocks/route-map-mock.tsx
+
+import { GripVertical, MapPin } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+interface PinProps {
+  left: number
+  top: number
+  tone: 'sky' | 'amber'
+  number: number
+}
+
+function Pin({ left, top, tone, number }: PinProps) {
+  return (
+    <span
+      className={cn(
+        'ring-background absolute flex size-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full text-[10px] font-semibold text-white ring-2',
+        tone === 'sky' ? 'bg-sky-500' : 'bg-amber-500'
+      )}
+      style={{ left: `${left}%`, top: `${top}%` }}>
+      {number}
+    </span>
+  )
+}
+
+const ROUTES = [
+  {
+    initials: 'DK',
+    tone: 'sky' as const,
+    label: 'Dana K. · 3 stops · 38 mi',
+    stops: [
+      { time: '9:00', name: 'Nguyen residence' },
+      { time: '11:15', name: 'Lakeside Dental' },
+      { time: '1:45', name: 'Mercer St Bakery' },
+    ],
+  },
+  {
+    initials: 'MT',
+    tone: 'amber' as const,
+    label: 'Marcus T. · 2 stops · 21 mi',
+    stops: [
+      { time: '8:30', name: 'Hilltop Cafe' },
+      { time: '11:00', name: 'Hawthorne Apts' },
+    ],
+  },
+]
+
+/**
+ * A route-planning map: a faint street grid, dashed suggested routes for two
+ * workers connecting numbered stop pins, and a reorderable stop list panel —
+ * echoing the product's route planner.
+ */
+export function MockRouteMap({ className }: { className?: string }) {
+  return (
+    <div className={cn('flex flex-col gap-4 lg:flex-row', className)}>
+      <div className='bg-muted/50 ring-foreground/10 relative aspect-[16/10] flex-1 overflow-hidden rounded-xl ring-1'>
+        <div
+          aria-hidden
+          className='absolute inset-0 bg-[repeating-linear-gradient(0deg,var(--color-foreground),var(--color-foreground)_1px,transparent_1px,transparent_32px),repeating-linear-gradient(90deg,var(--color-foreground),var(--color-foreground)_1px,transparent_1px,transparent_32px)] opacity-[0.06]'
+        />
+        <svg
+          aria-hidden
+          viewBox='0 0 100 100'
+          preserveAspectRatio='none'
+          className='absolute inset-0 h-full w-full'>
+          <polyline
+            points='8,82 8,60 28,60 28,30 52,30 52,18 78,18'
+            className='fill-none stroke-sky-500'
+            strokeWidth='2'
+            vectorEffect='non-scaling-stroke'
+            strokeLinejoin='round'
+            strokeLinecap='round'
+            strokeDasharray='1.4 1'
+            opacity='0.7'
+          />
+          <polyline
+            points='8,82 20,82 20,20 44,20 44,68'
+            className='fill-none stroke-amber-500'
+            strokeWidth='2'
+            vectorEffect='non-scaling-stroke'
+            strokeLinejoin='round'
+            strokeLinecap='round'
+            strokeDasharray='1.4 1'
+            opacity='0.7'
+          />
+        </svg>
+        <span
+          className='bg-foreground/10 ring-background text-muted-foreground absolute flex size-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full ring-2'
+          style={{ left: '8%', top: '82%' }}>
+          <MapPin className='size-3.5' />
+        </span>
+        <Pin left={28} top={60} tone='sky' number={1} />
+        <Pin left={52} top={30} tone='sky' number={2} />
+        <Pin left={78} top={18} tone='sky' number={3} />
+        <Pin left={20} top={20} tone='amber' number={1} />
+        <Pin left={44} top={68} tone='amber' number={2} />
+      </div>
+
+      <div className='w-full shrink-0 lg:w-56'>
+        <div className='bg-card ring-foreground/10 flex h-full flex-col rounded-xl border border-transparent p-3 shadow-xl shadow-black/5 ring-1'>
+          {ROUTES.map((route) => (
+            <div key={route.initials} className='not-first:mt-3 not-first:border-t not-first:pt-3'>
+              <div className='flex items-center gap-1.5 px-1 pb-2'>
+                <span
+                  className={cn(
+                    'flex size-4 shrink-0 items-center justify-center rounded-full text-[8px] font-semibold',
+                    route.tone === 'sky'
+                      ? 'bg-sky-500/15 text-sky-600 dark:text-sky-400'
+                      : 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
+                  )}>
+                  {route.initials}
+                </span>
+                <span className='truncate text-xs font-medium'>{route.label}</span>
+              </div>
+              <ul className='divide-border/70 divide-y'>
+                {route.stops.map((stop) => (
+                  <li key={stop.name} className='flex items-center gap-2 py-1.5'>
+                    <GripVertical className='text-muted-foreground/40 size-3 shrink-0' />
+                    <span className='text-muted-foreground w-10 shrink-0 text-[10px]'>
+                      {stop.time}
+                    </span>
+                    <span className='truncate text-xs'>{stop.name}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+          <button
+            type='button'
+            className='bg-foreground text-background mt-auto w-full rounded-md py-1.5 text-[11px] font-medium'>
+            Apply times to schedule
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/_mocks/worker-phone-mock.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_mocks/worker-phone-mock.tsx
@@ -1,0 +1,141 @@
+// apps/homepage/src/app/platform/dispatch/_mocks/worker-phone-mock.tsx
+
+import { Camera, Check, Plus } from 'lucide-react'
+import { cn } from '~/lib/utils'
+
+interface AgendaItem {
+  time: string
+  job: string
+  status: string
+  tone: 'emerald' | 'amber' | 'sky'
+  active?: boolean
+}
+
+const AGENDA: AgendaItem[] = [
+  { time: '8:30', job: 'Furnace tune-up — Alder Grove HOA', status: 'Done', tone: 'emerald' },
+  {
+    time: '10:00',
+    job: 'Water heater install — Nguyen residence',
+    status: 'En route',
+    tone: 'amber',
+    active: true,
+  },
+  { time: '1:00', job: 'Drain clearing — Hilltop Cafe', status: 'Scheduled', tone: 'sky' },
+]
+
+const STATUS_CLASS: Record<AgendaItem['tone'], string> = {
+  emerald: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+  amber: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  sky: 'bg-sky-500/15 text-sky-600 dark:text-sky-400',
+}
+
+const CHECKLIST = [
+  { label: 'Water heater installed', done: true },
+  { label: 'Area cleaned', done: true },
+  { label: 'Customer walkthrough', done: false },
+]
+
+/**
+ * A phone-frame mock of the worker's mobile schedule: an agenda of today's
+ * visits, the active visit expanded with an advancing status button, a
+ * quality checklist, and photo attachments.
+ */
+export function MockWorkerPhone({ className }: { className?: string }) {
+  return (
+    <div className={cn('mx-auto w-64 sm:w-72', className)}>
+      <div className='border-foreground/10 bg-foreground/[0.03] rounded-[2rem] border p-1.5 shadow-xl shadow-black/10'>
+        <div className='bg-card rounded-[1.5rem] pb-4'>
+          <div className='flex justify-center pt-2.5'>
+            <div className='bg-foreground/15 h-1 w-10 rounded-full' />
+          </div>
+
+          <div className='px-3.5 pt-3'>
+            <div className='text-foreground text-sm font-semibold'>Today</div>
+            <div className='text-muted-foreground text-[10px]'>Tue, Jul 21 · Dana K.</div>
+          </div>
+
+          <ul className='mt-3 space-y-1.5 px-3.5'>
+            {AGENDA.map((item) => (
+              <li
+                key={item.job}
+                className={cn(
+                  'rounded-lg px-2 py-1.5',
+                  item.active
+                    ? 'bg-violet-500/[0.07] ring-violet-500/25 ring-1'
+                    : 'text-muted-foreground'
+                )}>
+                <div className='flex items-center gap-2'>
+                  <span className='text-muted-foreground w-9 shrink-0 text-[10px]'>
+                    {item.time}
+                  </span>
+                  <span
+                    className={cn(
+                      'flex-1 truncate text-[11px]',
+                      item.active ? 'text-foreground font-medium' : undefined
+                    )}>
+                    {item.job}
+                  </span>
+                  <span
+                    className={cn(
+                      'shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-medium',
+                      STATUS_CLASS[item.tone]
+                    )}>
+                    {item.status}
+                  </span>
+                </div>
+
+                {item.active && (
+                  <div className='mt-2.5 space-y-3'>
+                    <div className='text-muted-foreground text-[10px]'>418 Alder Grove Ln</div>
+
+                    <button
+                      type='button'
+                      className='bg-violet-500/90 w-full rounded-lg py-2 text-center text-[11px] font-medium text-white'>
+                      Arrived on site →
+                    </button>
+
+                    <div className='space-y-1'>
+                      {CHECKLIST.map((check) => (
+                        <div key={check.label} className='flex items-center gap-1.5'>
+                          <span
+                            className={cn(
+                              'flex size-3.5 shrink-0 items-center justify-center rounded-[4px]',
+                              check.done
+                                ? 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
+                                : 'border-muted-foreground/40 border'
+                            )}>
+                            {check.done && <Check className='size-2.5' />}
+                          </span>
+                          <span
+                            className={cn(
+                              'text-[10px]',
+                              check.done ? 'text-foreground' : 'text-muted-foreground'
+                            )}>
+                            {check.label}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+
+                    <div className='flex gap-1.5'>
+                      <div className='from-muted to-muted-foreground/20 relative flex h-10 w-10 items-center justify-center rounded-md bg-gradient-to-br'>
+                        <Camera className='text-background/70 size-3.5' />
+                      </div>
+                      <div className='from-muted to-muted-foreground/20 relative flex h-10 w-10 items-center justify-center rounded-md bg-gradient-to-br'>
+                        <Camera className='text-background/70 size-3.5' />
+                      </div>
+                      <div className='border-muted-foreground/30 text-muted-foreground/70 flex h-10 w-10 flex-col items-center justify-center gap-0.5 rounded-md border border-dashed'>
+                        <Plus className='size-3' />
+                        <span className='text-[8px]'>Photo</span>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/homepage/src/app/platform/dispatch/page.tsx
+++ b/apps/homepage/src/app/platform/dispatch/page.tsx
@@ -1,0 +1,58 @@
+// apps/homepage/src/app/platform/dispatch/page.tsx
+import type { Metadata } from 'next'
+import { config } from '~/lib/config'
+import LogoCloudTwo from '../../_components/logo-cloud'
+import FooterSection from '../../_components/main/footer-section'
+import Header from '../../_components/main/header'
+import { BreadcrumbJsonLd } from '../../_components/seo/breadcrumb-json-ld'
+import BoardSection from './_components/board-section'
+import DispatchFaqSection from './_components/dispatch-faq-section'
+import DispatchFinalCta from './_components/dispatch-final-cta'
+import DispatchHero from './_components/dispatch-hero'
+import IndustriesGrid from './_components/industries-grid'
+import IntakeSection from './_components/intake-section'
+import JobRecordsSection from './_components/job-records-section'
+import MoneySection from './_components/money-section'
+import PipelineSection from './_components/pipeline-section'
+import PlatformSection from './_components/platform-section'
+import RoadmapStrip from './_components/roadmap-strip'
+import RoutePlannerSection from './_components/route-planner-section'
+import WorkerSection from './_components/worker-section'
+
+export const metadata: Metadata = {
+  alternates: { canonical: '/platform/dispatch' },
+  title: `Field Service Dispatch Software | ${config.shortName}`,
+  description: `Schedule and dispatch field workers, manage work orders, quote and invoice jobs — with an AI-powered CRM and helpdesk built in. ${config.shortName} runs your whole field service pipeline.`,
+}
+
+export default function DispatchPage() {
+  return (
+    <div id='root' className='bg-background relative h-screen overflow-y-auto'>
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', href: 'https://auxx.ai' },
+          { name: 'Platform', href: 'https://auxx.ai/platform' },
+          { name: 'Dispatch' },
+        ]}
+      />
+      <Header />
+      <main>
+        <DispatchHero />
+        <PipelineSection />
+        <LogoCloudTwo />
+        <IntakeSection />
+        <BoardSection />
+        <JobRecordsSection />
+        <WorkerSection />
+        <RoutePlannerSection />
+        <MoneySection />
+        <PlatformSection />
+        <RoadmapStrip />
+        <IndustriesGrid />
+        <DispatchFaqSection />
+        <DispatchFinalCta />
+      </main>
+      <FooterSection />
+    </div>
+  )
+}

--- a/apps/homepage/src/app/sitemap.ts
+++ b/apps/homepage/src/app/sitemap.ts
@@ -76,6 +76,36 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
+      url: `${baseUrl}/platform/dispatch`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/industries`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/industries/hvac`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/industries/plumbing`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/industries/pest-control`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/platform/live-chat`,
       lastModified: new Date(),
       changeFrequency: 'monthly',


### PR DESCRIPTION
## Summary

Marketing surface for the shipped Dispatch module (plan: `plans/homepage/dispatch/README.md`, local).

### `/platform/dispatch` — flagship feature page
14 sections modeled on the reporting/crm/data-model design language, all product visuals as pure CSS/JSX mocks:
- Hero with full dispatch-board mock (drag ghost, availability/time-off shading, recurring badge)
- Request → Quote → Job → Invoice pipeline strip with one coherent data story (REQ-1187 → Q-2051 → WO-1042 → INV-3007)
- Intake dialog, board, job records, worker phone mock, route-planner map, quotes/invoices/payments strip
- Platform cross-link cards (Kopilot / Workflows / Reporting / CRM), industries grid, FAQ with `FAQPage` JSON-LD
- **Claims guardrail**: unshipped features (live GPS, customer "on the way" link, online request form, SMS) appear only in a clearly-labeled "On the roadmap" strip

### `/industries/*` — SEO vertical landing pages
- Config-driven template (`app/industries/_data/verticals.ts`) + `[vertical]/page.tsx` with `generateStaticParams`
- Wave 1: **HVAC**, **Plumbing**, **Pest Control** + an `/industries` index
- Hand-written per-trade copy (pains, workflow, custom-field examples, FAQs) — no shared boilerplate between verticals; no invented prices/stats/testimonials

### Wiring
- Header: Dispatch under Platform ▸ Operations; new Industries column in the Solutions dropdown (no new top-level nav item)
- Footer: Dispatch link + Industries group; sitemap: 5 new URLs
- New shared `FaqJsonLd` SEO component

## Verification
- `biome check` clean, homepage `tsc --noEmit` clean
- All 5 routes return 200; browser-checked full pages in light **and** dark mode, both nav dropdowns, zero console errors