### PR TITLE
feat(dispatch): horizontal timeline board view with configurable hour window

### DIFF
--- a/apps/homepage/src/app/platform/dispatch/_components/route-planner-section.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_components/route-planner-section.tsx
@@ -1,7 +1,7 @@
 // apps/homepage/src/app/platform/dispatch/_components/route-planner-section.tsx
 
 import { CheckCheck, GripVertical, Route } from 'lucide-react'
-import { MockRouteMap } from '../_mocks/route-map-mock'
+import { MockRoutePlanner } from '../_mocks/route-map-mock'
 
 const beats = [
   {
@@ -34,7 +34,7 @@ export default function RoutePlannerSection() {
             to the board.
           </p>
         </div>
-        <MockRouteMap className='mx-auto mt-12 max-w-5xl' />
+        <MockRoutePlanner className='mx-auto mt-12 max-w-5xl text-left' />
         <ul className='mx-auto mt-12 grid max-w-4xl gap-x-6 gap-y-8 sm:grid-cols-3'>
           {beats.map((beat) => (
             <li key={beat.name} className='space-y-2'>

--- a/apps/homepage/src/app/platform/dispatch/_mocks/route-map-mock.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_mocks/route-map-mock.tsx
@@ -1,137 +1,386 @@
 // apps/homepage/src/app/platform/dispatch/_mocks/route-map-mock.tsx
 
-import { GripVertical, MapPin } from 'lucide-react'
+import { ChevronDown, ChevronLeft, ChevronRight, Home, Minus, Plus } from 'lucide-react'
+import { MockBrowserChrome, MockMainPage } from '~/app/platform/ai/_mocks'
 import { cn } from '~/lib/utils'
 
-interface PinProps {
+/** Teardrop pin path copied from the real planner map (`planner-map.tsx` §2.2): 28×38, head
+ * circle radius 14 centered at (14,14), tip at (14,38). */
+const TEARDROP_PATH_D =
+  'M14 0C6.268 0 0 6.268 0 14c0 10.5 14 24 14 24s14-13.5 14-24C28 6.268 21.732 0 14 0z'
+const PIN_OUTLINE_COLOR = 'rgba(0,0,0,0.45)'
+
+interface Stop {
+  number: string
+  eta: string
   left: number
   top: number
-  tone: 'sky' | 'amber'
-  number: number
 }
 
-function Pin({ left, top, tone, number }: PinProps) {
-  return (
-    <span
-      className={cn(
-        'ring-background absolute flex size-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full text-[10px] font-semibold text-white ring-2',
-        tone === 'sky' ? 'bg-sky-500' : 'bg-amber-500'
-      )}
-      style={{ left: `${left}%`, top: `${top}%` }}>
-      {number}
-    </span>
-  )
+interface Worker {
+  name: string
+  /** Route/pin fill — full-saturation hex, matching the real planner's worker colors. */
+  hex: string
+  /** Sidebar color-dot class for the same tone. */
+  dot: string
+  /** Amber "times not applied" drift dot on the Routes row (plan 20 §3.2). */
+  drift?: boolean
+  /** Street-following polyline in the map's 0–100 coordinate space. */
+  line: string
+  stops: Stop[]
 }
 
-const ROUTES = [
+const WORKERS: Worker[] = [
   {
-    initials: 'DK',
-    tone: 'sky' as const,
-    label: 'Dana K. · 3 stops · 38 mi',
+    name: 'Marcus T.',
+    hex: '#0ea5e9',
+    dot: 'bg-sky-500',
+    drift: true,
+    line: '14,72 14,46 38,46 38,22 62,22 84,22 84,34',
     stops: [
-      { time: '9:00', name: 'Nguyen residence' },
-      { time: '11:15', name: 'Lakeside Dental' },
-      { time: '1:45', name: 'Mercer St Bakery' },
+      { number: 'WO-1042', eta: '9:00 AM', left: 38, top: 46 },
+      { number: 'WO-1038', eta: '10:45 AM', left: 62, top: 22 },
+      { number: 'WO-1051', eta: '1:15 PM', left: 84, top: 34 },
     ],
   },
   {
-    initials: 'MT',
-    tone: 'amber' as const,
-    label: 'Marcus T. · 2 stops · 21 mi',
+    name: 'Dana K.',
+    hex: '#10b981',
+    dot: 'bg-emerald-500',
+    line: '14,72 48,72 48,58 70,58',
     stops: [
-      { time: '8:30', name: 'Hilltop Cafe' },
-      { time: '11:00', name: 'Hawthorne Apts' },
+      { number: 'WO-1047', eta: '8:30 AM', left: 48, top: 72 },
+      { number: 'WO-1044', eta: '11:20 AM', left: 70, top: 58 },
     ],
   },
 ]
 
+/** Unscheduled work orders — neutral, unnumbered pins on the map (like the real backlog pins). */
+const BACKLOG = [
+  { number: 'WO-1056', title: 'Gutter repair', left: 26, top: 58 },
+  { number: 'WO-1058', title: 'Filter replacement', left: 66, top: 86 },
+]
+
+// July 2026, Monday start; negative = outside the displayed month.
+const MINI_WEEKS = [
+  [-29, -30, 1, 2, 3, 4, 5],
+  [6, 7, 8, 9, 10, 11, 12],
+  [13, 14, 15, 16, 17, 18, 19],
+  [20, 21, 22, 23, 24, 25, 26],
+  [27, 28, 29, 30, 31, -1, -2],
+]
+const MINI_SELECTED_DAY = 20
+const MINI_DENSITY_DAYS = new Set([21, 22, 24])
+const MINI_WEEKDAYS = ['M', 'T', 'W', 'T', 'F', 'S', 'S']
+
 /**
- * A route-planning map: a faint street grid, dashed suggested routes for two
- * workers connecting numbered stop pins, and a reorderable stop list panel —
- * echoing the product's route planner.
+ * The dispatch route planner as a full app window: browser chrome, the dispatch module
+ * sidebar (mini calendar, Backlog, Routes stop lists), and the planner map with numbered
+ * teardrop pins, per-worker route polylines, and the home-base marker — a static facsimile
+ * of `apps/web/src/components/dispatch/ui/route-planner/` built from the shared homepage
+ * mock primitives.
  */
-export function MockRouteMap({ className }: { className?: string }) {
+export function MockRoutePlanner({ className }: { className?: string }) {
   return (
-    <div className={cn('flex flex-col gap-4 lg:flex-row', className)}>
-      <div className='bg-muted/50 ring-foreground/10 relative aspect-[16/10] flex-1 overflow-hidden rounded-xl ring-1'>
-        <div
-          aria-hidden
-          className='absolute inset-0 bg-[repeating-linear-gradient(0deg,var(--color-foreground),var(--color-foreground)_1px,transparent_1px,transparent_32px),repeating-linear-gradient(90deg,var(--color-foreground),var(--color-foreground)_1px,transparent_1px,transparent_32px)] opacity-[0.06]'
-        />
-        <svg
-          aria-hidden
-          viewBox='0 0 100 100'
-          preserveAspectRatio='none'
-          className='absolute inset-0 h-full w-full'>
-          <polyline
-            points='8,82 8,60 28,60 28,30 52,30 52,18 78,18'
-            className='fill-none stroke-sky-500'
-            strokeWidth='2'
-            vectorEffect='non-scaling-stroke'
-            strokeLinejoin='round'
-            strokeLinecap='round'
-            strokeDasharray='1.4 1'
-            opacity='0.7'
-          />
-          <polyline
-            points='8,82 20,82 20,20 44,20 44,68'
-            className='fill-none stroke-amber-500'
-            strokeWidth='2'
-            vectorEffect='non-scaling-stroke'
-            strokeLinejoin='round'
-            strokeLinecap='round'
-            strokeDasharray='1.4 1'
-            opacity='0.7'
-          />
-        </svg>
-        <span
-          className='bg-foreground/10 ring-background text-muted-foreground absolute flex size-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full ring-2'
-          style={{ left: '8%', top: '82%' }}>
-          <MapPin className='size-3.5' />
+    <MockBrowserChrome variant='regular' url='app.auxx.ai/app/dispatch' className={className}>
+      <div className='flex h-[440px] md:h-[540px]'>
+        <MockDispatchSidebar className='hidden md:flex' />
+        <MockMainPage>
+          <PlannerToolbar />
+          <MockPlannerMap />
+        </MockMainPage>
+      </div>
+    </MockBrowserChrome>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sidebar — facsimile of `dispatch/ui/sidebar/dispatch-sidebar.tsx` (map mode)
+// ---------------------------------------------------------------------------
+
+function MockDispatchSidebar({ className }: { className?: string }) {
+  return (
+    <aside
+      style={{ width: 220 }}
+      className={cn(
+        'flex shrink-0 flex-col overflow-hidden border-r border-mock-sidebar-border bg-mock-sidebar text-mock-sidebar-foreground',
+        className
+      )}>
+      <MiniMonthMock />
+      <div className='flex-1 space-y-2 overflow-hidden px-2 pb-2'>
+        <BacklogGroupMock />
+        <RoutesGroupMock />
+      </div>
+    </aside>
+  )
+}
+
+function MiniMonthMock() {
+  return (
+    <div className='px-3 pb-2 pt-3'>
+      <div className='flex items-center justify-between px-1 pb-1.5'>
+        <span className='text-xs font-medium'>July 2026</span>
+        <span className='flex items-center gap-1 text-mock-sidebar-muted'>
+          <ChevronLeft className='size-3' />
+          <ChevronRight className='size-3' />
         </span>
-        <Pin left={28} top={60} tone='sky' number={1} />
-        <Pin left={52} top={30} tone='sky' number={2} />
-        <Pin left={78} top={18} tone='sky' number={3} />
-        <Pin left={20} top={20} tone='amber' number={1} />
-        <Pin left={44} top={68} tone='amber' number={2} />
+      </div>
+      <div className='grid grid-cols-7 text-center text-[9px] text-mock-sidebar-muted'>
+        {MINI_WEEKDAYS.map((day, i) => (
+          <span key={`${day}-${i}`} className='flex h-4 items-center justify-center'>
+            {day}
+          </span>
+        ))}
+      </div>
+      <div className='grid grid-cols-7'>
+        {MINI_WEEKS.flat().map((value, i) => {
+          const day = Math.abs(value)
+          const outside = value < 0
+          const selected = !outside && day === MINI_SELECTED_DAY
+          return (
+            <span
+              key={i}
+              className={cn(
+                'relative flex h-5 items-center justify-center rounded-md text-[10px] tabular-nums',
+                outside ? 'text-mock-sidebar-muted/50' : 'text-mock-sidebar-foreground',
+                selected && 'bg-foreground font-medium text-background'
+              )}>
+              {day}
+              {!outside && !selected && MINI_DENSITY_DAYS.has(day) && (
+                <span className='absolute bottom-px left-1/2 size-[3px] -translate-x-1/2 rounded-full bg-mock-sidebar-muted' />
+              )}
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function GroupLabel({ title, trailing }: { title: string; trailing?: React.ReactNode }) {
+  return (
+    <div className='flex h-6 items-center justify-between rounded-md px-2 text-xs font-medium text-mock-sidebar-muted'>
+      <span>{title}</span>
+      {trailing ?? <ChevronDown className='size-3' />}
+    </div>
+  )
+}
+
+function BacklogGroupMock() {
+  return (
+    <div>
+      <GroupLabel
+        title='Backlog'
+        trailing={<span className='tabular-nums'>{BACKLOG.length}</span>}
+      />
+      <div className='px-2 pb-0.5 pt-1 text-[10px] font-medium uppercase tracking-wide text-mock-sidebar-muted/80'>
+        Unscheduled
+      </div>
+      <ul className='flex flex-col gap-px'>
+        {BACKLOG.map((item) => (
+          <li key={item.number} className='flex h-7 items-center gap-2 rounded-md px-2 text-xs'>
+            <span className='size-1.5 shrink-0 rounded-full bg-mock-sidebar-muted/60' />
+            <span className='shrink-0'>{item.number}</span>
+            <span className='truncate text-mock-sidebar-muted'>{item.title}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function RoutesGroupMock() {
+  return (
+    <div>
+      <GroupLabel title='Routes' />
+      <ul className='flex flex-col gap-px'>
+        {WORKERS.map((worker) => (
+          <li key={worker.name}>
+            <div className='flex h-7 items-center rounded-md px-2 text-xs'>
+              <span className={cn('mr-2 size-2 shrink-0 rounded-full', worker.dot)} />
+              <span className='truncate font-medium'>{worker.name}</span>
+              {worker.drift && (
+                <span className='ml-1.5 size-1.5 shrink-0 rounded-full bg-amber-500' />
+              )}
+              <ChevronDown className='ml-1 size-3 shrink-0 text-mock-sidebar-muted' />
+              <span className='ml-auto text-mock-sidebar-muted tabular-nums'>
+                {worker.stops.length}
+              </span>
+            </div>
+            <ul className='flex flex-col gap-px'>
+              {worker.stops.map((stop, index) => (
+                <li key={stop.number} className='flex h-7 items-center rounded-md px-2 text-xs'>
+                  <span className='mr-2 text-mock-sidebar-muted tabular-nums'>{index + 1}.</span>
+                  <span className='truncate'>{stop.number}</span>
+                  <span className='ml-auto text-mock-sidebar-muted'>{stop.eta}</span>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main panel — toolbar + map facsimile of `route-planner/planner-map.tsx`
+// ---------------------------------------------------------------------------
+
+function PlannerToolbar() {
+  return (
+    <div className='flex items-center justify-between border-b border-mock-window-border px-3 py-2'>
+      <div className='flex items-center gap-1 rounded-lg bg-muted p-0.5 text-[10px] font-medium'>
+        <span className='px-2 py-1 text-muted-foreground'>Calendar</span>
+        <span className='rounded-md bg-background px-2 py-1 text-foreground shadow-sm'>Map</span>
+      </div>
+      <div className='flex items-center gap-2 text-xs text-muted-foreground'>
+        <ChevronLeft className='size-3.5' />
+        <span className='font-medium text-foreground'>Mon, Jul 20</span>
+        <ChevronRight className='size-3.5' />
+      </div>
+    </div>
+  )
+}
+
+interface TeardropPinProps {
+  left: number
+  top: number
+  /** Worker hex fill; omit for the neutral backlog pin (fills with `currentColor`). */
+  fill?: string
+  order?: number
+}
+
+function TeardropPin({ left, top, fill, order }: TeardropPinProps) {
+  return (
+    <div
+      className={cn(
+        'absolute -translate-x-1/2 -translate-y-full',
+        !fill && 'text-slate-600 dark:text-slate-400'
+      )}
+      style={{ left: `${left}%`, top: `${top}%` }}>
+      <svg
+        width='28'
+        height='38'
+        viewBox='0 0 28 38'
+        className='block drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)]'>
+        <path
+          d={TEARDROP_PATH_D}
+          fill={fill ?? 'currentColor'}
+          stroke={PIN_OUTLINE_COLOR}
+          strokeWidth='1.5'
+        />
+      </svg>
+      {order != null && (
+        <span className='absolute left-0 top-0 flex size-7 items-center justify-center text-[13px] font-extrabold text-white'>
+          {order}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function MockPlannerMap() {
+  return (
+    <div className='relative flex-1 overflow-hidden bg-[#f2efe9] dark:bg-[#1a1f27]'>
+      {/* Minor street grid */}
+      <div
+        aria-hidden
+        className='absolute inset-0 bg-[repeating-linear-gradient(0deg,var(--color-foreground),var(--color-foreground)_1px,transparent_1px,transparent_28px),repeating-linear-gradient(90deg,var(--color-foreground),var(--color-foreground)_1px,transparent_1px,transparent_28px)] opacity-[0.05]'
+      />
+      {/* Park + water blocks */}
+      <div
+        aria-hidden
+        className='absolute rounded-xl bg-emerald-600/15 dark:bg-emerald-400/10'
+        style={{ left: '17%', top: '26%', width: '18%', height: '16%' }}
+      />
+      <div
+        aria-hidden
+        className='absolute bottom-0 right-0 h-1/5 w-1/4 rounded-tl-[48px] bg-sky-600/15 dark:bg-sky-400/10'
+      />
+      {/* Major roads + route polylines */}
+      <svg
+        aria-hidden
+        viewBox='0 0 100 100'
+        preserveAspectRatio='none'
+        className='absolute inset-0 h-full w-full'>
+        {[22, 46, 72].map((y) => (
+          <line
+            key={`h-${y}`}
+            x1='0'
+            y1={y}
+            x2='100'
+            y2={y}
+            className='stroke-white dark:stroke-[#2a3140]'
+            strokeWidth='5'
+            vectorEffect='non-scaling-stroke'
+          />
+        ))}
+        {[14, 38, 62, 84].map((x) => (
+          <line
+            key={`v-${x}`}
+            x1={x}
+            y1='0'
+            x2={x}
+            y2='100'
+            className='stroke-white dark:stroke-[#2a3140]'
+            strokeWidth='4'
+            vectorEffect='non-scaling-stroke'
+          />
+        ))}
+        {WORKERS.map((worker) => (
+          <polyline
+            key={worker.name}
+            points={worker.line}
+            fill='none'
+            stroke={worker.hex}
+            strokeWidth='3'
+            strokeLinejoin='round'
+            strokeLinecap='round'
+            vectorEffect='non-scaling-stroke'
+            opacity='0.9'
+          />
+        ))}
+      </svg>
+
+      {/* Home-base marker at the depot */}
+      <div
+        className='absolute flex size-8 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-2 border-white bg-slate-800 shadow-md dark:border-slate-800 dark:bg-slate-200'
+        style={{ left: '14%', top: '72%' }}
+        title='Home base'>
+        <Home className='size-4 text-white dark:text-slate-800' />
       </div>
 
-      <div className='w-full shrink-0 lg:w-56'>
-        <div className='bg-card ring-foreground/10 flex h-full flex-col rounded-xl border border-transparent p-3 shadow-xl shadow-black/5 ring-1'>
-          {ROUTES.map((route) => (
-            <div key={route.initials} className='not-first:mt-3 not-first:border-t not-first:pt-3'>
-              <div className='flex items-center gap-1.5 px-1 pb-2'>
-                <span
-                  className={cn(
-                    'flex size-4 shrink-0 items-center justify-center rounded-full text-[8px] font-semibold',
-                    route.tone === 'sky'
-                      ? 'bg-sky-500/15 text-sky-600 dark:text-sky-400'
-                      : 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
-                  )}>
-                  {route.initials}
-                </span>
-                <span className='truncate text-xs font-medium'>{route.label}</span>
-              </div>
-              <ul className='divide-border/70 divide-y'>
-                {route.stops.map((stop) => (
-                  <li key={stop.name} className='flex items-center gap-2 py-1.5'>
-                    <GripVertical className='text-muted-foreground/40 size-3 shrink-0' />
-                    <span className='text-muted-foreground w-10 shrink-0 text-[10px]'>
-                      {stop.time}
-                    </span>
-                    <span className='truncate text-xs'>{stop.name}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-          <button
-            type='button'
-            className='bg-foreground text-background mt-auto w-full rounded-md py-1.5 text-[11px] font-medium'>
-            Apply times to schedule
-          </button>
-        </div>
+      {/* Numbered worker pins + neutral backlog pins */}
+      {WORKERS.flatMap((worker) =>
+        worker.stops.map((stop, index) => (
+          <TeardropPin
+            key={stop.number}
+            left={stop.left}
+            top={stop.top}
+            fill={worker.hex}
+            order={index + 1}
+          />
+        ))
+      )}
+      {BACKLOG.map((item) => (
+        <TeardropPin key={item.number} left={item.left} top={item.top} />
+      ))}
+
+      {/* Zoom control (MapLibre NavigationControl, no compass) */}
+      <div className='absolute right-2 top-2 flex flex-col overflow-hidden rounded-md bg-white text-slate-700 shadow-md ring-1 ring-black/10 dark:bg-[#23272e] dark:text-slate-300 dark:ring-white/10'>
+        <span className='flex size-7 items-center justify-center'>
+          <Plus className='size-3.5' />
+        </span>
+        <span className='h-px bg-black/10 dark:bg-white/10' />
+        <span className='flex size-7 items-center justify-center'>
+          <Minus className='size-3.5' />
+        </span>
       </div>
+
+      <span className='absolute bottom-1 right-1.5 text-[8px] text-black/40 dark:text-white/30'>
+        © OpenFreeMap
+      </span>
     </div>
   )
 }

--- a/apps/homepage/src/app/platform/dispatch/_mocks/worker-phone-mock.tsx
+++ b/apps/homepage/src/app/platform/dispatch/_mocks/worker-phone-mock.tsx
@@ -1,141 +1,228 @@
 // apps/homepage/src/app/platform/dispatch/_mocks/worker-phone-mock.tsx
 
-import { Camera, Check, Plus } from 'lucide-react'
+import {
+  Camera,
+  Check,
+  ChevronRight,
+  Image as ImageIcon,
+  MapPin,
+  MoreVertical,
+  Plus,
+} from 'lucide-react'
 import { cn } from '~/lib/utils'
 
-interface AgendaItem {
-  time: string
-  job: string
-  status: string
-  tone: 'emerald' | 'amber' | 'sky'
-  active?: boolean
-}
-
-const AGENDA: AgendaItem[] = [
-  { time: '8:30', job: 'Furnace tune-up — Alder Grove HOA', status: 'Done', tone: 'emerald' },
-  {
-    time: '10:00',
-    job: 'Water heater install — Nguyen residence',
-    status: 'En route',
-    tone: 'amber',
-    active: true,
-  },
-  { time: '1:00', job: 'Drain clearing — Hilltop Cafe', status: 'Scheduled', tone: 'sky' },
-]
-
-const STATUS_CLASS: Record<AgendaItem['tone'], string> = {
-  emerald: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
-  amber: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
-  sky: 'bg-sky-500/15 text-sky-600 dark:text-sky-400',
-}
-
-const CHECKLIST = [
-  { label: 'Water heater installed', done: true },
-  { label: 'Area cleaned', done: true },
-  { label: 'Customer walkthrough', done: false },
-]
-
 /**
- * A phone-frame mock of the worker's mobile schedule: an agenda of today's
- * visits, the active visit expanded with an advancing status button, a
- * quality checklist, and photo attachments.
+ * The worker's mobile surface — a static facsimile of the real visit page
+ * (`apps/web/src/components/schedule/ui/visit-detail-content.tsx`, the same content the
+ * desktop `VisitDrawer` hosts): Schedule breadcrumb, Visit/Notes outline tabs, the General
+ * section with the one-tap advancing status button, and the Notes tab's quality checklist
+ * with notes and photo capture. Rendered as two phones, one per tab.
  */
 export function MockWorkerPhone({ className }: { className?: string }) {
   return (
-    <div className={cn('mx-auto w-64 sm:w-72', className)}>
-      <div className='border-foreground/10 bg-foreground/[0.03] rounded-[2rem] border p-1.5 shadow-xl shadow-black/10'>
-        <div className='bg-card rounded-[1.5rem] pb-4'>
+    <div className={cn('mx-auto flex w-fit items-start', className)}>
+      <PhoneFrame className='z-10 -rotate-1'>
+        <VisitTabScreen />
+      </PhoneFrame>
+      <PhoneFrame className='-ml-8 mt-10 hidden rotate-2 sm:block'>
+        <NotesTabScreen />
+      </PhoneFrame>
+    </div>
+  )
+}
+
+function PhoneFrame({ className, children }: { className?: string; children: React.ReactNode }) {
+  return (
+    <div className={cn('w-60', className)}>
+      <div className='rounded-[2rem] border border-foreground/10 bg-foreground/[0.03] p-1.5 shadow-xl shadow-black/10'>
+        <div className='overflow-hidden rounded-[1.5rem] bg-mock-window pb-3 text-mock-window-foreground'>
           <div className='flex justify-center pt-2.5'>
-            <div className='bg-foreground/15 h-1 w-10 rounded-full' />
+            <div className='h-1 w-10 rounded-full bg-foreground/15' />
           </div>
-
-          <div className='px-3.5 pt-3'>
-            <div className='text-foreground text-sm font-semibold'>Today</div>
-            <div className='text-muted-foreground text-[10px]'>Tue, Jul 21 · Dana K.</div>
-          </div>
-
-          <ul className='mt-3 space-y-1.5 px-3.5'>
-            {AGENDA.map((item) => (
-              <li
-                key={item.job}
-                className={cn(
-                  'rounded-lg px-2 py-1.5',
-                  item.active
-                    ? 'bg-violet-500/[0.07] ring-violet-500/25 ring-1'
-                    : 'text-muted-foreground'
-                )}>
-                <div className='flex items-center gap-2'>
-                  <span className='text-muted-foreground w-9 shrink-0 text-[10px]'>
-                    {item.time}
-                  </span>
-                  <span
-                    className={cn(
-                      'flex-1 truncate text-[11px]',
-                      item.active ? 'text-foreground font-medium' : undefined
-                    )}>
-                    {item.job}
-                  </span>
-                  <span
-                    className={cn(
-                      'shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-medium',
-                      STATUS_CLASS[item.tone]
-                    )}>
-                    {item.status}
-                  </span>
-                </div>
-
-                {item.active && (
-                  <div className='mt-2.5 space-y-3'>
-                    <div className='text-muted-foreground text-[10px]'>418 Alder Grove Ln</div>
-
-                    <button
-                      type='button'
-                      className='bg-violet-500/90 w-full rounded-lg py-2 text-center text-[11px] font-medium text-white'>
-                      Arrived on site →
-                    </button>
-
-                    <div className='space-y-1'>
-                      {CHECKLIST.map((check) => (
-                        <div key={check.label} className='flex items-center gap-1.5'>
-                          <span
-                            className={cn(
-                              'flex size-3.5 shrink-0 items-center justify-center rounded-[4px]',
-                              check.done
-                                ? 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
-                                : 'border-muted-foreground/40 border'
-                            )}>
-                            {check.done && <Check className='size-2.5' />}
-                          </span>
-                          <span
-                            className={cn(
-                              'text-[10px]',
-                              check.done ? 'text-foreground' : 'text-muted-foreground'
-                            )}>
-                            {check.label}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-
-                    <div className='flex gap-1.5'>
-                      <div className='from-muted to-muted-foreground/20 relative flex h-10 w-10 items-center justify-center rounded-md bg-gradient-to-br'>
-                        <Camera className='text-background/70 size-3.5' />
-                      </div>
-                      <div className='from-muted to-muted-foreground/20 relative flex h-10 w-10 items-center justify-center rounded-md bg-gradient-to-br'>
-                        <Camera className='text-background/70 size-3.5' />
-                      </div>
-                      <div className='border-muted-foreground/30 text-muted-foreground/70 flex h-10 w-10 flex-col items-center justify-center gap-0.5 rounded-md border border-dashed'>
-                        <Plus className='size-3' />
-                        <span className='text-[8px]'>Photo</span>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </li>
-            ))}
-          </ul>
+          {children}
         </div>
       </div>
     </div>
+  )
+}
+
+/** Breadcrumb header — facsimile of the mobile `MainPageHeader` on the visit page. */
+function BreadcrumbHeader() {
+  return (
+    <div className='flex items-center gap-1 px-3.5 pt-2.5 text-[10px]'>
+      <span className='text-muted-foreground'>Schedule</span>
+      <ChevronRight className='size-2.5 text-muted-foreground/60' />
+      <span className='truncate font-medium'>Water heater install</span>
+    </div>
+  )
+}
+
+/** Visit/Notes tab bar — facsimile of the `outline` TabsList (`@auxx/ui` tabs). */
+function TabBar({ active }: { active: 'visit' | 'notes' }) {
+  return (
+    <div className='mt-2 flex w-full items-center gap-1 border-b border-foreground/10 bg-muted/50 px-2 py-1'>
+      {(['visit', 'notes'] as const).map((tab) => (
+        <span
+          key={tab}
+          className={cn(
+            'relative rounded-md px-2.5 py-0.5 text-[10px] font-medium capitalize',
+            tab === active
+              ? 'text-foreground after:absolute after:inset-x-0 after:-bottom-1 after:h-0.5 after:bg-foreground'
+              : 'text-muted-foreground'
+          )}>
+          {tab}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/** Uppercase section header — facsimile of `@auxx/ui` `Section`'s title row. */
+function SectionTitle({ icon, title }: { icon?: React.ReactNode; title: string }) {
+  return (
+    <div className='flex items-center gap-1 pb-1.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground'>
+      {icon}
+      {title}
+    </div>
+  )
+}
+
+const LINE_ITEMS = [
+  { name: '50 gal water heater', qty: 1 },
+  { name: 'Install labor (hrs)', qty: 3 },
+]
+
+function VisitTabScreen() {
+  return (
+    <>
+      <BreadcrumbHeader />
+      <TabBar active='visit' />
+
+      <div className='border-b border-foreground/10 p-3'>
+        <SectionTitle icon={<MapPin className='size-3' />} title='General' />
+        <div className='flex flex-col gap-2'>
+          <div>
+            <div className='text-[11px] font-medium'>Nguyen Residence</div>
+            <div className='text-[10px] text-sky-600 underline underline-offset-2 dark:text-sky-400'>
+              418 Alder Grove Ln, Portland
+            </div>
+          </div>
+          <div className='text-[10px] text-muted-foreground'>Mon, Jul 20 · 10:00 AM – 12:00 PM</div>
+          <div className='text-[10px]'>#WO-1047 · Water heater install</div>
+          <div className='flex items-center gap-1.5'>
+            <span className='flex-1 rounded-md bg-foreground py-1.5 text-center text-[10px] font-medium text-background'>
+              Arrived
+            </span>
+            <span className='flex size-6 items-center justify-center rounded-md text-muted-foreground'>
+              <MoreVertical className='size-3' />
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className='border-b border-foreground/10 p-3'>
+        <SectionTitle title='Instructions' />
+        <p className='text-[10px] text-muted-foreground'>
+          Gate code 4482. Shut off the water main before the swap — valve is in the garage.
+        </p>
+      </div>
+
+      <div className='p-3 pb-1'>
+        <SectionTitle title='Line items' />
+        <ul className='flex flex-col gap-1.5'>
+          {LINE_ITEMS.map((line) => (
+            <li
+              key={line.name}
+              className='flex items-center justify-between gap-2 rounded-md border border-foreground/10 p-1.5 text-[10px]'>
+              <span className='truncate font-medium'>{line.name}</span>
+              <span className='shrink-0 text-muted-foreground'>Qty {line.qty}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  )
+}
+
+const CHECKLIST = [
+  { label: 'Old unit hauled away', done: true },
+  { label: 'Pressure valve tested', done: true, photos: 2 },
+  { label: 'Customer walkthrough', done: false, required: true, expanded: true },
+]
+
+function QcCheckbox({ done }: { done: boolean }) {
+  return (
+    <span
+      className={cn(
+        'flex size-3.5 shrink-0 items-center justify-center rounded-[4px]',
+        done ? 'bg-foreground text-background' : 'border border-muted-foreground/40'
+      )}>
+      {done && <Check className='size-2.5' />}
+    </span>
+  )
+}
+
+function NotesTabScreen() {
+  return (
+    <>
+      <BreadcrumbHeader />
+      <TabBar active='notes' />
+
+      <div className='flex flex-col gap-0.5 p-3'>
+        {CHECKLIST.map((item) => (
+          <div key={item.label} className='rounded-md px-1 py-1'>
+            <div className='flex items-center gap-2'>
+              <QcCheckbox done={item.done} />
+              <span
+                className={cn(
+                  'flex-1 truncate text-[10px]',
+                  item.done && 'text-muted-foreground line-through'
+                )}>
+                {item.label}
+              </span>
+              {item.required && (
+                <span className='shrink-0 rounded-full bg-amber-500/15 px-1.5 py-px text-[8px] font-medium text-amber-600 dark:text-amber-400'>
+                  Required
+                </span>
+              )}
+              {item.photos && (
+                <span className='flex shrink-0 items-center gap-0.5 text-[9px] text-muted-foreground'>
+                  <ImageIcon className='size-2.5' />
+                  {item.photos}
+                </span>
+              )}
+            </div>
+
+            {item.expanded && (
+              <div className='mt-1.5 space-y-1.5 pl-5'>
+                <div className='rounded-md border border-foreground/10 px-1.5 py-1 text-[9px] text-muted-foreground/70'>
+                  Add a note…
+                </div>
+                <div className='flex items-center gap-1.5'>
+                  <div className='flex size-9 items-center justify-center rounded-md bg-gradient-to-br from-muted to-muted-foreground/20'>
+                    <Camera className='size-3 text-background/70' />
+                  </div>
+                  <div className='flex size-9 items-center justify-center rounded-md bg-gradient-to-br from-muted to-muted-foreground/20'>
+                    <Camera className='size-3 text-background/70' />
+                  </div>
+                  <div className='flex size-9 items-center justify-center rounded-md border border-dashed border-muted-foreground/30 text-muted-foreground/70'>
+                    <Camera className='size-3' />
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+
+        <div className='mt-1.5 flex items-center gap-1.5'>
+          <div className='flex-1 rounded-md border border-foreground/10 px-1.5 py-1 text-[9px] text-muted-foreground/70'>
+            Add a check…
+          </div>
+          <span className='flex size-6 items-center justify-center rounded-md border border-foreground/10 text-muted-foreground'>
+            <Plus className='size-3' />
+          </span>
+        </div>
+      </div>
+    </>
   )
 }

--- a/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
 import type { ExistingVisitForOverlap } from '../schedule-popover'
 import type { useBoardMutations } from './hooks/use-board-mutations'
+import { useTimelineHourWindow } from './hooks/use-timeline-hour-window'
 import type { BoardResourceInput, BoardViewMode, DispatchVisitEvent } from './types'
 import { isPastVisitEvent } from './utils'
 import { VisitChipContent, VisitChipMonthContent } from './visit-chip-content'
@@ -153,9 +154,12 @@ export function BoardCalendarGrid({
     [onActiveVisitChange]
   )
 
-  // Both `day` and `timeline` render the same resource day-stream (plan 18); they differ only by
-  // `resourceDaysVisible` (1 vs 3), passed to `EventCalendar` below.
-  const calendarView = view === 'day' || view === 'timeline' ? 'resource' : view
+  // `day` maps onto the shared vertical resource day-stream (plan 18, `resourceDaysVisible=1`).
+  // `timeline` is its own horizontal worker-rows-by-hour calendar view (plan 33) — it passes
+  // through unchanged and no longer shares `resource`'s rendering.
+  const calendarView = view === 'day' ? 'resource' : view
+
+  const hourWindow = useTimelineHourWindow()
 
   const calendarResources: CalendarResource[] = useMemo(
     () =>
@@ -180,7 +184,7 @@ export function BoardCalendarGrid({
       onRangeChange={onRangeChange}
       weekStartsOn={weekStartsOn}
       resources={view === 'day' || view === 'timeline' ? calendarResources : undefined}
-      resourceDaysVisible={view === 'timeline' ? 3 : 1}
+      hourWindow={hourWindow}
       backgroundEvents={backgroundEvents}
       events={events}
       renderEvent={renderEvent}

--- a/apps/web/src/components/dispatch/ui/board/hooks/use-timeline-hour-window.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-timeline-hour-window.ts
@@ -1,0 +1,66 @@
+// apps/web/src/components/dispatch/ui/board/hooks/use-timeline-hour-window.ts
+
+'use client'
+
+import { useMemo } from 'react'
+import { useSettings } from '~/hooks/use-settings'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
+import { api } from '~/trpc/react'
+
+/** While loading, or when the org has no weekly-hours template at all. */
+const FALLBACK_WINDOW = { start: 6, end: 20 }
+
+const BUFFER_HOURS = 2
+
+/**
+ * The Timeline board view's hour window (plan 33 §2.2): `[floor(minStart) − 2h, ceil(maxEnd) +
+ * 2h]` over the org weekly working-hours template's enabled days, clamped to `[0, 24]`. An
+ * explicit settings override (`dispatch.board.timelineStartHour`/`timelineEndHour`) wins when
+ * BOTH keys are set to numbers with `end > start`. Falls back to `{ start: 6, end: 20 }` while
+ * loading or when the template is empty/absent.
+ *
+ * Queries `availability.getWeeklyHours` with the same input as
+ * `use-availability-shading.ts`'s `orgWeekly` query and the same `ORG_STATIC_STALE_TIME`, so
+ * react-query dedupes the two callers into one request/cache entry.
+ */
+export function useTimelineHourWindow(): { start: number; end: number } {
+  const orgWeekly = api.availability.getWeeklyHours.useQuery(
+    { subject: { type: 'organization' } },
+    { staleTime: ORG_STATIC_STALE_TIME }
+  )
+
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const overrideStart = getSetting('dispatch.board.timelineStartHour')
+  const overrideEnd = getSetting('dispatch.board.timelineEndHour')
+
+  return useMemo(() => {
+    if (
+      typeof overrideStart === 'number' &&
+      typeof overrideEnd === 'number' &&
+      overrideEnd > overrideStart
+    ) {
+      // Whole hours only — the view's hour ticks and day width assume integer window bounds.
+      return {
+        start: Math.max(0, Math.min(24, Math.round(overrideStart))),
+        end: Math.max(0, Math.min(24, Math.round(overrideEnd))),
+      }
+    }
+
+    const days = orgWeekly.data?.days ?? []
+    let minStart: number | undefined
+    let maxEnd: number | undefined
+    for (const day of days) {
+      for (const range of day.ranges) {
+        minStart = minStart === undefined ? range.start : Math.min(minStart, range.start)
+        maxEnd = maxEnd === undefined ? range.end : Math.max(maxEnd, range.end)
+      }
+    }
+    if (minStart === undefined || maxEnd === undefined) return FALLBACK_WINDOW
+
+    // `range.start`/`range.end` are minutes-since-midnight; convert to hours before buffering.
+    const start = Math.max(0, Math.floor(minStart / 60) - BUFFER_HOURS)
+    const end = Math.min(24, Math.ceil(maxEnd / 60) + BUFFER_HOURS)
+    if (end <= start) return FALLBACK_WINDOW
+    return { start, end }
+  }, [orgWeekly.data, overrideStart, overrideEnd])
+}

--- a/apps/web/src/components/dispatch/ui/dispatch-general-settings-page.tsx
+++ b/apps/web/src/components/dispatch/ui/dispatch-general-settings-page.tsx
@@ -3,7 +3,7 @@
 
 import { FeatureKey } from '@auxx/lib/permissions/client'
 import type { SettingValue } from '@auxx/lib/settings/client'
-import { Lock, Route as RouteIcon } from 'lucide-react'
+import { Clock, Lock, Route as RouteIcon } from 'lucide-react'
 import { EmptyState } from '~/components/global/empty-state'
 import { FieldPanel } from '~/components/global/forms/field-panel'
 import { FormSaveBar } from '~/components/global/forms/form-save-bar'
@@ -47,7 +47,11 @@ export function DispatchGeneralSettingsPage() {
 /** Scalar catalog keys this page's draft owns — `useSettings({scope:'GENERAL'})` returns every
  * `'GENERAL'`-scope setting across the whole app, so the draft/save must stay scoped to exactly
  * these keys or a save here would clobber unrelated GENERAL settings. */
-const DRAFT_KEYS = ['dispatch.routes.autoApplyTimes'] as const
+const DRAFT_KEYS = [
+  'dispatch.routes.autoApplyTimes',
+  'dispatch.board.timelineStartHour',
+  'dispatch.board.timelineEndHour',
+] as const
 
 function DispatchGeneralSettingsBody() {
   const { getSetting, batchUpdateOrganizationSettings, isBatchUpdatingOrgSettings } = useSettings({
@@ -63,7 +67,7 @@ function DispatchGeneralSettingsBody() {
     onSave: (next) => {
       const changed = DRAFT_KEYS.filter((key) => next[key] !== server[key]).map((key) => ({
         key,
-        value: next[key],
+        value: next[key] ?? null,
       }))
       if (changed.length > 0) batchUpdateOrganizationSettings(changed)
     },
@@ -71,7 +75,10 @@ function DispatchGeneralSettingsBody() {
 
   const controlled = (key: (typeof DRAFT_KEYS)[number]) => ({
     value: draft[key],
-    onChange: (value: unknown) => patch({ [key]: value as SettingValue }),
+    // NUMBER inputs report a clear as `undefined` (the node-input convention), not `null` —
+    // normalize here since `SettingValue`/the server normalizer only accept `null` for "unset".
+    onChange: (value: unknown) =>
+      patch({ [key]: (value === undefined ? null : value) as SettingValue }),
   })
 
   return (
@@ -93,6 +100,31 @@ function DispatchGeneralSettingsBody() {
               title='Auto-apply times on reorder'
               description='Reordering a route automatically re-chains provisional stop times. Confirmed (promised) times stay fixed — reordering around them surfaces a conflict instead of moving them.'
               {...controlled('dispatch.routes.autoApplyTimes')}
+            />
+          </FieldPanel>
+        </SettingsSection>
+
+        <SettingsSection
+          icon={Clock}
+          title='Board'
+          description='Dispatch board timeline view behavior.'>
+          <FieldPanel
+            className='mt-1 p-0'
+            resizeId='dispatch-general-settings-board'
+            defaultLabelWidth={260}>
+            <SettingsFieldRow
+              settingKey='dispatch.board.timelineStartHour'
+              title='Timeline start hour'
+              description='Automatic — working hours ± 2h buffer. Set both start and end to override.'
+              placeholder='Automatic'
+              {...controlled('dispatch.board.timelineStartHour')}
+            />
+            <SettingsFieldRow
+              settingKey='dispatch.board.timelineEndHour'
+              title='Timeline end hour'
+              description='Automatic — working hours ± 2h buffer. Set both start and end to override.'
+              placeholder='Automatic'
+              {...controlled('dispatch.board.timelineEndHour')}
             />
           </FieldPanel>
         </SettingsSection>

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -387,6 +387,26 @@ export const SETTINGS_CATALOG = {
       'When on, reordering a route automatically re-chains scheduled times for provisional ' +
       'stops (confirmed times hold as anchors)',
   },
+  // Dispatch board timeline view (plan 33 §2.3) — hour-window override for the horizontal
+  // timeline; unset (null) = auto-derive from the org weekly working-hours template ± 2h buffer.
+  'dispatch.board.timelineStartHour': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'NUMBER',
+    defaultValue: null,
+    description:
+      'Timeline board view start hour (0-24). Unset = automatic — derived from working hours ' +
+      '± 2h buffer.',
+  },
+  'dispatch.board.timelineEndHour': {
+    scope: 'GENERAL',
+    access: 'org',
+    fieldType: 'NUMBER',
+    defaultValue: null,
+    description:
+      'Timeline board view end hour (0-24). Unset = automatic — derived from working hours ' +
+      '± 2h buffer.',
+  },
 
   // ── DOCUMENTS (quote/invoice PDF + email settings, money MQ2 build spec §A) ──────────────
   // `documents.taxRates` moved here from GENERAL (money MQ1 §G.1 shipped it under GENERAL —

--- a/packages/ui/src/components/event-calendar/assign-lanes.ts
+++ b/packages/ui/src/components/event-calendar/assign-lanes.ts
@@ -1,0 +1,48 @@
+// packages/ui/src/components/event-calendar/assign-lanes.ts
+
+import type { EventCalendarItem } from './types'
+
+export interface AssignLanesResult {
+  /** Event id → lane index (0-based) it was placed in. */
+  lanes: Map<string, number>
+  /** Number of lanes used to fit every event — `0` for an empty input, otherwise `>= 1`. */
+  laneCount: number
+}
+
+/**
+ * Greedy interval-partitioning ("minimum number of rooms"): sort events by start time (ties
+ * broken by longer duration first), then place each event in the first lane whose last-placed
+ * event ends at or before this event's start. Overlapping events land in different lanes.
+ *
+ * Pure and orientation-agnostic — the horizontal timeline view uses it per worker per rendered
+ * day to size stacked event lanes (`TimelineLaneHeight` per lane); nothing here assumes an axis.
+ */
+export function assignLanes(events: EventCalendarItem[]): AssignLanesResult {
+  if (events.length === 0) return { lanes: new Map(), laneCount: 0 }
+
+  const sorted = [...events].sort((a, b) => {
+    const aStart = new Date(a.start).getTime()
+    const bStart = new Date(b.start).getTime()
+    if (aStart !== bStart) return aStart - bStart
+    const aDuration = new Date(a.end).getTime() - aStart
+    const bDuration = new Date(b.end).getTime() - bStart
+    return bDuration - aDuration
+  })
+
+  // laneEnds[i] = end time (ms) of the last event currently occupying lane i.
+  const laneEnds: number[] = []
+  const lanes = new Map<string, number>()
+
+  for (const event of sorted) {
+    const start = new Date(event.start).getTime()
+    const end = new Date(event.end).getTime()
+
+    let lane = laneEnds.findIndex((laneEnd) => laneEnd <= start)
+    if (lane === -1) lane = laneEnds.length
+
+    laneEnds[lane] = end
+    lanes.set(event.id, lane)
+  }
+
+  return { lanes, laneCount: laneEnds.length }
+}

--- a/packages/ui/src/components/event-calendar/background-events.tsx
+++ b/packages/ui/src/components/event-calendar/background-events.tsx
@@ -14,6 +14,17 @@ interface BackgroundEventsLayerProps {
   /** When set, only background events matching this resource (or with no `resourceId`) render. */
   resourceId?: string
   cellHeight: number
+  /**
+   * Layout orientation. `'y'` (default) positions segments as `top`/`height` against
+   * `StartHour..24` — week/day/resource's vertical grids. `'x'` positions them as `left`/`width`
+   * (percent of `windowStartHour..windowEndHour`) and spans full row height — the horizontal
+   * timeline view.
+   */
+  orientation?: 'x' | 'y'
+  /** Visible hour window start — `orientation: 'x'` only. */
+  windowStartHour?: number
+  /** Visible hour window end — `orientation: 'x'` only. */
+  windowEndHour?: number
 }
 
 /**
@@ -27,6 +38,9 @@ export function BackgroundEventsLayer({
   day,
   resourceId,
   cellHeight,
+  orientation = 'y',
+  windowStartHour,
+  windowEndHour,
 }: BackgroundEventsLayerProps) {
   const dayEvents = events.filter((bg) => {
     if (bg.resourceId !== undefined && bg.resourceId !== resourceId) return false
@@ -37,6 +51,41 @@ export function BackgroundEventsLayer({
   })
 
   if (dayEvents.length === 0) return null
+
+  if (orientation === 'x') {
+    const winStart = windowStartHour ?? StartHour
+    const winEnd = windowEndHour ?? 24
+    const windowHours = winEnd - winStart
+    if (windowHours <= 0) return null
+
+    return (
+      <>
+        {dayEvents.map((bg, index) => {
+          const start = new Date(bg.start)
+          const end = new Date(bg.end)
+          const startHour = isSameDay(day, start) ? getHours(start) + getMinutes(start) / 60 : 0
+          const endHour = isSameDay(day, end) ? getHours(end) + getMinutes(end) / 60 : 24
+          // Clamp to the visible hour window — segments entirely outside it collapse to nothing.
+          const clampedStart = Math.min(Math.max(startHour, winStart), winEnd)
+          const clampedEnd = Math.min(Math.max(endHour, winStart), winEnd)
+          if (clampedEnd <= clampedStart) return null
+          const left = ((clampedStart - winStart) / windowHours) * 100
+          const width = ((clampedEnd - clampedStart) / windowHours) * 100
+
+          return (
+            <div
+              key={index}
+              className={cn(
+                'pointer-events-none absolute inset-y-0 z-0',
+                bg.className ?? 'bg-muted/40'
+              )}
+              style={{ left: `${left}%`, width: `${width}%` }}
+            />
+          )
+        })}
+      </>
+    )
+  }
 
   return (
     <>

--- a/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
+++ b/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
@@ -37,6 +37,8 @@ interface CalendarDndContextValue<T extends EventCalendarItem = EventCalendarIte
   /** Resource id of the hovered cell (resource view) — lets the drop outline pick its column. */
   currentResourceId: string | null
   eventHeight: number | null
+  /** Chip width (px) of the drag source — set only for horizontal (timeline) chips. */
+  eventWidth: number | null
 }
 
 const CalendarDndContext = createContext<CalendarDndContextValue>({
@@ -48,6 +50,7 @@ const CalendarDndContext = createContext<CalendarDndContextValue>({
   currentTime: null,
   currentResourceId: null,
   eventHeight: null,
+  eventWidth: null,
 })
 
 export const useCalendarDnd = () => useContext(CalendarDndContext)
@@ -93,6 +96,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
   const [currentTime, setCurrentTime] = useState<Date | null>(null)
   const [currentResourceId, setCurrentResourceId] = useState<string | null>(null)
   const [eventHeight, setEventHeight] = useState<number | null>(null)
+  const [eventWidth, setEventWidth] = useState<number | null>(null)
   const [foreignActive, setForeignActive] = useState<Active | null>(null)
 
   const sensors = useSensors(
@@ -123,7 +127,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
   const handleDragStart = (event: DragStartEvent) => {
     const { active } = event
     const data = active.data.current as
-      | { event?: T; view?: DraggableView; height?: number }
+      | { event?: T; view?: DraggableView; height?: number; width?: number }
       | undefined
     if (!data?.event) {
       setForeignActive(active)
@@ -136,6 +140,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
     setActiveView(data.view ?? null)
     setCurrentTime(new Date(data.event.start))
     setEventHeight(data.height ?? null)
+    setEventWidth(data.width ?? null)
   }
 
   const handleDragOver = (event: DragOverEvent) => {
@@ -182,6 +187,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
     setCurrentTime(null)
     setCurrentResourceId(null)
     setEventHeight(null)
+    setEventWidth(null)
     setForeignActive(null)
   }
 
@@ -241,6 +247,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
           currentTime,
           currentResourceId,
           eventHeight,
+          eventWidth,
         }}>
         {children}
 
@@ -256,7 +263,11 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
           {activeEvent && activeView ? (
             <div
               className='opacity-80'
-              style={{ width: '100%', height: eventHeight ? `${eventHeight}px` : 'auto' }}>
+              style={
+                eventWidth
+                  ? { width: `${eventWidth}px`, height: eventHeight ? `${eventHeight}px` : '100%' }
+                  : { width: '100%', height: eventHeight ? `${eventHeight}px` : 'auto' }
+              }>
               <EventItem
                 event={activeEvent}
                 view={activeView as CalendarView}

--- a/packages/ui/src/components/event-calendar/constants.ts
+++ b/packages/ui/src/components/event-calendar/constants.ts
@@ -62,3 +62,12 @@ export const SnapMinutes = 15
 /** Current-time indicator accent — a fixed brand accent, not tied to any event color. */
 export const CurrentTimeLineClass = 'bg-rose-600 dark:bg-rose-500'
 export const CurrentTimeLabelClass = 'bg-rose-600 text-white dark:bg-rose-500'
+
+/** Pixels per hour on the horizontal timeline view's x-axis (plan 33). */
+export const TimelineHourWidth = 96
+
+/** Height (px) of one event lane within a timeline worker row (plan 33). */
+export const TimelineLaneHeight = 28
+
+/** Width (px) of the sticky-left worker rail in the horizontal timeline view (plan 33). */
+export const TimelineRailWidth = 160

--- a/packages/ui/src/components/event-calendar/day-resource-group.tsx
+++ b/packages/ui/src/components/event-calendar/day-resource-group.tsx
@@ -52,7 +52,7 @@ interface DayResourceGroupProps<T extends EventCalendarItem = EventCalendarItem>
  *
  * Computes its own `day` and does its own per-worker event filtering — the
  * caller never slices `events` per day, which is what keeps a single memoized
- * group stable across scroll frames. The group's left edge carries the strong
+ * group stable across scroll frames. The group's left edge carries a hairline
  * day-boundary border; worker sub-columns keep the hairline inner border.
  */
 function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>({
@@ -91,7 +91,7 @@ function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>(
 
   return (
     <div
-      className='border-border absolute border-l-2'
+      className='border-border/70 absolute border-l'
       style={{
         top,
         left: 0,

--- a/packages/ui/src/components/event-calendar/draggable-event.tsx
+++ b/packages/ui/src/components/event-calendar/draggable-event.tsx
@@ -9,7 +9,7 @@ import { differenceInDays } from 'date-fns'
 import { useRef, useState } from 'react'
 
 import { useCalendarDnd } from './calendar-dnd-context'
-import { WeekCellsHeight } from './constants'
+import { TimelineHourWidth, WeekCellsHeight } from './constants'
 import { EventItem } from './event-item'
 import { useEventResize } from './hooks/use-event-resize'
 import type { CalendarView, EventCalendarItem, RenderEvent } from './types'
@@ -20,6 +20,8 @@ interface DraggableEventProps<T extends EventCalendarItem = EventCalendarItem> {
   showTime?: boolean
   onClick?: (e: React.MouseEvent) => void
   height?: number
+  /** Chip width (px) — only meaningful with `orientation: 'x'` (the horizontal timeline). */
+  width?: number
   isFirstDay?: boolean
   isLastDay?: boolean
   /** Active selection — the event whose detail/popover is open. Draws the in-color ring. */
@@ -27,6 +29,12 @@ interface DraggableEventProps<T extends EventCalendarItem = EventCalendarItem> {
   renderEvent?: RenderEvent<T>
   /** Enables the top/bottom-edge resize handles — only meaningful in week/day/resource. */
   onResize?: (event: T, newStart: Date, newEnd: Date) => void
+  /**
+   * Resize/handle axis. `'y'` (default) is today's week/day/resource chip: top/bottom handles,
+   * height-driven preview. `'x'` is the horizontal timeline's chip: left/right handles,
+   * width-driven preview, full-height (`100%`).
+   */
+  orientation?: 'x' | 'y'
 }
 
 export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>({
@@ -35,11 +43,13 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
   showTime,
   onClick,
   height,
+  width,
   isFirstDay = true,
   isLastDay = true,
   isSelected,
   renderEvent,
   onResize,
+  orientation = 'y',
 }: DraggableEventProps<T>) {
   const { activeId, hasDropHandler } = useCalendarDnd()
   const elementRef = useRef<HTMLDivElement>(null)
@@ -57,6 +67,7 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
       event,
       view,
       height: height || elementRef.current?.offsetHeight || null,
+      width: width || elementRef.current?.offsetWidth || null,
       isMultiDay: isMultiDayEvent,
       dragHandlePosition,
       isFirstDay,
@@ -66,9 +77,10 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
 
   const canResize =
     onResize !== undefined && (view === 'week' || view === 'day' || view === 'resource')
-  const { isResizing, previewHeight, previewOffsetY, getResizeHandleProps } = useEventResize({
+  const { isResizing, previewSize, previewOffset, getResizeHandleProps } = useEventResize({
     event,
-    cellHeight: WeekCellsHeight,
+    axis: orientation,
+    cellSize: orientation === 'x' ? TimelineHourWidth : WeekCellsHeight,
     onResize,
   })
 
@@ -94,18 +106,29 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
   // pointer `transform` to it (that would make the origin chase the cursor as a second ghost).
   const isDragSource = isDragging || activeId === `${event.id}-${view}`
 
-  const effectiveHeight = isResizing && previewHeight !== null ? previewHeight : height
+  const effectiveSize =
+    isResizing && previewSize !== null ? previewSize : orientation === 'x' ? width : height
+
+  // 'y' (default): height-driven chip, unchanged from pre-orientation behavior.
+  // 'x': full-height chip, width-driven by the resize preview.
+  const sizeStyle =
+    orientation === 'x'
+      ? { height: '100%', width: effectiveSize || 'auto' }
+      : { height: effectiveSize || 'auto' }
+
+  const previewTransform =
+    isResizing && previewOffset !== 0
+      ? orientation === 'x'
+        ? `translateX(${previewOffset}px)`
+        : `translateY(${previewOffset}px)`
+      : undefined
 
   // During a resize the dnd transform is null (resize stops propagation, so no move-drag),
-  // so the top-edge preview translate lives in the else branch alongside the height.
+  // so the start-edge preview translate lives in the else branch alongside the size.
   const style =
     transform && !isDragSource
-      ? { transform: CSS.Translate.toString(transform), height: effectiveHeight || 'auto' }
-      : {
-          height: effectiveHeight || 'auto',
-          transform:
-            isResizing && previewOffsetY !== 0 ? `translateY(${previewOffsetY}px)` : undefined,
-        }
+      ? { transform: CSS.Translate.toString(transform), ...sizeStyle }
+      : { ...sizeStyle, transform: previewTransform }
 
   return (
     <div
@@ -131,20 +154,34 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
         dndAttributes={hasDropHandler ? attributes : undefined}
         renderEvent={renderEvent}
       />
-      {canResize && (
-        <>
-          {/* Invisible top drag zone — resizes the start time. */}
-          <div
-            {...getResizeHandleProps('top')}
-            className='absolute inset-x-0 top-0 h-2 cursor-ns-resize touch-none'
-          />
-          {/* Invisible bottom drag zone — resizes the end time. */}
-          <div
-            {...getResizeHandleProps('bottom')}
-            className='absolute inset-x-0 bottom-0 h-2 cursor-ns-resize touch-none'
-          />
-        </>
-      )}
+      {canResize &&
+        (orientation === 'x' ? (
+          <>
+            {/* Invisible left drag zone — resizes the start time. */}
+            <div
+              {...getResizeHandleProps('start')}
+              className='absolute inset-y-0 left-0 w-2 cursor-ew-resize touch-none'
+            />
+            {/* Invisible right drag zone — resizes the end time. */}
+            <div
+              {...getResizeHandleProps('end')}
+              className='absolute inset-y-0 right-0 w-2 cursor-ew-resize touch-none'
+            />
+          </>
+        ) : (
+          <>
+            {/* Invisible top drag zone — resizes the start time. */}
+            <div
+              {...getResizeHandleProps('start')}
+              className='absolute inset-x-0 top-0 h-2 cursor-ns-resize touch-none'
+            />
+            {/* Invisible bottom drag zone — resizes the end time. */}
+            <div
+              {...getResizeHandleProps('end')}
+              className='absolute inset-x-0 bottom-0 h-2 cursor-ns-resize touch-none'
+            />
+          </>
+        ))}
     </div>
   )
 }

--- a/packages/ui/src/components/event-calendar/drop-preview.tsx
+++ b/packages/ui/src/components/event-calendar/drop-preview.tsx
@@ -47,3 +47,55 @@ export function DropPreview({ day, resourceId }: DropPreviewProps) {
     />
   )
 }
+
+interface DropPreviewXProps {
+  /** The day section's day — the outline shows only when the snapped drop target lands here. */
+  day: Date
+  /** Worker row id — the outline shows only when the hovered row matches. */
+  resourceId?: string
+  /** Visible hour window start — same window the section's chips/background shading use. */
+  windowStartHour: number
+  /** Visible hour window end. */
+  windowEndHour: number
+}
+
+/**
+ * Horizontal counterpart to `DropPreview` for the timeline view: outlines the snapped landing
+ * slot as a `left`/`width` block spanning the full row height, instead of `top`/`height`. Reads
+ * the same DnD context and mirrors `DropPreview`'s gating — renders only while a timed drag is
+ * hovering this exact day + worker row.
+ */
+export function DropPreviewX({
+  day,
+  resourceId,
+  windowStartHour,
+  windowEndHour,
+}: DropPreviewXProps) {
+  const { activeEvent, currentTime, activeView, currentResourceId } = useCalendarDnd()
+
+  // No timed drag in flight, or a month drag (whole-day, no time slot to outline).
+  if (!activeEvent || !currentTime || activeView === 'month') return null
+  if (!isSameDay(currentTime, day)) return null
+  // The timeline packs every worker's row in the same day section — gate on the hovered row too.
+  if (resourceId !== undefined && currentResourceId !== resourceId) return null
+
+  const windowHours = windowEndHour - windowStartHour
+  if (windowHours <= 0) return null
+  const windowMinutes = windowHours * 60
+
+  const startMinutes = (currentTime.getHours() - windowStartHour) * 60 + currentTime.getMinutes()
+  const durationMinutes = differenceInMinutes(
+    new Date(activeEvent.end),
+    new Date(activeEvent.start)
+  )
+  const left = (startMinutes / windowMinutes) * 100
+  // Floor a zero/negative duration to a quarter hour so the outline is always visible.
+  const width = Math.max((durationMinutes / windowMinutes) * 100, (15 / windowMinutes) * 100)
+
+  return (
+    <div
+      className='border-primary/70 bg-primary/5 pointer-events-none absolute inset-y-0.5 z-30 rounded-md border-2 border-dashed'
+      style={{ left: `${left}%`, width: `${width}%` }}
+    />
+  )
+}

--- a/packages/ui/src/components/event-calendar/event-calendar.tsx
+++ b/packages/ui/src/components/event-calendar/event-calendar.tsx
@@ -32,6 +32,7 @@ import { AgendaView } from './agenda-view'
 import { CalendarDndProvider, useCalendarDnd } from './calendar-dnd-context'
 import {
   AgendaDaysToShow,
+  EndHour,
   EventGap,
   EventHeight,
   GridAllDayChipHeight,
@@ -40,8 +41,10 @@ import {
   GridHeaderHeight,
   GridTickHeight,
   GridTickMinutes,
+  StartHour,
 } from './constants'
 import { DayView, DayViewHeader } from './day-view'
+import { HorizontalTimelineView } from './horizontal-timeline-view'
 import { MonthView } from './month-view'
 import { ResourceTimelineView } from './resource-timeline-view'
 import type {
@@ -50,8 +53,12 @@ import type {
   CalendarView,
   EventCalendarItem,
   RenderEvent,
+  TimelineHourWindow,
 } from './types'
 import { WeekView } from './week-view'
+
+/** Module-level default — an inline `{}` default would break `TimelineDaySection`'s memo every render. */
+const DefaultHourWindow: TimelineHourWindow = { start: StartHour, end: EndHour }
 
 export interface EventCalendarProps<T extends EventCalendarItem = EventCalendarItem> {
   events?: T[]
@@ -68,6 +75,8 @@ export interface EventCalendarProps<T extends EventCalendarItem = EventCalendarI
   resources?: CalendarResource[]
   /** Resource timeline only — how many days to aim for across the viewport (Day=1, Timeline=3). */
   resourceDaysVisible?: number
+  /** Horizontal timeline (`view='timeline'`) only — visible hour range. Defaults to the full day. */
+  hourWindow?: TimelineHourWindow
   backgroundEvents?: BackgroundEvent[]
   renderEvent?: RenderEvent<T>
   /** Id of the actively-selected event (its detail/popover open) — draws the in-color ring. */
@@ -101,6 +110,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
   weekStartsOn = 1,
   resources,
   resourceDaysVisible = 1,
+  hourWindow = DefaultHourWindow,
   backgroundEvents,
   renderEvent,
   selectedEventId,
@@ -138,7 +148,8 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
     if (view === 'month')
       onDateChange(startOfWeek(subMonths(viewedMonthStart, 1), { weekStartsOn }))
     else if (view === 'week') onDateChange(subWeeks(date, 1))
-    else if (view === 'day' || view === 'resource') onDateChange(addDays(date, -1))
+    else if (view === 'day' || view === 'resource' || view === 'timeline')
+      onDateChange(addDays(date, -1))
     else if (view === 'agenda') onDateChange(addDays(date, -AgendaDaysToShow))
   }
 
@@ -146,7 +157,8 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
     if (view === 'month')
       onDateChange(startOfWeek(addMonths(viewedMonthStart, 1), { weekStartsOn }))
     else if (view === 'week') onDateChange(addWeeks(date, 1))
-    else if (view === 'day' || view === 'resource') onDateChange(addDays(date, 1))
+    else if (view === 'day' || view === 'resource' || view === 'timeline')
+      onDateChange(addDays(date, 1))
     else if (view === 'agenda') onDateChange(addDays(date, AgendaDaysToShow))
   }
 
@@ -180,7 +192,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
       // Placeholder — the week stream reports its own visible range (skipped below).
       return [date, addDays(date, 6)]
     }
-    if (view === 'day' || view === 'resource') {
+    if (view === 'day' || view === 'resource' || view === 'timeline') {
       return [startOfDay(date), endOfDay(date)]
     }
     // agenda
@@ -188,8 +200,8 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
   }, [date, view, weekStartsOn])
 
   useEffect(() => {
-    // The month/week/resource streams drive their own range via onVisibleRangeChange.
-    if (view === 'month' || view === 'week' || view === 'resource') return
+    // The month/week/resource/timeline streams drive their own range via onVisibleRangeChange.
+    if (view === 'month' || view === 'week' || view === 'resource' || view === 'timeline') return
     onRangeChange?.(rangeFrom, rangeTo)
   }, [view, rangeFrom, rangeTo, onRangeChange])
 
@@ -204,7 +216,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
         ? format(start, 'MMMM yyyy')
         : `${format(start, 'MMM')} - ${format(end, 'MMM yyyy')}`
     }
-    if (view === 'day' || view === 'resource') {
+    if (view === 'day' || view === 'resource' || view === 'timeline') {
       return <DayViewHeader currentDate={date} />
     }
     if (view === 'agenda') {
@@ -283,8 +295,8 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
       <div
         className={cn(
           'flex min-h-0 flex-1 flex-col',
-          // The month/week/resource streams own their own (snap) scroll containers.
-          view === 'month' || view === 'week' || view === 'resource'
+          // The month/week/resource/timeline streams own their own (snap) scroll containers.
+          view === 'month' || view === 'week' || view === 'resource' || view === 'timeline'
             ? 'overflow-hidden'
             : 'overflow-y-auto'
         )}>
@@ -340,6 +352,23 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
               backgroundEvents={backgroundEvents}
               onEventSelect={handleEventSelect}
               onSlotClick={handleSlotClick}
+              onEventResize={onEventResize}
+              renderEvent={renderEvent}
+              selectedEventId={selectedEventId}
+              onDateChange={onDateChange}
+              onVisibleRangeChange={onRangeChange}
+            />
+          ) : null)}
+        {view === 'timeline' &&
+          (resources ? (
+            <HorizontalTimelineView
+              currentDate={date}
+              events={events}
+              resources={resources}
+              weekStartsOn={weekStartsOn}
+              backgroundEvents={backgroundEvents}
+              hourWindow={hourWindow}
+              onEventSelect={handleEventSelect}
               onEventResize={onEventResize}
               renderEvent={renderEvent}
               selectedEventId={selectedEventId}

--- a/packages/ui/src/components/event-calendar/hooks/use-event-resize.ts
+++ b/packages/ui/src/components/event-calendar/hooks/use-event-resize.ts
@@ -8,13 +8,22 @@ import { useCallback, useRef, useState } from 'react'
 import { MinEventDurationMinutes, SnapMinutes } from '../constants'
 import type { EventCalendarItem } from '../types'
 
-/** Which edge of the chip the active resize gesture is dragging. */
-export type ResizeEdge = 'top' | 'bottom'
+/**
+ * Which edge of the chip the active resize gesture is dragging. `'start'` is the top edge on a
+ * vertical (`axis: 'y'`) chip or the left edge on a horizontal (`axis: 'x'`) chip; `'end'` is the
+ * bottom/right edge respectively.
+ */
+export type ResizeEdge = 'start' | 'end'
 
 interface UseEventResizeOptions<T extends EventCalendarItem> {
   event: T
-  /** Pixels per hour (`WeekCellsHeight`) — used to translate pointer delta into minutes. */
-  cellHeight: number
+  /**
+   * Pixels per hour along the resize axis — used to translate pointer delta into minutes.
+   * `WeekCellsHeight` for `axis: 'y'`, `TimelineHourWidth` for `axis: 'x'`.
+   */
+  cellSize: number
+  /** Which pointer axis drives the resize — `'y'` reads `clientY` (default), `'x'` reads `clientX`. */
+  axis?: 'x' | 'y'
   onResize?: (event: T, newStart: Date, newEnd: Date) => void
 }
 
@@ -27,23 +36,26 @@ interface ResizeHandleProps {
 
 export interface UseEventResizeResult {
   isResizing: boolean
-  /** Live preview height (px) while dragging a handle — falls back to the chip's own height when idle. */
-  previewHeight: number | null
+  /** Live preview chip size (px) along the resize axis while dragging a handle — falls back to the chip's own size when idle. */
+  previewSize: number | null
   /**
-   * Live preview vertical offset (px) while dragging the TOP handle — the chip's top edge moves
-   * up/down (negative = up) so the bottom edge stays visually fixed. Always 0 for the bottom handle.
+   * Live preview offset (px) along the resize axis while dragging the START handle — shifts the
+   * chip's start edge (negative = toward the origin) so the END edge stays visually fixed while
+   * the chip grows/shrinks. Always 0 while dragging the end handle (its start edge never moves).
    */
-  previewOffsetY: number
+  previewOffset: number
   /** Returns the pointer handlers for one edge; the handler captures that edge on pointerdown. */
   getResizeHandleProps: (edge: ResizeEdge) => ResizeHandleProps
 }
 
 /**
- * Two-edge resize handles for week/day/resource event chips: the top handle drags the start
- * time, the bottom handle drags the end time — in both cases the OPPOSITE edge stays visually
- * fixed.
+ * Two-edge resize handles for timed event chips: the start handle drags the start time, the end
+ * handle drags the end time — in both cases the OPPOSITE edge stays visually fixed. `axis`
+ * selects the pointer/orientation: `'y'` (default) for week/day/resource's vertical chips,
+ * `'x'` for the horizontal timeline's chips. The date math (15-min snap, min-duration clamp) is
+ * identical on both axes.
  *
- * Deliberately NOT routed through dnd-kit — resize needs its own vertical-only drag rooted at a
+ * Deliberately NOT routed through dnd-kit — resize needs its own single-axis drag rooted at a
  * chip edge, and layering a second dnd-kit draggable on top of `DraggableEvent`'s existing
  * move-drag is more fragile than a plain pointer-capture handler scoped to the handle element.
  * The handle calls `e.stopPropagation()` on pointerdown so it never bubbles into the parent
@@ -51,16 +63,22 @@ export interface UseEventResizeResult {
  */
 export function useEventResize<T extends EventCalendarItem>({
   event,
-  cellHeight,
+  cellSize,
+  axis = 'y',
   onResize,
 }: UseEventResizeOptions<T>): UseEventResizeResult {
   const [isResizing, setIsResizing] = useState(false)
-  const [previewHeight, setPreviewHeight] = useState<number | null>(null)
-  const [previewOffsetY, setPreviewOffsetY] = useState(0)
-  const startRef = useRef<{ pointerY: number; startHeight: number; edge: ResizeEdge } | null>(null)
+  const [previewSize, setPreviewSize] = useState<number | null>(null)
+  const [previewOffset, setPreviewOffset] = useState(0)
+  const startRef = useRef<{ pointerPos: number; startSize: number; edge: ResizeEdge } | null>(null)
 
-  const pixelsPerMinute = cellHeight / 60
-  const minHeight = MinEventDurationMinutes * pixelsPerMinute
+  const pixelsPerMinute = cellSize / 60
+  const minSize = MinEventDurationMinutes * pixelsPerMinute
+
+  const readPointerPos = useCallback(
+    (e: { clientX: number; clientY: number }) => (axis === 'x' ? e.clientX : e.clientY),
+    [axis]
+  )
 
   const handlePointerDown = useCallback(
     (edge: ResizeEdge, e: React.PointerEvent<HTMLDivElement>) => {
@@ -68,51 +86,52 @@ export function useEventResize<T extends EventCalendarItem>({
       e.preventDefault()
       e.currentTarget.setPointerCapture(e.pointerId)
       const duration = differenceInMinutes(new Date(event.end), new Date(event.start))
-      const startHeight = duration * pixelsPerMinute
-      startRef.current = { pointerY: e.clientY, startHeight, edge }
+      const startSize = duration * pixelsPerMinute
+      startRef.current = { pointerPos: readPointerPos(e), startSize, edge }
       setIsResizing(true)
-      setPreviewHeight(startHeight)
-      setPreviewOffsetY(0)
+      setPreviewSize(startSize)
+      setPreviewOffset(0)
     },
-    [event.start, event.end, pixelsPerMinute]
+    [event.start, event.end, pixelsPerMinute, readPointerPos]
   )
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (!startRef.current) return
       e.stopPropagation()
-      const { pointerY, startHeight, edge } = startRef.current
-      const deltaY = e.clientY - pointerY
-      if (edge === 'bottom') {
-        setPreviewHeight(Math.max(minHeight, startHeight + deltaY))
-        setPreviewOffsetY(0)
+      const { pointerPos, startSize, edge } = startRef.current
+      const delta = readPointerPos(e) - pointerPos
+      if (edge === 'end') {
+        setPreviewSize(Math.max(minSize, startSize + delta))
+        setPreviewOffset(0)
       } else {
-        // Top edge: growing the chip means its top moves up (negative offset), bottom stays put.
-        const nextHeight = Math.max(minHeight, startHeight - deltaY)
-        setPreviewHeight(nextHeight)
-        setPreviewOffsetY(startHeight - nextHeight)
+        // Start edge: growing the chip means its start moves toward the origin (negative
+        // offset), the end edge stays put.
+        const nextSize = Math.max(minSize, startSize - delta)
+        setPreviewSize(nextSize)
+        setPreviewOffset(startSize - nextSize)
       }
     },
-    [minHeight]
+    [minSize, readPointerPos]
   )
 
   const finishResize = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (!startRef.current) return
       e.stopPropagation()
-      const { pointerY, edge } = startRef.current
-      const deltaY = e.clientY - pointerY
-      const deltaMinutes = deltaY / pixelsPerMinute
+      const { pointerPos, edge } = startRef.current
+      const delta = readPointerPos(e) - pointerPos
+      const deltaMinutes = delta / pixelsPerMinute
       const start = new Date(event.start)
       const end = new Date(event.end)
       const duration = differenceInMinutes(end, start)
 
       startRef.current = null
       setIsResizing(false)
-      setPreviewHeight(null)
-      setPreviewOffsetY(0)
+      setPreviewSize(null)
+      setPreviewOffset(0)
 
-      if (edge === 'bottom') {
+      if (edge === 'end') {
         const newDuration = Math.max(
           MinEventDurationMinutes,
           Math.round((duration + deltaMinutes) / SnapMinutes) * SnapMinutes
@@ -132,7 +151,7 @@ export function useEventResize<T extends EventCalendarItem>({
         }
       }
     },
-    [event, pixelsPerMinute, onResize]
+    [event, pixelsPerMinute, onResize, readPointerPos]
   )
 
   const cancelResize = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
@@ -140,8 +159,8 @@ export function useEventResize<T extends EventCalendarItem>({
     e.stopPropagation()
     startRef.current = null
     setIsResizing(false)
-    setPreviewHeight(null)
-    setPreviewOffsetY(0)
+    setPreviewSize(null)
+    setPreviewOffset(0)
   }, [])
 
   const getResizeHandleProps = useCallback(
@@ -156,8 +175,8 @@ export function useEventResize<T extends EventCalendarItem>({
 
   return {
     isResizing,
-    previewHeight,
-    previewOffsetY,
+    previewSize,
+    previewOffset,
     getResizeHandleProps,
   }
 }

--- a/packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
@@ -1,0 +1,467 @@
+// packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
+
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import {
+  addDays,
+  addHours,
+  differenceInCalendarDays,
+  endOfDay,
+  format,
+  isSameDay,
+  isToday,
+  startOfDay,
+} from 'date-fns'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+
+import { assignLanes } from './assign-lanes'
+import {
+  CurrentTimeLabelClass,
+  StreamEndYear,
+  StreamStartYear,
+  TimelineHourWidth,
+  TimelineLaneHeight,
+  TimelineRailWidth,
+} from './constants'
+import { TimelineDaySection } from './timeline-day-section'
+import type {
+  BackgroundEvent,
+  CalendarResource,
+  EventCalendarItem,
+  RenderEvent,
+  TimelineHourWindow,
+} from './types'
+import { getAllEventsForDay, isMultiDayEvent } from './utils'
+
+/** Height (px) of the sticky date-label row (row 1 of the two-tier header) — matches `ResourceTimelineView`. */
+const DateLabelHeight = 32
+
+/** Height (px) of the hour-tick row (row 2 of the two-tier header). */
+const HourTickHeight = 24
+
+/** Extra padding (px) added on top of `maxLanes * TimelineLaneHeight` when sizing a worker row. */
+const RowPadding = 8
+
+/** Stable empty default — an inline `[]` would break `TimelineDaySection`'s memo every scroll frame. */
+const NoBackgroundEvents: BackgroundEvent[] = []
+
+interface HorizontalTimelineViewProps<T extends EventCalendarItem = EventCalendarItem> {
+  /** Scroll target = the literal leftmost visible day (no `startOfWeek` normalization). */
+  currentDate: Date
+  events: T[]
+  /** The K worker rows rendered inside every rendered day. */
+  resources: CalendarResource[]
+  /** Unused — kept for prop-signature symmetry with `ResourceTimelineView`. */
+  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6
+  backgroundEvents?: BackgroundEvent[]
+  /** Visible hour range — `dayWidth` derives from this, not from a viewport clamp. */
+  hourWindow: TimelineHourWindow
+  onEventSelect: (event: T) => void
+  onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
+  renderEvent?: RenderEvent<T>
+  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
+  selectedEventId?: string | null
+  /** Fires when a user scroll settles on a new leftmost day. */
+  onDateChange?: (date: Date) => void
+  /** Fires with the rendered (visible + overscan) day window — consumers fetch this. */
+  onVisibleRangeChange?: (from: Date, to: Date) => void
+}
+
+/**
+ * The horizontal dispatch-board timeline — worker rows × hours, time flowing left→right. Same
+ * epoch/virtualizer day-stream shell as `ResourceTimelineView` (this IS `WeekView`/
+ * `ResourceTimelineView`'s architecture, just rotated 90°): the virtualizer still counts days,
+ * the sizing/settle-snap/scroll-anchor machinery is lifted near-verbatim. The differences are all
+ * in what a rendered "day" looks like: instead of K vertical worker sub-columns inside an hour
+ * grid, each day is `windowHours × TimelineHourWidth` wide and contains K horizontal worker rows
+ * whose lane stacks (see `assignLanes`) can grow taller when visits overlap.
+ *
+ * `dayWidth` is window-derived (`windowHours × TimelineHourWidth`), NOT clamp-derived — the
+ * sizing effect only measures how much width is available (`avail`) to decide whether a full day
+ * fits (`snapEnabled`); it never shrinks `dayWidth` itself the way `ResourceTimelineView`'s hybrid
+ * clamp does.
+ */
+export function HorizontalTimelineView<T extends EventCalendarItem = EventCalendarItem>({
+  currentDate,
+  events,
+  resources,
+  weekStartsOn: _weekStartsOn,
+  backgroundEvents = NoBackgroundEvents,
+  hourWindow,
+  onEventSelect,
+  onEventResize,
+  renderEvent,
+  selectedEventId,
+  onDateChange,
+  onVisibleRangeChange,
+}: HorizontalTimelineViewProps<T>) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [snapEnabled, setSnapEnabled] = useState(true)
+  const [viewportHeight, setViewportHeight] = useState(0)
+
+  const windowStart = hourWindow.start
+  const windowEnd = hourWindow.end
+  const windowHours = Math.max(0, windowEnd - windowStart)
+  const dayWidth = Math.max(1, windowHours * TimelineHourWidth)
+
+  const { epoch, dayCount } = useMemo(() => {
+    const start = startOfDay(new Date(StreamStartYear, 0, 1))
+    const count = differenceInCalendarDays(new Date(StreamEndYear, 0, 1), start) + 1
+    return { epoch: start, dayCount: count }
+  }, [])
+
+  const dayAt = useCallback((index: number) => addDays(epoch, index), [epoch])
+
+  const dayIndexOf = useCallback(
+    (date: Date) => Math.min(dayCount - 1, Math.max(0, differenceInCalendarDays(date, epoch))),
+    [epoch, dayCount]
+  )
+
+  const virtualizer = useVirtualizer({
+    horizontal: true,
+    count: dayCount,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: useCallback(() => dayWidth, [dayWidth]),
+    overscan: 1,
+  })
+
+  // ── sizing: dayWidth is window-derived (see above) — this effect only measures how much width
+  // is available beside the fixed-width rail, to decide whether a full day fits (snapEnabled).
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const applySize = () => {
+      const avail = Math.max(1, el.clientWidth - TimelineRailWidth)
+      setSnapEnabled(dayWidth <= avail)
+      // Body min-height: the row/day grid stretches to fill the viewport even with few workers.
+      setViewportHeight(el.clientHeight)
+    }
+    applySize()
+    const observer = new ResizeObserver(applySize)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [dayWidth])
+
+  // Layout effect, declared BEFORE the scroll-to effect below: the virtualizer's measurement
+  // cache must reflect the new day width before anything scrolls by it.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure when dayWidth changes
+  useLayoutEffect(() => {
+    virtualizer.measure()
+  }, [dayWidth, virtualizer])
+
+  // ── currentDate → scroll ─────────────────────────────────────────────────
+  const targetIndex = dayIndexOf(currentDate)
+  const programmaticScrollRef = useRef(false)
+  const currentDateRef = useRef(currentDate)
+  currentDateRef.current = currentDate
+  // Set when a scroll-settle emits onDateChange — that date echoing back as the `currentDate`
+  // prop must NOT re-scroll (the user is already looking at it).
+  const lastEmittedDateRef = useRef<number | null>(null)
+  const lastDayWidthRef = useRef(dayWidth)
+  const lastScrollLeftRef = useRef(0)
+
+  useLayoutEffect(() => {
+    const dayWidthChanged = lastDayWidthRef.current !== dayWidth
+    if (!dayWidthChanged && lastEmittedDateRef.current === currentDateRef.current.getTime()) return
+    const el = scrollRef.current
+    if (!el) return
+    lastDayWidthRef.current = dayWidth
+    programmaticScrollRef.current = true
+    const targetOffset = targetIndex * dayWidth
+    el.scrollTo({ left: targetOffset })
+    lastScrollLeftRef.current = targetOffset
+    const timeout = setTimeout(() => {
+      programmaticScrollRef.current = false
+    }, 300)
+    return () => clearTimeout(timeout)
+  }, [targetIndex, dayWidth])
+
+  // ── scroll → snap → currentDate ──────────────────────────────────────────
+  // Same JS settle-snap as week/resource-timeline. This container scrolls BOTH axes — the settle
+  // handler compares scrollLeft against its value from before this gesture and skips when
+  // unchanged, so a pure vertical scroll never yanks sideways. Snapping is GUARDED by
+  // snapEnabled: when a day is wider than the viewport (the common case at this width) we skip
+  // the snap-scroll but still emit the (rounded) leftmost day.
+  const settleTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const handleScroll = useCallback(() => {
+    clearTimeout(settleTimeoutRef.current)
+    settleTimeoutRef.current = setTimeout(() => {
+      if (programmaticScrollRef.current) return
+      const el = scrollRef.current
+      if (!el) return
+      const { scrollLeft } = el
+      if (scrollLeft === lastScrollLeftRef.current) return
+      lastScrollLeftRef.current = scrollLeft
+
+      const snapIndex = Math.min(dayCount - 1, Math.max(0, Math.round(scrollLeft / dayWidth)))
+      if (snapEnabled) {
+        const snapOffset = snapIndex * dayWidth
+        if (Math.abs(scrollLeft - snapOffset) > 2) {
+          el.scrollTo({ left: snapOffset, behavior: 'smooth' })
+          return // the smooth scroll re-settles here, aligned
+        }
+      }
+      const leftmost = dayAt(snapIndex)
+      if (!isSameDay(leftmost, currentDateRef.current)) {
+        lastEmittedDateRef.current = leftmost.getTime()
+        onDateChange?.(leftmost)
+      }
+    }, 160)
+  }, [dayCount, dayWidth, dayAt, onDateChange, snapEnabled])
+
+  useEffect(() => () => clearTimeout(settleTimeoutRef.current), [])
+
+  // ── visible window → consumer fetch range ────────────────────────────────
+  const virtualItems = virtualizer.getVirtualItems()
+  const firstIndex = virtualItems[0]?.index
+  const lastIndex = virtualItems[virtualItems.length - 1]?.index
+
+  useEffect(() => {
+    if (firstIndex === undefined || lastIndex === undefined) return
+    // End-inclusive `to` (endOfDay), matching the week/month/resource stream convention.
+    onVisibleRangeChange?.(dayAt(firstIndex), endOfDay(dayAt(lastIndex)))
+  }, [firstIndex, lastIndex, dayAt, onVisibleRangeChange])
+
+  // ── row geometry: lanes per worker per rendered day ──────────────────────
+  // `assignLanes` runs per resource per RENDERED day (all-day/multi-day events participate as
+  // synthetic full-window intervals for that day) so overlap stacking never straddles a day
+  // boundary. `maxLanes` is the max across the rendered window so a row's height doesn't change
+  // while scrolling within it (it may still shift when scrolling INTO a differently-stacked day
+  // — same accepted-v1 precedent as the vertical streams' all-day lane).
+  //
+  // Lane maps are keyed `${resourceId}|${dayISOString}` (not just `resourceId`): a multi-day
+  // event can land in a different lane on each day segment it spans, so the day must be part of
+  // the key — see `TimelineDaySection`'s doc comment.
+  const { rowHeights, rowTops, laneMapsByResource } = useMemo(() => {
+    const laneMapsByResource = new Map<string, Map<string, number>>()
+    const rowHeights: number[] = []
+
+    for (const resource of resources) {
+      let maxLanes = 1
+      if (firstIndex !== undefined && lastIndex !== undefined) {
+        const resourceEvents = events.filter((event) => event.resourceId === resource.id)
+        const timedEvents = resourceEvents.filter(
+          (event) => !event.allDay && !isMultiDayEvent(event)
+        )
+        const spanningEvents = resourceEvents.filter(
+          (event) => event.allDay || isMultiDayEvent(event)
+        )
+
+        for (let i = firstIndex; i <= lastIndex; i++) {
+          const day = dayAt(i)
+          const dayStart = startOfDay(day)
+          const dayWinStart = addHours(dayStart, windowStart)
+          const dayWinEnd = addHours(dayStart, windowEnd)
+
+          const dayTimedEvents = timedEvents.filter((event) => {
+            const eventStart = new Date(event.start)
+            const eventEnd = new Date(event.end)
+            return (
+              isSameDay(day, eventStart) ||
+              isSameDay(day, eventEnd) ||
+              (eventStart < day && eventEnd > day)
+            )
+          })
+          // Multi-day/all-day events occupy a full-window synthetic interval for THIS day, so
+          // they claim a whole lane alongside timed events rather than being ignored by
+          // `assignLanes` (which only reads `.start`/`.end`).
+          const daySpanningEvents = getAllEventsForDay(spanningEvents, day).map((event) => ({
+            ...event,
+            start: dayWinStart,
+            end: dayWinEnd,
+          }))
+
+          const { lanes, laneCount } = assignLanes([...dayTimedEvents, ...daySpanningEvents])
+          laneMapsByResource.set(`${resource.id}|${day.toISOString()}`, lanes)
+          if (laneCount > maxLanes) maxLanes = laneCount
+        }
+      }
+      rowHeights.push(maxLanes * TimelineLaneHeight + RowPadding)
+    }
+
+    const rowTops: number[] = []
+    let acc = 0
+    for (const h of rowHeights) {
+      rowTops.push(acc)
+      acc += h
+    }
+
+    return { rowHeights, rowTops, laneMapsByResource }
+  }, [resources, events, firstIndex, lastIndex, dayAt, windowStart, windowEnd])
+
+  const totalRowsHeight = rowHeights.reduce((sum, h) => sum + h, 0)
+  const headerHeight = DateLabelHeight + HourTickHeight
+  // The body (rows + day sections + their vertical day borders) fills at least the visible
+  // viewport below the header — the grid never stops short above empty screen space.
+  const bodyHeight = Math.max(totalRowsHeight, viewportHeight - headerHeight)
+
+  // ── current time: 60s-interval state, window-relative (NOT `useCurrentTimeIndicator`'s 24h-%
+  // math — this view's x-axis is `hourWindow`, not the full day). The effect has an empty
+  // dependency array so it's mount-stable, same intent as `resource-timeline-view`'s
+  // `anchorNowRef` pattern (never torn down/recreated by scroll-driven re-renders).
+  const [now, setNow] = useState(() => new Date())
+  useEffect(() => {
+    const interval = setInterval(() => setNow(new Date()), 60000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const nowPosition = useMemo(() => {
+    if (windowHours <= 0) return null
+    const hourFloat = now.getHours() + now.getMinutes() / 60
+    if (hourFloat < windowStart || hourFloat > windowEnd) return null
+    return (hourFloat - windowStart) / windowHours
+  }, [now, windowStart, windowEnd, windowHours])
+
+  const nowLabel = useMemo(() => format(now, 'h:mm a'), [now])
+
+  const totalSize = virtualizer.getTotalSize()
+  const hourTicks = windowHours > 0 ? Math.round(windowHours) : 0
+
+  return (
+    <div data-slot='horizontal-timeline-view' className='flex min-h-0 flex-1 flex-col'>
+      <div ref={scrollRef} onScroll={handleScroll} className='min-h-0 flex-1 overflow-auto'>
+        <div
+          className='relative'
+          style={{
+            width: TimelineRailWidth + totalSize,
+            minHeight: headerHeight + bodyHeight,
+          }}>
+          {/* Two-tier sticky header: date labels + hour ticks. */}
+          <div
+            className='bg-background/80 border-border/70 sticky top-0 z-30 border-b backdrop-blur-md'
+            style={{ height: headerHeight }}>
+            {/* Corner — sticky on both axes: pinned left within the (already sticky-top) strip. */}
+            <div
+              className='bg-background border-border/70 text-muted-foreground/70 sticky left-0 z-10 flex items-center justify-center border-r text-sm'
+              style={{ width: TimelineRailWidth, height: headerHeight }}>
+              <span className='max-[479px]:sr-only'>{format(new Date(), 'O')}</span>
+            </div>
+
+            {/* Row 1 — per-day date label, spanning the whole day-section width, centered. */}
+            {virtualItems.map((v) => {
+              const day = dayAt(v.index)
+              const x = TimelineRailWidth + v.start
+              const today = isToday(day)
+              return (
+                <div
+                  key={`label-${v.key}`}
+                  className='text-muted-foreground/80 border-border/70 absolute flex items-center justify-center gap-1.5 border-l text-sm'
+                  style={{
+                    top: 0,
+                    left: 0,
+                    width: dayWidth,
+                    height: DateLabelHeight,
+                    transform: `translateX(${x}px)`,
+                  }}>
+                  <span className='uppercase'>{format(day, 'EEE')}</span>
+                  {/* Today's date sits in a filled badge (Notion look); other days stay plain. */}
+                  <span
+                    className={cn(
+                      'flex h-6 min-w-6 items-center justify-center rounded-full px-1 tabular-nums',
+                      today
+                        ? 'bg-primary text-primary-foreground font-semibold'
+                        : 'text-foreground font-medium'
+                    )}>
+                    {format(day, 'd')}
+                  </span>
+                </div>
+              )
+            })}
+
+            {/* Row 2 — hour tick labels every `TimelineHourWidth` px, plus the now-pill on today. */}
+            {virtualItems.map((v) => {
+              const day = dayAt(v.index)
+              const x = TimelineRailWidth + v.start
+              const today = isToday(day)
+              return (
+                <div
+                  key={`ticks-${v.key}`}
+                  className='border-border/70 absolute border-l text-[10px]'
+                  style={{
+                    top: DateLabelHeight,
+                    left: 0,
+                    width: dayWidth,
+                    height: HourTickHeight,
+                    transform: `translateX(${x}px)`,
+                  }}>
+                  {Array.from({ length: hourTicks }, (_, hourIndex) => {
+                    const tickDate = addHours(startOfDay(day), windowStart + hourIndex)
+                    return (
+                      <div
+                        key={hourIndex}
+                        className='border-border/50 text-muted-foreground/70 absolute top-0 h-full border-l pl-1 font-medium first:border-l-0'
+                        style={{ left: hourIndex * TimelineHourWidth, width: TimelineHourWidth }}>
+                        {format(tickDate, 'h a')}
+                      </div>
+                    )
+                  })}
+                  {today && nowPosition !== null && (
+                    <div
+                      className='pointer-events-none absolute top-0 z-20 -translate-x-1/2'
+                      style={{ left: `${nowPosition * 100}%` }}>
+                      <span
+                        className={cn(
+                          'rounded-full px-1.5 py-0.5 text-[10px] font-semibold whitespace-nowrap',
+                          CurrentTimeLabelClass
+                        )}>
+                        {nowLabel}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          {/* Sticky-left worker rail — pinned left only (no `top`: it scrolls vertically with
+              the rows below; its flow position already starts below the sticky header). */}
+          <div
+            className='bg-background sticky left-0 z-20 w-fit'
+            style={{ width: TimelineRailWidth }}>
+            <div className='relative' style={{ height: bodyHeight }}>
+              {resources.map((resource, ri) => (
+                <div
+                  key={resource.id}
+                  className='border-border/70 text-muted-foreground/80 absolute flex items-center border-b px-2 text-sm'
+                  style={{
+                    top: rowTops[ri] ?? 0,
+                    left: 0,
+                    width: TimelineRailWidth,
+                    height: rowHeights[ri] ?? TimelineLaneHeight,
+                  }}>
+                  {resource.header ?? resource.label}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {virtualItems.map((v) => (
+            <TimelineDaySection
+              key={v.key}
+              index={v.index}
+              x={TimelineRailWidth + v.start}
+              dayWidth={dayWidth}
+              top={headerHeight}
+              dayAt={dayAt}
+              resources={resources}
+              events={events}
+              backgroundEvents={backgroundEvents}
+              hourWindow={hourWindow}
+              rowHeights={rowHeights}
+              rowTops={rowTops}
+              bodyHeight={bodyHeight}
+              laneMapsByResource={laneMapsByResource}
+              onEventSelect={onEventSelect}
+              onEventResize={onEventResize}
+              renderEvent={renderEvent}
+              selectedEventId={selectedEventId}
+              nowPosition={nowPosition}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/components/event-calendar/index.ts
+++ b/packages/ui/src/components/event-calendar/index.ts
@@ -46,6 +46,7 @@ export {
   useCurrentTimeIndicator,
 } from './hooks/use-current-time-indicator'
 export { type UseEventResizeResult, useEventResize } from './hooks/use-event-resize'
+export { HorizontalTimelineView } from './horizontal-timeline-view'
 export { HourGutter } from './hour-gutter'
 export { MonthView } from './month-view'
 // Positioning util (day/week/resource share this — see position-events.ts)
@@ -59,6 +60,7 @@ export type {
   EventCalendarItem,
   RenderEvent,
   RenderEventContext,
+  TimelineHourWindow,
 } from './types'
 // Utils
 export {

--- a/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
@@ -348,7 +348,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
               return (
                 <div
                   key={`label-${v.key}`}
-                  className='text-muted-foreground/80 border-border absolute flex items-center justify-center gap-1.5 border-l-2 text-sm'
+                  className='text-muted-foreground/80 border-border/70 absolute flex items-center justify-center gap-1.5 border-l text-sm'
                   style={{
                     top: 0,
                     left: 0,
@@ -377,7 +377,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
               return (
                 <div
                   key={`workers-${v.key}`}
-                  className='border-border absolute grid border-l-2'
+                  className='border-border/70 absolute grid border-l'
                   style={{
                     top: DateLabelHeight,
                     left: 0,
@@ -404,7 +404,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
               return (
                 <div
                   key={`allday-${v.key}`}
-                  className='bg-muted/50 border-border absolute grid border-l-2'
+                  className='bg-muted/50 border-border/70 absolute grid border-l'
                   style={{
                     top: DateLabelHeight + WorkerHeaderHeight,
                     left: 0,

--- a/packages/ui/src/components/event-calendar/timeline-day-section.tsx
+++ b/packages/ui/src/components/event-calendar/timeline-day-section.tsx
@@ -1,0 +1,293 @@
+// packages/ui/src/components/event-calendar/timeline-day-section.tsx
+
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { isSameDay, isToday } from 'date-fns'
+import { memo } from 'react'
+
+import { BackgroundEventsLayer } from './background-events'
+import {
+  CurrentTimeLineClass,
+  MinEventDurationMinutes,
+  TimelineHourWidth,
+  TimelineLaneHeight,
+} from './constants'
+import { DraggableEvent } from './draggable-event'
+import { DropPreviewX } from './drop-preview'
+import { DroppableCell } from './droppable-cell'
+import type { BackgroundEvent, CalendarResource, EventCalendarItem, RenderEvent } from './types'
+import { getAllEventsForDay, isMultiDayEvent } from './utils'
+
+/** Vertical gap (px) subtracted from a lane's full height so stacked chips show a hairline seam. */
+const LaneGap = 2
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+interface TimelineDaySectionProps<T extends EventCalendarItem = EventCalendarItem> {
+  /** Stream day index — the section derives its own date via `dayAt(index)`. */
+  index: number
+  /** Horizontal offset (px), content-space, from the scroll container's origin — includes the rail. */
+  x: number
+  /** Rendered day-section width (px) = `windowHours × TimelineHourWidth`. */
+  dayWidth: number
+  /** Vertical offset (px) below the sticky header where the worker rows start. */
+  top: number
+  dayAt: (index: number) => Date
+  /** The K worker rows nested inside this day — identical set/order every day. */
+  resources: CalendarResource[]
+  events: T[]
+  backgroundEvents: BackgroundEvent[]
+  /** Visible hour range (fractional hours) shared with the shell and `HourGutter`-style ticks. */
+  hourWindow: { start: number; end: number }
+  /** Per-resource row height (px), same index order as `resources` — identical every rendered day. */
+  rowHeights: number[]
+  /** Per-resource row top offset (px, prefix sum of `rowHeights`). */
+  rowTops: number[]
+  /**
+   * Rendered section height (px) — `max(sum of rowHeights, viewport height below the header)`,
+   * computed by the shell so the day grid (and its vertical day border) always fills the screen
+   * even when a few worker rows don't.
+   */
+  bodyHeight: number
+  /**
+   * Event id → lane index, keyed by `${resourceId}|${dayISOString}` — lanes are assigned per
+   * resource PER RENDERED DAY (a multi-day event can occupy a different lane on each day segment
+   * it spans), so the outer key must include the day, not just the resource.
+   */
+  laneMapsByResource: Map<string, Map<string, number>>
+  onEventSelect: (event: T) => void
+  onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
+  renderEvent?: RenderEvent<T>
+  /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
+  selectedEventId?: string | null
+  /** Fraction (0..1) of the hour window "now" falls at — `null` when outside the window. */
+  nowPosition: number | null
+}
+
+/**
+ * One rendered day in the horizontal timeline stream — the `DayResourceGroup` counterpart, but
+ * time flows left→right instead of top→bottom: each of the K worker rows is a horizontal lane
+ * stack rather than a vertical hour grid. Memoized: `HorizontalTimelineView` re-renders on every
+ * scroll frame (the virtualizer's own subscription drives it), and sections are the expensive
+ * part (K rows × up to ~windowHours×4 droppable quarter-hour cells + per-worker event
+ * positioning). Every prop here is scroll-stable for a given `index`, so scrolling only
+ * mounts/unmounts sections at the window's edges.
+ *
+ * Computes its own `day` and does its own per-worker event filtering — the caller never slices
+ * `events` per day, which is what keeps a single memoized section stable across scroll frames.
+ * The section's left edge carries a hairline day-boundary border; worker rows keep a hairline
+ * bottom border.
+ */
+function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem>({
+  index,
+  x,
+  dayWidth,
+  top,
+  dayAt,
+  resources,
+  events,
+  backgroundEvents,
+  hourWindow,
+  rowHeights,
+  rowTops,
+  bodyHeight,
+  laneMapsByResource,
+  onEventSelect,
+  onEventResize,
+  renderEvent,
+  selectedEventId,
+  nowPosition,
+}: TimelineDaySectionProps<T>) {
+  const day = dayAt(index)
+  const dayIso = day.toISOString()
+  const today = isToday(day)
+  const { start: windowStart, end: windowEnd } = hourWindow
+  const windowHours = Math.max(0, windowEnd - windowStart)
+  const minChipWidth = (MinEventDurationMinutes / 60) * TimelineHourWidth
+  const slotCount = windowHours > 0 ? Math.round(windowHours * 4) : 0
+
+  // Timed single-day events touching this day — same overlap filter as `DayResourceGroup`.
+  const dayEvents = events.filter((event) => {
+    if (event.allDay || isMultiDayEvent(event)) return false
+    const eventStart = new Date(event.start)
+    const eventEnd = new Date(event.end)
+    return (
+      isSameDay(day, eventStart) || isSameDay(day, eventEnd) || (eventStart < day && eventEnd > day)
+    )
+  })
+  const spanningCandidates = events.filter((event) => event.allDay || isMultiDayEvent(event))
+  const spanningDayEvents = getAllEventsForDay(spanningCandidates, day)
+
+  const handleEventClick = (event: T, e: React.MouseEvent) => {
+    e.stopPropagation()
+    onEventSelect(event)
+  }
+
+  return (
+    <div
+      className='border-border/70 absolute border-l'
+      style={{
+        top,
+        left: 0,
+        width: dayWidth,
+        height: bodyHeight,
+        transform: `translateX(${x}px)`,
+      }}
+      data-today={today || undefined}>
+      {resources.map((resource, ri) => {
+        const rowTop = rowTops[ri] ?? 0
+        const rowHeight = rowHeights[ri] ?? TimelineLaneHeight
+        const laneMap = laneMapsByResource.get(`${resource.id}|${dayIso}`)
+
+        const resourceTimedEvents = dayEvents.filter((event) => event.resourceId === resource.id)
+        const resourceSpanningEvents = spanningDayEvents.filter(
+          (event) => event.resourceId === resource.id
+        )
+
+        return (
+          <div
+            key={resource.id}
+            className='border-border/40 absolute border-b'
+            style={{ top: rowTop, left: 0, width: dayWidth, height: rowHeight }}>
+            <BackgroundEventsLayer
+              events={backgroundEvents}
+              day={day}
+              resourceId={resource.id}
+              cellHeight={TimelineLaneHeight}
+              orientation='x'
+              windowStartHour={windowStart}
+              windowEndHour={windowEnd}
+            />
+
+            {resourceSpanningEvents.map((event) => {
+              const lane = laneMap?.get(event.id) ?? 0
+              const eventStart = new Date(event.start)
+              const eventEnd = new Date(event.end)
+              const isFirstDay = isSameDay(day, eventStart)
+              const isLastDay = isSameDay(day, eventEnd)
+              return (
+                <div
+                  key={`span-${event.id}`}
+                  className='absolute z-10 px-0.5'
+                  style={{
+                    top: lane * TimelineLaneHeight,
+                    left: 0,
+                    width: dayWidth,
+                    height: TimelineLaneHeight - LaneGap,
+                  }}
+                  onClick={(e) => e.stopPropagation()}>
+                  <DraggableEvent
+                    event={event}
+                    view='resource'
+                    orientation='x'
+                    onClick={(e) => handleEventClick(event, e)}
+                    showTime
+                    height={TimelineLaneHeight - LaneGap}
+                    width={dayWidth}
+                    onResize={onEventResize}
+                    renderEvent={renderEvent}
+                    isSelected={event.id === selectedEventId}
+                    isFirstDay={isFirstDay}
+                    isLastDay={isLastDay}
+                  />
+                </div>
+              )
+            })}
+
+            {windowHours > 0 &&
+              resourceTimedEvents.map((event) => {
+                const eventStart = new Date(event.start)
+                const eventEnd = new Date(event.end)
+                const startHourFloat = eventStart.getHours() + eventStart.getMinutes() / 60
+                const endHourFloat = eventEnd.getHours() + eventEnd.getMinutes() / 60
+                const clampedStart = clamp(startHourFloat, windowStart, windowEnd)
+                const clampedEnd = clamp(endHourFloat, windowStart, windowEnd)
+                if (clampedEnd <= clampedStart) return null
+
+                // Clamped to the window edge — squares off that edge (via isFirstDay/isLastDay,
+                // reusing the multi-day chip end-cap styling) as the "there's more outside the
+                // window" indicator called for by the plan.
+                const isClampedStart = startHourFloat < windowStart
+                const isClampedEnd = endHourFloat > windowEnd
+                const left = (clampedStart - windowStart) * TimelineHourWidth
+                const width = Math.max(
+                  (clampedEnd - clampedStart) * TimelineHourWidth,
+                  minChipWidth
+                )
+                const lane = laneMap?.get(event.id) ?? 0
+
+                return (
+                  <div
+                    key={event.id}
+                    className='absolute z-10 px-0.5'
+                    style={{
+                      top: lane * TimelineLaneHeight,
+                      left,
+                      height: TimelineLaneHeight - LaneGap,
+                    }}
+                    onClick={(e) => e.stopPropagation()}>
+                    <DraggableEvent
+                      event={event}
+                      view='resource'
+                      orientation='x'
+                      onClick={(e) => handleEventClick(event, e)}
+                      showTime
+                      height={TimelineLaneHeight - LaneGap}
+                      width={width}
+                      onResize={onEventResize}
+                      renderEvent={renderEvent}
+                      isSelected={event.id === selectedEventId}
+                      isFirstDay={!isClampedStart}
+                      isLastDay={!isClampedEnd}
+                    />
+                  </div>
+                )
+              })}
+
+            <DropPreviewX
+              day={day}
+              resourceId={resource.id}
+              windowStartHour={windowStart}
+              windowEndHour={windowEnd}
+            />
+
+            {/* Quarter-hour droppable cells — no `onClick`, click-to-create is out of scope. */}
+            {Array.from({ length: slotCount }, (_, slot) => {
+              const quarterHourTime = windowStart + slot * 0.25
+              return (
+                <div
+                  key={slot}
+                  className='absolute top-0'
+                  style={{
+                    left: slot * (TimelineHourWidth / 4),
+                    width: TimelineHourWidth / 4,
+                    height: rowHeight,
+                  }}>
+                  <DroppableCell
+                    id={`timeline-cell-${resource.id}-${dayIso}-${quarterHourTime}`}
+                    date={day}
+                    time={quarterHourTime}
+                    resourceId={resource.id}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        )
+      })}
+
+      {today && nowPosition !== null && (
+        <div
+          className={cn('pointer-events-none absolute inset-y-0 z-20 w-px', CurrentTimeLineClass)}
+          style={{ left: `${nowPosition * 100}%` }}
+        />
+      )}
+    </div>
+  )
+}
+
+// memo() drops the generic — the cast restores the generic call signature.
+export const TimelineDaySection = memo(TimelineDaySectionInner) as typeof TimelineDaySectionInner

--- a/packages/ui/src/components/event-calendar/types.ts
+++ b/packages/ui/src/components/event-calendar/types.ts
@@ -3,7 +3,7 @@
 import type { ReactNode } from 'react'
 
 /** Which grid the calendar shell is currently rendering. */
-export type CalendarView = 'month' | 'week' | 'day' | 'agenda' | 'resource'
+export type CalendarView = 'month' | 'week' | 'day' | 'agenda' | 'resource' | 'timeline'
 
 /**
  * Base event shape the calendar renders. Consumers extend this with their own
@@ -34,6 +34,16 @@ export interface CalendarResource {
   id: string
   label: string
   header?: ReactNode
+}
+
+/**
+ * Visible hour range for the horizontal timeline view (`HorizontalTimelineView`) — start/end are
+ * fractional hours (0–24). Defaults to `{ start: StartHour, end: EndHour }` (the full day) when a
+ * consumer doesn't derive a narrower working-hours window.
+ */
+export interface TimelineHourWindow {
+  start: number
+  end: number
 }
 
 /**

--- a/packages/ui/src/components/event-calendar/week-day-column.tsx
+++ b/packages/ui/src/components/event-calendar/week-day-column.tsx
@@ -58,7 +58,7 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
   dayWidth,
   top,
   dayAt,
-  weekStartsOn,
+  weekStartsOn: _weekStartsOn,
   hours,
   events,
   backgroundEvents,
@@ -70,7 +70,6 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
   currentTimePosition,
 }: WeekDayColumnProps<T>) {
   const day = dayAt(index)
-  const isWeekBoundary = day.getDay() === weekStartsOn
 
   const dayEvents = events.filter((event) => {
     if (event.allDay || isMultiDayEvent(event)) return false
@@ -92,10 +91,7 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
 
   return (
     <div
-      className={cn(
-        'absolute border-l border-border/40',
-        isWeekBoundary && 'border-l-2 border-border'
-      )}
+      className='absolute border-l border-border/40'
       style={{
         top,
         left: 0,

--- a/packages/ui/src/components/event-calendar/week-view.tsx
+++ b/packages/ui/src/components/event-calendar/week-view.tsx
@@ -343,15 +343,11 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
             {virtualItems.map((v) => {
               const day = dayAt(v.index)
               const x = gutterWidth + v.start
-              const isWeekBoundary = day.getDay() === weekStartsOn
               const dayAllDayEvents = getAllEventsForDay(allDayEvents, day)
               return (
                 <div
                   key={`allday-${v.key}`}
-                  className={cn(
-                    'bg-muted/50 absolute space-y-1 overflow-hidden border-l border-border/40 p-1',
-                    isWeekBoundary && 'border-l-2 border-border'
-                  )}
+                  className='bg-muted/50 absolute space-y-1 overflow-hidden border-l border-border/40 p-1'
                   style={{
                     top: HeaderLabelHeight,
                     left: 0,


### PR DESCRIPTION
## Summary

- Adds a **horizontal timeline view** to the dispatch board, built on the shared `@auxx/ui` event-calendar (new `horizontal-timeline-view`, `timeline-day-section`, and `assign-lanes` for stacking overlapping events into lanes).
- Adds two org settings — `dispatch.board.timelineStartHour` / `dispatch.board.timelineEndHour` — surfaced in the Dispatch General settings page under a new **Board** section. Unset (`null`) auto-derives the hour window from the org weekly working-hours template ± 2h buffer (`use-timeline-hour-window` hook).
- Assorted event-calendar refinements: drag/drop preview, event resize, draggable-event, background events, week view.
- Refreshes the homepage dispatch route-planner mocks (route map + worker phone).

## Notes

- NUMBER setting inputs report a clear as `undefined`; normalized to `null` in the settings page since the server normalizer only accepts `null` for "unset".

🤖 Generated with [Claude Code](https://claude.com/claude-code)