### PR TITLE
feat(settings): pin form save bar flush to the page bottom

### DIFF
--- a/apps/web/src/components/availability/ui/scheduling-settings-page.tsx
+++ b/apps/web/src/components/availability/ui/scheduling-settings-page.tsx
@@ -197,7 +197,7 @@ export function SchedulingSettingsPage() {
       title='Scheduling'
       description='Set business hours, holiday exceptions, and route/board behavior used across dispatch.'
       breadcrumbs={breadcrumbs}>
-      <div className='flex flex-col gap-8 p-3 sm:p-6'>
+      <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
         <div className='grid grid-cols-1 items-start gap-8 lg:grid-cols-2'>
           <SettingsSection
             icon={Clock}
@@ -222,21 +222,12 @@ export function SchedulingSettingsPage() {
               )}
             </FieldPanel>
             {weeklyQuery.isSuccess ? (
-              <div className='flex flex-col gap-3'>
-                <WeeklyHoursEditor
-                  value={draft}
-                  onChange={setDraft}
-                  weekStartsOn={weekStartsOn}
-                  use24HourTime={use24HourTime}
-                />
-                <FormSaveBar
-                  dirty={dirty}
-                  isSaving={saveWeeklyHours.isPending}
-                  onSave={save}
-                  onDiscard={discard}
-                  saveDisabled={!validateWeeklyDraft(draft)}
-                />
-              </div>
+              <WeeklyHoursEditor
+                value={draft}
+                onChange={setDraft}
+                weekStartsOn={weekStartsOn}
+                use24HourTime={use24HourTime}
+              />
             ) : (
               <Skeleton className='h-48 w-full rounded-xl' />
             )}
@@ -288,11 +279,20 @@ export function SchedulingSettingsPage() {
           </SettingsSection>
         </div>
 
+        {/* One page-level bar covering both drafts (weekly hours + routes/board) — each
+            save/discard only touches the draft that is actually dirty. */}
         <FormSaveBar
-          dirty={routesBoardDirty}
-          isSaving={isBatchUpdatingOrgSettings}
-          onSave={saveRoutesBoard}
-          onDiscard={discardRoutesBoard}
+          dirty={dirty || routesBoardDirty}
+          isSaving={saveWeeklyHours.isPending || isBatchUpdatingOrgSettings}
+          onSave={() => {
+            if (dirty) save()
+            if (routesBoardDirty) saveRoutesBoard()
+          }}
+          onDiscard={() => {
+            if (dirty) discard()
+            if (routesBoardDirty) discardRoutesBoard()
+          }}
+          saveDisabled={dirty && !validateWeeklyDraft(draft)}
         />
       </div>
     </SettingsPage>

--- a/apps/web/src/components/dispatch/ui/dispatch-general-settings-page.tsx
+++ b/apps/web/src/components/dispatch/ui/dispatch-general-settings-page.tsx
@@ -21,6 +21,7 @@ import {
   DocumentsLogoCell,
 } from '~/components/money/ui/settings/documents-logo-cell'
 import { SettingsFieldRow } from '~/components/settings/settings-field-row'
+import { ColorField } from '~/components/ui/color-field'
 import { BaseType } from '~/components/workflow/types'
 import { useSettings } from '~/hooks/use-settings'
 import { useUser } from '~/hooks/use-user'
@@ -124,7 +125,7 @@ function DispatchGeneralSettingsBody() {
       title='General'
       description='Business identity, regional defaults, and document branding.'
       breadcrumbs={BREADCRUMBS}>
-      <div className='flex flex-col gap-8 p-3 sm:p-6'>
+      <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
         <div className='grid grid-cols-1 items-start gap-8 lg:grid-cols-2'>
           <SettingsSection
             icon={Building2}
@@ -239,11 +240,15 @@ function DispatchGeneralSettingsBody() {
                   className='mt-1 p-0'
                   resizeId='general-branding'
                   defaultLabelWidth={200}>
-                  <SettingsFieldRow
-                    settingKey='documents.accentColor'
-                    title='Accent color'
-                    {...controlled('documents.accentColor')}
-                  />
+                  <SettingsFieldRow settingKey='documents.accentColor' title='Accent color'>
+                    <ColorField
+                      value={(draft['documents.accentColor'] as string) || ''}
+                      onChange={(value) =>
+                        patch({ 'documents.accentColor': value === '' ? null : value })
+                      }
+                      clearable
+                    />
+                  </SettingsFieldRow>
                   <SettingsFieldRow
                     settingKey='documents.paperSize'
                     title='Paper size'

--- a/apps/web/src/components/dispatch/ui/quality-checks-page.tsx
+++ b/apps/web/src/components/dispatch/ui/quality-checks-page.tsx
@@ -355,7 +355,7 @@ export function QualityChecksPage() {
       title='Quality Checks'
       description='Manage the quality-check checklist workers complete on every visit.'
       breadcrumbs={BREADCRUMBS}>
-      <div className='grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
+      <div className='grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
         <div className='min-w-0'>
           <div className='flex flex-col gap-3 p-3'>
             <div className='flex items-center justify-end'>

--- a/apps/web/src/components/global/forms/form-save-bar.tsx
+++ b/apps/web/src/components/global/forms/form-save-bar.tsx
@@ -21,10 +21,13 @@ export interface FormSaveBarProps {
 }
 
 /**
- * The shared unsaved-changes bar (10-settings-forms-unification.md) — a sticky, full-width bottom
- * bar that springs into view while a {@link useDirtyDraft} is dirty (or a save is in flight) and
- * springs away when clean. Replaces the five hand-rolled Save/Discard idioms across the money and
- * dispatch settings surfaces.
+ * The shared unsaved-changes bar (10-settings-forms-unification.md) — a sticky bottom bar that
+ * springs into view while a {@link useDirtyDraft} is dirty (or a save is in flight) and springs
+ * away when clean. Designed as the last child of a settings page's `flex flex-1 flex-col gap-8
+ * p-3 sm:p-6` content wrapper: `mt-auto` keeps it at the page bottom even when content is short,
+ * and the negative margins cancel the wrapper padding so it spans the full page width, flush
+ * with the bottom edge. Pairs with `noFade` on the SettingsPage ScrollArea — the viewport's
+ * bottom fade mask would otherwise wash out the pinned bar.
  */
 export function FormSaveBar({
   dirty,
@@ -42,13 +45,14 @@ export function FormSaveBar({
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 16 }}
           transition={SPRING}
-          className='sticky bottom-0 z-10 flex items-center justify-end gap-3 border-t bg-background/95 py-3 backdrop-blur'>
+          className='sticky bottom-0 z-10 mt-auto -mx-3 -mb-3 flex items-center justify-end gap-3 border-t bg-background/95 px-3 py-2 backdrop-blur sm:-mx-6 sm:-mb-6 sm:px-3 rounded-br-xl'>
           <span className='mr-auto text-xs text-muted-foreground'>{label}</span>
-          <Button type='button' variant='outline' size='sm' onClick={onDiscard} disabled={isSaving}>
+          <Button type='button' variant='ghost' size='sm' onClick={onDiscard} disabled={isSaving}>
             Discard
           </Button>
           <Button
             type='button'
+            variant='outline'
             size='sm'
             onClick={onSave}
             loading={isSaving}

--- a/apps/web/src/components/global/settings-page.tsx
+++ b/apps/web/src/components/global/settings-page.tsx
@@ -82,7 +82,8 @@ export default function SettingsPage({
   }, [])
 
   return (
-    <ScrollArea viewportRef={viewportRef} className='h-full w-full'>
+    // noFade: the sticky FormSaveBar sits at the viewport bottom — the edge fade would mask it.
+    <ScrollArea viewportRef={viewportRef} noFade className='h-full w-full'>
       {breadcrumbs.length > 0 && (
         <header className='w-full flex-none border-b overflow-hidden'>
           <div className='flex items-center gap-2 px-3 py-1.5 no-scrollbar overflow-x-auto'>

--- a/apps/web/src/components/money/ui/settings/invoicing-page.tsx
+++ b/apps/web/src/components/money/ui/settings/invoicing-page.tsx
@@ -96,7 +96,7 @@ function InvoicingSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }
       title='Invoicing'
       description='Configure automated invoice drafts and PDF defaults for completed jobs and visits.'
       breadcrumbs={breadcrumbs}>
-      <div className='flex flex-col gap-8 p-3 sm:p-6'>
+      <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
         <SettingsSection
           icon={Receipt}
           title='Automation'

--- a/apps/web/src/components/money/ui/settings/payments-page.tsx
+++ b/apps/web/src/components/money/ui/settings/payments-page.tsx
@@ -163,7 +163,7 @@ function PaymentsSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }[
       title='Payments'
       description='Collect payments online by connecting your Stripe account.'
       breadcrumbs={breadcrumbs}>
-      <div className='flex flex-col gap-8 p-3 sm:p-6'>
+      <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
         <SettingsSection
           icon={CreditCard}
           title='Stripe'

--- a/apps/web/src/components/money/ui/settings/products-services-page.tsx
+++ b/apps/web/src/components/money/ui/settings/products-services-page.tsx
@@ -224,7 +224,7 @@ export function ProductsServicesPage() {
       subHeader={
         <ResponsiveTabs value={activeTab} onValueChange={handleTabChange} size='sm' items={TABS} />
       }>
-      <div className='grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
+      <div className='grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
         <div className='min-w-0'>
           {activeTab === 'products' ? (
             <ProductsList

--- a/apps/web/src/components/money/ui/settings/quotes-page.tsx
+++ b/apps/web/src/components/money/ui/settings/quotes-page.tsx
@@ -117,7 +117,7 @@ function QuotesSettingsBody({ breadcrumbs }: { breadcrumbs: { title: string }[] 
           Preview PDF
         </Button>
       }>
-      <div className='flex flex-col gap-8 p-3 sm:p-6'>
+      <div className='flex flex-1 flex-col gap-8 p-3 sm:p-6'>
         <SettingsSection
           icon={FileText}
           title='Quote PDF defaults'


### PR DESCRIPTION
## Summary

Polish pass on the shared `FormSaveBar` and the settings pages that host it.

- **FormSaveBar**: designed as the last child of a settings page's content wrapper — `mt-auto` keeps it at the page bottom even when content is short, and negative margins cancel the wrapper padding so the sticky bar spans the full page width, flush with the bottom edge. Discard is now `ghost`, Save `outline`.
- **SettingsPage**: `noFade` on the ScrollArea — the viewport's bottom fade mask would otherwise wash out the pinned bar.
- **Settings pages** (invoicing, payments, quotes, products/services, quality checks, dispatch general, scheduling): content wrappers get `flex-1` / `min-h-0` so the bar actually pins.
- **Scheduling**: the weekly-hours section's inline save bar is merged into one page-level bar covering both drafts (weekly hours + routes/board) — save/discard only touch the draft that is actually dirty.
- **Dispatch general**: the accent-color row now renders a clearable `ColorField` instead of the generic settings field input.

## Test plan
- [ ] Short settings page (payments): bar pins to the viewport bottom, flush with edges
- [ ] Long page (scheduling): bar stays sticky while scrolling, no fade over it
- [ ] Scheduling: edit only hours or only routes/board — save touches just that draft
- [ ] Dispatch general: pick + clear accent color