### PR TITLE
fix(dispatch): single geocode per work order address write via normalize listener

### DIFF
--- a/apps/worker/scripts/verify-dispatch-route-planner.ts
+++ b/apps/worker/scripts/verify-dispatch-route-planner.ts
@@ -5,7 +5,8 @@
  * Exercises the REAL `@auxx/lib/dispatch/route-planner/*` + `@auxx/lib/geocoding` write/read
  * paths added in Phase 1: the pure `suggestRouteOrder` NN+2-opt heuristic, `setRouteOrder`'s
  * bulk write + removed-stop null-out, `applyRouteTimes`' chained ETA math (contract item 12),
- * the `geocodeOnAddressChange` field-change hook (env-gated MapTiler + a test-only fetch
+ * address-set-time visit pinning (the ADDRESS_STRUCT normalize hook + the
+ * `syncVisitPinsOnAddressNormalized` listener; env-gated MapTiler + a test-only fetch
  * override), `getRoutePlannerBoard`'s day/backlog/projection split, `getRouteLegs`' Mapbox-less
  * fallback + content-addressed Redis cache, and entity migration 039 (`work_order.tags`).
  *
@@ -35,12 +36,15 @@
  * (packages/lib/src/resources/hooks/work-order-hooks.ts) appended `work_order_number` to the
  * values map via `{ ...values, [field.id]: recordNumber }` — LAST in iteration order. Because
  * post-write field-change hooks fire in per-field iteration order during the same create call,
- * `work_order_address`'s hook (`geocodeOnAddressChange`, which UPDATEs existing `WorkOrderVisit`
- * rows) fired BEFORE `work_order_number`'s hook (`ensureVisitOnWorkOrderCreate`, which CREATES
- * the visit row) whenever a work order was created with both an address and any other field in
- * one `handler.create` call — the geocode UPDATE silently matched zero rows and the pin was
- * lost. Fixed by flipping the spread order so the number (and its visit-creation hook) always
- * fires first. Section 4's `4c` sub-test exercises exactly this combined-create path.
+ * `work_order_address`'s hook (then `geocodeOnAddressChange`, which UPDATEs existing
+ * `WorkOrderVisit` rows) fired BEFORE `work_order_number`'s hook (`ensureVisitOnWorkOrderCreate`,
+ * which CREATES the visit row) whenever a work order was created with both an address and any
+ * other field in one `handler.create` call — the geocode UPDATE silently matched zero rows and
+ * the pin was lost. Fixed by flipping the spread order so the number (and its visit-creation
+ * hook) always fires first. The pin write has since moved to the address-normalize listener
+ * (`syncVisitPinsOnAddressNormalized`), which fires strictly after the address field's hook
+ * dispatch, so the same ordering guarantee still protects it. Section 4's `4c` sub-test
+ * exercises exactly this combined-create path.
  *
  * Run (from repo root) under the worker runtime:
  *   cd apps/worker && npx dotenv -e ../../.env -- node --conditions source --import tsx/esm \
@@ -251,6 +255,24 @@ async function getVisitById(visitId: string) {
     where: (t, { eq }) => eq(t.id, visitId),
   })
   if (!visit) throw new Error(`No visit row found for ${visitId}`)
+  return visit
+}
+
+/**
+ * Visit pins now land via the address-normalize listener's fire-and-forget chain
+ * (`syncVisitPinsOnAddressNormalized`, visit-hooks.ts) — strictly AFTER the save response, not
+ * inline in it — so section 4's coord assertions poll briefly instead of reading immediately.
+ */
+async function waitForVisitCoords(visitId: string, expected: LatLng, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs
+  let visit = await getVisitById(visitId)
+  while (
+    (visit.latitude !== expected.lat || visit.longitude !== expected.lng) &&
+    Date.now() < deadline
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    visit = await getVisitById(visitId)
+  }
   return visit
 }
 
@@ -650,9 +672,10 @@ async function main() {
     })
 
     // ══════════════════════════════════════════════════════════════════════
-    // 4. geocodeOnAddressChange — env-gated, injectable-fetch stub, all-visit-rows fan-out
+    // 4. address-geocode visit pinning (normalize hook + syncVisitPinsOnAddressNormalized
+    //    listener) — env-gated, injectable-fetch stub, all-visit-rows fan-out
     // ══════════════════════════════════════════════════════════════════════
-    console.log('4: geocodeOnAddressChange hook')
+    console.log('4: address-geocode visit pinning')
 
     // 4a: no MAPTILER_API_KEY -> address write leaves coords null, never throws.
     await withoutEnv('MAPTILER_API_KEY', async () => {
@@ -711,7 +734,10 @@ async function main() {
             country: 'US',
           },
         })
-        const [afterK1a, afterK2a] = await Promise.all([getVisitById(vK1.id), getVisitById(vK2.id)])
+        const [afterK1a, afterK2a] = await Promise.all([
+          waitForVisitCoords(vK1.id, stub1),
+          waitForVisitCoords(vK2.id, stub1),
+        ])
         check(
           '4b (address create): visit 1 latitude/longitude = stubbed coords',
           afterK1a.latitude === stub1.lat && afterK1a.longitude === stub1.lng,
@@ -733,7 +759,10 @@ async function main() {
             country: 'US',
           },
         })
-        const [afterK1b, afterK2b] = await Promise.all([getVisitById(vK1.id), getVisitById(vK2.id)])
+        const [afterK1b, afterK2b] = await Promise.all([
+          waitForVisitCoords(vK1.id, stub2),
+          waitForVisitCoords(vK2.id, stub2),
+        ])
         check(
           '4b (address change): visit 1 updated to the NEW stubbed coords',
           afterK1b.latitude === stub2.lat && afterK1b.longitude === stub2.lng,
@@ -760,7 +789,7 @@ async function main() {
           },
         })
         createdRecordIds.push(woL.recordId)
-        const vL = await getVisit(woL.instance.id)
+        const vL = await waitForVisitCoords((await getVisit(woL.instance.id)).id, stub3)
         check(
           '4c: address set in the SAME create() call still geocodes the auto-created visit row',
           vL.latitude === stub3.lat && vL.longitude === stub3.lng,

--- a/packages/lib/src/dispatch/recurring/materialize.ts
+++ b/packages/lib/src/dispatch/recurring/materialize.ts
@@ -116,7 +116,8 @@ export async function materializeVisits(
   // Coord inheritance (route planner build contract item 9, plans/dispatch/09-route-planner.md
   // §B): a newly materialized visit copies latitude/longitude/geocodedAt from any already-
   // geocoded sibling visit of this same recurring series — never re-geocoded here, the
-  // address-set-time hook (`geocodeOnAddressChange`) is the only geocoder writer.
+  // address-normalize listener (`syncVisitPinsOnAddressNormalized`, visit-hooks.ts) is the
+  // only geocoder writer.
   const geocodedSibling = existingRows.find((r) => r.latitude !== null && r.longitude !== null)
   // §4.4: consumed = existing rows (any status, detached included — a skip consumes its
   // occurrence), derived from rows, not a counter column. Only rows STRICTLY BEFORE the

--- a/packages/lib/src/dispatch/route-planner/backfill.ts
+++ b/packages/lib/src/dispatch/route-planner/backfill.ts
@@ -1,10 +1,11 @@
 // packages/lib/src/dispatch/route-planner/backfill.ts
 //
 // One-time geocode backfill (plans/dispatch/09-route-planner.md §I): work orders whose
-// addresses were saved BEFORE the `geocodeOnAddressChange` hook existed have visit rows with
+// addresses were saved BEFORE address-set-time geocoding existed (today the
+// `syncVisitPinsOnAddressNormalized` listener in visit-hooks.ts) have visit rows with
 // null coordinates and therefore no map pin. This walks every ungeocoded visit, geocodes its
 // work order's `work_order_address` once, and stamps the coords onto all of that work order's
-// visit rows — the same quiet-UPDATE write the hook does. Safe to re-run (already-geocoded
+// visit rows — the same quiet-UPDATE write the listener does. Safe to re-run (already-geocoded
 // visits are excluded by the null-latitude filter). Called by
 // `apps/worker/scripts/backfill-geocode-visits.ts`.
 

--- a/packages/lib/src/dispatch/visit-hooks.ts
+++ b/packages/lib/src/dispatch/visit-hooks.ts
@@ -1,12 +1,10 @@
 // packages/lib/src/dispatch/visit-hooks.ts
 
 import { database, schema } from '@auxx/database'
-import { extractValue, type TypedFieldValue } from '@auxx/types'
 import { parseRecordId } from '@auxx/types/resource'
-import { type AddressStructValue, formatAddressForGeocode } from '@auxx/utils/address'
 import { and, eq } from 'drizzle-orm'
 import type { EntityFieldChangeHandler } from '../field-hooks/types'
-import { geocode } from '../geocoding'
+import type { AddressNormalizedListener } from '../geocoding/address-normalize-hook'
 import { ensureVisitForWorkOrder } from './visit-mutations'
 
 /**
@@ -23,34 +21,32 @@ export const ensureVisitOnWorkOrderCreate: EntityFieldChangeHandler = async (eve
 }
 
 /**
- * Geocode a work order's address the instant it's set (create AND update — route planner
- * build contract item 8, amending 02 §6's original "geocode at schedule time" to "geocode at
- * address-set time": unscheduled backlog jobs need pins too). Keyed off `work_order_address`
- * (ADDRESS_STRUCT); no `oldValue === null` gate, unlike {@link ensureVisitOnWorkOrderCreate} —
- * the service address can change after creation and must re-geocode every time.
+ * Pin a work order's visit rows the instant its address geocodes (create AND update — route
+ * planner build contract item 8, amending 02 §6's original "geocode at schedule time" to
+ * "geocode at address-set time": unscheduled backlog jobs need pins too). Registered as an
+ * address-normalized LISTENER (`registerAddressNormalizedListener`, wired in
+ * `field-hooks/register-hooks.ts`), not a field-change hook: the ADDRESS_STRUCT normalize hook
+ * (`geocoding/address-normalize-hook.ts`) already geocodes every address write server-side, so
+ * this rides its result instead of making a second MapTiler call per write (plans/address-field
+ * §9 follow-up 2). The normalize chain runs fire-and-forget off the save request, so pins land
+ * moments after the save response — same visibility contract as before: no broadcast, the next
+ * board/map refetch picks them up.
  *
  * Writes `latitude`/`longitude`/`geocodedAt` directly onto ALL of that work order's visit rows
  * via a quiet Drizzle `UPDATE` — deliberately NOT through `afterVisitWrite` (geocoding isn't a
- * schedule mutation; no mirror/roll-up/broadcast needed, the next board/map refetch picks it
- * up). Failure or a missing `MAPTILER_API_KEY` is non-fatal — `geocode()` never throws, so a
- * `null` result just leaves the visit(s) unpinned.
+ * schedule mutation; no mirror/roll-up/broadcast needed). A failed geocode or missing
+ * `MAPTILER_API_KEY` never reaches this listener — the visit(s) just stay unpinned.
  */
-export const geocodeOnAddressChange: EntityFieldChangeHandler = async (event) => {
+export const syncVisitPinsOnAddressNormalized: AddressNormalizedListener = async (
+  event,
+  struct
+) => {
   if (event.field.systemAttribute !== 'work_order_address') return
-
-  const typed = event.newValue as TypedFieldValue | TypedFieldValue[] | null
-  const first = Array.isArray(typed) ? typed[0] : typed
-  const addressValue = first ? (extractValue(first) as Partial<AddressStructValue> | null) : null
-  if (!addressValue || typeof addressValue !== 'object') return
-
-  const line = formatAddressForGeocode(addressValue)
-  const result = await geocode(line)
-  if (!result) return
 
   const { entityInstanceId } = parseRecordId(event.recordId)
   await database
     .update(schema.WorkOrderVisit)
-    .set({ latitude: result.lat, longitude: result.lng, geocodedAt: new Date() })
+    .set({ latitude: struct.lat, longitude: struct.lng, geocodedAt: new Date() })
     .where(
       and(
         eq(schema.WorkOrderVisit.organizationId, event.organizationId),

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -2,8 +2,14 @@
 
 import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import { registerInventoryDeductionRule } from '../data-connectors/inventory-bridge-rule-action'
-import { ensureVisitOnWorkOrderCreate, geocodeOnAddressChange } from '../dispatch/visit-hooks'
-import { normalizeAddressOnChange } from '../geocoding/address-normalize-hook'
+import {
+  ensureVisitOnWorkOrderCreate,
+  syncVisitPinsOnAddressNormalized,
+} from '../dispatch/visit-hooks'
+import {
+  normalizeAddressOnChange,
+  registerAddressNormalizedListener,
+} from '../geocoding/address-normalize-hook'
 import { generateDraftOnCompletion } from '../money/auto-invoice'
 import {
   BILLING_PROJECTION_ATTRS,
@@ -108,21 +114,19 @@ export function registerAllHooks(): void {
   // `work_order_status` lands on `completed`/`ended` — catches the visit roll-up, M2c's
   // `endEngagement`, kanban drags, and manual drawer edits, all through this one hook.
   //
-  // Route planner build contract item 8 (09-route-planner.md §B): geocode the work order's
-  // address the instant it's set (create AND update), writing straight onto its visit row(s) —
-  // unscheduled backlog jobs need pins too, not just scheduled ones.
-  //
   // `registerEntityFieldChangeHooks` appends per-call (registry.ts:137-144), so this could
-  // also be a second/third call — combined into one array here since all three handlers share
+  // also be separate calls — combined into one array here since all these handlers share
   // the 'work-orders' slug and read more naturally listed together.
   //
   // Client-notifications plan §4.3: enroll the seeded `job_follow_up` sequence on the same
   // completion door (`enrollJobFollowUpOnCompletion` — independent handler, no recursion risk,
   // never writes `work_order_status` itself).
+  //
+  // (Route planner item 8's visit-pin geocode used to be a third handler here — it now rides
+  // the ADDRESS_STRUCT normalize hook via `registerAddressNormalizedListener` below.)
   registerEntityFieldChangeHooks('work-orders', [
     ensureVisitOnWorkOrderCreate,
     generateDraftOnCompletion,
-    geocodeOnAddressChange,
     enrollJobFollowUpOnCompletion,
     syncBillingOnWorkOrderChange,
   ])
@@ -164,10 +168,15 @@ export function registerAllHooks(): void {
   // Address field (plans/address-field/01-single-input-address-field.md §5 items 2-3,
   // decision #5/#13): field-type-keyed (NOT entity-scoped) so it runs for every ADDRESS_STRUCT
   // field on every entity without flipping `hasEntityFieldChangeHooks` on for entities that have
-  // no address fields. On `work_order_address` this dispatches AFTER the entity-chain's own
-  // `geocodeOnAddressChange` (visit-hooks, still registered above) — two MapTiler calls per
-  // write there, accepted for v1 (§5 item 5).
+  // no address fields.
   registerFieldTypeChangeHooks(FieldTypeEnum.ADDRESS_STRUCT, [normalizeAddressOnChange])
+
+  // Route planner build contract item 8 (09-route-planner.md §B): pin the work order's visit
+  // row(s) whenever its address geocodes — unscheduled backlog jobs need pins too. Rides the
+  // normalize hook's geocode via the listener seam instead of an entity-scoped hook making its
+  // own MapTiler call, retiring the v1 double-geocode on `work_order_address` writes
+  // (plans/address-field §9 follow-up 2).
+  registerAddressNormalizedListener(syncVisitPinsOnAddressNormalized)
 
   // ---------------------------------------------------------------------------
   // PRE-WRITE HOOKS

--- a/packages/lib/src/geocoding/__tests__/address-normalize-hook.test.ts
+++ b/packages/lib/src/geocoding/__tests__/address-normalize-hook.test.ts
@@ -43,13 +43,24 @@ vi.mock('../../field-values/field-value-queries', () => ({ getValue: vi.fn() }))
 import { setValueWithBuiltIn } from '../../field-values/field-value-mutations'
 import { getValue } from '../../field-values/field-value-queries'
 import { publishFieldValueUpdates } from '../../realtime/publish-helpers'
-import { normalizeAddressOnChange } from '../address-normalize-hook'
+import {
+  normalizeAddressOnChange,
+  registerAddressNormalizedListener,
+} from '../address-normalize-hook'
 import { geocodeStructured } from '../geocoder'
 
 const mockedGeocode = geocodeStructured as unknown as ReturnType<typeof vi.fn>
 const mockedSetValue = setValueWithBuiltIn as unknown as ReturnType<typeof vi.fn>
 const mockedGetValue = getValue as unknown as ReturnType<typeof vi.fn>
 const mockedPublish = publishFieldValueUpdates as unknown as ReturnType<typeof vi.fn>
+
+// There is no unregister (production never needs one), so both listeners stay subscribed for the
+// whole suite and are reset per test. `failingListener` is registered FIRST to prove a throwing
+// listener never starves the ones after it.
+const failingListener = vi.fn()
+const listener = vi.fn()
+registerAddressNormalizedListener(failingListener)
+registerAddressNormalizedListener(listener)
 
 const recordId: RecordId = toRecordId('contact', 'inst-1')
 
@@ -105,6 +116,9 @@ describe('normalizeAddressOnChange', () => {
     mockedSetValue.mockReset()
     mockedPublish.mockReset()
     mockedGetValue.mockReset()
+    failingListener.mockReset()
+    listener.mockReset()
+    failingListener.mockResolvedValue(undefined)
     mockedPublish.mockResolvedValue(undefined)
     mockedSetValue.mockResolvedValue({
       state: 'complete',
@@ -382,6 +396,91 @@ describe('normalizeAddressOnChange', () => {
     expect(organizationId).toBe('org-1')
     expect(entries).toHaveLength(1)
     expect(entries[0].value).not.toBeNull()
+  })
+
+  describe('normalized-address listeners', () => {
+    it('fire with the merged struct after a successful geocode + write-back', async () => {
+      mockedGeocode.mockResolvedValue({
+        lat: 30.1,
+        lng: -97.1,
+        placeName: 'x',
+        relevance: 1,
+        components: {},
+      })
+      const event = buildEvent({
+        newValue: jsonValue({ street1: '123 Main St', city: 'Austin', _source: 'single' }),
+      })
+      await normalizeAddressOnChange(event)
+      await flush()
+      expect(listener).toHaveBeenCalledTimes(1)
+      const [listenerEvent, struct] = listener.mock.calls[0]!
+      expect(listenerEvent).toBe(event)
+      expect(struct).toMatchObject({ street1: '123 Main St', lat: 30.1, lng: -97.1 })
+      expect(struct._source).toBeUndefined()
+    })
+
+    it('do not fire when the geocoder returns null', async () => {
+      mockedGeocode.mockResolvedValue(null)
+      await normalizeAddressOnChange(
+        buildEvent({ newValue: jsonValue({ street1: '123 Main St', _source: 'single' }) })
+      )
+      await flush()
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('do not fire when the stale-write guard skips the write-back', async () => {
+      mockedGeocode.mockResolvedValue({
+        lat: 1,
+        lng: 2,
+        placeName: 'x',
+        relevance: 1,
+        components: {},
+      })
+      const event = buildEvent({
+        newValue: jsonValue({ street1: '123 Main St', city: 'Austin' }),
+      })
+      mockedGetValue.mockResolvedValue(jsonValue({ street1: '456 Oak Ave', city: 'Dallas' }))
+      await normalizeAddressOnChange(event)
+      await flush()
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('fire with the already-stamped coords on the idempotence-guard path, without geocoding', async () => {
+      const stamped = {
+        street1: '123 Main St',
+        city: 'Austin',
+        state: 'TX',
+        zipCode: '78701',
+        country: 'US',
+        lat: 30.1,
+        lng: -97.1,
+        geocodedAt: '2026-01-01T00:00:00.000Z',
+      }
+      await normalizeAddressOnChange(
+        buildEvent({ oldValue: jsonValue(stamped), newValue: jsonValue({ ...stamped }) })
+      )
+      await flush()
+      expect(mockedGeocode).not.toHaveBeenCalled()
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener.mock.calls[0]![1]).toMatchObject({ lat: 30.1, lng: -97.1 })
+    })
+
+    it('a throwing listener is isolated — later listeners still fire', async () => {
+      failingListener.mockRejectedValue(new Error('boom'))
+      mockedGeocode.mockResolvedValue({
+        lat: 1,
+        lng: 2,
+        placeName: 'x',
+        relevance: 1,
+        components: {},
+      })
+      await normalizeAddressOnChange(
+        buildEvent({ newValue: jsonValue({ street1: '123 Main St', _source: 'structured' }) })
+      )
+      await flush()
+      expect(failingListener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('does not publish realtime when the quiet write produced no values', async () => {

--- a/packages/lib/src/geocoding/address-normalize-hook.ts
+++ b/packages/lib/src/geocoding/address-normalize-hook.ts
@@ -3,8 +3,10 @@
 // Server-side geocoder normalization for ADDRESS_STRUCT field writes
 // (plans/address-field/01-single-input-address-field.md §5 item 3, decision #5). Registered as
 // a field-type-keyed post-write hook (decision #13, `field-hooks/registry.ts`), so it runs for
-// every ADDRESS_STRUCT field on every entity — not just `work_order_address` (dispatch's
-// visit-hooks geocode is untouched and still runs first on that field, see §5 item 5).
+// every ADDRESS_STRUCT field on every entity — not just `work_order_address`. Feature modules
+// that need the geocode result (dispatch visit pins) subscribe via
+// {@link registerAddressNormalizedListener} instead of geocoding again themselves — this is THE
+// one MapTiler call per address write (§9 follow-up 2 retired the v1 double-geocode).
 //
 // Field-change post-hooks are awaited inline in the save request
 // (`field-values/field-value-mutations.ts`), so this handler itself does only cheap synchronous
@@ -81,6 +83,50 @@ function stripSource(struct: AddressStructLike): AddressStructLike {
   return next
 }
 
+/** Struct delivered to normalized-address listeners — the stored components plus a guaranteed
+ * geocode stamp. */
+export type NormalizedAddressStruct = Partial<AddressStructValue> & { lat: number; lng: number }
+
+/** Fired once the hook has coordinates for a write — either freshly geocoded (after the quiet
+ * write-back landed) or already stamped on the incoming struct (idempotence-guard path, where
+ * no geocode runs). Never fired when the geocoder fails/no-ops — consumers just see no update. */
+export type AddressNormalizedListener = (
+  event: EntityFieldChangeEvent,
+  struct: NormalizedAddressStruct
+) => Promise<void> | void
+
+const normalizedListeners: AddressNormalizedListener[] = []
+
+/**
+ * Subscribe to address normalizations. Feature modules that need the geocode result (dispatch
+ * visit pins, `field-hooks/register-hooks.ts`) register here instead of making a second MapTiler
+ * call per write. The subscription direction keeps this module free of feature imports — dispatch
+ * already imports geocoding, so the reverse would cycle.
+ */
+export function registerAddressNormalizedListener(listener: AddressNormalizedListener): void {
+  normalizedListeners.push(listener)
+}
+
+/** Fan the geocoded struct out to listeners, each isolated — a listener failure is logged and
+ * never affects the others or the caller. No-op unless the struct carries numeric coordinates. */
+async function notifyAddressNormalized(
+  event: EntityFieldChangeEvent,
+  struct: AddressStructLike
+): Promise<void> {
+  if (typeof struct.lat !== 'number' || typeof struct.lng !== 'number') return
+  for (const listener of normalizedListeners) {
+    try {
+      await listener(event, struct as NormalizedAddressStruct)
+    } catch (error) {
+      logger.error('Address normalized listener failed', {
+        recordId: event.recordId,
+        fieldId: event.field.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+}
+
 /**
  * Post-write hook for ADDRESS_STRUCT fields (registered field-type-keyed, not entity-scoped —
  * fires for every ADDRESS_STRUCT field regardless of entity). Bails fast on cheap synchronous
@@ -103,6 +149,11 @@ export const normalizeAddressOnChange: EntityFieldChangeHandler = async (event) 
   if (hasStampedGeo) {
     const oldStruct = extractStruct(event.oldValue)
     if (oldStruct && componentHash(oldStruct) === componentHash(newStruct)) {
+      // Nothing to geocode, but listeners (visit pins) still get the already-stamped coords —
+      // a no-op resave used to re-pin through dispatch's own geocode hook, and this keeps that
+      // robustness for one cheap UPDATE. Fire-and-forget; notify never rejects (per-listener
+      // catch), so a bare void is safe.
+      void notifyAddressNormalized(event, newStruct)
       return
     }
   }
@@ -137,7 +188,10 @@ async function runNormalize(
     return
   }
 
-  await writeBack(event, struct, mergeAddress(struct, geocoded, source))
+  const merged = mergeAddress(struct, geocoded, source)
+  if (await writeBack(event, struct, merged)) {
+    await notifyAddressNormalized(event, merged)
+  }
 }
 
 /**
@@ -197,12 +251,15 @@ function mergeAddress(
  * edit). We then publish the realtime update ourselves so open drawers pick up the canonical
  * struct — publishing the FULL composed value, since a value-less realtime publish is silently
  * dropped by subscribers.
+ *
+ * Returns whether the write landed — `false` on the stale-write bail (the newer write's own
+ * normalize run owns the field, listeners included) or an empty write result.
  */
 async function writeBack(
   event: EntityFieldChangeEvent,
   original: AddressStructLike,
   merged: AddressStructLike
-): Promise<void> {
+): Promise<boolean> {
   const ctx = createFieldValueContext(event.organizationId, event.userId, undefined, undefined, {
     skipPreHooks: true,
   })
@@ -213,7 +270,7 @@ async function writeBack(
   const current = extractStruct(
     await getValue(ctx, { recordId: event.recordId, fieldId: event.field.id }, event.field)
   )
-  if (!current || componentHash(current) !== componentHash(original)) return
+  if (!current || componentHash(current) !== componentHash(original)) return false
 
   const result = await setValueWithBuiltIn(ctx, {
     recordId: event.recordId,
@@ -222,7 +279,7 @@ async function writeBack(
     publishEvents: false,
   })
 
-  if (result.values.length === 0) return
+  if (result.values.length === 0) return false
 
   const { entityInstanceId } = parseRecordId(event.recordId)
   const publishRecordId = event.field.entityDefinitionId
@@ -242,4 +299,6 @@ async function writeBack(
       error: error instanceof Error ? error.message : String(error),
     })
   })
+
+  return true
 }

--- a/packages/lib/src/geocoding/index.ts
+++ b/packages/lib/src/geocoding/index.ts
@@ -3,5 +3,10 @@
 // Server entrypoint for address geocoding (MapTiler, env-gated). Distinct from `../geo/`
 // (IP-based visitor geolocation) — see geocoder.ts's file comment.
 
+export type { AddressNormalizedListener, NormalizedAddressStruct } from './address-normalize-hook'
+export {
+  normalizeAddressOnChange,
+  registerAddressNormalizedListener,
+} from './address-normalize-hook'
 export { geocode, geocodeStructured, setGeocodeFetcherForTesting } from './geocoder'
 export type { GeocodeComponents, GeocodeResult, GeocodeStructuredResult } from './types'


### PR DESCRIPTION
## Summary

Retires the v1 double-geocode accepted in the address-field build (plans/address-field/01 §9 follow-up 2): every `work_order_address` write made **two** MapTiler calls — one in dispatch's entity-scoped `geocodeOnAddressChange` hook (visit pins), one in the ADDRESS_STRUCT normalize hook (struct canonicalization). Now there is exactly one.

- **`geocoding/address-normalize-hook.ts`**: new listener seam `registerAddressNormalizedListener()`. Listeners get the merged struct after a successful geocode + quiet write-back, and on the idempotence-guard path (no-op resave of an already-stamped struct) with the existing coords. Never fired on geocoder failure or the stale-write bail — the newer write's own run owns the field. Subscription direction avoids a geocoding → dispatch import cycle.
- **`dispatch/visit-hooks.ts`**: `geocodeOnAddressChange` deleted; `syncVisitPinsOnAddressNormalized` (an `AddressNormalizedListener`) writes lat/lng onto all the work order's visit rows from the normalizer's result.
- **`field-hooks/register-hooks.ts`**: registration swapped accordingly.

## Behavior change

Visit pins used to land inline in the save request (the old hook blocked the save on MapTiler, up to 5s); they now land fire-and-forget just after the save response. Same documented visibility contract (next board/map refetch picks them up), faster address saves on work orders. `verify-dispatch-route-planner.ts` §4 polls for pins instead of reading inline.

## Notes

- plans/dispatch/26 workstream A (geocode failure stamping) was written against the deleted hook; since the listener fires only on success, A.2/A.2a need a failure-aware signal when built (re-grounding note added to the plan doc, untracked).

## Testing

- 41 unit tests pass, incl. 5 new listener tests (merged-struct delivery, no-fire on geocoder null / stale-write bail, idempotence-path delivery, throwing-listener isolation)
- `verify-dispatch-route-planner.ts` end-to-end against dev DB: 63/63, §4 exercises the new path incl. the combined-create ordering case
- `tsc` clean on touched files (pre-existing baseline errors elsewhere unchanged)