### PR TITLE
feat(dispatch): badge-look calendar event chip colors from option palette

### DIFF
--- a/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
+++ b/apps/web/src/components/dispatch/ui/board/hooks/use-board-data.ts
@@ -3,7 +3,11 @@
 'use client'
 
 import { weekStartToIndex } from '@auxx/lib/availability/client'
-import { getOptionColorHex } from '@auxx/lib/custom-fields/client'
+import {
+  getOptionColor,
+  type OptionColor,
+  type SelectOptionColor,
+} from '@auxx/lib/custom-fields/client'
 import {
   addMonths,
   addWeeks,
@@ -168,13 +172,14 @@ export function useBoardData() {
     [allWorkers, selectedWorkerIds]
   )
 
-  // Resolve the stored `SelectOptionColor` id (e.g. 'amber', 'forest') to a real hex — the
-  // calendar feeds this straight into `--ec-color`/`color-mix`, where several ids aren't valid
-  // CSS color names and would render as no color at all.
+  // Resolve the stored `SelectOptionColor` id (e.g. 'amber', 'forest') to its full
+  // `OPTION_COLORS` entry — chips render its badge/border classes (badge look), while
+  // hex-consuming surfaces (sidebar dots, map pins) read `.hex` (several ids aren't valid CSS
+  // color names, so the raw id must never reach a CSS color slot).
   const colorByUserId = useMemo(() => {
-    const map = new Map<string, string>()
+    const map = new Map<string, OptionColor>()
     for (const w of allWorkers) {
-      if (w.color) map.set(w.userId, getOptionColorHex(w.color))
+      if (w.color) map.set(w.userId, getOptionColor(w.color as SelectOptionColor))
     }
     return map
   }, [allWorkers])

--- a/apps/web/src/components/dispatch/ui/board/utils.ts
+++ b/apps/web/src/components/dispatch/ui/board/utils.ts
@@ -1,6 +1,11 @@
 // apps/web/src/components/dispatch/ui/board/utils.ts
 
-import type { BackgroundEvent } from '@auxx/ui/components/event-calendar'
+import {
+  getOptionColor,
+  type OptionColor,
+  type SelectOptionColor,
+} from '@auxx/lib/custom-fields/client'
+import type { BackgroundEvent, EventColorClasses } from '@auxx/ui/components/event-calendar'
 import {
   addDays,
   addMonths,
@@ -72,6 +77,18 @@ export function isPastVisitEvent(event: Pick<DispatchVisitEvent, 'status' | 'end
 export const DEFAULT_WORKER_COLOR = '#6366f1'
 /** Color for the always-first "Unassigned" column's chips. */
 export const UNASSIGNED_COLOR = '#94a3b8'
+/** Palette-id twins of the two hex fallbacks above, for the badge-look chip classes. */
+const DEFAULT_WORKER_COLOR_ID: SelectOptionColor = 'indigo'
+const UNASSIGNED_COLOR_ID: SelectOptionColor = 'gray'
+
+/** Project an `OPTION_COLORS` entry onto the calendar chip's badge-look class contract. */
+function toEventColorClasses(color: OptionColor): EventColorClasses {
+  return {
+    badge: color.badgeClasses,
+    selectedBorder: color.selectedBorderClasses,
+    solid: color.swatch,
+  }
+}
 
 export function isVisitStatus(value: string): value is VisitStatus {
   return (VISIT_STATUS_VALUES as readonly string[]).includes(value)
@@ -172,15 +189,19 @@ export function splitVisits(visits: BoardVisit[]) {
 export function visitToEvent(
   visit: BoardVisit & { startTime: Date; endTime: Date },
   workOrderById: Map<string, BoardWorkOrder>,
-  colorByUserId: Map<string, string>
+  colorByUserId: Map<string, OptionColor>
 ): DispatchVisitEvent {
   const workOrder = workOrderById.get(visit.workOrderId)
   const title = workOrder
     ? `${workOrder.number ? `${workOrder.number} · ` : ''}${workOrder.displayName ?? 'Work order'}`
     : 'Work order'
-  const color = visit.assigneeUserId
-    ? (colorByUserId.get(visit.assigneeUserId) ?? DEFAULT_WORKER_COLOR)
-    : UNASSIGNED_COLOR
+  // Chip coloring is the badge look (plan 11 follow-up): the assigned worker's stored palette
+  // entry supplies `colorClasses`; the resolved hex is still stamped on `color` for non-chip
+  // consumers (sidebar dots, map pins).
+  const optionColor = visit.assigneeUserId
+    ? (colorByUserId.get(visit.assigneeUserId) ?? getOptionColor(DEFAULT_WORKER_COLOR_ID))
+    : getOptionColor(UNASSIGNED_COLOR_ID)
+  const color = visit.assigneeUserId ? optionColor.hex : UNASSIGNED_COLOR
 
   return {
     id: visit.id,
@@ -188,6 +209,7 @@ export function visitToEvent(
     start: visit.startTime,
     end: visit.endTime,
     color,
+    colorClasses: toEventColorClasses(optionColor),
     resourceId: visit.assigneeUserId ?? UNASSIGNED_RESOURCE_ID,
     workOrderId: visit.workOrderId,
     assigneeUserId: visit.assigneeUserId,

--- a/apps/web/src/components/dispatch/ui/sidebar/dispatch-sidebar.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/dispatch-sidebar.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import type { OptionColor } from '@auxx/lib/custom-fields/client'
 import { ModuleSidebar } from '@auxx/ui/components/module-sidebar'
 import {
   SidebarFooter,
@@ -42,7 +43,7 @@ interface DispatchSidebarProps {
   view?: 'day' | 'week' | 'month' | 'timeline'
   weekStartsOn: WeekStartIndex
   allWorkers: BoardWorker[]
-  colorByUserId: Map<string, string>
+  colorByUserId: Map<string, OptionColor>
   /** Calendar mode's flat backlog list (`use-board-data.ts`'s `backlogEvents`). */
   backlogEvents: BacklogItem[]
   /** Map mode's route planner read — all four are required together (map mode only). */

--- a/apps/web/src/components/dispatch/ui/sidebar/workers-group.tsx
+++ b/apps/web/src/components/dispatch/ui/sidebar/workers-group.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import type { OptionColor } from '@auxx/lib/custom-fields/client'
 import { DropdownMenuItem } from '@auxx/ui/components/dropdown-menu'
 import { SidebarGroup, SidebarGroupCollapse, SidebarMenu } from '@auxx/ui/components/sidebar'
 import { cn } from '@auxx/ui/lib/utils'
@@ -16,10 +17,10 @@ import { DEFAULT_WORKER_COLOR, UNASSIGNED_COLOR } from '../board/utils'
 
 interface WorkersGroupProps {
   workers: BoardWorker[]
-  /** Hex-resolved per-worker color (`use-board-data.ts`'s `colorByUserId` — the stored
-   * `SelectOptionColor` id already resolved to a real hex via `getOptionColorHex`, not the raw
-   * `worker.color` field, which several ids can't render directly as a CSS color). */
-  colorByUserId: Map<string, string>
+  /** Per-worker `OPTION_COLORS` entry (`use-board-data.ts`'s `colorByUserId` — the stored
+   * `SelectOptionColor` id resolved to its palette entry; this row's dot reads `.hex`, since
+   * several palette ids can't render directly as a CSS color). */
+  colorByUserId: Map<string, OptionColor>
   hiddenWorkerIds: string[]
   onToggleWorker: (workerId: string) => void
   open: boolean
@@ -136,7 +137,7 @@ export function WorkersGroup({
               id={worker.id}
               userId={worker.userId}
               label={worker.user?.name ?? worker.user?.email ?? 'Worker'}
-              color={colorByUserId.get(worker.userId) ?? DEFAULT_WORKER_COLOR}
+              color={colorByUserId.get(worker.userId)?.hex ?? DEFAULT_WORKER_COLOR}
               visible={!hidden.has(worker.userId)}
               onToggle={() => onToggleWorker(worker.userId)}
               mode={mode}

--- a/apps/web/src/components/dispatch/ui/worker-dialog.tsx
+++ b/apps/web/src/components/dispatch/ui/worker-dialog.tsx
@@ -7,6 +7,7 @@ import { DialogNav, DialogNavPage, DialogNavPages } from '@auxx/ui/components/di
 import { useEffect, useState } from 'react'
 import { ExceptionListEditor } from '~/components/availability/ui/exception-list-editor'
 import { useSettings } from '~/hooks/use-settings'
+import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
 import type { DispatchWorkerRow } from './worker-card'
 import { WorkerHoursPage } from './worker-hours-page'
 import { WorkerProfilePage } from './worker-profile-page'
@@ -34,6 +35,14 @@ export function WorkerDialog({ open, onOpenChange, worker }: WorkerDialogProps) 
   const [page, setPage] = useState<WorkerDialogPage>('profile')
   const { getSetting } = useSettings({ scope: 'GENERAL' })
 
+  // The active page reports its draft's dirty state up; closing (Esc, outside click, Cancel)
+  // goes through the guard so unsaved edits always get a discard confirmation.
+  const [isDirty, setIsDirty] = useState(false)
+  const { guardProps, guardedClose, ConfirmDialog } = useUnsavedChangesGuard({
+    isDirty,
+    onConfirmedClose: () => onOpenChange(false),
+  })
+
   // Always reopen on Profile — never mid-page from a previous session.
   useEffect(() => {
     if (open) setPage('profile')
@@ -51,42 +60,57 @@ export function WorkerDialog({ open, onOpenChange, worker }: WorkerDialogProps) 
   const name = worker.user?.name || worker.user?.email || 'Worker'
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size='content' position='tc' innerClassName='p-0'>
-        <DialogNav
-          title={name}
-          description='Manage this dispatch worker.'
-          heading={name}
-          crumbs={[
-            { label: 'Profile', active: page === 'profile', onClick: () => setPage('profile') },
-            { label: 'Time off', active: page === 'time-off', onClick: () => setPage('time-off') },
-            { label: 'Hours', active: page === 'hours', onClick: () => setPage('hours') },
-          ]}
-        />
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent size='content' position='tc' innerClassName='p-0' {...guardProps}>
+          <DialogNav
+            title={name}
+            description='Manage this dispatch worker.'
+            heading={name}
+            crumbs={[
+              { label: 'Profile', active: page === 'profile', onClick: () => setPage('profile') },
+              {
+                label: 'Time off',
+                active: page === 'time-off',
+                onClick: () => setPage('time-off'),
+              },
+              { label: 'Hours', active: page === 'hours', onClick: () => setPage('hours') },
+            ]}
+          />
 
-        <DialogNavPages value={page}>
-          <DialogNavPage value='profile' size='md'>
-            <WorkerProfilePage worker={worker} onRemoved={() => onOpenChange(false)} />
-          </DialogNavPage>
-
-          <DialogNavPage value='time-off' size='md'>
-            <div className='p-4'>
-              <ExceptionListEditor
-                subject={{ type: 'worker', userId: worker.userId }}
-                use24HourTime={use24HourTime}
+          <DialogNavPages value={page}>
+            <DialogNavPage value='profile' size='md'>
+              <WorkerProfilePage
+                worker={worker}
+                onRemoved={() => onOpenChange(false)}
+                onCancel={guardedClose}
+                onDirtyChange={setIsDirty}
               />
-            </div>
-          </DialogNavPage>
+            </DialogNavPage>
 
-          <DialogNavPage value='hours' size='md'>
-            <WorkerHoursPage
-              userId={worker.userId}
-              weekStartsOn={weekStartsOn}
-              use24HourTime={use24HourTime}
-            />
-          </DialogNavPage>
-        </DialogNavPages>
-      </DialogContent>
-    </Dialog>
+            <DialogNavPage value='time-off' size='md'>
+              <div className='p-4'>
+                <ExceptionListEditor
+                  subject={{ type: 'worker', userId: worker.userId }}
+                  use24HourTime={use24HourTime}
+                />
+              </div>
+            </DialogNavPage>
+
+            <DialogNavPage value='hours' size='md'>
+              <WorkerHoursPage
+                userId={worker.userId}
+                weekStartsOn={weekStartsOn}
+                use24HourTime={use24HourTime}
+                onCancel={guardedClose}
+                onDirtyChange={setIsDirty}
+              />
+            </DialogNavPage>
+          </DialogNavPages>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog />
+    </>
   )
 }

--- a/apps/web/src/components/dispatch/ui/worker-hours-page.tsx
+++ b/apps/web/src/components/dispatch/ui/worker-hours-page.tsx
@@ -5,10 +5,11 @@ import { detectTimezone } from '@auxx/config/client'
 import type { WeeklyHours } from '@auxx/lib/availability/client'
 import { Button } from '@auxx/ui/components/button'
 import { DialogFooter } from '@auxx/ui/components/dialog'
-import { KbdSubmit } from '@auxx/ui/components/kbd'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError } from '@auxx/ui/components/toast'
 import { ToggleCard } from '@auxx/ui/components/toggle-card'
+import { useEffect } from 'react'
 import {
   validateWeeklyDraft,
   type WeeklyHoursDraft,
@@ -70,6 +71,10 @@ interface WorkerHoursPageProps {
   userId: string
   weekStartsOn: 0 | 1 | 6
   use24HourTime: boolean
+  /** Close request (Cancel button) — the dialog guards it against unsaved changes. */
+  onCancel: () => void
+  /** Reports the draft's dirty state up to the dialog's unsaved-changes guard. */
+  onDirtyChange: (dirty: boolean) => void
 }
 
 /**
@@ -80,7 +85,13 @@ interface WorkerHoursPageProps {
  * with an empty set (deletes them), returning to inherited. Draft/save run on the shared
  * {@link useDirtyDraft} + a dialog footer (10-settings-forms-unification.md).
  */
-export function WorkerHoursPage({ userId, weekStartsOn, use24HourTime }: WorkerHoursPageProps) {
+export function WorkerHoursPage({
+  userId,
+  weekStartsOn,
+  use24HourTime,
+  onCancel,
+  onDirtyChange,
+}: WorkerHoursPageProps) {
   const utils = api.useUtils()
   const [confirm, ConfirmDialog] = useConfirm()
 
@@ -113,7 +124,7 @@ export function WorkerHoursPage({ userId, weekStartsOn, use24HourTime }: WorkerH
     weekly: hasWorkerRows ? buildDraftFromResponse(workerQuery.data, detectTimezone()) : null,
   }
 
-  const { draft, patch, dirty, save, discard } = useDirtyDraft(server, {
+  const { draft, patch, dirty, save } = useDirtyDraft(server, {
     isSaving: saveWeeklyHours.isPending,
     onSave: (next) => {
       if (next.useOrgDefault) {
@@ -131,6 +142,11 @@ export function WorkerHoursPage({ userId, weekStartsOn, use24HourTime }: WorkerH
       saveWeeklyHours.mutate({ subject, weekly: toWeeklyHours(next.weekly) })
     },
   })
+
+  useEffect(() => {
+    onDirtyChange(dirty)
+    return () => onDirtyChange(false)
+  }, [dirty, onDirtyChange])
 
   async function handleToggleUseOrgDefault(nextOn: boolean) {
     if (nextOn) {
@@ -154,36 +170,38 @@ export function WorkerHoursPage({ userId, weekStartsOn, use24HourTime }: WorkerH
     !draft.useOrgDefault && draft.weekly != null && !validateWeeklyDraft(draft.weekly)
 
   return (
-    <div className='flex flex-col gap-4 p-4'>
-      <ToggleCard
-        title='Use organization default'
-        description="Follow the org's weekly hours, or set custom hours for this worker."
-        checked={draft.useOrgDefault}
-        onCheckedChange={handleToggleUseOrgDefault}
-        switchSize='default'
-        disabled={loading}
-      />
-
-      {loading ? (
-        <Skeleton className='h-48 w-full rounded-xl' />
-      ) : (
-        <WeeklyHoursEditor
-          value={editorValue}
-          onChange={(weekly) => patch({ weekly })}
-          weekStartsOn={weekStartsOn}
-          use24HourTime={use24HourTime}
-          readOnly={draft.useOrgDefault}
+    <div className='flex flex-col'>
+      <div className='flex flex-col gap-4 p-4'>
+        <ToggleCard
+          title='Use organization default'
+          description="Follow the org's weekly hours, or set custom hours for this worker."
+          checked={draft.useOrgDefault}
+          onCheckedChange={handleToggleUseOrgDefault}
+          switchSize='default'
+          disabled={loading}
         />
-      )}
 
-      <DialogFooter className='border-t pt-3'>
+        {loading ? (
+          <Skeleton className='h-48 w-full rounded-xl' />
+        ) : (
+          <WeeklyHoursEditor
+            value={editorValue}
+            onChange={(weekly) => patch({ weekly })}
+            weekStartsOn={weekStartsOn}
+            use24HourTime={use24HourTime}
+            readOnly={draft.useOrgDefault}
+          />
+        )}
+      </div>
+
+      <DialogFooter className='mt-0 border-t px-4 py-3'>
         <Button
           type='button'
           variant='ghost'
           size='sm'
-          onClick={discard}
-          disabled={!dirty || saveWeeklyHours.isPending}>
-          Discard
+          onClick={onCancel}
+          disabled={saveWeeklyHours.isPending}>
+          Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
         </Button>
         <Button
           type='button'

--- a/apps/web/src/components/dispatch/ui/worker-profile-page.tsx
+++ b/apps/web/src/components/dispatch/ui/worker-profile-page.tsx
@@ -5,9 +5,10 @@ import { FieldType } from '@auxx/database/enums'
 import type { SelectOptionColor } from '@auxx/lib/custom-fields/client'
 import { Button } from '@auxx/ui/components/button'
 import { DialogFooter } from '@auxx/ui/components/dialog'
-import { KbdSubmit } from '@auxx/ui/components/kbd'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { Trash2 } from 'lucide-react'
+import { useEffect } from 'react'
 import type { AddressStruct } from '~/components/fields/inputs/address-struct-input-field'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
@@ -44,6 +45,10 @@ interface WorkerProfileDraft {
 interface WorkerProfilePageProps {
   worker: DispatchWorkerRow
   onRemoved: () => void
+  /** Close request (Cancel button) — the dialog guards it against unsaved changes. */
+  onCancel: () => void
+  /** Reports the draft's dirty state up to the dialog's unsaved-changes guard. */
+  onDirtyChange: (dirty: boolean) => void
 }
 
 /**
@@ -53,7 +58,12 @@ interface WorkerProfilePageProps {
  * field (10-settings-forms-unification.md). Save fans out to `upsertWorker` (color + home base +
  * route flags) and `setWorkerActive` (only when the toggle changed).
  */
-export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps) {
+export function WorkerProfilePage({
+  worker,
+  onRemoved,
+  onCancel,
+  onDirtyChange,
+}: WorkerProfilePageProps) {
   const utils = api.useUtils()
   const [confirm, ConfirmDialog] = useConfirm()
 
@@ -89,7 +99,7 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
     routeEndAtHome: worker.routeEndAtHome,
   }
 
-  const { draft, patch, dirty, save, discard } = useDirtyDraft(server, {
+  const { draft, patch, dirty, save } = useDirtyDraft(server, {
     isSaving,
     onSave: (next) => {
       const addressChanged = JSON.stringify(next.homeBase) !== JSON.stringify(server.homeBase)
@@ -111,6 +121,11 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
     },
   })
 
+  useEffect(() => {
+    onDirtyChange(dirty)
+    return () => onDirtyChange(false)
+  }, [dirty, onDirtyChange])
+
   async function handleRemove() {
     const confirmed = await confirm({
       title: 'Remove worker?',
@@ -123,84 +138,86 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
   }
 
   return (
-    <div className='flex flex-col gap-4 p-4'>
-      <FieldPanel
-        orientation='responsive'
-        breakpoint='md'
-        resizeId='worker-profile'
-        defaultLabelWidth={140}
-        className='p-0'>
-        <FieldPanelRow title='Board color' type={BaseType.ENUM} showIcon>
-          <div className='py-2'>
-            <ColorTagPicker
-              value={draft.color}
-              onChange={(color) => patch({ color })}
-              disabled={isSaving}
-            />
-          </div>
-        </FieldPanelRow>
+    <div className='flex flex-col'>
+      <div className='flex flex-col gap-4 p-4 '>
+        <FieldPanel
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='worker-profile'
+          defaultLabelWidth={140}
+          className='p-0'>
+          <FieldPanelRow title='Board color' type={BaseType.ENUM} showIcon>
+            <div className='py-2'>
+              <ColorTagPicker
+                value={draft.color}
+                onChange={(color) => patch({ color })}
+                disabled={isSaving}
+              />
+            </div>
+          </FieldPanelRow>
 
-        <FieldPanelRow
-          title='Home base'
-          type={BaseType.STRING}
-          showIcon
-          description='Used for routing on the live map (M3).'>
-          <div className='py-2'>
+          <FieldPanelRow
+            title='Home base'
+            type={BaseType.STRING}
+            showIcon
+            description='Used for routing on the live map (M3).'>
+            <div className='py-2'>
+              <FieldInputAdapter
+                fieldType={FieldType.ADDRESS_STRUCT}
+                value={draft.homeBase}
+                onChange={(homeBase) => patch({ homeBase: homeBase as AddressStruct })}
+                disabled={isSaving}
+              />
+            </div>
+          </FieldPanelRow>
+
+          <FieldPanelRow
+            title='Active'
+            type={BaseType.BOOLEAN}
+            showIcon
+            description='Inactive workers are hidden from the board.'>
             <FieldInputAdapter
-              fieldType={FieldType.ADDRESS_STRUCT}
-              value={draft.homeBase}
-              onChange={(homeBase) => patch({ homeBase: homeBase as AddressStruct })}
+              fieldType={FieldType.CHECKBOX}
+              fieldOptions={{ variant: 'switch' }}
+              value={draft.isActive}
+              onChange={(isActive) => patch({ isActive: isActive as boolean })}
               disabled={isSaving}
             />
-          </div>
-        </FieldPanelRow>
+          </FieldPanelRow>
 
-        <FieldPanelRow
-          title='Active'
-          type={BaseType.BOOLEAN}
-          showIcon
-          description='Inactive workers are hidden from the board.'>
-          <FieldInputAdapter
-            fieldType={FieldType.CHECKBOX}
-            fieldOptions={{ variant: 'switch' }}
-            value={draft.isActive}
-            onChange={(isActive) => patch({ isActive: isActive as boolean })}
-            disabled={isSaving}
-          />
-        </FieldPanelRow>
+          <FieldPanelRow
+            title='Start at home'
+            type={BaseType.BOOLEAN}
+            showIcon
+            description='Route begins at the business address.'>
+            <FieldInputAdapter
+              fieldType={FieldType.CHECKBOX}
+              fieldOptions={{ variant: 'switch' }}
+              value={draft.routeStartAtHome}
+              onChange={(routeStartAtHome) =>
+                patch({ routeStartAtHome: routeStartAtHome as boolean })
+              }
+              disabled={isSaving}
+            />
+          </FieldPanelRow>
 
-        <FieldPanelRow
-          title='Start at home'
-          type={BaseType.BOOLEAN}
-          showIcon
-          description='Route begins at the business address.'>
-          <FieldInputAdapter
-            fieldType={FieldType.CHECKBOX}
-            fieldOptions={{ variant: 'switch' }}
-            value={draft.routeStartAtHome}
-            onChange={(routeStartAtHome) =>
-              patch({ routeStartAtHome: routeStartAtHome as boolean })
-            }
-            disabled={isSaving}
-          />
-        </FieldPanelRow>
+          <FieldPanelRow
+            title='End at home'
+            type={BaseType.BOOLEAN}
+            showIcon
+            description='Route ends at the business address.'>
+            <FieldInputAdapter
+              fieldType={FieldType.CHECKBOX}
+              fieldOptions={{ variant: 'switch' }}
+              value={draft.routeEndAtHome}
+              onChange={(routeEndAtHome) => patch({ routeEndAtHome: routeEndAtHome as boolean })}
+              disabled={isSaving}
+            />
+          </FieldPanelRow>
+        </FieldPanel>
+      </div>
 
-        <FieldPanelRow
-          title='End at home'
-          type={BaseType.BOOLEAN}
-          showIcon
-          description='Route ends at the business address.'>
-          <FieldInputAdapter
-            fieldType={FieldType.CHECKBOX}
-            fieldOptions={{ variant: 'switch' }}
-            value={draft.routeEndAtHome}
-            onChange={(routeEndAtHome) => patch({ routeEndAtHome: routeEndAtHome as boolean })}
-            disabled={isSaving}
-          />
-        </FieldPanelRow>
-      </FieldPanel>
-
-      <DialogFooter className='border-t pt-3 sm:justify-between'>
+      <DialogFooter className='border-t py-2! sm:justify-between'>
         <Button
           type='button'
           variant='ghost'
@@ -211,13 +228,8 @@ export function WorkerProfilePage({ worker, onRemoved }: WorkerProfilePageProps)
           <Trash2 /> Remove worker
         </Button>
         <div className='flex items-center gap-2'>
-          <Button
-            type='button'
-            variant='ghost'
-            size='sm'
-            onClick={discard}
-            disabled={!dirty || isSaving}>
-            Discard
+          <Button type='button' variant='ghost' size='sm' onClick={onCancel} disabled={isSaving}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
           </Button>
           <Button
             type='button'

--- a/packages/ui/src/components/event-calendar/event-item.tsx
+++ b/packages/ui/src/components/event-calendar/event-item.tsx
@@ -58,8 +58,9 @@ function EventWrapper({
         'focus-visible:border-ring focus-visible:ring-ring/50 flex h-full w-full overflow-hidden text-left font-medium transition outline-none select-none focus-visible:ring-[3px] data-dragging:cursor-grabbing data-dragging:shadow-lg',
         getBorderRadiusClasses(isFirstDay, isLastDay),
         // Selected ring last so it wins over the resting look (but focus-visible:ring-[3px]
-        // still layers on top when the chip is keyboard-focused).
-        isSelected && eventSelectedRingClass,
+        // still layers on top when the chip is keyboard-focused). Badge-look chips signal
+        // selection via their darker border instead (folded into `tintBg` below).
+        isSelected && !event.colorClasses && eventSelectedRingClass,
         className
       )}
       style={eventColorVar(event.color)}
@@ -136,10 +137,21 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
     [displayStart, displayEnd]
   )
 
-  // Dragged chips get an emphasized fill so they read as visibly "darker" than the
-  // solid origin left behind. Swapped in for `eventTintBgClass` (never both) to avoid
-  // two competing `background-color` utilities.
-  const tintBg = isDragging ? eventTintBgStrongClass : eventTintBgClass
+  // Badge-look path: `colorClasses` (OPTION_COLORS-style) replaces the `--ec-color` tint —
+  // bg/text/border come from `badge`, and selected/dragging swaps in the darker
+  // `selectedBorder` (later in the cn() call, so tailwind-merge lets it win the border-color
+  // conflict). Text classes stay undefined so inner nodes inherit the badge's text color.
+  // Hex path: dragged chips get an emphasized fill so they read as visibly "darker" than the
+  // solid origin left behind. Swapped in for `eventTintBgClass` (never both) to avoid two
+  // competing `background-color` utilities.
+  const colorClasses = event.colorClasses
+  const tintBg = colorClasses
+    ? cn('border', colorClasses.badge, (isDragging || isSelected) && colorClasses.selectedBorder)
+    : isDragging
+      ? eventTintBgStrongClass
+      : eventTintBgClass
+  const tintText = colorClasses ? undefined : eventTintTextClass
+  const solidBg = colorClasses ? colorClasses.solid : eventSolidBgClass
 
   const getEventTime = () => {
     if (event.allDay) return 'All day'
@@ -182,11 +194,11 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
             <span
               className={cn(
                 'flex size-4 shrink-0 items-center justify-center rounded-full',
-                eventSolidBgClass
+                solidBg
               )}>
               <span className='size-1.5 rounded-full bg-black/40' />
             </span>
-            <span className={cn('truncate font-semibold', eventTintTextClass)}>{event.title}</span>
+            <span className={cn('truncate font-semibold', tintText)}>{event.title}</span>
             {event.badge && <span className='ml-auto shrink-0 opacity-70'>{event.badge}</span>}
           </>
         )}
@@ -209,7 +221,7 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
         className={cn(
           'mt-[var(--event-gap)] h-[var(--event-height)] items-center gap-1.5 rounded-md px-1 text-[10px] sm:px-1.5 sm:text-xs',
           tintBg,
-          eventTintTextClass,
+          tintText,
           'hover:brightness-105 dark:hover:brightness-110',
           className
         )}
@@ -219,7 +231,7 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
         onTouchStart={onTouchStart}>
         {resolveContent(
           <>
-            <span className={cn('h-full w-1 shrink-0 rounded-full', eventSolidBgClass)} />
+            <span className={cn('h-full w-1 shrink-0 rounded-full', solidBg)} />
             <span className='min-w-0 flex-1 truncate font-semibold'>{event.title}</span>
             {!event.allDay && (
               <span className='shrink-0 font-normal opacity-70'>
@@ -254,7 +266,7 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
         onTouchStart={onTouchStart}>
         {resolveContent(
           durationMinutes < 45 ? (
-            <div className={cn('truncate font-semibold', eventTintTextClass)}>
+            <div className={cn('truncate font-semibold', tintText)}>
               {event.title}{' '}
               {showTime && (
                 <span className='font-normal opacity-70'>
@@ -264,10 +276,9 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
             </div>
           ) : (
             <>
-              <div className={cn('truncate font-semibold', eventTintTextClass)}>{event.title}</div>
+              <div className={cn('truncate font-semibold', tintText)}>{event.title}</div>
               {showTime && (
-                <div
-                  className={cn('truncate text-[11px] font-normal opacity-70', eventTintTextClass)}>
+                <div className={cn('truncate text-[11px] font-normal opacity-70', tintText)}>
                   {getEventTime()}
                 </div>
               )}
@@ -284,8 +295,8 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
       type='button'
       className={cn(
         'focus-visible:border-ring focus-visible:ring-ring/50 flex w-full flex-col gap-1 rounded-xl p-2 text-left transition outline-none focus-visible:ring-[3px]',
-        eventTintBgClass,
-        isSelected && eventSelectedRingClass,
+        tintBg,
+        isSelected && !colorClasses && eventSelectedRingClass,
         className
       )}
       style={eventColorVar(event.color)}
@@ -297,7 +308,7 @@ export function EventItem<T extends EventCalendarItem = EventCalendarItem>({
       {...dndAttributes}>
       {resolveContent(
         <>
-          <div className={cn('text-sm font-semibold', eventTintTextClass)}>{event.title}</div>
+          <div className={cn('text-sm font-semibold', tintText)}>{event.title}</div>
           <div className='text-muted-foreground text-xs'>
             {event.allDay ? (
               <span>All day</span>

--- a/packages/ui/src/components/event-calendar/index.ts
+++ b/packages/ui/src/components/event-calendar/index.ts
@@ -58,6 +58,7 @@ export type {
   CalendarResource,
   CalendarView,
   EventCalendarItem,
+  EventColorClasses,
   RenderEvent,
   RenderEventContext,
   TimelineHourWindow,

--- a/packages/ui/src/components/event-calendar/types.ts
+++ b/packages/ui/src/components/event-calendar/types.ts
@@ -6,6 +6,21 @@ import type { ReactNode } from 'react'
 export type CalendarView = 'month' | 'week' | 'day' | 'agenda' | 'resource' | 'timeline'
 
 /**
+ * Class-based chip coloring (the app's badge look). When an event carries this, the chip
+ * renders these Tailwind classes instead of deriving a tint from `color` via
+ * `--ec-color`/`color-mix`. The calendar ships no palette — consumers stamp these from their
+ * own source (e.g. `OPTION_COLORS` in `@auxx/lib/custom-fields/client`).
+ */
+export interface EventColorClasses {
+  /** Resting chip: bg + text + border-color classes (an `OptionColor.badgeClasses` string). */
+  badge: string
+  /** Darker border-color classes swapped in for the selected/dragging chip. */
+  selectedBorder: string
+  /** Solid swatch bg class (e.g. `bg-amber-500`) for the color dot / month-chip left bar. */
+  solid: string
+}
+
+/**
  * Base event shape the calendar renders. Consumers extend this with their own
  * fields (e.g. a dispatch visit's `workOrderId`/`assigneeUserId`) via the `T`
  * generic on `EventCalendar`/`CalendarDndProvider` and the view components.
@@ -22,6 +37,8 @@ export interface EventCalendarItem {
   allDay?: boolean
   /** Raw class name (or inline-style-friendly token) — the calendar no longer ships a fixed color palette. */
   color?: string
+  /** Badge-look coloring — takes precedence over the `color` tint when present. */
+  colorClasses?: EventColorClasses
   location?: string
   /** Set when the event belongs to a `resources` day-view column. */
   resourceId?: string


### PR DESCRIPTION
## Summary

Two dispatch changes:

1. **Badge-look event chip colors** — the board's event chips looked washed out (`--ec-color`/`color-mix` tint from the worker's hex). Chips now render the app's badge look straight from the shared `OPTION_COLORS` palette: `badgeClasses` for the resting chip (bg/text/border), `selectedBorderClasses` swapped in for the selected/dragging state, and the `swatch` class for the solid dot / month-chip left bar.
2. **Unsaved-changes guard for the worker dialog** — the profile/hours pages report their draft's dirty state up, and Esc / outside click / Cancel route through `useUnsavedChangesGuard` so unsaved edits get a discard confirmation.

## How (chip colors)

- `packages/ui` event-calendar stays palette-free: `EventCalendarItem` grows an optional `colorClasses` field (`EventColorClasses`: `badge`/`selectedBorder`/`solid`) that wins over the `color` hex when present. All chip rendering funnels through `EventItem`, so board week/month/day, resource timeline, horizontal timeline, and the drag overlay all pick this up.
- The dispatch board stamps `colorClasses` in `visitToEvent` from the assigned worker's stored palette entry — `indigo` fallback for colorless workers, `gray` for unassigned. `use-board-data`'s `colorByUserId` now carries the full `OptionColor` entry; hex consumers (sidebar dots, map pins) read `.hex` and are visually unchanged.
- Events without `colorClasses` (Google account events, meetings/tasks sources, dynamic-table calendars) keep the existing hex-tint path unchanged.

## Notes

- Selection affordance on badge chips is the darker 1px border (same treatment as `procedure-step-badge`) instead of the old 2px inset ring.
- The generic calendar page sources still use their hardcoded hex tints; flipping them to the badge look just needs a palette id per source.