### PR TITLE
feat(dispatch): series-end symmetry — resumable skip-future, ends editor, visible series state

### DIFF
--- a/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-section.tsx
@@ -14,6 +14,7 @@ import { SchedulePopover } from '../schedule-popover'
 import { splitJobVisits } from './job-schedule-utils'
 import { RecurringEngagementCard } from './recurring-engagement-card'
 import { ScheduleVisitRow } from './schedule-visit-row'
+import { SeriesEndRow } from './series-end'
 import { useJobVisits } from './use-job-visits'
 import { VisitCard } from './visit-card'
 
@@ -92,6 +93,7 @@ export function JobScheduleSection({ recordId }: DetailViewTabProps) {
           canEdit={canEdit}
           primaryVisit={primaryVisit}
           existingVisits={existingVisits}
+          visits={visits}
           onRefresh={refresh}
         />
       )}
@@ -123,6 +125,19 @@ export function JobScheduleSection({ recordId }: DetailViewTabProps) {
             />
           )}
         />
+      )}
+
+      {/* Terminator row (plan 36 §B.3): "Series ends after Aug 18 — Extend". Makes the
+       * absence of visits past the end date self-answering; renders nothing when open-ended. */}
+      {jobType === 'recurring' && (
+        <div className={TREE_SECONDARY_NOTRUNCATE}>
+          <SeriesEndRow
+            workOrderRecordId={recordId}
+            canEdit={canEdit && status !== 'ended'}
+            visits={visits}
+            onChanged={refresh}
+          />
+        </div>
       )}
 
       {history.length > 0 && (

--- a/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-utils.ts
+++ b/apps/web/src/components/dispatch/ui/job-schedule/job-schedule-utils.ts
@@ -130,7 +130,7 @@ export function cancelVisitConfirmOptions(isSeries: boolean) {
     ? {
         title: 'Skip this visit?',
         description:
-          'The visit stays in the job\'s history as skipped and won\'t be regenerated. "Skip this and future visits" also ends the series after this one.',
+          'The visit stays in the job\'s history as skipped and won\'t be regenerated. "Skip this and future visits" also ends the series after this one — you can restore the last skipped visit or extend the series later.',
         confirmText: 'Skip visit',
         alternateText: 'Skip this and future visits',
         cancelText: 'Keep visit',
@@ -144,6 +144,25 @@ export function cancelVisitConfirmOptions(isSeries: boolean) {
         cancelText: 'Keep visit',
         destructive: true,
       }
+}
+
+/**
+ * Confirm-dialog copy for restoring the series BOUNDARY visit — the skipped occurrence a
+ * "Skip this and future visits" ended the series at (plan 36 §B.1). Mirrors the skip dialog's
+ * two-choice shape: primary restores the visit in place (it stays the series' final
+ * occurrence), `alternateText` resolves `'alternate'` → `restoreVisit` with
+ * `resumeSeries: true` (clears the end date, regenerates the tail). Non-boundary skipped
+ * rows restore directly, no dialog.
+ */
+export function restoreSeriesBoundaryConfirmOptions() {
+  return {
+    title: 'Restore this visit?',
+    description:
+      'This visit is where the series ends. "Restore and resume future visits" also removes the end date and regenerates future visits from the schedule — customized visits removed by the skip are not restored.',
+    confirmText: 'Restore visit',
+    alternateText: 'Restore and resume future visits',
+    cancelText: 'Keep skipped',
+  }
 }
 
 /** Newest-first split of a work order's visits into "upcoming" and "history" (07 §F.3). */

--- a/apps/web/src/components/dispatch/ui/job-schedule/recurring-engagement-card.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/recurring-engagement-card.tsx
@@ -1,25 +1,26 @@
 // apps/web/src/components/dispatch/ui/job-schedule/recurring-engagement-card.tsx
 'use client'
 
-import { describeRecurrenceParts, type RecurrencePattern } from '@auxx/lib/recurrence/client'
+import { describeRecurrenceParts } from '@auxx/lib/recurrence/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { toastError } from '@auxx/ui/components/toast'
 import { TREE_SECONDARY_NOTRUNCATE, TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
-import { Pause, Pencil, Play, Repeat, XCircle } from 'lucide-react'
+import { CalendarOff, Pause, Pencil, Play, Repeat, XCircle } from 'lucide-react'
 import { useMemo } from 'react'
 import { DetailSectionActions, DetailSectionTitleExtra } from '~/components/detail-view'
 import type { RecordId } from '~/components/resources'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useSettings } from '~/hooks/use-settings'
-import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
 import { api } from '~/trpc/react'
 import { scalarSetting } from '../recurrence/recurrence-utils'
 import { type ExistingVisitForOverlap, SchedulePopover } from '../schedule-popover'
+import { SeriesEndEditor, useSeriesRule } from './series-end'
 import type { JobVisit } from './use-job-visits'
 
+const DEFAULT_ENGAGEMENT_BADGE = { label: 'Active', variant: 'green' } as const
 const ENGAGEMENT_BADGE: Record<string, { label: string; variant: 'green' | 'amber' | 'gray' }> = {
-  active: { label: 'Active', variant: 'green' },
+  active: DEFAULT_ENGAGEMENT_BADGE,
   paused: { label: 'Paused', variant: 'amber' },
   ended: { label: 'Ended', variant: 'gray' },
 }
@@ -33,6 +34,8 @@ export interface RecurringEngagementCardProps {
   /** The next-upcoming visit — the Edit action reschedules/re-configures through it. */
   primaryVisit: JobVisit | undefined
   existingVisits: ExistingVisitForOverlap[]
+  /** All of the job's visits — skip count + the end editor's shorten-confirm count (plan 36). */
+  visits: JobVisit[]
   onRefresh: () => void
 }
 
@@ -52,6 +55,7 @@ export function RecurringEngagementCard({
   canEdit,
   primaryVisit,
   existingVisits,
+  visits,
   onRefresh,
 }: RecurringEngagementCardProps) {
   const utils = api.useUtils()
@@ -62,17 +66,12 @@ export function RecurringEngagementCard({
     | 'sunday'
     | 'saturday'
 
-  const ruleQuery = api.dispatch.getRecurrence.useQuery(
-    { workOrderRecordId: recordId },
-    { staleTime: ORG_STATIC_STALE_TIME }
-  )
+  const { rule, pattern, until, windowEmpty } = useSeriesRule(recordId)
 
   const summary = useMemo(() => {
-    if (!ruleQuery.data) return null
-    return describeRecurrenceParts(ruleQuery.data.pattern as unknown as RecurrencePattern, {
-      weekStart,
-    })
-  }, [ruleQuery.data, weekStart])
+    if (!pattern) return null
+    return describeRecurrenceParts(pattern, { weekStart })
+  }, [pattern, weekStart])
 
   const invalidate = () => {
     void utils.dispatch.getRecurrence.invalidate({
@@ -106,9 +105,23 @@ export function RecurringEngagementCard({
     onSuccess: invalidate,
   })
 
-  if (!ruleQuery.data) return null
+  if (!rule) return null
 
-  const badge = ENGAGEMENT_BADGE[status] ?? ENGAGEMENT_BADGE.active
+  const badge = ENGAGEMENT_BADGE[status] ?? DEFAULT_ENGAGEMENT_BADGE
+  // Plan 36 §B.2/§B.4 — the always-visible series state: end date, skip count, and the
+  // dead-window read-time guard ("Series ended" when a scope edit re-anchored the pattern
+  // past its own end — nothing can generate even though the status may still read Active).
+  const skipped = visits.filter(
+    (visit) => visit.status === 'canceled' && visit.recurrenceRuleId
+  ).length
+  const endsLine = windowEmpty
+    ? 'Series ended — no further visits will be generated'
+    : [
+        summary?.ends ?? (canEdit && status !== 'ended' ? 'no end date' : null),
+        skipped > 0 ? `${skipped} skipped` : null,
+      ]
+        .filter(Boolean)
+        .join(' · ')
 
   const handlePause = async () => {
     const confirmed = await confirm({
@@ -193,19 +206,34 @@ export function RecurringEngagementCard({
         icon={<Repeat className='size-4' />}
         title={<span className='text-sm'>{summary?.frequency}</span>}
         secondary={
-          summary?.ends ? (
-            <span className='text-xs text-muted-foreground'>{summary.ends}</span>
-          ) : undefined
+          endsLine ? <span className='text-xs text-muted-foreground'>{endsLine}</span> : undefined
         }
         actions={
           canEdit && status !== 'ended' ? (
-            <TreeRowButton
-              variant='destructive'
-              tooltipText='End engagement'
-              disabled={endEngagement.isPending}
-              onClick={handleEnd}>
-              <XCircle />
-            </TreeRowButton>
+            <>
+              {/* Plan 36 §B.2 — the series end date is ownable here: set, move, or clear. */}
+              <SeriesEndEditor
+                workOrderRecordId={recordId}
+                until={until}
+                visits={visits}
+                onChanged={() => {
+                  invalidate()
+                  onRefresh()
+                }}
+                trigger={
+                  <TreeRowButton tooltipText={until ? 'Change end date' : 'Set end date'}>
+                    <CalendarOff />
+                  </TreeRowButton>
+                }
+              />
+              <TreeRowButton
+                variant='destructive'
+                tooltipText='End engagement'
+                disabled={endEngagement.isPending}
+                onClick={handleEnd}>
+                <XCircle />
+              </TreeRowButton>
+            </>
           ) : undefined
         }
       />

--- a/apps/web/src/components/dispatch/ui/job-schedule/schedule-visit-row.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/schedule-visit-row.tsx
@@ -16,8 +16,10 @@ import {
   cancelVisitConfirmOptions,
   formatVisitWindow,
   movedFromLabel,
+  restoreSeriesBoundaryConfirmOptions,
   VISIT_STATUS_BADGE_VARIANT,
 } from './job-schedule-utils'
+import { useSeriesRule } from './series-end'
 import type { JobVisit, UseJobVisitsResult } from './use-job-visits'
 
 export interface ScheduleVisitRowProps {
@@ -64,6 +66,13 @@ export function ScheduleVisitRow({
   const statusLabel = visitStatusLabel(visit.status, visit.recurrenceRuleId)
   const moved = movedFromLabel(visit)
 
+  // Plan 36 §B.1 — boundary detection: this skipped occurrence is where the series ends
+  // (a "Skip this and future" stamped its date as the pattern's `until`), so restoring it
+  // asks visit-only vs resume. Non-boundary rows restore directly.
+  const { until: seriesUntil } = useSeriesRule(workOrderRecordId, canRestore && isSeries)
+  const isSeriesBoundary =
+    canRestore && isSeries && Boolean(visit.occurrenceDate) && seriesUntil === visit.occurrenceDate
+
   const handleCancel = async () => {
     const choice = await confirm(cancelVisitConfirmOptions(isSeries))
     if (!choice) return
@@ -72,6 +81,16 @@ export function ScheduleVisitRow({
     } else {
       mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
     }
+  }
+
+  const handleRestore = async () => {
+    if (!isSeriesBoundary) {
+      mutations.restoreVisit.mutate({ visitId: visit.id })
+      return
+    }
+    const choice = await confirm(restoreSeriesBoundaryConfirmOptions())
+    if (!choice) return
+    mutations.restoreVisit.mutate({ visitId: visit.id, resumeSeries: choice === 'alternate' })
   }
 
   return (
@@ -133,7 +152,7 @@ export function ScheduleVisitRow({
                 <TreeRowButton
                   tooltipText='Restore'
                   disabled={mutations.restoreVisit.isPending}
-                  onClick={() => mutations.restoreVisit.mutate({ visitId: visit.id })}>
+                  onClick={() => void handleRestore()}>
                   <RotateCcw />
                 </TreeRowButton>
               )}

--- a/apps/web/src/components/dispatch/ui/job-schedule/series-end.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/series-end.tsx
@@ -1,0 +1,273 @@
+// apps/web/src/components/dispatch/ui/job-schedule/series-end.tsx
+'use client'
+
+// Series-end visibility + editing (plan 36 §B) — the pieces that stop a recurring series'
+// end state living invisibly inside the rule pattern: a shared rule query, the "Ends" date
+// editor (the explicit reverse of "Skip this and future"), the terminator row after the last
+// upcoming visit, and the drawer's compact series summary line.
+
+import type { RecurrencePattern } from '@auxx/lib/recurrence/client'
+import { describeRecurrenceParts } from '@auxx/lib/recurrence/client'
+import type { RecordId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { toastError } from '@auxx/ui/components/toast'
+import { TreeRow, TreeRowButton } from '@auxx/ui/components/tree-row'
+import { format, parseISO } from 'date-fns'
+import { CalendarOff, CalendarPlus, Repeat } from 'lucide-react'
+import { type ReactNode, useState } from 'react'
+import { DateTimePickerContent } from '~/components/pickers/date-time-picker'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useSettings } from '~/hooks/use-settings'
+import { ORG_STATIC_STALE_TIME } from '~/trpc/query-client'
+import { api } from '~/trpc/react'
+import { scalarSetting } from '../recurrence/recurrence-utils'
+import type { JobVisit } from './use-job-visits'
+
+/**
+ * The work order's recurrence rule (shared `dispatch.getRecurrence` read — one fetch per
+ * work order, every consumer dedupes onto the same query key). `enabled: false` skips the
+ * fetch entirely for surfaces that already know the job has no series.
+ */
+export function useSeriesRule(workOrderRecordId: RecordId, enabled = true) {
+  const query = api.dispatch.getRecurrence.useQuery(
+    { workOrderRecordId },
+    { staleTime: ORG_STATIC_STALE_TIME, enabled }
+  )
+  const rule = query.data ?? null
+  const pattern = (rule?.pattern ?? null) as RecurrencePattern | null
+  return {
+    rule,
+    pattern,
+    /** The pattern's inclusive local-ISO end date; `undefined` = open-ended. */
+    until: pattern?.until,
+    /** `until` before `effectiveFrom` — an empty generation window, nothing ever generates. */
+    windowEmpty:
+      pattern?.until !== undefined && rule !== null && pattern.until < rule.effectiveFrom,
+  }
+}
+
+export interface SeriesEndEditorProps {
+  workOrderRecordId: RecordId
+  /** The pattern's current end date (local ISO), `undefined` when open-ended. */
+  until: string | undefined
+  /** This job's visits — counts how many upcoming series rows a shorten removes (§B.5). */
+  visits: JobVisit[]
+  onChanged: () => void
+  trigger: ReactNode
+}
+
+/**
+ * "Ends" date editor (plan 36 §B.2) — a popover date picker + "Remove end date" wired to
+ * `dispatch.setSeriesEnd`. Shortening confirms with the number of upcoming visits it removes;
+ * extending/clearing commits directly (additive, nothing lost).
+ */
+export function SeriesEndEditor({
+  workOrderRecordId,
+  until,
+  visits,
+  onChanged,
+  trigger,
+}: SeriesEndEditorProps) {
+  const [open, setOpen] = useState(false)
+  const [confirm, ConfirmDialog] = useConfirm()
+  const setSeriesEnd = api.dispatch.setSeriesEnd.useMutation({
+    onError: (error) =>
+      toastError({ title: 'Error updating series end', description: error.message }),
+    onSuccess: onChanged,
+  })
+
+  const commit = async (next: string | null) => {
+    setOpen(false)
+    if (next !== null) {
+      const removed = visits.filter(
+        (visit) =>
+          visit.recurrenceRuleId &&
+          visit.status === 'scheduled' &&
+          visit.occurrenceDate &&
+          visit.occurrenceDate > next
+      ).length
+      if (removed > 0) {
+        const confirmed = await confirm({
+          title: `End series on ${format(parseISO(next), 'MMM d, yyyy')}?`,
+          description: `Removes ${removed} upcoming visit${removed === 1 ? '' : 's'} after that date. Completed and skipped visits stay in history.`,
+          confirmText: 'End series',
+          cancelText: 'Keep schedule',
+          destructive: true,
+        })
+        if (!confirmed) return
+      }
+    }
+    setSeriesEnd.mutate({ workOrderRecordId, until: next })
+  }
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+        <PopoverContent className='w-auto p-0' align='start'>
+          <SeriesEndPickerContent
+            until={until}
+            onPick={(next) => void commit(next)}
+            pending={setSeriesEnd.isPending}
+          />
+        </PopoverContent>
+      </Popover>
+      <ConfirmDialog />
+    </>
+  )
+}
+
+function SeriesEndPickerContent({
+  until,
+  onPick,
+  pending,
+}: {
+  until: string | undefined
+  onPick: (next: string | null) => void
+  pending: boolean
+}) {
+  return (
+    <div>
+      <DateTimePickerContent
+        mode='date'
+        noConfirm
+        minDate={new Date()}
+        value={until ? parseISO(until) : undefined}
+        onChange={(date: Date | undefined) => {
+          if (date) onPick(format(date, 'yyyy-MM-dd'))
+        }}
+      />
+      {until && (
+        <div className='border-t p-1.5'>
+          <Button
+            variant='ghost'
+            size='sm'
+            className='w-full justify-start'
+            disabled={pending}
+            onClick={() => onPick(null)}>
+            <CalendarOff /> Remove end date
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export interface SeriesEndRowProps {
+  workOrderRecordId: RecordId
+  canEdit: boolean
+  visits: JobVisit[]
+  onChanged: () => void
+  depth?: number
+}
+
+/**
+ * Terminator row (plan 36 §B.3) — rendered after the last upcoming visit when the series has
+ * an end date: "Series ends after Aug 18", with an Extend action opening the end editor. This
+ * is what makes "why is there nothing after Aug 18" self-answering. Renders nothing for an
+ * open-ended series or a rule-less job.
+ */
+export function SeriesEndRow({
+  workOrderRecordId,
+  canEdit,
+  visits,
+  onChanged,
+  depth,
+}: SeriesEndRowProps) {
+  const hasSeries = visits.some((visit) => visit.recurrenceRuleId)
+  const { rule, until } = useSeriesRule(workOrderRecordId, hasSeries)
+  if (!rule || !until) return null
+
+  return (
+    <TreeRow
+      depth={depth}
+      icon={<CalendarOff className='size-4' />}
+      title={
+        <span className='text-sm text-muted-foreground'>
+          Series ends after {format(parseISO(until), 'EEE, MMM d')}
+        </span>
+      }
+      actions={
+        canEdit ? (
+          <SeriesEndEditor
+            workOrderRecordId={workOrderRecordId}
+            until={until}
+            visits={visits}
+            onChanged={onChanged}
+            trigger={
+              <TreeRowButton tooltipText='Extend series'>
+                <CalendarPlus />
+              </TreeRowButton>
+            }
+          />
+        ) : undefined
+      }
+    />
+  )
+}
+
+export interface SeriesSummaryRowProps {
+  workOrderRecordId: RecordId
+  canEdit: boolean
+  visits: JobVisit[]
+  onChanged: () => void
+}
+
+/**
+ * Compact always-visible series state for the DRAWER schedule card (plan 36 §B.4) — the full
+ * job view has `RecurringEngagementCard` for this; the drawer previously showed nothing:
+ * "Weekly on Wed, Thu · ends Aug 18 · 3 skipped", or the dead-window "Series ended" state
+ * when a scope edit re-anchored the pattern past its own end (§2 rec). Renders nothing for a
+ * rule-less job.
+ */
+export function SeriesSummaryRow({
+  workOrderRecordId,
+  canEdit,
+  visits,
+  onChanged,
+}: SeriesSummaryRowProps) {
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const weekStart = (scalarSetting(getSetting('organization.weekStart')) ?? 'monday') as
+    | 'monday'
+    | 'sunday'
+    | 'saturday'
+  const hasSeries = visits.some((visit) => visit.recurrenceRuleId)
+  const { rule, pattern, until, windowEmpty } = useSeriesRule(workOrderRecordId, hasSeries)
+  if (!rule || !pattern) return null
+
+  const parts = describeRecurrenceParts(pattern, { weekStart })
+  const skipped = visits.filter(
+    (visit) => visit.status === 'canceled' && visit.recurrenceRuleId
+  ).length
+  const secondary = windowEmpty
+    ? 'Series ended — no further visits will be generated'
+    : [parts.ends ?? (canEdit ? 'no end date' : null), skipped > 0 ? `${skipped} skipped` : null]
+        .filter(Boolean)
+        .join(' · ')
+
+  return (
+    <TreeRow
+      icon={<Repeat className='size-4' />}
+      title={<span className='text-sm'>{parts.frequency}</span>}
+      secondary={
+        secondary ? <span className='text-xs text-muted-foreground'>{secondary}</span> : undefined
+      }
+      actions={
+        canEdit ? (
+          <SeriesEndEditor
+            workOrderRecordId={workOrderRecordId}
+            until={until}
+            visits={visits}
+            onChanged={onChanged}
+            trigger={
+              <TreeRowButton tooltipText={until ? 'Change end date' : 'Set end date'}>
+                <CalendarOff />
+              </TreeRowButton>
+            }
+          />
+        ) : undefined
+      }
+    />
+  )
+}

--- a/apps/web/src/components/dispatch/ui/job-schedule/use-job-visits.ts
+++ b/apps/web/src/components/dispatch/ui/job-schedule/use-job-visits.ts
@@ -32,6 +32,9 @@ export function useJobVisits(workOrderRecordId: RecordId) {
 
   const invalidate = useCallback(() => {
     void utils.dispatch.listVisits.invalidate({ workOrderRecordId })
+    // Skip-future / restore-resume / series-end edits change the rule's `until` — keep the
+    // series summary + terminator row (plan 36 §B) in step with the visit list.
+    void utils.dispatch.getRecurrence.invalidate({ workOrderRecordId })
   }, [utils, workOrderRecordId])
 
   const onEvent = useCallback(

--- a/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
+++ b/apps/web/src/components/dispatch/ui/job-schedule/visit-detail-panel.tsx
@@ -43,8 +43,10 @@ import {
   isVisitDispatchable,
   movedFromLabel,
   resolveVisitDurationMinutes,
+  restoreSeriesBoundaryConfirmOptions,
   VISIT_STATUS_BADGE_VARIANT,
 } from './job-schedule-utils'
+import { useSeriesRule } from './series-end'
 import { useJobVisits } from './use-job-visits'
 import { VisitDateBlock } from './visit-date-block'
 import { VisitProofOfWork } from './visit-proof-of-work'
@@ -85,6 +87,13 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
   const assigneeActorId = visit?.assigneeUserId ? toActorId('user', visit.assigneeUserId) : null
   const hydratedAssignee = useActors(assigneeActorId ? [assigneeActorId] : [])
   const assignee = assigneeActorId ? hydratedAssignee.get(assigneeActorId) : undefined
+
+  // Plan 36 §B.1 — boundary detection for the Restore chooser (before the early returns:
+  // hooks must run unconditionally).
+  const { until: seriesUntil } = useSeriesRule(
+    recordId,
+    Boolean(visit && visit.status === 'canceled' && visit.recurrenceRuleId)
+  )
 
   if (isLoading && !visit) {
     return <div className='p-6 text-sm text-muted-foreground'>Loading visit...</div>
@@ -133,6 +142,21 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
     } else {
       mutations.setVisitStatus.mutate({ visitId: visit.id, status: 'canceled' })
     }
+  }
+
+  // This skipped occurrence is where the series ends — restoring it asks visit-only vs
+  // resume (plan 36 §B.1); non-boundary rows restore directly.
+  const isSeriesBoundary =
+    canRestore && isSeries && Boolean(visit.occurrenceDate) && seriesUntil === visit.occurrenceDate
+
+  const handleRestore = async () => {
+    if (!isSeriesBoundary) {
+      mutations.restoreVisit.mutate({ visitId: visit.id })
+      return
+    }
+    const choice = await confirm(restoreSeriesBoundaryConfirmOptions())
+    if (!choice) return
+    mutations.restoreVisit.mutate({ visitId: visit.id, resumeSeries: choice === 'alternate' })
   }
 
   return (
@@ -208,7 +232,7 @@ export function VisitDetailPanel({ recordId, itemId }: RecordDrillContext) {
                 variant='outline'
                 size='sm'
                 loading={mutations.restoreVisit.isPending}
-                onClick={() => mutations.restoreVisit.mutate({ visitId: visit.id })}>
+                onClick={() => void handleRestore()}>
                 <RotateCcw /> Restore
               </Button>
             )}

--- a/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
+++ b/apps/web/src/components/drawers/cards/work-order-related-cards.tsx
@@ -18,6 +18,7 @@ import { useRouter } from 'next/navigation'
 import { Fragment, useState } from 'react'
 import { splitJobVisits } from '~/components/dispatch/ui/job-schedule/job-schedule-utils'
 import { ScheduleVisitRow } from '~/components/dispatch/ui/job-schedule/schedule-visit-row'
+import { SeriesEndRow, SeriesSummaryRow } from '~/components/dispatch/ui/job-schedule/series-end'
 import type { JobVisit } from '~/components/dispatch/ui/job-schedule/use-job-visits'
 import { useJobVisits } from '~/components/dispatch/ui/job-schedule/use-job-visits'
 import { SchedulePopover } from '~/components/dispatch/ui/schedule-popover'
@@ -83,6 +84,14 @@ export function WorkOrderScheduleCard({ recordId }: DrawerTabProps) {
           />
         </DrawerCardActions>
       )}
+      {/* Series state, always visible (plan 36 §B.4) — the drawer previously showed nothing:
+       * "Weekly on Wed, Thu · ends Aug 18 · 3 skipped". Renders nothing for rule-less jobs. */}
+      <SeriesSummaryRow
+        workOrderRecordId={recordId}
+        canEdit={canEdit}
+        visits={visits}
+        onChanged={refresh}
+      />
       {!loading && !visits.length ? (
         <EmptyRow label='No visits yet' />
       ) : (
@@ -94,6 +103,13 @@ export function WorkOrderScheduleCard({ recordId }: DrawerTabProps) {
           renderRow={renderVisitRow}
         />
       )}
+      {/* Terminator row (plan 36 §B.3) — where the upcoming list stops and why. */}
+      <SeriesEndRow
+        workOrderRecordId={recordId}
+        canEdit={canEdit}
+        visits={visits}
+        onChanged={refresh}
+      />
       {history.length > 0 && (
         <TreeRow
           icon={<History className='size-4' />}

--- a/apps/web/src/server/api/routers/dispatch.ts
+++ b/apps/web/src/server/api/routers/dispatch.ts
@@ -39,6 +39,7 @@ import {
   setMyQcItemNote,
   setRecurrenceRule,
   setRouteOrder,
+  setSeriesEnd,
   setVisitDuration,
   setVisitStatus,
   setWorkerActive,
@@ -248,13 +249,16 @@ export const dispatchRouter = createTRPCRouter({
       })
     }),
   // Plan 30 §A.1 — bring a canceled visit back to `scheduled` IN PLACE (never a new time).
+  // `resumeSeries` (plan 36 §A.2): on the series boundary visit only, also clears the
+  // pattern's `until` and regenerates the tail — the symmetric undo of "Skip this and future".
   restoreVisit: dispatchAdminProcedure
-    .input(z.object({ visitId: z.string() }))
+    .input(z.object({ visitId: z.string(), resumeSeries: z.boolean().optional() }))
     .mutation(async ({ ctx, input }) => {
       return restoreVisit({
         organizationId: ctx.session.organizationId,
         userId: ctx.session.user.id,
         visitId: input.visitId,
+        resumeSeries: input.resumeSeries,
         excludeSocketId: excludeSocketId(ctx),
       })
     }),
@@ -665,6 +669,28 @@ export const dispatchRouter = createTRPCRouter({
         template: input.template,
         timezone: input.timezone,
         effectiveFrom: input.effectiveFrom,
+        excludeSocketId: excludeSocketId(ctx),
+      })
+    }),
+  // Plan 36 §A.1 — set, move, or clear the series end date in place (the engagement card's
+  // "Ends" control and the terminator row's Extend). `null` clears it (open-ended).
+  setSeriesEnd: dispatchAdminProcedure
+    .input(
+      z.object({
+        workOrderRecordId: recordIdSchema,
+        until: z
+          .string()
+          .regex(/^\d{4}-\d{2}-\d{2}$/)
+          .nullable(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { entityInstanceId } = parseRecordId(input.workOrderRecordId)
+      return setSeriesEnd({
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.user.id,
+        workOrderInstanceId: entityInstanceId,
+        until: input.until,
         excludeSocketId: excludeSocketId(ctx),
       })
     }),

--- a/apps/worker/scripts/verify-dispatch-series-end.ts
+++ b/apps/worker/scripts/verify-dispatch-series-end.ts
@@ -1,0 +1,363 @@
+// apps/worker/scripts/verify-dispatch-series-end.ts
+/**
+ * Series-end symmetry verification (plans/dispatch/36-series-end-symmetry.md §C). Exercises
+ * the REAL write paths in `packages/lib/src/dispatch/`:
+ *
+ * - `cancelVisitFollowing` (recurring/engagement-actions.ts): `until` stamp + tail delete +
+ *   the new synchronous exhaustion check (must NOT end an engagement that still has upcoming
+ *   occurrences).
+ * - `restoreVisit` (visit-mutations.ts): visit-only restore leaves `until`; `resumeSeries`
+ *   clears `until` + regenerates the tail; rejected off the series boundary and on an ended
+ *   engagement.
+ * - `setSeriesEnd` (recurring/rule-mutations.ts): shorten deletes the tail, extend/clear
+ *   regenerates, past / pre-`effectiveFrom` / ended-engagement writes rejected.
+ * - `maybeEndExhaustedEngagement` (recurring/materialize.ts): an empty generation window
+ *   (`until < effectiveFrom`, the WO-0002 specimen) auto-ends the engagement as soon as no
+ *   future scheduled rows remain.
+ *
+ * Work orders are created via `UnifiedCrudHandler.create` (M1 hooks), prefixed
+ * "[series-end-verify]", and deleted at the end — `WorkOrderVisit.workOrderId` AND
+ * `RecurrenceRule.subjectId` cascade on `EntityInstance` delete (the
+ * `verify-dispatch-recurring.ts` precedent). No dispatch/notification/money path is touched,
+ * so no queue pausing is needed (unlike `verify-dispatch-scheduling-fixes.ts`).
+ *
+ * Timing: the dev org has no `OperatingHours` row so the org resolves to 'UTC' (asserted as a
+ * precondition); all rules here are created with `timezone: 'UTC'` and day math is plain UTC.
+ *
+ * Run (from repo root) under the worker runtime:
+ *   cd apps/worker && npx dotenv -e ../../.env -- node --conditions source --import tsx/esm \
+ *     scripts/verify-dispatch-series-end.ts
+ */
+
+import { database } from '@auxx/database'
+import {
+  cancelVisitFollowing,
+  getWorkOrderStatus,
+  materializeVisits,
+  restoreVisit,
+  setRecurrenceRule,
+  setSeriesEnd,
+  setVisitStatus,
+} from '@auxx/lib/dispatch'
+import { BadRequestError } from '@auxx/lib/errors'
+import type { RecurrencePattern } from '@auxx/lib/recurrence'
+import { UnifiedCrudHandler } from '@auxx/lib/resources'
+
+let pass = 0
+let fail = 0
+function check(name: string, ok: boolean, detail?: unknown) {
+  if (ok) {
+    pass++
+    console.log(`  ✅ ${name}`)
+  } else {
+    fail++
+    console.log(`  ❌ ${name}`, detail ?? '')
+  }
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+function addDaysToIso(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00.000Z`)
+  d.setUTCDate(d.getUTCDate() + days)
+  return isoDate(d)
+}
+function weekdayOfIso(iso: string): number {
+  return new Date(`${iso}T00:00:00.000Z`).getUTCDay()
+}
+
+async function getVisitsSorted(workOrderInstanceId: string) {
+  return database.query.WorkOrderVisit.findMany({
+    where: (t, { eq }) => eq(t.workOrderId, workOrderInstanceId),
+    orderBy: (t, { asc }) => [asc(t.occurrenceDate), asc(t.startTime)],
+  })
+}
+
+async function getRule(workOrderInstanceId: string) {
+  const rule = await database.query.RecurrenceRule.findFirst({
+    where: (t, { eq }) => eq(t.subjectId, workOrderInstanceId),
+  })
+  if (!rule) throw new Error(`No rule for work order ${workOrderInstanceId}`)
+  return rule
+}
+
+async function getPattern(workOrderInstanceId: string): Promise<RecurrencePattern> {
+  return (await getRule(workOrderInstanceId)).pattern as RecurrencePattern
+}
+
+async function expectThrow(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+    return undefined
+  } catch (err) {
+    return err ?? new Error('threw a falsy value')
+  }
+}
+
+async function main() {
+  const user = await database.query.User.findFirst({
+    columns: { id: true },
+    where: (t, { eq }) => eq(t.email, 'm4rkuskk@gmail.com'),
+  })
+  if (!user) throw new Error('Dev user not found')
+  const organizationId = 'u45w22ft66ymiaa19ohs7m9f' // Marki Corp (primary dev org)
+  const userId = user.id
+  console.log(`Org ${organizationId}, user ${userId}`)
+
+  const opHours = await database.query.OperatingHours.findFirst({
+    where: (t, { and, eq }) =>
+      and(eq(t.organizationId, organizationId), eq(t.subjectType, 'organization')),
+    columns: { timezone: true },
+  })
+  if (opHours?.timezone && opHours.timezone !== 'UTC') {
+    throw new Error(`Expected dev org timezone 'UTC', got '${opHours.timezone}'`)
+  }
+
+  const todayIso = isoDate(new Date())
+  const anchorIso = addDaysToIso(todayIso, 3)
+  const weekday = weekdayOfIso(anchorIso)
+
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+  const createdRecordIds: string[] = []
+
+  async function createRecurringWO(title: string, pattern: RecurrencePattern) {
+    const wo = await handler.create('work_order', {
+      work_order_title: `[series-end-verify] ${title}`,
+    })
+    createdRecordIds.push(wo.recordId)
+    await setRecurrenceRule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo.instance.id,
+      pattern,
+      template: { startMinute: 720, durationMinutes: 60 },
+      timezone: 'UTC',
+      effectiveFrom: anchorIso,
+    })
+    return wo
+  }
+
+  try {
+    // ══════════════════════════════════════════════════════════════════════
+    // 1. Skip-future stamps `until`, deletes the tail, does NOT end an engagement that
+    //    still has upcoming occurrences; visit-only restore leaves `until` in place.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('1: skip-future → restore (visit only)')
+    const weekly: RecurrencePattern = { frequency: 'weekly', interval: 1, weekdays: [weekday] }
+    const wo1 = await createRecurringWO('skip-future restore', weekly)
+    const rows1 = (await getVisitsSorted(wo1.instance.id)).filter((r) => r.recurrenceRuleId)
+    check('setup: horizon materialized several occurrences', rows1.length >= 4, rows1.length)
+    const target1 = rows1[2]!
+
+    await cancelVisitFollowing({ organizationId, userId, visitId: target1.id })
+    const after1 = await getVisitsSorted(wo1.instance.id)
+    check(
+      'target tombstoned (canceled)',
+      after1.find((r) => r.id === target1.id)?.status === 'canceled'
+    )
+    check(
+      'later scheduled rows deleted',
+      after1.filter(
+        (r) =>
+          r.occurrenceDate && target1.occurrenceDate && r.occurrenceDate > target1.occurrenceDate
+      ).length === 0
+    )
+    check(
+      'pattern.until = target occurrenceDate',
+      (await getPattern(wo1.instance.id)).until === target1.occurrenceDate
+    )
+    check(
+      'exhaustion check did NOT end the engagement (upcoming occurrences remain)',
+      (await getWorkOrderStatus(organizationId, userId, wo1.instance.id)) === 'active'
+    )
+
+    await restoreVisit({ organizationId, userId, visitId: target1.id })
+    const restored1 = (await getVisitsSorted(wo1.instance.id)).find((r) => r.id === target1.id)
+    check('visit-only restore: status → scheduled in place', restored1?.status === 'scheduled')
+    check(
+      'visit-only restore leaves pattern.until (series still ends there)',
+      (await getPattern(wo1.instance.id)).until === target1.occurrenceDate
+    )
+    await materializeVisits(await getRule(wo1.instance.id), { userId })
+    check(
+      're-materialize regenerates nothing past until',
+      (await getVisitsSorted(wo1.instance.id)).filter(
+        (r) =>
+          r.occurrenceDate && target1.occurrenceDate && r.occurrenceDate > target1.occurrenceDate
+      ).length === 0
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 2. Boundary restore with resumeSeries clears `until` + regenerates the tail;
+    //    resumeSeries off the boundary is rejected.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('2: skip-future → restore + resume')
+    await cancelVisitFollowing({ organizationId, userId, visitId: target1.id })
+    await restoreVisit({ organizationId, userId, visitId: target1.id, resumeSeries: true })
+    const pattern2 = await getPattern(wo1.instance.id)
+    check('resume clears pattern.until (open-ended again)', pattern2.until === undefined, pattern2)
+    const resumed2 = await getVisitsSorted(wo1.instance.id)
+    check(
+      'resume regenerates the tail past the old boundary',
+      resumed2.some(
+        (r) =>
+          r.status === 'scheduled' &&
+          r.occurrenceDate &&
+          target1.occurrenceDate &&
+          r.occurrenceDate > target1.occurrenceDate
+      )
+    )
+    check(
+      'restored boundary row not duplicated',
+      resumed2.filter((r) => r.occurrenceDate === target1.occurrenceDate).length === 1
+    )
+
+    const nonBoundary2 = resumed2.find((r) => r.recurrenceRuleId && r.status === 'scheduled')!
+    await setVisitStatus({ organizationId, userId, visitId: nonBoundary2.id, status: 'canceled' })
+    const err2 = await expectThrow(() =>
+      restoreVisit({ organizationId, userId, visitId: nonBoundary2.id, resumeSeries: true })
+    )
+    check(
+      'resumeSeries off the boundary rejected (BadRequest)',
+      err2 instanceof BadRequestError,
+      err2
+    )
+    await restoreVisit({ organizationId, userId, visitId: nonBoundary2.id })
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 3. setSeriesEnd: shorten deletes the tail; invalid writes rejected; clear regenerates.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('3: setSeriesEnd')
+    const rows3 = (await getVisitsSorted(wo1.instance.id)).filter(
+      (r) => r.recurrenceRuleId && r.status === 'scheduled'
+    )
+    const cutoff3 = rows3[1]!.occurrenceDate!
+    await setSeriesEnd({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo1.instance.id,
+      until: cutoff3,
+    })
+    check('shorten stamps pattern.until', (await getPattern(wo1.instance.id)).until === cutoff3)
+    check(
+      'shorten deletes scheduled rows past the end',
+      (await getVisitsSorted(wo1.instance.id)).filter(
+        (r) => r.status === 'scheduled' && r.occurrenceDate && r.occurrenceDate > cutoff3
+      ).length === 0
+    )
+
+    const errPast = await expectThrow(() =>
+      setSeriesEnd({
+        organizationId,
+        userId,
+        workOrderInstanceId: wo1.instance.id,
+        until: addDaysToIso(todayIso, -1),
+      })
+    )
+    check('past end date rejected', errPast instanceof BadRequestError, errPast)
+
+    // effectiveFrom is the anchor (today+3); today+1 is >= today but before it.
+    const errWindow = await expectThrow(() =>
+      setSeriesEnd({
+        organizationId,
+        userId,
+        workOrderInstanceId: wo1.instance.id,
+        until: addDaysToIso(todayIso, 1),
+      })
+    )
+    check('end date before effectiveFrom rejected', errWindow instanceof BadRequestError, errWindow)
+
+    await setSeriesEnd({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo1.instance.id,
+      until: null,
+    })
+    check('clear removes pattern.until', (await getPattern(wo1.instance.id)).until === undefined)
+    check(
+      'clear regenerates the tail',
+      (await getVisitsSorted(wo1.instance.id)).some(
+        (r) => r.status === 'scheduled' && r.occurrenceDate && r.occurrenceDate > cutoff3
+      )
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 4. Empty generation window (until < effectiveFrom, the WO-0002 specimen) auto-ends the
+    //    engagement once no future scheduled rows remain; ended engagements reject both
+    //    setSeriesEnd and resumeSeries.
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('4: window-empty auto-end')
+    const bounded: RecurrencePattern = {
+      frequency: 'weekly',
+      interval: 1,
+      weekdays: [weekday],
+      until: addDaysToIso(anchorIso, 7), // exactly two occurrences: anchor, anchor+7
+    }
+    const wo4 = await createRecurringWO('window empty', bounded)
+    const rows4 = (await getVisitsSorted(wo4.instance.id)).filter((r) => r.recurrenceRuleId)
+    check('setup: bounded series materialized 2 occurrences', rows4.length === 2, rows4.length)
+    for (const row of rows4) {
+      await setVisitStatus({ organizationId, userId, visitId: row.id, status: 'canceled' })
+    }
+    check(
+      'skips alone do not end the series early (until still ahead)',
+      (await getWorkOrderStatus(organizationId, userId, wo4.instance.id)) === 'active'
+    )
+
+    // Scope-edit re-anchor past the pattern's own end — legal, but the window is now empty
+    // and nothing is upcoming, so the synchronous exhaustion check must end the engagement.
+    await setRecurrenceRule({
+      organizationId,
+      userId,
+      workOrderInstanceId: wo4.instance.id,
+      pattern: bounded,
+      template: { startMinute: 720, durationMinutes: 60 },
+      timezone: 'UTC',
+      effectiveFrom: addDaysToIso(anchorIso, 14),
+    })
+    check(
+      'empty-window scope edit auto-ends the engagement',
+      (await getWorkOrderStatus(organizationId, userId, wo4.instance.id)) === 'ended'
+    )
+
+    const errEnded = await expectThrow(() =>
+      setSeriesEnd({
+        organizationId,
+        userId,
+        workOrderInstanceId: wo4.instance.id,
+        until: addDaysToIso(anchorIso, 30),
+      })
+    )
+    check('setSeriesEnd on an ended engagement rejected', errEnded instanceof BadRequestError)
+
+    const boundary4 = (await getVisitsSorted(wo4.instance.id)).find(
+      (r) => r.occurrenceDate === bounded.until
+    )!
+    const errResumeEnded = await expectThrow(() =>
+      restoreVisit({ organizationId, userId, visitId: boundary4.id, resumeSeries: true })
+    )
+    check(
+      'resumeSeries on an ended engagement rejected',
+      errResumeEnded instanceof BadRequestError,
+      errResumeEnded
+    )
+  } finally {
+    console.log(`Cleanup: deleting ${createdRecordIds.length} verify records`)
+    for (const recordId of createdRecordIds.reverse()) {
+      try {
+        await handler.delete(recordId as never)
+      } catch (err) {
+        console.log(`  cleanup failed for ${recordId}:`, err instanceof Error ? err.message : err)
+      }
+    }
+  }
+
+  console.log(`\n${pass}/${pass + fail} passed`)
+  process.exit(fail > 0 ? 1 : 0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/lib/src/dispatch/index.ts
+++ b/packages/lib/src/dispatch/index.ts
@@ -63,15 +63,18 @@ export type {
   EngagementActionInput,
   RecurrenceTemplate,
   SetRecurrenceRuleInput,
+  SetSeriesEndInput,
 } from './recurring'
 export {
   cancelVisitFollowing,
   endEngagement,
   getWorkOrderStatus,
   materializeVisits,
+  maybeEndExhaustedEngagement,
   pauseEngagement,
   resumeEngagement,
   setRecurrenceRule,
+  setSeriesEnd,
   sweepRecurringVisits,
 } from './recurring'
 export type {

--- a/packages/lib/src/dispatch/recurring/engagement-actions.ts
+++ b/packages/lib/src/dispatch/recurring/engagement-actions.ts
@@ -16,7 +16,7 @@ import { exitRunsForDeadVisitSubjects } from '../../sequences/hooks'
 import { publishVisitChanged } from '../broadcast'
 import { mirrorVisitOntoWorkOrder } from '../mirror'
 import { setVisitStatus } from '../visit-mutations'
-import { materializeVisits, todayLocalDate } from './materialize'
+import { materializeVisits, maybeEndExhaustedEngagement, todayLocalDate } from './materialize'
 
 const logger = createScopedLogger('dispatch:recurring:engagement-actions')
 
@@ -222,13 +222,14 @@ export async function cancelVisitFollowing(input: CancelVisitFollowingInput): Pr
   await setVisitStatus({ organizationId, userId, visitId, status: 'canceled', excludeSocketId })
 
   const { count: _count, ...pattern } = rule.pattern as unknown as RecurrencePattern
-  await database
+  const [updatedRule] = await database
     .update(schema.RecurrenceRule)
     .set({
       pattern: { ...pattern, until: visit.occurrenceDate } as unknown as Record<string, unknown>,
       updatedAt: new Date(),
     })
     .where(eq(schema.RecurrenceRule.id, rule.id))
+    .returning()
 
   const deleted = await database
     .delete(schema.WorkOrderVisit)
@@ -249,4 +250,9 @@ export async function cancelVisitFollowing(input: CancelVisitFollowingInput): Pr
   // The deletions can change the job's next-visit mirror — mirror + broadcast once more on
   // top of `setVisitStatus`'s own (which ran before the future rows disappeared).
   await mirrorAndBroadcast(rule, userId, excludeSocketId)
+
+  // Plan 36 §A.3: this skip may have killed the whole remaining series (target was the only
+  // upcoming occurrence, or the rule window is now empty) — check synchronously instead of
+  // leaving the engagement claiming Active until the daily sweep catches it.
+  if (updatedRule) await maybeEndExhaustedEngagement(updatedRule)
 }

--- a/packages/lib/src/dispatch/recurring/index.ts
+++ b/packages/lib/src/dispatch/recurring/index.ts
@@ -9,6 +9,15 @@ export {
   pauseEngagement,
   resumeEngagement,
 } from './engagement-actions'
-export { getWorkOrderStatus, materializeVisits, sweepRecurringVisits } from './materialize'
-export type { RecurrenceTemplate, SetRecurrenceRuleInput } from './rule-mutations'
-export { setRecurrenceRule } from './rule-mutations'
+export {
+  getWorkOrderStatus,
+  materializeVisits,
+  maybeEndExhaustedEngagement,
+  sweepRecurringVisits,
+} from './materialize'
+export type {
+  RecurrenceTemplate,
+  SetRecurrenceRuleInput,
+  SetSeriesEndInput,
+} from './rule-mutations'
+export { setRecurrenceRule, setSeriesEnd } from './rule-mutations'

--- a/packages/lib/src/dispatch/recurring/materialize.ts
+++ b/packages/lib/src/dispatch/recurring/materialize.ts
@@ -183,19 +183,25 @@ export async function materializeVisits(
 }
 
 /**
- * Auto-end an exhausted recurring engagement (§4.1/§4.4): exhausted = the pattern has an
- * `until`/`count` end condition AND that end is consumed (`until` before today, or `count`
- * reached by existing rows) AND no future `scheduled` visits remain. Writes
- * `work_order_status` → `ended` via plain `FieldValueService` (the sanctioned engine writer)
- * then mirrors + broadcasts.
+ * Auto-end an exhausted recurring engagement (§4.1/§4.4, plan 36 §A.3): exhausted = the
+ * pattern has an `until`/`count` end condition AND that end is consumed — `until` before
+ * today, `until` before `effectiveFrom` (an empty generation window: a scope edit re-anchored
+ * the pattern past its own end, so nothing can ever generate), or `count` reached by existing
+ * rows — AND no future `scheduled` visits remain. Writes `work_order_status` → `ended` via
+ * plain `FieldValueService` (the sanctioned engine writer) then mirrors + broadcasts.
+ *
+ * Exported (plan 36) so the mutations that can end a series (`cancelVisitFollowing`,
+ * `setSeriesEnd`, `setRecurrenceRule`) run it synchronously instead of leaving a dead rule
+ * claiming Active until the daily sweep catches it.
  */
-async function maybeEndExhaustedEngagement(rule: RecurrenceRuleRow): Promise<void> {
+export async function maybeEndExhaustedEngagement(rule: RecurrenceRuleRow): Promise<void> {
   const pattern = rule.pattern as unknown as RecurrencePattern
   if (pattern.until === undefined && pattern.count === undefined) return // never-ending
 
   const todayIso = todayLocalDate(rule.timezone)
 
-  const untilExhausted = pattern.until !== undefined && pattern.until < todayIso
+  const untilExhausted =
+    pattern.until !== undefined && (pattern.until < todayIso || pattern.until < rule.effectiveFrom)
   let countExhausted = false
   if (pattern.count !== undefined) {
     const [row] = await database

--- a/packages/lib/src/dispatch/recurring/rule-mutations.ts
+++ b/packages/lib/src/dispatch/recurring/rule-mutations.ts
@@ -13,12 +13,20 @@ import { extractValue } from '@auxx/types'
 import { toRecordId } from '@auxx/types/resource'
 import { addDays, format } from 'date-fns'
 import { fromZonedTime, toZonedTime } from 'date-fns-tz'
-import { and, asc, eq, gte, inArray, isNotNull, isNull } from 'drizzle-orm'
+import { and, asc, eq, gt, gte, inArray, isNotNull, isNull } from 'drizzle-orm'
 import { getOrgCache } from '../../cache'
+import { BadRequestError, NotFoundError } from '../../errors'
 import { FieldValueService } from '../../field-values/field-value-service'
 import { expandOccurrences, type RecurrencePattern } from '../../recurrence'
 import { exitRunsForDeadVisitSubjects } from '../../sequences/hooks'
-import { getWorkOrderStatus, materializeVisits, todayLocalDate } from './materialize'
+import { publishVisitChanged } from '../broadcast'
+import { mirrorVisitOntoWorkOrder } from '../mirror'
+import {
+  getWorkOrderStatus,
+  materializeVisits,
+  maybeEndExhaustedEngagement,
+  todayLocalDate,
+} from './materialize'
 
 const logger = createScopedLogger('dispatch:recurring:rule-mutations')
 
@@ -353,5 +361,124 @@ export async function setRecurrenceRule(input: SetRecurrenceRuleInput): Promise<
   }
 
   await materializeVisits(rule, { userId, excludeSocketId })
+
+  // Plan 36 §A.3/§A.4: a scope edit can legally re-anchor `effectiveFrom` past the pattern's
+  // own `until` (the tail segment is simply empty) — but then the series may be fully dead.
+  // Run the exhaustion check synchronously so the engagement never silently claims Active
+  // over a rule that can't generate; cheap no-op for a never-ending pattern.
+  await maybeEndExhaustedEngagement(rule)
   return rule
+}
+
+/** Input for {@link setSeriesEnd}. */
+export interface SetSeriesEndInput {
+  organizationId: string
+  userId: string
+  /** EntityInstance id of the work order (not the RecordId). */
+  workOrderInstanceId: string
+  /** Inclusive local ISO end date (`YYYY-MM-DD`); `null` clears the end (open-ended). */
+  until: string | null
+  /** Realtime echo-suppression — the acting client's own socket id (07 §B.4). */
+  excludeSocketId?: string
+}
+
+/**
+ * Set, move, or clear a series' end date IN PLACE (plan 36 §A.1) — the engagement card's
+ * "Ends" control, and the explicit reverse of `cancelVisitFollowing`'s `until` stamp. Pattern
+ * and template stay untouched (`count` is stripped — `until`/`count` are mutually exclusive).
+ *
+ * Shortening deletes the rule's later `scheduled` rows slot-based (`occurrenceDate` strictly
+ * after the new end) — detached overrides included, their slot is gone with the series;
+ * `done`/in-flight rows stay as history, existing tombstones stay. Extending or clearing
+ * re-materializes the tail (template occurrences only — overrides a previous shorten deleted
+ * are NOT resurrected). A paused engagement only gets the rule write (resume owns
+ * regeneration); an ended engagement is rejected (terminal — plan 06 §8).
+ */
+export async function setSeriesEnd(input: SetSeriesEndInput): Promise<RecurrenceRuleRow> {
+  const { organizationId, userId, workOrderInstanceId, until, excludeSocketId } = input
+
+  const rule = await database.query.RecurrenceRule.findFirst({
+    where: and(
+      eq(schema.RecurrenceRule.organizationId, organizationId),
+      eq(schema.RecurrenceRule.subjectType, 'work_order_visits'),
+      eq(schema.RecurrenceRule.subjectId, workOrderInstanceId)
+    ),
+  })
+  if (!rule) throw new NotFoundError('No recurrence rule for this work order')
+
+  const status = await getWorkOrderStatus(organizationId, userId, workOrderInstanceId)
+  if (status === 'ended') {
+    throw new BadRequestError('This engagement has ended — create a new job to schedule again')
+  }
+
+  if (until !== null) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(until)) {
+      throw new BadRequestError('End date must be a YYYY-MM-DD date')
+    }
+    // Ending in the past is `endEngagement`'s job; a window-empty write (`until` before
+    // `effectiveFrom`) is only ever legal as a scope-edit side effect (§A.4), never manually.
+    if (until < todayLocalDate(rule.timezone)) {
+      throw new BadRequestError('The end date cannot be in the past — end the engagement instead')
+    }
+    if (until < rule.effectiveFrom) {
+      throw new BadRequestError(
+        'The end date cannot come before the date the current schedule takes effect'
+      )
+    }
+  }
+
+  const { count: _count, until: _until, ...rest } = rule.pattern as unknown as RecurrencePattern
+  const pattern = (until === null ? rest : { ...rest, until }) as RecurrencePattern
+
+  const [updated] = await database
+    .update(schema.RecurrenceRule)
+    .set({ pattern: pattern as unknown as Record<string, unknown>, updatedAt: new Date() })
+    .where(eq(schema.RecurrenceRule.id, rule.id))
+    .returning()
+  if (!updated) throw new NotFoundError('Recurrence rule not found')
+
+  if (until !== null) {
+    const deleted = await database
+      .delete(schema.WorkOrderVisit)
+      .where(
+        and(
+          eq(schema.WorkOrderVisit.recurrenceRuleId, rule.id),
+          eq(schema.WorkOrderVisit.status, 'scheduled'),
+          gt(schema.WorkOrderVisit.occurrenceDate, until)
+        )
+      )
+      .returning({ id: schema.WorkOrderVisit.id })
+    if (deleted.length > 0) {
+      try {
+        await exitRunsForDeadVisitSubjects(
+          organizationId,
+          deleted.map((row) => row.id),
+          'canceled'
+        )
+      } catch (error) {
+        logger.error('Failed to exit sequence runs for series-end-deleted visits', {
+          error,
+          ruleId: rule.id,
+        })
+      }
+    }
+  }
+
+  if (status === 'paused') {
+    // Pause already deleted the future rows — never regenerate them here (resume owns that).
+    // Mirror + broadcast directly so other tabs still refresh the rule state.
+    await mirrorVisitOntoWorkOrder(organizationId, userId, rule.subjectId)
+    await publishVisitChanged(
+      organizationId,
+      { visitId: rule.id, workOrderId: rule.subjectId },
+      { excludeSocketId }
+    )
+  } else {
+    // Extend/clear regenerates the tail; a shorten rides the same call for its
+    // mirror + broadcast (nothing new inserts past `until` — the expansion stops there).
+    await materializeVisits(updated, { userId, excludeSocketId })
+  }
+
+  await maybeEndExhaustedEngagement(updated)
+  return updated
 }

--- a/packages/lib/src/dispatch/types.ts
+++ b/packages/lib/src/dispatch/types.ts
@@ -89,6 +89,14 @@ export interface RestoreVisitInput {
   organizationId: string
   userId: string
   visitId: string
+  /**
+   * Plan 36 §A.2 — also resume the series: only legal on the series' boundary visit (the
+   * canceled occurrence whose `occurrenceDate` equals the rule pattern's `until`, i.e. the
+   * visit a "Skip this and future" ended the series at). Clears the pattern's `until` and
+   * re-materializes the tail (template occurrences only — overrides the skip deleted are
+   * NOT resurrected).
+   */
+  resumeSeries?: boolean
   excludeSocketId?: string
 }
 

--- a/packages/lib/src/dispatch/visit-mutations.ts
+++ b/packages/lib/src/dispatch/visit-mutations.ts
@@ -10,6 +10,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import { BadRequestError, NotFoundError } from '../errors'
 import { maybeGenerateVisitInvoiceDraft } from '../money/auto-invoice'
+import type { RecurrencePattern } from '../recurrence'
 import {
   enrollVisitEnRouteSequences,
   enrollVisitScheduledSequences,
@@ -20,6 +21,9 @@ import { reanchorSequenceRuns } from '../sequences/reanchor'
 import { publishVisitChanged } from './broadcast'
 import { type LifecycleTrigger, rollUpWorkOrderStatus } from './lifecycle'
 import { mirrorVisitOntoWorkOrder } from './mirror'
+// Direct module import (not the ./recurring barrel) — the barrel pulls engagement-actions,
+// which imports this file back (the lib barrel-cycle gotcha).
+import { getWorkOrderStatus, materializeVisits } from './recurring/materialize'
 import type {
   AddVisitInput,
   AssignVisitInput,
@@ -223,9 +227,14 @@ export async function scheduleVisit(input: ScheduleVisitInput): Promise<WorkOrde
  * restores to its overridden time, not the template slot) and clears `dispatchedAt` (it was
  * already cleared at cancel, §A.2 — this is belt-and-suspenders). Never sends a worker
  * notification — the visit comes back undispatched, "Dispatch" reads fresh again.
+ *
+ * With `resumeSeries` (plan 36 §A.2 — only legal on the series boundary visit, the occurrence
+ * a "Skip this and future" ended the series at): also clears the rule pattern's `until` and
+ * re-materializes the tail, making restore the symmetric undo of skip-future. Without it, the
+ * restored visit stays the series' final occurrence.
  */
 export async function restoreVisit(input: RestoreVisitInput): Promise<WorkOrderVisitRow> {
-  const { organizationId, userId, visitId, excludeSocketId } = input
+  const { organizationId, userId, visitId, resumeSeries, excludeSocketId } = input
 
   const existing = await database.query.WorkOrderVisit.findFirst({
     where: and(
@@ -236,6 +245,30 @@ export async function restoreVisit(input: RestoreVisitInput): Promise<WorkOrderV
   if (!existing) throw new NotFoundError('Visit not found')
   if (existing.status !== 'canceled') {
     throw new BadRequestError('Only a canceled visit can be restored')
+  }
+
+  // Verify the boundary condition server-side before any write — the client should never
+  // offer "resume" elsewhere, and a stale client must not clear an unrelated end date.
+  let seriesRule: typeof schema.RecurrenceRule.$inferSelect | undefined
+  if (resumeSeries) {
+    if (!existing.recurrenceRuleId || !existing.occurrenceDate) {
+      throw new BadRequestError('Visit is not part of a recurring series')
+    }
+    seriesRule = await database.query.RecurrenceRule.findFirst({
+      where: and(
+        eq(schema.RecurrenceRule.id, existing.recurrenceRuleId),
+        eq(schema.RecurrenceRule.organizationId, organizationId)
+      ),
+    })
+    if (!seriesRule) throw new NotFoundError('Recurrence rule not found')
+    const pattern = seriesRule.pattern as unknown as RecurrencePattern
+    if (pattern.until !== existing.occurrenceDate) {
+      throw new BadRequestError('Visit is not the end of its series')
+    }
+    const status = await getWorkOrderStatus(organizationId, userId, existing.workOrderId)
+    if (status === 'ended') {
+      throw new BadRequestError('This engagement has ended — create a new job to schedule again')
+    }
   }
 
   const [updated] = await database
@@ -254,6 +287,22 @@ export async function restoreVisit(input: RestoreVisitInput): Promise<WorkOrderV
   // `scheduleVisit` (lifecycle.ts): restoring a canceled visit is a forward move, never the
   // `canceled`/`unscheduled` reset.
   await afterVisitWrite(updated, { userId, trigger: 'scheduled', excludeSocketId })
+
+  // Plan 36 §A.2 — resume: clear the pattern's `until` (back to open-ended; the pre-skip
+  // value isn't stored anywhere) and regenerate the tail. A paused engagement only gets the
+  // rule write — pause deleted the future rows and resume owns regeneration.
+  if (resumeSeries && seriesRule) {
+    const { until: _until, ...pattern } = seriesRule.pattern as unknown as RecurrencePattern
+    const [updatedRule] = await database
+      .update(schema.RecurrenceRule)
+      .set({ pattern: pattern as unknown as Record<string, unknown>, updatedAt: new Date() })
+      .where(eq(schema.RecurrenceRule.id, seriesRule.id))
+      .returning()
+    const status = await getWorkOrderStatus(organizationId, userId, existing.workOrderId)
+    if (updatedRule && status !== 'paused') {
+      await materializeVisits(updatedRule, { userId, excludeSocketId })
+    }
+  }
 
   // Client-notification hooks (plan 19 §4.3): one-off only, mirrors the scheduleVisit revive.
   // Time-less restores (a canceled backlog row) skip enrollment — `visit:scheduled` means a


### PR DESCRIPTION
## Summary

Plan 36 (`plans/dispatch/36-series-end-symmetry.md`, follow-up to plans 29/30): scheduling, skipping, and restoring recurring visits stop being a guessing game. The series-level consequences of "Skip this and future" were written into the `RecurrenceRule` pattern where no scheduler could see them, and the action had no symmetric undo — restoring the skipped visit brought the visit back but the series stayed silently dead (live-reproduced on WO-0002, which also carried a contradictory `effectiveFrom > until` rule that could never generate again while claiming Active).

### Server (`packages/lib/src/dispatch`)

- **`restoreVisit` gains `resumeSeries`** — on the series *boundary* visit (the occurrence whose `occurrenceDate` equals the pattern's `until`, i.e. where a skip-future ended the series), restore can also clear `until` and re-materialize the tail. Boundary is server-verified; rejected off-boundary and on ended engagements.
- **New `dispatch.setSeriesEnd`** — set, move, or clear the series end date in place (the explicit reverse of skip-future's `until` stamp). Shortening deletes later `scheduled` rows slot-based (done/in-flight/tombstones stay); extending/clearing re-materializes; past dates and dates before `effectiveFrom` rejected; paused engagements get the rule write only; ended engagements rejected.
- **`maybeEndExhaustedEngagement` exported + window-aware** — an empty generation window (`until < effectiveFrom`) now counts as exhausted, and the check runs synchronously after `cancelVisitFollowing` / `setSeriesEnd` / `setRecurrenceRule` instead of waiting for the daily sweep. A dead rule can no longer silently claim Active.

### UI (`apps/web`)

- Restoring the boundary visit opens a two-choice dialog mirroring the skip dialog: **Restore visit** (stays the series' final occurrence) vs **Restore and resume future visits**. Non-boundary skips keep one-click restore.
- New `series-end.tsx`: the **"Ends" date editor** (picker + "Remove end date"; shortening confirms with the number of upcoming visits removed), the **terminator row** "Series ends after Tue, Aug 18 — Extend" after the last upcoming visit, and the **drawer series summary** ("Weekly on Wed, Thu · ends Aug 18 · 3 skipped") — the drawer previously showed zero series state. Empty-window rules render "Series ended — no further visits will be generated".
- Engagement card's end condition becomes editable + shows skip count; skip-future confirm copy now says the action is reversible later.

## Verification

- `apps/worker/scripts/verify-dispatch-series-end.ts` — **23/23** against the dev DB: skip-future stamps/deletes/does-not-over-end, visit-only restore leaves `until`, resume clears + regenerates (without resurrecting deleted overrides), all `setSeriesEnd` paths + rejections, empty-window scope edit auto-ends the engagement, ended-engagement rejections.
- Browser pass on WO-0002: dead-window summary rendered, skip-future → boundary chooser → resume brought back the visit **and** the tail (Aug 27 + Sep occurrences), summary flipped live to "no end date · 2 skipped", terminator row cleared, no console errors. Side effect: repaired WO-0002's contradictory rule.
- Typecheck clean in touched files (`packages/lib`, `apps/web`, `apps/worker`); Biome clean.

No schema change, no migration.