### PR TITLE
feat(dispatch): vertical grid hour zoom, gutter drag handles, off-day shading

### DIFF
--- a/apps/web/src/components/dispatch/stores/timeline-view-store.ts
+++ b/apps/web/src/components/dispatch/stores/timeline-view-store.ts
@@ -7,6 +7,9 @@ import {
   TimelineRailWidth,
   TimelineRailWidthMax,
   TimelineRailWidthMin,
+  WeekCellsHeight,
+  WeekCellsHeightMax,
+  WeekCellsHeightMin,
 } from '@auxx/ui/components/event-calendar'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
@@ -18,24 +21,31 @@ interface TimelineViewState {
   hourWidth: number
   /** Width (px) of the sticky-left worker rail (plan 35 §4). */
   railWidth: number
+  /** Px-per-hour on the vertical week/day grids' y-axis — committed zoom level. */
+  gridHourHeight: number
   setHourWidth: (px: number) => void
   setRailWidth: (px: number) => void
+  setGridHourHeight: (px: number) => void
 }
 
 /**
- * Per-device timeline view preferences (plan 35 design record: personal, not org settings) —
- * zoom level and worker-rail width, persisted to localStorage. Consumers must use selectors
- * (`useTimelineViewStore((s) => s.hourWidth)`), never destructure the whole store.
+ * Per-device calendar view preferences (plan 35 design record: personal, not org settings) —
+ * timeline zoom/rail width plus the vertical grids' zoom, persisted to localStorage. Consumers
+ * must use selectors (`useTimelineViewStore((s) => s.hourWidth)`), never destructure the whole
+ * store.
  */
 export const useTimelineViewStore = create<TimelineViewState>()(
   persist(
     (set) => ({
       hourWidth: TimelineHourWidth,
       railWidth: TimelineRailWidth,
+      gridHourHeight: WeekCellsHeight,
       setHourWidth: (px) =>
         set({ hourWidth: clamp(Math.round(px), TimelineHourWidthMin, TimelineHourWidthMax) }),
       setRailWidth: (px) =>
         set({ railWidth: clamp(Math.round(px), TimelineRailWidthMin, TimelineRailWidthMax) }),
+      setGridHourHeight: (px) =>
+        set({ gridHourHeight: clamp(Math.round(px), WeekCellsHeightMin, WeekCellsHeightMax) }),
     }),
     { name: 'dispatch-timeline-view', version: 1 }
   )

--- a/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
+++ b/apps/web/src/components/dispatch/ui/board/board-calendar-grid.tsx
@@ -167,6 +167,9 @@ export function BoardCalendarGrid({
   const timelineRailWidth = useTimelineViewStore((s) => s.railWidth)
   const setTimelineHourWidth = useTimelineViewStore((s) => s.setHourWidth)
   const setTimelineRailWidth = useTimelineViewStore((s) => s.setRailWidth)
+  // Vertical week/day grid zoom — same per-device persistence, committed by ctrl+wheel/pinch.
+  const gridHourHeight = useTimelineViewStore((s) => s.gridHourHeight)
+  const setGridHourHeight = useTimelineViewStore((s) => s.setGridHourHeight)
 
   const calendarResources: CalendarResource[] = useMemo(
     () =>
@@ -196,6 +199,8 @@ export function BoardCalendarGrid({
       onTimelineHourWidthChange={setTimelineHourWidth}
       timelineRailWidth={timelineRailWidth}
       onTimelineRailWidthChange={setTimelineRailWidth}
+      gridHourHeight={gridHourHeight}
+      onGridHourHeightChange={setGridHourHeight}
       backgroundEvents={backgroundEvents}
       events={events}
       renderEvent={renderEvent}

--- a/apps/web/src/components/dispatch/ui/board/utils.ts
+++ b/apps/web/src/components/dispatch/ui/board/utils.ts
@@ -244,7 +244,8 @@ export function offHoursBackgroundEvents(
     start.setHours(0, startMin, 0, 0)
     const end = new Date(date)
     end.setHours(0, endMin, 0, 0)
-    events.push({ resourceId, date, start, end, className: 'bg-muted/60' })
+    // Match the month view's off-day tint — `muted`-based tints disappear on white.
+    events.push({ resourceId, date, start, end, className: 'bg-muted-foreground/6' })
   }
 
   for (const range of sorted) {

--- a/packages/ui/src/components/event-calendar/background-events.tsx
+++ b/packages/ui/src/components/event-calendar/background-events.tsx
@@ -77,7 +77,7 @@ export function BackgroundEventsLayer({
               key={index}
               className={cn(
                 'pointer-events-none absolute inset-y-0 z-0',
-                bg.className ?? 'bg-muted/40'
+                bg.className ?? 'bg-muted-foreground/6'
               )}
               style={{ left: `${left}%`, width: `${width}%` }}
             />
@@ -102,7 +102,7 @@ export function BackgroundEventsLayer({
             key={index}
             className={cn(
               'pointer-events-none absolute inset-x-0 z-0',
-              bg.className ?? 'bg-muted/40'
+              bg.className ?? 'bg-muted-foreground/6'
             )}
             style={{ top: `${top}px`, height: `${height}px` }}
           />

--- a/packages/ui/src/components/event-calendar/constants.ts
+++ b/packages/ui/src/components/event-calendar/constants.ts
@@ -31,6 +31,10 @@ const MinutesPerHour = 60
  */
 export const WeekCellsHeight = GridTickHeight * (MinutesPerHour / GridTickMinutes)
 
+/** Zoom clamps (px per hour) for the vertical week/day/resource grids' scale gesture. */
+export const WeekCellsHeightMin = 24
+export const WeekCellsHeightMax = 144
+
 /** Height (px) of the sticky day-header row (weekday + date). Mirrors Notion's `--grid-header-height`. */
 export const GridHeaderHeight = 53
 

--- a/packages/ui/src/components/event-calendar/day-resource-group.tsx
+++ b/packages/ui/src/components/event-calendar/day-resource-group.tsx
@@ -7,7 +7,7 @@ import { isSameDay, isToday } from 'date-fns'
 import { memo } from 'react'
 
 import { BackgroundEventsLayer } from './background-events'
-import { StartHour, WeekCellsHeight } from './constants'
+import { StartHour } from './constants'
 import { CurrentTimeLine } from './current-time-line'
 import { DraggableEvent } from './draggable-event'
 import { DropPreview } from './drop-preview'
@@ -39,6 +39,8 @@ interface DayResourceGroupProps<T extends EventCalendarItem = EventCalendarItem>
   selectedEventId?: string | null
   /** Current-time line position (% of the hour grid) — shared math, rendered only when `isToday(day)`. */
   currentTimePosition: number
+  /** Px-per-hour of the timed grid — the zoomable vertical scale (scroll-stable; changes only on zoom). */
+  hourHeight: number
 }
 
 /**
@@ -71,6 +73,7 @@ function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>(
   renderEvent,
   selectedEventId,
   currentTimePosition,
+  hourHeight,
 }: DayResourceGroupProps<T>) {
   const day = dayAt(index)
   const today = isToday(day)
@@ -96,7 +99,7 @@ function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>(
         top,
         left: 0,
         width: dayWidth,
-        height: hours.length * WeekCellsHeight,
+        height: hours.length * hourHeight,
         transform: `translateX(${x}px)`,
         display: 'grid',
         gridTemplateColumns: `repeat(${resources.length}, minmax(0, 1fr))`,
@@ -105,7 +108,7 @@ function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>(
       {resources.map((resource) => {
         const resourceEvents = dayEvents.filter((event) => event.resourceId === resource.id)
         const positioned = positionEventsForDay(resourceEvents, day, {
-          cellHeight: WeekCellsHeight,
+          cellHeight: hourHeight,
           startHour: StartHour,
         })
         return (
@@ -114,7 +117,7 @@ function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>(
               events={backgroundEvents}
               day={day}
               resourceId={resource.id}
-              cellHeight={WeekCellsHeight}
+              cellHeight={hourHeight}
             />
 
             {positioned.map((p) => (
@@ -137,6 +140,7 @@ function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>(
                     showTime
                     height={p.height}
                     onResize={onEventResize}
+                    cellSize={hourHeight}
                     renderEvent={renderEvent}
                     isSelected={p.event.id === selectedEventId}
                   />
@@ -144,7 +148,7 @@ function DayResourceGroupInner<T extends EventCalendarItem = EventCalendarItem>(
               </div>
             ))}
 
-            <DropPreview day={day} resourceId={resource.id} />
+            <DropPreview day={day} resourceId={resource.id} cellHeight={hourHeight} />
 
             {today && <CurrentTimeLine position={currentTimePosition} />}
 

--- a/packages/ui/src/components/event-calendar/day-view.tsx
+++ b/packages/ui/src/components/event-calendar/day-view.tsx
@@ -29,6 +29,8 @@ interface DayViewProps<T extends EventCalendarItem = EventCalendarItem> {
   renderEvent?: RenderEvent<T>
   /** Id of the actively-selected event (detail/popover open) — draws the in-color ring. */
   selectedEventId?: string | null
+  /** Px-per-hour of the timed grid — the zoomable vertical scale. Defaults to `WeekCellsHeight`. */
+  hourHeight?: number
 }
 
 /** Big date header — day + month bold, year regular, weekday name below. */
@@ -53,6 +55,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
   onEventResize,
   renderEvent,
   selectedEventId,
+  hourHeight = WeekCellsHeight,
 }: DayViewProps<T>) {
   const hours = useMemo(() => {
     const dayStart = startOfDay(currentDate)
@@ -88,10 +91,10 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
   const positionedEvents = useMemo(
     () =>
       positionEventsForDay(timeEvents, currentDate, {
-        cellHeight: WeekCellsHeight,
+        cellHeight: hourHeight,
         startHour: StartHour,
       }),
-    [currentDate, timeEvents]
+    [currentDate, timeEvents, hourHeight]
   )
 
   const handleEventClick = (event: T, e: React.MouseEvent) => {
@@ -153,7 +156,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
           <BackgroundEventsLayer
             events={backgroundEvents}
             day={currentDate}
-            cellHeight={WeekCellsHeight}
+            cellHeight={hourHeight}
           />
 
           {positionedEvents.map((positioned) => (
@@ -176,6 +179,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
                   showTime
                   height={positioned.height}
                   onResize={onEventResize}
+                  cellSize={hourHeight}
                   renderEvent={renderEvent}
                   isSelected={positioned.event.id === selectedEventId}
                 />
@@ -183,7 +187,7 @@ export function DayView<T extends EventCalendarItem = EventCalendarItem>({
             </div>
           ))}
 
-          <DropPreview day={currentDate} />
+          <DropPreview day={currentDate} cellHeight={hourHeight} />
 
           {currentTimeVisible && <CurrentTimeLine position={currentTimePosition} />}
 

--- a/packages/ui/src/components/event-calendar/drop-preview.tsx
+++ b/packages/ui/src/components/event-calendar/drop-preview.tsx
@@ -12,6 +12,8 @@ interface DropPreviewProps {
   day: Date
   /** Resource column id (resource view only) — the outline shows only when the hovered cell matches. */
   resourceId?: string
+  /** Px-per-hour of the column's grid — pass when the grid is zoomed. Defaults to `WeekCellsHeight`. */
+  cellHeight?: number
 }
 
 /**
@@ -22,7 +24,7 @@ interface DropPreviewProps {
  * nothing unless a timed drag is in progress and its target resolves to this
  * exact column.
  */
-export function DropPreview({ day, resourceId }: DropPreviewProps) {
+export function DropPreview({ day, resourceId, cellHeight = WeekCellsHeight }: DropPreviewProps) {
   const { activeEvent, currentTime, activeView, currentResourceId } = useCalendarDnd()
 
   // No timed drag in flight, or a month drag (whole-day, no time slot to outline).
@@ -36,9 +38,9 @@ export function DropPreview({ day, resourceId }: DropPreviewProps) {
     new Date(activeEvent.end),
     new Date(activeEvent.start)
   )
-  const top = (startMinutes / 60) * WeekCellsHeight
+  const top = (startMinutes / 60) * cellHeight
   // Floor a zero/negative duration to a single quarter-hour so the outline is always visible.
-  const height = Math.max((durationMinutes / 60) * WeekCellsHeight, WeekCellsHeight / 4)
+  const height = Math.max((durationMinutes / 60) * cellHeight, cellHeight / 4)
 
   return (
     <div

--- a/packages/ui/src/components/event-calendar/event-calendar.tsx
+++ b/packages/ui/src/components/event-calendar/event-calendar.tsx
@@ -26,7 +26,15 @@ import {
   subWeeks,
 } from 'date-fns'
 import { CalendarCheck, ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
-import { type CSSProperties, type ReactNode, useEffect, useMemo } from 'react'
+import {
+  type CSSProperties,
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 
 import { AgendaView } from './agenda-view'
 import { CalendarDndProvider, useCalendarDnd } from './calendar-dnd-context'
@@ -39,9 +47,11 @@ import {
   GridAllDayChipSpacing,
   GridAllDayPaddingTop,
   GridHeaderHeight,
-  GridTickHeight,
   GridTickMinutes,
   StartHour,
+  WeekCellsHeight,
+  WeekCellsHeightMax,
+  WeekCellsHeightMin,
 } from './constants'
 import { DayView, DayViewHeader } from './day-view'
 import { HorizontalTimelineView } from './horizontal-timeline-view'
@@ -59,6 +69,30 @@ import { WeekView } from './week-view'
 
 /** Module-level default — an inline `{}` default would break `TimelineDaySection`'s memo every render. */
 const DefaultHourWindow: TimelineHourWindow = { start: StartHour, end: EndHour }
+
+const clampHourHeight = (px: number) =>
+  Math.min(WeekCellsHeightMax, Math.max(WeekCellsHeightMin, px))
+
+/** Multiplicative zoom gain per wheel `deltaY` unit (ctrl+wheel / trackpad pinch). */
+const WheelZoomGain = 0.01
+
+/** Idle time (ms) after the last ctrl+wheel event before the vertical-grid zoom commits. */
+const WheelZoomCommitDelay = 160
+
+/**
+ * Nearest ancestor (up to and including `root`) whose computed overflow-y scrolls — the vertical
+ * grids' scroll container differs per view (day scrolls the shell's own container; week/resource
+ * own an inner two-axis scroller).
+ */
+function findScrollContainer(from: HTMLElement | null, root: HTMLElement): HTMLElement {
+  let el: HTMLElement | null = from
+  while (el && el !== root) {
+    const { overflowY } = getComputedStyle(el)
+    if (overflowY === 'auto' || overflowY === 'scroll') return el
+    el = el.parentElement
+  }
+  return root
+}
 
 export interface EventCalendarProps<T extends EventCalendarItem = EventCalendarItem> {
   events?: T[]
@@ -85,6 +119,10 @@ export interface EventCalendarProps<T extends EventCalendarItem = EventCalendarI
   timelineRailWidth?: number
   /** Fires when the timeline rail-width drag commits a new width. */
   onTimelineRailWidthChange?: (px: number) => void
+  /** Vertical-grid zoom: controlled px-per-hour for week/day/resource views. Omit for internal state. */
+  gridHourHeight?: number
+  /** Fires when a vertical-grid zoom gesture (ctrl+wheel / pinch) commits a new px-per-hour. */
+  onGridHourHeightChange?: (px: number) => void
   backgroundEvents?: BackgroundEvent[]
   renderEvent?: RenderEvent<T>
   /** Id of the actively-selected event (its detail/popover open) — draws the in-color ring. */
@@ -123,6 +161,8 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
   onTimelineHourWidthChange,
   timelineRailWidth,
   onTimelineRailWidthChange,
+  gridHourHeight,
+  onGridHourHeightChange,
   backgroundEvents,
   renderEvent,
   selectedEventId,
@@ -244,6 +284,179 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
   const dndContext = useCalendarDnd()
   const withinAmbientProvider = dndContext.isCalendarDndContext
 
+  // ── vertical-grid zoom (week/day/resource) ────────────────────────────────
+  // Same controlled-or-internal shape as the timeline's hourWidth, but a far simpler gesture:
+  // there is no virtualized stream on the y-axis, so keeping the time under the cursor
+  // stationary is just a scrollTop adjustment — no CSS-var compensation machinery. Live wheel
+  // frames render through React state; the (rounded) commit debounces behind the last event.
+  const viewContainerRef = useRef<HTMLDivElement>(null)
+  const [internalGridHourHeight, setInternalGridHourHeight] = useState(WeekCellsHeight)
+  const committedGridHourHeight = clampHourHeight(gridHourHeight ?? internalGridHourHeight)
+  const [liveGridHourHeight, setLiveGridHourHeight] = useState<number | null>(null)
+  const effectiveGridHourHeight = liveGridHourHeight ?? committedGridHourHeight
+
+  const gridZoomRef = useRef<{
+    scroller: HTMLElement
+    /** Grid-origin Y in the scroller's content space — zoom-invariant (header chrome is fixed). */
+    gridTop: number
+    /** Live fractional px-per-hour — the JS-space source the DOM follows. */
+    hourHeight: number
+    /** Virtual scrollTop paired with `hourHeight` — applied to the DOM after each render. */
+    scrollTop: number
+  } | null>(null)
+  const gridZoomCommitTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const pendingGridScrollRef = useRef<{ scroller: HTMLElement; top: number } | null>(null)
+  const gridZoomGeoRef = useRef({ view, committedGridHourHeight, onGridHourHeightChange })
+  gridZoomGeoRef.current = { view, committedGridHourHeight, onGridHourHeightChange }
+
+  // The wheel handler mutates the gesture's virtual scrollTop in JS-space; the DOM catches up
+  // here, after React has re-rendered the grid at the new height. No dependency array —
+  // deliberately runs every render while a gesture (or a commit's scroll) is pending.
+  useLayoutEffect(() => {
+    const gesture = gridZoomRef.current
+    if (gesture) gesture.scroller.scrollTop = gesture.scrollTop
+    const pending = pendingGridScrollRef.current
+    if (pending) {
+      pendingGridScrollRef.current = null
+      pending.scroller.scrollTop = pending.top
+    }
+  })
+
+  useEffect(() => {
+    const root = viewContainerRef.current
+    if (!root) return
+
+    const isVerticalGridView = () => {
+      const { view: currentView } = gridZoomGeoRef.current
+      return currentView === 'week' || currentView === 'day' || currentView === 'resource'
+    }
+
+    /** Scroller + zoom-invariant grid-origin Y for the view under `target`. */
+    const resolveGeometry = (target: HTMLElement) => {
+      const scroller = findScrollContainer(target, root)
+      const gutter = scroller.querySelector('[data-slot="hour-gutter"]')
+      if (!gutter) return null
+      const gridTop =
+        gutter.getBoundingClientRect().top -
+        scroller.getBoundingClientRect().top +
+        scroller.scrollTop
+      return { scroller, gridTop }
+    }
+
+    /** Ends the active gesture: commits the rounded height + the re-anchored scrollTop. */
+    const commitGridZoom = () => {
+      const g = gridZoomRef.current
+      if (!g) return
+      gridZoomRef.current = null
+      const finalHeight = clampHourHeight(Math.round(g.hourHeight))
+      // Re-anchor at the scroller's top edge for the (≤0.5px/hour) rounding delta.
+      const topHours = (g.scrollTop - g.gridTop) / g.hourHeight
+      pendingGridScrollRef.current = {
+        scroller: g.scroller,
+        top: Math.max(0, g.scrollTop + topHours * (finalHeight - g.hourHeight)),
+      }
+      const commit = gridZoomGeoRef.current.onGridHourHeightChange
+      if (commit) commit(finalHeight)
+      else setInternalGridHourHeight(finalHeight)
+      setLiveGridHourHeight(null)
+    }
+
+    // Non-passive so `preventDefault` can stop the browser's page zoom.
+    const onWheel = (e: WheelEvent) => {
+      const { committedGridHourHeight: committed } = gridZoomGeoRef.current
+      if (!e.ctrlKey || !isVerticalGridView()) return
+      e.preventDefault()
+
+      let gesture = gridZoomRef.current
+      if (!gesture) {
+        const geo = resolveGeometry(e.target as HTMLElement)
+        if (!geo) return
+        gesture = { ...geo, hourHeight: committed, scrollTop: geo.scroller.scrollTop }
+        gridZoomRef.current = gesture
+      }
+
+      const oldHeight = gesture.hourHeight
+      const newHeight = clampHourHeight(oldHeight * Math.exp(-e.deltaY * WheelZoomGain))
+      // Anchor: the time under the cursor stays put — scrollTop absorbs the anchor's growth.
+      const cursorOffset = e.clientY - gesture.scroller.getBoundingClientRect().top
+      const anchorHours = (gesture.scrollTop + cursorOffset - gesture.gridTop) / oldHeight
+      gesture.hourHeight = newHeight
+      gesture.scrollTop = Math.max(0, gesture.scrollTop + anchorHours * (newHeight - oldHeight))
+      setLiveGridHourHeight(newHeight)
+
+      clearTimeout(gridZoomCommitTimerRef.current)
+      gridZoomCommitTimerRef.current = setTimeout(commitGridZoom, WheelZoomCommitDelay)
+    }
+
+    // Border drag on the gutter's `data-hour-zoom-handle` strips (parity with the timeline's
+    // draggable hour borders): the grabbed hour rule tracks the pointer — height' = start + dy —
+    // while the hour above it stays anchored via the same virtual-scrollTop plumbing.
+    const onPointerDown = (e: PointerEvent) => {
+      const { committedGridHourHeight: committed } = gridZoomGeoRef.current
+      if (e.button !== 0 || !isVerticalGridView() || gridZoomRef.current) return
+      const handle = (e.target as HTMLElement | null)?.closest?.('[data-hour-zoom-handle]')
+      if (!(handle instanceof HTMLElement)) return
+      const borderIndex = Number(handle.dataset.hourZoomHandle)
+      if (!Number.isFinite(borderIndex)) return
+      const geo = resolveGeometry(handle)
+      if (!geo) return
+      e.preventDefault()
+
+      gridZoomRef.current = { ...geo, hourHeight: committed, scrollTop: geo.scroller.scrollTop }
+      const startClientY = e.clientY
+      // Anchor the grabbed hour's TOP edge, so the dragged border sits exactly one (new)
+      // hour-height below it and tracks the pointer.
+      const anchorHours = borderIndex - 1
+
+      const onMove = (me: PointerEvent) => {
+        const g = gridZoomRef.current
+        if (!g) return
+        const newHeight = clampHourHeight(committed + (me.clientY - startClientY))
+        if (newHeight === g.hourHeight) return
+        g.scrollTop = Math.max(0, g.scrollTop + anchorHours * (newHeight - g.hourHeight))
+        g.hourHeight = newHeight
+        setLiveGridHourHeight(newHeight)
+      }
+      const onUp = () => {
+        window.removeEventListener('pointermove', onMove)
+        window.removeEventListener('pointerup', onUp)
+        window.removeEventListener('pointercancel', onUp)
+        commitGridZoom()
+      }
+      window.addEventListener('pointermove', onMove)
+      window.addEventListener('pointerup', onUp)
+      window.addEventListener('pointercancel', onUp)
+    }
+
+    /** Double-click a gutter handle → reset to the default scale, keeping that border put. */
+    const onDoubleClick = (e: MouseEvent) => {
+      const { committedGridHourHeight: committed } = gridZoomGeoRef.current
+      if (!isVerticalGridView() || committed === WeekCellsHeight || gridZoomRef.current) return
+      const handle = (e.target as HTMLElement | null)?.closest?.('[data-hour-zoom-handle]')
+      if (!(handle instanceof HTMLElement)) return
+      const geo = resolveGeometry(handle)
+      if (!geo) return
+      const anchorHours = Number(handle.dataset.hourZoomHandle) - 1
+      pendingGridScrollRef.current = {
+        scroller: geo.scroller,
+        top: Math.max(0, geo.scroller.scrollTop + anchorHours * (WeekCellsHeight - committed)),
+      }
+      const commit = gridZoomGeoRef.current.onGridHourHeightChange
+      if (commit) commit(WeekCellsHeight)
+      else setInternalGridHourHeight(WeekCellsHeight)
+    }
+
+    root.addEventListener('wheel', onWheel, { passive: false })
+    root.addEventListener('pointerdown', onPointerDown)
+    root.addEventListener('dblclick', onDoubleClick)
+    return () => {
+      root.removeEventListener('wheel', onWheel)
+      root.removeEventListener('pointerdown', onPointerDown)
+      root.removeEventListener('dblclick', onDoubleClick)
+      clearTimeout(gridZoomCommitTimerRef.current)
+    }
+  }, [])
+
   const body = (
     <>
       {!hideToolbar && (
@@ -305,6 +518,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
       )}
 
       <div
+        ref={viewContainerRef}
         className={cn(
           'flex min-h-0 flex-1 flex-col',
           // The month/week/resource/timeline streams own their own (snap) scroll containers.
@@ -339,6 +553,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
             selectedEventId={selectedEventId}
             onDateChange={onDateChange}
             onVisibleRangeChange={onRangeChange}
+            hourHeight={effectiveGridHourHeight}
           />
         )}
         {view === 'day' && (
@@ -351,6 +566,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
             onEventResize={onEventResize}
             renderEvent={renderEvent}
             selectedEventId={selectedEventId}
+            hourHeight={effectiveGridHourHeight}
           />
         )}
         {view === 'resource' &&
@@ -369,6 +585,7 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
               selectedEventId={selectedEventId}
               onDateChange={onDateChange}
               onVisibleRangeChange={onRangeChange}
+              hourHeight={effectiveGridHourHeight}
             />
           ) : null)}
         {view === 'timeline' &&
@@ -413,8 +630,9 @@ function EventCalendarInner<T extends EventCalendarItem = EventCalendarItem>({
           '--event-height': `${EventHeight}px`,
           '--event-gap': `${EventGap}px`,
           // Notion-style tick grid: the hour-row height derives from the 5-minute
-          // tick, so every timed cell/position scales off one knob.
-          '--grid-tick-height': `${GridTickHeight}px`,
+          // tick, so every timed cell/position scales off one knob — here fed by
+          // the (zoomable) grid hour height instead of the static constant.
+          '--grid-tick-height': `${(effectiveGridHourHeight * GridTickMinutes) / 60}px`,
           '--grid-tick-minutes': `${GridTickMinutes}`,
           '--week-cells-height': `calc(var(--grid-tick-height) * 60 / var(--grid-tick-minutes))`,
           '--grid-header-height': `${GridHeaderHeight}px`,

--- a/packages/ui/src/components/event-calendar/hour-gutter.tsx
+++ b/packages/ui/src/components/event-calendar/hour-gutter.tsx
@@ -17,20 +17,36 @@ interface HourGutterProps {
 /**
  * Fixed-width hour-label column shared by day/week/resource grids — labels
  * render "9 AM"-style (12h, matching the app's en-US convention), small and
- * muted, straddling each hour rule (Notion-calendar look). No vertical border
- * against the grid — the gutter reads as a clean label rail, not a boxed cell.
+ * muted, aligned to each hour rule (Notion-calendar look). No full-width rules
+ * inside the gutter (they'd strike the labels) — just a short right-edge tick
+ * continuing each grid rule.
+ *
+ * Each hour boundary also carries a full-gutter-width drag handle
+ * (`data-hour-zoom-handle`) — the vertical grids' hour-zoom affordance, the
+ * counterpart to the timeline's draggable hour borders. The gutter stays dumb:
+ * `EventCalendar` owns the gesture via pointer delegation on that attribute.
  */
 export function HourGutter({ hours, nowIndicator, className }: HourGutterProps) {
   return (
-    <div className={cn('relative w-12 shrink-0 sm:w-14', className)}>
+    <div data-slot='hour-gutter' className={cn('relative w-12 shrink-0 sm:w-14', className)}>
       {hours.map((hour, index) => (
         <div
           key={hour.toISOString()}
-          className='relative flex h-[var(--week-cells-height)] items-start justify-center border-b border-border/70 last:border-b-0'>
+          className='relative flex h-[var(--week-cells-height)] items-start justify-center'>
           {index > 0 && (
-            <span className='text-muted-foreground/70 -translate-y-1/2 text-[10px] font-medium'>
-              {format(hour, 'h a')}
-            </span>
+            <>
+              <span className='text-muted-foreground/70 -translate-y-1/2 text-[10px] font-medium'>
+                {format(hour, 'h a')}
+              </span>
+              {/* Hour-zoom drag handle straddling the boundary — drag to rescale the hour
+                  grid, double-click to reset. The tick stays small; it darkens and widens
+                  a touch on hover as the affordance. */}
+              <div
+                data-hour-zoom-handle={index}
+                className='group/zoom absolute inset-x-0 top-0 h-3 -translate-y-1/2 cursor-ns-resize touch-none'>
+                <div className='bg-border/70 group-hover/zoom:bg-muted-foreground/60 absolute top-1/2 right-0 h-px w-1.5 -translate-y-1/2 transition-all group-hover/zoom:w-3' />
+              </div>
+            </>
           )}
         </div>
       ))}

--- a/packages/ui/src/components/event-calendar/index.ts
+++ b/packages/ui/src/components/event-calendar/index.ts
@@ -22,6 +22,8 @@ export {
   TimelineRailWidthMax,
   TimelineRailWidthMin,
   WeekCellsHeight,
+  WeekCellsHeightMax,
+  WeekCellsHeightMin,
 } from './constants'
 export { CurrentTimeGutterLabel, CurrentTimeLine } from './current-time-line'
 export { DayView, DayViewHeader } from './day-view'

--- a/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
+++ b/packages/ui/src/components/event-calendar/resource-timeline-view.tsx
@@ -72,6 +72,8 @@ interface ResourceTimelineViewProps<T extends EventCalendarItem = EventCalendarI
   onDateChange?: (date: Date) => void
   /** Fires with the rendered (visible + overscan) day window — consumers fetch this. */
   onVisibleRangeChange?: (from: Date, to: Date) => void
+  /** Px-per-hour of the timed grid — the zoomable vertical scale. Defaults to `WeekCellsHeight`. */
+  hourHeight?: number
 }
 
 /**
@@ -104,6 +106,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
   selectedEventId,
   onDateChange,
   onVisibleRangeChange,
+  hourHeight = WeekCellsHeight,
 }: ResourceTimelineViewProps<T>) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const gutterRef = useRef<HTMLDivElement>(null)
@@ -313,7 +316,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
           className='relative'
           style={{
             width: gutterWidth + totalSize,
-            minHeight: headerHeight + hours.length * WeekCellsHeight,
+            minHeight: headerHeight + hours.length * hourHeight,
           }}>
           {/* Two-tier sticky header: date labels + worker sub-headers + always-visible all-day lane. */}
           <div
@@ -489,6 +492,7 @@ export function ResourceTimelineView<T extends EventCalendarItem = EventCalendar
               renderEvent={renderEvent}
               selectedEventId={selectedEventId}
               currentTimePosition={currentTimePosition}
+              hourHeight={hourHeight}
             />
           ))}
         </div>

--- a/packages/ui/src/components/event-calendar/week-day-column.tsx
+++ b/packages/ui/src/components/event-calendar/week-day-column.tsx
@@ -7,7 +7,7 @@ import { isSameDay, isToday } from 'date-fns'
 import { memo } from 'react'
 
 import { BackgroundEventsLayer } from './background-events'
-import { StartHour, WeekCellsHeight } from './constants'
+import { StartHour } from './constants'
 import { CurrentTimeLine } from './current-time-line'
 import { DraggableEvent } from './draggable-event'
 import { DropPreview } from './drop-preview'
@@ -38,6 +38,8 @@ interface WeekDayColumnProps<T extends EventCalendarItem = EventCalendarItem> {
   selectedEventId?: string | null
   /** Current-time line position (% of the hour grid) — shared math, rendered only when `isToday(day)`. */
   currentTimePosition: number
+  /** Px-per-hour of the timed grid — the zoomable vertical scale (scroll-stable; changes only on zoom). */
+  hourHeight: number
 }
 
 /**
@@ -68,6 +70,7 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
   renderEvent,
   selectedEventId,
   currentTimePosition,
+  hourHeight,
 }: WeekDayColumnProps<T>) {
   const day = dayAt(index)
 
@@ -80,7 +83,7 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
     )
   })
   const positioned = positionEventsForDay(dayEvents, day, {
-    cellHeight: WeekCellsHeight,
+    cellHeight: hourHeight,
     startHour: StartHour,
   })
 
@@ -96,11 +99,11 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
         top,
         left: 0,
         width: dayWidth,
-        height: hours.length * WeekCellsHeight,
+        height: hours.length * hourHeight,
         transform: `translateX(${x}px)`,
       }}
       data-today={isToday(day) || undefined}>
-      <BackgroundEventsLayer events={backgroundEvents} day={day} cellHeight={WeekCellsHeight} />
+      <BackgroundEventsLayer events={backgroundEvents} day={day} cellHeight={hourHeight} />
 
       {positioned.map((p) => (
         <div
@@ -122,6 +125,7 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
               showTime
               height={p.height}
               onResize={onEventResize}
+              cellSize={hourHeight}
               renderEvent={renderEvent}
               isSelected={p.event.id === selectedEventId}
             />
@@ -129,7 +133,7 @@ function WeekDayColumnInner<T extends EventCalendarItem = EventCalendarItem>({
         </div>
       ))}
 
-      <DropPreview day={day} />
+      <DropPreview day={day} cellHeight={hourHeight} />
 
       {isToday(day) && <CurrentTimeLine position={currentTimePosition} />}
 

--- a/packages/ui/src/components/event-calendar/week-view.tsx
+++ b/packages/ui/src/components/event-calendar/week-view.tsx
@@ -63,6 +63,8 @@ interface WeekViewProps<T extends EventCalendarItem = EventCalendarItem> {
   onDateChange?: (date: Date) => void
   /** Fires with the rendered (visible + overscan) day window — consumers fetch this. */
   onVisibleRangeChange?: (from: Date, to: Date) => void
+  /** Px-per-hour of the timed grid — the zoomable vertical scale. Defaults to `WeekCellsHeight`. */
+  hourHeight?: number
 }
 
 /**
@@ -93,6 +95,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
   selectedEventId,
   onDateChange,
   onVisibleRangeChange,
+  hourHeight = WeekCellsHeight,
 }: WeekViewProps<T>) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const gutterRef = useRef<HTMLDivElement>(null)
@@ -279,7 +282,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
           className='relative'
           style={{
             width: gutterWidth + totalSize,
-            minHeight: headerHeight + hours.length * WeekCellsHeight,
+            minHeight: headerHeight + hours.length * hourHeight,
           }}>
           {/* Sticky header strip: day labels + always-visible all-day lane. */}
           <div
@@ -419,6 +422,7 @@ export function WeekView<T extends EventCalendarItem = EventCalendarItem>({
               renderEvent={renderEvent}
               selectedEventId={selectedEventId}
               currentTimePosition={currentTimePosition}
+              hourHeight={hourHeight}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

Extends plan 35's timeline zoom to the vertical calendar grids (day/week/resource), plus two visual fixes surfaced while comparing views.

### Hour-scale zoom for day/week/resource views
- `EventCalendar` gains `gridHourHeight` / `onGridHourHeightChange` (same controlled-or-internal pattern as `timelineHourWidth`) and owns the gesture: the live value feeds `--grid-tick-height`, so the whole CSS layer rescales off the existing single knob, and `hourHeight` threads into the views' JS position math (`positionEventsForDay`, `BackgroundEventsLayer`, `DraggableEvent` `cellSize`, `DropPreview`).
- **Ctrl+wheel / trackpad pinch** zooms with the time under the cursor anchored — a plain virtual-scrollTop adjustment, none of the timeline's CSS-var compensation machinery is needed on the y-axis. Live frames render through React state; the rounded commit debounces behind the last event.
- **Gutter drag handles**: every hour boundary in the hour gutter is a full-width, 12px-tall drag strip (small tick as the visual, darkens/widens on hover). Dragging tracks the grabbed hour rule exactly, like the timeline's border drag; double-click resets to the default 48px/hour. The gutter stays dumb — `EventCalendar` picks the strips up via pointer delegation on `data-hour-zoom-handle`.
- Zoom clamps 24–144px/hour (`WeekCellsHeightMin`/`Max`); persisted per device in the dispatch view store alongside the timeline zoom, shared across day/week.

### Visual fixes
- Off-day/off-hours shading in day/week/timeline was `bg-muted/60`, nearly invisible on white. Now `bg-muted-foreground/6`, matching the approach month view already used.
- Hour-gutter labels were struck through by full-width hour rules; rules now stop at the grid, with a short right-edge tick continuing each rule into the gutter.

## Testing
- Verified live in the running app: gutter drag round-trips (48→72→48 committed + persisted), pinch zoom anchors under the cursor, chip positions scale pixel-exactly with the grid, and drag-resize snap math tracks the zoomed scale.
- Biome clean; `@auxx/ui` typecheck shows no errors in touched files (70 pre-existing errors elsewhere, count unchanged vs base).