### PR TITLE
feat(dispatch): timeline zoom + drag time pills + resizable worker rail

### DIFF
--- a/apps/web/src/components/dispatch/stores/timeline-view-store.ts
+++ b/apps/web/src/components/dispatch/stores/timeline-view-store.ts
@@ -1,0 +1,42 @@
+// apps/web/src/components/dispatch/stores/timeline-view-store.ts
+
+import {
+  TimelineHourWidth,
+  TimelineHourWidthMax,
+  TimelineHourWidthMin,
+  TimelineRailWidth,
+  TimelineRailWidthMax,
+  TimelineRailWidthMin,
+} from '@auxx/ui/components/event-calendar'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value))
+
+interface TimelineViewState {
+  /** Px-per-hour on the timeline's x-axis — committed zoom level (plan 35 §5). */
+  hourWidth: number
+  /** Width (px) of the sticky-left worker rail (plan 35 §4). */
+  railWidth: number
+  setHourWidth: (px: number) => void
+  setRailWidth: (px: number) => void
+}
+
+/**
+ * Per-device timeline view preferences (plan 35 design record: personal, not org settings) —
+ * zoom level and worker-rail width, persisted to localStorage. Consumers must use selectors
+ * (`useTimelineViewStore((s) => s.hourWidth)`), never destructure the whole store.
+ */
+export const useTimelineViewStore = create<TimelineViewState>()(
+  persist(
+    (set) => ({
+      hourWidth: TimelineHourWidth,
+      railWidth: TimelineRailWidth,
+      setHourWidth: (px) =>
+        set({ hourWidth: clamp(Math.round(px), TimelineHourWidthMin, TimelineHourWidthMax) }),
+      setRailWidth: (px) =>
+        set({ railWidth: clamp(Math.round(px), TimelineRailWidthMin, TimelineRailWidthMax) }),
+    }),
+    { name: 'dispatch-timeline-view', version: 1 }
+  )
+)

--- a/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
@@ -12,6 +12,7 @@ import {
 } from '@auxx/ui/components/event-calendar'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useDispatchSidebarStore } from '../../stores/dispatch-sidebar-store'
+import { useTimelineViewStore } from '../../stores/timeline-view-store'
 import type { ExistingVisitForOverlap } from '../schedule-popover'
 import type { useBoardMutations } from './hooks/use-board-mutations'
 import { useTimelineHourWindow } from './hooks/use-timeline-hour-window'
@@ -161,6 +162,12 @@ export function BoardCalendarGrid({
 
   const hourWindow = useTimelineHourWindow()
 
+  // Per-device timeline zoom + rail width (plan 35) — persisted, gesture commits write back.
+  const timelineHourWidth = useTimelineViewStore((s) => s.hourWidth)
+  const timelineRailWidth = useTimelineViewStore((s) => s.railWidth)
+  const setTimelineHourWidth = useTimelineViewStore((s) => s.setHourWidth)
+  const setTimelineRailWidth = useTimelineViewStore((s) => s.setRailWidth)
+
   const calendarResources: CalendarResource[] = useMemo(
     () =>
       resources.map((r) => ({
@@ -185,6 +192,10 @@ export function BoardCalendarGrid({
       weekStartsOn={weekStartsOn}
       resources={view === 'day' || view === 'timeline' ? calendarResources : undefined}
       hourWindow={hourWindow}
+      timelineHourWidth={timelineHourWidth}
+      onTimelineHourWidthChange={setTimelineHourWidth}
+      timelineRailWidth={timelineRailWidth}
+      onTimelineRailWidthChange={setTimelineRailWidth}
       backgroundEvents={backgroundEvents}
       events={events}
       renderEvent={renderEvent}

--- a/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
+++ b/packages/ui/src/components/event-calendar/calendar-dnd-context.tsx
@@ -20,6 +20,7 @@ import { addMinutes, differenceInMinutes } from 'date-fns'
 import { createContext, type ReactNode, useContext, useEffect, useId, useState } from 'react'
 
 import { EventItem } from './event-item'
+import { TimeRangePill } from './time-range-pill'
 import type { CalendarView, EventCalendarItem, RenderEvent } from './types'
 
 type DraggableView = 'month' | 'week' | 'day' | 'resource'
@@ -262,7 +263,7 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
           modifiers={foreignActive ? [snapCenterToCursor] : []}>
           {activeEvent && activeView ? (
             <div
-              className='opacity-80'
+              className='relative opacity-80'
               style={
                 eventWidth
                   ? { width: `${eventWidth}px`, height: eventHeight ? `${eventHeight}px` : '100%' }
@@ -276,6 +277,18 @@ export function CalendarDndProvider<T extends EventCalendarItem = EventCalendarI
                 currentTime={currentTime || undefined}
                 renderEvent={renderEvent}
               />
+              {/* Live snapped landing time (plan 35 §3) — month drags are whole-day, no pill. */}
+              {activeView !== 'month' && currentTime && (
+                <div className='absolute top-full left-0 mt-1'>
+                  <TimeRangePill
+                    start={currentTime}
+                    end={addMinutes(
+                      currentTime,
+                      differenceInMinutes(new Date(activeEvent.end), new Date(activeEvent.start))
+                    )}
+                  />
+                </div>
+              )}
             </div>
           ) : (
             foreignActive && renderForeignOverlay?.(foreignActive)

--- a/packages/ui/src/components/event-calendar/constants.ts
+++ b/packages/ui/src/components/event-calendar/constants.ts
@@ -63,11 +63,19 @@ export const SnapMinutes = 15
 export const CurrentTimeLineClass = 'bg-rose-600 dark:bg-rose-500'
 export const CurrentTimeLabelClass = 'bg-rose-600 text-white dark:bg-rose-500'
 
-/** Pixels per hour on the horizontal timeline view's x-axis (plan 33). */
+/** Default pixels per hour on the horizontal timeline view's x-axis (plan 33; zoomable, plan 35). */
 export const TimelineHourWidth = 96
+
+/** Zoom clamps (px per hour) for the horizontal timeline's scale gestures (plan 35). */
+export const TimelineHourWidthMin = 40
+export const TimelineHourWidthMax = 240
 
 /** Height (px) of one event lane within a timeline worker row (plan 33). */
 export const TimelineLaneHeight = 28
 
-/** Width (px) of the sticky-left worker rail in the horizontal timeline view (plan 33). */
+/** Default width (px) of the sticky-left worker rail in the horizontal timeline view (plan 33). */
 export const TimelineRailWidth = 160
+
+/** Drag-resize clamps (px) for the timeline's worker rail (plan 35). */
+export const TimelineRailWidthMin = 120
+export const TimelineRailWidthMax = 320

--- a/packages/ui/src/components/event-calendar/draggable-event.tsx
+++ b/packages/ui/src/components/event-calendar/draggable-event.tsx
@@ -12,6 +12,7 @@ import { useCalendarDnd } from './calendar-dnd-context'
 import { TimelineHourWidth, WeekCellsHeight } from './constants'
 import { EventItem } from './event-item'
 import { useEventResize } from './hooks/use-event-resize'
+import { TimeRangePill } from './time-range-pill'
 import type { CalendarView, EventCalendarItem, RenderEvent } from './types'
 
 interface DraggableEventProps<T extends EventCalendarItem = EventCalendarItem> {
@@ -35,6 +36,11 @@ interface DraggableEventProps<T extends EventCalendarItem = EventCalendarItem> {
    * width-driven preview, full-height (`100%`).
    */
   orientation?: 'x' | 'y'
+  /**
+   * Px-per-hour along the resize axis — pass when the axis scale is dynamic (the zoomable
+   * timeline). Defaults to the static constants (`TimelineHourWidth` / `WeekCellsHeight`).
+   */
+  cellSize?: number
 }
 
 export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>({
@@ -50,6 +56,7 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
   renderEvent,
   onResize,
   orientation = 'y',
+  cellSize,
 }: DraggableEventProps<T>) {
   const { activeId, hasDropHandler } = useCalendarDnd()
   const elementRef = useRef<HTMLDivElement>(null)
@@ -77,12 +84,13 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
 
   const canResize =
     onResize !== undefined && (view === 'week' || view === 'day' || view === 'resource')
-  const { isResizing, previewSize, previewOffset, getResizeHandleProps } = useEventResize({
-    event,
-    axis: orientation,
-    cellSize: orientation === 'x' ? TimelineHourWidth : WeekCellsHeight,
-    onResize,
-  })
+  const { isResizing, previewSize, previewOffset, previewTimes, resizeEdge, getResizeHandleProps } =
+    useEventResize({
+      event,
+      axis: orientation,
+      cellSize: cellSize ?? (orientation === 'x' ? TimelineHourWidth : WeekCellsHeight),
+      onResize,
+    })
 
   const handleMouseDown = (e: React.MouseEvent) => {
     if (elementRef.current) {
@@ -110,10 +118,12 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
     isResizing && previewSize !== null ? previewSize : orientation === 'x' ? width : height
 
   // 'y' (default): height-driven chip, unchanged from pre-orientation behavior.
-  // 'x': full-height chip, width-driven by the resize preview.
+  // 'x': full-height chip, width-driven by the resize preview. Without an explicit `width`
+  // prop the chip fills its wrapper (the timeline positions wrappers in day-percentages so
+  // chips track zoom without re-rendering — plan 35 §5.4).
   const sizeStyle =
     orientation === 'x'
-      ? { height: '100%', width: effectiveSize || 'auto' }
+      ? { height: '100%', width: effectiveSize || '100%' }
       : { height: effectiveSize || 'auto' }
 
   const previewTransform =
@@ -182,6 +192,21 @@ export function DraggableEvent<T extends EventCalendarItem = EventCalendarItem>(
             />
           </>
         ))}
+      {/* Live snapped commit times while resizing (plan 35 §3.2), anchored to the dragged
+          edge: outside the chip so it never covers the edge being adjusted. */}
+      {isResizing && previewTimes && resizeEdge && (
+        <div
+          className={cn(
+            'absolute z-50',
+            orientation === 'x'
+              ? cn('bottom-full mb-1', resizeEdge === 'start' ? 'left-0' : 'right-0')
+              : resizeEdge === 'start'
+                ? 'bottom-full left-0 mb-1'
+                : 'top-full left-0 mt-1'
+          )}>
+          <TimeRangePill start={previewTimes.start} end={previewTimes.end} />
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/ui/src/components/event-calendar/event-calendar.tsx
+++ b/packages/ui/src/components/event-calendar/event-calendar.tsx
@@ -77,6 +77,14 @@ export interface EventCalendarProps<T extends EventCalendarItem = EventCalendarI
   resourceDaysVisible?: number
   /** Horizontal timeline (`view='timeline'`) only — visible hour range. Defaults to the full day. */
   hourWindow?: TimelineHourWindow
+  /** Timeline zoom (plan 35): controlled px-per-hour. Omit for the view's internal state. */
+  timelineHourWidth?: number
+  /** Fires when a timeline zoom gesture (border drag / ctrl+wheel) commits a new px-per-hour. */
+  onTimelineHourWidthChange?: (px: number) => void
+  /** Timeline worker-rail width (plan 35): controlled px. Omit for the view's internal state. */
+  timelineRailWidth?: number
+  /** Fires when the timeline rail-width drag commits a new width. */
+  onTimelineRailWidthChange?: (px: number) => void
   backgroundEvents?: BackgroundEvent[]
   renderEvent?: RenderEvent<T>
   /** Id of the actively-selected event (its detail/popover open) — draws the in-color ring. */
@@ -111,6 +119,10 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
   resources,
   resourceDaysVisible = 1,
   hourWindow = DefaultHourWindow,
+  timelineHourWidth,
+  onTimelineHourWidthChange,
+  timelineRailWidth,
+  onTimelineRailWidthChange,
   backgroundEvents,
   renderEvent,
   selectedEventId,
@@ -368,6 +380,10 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
               weekStartsOn={weekStartsOn}
               backgroundEvents={backgroundEvents}
               hourWindow={hourWindow}
+              hourWidth={timelineHourWidth}
+              onHourWidthChange={onTimelineHourWidthChange}
+              railWidth={timelineRailWidth}
+              onRailWidthChange={onTimelineRailWidthChange}
               onEventSelect={handleEventSelect}
               onEventResize={onEventResize}
               renderEvent={renderEvent}

--- a/packages/ui/src/components/event-calendar/event-item.tsx
+++ b/packages/ui/src/components/event-calendar/event-item.tsx
@@ -4,7 +4,7 @@
 
 import { cn } from '@auxx/ui/lib/utils'
 import type { DraggableAttributes, SyntheticListenerMap } from '@dnd-kit/core'
-import { differenceInMinutes, format, getMinutes } from 'date-fns'
+import { differenceInMinutes } from 'date-fns'
 import { useMemo } from 'react'
 import type { CalendarView, EventCalendarItem, RenderEvent } from './types'
 import {
@@ -14,12 +14,9 @@ import {
   eventTintBgClass,
   eventTintBgStrongClass,
   eventTintTextClass,
+  formatTimeWithOptionalMinutes,
   getBorderRadiusClasses,
 } from './utils'
-
-const formatTimeWithOptionalMinutes = (date: Date) => {
-  return format(date, getMinutes(date) === 0 ? 'ha' : 'h:mma').toLowerCase()
-}
 
 interface EventWrapperProps {
   event: EventCalendarItem

--- a/packages/ui/src/components/event-calendar/hooks/use-event-resize.ts
+++ b/packages/ui/src/components/event-calendar/hooks/use-event-resize.ts
@@ -44,8 +44,46 @@ export interface UseEventResizeResult {
    * the chip grows/shrinks. Always 0 while dragging the end handle (its start edge never moves).
    */
   previewOffset: number
+  /**
+   * The snapped/clamped start–end a release right now would commit — computed with the SAME math
+   * as `finishResize`, so a time pill rendered from these can never disagree with the write.
+   * `null` while idle.
+   */
+  previewTimes: { start: Date; end: Date } | null
+  /** Which edge the active gesture is dragging — `null` while idle. Anchors the time pill. */
+  resizeEdge: ResizeEdge | null
   /** Returns the pointer handlers for one edge; the handler captures that edge on pointerdown. */
   getResizeHandleProps: (edge: ResizeEdge) => ResizeHandleProps
+}
+
+/**
+ * The single source of the resize commit math (15-min snap + min-duration clamp), shared by the
+ * live `previewTimes` and `finishResize` so the pill always shows exactly what release writes.
+ */
+function computeResizeTimes(
+  event: EventCalendarItem,
+  edge: ResizeEdge,
+  deltaMinutes: number
+): { start: Date; end: Date } {
+  const start = new Date(event.start)
+  const end = new Date(event.end)
+  const duration = differenceInMinutes(end, start)
+
+  if (edge === 'end') {
+    const newDuration = Math.max(
+      MinEventDurationMinutes,
+      Math.round((duration + deltaMinutes) / SnapMinutes) * SnapMinutes
+    )
+    return { start, end: addMinutes(start, newDuration) }
+  }
+
+  const snappedDelta = Math.round(deltaMinutes / SnapMinutes) * SnapMinutes
+  // Clamp so the remaining duration never drops below the minimum: newStart can be no later
+  // than `end - MinEventDurationMinutes`.
+  const maxStart = addMinutes(end, -MinEventDurationMinutes)
+  let newStart = addMinutes(start, snappedDelta)
+  if (newStart > maxStart) newStart = maxStart
+  return { start: newStart, end }
 }
 
 /**
@@ -70,6 +108,8 @@ export function useEventResize<T extends EventCalendarItem>({
   const [isResizing, setIsResizing] = useState(false)
   const [previewSize, setPreviewSize] = useState<number | null>(null)
   const [previewOffset, setPreviewOffset] = useState(0)
+  const [previewTimes, setPreviewTimes] = useState<{ start: Date; end: Date } | null>(null)
+  const [resizeEdge, setResizeEdge] = useState<ResizeEdge | null>(null)
   const startRef = useRef<{ pointerPos: number; startSize: number; edge: ResizeEdge } | null>(null)
 
   const pixelsPerMinute = cellSize / 60
@@ -91,6 +131,8 @@ export function useEventResize<T extends EventCalendarItem>({
       setIsResizing(true)
       setPreviewSize(startSize)
       setPreviewOffset(0)
+      setPreviewTimes({ start: new Date(event.start), end: new Date(event.end) })
+      setResizeEdge(edge)
     },
     [event.start, event.end, pixelsPerMinute, readPointerPos]
   )
@@ -111,8 +153,17 @@ export function useEventResize<T extends EventCalendarItem>({
         setPreviewSize(nextSize)
         setPreviewOffset(startSize - nextSize)
       }
+      const next = computeResizeTimes(event, edge, delta / pixelsPerMinute)
+      // Snapped times only move at 15-min steps — skip the state write between steps.
+      setPreviewTimes((prev) =>
+        prev &&
+        prev.start.getTime() === next.start.getTime() &&
+        prev.end.getTime() === next.end.getTime()
+          ? prev
+          : next
+      )
     },
-    [minSize, readPointerPos]
+    [minSize, readPointerPos, event, pixelsPerMinute]
   )
 
   const finishResize = useCallback(
@@ -121,35 +172,19 @@ export function useEventResize<T extends EventCalendarItem>({
       e.stopPropagation()
       const { pointerPos, edge } = startRef.current
       const delta = readPointerPos(e) - pointerPos
-      const deltaMinutes = delta / pixelsPerMinute
-      const start = new Date(event.start)
-      const end = new Date(event.end)
-      const duration = differenceInMinutes(end, start)
 
       startRef.current = null
       setIsResizing(false)
       setPreviewSize(null)
       setPreviewOffset(0)
+      setPreviewTimes(null)
+      setResizeEdge(null)
 
-      if (edge === 'end') {
-        const newDuration = Math.max(
-          MinEventDurationMinutes,
-          Math.round((duration + deltaMinutes) / SnapMinutes) * SnapMinutes
-        )
-        if (newDuration !== duration) {
-          onResize?.(event, start, addMinutes(start, newDuration))
-        }
-      } else {
-        const snappedDelta = Math.round(deltaMinutes / SnapMinutes) * SnapMinutes
-        // Clamp so the remaining duration never drops below the minimum: newStart can be no
-        // later than `end - MinEventDurationMinutes`.
-        const maxStart = addMinutes(end, -MinEventDurationMinutes)
-        let newStart = addMinutes(start, snappedDelta)
-        if (newStart > maxStart) newStart = maxStart
-        if (newStart.getTime() !== start.getTime()) {
-          onResize?.(event, newStart, end)
-        }
-      }
+      const { start, end } = computeResizeTimes(event, edge, delta / pixelsPerMinute)
+      const changed =
+        start.getTime() !== new Date(event.start).getTime() ||
+        end.getTime() !== new Date(event.end).getTime()
+      if (changed) onResize?.(event, start, end)
     },
     [event, pixelsPerMinute, onResize, readPointerPos]
   )
@@ -161,6 +196,8 @@ export function useEventResize<T extends EventCalendarItem>({
     setIsResizing(false)
     setPreviewSize(null)
     setPreviewOffset(0)
+    setPreviewTimes(null)
+    setResizeEdge(null)
   }, [])
 
   const getResizeHandleProps = useCallback(
@@ -177,6 +214,8 @@ export function useEventResize<T extends EventCalendarItem>({
     isResizing,
     previewSize,
     previewOffset,
+    previewTimes,
+    resizeEdge,
     getResizeHandleProps,
   }
 }

--- a/packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/horizontal-timeline-view.tsx
@@ -14,7 +14,15 @@ import {
   isToday,
   startOfDay,
 } from 'date-fns'
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 
 import { assignLanes } from './assign-lanes'
 import {
@@ -22,10 +30,15 @@ import {
   StreamEndYear,
   StreamStartYear,
   TimelineHourWidth,
+  TimelineHourWidthMax,
+  TimelineHourWidthMin,
   TimelineLaneHeight,
   TimelineRailWidth,
+  TimelineRailWidthMax,
+  TimelineRailWidthMin,
 } from './constants'
-import { TimelineDaySection } from './timeline-day-section'
+import { StickyRailShadow } from './sticky-rail-shadow'
+import { type DayLaneAssignment, TimelineDaySection } from './timeline-day-section'
 import type {
   BackgroundEvent,
   CalendarResource,
@@ -44,8 +57,41 @@ const HourTickHeight = 24
 /** Extra padding (px) added on top of `maxLanes * TimelineLaneHeight` when sizing a worker row. */
 const RowPadding = 8
 
+/** Below this px-per-hour, hour-tick labels thin to every 2nd hour (borders stay hourly). */
+const HourLabelThinningWidth = 56
+
+/** Multiplicative zoom gain per wheel `deltaY` unit (ctrl+wheel / trackpad pinch). */
+const WheelZoomGain = 0.01
+
+/** Idle time (ms) after the last ctrl+wheel event before the zoom commits. */
+const WheelCommitDelayMs = 160
+
 /** Stable empty default — an inline `[]` would break `TimelineDaySection`'s memo every scroll frame. */
 const NoBackgroundEvents: BackgroundEvent[] = []
+
+const clampHourWidth = (px: number) =>
+  Math.min(TimelineHourWidthMax, Math.max(TimelineHourWidthMin, px))
+const clampRailWidth = (px: number) =>
+  Math.min(TimelineRailWidthMax, Math.max(TimelineRailWidthMin, px))
+
+interface ZoomGesture {
+  /** Live px-per-hour — flushed to `--tl-day-width` per move, committed to state on release. */
+  hourWidth: number
+  /** Live anchor compensation (px) — added into every day-section/header `translateX` calc so
+   * the anchor point stays put visually while `scrollLeft` stays untouched (plan 35 §5.4). */
+  comp: number
+  /** Hours-from-stream-origin of the drag anchor — fixed for a border drag, `null` for wheel
+   * (each wheel event re-derives its anchor from the pointer, drift-free). */
+  anchorH: number | null
+  startHourWidth: number
+  startClientX: number
+}
+
+interface RailGesture {
+  width: number
+  startWidth: number
+  startClientX: number
+}
 
 interface HorizontalTimelineViewProps<T extends EventCalendarItem = EventCalendarItem> {
   /** Scroll target = the literal leftmost visible day (no `startOfWeek` normalization). */
@@ -58,6 +104,14 @@ interface HorizontalTimelineViewProps<T extends EventCalendarItem = EventCalenda
   backgroundEvents?: BackgroundEvent[]
   /** Visible hour range — `dayWidth` derives from this, not from a viewport clamp. */
   hourWindow: TimelineHourWindow
+  /** Controlled px-per-hour zoom (plan 35) — clamped to [`TimelineHourWidthMin`, `TimelineHourWidthMax`].
+   * Omit for internal state. Gestures report commits via `onHourWidthChange`. */
+  hourWidth?: number
+  onHourWidthChange?: (px: number) => void
+  /** Controlled worker-rail width (plan 35) — clamped to [`TimelineRailWidthMin`, `TimelineRailWidthMax`].
+   * Omit for internal state. Drags report commits via `onRailWidthChange`. */
+  railWidth?: number
+  onRailWidthChange?: (px: number) => void
   onEventSelect: (event: T) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
@@ -75,12 +129,22 @@ interface HorizontalTimelineViewProps<T extends EventCalendarItem = EventCalenda
  * `ResourceTimelineView`'s architecture, just rotated 90°): the virtualizer still counts days,
  * the sizing/settle-snap/scroll-anchor machinery is lifted near-verbatim. The differences are all
  * in what a rendered "day" looks like: instead of K vertical worker sub-columns inside an hour
- * grid, each day is `windowHours × TimelineHourWidth` wide and contains K horizontal worker rows
- * whose lane stacks (see `assignLanes`) can grow taller when visits overlap.
+ * grid, each day is `windowHours × hourWidth` wide and contains K horizontal worker rows whose
+ * lane stacks (see `assignLanes`) can grow taller when visits overlap.
  *
- * `dayWidth` is window-derived (`windowHours × TimelineHourWidth`), NOT clamp-derived — the
- * sizing effect only measures how much width is available (`avail`) to decide whether a full day
- * fits (`snapEnabled`); it never shrinks `dayWidth` itself the way `ResourceTimelineView`'s hybrid
+ * **Zoom + rail resize (plan 35)**: `hourWidth` (px/hour) and `railWidth` are controlled props
+ * with gesture support — hour-border drag and ctrl+wheel (trackpad pinch) rescale time, the
+ * rail's right border drags its width. Gestures never setState per frame: all horizontal
+ * geometry hangs off three CSS variables on the scroll container (`--tl-day-width`,
+ * `--tl-rail-width`, `--tl-zoom-comp`) and day sections position themselves from their stream
+ * `index` via `calc()`, so a gesture frame is two style-property writes. `--tl-zoom-comp` is the
+ * anchor trick: instead of chasing `scrollLeft` (whose jumps would thrash the virtualizer's
+ * mount set mid-gesture), the whole content plane is translated so the grabbed border / pointer
+ * anchor stays put; release folds the compensation into one committed `scrollLeft` write.
+ *
+ * `dayWidth` is window-derived (`windowHours × hourWidth`), NOT clamp-derived — the sizing
+ * effect only measures how much width is available (`avail`) to decide whether a full day fits
+ * (`snapEnabled`); it never shrinks `dayWidth` itself the way `ResourceTimelineView`'s hybrid
  * clamp does.
  */
 export function HorizontalTimelineView<T extends EventCalendarItem = EventCalendarItem>({
@@ -90,6 +154,10 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
   weekStartsOn: _weekStartsOn,
   backgroundEvents = NoBackgroundEvents,
   hourWindow,
+  hourWidth: hourWidthProp,
+  onHourWidthChange,
+  railWidth: railWidthProp,
+  onRailWidthChange,
   onEventSelect,
   onEventResize,
   renderEvent,
@@ -101,10 +169,17 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
   const [snapEnabled, setSnapEnabled] = useState(true)
   const [viewportHeight, setViewportHeight] = useState(0)
 
+  // Controlled-or-internal zoom/rail state — web passes the persisted store values; standalone
+  // usage still gets working gestures.
+  const [internalHourWidth, setInternalHourWidth] = useState(TimelineHourWidth)
+  const [internalRailWidth, setInternalRailWidth] = useState(TimelineRailWidth)
+  const hourWidth = clampHourWidth(hourWidthProp ?? internalHourWidth)
+  const railWidth = clampRailWidth(railWidthProp ?? internalRailWidth)
+
   const windowStart = hourWindow.start
   const windowEnd = hourWindow.end
   const windowHours = Math.max(0, windowEnd - windowStart)
-  const dayWidth = Math.max(1, windowHours * TimelineHourWidth)
+  const dayWidth = Math.max(1, windowHours * hourWidth)
 
   const { epoch, dayCount } = useMemo(() => {
     const start = startOfDay(new Date(StreamStartYear, 0, 1))
@@ -119,21 +194,72 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
     [epoch, dayCount]
   )
 
+  // The virtualizer reads day size through a ref so a throttle-free `measure()` after a zoom
+  // commit sees the new width without waiting for a state-closure refresh (plan 35 §5.5).
+  const dayWidthRef = useRef(dayWidth)
+  dayWidthRef.current = dayWidth
+
   const virtualizer = useVirtualizer({
     horizontal: true,
     count: dayCount,
     getScrollElement: () => scrollRef.current,
-    estimateSize: useCallback(() => dayWidth, [dayWidth]),
+    estimateSize: useCallback(() => dayWidthRef.current, []),
     overscan: 1,
   })
 
+  // ── gesture plumbing (plan 35) ───────────────────────────────────────────
+  // Live gesture state lives in refs; committed values live in props/state. `applyCssVars` is
+  // idempotent and re-run as a layout effect on EVERY render, so an unrelated re-render
+  // mid-gesture (the 60s now-tick, a realtime event update) can never clobber gesture geometry —
+  // React writes the committed style attr, then this re-asserts the live values pre-paint.
+  const zoomGestureRef = useRef<ZoomGesture | null>(null)
+  const railGestureRef = useRef<RailGesture | null>(null)
+  const pendingScrollLeftRef = useRef<number | null>(null)
+  const wheelCommitTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  // Committed geometry + commit callbacks behind refs so the stable wheel listener and
+  // timer-fired commits never read stale closures.
+  const geoRef = useRef({ hourWidth, railWidth, windowHours })
+  geoRef.current = { hourWidth, railWidth, windowHours }
+  const commitCallbacksRef = useRef({ onHourWidthChange, onRailWidthChange })
+  commitCallbacksRef.current = { onHourWidthChange, onRailWidthChange }
+
+  const applyCssVars = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const liveHourWidth = zoomGestureRef.current?.hourWidth ?? geoRef.current.hourWidth
+    const liveRailWidth = railGestureRef.current?.width ?? geoRef.current.railWidth
+    const comp = zoomGestureRef.current?.comp ?? 0
+    el.style.setProperty(
+      '--tl-day-width',
+      `${Math.max(1, geoRef.current.windowHours * liveHourWidth)}px`
+    )
+    el.style.setProperty('--tl-rail-width', `${liveRailWidth}px`)
+    el.style.setProperty('--tl-zoom-comp', `${comp}px`)
+  }, [])
+
+  // No dependency array — deliberately runs every render (see above).
+  useLayoutEffect(applyCssVars)
+
+  const commitHourWidth = useCallback((px: number) => {
+    const cb = commitCallbacksRef.current.onHourWidthChange
+    if (cb) cb(px)
+    else setInternalHourWidth(px)
+  }, [])
+
+  const commitRailWidth = useCallback((px: number) => {
+    const cb = commitCallbacksRef.current.onRailWidthChange
+    if (cb) cb(px)
+    else setInternalRailWidth(px)
+  }, [])
+
   // ── sizing: dayWidth is window-derived (see above) — this effect only measures how much width
-  // is available beside the fixed-width rail, to decide whether a full day fits (snapEnabled).
+  // is available beside the rail, to decide whether a full day fits (snapEnabled).
   useLayoutEffect(() => {
     const el = scrollRef.current
     if (!el) return
     const applySize = () => {
-      const avail = Math.max(1, el.clientWidth - TimelineRailWidth)
+      const avail = Math.max(1, el.clientWidth - railWidth)
       setSnapEnabled(dayWidth <= avail)
       // Body min-height: the row/day grid stretches to fill the viewport even with few workers.
       setViewportHeight(el.clientHeight)
@@ -142,7 +268,7 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
     const observer = new ResizeObserver(applySize)
     observer.observe(el)
     return () => observer.disconnect()
-  }, [dayWidth])
+  }, [dayWidth, railWidth])
 
   // Layout effect, declared BEFORE the scroll-to effect below: the virtualizer's measurement
   // cache must reflect the new day width before anything scrolls by it.
@@ -163,10 +289,26 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
   const lastScrollLeftRef = useRef(0)
 
   useLayoutEffect(() => {
-    const dayWidthChanged = lastDayWidthRef.current !== dayWidth
-    if (!dayWidthChanged && lastEmittedDateRef.current === currentDateRef.current.getTime()) return
     const el = scrollRef.current
     if (!el) return
+    // Zoom-commit path (plan 35 §5.5): the gesture already computed the anchor-correct
+    // scrollLeft (current scroll minus the folded-away `--tl-zoom-comp`) — consume it INSTEAD
+    // of the hour-window re-anchor below, which would yank the view to `currentDate`'s left
+    // edge on every zoom release.
+    if (pendingScrollLeftRef.current !== null) {
+      const target = pendingScrollLeftRef.current
+      pendingScrollLeftRef.current = null
+      lastDayWidthRef.current = dayWidth
+      programmaticScrollRef.current = true
+      el.scrollTo({ left: target })
+      lastScrollLeftRef.current = target
+      const timeout = setTimeout(() => {
+        programmaticScrollRef.current = false
+      }, 300)
+      return () => clearTimeout(timeout)
+    }
+    const dayWidthChanged = lastDayWidthRef.current !== dayWidth
+    if (!dayWidthChanged && lastEmittedDateRef.current === currentDateRef.current.getTime()) return
     lastDayWidthRef.current = dayWidth
     programmaticScrollRef.current = true
     const targetOffset = targetIndex * dayWidth
@@ -189,6 +331,8 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
     clearTimeout(settleTimeoutRef.current)
     settleTimeoutRef.current = setTimeout(() => {
       if (programmaticScrollRef.current) return
+      // Gesture scroll writes (rail drags nudge scrollLeft live) must not settle-snap.
+      if (zoomGestureRef.current || railGestureRef.current) return
       const el = scrollRef.current
       if (!el) return
       const { scrollLeft } = el
@@ -213,6 +357,218 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
 
   useEffect(() => () => clearTimeout(settleTimeoutRef.current), [])
 
+  // ── zoom gestures (plan 35 §5) ───────────────────────────────────────────
+
+  /** Ends the active zoom gesture: folds `--tl-zoom-comp` into one committed scrollLeft. */
+  const finishZoomGesture = useCallback(() => {
+    const gesture = zoomGestureRef.current
+    if (!gesture) return
+    clearTimeout(wheelCommitTimerRef.current)
+    zoomGestureRef.current = null
+    const el = scrollRef.current
+    if (!el) return
+
+    // The committed value is an INTEGER while the live gesture value (wheel path: ×e^Δ) is
+    // fractional. The fold-away scrollLeft must be derived for the width actually committed —
+    // a naive `scrollLeft − comp` assumes the live width sticks, and the mismatch is
+    // (live − committed) × hoursFromStreamOrigin ≈ THOUSANDS of px (days) per 0.5px/hr of
+    // rounding. Anchor instead on the time-point at the viewport's left edge, computed from the
+    // LIVE visual state, and re-project it at the committed width — exact for any rounding.
+    const finalHourWidth = clampHourWidth(Math.round(gesture.hourWidth))
+    const rail = railGestureRef.current?.width ?? geoRef.current.railWidth
+    const hoursAtViewportLeft = (el.scrollLeft - gesture.comp - rail) / gesture.hourWidth
+    const target = rail + finalHourWidth * hoursAtViewportLeft
+
+    if (finalHourWidth === geoRef.current.hourWidth) {
+      // Rounds back to the already-committed width — no re-render will consume a pending
+      // scrollLeft, so fold the (possibly non-zero) comp imperatively: committed vars + the
+      // re-projected scrollLeft in the same frame. Skipping this and just re-asserting vars
+      // would discard comp and jump the view by days.
+      programmaticScrollRef.current = true
+      applyCssVars()
+      el.scrollLeft = target
+      lastScrollLeftRef.current = target
+      setTimeout(() => {
+        programmaticScrollRef.current = false
+      }, 200)
+      return
+    }
+
+    pendingScrollLeftRef.current = target
+    commitHourWidth(finalHourWidth)
+  }, [applyCssVars, commitHourWidth])
+
+  /** Border drag: the grabbed hour's LEFT edge is the anchor, so the dragged border tracks the
+   * pointer exactly (`hourWidth' = start + dx` puts it one hour-width right of the anchor). */
+  const beginBorderZoom = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>, dayIndex: number, hourIndex: number) => {
+      const { hourWidth: committed, windowHours: wh } = geoRef.current
+      // A commit is mid-flight (pending scrollLeft not yet consumed by the re-render) —
+      // starting a gesture now would seed from stale committed values. Next attempt re-enters.
+      if (wh <= 0 || pendingScrollLeftRef.current !== null) return
+      e.preventDefault()
+      e.stopPropagation()
+      e.currentTarget.setPointerCapture(e.pointerId)
+      zoomGestureRef.current = {
+        hourWidth: committed,
+        comp: 0,
+        anchorH: dayIndex * wh + hourIndex - 1,
+        startHourWidth: committed,
+        startClientX: e.clientX,
+      }
+    },
+    []
+  )
+
+  const moveBorderZoom = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const gesture = zoomGestureRef.current
+      if (!gesture || gesture.anchorH === null) return
+      e.stopPropagation()
+      const next = clampHourWidth(gesture.startHourWidth + (e.clientX - gesture.startClientX))
+      if (next === gesture.hourWidth) return
+      gesture.hourWidth = next
+      gesture.comp = (gesture.startHourWidth - next) * gesture.anchorH
+      applyCssVars()
+    },
+    [applyCssVars]
+  )
+
+  const endBorderZoom = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!zoomGestureRef.current || zoomGestureRef.current.anchorH === null) return
+      e.stopPropagation()
+      finishZoomGesture()
+    },
+    [finishZoomGesture]
+  )
+
+  /** Double-click an hour border → reset to the default scale, keeping that border stationary. */
+  const resetZoom = useCallback(
+    (dayIndex: number, hourIndex: number) => {
+      const { hourWidth: committed, windowHours: wh } = geoRef.current
+      if (wh <= 0 || committed === TimelineHourWidth) return
+      if (pendingScrollLeftRef.current !== null) return
+      const el = scrollRef.current
+      if (!el) return
+      const anchorH = dayIndex * wh + hourIndex
+      pendingScrollLeftRef.current = el.scrollLeft + (TimelineHourWidth - committed) * anchorH
+      commitHourWidth(TimelineHourWidth)
+    },
+    [commitHourWidth]
+  )
+
+  // Ctrl+wheel / trackpad pinch — non-passive so `preventDefault` can stop the browser's page
+  // zoom. Each event re-derives its anchor (the time under the pointer) from LIVE values, so
+  // continuous pinches stay drift-free; the commit debounces behind the last event.
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey) return
+      const { railWidth: committedRail, windowHours: wh } = geoRef.current
+      if (wh <= 0) return
+      e.preventDefault()
+      // A commit is mid-flight — swallow this event (still prevented from page-zooming); the
+      // next one starts a fresh gesture from the settled committed state.
+      if (pendingScrollLeftRef.current !== null) return
+      let gesture = zoomGestureRef.current
+      if (!gesture) {
+        gesture = {
+          hourWidth: geoRef.current.hourWidth,
+          comp: 0,
+          anchorH: null,
+          startHourWidth: geoRef.current.hourWidth,
+          startClientX: 0,
+        }
+        zoomGestureRef.current = gesture
+      }
+      const liveRail = railGestureRef.current?.width ?? committedRail
+      const pointerX = e.clientX - el.getBoundingClientRect().left
+      // Hours-from-stream-origin of the content point under the pointer, in live scale.
+      const anchorH = (el.scrollLeft + pointerX - liveRail - gesture.comp) / gesture.hourWidth
+      const next = clampHourWidth(gesture.hourWidth * Math.exp(-e.deltaY * WheelZoomGain))
+      gesture.comp += (gesture.hourWidth - next) * anchorH
+      gesture.hourWidth = next
+      applyCssVars()
+      clearTimeout(wheelCommitTimerRef.current)
+      wheelCommitTimerRef.current = setTimeout(finishZoomGesture, WheelCommitDelayMs)
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => {
+      el.removeEventListener('wheel', onWheel)
+      clearTimeout(wheelCommitTimerRef.current)
+    }
+  }, [applyCssVars, finishZoomGesture])
+
+  // ── rail resize gesture (plan 35 §4) ─────────────────────────────────────
+  // Growing the rail shifts all content right by Δ; a matching scrollLeft nudge keeps the same
+  // time under the viewport edge (the rail expands over the seam, sidebar-style). scrollLeft
+  // moves live here (small, bounded deltas — no virtualizer hazard), guarded from the settle
+  // handler by the gesture-ref check above.
+  const beginRailResize = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (pendingScrollLeftRef.current !== null) return
+    e.preventDefault()
+    e.stopPropagation()
+    e.currentTarget.setPointerCapture(e.pointerId)
+    const committed = geoRef.current.railWidth
+    railGestureRef.current = { width: committed, startWidth: committed, startClientX: e.clientX }
+  }, [])
+
+  const moveRailResize = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const gesture = railGestureRef.current
+      if (!gesture) return
+      e.stopPropagation()
+      const next = clampRailWidth(gesture.startWidth + (e.clientX - gesture.startClientX))
+      const delta = next - gesture.width
+      if (delta === 0) return
+      gesture.width = next
+      applyCssVars()
+      const el = scrollRef.current
+      if (el) el.scrollLeft += delta
+    },
+    [applyCssVars]
+  )
+
+  const endRailResize = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const gesture = railGestureRef.current
+      if (!gesture) return
+      e.stopPropagation()
+      railGestureRef.current = null
+      const el = scrollRef.current
+      if (el) lastScrollLeftRef.current = el.scrollLeft
+      if (gesture.width !== geoRef.current.railWidth) commitRailWidth(gesture.width)
+      else applyCssVars()
+    },
+    [applyCssVars, commitRailWidth]
+  )
+
+  /** Double-click the rail border → reset to the default width, content staying anchored. */
+  const resetRail = useCallback(() => {
+    const committed = geoRef.current.railWidth
+    if (committed === TimelineRailWidth) return
+    const el = scrollRef.current
+    if (el) {
+      programmaticScrollRef.current = true
+      el.scrollLeft += TimelineRailWidth - committed
+      lastScrollLeftRef.current = el.scrollLeft
+      setTimeout(() => {
+        programmaticScrollRef.current = false
+      }, 200)
+    }
+    commitRailWidth(TimelineRailWidth)
+  }, [commitRailWidth])
+
+  const railResizeHandleProps = {
+    onPointerDown: beginRailResize,
+    onPointerMove: moveRailResize,
+    onPointerUp: endRailResize,
+    onPointerCancel: endRailResize,
+    onDoubleClick: resetRail,
+  }
+
   // ── visible window → consumer fetch range ────────────────────────────────
   const virtualItems = virtualizer.getVirtualItems()
   const firstIndex = virtualItems[0]?.index
@@ -231,11 +587,12 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
   // while scrolling within it (it may still shift when scrolling INTO a differently-stacked day
   // — same accepted-v1 precedent as the vertical streams' all-day lane).
   //
-  // Lane maps are keyed `${resourceId}|${dayISOString}` (not just `resourceId`): a multi-day
-  // event can land in a different lane on each day segment it spans, so the day must be part of
-  // the key — see `TimelineDaySection`'s doc comment.
+  // Lane assignments are keyed `${resourceId}|${dayISOString}` (not just `resourceId`): a
+  // multi-day event can land in a different lane on each day segment it spans, so the day must
+  // be part of the key — see `TimelineDaySection`'s doc comment. Each value carries `laneCount`
+  // too, which the section needs to center that day's stack in the row (plan 35 §1).
   const { rowHeights, rowTops, laneMapsByResource } = useMemo(() => {
-    const laneMapsByResource = new Map<string, Map<string, number>>()
+    const laneMapsByResource = new Map<string, DayLaneAssignment>()
     const rowHeights: number[] = []
 
     for (const resource of resources) {
@@ -274,7 +631,7 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
           }))
 
           const { lanes, laneCount } = assignLanes([...dayTimedEvents, ...daySpanningEvents])
-          laneMapsByResource.set(`${resource.id}|${day.toISOString()}`, lanes)
+          laneMapsByResource.set(`${resource.id}|${day.toISOString()}`, { lanes, laneCount })
           if (laneCount > maxLanes) maxLanes = laneCount
         }
       }
@@ -316,16 +673,34 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
 
   const nowLabel = useMemo(() => format(now, 'h:mm a'), [now])
 
-  const totalSize = virtualizer.getTotalSize()
   const hourTicks = windowHours > 0 ? Math.round(windowHours) : 0
+  // Tick-label thinning at small scales — every hour still gets its border (the grab surface).
+  const hourLabelStep = hourWidth < HourLabelThinningWidth ? 2 : 1
+
+  // Shared calc() for the per-day x offset — headers and day sections use the same expression
+  // so gestures move them in lockstep.
+  const dayTranslateX = (index: number) =>
+    `translateX(calc(var(--tl-rail-width) + ${index} * var(--tl-day-width) + var(--tl-zoom-comp, 0px)))`
 
   return (
     <div data-slot='horizontal-timeline-view' className='flex min-h-0 flex-1 flex-col'>
-      <div ref={scrollRef} onScroll={handleScroll} className='min-h-0 flex-1 overflow-auto'>
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className='min-h-0 flex-1 overflow-auto'
+        style={
+          {
+            // Committed geometry — the always-run layout effect re-asserts live gesture values
+            // on top of these pre-paint (see `applyCssVars`).
+            '--tl-day-width': `${dayWidth}px`,
+            '--tl-rail-width': `${railWidth}px`,
+            '--tl-zoom-comp': '0px',
+          } as CSSProperties
+        }>
         <div
           className='relative'
           style={{
-            width: TimelineRailWidth + totalSize,
+            width: `calc(var(--tl-rail-width) + ${dayCount} * var(--tl-day-width))`,
             minHeight: headerHeight + bodyHeight,
           }}>
           {/* Two-tier sticky header: date labels + hour ticks. */}
@@ -334,15 +709,20 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
             style={{ height: headerHeight }}>
             {/* Corner — sticky on both axes: pinned left within the (already sticky-top) strip. */}
             <div
-              className='bg-background border-border/70 text-muted-foreground/70 sticky left-0 z-10 flex items-center justify-center border-r text-sm'
-              style={{ width: TimelineRailWidth, height: headerHeight }}>
+              className='bg-background text-muted-foreground/70 sticky left-0 z-10 flex items-center justify-center text-sm'
+              style={{ width: 'var(--tl-rail-width)', height: headerHeight }}>
               <span className='max-[479px]:sr-only'>{format(new Date(), 'O')}</span>
+              {/* Rail-width drag handle (corner segment) — one continuous strip with the rail's. */}
+              <div
+                {...railResizeHandleProps}
+                className='hover:bg-border/70 absolute inset-y-0 right-0 z-20 w-[5px] cursor-col-resize touch-none select-none'
+              />
+              <StickyRailShadow />
             </div>
 
             {/* Row 1 — per-day date label, spanning the whole day-section width, centered. */}
             {virtualItems.map((v) => {
               const day = dayAt(v.index)
-              const x = TimelineRailWidth + v.start
               const today = isToday(day)
               return (
                 <div
@@ -351,29 +731,29 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
                   style={{
                     top: 0,
                     left: 0,
-                    width: dayWidth,
+                    width: 'var(--tl-day-width)',
                     height: DateLabelHeight,
-                    transform: `translateX(${x}px)`,
+                    transform: dayTranslateX(v.index),
                   }}>
                   <span className='uppercase'>{format(day, 'EEE')}</span>
-                  {/* Today's date sits in a filled badge (Notion look); other days stay plain. */}
+                  {/* Today's date sits in a filled pill (Notion look); other days stay plain. */}
                   <span
                     className={cn(
-                      'flex h-6 min-w-6 items-center justify-center rounded-full px-1 tabular-nums',
+                      'flex h-6 items-center justify-center rounded-full px-2 whitespace-nowrap tabular-nums',
                       today
                         ? 'bg-primary text-primary-foreground font-semibold'
                         : 'text-foreground font-medium'
                     )}>
-                    {format(day, 'd')}
+                    {format(day, 'MMM d')}
                   </span>
                 </div>
               )
             })}
 
-            {/* Row 2 — hour tick labels every `TimelineHourWidth` px, plus the now-pill on today. */}
+            {/* Row 2 — hour tick labels, the zoom grab strips on each hour border, and the
+                now-pill on today. */}
             {virtualItems.map((v) => {
               const day = dayAt(v.index)
-              const x = TimelineRailWidth + v.start
               const today = isToday(day)
               return (
                 <div
@@ -382,9 +762,9 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
                   style={{
                     top: DateLabelHeight,
                     left: 0,
-                    width: dayWidth,
+                    width: 'var(--tl-day-width)',
                     height: HourTickHeight,
-                    transform: `translateX(${x}px)`,
+                    transform: dayTranslateX(v.index),
                   }}>
                   {Array.from({ length: hourTicks }, (_, hourIndex) => {
                     const tickDate = addHours(startOfDay(day), windowStart + hourIndex)
@@ -392,11 +772,29 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
                       <div
                         key={hourIndex}
                         className='border-border/50 text-muted-foreground/70 absolute top-0 h-full border-l pl-1 font-medium first:border-l-0'
-                        style={{ left: hourIndex * TimelineHourWidth, width: TimelineHourWidth }}>
-                        {format(tickDate, 'h a')}
+                        style={{
+                          left: `${(hourIndex / windowHours) * 100}%`,
+                          width: `${100 / windowHours}%`,
+                        }}>
+                        {hourIndex % hourLabelStep === 0 ? format(tickDate, 'h a') : null}
                       </div>
                     )
                   })}
+                  {/* Zoom grab strips — one per hour border (incl. the day boundary at index 0).
+                      Drag = rescale px-per-hour anchored so the border tracks the pointer;
+                      double-click = reset to the default scale. */}
+                  {Array.from({ length: hourTicks }, (_, hourIndex) => (
+                    <div
+                      key={`zoom-${hourIndex}`}
+                      onPointerDown={(e) => beginBorderZoom(e, v.index, hourIndex)}
+                      onPointerMove={moveBorderZoom}
+                      onPointerUp={endBorderZoom}
+                      onPointerCancel={endBorderZoom}
+                      onDoubleClick={() => resetZoom(v.index, hourIndex)}
+                      className='absolute inset-y-0 z-10 w-[7px] cursor-ew-resize touch-none select-none'
+                      style={{ left: `calc(${(hourIndex / windowHours) * 100}% - 3px)` }}
+                    />
+                  ))}
                   {today && nowPosition !== null && (
                     <div
                       className='pointer-events-none absolute top-0 z-20 -translate-x-1/2'
@@ -418,22 +816,26 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
           {/* Sticky-left worker rail — pinned left only (no `top`: it scrolls vertically with
               the rows below; its flow position already starts below the sticky header). */}
           <div
-            className='bg-background sticky left-0 z-20 w-fit'
-            style={{ width: TimelineRailWidth }}>
+            className='bg-background sticky left-0 z-20'
+            style={{ width: 'var(--tl-rail-width)' }}>
             <div className='relative' style={{ height: bodyHeight }}>
               {resources.map((resource, ri) => (
                 <div
                   key={resource.id}
-                  className='border-border/70 text-muted-foreground/80 absolute flex items-center border-b px-2 text-sm'
+                  className='border-border/70 text-muted-foreground/80 absolute right-0 left-0 flex items-center border-b px-2 text-sm'
                   style={{
                     top: rowTops[ri] ?? 0,
-                    left: 0,
-                    width: TimelineRailWidth,
                     height: rowHeights[ri] ?? TimelineLaneHeight,
                   }}>
                   {resource.header ?? resource.label}
                 </div>
               ))}
+              {/* Rail-width drag handle (body segment). */}
+              <div
+                {...railResizeHandleProps}
+                className='hover:bg-border/70 absolute inset-y-0 right-0 z-20 w-[5px] cursor-col-resize touch-none select-none'
+              />
+              <StickyRailShadow />
             </div>
           </div>
 
@@ -441,14 +843,13 @@ export function HorizontalTimelineView<T extends EventCalendarItem = EventCalend
             <TimelineDaySection
               key={v.key}
               index={v.index}
-              x={TimelineRailWidth + v.start}
-              dayWidth={dayWidth}
               top={headerHeight}
               dayAt={dayAt}
               resources={resources}
               events={events}
               backgroundEvents={backgroundEvents}
               hourWindow={hourWindow}
+              hourWidth={hourWidth}
               rowHeights={rowHeights}
               rowTops={rowTops}
               bodyHeight={bodyHeight}

--- a/packages/ui/src/components/event-calendar/index.ts
+++ b/packages/ui/src/components/event-calendar/index.ts
@@ -15,6 +15,12 @@ export {
   MinEventDurationMinutes,
   SnapMinutes,
   StartHour,
+  TimelineHourWidth,
+  TimelineHourWidthMax,
+  TimelineHourWidthMin,
+  TimelineRailWidth,
+  TimelineRailWidthMax,
+  TimelineRailWidthMin,
   WeekCellsHeight,
 } from './constants'
 export { CurrentTimeGutterLabel, CurrentTimeLine } from './current-time-line'
@@ -52,6 +58,7 @@ export { MonthView } from './month-view'
 // Positioning util (day/week/resource share this — see position-events.ts)
 export { type PositionedEvent, positionEventsForDay } from './position-events'
 export { ResourceTimelineView } from './resource-timeline-view'
+export { TimeRangePill } from './time-range-pill'
 // Types
 export type {
   BackgroundEvent,

--- a/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
@@ -30,6 +30,7 @@ import { DayResourceGroup } from './day-resource-group'
 import { EventItem } from './event-item'
 import { useCurrentTimeIndicator } from './hooks/use-current-time-indicator'
 import { HourGutter } from './hour-gutter'
+import { StickyRailShadow } from './sticky-rail-shadow'
 import type { BackgroundEvent, CalendarResource, EventCalendarItem, RenderEvent } from './types'
 import { getAllEventsForDay, isMultiDayEvent } from './utils'
 
@@ -320,7 +321,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
             style={{ height: headerHeight }}>
             {/* Corner — sticky on both axes: pinned left within the (already sticky-top) strip. */}
             <div
-              className='bg-background border-border/70 sticky left-0 z-10 flex flex-col border-r'
+              className='bg-background sticky left-0 z-10 flex flex-col'
               style={{ width: gutterWidth, height: headerHeight }}>
               <div
                 className='text-muted-foreground/70 flex items-center justify-center text-sm'
@@ -332,6 +333,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
                   All day
                 </span>
               </div>
+              <StickyRailShadow />
             </div>
 
             {/* Full-width hairline between the worker sub-headers and the all-day lane. */}
@@ -466,6 +468,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
                   : undefined
               }
             />
+            <StickyRailShadow />
           </div>
 
           {virtualItems.map((v) => (

--- a/packages/ui/src/components/event-calendar/sticky-rail-shadow.tsx
+++ b/packages/ui/src/components/event-calendar/sticky-rail-shadow.tsx
@@ -1,0 +1,20 @@
+// packages/ui/src/components/event-calendar/sticky-rail-shadow.tsx
+
+'use client'
+
+/**
+ * Right-edge drop shadow for a calendar stream's sticky-left rail (the week/day hour gutter,
+ * the timeline's worker rail) — the dynamic table's pinned-column shadow recipe
+ * (`virtual-table-body.tsx`), minus its scroll-state opacity logic: the calendar streams sit
+ * mid-stream at all times, so the shadow is ALWAYS on. A 1px strip hugging the parent's right
+ * edge whose box-shadow is clip-path'd to cast rightward only, over the scrolling grid.
+ * The parent must be positioned (the sticky rails all are).
+ */
+export function StickyRailShadow() {
+  return (
+    <div
+      aria-hidden
+      className='pointer-events-none absolute inset-y-0 left-full -ml-px w-px bg-transparent shadow-[6px_0_16px_4px_rgb(0,0,0,0.2)] dark:shadow-[6px_0_16px_4px_rgb(0,0,0,0.9)] [clip-path:inset(0px_-38px_0px_0px)]'
+    />
+  )
+}

--- a/packages/ui/src/components/event-calendar/time-range-pill.tsx
+++ b/packages/ui/src/components/event-calendar/time-range-pill.tsx
@@ -1,0 +1,30 @@
+// packages/ui/src/components/event-calendar/time-range-pill.tsx
+
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+
+import { formatTimeWithOptionalMinutes } from './utils'
+
+interface TimeRangePillProps {
+  start: Date
+  end: Date
+  className?: string
+}
+
+/**
+ * The small dark start–end readout shown while a chip is being drag-moved (on the `DragOverlay`
+ * ghost) or edge-resized (anchored to the dragged edge) — plan 35 §3. Deliberately a fixed dark
+ * chip in BOTH themes so it reads as a floating tooltip, not a chip.
+ */
+export function TimeRangePill({ start, end, className }: TimeRangePillProps) {
+  return (
+    <span
+      className={cn(
+        'pointer-events-none rounded-md bg-zinc-950/90 px-1.5 py-0.5 text-[11px] font-medium whitespace-nowrap text-zinc-50 tabular-nums shadow-sm dark:bg-zinc-800/95',
+        className
+      )}>
+      {formatTimeWithOptionalMinutes(start)} – {formatTimeWithOptionalMinutes(end)}
+    </span>
+  )
+}

--- a/packages/ui/src/components/event-calendar/timeline-day-section.tsx
+++ b/packages/ui/src/components/event-calendar/timeline-day-section.tsx
@@ -7,12 +7,7 @@ import { isSameDay, isToday } from 'date-fns'
 import { memo } from 'react'
 
 import { BackgroundEventsLayer } from './background-events'
-import {
-  CurrentTimeLineClass,
-  MinEventDurationMinutes,
-  TimelineHourWidth,
-  TimelineLaneHeight,
-} from './constants'
+import { CurrentTimeLineClass, MinEventDurationMinutes, TimelineLaneHeight } from './constants'
 import { DraggableEvent } from './draggable-event'
 import { DropPreviewX } from './drop-preview'
 import { DroppableCell } from './droppable-cell'
@@ -26,13 +21,17 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
 }
 
+/** Per-resource-per-day lane assignment — the map plus its lane count (row-centering needs it). */
+export interface DayLaneAssignment {
+  lanes: Map<string, number>
+  laneCount: number
+}
+
 interface TimelineDaySectionProps<T extends EventCalendarItem = EventCalendarItem> {
-  /** Stream day index — the section derives its own date via `dayAt(index)`. */
+  /** Stream day index — the section derives its own date via `dayAt(index)` AND its own x
+   * position via `calc(var(--tl-rail-width) + index × var(--tl-day-width) + var(--tl-zoom-comp))`
+   * (plan 35 §5.4 — index-based positioning keeps section props stable across scroll AND zoom). */
   index: number
-  /** Horizontal offset (px), content-space, from the scroll container's origin — includes the rail. */
-  x: number
-  /** Rendered day-section width (px) = `windowHours × TimelineHourWidth`. */
-  dayWidth: number
   /** Vertical offset (px) below the sticky header where the worker rows start. */
   top: number
   dayAt: (index: number) => Date
@@ -42,6 +41,9 @@ interface TimelineDaySectionProps<T extends EventCalendarItem = EventCalendarIte
   backgroundEvents: BackgroundEvent[]
   /** Visible hour range (fractional hours) shared with the shell and `HourGutter`-style ticks. */
   hourWindow: { start: number; end: number }
+  /** COMMITTED px-per-hour — feeds the resize hook's px→minutes math only; all layout inside the
+   * section is day-percentages, so mid-gesture zoom never needs this to update. */
+  hourWidth: number
   /** Per-resource row height (px), same index order as `resources` — identical every rendered day. */
   rowHeights: number[]
   /** Per-resource row top offset (px, prefix sum of `rowHeights`). */
@@ -53,11 +55,11 @@ interface TimelineDaySectionProps<T extends EventCalendarItem = EventCalendarIte
    */
   bodyHeight: number
   /**
-   * Event id → lane index, keyed by `${resourceId}|${dayISOString}` — lanes are assigned per
-   * resource PER RENDERED DAY (a multi-day event can occupy a different lane on each day segment
-   * it spans), so the outer key must include the day, not just the resource.
+   * Lane assignment keyed by `${resourceId}|${dayISOString}` — lanes are assigned per resource
+   * PER RENDERED DAY (a multi-day event can occupy a different lane on each day segment it
+   * spans), so the outer key must include the day, not just the resource.
    */
-  laneMapsByResource: Map<string, Map<string, number>>
+  laneMapsByResource: Map<string, DayLaneAssignment>
   onEventSelect: (event: T) => void
   onEventResize?: (event: T, newStart: Date, newEnd: Date) => void
   renderEvent?: RenderEvent<T>
@@ -76,6 +78,11 @@ interface TimelineDaySectionProps<T extends EventCalendarItem = EventCalendarIte
  * positioning). Every prop here is scroll-stable for a given `index`, so scrolling only
  * mounts/unmounts sections at the window's edges.
  *
+ * All horizontal geometry inside the section is expressed in PERCENTAGES of the section, and the
+ * section's own width/x come from the `--tl-day-width`/`--tl-rail-width`/`--tl-zoom-comp` CSS
+ * variables (plan 35 §5.4) — so a zoom or rail-resize gesture restyles the whole section tree
+ * with two style-property writes and ZERO section re-renders.
+ *
  * Computes its own `day` and does its own per-worker event filtering — the caller never slices
  * `events` per day, which is what keeps a single memoized section stable across scroll frames.
  * The section's left edge carries a hairline day-boundary border; worker rows keep a hairline
@@ -83,14 +90,13 @@ interface TimelineDaySectionProps<T extends EventCalendarItem = EventCalendarIte
  */
 function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem>({
   index,
-  x,
-  dayWidth,
   top,
   dayAt,
   resources,
   events,
   backgroundEvents,
   hourWindow,
+  hourWidth,
   rowHeights,
   rowTops,
   bodyHeight,
@@ -106,7 +112,7 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
   const today = isToday(day)
   const { start: windowStart, end: windowEnd } = hourWindow
   const windowHours = Math.max(0, windowEnd - windowStart)
-  const minChipWidth = (MinEventDurationMinutes / 60) * TimelineHourWidth
+  const minChipWidthPct = windowHours > 0 ? (MinEventDurationMinutes / 60 / windowHours) * 100 : 0
   const slotCount = windowHours > 0 ? Math.round(windowHours * 4) : 0
 
   // Timed single-day events touching this day — same overlap filter as `DayResourceGroup`.
@@ -132,15 +138,20 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
       style={{
         top,
         left: 0,
-        width: dayWidth,
+        width: 'var(--tl-day-width)',
         height: bodyHeight,
-        transform: `translateX(${x}px)`,
+        transform: `translateX(calc(var(--tl-rail-width) + ${index} * var(--tl-day-width) + var(--tl-zoom-comp, 0px)))`,
       }}
       data-today={today || undefined}>
       {resources.map((resource, ri) => {
         const rowTop = rowTops[ri] ?? 0
         const rowHeight = rowHeights[ri] ?? TimelineLaneHeight
-        const laneMap = laneMapsByResource.get(`${resource.id}|${dayIso}`)
+        const assignment = laneMapsByResource.get(`${resource.id}|${dayIso}`)
+        const laneMap = assignment?.lanes
+        const dayLanes = Math.max(1, assignment?.laneCount ?? 1)
+        // Center THIS day's lane stack in the (window-max-sized) row — a lone chip on a worker
+        // whose row is tall because of a stacked day elsewhere sits centered, not top-pinned.
+        const laneOffsetY = Math.max(0, (rowHeight - (dayLanes * TimelineLaneHeight - LaneGap)) / 2)
 
         const resourceTimedEvents = dayEvents.filter((event) => event.resourceId === resource.id)
         const resourceSpanningEvents = spanningDayEvents.filter(
@@ -150,8 +161,8 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
         return (
           <div
             key={resource.id}
-            className='border-border/40 absolute border-b'
-            style={{ top: rowTop, left: 0, width: dayWidth, height: rowHeight }}>
+            className='border-border/40 absolute right-0 left-0 border-b'
+            style={{ top: rowTop, height: rowHeight }}>
             <BackgroundEventsLayer
               events={backgroundEvents}
               day={day}
@@ -171,11 +182,9 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
               return (
                 <div
                   key={`span-${event.id}`}
-                  className='absolute z-10 px-0.5'
+                  className='absolute right-0 left-0 z-10 px-0.5'
                   style={{
-                    top: lane * TimelineLaneHeight,
-                    left: 0,
-                    width: dayWidth,
+                    top: laneOffsetY + lane * TimelineLaneHeight,
                     height: TimelineLaneHeight - LaneGap,
                   }}
                   onClick={(e) => e.stopPropagation()}>
@@ -183,10 +192,10 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
                     event={event}
                     view='resource'
                     orientation='x'
+                    cellSize={hourWidth}
                     onClick={(e) => handleEventClick(event, e)}
                     showTime
                     height={TimelineLaneHeight - LaneGap}
-                    width={dayWidth}
                     onResize={onEventResize}
                     renderEvent={renderEvent}
                     isSelected={event.id === selectedEventId}
@@ -212,10 +221,10 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
                 // window" indicator called for by the plan.
                 const isClampedStart = startHourFloat < windowStart
                 const isClampedEnd = endHourFloat > windowEnd
-                const left = (clampedStart - windowStart) * TimelineHourWidth
-                const width = Math.max(
-                  (clampedEnd - clampedStart) * TimelineHourWidth,
-                  minChipWidth
+                const leftPct = ((clampedStart - windowStart) / windowHours) * 100
+                const widthPct = Math.max(
+                  ((clampedEnd - clampedStart) / windowHours) * 100,
+                  minChipWidthPct
                 )
                 const lane = laneMap?.get(event.id) ?? 0
 
@@ -224,8 +233,9 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
                     key={event.id}
                     className='absolute z-10 px-0.5'
                     style={{
-                      top: lane * TimelineLaneHeight,
-                      left,
+                      top: laneOffsetY + lane * TimelineLaneHeight,
+                      left: `${leftPct}%`,
+                      width: `${widthPct}%`,
                       height: TimelineLaneHeight - LaneGap,
                     }}
                     onClick={(e) => e.stopPropagation()}>
@@ -233,10 +243,10 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
                       event={event}
                       view='resource'
                       orientation='x'
+                      cellSize={hourWidth}
                       onClick={(e) => handleEventClick(event, e)}
                       showTime
                       height={TimelineLaneHeight - LaneGap}
-                      width={width}
                       onResize={onEventResize}
                       renderEvent={renderEvent}
                       isSelected={event.id === selectedEventId}
@@ -262,8 +272,8 @@ function TimelineDaySectionInner<T extends EventCalendarItem = EventCalendarItem
                   key={slot}
                   className='absolute top-0'
                   style={{
-                    left: slot * (TimelineHourWidth / 4),
-                    width: TimelineHourWidth / 4,
+                    left: `${(slot / slotCount) * 100}%`,
+                    width: `${100 / slotCount}%`,
                     height: rowHeight,
                   }}>
                   <DroppableCell

--- a/packages/ui/src/components/event-calendar/utils.ts
+++ b/packages/ui/src/components/event-calendar/utils.ts
@@ -1,10 +1,15 @@
 // packages/ui/src/components/event-calendar/utils.ts
 
-import { isSameDay } from 'date-fns'
+import { format, getMinutes, isSameDay } from 'date-fns'
 import type { CSSProperties } from 'react'
 
 import { DefaultEventColor } from './constants'
 import type { EventCalendarItem } from './types'
+
+/** Compact chip-style time — `9am` on the hour, `9:30am` otherwise. */
+export function formatTimeWithOptionalMinutes(date: Date): string {
+  return format(date, getMinutes(date) === 0 ? 'ha' : 'h:mma').toLowerCase()
+}
 
 /**
  * Sets the `--ec-color` custom property an event chip's Tailwind arbitrary-value

--- a/packages/ui/src/components/event-calendar/week-view.tsx
+++ b/packages/ui/src/components/event-calendar/week-view.tsx
@@ -30,6 +30,7 @@ import {
 import { EventItem } from './event-item'
 import { useCurrentTimeIndicator } from './hooks/use-current-time-indicator'
 import { HourGutter } from './hour-gutter'
+import { StickyRailShadow } from './sticky-rail-shadow'
 import type { BackgroundEvent, EventCalendarItem, RenderEvent } from './types'
 import { getAllEventsForDay, isMultiDayEvent } from './utils'
 import { WeekDayColumn } from './week-day-column'
@@ -286,7 +287,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
             style={{ height: headerHeight }}>
             {/* Corner — sticky on both axes: pinned left within the (already sticky-top) strip. */}
             <div
-              className='bg-background border-border/70 sticky left-0 z-10 flex flex-col border-r'
+              className='bg-background sticky left-0 z-10 flex flex-col'
               style={{ width: gutterWidth, height: headerHeight }}>
               <div
                 className='text-muted-foreground/70 flex items-center justify-center text-sm'
@@ -298,6 +299,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
                   All day
                 </span>
               </div>
+              <StickyRailShadow />
             </div>
 
             {/* Full-width hairline between the date-label row and the all-day lane — runs
@@ -396,6 +398,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
                   : undefined
               }
             />
+            <StickyRailShadow />
           </div>
 
           {virtualItems.map((v) => (


### PR DESCRIPTION
## Summary

Plan 35 — five polish items on the plan-33 horizontal timeline board (#1241), plus a follow-up jump fix and rail shadows:

- **Centered chips** — each day's lane stack centers vertically in its worker row (chips previously hugged the row's top border; the row padding sat entirely below the stack).
- **Full date headers** — gray weekday + `Jul 17` instead of the bare day number; today's filled pill wraps the whole date.
- **Drag/resize time pill** — a small dark pill with the live snapped start–end times, on the drag ghost in every time-based view and anchored to the dragged edge during resize. The resize pill reads new `previewTimes` off `useEventResize`, computed by the same snap/clamp function as the commit, so the pill and the write can never diverge.
- **Resizable worker rail** — drag the rail's right border, clamped [120, 320], double-click resets.
- **Zoom** — px-per-hour scale [40, 240] via hour-border drag or ctrl+wheel/trackpad pinch, with hour-label thinning at small scales and double-click reset.
- **Sticky-rail shadow** — always-on right-edge shadow on the worker rail and day/week hour gutters (the dynamic table's pinned-column recipe minus its scroll-state logic); header corners drop their `border-r` so the shadow is the single continuous edge.

## Zoom architecture

Gestures never touch React state, `scrollLeft`, or the virtualizer: all horizontal geometry hangs off three CSS variables on the scroll container, day sections position themselves from their stream index via `calc()`, and everything inside a section is day-percentages — so a gesture frame is two style-property writes with zero section re-renders. `--tl-zoom-comp` translates the content plane to keep the grabbed border (or wheel pointer) stationary; release folds the compensation into one committed `scrollLeft`, re-projected at the committed **integer** width (fractional pinch widths round on commit — a naive `scrollLeft − comp` fold was off by `(live − committed) × hoursFromStreamOrigin`, i.e. days, which showed up as the view jumping to a random date).

Zoom and rail width persist per-device in a new zustand store (`dispatch-timeline-view`).

## Verification

- Browser (chrome-devtools MCP): chip-centering gap measurements; fractional pinch-in/out, tiny rounds-to-same pinch, and rapid alternating bursts all hold the visible date; border drag tracks the pointer exactly (+30px drag → border moved +30.0px); rail drag compensates scrollLeft; double-click resets; resize pill shows snap-exact times and pointercancel commits nothing; Day/Week regression clean; console clean.
- `packages/ui` + `apps/web` tsc: zero new errors (repo-wide counts match the pre-existing baselines). Biome clean.
- Owed: human gesture pass (real trackpad pinch feel, chip move-drag ghost pill).