### PR TITLE
feat(money): create jobs from unaccepted quotes with accept-time sync

### DIFF
--- a/apps/web/src/components/custom-fields/ui/option-color-picker.tsx
+++ b/apps/web/src/components/custom-fields/ui/option-color-picker.tsx
@@ -53,14 +53,20 @@ export function OptionColorPicker({
           value={value}
           onValueChange={(v) => onChange(v as SelectOptionColor)}>
           {OPTION_COLORS.map((color) => (
-            <DropdownMenuRadioItem key={color.id} value={color.id} className='pl-1.5'>
-              <div
-                className={cn(
-                  'size-3 rounded-full ring-1 ring-inset ring-black/10 dark:ring-white/10 mr-2',
-                  color.swatch
-                )}
-              />
-              {color.label}
+            <DropdownMenuRadioItem
+              key={color.id}
+              value={color.id}
+              indicator='check'
+              className='pl-1.5'>
+              <span className='flex items-center gap-2'>
+                <span
+                  className={cn(
+                    'size-3 rounded-full ring-1 ring-inset ring-black/10 dark:ring-white/10',
+                    color.swatch
+                  )}
+                />
+                {color.label}
+              </span>
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>

--- a/apps/web/src/components/drawers/cards/quote-jobs-card.tsx
+++ b/apps/web/src/components/drawers/cards/quote-jobs-card.tsx
@@ -2,7 +2,16 @@
 'use client'
 
 import { extractRelationshipRecordIds } from '@auxx/lib/field-values/client'
+import { getInstanceId } from '@auxx/types/resource'
+import { Button } from '@auxx/ui/components/button'
+import { toastError } from '@auxx/ui/components/toast'
+import { Plus } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { Tooltip } from '~/components/global/tooltip'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useConfirm } from '~/hooks/use-confirm'
+import { api } from '~/trpc/react'
+import { DrawerCardActions } from '../drawer-card-actions'
 import type { DrawerTabProps } from '../drawer-tab-registry'
 import {
   EmptyRow,
@@ -11,26 +20,84 @@ import {
   TREE_SECONDARY_NOTRUNCATE,
 } from './related-record-row'
 
+/** Statuses a job can be created from (money plan 20 §2.1) — mirrors the server allowlist
+ * in `convertQuoteToWorkOrder`; pre-approval converts get a confirm dialog first. */
+const CONVERTIBLE_STATUSES = new Set(['draft', 'sent', 'approved'])
+
 /**
  * QuoteJobsCard — the work order(s) this quote was converted into (dispatch v5
  * build spec 01: the public accept page auto-converts, so the resulting job must
  * be visible from the quote). Resolves via the `quote_work_orders` inverse of
  * `work_order_quote` — the WorkOrderBillingCard read pattern.
+ *
+ * With no job yet, the card header carries a "Create job" action (money plan 20 §G) that
+ * routes through `convertQuoteToWorkOrder` — a hand-created job that never sets
+ * `work_order_quote` is invisible to the one-active-job guard and acceptance WOULD
+ * duplicate it, so this action is how manual jobs stay on the linked path.
  */
 export function QuoteJobsCard({ recordId }: DrawerTabProps) {
-  const { values, isLoading } = useSystemValues(recordId, ['quote_work_orders'], {
+  const router = useRouter()
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const { values, isLoading } = useSystemValues(recordId, ['quote_work_orders', 'quote_status'], {
     autoFetch: true,
   })
   const workOrderRecordIds = extractRelationshipRecordIds(values.quote_work_orders)
+  const status = (values.quote_status as string | undefined) ?? 'draft'
 
-  if (isLoading) return <RowSkeleton />
-  if (workOrderRecordIds.length === 0) return <EmptyRow label='Not converted to a job yet' />
+  const convertToWorkOrder = api.money.convertQuoteToWorkOrder.useMutation({
+    onError: (error) => toastError({ title: 'Error creating job', description: error.message }),
+  })
+
+  const handleCreateJob = async () => {
+    // Early convert (money plan 20 §F): allowed pre-acceptance, but confirmed.
+    if (status !== 'approved') {
+      const confirmed = await confirm({
+        title: 'Create job before acceptance?',
+        description: "This quote hasn't been accepted yet. Create the job anyway?",
+        confirmText: 'Create job',
+        cancelText: 'Cancel',
+      })
+      if (!confirmed) return
+    }
+    try {
+      const result = await convertToWorkOrder.mutateAsync({ quoteRecordId: recordId })
+      router.push(`/app/work-orders/${getInstanceId(result.recordId)}`)
+    } catch {
+      // onError above already surfaced the toast.
+    }
+  }
+
+  const showCreateAction =
+    !isLoading && workOrderRecordIds.length === 0 && CONVERTIBLE_STATUSES.has(status)
 
   return (
-    <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
-      {workOrderRecordIds.map((id) => (
-        <RelatedRecordRow key={id} recordId={id} statusAttr='work_order_status' />
-      ))}
-    </div>
+    <>
+      {showCreateAction && (
+        <DrawerCardActions>
+          <Tooltip content='Create job' allowInteraction>
+            <Button
+              variant='ghost'
+              size='icon-xs'
+              loading={convertToWorkOrder.isPending}
+              onClick={handleCreateJob}>
+              <Plus />
+            </Button>
+          </Tooltip>
+        </DrawerCardActions>
+      )}
+      <ConfirmDialog />
+      {isLoading ? (
+        <RowSkeleton />
+      ) : workOrderRecordIds.length === 0 ? (
+        <EmptyRow label='Not converted to a job yet' />
+      ) : (
+        <div className={`space-y-0.5 ${TREE_SECONDARY_NOTRUNCATE}`}>
+          {workOrderRecordIds.map((id) => (
+            <RelatedRecordRow key={id} recordId={id} statusAttr='work_order_status' />
+          ))}
+        </div>
+      )}
+    </>
   )
 }

--- a/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
+++ b/apps/web/src/components/money/ui/quote/quote-line-items-tab.tsx
@@ -43,6 +43,9 @@ const EXPIRABLE_STATUSES = new Set(['draft', 'sent'])
 const SENDABLE_STATUSES = new Set(['draft', 'sent'])
 /** Post-draft statuses that can be returned to draft for editing (mirrors invoice SENT_STATUSES). */
 const REVERTIBLE_STATUSES = new Set(['sent', 'approved', 'declined', 'canceled'])
+/** Statuses a job can be created from (money plan 20 §2.1) — mirrors the server allowlist
+ * in `convertQuoteToWorkOrder`; pre-approval converts get a confirm dialog first. */
+const CONVERTIBLE_STATUSES = new Set(['draft', 'sent', 'approved'])
 
 export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabProps) {
   const router = useRouter()
@@ -87,6 +90,17 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
   })
 
   const handleConvert = async () => {
+    // Early convert (money plan 20 §F): allowed pre-acceptance, but confirmed — the
+    // customer hasn't formally said yes yet.
+    if (status !== 'approved') {
+      const confirmed = await confirm({
+        title: 'Create job before acceptance?',
+        description: "This quote hasn't been accepted yet. Create the job anyway?",
+        confirmText: 'Create job',
+        cancelText: 'Cancel',
+      })
+      if (!confirmed) return
+    }
     try {
       const result = await convertToWorkOrder.mutateAsync({ quoteRecordId: recordId })
       // work_order now has a detail page (dispatch M2 build spec §F.2) — land on
@@ -175,7 +189,7 @@ export function QuoteLineItemsTab({ recordId, variant = 'tab' }: DetailViewTabPr
             </>
           )}
 
-          {status === 'approved' && !convertedWorkOrderRecordId && (
+          {CONVERTIBLE_STATUSES.has(status) && !convertedWorkOrderRecordId && (
             <DropdownMenuItem onClick={handleConvert}>
               <SquareArrowOutUpRight /> Convert to job
             </DropdownMenuItem>

--- a/apps/worker/scripts/run-entity-migration-047.ts
+++ b/apps/worker/scripts/run-entity-migration-047.ts
@@ -1,0 +1,32 @@
+// apps/worker/scripts/run-entity-migration-047.ts
+/**
+ * One-off runner for entity migration 047 (line_item.sourceLine provenance field — money
+ * plan 20 §E, plans/dispatch/money/20-early-job-from-quote.md) across all orgs.
+ * Runs ONLY 047 — deliberately not runAllEntityMigrations, so pending migrations from parallel
+ * work stay untouched. Idempotent — safe to re-run to confirm alreadyUpToDate.
+ *
+ * Run (from repo root) under the worker runtime so the @auxx/lib import chain
+ * resolves its native ESM deps:
+ *   node --conditions source --env-file .env --import tsx/esm \
+ *     apps/worker/scripts/run-entity-migration-047.ts
+ */
+
+import { database } from '@auxx/database'
+import {
+  ALL_ENTITY_MIGRATIONS,
+  runEntityMigrationForAllOrgs,
+} from '@auxx/lib/seed/entity-migrations'
+
+async function main() {
+  const migration = ALL_ENTITY_MIGRATIONS.find((m) => m.id === '047-line-item-source-line')
+  if (!migration) throw new Error('Migration 047 not found in registry')
+
+  await runEntityMigrationForAllOrgs(database, migration)
+  console.log('done')
+  process.exit(0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/worker/scripts/verify-money-early-convert.ts
+++ b/apps/worker/scripts/verify-money-early-convert.ts
@@ -1,0 +1,597 @@
+// apps/worker/scripts/verify-money-early-convert.ts
+/**
+ * Money plan 20 (early job from quote — convert before acceptance) integration verification
+ * (plans/dispatch/money/20-early-job-from-quote.md §5). Exercises the real write paths —
+ * `convertQuoteToWorkOrder` (relaxed draft/sent/approved gate + one-active-job guard +
+ * `line_item_source_line` provenance stamp), `acceptQuoteByToken`'s existing-job branch
+ * (skip-create + deposit stamp + review-variant notification + `linkedExistingJob`), and
+ * `declineQuoteByToken`'s job-reference suffix — end to end against the live dev DB.
+ *
+ * SAFETY: same posture as verify-money-line-pricing.ts — `acceptQuoteByToken`/
+ * `declineQuoteByToken`'s only side-notification path is `notifyQuoteCreator` →
+ * `NotificationService.sendNotification`, which is DB-insert + realtime-publish ONLY (no
+ * email/queue path exists). Nothing Stripe-shaped is called; the one PaymentTransaction row
+ * is a synthetic `manual` ledger insert this script deletes in cleanup.
+ *
+ * Org settings this script depends on (`documents.quote.acceptancePageEnabled`,
+ * `documents.quote.autoConvertOnAccept`, `documents.quote.allowDecline`) are read first and
+ * flipped on only if found off, with byte-exact restore in `finally` (line-pricing recipe).
+ *
+ * Creates records prefixed "[EC-verify]" and deletes/reverts everything in a try/finally.
+ * Cleanup order: notifications + payment txns (raw rows) → lines → work orders → quotes →
+ * contact (work orders BEFORE quotes — the quote pre-delete guard mirrors the active-job
+ * lookup).
+ *
+ * Run (from repo root) under the worker runtime:
+ *   cd apps/worker && npx dotenv -- node --conditions source --import tsx/esm \
+ *     scripts/verify-money-early-convert.ts
+ */
+
+import { database, schema } from '@auxx/database'
+import { getOrgCache } from '@auxx/lib/cache'
+import {
+  acceptQuoteByToken,
+  convertQuoteToWorkOrder,
+  declineQuoteByToken,
+  ensureQuotePublicToken,
+  markQuoteSent,
+} from '@auxx/lib/money'
+import { UnifiedCrudHandler } from '@auxx/lib/resources'
+import { ALL_ENTITY_MIGRATIONS } from '@auxx/lib/seed/entity-migrations'
+import { getOrganizationSetting, updateOrganizationSetting } from '@auxx/lib/settings'
+
+/** Build a RecordId string without pulling in `@auxx/types` (not a worker dependency). */
+function toRecordId(entityDefinitionId: string, entityInstanceId: string) {
+  return `${entityDefinitionId}:${entityInstanceId}` as never
+}
+
+let pass = 0
+let fail = 0
+function check(name: string, ok: boolean, detail?: unknown) {
+  if (ok) {
+    pass++
+    console.log(`  ✅ ${name}`)
+  } else {
+    fail++
+    console.log(`  ❌ ${name}`, detail ?? '')
+  }
+}
+
+/** Run `fn`, expecting it to throw. Returns the caught error (or `undefined` if it didn't). */
+async function expectThrow(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+    return undefined
+  } catch (err) {
+    return err ?? new Error('threw a falsy value')
+  }
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+async function entityDefId(organizationId: string, entityType: string) {
+  const def = await database.query.EntityDefinition.findFirst({
+    columns: { id: true },
+    where: (t, { and, eq }) =>
+      and(eq(t.organizationId, organizationId), eq(t.entityType, entityType)),
+  })
+  return def?.id ?? null
+}
+
+async function fieldId(organizationId: string, entityType: string, systemAttribute: string) {
+  const defId = await entityDefId(organizationId, entityType)
+  if (!defId) return null
+  const field = await database.query.CustomField.findFirst({
+    columns: { id: true },
+    where: (t, { and, eq }) =>
+      and(eq(t.entityDefinitionId, defId), eq(t.systemAttribute, systemAttribute)),
+  })
+  return field?.id ?? null
+}
+
+/** Read one `FieldValue` row by (entityType, instanceId, systemAttribute). `null` when unset. */
+async function fieldValueByAttr(
+  organizationId: string,
+  entityType: string,
+  instanceId: string,
+  systemAttribute: string
+) {
+  const fid = await fieldId(organizationId, entityType, systemAttribute)
+  if (!fid) return null
+  const fv = await database.query.FieldValue.findFirst({
+    where: (t, { and, eq }) => and(eq(t.entityId, instanceId), eq(t.fieldId, fid)),
+  })
+  return fv ?? null
+}
+
+/** `line_item` instance ids on a work order. */
+async function lineIdsForWorkOrder(handler: UnifiedCrudHandler, workOrderRecordId: unknown) {
+  const { ids } = await handler.listFiltered({
+    entityDefinitionId: 'line_item',
+    filters: [
+      {
+        id: 'f',
+        logicalOperator: 'AND',
+        conditions: [
+          { id: 'c', fieldId: 'line_item:workOrder', operator: 'is', value: workOrderRecordId },
+        ],
+      },
+    ],
+    limit: 200,
+    mode: 'oneshot',
+  })
+  return ids
+}
+
+/** `work_order` instance ids linked to a given quote (all statuses). */
+async function workOrderIdsForQuote(handler: UnifiedCrudHandler, quoteRecordId: unknown) {
+  const { ids } = await handler.listFiltered({
+    entityDefinitionId: 'work_order',
+    filters: [
+      {
+        id: 'f',
+        logicalOperator: 'AND',
+        conditions: [
+          { id: 'c', fieldId: 'work_order:quote', operator: 'is', value: quoteRecordId },
+        ],
+      },
+    ],
+    limit: 10,
+    mode: 'oneshot',
+  })
+  return ids
+}
+
+/** Newest notification message for a quote instance, or null. */
+async function latestNotificationMessage(organizationId: string, quoteInstanceId: string) {
+  const row = await database.query.Notification.findFirst({
+    where: (t, { and, eq }) =>
+      and(
+        eq(t.organizationId, organizationId),
+        eq(t.entityType, 'quote'),
+        eq(t.entityId, quoteInstanceId)
+      ),
+    orderBy: (t, { desc }) => desc(t.createdAt),
+  })
+  return row?.message ?? null
+}
+
+async function main() {
+  const user = await database.query.User.findFirst({
+    columns: { id: true },
+    where: (t, { eq }) => eq(t.email, 'm4rkuskk@gmail.com'),
+  })
+  if (!user) throw new Error('Dev user not found')
+  const organizationId = 'u45w22ft66ymiaa19ohs7m9f' // Marki Corp (primary dev org)
+  const userId = user.id
+  console.log(`Org ${organizationId}, user ${userId}`)
+
+  const handler = new UnifiedCrudHandler(organizationId, userId)
+
+  const createdContactIds: string[] = []
+  const createdQuoteIds: string[] = []
+  const createdLineIds: string[] = []
+  const createdWorkOrderIds: string[] = []
+  const createdPaymentTransactionIds: string[] = []
+
+  // ── Defensive org-settings guard (byte-exact restore) ────────────────────────
+  const settingKeys = [
+    'documents.quote.acceptancePageEnabled',
+    'documents.quote.autoConvertOnAccept',
+    'documents.quote.allowDecline',
+  ] as const
+  const overridden: Array<{ key: (typeof settingKeys)[number]; original: unknown }> = []
+
+  try {
+    for (const key of settingKeys) {
+      const original = await getOrganizationSetting({ organizationId, key })
+      if (original === false) {
+        await updateOrganizationSetting({ organizationId, key, value: true })
+        await getOrgCache().invalidateAndRecompute(organizationId, ['orgSettings'])
+        overridden.push({ key, original })
+      }
+    }
+
+    // Migration 047 must have run for the provenance stamp to have a field to land on.
+    // It's idempotent, so applying it here doubles as the §5 idempotency check setup.
+    const migration047 = ALL_ENTITY_MIGRATIONS.find((m) => m.id === '047-line-item-source-line')
+    if (!migration047) throw new Error('Migration 047 not found in registry')
+    await migration047.up(database, organizationId)
+    await getOrgCache().invalidateAndRecompute(organizationId, ['customFields'])
+
+    const contact = await handler.create('contact', {
+      first_name: '[EC-verify]',
+      last_name: 'Test Customer',
+      primary_email: 'ec-verify@example.com',
+    })
+    createdContactIds.push(contact.instance.id)
+    const contactRecordId = toRecordId('contact', contact.instance.id)
+
+    async function seedQuote(title: string, opts?: { withOptional?: boolean }) {
+      const quote = await handler.create('quote', {
+        quote_title: title,
+        quote_contact: contactRecordId,
+      })
+      createdQuoteIds.push(quote.instance.id)
+      const required = await handler.create('line_item', {
+        line_item_name: '[EC-verify] Required line',
+        line_item_qty: 1,
+        line_item_unit_price: 10000,
+        line_item_taxable: false,
+        line_item_quote: quote.recordId,
+      })
+      createdLineIds.push(required.instance.id)
+      let optional: Awaited<ReturnType<typeof handler.create>> | undefined
+      if (opts?.withOptional) {
+        optional = await handler.create('line_item', {
+          line_item_name: '[EC-verify] Optional line (pre-checked)',
+          line_item_qty: 1,
+          line_item_unit_price: 5000,
+          line_item_taxable: false,
+          line_item_optional: true,
+          line_item_optional_selected: true,
+          line_item_quote: quote.recordId,
+        })
+        createdLineIds.push(optional.instance.id)
+      }
+      return { quote, required, optional }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // A. Convert gate + guard + provenance (plan §5.1–§5.3)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('A: convert gate + guard + provenance')
+
+    // A.1 — early convert straight from DRAFT.
+    const a = await seedQuote('[EC-verify] Draft-convert quote')
+    const woA1 = await convertQuoteToWorkOrder({
+      organizationId,
+      userId,
+      quoteInstanceId: a.quote.instance.id,
+    })
+    createdWorkOrderIds.push(woA1.instance.id)
+    check('A1: convert on a draft quote succeeds', !!woA1.instance.id)
+
+    // A.2 — copied line carries source-line provenance.
+    const woA1LineIds = await lineIdsForWorkOrder(handler, woA1.recordId)
+    createdLineIds.push(...woA1LineIds)
+    check('A2: exactly one copied line on the job', woA1LineIds.length === 1, woA1LineIds)
+    const a2Provenance = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      woA1LineIds[0]!,
+      'line_item_source_line'
+    )
+    check(
+      'A2: copy stamped line_item_source_line = source quote-line instance id',
+      a2Provenance?.valueText === a.required.instance.id,
+      a2Provenance?.valueText
+    )
+
+    // A.3 — one-active-job guard rejects a second convert.
+    const a3Err = await expectThrow(() =>
+      convertQuoteToWorkOrder({ organizationId, userId, quoteInstanceId: a.quote.instance.id })
+    )
+    check(
+      'A3: second convert rejected (active job exists)',
+      !!a3Err && errMessage(a3Err).includes('already been converted'),
+      a3Err && errMessage(a3Err)
+    )
+
+    // A.4 — canceled jobs don't count: cancel, convert again succeeds.
+    await handler.update(toRecordId('work_order', woA1.instance.id), {
+      work_order_status: 'canceled',
+    })
+    const woA4 = await convertQuoteToWorkOrder({
+      organizationId,
+      userId,
+      quoteInstanceId: a.quote.instance.id,
+    })
+    createdWorkOrderIds.push(woA4.instance.id)
+    createdLineIds.push(...(await lineIdsForWorkOrder(handler, woA4.recordId)))
+    check('A4: convert succeeds again after the job is canceled', !!woA4.instance.id)
+
+    // A.5 — declined quote rejects.
+    const a5 = await seedQuote('[EC-verify] Declined quote')
+    await markQuoteSent({ organizationId, userId, quoteInstanceId: a5.quote.instance.id })
+    const a5Token = await ensureQuotePublicToken(organizationId, a5.quote.instance.id)
+    await declineQuoteByToken(a5Token)
+    const a5Err = await expectThrow(() =>
+      convertQuoteToWorkOrder({ organizationId, userId, quoteInstanceId: a5.quote.instance.id })
+    )
+    check(
+      'A5: convert on a declined quote rejects with the status message',
+      !!a5Err && errMessage(a5Err).includes("quote is 'declined'"),
+      a5Err && errMessage(a5Err)
+    )
+
+    // A.6 — canceled quote rejects (canceled is freely settable, per the quote status hook).
+    const a6 = await seedQuote('[EC-verify] Canceled quote')
+    await handler.update(a6.quote.recordId, { quote_status: 'canceled' })
+    const a6Err = await expectThrow(() =>
+      convertQuoteToWorkOrder({ organizationId, userId, quoteInstanceId: a6.quote.instance.id })
+    )
+    check(
+      'A6: convert on a canceled quote rejects with the status message',
+      !!a6Err && errMessage(a6Err).includes("quote is 'canceled'"),
+      a6Err && errMessage(a6Err)
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // B. Accept with an existing early job (plan §5.4)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('B: accept with existing early job')
+
+    const b = await seedQuote('[EC-verify] Early-then-accept quote')
+    await markQuoteSent({ organizationId, userId, quoteInstanceId: b.quote.instance.id })
+    const woB = await convertQuoteToWorkOrder({
+      organizationId,
+      userId,
+      quoteInstanceId: b.quote.instance.id,
+    })
+    createdWorkOrderIds.push(woB.instance.id)
+    createdLineIds.push(...(await lineIdsForWorkOrder(handler, woB.recordId)))
+    check('B0: early convert from SENT succeeds', !!woB.instance.id)
+
+    // Synthetic pre-paid deposit: quote-linked succeeded charge with no work order yet
+    // (the shape `createStripeDepositCheckout` leaves behind pre-convert).
+    const [depositTxn] = await database
+      .insert(schema.PaymentTransaction)
+      .values({
+        organizationId,
+        provider: 'manual',
+        kind: 'charge',
+        status: 'succeeded',
+        amount: 2500,
+        currency: 'usd',
+        quoteInstanceId: b.quote.instance.id,
+        createdByUserId: userId,
+      })
+      .returning({ id: schema.PaymentTransaction.id })
+    createdPaymentTransactionIds.push(depositTxn!.id)
+
+    const bToken = await ensureQuotePublicToken(organizationId, b.quote.instance.id)
+    const bResult = await acceptQuoteByToken(bToken, { name: 'Verify Customer' })
+    check(
+      'B1: accept with existing job — converted:false, linkedExistingJob:true',
+      bResult.alreadyAccepted === false &&
+        bResult.converted === false &&
+        bResult.linkedExistingJob === true,
+      bResult
+    )
+
+    const bJobIds = await workOrderIdsForQuote(handler, b.quote.recordId)
+    check('B2: still exactly one job for the quote (no duplicate)', bJobIds.length === 1, bJobIds)
+
+    const bTxnAfter = await database.query.PaymentTransaction.findFirst({
+      where: (t, { eq }) => eq(t.id, depositTxn!.id),
+    })
+    check(
+      'B3: deposit txn stamped onto the existing job at accept',
+      bTxnAfter?.workOrderInstanceId === woB.instance.id,
+      bTxnAfter?.workOrderInstanceId
+    )
+
+    const bMessage = await latestNotificationMessage(organizationId, b.quote.instance.id)
+    check(
+      'B4: notification is the review variant (no selection delta)',
+      !!bMessage?.includes('already exists; review its line items'),
+      bMessage
+    )
+
+    const bStatus = await fieldValueByAttr(
+      organizationId,
+      'quote',
+      b.quote.instance.id,
+      'quote_status'
+    )
+    check('B5: quote is approved', bStatus?.optionId === 'approved', bStatus?.optionId)
+
+    // ══════════════════════════════════════════════════════════════════════
+    // C. Accept-time selection change flags drift, never edits the job (plan §2.3/§5.4)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('C: selection-changed variant + snapshot untouched')
+
+    const c = await seedQuote('[EC-verify] Selection-change quote', { withOptional: true })
+    await markQuoteSent({ organizationId, userId, quoteInstanceId: c.quote.instance.id })
+    const woC = await convertQuoteToWorkOrder({
+      organizationId,
+      userId,
+      quoteInstanceId: c.quote.instance.id,
+    })
+    createdWorkOrderIds.push(woC.instance.id)
+    const woCLinesBefore = await lineIdsForWorkOrder(handler, woC.recordId)
+    createdLineIds.push(...woCLinesBefore)
+    check(
+      'C0: early job snapshot copied required + pre-checked optional (2 lines)',
+      woCLinesBefore.length === 2,
+      woCLinesBefore
+    )
+
+    const cToken = await ensureQuotePublicToken(organizationId, c.quote.instance.id)
+    const cResult = await acceptQuoteByToken(cToken, {
+      name: 'Verify Customer',
+      selectedLineIds: [], // explicit deselect-all — a real selection change
+    })
+    check(
+      'C1: accept with existing job — linkedExistingJob:true',
+      cResult.linkedExistingJob === true && cResult.converted === false,
+      cResult
+    )
+    const cMessage = await latestNotificationMessage(organizationId, c.quote.instance.id)
+    check(
+      'C2: notification is the selection-changed variant',
+      !!cMessage?.includes('option selection changed'),
+      cMessage
+    )
+    const woCLinesAfter = await lineIdsForWorkOrder(handler, woC.recordId)
+    check(
+      'C3: job line snapshot untouched by acceptance (still 2 lines)',
+      woCLinesAfter.length === 2,
+      woCLinesAfter
+    )
+    const cOptionalFlag = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      c.optional!.instance.id,
+      'line_item_optional_selected'
+    )
+    check(
+      'C4: QUOTE optional line deselected by the submitted selection',
+      cOptionalFlag?.valueBoolean === false,
+      cOptionalFlag?.valueBoolean
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // D. Accept with NO job — fresh auto-convert unchanged (plan §5.5)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('D: fresh auto-convert on accept')
+
+    const d = await seedQuote('[EC-verify] Fresh-convert quote')
+    await markQuoteSent({ organizationId, userId, quoteInstanceId: d.quote.instance.id })
+    const dToken = await ensureQuotePublicToken(organizationId, d.quote.instance.id)
+    const dResult = await acceptQuoteByToken(dToken, { name: 'Verify Customer' })
+    check(
+      'D1: accept with no job — converted:true, linkedExistingJob:false',
+      dResult.converted === true && dResult.linkedExistingJob === false,
+      dResult
+    )
+    const dJobIds = await workOrderIdsForQuote(handler, d.quote.recordId)
+    createdWorkOrderIds.push(...dJobIds)
+    check('D1: exactly one job created', dJobIds.length === 1, dJobIds)
+    const dJobLineIds = await lineIdsForWorkOrder(handler, toRecordId('work_order', dJobIds[0]!))
+    createdLineIds.push(...dJobLineIds)
+    const dProvenance = await fieldValueByAttr(
+      organizationId,
+      'line_item',
+      dJobLineIds[0]!,
+      'line_item_source_line'
+    )
+    check(
+      'D2: auto-converted copy carries source-line provenance',
+      dProvenance?.valueText === d.required.instance.id,
+      dProvenance?.valueText
+    )
+    const dMessage = await latestNotificationMessage(organizationId, d.quote.instance.id)
+    check(
+      'D3: notification is the plain accepted message (no review suffix)',
+      !!dMessage?.includes('accepted quote') && !dMessage.includes('review'),
+      dMessage
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // E. Decline with an existing early job (plan §5.6)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('E: decline with existing early job')
+
+    const e = await seedQuote('[EC-verify] Early-then-decline quote')
+    await markQuoteSent({ organizationId, userId, quoteInstanceId: e.quote.instance.id })
+    const woE = await convertQuoteToWorkOrder({
+      organizationId,
+      userId,
+      quoteInstanceId: e.quote.instance.id,
+    })
+    createdWorkOrderIds.push(woE.instance.id)
+    createdLineIds.push(...(await lineIdsForWorkOrder(handler, woE.recordId)))
+
+    const eToken = await ensureQuotePublicToken(organizationId, e.quote.instance.id)
+    const eResult = await declineQuoteByToken(eToken, { reason: 'Too expensive' })
+    check('E1: decline succeeds', eResult.alreadyDeclined === false, eResult)
+    const eMessage = await latestNotificationMessage(organizationId, e.quote.instance.id)
+    check(
+      'E2: decline notification carries the existing-job reference',
+      !!eMessage?.includes('exists for this quote'),
+      eMessage
+    )
+    const eJobStatus = await fieldValueByAttr(
+      organizationId,
+      'work_order',
+      woE.instance.id,
+      'work_order_status'
+    )
+    check(
+      'E3: job untouched by decline (never auto-canceled)',
+      eJobStatus?.optionId !== 'canceled',
+      eJobStatus?.optionId
+    )
+
+    // ══════════════════════════════════════════════════════════════════════
+    // F. Migration 047 idempotency (plan §5)
+    // ══════════════════════════════════════════════════════════════════════
+    console.log('F: migration idempotency')
+    const migrationRun1 = await migration047.up(database, organizationId)
+    check(
+      'F1: migration 047 re-run #1 is alreadyUpToDate',
+      migrationRun1.alreadyUpToDate === true,
+      migrationRun1
+    )
+    const migrationRun2 = await migration047.up(database, organizationId)
+    check(
+      'F1: migration 047 re-run #2 is alreadyUpToDate',
+      migrationRun2.alreadyUpToDate === true,
+      migrationRun2
+    )
+  } finally {
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+    console.log(
+      `Cleanup: ${createdPaymentTransactionIds.length} payment txns, ` +
+        `${createdLineIds.length} lines, ${createdWorkOrderIds.length} work orders, ` +
+        `${createdQuoteIds.length} quotes, ${createdContactIds.length} contacts`
+    )
+    // Raw deletes — apps/worker has no direct drizzle-orm dependency (route-planner script
+    // precedent), so operator-needing writes go through the pg client.
+    if (createdPaymentTransactionIds.length > 0) {
+      await database.$client.query('DELETE FROM "PaymentTransaction" WHERE id = ANY($1)', [
+        createdPaymentTransactionIds,
+      ])
+    }
+    if (createdQuoteIds.length > 0) {
+      await database.$client.query(
+        `DELETE FROM "Notification" WHERE "organizationId" = $1 AND "entityType" = 'quote' AND "entityId" = ANY($2)`,
+        [organizationId, createdQuoteIds]
+      )
+    }
+    for (const id of [...new Set(createdLineIds)]) {
+      try {
+        await handler.delete(toRecordId('line_item', id))
+      } catch (err) {
+        console.log(`  cleanup failed for line_item:${id}:`, errMessage(err))
+      }
+    }
+    for (const id of [...new Set(createdWorkOrderIds)]) {
+      try {
+        await handler.delete(toRecordId('work_order', id))
+      } catch (err) {
+        console.log(`  cleanup failed for work_order:${id}:`, errMessage(err))
+      }
+    }
+    for (const id of [...new Set(createdQuoteIds)]) {
+      try {
+        await handler.delete(toRecordId('quote', id))
+      } catch (err) {
+        console.log(`  cleanup failed for quote:${id}:`, errMessage(err))
+      }
+    }
+    for (const id of [...new Set(createdContactIds)]) {
+      try {
+        await handler.delete(toRecordId('contact', id))
+      } catch (err) {
+        console.log(`  cleanup failed for contact:${id}:`, errMessage(err))
+      }
+    }
+    for (const { key, original } of overridden) {
+      await updateOrganizationSetting({ organizationId, key, value: original })
+      await getOrgCache().invalidateAndRecompute(organizationId, ['orgSettings'])
+    }
+  }
+
+  console.log(`\n${pass} passed, ${fail} failed`)
+  process.exit(fail > 0 ? 1 : 0)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/lib/src/dispatch/convert-to-work-order.ts
+++ b/packages/lib/src/dispatch/convert-to-work-order.ts
@@ -43,9 +43,9 @@ export async function convertRequestToWorkOrder(input: ConvertRequestToWorkOrder
 
   // Money MQ1 (01-ui #5): if an approved quote already exists for this request, convert
   // THROUGH the quote instead — same request status flip, but lines come along too.
-  // Delegates to `convertQuoteToWorkOrder`, which does its own approved-status assertion
-  // and request→'converted' mirror, so we return early rather than falling through to the
-  // plain (line-less) path below.
+  // Delegates to `convertQuoteToWorkOrder`, which does its own status allowlist + active-job
+  // guard and request→'converted' mirror, so we return early rather than falling through to
+  // the plain (line-less) path below.
   const approvedQuotes = await handler.listFiltered({
     entityDefinitionId: 'quote',
     filters: [

--- a/packages/lib/src/money/convert-quote.ts
+++ b/packages/lib/src/money/convert-quote.ts
@@ -17,12 +17,84 @@ import type { ConvertQuoteToWorkOrderInput } from './types'
 
 const logger = createScopedLogger('money:convert-quote')
 
+/** Quote statuses a job can be created from (money plan 20 §2.1) — every pre-terminal
+ * stage. Early converts (draft/sent) are the "customer said yes on the phone" flow; the
+ * client shows a confirm dialog before them. */
+const CONVERTIBLE_QUOTE_STATUSES = new Set(['draft', 'sent', 'approved'])
+
 /** Unwrap a `getFieldValues()` map entry — takes the first value if array-returned. */
 function firstTyped(
   entry: TypedFieldValue | TypedFieldValue[] | undefined
 ): TypedFieldValue | undefined {
   if (!entry) return undefined
   return Array.isArray(entry) ? entry[0] : entry
+}
+
+/**
+ * The active (non-canceled) work order already converted from a quote, or undefined.
+ * Shared by the convert guard below and the accept path (money plan 20 §C) — the quote
+ * stays `approved` after conversion (there is no `converted` quote status), so this
+ * lookup is the only duplicate-job defense. Canceled jobs don't count: a canceled
+ * conversion can be redone.
+ */
+export async function findActiveJobForQuote(
+  handler: UnifiedCrudHandler,
+  quoteRecordId: string
+): Promise<string | undefined> {
+  const existingJobs = await handler.listFiltered({
+    entityDefinitionId: 'work_order',
+    filters: [
+      {
+        id: 'converted-job-guard',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'converted-job-guard-quote',
+            fieldId: 'work_order:quote',
+            operator: 'is',
+            value: quoteRecordId,
+          },
+          {
+            id: 'converted-job-guard-status',
+            fieldId: 'work_order:status',
+            operator: 'not in',
+            value: ['canceled'],
+          },
+        ],
+      },
+    ],
+    limit: 1,
+    mode: 'oneshot',
+  })
+  return existingJobs.ids[0]
+}
+
+/**
+ * Stamp succeeded deposit charges for a quote onto its work order (MP2 §B.6). Covers a
+ * deposit paid before any work order existed — at auto-convert, at manual convert, or
+ * (money plan 20 §C) at accept time when an early-converted job already exists.
+ * Idempotent via `isNull(workOrderInstanceId)`. A direct write, not routed through
+ * `ledger.ts` — the plan sanctions this as the one exception to that file being the sole
+ * PaymentTransaction writer, since it's stamping linkage, not settling money.
+ */
+export async function stampQuoteDepositsOnWorkOrder(params: {
+  organizationId: string
+  quoteInstanceId: string
+  workOrderInstanceId: string
+}): Promise<void> {
+  const { organizationId, quoteInstanceId, workOrderInstanceId } = params
+  await database
+    .update(schema.PaymentTransaction)
+    .set({ workOrderInstanceId })
+    .where(
+      and(
+        eq(schema.PaymentTransaction.organizationId, organizationId),
+        eq(schema.PaymentTransaction.quoteInstanceId, quoteInstanceId),
+        eq(schema.PaymentTransaction.kind, 'charge'),
+        eq(schema.PaymentTransaction.status, 'succeeded'),
+        isNull(schema.PaymentTransaction.workOrderInstanceId)
+      )
+    )
 }
 
 /**
@@ -40,7 +112,7 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
   const cache = getOrgCache()
   const quoteRecordId = toRecordId('quote', quoteInstanceId)
 
-  // ─── Step 1: assert approved ────────────────────────────────────────────────
+  // ─── Step 1: assert convertible ─────────────────────────────────────────────
   const cf = await cache
     .from(organizationId, 'customFields')
     .bySystemAttributes([
@@ -68,43 +140,14 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
 
   const statusTyped = cf.quote_status ? firstTyped(quoteValues.get(cf.quote_status.id)) : undefined
   const status = statusTyped ? (extractValue(statusTyped) as string) : undefined
-  if (status !== 'approved') {
-    throw new BadRequestError(
-      `Cannot convert to work order — quote must be 'approved' (currently '${status ?? 'unknown'}')`
-    )
+  if (!status || !CONVERTIBLE_QUOTE_STATUSES.has(status)) {
+    throw new BadRequestError(`Cannot convert to work order — quote is '${status ?? 'unknown'}'`)
   }
 
-  // One-job-per-quote guard: the quote stays `approved` after conversion (there is
-  // no `converted` quote status), so without this a second convert — e.g. the admin
-  // clicking "Convert to job" after the public accept page already auto-converted —
-  // would silently duplicate the job. Canceled jobs don't count: a canceled
-  // conversion can be redone.
-  const existingJobs = await handler.listFiltered({
-    entityDefinitionId: 'work_order',
-    filters: [
-      {
-        id: 'converted-job-guard',
-        logicalOperator: 'AND',
-        conditions: [
-          {
-            id: 'converted-job-guard-quote',
-            fieldId: 'work_order:quote',
-            operator: 'is',
-            value: quoteRecordId,
-          },
-          {
-            id: 'converted-job-guard-status',
-            fieldId: 'work_order:status',
-            operator: 'not in',
-            value: ['canceled'],
-          },
-        ],
-      },
-    ],
-    limit: 1,
-    mode: 'oneshot',
-  })
-  if (existingJobs.ids.length > 0) {
+  // One-ACTIVE-job-per-quote guard — e.g. the admin clicking "Convert to job" after the
+  // public accept page already auto-converted would silently duplicate the job.
+  const existingJobInstanceId = await findActiveJobForQuote(handler, quoteRecordId)
+  if (existingJobInstanceId) {
     throw new BadRequestError('This quote has already been converted to a job')
   }
 
@@ -158,25 +201,15 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
   const createdWorkOrder = await handler.create('work_order', workOrderValues)
   const workOrderRecordId = createdWorkOrder.recordId
 
-  // MP2 (§B.6): stamp any pre-paid deposit for this quote onto the newly created work order —
-  // covers a deposit paid before `documents.quote.autoConvertOnAccept` ran (or the setting is
-  // off), where the checkout-time write (`createStripeDepositCheckout`) couldn't resolve a work
-  // order yet. `isNull(workOrderInstanceId)` makes this idempotent against a second manual
-  // convert attempt. A direct write, not routed through `ledger.ts` — the plan sanctions this as
-  // the one exception to that file being the sole PaymentTransaction writer, since it's stamping
-  // linkage, not settling money.
-  await database
-    .update(schema.PaymentTransaction)
-    .set({ workOrderInstanceId: createdWorkOrder.instance.id })
-    .where(
-      and(
-        eq(schema.PaymentTransaction.organizationId, organizationId),
-        eq(schema.PaymentTransaction.quoteInstanceId, quoteInstanceId),
-        eq(schema.PaymentTransaction.kind, 'charge'),
-        eq(schema.PaymentTransaction.status, 'succeeded'),
-        isNull(schema.PaymentTransaction.workOrderInstanceId)
-      )
-    )
+  // Stamp any pre-paid deposit for this quote onto the newly created work order — covers a
+  // deposit paid before `documents.quote.autoConvertOnAccept` ran (or the setting is off),
+  // where the checkout-time write (`createStripeDepositCheckout`) couldn't resolve a work
+  // order yet.
+  await stampQuoteDepositsOnWorkOrder({
+    organizationId,
+    quoteInstanceId,
+    workOrderInstanceId: createdWorkOrder.instance.id,
+  })
 
   // ─── Step 4: copy lines, ordered by sortOrder ───────────────────────────────
   // No `line_item_quote` on the copies — the quote keeps its own lines untouched;
@@ -197,6 +230,7 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
       'line_item_catalog_item',
       'line_item_optional',
       'line_item_optional_selected',
+      'line_item_source_line',
     ] as const)
 
   const { ids: lineInstanceIds } = await handler.listFiltered({
@@ -281,6 +315,11 @@ export async function convertQuoteToWorkOrder(input: ConvertQuoteToWorkOrderInpu
     }
     if (catalogItemTyped?.type === 'relationship') {
       copyValues.line_item_catalog_item = catalogItemTyped.recordId
+    }
+    // Provenance back to the source quote line (money plan 20 §E) — enables a future
+    // accept-time auto-reconcile. Gated on the field existing (pre-migration-047 orgs).
+    if (lineCf.line_item_source_line) {
+      copyValues.line_item_source_line = lineInstanceId
     }
 
     await handler.create('line_item', copyValues)

--- a/packages/lib/src/money/quote-acceptance.ts
+++ b/packages/lib/src/money/quote-acceptance.ts
@@ -9,7 +9,11 @@ import { FieldValueService } from '../field-values/field-value-service'
 import { NotificationService } from '../notifications/notification-service'
 import { UnifiedCrudHandler } from '../resources/crud'
 import { batchReadSystemValues } from './billing-projection'
-import { convertQuoteToWorkOrder } from './convert-quote'
+import {
+  convertQuoteToWorkOrder,
+  findActiveJobForQuote,
+  stampQuoteDepositsOnWorkOrder,
+} from './convert-quote'
 import { approveQuote, declineQuote } from './quote-lifecycle'
 import type { PublicQuotePayload } from './quote-public-token'
 import { getPublicQuotePayload, resolveQuoteByPublicToken } from './quote-public-token'
@@ -114,6 +118,13 @@ export interface AcceptQuoteByTokenResult {
   alreadyAccepted: boolean
   /** `true` when auto-convert-to-work-order ran and succeeded. */
   converted: boolean
+  /**
+   * `true` when an active job already existed for this quote at accept time (early
+   * convert, money plan 20) — the create was skipped (NOT an error), deposits were
+   * stamped onto the existing job, and the creator notification carries the
+   * review-the-job variant.
+   */
+  linkedExistingJob: boolean
 }
 
 /**
@@ -147,13 +158,17 @@ export function validateSelectedLineIds(
  * Zero-optional quotes (no `line_item_optional` lines at all) are a total no-op — today's exact
  * path, `selectedLineIds` or not. See {@link AcceptQuoteByTokenInput.selectedLineIds} for the
  * `undefined` vs `[]` distinction that governs everything past that point.
+ *
+ * @returns The instance ids of the optional lines whose stored `optionalSelected` actually
+ * changed — the accept path uses a non-empty result to pick the "option selection changed"
+ * notification variant when an early-converted job exists (money plan 20 §D).
  */
 async function applyOptionalLineSelections(params: {
   organizationId: string
   userId: string
   quoteInstanceId: string
   selectedLineIds: string[] | undefined
-}): Promise<void> {
+}): Promise<string[]> {
   const { organizationId, userId, quoteInstanceId, selectedLineIds } = params
   const quoteRecordId = toRecordId('quote', quoteInstanceId)
   const handler = new UnifiedCrudHandler(organizationId, userId)
@@ -185,10 +200,10 @@ async function applyOptionalLineSelections(params: {
   })
 
   // Zero-optional quote: skip entirely, no matter what the caller submitted.
-  if (optionalLineInstanceIds.length === 0) return
+  if (optionalLineInstanceIds.length === 0) return []
   // No selection submitted (internal/legacy accept, or acceptancePageEnabled off): the
   // seller's pre-checked defaults ARE the selection — leave them untouched.
-  if (selectedLineIds === undefined) return
+  if (selectedLineIds === undefined) return []
 
   const selectedSet = validateSelectedLineIds(optionalLineInstanceIds, selectedLineIds)
 
@@ -196,7 +211,7 @@ async function applyOptionalLineSelections(params: {
     .from(organizationId, 'customFields')
     .bySystemAttributes(['line_item_optional_selected'] as const)
   const optionalSelectedField = cf.line_item_optional_selected
-  if (!optionalSelectedField) return // pre-migration org — field doesn't exist, nothing to write
+  if (!optionalSelectedField) return [] // pre-migration org — field doesn't exist, nothing to write
 
   const fieldValueService = new FieldValueService(organizationId, userId)
   const currentById = await batchReadSystemValues({
@@ -212,6 +227,7 @@ async function applyOptionalLineSelections(params: {
   // but the row is orphaned from every query that resolves the real def UUID first).
   const lineItemDefId = await requireCachedEntityDefId(organizationId, 'line_item')
 
+  const changedLineIds: string[] = []
   for (const lineInstanceId of optionalLineInstanceIds) {
     const nextSelected = selectedSet.has(lineInstanceId)
     const currentSelected =
@@ -219,6 +235,7 @@ async function applyOptionalLineSelections(params: {
         | boolean
         | undefined) ?? true
     if (currentSelected === nextSelected) continue // stored value already matches — skip the write
+    changedLineIds.push(lineInstanceId)
 
     // Hook-free write path (amendment 3) — `setValueWithType` bypasses the field-change hooks
     // that `setValuesForEntity` fires, so this doesn't trigger N redundant per-line recomputes;
@@ -237,6 +254,33 @@ async function applyOptionalLineSelections(params: {
     documentType: 'quote',
     documentInstanceId: quoteInstanceId,
   })
+
+  return changedLineIds
+}
+
+/**
+ * Best-effort display number of a work order (`WO-0007`) for notification copy — undefined
+ * on any failure so callers can fall back to numberless phrasing.
+ */
+async function readWorkOrderNumber(params: {
+  organizationId: string
+  userId: string
+  workOrderInstanceId: string
+}): Promise<string | undefined> {
+  const { organizationId, userId, workOrderInstanceId } = params
+  try {
+    const byId = await batchReadSystemValues({
+      service: new FieldValueService(organizationId, userId),
+      organizationId,
+      entityType: 'work_order',
+      entityInstanceIds: [workOrderInstanceId],
+      attributes: ['work_order_number'] as const,
+    })
+    const number = byId.get(workOrderInstanceId)?.get('work_order_number')
+    return typeof number === 'string' && number ? number : undefined
+  } catch {
+    return undefined
+  }
 }
 
 /**
@@ -257,7 +301,7 @@ export async function acceptQuoteByToken(
   const systemUserId = await getOrgCache().get(organizationId, 'systemUser')
 
   if (payload.status === 'approved') {
-    return { alreadyAccepted: true, converted: false }
+    return { alreadyAccepted: true, converted: false, linkedExistingJob: false }
   }
   if (payload.status !== 'sent') {
     throw new BadRequestError('This quote can no longer be accepted')
@@ -271,7 +315,7 @@ export async function acceptQuoteByToken(
     throw new BadRequestError('Please type your full name to accept')
   }
 
-  await applyOptionalLineSelections({
+  const selectionChangedLineIds = await applyOptionalLineSelections({
     organizationId,
     userId: systemUserId,
     quoteInstanceId,
@@ -290,11 +334,44 @@ export async function acceptQuoteByToken(
     values,
   })
 
-  await notifyQuoteCreator({
-    organizationId,
-    quoteInstanceId,
-    message: `${payload.contact.name || 'A customer'} accepted quote ${payload.number}`,
-  })
+  // Early-converted job detection (money plan 20 §C) — a job created from this quote
+  // BEFORE acceptance. The snapshot model means we never touch its lines here; we skip
+  // the auto-convert (not an error), stamp deposits, and flag the drift for a human via
+  // the notification variants below.
+  const handler = new UnifiedCrudHandler(organizationId, systemUserId)
+  const existingJobInstanceId = await findActiveJobForQuote(
+    handler,
+    toRecordId('quote', quoteInstanceId)
+  )
+
+  const who = payload.contact.name || 'A customer'
+  let message = `${who} accepted quote ${payload.number}`
+  if (existingJobInstanceId) {
+    const jobNumber = await readWorkOrderNumber({
+      organizationId,
+      userId: systemUserId,
+      workOrderInstanceId: existingJobInstanceId,
+    })
+    const jobRef = jobNumber ? `job ${jobNumber}` : 'its job'
+    // The quote may also have been edited since the early convert in ways we can't
+    // cheaply diff (FieldValue writes don't bump EntityInstance.updatedAt), so the
+    // no-delta variant still says review.
+    message =
+      selectionChangedLineIds.length > 0
+        ? `${who} accepted quote ${payload.number} — their option selection changed; review ${jobRef}'s line items`
+        : `${who} accepted quote ${payload.number} — ${jobRef} already exists; review its line items for changes`
+  }
+  await notifyQuoteCreator({ organizationId, quoteInstanceId, message })
+
+  if (existingJobInstanceId) {
+    // Covers a deposit paid after the early convert but before accept; idempotent.
+    await stampQuoteDepositsOnWorkOrder({
+      organizationId,
+      quoteInstanceId,
+      workOrderInstanceId: existingJobInstanceId,
+    })
+    return { alreadyAccepted: false, converted: false, linkedExistingJob: true }
+  }
 
   const { getOrganizationSetting } = await import('../settings/settings-service')
   const autoConvertOnAccept = await getOrganizationSetting({
@@ -305,6 +382,8 @@ export async function acceptQuoteByToken(
   let converted = false
   if (autoConvertOnAccept !== false) {
     try {
+      // Runs AFTER applyOptionalLineSelections, so the fresh job's line snapshot already
+      // reflects the customer's final selection — zero drift by construction.
       await convertQuoteToWorkOrder({ organizationId, userId: systemUserId, quoteInstanceId })
       converted = true
     } catch (error) {
@@ -316,7 +395,7 @@ export async function acceptQuoteByToken(
     }
   }
 
-  return { alreadyAccepted: false, converted }
+  return { alreadyAccepted: false, converted, linkedExistingJob: false }
 }
 
 /** Input for {@link declineQuoteByToken}. */
@@ -364,12 +443,30 @@ export async function declineQuoteByToken(
     })
   }
 
+  // Early-converted job warning (money plan 20 §D) — the declined quote may already have a
+  // job with scheduled visits. Never auto-cancel; just make the notification say so. The
+  // job's Origin card shows the declined quote badge on its own.
+  let jobSuffix = ''
+  const handler = new UnifiedCrudHandler(organizationId, systemUserId)
+  const existingJobInstanceId = await findActiveJobForQuote(
+    handler,
+    toRecordId('quote', quoteInstanceId)
+  )
+  if (existingJobInstanceId) {
+    const jobNumber = await readWorkOrderNumber({
+      organizationId,
+      userId: systemUserId,
+      workOrderInstanceId: existingJobInstanceId,
+    })
+    jobSuffix = ` — ${jobNumber ? `job ${jobNumber}` : 'a job'} exists for this quote`
+  }
+
   await notifyQuoteCreator({
     organizationId,
     quoteInstanceId,
     message: reason
-      ? `${payload.contact.name || 'A customer'} declined quote ${payload.number}: ${reason}`
-      : `${payload.contact.name || 'A customer'} declined quote ${payload.number}`,
+      ? `${payload.contact.name || 'A customer'} declined quote ${payload.number}: ${reason}${jobSuffix}`
+      : `${payload.contact.name || 'A customer'} declined quote ${payload.number}${jobSuffix}`,
   })
 
   return { alreadyDeclined: false }

--- a/packages/lib/src/resources/registry/resources/line-item-fields.ts
+++ b/packages/lib/src/resources/registry/resources/line-item-fields.ts
@@ -323,6 +323,28 @@ export const LINE_ITEM_FIELDS: Record<string, ResourceField> = {
     description: 'Plain text bridge to WorkOrderVisit — visits are not entities (dispatch lock)',
   },
 
+  sourceLine: {
+    id: toFieldId('sourceLine'),
+    key: 'sourceLine',
+    label: 'Source Line',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'line_item_source_line',
+    systemSortOrder: 'aD1',
+    showInPanel: false,
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'Quote-line instance id this line was copied from at convert (money plan 20 §E) — provenance only, no reader yet',
+  },
+
   catalogItem: {
     id: toFieldId('catalogItem'),
     key: 'catalogItem',

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -49,6 +49,7 @@ import { migration043WorkOrderBillingAllocations } from './migrations/043-work-o
 import { migration044LinePricingFields } from './migrations/044-line-pricing-fields'
 import { migration045DefaultEntityDashboards } from './migrations/045-default-entity-dashboards'
 import { migration046LayeredDefaultViews } from './migrations/046-layered-default-views'
+import { migration047LineItemSourceLine } from './migrations/047-line-item-source-line'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -103,6 +104,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration044LinePricingFields,
   migration045DefaultEntityDashboards,
   migration046LayeredDefaultViews,
+  migration047LineItemSourceLine,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/047-line-item-source-line.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/047-line-item-source-line.ts
@@ -1,0 +1,51 @@
+// packages/lib/src/seed/entity-migrations/migrations/047-line-item-source-line.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { LINE_ITEM_FIELDS } from '../../../resources/registry/resources/line-item-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:047')
+
+/**
+ * Migration 047: add `line_item.sourceLine` (money plan 20 §E — early job from quote).
+ * Plain-text provenance pointer stamped by `convertQuoteToWorkOrder` on each copied line:
+ * the source quote-line's instance id. No reader in plan 20 — it exists so a future
+ * accept-time auto-reconcile can diff an early job's snapshot against the accepted quote.
+ *
+ * Fresh orgs get the field for free via `LINE_ITEM_FIELDS` (entity-seeder); this only
+ * backfills orgs that installed `line_item` (032) before the field existed. No value
+ * backfill — pre-existing copies simply have no provenance, which is honest.
+ */
+export const migration047LineItemSourceLine: EntityMigration = {
+  id: '047-line-item-source-line',
+  description: 'Add line_item.sourceLine provenance field (money plan 20)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const lineItemDef = existing.entityDefs.get('line_item')
+    if (!lineItemDef) {
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    await ensureCustomFields(
+      db,
+      organizationId,
+      'line_item',
+      lineItemDef.id,
+      { sourceLine: LINE_ITEM_FIELDS.sourceLine! },
+      existing,
+      state
+    )
+
+    const alreadyUpToDate = state.fieldsCreated === 0
+    if (!alreadyUpToDate) {
+      logger.info('Migration 047 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -305,6 +305,7 @@ export const SYSTEM_ATTRIBUTES = [
   'line_item_discount',
   'line_item_sort_order',
   'line_item_visit_id',
+  'line_item_source_line',
   'line_item_catalog_item',
   'line_item_quote',
   'line_item_work_order',


### PR DESCRIPTION
## Summary

Implements early job creation from quotes (plan money/20): the "customer said yes on the phone" flow — get the job on the calendar before the formal quote acceptance arrives, without duplicating the job when acceptance does arrive.

### Server (`packages/lib/src/money/`)
- **Convert gate relaxed** to `draft | sent | approved` (declined/canceled still blocked). The one-active-job-per-quote guard is unchanged, extracted to a shared `findActiveJobForQuote`; the MP2 deposit stamp is extracted to `stampQuoteDepositsOnWorkOrder` (idempotent, reused below).
- **Accept path is existing-job-aware**: `acceptQuoteByToken` detects an early-converted active job before auto-converting — skips the duplicate create cleanly (previously the guard threw and was swallowed as an error log), stamps pre-paid deposits onto the existing job, returns `linkedExistingJob: true`, and sends a review-variant creator notification ("their option selection changed; review job WO-xxxx's line items" when the customer changed optional lines on the accept page). Job lines are never auto-edited — snapshot model, drift is flagged for a human.
- **Decline** notifications append "— job WO-xxxx exists for this quote" when an early job exists (never auto-canceled).
- **Line provenance**: converted copies are stamped with `line_item_source_line` (source quote-line instance id) — no reader yet, enables a future accept-time auto-reconcile. New registry field + `SystemAttribute` union entry + entity migration **047** (applied dev, 26 orgs; **owed on prod**).

### Client
- Quote tab menu shows **Convert to job** for draft/sent/approved with a confirm dialog pre-acceptance ("This quote hasn't been accepted yet. Create the job anyway?").
- Quote drawer **Jobs card** gains a "Create job" header action (DrawerCardActions portal) — routes through the convert mutation so manual jobs stay linked; an unlinked hand-made job would be invisible to the guard and duplicated on accept.

### Also included
- `fix(fields)`: option color picker dropdown — check indicator + swatch layout (concurrent session's tweak, riding along per request).

## Verification
- NEW `verify-money-early-convert.ts` **27/27 ×2** — gate matrix (draft/sent allow, declined/canceled reject), guard + canceled-job re-convert, provenance stamp, accept-with-existing-job (no duplicate, deposit stamped, both notification variants, snapshot untouched), fresh auto-convert unchanged, decline job-reference, migration 047 idempotency.
- Regressions: line-pricing **41/41**, mq1 **45/45**, deposit-allocations **45/45**, delete-safety **31/31**.
- Biome clean; zero new type errors in touched files (web repo-wide baseline unchanged; the flagged convert-quote lines are verbatim-at-HEAD lib baseline).
- Owed post-merge: web dev-server restart (rebuilt `@auxx/types` + `@auxx/lib` dists), browser pass, migration 047 on prod.